### PR TITLE
Enable VHE mode and recursive nested virtualization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ CONTAINER_RUN := podman run --rm --privileged \
 	_test-unit _test-fast _test-all _test-root \
 	container-build container-test container-test-unit container-test-fast container-test-all \
 	container-shell container-clean setup-btrfs setup-fcvm setup-pjdfstest bench lint fmt \
-	rebuild-fc dev-fc-test
+	rebuild-fc dev-fc-test inception-vm inception-exec inception-wait-exec inception-stop inception-status
 
 all: build
 
@@ -266,3 +266,144 @@ dev-fc-test: rebuild-fc build
 	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E' \
 	RUST_LOG=debug \
 	$(NEXTEST) $(NEXTEST_CAPTURE) --features privileged-tests $(FILTER)
+
+# =============================================================================
+# Inception VM development targets
+# =============================================================================
+# These targets manage a SINGLE inception VM for debugging.
+# Only ONE VM can exist at a time - inception-vm kills any existing VM first.
+
+# Find the inception kernel (latest vmlinux-*.bin with KVM support)
+INCEPTION_KERNEL := $(shell ls -t /mnt/fcvm-btrfs/kernels/vmlinux-*.bin 2>/dev/null | head -1)
+INCEPTION_VM_NAME := inception-dev
+INCEPTION_VM_LOG := /tmp/inception-vm.log
+INCEPTION_VM_PID := /tmp/inception-vm.pid
+
+# Start an inception VM (kills any existing VM first)
+# Usage: make inception-vm
+inception-vm: build
+	@echo "==> Ensuring clean environment (killing ALL existing VMs)..."
+	@sudo pkill -9 firecracker 2>/dev/null || true
+	@sudo pkill -9 -f "fcvm podman" 2>/dev/null || true
+	@sleep 2
+	@if pgrep firecracker >/dev/null 2>&1; then \
+		echo "ERROR: Could not kill existing firecracker"; \
+		exit 1; \
+	fi
+	@sudo rm -f $(INCEPTION_VM_PID) $(INCEPTION_VM_LOG)
+	@sudo rm -rf /mnt/fcvm-btrfs/state/vm-*.json
+	@if [ -z "$(INCEPTION_KERNEL)" ]; then \
+		echo "ERROR: No inception kernel found. Run ./kernel/build.sh first."; \
+		exit 1; \
+	fi
+	@echo "==> Starting SINGLE inception VM"
+	@echo "==> Kernel: $(INCEPTION_KERNEL)"
+	@echo "==> Log: $(INCEPTION_VM_LOG)"
+	@echo "==> Use 'make inception-exec CMD=...' to run commands"
+	@echo "==> Use 'make inception-stop' to stop"
+	@sudo ./target/release/fcvm podman run \
+		--name $(INCEPTION_VM_NAME) \
+		--network bridged \
+		--kernel $(INCEPTION_KERNEL) \
+		--privileged \
+		--map /mnt/fcvm-btrfs:/mnt/fcvm-btrfs \
+		--cmd "sleep infinity" \
+		alpine:latest > $(INCEPTION_VM_LOG) 2>&1 & \
+	sleep 2; \
+	FCVM_PID=$$(pgrep -n -f "fcvm podman run.*$(INCEPTION_VM_NAME)"); \
+	echo "$$FCVM_PID" | sudo tee $(INCEPTION_VM_PID) > /dev/null; \
+	echo "==> VM started with fcvm PID $$FCVM_PID"; \
+	echo "==> Waiting for boot..."; \
+	sleep 20; \
+	FC_COUNT=$$(pgrep -c firecracker || echo 0); \
+	if [ "$$FC_COUNT" -ne 1 ]; then \
+		echo "ERROR: Expected 1 firecracker, got $$FC_COUNT"; \
+		exit 1; \
+	fi; \
+	echo "==> VM ready. Tailing log (Ctrl+C to stop tail, VM keeps running):"; \
+	tail -f $(INCEPTION_VM_LOG)
+
+# Run a command inside the running inception VM
+# Usage: make inception-exec CMD="ls -la /dev/kvm"
+# Usage: make inception-exec CMD="/mnt/fcvm-btrfs/check_kvm_caps"
+CMD ?= uname -a
+inception-exec:
+	@if [ ! -f $(INCEPTION_VM_PID) ]; then \
+		echo "ERROR: No PID file found at $(INCEPTION_VM_PID)"; \
+		echo "Start a VM with 'make inception-vm' first."; \
+		exit 1; \
+	fi; \
+	PID=$$(cat $(INCEPTION_VM_PID)); \
+	if ! kill -0 $$PID 2>/dev/null; then \
+		echo "ERROR: VM process $$PID is not running"; \
+		echo "Start a VM with 'make inception-vm' first."; \
+		rm -f $(INCEPTION_VM_PID); \
+		exit 1; \
+	fi; \
+	echo "==> Running in VM (PID $$PID): $(CMD)"; \
+	sudo ./target/release/fcvm exec --pid $$PID -- $(CMD)
+
+# Wait for VM to be ready and then run a command
+# Usage: make inception-wait-exec CMD="/mnt/fcvm-btrfs/check_kvm_caps"
+inception-wait-exec: build
+	@echo "==> Waiting for inception VM to be ready..."
+	@if [ ! -f $(INCEPTION_VM_PID) ]; then \
+		echo "ERROR: No PID file found. Start a VM with 'make inception-vm &' first."; \
+		exit 1; \
+	fi; \
+	PID=$$(cat $(INCEPTION_VM_PID)); \
+	for i in $$(seq 1 30); do \
+		if ! kill -0 $$PID 2>/dev/null; then \
+			echo "ERROR: VM process $$PID exited"; \
+			rm -f $(INCEPTION_VM_PID); \
+			exit 1; \
+		fi; \
+		if sudo ./target/release/fcvm exec --pid $$PID -- true 2>/dev/null; then \
+			echo "==> VM ready (PID $$PID)"; \
+			echo "==> Running: $(CMD)"; \
+			sudo ./target/release/fcvm exec --pid $$PID -- $(CMD); \
+			exit 0; \
+		fi; \
+		sleep 2; \
+		echo "  Waiting... ($$i/30)"; \
+	done; \
+	echo "ERROR: Timeout waiting for VM to be ready"; \
+	exit 1
+
+# Stop the inception VM
+inception-stop:
+	@if [ -f $(INCEPTION_VM_PID) ]; then \
+		PID=$$(cat $(INCEPTION_VM_PID)); \
+		if kill -0 $$PID 2>/dev/null; then \
+			echo "==> Stopping VM (PID $$PID)..."; \
+			sudo kill $$PID 2>/dev/null || true; \
+			sleep 1; \
+			if kill -0 $$PID 2>/dev/null; then \
+				echo "==> Force killing..."; \
+				sudo kill -9 $$PID 2>/dev/null || true; \
+			fi; \
+			echo "==> VM stopped."; \
+		else \
+			echo "==> VM process $$PID not running (stale PID file)"; \
+		fi; \
+		rm -f $(INCEPTION_VM_PID); \
+	else \
+		echo "==> No PID file found. No VM to stop."; \
+	fi
+
+# Show VM status
+inception-status:
+	@echo "=== Inception VM Status ==="
+	@if [ -f $(INCEPTION_VM_PID) ]; then \
+		PID=$$(cat $(INCEPTION_VM_PID)); \
+		if kill -0 $$PID 2>/dev/null; then \
+			echo "VM PID: $$PID (running)"; \
+			ps -p $$PID -o pid,ppid,user,%cpu,%mem,etime,cmd --no-headers 2>/dev/null || true; \
+		else \
+			echo "VM PID: $$PID (NOT running - stale PID file)"; \
+			rm -f $(INCEPTION_VM_PID); \
+		fi; \
+	else \
+		echo "No PID file found at $(INCEPTION_VM_PID)"; \
+		echo "No VM running."; \
+	fi

