### PR TITLE
Move inception build artifacts to artifacts/ directory

### DIFF
--- a/Containerfile.inception
+++ b/Containerfile.inception
@@ -1,0 +1,53 @@
+# Inception test container - self-contained with fcvm, fc-agent, firecracker
+#
+# Uses Ubuntu 24.04 to match host glibc (2.39).
+#
+# Build:
+#   cp target/release/fcvm target/release/fc-agent artifacts/
+#   cp /usr/local/bin/firecracker artifacts/firecracker-nv2
+#   sudo podman build -t localhost/inception-test -f Containerfile.inception .
+#
+# The inception test is driven by test_inception_chain.rs which:
+# 1. Runs L1 with --cmd "sleep infinity"
+# 2. Execs into L1's container to verify KVM works
+# 3. Execs into L1's container to start L2
+# 4. Repeats for each level
+
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    iproute2 iptables podman skopeo python3 kmod procps fuse3 curl nginx \
+    fuse-overlayfs sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure podman to use fuse-overlayfs (required for nested containers)
+# Must set runroot/graphroot explicitly for nested container environments
+RUN mkdir -p /etc/containers /var/lib/containers/storage && \
+    printf '%s\n' \
+        '[storage]' \
+        'driver = "overlay"' \
+        'runroot = "/run/containers/storage"' \
+        'graphroot = "/var/lib/containers/storage"' \
+        '[storage.options.overlay]' \
+        'mount_program = "/usr/bin/fuse-overlayfs"' \
+        > /etc/containers/storage.conf
+
+# Copy pre-built binaries (host glibc 2.39 matches ubuntu:24.04)
+COPY artifacts/fcvm artifacts/fc-agent /usr/local/bin/
+COPY artifacts/firecracker-nv2 /usr/local/bin/firecracker
+RUN chmod +x /usr/local/bin/fcvm /usr/local/bin/fc-agent /usr/local/bin/firecracker
+
+# Copy config file for nested fcvm (uses same paths as host via FUSE mount)
+RUN mkdir -p /etc/fcvm
+COPY rootfs-config.toml /etc/fcvm/rootfs-config.toml
+
+# Recursive inception script: /usr/local/bin/inception
+# Usage: inception <current_level> <max_level> <kernel_path> <image_cache_path>
+# When current == max, echoes success marker. Otherwise starts nested VM.
+COPY inception.sh /usr/local/bin/inception
+RUN chmod +x /usr/local/bin/inception
+
+# Default command - create runtime dirs, start nginx (for health checks), and sleep
+# /run/netns is needed for ip netns (bridged networking)
+# /run/containers/storage is needed for podman
+CMD ["sh", "-c", "mkdir -p /run/netns /run/containers/storage && nginx && sleep infinity"]

--- a/Makefile
+++ b/Makefile
@@ -229,14 +229,14 @@ _setup-fcvm:
 	./target/release/fcvm setup
 
 # Inception test setup - builds container with matching CAS chain
-# Ensures: bin/fc-agent == target/release/fc-agent, initrd SHA matches, container cached
+# Ensures: artifacts/fc-agent == target/release/fc-agent, initrd SHA matches, container cached
 setup-inception: setup-fcvm
 	@echo "==> Setting up inception test container..."
-	@echo "==> Copying binaries to bin/..."
-	mkdir -p bin
-	cp target/release/fcvm bin/
-	cp target/$(MUSL_TARGET)/release/fc-agent bin/
-	cp /usr/local/bin/firecracker firecracker-nv2 2>/dev/null || true
+	@echo "==> Copying binaries to artifacts/..."
+	mkdir -p artifacts
+	cp target/release/fcvm artifacts/
+	cp target/$(MUSL_TARGET)/release/fc-agent artifacts/
+	cp /usr/local/bin/firecracker artifacts/firecracker-nv2 2>/dev/null || true
 	@echo "==> Building inception-test container..."
 	podman rmi localhost/inception-test 2>/dev/null || true
 	podman build -t localhost/inception-test -f Containerfile.inception .
@@ -251,7 +251,7 @@ setup-inception: setup-fcvm
 		sudo skopeo copy containers-storage:localhost/inception-test "dir:$$CACHE_DIR"; \
 	fi
 	@echo "==> Verification..."
-	@echo "fc-agent SHA: $$(sha256sum bin/fc-agent | cut -c1-12)"
+	@echo "fc-agent SHA: $$(sha256sum artifacts/fc-agent | cut -c1-12)"
 	@echo "Container fc-agent SHA: $$(podman run --rm localhost/inception-test sha256sum /usr/local/bin/fc-agent | cut -c1-12)"
 	@echo "Initrd: $$(ls -1 /mnt/fcvm-btrfs/initrd/fc-agent-*.initrd | tail -1)"
 	@DIGEST=$$(podman inspect localhost/inception-test --format '{{.Digest}}'); \

