### PR TITLE
Enable nested virtualization with performance benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "exec-proto"
+version = "0.1.0"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +577,7 @@ name = "fc-agent"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "exec-proto",
  "fs2",
  "fuse-pipe",
  "libc",
@@ -594,6 +599,7 @@ dependencies = [
  "clap_complete",
  "criterion",
  "directories",
+ "exec-proto",
  "fs2",
  "fuse-pipe",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
-members = [".", "fuse-pipe", "fc-agent"]
+members = [".", "fuse-pipe", "fc-agent", "exec-proto"]
 # Build all members by default (not just the root package)
-default-members = [".", "fuse-pipe", "fc-agent"]
+default-members = [".", "fuse-pipe", "fc-agent", "exec-proto"]
 # Exclude sync-test (used only for Makefile sync verification)
 exclude = ["sync-test"]
 # Resolver v2 makes --no-default-features work across all workspace members
@@ -52,7 +52,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tracing-log = "0.2"  # Bridge log crate to tracing (for fuse-backend-rs)
 libc = "0.2"
-nix = { version = "0.29", features = ["sched", "net", "fs", "user", "mount", "signal"] }
+nix = { version = "0.29", features = ["sched", "net", "fs", "user", "mount", "signal", "term"] }
 chrono = { version = "0.4", features = ["serde"] }
 tempfile = "3"
 rand = "0.8"
@@ -65,6 +65,7 @@ memmap2 = "0.9"
 vmm-sys-util = "0.12"
 shell-words = "1"
 fuse-pipe = { path = "fuse-pipe", default-features = false }
+exec-proto = { path = "exec-proto" }
 url = "2"
 tokio-util = "0.7"
 regex = "1.12.2"

--- a/Containerfile.inception
+++ b/Containerfile.inception
@@ -1,0 +1,53 @@
+# Inception test container - self-contained with fcvm, fc-agent, firecracker
+#
+# Uses Ubuntu 24.04 to match host glibc (2.39).
+#
+# Build:
+#   cp target/release/fcvm target/release/fc-agent artifacts/
+#   cp /usr/local/bin/firecracker artifacts/firecracker-nv2
+#   sudo podman build -t localhost/inception-test -f Containerfile.inception .
+#
+# The inception test is driven by test_inception_chain.rs which:
+# 1. Runs L1 with --cmd "sleep infinity"
+# 2. Execs into L1's container to verify KVM works
+# 3. Execs into L1's container to start L2
+# 4. Repeats for each level
+
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    iproute2 iptables podman skopeo python3 kmod procps fuse3 curl nginx \
+    fuse-overlayfs sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure podman to use fuse-overlayfs (required for nested containers)
+# Must set runroot/graphroot explicitly for nested container environments
+RUN mkdir -p /etc/containers /var/lib/containers/storage && \
+    printf '%s\n' \
+        '[storage]' \
+        'driver = "overlay"' \
+        'runroot = "/run/containers/storage"' \
+        'graphroot = "/var/lib/containers/storage"' \
+        '[storage.options.overlay]' \
+        'mount_program = "/usr/bin/fuse-overlayfs"' \
+        > /etc/containers/storage.conf
+
+# Copy pre-built binaries (host glibc 2.39 matches ubuntu:24.04)
+COPY artifacts/fcvm artifacts/fc-agent /usr/local/bin/
+COPY artifacts/firecracker-nv2 /usr/local/bin/firecracker
+RUN chmod +x /usr/local/bin/fcvm /usr/local/bin/fc-agent /usr/local/bin/firecracker
+
+# Copy config file for nested fcvm (uses same paths as host via FUSE mount)
+RUN mkdir -p /etc/fcvm
+COPY rootfs-config.toml /etc/fcvm/rootfs-config.toml
+
+# Recursive inception script: /usr/local/bin/inception
+# Usage: inception <current_level> <max_level> <kernel_path> <image_cache_path>
+# When current == max, echoes success marker. Otherwise starts nested VM.
+COPY inception.sh /usr/local/bin/inception
+RUN chmod +x /usr/local/bin/inception
+
+# Default command - create runtime dirs, start nginx (for health checks), and sleep
+# /run/netns is needed for ip netns (bridged networking)
+# /run/containers/storage is needed for podman
+CMD ["sh", "-c", "mkdir -p /run/netns /run/containers/storage && nginx && sleep infinity"]

--- a/Makefile
+++ b/Makefile
@@ -229,14 +229,14 @@ _setup-fcvm:
 	./target/release/fcvm setup
 
 # Inception test setup - builds container with matching CAS chain
-# Ensures: bin/fc-agent == target/release/fc-agent, initrd SHA matches, container cached
+# Ensures: artifacts/fc-agent == target/release/fc-agent, initrd SHA matches, container cached
 setup-inception: setup-fcvm
 	@echo "==> Setting up inception test container..."
-	@echo "==> Copying binaries to bin/..."
-	mkdir -p bin
-	cp target/release/fcvm bin/
-	cp target/$(MUSL_TARGET)/release/fc-agent bin/
-	cp /usr/local/bin/firecracker firecracker-nv2 2>/dev/null || true
+	@echo "==> Copying binaries to artifacts/..."
+	mkdir -p artifacts
+	cp target/release/fcvm artifacts/
+	cp target/$(MUSL_TARGET)/release/fc-agent artifacts/
+	cp /usr/local/bin/firecracker artifacts/firecracker-nv2 2>/dev/null || true
 	@echo "==> Building inception-test container..."
 	podman rmi localhost/inception-test 2>/dev/null || true
 	podman build -t localhost/inception-test -f Containerfile.inception .
@@ -251,7 +251,7 @@ setup-inception: setup-fcvm
 		sudo skopeo copy containers-storage:localhost/inception-test "dir:$$CACHE_DIR"; \
 	fi
 	@echo "==> Verification..."
-	@echo "fc-agent SHA: $$(sha256sum bin/fc-agent | cut -c1-12)"
+	@echo "fc-agent SHA: $$(sha256sum artifacts/fc-agent | cut -c1-12)"
 	@echo "Container fc-agent SHA: $$(podman run --rm localhost/inception-test sha256sum /usr/local/bin/fc-agent | cut -c1-12)"
 	@echo "Initrd: $$(ls -1 /mnt/fcvm-btrfs/initrd/fc-agent-*.initrd | tail -1)"
 	@DIGEST=$$(podman inspect localhost/inception-test --format '{{.Digest}}'); \

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ CONTAINER_RUN := podman run --rm --privileged \
 	_test-unit _test-fast _test-all _test-root \
 	container-build container-test container-test-unit container-test-fast container-test-all \
 	container-shell container-clean setup-btrfs setup-fcvm setup-pjdfstest bench lint fmt \
-	rebuild-fc dev-fc-test
+	rebuild-fc dev-fc-test inception-vm inception-exec inception-wait-exec inception-stop inception-status
 
 all: build
 
@@ -266,3 +266,144 @@ dev-fc-test: rebuild-fc build
 	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E' \
 	RUST_LOG=debug \
 	$(NEXTEST) $(NEXTEST_CAPTURE) --features privileged-tests $(FILTER)
+
+# =============================================================================
+# Inception VM development targets
+# =============================================================================
+# These targets manage a SINGLE inception VM for debugging.
+# Only ONE VM can exist at a time - inception-vm kills any existing VM first.
+
+# Find the inception kernel (latest vmlinux-*.bin with KVM support)
+INCEPTION_KERNEL := $(shell ls -t /mnt/fcvm-btrfs/kernels/vmlinux-*.bin 2>/dev/null | head -1)
+INCEPTION_VM_NAME := inception-dev
+INCEPTION_VM_LOG := /tmp/inception-vm.log
+INCEPTION_VM_PID := /tmp/inception-vm.pid
+
+# Start an inception VM (kills any existing VM first)
+# Usage: make inception-vm
+inception-vm: build
+	@echo "==> Ensuring clean environment (killing ALL existing VMs)..."
+	@sudo pkill -9 firecracker 2>/dev/null || true
+	@sudo pkill -9 -f "fcvm podman" 2>/dev/null || true
+	@sleep 2
+	@if pgrep firecracker >/dev/null 2>&1; then \
+		echo "ERROR: Could not kill existing firecracker"; \
+		exit 1; \
+	fi
+	@sudo rm -f $(INCEPTION_VM_PID) $(INCEPTION_VM_LOG)
+	@sudo rm -rf /mnt/fcvm-btrfs/state/vm-*.json
+	@if [ -z "$(INCEPTION_KERNEL)" ]; then \
+		echo "ERROR: No inception kernel found. Run ./kernel/build.sh first."; \
+		exit 1; \
+	fi
+	@echo "==> Starting SINGLE inception VM"
+	@echo "==> Kernel: $(INCEPTION_KERNEL)"
+	@echo "==> Log: $(INCEPTION_VM_LOG)"
+	@echo "==> Use 'make inception-exec CMD=...' to run commands"
+	@echo "==> Use 'make inception-stop' to stop"
+	@sudo ./target/release/fcvm podman run \
+		--name $(INCEPTION_VM_NAME) \
+		--network bridged \
+		--kernel $(INCEPTION_KERNEL) \
+		--privileged \
+		--map /mnt/fcvm-btrfs:/mnt/fcvm-btrfs \
+		--cmd "sleep infinity" \
+		alpine:latest > $(INCEPTION_VM_LOG) 2>&1 & \
+	sleep 2; \
+	FCVM_PID=$$(pgrep -n -f "fcvm podman run.*$(INCEPTION_VM_NAME)"); \
+	echo "$$FCVM_PID" | sudo tee $(INCEPTION_VM_PID) > /dev/null; \
+	echo "==> VM started with fcvm PID $$FCVM_PID"; \
+	echo "==> Waiting for boot..."; \
+	sleep 20; \
+	FC_COUNT=$$(pgrep -c firecracker || echo 0); \
+	if [ "$$FC_COUNT" -ne 1 ]; then \
+		echo "ERROR: Expected 1 firecracker, got $$FC_COUNT"; \
+		exit 1; \
+	fi; \
+	echo "==> VM ready. Tailing log (Ctrl+C to stop tail, VM keeps running):"; \
+	tail -f $(INCEPTION_VM_LOG)
+
+# Run a command inside the running inception VM
+# Usage: make inception-exec CMD="ls -la /dev/kvm"
+# Usage: make inception-exec CMD="/mnt/fcvm-btrfs/check_kvm_caps"
+CMD ?= uname -a
+inception-exec:
+	@if [ ! -f $(INCEPTION_VM_PID) ]; then \
+		echo "ERROR: No PID file found at $(INCEPTION_VM_PID)"; \
+		echo "Start a VM with 'make inception-vm' first."; \
+		exit 1; \
+	fi; \
+	PID=$$(cat $(INCEPTION_VM_PID)); \
+	if ! kill -0 $$PID 2>/dev/null; then \
+		echo "ERROR: VM process $$PID is not running"; \
+		echo "Start a VM with 'make inception-vm' first."; \
+		rm -f $(INCEPTION_VM_PID); \
+		exit 1; \
+	fi; \
+	echo "==> Running in VM (PID $$PID): $(CMD)"; \
+	sudo ./target/release/fcvm exec --pid $$PID -- $(CMD)
+
+# Wait for VM to be ready and then run a command
+# Usage: make inception-wait-exec CMD="/mnt/fcvm-btrfs/check_kvm_caps"
+inception-wait-exec: build
+	@echo "==> Waiting for inception VM to be ready..."
+	@if [ ! -f $(INCEPTION_VM_PID) ]; then \
+		echo "ERROR: No PID file found. Start a VM with 'make inception-vm &' first."; \
+		exit 1; \
+	fi; \
+	PID=$$(cat $(INCEPTION_VM_PID)); \
+	for i in $$(seq 1 30); do \
+		if ! kill -0 $$PID 2>/dev/null; then \
+			echo "ERROR: VM process $$PID exited"; \
+			rm -f $(INCEPTION_VM_PID); \
+			exit 1; \
+		fi; \
+		if sudo ./target/release/fcvm exec --pid $$PID -- true 2>/dev/null; then \
+			echo "==> VM ready (PID $$PID)"; \
+			echo "==> Running: $(CMD)"; \
+			sudo ./target/release/fcvm exec --pid $$PID -- $(CMD); \
+			exit 0; \
+		fi; \
+		sleep 2; \
+		echo "  Waiting... ($$i/30)"; \
+	done; \
+	echo "ERROR: Timeout waiting for VM to be ready"; \
+	exit 1
+
+# Stop the inception VM
+inception-stop:
+	@if [ -f $(INCEPTION_VM_PID) ]; then \
+		PID=$$(cat $(INCEPTION_VM_PID)); \
+		if kill -0 $$PID 2>/dev/null; then \
+			echo "==> Stopping VM (PID $$PID)..."; \
+			sudo kill $$PID 2>/dev/null || true; \
+			sleep 1; \
+			if kill -0 $$PID 2>/dev/null; then \
+				echo "==> Force killing..."; \
+				sudo kill -9 $$PID 2>/dev/null || true; \
+			fi; \
+			echo "==> VM stopped."; \
+		else \
+			echo "==> VM process $$PID not running (stale PID file)"; \
+		fi; \
+		rm -f $(INCEPTION_VM_PID); \
+	else \
+		echo "==> No PID file found. No VM to stop."; \
+	fi
+
+# Show VM status
+inception-status:
+	@echo "=== Inception VM Status ==="
+	@if [ -f $(INCEPTION_VM_PID) ]; then \
+		PID=$$(cat $(INCEPTION_VM_PID)); \
+		if kill -0 $$PID 2>/dev/null; then \
+			echo "VM PID: $$PID (running)"; \
+			ps -p $$PID -o pid,ppid,user,%cpu,%mem,etime,cmd --no-headers 2>/dev/null || true; \
+		else \
+			echo "VM PID: $$PID (NOT running - stale PID file)"; \
+			rm -f $(INCEPTION_VM_PID); \
+		fi; \
+	else \
+		echo "No PID file found at $(INCEPTION_VM_PID)"; \
+		echo "No VM running."; \
+	fi

--- a/exec-proto/Cargo.toml
+++ b/exec-proto/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "exec-proto"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/exec-proto/src/lib.rs
+++ b/exec-proto/src/lib.rs
@@ -1,0 +1,268 @@
+//! Length-prefixed binary protocol for TTY exec
+//!
+//! Wire format:
+//!   [1-byte type][4-byte length (big-endian)][payload]
+//!
+//! Message types:
+//!   0x01 DATA  - raw PTY output (payload = bytes)
+//!   0x02 EXIT  - process exit (payload = 4-byte i32 exit code)
+//!   0x03 ERROR - error message (payload = UTF-8 string)
+//!   0x04 STDIN - input to PTY from host (payload = bytes)
+//!
+//! This protocol is used for TTY mode exec to cleanly separate
+//! control messages (exit code) from raw terminal data.
+
+use std::io::{self, Read, Write};
+
+/// Message types for the TTY exec protocol
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageType {
+    Data = 0x01,
+    Exit = 0x02,
+    ErrorMsg = 0x03,
+    Stdin = 0x04,
+}
+
+impl MessageType {
+    fn from_u8(value: u8) -> io::Result<Self> {
+        Self::from_u8_opt(value).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unknown message type: {:#x}", value),
+            )
+        })
+    }
+
+    /// Parse message type from byte, returning None for unknown types
+    pub fn from_u8_opt(value: u8) -> Option<Self> {
+        match value {
+            0x01 => Some(MessageType::Data),
+            0x02 => Some(MessageType::Exit),
+            0x03 => Some(MessageType::ErrorMsg),
+            0x04 => Some(MessageType::Stdin),
+            _ => None,
+        }
+    }
+}
+
+/// A message in the TTY exec protocol
+#[derive(Debug, Clone)]
+pub enum Message {
+    /// Raw terminal output data
+    Data(Vec<u8>),
+    /// Process exit code
+    Exit(i32),
+    /// Error message
+    Error(String),
+    /// Input data from host to PTY
+    Stdin(Vec<u8>),
+}
+
+impl Message {
+    /// Write a message to a writer using the binary protocol
+    pub fn write_to<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        match self {
+            Message::Data(data) => {
+                writer.write_all(&[MessageType::Data as u8])?;
+                writer.write_all(&(data.len() as u32).to_be_bytes())?;
+                writer.write_all(data)?;
+            }
+            Message::Exit(code) => {
+                writer.write_all(&[MessageType::Exit as u8])?;
+                writer.write_all(&4u32.to_be_bytes())?;
+                writer.write_all(&code.to_be_bytes())?;
+            }
+            Message::Error(msg) => {
+                let bytes = msg.as_bytes();
+                writer.write_all(&[MessageType::ErrorMsg as u8])?;
+                writer.write_all(&(bytes.len() as u32).to_be_bytes())?;
+                writer.write_all(bytes)?;
+            }
+            Message::Stdin(data) => {
+                writer.write_all(&[MessageType::Stdin as u8])?;
+                writer.write_all(&(data.len() as u32).to_be_bytes())?;
+                writer.write_all(data)?;
+            }
+        }
+        writer.flush()
+    }
+
+    /// Read a message from a reader using the binary protocol
+    pub fn read_from<R: Read>(reader: &mut R) -> io::Result<Self> {
+        // Read type byte
+        let mut type_buf = [0u8; 1];
+        reader.read_exact(&mut type_buf)?;
+        let msg_type = MessageType::from_u8(type_buf[0])?;
+
+        // Read length (4 bytes big-endian)
+        let mut len_buf = [0u8; 4];
+        reader.read_exact(&mut len_buf)?;
+        let len = u32::from_be_bytes(len_buf) as usize;
+
+        // Sanity check: limit message size to 16MB
+        if len > 16 * 1024 * 1024 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("message too large: {} bytes", len),
+            ));
+        }
+
+        // Read payload
+        let mut payload = vec![0u8; len];
+        reader.read_exact(&mut payload)?;
+
+        // Parse based on type
+        match msg_type {
+            MessageType::Data => Ok(Message::Data(payload)),
+            MessageType::Exit => {
+                if payload.len() != 4 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "exit message must have 4-byte payload",
+                    ));
+                }
+                let code = i32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]);
+                Ok(Message::Exit(code))
+            }
+            MessageType::ErrorMsg => {
+                let msg = String::from_utf8(payload).map_err(|e| {
+                    io::Error::new(io::ErrorKind::InvalidData, format!("invalid UTF-8: {}", e))
+                })?;
+                Ok(Message::Error(msg))
+            }
+            MessageType::Stdin => Ok(Message::Stdin(payload)),
+        }
+    }
+}
+
+/// Write a Data message directly (convenience function for high-frequency writes)
+pub fn write_data<W: Write>(writer: &mut W, data: &[u8]) -> io::Result<()> {
+    writer.write_all(&[MessageType::Data as u8])?;
+    writer.write_all(&(data.len() as u32).to_be_bytes())?;
+    writer.write_all(data)?;
+    writer.flush()
+}
+
+/// Write an Exit message directly
+pub fn write_exit<W: Write>(writer: &mut W, code: i32) -> io::Result<()> {
+    writer.write_all(&[MessageType::Exit as u8])?;
+    writer.write_all(&4u32.to_be_bytes())?;
+    writer.write_all(&code.to_be_bytes())?;
+    writer.flush()
+}
+
+/// Write an Error message directly
+pub fn write_error<W: Write>(writer: &mut W, msg: &str) -> io::Result<()> {
+    let bytes = msg.as_bytes();
+    writer.write_all(&[MessageType::ErrorMsg as u8])?;
+    writer.write_all(&(bytes.len() as u32).to_be_bytes())?;
+    writer.write_all(bytes)?;
+    writer.flush()
+}
+
+/// Write a Stdin message directly
+pub fn write_stdin<W: Write>(writer: &mut W, data: &[u8]) -> io::Result<()> {
+    writer.write_all(&[MessageType::Stdin as u8])?;
+    writer.write_all(&(data.len() as u32).to_be_bytes())?;
+    writer.write_all(data)?;
+    writer.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_data_roundtrip() {
+        let msg = Message::Data(b"hello world".to_vec());
+        let mut buf = Vec::new();
+        msg.write_to(&mut buf).unwrap();
+
+        let mut cursor = Cursor::new(buf);
+        let decoded = Message::read_from(&mut cursor).unwrap();
+
+        match decoded {
+            Message::Data(data) => assert_eq!(data, b"hello world"),
+            _ => panic!("wrong message type"),
+        }
+    }
+
+    #[test]
+    fn test_exit_roundtrip() {
+        let msg = Message::Exit(42);
+        let mut buf = Vec::new();
+        msg.write_to(&mut buf).unwrap();
+
+        let mut cursor = Cursor::new(buf);
+        let decoded = Message::read_from(&mut cursor).unwrap();
+
+        match decoded {
+            Message::Exit(code) => assert_eq!(code, 42),
+            _ => panic!("wrong message type"),
+        }
+    }
+
+    #[test]
+    fn test_negative_exit_code() {
+        let msg = Message::Exit(-1);
+        let mut buf = Vec::new();
+        msg.write_to(&mut buf).unwrap();
+
+        let mut cursor = Cursor::new(buf);
+        let decoded = Message::read_from(&mut cursor).unwrap();
+
+        match decoded {
+            Message::Exit(code) => assert_eq!(code, -1),
+            _ => panic!("wrong message type"),
+        }
+    }
+
+    #[test]
+    fn test_error_roundtrip() {
+        let msg = Message::Error("something went wrong".to_string());
+        let mut buf = Vec::new();
+        msg.write_to(&mut buf).unwrap();
+
+        let mut cursor = Cursor::new(buf);
+        let decoded = Message::read_from(&mut cursor).unwrap();
+
+        match decoded {
+            Message::Error(s) => assert_eq!(s, "something went wrong"),
+            _ => panic!("wrong message type"),
+        }
+    }
+
+    #[test]
+    fn test_stdin_roundtrip() {
+        let msg = Message::Stdin(b"user input".to_vec());
+        let mut buf = Vec::new();
+        msg.write_to(&mut buf).unwrap();
+
+        let mut cursor = Cursor::new(buf);
+        let decoded = Message::read_from(&mut cursor).unwrap();
+
+        match decoded {
+            Message::Stdin(data) => assert_eq!(data, b"user input"),
+            _ => panic!("wrong message type"),
+        }
+    }
+
+    #[test]
+    fn test_binary_data() {
+        // Test with binary data including null bytes and escape sequences
+        let binary = vec![0x00, 0x01, 0x1b, 0x5b, 0x31, 0x6d, 0xff];
+        let msg = Message::Data(binary.clone());
+        let mut buf = Vec::new();
+        msg.write_to(&mut buf).unwrap();
+
+        let mut cursor = Cursor::new(buf);
+        let decoded = Message::read_from(&mut cursor).unwrap();
+
+        match decoded {
+            Message::Data(data) => assert_eq!(data, binary),
+            _ => panic!("wrong message type"),
+        }
+    }
+}

