### PR TITLE
Remove chmod 777 and block sudo in unprivileged tests

### DIFF
--- a/.github/workflows/kernels.yml
+++ b/.github/workflows/kernels.yml
@@ -116,7 +116,7 @@ jobs:
             sudo mkfs.btrfs /var/fcvm-btrfs.img
             sudo mount /var/fcvm-btrfs.img /mnt/fcvm-btrfs
           fi
-          sudo chmod 777 /mnt/fcvm-btrfs
+          sudo chown $USER:$USER /mnt/fcvm-btrfs
 
       - name: Build kernel using fcvm
         if: steps.check.outputs.exists == 'false' || inputs.force_build == true

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ MUSL_TARGET := x86_64-unknown-linux-musl
 endif
 
 # Base test command
-NEXTEST := CARGO_TARGET_DIR=target cargo nextest $(NEXTEST_CMD) --release
+export CARGO_TARGET_DIR := target
+NEXTEST := cargo nextest $(NEXTEST_CMD) --release
 
 # Optional cargo cache directory (for CI caching)
 CARGO_CACHE_DIR ?=
@@ -187,11 +188,11 @@ _test-unit:
 
 _test-fast:
 	RUST_LOG="$(TEST_LOG)" \
-	$(NEXTEST) $(NEXTEST_CAPTURE) --no-default-features --features integration-fast $(FILTER)
+	./scripts/no-sudo.sh $(NEXTEST) $(NEXTEST_CAPTURE) --no-default-features --features integration-fast $(FILTER)
 
 _test-all:
 	RUST_LOG="$(TEST_LOG)" \
-	$(NEXTEST) $(NEXTEST_CAPTURE) $(FILTER)
+	./scripts/no-sudo.sh $(NEXTEST) $(NEXTEST_CAPTURE) $(FILTER)
 
 _test-root:
 	RUST_LOG="$(TEST_LOG)" \

--- a/Makefile
+++ b/Makefile
@@ -264,9 +264,12 @@ setup-btrfs:
 	fi
 	@# Ensure image-cache exists with correct permissions (may be missing on older setups)
 	@sudo mkdir -p /mnt/fcvm-btrfs/image-cache && sudo chown $$(id -un):$$(id -gn) /mnt/fcvm-btrfs/image-cache
-	@# Create per-mode data directories (owned by root for root tests, by user for rootless)
+	@# Create per-mode data directories
+	@# ROOT_DATA_DIR: owned by root (tests run with sudo)
+	@# CONTAINER_DATA_DIR: owned by user (podman rootless maps to subordinate UIDs)
 	@sudo mkdir -p $(ROOT_DATA_DIR)/{state,snapshots,vm-disks}
 	@sudo mkdir -p $(CONTAINER_DATA_DIR)/{state,snapshots,vm-disks}
+	@sudo chown -R $$(id -un):$$(id -gn) $(CONTAINER_DATA_DIR)
 
 setup-fcvm: build setup-btrfs
 	@FREE_GB=$$(df -BG /mnt/fcvm-btrfs 2>/dev/null | awk 'NR==2 {gsub("G",""); print $$4}'); \

--- a/Makefile
+++ b/Makefile
@@ -263,9 +263,9 @@ setup-btrfs:
 	fi
 	@# Ensure image-cache exists with correct permissions (may be missing on older setups)
 	@sudo mkdir -p /mnt/fcvm-btrfs/image-cache && sudo chown $$(id -un):$$(id -gn) /mnt/fcvm-btrfs/image-cache
-	@# Create per-mode data directories with world-writable permissions
-	@sudo mkdir -p $(ROOT_DATA_DIR)/{state,snapshots,vm-disks} && sudo chmod -R 777 $(ROOT_DATA_DIR)
-	@sudo mkdir -p $(CONTAINER_DATA_DIR)/{state,snapshots,vm-disks} && sudo chmod -R 777 $(CONTAINER_DATA_DIR)
+	@# Create per-mode data directories (owned by root for root tests, by user for rootless)
+	@sudo mkdir -p $(ROOT_DATA_DIR)/{state,snapshots,vm-disks}
+	@sudo mkdir -p $(CONTAINER_DATA_DIR)/{state,snapshots,vm-disks}
 
 setup-fcvm: build setup-btrfs
 	@FREE_GB=$$(df -BG /mnt/fcvm-btrfs 2>/dev/null | awk 'NR==2 {gsub("G",""); print $$4}'); \

--- a/fuse-pipe/src/server/pipelined.rs
+++ b/fuse-pipe/src/server/pipelined.rs
@@ -73,10 +73,6 @@ impl<H: FilesystemHandler + 'static> AsyncServer<H> {
 
         let listener = UnixListener::bind(socket_path)?;
 
