### PR TITLE
Remove sudo from fcvm Rust code

### DIFF
--- a/src/network/namespace.rs
+++ b/src/network/namespace.rs
@@ -10,8 +10,8 @@ use tracing::{debug, warn};
 pub async fn create_namespace(ns_name: &str) -> Result<()> {
     debug!(namespace = %ns_name, "creating network namespace");
 
-    let output = Command::new("sudo")
-        .args(["ip", "netns", "add", ns_name])
+    let output = Command::new("ip")
+        .args(["netns", "add", ns_name])
         .output()
         .await
         .context("executing ip netns add")?;
@@ -36,8 +36,8 @@ pub async fn create_namespace(ns_name: &str) -> Result<()> {
 pub async fn delete_namespace(ns_name: &str) -> Result<()> {
     debug!(namespace = %ns_name, "deleting network namespace");
 
-    let output = Command::new("sudo")
-        .args(["ip", "netns", "del", ns_name])
+    let output = Command::new("ip")
+        .args(["netns", "del", ns_name])
         .output()
         .await
         .context("executing ip netns del")?;
@@ -70,10 +70,10 @@ pub async fn exec_in_namespace(ns_name: &str, command: &[&str]) -> Result<std::p
         anyhow::bail!("command cannot be empty");
     }
 
-    let mut args = vec!["ip", "netns", "exec", ns_name];
+    let mut args = vec!["netns", "exec", ns_name];
     args.extend_from_slice(command);
 
-    let output = Command::new("sudo")
+    let output = Command::new("ip")
         .args(&args)
         .output()
         .await

--- a/src/network/portmap.rs
+++ b/src/network/portmap.rs
@@ -41,8 +41,7 @@ pub async fn setup_port_mappings(guest_ip: &str, mappings: &[PortMapping]) -> Re
             )
         };
 
-        let output = Command::new("sudo")
-            .arg("iptables")
+        let output = Command::new("iptables")
             .args(dnat_rule.split_whitespace())
             .output()
             .await
@@ -72,8 +71,7 @@ pub async fn setup_port_mappings(guest_ip: &str, mappings: &[PortMapping]) -> Re
             )
         };
 
-        let output = Command::new("sudo")
-            .arg("iptables")
+        let output = Command::new("iptables")
             .args(output_dnat_rule.split_whitespace())
             .output()
             .await
@@ -98,8 +96,7 @@ pub async fn setup_port_mappings(guest_ip: &str, mappings: &[PortMapping]) -> Re
             guest_ip, proto_str, mapping.guest_port
         );
 
-        let output = Command::new("sudo")
-            .arg("iptables")
+        let output = Command::new("iptables")
             .args(masq_rule.split_whitespace())
             .output()
             .await
@@ -121,8 +118,7 @@ pub async fn setup_port_mappings(guest_ip: &str, mappings: &[PortMapping]) -> Re
             proto_str, guest_ip, mapping.guest_port
         );
 
-        let output = Command::new("sudo")
-            .arg("iptables")
+        let output = Command::new("iptables")
             .args(forward_rule.split_whitespace())
             .output()
             .await
@@ -159,8 +155,8 @@ pub async fn setup_port_mappings(guest_ip: &str, mappings: &[PortMapping]) -> Re
 pub async fn enable_route_localnet(interface: &str) -> Result<()> {
     let sysctl_path = format!("net.ipv4.conf.{}.route_localnet", interface);
 
-    let output = Command::new("sudo")
-        .args(["sysctl", "-w", &format!("{}=1", sysctl_path)])
+    let output = Command::new("sysctl")
+        .args(["-w", &format!("{}=1", sysctl_path)])
         .output()
         .await
         .with_context(|| format!("enabling route_localnet on {}", interface))?;
@@ -188,8 +184,7 @@ async fn delete_rule(rule: &str) -> Result<()> {
     // Convert -A to -D for deletion
     let delete_rule = rule.replace(" -A ", " -D ");
 
-    let output = Command::new("sudo")
-        .arg("iptables")
+    let output = Command::new("iptables")
         .args(delete_rule.split_whitespace())
         .output()
         .await
@@ -242,8 +237,8 @@ pub async fn ensure_global_nat(vm_subnet: &str, outbound_iface: &str) -> Result<
     );
 
     // Enable IP forwarding
-    let output = Command::new("sudo")
-        .args(["sysctl", "-w", "net.ipv4.ip_forward=1"])
+    let output = Command::new("sysctl")
+        .args(["-w", "net.ipv4.ip_forward=1"])
         .output()
         .await
         .context("enabling IP forwarding")?;
@@ -254,9 +249,8 @@ pub async fn ensure_global_nat(vm_subnet: &str, outbound_iface: &str) -> Result<
     }
 
     // Check if MASQUERADE rule already exists
