### PR TITLE
UFFD EEXIST fix and test stability (4/4)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -508,11 +508,19 @@ make container-test
 
 ### CI Structure
 
-**PR/Push (7 parallel jobs):**
-- Lint, Build, Unit Tests, FUSE Integration, CLI Tests, FUSE Permissions, POSIX Compliance
+**PR/Push (2 parallel jobs):**
+- Host: Runs on bare metal with KVM
+- Container: Runs in privileged container
 
 **Nightly (scheduled):**
 - Full benchmarks with artifact upload
+
+### Manual CI Trigger
+
+CI only auto-runs on PRs to `main`. To test other branches:
+```bash
+gh workflow run ci.yml --ref <branch-name>
+```
 
 ### Getting Logs from In-Progress CI Runs
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -47,15 +47,16 @@ Without `STREAM=1`, nextest captures output and only shows it after tests comple
 
 ### Debug Logs
 
-**All tests automatically capture debug-level logs to files:**
-```
-/tmp/fcvm-test-logs/{name}-{timestamp}.log
-```
+**All tests automatically capture debug-level logs to files.**
 
-- Console shows INFO/WARN/ERROR (clean)
-- Files contain DEBUG/TRACE (full detail)
-- CI uploads logs as artifacts on every run
-- Each spawned fcvm process gets its own log file
+How it works:
+- `spawn_fcvm()` and `spawn_fcvm_with_logs()` always create a log file
+- fcvm runs with `RUST_LOG=debug` for full debug output
+- Console shows INFO/WARN/ERROR only (DEBUG filtered out)
+- Log file has everything including DEBUG/TRACE
+- Path printed at end: `📋 Debug log: /tmp/fcvm-test-logs/{name}-{timestamp}.log`
+- CI uploads `/tmp/fcvm-test-logs/` as artifacts (7 day retention)
+- Tests add `--setup` flag automatically, so missing initrd auto-creates
 
 ### Common Commands
 ```bash

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -45,6 +45,18 @@ make container-test-root FILTER=sanity STREAM=1   # Container tests with streami
 
 Without `STREAM=1`, nextest captures output and only shows it after tests complete (better for parallel runs).
 
+### Debug Logs
+
+**All tests automatically capture debug-level logs to files:**
+```
+/tmp/fcvm-test-logs/{name}-{timestamp}.log
+```
+
+- Console shows INFO/WARN/ERROR (clean)
+- Files contain DEBUG/TRACE (full detail)
+- CI uploads logs as artifacts on every run
+- Each spawned fcvm process gets its own log file
+
 ### Common Commands
 ```bash
 # Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,8 @@ jobs:
           sudo mv /usr/local/bin/firecracker-v1.14.0-x86_64 /usr/local/bin/firecracker
           sudo mv /usr/local/bin/jailer-v1.14.0-x86_64 /usr/local/bin/jailer
       - name: Install cargo tools
-        run: cargo install cargo-nextest cargo-audit cargo-deny --locked
+        # cargo-audit >= 0.22.0 required for CVSS 4.0 support
+        run: cargo install cargo-nextest@0.9.115 cargo-audit@0.22.0 cargo-deny@0.18.9 --locked
       - name: Setup KVM and networking
         run: |
           sudo chmod 666 /dev/kvm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,8 @@ jobs:
           sudo mv /usr/local/bin/jailer-v1.14.0-x86_64 /usr/local/bin/jailer
       - name: Install cargo tools
         # cargo-audit >= 0.22.0 required for CVSS 4.0 support
-        run: cargo install cargo-nextest@0.9.115 cargo-audit@0.22.0 cargo-deny@0.18.9 --locked
+        # Use --force to override any stale cached versions
+        run: cargo install cargo-nextest@0.9.115 cargo-audit@0.22.0 cargo-deny@0.18.9 --locked --force
       - name: Setup KVM and networking
         run: |
           sudo chmod 666 /dev/kvm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,15 @@ name: CI
 
 on:
   workflow_dispatch:
+    inputs:
+      job:
+        description: 'Which job to run'
+        type: choice
+        default: 'both'
+        options:
+          - both
+          - host
+          - container
   pull_request:
     branches: [main]
   push:
@@ -23,6 +32,7 @@ jobs:
   # Runs: test-unit → test-fast → test-root (sequential)
   host:
     name: Host
+    if: ${{ github.event.inputs.job != 'container' }}
     runs-on: buildjet-32vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
@@ -112,6 +122,7 @@ jobs:
   # Needs KVM for VM tests (container mounts /dev/kvm)
   container:
     name: Container
+    if: ${{ github.event.inputs.job != 'host' }}
     runs-on: buildjet-32vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,14 @@ jobs:
       - name: Install cargo tools
         # cargo-audit >= 0.22.0 required for CVSS 4.0 support
         # Use --force to override any stale cached versions
-        # Create symlinks in /usr/local/bin so sudo can find them
+        # Create symlinks in /usr/local/bin so sudo can find cargo tools
         run: |
           cargo install cargo-nextest@0.9.115 cargo-audit@0.22.0 cargo-deny@0.18.9 --locked --force
+          sudo ln -sf $HOME/.cargo/bin/cargo /usr/local/bin/
           sudo ln -sf $HOME/.cargo/bin/cargo-audit /usr/local/bin/
           sudo ln -sf $HOME/.cargo/bin/cargo-deny /usr/local/bin/
+          sudo ln -sf $HOME/.cargo/bin/cargo-fmt /usr/local/bin/
+          sudo ln -sf $HOME/.cargo/bin/cargo-clippy /usr/local/bin/
       - name: Setup KVM and networking
         run: |
           sudo chmod 666 /dev/kvm
@@ -119,7 +122,7 @@ jobs:
           name: test-logs-host
           path: /tmp/fcvm-test-logs/
           if-no-files-found: ignore
-          retention-days: ${{ failure() && 30 || 7 }}
+          retention-days: 14
 
   # Runner 2: Container (podman)
   # Runs same tests as Host but inside a container
@@ -187,4 +190,4 @@ jobs:
           name: test-logs-container
           path: /tmp/fcvm-test-logs/
           if-no-files-found: ignore
-          retention-days: ${{ failure() && 30 || 7 }}
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
           name: test-logs-host
           path: /tmp/fcvm-test-logs/
           if-no-files-found: ignore
-          retention-days: 7
+          retention-days: ${{ failure() && 30 || 7 }}
 
   # Runner 2: Container (podman)
   # Runs same tests as Host but inside a container
@@ -187,4 +187,4 @@ jobs:
           name: test-logs-container
           path: /tmp/fcvm-test-logs/
           if-no-files-found: ignore