-        // Make socket accessible by Firecracker running in user namespace (UID 100000)
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(socket_path, std::fs::Permissions::from_mode(0o777))?;
-
         // Signal ready BEFORE entering accept loop
         if let Some(tx) = ready {
             let _ = tx.send(());

--- a/scripts/no-sudo.sh
+++ b/scripts/no-sudo.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Prevent sudo access for unprivileged tests
+#
+# This script shadows the real sudo with a stub that errors.
+# Used to ensure unprivileged tests can't accidentally escalate to root.
+
+set -e
+
+NOSUDO_DIR=$(mktemp -d)
+trap "rm -rf $NOSUDO_DIR" EXIT
+
+cat > "$NOSUDO_DIR/sudo" << 'EOF'
+#!/bin/bash
+echo "ERROR: sudo is not allowed in unprivileged tests" >&2
+echo "This test should work without root access." >&2
+exit 1
+EOF
+chmod +x "$NOSUDO_DIR/sudo"
+
+export PATH="$NOSUDO_DIR:$PATH"
+"$@"

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -655,7 +655,6 @@ async fn cmd_podman_run(args: RunArgs) -> Result<()> {
         .await
         .context("creating VM data directory")?;
 
-
     let socket_path = data_dir.join("firecracker.sock");
 
     // Create VM state
@@ -930,7 +929,6 @@ async fn run_vm_setup(
         .create_cow_disk()
         .await
         .context("creating CoW disk")?;
-
 
     info!(rootfs = %rootfs_path.display(), "disk prepared (fc-agent baked into Layer 2)");
 

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -270,11 +270,6 @@ async fn run_status_listener(
     let listener = UnixListener::bind(socket_path)
         .with_context(|| format!("binding status listener to {}", socket_path))?;
 
-    // Make socket accessible by Firecracker running in user namespace (UID 100000)
-    use std::os::unix::fs::PermissionsExt;
-    std::fs::set_permissions(socket_path, std::fs::Permissions::from_mode(0o777))
-        .with_context(|| format!("chmod status socket {}", socket_path))?;
-
     info!(socket = %socket_path, "Status listener started");
 
     let ready_file = runtime_dir.join("container-ready");
@@ -350,11 +345,6 @@ async fn run_output_listener(socket_path: &str, vm_id: &str) -> Result<Vec<(Stri
 
     let listener = UnixListener::bind(socket_path)
         .with_context(|| format!("binding output listener to {}", socket_path))?;
-
-    // Make socket accessible by Firecracker
-    use std::os::unix::fs::PermissionsExt;
-    std::fs::set_permissions(socket_path, std::fs::Permissions::from_mode(0o777))
-        .with_context(|| format!("chmod output socket {}", socket_path))?;
 
     info!(socket = %socket_path, "Output listener started");
 
@@ -665,14 +655,6 @@ async fn cmd_podman_run(args: RunArgs) -> Result<()> {
         .await
         .context("creating VM data directory")?;
 
-    // For rootless mode, make directory world-writable so processes inside the user
-    // namespace can create sockets. User namespace UID 0 maps to subordinate UID
-    // (typically 100000+), which doesn't match the directory owner (UID 1000).
-    if matches!(args.network, NetworkMode::Rootless) {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&data_dir, std::fs::Permissions::from_mode(0o777))
-            .context("setting directory permissions for rootless mode")?;
-    }
 
     let socket_path = data_dir.join("firecracker.sock");
 
@@ -949,15 +931,6 @@ async fn run_vm_setup(
         .await
         .context("creating CoW disk")?;
 
-    // For rootless mode, make disk directory and file world-accessible
-    // Firecracker runs as UID 100000+ inside namespace, can't access UID 1000 files
-    if network.as_any().downcast_ref::<SlirpNetwork>().is_some() {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&vm_dir, std::fs::Permissions::from_mode(0o777))
-            .context("setting disk directory permissions for rootless mode")?;
-        std::fs::set_permissions(&rootfs_path, std::fs::Permissions::from_mode(0o666))
-            .context("setting disk file permissions for rootless mode")?;
-    }
 
     info!(rootfs = %rootfs_path.display(), "disk prepared (fc-agent baked into Layer 2)");
 

--- a/tests/test_no_sudo.rs
+++ b/tests/test_no_sudo.rs
@@ -1,0 +1,27 @@
+//! Test that sudo is blocked in unprivileged tests.
+//!
+//! This test verifies that the no-sudo.sh wrapper is working correctly
+//! and that unprivileged tests cannot escalate to root.
+
+#![cfg(feature = "integration-fast")]
+#![cfg(not(feature = "privileged-tests"))]
+
+#[test]
+fn test_sudo_is_blocked() {
+    let output = std::process::Command::new("sudo")
+        .arg("true")
+        .output()
+        .expect("failed to execute sudo");
+
+    assert!(
+        !output.status.success(),
+        "sudo should be blocked in unprivileged tests"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not allowed"),
+        "sudo should show 'not allowed' error, got: {}",
+        stderr
+    );
+}


### PR DESCRIPTION
## Summary

- Remove all `chmod 777` calls - use ownership semantics instead of world-writable permissions
- Block sudo access in unprivileged tests (`test-fast`, `test-all`) via PATH shadowing

## Changes

### Remove chmod 777 (commit 05b5da0)

With `--map-root-user`, the current user (UID 1000) maps to UID 0 inside the user namespace. Combined with `--preserve-credentials` when using nsenter, files created inside appear as UID 1000 outside - no permission mismatch needed.

Removed chmod 777 from:
- Socket files (podman.rs, vm.rs, pipelined.rs)
- Data directories (podman.rs, snapshot.rs)
- Makefile per-mode directories
- CI workflow (use chown instead)

### Block sudo in unprivileged tests (commit 293d964)

Adds PATH shadowing to prevent unprivileged tests from accidentally escalating to root. Container tests are unaffected since they run in a sandboxed environment.

- `scripts/no-sudo.sh`: Creates temp dir with fake sudo that errors, prepends to PATH
- `Makefile`: Wraps `_test-fast` and `_test-all` with no-sudo.sh
- `tests/test_no_sudo.rs`: Verification test confirms sudo is blocked

## Test plan

- [x] `make test-fast FILTER=sudo` - test_sudo_is_blocked passes
- [x] `make test-fast FILTER=sanity` - rootless tests pass without sudo
- [x] `make test-root FILTER=sanity` - privileged tests still work with real sudo