--- a/fc-agent/Cargo.toml
+++ b/fc-agent/Cargo.toml
@@ -12,4 +12,5 @@ reqwest = { version = "0.11", default-features = false, features = ["json"] }
 libc = "0.2"
 fs2 = "0.4"
 fuse-pipe = { path = "../fuse-pipe", default-features = false }
+exec-proto = { path = "../exec-proto" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/fc-agent/src/main.rs
+++ b/fc-agent/src/main.rs
@@ -675,8 +675,9 @@ async fn run_exec_server() {
         return;
     }
 
-    // Start listening
-    let listen_result = unsafe { libc::listen(listener_fd, 5) };
+    // Start listening with larger backlog for parallel exec stress
+    // Default of 5 is too small when many execs arrive simultaneously
+    let listen_result = unsafe { libc::listen(listener_fd, 128) };
     if listen_result < 0 {
         eprintln!(
             "[fc-agent] ERROR: failed to listen on vsock: {}",

--- a/fuse-pipe/src/client/multiplexer.rs
+++ b/fuse-pipe/src/client/multiplexer.rs
@@ -204,7 +204,8 @@ impl Multiplexer {
                 collector.record(unique, op, s);
             } else {
                 // No collector - print trace directly
-                s.print(unique);
+                let op = op_name.as_deref().unwrap_or("unknown");
+                s.print(unique, op);
             }
         }
 

--- a/fuse-pipe/src/client/multiplexer.rs
+++ b/fuse-pipe/src/client/multiplexer.rs
@@ -228,12 +228,25 @@ fn writer_loop(
     request_rx: Receiver<PendingRequest>,
     pending: Arc<DashMap<u64, Sender<ResponsePayload>>>,
 ) {
+    let mut count = 0u64;
     while let Ok(req) = request_rx.recv() {
+        count += 1;
+        if count <= 10 || count.is_multiple_of(100) {
+            tracing::info!(target: "fuse-pipe::mux", count, pending_count = pending.len(), "writer: sent requests");
+        }
+
         // Register the response channel BEFORE writing (to avoid race)
         pending.insert(req.unique, req.response_tx);
 
         // Write to socket
-        if socket.write_all(&req.data).is_err() || socket.flush().is_err() {
+        let write_result = socket.write_all(&req.data);
+        let flush_result = if write_result.is_ok() {
+            socket.flush()
+        } else {
+            Ok(())
+        };
+        if let Err(e) = write_result.as_ref().and(flush_result.as_ref()) {
+            tracing::warn!(target: "fuse-pipe::mux", unique = req.unique, error = %e, error_kind = ?e.kind(), "writer: socket write failed");
             // Remove from pending and signal error
             if let Some((_, tx)) = pending.remove(&req.unique) {
                 let _ = tx.send((VolumeResponse::error(libc::EIO), None));
@@ -242,22 +255,26 @@ fn writer_loop(
         // Note: client_socket_write is marked by server_recv on the server side
         // since we can't update the span after serialization
     }
+    tracing::info!(target: "fuse-pipe::mux", count, "writer: exiting");
 }
 
 /// Reader thread: reads responses from socket, routes to waiting readers.
 fn reader_loop(mut socket: UnixStream, pending: Arc<DashMap<u64, Sender<ResponsePayload>>>) {
     let mut len_buf = [0u8; 4];
+    let mut count = 0u64;
 
     loop {
         // Read response length
         if socket.read_exact(&mut len_buf).is_err() {
             // Server disconnected - fail all pending requests
+            tracing::warn!(target: "fuse-pipe::mux", count, pending_count = pending.len(), "reader: socket read failed, disconnected");
             fail_all_pending(&pending);
             break;
         }
 
         let len = u32::from_be_bytes(len_buf) as usize;
         if len > MAX_MESSAGE_SIZE {
+            tracing::error!(target: "fuse-pipe::mux", len, "reader: oversized message");
             fail_all_pending(&pending);
             break;
         }
@@ -265,8 +282,14 @@ fn reader_loop(mut socket: UnixStream, pending: Arc<DashMap<u64, Sender<Response
         // Read response body
         let mut resp_buf = vec![0u8; len];
         if socket.read_exact(&mut resp_buf).is_err() {
+            tracing::warn!(target: "fuse-pipe::mux", count, "reader: failed to read response body");
             fail_all_pending(&pending);
             break;
+        }
+
+        count += 1;
+        if count <= 10 || count.is_multiple_of(100) {
+            tracing::info!(target: "fuse-pipe::mux", count, pending_count = pending.len(), "reader: received responses");
         }
 
         // Deserialize and route to waiting reader (lock-free lookup + remove)
@@ -282,6 +305,7 @@ fn reader_loop(mut socket: UnixStream, pending: Arc<DashMap<u64, Sender<Response
             }
         }
     }
+    tracing::info!(target: "fuse-pipe::mux", count, "reader: exiting");
 }
 
 /// Fail all pending requests on disconnect.

--- a/inception.sh
+++ b/inception.sh
@@ -46,7 +46,7 @@ NEXT=$((LEVEL + 1))
 # VM memory: reduce at each level to fit in parent's memory
 case $NEXT in
     1) READERS=64; MEM=2048 ;;
-    2) READERS=16; MEM=1024 ;;
+    2) READERS=64; MEM=1536 ;;
     3) READERS=8;  MEM=768 ;;
     *) READERS=4;  MEM=512 ;;
 esac

--- a/inception.sh
+++ b/inception.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# Recursive inception script for nested virtualization testing
+# Usage: inception <current_level> <max_level> <kernel_path> <image_cache_path>
+set -e
+
+LEVEL=$1
+MAX=$2
+KERNEL=$3
+IMAGE_CACHE=$4
+
+echo "[L${LEVEL}] Starting level ${LEVEL} of ${MAX} (CAS verified)"
+
+# Start nginx for health checks (this script overrides the default CMD)
+mkdir -p /run/netns /run/containers/storage
+nginx 2>/dev/null || true
+
+if [ "$LEVEL" -ge "$MAX" ]; then
+    echo "INCEPTION_CHAIN_${MAX}_LEVELS_SUCCESS"
+    exit 0
+fi
+
+# Setup for nested VM
+modprobe tun 2>/dev/null || true
+mkdir -p /dev/net
+mknod /dev/net/tun c 10 200 2>/dev/null || true
+chmod 666 /dev/net/tun 2>/dev/null || true
+
+# Import image if needed
+if [ -d "$IMAGE_CACHE" ] && ! podman image exists localhost/inception-test 2>/dev/null; then
+    echo "[L${LEVEL}] Importing inception image from $IMAGE_CACHE..."
+    echo "[L${LEVEL}] Checking cache dir contents..."
+    ls -la "$IMAGE_CACHE" 2>&1 || echo "[L${LEVEL}] Failed to list cache dir"
+    echo "[L${LEVEL}] Running skopeo..."
+    if ! skopeo copy "dir:$IMAGE_CACHE" containers-storage:localhost/inception-test 2>&1; then
+        echo "[L${LEVEL}] SKOPEO FAILED!"
+        exit 1
+    fi
+    echo "[L${LEVEL}] Import complete"
+fi
+
+# Calculate next level
+NEXT=$((LEVEL + 1))
+
+# Calculate resources for nested level to prevent OOM.
+# FUSE readers: memory per mount = readers × 8MB stack
+# VM memory: reduce at each level to fit in parent's memory
+case $NEXT in
+    1) READERS=64; MEM=2048 ;;
+    2) READERS=16; MEM=1024 ;;
+    3) READERS=8;  MEM=768 ;;
+    *) READERS=4;  MEM=512 ;;
+esac
+
+echo "[L${LEVEL}] Starting nested VM (L${NEXT}) with ${READERS} FUSE readers and ${MEM}MB RAM..."
+
+# fcvm now automatically puts sockets in /tmp/fcvm-sockets (local) and
+# disks in data_dir (FUSE). No loopback btrfs needed!
+FCVM_NV2=1 FCVM_FUSE_READERS=$READERS /usr/local/bin/fcvm podman run \
+    --name "inception-L${NEXT}-$$" \
+    --network bridged \
+    --kernel "$KERNEL" \
+    --privileged \
+    --mem "$MEM" \
+    --map /mnt/fcvm-btrfs:/mnt/fcvm-btrfs \
+    --map /root/.config/fcvm:/root/.config/fcvm:ro \
+    --cmd "inception $NEXT $MAX $KERNEL $IMAGE_CACHE" \
+    localhost/inception-test

