### PR TITLE
Use per-user lock file to prevent root/non-root test conflicts

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -168,7 +168,8 @@ static CONFIG_INIT: Once = Once::new();
 /// 4. Releases lock (automatically on drop)
 fn ensure_config_exists() {
     CONFIG_INIT.call_once(|| {
-        let lock_path = "/tmp/fcvm-config-gen.lock";
+        let uid = unsafe { libc::getuid() };
+        let lock_path = format!("/tmp/fcvm-config-gen-{}.lock", uid);
         let lock_file = std::fs::OpenOptions::new()
             .create(true)
             .write(true)


### PR DESCRIPTION
## Summary
- Use UID-specific lock file path to prevent permission conflicts between root and non-root tests

## Problem
Running `make test-root` (sudo) then `make test-fast` (non-root) failed because the lock file `/tmp/fcvm-config-gen.lock` was owned by root and non-root user couldn't write to it.

## Solution
Append UID to lock file path so each user gets their own:
- Root: `/tmp/fcvm-config-gen-0.lock`
- Ubuntu: `/tmp/fcvm-config-gen-1000.lock`

## Test plan
- [x] `make test-fast FILTER=sanity` - passed
- [x] `make test-root FILTER=sanity` - passed  
- [x] `make test-fast FILTER=sanity` again - passed (no permission error)