### PR TITLE
Clean up CLI output and fix README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ The `--setup` flag triggers setup if kernel/rootfs are missing. Only works with 
 fcvm podman run --name web1 public.ecr.aws/nginx/nginx:alpine
 
 # With port forwarding (8080 on host -> 80 in guest)
+# Note: In rootless mode, use the assigned loopback IP (e.g., curl 127.0.0.2:8080)
+# In bridged mode, use the veth host IP (see fcvm ls --json for the IP)
 fcvm podman run --name web1 --publish 8080:80 public.ecr.aws/nginx/nginx:alpine
 
 # With host directory mapping (via fuse-pipe)
@@ -182,8 +184,8 @@ sudo fcvm snapshot run --pid <serve_pid> --name clone2 --network bridged
 # 5. Clone with port forwarding (each clone can have unique ports)
 sudo fcvm snapshot run --pid <serve_pid> --name web1 --network bridged --publish 8081:80
 sudo fcvm snapshot run --pid <serve_pid> --name web2 --network bridged --publish 8082:80
-curl localhost:8081  # Reaches clone web1
-curl localhost:8082  # Reaches clone web2
+# Get the host IP from fcvm ls --json, then curl it:
+#   curl $(sudo fcvm ls --json | jq -r '.[] | select(.name=="web1") | .config.network.host_ip'):8081
 
 # 6. Clone and execute command (auto-cleans up after)
 sudo fcvm snapshot run --pid <serve_pid> --network bridged --exec "curl localhost"
@@ -284,7 +286,7 @@ sudo fcvm podman run --name multi-port \
 
 # Multiple volume mappings (comma-separated, with read-only)
 sudo fcvm podman run --name multi-vol \
-  --map /tmp/logs:/var/log,/tmp/data:/data:ro \
+  --map /tmp/logs:/logs,/tmp/data:/data:ro \
   public.ecr.aws/nginx/nginx:alpine
 
 # Combined

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -406,8 +406,13 @@ async fn run_output_listener(socket_path: &str, vm_id: &str) -> Result<Vec<(Stri
                 // Parse raw line format: stream:content
                 let line = line_buf.trim_end();
                 if let Some((stream, content)) = line.split_once(':') {
-                    // Print to host's stderr with prefix (using tracing)
-                    eprintln!("[ctr:{}] {}", stream, content);
+                    // Print container output directly (stdout to stdout, stderr to stderr)
+                    // No prefix - clean output for scripting
+                    if stream == "stdout" {
+                        println!("{}", content);
+                    } else {
+                        eprintln!("{}", content);
+                    }
                     output_lines.push((stream.to_string(), content.to_string()));
 
                     // Send ack back (bidirectional)

--- a/src/firecracker/vm.rs
+++ b/src/firecracker/vm.rs
@@ -414,7 +414,7 @@ impl VmManager {
                 .context("running chmod via nsenter")?;
             if !chmod_output.status.success() {
                 let stderr = String::from_utf8_lossy(&chmod_output.stderr);
-                warn!(target: "vm", vm_id = %self.vm_id, stderr = %stderr, "chmod via nsenter failed (non-fatal)");
+                debug!(target: "vm", vm_id = %self.vm_id, stderr = %stderr, "chmod via nsenter failed (non-fatal)");
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,8 +50,8 @@ async fn main() -> Result<()> {
     }
 
     // Initialize logging
-    // Use RUST_LOG if set, otherwise default to INFO
-    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    // Use RUST_LOG if set, otherwise default to WARN (quiet by default, use RUST_LOG=info for verbose)
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"));
 
     // If --sub-process flag is set, disable timestamps AND level (subprocess mode)
     // Parent process already shows timestamp and level, so subprocess just shows the message

--- a/tests/test_localhost_image.rs
+++ b/tests/test_localhost_image.rs
@@ -48,33 +48,33 @@ async fn test_localhost_hello_world() -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("failed to get child PID"))?;
     println!("  fcvm process started (PID: {})", fcvm_pid);
 
-    // Spawn task to collect stdout
+    // Monitor stdout for container output (goes directly to stdout without prefix)
     let stdout = child.stdout.take();
     let stdout_task = tokio::spawn(async move {
+        let mut found_hello = false;
         if let Some(stdout) = stdout {
             let reader = BufReader::new(stdout);
             let mut lines = reader.lines();
             while let Ok(Some(line)) = lines.next_line().await {
                 eprintln!("[VM stdout] {}", line);
+                // Check for container output (no prefix in clean output mode)
+                if line.contains("Hello from localhost container!") {
+                    found_hello = true;
+                }
             }
         }
+        found_hello
     });
 
-    // Monitor stderr for container output and exit status
-    // Output comes via bidirectional vsock channel as [ctr:stdout] or [ctr:stderr]
+    // Monitor stderr for exit status (logs still go to stderr)
     let stderr = child.stderr.take();
     let stderr_task = tokio::spawn(async move {
-        let mut found_hello = false;
         let mut exited_zero = false;
         if let Some(stderr) = stderr {
             let reader = BufReader::new(stderr);
             let mut lines = reader.lines();
             while let Ok(Some(line)) = lines.next_line().await {
                 eprintln!("[VM stderr] {}", line);
-                // Check for container output via bidirectional vsock channel
-                if line.contains("[ctr:stdout] Hello from localhost container!") {
-                    found_hello = true;
-                }
                 // Check for container exit with code 0
                 if line.contains("Container exit notification received")
                     && line.contains("exit_code=0")
@@ -83,7 +83,7 @@ async fn test_localhost_hello_world() -> Result<()> {
                 }
             }
         }
-        (found_hello, exited_zero)
+        exited_zero
     });
 
     // Wait for the process to exit (with timeout)
@@ -108,8 +108,8 @@ async fn test_localhost_hello_world() -> Result<()> {
     }
 
     // Wait for output tasks
-    let _ = stdout_task.await;
-    let (found_hello, container_exited_zero) = stderr_task.await.unwrap_or((false, false));
+    let found_hello = stdout_task.await.unwrap_or(false);
+    let container_exited_zero = stderr_task.await.unwrap_or(false);
 
     // Check results - verify we got the container output
     if found_hello {
@@ -123,9 +123,7 @@ async fn test_localhost_hello_world() -> Result<()> {
         Ok(())
     } else {
         println!("\n❌ LOCALHOST IMAGE TEST FAILED!");
-        println!(
-            "  - Did not find expected output: '[ctr:stdout] Hello from localhost container!'"
-        );
+        println!("  - Did not find expected output: 'Hello from localhost container!'");
         println!("  - Check logs above for error details");
         anyhow::bail!("Localhost image test failed")
     }


### PR DESCRIPTION
## Summary

- Fix README examples for port forwarding (use assigned IP, not localhost)
- Fix README multi-volume example (`/var/log` breaks nginx → `/logs`)
- Default log level changed from `info` to `warn` (quiet by default)
- Container stdout → host stdout, stderr → host stderr (no `[ctr:stdout]` prefix)
- Non-fatal nsenter chmod warning demoted to debug level

## Result

```
$ fcvm podman run --name test alpine:latest echo "hello world"
hello world
```

Clean output for scripting. Verbose logging available with `RUST_LOG=info`.

## Test plan

- [x] `make test-root FILTER=sanity` (3/3 pass)
- [x] `make test-root FILTER=localhost` (1/1 pass)
- [x] `make test-root FILTER=exec` (6/6 pass)
- [x] Manual test: one-shot command shows only container output
- [x] Manual test: stdout/stderr separation works correctly