-    let output = Command::new("sudo")
+    let output = Command::new("iptables")
         .args([
-            "iptables",
             "-t",
             "nat",
             "-C",
@@ -278,9 +272,8 @@ pub async fn ensure_global_nat(vm_subnet: &str, outbound_iface: &str) -> Result<
     }
 
     // Add MASQUERADE rule for outbound traffic
-    let output = Command::new("sudo")
+    let output = Command::new("iptables")
         .args([
-            "iptables",
             "-t",
             "nat",
             "-A",

--- a/tests/test_kvm.rs
+++ b/tests/test_kvm.rs
@@ -216,8 +216,8 @@ async fn ensure_firecracker_nv2() -> Result<()> {
     }
 
     println!("  Installing Firecracker to /usr/local/bin...");
-    let status = tokio::process::Command::new("sudo")
-        .args(["cp", binary.to_str().unwrap(), "/usr/local/bin/firecracker"])
+    let status = tokio::process::Command::new("cp")
+        .args([binary.to_str().unwrap(), "/usr/local/bin/firecracker"])
         .status()
         .await
         .context("installing Firecracker")?;
@@ -796,13 +796,12 @@ async fn ensure_inception_image() -> Result<()> {
 
         if !PathBuf::from(&cache_dir).exists() {
             println!("Exporting to CAS cache: {}", cache_dir);
-            tokio::process::Command::new("sudo")
-                .args(["mkdir", "-p", &cache_dir])
+            tokio::process::Command::new("mkdir")
+                .args(["-p", &cache_dir])
                 .output()
                 .await?;
-            let skopeo_out = tokio::process::Command::new("sudo")
+            let skopeo_out = tokio::process::Command::new("skopeo")
                 .args([
-                    "skopeo",
                     "copy",
                     "containers-storage:localhost/inception-test",
                     &format!("dir:{}", cache_dir),
@@ -1275,9 +1274,8 @@ FCVM_FUSE_TRACE_RATE=100 fcvm podman run --name l2 --network bridged --privilege
     println!("Wrote inception scripts to /mnt/fcvm-btrfs/inception-scripts/");
 
     // Run L1 with --cmd that executes the script
-    let output = tokio::process::Command::new("sudo")
+    let output = tokio::process::Command::new("./target/release/fcvm")
         .args([
-            "./target/release/fcvm",
             "podman",
             "run",
             "--name",
@@ -1558,14 +1556,13 @@ async fn test_skopeo_import_over_fuse() -> Result<()> {
     // Check if already in CAS cache
     if !std::path::Path::new(&cache_dir).exists() {
         println!("   Exporting to CAS cache...");
-        tokio::process::Command::new("sudo")
-            .args(["mkdir", "-p", &cache_dir])
+        tokio::process::Command::new("mkdir")
+            .args(["-p", &cache_dir])
             .output()
             .await?;
 
-        let export_output = tokio::process::Command::new("sudo")
+        let export_output = tokio::process::Command::new("skopeo")
             .args([
-                "skopeo",
                 "copy",
                 "containers-storage:localhost/inception-test",
                 &format!("dir:{}", cache_dir),


### PR DESCRIPTION
## Summary
- Eliminate all `sudo` invocations from fcvm Rust code
- Privilege escalation now happens at Makefile level via `CARGO_TARGET_*_RUNNER='sudo -E'`
- Add branch name to test log filenames in CLAUDE.md

## Changes
- **src/network/namespace.rs**: Remove sudo from `ip netns` commands
- **src/network/portmap.rs**: Remove sudo from iptables/sysctl commands  
- **src/network/veth.rs**: Remove sudo from ip link/iptables commands
- **tests/test_kvm.rs**: Remove sudo from test utility commands
- **.claude/CLAUDE.md**: Add branch name pattern to tee log filenames

## Test Results
```
make test-root: 235/238 passed (3 flaky tests passed on retry)
```

All networking tests (namespace, veth, portmap, bridged) pass.