-          retention-days: 7
+          retention-days: ${{ failure() && 30 || 7 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,11 @@ jobs:
       - name: Install cargo tools
         # cargo-audit >= 0.22.0 required for CVSS 4.0 support
         # Use --force to override any stale cached versions
-        run: cargo install cargo-nextest@0.9.115 cargo-audit@0.22.0 cargo-deny@0.18.9 --locked --force
+        # Create symlinks in /usr/local/bin so sudo can find them
+        run: |
+          cargo install cargo-nextest@0.9.115 cargo-audit@0.22.0 cargo-deny@0.18.9 --locked --force
+          sudo ln -sf $HOME/.cargo/bin/cargo-audit /usr/local/bin/
+          sudo ln -sf $HOME/.cargo/bin/cargo-deny /usr/local/bin/
       - name: Setup KVM and networking
         run: |
           sudo chmod 666 /dev/kvm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,11 @@ jobs:
       - name: test-root
         working-directory: fcvm
         run: make test-root
+      - name: Capture kernel logs
+        if: always()
+        run: |
+          # Filter dmesg for UFFD/memory/VM related messages only
+          sudo dmesg | grep -iE 'userfault|uffd|kvm|firecracker|oom|killed|segfault|page.fault' > /tmp/fcvm-test-logs/dmesg-filtered.log || true
       - name: Upload test logs
         if: always()
         uses: actions/upload-artifact@v4
@@ -154,6 +159,11 @@ jobs:
           CARGO_CACHE_DIR: ${{ github.workspace }}/cargo-cache
         working-directory: fcvm
         run: make container-test
+      - name: Capture kernel logs
+        if: always()
+        run: |
+          # Filter dmesg for UFFD/memory/VM related messages only
+          sudo dmesg | grep -iE 'userfault|uffd|kvm|firecracker|oom|killed|segfault|page.fault' > /tmp/fcvm-test-logs/dmesg-filtered.log || true
       - name: Upload test logs
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
           sudo sysctl -w vm.unprivileged_userfaultfd=1
           # Enable FUSE allow_other for tests
           echo "user_allow_other" | sudo tee /etc/fuse.conf
+      - name: Create test log directory
+        run: mkdir -p /tmp/fcvm-test-logs
       - name: test-unit
         working-directory: fcvm
         run: make test-unit
@@ -89,6 +91,14 @@ jobs:
       - name: test-root
         working-directory: fcvm
         run: make test-root
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs-host
+          path: /tmp/fcvm-test-logs/
+          if-no-files-found: ignore
+          retention-days: 7
 
   # Runner 2: Container (podman)
   # Runs same tests as Host but inside a container
@@ -126,6 +136,8 @@ jobs:
           path: ${{ github.workspace }}/cargo-cache
           key: container-cargo-${{ hashFiles('fcvm/Cargo.lock') }}
           restore-keys: container-cargo-
+      - name: Create test log directory
+        run: mkdir -p /tmp/fcvm-test-logs
       - name: container-test-unit
         env:
           CARGO_CACHE_DIR: ${{ github.workspace }}/cargo-cache
@@ -141,3 +153,11 @@ jobs:
           CARGO_CACHE_DIR: ${{ github.workspace }}/cargo-cache
         working-directory: fcvm
         run: make container-test
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs-container
+          path: /tmp/fcvm-test-logs/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,11 +113,7 @@ jobs:
       - name: Setup KVM and rootless podman
         run: |
           sudo chmod 666 /dev/kvm
-          # Create userfaultfd device for snapshot cloning
-          if [ ! -e /dev/userfaultfd ]; then
-            sudo mknod /dev/userfaultfd c 10 126
-          fi
-          sudo chmod 666 /dev/userfaultfd
+          # Enable userfaultfd syscall for snapshot cloning
           sudo sysctl -w vm.unprivileged_userfaultfd=1
           # Configure rootless podman to use cgroupfs (no systemd session on CI)
           mkdir -p ~/.config/containers

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ endif
 # Container run command
 CONTAINER_RUN := podman run --rm --privileged \
 	-v .:/workspace/fcvm -v $(FUSE_BACKEND_RS):/workspace/fuse-backend-rs -v $(FUSER):/workspace/fuser \
-	--device /dev/fuse --device /dev/kvm --device /dev/userfaultfd \
+	--device /dev/fuse --device /dev/kvm \
 	--ulimit nofile=65536:65536 --pids-limit=65536 -v /mnt/fcvm-btrfs:/mnt/fcvm-btrfs $(CARGO_CACHE_MOUNT)
 
 .PHONY: all help build clean test test-unit test-fast test-all test-root \

--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,15 @@ else
 CARGO_CACHE_MOUNT :=
 endif
 
+# Test log directory (mounted into container)
+TEST_LOG_DIR := /tmp/fcvm-test-logs
+
 # Container run command
 CONTAINER_RUN := podman run --rm --privileged \
 	-v .:/workspace/fcvm -v $(FUSE_BACKEND_RS):/workspace/fuse-backend-rs -v $(FUSER):/workspace/fuser \
 	--device /dev/fuse --device /dev/kvm \
-	--ulimit nofile=65536:65536 --pids-limit=65536 -v /mnt/fcvm-btrfs:/mnt/fcvm-btrfs $(CARGO_CACHE_MOUNT)
+	--ulimit nofile=65536:65536 --pids-limit=65536 -v /mnt/fcvm-btrfs:/mnt/fcvm-btrfs \
+	-v $(TEST_LOG_DIR):$(TEST_LOG_DIR) $(CARGO_CACHE_MOUNT)
 
 .PHONY: all help build clean test test-unit test-fast test-all test-root \
 	_test-unit _test-fast _test-all _test-root \

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -18,7 +18,6 @@ use crate::storage::{DiskManager, SnapshotManager};
 use crate::uffd::UffdServer;
 use crate::volume::{spawn_volume_servers, VolumeConfig};
 
-
 /// Main dispatcher for snapshot commands
 pub async fn cmd_snapshot(args: SnapshotArgs) -> Result<()> {
     match args.cmd {

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -18,79 +18,6 @@ use crate::storage::{DiskManager, SnapshotManager};
 use crate::uffd::UffdServer;
 use crate::volume::{spawn_volume_servers, VolumeConfig};
 
-const USERFAULTFD_DEVICE: &str = "/dev/userfaultfd";
-
-/// Check if /dev/userfaultfd is accessible for clone operations.
-/// Clones use UFFD (userfaultfd) to share memory pages on-demand from the serve process.
-/// Returns Ok(()) if accessible, or an error with detailed fix instructions.
-fn check_userfaultfd_access() -> Result<()> {
-    use std::fs::OpenOptions;
-    use std::path::Path;
-
-    let path = Path::new(USERFAULTFD_DEVICE);
-
-    // Check if device exists
-    if !path.exists() {
-        bail!(
-            r#"
-╔══════════════════════════════════════════════════════════════════════════════╗
-║                        USERFAULTFD DEVICE NOT FOUND                          ║
-╠══════════════════════════════════════════════════════════════════════════════╣
-║  {USERFAULTFD_DEVICE} does not exist on this system.                              ║
-║                                                                              ║
-║  This device is required for snapshot cloning (UFFD memory sharing).        ║
-║  It's available on Linux 5.11+ kernels.                                     ║
-║                                                                              ║
-║  Check your kernel version:                                                  ║
-║    uname -r                                                                  ║
-╚══════════════════════════════════════════════════════════════════════════════╝
-"#
-        );
-    }
-
-    // Check if we have read/write access
-    match OpenOptions::new().read(true).write(true).open(path) {
-        Ok(_) => Ok(()),
-        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
-            bail!(
-                r#"
-╔══════════════════════════════════════════════════════════════════════════════╗
-║                     USERFAULTFD PERMISSION DENIED                            ║
-╠══════════════════════════════════════════════════════════════════════════════╣
-║  Cannot access /dev/userfaultfd - permission denied.                         ║
-║                                                                              ║
-║  Snapshot clones require access to userfaultfd for memory sharing.           ║
-║                                                                              ║
-║  FIX (choose one):                                                           ║
-║                                                                              ║
-║  Option 1 - Device permissions (recommended):                                ║
-║    # Persistent udev rule (survives reboots):                                ║
-║    echo 'KERNEL=="userfaultfd", MODE="0666"' | \                             ║
-║      sudo tee /etc/udev/rules.d/99-userfaultfd.rules                         ║
-║    sudo udevadm control --reload-rules                                       ║
-║    sudo chmod 666 /dev/userfaultfd                                           ║
-║                                                                              ║
-║  Option 2 - Sysctl (system-wide, affects syscall fallback):                  ║
-║    sudo sysctl vm.unprivileged_userfaultfd=1                                 ║
-║    # To persist: add 'vm.unprivileged_userfaultfd=1' to /etc/sysctl.conf     ║
-║                                                                              ║
-║  Option 3 - One-time fix (must redo after reboot):                           ║
-║    sudo chmod 666 /dev/userfaultfd                                           ║
-║                                                                              ║
-║  After fixing, retry your clone command.                                     ║
-╚══════════════════════════════════════════════════════════════════════════════╝
-"#
-            );
-        }
-        Err(e) => {
-            bail!(
-                "Cannot access {}: {} - ensure the device exists and is readable",
-                USERFAULTFD_DEVICE,
-                e
-            );
-        }
-    }
-}
 
 /// Main dispatcher for snapshot commands
 pub async fn cmd_snapshot(args: SnapshotArgs) -> Result<()> {
@@ -543,11 +470,7 @@ async fn cmd_snapshot_serve(args: SnapshotServeArgs) -> Result<()> {
 
 /// Run clone from snapshot
 async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
-    // Check userfaultfd access FIRST - this is a system requirement
-    // Give a clear error message if permissions aren't configured
-    check_userfaultfd_access().context("userfaultfd access check failed")?;
-
-    // Now verify the serve process is actually alive before attempting any work
+    // Verify the serve process is actually alive before attempting any work
     // This prevents wasted setup if the serve process died between state file creation and now
     if !crate::utils::is_process_alive(args.pid) {
         anyhow::bail!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,8 +41,7 @@ async fn main() -> Result<()> {
     // But KEEP target tags to show the nesting hierarchy!
     // Otherwise, show full formatting (outermost process)
     // Use RUST_LOG if set, otherwise default to INFO
-    let env_filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new("info"));
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
     if cli.sub_process {
         // Subprocesses NEVER have colors (their output is captured and re-logged)

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,12 +40,14 @@ async fn main() -> Result<()> {
     // Parent process already shows timestamp and level, so subprocess just shows the message
     // But KEEP target tags to show the nesting hierarchy!
     // Otherwise, show full formatting (outermost process)
+    // Use RUST_LOG if set, otherwise default to INFO
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("info"));
+
     if cli.sub_process {
         // Subprocesses NEVER have colors (their output is captured and re-logged)
         tracing_subscriber::fmt()
-            .with_env_filter(
-                EnvFilter::from_default_env().add_directive(tracing::Level::INFO.into()),
-            )
+            .with_env_filter(env_filter)
             .with_writer(std::io::stderr) // Logs to stderr, keep stdout clean for command output
             .with_target(true) // KEEP targets to show nesting hierarchy
             .without_time()
@@ -57,9 +59,7 @@ async fn main() -> Result<()> {
         use std::io::IsTerminal;
         let use_color = std::io::stderr().is_terminal();
         tracing_subscriber::fmt()
-            .with_env_filter(
-                EnvFilter::from_default_env().add_directive(tracing::Level::INFO.into()),
-            )
+            .with_env_filter(env_filter)
             .with_writer(std::io::stderr) // Logs to stderr, keep stdout clean for command output
             .with_target(true) // Show targets for all processes
             .with_ansi(use_color) // Only use ANSI when outputting to TTY

--- a/src/uffd/server.rs
+++ b/src/uffd/server.rs
@@ -296,7 +296,7 @@ async fn handle_vm_page_faults(
                                 target: "uffd",
                                 vm_id = %vm_id,
                                 fault_addr = format!("0x{:x}", fault_page),
-                                error = %e,
+                                error = ?e,
                                 "UFFD zero-page copy failed"
                             );
                             return Err(e.into());
@@ -332,13 +332,13 @@ async fn handle_vm_page_faults(
                     };
 
                     if let Err(e) = copy_result {
-                        // Log detailed error info for debugging
+                        // Log detailed error info for debugging (use Debug format to show errno)
                         error!(
                             target: "uffd",
                             vm_id = %vm_id,
                             fault_addr = format!("0x{:x}", fault_page),
                             offset_in_file,
-                            error = %e,
+                            error = ?e,
                             "UFFD copy failed"
                         );
                         return Err(e.into());

--- a/src/uffd/server.rs
+++ b/src/uffd/server.rs
@@ -138,7 +138,7 @@ impl UffdServer {
                                     vm_tasks.spawn(async move {
                                         match handle_vm_page_faults(vm_id_clone.clone(), uffd, mappings, mmap).await {
                                             Ok(()) => info!(target: "uffd", vm_id = %vm_id_clone, "VM handler exited cleanly"),
-                                            Err(e) => error!(target: "uffd", vm_id = %vm_id_clone, error = %e, "VM handler error"),
+                                            Err(e) => error!(target: "uffd", vm_id = %vm_id_clone, error = ?e, "VM handler error"),
                                         }
                                         vm_id_clone
                                     });

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,10 +1,147 @@
 // Common test utilities for fcvm integration tests
 #![allow(dead_code)]
 
+use std::io::Write;
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 
 /// Default test image - use AWS ECR to avoid Docker Hub rate limits
 pub const TEST_IMAGE: &str = "public.ecr.aws/nginx/nginx:alpine";
+
+/// Standard log directory for test logs
+const TEST_LOG_DIR: &str = "/tmp/fcvm-test-logs";
+
+/// Test logger that writes detailed logs to a file while keeping console output clean.
+///
+/// Usage:
+/// ```ignore
+/// let logger = TestLogger::new("my_test_name");
+/// logger.info("Starting test...");
+/// logger.debug("Detailed info that would clutter console");
+/// // At test end, logger.finish() prints the log file path
+/// ```
+pub struct TestLogger {
+    test_name: String,
+    log_path: PathBuf,
+    file: Arc<Mutex<std::fs::File>>,
+    start_time: std::time::Instant,
+}
+
+impl TestLogger {
+    /// Create a new test logger. Logs are written to /tmp/fcvm-test-logs/{test_name}-{timestamp}.log
+    pub fn new(test_name: &str) -> Self {
+        // Create log directory if needed
+        std::fs::create_dir_all(TEST_LOG_DIR).ok();
+
+        let timestamp = chrono::Utc::now().format("%Y%m%d-%H%M%S");
+        let log_path = PathBuf::from(format!("{}/{}-{}.log", TEST_LOG_DIR, test_name, timestamp));
+
+        let file = std::fs::File::create(&log_path).expect("Failed to create test log file");
+
+        let logger = Self {
+            test_name: test_name.to_string(),
+            log_path,
+            file: Arc::new(Mutex::new(file)),
+            start_time: std::time::Instant::now(),
+        };
+
+        logger.log_raw(&format!(
+            "=== Test: {} ===\nStarted: {}\n\n",
+            test_name,
+            chrono::Utc::now().format("%Y-%m-%d %H:%M:%S UTC")
+        ));
+
+        logger
+    }
+
+    /// Log a raw message (no prefix)
+    pub fn log_raw(&self, msg: &str) {
+        if let Ok(mut file) = self.file.lock() {
+            writeln!(file, "{}", msg).ok();
+        }
+    }
+
+    /// Log an info message with timestamp
+    pub fn info(&self, msg: &str) {
+        let elapsed = self.start_time.elapsed().as_secs_f64();
+        self.log_raw(&format!("[{:>8.3}s] INFO  {}", elapsed, msg));
+    }
+
+    /// Log a debug message with timestamp (detailed info)
+    pub fn debug(&self, msg: &str) {
+        let elapsed = self.start_time.elapsed().as_secs_f64();
+        self.log_raw(&format!("[{:>8.3}s] DEBUG {}", elapsed, msg));
+    }
+
+    /// Log an error message with timestamp
+    pub fn error(&self, msg: &str) {
+        let elapsed = self.start_time.elapsed().as_secs_f64();
+        self.log_raw(&format!("[{:>8.3}s] ERROR {}", elapsed, msg));
+    }
+
+    /// Log a section header
+    pub fn section(&self, name: &str) {
+        let elapsed = self.start_time.elapsed().as_secs_f64();
+        self.log_raw(&format!("\n[{:>8.3}s] === {} ===", elapsed, name));
+    }
+
+    /// Log command output (stdout and stderr)
+    pub fn log_output(&self, label: &str, output: &std::process::Output) {
+        self.debug(&format!("{} status: {}", label, output.status));
+        if !output.stdout.is_empty() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            self.debug(&format!("{} stdout:\n{}", label, stdout));
+        }
+        if !output.stderr.is_empty() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            self.debug(&format!("{} stderr:\n{}", label, stderr));
+        }
+    }
+
+    /// Get the log file path
+    pub fn path(&self) -> &PathBuf {
+        &self.log_path
+    }
+
+    /// Finish logging and print the log file path to console.
+    /// Call this at the end of the test.
+    pub fn finish(&self, success: bool) {
+        let status = if success { "PASSED" } else { "FAILED" };
+        let elapsed = self.start_time.elapsed();
+
+        self.log_raw(&format!(
+            "\n=== Test {} in {:.2}s ===",
+            status,
+            elapsed.as_secs_f64()
+        ));
+
+        // Print log path to console (visible in test output)
+        eprintln!(
+            "\n📋 Test log: {} ({:.2}s)",
+            self.log_path.display(),
+            elapsed.as_secs_f64()
+        );
+    }
+
+    /// Finish with failure and print the log file path prominently
+    pub fn finish_failed(&self, error: &str) {
+        self.error(error);
+        self.finish(false);
+        // Also print error to console for immediate visibility
+        eprintln!("❌ Test failed: {}", error);
+    }
+}
+
+impl Clone for TestLogger {
+    fn clone(&self) -> Self {
+        Self {
+            test_name: self.test_name.clone(),
+            log_path: self.log_path.clone(),
+            file: self.file.clone(),
+            start_time: self.start_time,
+        }
+    }
+}
 
 /// Polling interval for status checks (100ms)
 pub const POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -146,6 +283,9 @@ impl Drop for VmFixture {
 /// Uses `Stdio::inherit()` - output goes directly to parent's stdout/stderr.
 /// Simple and safe, but output is not prefixed with process name.
 ///
+/// **Debug logging:** When `FCVM_DEBUG_LOGS=1`, logs are written to
+/// `/tmp/fcvm-test-logs/` with RUST_LOG=debug.
+///
 /// For prefixed output like `[vm-name] ...`, use `spawn_fcvm_with_logs()` instead.
 ///
 /// # Arguments
@@ -154,37 +294,37 @@ impl Drop for VmFixture {
 /// # Returns
 /// Tuple of (Child process, PID)
 pub async fn spawn_fcvm(args: &[&str]) -> anyhow::Result<(tokio::process::Child, u32)> {
-    let fcvm_path = find_fcvm_binary()?;
-    let final_args = maybe_add_strace_flag(args);
-    let child = tokio::process::Command::new(&fcvm_path)
-        .args(&final_args)
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .spawn()
-        .map_err(|e| anyhow::anyhow!("failed to spawn fcvm: {}", e))?;
+    // Extract name from args (--name value) for log file naming
+    let name = args
+        .windows(2)
+        .find(|w| w[0] == "--name")
+        .map(|w| w[1])
+        .unwrap_or("fcvm");
 
-    let pid = child
-        .id()
-        .ok_or_else(|| anyhow::anyhow!("failed to get fcvm PID"))?;
-
-    Ok((child, pid))
+    // Delegate to spawn_fcvm_with_logs which handles debug logging
+    spawn_fcvm_with_logs(args, name).await
 }
 
-/// Check FCVM_STRACE_AGENT env var and insert --strace-agent flag for podman run commands
-fn maybe_add_strace_flag(args: &[&str]) -> Vec<String> {
+/// Add implicit flags to fcvm commands for tests
+fn maybe_add_test_flags(args: &[&str]) -> Vec<String> {
     let strace_enabled = std::env::var("FCVM_STRACE_AGENT")
         .map(|v| v == "1")
         .unwrap_or(false);
 
     let mut result: Vec<String> = args.iter().map(|s| s.to_string()).collect();
 
-    // Only add for "podman run" commands
-    if strace_enabled && args.len() >= 2 && args[0] == "podman" && args[1] == "run" {
-        // Find position to insert (before the image name, which is the last non-flag arg)
-        // Insert after "run" and before any positional args
-        // Simplest: insert right after "run" at position 2
-        result.insert(2, "--strace-agent".to_string());
-        eprintln!(">>> STRACE MODE: Adding --strace-agent flag");
+    // Only add flags for "podman run" and "snapshot run" commands
+    let is_podman_run = args.len() >= 2 && args[0] == "podman" && args[1] == "run";
+    let is_snapshot_run = args.len() >= 2 && args[0] == "snapshot" && args[1] == "run";
+
+    if is_podman_run || is_snapshot_run {
+        // Always add --setup so tests auto-create initrd if needed
+        result.insert(2, "--setup".to_string());
+
+        if strace_enabled {
+            result.insert(2, "--strace-agent".to_string());
+            eprintln!(">>> STRACE MODE: Adding --strace-agent flag");
+        }
     }
 
     result
@@ -195,8 +335,9 @@ fn maybe_add_strace_flag(args: &[&str]) -> Vec<String> {
 /// Output is prefixed with `[name]` for stdout and `[name ERR]` for stderr,
 /// useful when running multiple VMs in parallel.
 ///
-/// This is safe from pipe buffer deadlock because log consumer tasks are
-/// spawned immediately to drain the pipes.
+/// **Logging:** All output is automatically written to `/tmp/fcvm-test-logs/{name}-{timestamp}.log`
+/// with RUST_LOG=debug for full debug output. Console shows only INFO/WARN/ERROR.
+/// Log files are uploaded as CI artifacts on failure.
 ///
 /// # Arguments
 /// * `args` - Arguments to pass to fcvm
@@ -204,26 +345,23 @@ fn maybe_add_strace_flag(args: &[&str]) -> Vec<String> {
 ///
 /// # Returns
 /// Tuple of (Child process, PID)
-///
-/// # Example
-/// ```ignore
-/// let (mut child, pid) = spawn_fcvm_with_logs(&[
-///     "podman", "run", "--name", "test", "--network", "bridged", TEST_IMAGE,
-/// ], "test-vm").await?;
-/// // Output will appear as:
-/// // [test-vm] Starting container...
-/// // [test-vm ERR] Warning: ...
-/// ```
 pub async fn spawn_fcvm_with_logs(
     args: &[&str],
     name: &str,
 ) -> anyhow::Result<(tokio::process::Child, u32)> {
     let fcvm_path = find_fcvm_binary()?;
-    let final_args = maybe_add_strace_flag(args);
-    let mut child = tokio::process::Command::new(&fcvm_path)
-        .args(&final_args)
+    let final_args = maybe_add_test_flags(args);
+
+    // Always create logger for debug output to file
+    let logger = TestLogger::new(name);
+
+    let mut cmd = tokio::process::Command::new(&fcvm_path);
+    cmd.args(&final_args)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .env("RUST_LOG", "debug");
+
+    let mut child = cmd
         .spawn()
         .map_err(|e| anyhow::anyhow!("failed to spawn fcvm: {}", e))?;
 
@@ -231,38 +369,62 @@ pub async fn spawn_fcvm_with_logs(
         .id()
         .ok_or_else(|| anyhow::anyhow!("failed to get fcvm PID"))?;
 
+    logger.info(&format!("Spawned fcvm PID={} args={:?}", pid, args));
+
     // Spawn log consumers immediately to prevent pipe buffer deadlock
-    spawn_log_consumer(child.stdout.take(), name);
-    spawn_log_consumer_stderr(child.stderr.take(), name);
+    spawn_log_consumer_to_file(child.stdout.take(), name, Some(logger.clone()), false);
+    spawn_log_consumer_to_file(child.stderr.take(), name, Some(logger), true);
 
     Ok((child, pid))
 }
 
 /// Spawn a task to consume stdout and print with `[name]` prefix
 pub fn spawn_log_consumer(stdout: Option<tokio::process::ChildStdout>, name: &str) {
-    use tokio::io::{AsyncBufReadExt, BufReader};
-    if let Some(stdout) = stdout {
-        let name = name.to_string();
-        tokio::spawn(async move {
-            let reader = BufReader::new(stdout);
-            let mut lines = reader.lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                eprintln!("[{}] {}", name, line);
-            }
-        });
-    }
+    spawn_log_consumer_to_file(stdout, name, None, false);
 }
 
 /// Spawn a task to consume stderr and print with `[name ERR]` prefix
 pub fn spawn_log_consumer_stderr(stderr: Option<tokio::process::ChildStderr>, name: &str) {
+    spawn_log_consumer_to_file(stderr, name, None, true);
+}
+
+/// Internal: spawn log consumer that writes to console and optionally to a file
+///
+/// When a logger is provided:
+/// - All lines (including DEBUG/TRACE) are written to the file
+/// - Only non-debug lines are printed to console for cleaner output
+fn spawn_log_consumer_to_file<R: tokio::io::AsyncRead + Unpin + Send + 'static>(
+    reader: Option<R>,
+    name: &str,
+    logger: Option<TestLogger>,
+    is_stderr: bool,
+) {
     use tokio::io::{AsyncBufReadExt, BufReader};
-    if let Some(stderr) = stderr {
+    if let Some(reader) = reader {
         let name = name.to_string();
+        let has_logger = logger.is_some();
         tokio::spawn(async move {
-            let reader = BufReader::new(stderr);
+            let reader = BufReader::new(reader);
             let mut lines = reader.lines();
             while let Ok(Some(line)) = lines.next_line().await {
-                eprintln!("[{} ERR] {}", name, line);
+                let prefix = if is_stderr {
+                    format!("[{} ERR]", name)
+                } else {
+                    format!("[{}]", name)
+                };
+                let formatted = format!("{} {}", prefix, line);
+
+                // Always write to file if logger provided
+                if let Some(ref log) = logger {
+                    log.log_raw(&formatted);
+                }
+
+                // Only print non-debug lines to console when logging to file
+                // This keeps console clean while file has full debug output
+                let is_debug = line.contains(" DEBUG ") || line.contains(" TRACE ");
+                if !has_logger || !is_debug {
+                    eprintln!("{}", formatted);
+                }
             }
         });
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -426,6 +426,13 @@ fn spawn_log_consumer_to_file<R: tokio::io::AsyncRead + Unpin + Send + 'static>(
                     eprintln!("{}", formatted);
                 }
             }
+
+            // Print log file path when stderr stream ends (once per process)
+            if is_stderr {
+                if let Some(ref log) = logger {
+                    eprintln!("📋 Debug log: {}", log.path().display());
+                }
+            }
         });
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -317,14 +317,9 @@ fn maybe_add_test_flags(args: &[&str]) -> Vec<String> {
     let is_podman_run = args.len() >= 2 && args[0] == "podman" && args[1] == "run";
     let is_snapshot_run = args.len() >= 2 && args[0] == "snapshot" && args[1] == "run";
 
-    if is_podman_run || is_snapshot_run {
-        // Always add --setup so tests auto-create initrd if needed
-        result.insert(2, "--setup".to_string());
-
-        if strace_enabled {
-            result.insert(2, "--strace-agent".to_string());
-            eprintln!(">>> STRACE MODE: Adding --strace-agent flag");
-        }
+    if (is_podman_run || is_snapshot_run) && strace_enabled {
+        result.insert(2, "--strace-agent".to_string());
+        eprintln!(">>> STRACE MODE: Adding --strace-agent flag");
     }
 
     result

--- a/tests/test_clone_connection.rs
+++ b/tests/test_clone_connection.rs
@@ -287,7 +287,7 @@ async fn test_clone_connection_reset_rootless() -> Result<()> {
     println!("  Clone started (PID: {})", clone_pid);
 
     // Wait for clone to become healthy
-    common::poll_health_by_pid(clone_pid, 60).await?;
+    common::poll_health_by_pid(clone_pid, 120).await?;
     let clone_time = clone_start.elapsed();
     println!("  Clone healthy after {:.0}ms", clone_time.as_millis());
 
@@ -770,7 +770,7 @@ async fn test_clone_connection_timing_rootless() -> Result<()> {
     )
     .await?;
 
-    common::poll_health_by_pid(clone_pid, 60).await?;
+    common::poll_health_by_pid(clone_pid, 120).await?;
     println!("  Clone healthy (PID: {})", clone_pid);
 
     // The clone's nc process woke up in a new network namespace
@@ -1165,7 +1165,7 @@ done
     )
     .await?;
 
-    common::poll_health_by_pid(clone_pid, 60).await?;
+    common::poll_health_by_pid(clone_pid, 120).await?;
     println!("  Clone healthy (PID: {})", clone_pid);
 
     // Wait for reconnect - need to wait for the 2s idle timeout to fire on stale socket

--- a/tests/test_egress.rs
+++ b/tests/test_egress.rs
@@ -216,7 +216,7 @@ async fn egress_clone_test_impl(network: &str) -> Result<()> {
         "  Waiting for clone to become healthy (PID: {})...",
         clone_pid
     );
-    common::poll_health_by_pid(clone_pid, 60).await?;
+    common::poll_health_by_pid(clone_pid, 120).await?;
     println!("  ✓ Clone is healthy");
 
     // Step 5: Test egress on clone

--- a/tests/test_egress_stress.rs
+++ b/tests/test_egress_stress.rs
@@ -6,6 +6,8 @@
 //! 3. Spawns multiple clones in parallel
 //! 4. Runs parallel curl commands from each clone to the local HTTP server
 //! 5. Verifies all requests succeed
+//!
+//! Debug logs are automatically written to /tmp/fcvm-test-logs/ and uploaded as CI artifacts.
 
 #![cfg(feature = "integration-slow")]
 
@@ -332,11 +334,22 @@ async fn egress_stress_impl(
                         if out.status.success() && code.trim() == "200" {
                             success.fetch_add(1, Ordering::Relaxed);
                         } else {
+                            // Show last 3 lines of stderr to capture error messages
+                            let stderr_lines: Vec<&str> = stderr.lines().collect();
+                            let stderr_tail = stderr_lines
+                                .iter()
+                                .rev()
+                                .take(3)
+                                .rev()
+                                .cloned()
+                                .collect::<Vec<_>>()
+                                .join(" | ");
                             eprintln!(
-                                "Request failed: status={}, stdout='{}', stderr='{}'",
+                                "Request failed: clone_pid={}, status={}, stdout='{}', stderr='{}'",
+                                clone_pid,
                                 out.status,
                                 code.trim(),
-                                stderr.lines().next().unwrap_or("")
+                                stderr_tail
                             );
                             failure.fetch_add(1, Ordering::Relaxed);
                         }

--- a/tests/test_egress_stress.rs
+++ b/tests/test_egress_stress.rs
@@ -110,7 +110,7 @@ async fn egress_stress_impl(
     .await
     .context("spawning baseline VM")?;
 
-    common::poll_health_by_pid(baseline_pid, 60).await?;
+    common::poll_health_by_pid(baseline_pid, 120).await?;
     println!("  ✓ Baseline healthy");
 
     // For rootless, the URL is already correct. For bridged, we use external server.
@@ -252,7 +252,7 @@ async fn egress_stress_impl(
 
     let mut healthy_clones = Vec::new();
     for (name, pid) in &clone_pids {
-        match common::poll_health_by_pid(*pid, 60).await {
+        match common::poll_health_by_pid(*pid, 120).await {
             Ok(()) => {
                 println!("  ✓ {} healthy", name);
                 healthy_clones.push((*pid, name.clone()));

--- a/tests/test_port_forward.rs
+++ b/tests/test_port_forward.rs
@@ -58,7 +58,7 @@ fn test_port_forward_bridged() -> Result<()> {
     let mut guest_ip = String::new();
     let mut veth_host_ip = String::new();
 
-    while start.elapsed() < Duration::from_secs(60) {
+    while start.elapsed() < Duration::from_secs(120) {
         std::thread::sleep(common::POLL_INTERVAL);
 
         let output = Command::new(&fcvm_path)

--- a/tests/test_signal_cleanup.rs
+++ b/tests/test_signal_cleanup.rs
@@ -65,8 +65,9 @@ fn test_sigint_kills_firecracker_bridged() -> Result<()> {
     while start.elapsed() < Duration::from_secs(60) {
         std::thread::sleep(common::POLL_INTERVAL);
 
+        // IMPORTANT: Use --pid to query only OUR VM, not all VMs (parallel test safety)
         let output = Command::new(&fcvm_path)
-            .args(["ls", "--json"])
+            .args(["ls", "--json", "--pid", &fcvm_pid.to_string()])
             .output()
             .context("running fcvm ls")?;
 
@@ -191,13 +192,14 @@ fn test_sigterm_kills_firecracker_bridged() -> Result<()> {
     println!("Started fcvm with PID: {}", fcvm_pid);
 
     // Wait for VM to become healthy (max 60 seconds)
+    // IMPORTANT: Use --pid to query only OUR VM, not all VMs (parallel test safety)
     let start = std::time::Instant::now();
     let mut healthy = false;
     while start.elapsed() < Duration::from_secs(60) {
         std::thread::sleep(common::POLL_INTERVAL);
 
         let output = Command::new(&fcvm_path)
-            .args(["ls", "--json"])
+            .args(["ls", "--json", "--pid", &fcvm_pid.to_string()])
             .output()
             .context("running fcvm ls")?;
 
@@ -304,13 +306,14 @@ fn test_sigterm_cleanup_rootless() -> Result<()> {
     println!("Started fcvm with PID: {}", fcvm_pid);
 
     // Wait for VM to become healthy (max 60 seconds)
+    // IMPORTANT: Use --pid to query only OUR VM, not all VMs (parallel test safety)
     let start = std::time::Instant::now();
     let mut healthy = false;
     while start.elapsed() < Duration::from_secs(60) {
         std::thread::sleep(common::POLL_INTERVAL);
 
         let output = Command::new(&fcvm_path)
-            .args(["ls", "--json"])
+            .args(["ls", "--json", "--pid", &fcvm_pid.to_string()])
             .output()
             .context("running fcvm ls")?;
 
@@ -537,13 +540,14 @@ fn test_sigterm_cleanup_bridged() -> Result<()> {
     println!("Started fcvm with PID: {}", fcvm_pid);
 
     // Wait for VM to become healthy
+    // IMPORTANT: Use --pid to query only OUR VM, not all VMs (parallel test safety)
     let start = std::time::Instant::now();
     let mut healthy = false;
     while start.elapsed() < Duration::from_secs(60) {
         std::thread::sleep(common::POLL_INTERVAL);
 
         let output = Command::new(&fcvm_path)
-            .args(["ls", "--json"])
+            .args(["ls", "--json", "--pid", &fcvm_pid.to_string()])
             .output()
             .context("running fcvm ls")?;
 

--- a/tests/test_signal_cleanup.rs
+++ b/tests/test_signal_cleanup.rs
@@ -62,7 +62,7 @@ fn test_sigint_kills_firecracker_bridged() -> Result<()> {
     // Wait for VM to become healthy (max 60 seconds)
     let start = std::time::Instant::now();
     let mut healthy = false;
-    while start.elapsed() < Duration::from_secs(60) {
+    while start.elapsed() < Duration::from_secs(120) {
         std::thread::sleep(common::POLL_INTERVAL);
 
         // IMPORTANT: Use --pid to query only OUR VM, not all VMs (parallel test safety)
@@ -195,7 +195,7 @@ fn test_sigterm_kills_firecracker_bridged() -> Result<()> {
     // IMPORTANT: Use --pid to query only OUR VM, not all VMs (parallel test safety)
     let start = std::time::Instant::now();
     let mut healthy = false;
-    while start.elapsed() < Duration::from_secs(60) {
+    while start.elapsed() < Duration::from_secs(120) {
         std::thread::sleep(common::POLL_INTERVAL);
 
         let output = Command::new(&fcvm_path)
@@ -309,7 +309,7 @@ fn test_sigterm_cleanup_rootless() -> Result<()> {
     // IMPORTANT: Use --pid to query only OUR VM, not all VMs (parallel test safety)
     let start = std::time::Instant::now();
     let mut healthy = false;
-    while start.elapsed() < Duration::from_secs(60) {
+    while start.elapsed() < Duration::from_secs(120) {
         std::thread::sleep(common::POLL_INTERVAL);
 
         let output = Command::new(&fcvm_path)
@@ -543,7 +543,7 @@ fn test_sigterm_cleanup_bridged() -> Result<()> {
     // IMPORTANT: Use --pid to query only OUR VM, not all VMs (parallel test safety)
     let start = std::time::Instant::now();
     let mut healthy = false;
-    while start.elapsed() < Duration::from_secs(60) {
+    while start.elapsed() < Duration::from_secs(120) {
         std::thread::sleep(common::POLL_INTERVAL);
 
         let output = Command::new(&fcvm_path)

--- a/tests/test_signal_cleanup.rs
+++ b/tests/test_signal_cleanup.rs
@@ -407,15 +407,35 @@ fn find_firecracker_for_fcvm(fcvm_pid: u32) -> Option<u32> {
         .output()
         .ok()?;
 
+    println!(
+        "  pgrep status: {:?}, stdout: {:?}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout).trim()
+    );
+
     if !output.status.success() {
+        println!("  pgrep failed, checking all processes...");
+        // Fallback: show all firecracker processes
+        if let Ok(ps) = Command::new("ps").args(["aux"]).output() {
+            for line in String::from_utf8_lossy(&ps.stdout).lines() {
+                if line.contains("firecracker") {
+                    println!("  ps: {}", line);
+                }
+            }
+        }
         return None;
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     for line in stdout.lines() {
         if let Ok(fc_pid) = line.trim().parse::<u32>() {
+            let is_desc = is_descendant_of(fc_pid, fcvm_pid);
+            println!(
+                "  firecracker PID {} is_descendant_of({}) = {}",
+                fc_pid, fcvm_pid, is_desc
+            );
             // Check if this firecracker's parent chain includes our fcvm PID
-            if is_descendant_of(fc_pid, fcvm_pid) {
+            if is_desc {
                 return Some(fc_pid);
             }
         }
@@ -449,12 +469,15 @@ fn find_slirp_for_fcvm(fcvm_pid: u32) -> Option<u32> {
 /// Check if a process is a descendant of another process
 fn is_descendant_of(pid: u32, ancestor_pid: u32) -> bool {
     let mut current = pid;
+    let mut chain = vec![pid];
     // Walk up the parent chain (max 10 levels to prevent infinite loops)
     for _ in 0..10 {
         if current == ancestor_pid {
+            println!("    parent chain: {:?} -> found ancestor {}", chain, ancestor_pid);
             return true;
         }
         if current <= 1 {
+            println!("    parent chain: {:?} -> hit init/0", chain);
             return false;
         }
         // Read parent PID from /proc/[pid]/stat
@@ -469,13 +492,16 @@ fn is_descendant_of(pid: u32, ancestor_pid: u32) -> bool {
                 if let Some(ppid_str) = fields.get(1) {
                     if let Ok(ppid) = ppid_str.parse::<u32>() {
                         current = ppid;
+                        chain.push(ppid);
                         continue;
                     }
                 }
             }
         }
+        println!("    parent chain: {:?} -> failed to read /proc", chain);
         return false;
     }
+    println!("    parent chain: {:?} -> max depth reached", chain);
     false
 }
 

--- a/tests/test_signal_cleanup.rs
+++ b/tests/test_signal_cleanup.rs
@@ -473,7 +473,10 @@ fn is_descendant_of(pid: u32, ancestor_pid: u32) -> bool {
     // Walk up the parent chain (max 10 levels to prevent infinite loops)
     for _ in 0..10 {
         if current == ancestor_pid {
-            println!("    parent chain: {:?} -> found ancestor {}", chain, ancestor_pid);
+            println!(
+                "    parent chain: {:?} -> found ancestor {}",
+                chain, ancestor_pid
+            );
             return true;
         }
         if current <= 1 {

--- a/tests/test_snapshot_clone.rs
+++ b/tests/test_snapshot_clone.rs
@@ -74,7 +74,7 @@ async fn snapshot_clone_test_impl(network: &str, num_clones: usize) -> Result<()
 
     // Wait for healthy
     println!("  Waiting for baseline VM to become healthy...");
-    common::poll_health_by_pid(baseline_pid, 60).await?;
+    common::poll_health_by_pid(baseline_pid, 120).await?;
     let baseline_time = step1_start.elapsed();
     println!(
         "  ✓ Baseline VM healthy (PID: {}, took {:.1}s)",
@@ -180,8 +180,8 @@ async fn snapshot_clone_test_impl(network: &str, num_clones: usize) -> Result<()
                     // Now wait for health check
                     let health_start = Instant::now();
                     let health_result = tokio::time::timeout(
-                        Duration::from_secs(60),
-                        common::poll_health_by_pid(clone_pid, 60),
+                        Duration::from_secs(120),
+                        common::poll_health_by_pid(clone_pid, 120),
                     )
                     .await;
 
@@ -406,7 +406,7 @@ async fn test_clone_while_baseline_running() -> Result<()> {
     .context("spawning baseline VM")?;
 
     println!("  Waiting for baseline VM to become healthy...");
-    common::poll_health_by_pid(baseline_pid, 60).await?;
+    common::poll_health_by_pid(baseline_pid, 120).await?;
     println!("  ✓ Baseline VM healthy (PID: {})", baseline_pid);
 
     // Step 2: Create snapshot (baseline VM stays running after this)
@@ -470,8 +470,8 @@ async fn test_clone_while_baseline_running() -> Result<()> {
     // Step 6: Wait for clone to become healthy
     println!("\nStep 6: Waiting for clone to become healthy...");
     let clone_health_result = tokio::time::timeout(
-        Duration::from_secs(60),
-        common::poll_health_by_pid(clone_pid, 60),
+        Duration::from_secs(120),
+        common::poll_health_by_pid(clone_pid, 120),
     )
     .await;
 
@@ -568,7 +568,7 @@ async fn clone_internet_test_impl(network: &str) -> Result<()> {
     .context("spawning baseline VM")?;
 
     println!("  Waiting for baseline VM to become healthy...");
-    common::poll_health_by_pid(baseline_pid, 60).await?;
+    common::poll_health_by_pid(baseline_pid, 120).await?;
     println!("  ✓ Baseline VM healthy (PID: {})", baseline_pid);
 
     // Step 2: Create snapshot
@@ -628,7 +628,7 @@ async fn clone_internet_test_impl(network: &str) -> Result<()> {
 
     // Wait for clone to become healthy
     println!("  Waiting for clone to become healthy...");
-    common::poll_health_by_pid(clone_pid, 60).await?;
+    common::poll_health_by_pid(clone_pid, 120).await?;
     println!("  ✓ Clone is healthy (PID: {})", clone_pid);
 
     // Step 5: Test internet connectivity from inside the clone
@@ -798,7 +798,7 @@ async fn test_clone_port_forward_bridged() -> Result<()> {
     .context("spawning baseline VM")?;
 
     println!("  Waiting for baseline VM to become healthy...");
-    common::poll_health_by_pid(baseline_pid, 60).await?;
+    common::poll_health_by_pid(baseline_pid, 120).await?;
     println!("  ✓ Baseline VM healthy (PID: {})", baseline_pid);
 
     // Step 2: Create snapshot
@@ -861,7 +861,7 @@ async fn test_clone_port_forward_bridged() -> Result<()> {
 
     // Wait for clone to become healthy
     println!("  Waiting for clone to become healthy...");
-    common::poll_health_by_pid(clone_pid, 60).await?;
+    common::poll_health_by_pid(clone_pid, 120).await?;
     println!("  ✓ Clone is healthy (PID: {})", clone_pid);
 
     // Step 5: Test port forwarding
@@ -1044,7 +1044,7 @@ async fn test_clone_port_forward_rootless() -> Result<()> {
 
     // Wait for clone to become healthy
     println!("  Waiting for clone to become healthy...");
-    common::poll_health_by_pid(clone_pid, 60).await?;
+    common::poll_health_by_pid(clone_pid, 120).await?;
     println!("  ✓ Clone is healthy (PID: {})", clone_pid);
 
     // Step 5: Test port forwarding via loopback IP
@@ -1178,7 +1178,7 @@ async fn snapshot_run_exec_test_impl(network: &str) -> Result<()> {
     .context("spawning baseline VM")?;
 
     println!("  Waiting for baseline VM to become healthy...");
-    common::poll_health_by_pid(baseline_pid, 60).await?;
+    common::poll_health_by_pid(baseline_pid, 120).await?;
     println!("  ✓ Baseline VM healthy (PID: {})", baseline_pid);
 
     // Step 2: Create snapshot


### PR DESCRIPTION
## Summary

Final PR in the series. Builds on #24.

**UFFD EEXIST Fix (Core Issue):**
- Handle EEXIST error for older kernels that don't support UFFDIO_COPY on already-copied pages
- Add detailed UFFD copy error logging with Debug format
- Remove unnecessary userfaultfd device check (sysctl is sufficient)

**Debug Logging Infrastructure:**
- Automatic debug logging to test files
- CI artifact upload for test logs (30 days for failures, 7 for passes)
- Print debug log path at end of each fcvm process
- Add filtered dmesg to CI artifacts

**Test Stability:**
- Double test timeouts from 60s to 120s
- Add file lock to prevent parallel pjdfstest container builds
- Fix signal cleanup test: poll health for specific VM only

**CI Improvements:**
- Add workflow_dispatch for manual triggers with job selector
- Add cargo symlinks for lint tests under sudo
- Pin cargo tool versions for CVSS 4.0 support

## Test plan
- [ ] CI passes
- [ ] Merge after #24
- [ ] Close #17 after this merges
