### PR TITLE
Add centralized graceful_kill utility for proper VM cleanup

### DIFF
--- a/benches/clone.rs
+++ b/benches/clone.rs
@@ -305,9 +305,11 @@ impl CloneFixture {
     }
 
     fn kill(&mut self) {
-        // Kill both processes and wait to reap them
-        let _ = self.serve_child.kill();
-        let _ = self.baseline_child.kill();
+        // Gracefully kill both processes (SIGTERM first, then SIGKILL)
+        // Kill serve first (it will cascade to clones)
+        fcvm::utils::graceful_kill(self.serve_pid, 2000);
+        fcvm::utils::graceful_kill(self.baseline_child.id(), 2000);
+        // Wait to reap and avoid zombies
         let _ = self.serve_child.wait();
         let _ = self.baseline_child.wait();
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,9 @@
 //! Utility functions for process management and system operations.
 
 use std::path::Path;
+use std::process::Command;
+use std::thread;
+use std::time::Duration;
 
 /// Check if a process is alive by checking /proc/{pid} existence.
 ///
@@ -14,6 +17,70 @@ use std::path::Path;
 /// `true` if the process exists, `false` otherwise
 pub fn is_process_alive(pid: u32) -> bool {
     Path::new(&format!("/proc/{}", pid)).exists()
+}
+
+/// Gracefully kill a process by sending SIGTERM first, then SIGKILL if needed.
+///
+/// This allows the process to run cleanup handlers (network teardown, file cleanup, etc.)
+/// before being forcefully terminated.
+///
+/// # Arguments
+/// * `pid` - Process ID to kill
+/// * `timeout_ms` - Maximum time to wait for graceful shutdown (in milliseconds)
+///
+/// # Behavior
+/// 1. Sends SIGTERM to allow graceful shutdown
+/// 2. Waits up to `timeout_ms` for process to exit
+/// 3. Sends SIGKILL if still running
+pub fn graceful_kill(pid: u32, timeout_ms: u64) {
+    // Send SIGTERM first for graceful shutdown
+    let _ = Command::new("kill")
+        .args(["-TERM", &pid.to_string()])
+        .output();
+
+    // Wait for process to exit gracefully
+    let interval = Duration::from_millis(100);
+    let iterations = (timeout_ms / 100).max(1);
+
+    for _ in 0..iterations {
+        if !is_process_alive(pid) {
+            return; // Process exited gracefully
+        }
+        thread::sleep(interval);
+    }
+
+    // Force kill if still running
+    let _ = Command::new("kill")
+        .args(["-KILL", &pid.to_string()])
+        .output();
+}
+
+/// Async version of graceful_kill for use in async contexts.
+///
+/// Same behavior as `graceful_kill` but uses tokio for sleeping.
+pub async fn graceful_kill_async(pid: u32, timeout_ms: u64) {
+    // Send SIGTERM first for graceful shutdown
+    let _ = tokio::process::Command::new("kill")
+        .args(["-TERM", &pid.to_string()])
+        .output()
+        .await;
+
+    // Wait for process to exit gracefully
+    let interval = tokio::time::Duration::from_millis(100);
+    let iterations = (timeout_ms / 100).max(1);
+
+    for _ in 0..iterations {
+        if !is_process_alive(pid) {
+            return; // Process exited gracefully
+        }
+        tokio::time::sleep(interval).await;
+    }
+
+    // Force kill if still running
+    let _ = tokio::process::Command::new("kill")
+        .args(["-KILL", &pid.to_string()])
+        .output()
+        .await;
 }
 
 #[cfg(test)]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -329,9 +329,9 @@ impl VmFixture {
 
 impl Drop for VmFixture {
     fn drop(&mut self) {
-        // Kill the VM process (start_kill is synchronous)
-        let _ = self.child.start_kill();
-        // try_wait is synchronous - check for exit without blocking
+        // Use centralized graceful kill (SIGTERM first, then SIGKILL)
+        // This allows fcvm to run cleanup handlers
+        fcvm::utils::graceful_kill(self.pid, 2000);
         let _ = self.child.try_wait();
 
         // Cleanup directories

--- a/tests/test_port_forward.rs
+++ b/tests/test_port_forward.rs
@@ -99,7 +99,8 @@ fn test_port_forward_bridged() -> Result<()> {
     }
 
     if !healthy {
-        let _ = fcvm.kill();
+        fcvm::utils::graceful_kill(fcvm_pid, 2000);
+        let _ = fcvm.wait();
         anyhow::bail!("VM did not become healthy within 60 seconds");
     }
 
@@ -236,7 +237,8 @@ fn test_port_forward_rootless() -> Result<()> {
     }
 
     if !healthy {
-        let _ = fcvm.kill();
+        fcvm::utils::graceful_kill(fcvm_pid, 2000);
+        let _ = fcvm.wait();
         anyhow::bail!("VM did not become healthy within 90 seconds");
     }
 

--- a/tests/test_signal_cleanup.rs
+++ b/tests/test_signal_cleanup.rs
@@ -82,8 +82,9 @@ fn test_sigint_kills_firecracker_bridged() -> Result<()> {
     }
 
     if !healthy {
-        // Kill fcvm if it didn't become healthy
-        let _ = fcvm.kill();
+        // Kill fcvm gracefully if it didn't become healthy
+        fcvm::utils::graceful_kill(fcvm_pid, 2000);
+        let _ = fcvm.wait();
         anyhow::bail!("VM did not become healthy within 60 seconds");
     }
 
@@ -214,7 +215,8 @@ fn test_sigterm_kills_firecracker_bridged() -> Result<()> {
     }
 
     if !healthy {
-        let _ = fcvm.kill();
+        fcvm::utils::graceful_kill(fcvm_pid, 2000);
+        let _ = fcvm.wait();
         anyhow::bail!("VM did not become healthy within 60 seconds");
     }
 
@@ -328,7 +330,8 @@ fn test_sigterm_cleanup_rootless() -> Result<()> {
     }
 
     if !healthy {
-        let _ = fcvm.kill();
+        fcvm::utils::graceful_kill(fcvm_pid, 2000);
+        let _ = fcvm.wait();
         anyhow::bail!("VM did not become healthy within 60 seconds");
     }
 
@@ -562,7 +565,8 @@ fn test_sigterm_cleanup_bridged() -> Result<()> {
     }
 
     if !healthy {
-        let _ = fcvm.kill();
+        fcvm::utils::graceful_kill(fcvm_pid, 2000);
+        let _ = fcvm.wait();
         anyhow::bail!("VM did not become healthy within 60 seconds");
     }
 


### PR DESCRIPTION
## Summary

- Add `graceful_kill()` and `graceful_kill_async()` utilities to `src/utils.rs`
- Update all test fixtures and benchmarks to use graceful shutdown (SIGTERM → wait → SIGKILL)
- Fix error paths in integration tests to clean up properly

## Problem

Test fixtures used `start_kill()`/`kill()` which sends SIGKILL immediately. SIGKILL cannot be caught, so fcvm's cleanup handlers never run - leaving behind:
- VM disk directories (`/mnt/fcvm-btrfs/vm-disks/{vm_id}`)
- State files (`/mnt/fcvm-btrfs/state/{vm_id}.json`)
- Snapshots and UFFD sockets

## Solution

Centralized `graceful_kill(pid, timeout_ms)` function that:
1. Sends SIGTERM first (allows cleanup handlers to run)
2. Polls for process exit up to timeout
3. Sends SIGKILL only if process doesn't exit gracefully

## Files Changed

- `src/utils.rs` - New graceful_kill functions
- `tests/common/mod.rs` - VmFixture::drop
- `benches/exec.rs` - VmFixture and CloneFixture
- `benches/clone.rs` - CloneFixture  
- `src/uffd/handler.rs` - UffdHandler::drop
- `tests/test_port_forward.rs` - Error path cleanup
- `tests/test_signal_cleanup.rs` - Error path cleanup

## Test plan

- [ ] `make test-root` passes
- [ ] No leftover VM directories after test run