### PR TITLE
Separate -i and -t flags for exec command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "exec-proto"
+version = "0.1.0"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +577,7 @@ name = "fc-agent"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "exec-proto",
  "fs2",
  "fuse-pipe",
  "libc",
@@ -594,6 +599,7 @@ dependencies = [
  "clap_complete",
  "criterion",
  "directories",
+ "exec-proto",
  "fs2",
  "fuse-pipe",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
-members = [".", "fuse-pipe", "fc-agent"]
+members = [".", "fuse-pipe", "fc-agent", "exec-proto"]
 # Build all members by default (not just the root package)
-default-members = [".", "fuse-pipe", "fc-agent"]
+default-members = [".", "fuse-pipe", "fc-agent", "exec-proto"]
 # Exclude sync-test (used only for Makefile sync verification)
 exclude = ["sync-test"]
 # Resolver v2 makes --no-default-features work across all workspace members
@@ -52,7 +52,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tracing-log = "0.2"  # Bridge log crate to tracing (for fuse-backend-rs)
 libc = "0.2"
-nix = { version = "0.29", features = ["sched", "net", "fs", "user", "mount", "signal"] }
+nix = { version = "0.29", features = ["sched", "net", "fs", "user", "mount", "signal", "term"] }
 chrono = { version = "0.4", features = ["serde"] }
 tempfile = "3"
 rand = "0.8"
@@ -65,6 +65,7 @@ memmap2 = "0.9"
 vmm-sys-util = "0.12"
 shell-words = "1"
 fuse-pipe = { path = "fuse-pipe", default-features = false }
+exec-proto = { path = "exec-proto" }
 url = "2"
 tokio-util = "0.7"
 regex = "1.12.2"

--- a/exec-proto/Cargo.toml
+++ b/exec-proto/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "exec-proto"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/exec-proto/src/lib.rs
+++ b/exec-proto/src/lib.rs
@@ -1,0 +1,268 @@
+//! Length-prefixed binary protocol for TTY exec
+//!
+//! Wire format:
+//!   [1-byte type][4-byte length (big-endian)][payload]
+//!
+//! Message types:
+//!   0x01 DATA  - raw PTY output (payload = bytes)
+//!   0x02 EXIT  - process exit (payload = 4-byte i32 exit code)
+//!   0x03 ERROR - error message (payload = UTF-8 string)
+//!   0x04 STDIN - input to PTY from host (payload = bytes)
+//!
+//! This protocol is used for TTY mode exec to cleanly separate
+//! control messages (exit code) from raw terminal data.
+
+use std::io::{self, Read, Write};
+
+/// Message types for the TTY exec protocol
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageType {
+    Data = 0x01,
+    Exit = 0x02,
+    ErrorMsg = 0x03,
+    Stdin = 0x04,
+}
+
+impl MessageType {
+    fn from_u8(value: u8) -> io::Result<Self> {
+        Self::from_u8_opt(value).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unknown message type: {:#x}", value),
+            )
+        })
+    }
+
+    /// Parse message type from byte, returning None for unknown types
+    pub fn from_u8_opt(value: u8) -> Option<Self> {
+        match value {
+            0x01 => Some(MessageType::Data),
+            0x02 => Some(MessageType::Exit),
+            0x03 => Some(MessageType::ErrorMsg),
+            0x04 => Some(MessageType::Stdin),
+            _ => None,
+        }
+    }
+}
+
+/// A message in the TTY exec protocol
+#[derive(Debug, Clone)]
+pub enum Message {
+    /// Raw terminal output data
+    Data(Vec<u8>),
+    /// Process exit code
+    Exit(i32),
+    /// Error message
+    Error(String),
+    /// Input data from host to PTY
+    Stdin(Vec<u8>),
+}
+
+impl Message {
+    /// Write a message to a writer using the binary protocol
+    pub fn write_to<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        match self {
+            Message::Data(data) => {
+                writer.write_all(&[MessageType::Data as u8])?;
+                writer.write_all(&(data.len() as u32).to_be_bytes())?;
+                writer.write_all(data)?;
+            }
+            Message::Exit(code) => {
+                writer.write_all(&[MessageType::Exit as u8])?;
+                writer.write_all(&4u32.to_be_bytes())?;
+                writer.write_all(&code.to_be_bytes())?;
+            }
+            Message::Error(msg) => {
+                let bytes = msg.as_bytes();
+                writer.write_all(&[MessageType::ErrorMsg as u8])?;
+                writer.write_all(&(bytes.len() as u32).to_be_bytes())?;
+                writer.write_all(bytes)?;
+            }
+            Message::Stdin(data) => {
+                writer.write_all(&[MessageType::Stdin as u8])?;
+                writer.write_all(&(data.len() as u32).to_be_bytes())?;
+                writer.write_all(data)?;
+            }
+        }
+        writer.flush()
+    }
+
+    /// Read a message from a reader using the binary protocol
+    pub fn read_from<R: Read>(reader: &mut R) -> io::Result<Self> {
+        // Read type byte
+        let mut type_buf = [0u8; 1];
+        reader.read_exact(&mut type_buf)?;
+        let msg_type = MessageType::from_u8(type_buf[0])?;
+
+        // Read length (4 bytes big-endian)
+        let mut len_buf = [0u8; 4];
+        reader.read_exact(&mut len_buf)?;
+        let len = u32::from_be_bytes(len_buf) as usize;
+
+        // Sanity check: limit message size to 16MB
+        if len > 16 * 1024 * 1024 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("message too large: {} bytes", len),
+            ));
+        }
+
+        // Read payload
+        let mut payload = vec![0u8; len];
+        reader.read_exact(&mut payload)?;
+
+        // Parse based on type
+        match msg_type {
+            MessageType::Data => Ok(Message::Data(payload)),
+            MessageType::Exit => {
+                if payload.len() != 4 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "exit message must have 4-byte payload",
+                    ));
+                }
+                let code = i32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]);
+                Ok(Message::Exit(code))
+            }
+            MessageType::ErrorMsg => {
+                let msg = String::from_utf8(payload).map_err(|e| {
+                    io::Error::new(io::ErrorKind::InvalidData, format!("invalid UTF-8: {}", e))
+                })?;
+                Ok(Message::Error(msg))
+            }
+            MessageType::Stdin => Ok(Message::Stdin(payload)),
+        }
+    }
+}
+
+/// Write a Data message directly (convenience function for high-frequency writes)
+pub fn write_data<W: Write>(writer: &mut W, data: &[u8]) -> io::Result<()> {
+    writer.write_all(&[MessageType::Data as u8])?;
+    writer.write_all(&(data.len() as u32).to_be_bytes())?;
+    writer.write_all(data)?;
+    writer.flush()
+}
+
+/// Write an Exit message directly
+pub fn write_exit<W: Write>(writer: &mut W, code: i32) -> io::Result<()> {
+    writer.write_all(&[MessageType::Exit as u8])?;
+    writer.write_all(&4u32.to_be_bytes())?;
+    writer.write_all(&code.to_be_bytes())?;
+    writer.flush()
+}
+
+/// Write an Error message directly
+pub fn write_error<W: Write>(writer: &mut W, msg: &str) -> io::Result<()> {
+    let bytes = msg.as_bytes();
+    writer.write_all(&[MessageType::ErrorMsg as u8])?;
+    writer.write_all(&(bytes.len() as u32).to_be_bytes())?;
+    writer.write_all(bytes)?;
+    writer.flush()
+}
+
+/// Write a Stdin message directly
+pub fn write_stdin<W: Write>(writer: &mut W, data: &[u8]) -> io::Result<()> {
+    writer.write_all(&[MessageType::Stdin as u8])?;
+    writer.write_all(&(data.len() as u32).to_be_bytes())?;
+    writer.write_all(data)?;
+    writer.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_data_roundtrip() {
+        let msg = Message::Data(b"hello world".to_vec());
+        let mut buf = Vec::new();
+        msg.write_to(&mut buf).unwrap();
+
+        let mut cursor = Cursor::new(buf);
+        let decoded = Message::read_from(&mut cursor).unwrap();
+
+        match decoded {
+            Message::Data(data) => assert_eq!(data, b"hello world"),
+            _ => panic!("wrong message type"),
+        }
+    }
+
+    #[test]
+    fn test_exit_roundtrip() {
+        let msg = Message::Exit(42);
+        let mut buf = Vec::new();
+        msg.write_to(&mut buf).unwrap();
+
+        let mut cursor = Cursor::new(buf);
+        let decoded = Message::read_from(&mut cursor).unwrap();
+
+        match decoded {
+            Message::Exit(code) => assert_eq!(code, 42),
+            _ => panic!("wrong message type"),
+        }
+    }
+
+    #[test]
+    fn test_negative_exit_code() {
+        let msg = Message::Exit(-1);
+        let mut buf = Vec::new();
+        msg.write_to(&mut buf).unwrap();
+
+        let mut cursor = Cursor::new(buf);
+        let decoded = Message::read_from(&mut cursor).unwrap();
+
+        match decoded {
+            Message::Exit(code) => assert_eq!(code, -1),
+            _ => panic!("wrong message type"),
+        }
+    }
+
+    #[test]
+    fn test_error_roundtrip() {
+        let msg = Message::Error("something went wrong".to_string());
+        let mut buf = Vec::new();
+        msg.write_to(&mut buf).unwrap();
+
+        let mut cursor = Cursor::new(buf);
+        let decoded = Message::read_from(&mut cursor).unwrap();
+
+        match decoded {
+            Message::Error(s) => assert_eq!(s, "something went wrong"),
+            _ => panic!("wrong message type"),
+        }
+    }
+
+    #[test]
+    fn test_stdin_roundtrip() {
+        let msg = Message::Stdin(b"user input".to_vec());
+        let mut buf = Vec::new();
+        msg.write_to(&mut buf).unwrap();
+
+        let mut cursor = Cursor::new(buf);
+        let decoded = Message::read_from(&mut cursor).unwrap();
+
+        match decoded {
+            Message::Stdin(data) => assert_eq!(data, b"user input"),
+            _ => panic!("wrong message type"),
+        }
+    }
+
+    #[test]
+    fn test_binary_data() {
+        // Test with binary data including null bytes and escape sequences
+        let binary = vec![0x00, 0x01, 0x1b, 0x5b, 0x31, 0x6d, 0xff];
+        let msg = Message::Data(binary.clone());
+        let mut buf = Vec::new();
+        msg.write_to(&mut buf).unwrap();
+
+        let mut cursor = Cursor::new(buf);
+        let decoded = Message::read_from(&mut cursor).unwrap();
+
+        match decoded {
+            Message::Data(data) => assert_eq!(data, binary),
+            _ => panic!("wrong message type"),
+        }
+    }
+}

