### PR TITLE
Add FUSE remap_file_range support for FICLONE/FICLONERANGE

### DIFF
--- a/rootfs-plan.toml
+++ b/rootfs-plan.toml
@@ -1,0 +1,121 @@
+# Rootfs Modification Plan
+#
+# This file describes all modifications applied to the base Ubuntu cloud image.
+# The SHA256 of the generated setup script determines the image name: layer2-{sha}.raw
+# If this file changes, Layer 2 is rebuilt automatically.
+#
+# fc-agent is NOT in Layer 2 at all (neither binary nor service).
+# Both are injected per-VM at boot time via initrd.
+# This allows updating fc-agent without rebuilding Layer 2.
+
+[base]
+# Ubuntu 24.04 LTS (Noble Numbat) cloud images
+# Using "current" for latest updates - URL changes trigger plan SHA change
+version = "24.04"
+# Codename used to download packages from correct Ubuntu release
+codename = "noble"
+
+[base.arm64]
+url = "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-arm64.img"
+
+[base.amd64]
+url = "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
+
+[kernel]
+# Kata Containers kernel with FUSE support built-in
+# Firecracker's official kernel lacks FUSE, but Kata's has it
+# URL hash is included in Layer 2 SHA calculation
+
+[kernel.arm64]
+# Kata 3.24.0 release - kernel 6.12.47 with CONFIG_FUSE_FS=y
+url = "https://github.com/kata-containers/kata-containers/releases/download/3.24.0/kata-static-3.24.0-arm64.tar.zst"
+# Path within the tarball to extract
+path = "opt/kata/share/kata-containers/vmlinux-6.12.47-173"
+
+[kernel.amd64]
+url = "https://github.com/kata-containers/kata-containers/releases/download/3.24.0/kata-static-3.24.0-amd64.tar.zst"
+path = "opt/kata/share/kata-containers/vmlinux-6.12.47-173"
+
+[packages]
+# Container runtime
+runtime = ["podman", "crun", "fuse-overlayfs", "skopeo"]
+
+# FUSE support for overlay filesystem
+fuse = ["fuse3"]
+
+# System services
+system = ["haveged", "chrony"]
+
+# Debugging tools
+debug = ["strace"]
+
+[services]
+# Services to enable
+# NOTE: fc-agent is NOT enabled here - it's injected per-VM via initrd
+# NOTE: systemd-resolved is NOT enabled - DNS comes from kernel cmdline via fc-agent
+enable = [
+    "haveged",
+    "chrony",
+    "systemd-networkd",
+]
+
+# Services to disable
+disable = [
+    "multipathd",
+    "snapd",
+    "cloud-init",
+    "cloud-config",
+    "cloud-final",
+]
+
+[files]
+# Files to create/modify in the rootfs
+
+[files."/etc/resolv.conf"]
+content = """
+# Placeholder - fc-agent configures DNS at boot from kernel cmdline
+nameserver 127.0.0.53
+"""
+
+[files."/etc/chrony/chrony.conf"]
+content = """
+# NTP servers from pool.ntp.org
+pool pool.ntp.org iburst
+
+# Allow clock to be stepped (not slewed) for large time differences
+makestep 1.0 3
+
+# Directory for drift and other runtime files
+driftfile /var/lib/chrony/drift
+"""
+
+[files."/etc/systemd/network/10-eth0.network"]
+content = """
+[Match]
+Name=eth0
+
+[Network]
+# Keep kernel IP configuration from ip= boot parameter
+KeepConfiguration=yes
+"""
+
+[files."/etc/systemd/network/10-eth0.network.d/mmds.conf"]
+content = """
+[Route]
+Destination=169.254.169.254/32
+Scope=link
+"""
+
+# NOTE: fc-agent.service is NOT defined here - it's injected per-VM via initrd
+
+[fstab]
+# Lines to remove from /etc/fstab (patterns to filter out)
+remove_patterns = ["LABEL=BOOT", "LABEL=UEFI"]
+
+[cleanup]
+# Patterns to remove for smaller image
+remove_dirs = [
+    "/usr/share/doc/*",
+    "/usr/share/man/*",
+    "/var/cache/apt/archives/*",
+]


### PR DESCRIPTION
## Summary

Enables `cp --reflink=always` and FICLONE/FICLONERANGE ioctls through FUSE by adding remap_file_range support to the full stack.

**Problem:** FICLONE fails with EOPNOTSUPP through FUSE because there's no kernel opcode for it.

**Solution:** 
- Kernel patch adds FUSE_REMAP_FILE_RANGE opcode (54)
- fuse-pipe protocol extension for RemapFileRange
- Passthrough implementation using copy_file_range (which handles FICLONE on btrfs)
- Integration tests that skip gracefully on unpatched kernels

## Full Stack Implementation

| Layer | Component | Changes |
|-------|-----------|---------|
| Kernel | `kernel/build.sh` | Inlines FUSE_REMAP_FILE_RANGE patch (opcode 54, struct, handler) |
| fuser | [ejc3/fuser:remap-file-range](https://github.com/ejc3/fuser) | Opcode constant + `remap_file_range` trait method |
| fuse-backend-rs | [ejc3/fuse-backend-rs:remap-file-range](https://github.com/ejc3/fuse-backend-rs) | PassthroughFs impl using copy_file_range |
| libfuse | [ejc3/libfuse:remap-file-range](https://github.com/ejc3/libfuse) | passthrough_ll.c impl for C-based testing |
| fuse-pipe | `src/protocol/`, `src/client/`, `src/server/` | Wire protocol + handler |
| Tests | `tests/test_remap_file_range.rs` | VM end-to-end test |
| Tests | `fuse-pipe/tests/test_remap_file_range.rs` | Host-side FUSE tests |
| Tests | `Containerfile.libfuse-remap` | libfuse container test |

## Key Fixes During Development

1. **Opcode 54** (not 53) - opcode 53 is reserved for FUSE_SYNCFS
2. **len=0 semantics** - FICLONE passes len=0 meaning "to end of file", fixed underflow in writeback range calculation
3. **Return value** - must return bytes cloned via `fuse_write_out`, not just success/fail
4. **Exit code handling** - `cp --reflink=always` returns 1 (not errno) on failure

## Test Behavior

Tests skip gracefully without patched kernel - **won't break CI**:

| Test | Skip Condition |
|------|----------------|
| `test_ficlone_cp_reflink_in_vm` | No btrfs, or exit code 1/38/95 |
| `test_ficlone_whole_file` | ENOSYS or EOPNOTSUPP from kernel |
| `test_ficlonerange_partial` | ENOSYS or EOPNOTSUPP from kernel |

To run with patched kernel:
```bash
REMAP_KERNEL=/mnt/fcvm-btrfs/kernels/vmlinux-6.12.10-*.bin make test-root FILTER=remap
```

## Verified Working

```
remap_file_range called ino_in=2 fh_in=2 offset_in=0 ino_out=3 fh_out=3 len=0 remap_flags=0
remap_file_range response response=Written { size: 0 }
[ctr:stdout] FICLONE test passed
✓ Verified: files share physical extents (true reflink)
[REMAP-VM] ✓ ficlone (6.9s)
```

## Test plan

- [x] `cargo build --release` passes
- [x] `make test-root` passes (tests skip on standard kernel)
- [x] `REMAP_KERNEL=... make test-root FILTER=remap` passes with patched kernel
- [x] libfuse container test passes: FICLONE + FICLONERANGE (offset=0 and offset=512KB)
- [x] `filefrag` confirms shared extents (true reflinks on btrfs)
