### PR TITLE
Add disk cleanup step to CI before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,9 @@ jobs:
           echo "user_allow_other" | sudo tee /etc/fuse.conf
       - name: Create test log directory
         run: mkdir -p /tmp/fcvm-test-logs
+      - name: Clean test data
+        working-directory: fcvm
+        run: make clean-test-data || true
       - name: test-unit
         working-directory: fcvm
         run: make test-unit
@@ -292,6 +295,9 @@ jobs:
           restore-keys: container-cargo-
       - name: Create test log directory
         run: mkdir -p /tmp/fcvm-test-logs
+      - name: Clean test data
+        working-directory: fcvm
+        run: make clean-test-data || true
       - name: container-test-unit
         env:
           CARGO_CACHE_DIR: ${{ github.workspace }}/cargo-cache


### PR DESCRIPTION
Runner disk filled up causing 'Need 15GB free' errors.
Add make clean-test-data before test runs to clear leftover
VM disks and snapshots from previous runs.