--- a/inception.sh
+++ b/inception.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# Recursive inception script for nested virtualization testing
+# Usage: inception <current_level> <max_level> <kernel_path> <image_cache_path>
+set -e
+
+LEVEL=$1
+MAX=$2
+KERNEL=$3
+IMAGE_CACHE=$4
+
+echo "[L${LEVEL}] Starting level ${LEVEL} of ${MAX} (CAS verified)"
+
+# Start nginx for health checks (this script overrides the default CMD)
+mkdir -p /run/netns /run/containers/storage
+nginx 2>/dev/null || true
+
+if [ "$LEVEL" -ge "$MAX" ]; then
+    echo "INCEPTION_CHAIN_${MAX}_LEVELS_SUCCESS"
+    exit 0
+fi
+
+# Setup for nested VM
+modprobe tun 2>/dev/null || true
+mkdir -p /dev/net
+mknod /dev/net/tun c 10 200 2>/dev/null || true
+chmod 666 /dev/net/tun 2>/dev/null || true
+
+# Import image if needed
+if [ -d "$IMAGE_CACHE" ] && ! podman image exists localhost/inception-test 2>/dev/null; then
+    echo "[L${LEVEL}] Importing inception image from $IMAGE_CACHE..."
+    echo "[L${LEVEL}] Checking cache dir contents..."
+    ls -la "$IMAGE_CACHE" 2>&1 || echo "[L${LEVEL}] Failed to list cache dir"
+    echo "[L${LEVEL}] Running skopeo..."
+    if ! skopeo copy "dir:$IMAGE_CACHE" containers-storage:localhost/inception-test 2>&1; then
+        echo "[L${LEVEL}] SKOPEO FAILED!"
+        exit 1
+    fi
+    echo "[L${LEVEL}] Import complete"
+fi
+
+# Calculate next level
+NEXT=$((LEVEL + 1))
+
+# Calculate resources for nested level to prevent OOM.
+# FUSE readers: memory per mount = readers × 8MB stack
+# VM memory: reduce at each level to fit in parent's memory
+case $NEXT in
+    1) READERS=64; MEM=2048 ;;
+    2) READERS=16; MEM=1024 ;;
+    3) READERS=8;  MEM=768 ;;
+    *) READERS=4;  MEM=512 ;;
+esac
+
+echo "[L${LEVEL}] Starting nested VM (L${NEXT}) with ${READERS} FUSE readers and ${MEM}MB RAM..."
+
+# fcvm now automatically puts sockets in /tmp/fcvm-sockets (local) and
+# disks in data_dir (FUSE). No loopback btrfs needed!
+FCVM_NV2=1 FCVM_FUSE_READERS=$READERS /usr/local/bin/fcvm podman run \
+    --name "inception-L${NEXT}-$$" \
+    --network bridged \
+    --kernel "$KERNEL" \
+    --privileged \
+    --mem "$MEM" \
+    --map /mnt/fcvm-btrfs:/mnt/fcvm-btrfs \
+    --map /root/.config/fcvm:/root/.config/fcvm:ro \
+    --cmd "inception $NEXT $MAX $KERNEL $IMAGE_CACHE" \
+    localhost/inception-test

--- a/tests/test_kvm.rs
+++ b/tests/test_kvm.rs
@@ -704,7 +704,7 @@ async fn ensure_inception_image() -> Result<()> {
     let combined_sha = hex::encode(&hasher.finalize()[..6]);
 
     // Check if we have a marker file with the current SHA
-    let marker_path = PathBuf::from("bin/.inception-sha");
+    let marker_path = PathBuf::from("artifacts/.inception-sha");
     let cached_sha = std::fs::read_to_string(&marker_path).unwrap_or_default();
 
     let need_rebuild = cached_sha.trim() != combined_sha;
@@ -721,10 +721,10 @@ async fn ensure_inception_image() -> Result<()> {
         );
 
         // Copy all inputs to build context
-        tokio::fs::create_dir_all("bin").await.ok();
-        std::fs::copy(&src_fcvm, "bin/fcvm").context("copying fcvm to bin/")?;
-        std::fs::copy(&src_agent, "bin/fc-agent").context("copying fc-agent to bin/")?;
-        std::fs::copy(&src_firecracker, "firecracker-nv2").ok();
+        tokio::fs::create_dir_all("artifacts").await.ok();
+        std::fs::copy(&src_fcvm, "artifacts/fcvm").context("copying fcvm to artifacts/")?;
+        std::fs::copy(&src_agent, "artifacts/fc-agent").context("copying fc-agent to artifacts/")?;
+        std::fs::copy(&src_firecracker, "artifacts/firecracker-nv2").ok();
 
         // Force rebuild by removing old image
         tokio::process::Command::new("podman")


### PR DESCRIPTION
## Summary

- Move derived files (fcvm, fc-agent, firecracker-nv2) to `artifacts/` which is already gitignored
- Add source files (Containerfile.inception, inception.sh) that were missing from repo

## Changes

- **Makefile**: Copy binaries to `artifacts/` instead of `bin/`
- **Containerfile.inception**: Update COPY paths to use `artifacts/`
- **test_kvm.rs**: Use `artifacts/` for SHA marker and binary copies
- **New files**: `Containerfile.inception`, `inception.sh` (source files for inception tests)

## Test Results

```
test test_inception_l2 ... ok
test result: ok. 1 passed; 0 failed; finished in 68.87s
```

Both Host→L1 and L1→L2 use cached OCI archives.