### PR TITLE
Rust packaging for cargo install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,39 @@ env:
   CONTAINER_ARCH: x86_64
 
 jobs:
+  # Runner 0: Packaging (default GitHub runner, no KVM needed)
+  # Verifies cargo install works without source tree access
+  packaging:
+    name: Packaging
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: fcvm
+      - uses: actions/checkout@v4
+        with:
+          repository: ejc3/fuse-backend-rs
+          ref: master
+          path: fuse-backend-rs
+      - uses: actions/checkout@v4
+        with:
+          repository: ejc3/fuser
+          ref: master
+          path: fuser
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: fcvm -> target
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y libfuse3-dev libclang-dev clang
+      - name: Build release
+        working-directory: fcvm
+        run: cargo build --release -p fcvm
+      - name: Test packaging
+        working-directory: fcvm
+        run: ./scripts/test-packaging.sh ./target/release/fcvm
+
   # Runner 1: Host (bare metal with KVM)
   # Runs: test-unit → test-fast → test-root (sequential)
   host:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004eef6b14ce34759aa7de4aea3217e368f463f46a3ed3764ca4b5a4404003b4"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,6 +591,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
+ "clap_complete",
  "criterion",
  "directories",
  "fs2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,34 @@ resolver = "2"
 name = "fcvm"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.75"
+authors = ["ejc3"]
+description = "Firecracker VM runner for Podman containers with sub-second cloning"
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/ejc3/fcvm"
+homepage = "https://github.com/ejc3/fcvm"
+keywords = ["firecracker", "vm", "container", "podman", "microvm"]
+categories = ["command-line-utilities", "virtualization"]
+exclude = [
+    ".github/",
+    ".claude/",
+    "tests/",
+    "benches/",
+    "scripts/",
+    "Containerfile",
+    "Makefile",
+]
+
+[profile.release]
+lto = "thin"
+strip = true
+codegen-units = 1
 
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
+clap_complete = "4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,190 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to the Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+Copyright 2025 ejc3
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 ejc3
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,11 @@ build:
 	CARGO_TARGET_DIR=target cargo build --release -p fc-agent --target $(MUSL_TARGET)
 	@mkdir -p target/release && cp target/$(MUSL_TARGET)/release/fc-agent target/release/fc-agent
 
+# Test that the release binary works without source tree (simulates cargo install)
+test-packaging: build
+	@echo "==> Testing packaging (simulates cargo install)..."
+	./scripts/test-packaging.sh ./target/release/fcvm
+
 clean:
 	sudo rm -rf target
 

--- a/scripts/test-packaging.sh
+++ b/scripts/test-packaging.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Test that fcvm works when installed via cargo install (no source tree access).
+#
+# This script simulates what happens after `cargo install fcvm`:
+# 1. Binary is in ~/.cargo/bin (away from source tree)
+# 2. No config file exists yet
+# 3. User runs fcvm setup --generate-config
+# 4. User runs fcvm setup (finds the generated config)
+
+set -euo pipefail
+
+BINARY="${1:-./target/release/fcvm}"
+
+if [[ ! -f "$BINARY" ]]; then
+    echo "ERROR: Binary not found: $BINARY"
+    echo "Run: cargo build --release"
+    exit 1
+fi
+
+echo "=== Testing packaging workflow ==="
+echo "Binary: $BINARY"
+
+# Create isolated environment
+INSTALL_DIR=$(mktemp -d)
+CONFIG_DIR=$(mktemp -d)
+trap "rm -rf $INSTALL_DIR; sudo rm -rf $CONFIG_DIR 2>/dev/null || true" EXIT
+
+# Copy binary (simulates ~/.cargo/bin/fcvm)
+cp "$BINARY" "$INSTALL_DIR/fcvm"
+chmod +x "$INSTALL_DIR/fcvm"
+FCVM="$INSTALL_DIR/fcvm"
+
+echo ""
+echo "Step 1: Run setup without config (should fail with helpful message)"
+set +e
+OUTPUT=$(XDG_CONFIG_HOME="$CONFIG_DIR" HOME="$CONFIG_DIR" "$FCVM" setup 2>&1)
+EXIT_CODE=$?
+set -e
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+    echo "FAIL: setup should fail without config"
+    echo "Output: $OUTPUT"
+    exit 1
+fi
+
+if echo "$OUTPUT" | grep -q "No rootfs config found"; then
+    echo "PASS: Got helpful error message"
+else
+    echo "FAIL: Expected 'No rootfs config found' message"
+    echo "Output: $OUTPUT"
+    exit 1
+fi
+
+if echo "$OUTPUT" | grep -q "CARGO_MANIFEST_DIR"; then
+    echo "FAIL: Error message exposes CARGO_MANIFEST_DIR (hardcoded path)"
+    echo "Output: $OUTPUT"
+    exit 1
+fi
+
+if echo "$OUTPUT" | grep -q "panicked"; then
+    echo "FAIL: Binary panicked"
+    echo "Output: $OUTPUT"
+    exit 1
+fi
+
+echo ""
+echo "Step 2: Generate config"
+XDG_CONFIG_HOME="$CONFIG_DIR" HOME="$CONFIG_DIR" "$FCVM" setup --generate-config
+
+CONFIG_FILE="$CONFIG_DIR/fcvm/rootfs-config.toml"
+if [[ ! -f "$CONFIG_FILE" ]]; then
+    echo "FAIL: Config file not created at $CONFIG_FILE"
+    exit 1
+fi
+echo "PASS: Config created at $CONFIG_FILE"
+
+echo ""
+echo "Step 3: Verify setup finds the config"
+set +e
+OUTPUT=$(XDG_CONFIG_HOME="$CONFIG_DIR" HOME="$CONFIG_DIR" FCVM_BASE_DIR="$INSTALL_DIR/data" "$FCVM" setup 2>&1)
+set -e
+
+if echo "$OUTPUT" | grep -q "No rootfs config found"; then
+    echo "FAIL: Still complaining about missing config"
+    echo "Output: $OUTPUT"
+    exit 1
+fi
+
+# It will fail for other reasons (no btrfs, etc) but should find the config
+if echo "$OUTPUT" | grep -q "loaded rootfs config"; then
+    echo "PASS: Found and loaded config"
+else
+    echo "PASS: Config lookup succeeded (may fail for other reasons)"
+fi
+
+echo ""
+echo "=== All packaging tests passed ==="

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,4 +1,5 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap_complete::Shell;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -33,6 +34,8 @@ pub enum Commands {
     Exec(ExecArgs),
     /// Setup kernel and rootfs (kernel ~15MB download, rootfs ~10GB creation, takes 5-10 minutes)
     Setup(SetupArgs),
+    /// Generate shell completions
+    Completions(CompletionsArgs),
 }
 
 // ============================================================================
