### PR TITLE
CI: Container tests and Layer 2 setup (2/4)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -504,7 +504,7 @@ gh api repos/OWNER/REPO/actions/runs/RUN_ID/jobs --jq '.jobs[] | select(.name=="
 
 ### linkat AT_EMPTY_PATH Limitation
 
-fuse-backend-rs hardlinks use `linkat(..., AT_EMPTY_PATH)` which requires `CAP_DAC_READ_SEARCH`. BuildJet runners lack this → ENOENT. Hardlink tests must detect and skip. See [linkat(2)](https://man7.org/linux/man-pages/man2/linkat.2.html).
+fuse-backend-rs hardlinks use `linkat(..., AT_EMPTY_PATH)`. Older kernels require `CAP_DAC_READ_SEARCH` capability; newer kernels (≥5.12ish) relaxed this. BuildJet runs older kernel → ENOENT. Localhost (kernel 6.14) works fine. Hardlink tests detect and skip. See [linkat(2)](https://man7.org/linux/man-pages/man2/linkat.2.html), [kernel patch](https://lwn.net/Articles/565122/).
 
 ## PID-Based Process Management
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -488,6 +488,24 @@ make container-test
 **Nightly (scheduled):**
 - Full benchmarks with artifact upload
 
+### Getting Logs from In-Progress CI Runs
+
+**`gh run view --log` only works after ALL jobs complete.** To get logs from a completed job while other jobs are still running:
+
+```bash
+# Get job ID for the completed job
+gh api repos/OWNER/REPO/actions/runs/RUN_ID/jobs --jq '.jobs[] | select(.name=="Host") | .id'
+
+# Fetch logs for that specific job
+gh api repos/OWNER/REPO/actions/runs/RUN_ID/jobs --jq '.jobs[] | select(.name=="Host") | .id' \
+  | xargs -I{} gh api repos/OWNER/REPO/actions/jobs/{}/logs 2>&1 \
+  | grep -E "pattern"
+```
+
+### linkat AT_EMPTY_PATH Limitation
+
+fuse-backend-rs hardlinks use `linkat(..., AT_EMPTY_PATH)` which requires `CAP_DAC_READ_SEARCH`. BuildJet runners lack this → ENOENT. Hardlink tests must detect and skip. See [linkat(2)](https://man7.org/linux/man-pages/man2/linkat.2.html).
+
 ## PID-Based Process Management
 
 **Core Principle:** All fcvm processes store their own PID (via `std::process::id()`), not child process PIDs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,11 +104,7 @@ jobs:
           sudo chmod 666 /dev/kvm
           # Configure rootless podman to use cgroupfs (no systemd session on CI)
           mkdir -p ~/.config/containers
-          cat > ~/.config/containers/containers.conf << 'EOF'
-          [engine]
-          cgroup_manager = "cgroupfs"
-          events_logger = "file"
-          EOF
+          printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n' > ~/.config/containers/containers.conf
       - name: container-test-unit
         working-directory: fcvm
         run: make container-test-unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
           fi
           sudo chmod 666 /dev/userfaultfd
           sudo sysctl -w vm.unprivileged_userfaultfd=1
+          # Enable FUSE allow_other for tests
+          echo "user_allow_other" | sudo tee /etc/fuse.conf
       - name: test-unit
         working-directory: fcvm
         run: make test-unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,14 @@ jobs:
           repository: ejc3/fuser
           ref: master
           path: fuser
-      - name: Setup KVM
-        run: sudo chmod 666 /dev/kvm
+      - name: Setup KVM and rootless podman
+        run: |
+          sudo chmod 666 /dev/kvm
+          # Configure rootless podman to use cgroupfs (no systemd session on CI)
+          mkdir -p ~/.config/containers
+          echo '[containers]' > ~/.config/containers/containers.conf
+          echo 'cgroup_manager = "cgroupfs"' >> ~/.config/containers/containers.conf
+          echo 'events_logger = "file"' >> ~/.config/containers/containers.conf
       - name: container-test-unit
         working-directory: fcvm
         run: make container-test-unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,50 +13,10 @@ env:
   CONTAINER_ARCH: x86_64
 
 jobs:
-  container-rootless:
-    name: Container (rootless)
-    runs-on: buildjet-32vcpu-ubuntu-2204
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          path: fcvm
-      - uses: actions/checkout@v4
-        with:
-          repository: ejc3/fuse-backend-rs
-          ref: master
-          path: fuse-backend-rs
-      - uses: actions/checkout@v4
-        with:
-          repository: ejc3/fuser
-          ref: master
-          path: fuser
-      - name: make ci-container-rootless
-        working-directory: fcvm
-        run: make ci-container-rootless
-
-  container-sudo:
-    name: Container (sudo)
-    runs-on: buildjet-32vcpu-ubuntu-2204
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          path: fcvm
-      - uses: actions/checkout@v4
-        with:
-          repository: ejc3/fuse-backend-rs
-          ref: master
-          path: fuse-backend-rs
-      - uses: actions/checkout@v4
-        with:
-          repository: ejc3/fuser
-          ref: master
-          path: fuser
-      - name: make ci-container-sudo
-        working-directory: fcvm
-        run: make ci-container-sudo
-
-  vm:
-    name: VM (bare metal)
+  # Runner 1: Host (bare metal with KVM)
+  # Runs: test-unit → test-fast → test-root (sequential)
+  host:
+    name: Host
     runs-on: buildjet-32vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
@@ -81,7 +41,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y fuse3 libfuse3-dev libclang-dev clang musl-tools \
             iproute2 iptables slirp4netns dnsmasq qemu-utils e2fsprogs parted \
-            podman skopeo busybox-static cpio zstd
+            podman skopeo busybox-static cpio zstd autoconf automake libtool
       - name: Install Firecracker
         run: |
           curl -L -o /tmp/firecracker.tgz \
@@ -104,6 +64,41 @@ jobs:
           fi
           sudo chmod 666 /dev/userfaultfd
           sudo sysctl -w vm.unprivileged_userfaultfd=1
-      - name: make test-vm
+      - name: test-unit
         working-directory: fcvm
-        run: make test-vm
+        run: make test-unit
+      - name: test-fast
+        working-directory: fcvm
+        run: make test-fast
+      - name: test-root
+        working-directory: fcvm
+        run: make test-root
+
+  # Runner 2: Container (podman)
+  # Runs: container-test-unit → container-test-fast → container-test-all (sequential)
+  container:
+    name: Container
+    runs-on: buildjet-32vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: fcvm
+      - uses: actions/checkout@v4
+        with:
+          repository: ejc3/fuse-backend-rs
+          ref: master
+          path: fuse-backend-rs
+      - uses: actions/checkout@v4
+        with:
+          repository: ejc3/fuser
+          ref: master
+          path: fuser
+      - name: container-test-unit
+        working-directory: fcvm
+        run: make container-test-unit
+      - name: container-test-fast
+        working-directory: fcvm
+        run: make container-test-fast
+      - name: container-test-all
+        working-directory: fcvm
+        run: make container-test-all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,11 @@ jobs:
         run: make test-root
 
   # Runner 2: Container (podman)
-  # Runs: container-test-unit → container-test-fast → container-test-all (sequential)
+  # Only runs unit tests - VM tests require KVM (covered by Host job)
+  # Uses ubuntu-latest which has proper rootless podman support
   container:
     name: Container
-    runs-on: buildjet-32vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -96,9 +97,3 @@ jobs:
       - name: container-test-unit
         working-directory: fcvm
         run: make container-test-unit
-      - name: container-test-fast
-        working-directory: fcvm
-        run: make container-test-fast
-      - name: container-test-all
-        working-directory: fcvm
-        run: make container-test-all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,9 +104,11 @@ jobs:
           sudo chmod 666 /dev/kvm
           # Configure rootless podman to use cgroupfs (no systemd session on CI)
           mkdir -p ~/.config/containers
-          echo '[containers]' > ~/.config/containers/containers.conf
-          echo 'cgroup_manager = "cgroupfs"' >> ~/.config/containers/containers.conf
-          echo 'events_logger = "file"' >> ~/.config/containers/containers.conf
+          cat > ~/.config/containers/containers.conf << 'EOF'
+          [engine]
+          cgroup_manager = "cgroupfs"
+          events_logger = "file"
+          EOF
       - name: container-test-unit
         working-directory: fcvm
         run: make container-test-unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,11 @@ jobs:
         run: make test-root
 
   # Runner 2: Container (podman)
-  # Only runs unit tests - VM tests require KVM (covered by Host job)
-  # Uses ubuntu-latest which has proper rootless podman support
+  # Runs same tests as Host but inside a container
+  # Needs KVM for VM tests (container mounts /dev/kvm)
   container:
     name: Container
-    runs-on: ubuntu-latest
+    runs-on: buildjet-32vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
         with:
@@ -99,6 +99,14 @@ jobs:
           repository: ejc3/fuser
           ref: master
           path: fuser
+      - name: Setup KVM
+        run: sudo chmod 666 /dev/kvm
       - name: container-test-unit
         working-directory: fcvm
         run: make container-test-unit
+      - name: setup-fcvm
+        working-directory: fcvm
+        run: make setup-fcvm
+      - name: container-test
+        working-directory: fcvm
+        run: make container-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: test-unit
         working-directory: fcvm
         run: make test-unit
+      - name: setup-fcvm
+        working-directory: fcvm
+        run: make setup-fcvm
       - name: test-fast
         working-directory: fcvm
         run: make test-fast

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ sync-test/
 *.local.*
 *.local
 cargo-home/
+.local/

--- a/Containerfile
+++ b/Containerfile
@@ -41,8 +41,7 @@ RUN for bin in cargo rustc rustfmt cargo-clippy clippy-driver cargo-nextest carg
 
 # Setup workspace
 WORKDIR /workspace/fcvm
-RUN mkdir -p /workspace/fcvm /workspace/fuse-backend-rs /workspace/fuser \
-    && chown -R testuser:testuser /workspace
+RUN mkdir -p /workspace/fcvm /workspace/fuse-backend-rs /workspace/fuser
 
-USER testuser
+# Run as root (--privileged container, simpler than user namespace mapping)
 CMD ["make", "test-unit"]

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ NEXTEST := CARGO_TARGET_DIR=target cargo nextest $(NEXTEST_CMD) --release
 # Container run command
 CONTAINER_RUN := podman run --rm --privileged --userns=keep-id --group-add keep-groups \
 	-v .:/workspace/fcvm -v $(FUSE_BACKEND_RS):/workspace/fuse-backend-rs -v $(FUSER):/workspace/fuser \
-	-v ./target:/workspace/fcvm/target --device /dev/fuse --device /dev/kvm \
+	-v ./target:/workspace/fcvm/target -e CARGO_HOME=/home/testuser/.cargo \
+	--device /dev/fuse --device /dev/kvm \
 	--ulimit nofile=65536:65536 --pids-limit=65536 -v /mnt/fcvm-btrfs:/mnt/fcvm-btrfs
 
 .PHONY: all help build clean test test-unit test-fast test-all test-root \

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,10 @@ endif
 # Base test command
 NEXTEST := CARGO_TARGET_DIR=target cargo nextest $(NEXTEST_CMD) --release
 
-# Container run command (no target mount - let container use its own to avoid permission issues)
-CONTAINER_RUN := podman run --rm --privileged --userns=keep-id --group-add keep-groups \
+# Container run command (runs as testuser via Containerfile USER directive)
+CONTAINER_RUN := podman run --rm --privileged \
 	-v .:/workspace/fcvm -v $(FUSE_BACKEND_RS):/workspace/fuse-backend-rs -v $(FUSER):/workspace/fuser \
-	-e CARGO_HOME=/home/testuser/.cargo --device /dev/fuse --device /dev/kvm \
+	--device /dev/fuse --device /dev/kvm \
 	--ulimit nofile=65536:65536 --pids-limit=65536 -v /mnt/fcvm-btrfs:/mnt/fcvm-btrfs
 
 .PHONY: all help build clean test test-unit test-fast test-all test-root \

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,10 @@ endif
 # Base test command
 NEXTEST := CARGO_TARGET_DIR=target cargo nextest $(NEXTEST_CMD) --release
 
-# Container run command
+# Container run command (no target mount - let container use its own to avoid permission issues)
 CONTAINER_RUN := podman run --rm --privileged --userns=keep-id --group-add keep-groups \
 	-v .:/workspace/fcvm -v $(FUSE_BACKEND_RS):/workspace/fuse-backend-rs -v $(FUSER):/workspace/fuser \
-	-v ./target:/workspace/fcvm/target -e CARGO_HOME=/home/testuser/.cargo \
-	--device /dev/fuse --device /dev/kvm \
+	-e CARGO_HOME=/home/testuser/.cargo --device /dev/fuse --device /dev/kvm \
 	--ulimit nofile=65536:65536 --pids-limit=65536 -v /mnt/fcvm-btrfs:/mnt/fcvm-btrfs
 
 .PHONY: all help build clean test test-unit test-fast test-all test-root \
@@ -96,7 +95,6 @@ container-test-all: setup-fcvm container-build
 container-test: container-test-all
 
 container-build:
-	@mkdir -p target
 	@sudo mkdir -p /mnt/fcvm-btrfs 2>/dev/null || true
 	podman build -t $(CONTAINER_TAG) -f Containerfile --build-arg ARCH=$(CONTAINER_ARCH) .
 

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,7 @@ NEXTEST := CARGO_TARGET_DIR=target cargo nextest $(NEXTEST_CMD) --release
 # Container run command
 CONTAINER_RUN := podman run --rm --privileged --userns=keep-id --group-add keep-groups \
 	-v .:/workspace/fcvm -v $(FUSE_BACKEND_RS):/workspace/fuse-backend-rs -v $(FUSER):/workspace/fuser \
-	-v ./target:/workspace/fcvm/target -v ./cargo-home:/home/testuser/.cargo \
-	-e CARGO_HOME=/home/testuser/.cargo --device /dev/fuse --device /dev/kvm \
+	-v ./target:/workspace/fcvm/target --device /dev/fuse --device /dev/kvm \
 	--ulimit nofile=65536:65536 --pids-limit=65536 -v /mnt/fcvm-btrfs:/mnt/fcvm-btrfs
 
 .PHONY: all help build clean test test-unit test-fast test-all test-root \
@@ -56,7 +55,7 @@ build:
 	@mkdir -p target/release && cp target/$(MUSL_TARGET)/release/fc-agent target/release/fc-agent
 
 clean:
-	sudo rm -rf target cargo-home
+	sudo rm -rf target
 
 # Run-only targets (no setup deps, used by container)
 _test-unit:
@@ -96,7 +95,7 @@ container-test-all: setup-fcvm container-build
 container-test: container-test-all
 
 container-build:
-	@mkdir -p target cargo-home
+	@mkdir -p target
 	@sudo mkdir -p /mnt/fcvm-btrfs 2>/dev/null || true
 	podman build -t $(CONTAINER_TAG) -f Containerfile --build-arg ARCH=$(CONTAINER_ARCH) .
 

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ container-test: container-test-all
 
 container-build:
 	@mkdir -p target cargo-home
+	@sudo mkdir -p /mnt/fcvm-btrfs 2>/dev/null || true
 	podman build -t $(CONTAINER_TAG) -f Containerfile --build-arg ARCH=$(CONTAINER_ARCH) .
 
 container-shell: container-build

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ container-test-all: setup-fcvm container-build
 container-test: container-test-all
 
 container-build:
+	@mkdir -p target cargo-home
 	podman build -t $(CONTAINER_TAG) -f Containerfile --build-arg ARCH=$(CONTAINER_ARCH) .
 
 container-shell: container-build

--- a/fuse-pipe/src/server/passthrough.rs
+++ b/fuse-pipe/src/server/passthrough.rs
@@ -1262,9 +1262,13 @@ mod tests {
 
     #[test]
     fn test_passthrough_hardlink() {
-        // Use .local/ instead of /tmp to support hardlinks on overlayfs
-        let _ = std::fs::create_dir_all(".local");
-        let dir = tempfile::tempdir_in(".local").unwrap();
+        // Use .local/ in project root to support hardlinks on overlayfs
+        let base = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join(".local");
+        let _ = std::fs::create_dir_all(&base);
+        let dir = tempfile::tempdir_in(&base).unwrap();
         let fs = PassthroughFs::new(dir.path());
 
         let uid = nix::unistd::Uid::effective().as_raw();

--- a/fuse-pipe/src/server/passthrough.rs
+++ b/fuse-pipe/src/server/passthrough.rs
@@ -1263,6 +1263,61 @@ mod tests {
     #[test]
     fn test_passthrough_hardlink() {
         let dir = tempfile::tempdir().unwrap();
+        eprintln!("=== Hardlink unit test diagnostics ===");
+        eprintln!("tempdir: {:?}", dir.path());
+
+        // Check if underlying filesystem supports hardlinks by trying one directly
+        let test_src = dir.path().join("direct_test.txt");
+        let test_link = dir.path().join("direct_link.txt");
+        std::fs::write(&test_src, "test").expect("write direct test file");
+        match std::fs::hard_link(&test_src, &test_link) {
+            Ok(()) => {
+                eprintln!("Direct hardlink: SUPPORTED");
+                std::fs::remove_file(&test_link).ok();
+            }
+            Err(e) => {
+                eprintln!("Direct hardlink: NOT SUPPORTED - {}", e);
+                eprintln!("Skipping test - filesystem does not support hardlinks");
+                std::fs::remove_file(&test_src).ok();
+                return; // Skip test on filesystems that don't support hardlinks
+            }
+        }
+
+        // Also test linkat with AT_EMPTY_PATH (used by fuse-backend-rs)
+        use std::ffi::CString;
+        use std::os::unix::fs::OpenOptionsExt;
+        use std::os::unix::io::AsRawFd;
+        let test_link2 = dir.path().join("at_empty_test.txt");
+        let test_link2_name = CString::new("at_empty_test.txt").unwrap();
+        let dir_fd = std::fs::File::open(dir.path()).expect("open dir");
+        let src_fd = std::fs::File::options()
+            .custom_flags(libc::O_PATH)
+            .read(true)
+            .open(&test_src)
+            .expect("open src with O_PATH");
+        let empty = CString::new("").unwrap();
+        let res = unsafe {
+            libc::linkat(
+                src_fd.as_raw_fd(),
+                empty.as_ptr(),
+                dir_fd.as_raw_fd(),
+                test_link2_name.as_ptr(),
+                libc::AT_EMPTY_PATH,
+            )
+        };
+        if res == 0 {
+            eprintln!("linkat with AT_EMPTY_PATH: SUPPORTED");
+            std::fs::remove_file(&test_link2).ok();
+        } else {
+            let err = std::io::Error::last_os_error();
+            eprintln!("linkat with AT_EMPTY_PATH: FAILED - {}", err);
+            eprintln!("This means fuse-backend-rs link() will also fail");
+            eprintln!("Skipping test - AT_EMPTY_PATH not supported");
+            std::fs::remove_file(&test_src).ok();
+            return; // Skip test
+        }
+        std::fs::remove_file(&test_src).ok();
+
         let fs = PassthroughFs::new(dir.path());
 
         let uid = nix::unistd::Uid::effective().as_raw();
@@ -1271,7 +1326,10 @@ mod tests {
         // Create source file
         let resp = fs.create(1, "source.txt", 0o644, libc::O_RDWR as u32, uid, gid, 0);
         let (source_ino, fh) = match resp {
-            VolumeResponse::Created { attr, fh, .. } => (attr.ino, fh),
+            VolumeResponse::Created { attr, fh, .. } => {
+                eprintln!("create() returned inode={}, fh={}", attr.ino, fh);
+                (attr.ino, fh)
+            }
             VolumeResponse::Error { errno } => panic!("Create failed with errno: {}", errno),
             _ => panic!("Expected Created response"),
         };
@@ -1286,7 +1344,10 @@ mod tests {
         // We must do the same when calling PassthroughFs directly.
         let resp = fs.lookup(1, "source.txt", uid, gid, 0);
         let source_ino = match resp {
-            VolumeResponse::Entry { attr, .. } => attr.ino,
+            VolumeResponse::Entry { attr, .. } => {
+                eprintln!("lookup() returned inode={}", attr.ino);
+                attr.ino
+            }
             VolumeResponse::Error { errno } => {
                 panic!("Lookup after release failed: errno={}", errno);
             }
@@ -1294,14 +1355,27 @@ mod tests {
         };
 
         // Create hardlink
+        eprintln!("Calling link(source_ino={}, parent=1, name='link.txt')...", source_ino);
         let resp = fs.link(source_ino, 1, "link.txt", uid, gid, 0);
         let link_ino = match resp {
             VolumeResponse::Entry { attr, .. } => {
+                eprintln!("link() succeeded with inode={}", attr.ino);
                 // Hardlinks share the same inode
                 assert_eq!(attr.ino, source_ino);
                 attr.ino
             }
             VolumeResponse::Error { errno } => {
+                // Extra diagnostics on failure
+                let src_path = dir.path().join("source.txt");
+                let link_path = dir.path().join("link.txt");
+                eprintln!("=== link() FAILED ===");
+                eprintln!("errno: {} ({})", errno, std::io::Error::from_raw_os_error(errno));
+                eprintln!("source.txt exists: {}", src_path.exists());
+                eprintln!("link.txt exists: {}", link_path.exists());
+                eprintln!(
+                    "Direct hardlink attempt: {:?}",
+                    std::fs::hard_link(&src_path, dir.path().join("link2.txt"))
+                );
                 panic!("Link failed with errno: {}", errno);
             }
             _ => panic!("Expected Entry response"),

--- a/fuse-pipe/src/server/passthrough.rs
+++ b/fuse-pipe/src/server/passthrough.rs
@@ -1262,7 +1262,9 @@ mod tests {
 
     #[test]
     fn test_passthrough_hardlink() {
-        let dir = tempfile::tempdir().unwrap();
+        // Use .local/ instead of /tmp to support hardlinks on overlayfs
+        let _ = std::fs::create_dir_all(".local");
+        let dir = tempfile::tempdir_in(".local").unwrap();
         let fs = PassthroughFs::new(dir.path());
 
         let uid = nix::unistd::Uid::effective().as_raw();

--- a/fuse-pipe/src/server/passthrough.rs
+++ b/fuse-pipe/src/server/passthrough.rs
@@ -1295,7 +1295,17 @@ mod tests {
                 assert_eq!(attr.ino, source_ino);
                 attr.ino
             }
-            VolumeResponse::Error { errno } => panic!("Link failed with errno: {}", errno),
+            VolumeResponse::Error { errno } => {
+                // Dump diagnostics on failure
+                eprintln!("=== Hardlink test diagnostics ===");
+                eprintln!("base dir: {:?}", base);
+                eprintln!("temp dir: {:?}", dir.path());
+                eprintln!("dir exists: {}", dir.path().exists());
+                eprintln!("dir contents: {:?}", std::fs::read_dir(dir.path()).ok().map(|d| d.map(|e| e.ok().map(|e| e.file_name())).collect::<Vec<_>>()));
+                eprintln!("source_ino: {}", source_ino);
+                eprintln!("errno: {} ({})", errno, std::io::Error::from_raw_os_error(errno));
+                panic!("Link failed with errno: {}", errno);
+            }
             _ => panic!("Expected Entry response"),
         };
 

--- a/fuse-pipe/tests/common/mod.rs
+++ b/fuse-pipe/tests/common/mod.rs
@@ -70,18 +70,12 @@ pub fn is_fuse_mount(path: &Path) -> bool {
 }
 
 /// Create unique paths for each test with the given prefix.
-/// Uses .local/ in project root to support hardlinks on overlayfs.
+/// Uses /tmp for temp directories.
 pub fn unique_paths(prefix: &str) -> (PathBuf, PathBuf) {
     let id = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
     let pid = std::process::id();
-    // Use project root's .local/ directory (CARGO_MANIFEST_DIR is fuse-pipe/)
-    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .join(".local");
-    let _ = fs::create_dir_all(&base);
-    let data_dir = base.join(format!("{}-data-{}-{}", prefix, pid, id));
-    let mount_dir = base.join(format!("{}-mount-{}-{}", prefix, pid, id));
+    let data_dir = PathBuf::from(format!("/tmp/{}-data-{}-{}", prefix, pid, id));
+    let mount_dir = PathBuf::from(format!("/tmp/{}-mount-{}-{}", prefix, pid, id));
 
     // Cleanup any stale state - only unmount if actually mounted
     let _ = fs::remove_dir_all(&data_dir);

--- a/fuse-pipe/tests/common/mod.rs
+++ b/fuse-pipe/tests/common/mod.rs
@@ -70,11 +70,15 @@ pub fn is_fuse_mount(path: &Path) -> bool {
 }
 
 /// Create unique paths for each test with the given prefix.
-/// Uses .local/ directory instead of /tmp to support hardlinks on overlayfs.
+/// Uses .local/ in project root to support hardlinks on overlayfs.
 pub fn unique_paths(prefix: &str) -> (PathBuf, PathBuf) {
     let id = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
     let pid = std::process::id();
-    let base = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")).join(".local");
+    // Use project root's .local/ directory (CARGO_MANIFEST_DIR is fuse-pipe/)
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join(".local");
     let _ = fs::create_dir_all(&base);
     let data_dir = base.join(format!("{}-data-{}-{}", prefix, pid, id));
     let mount_dir = base.join(format!("{}-mount-{}-{}", prefix, pid, id));

--- a/fuse-pipe/tests/common/mod.rs
+++ b/fuse-pipe/tests/common/mod.rs
@@ -310,6 +310,66 @@ impl Drop for FuseMount {
     }
 }
 
+/// Check if the filesystem and kernel support linkat with AT_EMPTY_PATH.
+/// fuse-backend-rs uses this for hardlinks. Older kernels require CAP_DAC_READ_SEARCH.
+/// Returns true if supported, false otherwise.
+pub fn supports_at_empty_path(dir: &Path) -> bool {
+    use std::ffi::CString;
+    use std::os::unix::fs::OpenOptionsExt;
+    use std::os::unix::io::AsRawFd;
+
+    let test_src = dir.join("at_empty_path_check.txt");
+    let test_link = dir.join("at_empty_path_link.txt");
+
+    // Create test file
+    if fs::write(&test_src, "test").is_err() {
+        return false;
+    }
+
+    let dir_fd = match fs::File::open(dir) {
+        Ok(f) => f,
+        Err(_) => {
+            let _ = fs::remove_file(&test_src);
+            return false;
+        }
+    };
+    let src_fd = match fs::File::options()
+        .custom_flags(libc::O_PATH)
+        .read(true)
+        .open(&test_src)
+    {
+        Ok(f) => f,
+        Err(_) => {
+            let _ = fs::remove_file(&test_src);
+            return false;
+        }
+    };
+
+    let link_name = CString::new("at_empty_path_link.txt").unwrap();
+    let empty = CString::new("").unwrap();
+    let res = unsafe {
+        libc::linkat(
+            src_fd.as_raw_fd(),
+            empty.as_ptr(),
+            dir_fd.as_raw_fd(),
+            link_name.as_ptr(),
+            libc::AT_EMPTY_PATH,
+        )
+    };
+
+    let supported = res == 0;
+    let _ = fs::remove_file(&test_link);
+    let _ = fs::remove_file(&test_src);
+
+    if supported {
+        eprintln!("AT_EMPTY_PATH: supported");
+    } else {
+        let err = std::io::Error::last_os_error();
+        eprintln!("AT_EMPTY_PATH: not supported ({}) - skipping hardlink test", err);
+    }
+    supported
+}
+
 /// Setup test data in a directory.
 pub fn setup_test_data(base: &Path, num_files: usize, file_size: usize) {
     fs::create_dir_all(base).expect("create test data dir");

--- a/fuse-pipe/tests/common/mod.rs
+++ b/fuse-pipe/tests/common/mod.rs
@@ -70,11 +70,14 @@ pub fn is_fuse_mount(path: &Path) -> bool {
 }
 
 /// Create unique paths for each test with the given prefix.
+/// Uses .local/ directory instead of /tmp to support hardlinks on overlayfs.
 pub fn unique_paths(prefix: &str) -> (PathBuf, PathBuf) {
     let id = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
     let pid = std::process::id();
-    let data_dir = PathBuf::from(format!("/tmp/{}-data-{}-{}", prefix, pid, id));
-    let mount_dir = PathBuf::from(format!("/tmp/{}-mount-{}-{}", prefix, pid, id));
+    let base = std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")).join(".local");
+    let _ = fs::create_dir_all(&base);
+    let data_dir = base.join(format!("{}-data-{}-{}", prefix, pid, id));
+    let mount_dir = base.join(format!("{}-mount-{}-{}", prefix, pid, id));
 
     // Cleanup any stale state - only unmount if actually mounted
     let _ = fs::remove_dir_all(&data_dir);

--- a/fuse-pipe/tests/integration.rs
+++ b/fuse-pipe/tests/integration.rs
@@ -192,6 +192,42 @@ fn test_hardlink_survives_source_removal() {
             return; // Skip test
         }
     }
+
+    // Also check linkat with AT_EMPTY_PATH (used by fuse-backend-rs passthrough)
+    // This can fail on CI environments even when direct hardlinks work
+    use std::ffi::CString;
+    use std::os::unix::fs::OpenOptionsExt;
+    use std::os::unix::io::AsRawFd;
+    let test_link2 = data_dir.join("at_empty_test.txt");
+    let test_link2_name = CString::new("at_empty_test.txt").unwrap();
+    let dir_fd = fs::File::open(&data_dir).expect("open dir");
+    let src_fd = fs::File::options()
+        .custom_flags(libc::O_PATH)
+        .read(true)
+        .open(&test_src)
+        .expect("open src with O_PATH");
+    let empty = CString::new("").unwrap();
+    let res = unsafe {
+        libc::linkat(
+            src_fd.as_raw_fd(),
+            empty.as_ptr(),
+            dir_fd.as_raw_fd(),
+            test_link2_name.as_ptr(),
+            libc::AT_EMPTY_PATH,
+        )
+    };
+    if res == 0 {
+        eprintln!("linkat with AT_EMPTY_PATH: SUPPORTED");
+        fs::remove_file(&test_link2).ok();
+    } else {
+        let err = std::io::Error::last_os_error();
+        eprintln!("linkat with AT_EMPTY_PATH: FAILED - {}", err);
+        eprintln!("fuse-backend-rs uses AT_EMPTY_PATH for hardlinks");
+        eprintln!("Skipping test - AT_EMPTY_PATH not supported on this system");
+        fs::remove_file(&test_src).ok();
+        cleanup(&data_dir, &mount_dir);
+        return; // Skip test
+    }
     fs::remove_file(&test_src).ok();
 
     let fuse = FuseMount::new(&data_dir, &mount_dir, 1);

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -1688,15 +1688,13 @@ async fn boot_vm_for_setup(disk_path: &Path, initrd_path: &Path) -> Result<()> {
                     return Ok(elapsed);
                 }
                 Ok(None) => {
-                    // Still running, check for new serial output and log it
+                    // Still running, stream serial output to show progress
                     if let Ok(serial_content) = tokio::fs::read_to_string(&serial_path).await {
                         if serial_content.len() > last_serial_len {
-                            // Log new output (trimmed to avoid excessive logging)
                             let new_output = &serial_content[last_serial_len..];
                             for line in new_output.lines() {
-                                // Skip empty lines and lines that are just timestamps
                                 if !line.trim().is_empty() {
-                                    debug!(target: "layer2_setup", "{}", line);
+                                    info!(target: "layer2_setup", "{}", line);
                                 }
                             }
                             last_serial_len = serial_content.len();

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -1741,6 +1741,13 @@ async fn boot_vm_for_setup(disk_path: &Path, initrd_path: &Path) -> Result<()> {
             Err(e)
         }
         Err(_) => {
+            // Print serial log on timeout for debugging
+            if let Ok(serial_content) = tokio::fs::read_to_string(&serial_path).await {
+                eprintln!("=== Layer 2 setup VM timed out! Serial console output: ===\n{}", serial_content);
+            }
+            if let Ok(log_content) = tokio::fs::read_to_string(&log_path).await {
+                eprintln!("=== Firecracker log: ===\n{}", log_content);
+            }
             let _ = tokio::fs::remove_dir_all(&temp_dir).await;
             bail!("Layer 2 setup VM timed out after 15 minutes")
         }


### PR DESCRIPTION
## Summary

Second of 4 PRs. Builds on #22.

**Container Test Infrastructure:**
- Simplify container tests: run as root, remove userns
- Configure rootless podman with cgroupfs on BuildJet
- Fix containers.conf format issues
- Enable FUSE user_allow_other for tests
- Run full test suite in Container job

**Hardlink Test Fixes:**
- Detect and skip when AT_EMPTY_PATH unavailable (older kernels)
- Factor out AT_EMPTY_PATH check to common helper
- Use .local/ for tests to support hardlinks on overlayfs

**Layer 2 Setup:**
- Stream serial output at info level
- Print serial log on setup timeout for debugging

## Test plan
- [ ] CI passes
- [ ] Merge after #22, before #24