--- a/fc-agent/Cargo.toml
+++ b/fc-agent/Cargo.toml
@@ -12,4 +12,5 @@ reqwest = { version = "0.11", default-features = false, features = ["json"] }
 libc = "0.2"
 fs2 = "0.4"
 fuse-pipe = { path = "../fuse-pipe", default-features = false }
+exec-proto = { path = "../exec-proto" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -3,11 +3,16 @@
 //! Uses Firecracker's vsock to connect from host to guest.
 //! The guest (fc-agent) listens on vsock port 4998.
 //! The host connects via the vsock.sock Unix socket using the CONNECT protocol.
+//!
+//! TTY mode uses a length-prefixed binary protocol (see exec_proto.rs) to cleanly
+//! separate control messages from raw terminal data. Non-TTY mode continues to use
+//! JSON line protocol.
 
 use crate::cli::ExecArgs;
 use crate::paths;
 use crate::state::StateManager;
 use anyhow::{bail, Context, Result};
+use exec_proto;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
@@ -223,8 +228,10 @@ pub async fn cmd_exec(args: ExecArgs) -> Result<()> {
         );
     }
 
-    if tty {
-        run_tty_mode(stream)
+    // Use binary framing for any mode needing TTY or stdin forwarding
+    // JSON line mode only for plain non-interactive commands
+    if tty || interactive {
+        run_framed_mode(stream, tty, interactive)
     } else {
         run_line_mode(stream)
     }
@@ -275,121 +282,131 @@ fn run_line_mode(stream: UnixStream) -> Result<()> {
     Ok(())
 }
 
-/// Run in TTY mode with raw terminal
-fn run_tty_mode(stream: UnixStream) -> Result<()> {
+/// Run with binary framing protocol (for TTY and/or interactive modes)
+///
+/// Uses the binary framing protocol (exec_proto) to cleanly separate
+/// control messages (exit code) from raw terminal data.
+///
+/// - `tty`: If true, set terminal to raw mode for proper TTY handling
+/// - `interactive`: If true, forward stdin to the remote command
+fn run_framed_mode(stream: UnixStream, tty: bool, interactive: bool) -> Result<()> {
     use std::io::{stdin, stdout};
     use std::os::unix::io::AsRawFd;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
 
-    // Check if stdin is a TTY
     let stdin_fd = stdin().as_raw_fd();
-    let is_tty = unsafe { libc::isatty(stdin_fd) == 1 };
+    let mut orig_termios: Option<libc::termios> = None;
 
-    if !is_tty {
-        bail!("TTY mode requires a terminal. Use without -t for non-interactive mode.");
+    // Only set up raw terminal mode if TTY requested
+    if tty {
+        let is_tty = unsafe { libc::isatty(stdin_fd) == 1 };
+        if !is_tty {
+            bail!("TTY mode requires a terminal. Use without -t for non-interactive mode.");
+        }
+
+        // Save original terminal settings
+        let mut termios: libc::termios = unsafe { std::mem::zeroed() };
+        if unsafe { libc::tcgetattr(stdin_fd, &mut termios) } != 0 {
+            bail!("Failed to get terminal attributes");
+        }
+        orig_termios = Some(termios);
+
+        // Set raw mode
+        let mut raw_termios = termios;
+        unsafe {
+            libc::cfmakeraw(&mut raw_termios);
+        }
+        if unsafe { libc::tcsetattr(stdin_fd, libc::TCSANOW, &raw_termios) } != 0 {
+            bail!("Failed to set raw terminal mode");
+        }
     }
 
-    // Save original terminal settings
-    let mut orig_termios: libc::termios = unsafe { std::mem::zeroed() };
-    if unsafe { libc::tcgetattr(stdin_fd, &mut orig_termios) } != 0 {
-        bail!("Failed to get terminal attributes");
-    }
-
-    // Set raw mode
-    let mut raw_termios = orig_termios;
-    unsafe {
-        libc::cfmakeraw(&mut raw_termios);
-    }
-    if unsafe { libc::tcsetattr(stdin_fd, libc::TCSANOW, &raw_termios) } != 0 {
-        bail!("Failed to set raw terminal mode");
-    }
-
-    // Flag to track if we should restore terminal
+    // Flag to track completion
     let done = Arc::new(AtomicBool::new(false));
     let done_clone = done.clone();
 
-    // Restore terminal on panic
-    let orig_termios_copy = orig_termios;
-    let restore_terminal = move || unsafe {
-        libc::tcsetattr(stdin_fd, libc::TCSANOW, &orig_termios_copy);
-    };
-
     // Clone stream for reader/writer
     let read_stream = stream.try_clone().context("cloning stream for reader")?;
-    let write_stream = stream;
+    let mut write_stream = stream;
 
-    // Spawn thread to read from socket and write to stdout
+    // Spawn thread to read framed messages from socket and write to stdout
     let reader_done = done.clone();
     let reader_thread = std::thread::spawn(move || {
         let mut stdout = stdout().lock();
         let mut read_stream = read_stream;
-        let mut buf = [0u8; 4096];
 
         loop {
             if reader_done.load(Ordering::Relaxed) {
                 break;
             }
 
-            match read_stream.read(&mut buf) {
-                Ok(0) => break, // EOF
-                Ok(n) => {
-                    let data = &buf[..n];
-
-                    // Check for exit message - but write output data FIRST
-                    // The exit JSON may be in the same buffer as command output
-                    if let Some(exit_code) = try_parse_exit(data) {
-                        // Write everything BEFORE the exit JSON line
-                        // The exit JSON is on its own line at the end
-                        if let Some(pos) = find_exit_json_start(data) {
-                            if pos > 0 {
-                                let _ = stdout.write_all(&data[..pos]);
-                                let _ = stdout.flush();
-                            }
-                        }
-                        reader_done.store(true, Ordering::Relaxed);
-                        return Some(exit_code);
-                    }
-
-                    // Write raw data to stdout
-                    let _ = stdout.write_all(data);
+            // Read framed message using binary protocol
+            match exec_proto::Message::read_from(&mut read_stream) {
+                Ok(exec_proto::Message::Data(data)) => {
+                    // Write raw PTY data to stdout
+                    let _ = stdout.write_all(&data);
                     let _ = stdout.flush();
                 }
+                Ok(exec_proto::Message::Exit(code)) => {
+                    // Process exited, return the exit code
+                    reader_done.store(true, Ordering::Relaxed);
+                    return Some(code);
+                }
+                Ok(exec_proto::Message::Error(msg)) => {
+                    // Error from guest
+                    let _ = writeln!(stdout, "\r\nError: {}\r", msg);
+                    let _ = stdout.flush();
+                    reader_done.store(true, Ordering::Relaxed);
+                    return Some(1);
+                }
+                Ok(exec_proto::Message::Stdin(_)) => {
+                    // Should not receive STDIN from guest, ignore
+                }
                 Err(e) => {
-                    if e.kind() != std::io::ErrorKind::WouldBlock {
+                    if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                        // Connection closed
                         break;
                     }
+                    // Other error, log and exit
+                    eprintln!("\r\nProtocol error: {}\r", e);
+                    break;
                 }
             }
         }
         None
     });
 
-    // Spawn thread to read from stdin and write to socket
-    let writer_done = done.clone();
-    let writer_thread = std::thread::spawn(move || {
-        let stdin = stdin();
-        let mut stdin = stdin.lock();
-        let mut write_stream = write_stream;
-        let mut buf = [0u8; 1024];
+    // Only spawn writer thread if interactive mode (stdin forwarding)
+    let writer_thread = if interactive {
+        let writer_done = done.clone();
+        Some(std::thread::spawn(move || {
+            let stdin = stdin();
+            let mut stdin = stdin.lock();
+            let mut buf = [0u8; 1024];
 
-        loop {
-            if writer_done.load(Ordering::Relaxed) {
-                break;
-            }
-
-            match stdin.read(&mut buf) {
-                Ok(0) => break, // EOF
-                Ok(n) => {
-                    if write_stream.write_all(&buf[..n]).is_err() {
-                        break;
-                    }
-                    let _ = write_stream.flush();
+            loop {
+                if writer_done.load(Ordering::Relaxed) {
+                    break;
                 }
-                Err(_) => break,
+
+                match stdin.read(&mut buf) {
+                    Ok(0) => break, // EOF
+                    Ok(n) => {
+                        // Send stdin data as framed STDIN message
+                        if exec_proto::write_stdin(&mut write_stream, &buf[..n]).is_err() {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
             }
-        }
-    });
+        }))
+    } else {
+        // Not interactive - just drop the write_stream
+        drop(write_stream);
+        None
+    };
 
     // Wait for reader to finish (it detects exit)
     let exit_code = reader_thread.join().ok().flatten().unwrap_or(0);
@@ -397,8 +414,12 @@ fn run_tty_mode(stream: UnixStream) -> Result<()> {
     // Signal writer to stop
     done_clone.store(true, Ordering::Relaxed);
 
-    // Restore terminal
-    restore_terminal();
+    // Restore terminal if we set raw mode
+    if let Some(termios) = orig_termios {
+        unsafe {
+            libc::tcsetattr(stdin_fd, libc::TCSANOW, &termios);
+        }
+    }
 
     // Don't wait for writer - it may be blocked on stdin
     drop(writer_thread);
@@ -408,42 +429,6 @@ fn run_tty_mode(stream: UnixStream) -> Result<()> {
     }
 
     Ok(())
-}
-
-/// Try to parse an exit message from raw data
-fn try_parse_exit(data: &[u8]) -> Option<i32> {
-    // Look for JSON exit message at end of data
-    let s = String::from_utf8_lossy(data);
-    for line in s.lines() {
-        if let Ok(ExecResponse::Exit(code)) = serde_json::from_str::<ExecResponse>(line) {
-            return Some(code);
-        }
-    }
-    None
-}
-
-/// Find the byte position where the exit JSON starts in the data
-/// The exit JSON is always on its own line, so we look for the pattern
-fn find_exit_json_start(data: &[u8]) -> Option<usize> {
-    // The exit JSON looks like: {"type":"exit","data":...}
-    // It's always at the end of a line
-    let s = String::from_utf8_lossy(data);
-    for (i, line) in s.lines().enumerate() {
-        if serde_json::from_str::<ExecResponse>(line)
-            .map(|r| matches!(r, ExecResponse::Exit(_)))
-            .unwrap_or(false)
-        {
-            // Find the byte offset of this line
-            let mut offset = 0;
-            for (j, l) in s.lines().enumerate() {
-                if j == i {
-                    return Some(offset);
-                }
-                offset += l.len() + 1; // +1 for newline
-            }
-        }
-    }
-    None
 }
 
 /// Request sent to fc-agent exec server

--- a/tests/test_exec.rs
+++ b/tests/test_exec.rs
@@ -244,12 +244,275 @@ async fn exec_test_impl(network: &str) -> Result<()> {
     );
     println!("  ✓ script was interrupted by Ctrl-C");
 
+    // Test 13: Exit code propagation (non-zero exit codes) - non-TTY mode
+    // Uses non-TTY mode to avoid script wrapper issues with exit codes
+    println!("\nTest 13: Exit code propagation (VM - non-TTY)");
+    let exit_code =
+        run_exec_with_exit_code(&fcvm_path, fcvm_pid, true, &["sh", "-c", "exit 42"]).await?;
+    println!("  exit code: {}", exit_code);
+    assert_eq!(exit_code, 42, "exit code should be 42, got: {}", exit_code);
+    println!("  ✓ exit code 42 propagated correctly");
+
+    // Test 14: Exit code propagation (container) - non-TTY mode
+    println!("\nTest 14: Exit code propagation (container - non-TTY)");
+    let exit_code =
+        run_exec_with_exit_code(&fcvm_path, fcvm_pid, false, &["sh", "-c", "exit 7"]).await?;
+    println!("  exit code: {}", exit_code);
+    assert_eq!(exit_code, 7, "exit code should be 7, got: {}", exit_code);
+    println!("  ✓ exit code 7 propagated correctly");
+
+    // Test 15: stdin input is received by command (-it mode)
+    // Use head -1 instead of cat - it exits after reading one line
+    // (cat would hang waiting for EOF which doesn't propagate through PTY layers)
+    println!("\nTest 15: stdin input received (VM -it)");
+    let (exit_code, _, output) = run_exec_with_pty(
+        &fcvm_path,
+        fcvm_pid,
+        true, // in_vm
+        true, // interactive (-i)
+        true, // tty (-t)
+        &["head", "-1"],
+        Some("hello from stdin\n"),
+    )
+    .await?;
+    println!("  exit code: {}", exit_code);
+    println!("  output: {:?}", output);
+    assert!(
+        output.contains("hello from stdin"),
+        "should echo stdin input, got: {:?}",
+        output
+    );
+    println!("  ✓ stdin was received and echoed back");
+
+    // Test 16: stdin input (container -it)
+    println!("\nTest 16: stdin input received (container -it)");
+    let (exit_code, _, output) = run_exec_with_pty(
+        &fcvm_path,
+        fcvm_pid,
+        false, // in_vm=false (container)
+        true,  // interactive (-i)
+        true,  // tty (-t)
+        &["head", "-1"],
+        Some("container stdin test\n"),
+    )
+    .await?;
+    println!("  exit code: {}", exit_code);
+    println!("  output: {:?}", output);
+    assert!(
+        output.contains("container stdin test"),
+        "should echo stdin input, got: {:?}",
+        output
+    );
+    println!("  ✓ container stdin was received and echoed back");
+
+    // ======================================================================
+    // Test all 4 flag combinations for -i and -t (symmetric with podman)
+    // ======================================================================
+
+    // Test 17: -t only (VM) - TTY for output, no stdin
+    // Use `ls --color=auto` which needs TTY for colors but no stdin
+    println!("\nTest 17: -t only (VM) - TTY output, no stdin");
+    let (exit_code, _, output) = run_exec_with_pty(
+        &fcvm_path,
+        fcvm_pid,
+        true,  // in_vm
+        false, // interactive=false (no -i)
+        true,  // tty=true (-t)
+        &["echo", "tty-only-test"],
+        None, // no stdin input
+    )
+    .await?;
+    println!("  exit code: {}", exit_code);
+    println!("  output: {:?}", output);
+    assert!(
+        output.contains("tty-only-test"),
+        "should get output with -t only: {:?}",
+        output
+    );
+    assert_eq!(exit_code, 0, "exit code should be 0");
+    println!("  ✓ -t only works for VM exec");
+
+    // Test 18: -t only (container) - TTY for output, no stdin
+    println!("\nTest 18: -t only (container) - TTY output, no stdin");
+    let (exit_code, _, output) = run_exec_with_pty(
+        &fcvm_path,
+        fcvm_pid,
+        false, // in_vm=false (container)
+        false, // interactive=false (no -i)
+        true,  // tty=true (-t)
+        &["echo", "container-tty-only"],
+        None, // no stdin input
+    )
+    .await?;
+    println!("  exit code: {}", exit_code);
+    println!("  output: {:?}", output);
+    assert!(
+        output.contains("container-tty-only"),
+        "should get output with -t only: {:?}",
+        output
+    );
+    assert_eq!(exit_code, 0, "exit code should be 0");
+    println!("  ✓ -t only works for container exec");
+
+    // Test 19: -i only (VM) - stdin but no TTY (piping data)
+    // This uses non-TTY mode but with stdin - test via regular exec with -i
+    println!("\nTest 19: -i only (VM) - stdin without TTY");
+    {
+        let pid_str = fcvm_pid.to_string();
+        let mut child = tokio::process::Command::new(&fcvm_path)
+            .args(["exec", "--pid", &pid_str, "--vm", "-i", "--", "head", "-1"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .context("spawning exec with -i")?;
+
+        // Write to stdin
+        if let Some(mut stdin) = child.stdin.take() {
+            use tokio::io::AsyncWriteExt;
+            stdin.write_all(b"vm-interactive-input\n").await?;
+            stdin.flush().await?;
+            drop(stdin);
+        }
+
+        let output = child.wait_with_output().await?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        println!("  output: {:?}", stdout);
+        assert!(
+            stdout.contains("vm-interactive-input"),
+            "should echo stdin with -i: {:?}",
+            stdout
+        );
+        println!("  ✓ -i only works for VM exec");
+    }
+
+    // Test 20: -i only (container) - stdin but no TTY
+    println!("\nTest 20: -i only (container) - stdin without TTY");
+    {
+        let pid_str = fcvm_pid.to_string();
+        let mut child = tokio::process::Command::new(&fcvm_path)
+            .args(["exec", "--pid", &pid_str, "-i", "--", "head", "-1"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .context("spawning exec with -i")?;
+
+        // Write to stdin
+        if let Some(mut stdin) = child.stdin.take() {
+            use tokio::io::AsyncWriteExt;
+            stdin.write_all(b"container-interactive-input\n").await?;
+            stdin.flush().await?;
+            drop(stdin);
+        }
+
+        let output = child.wait_with_output().await?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        println!("  output: {:?}", stdout);
+        assert!(
+            stdout.contains("container-interactive-input"),
+            "should echo stdin with -i: {:?}",
+            stdout
+        );
+        println!("  ✓ -i only works for container exec");
+    }
+
+    // Test 21: neither -i nor -t (VM) - plain exec, no stdin, no TTY
+    println!("\nTest 21: neither -i nor -t (VM)");
+    let output = run_exec(&fcvm_path, fcvm_pid, true, &["echo", "plain-vm"]).await?;
+    println!("  output: {:?}", output.trim());
+    assert!(
+        output.contains("plain-vm"),
+        "should get output: {:?}",
+        output
+    );
+    println!("  ✓ plain exec (no flags) works for VM");
+
+    // Test 22: neither -i nor -t (container) - plain exec
+    println!("\nTest 22: neither -i nor -t (container)");
+    let output = run_exec(&fcvm_path, fcvm_pid, false, &["echo", "plain-container"]).await?;
+    println!("  output: {:?}", output.trim());
+    assert!(
+        output.contains("plain-container"),
+        "should get output: {:?}",
+        output
+    );
+    println!("  ✓ plain exec (no flags) works for container");
+
+    // Test 23: Verify -t without -i does NOT forward stdin (VM)
+    println!("\nTest 23: -t without -i should NOT forward stdin (VM)");
+    let (exit_code, _, output) = run_exec_with_pty(
+        &fcvm_path,
+        fcvm_pid,
+        true,                             // in_vm
+        false,                            // interactive=false (no -i)
+        true,                             // tty=true (-t)
+        &["head", "-1"],                  // waits for input
+        Some("this-should-not-appear\n"), // we send input but it should be ignored
+    )
+    .await?;
+    println!("  exit code: {} (expected timeout/signal)", exit_code);
+    println!("  output: {:?}", output);
+    // head -1 should timeout because stdin is not forwarded
+    assert!(
+        !output.contains("this-should-not-appear"),
+        "-t without -i should NOT forward stdin, but got: {:?}",
+        output
+    );
+    println!("  ✓ -t without -i correctly ignores stdin (VM)");
+
+    // Test 24: Verify -t without -i does NOT forward stdin (container)
+    println!("\nTest 24: -t without -i should NOT forward stdin (container)");
+    let (exit_code, _, output) = run_exec_with_pty(
+        &fcvm_path,
+        fcvm_pid,
+        false,                             // in_vm=false (container)
+        false,                             // interactive=false (no -i)
+        true,                              // tty=true (-t)
+        &["head", "-1"],                   // waits for input
+        Some("container-stdin-ignored\n"), // we send input but it should be ignored
+    )
+    .await?;
+    println!("  exit code: {} (expected timeout/signal)", exit_code);
+    println!("  output: {:?}", output);
+    // head -1 should timeout because stdin is not forwarded
+    assert!(
+        !output.contains("container-stdin-ignored"),
+        "-t without -i should NOT forward stdin, but got: {:?}",
+        output
+    );
+    println!("  ✓ -t without -i correctly ignores stdin (container)");
+
     // Cleanup
     println!("\nCleaning up...");
     common::kill_process(fcvm_pid).await;
 
     println!("✅ EXEC TEST PASSED! (network: {})", network);
     Ok(())
+}
+
+/// Run fcvm exec (no TTY) and return exit code
+async fn run_exec_with_exit_code(
+    fcvm_path: &std::path::Path,
+    pid: u32,
+    in_vm: bool,
+    cmd: &[&str],
+) -> Result<i32> {
+    let pid_str = pid.to_string();
+    let mut args = vec!["exec", "--pid", &pid_str];
+    if in_vm {
+        args.push("--vm");
+    }
+    args.push("--");
+    args.extend(cmd.iter().copied());
+
+    let output = tokio::process::Command::new(fcvm_path)
+        .args(&args)
+        .output()
+        .await
+        .context("running fcvm exec")?;
+
+    Ok(output.status.code().unwrap_or(-1))
 }
 
 /// Run fcvm exec (no TTY) and return stdout
@@ -425,6 +688,164 @@ async fn run_exec_tty(
     Ok((exit_code, duration, combined))
 }
 
+/// Run fcvm exec with PTY and optional stdin input
+///
+/// Uses nix::pty to properly allocate a PTY for the child process.
+///
+/// Flags:
+/// - `interactive`: Pass -i flag (stdin forwarding)
+/// - `tty`: Pass -t flag (TTY allocation)
+/// - `stdin_input`: Input to send (only makes sense with interactive=true)
+///
+/// Returns (exit_code, duration, output)
+async fn run_exec_with_pty(
+    fcvm_path: &std::path::Path,
+    pid: u32,
+    in_vm: bool,
+    interactive: bool,
+    tty: bool,
+    cmd: &[&str],
+    stdin_input: Option<&str>,
+) -> Result<(i32, Duration, String)> {
+    use nix::pty::openpty;
+    use nix::unistd::{close, dup2, fork, ForkResult};
+    use std::os::unix::io::{AsRawFd, FromRawFd};
+
+    let pid_str = pid.to_string();
+    let start = std::time::Instant::now();
+
+    // Allocate a PTY pair
+    let pty = openpty(None, None).context("opening PTY")?;
+
+    // Fork to run fcvm exec in child with PTY as stdin/stdout/stderr
+    match unsafe { fork() }.context("forking")? {
+        ForkResult::Child => {
+            // Child: set up PTY slave as stdin/stdout/stderr
+            unsafe {
+                // Create new session
+                libc::setsid();
+
+                // Set controlling terminal
+                libc::ioctl(pty.slave.as_raw_fd(), libc::TIOCSCTTY as _, 0);
+
+                // Redirect stdio to PTY slave
+                dup2(pty.slave.as_raw_fd(), 0).ok();
+                dup2(pty.slave.as_raw_fd(), 1).ok();
+                dup2(pty.slave.as_raw_fd(), 2).ok();
+
+                // Close original fds
+                if pty.slave.as_raw_fd() > 2 {
+                    close(pty.slave.as_raw_fd()).ok();
+                }
+                close(pty.master.as_raw_fd()).ok();
+            }
+
+            // Build command args as CStrings
+            use std::ffi::CString;
+            let prog = CString::new(fcvm_path.to_str().unwrap()).unwrap();
+            let mut args: Vec<CString> = vec![
+                CString::new(fcvm_path.to_str().unwrap()).unwrap(),
+                CString::new("exec").unwrap(),
+                CString::new("--pid").unwrap(),
+                CString::new(pid_str.as_str()).unwrap(),
+            ];
+            // Add flags based on parameters
+            if interactive && tty {
+                args.push(CString::new("-it").unwrap());
+            } else if interactive {
+                args.push(CString::new("-i").unwrap());
+            } else if tty {
+                args.push(CString::new("-t").unwrap());
+            }
+            if in_vm {
+                args.push(CString::new("--vm").unwrap());
+            }
+            args.push(CString::new("--").unwrap());
+            for c in cmd {
+                args.push(CString::new(*c).unwrap());
+            }
+
+            // Exec fcvm
+            nix::unistd::execvp(&prog, &args).expect("execvp failed");
+            unreachable!();
+        }
+        ForkResult::Parent { child } => {
+            // Parent: close slave, use master for I/O
+            close(pty.slave.as_raw_fd()).ok();
+
+            // Wrap master fd in File for I/O
+            let mut master = unsafe { std::fs::File::from_raw_fd(pty.master.as_raw_fd()) };
+
+            // Delay to let child start - container exec via podman needs more time
+            std::thread::sleep(Duration::from_millis(500));
+
+            // Write stdin input only if provided
+            if let Some(input) = stdin_input {
+                use std::io::Write;
+                master
+                    .write_all(input.as_bytes())
+                    .context("writing stdin")?;
+                master.flush().context("flushing")?;
+            }
+
+            // Read output with timeout
+            let mut output = Vec::new();
+            let mut buf = [0u8; 4096];
+
+            // Set non-blocking
+            unsafe {
+                let flags = libc::fcntl(pty.master.as_raw_fd(), libc::F_GETFL);
+                libc::fcntl(
+                    pty.master.as_raw_fd(),
+                    libc::F_SETFL,
+                    flags | libc::O_NONBLOCK,
+                );
+            }
+
+            let deadline = std::time::Instant::now() + Duration::from_secs(10);
+            loop {
+                if std::time::Instant::now() > deadline {
+                    // Timeout - kill child
+                    nix::sys::signal::kill(child, nix::sys::signal::Signal::SIGKILL).ok();
+                    break;
+                }
+
+                use std::io::Read;
+                match master.read(&mut buf) {
+                    Ok(0) => break, // EOF
+                    Ok(n) => output.extend_from_slice(&buf[..n]),
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        // Check if child exited
+                        match nix::sys::wait::waitpid(
+                            child,
+                            Some(nix::sys::wait::WaitPidFlag::WNOHANG),
+                        ) {
+                            Ok(nix::sys::wait::WaitStatus::Exited(_, _)) => break,
+                            Ok(nix::sys::wait::WaitStatus::Signaled(_, _, _)) => break,
+                            _ => {
+                                std::thread::sleep(Duration::from_millis(50));
+                            }
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+
+            // Wait for child to fully exit
+            let status = nix::sys::wait::waitpid(child, None).context("waiting for child")?;
+            let exit_code = match status {
+                nix::sys::wait::WaitStatus::Exited(_, code) => code,
+                _ => -1,
+            };
+
+            let duration = start.elapsed();
+            let output_str = String::from_utf8_lossy(&output).to_string();
+
+            Ok((exit_code, duration, output_str))
+        }
+    }
+}
+
 /// Stress test: Run 100 parallel TTY execs to verify no race conditions
 ///
 /// This test verifies that the TTY stdin fix works under heavy parallel load.
@@ -437,7 +858,10 @@ async fn test_exec_parallel_tty_stress() -> Result<()> {
     const TOTAL_EXECS: usize = 100;
     const WAVE_SIZE: usize = 10; // Run 10 at a time to avoid vsock backlog overflow
 
-    println!("\nParallel TTY Stress Test ({} execs in waves of {})", TOTAL_EXECS, WAVE_SIZE);
+    println!(
+        "\nParallel TTY Stress Test ({} execs in waves of {})",
+        TOTAL_EXECS, WAVE_SIZE
+    );
     println!("==========================================================");
 
     let fcvm_path = common::find_fcvm_binary()?;
@@ -466,7 +890,10 @@ async fn test_exec_parallel_tty_stress() -> Result<()> {
     println!("  VM is healthy");
 
     // Run execs in waves to avoid overwhelming vsock connection backlog
-    println!("\nRunning {} execs in waves of {}...", TOTAL_EXECS, WAVE_SIZE);
+    println!(
+        "\nRunning {} execs in waves of {}...",
+        TOTAL_EXECS, WAVE_SIZE
+    );
     let start = std::time::Instant::now();
 
     let mut success_count = 0;
@@ -503,7 +930,10 @@ async fn test_exec_parallel_tty_stress() -> Result<()> {
                     } else if output.contains('\x00') || output == "^@" {
                         // This is the null byte bug we're testing for
                         null_byte_failures += 1;
-                        failures.push((idx, format!("NULL BYTE: exit={}, output={:?}", exit_code, output)));
+                        failures.push((
+                            idx,
+                            format!("NULL BYTE: exit={}, output={:?}", exit_code, output),
+                        ));
                     } else {
                         other_failures += 1;
                         failures.push((idx, format!("exit={}, output={:?}", exit_code, output)));
@@ -524,10 +954,16 @@ async fn test_exec_parallel_tty_stress() -> Result<()> {
     println!("\n===== STRESS TEST RESULTS =====");
     println!("Total execs: {}", TOTAL_EXECS);
     println!("Success: {}", success_count);
-    println!("Null byte failures: {} (the bug we're testing for)", null_byte_failures);
+    println!(
+        "Null byte failures: {} (the bug we're testing for)",
+        null_byte_failures
+    );
     println!("Other failures: {}", other_failures);
     println!("Duration: {:?}", elapsed);
-    println!("Throughput: {:.1} execs/sec", TOTAL_EXECS as f64 / elapsed.as_secs_f64());
+    println!(
+        "Throughput: {:.1} execs/sec",
+        TOTAL_EXECS as f64 / elapsed.as_secs_f64()
+    );
 
     if !failures.is_empty() {
         println!("\n=== FAILURES (first 10) ===");


### PR DESCRIPTION
## Summary
Separates `-i` and `-t` flags for `fcvm exec`, matching podman/docker semantics:
- `-t`: allocate PTY (for colors/formatting)
- `-i`: forward stdin
- `-it`: both (interactive shell)
- neither: plain exec

## Changes
- Add `exec-proto` crate for binary framing protocol
- Unify `run_framed_mode()` for both TTY and non-TTY interactive modes
- fc-agent uses pipes for non-TTY interactive, PTY only with `-t`
- Add tests for all 4 flag combinations (VM + container)

## Test plan
- [x] Test 19-20: `-i` only mode (stdin without TTY)
- [x] Test 21-22: neither flag (plain exec)
- [x] Test 23-24: `-t` only (PTY without stdin)
- [x] All existing TTY tests pass