### PR TITLE
Fix TTY exec race condition and add Ctrl-C interrupt tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tracing-log = "0.2"  # Bridge log crate to tracing (for fuse-backend-rs)
 libc = "0.2"
-nix = { version = "0.29", features = ["sched", "net", "fs", "user", "mount"] }
+nix = { version = "0.29", features = ["sched", "net", "fs", "user", "mount", "signal"] }
 chrono = { version = "0.4", features = ["serde"] }
 tempfile = "3"
 rand = "0.8"


### PR DESCRIPTION
## Summary
- Fix race condition in fc-agent TTY exec where reader thread checked done flag before draining buffer
- Add polling-based interrupt tests that wait for expected output before sending SIGINT
- Use `wait_with_output()` for atomic output collection in non-interrupt TTY tests

## Test plan
- [x] Test 9/10: TTY allocation verified (no more empty output race)
- [x] Test 11/12: Ctrl-C interrupt tests poll for "READY"/"STARTED" before sending SIGINT
- [x] All 229 host tests pass
- [x] All 133 container tests pass
- [x] Host and container tests pass when run concurrently