@@ -52,6 +55,17 @@ pub struct SetupArgs {
     /// Path to custom rootfs config file
     #[arg(long)]
     pub config: Option<String>,
+}
+
+// ============================================================================
+// Completions Command
+// ============================================================================
+
+#[derive(Args, Debug)]
+pub struct CompletionsArgs {
+    /// Shell to generate completions for
+    #[arg(value_enum)]
+    pub shell: Shell,
 }
 
 // ============================================================================

--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -1,0 +1,12 @@
+use std::io;
+
+use clap::CommandFactory;
+use clap_complete::generate;
+
+use crate::cli::args::{Cli, CompletionsArgs};
+
+/// Generate shell completions to stdout.
+pub fn cmd_completions(args: CompletionsArgs) {
+    let mut cmd = Cli::command();
+    generate(args.shell, &mut cmd, "fcvm", &mut io::stdout());
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod common;
+pub mod completions;
 pub mod exec;
 pub mod ls;
 pub mod podman;
@@ -7,6 +8,7 @@ pub mod snapshot;
 pub mod snapshots;
 
 // Re-export command functions
+pub use completions::cmd_completions;
 pub use exec::cmd_exec;
 pub use ls::cmd_ls;
 pub use podman::cmd_podman;

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,8 +41,7 @@ async fn main() -> Result<()> {
     // But KEEP target tags to show the nesting hierarchy!
     // Otherwise, show full formatting (outermost process)
     // Use RUST_LOG if set, otherwise default to INFO
-    let env_filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new("info"));
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
     if cli.sub_process {
         // Subprocesses NEVER have colors (their output is captured and re-logged)
@@ -74,6 +73,10 @@ async fn main() -> Result<()> {
         Commands::Snapshots => commands::cmd_snapshots().await,
         Commands::Exec(args) => commands::cmd_exec(args).await,
         Commands::Setup(args) => commands::cmd_setup(args).await,
+        Commands::Completions(args) => {
+            commands::cmd_completions(args);
+            Ok(())
+        }
     };
 
     // Handle errors

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -531,13 +531,17 @@ pub fn find_config_file(explicit_path: Option<&str>) -> Result<PathBuf> {
         }
     }
 
-    // 5. Check CARGO_MANIFEST_DIR for development builds
-    let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(CONFIG_FILE);
-    if manifest_path.exists() {
-        return Ok(manifest_path);
+    // 5. Check CARGO_MANIFEST_DIR for development builds (debug only)
+    // In release builds (cargo install), this path would be stale and misleading
+    #[cfg(debug_assertions)]
+    {
+        let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(CONFIG_FILE);
+        if manifest_path.exists() {
+            return Ok(manifest_path);
+        }
     }
 
-    // 5. Error with helpful message
+    // 6. Error with helpful message
     bail!(
         "No rootfs config found.\n\n\
          Searched:\n  \

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -459,8 +459,8 @@ pub fn generate_setup_script(plan: &Plan) -> String {
 ///
 /// Writes the embedded default config to ~/.config/fcvm/rootfs-config.toml
 pub fn generate_config(force: bool) -> Result<PathBuf> {
-    let proj_dirs = ProjectDirs::from("", "", "fcvm")
-        .context("Could not determine config directory")?;
+    let proj_dirs =
+        ProjectDirs::from("", "", "fcvm").context("Could not determine config directory")?;
     let config_dir = proj_dirs.config_dir();
     let config_path = config_dir.join(CONFIG_FILE);
 
@@ -546,7 +546,9 @@ pub fn find_config_file(explicit_path: Option<&str>) -> Result<PathBuf> {
          <binary-dir>/{}\n\n\
          Generate the default config with:\n  \
          fcvm setup --generate-config",
-        CONFIG_FILE, CONFIG_FILE, CONFIG_FILE
+        CONFIG_FILE,
+        CONFIG_FILE,
+        CONFIG_FILE
     );
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -174,9 +174,7 @@ fn ensure_config_exists() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             panic!("Failed to generate config: {}", stderr);
         }
-        eprintln!(
-            ">>> Generated config at ~/.config/fcvm/rootfs-config.toml"
-        );
+        eprintln!(">>> Generated config at ~/.config/fcvm/rootfs-config.toml");
     });
 }
 

--- a/tests/test_packaging.rs
+++ b/tests/test_packaging.rs
@@ -1,0 +1,258 @@
+//! Integration tests for packaging features (completions, config generation).
+//!
+//! These tests verify that `cargo install` users can properly set up fcvm.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Get the fcvm binary path from cargo's test environment.
+/// This ensures we test the binary that was just built, not an old release.
+fn fcvm_binary() -> PathBuf {
+    // CARGO_BIN_EXE_fcvm is set by cargo during `cargo test`
+    PathBuf::from(env!("CARGO_BIN_EXE_fcvm"))
+}
+
+/// Test that shell completions generate valid output for all supported shells.
+#[test]
+fn test_completions_all_shells() {
+    let fcvm = fcvm_binary();
+
+    let shells = ["bash", "zsh", "fish", "elvish", "powershell"];
+
+    for shell in shells {
+        let output = Command::new(&fcvm)
+            .args(["completions", shell])
+            .output()
+            .expect("failed to run fcvm completions");
+
+        assert!(
+            output.status.success(),
+            "completions {} failed: {}",
+            shell,
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            !stdout.is_empty(),
+            "completions {} produced empty output",
+            shell
+        );
+
+        // Verify shell-specific markers
+        match shell {
+            "bash" => assert!(
+                stdout.contains("_fcvm()"),
+                "bash completions missing _fcvm function"
+            ),
+            "zsh" => assert!(
+                stdout.contains("#compdef fcvm"),
+                "zsh completions missing #compdef"
+            ),
+            "fish" => assert!(
+                stdout.contains("complete -c fcvm"),
+                "fish completions missing complete command"
+            ),
+            "elvish" => assert!(
+                stdout.contains("set edit:completion:arg-completer[fcvm]"),
+                "elvish completions missing arg-completer"
+            ),
+            "powershell" => assert!(
+                stdout.contains("Register-ArgumentCompleter"),
+                "powershell completions missing Register-ArgumentCompleter"
+            ),
+            _ => {}
+        }
+
+        // All completions should reference subcommands
+        assert!(
+            stdout.contains("podman") || stdout.contains("PODMAN"),
+            "completions {} missing podman subcommand",
+            shell
+        );
+        assert!(
+            stdout.contains("setup") || stdout.contains("SETUP"),
+            "completions {} missing setup subcommand",
+            shell
+        );
+    }
+}
+
+/// Test that --generate-config creates a config file.
+#[test]
+fn test_generate_config() {
+    let fcvm = fcvm_binary();
+
+    // Use a temp directory for XDG_CONFIG_HOME to avoid polluting real config
+    let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let config_dir = temp_dir.path().join("fcvm");
+    let config_path = config_dir.join("rootfs-config.toml");
+
+    // Generate config with custom XDG_CONFIG_HOME
+    let output = Command::new(&fcvm)
+        .args(["setup", "--generate-config", "--force"])
+        .env("XDG_CONFIG_HOME", temp_dir.path())
+        .output()
+        .expect("failed to run fcvm setup --generate-config");
+
+    assert!(
+        output.status.success(),
+        "generate-config failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Verify config file was created
+    assert!(
+        config_path.exists(),
+        "config file not created at {:?}",
+        config_path
+    );
+
+    // Verify config file has expected content
+    let content = std::fs::read_to_string(&config_path).expect("failed to read config");
+    assert!(
+        content.contains("[kernel]"),
+        "config missing [kernel] section"
+    );
+    assert!(
+        content.contains("[packages]"),
+        "config missing [packages] section"
+    );
+    assert!(
+        content.contains("[services]"),
+        "config missing [services] section"
+    );
+}
+
+/// Test that --generate-config without --force fails if file exists.
+#[test]
+fn test_generate_config_no_overwrite() {
+    let fcvm = fcvm_binary();
+
+    let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let config_dir = temp_dir.path().join("fcvm");
+    std::fs::create_dir_all(&config_dir).expect("failed to create config dir");
+    let config_path = config_dir.join("rootfs-config.toml");
+
+    // Create existing config
+    std::fs::write(&config_path, "# existing config").expect("failed to write config");
+
+    // Try to generate without --force
+    let output = Command::new(&fcvm)
+        .args(["setup", "--generate-config"])
+        .env("XDG_CONFIG_HOME", temp_dir.path())
+        .output()
+        .expect("failed to run fcvm setup --generate-config");
+
+    assert!(
+        !output.status.success(),
+        "generate-config should fail without --force when file exists"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("already exists") || stderr.contains("--force"),
+        "error message should mention file exists or --force flag"
+    );
+
+    // Verify original content unchanged
+    let content = std::fs::read_to_string(&config_path).expect("failed to read config");
+    assert_eq!(
+        content, "# existing config",
+        "config file should not be modified"
+    );
+}
+
+/// Test that --generate-config with --force overwrites existing file.
+#[test]
+fn test_generate_config_force_overwrite() {
+    let fcvm = fcvm_binary();
+
+    let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let config_dir = temp_dir.path().join("fcvm");
+    std::fs::create_dir_all(&config_dir).expect("failed to create config dir");
+    let config_path = config_dir.join("rootfs-config.toml");
+
+    // Create existing config
+    std::fs::write(&config_path, "# existing config").expect("failed to write config");
+
+    // Generate with --force
+    let output = Command::new(&fcvm)
+        .args(["setup", "--generate-config", "--force"])
+        .env("XDG_CONFIG_HOME", temp_dir.path())
+        .output()
+        .expect("failed to run fcvm setup --generate-config --force");
+
+    assert!(
+        output.status.success(),
+        "generate-config --force failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Verify config was overwritten with real content
+    let content = std::fs::read_to_string(&config_path).expect("failed to read config");
+    assert!(
+        content.contains("[kernel]"),
+        "config should contain [kernel] section after --force"
+    );
+    assert!(
+        content != "# existing config",
+        "config should be overwritten"
+    );
+}
+
+/// Test that fcvm --version shows version info.
+#[test]
+fn test_version_output() {
+    let fcvm = fcvm_binary();
+
+    let output = Command::new(&fcvm)
+        .arg("--version")
+        .output()
+        .expect("failed to run fcvm --version");
+
+    assert!(output.status.success(), "fcvm --version failed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("fcvm"),
+        "version output should contain 'fcvm'"
+    );
+    assert!(
+        stdout.contains("0.1.0"),
+        "version output should contain version number"
+    );
+}
+
+/// Test that fcvm --help shows all expected commands.
+#[test]
+fn test_help_shows_all_commands() {
+    let fcvm = fcvm_binary();
+
+    let output = Command::new(&fcvm)
+        .arg("--help")
+        .output()
+        .expect("failed to run fcvm --help");
+
+    assert!(output.status.success(), "fcvm --help failed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Verify all commands are listed
+    let expected_commands = [
+        "ls",
+        "podman",
+        "snapshot",
+        "snapshots",
+        "exec",
+        "setup",
+        "completions",
+    ];
+    for cmd in expected_commands {
+        assert!(
+            stdout.contains(cmd),
+            "help output missing '{}' command",
+            cmd
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Prepares fcvm for `cargo install` by:
- Package metadata (license, keywords, categories, release profile)
- License files (MIT OR Apache-2.0)
- Shell completions (`fcvm completions bash|zsh|fish`)
- Packaging integration tests
- CI job on ubuntu-latest to verify packaging works

## Changes

| File | Description |
|------|-------------|
| `Cargo.toml` | Package metadata, release profile |
| `LICENSE-MIT` | MIT license |
| `LICENSE-APACHE` | Apache 2.0 license |
| `src/commands/completions.rs` | Shell completion generator |
| `scripts/test-packaging.sh` | Simulates cargo install workflow |
| `.github/workflows/ci.yml` | Packaging job on ubuntu-latest |

## Test plan

- [x] `make test-packaging` passes
- [x] `cargo test --test test_packaging` passes
- [x] Shell completions generate for all shells