### PR TITLE
Add per-mode data directory isolation for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,15 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+      - name: Get dependency SHAs
+        id: deps
+        run: |
+          echo "fuser=$(git -C fuser rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "fuse-backend-rs=$(git -C fuse-backend-rs rev-parse HEAD)" >> $GITHUB_OUTPUT
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: fcvm -> target
+          shared-key: deps-${{ steps.deps.outputs.fuser }}-${{ steps.deps.outputs.fuse-backend-rs }}
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y libfuse3-dev libclang-dev clang
       - name: Install cargo tools
@@ -92,9 +98,15 @@ jobs:
           path: fuser
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+      - name: Get dependency SHAs
+        id: deps
+        run: |
+          echo "fuser=$(git -C fuser rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "fuse-backend-rs=$(git -C fuse-backend-rs rev-parse HEAD)" >> $GITHUB_OUTPUT
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: fcvm -> target
+          shared-key: deps-${{ steps.deps.outputs.fuser }}-${{ steps.deps.outputs.fuse-backend-rs }}
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y libfuse3-dev libclang-dev clang
       - name: Build release
@@ -128,11 +140,17 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Get dependency SHAs
+        id: deps
+        run: |
+          echo "fuser=$(git -C fuser rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "fuse-backend-rs=$(git -C fuse-backend-rs rev-parse HEAD)" >> $GITHUB_OUTPUT
       - uses: Swatinem/rust-cache@v2
         with:
           cache-provider: buildjet
           workspaces: fcvm -> target
           cache-on-failure: "true"
+          shared-key: deps-${{ steps.deps.outputs.fuser }}-${{ steps.deps.outputs.fuse-backend-rs }}
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,4 +98,3 @@ harness = false
 [[bench]]
 name = "clone"
 harness = false
-# Cache bust 1766935010

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,3 +98,4 @@ harness = false
 [[bench]]
 name = "clone"
 harness = false
+# Cache bust 1766935010

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -1,7 +1,8 @@
 use anyhow::{Context, Result};
 
 use crate::cli::args::SetupArgs;
-use crate::setup::rootfs::generate_config;
+use crate::paths;
+use crate::setup::rootfs::{generate_config, load_config};
 
 /// Run setup to download kernel and create rootfs.
 ///
@@ -16,6 +17,10 @@ pub async fn cmd_setup(args: SetupArgs) -> Result<()> {
         println!("  fcvm setup");
         return Ok(());
     }
+
+    // Load config and initialize paths (with helpful error if config missing)
+    let (config, _, _) = load_config(None)?;
+    paths::init_with_paths(&config.paths.data_dir, &config.paths.assets_dir);
 
     println!("Setting up fcvm (this may take 5-10 minutes on first run)...");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,8 +35,8 @@ async fn main() -> Result<()> {
 
     // Initialize paths - some commands don't need config
     match &cli.cmd {
-        Commands::Setup(args) if args.generate_config => {
-            // --generate-config doesn't need existing config
+        Commands::Setup(_) => {
+            // Setup handles its own config loading with proper error messages
             paths::init_with_defaults();
         }
         Commands::Completions(_) => {


### PR DESCRIPTION
## Summary

Add per-mode data directory isolation using `FCVM_DATA_DIR` environment variable to prevent test conflicts.

## Changes

### Per-Mode Data Directory Isolation
- `src/paths.rs`: Add `FCVM_DATA_DIR` environment variable support for overriding data directory
- `Makefile`: Set unique data directories per test mode (rootless vs bridged)
- `tests/common/mod.rs`: Improve test isolation with unique names

### Bug Fixes
- `src/commands/setup.rs`: Fix panic when config file is missing
- `tests/test_egress_stress.rs`: Fix container test failures

### CI Improvements
- `.github/workflows/ci.yml`: Add dependency SHAs to cache key for better invalidation

## Test plan
- [ ] `make test-fast` - rootless tests pass with isolated data dir
- [ ] `make test-root` - bridged tests pass with isolated data dir
- [ ] Tests no longer conflict when running in parallel