### PR TITLE
Fix TTY exec race conditions

### DIFF
--- a/fc-agent/src/main.rs
+++ b/fc-agent/src/main.rs
@@ -675,8 +675,9 @@ async fn run_exec_server() {
         return;
     }
 
-    // Start listening
-    let listen_result = unsafe { libc::listen(listener_fd, 5) };
+    // Start listening with larger backlog for parallel exec stress
+    // Default of 5 is too small when many execs arrive simultaneously
+    let listen_result = unsafe { libc::listen(listener_fd, 128) };
     if listen_result < 0 {
         eprintln!(
             "[fc-agent] ERROR: failed to listen on vsock: {}",


### PR DESCRIPTION
## Summary
- Fix null byte (`^@`) in TTY output caused by stdin garbage from test harness
- Fix lost output when exit JSON arrives in same buffer as command output
- Increase vsock backlog from 5 to 128 for parallel exec

## The Problem
1. **Null byte issue**: Test's `script` command inherited stdin from test harness. Under parallel execution, garbage could be forwarded to VM's PTY.

2. **Lost output issue**: When command output and exit JSON arrive in the same TCP packet:
   ```
   /dev/pts/0\r\n{"type":"exit","data":0}\n
   ```
   The old code checked for exit JSON FIRST, then returned without writing the output data.

3. **Connection refused**: Default backlog of 5 too small for parallel execs.

## The Fix
1. Set `.stdin(Stdio::null())` in test TTY wrapper
2. Write output data BEFORE the exit JSON line before returning
3. Increase backlog to 128

## Test Results
```
Running 100 execs in waves of 10...

===== STRESS TEST RESULTS =====
Total execs: 100
Success: 100
Null byte failures: 0
Other failures: 0
Duration: 402ms
Throughput: 248.4 execs/sec

✓ ALL 100 PARALLEL TTY EXECS PASSED!
```

## Test Plan
- [x] `make test-root FILTER=exec` passes
- [x] New stress test requires 100% success rate