### PR TITLE
Add inception kernel distribution via GitHub Releases

### DIFF
--- a/.github/workflows/kernels.yml
+++ b/.github/workflows/kernels.yml
@@ -1,0 +1,158 @@
+name: Build Kernels
+
+on:
+  push:
+    paths:
+      - 'kernel/**'
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      force_build:
+        description: 'Force rebuild even if release exists'
+        type: boolean
+        default: false
+
+# Cancel in-progress runs when a new revision is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Ensure self-hosted runner EC2 is running
+  ensure-runner:
+    name: Ensure Runner
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-1
+      - name: Start EC2 if stopped
+        run: |
+          INSTANCE_ID="i-0f116a86a2fd78cbe"
+          STATE=$(aws ec2 describe-instances --instance-ids $INSTANCE_ID --query 'Reservations[0].Instances[0].State.Name' --output text)
+          echo "Current state: $STATE"
+          if [ "$STATE" = "stopped" ]; then
+            echo "Starting instance..."
+            aws ec2 start-instances --instance-ids $INSTANCE_ID
+            aws ec2 wait instance-running --instance-ids $INSTANCE_ID
+            echo "Instance started, waiting for runner to register..."
+            sleep 60
+          fi
+
+  build-inception-kernel:
+    name: Build Inception Kernel
+    needs: ensure-runner
+    runs-on: [self-hosted, Linux, ARM64]
+    permissions:
+      contents: write  # Required for creating releases
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute kernel version and SHA
+        id: kernel
+        run: |
+          # Extract version from build.sh
+          VERSION=$(grep '^KERNEL_VERSION=' kernel/build.sh | head -1 | cut -d'"' -f2 || echo "6.18")
+          if [ -z "$VERSION" ]; then
+            VERSION=$(grep 'KERNEL_VERSION:-' kernel/build.sh | grep -oE '[0-9]+\.[0-9]+' | head -1 || echo "6.18")
+          fi
+
+          # Compute SHA from build inputs
+          SHA=$(cat kernel/build.sh kernel/inception.conf kernel/patches/*.patch 2>/dev/null | sha256sum | cut -c1-12)
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "sha=$SHA" >> $GITHUB_OUTPUT
+          echo "tag=kernel-inception-${VERSION}-${SHA}" >> $GITHUB_OUTPUT
+          echo "filename=vmlinux-inception-${VERSION}-${SHA}.bin" >> $GITHUB_OUTPUT
+
+          echo "Kernel version: $VERSION"
+          echo "Build SHA: $SHA"
+
+      - name: Check if release already exists
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.kernel.outputs.tag }}"
+          if gh release view "$TAG" &>/dev/null; then
+            echo "Release $TAG already exists"
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Release $TAG does not exist"
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build kernel
+        if: steps.check.outputs.exists == 'false' || inputs.force_build == true
+        run: |
+          KERNEL_PATH="/tmp/${{ steps.kernel.outputs.filename }}"
+          echo "Building kernel to: $KERNEL_PATH"
+
+          # Run build script
+          KERNEL_PATH="$KERNEL_PATH" ./kernel/build.sh
+
+          # Verify output
+          if [ ! -f "$KERNEL_PATH" ]; then
+            echo "ERROR: Kernel not found at $KERNEL_PATH"
+            exit 1
+          fi
+
+          ls -lh "$KERNEL_PATH"
+          file "$KERNEL_PATH"
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.exists == 'false' || inputs.force_build == true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.kernel.outputs.tag }}"
+          FILENAME="${{ steps.kernel.outputs.filename }}"
+          VERSION="${{ steps.kernel.outputs.version }}"
+          SHA="${{ steps.kernel.outputs.sha }}"
+
+          # Delete existing release if force rebuilding
+          if [ "${{ inputs.force_build }}" == "true" ]; then
+            gh release delete "$TAG" --yes 2>/dev/null || true
+          fi
+
+          # Create release with kernel binary
+          gh release create "$TAG" \
+            --title "Inception Kernel ${VERSION} (${SHA})" \
+            --notes "Auto-built inception kernel for fcvm nested virtualization.
+
+          **Kernel Version:** ${VERSION}
+          **Build SHA:** ${SHA}
+          **Architecture:** ARM64
+
+          This kernel includes:
+          - CONFIG_KVM=y for nested virtualization
+          - FUSE support for volume mounts
+          - MMFR4 override patch for NV2 guest support
+
+          **Usage:**
+          \`\`\`bash
+          fcvm setup  # Downloads automatically
+          fcvm podman run --kernel <path> --privileged ...
+          \`\`\`
+          " \
+            "/tmp/$FILENAME"
+
+          echo "✅ Created release: $TAG"
+
+      - name: Summary
+        run: |
+          echo "### Kernel Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Version | ${{ steps.kernel.outputs.version }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| SHA | ${{ steps.kernel.outputs.sha }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Tag | ${{ steps.kernel.outputs.tag }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Filename | ${{ steps.kernel.outputs.filename }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Already Existed | ${{ steps.check.outputs.exists }} |" >> $GITHUB_STEP_SUMMARY

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -51,6 +51,15 @@ pub struct SetupArgs {
     /// Path to custom rootfs config file
     #[arg(long)]
     pub config: Option<String>,
+
+    /// Also setup inception kernel for nested virtualization
+    #[arg(long)]
+    pub inception: bool,
+
+    /// Build kernels locally instead of downloading from releases
+    /// (use if download fails or you've modified kernel sources)
+    #[arg(long)]
+    pub build_kernels: bool,
 }
 
 // ============================================================================

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -42,7 +42,20 @@ pub async fn cmd_setup(args: SetupArgs) -> Result<()> {
         .context("setting up fc-agent initrd")?;
     println!("  ✓ Initrd ready: {}", initrd_path.display());
 
+    // Setup inception kernel if requested
+    if args.inception {
+        println!("\nSetting up inception kernel for nested virtualization...");
+        let inception_path = crate::setup::ensure_inception_kernel(args.build_kernels)
+            .await
+            .context("setting up inception kernel")?;
+        println!("  ✓ Inception kernel ready: {}", inception_path.display());
+    }
+
     println!("\nSetup complete! You can now run VMs with: fcvm podman run ...");
+    if args.inception {
+        println!("\nFor nested virtualization, use:");
+        println!("  fcvm podman run --kernel <inception-kernel-path> --privileged ...");
+    }
 
     Ok(())
 }

--- a/src/setup/kernel.rs
+++ b/src/setup/kernel.rs
@@ -383,7 +383,10 @@ async fn download_inception_kernel(url: &str, dest: &Path) -> Result<()> {
     let file_type = String::from_utf8_lossy(&output.stdout);
     if !file_type.contains("ELF") {
         let _ = tokio::fs::remove_file(&temp_path).await;
-        bail!("Downloaded file is not a valid kernel (not ELF): {}", file_type);
+        bail!(
+            "Downloaded file is not a valid kernel (not ELF): {}",
+            file_type
+        );
     }
 
     // Move to final location
@@ -413,7 +416,10 @@ async fn build_inception_kernel_locally(dest: &Path) -> Result<()> {
     }
 
     if !dest.exists() {
-        bail!("Kernel build completed but file not found at {}", dest.display());
+        bail!(
+            "Kernel build completed but file not found at {}",
+            dest.display()
+        );
     }
 
     Ok(())

--- a/src/setup/kernel.rs
+++ b/src/setup/kernel.rs
@@ -329,7 +329,7 @@ pub async fn ensure_inception_kernel(allow_build: bool) -> Result<PathBuf> {
             println!("  ✓ Inception kernel downloaded");
             info!(path = %kernel_path.display(), "inception kernel ready");
             flock.unlock().map_err(|(_, err)| err)?;
-            return Ok(kernel_path);
+            Ok(kernel_path)
         }
         Err(e) => {
             warn!(error = %e, "failed to download inception kernel");
@@ -339,7 +339,7 @@ pub async fn ensure_inception_kernel(allow_build: bool) -> Result<PathBuf> {
                 build_inception_kernel_locally(&kernel_path).await?;
                 println!("  ✓ Inception kernel built");
                 flock.unlock().map_err(|(_, err)| err)?;
-                return Ok(kernel_path);
+                Ok(kernel_path)
             } else {
                 flock.unlock().map_err(|(_, err)| err)?;
                 bail!(

--- a/src/setup/kernel.rs
+++ b/src/setup/kernel.rs
@@ -1,12 +1,18 @@
 use anyhow::{bail, Context, Result};
 use nix::fcntl::{Flock, FlockArg};
 use sha2::{Digest, Sha256};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::process::Command;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::paths;
 use crate::setup::rootfs::{load_plan, KernelArchConfig};
+
+/// GitHub repository for kernel releases
+const GITHUB_REPO: &str = "ejc3/fcvm";
+
+/// Inception kernel version (must match kernel/build.sh)
+const INCEPTION_KERNEL_VERSION: &str = "6.18";
 
 /// Compute SHA256 of bytes, return hex string (first 12 chars)
 fn compute_sha256_short(data: &[u8]) -> String {
@@ -201,4 +207,214 @@ async fn download_kernel(config: &KernelArchConfig, allow_create: bool) -> Resul
         .context("releasing kernel lock after download")?;
 
     Ok(kernel_path)
+}
+
+// ============================================================================
+// Inception Kernel (for nested virtualization)
+// ============================================================================
+
+/// Compute SHA for inception kernel based on build inputs.
+/// This matches the SHA computed in kernel/build.sh and CI workflow.
+pub fn compute_inception_kernel_sha() -> Result<String> {
+    let kernel_dir = Path::new("kernel");
+    let mut content = Vec::new();
+
+    // Read build.sh
+    let script = kernel_dir.join("build.sh");
+    if script.exists() {
+        content.extend(std::fs::read(&script).context("reading kernel/build.sh")?);
+    } else {
+        bail!("kernel/build.sh not found");
+    }
+
+    // Read inception.conf
+    let conf = kernel_dir.join("inception.conf");
+    if conf.exists() {
+        content.extend(std::fs::read(&conf).context("reading kernel/inception.conf")?);
+    }
+
+    // Read patches/*.patch (sorted for determinism)
+    let patches_dir = kernel_dir.join("patches");
+    if patches_dir.exists() {
+        let mut patches: Vec<_> = std::fs::read_dir(&patches_dir)?
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "patch"))
+            .collect();
+        patches.sort_by_key(|e| e.path());
+        for patch in patches {
+            content.extend(std::fs::read(patch.path())?);
+        }
+    }
+
+    Ok(compute_sha256_short(&content))
+}
+
+/// Get the inception kernel filename.
+pub fn inception_kernel_filename(sha: &str) -> String {
+    format!("vmlinux-inception-{}-{}.bin", INCEPTION_KERNEL_VERSION, sha)
+}
+
+/// Get the inception kernel release tag.
+pub fn inception_kernel_tag(sha: &str) -> String {
+    format!("kernel-inception-{}-{}", INCEPTION_KERNEL_VERSION, sha)
+}
+
+/// Ensure inception kernel exists.
+///
+/// 1. Check if already downloaded locally
+/// 2. Try to download from GitHub releases
+/// 3. If `allow_build` is true and download fails, build locally
+///
+/// Returns the path to the kernel binary.
+pub async fn ensure_inception_kernel(allow_build: bool) -> Result<PathBuf> {
+    let sha = compute_inception_kernel_sha()?;
+    let filename = inception_kernel_filename(&sha);
+    let kernel_dir = paths::kernel_dir();
+    let kernel_path = kernel_dir.join(&filename);
+
+    // Fast path: already exists
+    if kernel_path.exists() {
+        info!(
+            path = %kernel_path.display(),
+            sha = %sha,
+            "inception kernel already exists"
+        );
+        return Ok(kernel_path);
+    }
+
+    // Create directory
+    tokio::fs::create_dir_all(&kernel_dir)
+        .await
+        .context("creating kernel directory")?;
+
+    // Acquire lock to prevent race conditions
+    let lock_file = kernel_dir.join(format!("{}.lock", filename));
+    use std::os::unix::fs::OpenOptionsExt;
+    let lock_fd = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(&lock_file)
+        .context("opening inception kernel lock file")?;
+
+    let flock = Flock::lock(lock_fd, FlockArg::LockExclusive)
+        .map_err(|(_, err)| err)
+        .context("acquiring exclusive lock for inception kernel")?;
+
+    // Double-check after lock
+    if kernel_path.exists() {
+        debug!(
+            path = %kernel_path.display(),
+            "inception kernel already exists (created by another process)"
+        );
+        flock.unlock().map_err(|(_, err)| err)?;
+        return Ok(kernel_path);
+    }
+
+    // Try to download from GitHub releases
+    let tag = inception_kernel_tag(&sha);
+    let download_url = format!(
+        "https://github.com/{}/releases/download/{}/{}",
+        GITHUB_REPO, tag, filename
+    );
+
+    println!("⚙️  Downloading inception kernel...");
+    info!(url = %download_url, tag = %tag, "downloading inception kernel from GitHub releases");
+
+    let download_result = download_inception_kernel(&download_url, &kernel_path).await;
+
+    match download_result {
+        Ok(_) => {
+            println!("  ✓ Inception kernel downloaded");
+            info!(path = %kernel_path.display(), "inception kernel ready");
+            flock.unlock().map_err(|(_, err)| err)?;
+            return Ok(kernel_path);
+        }
+        Err(e) => {
+            warn!(error = %e, "failed to download inception kernel");
+
+            if allow_build {
+                println!("  → Download failed, building locally (this may take 10-20 minutes)...");
+                build_inception_kernel_locally(&kernel_path).await?;
+                println!("  ✓ Inception kernel built");
+                flock.unlock().map_err(|(_, err)| err)?;
+                return Ok(kernel_path);
+            } else {
+                flock.unlock().map_err(|(_, err)| err)?;
+                bail!(
+                    "Failed to download inception kernel: {}\n\
+                    \n\
+                    The kernel release may not exist yet. Options:\n\
+                    1. Wait for CI to build it (push to main triggers kernel build)\n\
+                    2. Build locally with: fcvm setup --build-kernels\n\
+                    3. Build manually with: ./kernel/build.sh",
+                    e
+                );
+            }
+        }
+    }
+}
+
+/// Download inception kernel from URL.
+async fn download_inception_kernel(url: &str, dest: &Path) -> Result<()> {
+    let temp_path = dest.with_extension("downloading");
+
+    let output = Command::new("curl")
+        .args(["-fSL", url, "-o"])
+        .arg(&temp_path)
+        .output()
+        .await
+        .context("running curl")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let _ = tokio::fs::remove_file(&temp_path).await;
+        bail!("curl failed: {}", stderr);
+    }
+
+    // Verify it's a valid ELF binary
+    let output = Command::new("file")
+        .arg(&temp_path)
+        .output()
+        .await
+        .context("running file command")?;
+
+    let file_type = String::from_utf8_lossy(&output.stdout);
+    if !file_type.contains("ELF") {
+        let _ = tokio::fs::remove_file(&temp_path).await;
+        bail!("Downloaded file is not a valid kernel (not ELF): {}", file_type);
+    }
+
+    // Move to final location
+    tokio::fs::rename(&temp_path, dest)
+        .await
+        .context("moving downloaded kernel to final location")?;
+
+    Ok(())
+}
+
+/// Build inception kernel locally using kernel/build.sh.
+async fn build_inception_kernel_locally(dest: &Path) -> Result<()> {
+    let script = Path::new("kernel/build.sh");
+    if !script.exists() {
+        bail!("kernel/build.sh not found - are you in the fcvm repository root?");
+    }
+
+    let output = Command::new(script)
+        .env("KERNEL_PATH", dest)
+        .output()
+        .await
+        .context("running kernel/build.sh")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("Kernel build failed: {}", stderr);
+    }
+
+    if !dest.exists() {
+        bail!("Kernel build completed but file not found at {}", dest.display());
+    }
+
+    Ok(())
 }

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -1,5 +1,5 @@
 pub mod kernel;
 pub mod rootfs;
 
-pub use kernel::ensure_kernel;
+pub use kernel::{ensure_inception_kernel, ensure_kernel};
 pub use rootfs::{ensure_fc_agent_initrd, ensure_rootfs};


### PR DESCRIPTION
## Summary

Adds automated kernel building and distribution via GitHub Releases.

## Changes

### CI Workflow (`.github/workflows/kernels.yml`)
- Triggers on push to `kernel/**` or manual dispatch
- Computes kernel SHA from `build.sh + inception.conf + patches`
- Builds inception kernel on self-hosted ARM64 runner
- Creates GitHub release with kernel binary
- Skips build if release already exists (SHA-based caching)

### fcvm setup
- `--inception` flag to download/setup inception kernel
- `--build-kernels` flag to force local build instead of download
- `ensure_inception_kernel()` tries download first, falls back to build
- Kernel naming: `vmlinux-inception-{version}-{sha}.bin`

## User Workflow

```bash
# Normal user - downloads from releases
fcvm setup --inception

# Developer - builds locally (if modifying kernel sources)
fcvm setup --inception --build-kernels
```

## How It Works

1. CI computes SHA from kernel sources
2. If release doesn't exist, builds kernel and creates release
3. `fcvm setup --inception` downloads from release by SHA
4. If download fails, user can `--build-kernels` to build locally

## Test Plan
- [ ] CI workflow triggers and builds kernel
- [ ] Release is created with correct naming
- [ ] `fcvm setup --inception` downloads kernel from release
- [ ] `--build-kernels` falls back to local build