### PR TITLE
Add 4-level inception chain test

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -195,6 +195,8 @@ Exception: For **forked libraries** (like fuse-backend-rs), we maintain compatib
 
 #### Creating a PR (Required for ALL Changes)
 
+**CRITICAL: TEST LOCALLY BEFORE PUSHING.** CI is for validation, not discovery. Run `make lint` and relevant tests locally first.
+
 ```bash
 # 1. Create feature branch
 git checkout -b fix-something
@@ -202,17 +204,21 @@ git checkout -b fix-something
 # 2. Make changes and commit
 git add -A && git commit -m "Fix something"
 
-# 3. Push and create PR
+# 3. TEST LOCALLY FIRST (required!)
+make lint                    # Must pass
+make test-root FILTER=<relevant>  # Run relevant tests
+
+# 4. Push and create PR (only after local tests pass)
 git push -u origin fix-something
 gh pr create --fill
 
-# 4. Wait for CI to pass
+# 5. Wait for CI to pass
 gh pr checks <pr-number>
 
-# 5. Merge when green
+# 6. Merge when green
 gh pr merge <pr-number> --merge --delete-branch
 
-# 6. Update local main
+# 7. Update local main
 git checkout main && git pull
 ```
 
@@ -221,10 +227,16 @@ git checkout main && git pull
 | Action | Command |
 |--------|---------|
 | Create branch | `git checkout -b branch-name` |
+| **Test locally first** | `make lint && make test-root FILTER=<relevant>` |
 | Push & create PR | `git push -u origin branch-name && gh pr create --fill` |
 | Check CI | `gh pr checks <pr-number>` |
 | Merge PR | `gh pr merge <pr-number> --merge --delete-branch` |
 | List my PRs | `gh pr list --author @me` |
+
+**Why test locally first:**
+- CI is slow and flaky - local tests give immediate feedback
+- Catches issues before wasting CI cycles
+- Shows actual test output for debugging
 
 **Why PRs are required:**
 - CI validates all changes before merge


### PR DESCRIPTION
## Summary

Adds `test_inception_chain_4_levels` to verify nested VMs work 4 levels deep:
- Host → Level 1 → Level 2 → Level 3 → Level 4
- Each intermediate level runs nginx:alpine with health checks
- Final level outputs success marker to prove chain works
- Skips gracefully if nested KVM unavailable (requires ARM64 FEAT_NV2)

## Implementation

- Level 1 started from host with `--kernel` (inception kernel) + `--privileged`
- Checks `KVM_CREATE_VM` ioctl works before proceeding with deeper levels
- Levels 2-4 started via `fcvm exec` into parent, running fcvm command
- Each level sets up TUN device, mounts fcvm binary/assets/config
- Cleanup cascades: killing Level 1 terminates all nested VMs

## Test plan

- [ ] CI passes (Container job runs privileged tests)
- [ ] Manual test on ARM64 with FEAT_NV2 (c7g.metal)

Note: This test requires hardware nested virtualization. It will skip gracefully on x86_64 or ARM64 without FEAT_NV2.