--- a/kernel/patches/mmfr4-override.patch
+++ b/kernel/patches/mmfr4-override.patch
@@ -1,0 +1,126 @@
+diff --git a/arch/arm64/include/asm/cpufeature.h b/arch/arm64/include/asm/cpufeature.h
+index 1234567..abcdefg 100644
+--- a/arch/arm64/include/asm/cpufeature.h
++++ b/arch/arm64/include/asm/cpufeature.h
+@@ -961,6 +961,7 @@ extern struct arm64_ftr_override id_aa64isar2_override;
+ extern struct arm64_ftr_override id_aa64mmfr0_override;
+ extern struct arm64_ftr_override id_aa64mmfr1_override;
+ extern struct arm64_ftr_override id_aa64mmfr2_override;
++extern struct arm64_ftr_override id_aa64mmfr4_override;
+ extern struct arm64_ftr_override id_aa64pfr0_override;
+ extern struct arm64_ftr_override id_aa64pfr1_override;
+ extern struct arm64_ftr_override id_aa64smfr0_override;
+diff --git a/arch/arm64/kernel/cpufeature.c b/arch/arm64/kernel/cpufeature.c
+index c840a93..bd69b5a 100644
+--- a/arch/arm64/kernel/cpufeature.c
++++ b/arch/arm64/kernel/cpufeature.c
+@@ -500,8 +500,10 @@ static const struct arm64_ftr_bits ftr_id_aa64mmfr3[] = {
+ };
+
+ static const struct arm64_ftr_bits ftr_id_aa64mmfr4[] = {
+-	S_ARM64_FTR_BITS(FTR_HIDDEN, FTR_STRICT, FTR_LOWER_SAFE, ID_AA64MMFR4_EL1_E2H0_SHIFT, 4, 0),
+-	ARM64_FTR_BITS(FTR_HIDDEN, FTR_STRICT, FTR_LOWER_SAFE, ID_AA64MMFR4_EL1_NV_frac_SHIFT, 4, 0),
++	/* Use FTR_HIGHER_SAFE for E2H0 and NV_frac to allow upward overrides via arm64.nv2.
++	 * This enables recursive nested virtualization by faking NV2 support. */
++	S_ARM64_FTR_BITS(FTR_HIDDEN, FTR_STRICT, FTR_HIGHER_SAFE, ID_AA64MMFR4_EL1_E2H0_SHIFT, 4, 0),
++	ARM64_FTR_BITS(FTR_HIDDEN, FTR_STRICT, FTR_HIGHER_SAFE, ID_AA64MMFR4_EL1_NV_frac_SHIFT, 4, 0),
+ 	ARM64_FTR_END,
+ };
+
+@@ -776,6 +776,7 @@ static const struct arm64_ftr_bits ftr_raz[] = {
+ struct arm64_ftr_override __read_mostly id_aa64mmfr0_override;
+ struct arm64_ftr_override __read_mostly id_aa64mmfr1_override;
+ struct arm64_ftr_override __read_mostly id_aa64mmfr2_override;
++struct arm64_ftr_override __read_mostly id_aa64mmfr4_override;
+ struct arm64_ftr_override __read_mostly id_aa64pfr0_override;
+ struct arm64_ftr_override __read_mostly id_aa64pfr1_override;
+ struct arm64_ftr_override __read_mostly id_aa64zfr0_override;
+@@ -849,7 +850,8 @@ static const struct __ftr_reg_entry {
+ 	ARM64_FTR_REG_OVERRIDE(SYS_ID_AA64MMFR2_EL1, ftr_id_aa64mmfr2,
+ 			       &id_aa64mmfr2_override),
+ 	ARM64_FTR_REG(SYS_ID_AA64MMFR3_EL1, ftr_id_aa64mmfr3),
+-	ARM64_FTR_REG(SYS_ID_AA64MMFR4_EL1, ftr_id_aa64mmfr4),
++	ARM64_FTR_REG_OVERRIDE(SYS_ID_AA64MMFR4_EL1, ftr_id_aa64mmfr4,
++			       &id_aa64mmfr4_override),
+ 
+ 	/* Op1 = 0, CRn = 10, CRm = 4 */
+ 	ARM64_FTR_REG(SYS_MPAMIDR_EL1, ftr_mpamidr),
+diff --git a/arch/arm64/kernel/image-vars.h b/arch/arm64/kernel/image-vars.h
+index 85bc629..554a7b1 100644
+--- a/arch/arm64/kernel/image-vars.h
++++ b/arch/arm64/kernel/image-vars.h
+@@ -51,6 +51,7 @@ PI_EXPORT_SYM(id_aa64isar2_override);
+ PI_EXPORT_SYM(id_aa64mmfr0_override);
+ PI_EXPORT_SYM(id_aa64mmfr1_override);
+ PI_EXPORT_SYM(id_aa64mmfr2_override);
++PI_EXPORT_SYM(id_aa64mmfr4_override);
+ PI_EXPORT_SYM(id_aa64pfr0_override);
+ PI_EXPORT_SYM(id_aa64pfr1_override);
+ PI_EXPORT_SYM(id_aa64smfr0_override);
+diff --git a/arch/arm64/kernel/pi/idreg-override.c b/arch/arm64/kernel/pi/idreg-override.c
+index bc57b29..ef404ca 100644
+--- a/arch/arm64/kernel/pi/idreg-override.c
++++ b/arch/arm64/kernel/pi/idreg-override.c
+@@ -106,6 +106,16 @@ static const struct ftr_set_desc mmfr2 __prel64_initconst = {
+ 	},
+ };
+ 
++static const struct ftr_set_desc mmfr4 __prel64_initconst = {
++	.name		= "id_aa64mmfr4",
++	.override	= &id_aa64mmfr4_override,
++	.fields		= {
++		FIELD("nv_frac", ID_AA64MMFR4_EL1_NV_frac_SHIFT, NULL),
++		FIELD("e2h0", ID_AA64MMFR4_EL1_E2H0_SHIFT, NULL),
++		{}
++	},
++};
++
+ static bool __init pfr0_sve_filter(u64 val)
+ {
+ 	/*
+@@ -220,6 +230,7 @@ PREL64(const struct ftr_set_desc, reg) regs[] __prel64_initconst = {
+ 	{ &mmfr0	},
+ 	{ &mmfr1	},
+ 	{ &mmfr2	},
++	{ &mmfr4	},
+ 	{ &pfr0 	},
+ 	{ &pfr1 	},
+ 	{ &isar1	},
+@@ -249,6 +260,7 @@ static const struct {
+ 	{ "arm64.nolva",		"id_aa64mmfr2.varange=0" },
+ 	{ "arm64.no32bit_el0",		"id_aa64pfr0.el0=1" },
+ 	{ "arm64.nompam",		"id_aa64pfr0.mpam=0 id_aa64pfr1.mpam_frac=0" },
++	{ "arm64.nv2",			"id_aa64mmfr4.nv_frac=2" },
+ };
+ 
+ static int __init parse_hexdigit(const char *p, u64 *v)
+diff --git a/arch/arm64/kvm/nested.c b/arch/arm64/kvm/nested.c
+index cdeeb8f..df3ee34 100644
+--- a/arch/arm64/kvm/nested.c
++++ b/arch/arm64/kvm/nested.c
+@@ -1504,6 +1504,13 @@ u64 limit_nv_id_reg(struct kvm *kvm, u32 reg, u64 val)
+ {
+ 	u64 orig_val = val;
+ 
++	/* Debug: trace ID register modifications for NV2 */
++	if (reg == SYS_ID_AA64MMFR4_EL1 || reg == SYS_ID_AA64MMFR2_EL1) {
++		pr_info("[NV2-DEBUG] limit_nv_id_reg: reg=0x%x val=0x%llx E2H0=%d\n",
++			reg, val,
++			test_bit(KVM_ARM_VCPU_HAS_EL2_E2H0, kvm->arch.vcpu_features));
++	}
++
+ 	switch (reg) {
+ 	case SYS_ID_AA64ISAR0_EL1:
+ 		/* Support everything but TME */
+@@ -1636,9 +1643,11 @@ u64 limit_nv_id_reg(struct kvm *kvm, u32 reg, u64 val)
+ 		 */
+ 		if (test_bit(KVM_ARM_VCPU_HAS_EL2_E2H0, kvm->arch.vcpu_features)) {
+ 			val = 0;
++			pr_info("[NV2-DEBUG] MMFR4: E2H0 mode, val=0\n");
+ 		} else {
+ 			val = SYS_FIELD_PREP_ENUM(ID_AA64MMFR4_EL1, NV_frac, NV2_ONLY);
+ 			val |= SYS_FIELD_PREP_ENUM(ID_AA64MMFR4_EL1, E2H0, NI_NV1);
++			pr_info("[NV2-DEBUG] MMFR4: VHE mode, val=0x%llx (NV_frac=NV2_ONLY)\n", val);
+ 		}
+ 		break;
+ 

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -3,11 +3,16 @@
 //! Uses Firecracker's vsock to connect from host to guest.
 //! The guest (fc-agent) listens on vsock port 4998.
 //! The host connects via the vsock.sock Unix socket using the CONNECT protocol.
+//!
+//! TTY mode uses a length-prefixed binary protocol (see exec_proto.rs) to cleanly
+//! separate control messages from raw terminal data. Non-TTY mode continues to use
+//! JSON line protocol.
 
 use crate::cli::ExecArgs;
 use crate::paths;
 use crate::state::StateManager;
 use anyhow::{bail, Context, Result};
+use exec_proto;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
@@ -223,8 +228,10 @@ pub async fn cmd_exec(args: ExecArgs) -> Result<()> {
         );
     }
 
-    if tty {
-        run_tty_mode(stream)
+    // Use binary framing for any mode needing TTY or stdin forwarding
+    // JSON line mode only for plain non-interactive commands
+    if tty || interactive {
+        run_framed_mode(stream, tty, interactive)
     } else {
         run_line_mode(stream)
     }
@@ -275,121 +282,131 @@ fn run_line_mode(stream: UnixStream) -> Result<()> {
     Ok(())
 }
 
-/// Run in TTY mode with raw terminal
-fn run_tty_mode(stream: UnixStream) -> Result<()> {
+/// Run with binary framing protocol (for TTY and/or interactive modes)
+///
+/// Uses the binary framing protocol (exec_proto) to cleanly separate
+/// control messages (exit code) from raw terminal data.
+///
+/// - `tty`: If true, set terminal to raw mode for proper TTY handling
+/// - `interactive`: If true, forward stdin to the remote command
+fn run_framed_mode(stream: UnixStream, tty: bool, interactive: bool) -> Result<()> {
     use std::io::{stdin, stdout};
     use std::os::unix::io::AsRawFd;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
 
-    // Check if stdin is a TTY
     let stdin_fd = stdin().as_raw_fd();
-    let is_tty = unsafe { libc::isatty(stdin_fd) == 1 };
+    let mut orig_termios: Option<libc::termios> = None;
 
-    if !is_tty {
-        bail!("TTY mode requires a terminal. Use without -t for non-interactive mode.");
+    // Only set up raw terminal mode if TTY requested
+    if tty {
+        let is_tty = unsafe { libc::isatty(stdin_fd) == 1 };
+        if !is_tty {
+            bail!("TTY mode requires a terminal. Use without -t for non-interactive mode.");
+        }
+
+        // Save original terminal settings
+        let mut termios: libc::termios = unsafe { std::mem::zeroed() };
+        if unsafe { libc::tcgetattr(stdin_fd, &mut termios) } != 0 {
+            bail!("Failed to get terminal attributes");
+        }
+        orig_termios = Some(termios);
+
+        // Set raw mode
+        let mut raw_termios = termios;
+        unsafe {
+            libc::cfmakeraw(&mut raw_termios);
+        }
+        if unsafe { libc::tcsetattr(stdin_fd, libc::TCSANOW, &raw_termios) } != 0 {
+            bail!("Failed to set raw terminal mode");
+        }
     }
 
-    // Save original terminal settings
-    let mut orig_termios: libc::termios = unsafe { std::mem::zeroed() };
-    if unsafe { libc::tcgetattr(stdin_fd, &mut orig_termios) } != 0 {
-        bail!("Failed to get terminal attributes");
-    }
-
-    // Set raw mode
-    let mut raw_termios = orig_termios;
-    unsafe {
-        libc::cfmakeraw(&mut raw_termios);
-    }
-    if unsafe { libc::tcsetattr(stdin_fd, libc::TCSANOW, &raw_termios) } != 0 {
-        bail!("Failed to set raw terminal mode");
-    }
-
-    // Flag to track if we should restore terminal
+    // Flag to track completion
     let done = Arc::new(AtomicBool::new(false));
     let done_clone = done.clone();
 
-    // Restore terminal on panic
-    let orig_termios_copy = orig_termios;
-    let restore_terminal = move || unsafe {
-        libc::tcsetattr(stdin_fd, libc::TCSANOW, &orig_termios_copy);
-    };
-
     // Clone stream for reader/writer
     let read_stream = stream.try_clone().context("cloning stream for reader")?;
-    let write_stream = stream;
+    let mut write_stream = stream;
 
-    // Spawn thread to read from socket and write to stdout
+    // Spawn thread to read framed messages from socket and write to stdout
     let reader_done = done.clone();
     let reader_thread = std::thread::spawn(move || {
         let mut stdout = stdout().lock();
         let mut read_stream = read_stream;
-        let mut buf = [0u8; 4096];
 
         loop {
             if reader_done.load(Ordering::Relaxed) {
                 break;
             }
 
-            match read_stream.read(&mut buf) {
-                Ok(0) => break, // EOF
-                Ok(n) => {
-                    let data = &buf[..n];
-
-                    // Check for exit message - but write output data FIRST
-                    // The exit JSON may be in the same buffer as command output
-                    if let Some(exit_code) = try_parse_exit(data) {
-                        // Write everything BEFORE the exit JSON line
-                        // The exit JSON is on its own line at the end
-                        if let Some(pos) = find_exit_json_start(data) {
-                            if pos > 0 {
-                                let _ = stdout.write_all(&data[..pos]);
-                                let _ = stdout.flush();
-                            }
-                        }
-                        reader_done.store(true, Ordering::Relaxed);
-                        return Some(exit_code);
-                    }
-
-                    // Write raw data to stdout
-                    let _ = stdout.write_all(data);
+            // Read framed message using binary protocol
+            match exec_proto::Message::read_from(&mut read_stream) {
+                Ok(exec_proto::Message::Data(data)) => {
+                    // Write raw PTY data to stdout
+                    let _ = stdout.write_all(&data);
                     let _ = stdout.flush();
                 }
+                Ok(exec_proto::Message::Exit(code)) => {
+                    // Process exited, return the exit code
+                    reader_done.store(true, Ordering::Relaxed);
+                    return Some(code);
+                }
+                Ok(exec_proto::Message::Error(msg)) => {
+                    // Error from guest
+                    let _ = writeln!(stdout, "\r\nError: {}\r", msg);
+                    let _ = stdout.flush();
+                    reader_done.store(true, Ordering::Relaxed);
+                    return Some(1);
+                }
+                Ok(exec_proto::Message::Stdin(_)) => {
+                    // Should not receive STDIN from guest, ignore
+                }
                 Err(e) => {
-                    if e.kind() != std::io::ErrorKind::WouldBlock {
+                    if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                        // Connection closed
                         break;
                     }
+                    // Other error, log and exit
+                    eprintln!("\r\nProtocol error: {}\r", e);
+                    break;
                 }
             }
         }
         None
     });
 
-    // Spawn thread to read from stdin and write to socket
-    let writer_done = done.clone();
-    let writer_thread = std::thread::spawn(move || {
-        let stdin = stdin();
-        let mut stdin = stdin.lock();
-        let mut write_stream = write_stream;
-        let mut buf = [0u8; 1024];
+    // Only spawn writer thread if interactive mode (stdin forwarding)
+    let writer_thread = if interactive {
+        let writer_done = done.clone();
+        Some(std::thread::spawn(move || {
+            let stdin = stdin();
+            let mut stdin = stdin.lock();
+            let mut buf = [0u8; 1024];
 
-        loop {
-            if writer_done.load(Ordering::Relaxed) {
-                break;
-            }
-
-            match stdin.read(&mut buf) {
-                Ok(0) => break, // EOF
-                Ok(n) => {
-                    if write_stream.write_all(&buf[..n]).is_err() {
-                        break;
-                    }
-                    let _ = write_stream.flush();
+            loop {
+                if writer_done.load(Ordering::Relaxed) {
+                    break;
                 }
-                Err(_) => break,
+
+                match stdin.read(&mut buf) {
+                    Ok(0) => break, // EOF
+                    Ok(n) => {
+                        // Send stdin data as framed STDIN message
+                        if exec_proto::write_stdin(&mut write_stream, &buf[..n]).is_err() {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
             }
-        }
-    });
+        }))
+    } else {
+        // Not interactive - just drop the write_stream
+        drop(write_stream);
+        None
+    };
 
     // Wait for reader to finish (it detects exit)
     let exit_code = reader_thread.join().ok().flatten().unwrap_or(0);
@@ -397,8 +414,12 @@ fn run_tty_mode(stream: UnixStream) -> Result<()> {
     // Signal writer to stop
     done_clone.store(true, Ordering::Relaxed);
 
-    // Restore terminal
-    restore_terminal();
+    // Restore terminal if we set raw mode
+    if let Some(termios) = orig_termios {
+        unsafe {
+            libc::tcsetattr(stdin_fd, libc::TCSANOW, &termios);
+        }
+    }
 
     // Don't wait for writer - it may be blocked on stdin
     drop(writer_thread);
@@ -408,42 +429,6 @@ fn run_tty_mode(stream: UnixStream) -> Result<()> {
     }
 
     Ok(())
-}
-
-/// Try to parse an exit message from raw data
-fn try_parse_exit(data: &[u8]) -> Option<i32> {
-    // Look for JSON exit message at end of data
-    let s = String::from_utf8_lossy(data);
-    for line in s.lines() {
-        if let Ok(ExecResponse::Exit(code)) = serde_json::from_str::<ExecResponse>(line) {
-            return Some(code);
-        }
-    }
-    None
-}
-
-/// Find the byte position where the exit JSON starts in the data
-/// The exit JSON is always on its own line, so we look for the pattern
-fn find_exit_json_start(data: &[u8]) -> Option<usize> {
-    // The exit JSON looks like: {"type":"exit","data":...}
-    // It's always at the end of a line
-    let s = String::from_utf8_lossy(data);
-    for (i, line) in s.lines().enumerate() {
-        if serde_json::from_str::<ExecResponse>(line)
-            .map(|r| matches!(r, ExecResponse::Exit(_)))
-            .unwrap_or(false)
-        {
-            // Find the byte offset of this line
-            let mut offset = 0;
-            for (j, l) in s.lines().enumerate() {
-                if j == i {
-                    return Some(offset);
-                }
-                offset += l.len() + 1; // +1 for newline
-            }
-        }
-    }
-    None
 }
 
 /// Request sent to fc-agent exec server

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -302,9 +302,9 @@ async fn cmd_podman_run(args: RunArgs) -> Result<()> {
         .collect::<Result<Vec<_>>>()
         .context("parsing volume mappings")?;
 
-    // For localhost/ images, use content-addressable cache for skopeo export
-    // This avoids lock contention when multiple VMs export the same image
-    let _image_export_dir = if args.image.starts_with("localhost/") {
+    // For localhost/ images, export as OCI archive for direct podman run
+    // Uses content-addressable cache to avoid re-exporting the same image
+    let image_archive_name = if args.image.starts_with("localhost/") {
         // Get image digest for content-addressable storage
         let inspect_output = tokio::process::Command::new("podman")
             .args(["image", "inspect", &args.image, "--format", "{{.Digest}}"])
@@ -323,6 +323,8 @@ async fn cmd_podman_run(args: RunArgs) -> Result<()> {
 
         let digest = String::from_utf8_lossy(&inspect_output.stdout)
             .trim()
+            // Strip "sha256:" prefix for use in filenames (colons invalid in paths)
+            .trim_start_matches("sha256:")
             .to_string();
 
         // Use content-addressable cache: /mnt/fcvm-btrfs/image-cache/{digest}/
@@ -342,51 +344,54 @@ async fn cmd_podman_run(args: RunArgs) -> Result<()> {
             .context("acquiring image cache lock")?;
 
         // Check if already cached (inside lock to prevent race)
-        let manifest_path = cache_dir.join("manifest.json");
-        if !manifest_path.exists() {
-            info!(image = %args.image, digest = %digest, "Exporting localhost image with skopeo");
+        // Use OCI archive format (single tar file) for faster FUSE transfer
+        let archive_path = cache_dir.with_extension("oci.tar");
+        if !archive_path.exists() {
+            info!(image = %args.image, digest = %digest, "Exporting localhost image as OCI archive");
 
-            // Create cache dir
-            tokio::fs::create_dir_all(&cache_dir)
-                .await
-                .context("creating image cache directory")?;
-
-            let output = tokio::process::Command::new("skopeo")
-                .arg("copy")
-                .arg(format!("containers-storage:{}", args.image))
-                .arg(format!("dir:{}", cache_dir.display()))
+            let output = tokio::process::Command::new("podman")
+                .args([
+                    "save",
+                    "--format",
+                    "oci-archive",
+                    "-o",
+                    archive_path.to_str().unwrap(),
+                    &args.image,
+                ])
                 .output()
                 .await
-                .context("running skopeo copy")?;
+                .context("running podman save")?;
 
             if !output.status.success() {
                 let stderr = String::from_utf8_lossy(&output.stderr);
                 // Clean up partial export
-                let _ = tokio::fs::remove_dir_all(&cache_dir).await;
+                let _ = tokio::fs::remove_file(&archive_path).await;
                 drop(lock_file); // Release lock before bailing
                 bail!(
-                    "Failed to export image '{}' with skopeo: {}",
+                    "Failed to export image '{}' with podman save: {}",
                     args.image,
                     stderr
                 );
             }
 
-            info!(dir = %cache_dir.display(), "Image exported to OCI directory");
+            info!(path = %archive_path.display(), "Image exported as OCI archive");
         } else {
-            info!(image = %args.image, digest = %digest, "Using cached image export");
+            info!(image = %args.image, digest = %digest, "Using cached OCI archive");
         }
 
         // Lock released when lock_file is dropped
         drop(lock_file);
 
-        // Add the cached image directory as a read-only volume mount
+        // Add the image-cache directory as a read-only volume mount
+        // Guest will access the archive at /tmp/fcvm-image/{digest}.oci.tar
         volume_mappings.push(VolumeMapping {
-            host_path: cache_dir.clone(),
+            host_path: image_cache_dir.clone(),
             guest_path: "/tmp/fcvm-image".to_string(),
             read_only: true,
         });
 
-        Some(cache_dir)
+        // Return the archive filename (relative to mount point)
+        Some(format!("{}.oci.tar", digest))
     } else {
         None
     };
@@ -564,6 +569,7 @@ async fn cmd_podman_run(args: RunArgs) -> Result<()> {
         &mut vm_state,
         &volume_mappings,
         &vsock_socket_path,
+        image_archive_name.as_deref(),
     )
     .await;
 
@@ -679,6 +685,7 @@ async fn run_vm_setup(
     vm_state: &mut VmState,
     volume_mappings: &[VolumeMapping],
     vsock_socket_path: &std::path::Path,
+    image_archive_name: Option<&str>,
 ) -> Result<(VmManager, Option<tokio::process::Child>)> {
     // Setup storage - just need CoW copy (fc-agent is injected via initrd at boot)
     let vm_dir = data_dir.join("disks");
@@ -1302,7 +1309,7 @@ async fn run_vm_setup(
                 }).collect::<std::collections::HashMap<_, _>>(),
                 "cmd": cmd_args,
                 "volumes": volume_mounts,
-                "image_dir": if args.image.starts_with("localhost/") { Some("/tmp/fcvm-image") } else { None },
+                "image_archive": image_archive_name.map(|name| format!("/tmp/fcvm-image/{}", name)),
                 "privileged": args.privileged,
             },
             "host-time": chrono::Utc::now().timestamp().to_string(),

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -1201,6 +1201,12 @@ async fn run_vm_setup(
         boot_args.push_str(&format!(" fuse_readers={}", readers));
     }
 
+    // Pass FUSE trace rate to fc-agent via kernel command line.
+    // Used for debugging FUSE latency. Rate N means trace every Nth request.
+    if let Ok(rate) = std::env::var("FCVM_FUSE_TRACE_RATE") {
+        boot_args.push_str(&format!(" fuse_trace_rate={}", rate));
+    }
+
     client
         .set_boot_source(crate::firecracker::api::BootSource {
             kernel_image_path: kernel_path.display().to_string(),

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -1182,8 +1182,10 @@ async fn run_vm_setup(
     //   VHE mode (E2H=1) allows the guest kernel to run at EL2, which is required
     //   for kvm-arm.mode=nested. This enables recursive nested virtualization.
     // - numa=off - Disable NUMA to avoid percpu allocation issues in nested contexts
+    // - arm64.nv2 - Override MMFR4.NV_frac to advertise NV2 support. Required because
+    //   virtual EL2 reads ID registers directly from hardware (TID3 only traps EL1 reads).
     if args.kernel.is_some() {
-        boot_args.push_str(" kvm-arm.mode=nested numa=off");
+        boot_args.push_str(" kvm-arm.mode=nested numa=off arm64.nv2");
     }
 
     client

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -1188,6 +1188,12 @@ async fn run_vm_setup(
         boot_args.push_str(" kvm-arm.mode=nested numa=off arm64.nv2");
     }
 
+    // Pass FUSE reader count to fc-agent via kernel command line.
+    // Used to reduce memory at deeper nesting levels (256 readers × 8MB = 2GB per mount).
+    if let Ok(readers) = std::env::var("FCVM_FUSE_READERS") {
+        boot_args.push_str(&format!(" fuse_readers={}", readers));
+    }
+
     client
         .set_boot_source(crate::firecracker::api::BootSource {
             kernel_image_path: kernel_path.display().to_string(),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -443,8 +443,10 @@ pub async fn spawn_fcvm_with_logs(
 
     // Enable nested virtualization when using inception kernel (--kernel flag)
     // FCVM_NV2=1 tells fcvm to pass --enable-nv2 to Firecracker for HAS_EL2 vCPU feature
+    // FCVM_FUSE_READERS=64 reduces memory usage for nested VMs (256 readers × 8MB = 2GB per mount)
     if args.contains(&"--kernel") {
         cmd.env("FCVM_NV2", "1");
+        cmd.env("FCVM_FUSE_READERS", "64");
     }
 
     let mut child = cmd

--- a/tests/test_exec.rs
+++ b/tests/test_exec.rs
@@ -244,12 +244,275 @@ async fn exec_test_impl(network: &str) -> Result<()> {
     );
     println!("  ✓ script was interrupted by Ctrl-C");
 
+    // Test 13: Exit code propagation (non-zero exit codes) - non-TTY mode
+    // Uses non-TTY mode to avoid script wrapper issues with exit codes
+    println!("\nTest 13: Exit code propagation (VM - non-TTY)");
+    let exit_code =
+        run_exec_with_exit_code(&fcvm_path, fcvm_pid, true, &["sh", "-c", "exit 42"]).await?;
+    println!("  exit code: {}", exit_code);
+    assert_eq!(exit_code, 42, "exit code should be 42, got: {}", exit_code);
+    println!("  ✓ exit code 42 propagated correctly");
+
+    // Test 14: Exit code propagation (container) - non-TTY mode
+    println!("\nTest 14: Exit code propagation (container - non-TTY)");
+    let exit_code =
+        run_exec_with_exit_code(&fcvm_path, fcvm_pid, false, &["sh", "-c", "exit 7"]).await?;
+    println!("  exit code: {}", exit_code);
+    assert_eq!(exit_code, 7, "exit code should be 7, got: {}", exit_code);
+    println!("  ✓ exit code 7 propagated correctly");
+
+    // Test 15: stdin input is received by command (-it mode)
+    // Use head -1 instead of cat - it exits after reading one line
+    // (cat would hang waiting for EOF which doesn't propagate through PTY layers)
+    println!("\nTest 15: stdin input received (VM -it)");
+    let (exit_code, _, output) = run_exec_with_pty(
+        &fcvm_path,
+        fcvm_pid,
+        true, // in_vm
+        true, // interactive (-i)
+        true, // tty (-t)
+        &["head", "-1"],
+        Some("hello from stdin\n"),
+    )
+    .await?;
+    println!("  exit code: {}", exit_code);
+    println!("  output: {:?}", output);
+    assert!(
+        output.contains("hello from stdin"),
+        "should echo stdin input, got: {:?}",
+        output
+    );
+    println!("  ✓ stdin was received and echoed back");
+
+    // Test 16: stdin input (container -it)
+    println!("\nTest 16: stdin input received (container -it)");
+    let (exit_code, _, output) = run_exec_with_pty(
+        &fcvm_path,
+        fcvm_pid,
+        false, // in_vm=false (container)
+        true,  // interactive (-i)
+        true,  // tty (-t)
+        &["head", "-1"],
+        Some("container stdin test\n"),
+    )
+    .await?;
+    println!("  exit code: {}", exit_code);
+    println!("  output: {:?}", output);
+    assert!(
+        output.contains("container stdin test"),
+        "should echo stdin input, got: {:?}",
+        output
+    );
+    println!("  ✓ container stdin was received and echoed back");
+
+    // ======================================================================
+    // Test all 4 flag combinations for -i and -t (symmetric with podman)
+    // ======================================================================
+
+    // Test 17: -t only (VM) - TTY for output, no stdin
+    // Use `ls --color=auto` which needs TTY for colors but no stdin
+    println!("\nTest 17: -t only (VM) - TTY output, no stdin");
+    let (exit_code, _, output) = run_exec_with_pty(
+        &fcvm_path,
+        fcvm_pid,
+        true,  // in_vm
+        false, // interactive=false (no -i)
+        true,  // tty=true (-t)
+        &["echo", "tty-only-test"],
+        None, // no stdin input
+    )
+    .await?;
+    println!("  exit code: {}", exit_code);
+    println!("  output: {:?}", output);
+    assert!(
+        output.contains("tty-only-test"),
+        "should get output with -t only: {:?}",
+        output
+    );
+    assert_eq!(exit_code, 0, "exit code should be 0");
+    println!("  ✓ -t only works for VM exec");
+
+    // Test 18: -t only (container) - TTY for output, no stdin
+    println!("\nTest 18: -t only (container) - TTY output, no stdin");
+    let (exit_code, _, output) = run_exec_with_pty(
+        &fcvm_path,
+        fcvm_pid,
+        false, // in_vm=false (container)
+        false, // interactive=false (no -i)
+        true,  // tty=true (-t)
+        &["echo", "container-tty-only"],
+        None, // no stdin input
+    )
+    .await?;
+    println!("  exit code: {}", exit_code);
+    println!("  output: {:?}", output);
+    assert!(
+        output.contains("container-tty-only"),
+        "should get output with -t only: {:?}",
+        output
+    );
+    assert_eq!(exit_code, 0, "exit code should be 0");
+    println!("  ✓ -t only works for container exec");
+
+    // Test 19: -i only (VM) - stdin but no TTY (piping data)
+    // This uses non-TTY mode but with stdin - test via regular exec with -i
+    println!("\nTest 19: -i only (VM) - stdin without TTY");
+    {
+        let pid_str = fcvm_pid.to_string();
+        let mut child = tokio::process::Command::new(&fcvm_path)
+            .args(["exec", "--pid", &pid_str, "--vm", "-i", "--", "head", "-1"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .context("spawning exec with -i")?;
+
+        // Write to stdin
+        if let Some(mut stdin) = child.stdin.take() {
+            use tokio::io::AsyncWriteExt;
+            stdin.write_all(b"vm-interactive-input\n").await?;
+            stdin.flush().await?;
+            drop(stdin);
+        }
+
+        let output = child.wait_with_output().await?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        println!("  output: {:?}", stdout);
+        assert!(
+            stdout.contains("vm-interactive-input"),
+            "should echo stdin with -i: {:?}",
+            stdout
+        );
+        println!("  ✓ -i only works for VM exec");
+    }
+
+    // Test 20: -i only (container) - stdin but no TTY
+    println!("\nTest 20: -i only (container) - stdin without TTY");
+    {
+        let pid_str = fcvm_pid.to_string();
+        let mut child = tokio::process::Command::new(&fcvm_path)
+            .args(["exec", "--pid", &pid_str, "-i", "--", "head", "-1"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .context("spawning exec with -i")?;
+
+        // Write to stdin
+        if let Some(mut stdin) = child.stdin.take() {
+            use tokio::io::AsyncWriteExt;
+            stdin.write_all(b"container-interactive-input\n").await?;
+            stdin.flush().await?;
+            drop(stdin);
+        }
+
+        let output = child.wait_with_output().await?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        println!("  output: {:?}", stdout);
+        assert!(
+            stdout.contains("container-interactive-input"),
+            "should echo stdin with -i: {:?}",
+            stdout
+        );
+        println!("  ✓ -i only works for container exec");
+    }
+
+    // Test 21: neither -i nor -t (VM) - plain exec, no stdin, no TTY
+    println!("\nTest 21: neither -i nor -t (VM)");
+    let output = run_exec(&fcvm_path, fcvm_pid, true, &["echo", "plain-vm"]).await?;
+    println!("  output: {:?}", output.trim());
+    assert!(
+        output.contains("plain-vm"),
+        "should get output: {:?}",
+        output
+    );
+    println!("  ✓ plain exec (no flags) works for VM");
+
+    // Test 22: neither -i nor -t (container) - plain exec
+    println!("\nTest 22: neither -i nor -t (container)");
+    let output = run_exec(&fcvm_path, fcvm_pid, false, &["echo", "plain-container"]).await?;
+    println!("  output: {:?}", output.trim());
+    assert!(
+        output.contains("plain-container"),
+        "should get output: {:?}",
+        output
+    );
+    println!("  ✓ plain exec (no flags) works for container");
+
+    // Test 23: Verify -t without -i does NOT forward stdin (VM)
+    println!("\nTest 23: -t without -i should NOT forward stdin (VM)");
+    let (exit_code, _, output) = run_exec_with_pty(
+        &fcvm_path,
+        fcvm_pid,
+        true,                             // in_vm
+        false,                            // interactive=false (no -i)
+        true,                             // tty=true (-t)
+        &["head", "-1"],                  // waits for input
+        Some("this-should-not-appear\n"), // we send input but it should be ignored
+    )
+    .await?;
+    println!("  exit code: {} (expected timeout/signal)", exit_code);
+    println!("  output: {:?}", output);
+    // head -1 should timeout because stdin is not forwarded
+    assert!(
+        !output.contains("this-should-not-appear"),
+        "-t without -i should NOT forward stdin, but got: {:?}",
+        output
+    );
+    println!("  ✓ -t without -i correctly ignores stdin (VM)");
+
+    // Test 24: Verify -t without -i does NOT forward stdin (container)
+    println!("\nTest 24: -t without -i should NOT forward stdin (container)");
+    let (exit_code, _, output) = run_exec_with_pty(
+        &fcvm_path,
+        fcvm_pid,
+        false,                             // in_vm=false (container)
+        false,                             // interactive=false (no -i)
+        true,                              // tty=true (-t)
+        &["head", "-1"],                   // waits for input
+        Some("container-stdin-ignored\n"), // we send input but it should be ignored
+    )
+    .await?;
+    println!("  exit code: {} (expected timeout/signal)", exit_code);
+    println!("  output: {:?}", output);
+    // head -1 should timeout because stdin is not forwarded
+    assert!(
+        !output.contains("container-stdin-ignored"),
+        "-t without -i should NOT forward stdin, but got: {:?}",
+        output
+    );
+    println!("  ✓ -t without -i correctly ignores stdin (container)");
+
     // Cleanup
     println!("\nCleaning up...");
     common::kill_process(fcvm_pid).await;
 
     println!("✅ EXEC TEST PASSED! (network: {})", network);
     Ok(())
+}
+
+/// Run fcvm exec (no TTY) and return exit code
+async fn run_exec_with_exit_code(
+    fcvm_path: &std::path::Path,
+    pid: u32,
+    in_vm: bool,
+    cmd: &[&str],
+) -> Result<i32> {
+    let pid_str = pid.to_string();
+    let mut args = vec!["exec", "--pid", &pid_str];
+    if in_vm {
+        args.push("--vm");
+    }
+    args.push("--");
+    args.extend(cmd.iter().copied());
+
+    let output = tokio::process::Command::new(fcvm_path)
+        .args(&args)
+        .output()
+        .await
+        .context("running fcvm exec")?;
+
+    Ok(output.status.code().unwrap_or(-1))
 }
 
 /// Run fcvm exec (no TTY) and return stdout
@@ -425,6 +688,164 @@ async fn run_exec_tty(
     Ok((exit_code, duration, combined))
 }
 
+/// Run fcvm exec with PTY and optional stdin input
+///
+/// Uses nix::pty to properly allocate a PTY for the child process.
+///
+/// Flags:
+/// - `interactive`: Pass -i flag (stdin forwarding)
+/// - `tty`: Pass -t flag (TTY allocation)
+/// - `stdin_input`: Input to send (only makes sense with interactive=true)
+///
+/// Returns (exit_code, duration, output)
+async fn run_exec_with_pty(
+    fcvm_path: &std::path::Path,
+    pid: u32,
+    in_vm: bool,
+    interactive: bool,
+    tty: bool,
+    cmd: &[&str],
+    stdin_input: Option<&str>,
+) -> Result<(i32, Duration, String)> {
+    use nix::pty::openpty;
+    use nix::unistd::{close, dup2, fork, ForkResult};
+    use std::os::unix::io::{AsRawFd, FromRawFd};
+
+    let pid_str = pid.to_string();
+    let start = std::time::Instant::now();
+
+    // Allocate a PTY pair
+    let pty = openpty(None, None).context("opening PTY")?;
+
+    // Fork to run fcvm exec in child with PTY as stdin/stdout/stderr
+    match unsafe { fork() }.context("forking")? {
+        ForkResult::Child => {
+            // Child: set up PTY slave as stdin/stdout/stderr
+            unsafe {
+                // Create new session
+                libc::setsid();
+
+                // Set controlling terminal
+                libc::ioctl(pty.slave.as_raw_fd(), libc::TIOCSCTTY as _, 0);
+
+                // Redirect stdio to PTY slave
+                dup2(pty.slave.as_raw_fd(), 0).ok();
+                dup2(pty.slave.as_raw_fd(), 1).ok();
+                dup2(pty.slave.as_raw_fd(), 2).ok();
+
+                // Close original fds
+                if pty.slave.as_raw_fd() > 2 {
+                    close(pty.slave.as_raw_fd()).ok();
+                }
+                close(pty.master.as_raw_fd()).ok();
+            }
+
+            // Build command args as CStrings
+            use std::ffi::CString;
+            let prog = CString::new(fcvm_path.to_str().unwrap()).unwrap();
+            let mut args: Vec<CString> = vec![
+                CString::new(fcvm_path.to_str().unwrap()).unwrap(),
+                CString::new("exec").unwrap(),
+                CString::new("--pid").unwrap(),
+                CString::new(pid_str.as_str()).unwrap(),
+            ];
+            // Add flags based on parameters
+            if interactive && tty {
+                args.push(CString::new("-it").unwrap());
+            } else if interactive {
+                args.push(CString::new("-i").unwrap());
+            } else if tty {
+                args.push(CString::new("-t").unwrap());
+            }
+            if in_vm {
+                args.push(CString::new("--vm").unwrap());
+            }
+            args.push(CString::new("--").unwrap());
+            for c in cmd {
+                args.push(CString::new(*c).unwrap());
+            }
+
+            // Exec fcvm
+            nix::unistd::execvp(&prog, &args).expect("execvp failed");
+            unreachable!();
+        }
+        ForkResult::Parent { child } => {
+            // Parent: close slave, use master for I/O
+            close(pty.slave.as_raw_fd()).ok();
+
+            // Wrap master fd in File for I/O
+            let mut master = unsafe { std::fs::File::from_raw_fd(pty.master.as_raw_fd()) };
+
+            // Delay to let child start - container exec via podman needs more time
+            std::thread::sleep(Duration::from_millis(500));
+
+            // Write stdin input only if provided
+            if let Some(input) = stdin_input {
+                use std::io::Write;
+                master
+                    .write_all(input.as_bytes())
+                    .context("writing stdin")?;
+                master.flush().context("flushing")?;
+            }
+
+            // Read output with timeout
+            let mut output = Vec::new();
+            let mut buf = [0u8; 4096];
+
+            // Set non-blocking
+            unsafe {
+                let flags = libc::fcntl(pty.master.as_raw_fd(), libc::F_GETFL);
+                libc::fcntl(
+                    pty.master.as_raw_fd(),
+                    libc::F_SETFL,
+                    flags | libc::O_NONBLOCK,
+                );
+            }
+
+            let deadline = std::time::Instant::now() + Duration::from_secs(10);
+            loop {
+                if std::time::Instant::now() > deadline {
+                    // Timeout - kill child
+                    nix::sys::signal::kill(child, nix::sys::signal::Signal::SIGKILL).ok();
+                    break;
+                }
+
+                use std::io::Read;
+                match master.read(&mut buf) {
+                    Ok(0) => break, // EOF
+                    Ok(n) => output.extend_from_slice(&buf[..n]),
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        // Check if child exited
+                        match nix::sys::wait::waitpid(
+                            child,
+                            Some(nix::sys::wait::WaitPidFlag::WNOHANG),
+                        ) {
+                            Ok(nix::sys::wait::WaitStatus::Exited(_, _)) => break,
+                            Ok(nix::sys::wait::WaitStatus::Signaled(_, _, _)) => break,
+                            _ => {
+                                std::thread::sleep(Duration::from_millis(50));
+                            }
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+
+            // Wait for child to fully exit
+            let status = nix::sys::wait::waitpid(child, None).context("waiting for child")?;
+            let exit_code = match status {
+                nix::sys::wait::WaitStatus::Exited(_, code) => code,
+                _ => -1,
+            };
+
+            let duration = start.elapsed();
+            let output_str = String::from_utf8_lossy(&output).to_string();
+
+            Ok((exit_code, duration, output_str))
+        }
+    }
+}
+
 /// Stress test: Run 100 parallel TTY execs to verify no race conditions
 ///
 /// This test verifies that the TTY stdin fix works under heavy parallel load.
@@ -437,7 +858,10 @@ async fn test_exec_parallel_tty_stress() -> Result<()> {
     const TOTAL_EXECS: usize = 100;
     const WAVE_SIZE: usize = 10; // Run 10 at a time to avoid vsock backlog overflow
 
-    println!("\nParallel TTY Stress Test ({} execs in waves of {})", TOTAL_EXECS, WAVE_SIZE);
+    println!(
+        "\nParallel TTY Stress Test ({} execs in waves of {})",
+        TOTAL_EXECS, WAVE_SIZE
+    );
     println!("==========================================================");
 
     let fcvm_path = common::find_fcvm_binary()?;
@@ -466,7 +890,10 @@ async fn test_exec_parallel_tty_stress() -> Result<()> {
     println!("  VM is healthy");
 
     // Run execs in waves to avoid overwhelming vsock connection backlog
-    println!("\nRunning {} execs in waves of {}...", TOTAL_EXECS, WAVE_SIZE);
+    println!(
+        "\nRunning {} execs in waves of {}...",
+        TOTAL_EXECS, WAVE_SIZE
+    );
     let start = std::time::Instant::now();
 
     let mut success_count = 0;
@@ -503,7 +930,10 @@ async fn test_exec_parallel_tty_stress() -> Result<()> {
                     } else if output.contains('\x00') || output == "^@" {
                         // This is the null byte bug we're testing for
                         null_byte_failures += 1;
-                        failures.push((idx, format!("NULL BYTE: exit={}, output={:?}", exit_code, output)));
+                        failures.push((
+                            idx,
+                            format!("NULL BYTE: exit={}, output={:?}", exit_code, output),
+                        ));
                     } else {
                         other_failures += 1;
                         failures.push((idx, format!("exit={}, output={:?}", exit_code, output)));
@@ -524,10 +954,16 @@ async fn test_exec_parallel_tty_stress() -> Result<()> {
     println!("\n===== STRESS TEST RESULTS =====");
     println!("Total execs: {}", TOTAL_EXECS);
     println!("Success: {}", success_count);
-    println!("Null byte failures: {} (the bug we're testing for)", null_byte_failures);
+    println!(
+        "Null byte failures: {} (the bug we're testing for)",
+        null_byte_failures
+    );
     println!("Other failures: {}", other_failures);
     println!("Duration: {:?}", elapsed);
-    println!("Throughput: {:.1} execs/sec", TOTAL_EXECS as f64 / elapsed.as_secs_f64());
+    println!(
+        "Throughput: {:.1} execs/sec",
+        TOTAL_EXECS as f64 / elapsed.as_secs_f64()
+    );
 
     if !failures.is_empty() {
         println!("\n=== FAILURES (first 10) ===");

--- a/tests/test_kvm.rs
+++ b/tests/test_kvm.rs
@@ -704,7 +704,7 @@ async fn ensure_inception_image() -> Result<()> {
     let combined_sha = hex::encode(&hasher.finalize()[..6]);
 
     // Check if we have a marker file with the current SHA
-    let marker_path = PathBuf::from("bin/.inception-sha");
+    let marker_path = PathBuf::from("artifacts/.inception-sha");
     let cached_sha = std::fs::read_to_string(&marker_path).unwrap_or_default();
 
     let need_rebuild = cached_sha.trim() != combined_sha;
@@ -721,10 +721,10 @@ async fn ensure_inception_image() -> Result<()> {
         );
 
         // Copy all inputs to build context
-        tokio::fs::create_dir_all("bin").await.ok();
-        std::fs::copy(&src_fcvm, "bin/fcvm").context("copying fcvm to bin/")?;
-        std::fs::copy(&src_agent, "bin/fc-agent").context("copying fc-agent to bin/")?;
-        std::fs::copy(&src_firecracker, "firecracker-nv2").ok();
+        tokio::fs::create_dir_all("artifacts").await.ok();
+        std::fs::copy(&src_fcvm, "artifacts/fcvm").context("copying fcvm to artifacts/")?;
+        std::fs::copy(&src_agent, "artifacts/fc-agent").context("copying fc-agent to artifacts/")?;
+        std::fs::copy(&src_firecracker, "artifacts/firecracker-nv2").ok();
 
         // Force rebuild by removing old image
         tokio::process::Command::new("podman")

--- a/tests/test_kvm.rs
+++ b/tests/test_kvm.rs
@@ -1,50 +1,33 @@
-//! Integration test for inception support - verifies /dev/kvm works in guest
+//! Integration tests for inception support - nested VMs using ARM64 FEAT_NV2.
 //!
-//! This test generates a custom rootfs-config.toml pointing to the inception
-//! kernel (with CONFIG_KVM=y), then verifies /dev/kvm works in the VM.
+//! # Nested Virtualization Status (2025-12-30)
 //!
-//! # Nested Virtualization Status (2025-12-29)
+//! ## L1→L2 Working!
+//! - Host runs L1 with inception kernel (6.18) and `--privileged --map /mnt/fcvm-btrfs`
+//! - L1 runs fcvm inside container to start L2
+//! - L2 executes commands successfully
 //!
-//! ## Implementation Complete (L1 only)
-//! - Host kernel 6.18.2-nested with `kvm-arm.mode=nested` properly initializes NV2 mode
-//! - KVM_CAP_ARM_EL2 (capability 240) returns 1, indicating nested virt is supported
-//! - vCPU init with KVM_ARM_VCPU_HAS_EL2 (bit 7) + HAS_EL2_E2H0 (bit 8) succeeds
-//! - Firecracker patched to:
-//!   - Enable HAS_EL2 + HAS_EL2_E2H0 features (--enable-nv2 CLI flag)
-//!   - Boot vCPU at EL2h (PSTATE_FAULT_BITS_64_EL2) so guest sees HYP mode
-//!   - Set EL2 registers: HCR_EL2, CNTHCTL_EL2, VMPIDR_EL2, VPIDR_EL2
+//! ## Key Components
+//! - **Host kernel**: 6.18.2-nested with `kvm-arm.mode=nested`
+//! - **Inception kernel**: 6.18 with `CONFIG_KVM=y`, FUSE_REMAP_FILE_RANGE support
+//! - **Firecracker**: Fork with NV2 support (`--enable-nv2` flag)
+//! - **Shared storage**: `/mnt/fcvm-btrfs` mounted via FUSE-over-vsock
 //!
-//! ## Guest kernel boot (working)
-//! - Guest dmesg shows: "CPU: All CPU(s) started at EL2"
-//! - KVM initializes: "kvm [1]: nv: 554 coarse grained trap handlers"
-//! - "kvm [1]: Hyp nVHE mode initialized successfully"
-//! - /dev/kvm can be opened successfully
+//! ## How L2 Works
+//! 1. Host writes L1 script to shared storage (`/mnt/fcvm-btrfs/l1-inception.sh`)
+//! 2. Host runs: `fcvm podman run --kernel {inception} --map /mnt/fcvm-btrfs --cmd /mnt/fcvm-btrfs/l1-inception.sh`
+//! 3. L1's script: imports image from shared cache, runs `fcvm podman run --cmd "echo MARKER"`
+//! 4. L2 echoes marker, exits
 //!
-//! ## Recursive Nesting Limitation (L2+)
-//! L1's KVM reports KVM_CAP_ARM_EL2=0, preventing L2+ VMs from using NV2.
-//! Root cause analysis (2025-12-29):
-//!
-//! 1. `kvm-arm.mode=nested` requires VHE mode (kernel at EL2)
-//! 2. VHE requires `is_kernel_in_hyp_mode()` = true at early boot
-//! 3. But NV2's `HAS_EL2_E2H0` flag forces nVHE mode (kernel at EL1)
-//! 4. E2H0 is required to avoid timer trap storms in NV2 contexts
-//! 5. Without VHE, L1's kernel uses `kvm-arm.mode=nvhe` and cannot advertise KVM_CAP_ARM_EL2
-//!
-//! The kernel's nested virt patches include recursive nesting code, but it's marked
-//! as "not tested yet". Until VHE mode works reliably with NV2, recursive nesting
-//! (host → L1 → L2 → L3...) is not possible.
+//! ## For Deeper Nesting (L3+)
+//! Build scripts from deepest level upward:
+//! - L3 script: `echo MARKER`
+//! - L2 script: import + `fcvm ... --cmd /mnt/fcvm-btrfs/l3.sh`
+//! - L1 script: import + `fcvm ... --cmd /mnt/fcvm-btrfs/l2.sh`
 //!
 //! ## Hardware
-//! - c7g.metal (Graviton3 / Neoverse-V1) supports FEAT_NV2
+//! - c7g.metal (Graviton3 / Neoverse-V1) with FEAT_NV2
 //! - MIDR: 0x411fd401 (ARM Neoverse-V1)
-//!
-//! ## References
-//! - KVM nested virt patches: https://lwn.net/Articles/921783/
-//! - ARM boot protocol: arch/arm64/kernel/head.S (init_kernel_el)
-//! - E2H0 handling: arch/arm64/include/asm/el2_setup.h (init_el2_hcr)
-//! - Nested config: arch/arm64/kvm/nested.c (case SYS_ID_AA64MMFR4_EL1)
-//!
-//! FAILS LOUDLY if /dev/kvm is not available.
 
 #![cfg(feature = "privileged-tests")]
 
@@ -55,7 +38,7 @@ use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
-const KERNEL_VERSION: &str = "6.12.10";
+const KERNEL_VERSION: &str = "6.18";
 const KERNEL_DIR: &str = "/mnt/fcvm-btrfs/kernels";
 const FIRECRACKER_NV2_REPO: &str = "https://github.com/ejc3/firecracker.git";
 const FIRECRACKER_NV2_BRANCH: &str = "nv2-inception";
@@ -692,18 +675,153 @@ except OSError as e:
     }
 }
 
+/// Build localhost/inception-test image with proper CAS invalidation
+///
+/// Computes a combined SHA of ALL inputs (binaries, scripts, Containerfile).
+/// Rebuilds and re-exports only when inputs change.
+async fn ensure_inception_image() -> Result<()> {
+    let fcvm_path = common::find_fcvm_binary()?;
+    let fcvm_dir = fcvm_path.parent().unwrap();
+
+    // All inputs that affect the container image
+    let src_fcvm = fcvm_dir.join("fcvm");
+    let src_agent = fcvm_dir.join("fc-agent");
+    let src_firecracker = PathBuf::from("/usr/local/bin/firecracker");
+    let src_inception = PathBuf::from("inception.sh");
+    let src_containerfile = PathBuf::from("Containerfile.inception");
+
+    // Compute combined SHA of all inputs
+    fn file_bytes(path: &Path) -> Vec<u8> {
+        std::fs::read(path).unwrap_or_default()
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(&file_bytes(&src_fcvm));
+    hasher.update(&file_bytes(&src_agent));
+    hasher.update(&file_bytes(&src_firecracker));
+    hasher.update(&file_bytes(&src_inception));
+    hasher.update(&file_bytes(&src_containerfile));
+    let combined_sha = hex::encode(&hasher.finalize()[..6]);
+
+    // Check if we have a marker file with the current SHA
+    let marker_path = PathBuf::from("bin/.inception-sha");
+    let cached_sha = std::fs::read_to_string(&marker_path).unwrap_or_default();
+
+    let need_rebuild = cached_sha.trim() != combined_sha;
+
+    if need_rebuild {
+        println!(
+            "Inputs changed (sha: {} → {}), rebuilding inception container...",
+            if cached_sha.is_empty() { "none" } else { cached_sha.trim() },
+            combined_sha
+        );
+
+        // Copy all inputs to build context
+        tokio::fs::create_dir_all("bin").await.ok();
+        std::fs::copy(&src_fcvm, "bin/fcvm").context("copying fcvm to bin/")?;
+        std::fs::copy(&src_agent, "bin/fc-agent").context("copying fc-agent to bin/")?;
+        std::fs::copy(&src_firecracker, "firecracker-nv2").ok();
+
+        // Force rebuild by removing old image
+        tokio::process::Command::new("podman")
+            .args(["rmi", "localhost/inception-test"])
+            .output()
+            .await
+            .ok();
+    }
+
+    // Check if image exists
+    let check = tokio::process::Command::new("podman")
+        .args(["image", "exists", "localhost/inception-test"])
+        .output()
+        .await?;
+
+    if check.status.success() && !need_rebuild {
+        println!("✓ localhost/inception-test up to date (sha: {})", combined_sha);
+        return Ok(());
+    }
+
+    // Build container
+    println!("Building localhost/inception-test...");
+    let output = tokio::process::Command::new("podman")
+        .args([
+            "build",
+            "-t",
+            "localhost/inception-test",
+            "-f",
+            "Containerfile.inception",
+            ".",
+        ])
+        .output()
+        .await
+        .context("running podman build")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("Failed to build inception container: {}", stderr);
+    }
+
+    // Export to CAS cache so nested VMs can access it
+    let digest_out = tokio::process::Command::new("podman")
+        .args([
+            "inspect",
+            "localhost/inception-test",
+            "--format",
+            "{{.Digest}}",
+        ])
+        .output()
+        .await?;
+    let digest = String::from_utf8_lossy(&digest_out.stdout)
+        .trim()
+        .to_string();
+
+    if !digest.is_empty() && digest.starts_with("sha256:") {
+        let cache_dir = format!("/mnt/fcvm-btrfs/image-cache/{}", digest);
+
+        if !PathBuf::from(&cache_dir).exists() {
+            println!("Exporting to CAS cache: {}", cache_dir);
+            tokio::process::Command::new("sudo")
+                .args(["mkdir", "-p", &cache_dir])
+                .output()
+                .await?;
+            let skopeo_out = tokio::process::Command::new("sudo")
+                .args([
+                    "skopeo",
+                    "copy",
+                    "containers-storage:localhost/inception-test",
+                    &format!("dir:{}", cache_dir),
+                ])
+                .output()
+                .await?;
+            if !skopeo_out.status.success() {
+                println!(
+                    "Warning: skopeo export failed: {}",
+                    String::from_utf8_lossy(&skopeo_out.stderr)
+                );
+            }
+        }
+
+        // Save the combined SHA as marker
+        std::fs::write(&marker_path, &combined_sha).ok();
+
+        println!(
+            "✓ localhost/inception-test ready (sha: {}, digest: {})",
+            combined_sha,
+            &digest[..std::cmp::min(19, digest.len())]
+        );
+    } else {
+        println!("✓ localhost/inception-test built (no digest available)");
+    }
+
+    Ok(())
+}
+
 /// Run an inception chain test with configurable depth.
 ///
 /// This function attempts to run VMs nested N levels deep:
 /// Host → Level 1 → Level 2 → ... → Level N
 ///
-/// LIMITATION (2025-12-29): Recursive nesting beyond L1 is NOT currently possible.
-/// L1's KVM reports KVM_CAP_ARM_EL2=0 because:
-/// - VHE mode is required for `kvm-arm.mode=nested`
-/// - But NV2's E2H0 flag forces nVHE mode to avoid timer trap storms
-/// - Without VHE, L1 cannot advertise nested virt capability
-///
-/// This test is kept for documentation and future testing when VHE+NV2 works.
+/// Each nested level uses localhost/inception-test which has fcvm baked in.
 ///
 /// REQUIRES: ARM64 with FEAT_NV2 (ARMv8.4+) and kvm-arm.mode=nested
 async fn run_inception_chain(total_levels: usize) -> Result<()> {
@@ -718,9 +836,9 @@ async fn run_inception_chain(total_levels: usize) -> Result<()> {
     // Ensure prerequisites
     ensure_firecracker_nv2().await?;
     let inception_kernel = ensure_inception_kernel().await?;
+    ensure_inception_image().await?;
 
     let fcvm_path = common::find_fcvm_binary()?;
-    let fcvm_dir = fcvm_path.parent().unwrap();
     let kernel_str = inception_kernel
         .to_str()
         .context("kernel path not valid UTF-8")?;
@@ -728,7 +846,6 @@ async fn run_inception_chain(total_levels: usize) -> Result<()> {
     // Home dir for config mount
     let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
     let config_mount = format!("{0}/.config/fcvm:/root/.config/fcvm:ro", home);
-    let fcvm_volume = format!("{}:/opt/fcvm", fcvm_dir.display());
 
     // Track PIDs for cleanup
     let mut level_pids: Vec<u32> = Vec::new();
@@ -740,10 +857,12 @@ async fn run_inception_chain(total_levels: usize) -> Result<()> {
         }
     }
 
-    // === Level 1: Start from host ===
+    // === Level 1: Start from host with localhost/inception-test ===
+    // This image has fcvm baked in, fcvm handles export to cache automatically
     println!("\n[Level 1] Starting outer VM from host...");
     let (vm_name_1, _, _, _) = common::unique_names("inception-L1");
 
+    // L1 uses 4GB RAM (needs to fit L2-L4 inside + overhead)
     let (mut _child1, pid1) = common::spawn_fcvm(&[
         "podman",
         "run",
@@ -754,13 +873,13 @@ async fn run_inception_chain(total_levels: usize) -> Result<()> {
         "--kernel",
         kernel_str,
         "--privileged",
+        "--mem",
+        "4096", // L1 gets 4GB, nested VMs get progressively less
         "--map",
         "/mnt/fcvm-btrfs:/mnt/fcvm-btrfs",
         "--map",
-        &fcvm_volume,
-        "--map",
         &config_mount,
-        common::TEST_IMAGE,
+        "localhost/inception-test",
     ])
     .await
     .context("spawning Level 1 VM")?;
@@ -775,13 +894,14 @@ async fn run_inception_chain(total_levels: usize) -> Result<()> {
     println!("[Level 1] ✓ Healthy!");
 
     // Check if nested KVM works before proceeding
+    // Run in container (default) which has python3 and access to /dev/kvm (privileged)
     println!("\n[Level 1] Checking if nested KVM works...");
     let output = tokio::process::Command::new(&fcvm_path)
         .args([
             "exec",
             "--pid",
             &pid1.to_string(),
-            "--vm",
+            // Default is container exec (no --vm flag needed)
             "--",
             "python3",
             "-c",
@@ -815,45 +935,28 @@ except OSError as e:
     // Each level starts the next, innermost level echoes success
     // This creates a single deeply-nested command that runs through all levels
 
-    // Start from innermost level and work outward
-    let mut nested_cmd = format!("echo {}", success_marker);
-
-    // Build the nested inception chain from inside out (Level N -> ... -> Level 2)
-    for level in (2..=total_levels).rev() {
-        let vm_name = format!("inception-L{}-{}", level, std::process::id());
-
-        // Use alpine for all levels to speed up boot
-        let image = "alpine:latest";
-
-        // Escape the inner command for shell embedding
-        let escaped_cmd = nested_cmd.replace('\'', "'\\''");
-
-        nested_cmd = format!(
-            r#"export PATH=/opt/fcvm:/mnt/fcvm-btrfs/bin:$PATH
-export HOME=/root
-modprobe tun 2>/dev/null || true
-mkdir -p /dev/net
-mknod /dev/net/tun c 10 200 2>/dev/null || true
-chmod 666 /dev/net/tun 2>/dev/null || true
-cd /mnt/fcvm-btrfs
-echo "[L{level}] Starting nested VM..."
-fcvm podman run \
-    --name {vm_name} \
-    --network bridged \
-    --kernel {kernel} \
-    --privileged \
-    --map /mnt/fcvm-btrfs:/mnt/fcvm-btrfs \
-    --map /opt/fcvm:/opt/fcvm \
-    --map /root/.config/fcvm:/root/.config/fcvm:ro \
-    --cmd '{escaped_cmd}' \
-    {image}"#,
-            level = level,
-            vm_name = vm_name,
-            kernel = kernel_str,
-            escaped_cmd = escaped_cmd,
-            image = image
-        );
+    // Get the exact image digest so we can pass the explicit cache path down the chain
+    let nested_image = "localhost/inception-test";
+    let digest_output = tokio::process::Command::new("podman")
+        .args(["inspect", nested_image, "--format", "{{.Digest}}"])
+        .output()
+        .await
+        .context("getting image digest")?;
+    let image_digest = String::from_utf8_lossy(&digest_output.stdout).trim().to_string();
+    if image_digest.is_empty() || !image_digest.starts_with("sha256:") {
+        bail!("Failed to get image digest: {:?}", String::from_utf8_lossy(&digest_output.stderr));
     }
+    let image_cache_path = format!("/mnt/fcvm-btrfs/image-cache/{}", image_digest);
+    println!("[Setup] Image digest: {}", image_digest);
+    println!("[Setup] Cache path: {}", image_cache_path);
+
+    // The inception script is baked into the container at /usr/local/bin/inception
+    // It takes: inception <current_level> <max_level> <kernel_path> <image_cache_path>
+    // Starting from level 2 (L1 is already running), going to total_levels
+    let inception_cmd = format!(
+        "inception 2 {} {} {}",
+        total_levels, kernel_str, image_cache_path
+    );
 
     println!(
         "\n[Levels 2-{}] Starting nested inception chain from Level 1...",
@@ -864,16 +967,17 @@ fcvm podman run \
         total_levels - 1
     );
 
+    // Run in container (default, no --vm) because the inception script is in the container
     let output = tokio::process::Command::new(&fcvm_path)
         .args([
             "exec",
             "--pid",
             &pid1.to_string(),
-            "--vm",
+            // Default is container exec (no --vm flag)
             "--",
             "sh",
             "-c",
-            &nested_cmd,
+            &inception_cmd,
         ])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -938,12 +1042,70 @@ fcvm podman run \
     }
 }
 
-/// Test 4 levels of nested VMs (inception chain)
+/// Test L1→L2 inception: run fcvm inside L1 to start L2
 ///
-/// Requires VHE mode in guest (HAS_EL2 without HAS_EL2_E2H0).
+/// L1: Host starts VM with localhost/inception-test + inception kernel
+/// L2: L1 container imports image from shared cache, then runs fcvm
 #[tokio::test]
-async fn test_inception_chain_4_levels() -> Result<()> {
-    run_inception_chain(4).await
+async fn test_inception_l2() -> Result<()> {
+    ensure_inception_image().await?;
+    let inception_kernel = ensure_inception_kernel().await?;
+    let kernel_str = inception_kernel.to_str().context("kernel path not valid UTF-8")?;
+
+    // Get the digest of localhost/inception-test so L2 can import from shared cache
+    let digest_out = tokio::process::Command::new("podman")
+        .args(["inspect", "localhost/inception-test", "--format", "{{.Digest}}"])
+        .output()
+        .await?;
+    let digest = String::from_utf8_lossy(&digest_out.stdout).trim().to_string();
+    println!("Image digest: {}", digest);
+
+    // For L1→L2, just write a simple script that does both steps:
+    // 1. Import image from shared cache
+    // 2. Run fcvm with --cmd to echo the marker
+    let l1_script = format!(r#"#!/bin/bash
+set -ex
+echo "L1: Importing image from shared cache..."
+skopeo copy dir:/mnt/fcvm-btrfs/image-cache/{} containers-storage:localhost/inception-test
+echo "L1: Starting L2 VM..."
+fcvm podman run --name l2 --network bridged --privileged localhost/inception-test --cmd "echo MARKER_L2_OK_12345"
+"#, digest);
+
+    let script_path = "/mnt/fcvm-btrfs/l1-inception.sh";
+    tokio::fs::write(script_path, &l1_script).await?;
+    tokio::process::Command::new("chmod")
+        .args(["+x", script_path])
+        .status()
+        .await?;
+    println!("Wrote L1 script to {}", script_path);
+
+    // Run L1 with --cmd that executes the script
+    let output = tokio::process::Command::new("sudo")
+        .args([
+            "./target/release/fcvm",
+            "podman", "run",
+            "--name", "l1-inception",
+            "--network", "bridged",
+            "--privileged",
+            "--kernel", kernel_str,
+            "--map", "/mnt/fcvm-btrfs:/mnt/fcvm-btrfs",
+            "localhost/inception-test",
+            "--cmd", "/mnt/fcvm-btrfs/l1-inception.sh",
+        ])
+        .output()
+        .await?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    println!("stdout: {}", stdout);
+    println!("stderr: {}", stderr);
+
+    // Look for the marker in stderr where container output appears
+    assert!(
+        stderr.contains("MARKER_L2_OK_12345"),
+        "L2 VM should run inside L1 and echo the marker. Check stderr above."
+    );
+    Ok(())
 }
 
 /// Test 32 levels of nested VMs (deep inception chain)
@@ -962,4 +1124,199 @@ async fn test_inception_chain_32_levels() -> Result<()> {
 #[ignore]
 async fn test_inception_chain_64_levels() -> Result<()> {
     run_inception_chain(64).await
+}
+
+/// Test skopeo import performance over FUSE (localhost/inception-test)
+///
+/// Measures how long it takes to import the full inception container image
+/// inside a VM when the image layers are accessed over FUSE-over-vsock.
+#[tokio::test]
+async fn test_skopeo_import_over_fuse() -> Result<()> {
+    println!("\nSkopeo Over FUSE Performance Test");
+    println!("==================================\n");
+
+    // 1. Ensure localhost/inception-test exists
+    println!("1. Ensuring localhost/inception-test exists...");
+    ensure_inception_image().await?;
+    println!("   ✓ Image ready");
+
+    // 2. Get image digest and export to CAS cache
+    println!("2. Getting image digest...");
+    let digest_output = tokio::process::Command::new("podman")
+        .args(["inspect", "localhost/inception-test", "--format", "{{.Digest}}"])
+        .output()
+        .await?;
+    let digest = String::from_utf8_lossy(&digest_output.stdout).trim().to_string();
+
+    if digest.is_empty() || !digest.starts_with("sha256:") {
+        bail!("Invalid digest: {}", digest);
+    }
+
+    let cache_dir = format!("/mnt/fcvm-btrfs/image-cache/{}", digest);
+    println!("   Digest: {}", &digest[..19]);
+
+    // Get image size
+    let size_output = tokio::process::Command::new("podman")
+        .args(["images", "localhost/inception-test", "--format", "{{.Size}}"])
+        .output()
+        .await?;
+    let size = String::from_utf8_lossy(&size_output.stdout).trim().to_string();
+    println!("   Size: {}", size);
+
+    // Check if already in CAS cache
+    if !std::path::Path::new(&cache_dir).exists() {
+        println!("   Exporting to CAS cache...");
+        tokio::process::Command::new("sudo")
+            .args(["mkdir", "-p", &cache_dir])
+            .output()
+            .await?;
+
+        let export_output = tokio::process::Command::new("sudo")
+            .args([
+                "skopeo",
+                "copy",
+                "containers-storage:localhost/inception-test",
+                &format!("dir:{}", cache_dir),
+            ])
+            .output()
+            .await?;
+
+        if !export_output.status.success() {
+            let stderr = String::from_utf8_lossy(&export_output.stderr);
+            bail!("Failed to export to CAS: {}", stderr);
+        }
+        println!("   ✓ Exported to CAS cache");
+    } else {
+        println!("   ✓ Already in CAS cache");
+    }
+
+    // 3. Start L1 VM with FUSE mount
+    println!("3. Starting L1 VM with FUSE mount...");
+
+    let inception_kernel = ensure_inception_kernel().await?;
+    let kernel_str = inception_kernel.to_str().context("kernel path not valid UTF-8")?;
+
+    let (vm_name, _, _, _) = common::unique_names("fuse-large");
+    let fcvm_path = common::find_fcvm_binary()?;
+
+    let (mut _child, vm_pid) = common::spawn_fcvm(&[
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--network",
+        "bridged",
+        "--kernel",
+        kernel_str,
+        "--privileged",
+        "--map",
+        "/mnt/fcvm-btrfs:/mnt/fcvm-btrfs",
+        common::TEST_IMAGE,
+    ])
+    .await
+    .context("spawning VM")?;
+
+    println!("   VM started (PID: {})", vm_pid);
+    println!("   Waiting for VM to be healthy...");
+
+    if let Err(e) = common::poll_health_by_pid(vm_pid, 120).await {
+        common::kill_process(vm_pid).await;
+        return Err(e.context("VM failed to become healthy"));
+    }
+    println!("   ✓ VM is healthy");
+
+    // 4. Time the skopeo import inside the VM
+    println!("\n4. Timing skopeo import inside VM...");
+    println!("   Source: {}", cache_dir);
+    println!("   Image size: {}", size);
+
+    let start = std::time::Instant::now();
+
+    let import_cmd = format!(
+        "time skopeo copy dir:{} containers-storage:localhost/imported 2>&1",
+        cache_dir
+    );
+
+    let import_output = tokio::process::Command::new(&fcvm_path)
+        .args([
+            "exec",
+            "--pid",
+            &vm_pid.to_string(),
+            "--vm",
+            "--",
+            "sh",
+            "-c",
+            &import_cmd,
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await?;
+
+    let elapsed = start.elapsed();
+
+    let stdout = String::from_utf8_lossy(&import_output.stdout);
+    println!("\n   Output:\n   {}", stdout.trim().replace('\n', "\n   "));
+
+    // 5. Verify the image was imported
+    println!("\n5. Verifying image was imported...");
+    let verify_output = tokio::process::Command::new(&fcvm_path)
+        .args([
+            "exec",
+            "--pid",
+            &vm_pid.to_string(),
+            "--vm",
+            "--",
+            "podman",
+            "images",
+            "localhost/imported",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await?;
+
+    let verify_stdout = String::from_utf8_lossy(&verify_output.stdout);
+    println!("   {}", verify_stdout.trim().replace('\n', "\n   "));
+
+    if !verify_stdout.contains("localhost/imported") {
+        common::kill_process(vm_pid).await;
+        bail!("Image was not imported correctly");
+    }
+    println!("   ✓ Image imported!");
+
+    // 6. Clean up
+    println!("\n6. Cleaning up...");
+    common::kill_process(vm_pid).await;
+
+    // 7. Report results
+    println!("\n==========================================");
+    println!("RESULT: {} image import over FUSE took {:?}", size, elapsed);
+    println!("==========================================");
+
+    // Calculate throughput
+    let size_mb: f64 = if size.contains("MB") {
+        size.replace(" MB", "").parse().unwrap_or(0.0)
+    } else if size.contains("GB") {
+        size.replace(" GB", "").parse::<f64>().unwrap_or(0.0) * 1024.0
+    } else {
+        0.0
+    };
+
+    if size_mb > 0.0 && elapsed.as_secs_f64() > 0.0 {
+        let throughput = size_mb / elapsed.as_secs_f64();
+        println!("Throughput: {:.1} MB/s", throughput);
+    }
+
+    if elapsed.as_secs() > 300 {
+        println!("\n⚠️  Import is VERY SLOW (>5min) - need optimization");
+    } else if elapsed.as_secs() > 60 {
+        println!("\n⚠️  Import is SLOW (>60s) - consider optimization");
+    } else if elapsed.as_secs() > 10 {
+        println!("\n⚠️  Import is MODERATE (10-60s)");
+    } else {
+        println!("\n✓ Import is FAST (<10s)");
+    }
+
+    Ok(())
 }

--- a/tests/test_kvm.rs
+++ b/tests/test_kvm.rs
@@ -696,11 +696,11 @@ async fn ensure_inception_image() -> Result<()> {
     }
 
     let mut hasher = Sha256::new();
-    hasher.update(&file_bytes(&src_fcvm));
-    hasher.update(&file_bytes(&src_agent));
-    hasher.update(&file_bytes(&src_firecracker));
-    hasher.update(&file_bytes(&src_inception));
-    hasher.update(&file_bytes(&src_containerfile));
+    hasher.update(file_bytes(&src_fcvm));
+    hasher.update(file_bytes(&src_agent));
+    hasher.update(file_bytes(&src_firecracker));
+    hasher.update(file_bytes(&src_inception));
+    hasher.update(file_bytes(&src_containerfile));
     let combined_sha = hex::encode(&hasher.finalize()[..6]);
 
     // Check if we have a marker file with the current SHA
@@ -831,6 +831,7 @@ async fn ensure_inception_image() -> Result<()> {
 /// Each nested level uses localhost/inception-test which has fcvm baked in.
 ///
 /// REQUIRES: ARM64 with FEAT_NV2 (ARMv8.4+) and kvm-arm.mode=nested
+#[allow(dead_code)] // Helper for future L3+ tests (currently L3 is too slow)
 async fn run_inception_chain(total_levels: usize) -> Result<()> {
     let success_marker = format!("INCEPTION_CHAIN_{}_LEVELS_SUCCESS", total_levels);
 
@@ -1269,11 +1270,7 @@ fcvm podman run --name l2 --network bridged --privileged \
             || line.contains("FUSE_READ_L")
         {
             // Strip ANSI codes and prefixes
-            let clean = line
-                .split("stdout]")
-                .last()
-                .unwrap_or(line)
-                .trim();
+            let clean = line.split("stdout]").last().unwrap_or(line).trim();
             println!("{}", clean);
         }
     }


### PR DESCRIPTION
## Summary

Enable ARM64 nested virtualization (FEAT_NV2) with L1→L2 inception working and comprehensive performance benchmarks.

- VHE mode enabled for guest KVM support
- MMFR4 kernel override to fix ID register visibility issue
- L2 inception test with egress and disk benchmarks
- L3+ tests documented as blocked (FUSE chain latency)

## Key Changes

### Nested Virtualization Support
- Switch from nVHE to VHE mode (`kvm-arm.mode=nested`)
- Add `arm64.nv2` boot parameter to override MMFR4 for recursive nesting
- Kernel patch: `kernel/patches/mmfr4-override.patch`

### Performance Benchmarks
L2 inception test now measures at each level:
- **Egress**: curl to ifconfig.me (both L1 and L2 work)
- **Local disk**: dd 10MB write/read
- **FUSE disk**: dd 10MB write/read through vsock

### Results (c7g.metal)

| Metric | L1 (1-hop) | L2 (2-hop) | Ratio |
|--------|------------|------------|-------|
| Egress | ✅ OK | ✅ OK | Both work |
| Local Write 10MB | 4ms | 11ms | 2.75x |
| Local Read 10MB | 2ms | 5ms | 2.5x |
| FUSE Write 10MB | 77ms | 205ms | 2.66x |
| FUSE Read 10MB | 41ms | 138ms | 3.37x |

### L3 Limitation Documented
L3+ tests are `#[ignore]` because 3-hop FUSE chain causes ~200-500ms per-request latency (vs bulk throughput which is acceptable). Boot takes 10+ minutes due to thousands of small file accesses.

## Test Plan
- [x] `make test-root FILTER=inception_l2` passes (~41s)
- [x] L1 and L2 egress verified (same public IP)
- [x] FUSE bulk throughput measured at each level
- [x] L3 limitation documented with clear root cause