### PR TITLE
Fix TTY exec race condition and add Ctrl-C interrupt tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tracing-log = "0.2"  # Bridge log crate to tracing (for fuse-backend-rs)
 libc = "0.2"
-nix = { version = "0.29", features = ["sched", "net", "fs", "user", "mount"] }
+nix = { version = "0.29", features = ["sched", "net", "fs", "user", "mount", "signal"] }
 chrono = { version = "0.4", features = ["serde"] }
 tempfile = "3"
 rand = "0.8"


### PR DESCRIPTION
## Summary

- Fix race condition in fc-agent TTY exec where output was lost for fast-exiting commands
- Add Tests 11-12 to verify SIGINT (Ctrl-C) interrupts sleep commands properly
- Use polling for output instead of arbitrary delays

## Changes

### fc-agent/src/main.rs
- Fix TTY race: Reader thread now drains PTY buffer until EOF instead of checking done flag
- Use `dup()` for fd ownership between threads
- Use `shutdown(fd, SHUT_RD)` to unblock writer thread instead of arbitrary sleep

### tests/test_exec.rs
- Test 11: Verify SIGINT interrupts `sleep 999` (polls for "READY" output first)
- Test 12: Verify Ctrl-C interrupts shell script (polls for "STARTED" before interrupting)
- `InterruptCondition::WaitForOutput` - polls stdout for expected string before sending SIGINT
- No arbitrary delays - all waits are condition-based
- Consolidated helpers: `run_exec` (no TTY) and `run_exec_tty` (with TTY)

### Cargo.toml
- Added "signal" feature to nix crate for `kill()` syscall

## Test plan
- [x] `make test-root FILTER=exec` - all 5 exec tests pass
- [x] Tests 11-12 use polling to wait for output before sending SIGINT