### PR TITLE
Replace Docker Hub images with ECR to avoid rate limits

### DIFF
--- a/tests/test_fuse_copy_file_range_vm.rs
+++ b/tests/test_fuse_copy_file_range_vm.rs
@@ -121,7 +121,7 @@ echo "SUCCESS: copy_file_range works through FUSE!"
         &map_arg,
         "--cmd",
         test_script,
-        "alpine:latest",
+        common::TEST_IMAGE, // Use ECR to avoid Docker Hub rate limits
     ])
     .stdout(Stdio::piped())
     .stderr(Stdio::piped());

--- a/tests/test_kvm.rs
+++ b/tests/test_kvm.rs
@@ -419,11 +419,12 @@ except OSError as e:
         chmod 666 /dev/net/tun
         cd /mnt/fcvm-btrfs
         # Use bridged networking (outer VM is privileged so iptables works)
+        # Use ECR image to avoid Docker Hub rate limits
         fcvm podman run \
             --name inner-test \
             --network bridged \
             --cmd "echo NESTED_SUCCESS_INNER_VM_WORKS" \
-            alpine:latest
+            public.ecr.aws/nginx/nginx:alpine
     "#;
 
     let output = tokio::process::Command::new(&fcvm_path)

--- a/tests/test_localhost_image.rs
+++ b/tests/test_localhost_image.rs
@@ -132,11 +132,11 @@ async fn build_test_image() -> Result<()> {
     let temp_dir = TempDir::new().context("creating temp dir")?;
     let containerfile_path = temp_dir.path().join("Containerfile");
 
-    // Write a simple Containerfile
+    // Write a simple Containerfile (use ECR to avoid Docker Hub rate limits)
     let mut file = std::fs::File::create(&containerfile_path)?;
     writeln!(
         file,
-        r#"FROM alpine:latest
+        r#"FROM public.ecr.aws/nginx/nginx:alpine
 CMD ["echo", "Hello from localhost container!"]"#
     )?;
 

--- a/tests/test_remap_file_range.rs
+++ b/tests/test_remap_file_range.rs
@@ -68,7 +68,7 @@ async fn run_remap_test_in_vm(test_name: &str, test_script: &str) -> Result<()> 
         &map_arg,
         "--cmd",
         test_script,
-        "alpine:latest",
+        common::TEST_IMAGE, // Use ECR to avoid Docker Hub rate limits
     ];
     cmd.args(&args)
         .stdout(Stdio::piped())

--- a/tests/test_sanity.rs
+++ b/tests/test_sanity.rs
@@ -121,14 +121,16 @@ async fn test_graceful_shutdown() -> Result<()> {
 
     let (vm_name, _, _, _) = common::unique_names("graceful");
 
-    // Start VM with alpine:latest which exits immediately (rootless mode)
+    // Start VM with container that exits immediately (rootless mode)
+    // Use public ECR image to avoid Docker Hub rate limits
     println!("Starting VM with container that exits immediately...");
     let (mut child, fcvm_pid) = common::spawn_fcvm(&[
         "podman",
         "run",
         "--name",
         &vm_name,
-        "alpine:latest", // Exits immediately with code 0
+        common::TEST_IMAGE, // nginx:alpine from ECR
+        "true",             // Exit immediately with code 0
     ])
     .await
     .context("spawning fcvm")?;
@@ -208,7 +210,7 @@ async fn test_ftrace_sanity() -> Result<()> {
         &vm_name,
         "--network",
         "bridged",
-        "alpine:latest",
+        common::TEST_IMAGE, // Use ECR to avoid Docker Hub rate limits
         "true",
     ])
     .await?;
@@ -242,13 +244,14 @@ async fn test_trailing_args_command() -> Result<()> {
 
     let (vm_name, _, _, _) = common::unique_names("trailing-args");
 
-    // Use trailing args: alpine:latest echo "test-marker-12345" (rootless mode)
+    // Use trailing args: image echo "test-marker-12345" (rootless mode)
+    // Use ECR image to avoid Docker Hub rate limits
     let (mut child, fcvm_pid) = common::spawn_fcvm(&[
         "podman",
         "run",
         "--name",
         &vm_name,
-        "alpine:latest",
+        common::TEST_IMAGE,
         "echo",
         "test-marker-12345",
     ])

--- a/tests/vsock-integrity/run-test.sh
+++ b/tests/vsock-integrity/run-test.sh
@@ -47,14 +47,14 @@ echo ""
 
 # Run L2 VM
 # Note: L2 just needs to run the vsock client - no nested virtualization needed
-# Use alpine:latest with vsock-integrity from FUSE mount
+# Use ECR image to avoid Docker Hub rate limits
 # FCVM_FUSE_MAX_WRITE=32768 prevents vsock data loss in L2 FUSE-over-FUSE
 FCVM_FUSE_MAX_WRITE=32768 fcvm podman run \
     --name l2-vsock-test \
     --network bridged \
     --vsock-dir "$VSOCK_DIR" \
     --map /mnt/fcvm-btrfs:/mnt/fcvm-btrfs \
-    alpine:latest \
+    public.ecr.aws/nginx/nginx:alpine \
     --cmd "/mnt/fcvm-btrfs/bin/vsock-integrity client-vsock 2 $VSOCK_PORT && echo $MARKER" 2>&1 | tee /tmp/l2-output.log
 
 # Kill echo server


### PR DESCRIPTION
## Summary
Replace all Docker Hub image references in tests with AWS ECR equivalents to avoid rate limiting.

## Problem
`test_graceful_shutdown` failed in CI because Docker Hub's unauthenticated pull rate limits blocked `alpine:latest`:
```
Error: initializing source docker://alpine:latest: toomanyrequests: You have reached your unauthenticated pull rate limit
```

## Solution
Use `public.ecr.aws/nginx/nginx:alpine` which has no rate limits. For tests that need to exit immediately, pass `true` as the command.

## Files Changed
- `tests/test_sanity.rs` - 3 usages
- `tests/test_fuse_copy_file_range_vm.rs` - 1 usage
- `tests/test_remap_file_range.rs` - 1 usage
- `tests/test_kvm.rs` - 1 usage (nested VM shell script)
- `tests/test_localhost_image.rs` - Containerfile FROM statement
- `tests/vsock-integrity/run-test.sh` - 1 usage

## Test plan
- [ ] All tests pass in CI (no more rate limit errors)