--- a/fuse-pipe/src/client/multiplexer.rs
+++ b/fuse-pipe/src/client/multiplexer.rs
@@ -228,12 +228,25 @@ fn writer_loop(
     request_rx: Receiver<PendingRequest>,
     pending: Arc<DashMap<u64, Sender<ResponsePayload>>>,
 ) {
+    let mut count = 0u64;
     while let Ok(req) = request_rx.recv() {
+        count += 1;
+        if count <= 10 || count.is_multiple_of(100) {
+            tracing::info!(target: "fuse-pipe::mux", count, pending_count = pending.len(), "writer: sent requests");
+        }
+
         // Register the response channel BEFORE writing (to avoid race)
         pending.insert(req.unique, req.response_tx);
 
         // Write to socket
-        if socket.write_all(&req.data).is_err() || socket.flush().is_err() {
+        let write_result = socket.write_all(&req.data);
+        let flush_result = if write_result.is_ok() {
+            socket.flush()
+        } else {
+            Ok(())
+        };
+        if let Err(e) = write_result.as_ref().and(flush_result.as_ref()) {
+            tracing::warn!(target: "fuse-pipe::mux", unique = req.unique, error = %e, error_kind = ?e.kind(), "writer: socket write failed");
             // Remove from pending and signal error
             if let Some((_, tx)) = pending.remove(&req.unique) {
                 let _ = tx.send((VolumeResponse::error(libc::EIO), None));
@@ -242,22 +255,26 @@ fn writer_loop(
         // Note: client_socket_write is marked by server_recv on the server side
         // since we can't update the span after serialization
     }
+    tracing::info!(target: "fuse-pipe::mux", count, "writer: exiting");
 }
 
 /// Reader thread: reads responses from socket, routes to waiting readers.
 fn reader_loop(mut socket: UnixStream, pending: Arc<DashMap<u64, Sender<ResponsePayload>>>) {
     let mut len_buf = [0u8; 4];
+    let mut count = 0u64;
 
     loop {
         // Read response length
         if socket.read_exact(&mut len_buf).is_err() {
             // Server disconnected - fail all pending requests
+            tracing::warn!(target: "fuse-pipe::mux", count, pending_count = pending.len(), "reader: socket read failed, disconnected");
             fail_all_pending(&pending);
             break;
         }
 
         let len = u32::from_be_bytes(len_buf) as usize;
         if len > MAX_MESSAGE_SIZE {
+            tracing::error!(target: "fuse-pipe::mux", len, "reader: oversized message");
             fail_all_pending(&pending);
             break;
         }
@@ -265,8 +282,14 @@ fn reader_loop(mut socket: UnixStream, pending: Arc<DashMap<u64, Sender<Response
         // Read response body
         let mut resp_buf = vec![0u8; len];
         if socket.read_exact(&mut resp_buf).is_err() {
+            tracing::warn!(target: "fuse-pipe::mux", count, "reader: failed to read response body");
             fail_all_pending(&pending);
             break;
+        }
+
+        count += 1;
+        if count <= 10 || count.is_multiple_of(100) {
+            tracing::info!(target: "fuse-pipe::mux", count, pending_count = pending.len(), "reader: received responses");
         }
 
         // Deserialize and route to waiting reader (lock-free lookup + remove)
@@ -282,6 +305,7 @@ fn reader_loop(mut socket: UnixStream, pending: Arc<DashMap<u64, Sender<Response
             }
         }
     }
+    tracing::info!(target: "fuse-pipe::mux", count, "reader: exiting");
 }
 
 /// Fail all pending requests on disconnect.

--- a/kernel/patches/mmfr4-override.patch
+++ b/kernel/patches/mmfr4-override.patch
@@ -1,0 +1,126 @@
+diff --git a/arch/arm64/include/asm/cpufeature.h b/arch/arm64/include/asm/cpufeature.h
+index 1234567..abcdefg 100644
+--- a/arch/arm64/include/asm/cpufeature.h
++++ b/arch/arm64/include/asm/cpufeature.h
+@@ -961,6 +961,7 @@ extern struct arm64_ftr_override id_aa64isar2_override;
+ extern struct arm64_ftr_override id_aa64mmfr0_override;
+ extern struct arm64_ftr_override id_aa64mmfr1_override;
+ extern struct arm64_ftr_override id_aa64mmfr2_override;
++extern struct arm64_ftr_override id_aa64mmfr4_override;
+ extern struct arm64_ftr_override id_aa64pfr0_override;
+ extern struct arm64_ftr_override id_aa64pfr1_override;
+ extern struct arm64_ftr_override id_aa64smfr0_override;
+diff --git a/arch/arm64/kernel/cpufeature.c b/arch/arm64/kernel/cpufeature.c
+index c840a93..bd69b5a 100644
+--- a/arch/arm64/kernel/cpufeature.c
++++ b/arch/arm64/kernel/cpufeature.c
+@@ -500,8 +500,10 @@ static const struct arm64_ftr_bits ftr_id_aa64mmfr3[] = {
+ };
+
+ static const struct arm64_ftr_bits ftr_id_aa64mmfr4[] = {
+-	S_ARM64_FTR_BITS(FTR_HIDDEN, FTR_STRICT, FTR_LOWER_SAFE, ID_AA64MMFR4_EL1_E2H0_SHIFT, 4, 0),
+-	ARM64_FTR_BITS(FTR_HIDDEN, FTR_STRICT, FTR_LOWER_SAFE, ID_AA64MMFR4_EL1_NV_frac_SHIFT, 4, 0),
++	/* Use FTR_HIGHER_SAFE for E2H0 and NV_frac to allow upward overrides via arm64.nv2.
++	 * This enables recursive nested virtualization by faking NV2 support. */
++	S_ARM64_FTR_BITS(FTR_HIDDEN, FTR_STRICT, FTR_HIGHER_SAFE, ID_AA64MMFR4_EL1_E2H0_SHIFT, 4, 0),
++	ARM64_FTR_BITS(FTR_HIDDEN, FTR_STRICT, FTR_HIGHER_SAFE, ID_AA64MMFR4_EL1_NV_frac_SHIFT, 4, 0),
+ 	ARM64_FTR_END,
+ };
+
+@@ -776,6 +776,7 @@ static const struct arm64_ftr_bits ftr_raz[] = {
+ struct arm64_ftr_override __read_mostly id_aa64mmfr0_override;
+ struct arm64_ftr_override __read_mostly id_aa64mmfr1_override;
+ struct arm64_ftr_override __read_mostly id_aa64mmfr2_override;
++struct arm64_ftr_override __read_mostly id_aa64mmfr4_override;
+ struct arm64_ftr_override __read_mostly id_aa64pfr0_override;
+ struct arm64_ftr_override __read_mostly id_aa64pfr1_override;
+ struct arm64_ftr_override __read_mostly id_aa64zfr0_override;
+@@ -849,7 +850,8 @@ static const struct __ftr_reg_entry {
+ 	ARM64_FTR_REG_OVERRIDE(SYS_ID_AA64MMFR2_EL1, ftr_id_aa64mmfr2,
+ 			       &id_aa64mmfr2_override),
+ 	ARM64_FTR_REG(SYS_ID_AA64MMFR3_EL1, ftr_id_aa64mmfr3),
+-	ARM64_FTR_REG(SYS_ID_AA64MMFR4_EL1, ftr_id_aa64mmfr4),
++	ARM64_FTR_REG_OVERRIDE(SYS_ID_AA64MMFR4_EL1, ftr_id_aa64mmfr4,
++			       &id_aa64mmfr4_override),
+ 
+ 	/* Op1 = 0, CRn = 10, CRm = 4 */
+ 	ARM64_FTR_REG(SYS_MPAMIDR_EL1, ftr_mpamidr),
+diff --git a/arch/arm64/kernel/image-vars.h b/arch/arm64/kernel/image-vars.h
+index 85bc629..554a7b1 100644
+--- a/arch/arm64/kernel/image-vars.h
++++ b/arch/arm64/kernel/image-vars.h
+@@ -51,6 +51,7 @@ PI_EXPORT_SYM(id_aa64isar2_override);
+ PI_EXPORT_SYM(id_aa64mmfr0_override);
+ PI_EXPORT_SYM(id_aa64mmfr1_override);
+ PI_EXPORT_SYM(id_aa64mmfr2_override);
++PI_EXPORT_SYM(id_aa64mmfr4_override);
+ PI_EXPORT_SYM(id_aa64pfr0_override);
+ PI_EXPORT_SYM(id_aa64pfr1_override);
+ PI_EXPORT_SYM(id_aa64smfr0_override);
+diff --git a/arch/arm64/kernel/pi/idreg-override.c b/arch/arm64/kernel/pi/idreg-override.c
+index bc57b29..ef404ca 100644
+--- a/arch/arm64/kernel/pi/idreg-override.c
++++ b/arch/arm64/kernel/pi/idreg-override.c
+@@ -106,6 +106,16 @@ static const struct ftr_set_desc mmfr2 __prel64_initconst = {
+ 	},
+ };
+ 
++static const struct ftr_set_desc mmfr4 __prel64_initconst = {
++	.name		= "id_aa64mmfr4",
++	.override	= &id_aa64mmfr4_override,
++	.fields		= {
++		FIELD("nv_frac", ID_AA64MMFR4_EL1_NV_frac_SHIFT, NULL),
++		FIELD("e2h0", ID_AA64MMFR4_EL1_E2H0_SHIFT, NULL),
++		{}
++	},
++};
++
+ static bool __init pfr0_sve_filter(u64 val)
+ {
+ 	/*
+@@ -220,6 +230,7 @@ PREL64(const struct ftr_set_desc, reg) regs[] __prel64_initconst = {
+ 	{ &mmfr0	},
+ 	{ &mmfr1	},
+ 	{ &mmfr2	},
++	{ &mmfr4	},
+ 	{ &pfr0 	},
+ 	{ &pfr1 	},
+ 	{ &isar1	},
+@@ -249,6 +260,7 @@ static const struct {
+ 	{ "arm64.nolva",		"id_aa64mmfr2.varange=0" },
+ 	{ "arm64.no32bit_el0",		"id_aa64pfr0.el0=1" },
+ 	{ "arm64.nompam",		"id_aa64pfr0.mpam=0 id_aa64pfr1.mpam_frac=0" },
++	{ "arm64.nv2",			"id_aa64mmfr4.nv_frac=2" },
+ };
+ 
+ static int __init parse_hexdigit(const char *p, u64 *v)
+diff --git a/arch/arm64/kvm/nested.c b/arch/arm64/kvm/nested.c
+index cdeeb8f..df3ee34 100644
+--- a/arch/arm64/kvm/nested.c
++++ b/arch/arm64/kvm/nested.c
+@@ -1504,6 +1504,13 @@ u64 limit_nv_id_reg(struct kvm *kvm, u32 reg, u64 val)
+ {
+ 	u64 orig_val = val;
+ 
++	/* Debug: trace ID register modifications for NV2 */
++	if (reg == SYS_ID_AA64MMFR4_EL1 || reg == SYS_ID_AA64MMFR2_EL1) {
++		pr_info("[NV2-DEBUG] limit_nv_id_reg: reg=0x%x val=0x%llx E2H0=%d\n",
++			reg, val,
++			test_bit(KVM_ARM_VCPU_HAS_EL2_E2H0, kvm->arch.vcpu_features));
++	}
++
+ 	switch (reg) {
+ 	case SYS_ID_AA64ISAR0_EL1:
+ 		/* Support everything but TME */
+@@ -1636,9 +1643,11 @@ u64 limit_nv_id_reg(struct kvm *kvm, u32 reg, u64 val)
+ 		 */
+ 		if (test_bit(KVM_ARM_VCPU_HAS_EL2_E2H0, kvm->arch.vcpu_features)) {
+ 			val = 0;
++			pr_info("[NV2-DEBUG] MMFR4: E2H0 mode, val=0\n");
+ 		} else {
+ 			val = SYS_FIELD_PREP_ENUM(ID_AA64MMFR4_EL1, NV_frac, NV2_ONLY);
+ 			val |= SYS_FIELD_PREP_ENUM(ID_AA64MMFR4_EL1, E2H0, NI_NV1);
++			pr_info("[NV2-DEBUG] MMFR4: VHE mode, val=0x%llx (NV_frac=NV2_ONLY)\n", val);
+ 		}
+ 		break;
+ 

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -1182,8 +1182,10 @@ async fn run_vm_setup(
     //   VHE mode (E2H=1) allows the guest kernel to run at EL2, which is required
     //   for kvm-arm.mode=nested. This enables recursive nested virtualization.
     // - numa=off - Disable NUMA to avoid percpu allocation issues in nested contexts
+    // - arm64.nv2 - Override MMFR4.NV_frac to advertise NV2 support. Required because
+    //   virtual EL2 reads ID registers directly from hardware (TID3 only traps EL1 reads).
     if args.kernel.is_some() {
-        boot_args.push_str(" kvm-arm.mode=nested numa=off");
+        boot_args.push_str(" kvm-arm.mode=nested numa=off arm64.nv2");
     }
 
     client

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -1188,6 +1188,12 @@ async fn run_vm_setup(
         boot_args.push_str(" kvm-arm.mode=nested numa=off arm64.nv2");
     }
 
+    // Pass FUSE reader count to fc-agent via kernel command line.
+    // Used to reduce memory at deeper nesting levels (256 readers × 8MB = 2GB per mount).
+    if let Ok(readers) = std::env::var("FCVM_FUSE_READERS") {
+        boot_args.push_str(&format!(" fuse_readers={}", readers));
+    }
+
     client
         .set_boot_source(crate::firecracker::api::BootSource {
             kernel_image_path: kernel_path.display().to_string(),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -443,8 +443,10 @@ pub async fn spawn_fcvm_with_logs(
 
     // Enable nested virtualization when using inception kernel (--kernel flag)
     // FCVM_NV2=1 tells fcvm to pass --enable-nv2 to Firecracker for HAS_EL2 vCPU feature
+    // FCVM_FUSE_READERS=64 reduces memory usage for nested VMs (256 readers × 8MB = 2GB per mount)
     if args.contains(&"--kernel") {
         cmd.env("FCVM_NV2", "1");
+        cmd.env("FCVM_FUSE_READERS", "64");
     }
 
     let mut child = cmd

--- a/tests/test_kvm.rs
+++ b/tests/test_kvm.rs
@@ -1,50 +1,33 @@
-//! Integration test for inception support - verifies /dev/kvm works in guest
+//! Integration tests for inception support - nested VMs using ARM64 FEAT_NV2.
 //!
-//! This test generates a custom rootfs-config.toml pointing to the inception
-//! kernel (with CONFIG_KVM=y), then verifies /dev/kvm works in the VM.
+//! # Nested Virtualization Status (2025-12-30)
 //!
-//! # Nested Virtualization Status (2025-12-29)
+//! ## L1→L2 Working!
+//! - Host runs L1 with inception kernel (6.18) and `--privileged --map /mnt/fcvm-btrfs`
+//! - L1 runs fcvm inside container to start L2
+//! - L2 executes commands successfully
 //!
-//! ## Implementation Complete (L1 only)
-//! - Host kernel 6.18.2-nested with `kvm-arm.mode=nested` properly initializes NV2 mode
-//! - KVM_CAP_ARM_EL2 (capability 240) returns 1, indicating nested virt is supported
-//! - vCPU init with KVM_ARM_VCPU_HAS_EL2 (bit 7) + HAS_EL2_E2H0 (bit 8) succeeds
-//! - Firecracker patched to:
-//!   - Enable HAS_EL2 + HAS_EL2_E2H0 features (--enable-nv2 CLI flag)
-//!   - Boot vCPU at EL2h (PSTATE_FAULT_BITS_64_EL2) so guest sees HYP mode
-//!   - Set EL2 registers: HCR_EL2, CNTHCTL_EL2, VMPIDR_EL2, VPIDR_EL2
+//! ## Key Components
+//! - **Host kernel**: 6.18.2-nested with `kvm-arm.mode=nested`
+//! - **Inception kernel**: 6.18 with `CONFIG_KVM=y`, FUSE_REMAP_FILE_RANGE support
+//! - **Firecracker**: Fork with NV2 support (`--enable-nv2` flag)
+//! - **Shared storage**: `/mnt/fcvm-btrfs` mounted via FUSE-over-vsock
 //!
-//! ## Guest kernel boot (working)
-//! - Guest dmesg shows: "CPU: All CPU(s) started at EL2"
-//! - KVM initializes: "kvm [1]: nv: 554 coarse grained trap handlers"
-//! - "kvm [1]: Hyp nVHE mode initialized successfully"
-//! - /dev/kvm can be opened successfully
+//! ## How L2 Works
+//! 1. Host writes L1 script to shared storage (`/mnt/fcvm-btrfs/l1-inception.sh`)
+//! 2. Host runs: `fcvm podman run --kernel {inception} --map /mnt/fcvm-btrfs --cmd /mnt/fcvm-btrfs/l1-inception.sh`
+//! 3. L1's script: imports image from shared cache, runs `fcvm podman run --cmd "echo MARKER"`
+//! 4. L2 echoes marker, exits
 //!
-//! ## Recursive Nesting Limitation (L2+)
-//! L1's KVM reports KVM_CAP_ARM_EL2=0, preventing L2+ VMs from using NV2.
-//! Root cause analysis (2025-12-29):
-//!
-//! 1. `kvm-arm.mode=nested` requires VHE mode (kernel at EL2)
-//! 2. VHE requires `is_kernel_in_hyp_mode()` = true at early boot
-//! 3. But NV2's `HAS_EL2_E2H0` flag forces nVHE mode (kernel at EL1)
-//! 4. E2H0 is required to avoid timer trap storms in NV2 contexts
-//! 5. Without VHE, L1's kernel uses `kvm-arm.mode=nvhe` and cannot advertise KVM_CAP_ARM_EL2
-//!
-//! The kernel's nested virt patches include recursive nesting code, but it's marked
-//! as "not tested yet". Until VHE mode works reliably with NV2, recursive nesting
-//! (host → L1 → L2 → L3...) is not possible.
+//! ## For Deeper Nesting (L3+)
+//! Build scripts from deepest level upward:
+//! - L3 script: `echo MARKER`
+//! - L2 script: import + `fcvm ... --cmd /mnt/fcvm-btrfs/l3.sh`
+//! - L1 script: import + `fcvm ... --cmd /mnt/fcvm-btrfs/l2.sh`
 //!
 //! ## Hardware
-//! - c7g.metal (Graviton3 / Neoverse-V1) supports FEAT_NV2
+//! - c7g.metal (Graviton3 / Neoverse-V1) with FEAT_NV2
 //! - MIDR: 0x411fd401 (ARM Neoverse-V1)
-//!
-//! ## References
-//! - KVM nested virt patches: https://lwn.net/Articles/921783/
-//! - ARM boot protocol: arch/arm64/kernel/head.S (init_kernel_el)
-//! - E2H0 handling: arch/arm64/include/asm/el2_setup.h (init_el2_hcr)
-//! - Nested config: arch/arm64/kvm/nested.c (case SYS_ID_AA64MMFR4_EL1)
-//!
-//! FAILS LOUDLY if /dev/kvm is not available.
 
 #![cfg(feature = "privileged-tests")]
 
@@ -55,7 +38,7 @@ use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
-const KERNEL_VERSION: &str = "6.12.10";
+const KERNEL_VERSION: &str = "6.18";
 const KERNEL_DIR: &str = "/mnt/fcvm-btrfs/kernels";
 const FIRECRACKER_NV2_REPO: &str = "https://github.com/ejc3/firecracker.git";
 const FIRECRACKER_NV2_BRANCH: &str = "nv2-inception";
@@ -692,18 +675,153 @@ except OSError as e:
     }
 }
 
+/// Build localhost/inception-test image with proper CAS invalidation
+///
+/// Computes a combined SHA of ALL inputs (binaries, scripts, Containerfile).
+/// Rebuilds and re-exports only when inputs change.
+async fn ensure_inception_image() -> Result<()> {
+    let fcvm_path = common::find_fcvm_binary()?;
+    let fcvm_dir = fcvm_path.parent().unwrap();
+
+    // All inputs that affect the container image
+    let src_fcvm = fcvm_dir.join("fcvm");
+    let src_agent = fcvm_dir.join("fc-agent");
+    let src_firecracker = PathBuf::from("/usr/local/bin/firecracker");
+    let src_inception = PathBuf::from("inception.sh");
+    let src_containerfile = PathBuf::from("Containerfile.inception");
+
+    // Compute combined SHA of all inputs
+    fn file_bytes(path: &Path) -> Vec<u8> {
+        std::fs::read(path).unwrap_or_default()
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(&file_bytes(&src_fcvm));
+    hasher.update(&file_bytes(&src_agent));
+    hasher.update(&file_bytes(&src_firecracker));
+    hasher.update(&file_bytes(&src_inception));
+    hasher.update(&file_bytes(&src_containerfile));
+    let combined_sha = hex::encode(&hasher.finalize()[..6]);
+
+    // Check if we have a marker file with the current SHA
+    let marker_path = PathBuf::from("bin/.inception-sha");
+    let cached_sha = std::fs::read_to_string(&marker_path).unwrap_or_default();
+
+    let need_rebuild = cached_sha.trim() != combined_sha;
+
+    if need_rebuild {
+        println!(
+            "Inputs changed (sha: {} → {}), rebuilding inception container...",
+            if cached_sha.is_empty() { "none" } else { cached_sha.trim() },
+            combined_sha
+        );
+
+        // Copy all inputs to build context
+        tokio::fs::create_dir_all("bin").await.ok();
+        std::fs::copy(&src_fcvm, "bin/fcvm").context("copying fcvm to bin/")?;
+        std::fs::copy(&src_agent, "bin/fc-agent").context("copying fc-agent to bin/")?;
+        std::fs::copy(&src_firecracker, "firecracker-nv2").ok();
+
+        // Force rebuild by removing old image
+        tokio::process::Command::new("podman")
+            .args(["rmi", "localhost/inception-test"])
+            .output()
+            .await
+            .ok();
+    }
+
+    // Check if image exists
+    let check = tokio::process::Command::new("podman")
+        .args(["image", "exists", "localhost/inception-test"])
+        .output()
+        .await?;
+
+    if check.status.success() && !need_rebuild {
+        println!("✓ localhost/inception-test up to date (sha: {})", combined_sha);
+        return Ok(());
+    }
+
+    // Build container
+    println!("Building localhost/inception-test...");
+    let output = tokio::process::Command::new("podman")
+        .args([
+            "build",
+            "-t",
+            "localhost/inception-test",
+            "-f",
+            "Containerfile.inception",
+            ".",
+        ])
+        .output()
+        .await
+        .context("running podman build")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("Failed to build inception container: {}", stderr);
+    }
+
+    // Export to CAS cache so nested VMs can access it
+    let digest_out = tokio::process::Command::new("podman")
+        .args([
+            "inspect",
+            "localhost/inception-test",
+            "--format",
+            "{{.Digest}}",
+        ])
+        .output()
+        .await?;
+    let digest = String::from_utf8_lossy(&digest_out.stdout)
+        .trim()
+        .to_string();
+
+    if !digest.is_empty() && digest.starts_with("sha256:") {
+        let cache_dir = format!("/mnt/fcvm-btrfs/image-cache/{}", digest);
+
+        if !PathBuf::from(&cache_dir).exists() {
+            println!("Exporting to CAS cache: {}", cache_dir);
+            tokio::process::Command::new("sudo")
+                .args(["mkdir", "-p", &cache_dir])
+                .output()
+                .await?;
+            let skopeo_out = tokio::process::Command::new("sudo")
+                .args([
+                    "skopeo",
+                    "copy",
+                    "containers-storage:localhost/inception-test",
+                    &format!("dir:{}", cache_dir),
+                ])
+                .output()
+                .await?;
+            if !skopeo_out.status.success() {
+                println!(
+                    "Warning: skopeo export failed: {}",
+                    String::from_utf8_lossy(&skopeo_out.stderr)
+                );
+            }
+        }
+
+        // Save the combined SHA as marker
+        std::fs::write(&marker_path, &combined_sha).ok();
+
+        println!(
+            "✓ localhost/inception-test ready (sha: {}, digest: {})",
+            combined_sha,
+            &digest[..std::cmp::min(19, digest.len())]
+        );
+    } else {
+        println!("✓ localhost/inception-test built (no digest available)");
+    }
+
+    Ok(())
+}
+
 /// Run an inception chain test with configurable depth.
 ///
 /// This function attempts to run VMs nested N levels deep:
 /// Host → Level 1 → Level 2 → ... → Level N
 ///
-/// LIMITATION (2025-12-29): Recursive nesting beyond L1 is NOT currently possible.
-/// L1's KVM reports KVM_CAP_ARM_EL2=0 because:
-/// - VHE mode is required for `kvm-arm.mode=nested`
-/// - But NV2's E2H0 flag forces nVHE mode to avoid timer trap storms
-/// - Without VHE, L1 cannot advertise nested virt capability
-///
-/// This test is kept for documentation and future testing when VHE+NV2 works.
+/// Each nested level uses localhost/inception-test which has fcvm baked in.
 ///
 /// REQUIRES: ARM64 with FEAT_NV2 (ARMv8.4+) and kvm-arm.mode=nested
 async fn run_inception_chain(total_levels: usize) -> Result<()> {
@@ -718,9 +836,9 @@ async fn run_inception_chain(total_levels: usize) -> Result<()> {
     // Ensure prerequisites
     ensure_firecracker_nv2().await?;
     let inception_kernel = ensure_inception_kernel().await?;
+    ensure_inception_image().await?;
 
     let fcvm_path = common::find_fcvm_binary()?;
-    let fcvm_dir = fcvm_path.parent().unwrap();
     let kernel_str = inception_kernel
         .to_str()
         .context("kernel path not valid UTF-8")?;
@@ -728,7 +846,6 @@ async fn run_inception_chain(total_levels: usize) -> Result<()> {
     // Home dir for config mount
     let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
     let config_mount = format!("{0}/.config/fcvm:/root/.config/fcvm:ro", home);
-    let fcvm_volume = format!("{}:/opt/fcvm", fcvm_dir.display());
 
     // Track PIDs for cleanup
     let mut level_pids: Vec<u32> = Vec::new();
@@ -740,10 +857,12 @@ async fn run_inception_chain(total_levels: usize) -> Result<()> {
         }
     }
 
-    // === Level 1: Start from host ===
+    // === Level 1: Start from host with localhost/inception-test ===
+    // This image has fcvm baked in, fcvm handles export to cache automatically
     println!("\n[Level 1] Starting outer VM from host...");
     let (vm_name_1, _, _, _) = common::unique_names("inception-L1");
 
+    // L1 uses 4GB RAM (needs to fit L2-L4 inside + overhead)
     let (mut _child1, pid1) = common::spawn_fcvm(&[
         "podman",
         "run",
@@ -754,13 +873,13 @@ async fn run_inception_chain(total_levels: usize) -> Result<()> {
         "--kernel",
         kernel_str,
         "--privileged",
+        "--mem",
+        "4096", // L1 gets 4GB, nested VMs get progressively less
         "--map",
         "/mnt/fcvm-btrfs:/mnt/fcvm-btrfs",
         "--map",
-        &fcvm_volume,
-        "--map",
         &config_mount,
-        common::TEST_IMAGE,
+        "localhost/inception-test",
     ])
     .await
     .context("spawning Level 1 VM")?;
@@ -775,13 +894,14 @@ async fn run_inception_chain(total_levels: usize) -> Result<()> {
     println!("[Level 1] ✓ Healthy!");
 
     // Check if nested KVM works before proceeding
+    // Run in container (default) which has python3 and access to /dev/kvm (privileged)
     println!("\n[Level 1] Checking if nested KVM works...");
     let output = tokio::process::Command::new(&fcvm_path)
         .args([
             "exec",
             "--pid",
             &pid1.to_string(),
-            "--vm",
+            // Default is container exec (no --vm flag needed)
             "--",
             "python3",
             "-c",
@@ -815,45 +935,28 @@ except OSError as e:
     // Each level starts the next, innermost level echoes success
     // This creates a single deeply-nested command that runs through all levels
 
-    // Start from innermost level and work outward
-    let mut nested_cmd = format!("echo {}", success_marker);
-
-    // Build the nested inception chain from inside out (Level N -> ... -> Level 2)
-    for level in (2..=total_levels).rev() {
-        let vm_name = format!("inception-L{}-{}", level, std::process::id());
-
-        // Use alpine for all levels to speed up boot
-        let image = "alpine:latest";
-
-        // Escape the inner command for shell embedding
-        let escaped_cmd = nested_cmd.replace('\'', "'\\''");
-
-        nested_cmd = format!(
-            r#"export PATH=/opt/fcvm:/mnt/fcvm-btrfs/bin:$PATH
-export HOME=/root
-modprobe tun 2>/dev/null || true
-mkdir -p /dev/net
-mknod /dev/net/tun c 10 200 2>/dev/null || true
-chmod 666 /dev/net/tun 2>/dev/null || true
-cd /mnt/fcvm-btrfs
-echo "[L{level}] Starting nested VM..."
-fcvm podman run \
-    --name {vm_name} \
-    --network bridged \
-    --kernel {kernel} \
-    --privileged \
-    --map /mnt/fcvm-btrfs:/mnt/fcvm-btrfs \
-    --map /opt/fcvm:/opt/fcvm \
-    --map /root/.config/fcvm:/root/.config/fcvm:ro \
-    --cmd '{escaped_cmd}' \
-    {image}"#,
-            level = level,
-            vm_name = vm_name,
-            kernel = kernel_str,
-            escaped_cmd = escaped_cmd,
-            image = image
-        );
+    // Get the exact image digest so we can pass the explicit cache path down the chain
+    let nested_image = "localhost/inception-test";
+    let digest_output = tokio::process::Command::new("podman")
+        .args(["inspect", nested_image, "--format", "{{.Digest}}"])
+        .output()
+        .await
+        .context("getting image digest")?;
+    let image_digest = String::from_utf8_lossy(&digest_output.stdout).trim().to_string();
+    if image_digest.is_empty() || !image_digest.starts_with("sha256:") {
+        bail!("Failed to get image digest: {:?}", String::from_utf8_lossy(&digest_output.stderr));
     }
+    let image_cache_path = format!("/mnt/fcvm-btrfs/image-cache/{}", image_digest);
+    println!("[Setup] Image digest: {}", image_digest);
+    println!("[Setup] Cache path: {}", image_cache_path);
+
+    // The inception script is baked into the container at /usr/local/bin/inception
+    // It takes: inception <current_level> <max_level> <kernel_path> <image_cache_path>
+    // Starting from level 2 (L1 is already running), going to total_levels
+    let inception_cmd = format!(
+        "inception 2 {} {} {}",
+        total_levels, kernel_str, image_cache_path
+    );
 
     println!(
         "\n[Levels 2-{}] Starting nested inception chain from Level 1...",
@@ -864,16 +967,17 @@ fcvm podman run \
         total_levels - 1
     );
 
+    // Run in container (default, no --vm) because the inception script is in the container
     let output = tokio::process::Command::new(&fcvm_path)
         .args([
             "exec",
             "--pid",
             &pid1.to_string(),
-            "--vm",
+            // Default is container exec (no --vm flag)
             "--",
             "sh",
             "-c",
-            &nested_cmd,
+            &inception_cmd,
         ])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -938,12 +1042,70 @@ fcvm podman run \
     }
 }
 
-/// Test 4 levels of nested VMs (inception chain)
+/// Test L1→L2 inception: run fcvm inside L1 to start L2
 ///
-/// Requires VHE mode in guest (HAS_EL2 without HAS_EL2_E2H0).
+/// L1: Host starts VM with localhost/inception-test + inception kernel
+/// L2: L1 container imports image from shared cache, then runs fcvm
 #[tokio::test]
-async fn test_inception_chain_4_levels() -> Result<()> {
-    run_inception_chain(4).await
+async fn test_inception_l2() -> Result<()> {
+    ensure_inception_image().await?;
+    let inception_kernel = ensure_inception_kernel().await?;
+    let kernel_str = inception_kernel.to_str().context("kernel path not valid UTF-8")?;
+
+    // Get the digest of localhost/inception-test so L2 can import from shared cache
+    let digest_out = tokio::process::Command::new("podman")
+        .args(["inspect", "localhost/inception-test", "--format", "{{.Digest}}"])
+        .output()
+        .await?;
+    let digest = String::from_utf8_lossy(&digest_out.stdout).trim().to_string();
+    println!("Image digest: {}", digest);
+
+    // For L1→L2, just write a simple script that does both steps:
+    // 1. Import image from shared cache
+    // 2. Run fcvm with --cmd to echo the marker
+    let l1_script = format!(r#"#!/bin/bash
+set -ex
+echo "L1: Importing image from shared cache..."
+skopeo copy dir:/mnt/fcvm-btrfs/image-cache/{} containers-storage:localhost/inception-test
+echo "L1: Starting L2 VM..."
+fcvm podman run --name l2 --network bridged --privileged localhost/inception-test --cmd "echo MARKER_L2_OK_12345"
+"#, digest);
+
+    let script_path = "/mnt/fcvm-btrfs/l1-inception.sh";
+    tokio::fs::write(script_path, &l1_script).await?;
+    tokio::process::Command::new("chmod")
+        .args(["+x", script_path])
+        .status()
+        .await?;
+    println!("Wrote L1 script to {}", script_path);
+
+    // Run L1 with --cmd that executes the script
+    let output = tokio::process::Command::new("sudo")
+        .args([
+            "./target/release/fcvm",
+            "podman", "run",
+            "--name", "l1-inception",
+            "--network", "bridged",
+            "--privileged",
+            "--kernel", kernel_str,
+            "--map", "/mnt/fcvm-btrfs:/mnt/fcvm-btrfs",
+            "localhost/inception-test",
+            "--cmd", "/mnt/fcvm-btrfs/l1-inception.sh",
+        ])
+        .output()
+        .await?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    println!("stdout: {}", stdout);
+    println!("stderr: {}", stderr);
+
+    // Look for the marker in stderr where container output appears
+    assert!(
+        stderr.contains("MARKER_L2_OK_12345"),
+        "L2 VM should run inside L1 and echo the marker. Check stderr above."
+    );
+    Ok(())
 }
 
 /// Test 32 levels of nested VMs (deep inception chain)
@@ -962,4 +1124,199 @@ async fn test_inception_chain_32_levels() -> Result<()> {
 #[ignore]
 async fn test_inception_chain_64_levels() -> Result<()> {
     run_inception_chain(64).await
+}
+
+/// Test skopeo import performance over FUSE (localhost/inception-test)
+///
+/// Measures how long it takes to import the full inception container image
+/// inside a VM when the image layers are accessed over FUSE-over-vsock.
+#[tokio::test]
+async fn test_skopeo_import_over_fuse() -> Result<()> {
+    println!("\nSkopeo Over FUSE Performance Test");
+    println!("==================================\n");
+
+    // 1. Ensure localhost/inception-test exists
+    println!("1. Ensuring localhost/inception-test exists...");
+    ensure_inception_image().await?;
+    println!("   ✓ Image ready");
+
+    // 2. Get image digest and export to CAS cache
+    println!("2. Getting image digest...");
+    let digest_output = tokio::process::Command::new("podman")
+        .args(["inspect", "localhost/inception-test", "--format", "{{.Digest}}"])
+        .output()
+        .await?;
+    let digest = String::from_utf8_lossy(&digest_output.stdout).trim().to_string();
+
+    if digest.is_empty() || !digest.starts_with("sha256:") {
+        bail!("Invalid digest: {}", digest);
+    }
+
+    let cache_dir = format!("/mnt/fcvm-btrfs/image-cache/{}", digest);
+    println!("   Digest: {}", &digest[..19]);
+
+    // Get image size
+    let size_output = tokio::process::Command::new("podman")
+        .args(["images", "localhost/inception-test", "--format", "{{.Size}}"])
+        .output()
+        .await?;
+    let size = String::from_utf8_lossy(&size_output.stdout).trim().to_string();
+    println!("   Size: {}", size);
+
+    // Check if already in CAS cache
+    if !std::path::Path::new(&cache_dir).exists() {
+        println!("   Exporting to CAS cache...");
+        tokio::process::Command::new("sudo")
+            .args(["mkdir", "-p", &cache_dir])
+            .output()
+            .await?;
+
+        let export_output = tokio::process::Command::new("sudo")
+            .args([
+                "skopeo",
+                "copy",
+                "containers-storage:localhost/inception-test",
+                &format!("dir:{}", cache_dir),
+            ])
+            .output()
+            .await?;
+
+        if !export_output.status.success() {
+            let stderr = String::from_utf8_lossy(&export_output.stderr);
+            bail!("Failed to export to CAS: {}", stderr);
+        }
+        println!("   ✓ Exported to CAS cache");
+    } else {
+        println!("   ✓ Already in CAS cache");
+    }
+
+    // 3. Start L1 VM with FUSE mount
+    println!("3. Starting L1 VM with FUSE mount...");
+
+    let inception_kernel = ensure_inception_kernel().await?;
+    let kernel_str = inception_kernel.to_str().context("kernel path not valid UTF-8")?;
+
+    let (vm_name, _, _, _) = common::unique_names("fuse-large");
+    let fcvm_path = common::find_fcvm_binary()?;
+
+    let (mut _child, vm_pid) = common::spawn_fcvm(&[
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--network",
+        "bridged",
+        "--kernel",
+        kernel_str,
+        "--privileged",
+        "--map",
+        "/mnt/fcvm-btrfs:/mnt/fcvm-btrfs",
+        common::TEST_IMAGE,
+    ])
+    .await
+    .context("spawning VM")?;
+
+    println!("   VM started (PID: {})", vm_pid);
+    println!("   Waiting for VM to be healthy...");
+
+    if let Err(e) = common::poll_health_by_pid(vm_pid, 120).await {
+        common::kill_process(vm_pid).await;
+        return Err(e.context("VM failed to become healthy"));
+    }
+    println!("   ✓ VM is healthy");
+
+    // 4. Time the skopeo import inside the VM
+    println!("\n4. Timing skopeo import inside VM...");
+    println!("   Source: {}", cache_dir);
+    println!("   Image size: {}", size);
+
+    let start = std::time::Instant::now();
+
+    let import_cmd = format!(
+        "time skopeo copy dir:{} containers-storage:localhost/imported 2>&1",
+        cache_dir
+    );
+
+    let import_output = tokio::process::Command::new(&fcvm_path)
+        .args([
+            "exec",
+            "--pid",
+            &vm_pid.to_string(),
+            "--vm",
+            "--",
+            "sh",
+            "-c",
+            &import_cmd,
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await?;
+
+    let elapsed = start.elapsed();
+
+    let stdout = String::from_utf8_lossy(&import_output.stdout);
+    println!("\n   Output:\n   {}", stdout.trim().replace('\n', "\n   "));
+
+    // 5. Verify the image was imported
+    println!("\n5. Verifying image was imported...");
+    let verify_output = tokio::process::Command::new(&fcvm_path)
+        .args([
+            "exec",
+            "--pid",
+            &vm_pid.to_string(),
+            "--vm",
+            "--",
+            "podman",
+            "images",
+            "localhost/imported",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await?;
+
+    let verify_stdout = String::from_utf8_lossy(&verify_output.stdout);
+    println!("   {}", verify_stdout.trim().replace('\n', "\n   "));
+
+    if !verify_stdout.contains("localhost/imported") {
+        common::kill_process(vm_pid).await;
+        bail!("Image was not imported correctly");
+    }
+    println!("   ✓ Image imported!");
+
+    // 6. Clean up
+    println!("\n6. Cleaning up...");
+    common::kill_process(vm_pid).await;
+
+    // 7. Report results
+    println!("\n==========================================");
+    println!("RESULT: {} image import over FUSE took {:?}", size, elapsed);
+    println!("==========================================");
+
+    // Calculate throughput
+    let size_mb: f64 = if size.contains("MB") {
+        size.replace(" MB", "").parse().unwrap_or(0.0)
+    } else if size.contains("GB") {
+        size.replace(" GB", "").parse::<f64>().unwrap_or(0.0) * 1024.0
+    } else {
+        0.0
+    };
+
+    if size_mb > 0.0 && elapsed.as_secs_f64() > 0.0 {
+        let throughput = size_mb / elapsed.as_secs_f64();
+        println!("Throughput: {:.1} MB/s", throughput);
+    }
+
+    if elapsed.as_secs() > 300 {
+        println!("\n⚠️  Import is VERY SLOW (>5min) - need optimization");
+    } else if elapsed.as_secs() > 60 {
+        println!("\n⚠️  Import is SLOW (>60s) - consider optimization");
+    } else if elapsed.as_secs() > 10 {
+        println!("\n⚠️  Import is MODERATE (10-60s)");
+    } else {
+        println!("\n✓ Import is FAST (<10s)");
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary

Enable ARM64 FEAT_NV2 nested virtualization with VHE mode, allowing fcvm to run recursively inside itself (inception). This PR enables:

- **L1 nesting**: Host → L1 VM with full KVM support
- **L2 nesting**: L1 → L2 via shared FUSE storage
- **L3+ tests**: Documented but blocked by FUSE chain latency

## What Works

- **L1→L2 inception test passes** (`test_inception_l2`): Host spawns L1, L1 spawns L2, L2 echoes marker
- **Shared storage via FUSE-over-vsock**: L2 imports container image from L1's FUSE mount
- **Recursive KVM**: L1 kernel sees `KVM_CAP_ARM_EL2=1` via MMFR4 override

## What Doesn't Work Yet

- **L3+ inception blocked by FUSE latency**: 3-hop FUSE chain causes ~3-5 second latency per request
- Root cause: PassthroughFs + `spawn_blocking` serialization at each hop
- FUSE mount initialization alone takes 10+ minutes at L3
- Tests added but `#[ignore]`d pending async PassthroughFs implementation

## The ID Register Problem (Solved)

When running fcvm inside an fcvm VM, the L1 guest's KVM initially reported `KVM_CAP_ARM_EL2=0`.

**Root cause:** Virtual EL2 reads ID registers directly from hardware.

1. Host KVM properly emulates ID registers - sets `MMFR4.NV_frac=NV2_ONLY`
2. `HCR_EL2.TID3` traps ID register reads - but **only for EL1 reads**
3. Virtual EL2 accesses bypass TID3 and read hardware directly
4. Guest sees `MMFR4=0` (hardware) instead of emulated value

**Solution:** Use kernel's ID register override mechanism with `arm64.nv2` boot parameter.

## Commits

1. **VHE mode for Firecracker** (`81a817d`) - Boot guest in VHE mode with HAS_EL2 feature

2. **Document ID register limitation** (`4c0a086`) - Why L1 sees MMFR4=0

3. **Enable recursive nesting** (`bc115b0`) - Kernel patch for MMFR4 override

4. **Document complex PR format** (`04bbb00`) - Update CLAUDE.md

5. **L1→L2 inception test working** (`40934a2`) - test_inception_l2 passes

6. **Add L3/L4 tests and FUSE diagnostics** (`647101f`)
   - Add test_inception_l3/l4 with `#[ignore]` and explanatory comments
   - Add request count logging to fuse-pipe for debugging
   - Add detailed socket error logging with error type/kind

## Files Changed

- `kernel/patches/mmfr4-override.patch` - MMFR4 override with FTR_HIGHER_SAFE
- `kernel/build.sh` - Build 6.18 kernel with patch
- `src/commands/podman.rs` - VHE boot args
- `tests/test_kvm.rs` - L2/L3/L4 inception tests
- `fuse-pipe/src/client/multiplexer.rs` - Request logging and error details
- `fuse-pipe/src/server/pipelined.rs` - Request count logging
- `src/storage/disk.rs` - Document FUSE_REMAP_FILE_RANGE requirement

## Test Results

```
# L1→L2 test passes:
$ cargo test test_inception_l2 --release
test test_inception_l2 ... ok

# L3 blocked by FUSE latency (documented, test ignored):
# Each L3 FUSE request takes 3-5 seconds through 3-hop chain
```

## Test Plan

- [x] L1 VM boots with VHE mode
- [x] MMFR4 override applied: `forced to 2`
- [x] KVM_CAP_ARM_EL2=1 in L1
- [x] test_inception_l2 passes
- [ ] test_inception_l3 (blocked by FUSE latency, needs async PassthroughFs)