### PR TITLE
Auto-create btrfs storage and streamline README Quick Start

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -54,8 +54,12 @@ pub async fn cmd_setup(args: SetupArgs) -> Result<()> {
         return Ok(());
     }
 
+    // Ensure btrfs storage is ready (creates loopback if needed)
+    // This must be done before accessing any paths under the configured assets_dir
+    crate::setup::ensure_storage(args.config.as_deref()).context("initializing storage")?;
+
     // Load config and initialize paths (with helpful error if config missing)
-    let (config, _, _) = load_config(None)?;
+    let (config, _, _) = load_config(args.config.as_deref())?;
     paths::init_with_paths(&config.paths.data_dir, &config.paths.assets_dir);
 
     println!("Setting up fcvm (this may take 5-10 minutes on first run)...");

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -141,7 +141,8 @@ async fn cmd_snapshot_create(args: SnapshotCreateArgs) -> Result<()> {
             if !output.status.success() {
                 let stderr = String::from_utf8_lossy(&output.stderr);
                 anyhow::bail!(
-                    "Failed to create reflink copy. Ensure /mnt/fcvm-btrfs is a btrfs filesystem. Error: {}",
+                    "Failed to create reflink copy. Ensure {} is a btrfs filesystem. Error: {}",
+                    crate::paths::assets_dir().display(),
                     stderr
                 );
             }
@@ -159,7 +160,9 @@ async fn cmd_snapshot_create(args: SnapshotCreateArgs) -> Result<()> {
 
         // Parse volume configs from VM state (format: HOST:GUEST[:ro])
         use super::common::VSOCK_VOLUME_PORT_BASE;
-        let volume_configs: Vec<SnapshotVolumeConfig> = vm_state.config.volumes
+        let volume_configs: Vec<SnapshotVolumeConfig> = vm_state
+            .config
+            .volumes
             .iter()
             .enumerate()
             .filter_map(|(idx, spec)| {
@@ -214,7 +217,10 @@ async fn cmd_snapshot_create(args: SnapshotCreateArgs) -> Result<()> {
             "snapshot created successfully"
         );
 
-        let vm_name = vm_state.name.as_deref().unwrap_or(truncate_id(&vm_state.vm_id, 8));
+        let vm_name = vm_state
+            .name
+            .as_deref()
+            .unwrap_or(truncate_id(&vm_state.vm_id, 8));
         println!(
             "✓ Snapshot '{}' created from VM '{}'",
             snapshot_name, vm_name

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,8 +36,8 @@ async fn main() -> Result<()> {
     // Initialize paths - some commands don't need config
     match &cli.cmd {
         Commands::Setup(_) => {
-            // Setup handles its own config loading with proper error messages
-            paths::init_with_defaults();
+            // Setup handles its own path initialization after loading config
+            // Don't pre-initialize here since setup may create storage first
         }
         Commands::Completions(_) => {
             // Shell completions don't need config

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -1,8 +1,10 @@
 pub mod kernel;
 pub mod rootfs;
+pub mod storage;
 
 pub use kernel::{
     ensure_kernel, ensure_profile_firecracker, get_firecracker_for_profile, get_kernel_path,
     get_kernel_url_hash, get_profile_firecracker_path, install_host_kernel,
 };
 pub use rootfs::{ensure_fc_agent_initrd, ensure_rootfs, get_kernel_profile, KernelProfile};
+pub use storage::ensure_storage;

--- a/src/setup/storage.rs
+++ b/src/setup/storage.rs
@@ -1,0 +1,195 @@
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tracing::info;
+
+use crate::setup::rootfs::load_config;
+
+const DEFAULT_SIZE_GB: u64 = 60;
+
+/// Required subdirectories under the btrfs mount
+const REQUIRED_DIRS: &[&str] = &[
+    "kernels",
+    "rootfs",
+    "initrd",
+    "state",
+    "snapshots",
+    "vm-disks",
+    "cache",
+    "image-cache",
+];
+
+/// Check if a path is a btrfs filesystem
+fn is_btrfs_mount(path: &Path) -> bool {
+    // Check if it's a mountpoint first
+    let output = Command::new("mountpoint").arg("-q").arg(path).status();
+
+    if output.map(|s| s.success()).unwrap_or(false) {
+        // Check filesystem type
+        let output = Command::new("stat")
+            .arg("-f")
+            .arg("-c")
+            .arg("%T")
+            .arg(path)
+            .output();
+
+        if let Ok(output) = output {
+            let fstype = String::from_utf8_lossy(&output.stdout);
+            return fstype.trim() == "btrfs";
+        }
+    }
+    false
+}
+
+/// Get storage paths from config
+fn get_storage_paths(config_path: Option<&str>) -> Result<(PathBuf, PathBuf)> {
+    let (config, _, _) = load_config(config_path)?;
+    let mount_point = PathBuf::from(&config.paths.assets_dir);
+    // Loopback image goes in /var with same basename
+    let loopback_name = mount_point
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "fcvm-btrfs".to_string());
+    let loopback_image = PathBuf::from(format!("/var/{}.img", loopback_name));
+    Ok((mount_point, loopback_image))
+}
+
+/// Ensure btrfs storage is set up at the configured assets_dir.
+///
+/// If the mount point doesn't exist or isn't btrfs, creates a loopback image
+/// in /var, formats it as btrfs, and mounts it.
+///
+/// This operation requires root privileges.
+pub fn ensure_storage(config_path: Option<&str>) -> Result<()> {
+    let (mount_point, loopback_image) = get_storage_paths(config_path)?;
+
+    // Already set up?
+    if is_btrfs_mount(&mount_point) {
+        // Check required directories exist
+        let mut all_dirs_exist = true;
+        for dir in REQUIRED_DIRS {
+            if !mount_point.join(dir).exists() {
+                all_dirs_exist = false;
+                break;
+            }
+        }
+        if all_dirs_exist {
+            return Ok(());
+        }
+    }
+
+    // Check if we're root (required for mount operations)
+    if !nix::unistd::Uid::effective().is_root() {
+        anyhow::bail!(
+            "Storage not initialized. Run with sudo:\n\n  \
+            sudo fcvm setup\n\n\
+            This creates a {}GB btrfs filesystem at {} for CoW disk snapshots.",
+            DEFAULT_SIZE_GB,
+            mount_point.display()
+        );
+    }
+
+    info!("Initializing btrfs storage at {}", mount_point.display());
+
+    // Check if already mounted but wrong filesystem type
+    if mount_point.exists() && mount_point.is_dir() {
+        let output = Command::new("mountpoint")
+            .arg("-q")
+            .arg(&mount_point)
+            .status()?;
+
+        if output.success() {
+            // Something is mounted but it's not btrfs
+            anyhow::bail!(
+                "{} is mounted but not btrfs. fcvm requires btrfs for CoW disk snapshots.\n\
+                Either unmount and let fcvm create btrfs, or mount a btrfs filesystem there.",
+                mount_point.display()
+            );
+        }
+    }
+
+    // Create loopback image if it doesn't exist
+    if !loopback_image.exists() {
+        info!(
+            "Creating {}GB loopback image at {}",
+            DEFAULT_SIZE_GB,
+            loopback_image.display()
+        );
+
+        // Create sparse file
+        let status = Command::new("truncate")
+            .arg("-s")
+            .arg(format!("{}G", DEFAULT_SIZE_GB))
+            .arg(&loopback_image)
+            .status()
+            .context("executing truncate")?;
+
+        if !status.success() {
+            anyhow::bail!("Failed to create loopback image");
+        }
+
+        // Format as btrfs
+        info!("Formatting as btrfs...");
+        let status = Command::new("mkfs.btrfs")
+            .arg(&loopback_image)
+            .status()
+            .context("executing mkfs.btrfs")?;
+
+        if !status.success() {
+            // Clean up the file on failure
+            let _ = std::fs::remove_file(&loopback_image);
+            anyhow::bail!("Failed to format loopback image as btrfs. Is btrfs-progs installed?");
+        }
+    }
+
+    // Create mount point
+    std::fs::create_dir_all(&mount_point).context("creating mount point")?;
+
+    // Mount the loopback image
+    info!("Mounting btrfs filesystem...");
+    let status = Command::new("mount")
+        .arg("-o")
+        .arg("loop")
+        .arg(&loopback_image)
+        .arg(&mount_point)
+        .status()
+        .context("executing mount")?;
+
+    if !status.success() {
+        anyhow::bail!(
+            "Failed to mount {}. Check dmesg for errors.",
+            loopback_image.display()
+        );
+    }
+
+    // Create required subdirectories
+    for dir in REQUIRED_DIRS {
+        let path = mount_point.join(dir);
+        std::fs::create_dir_all(&path)
+            .with_context(|| format!("creating directory {}", path.display()))?;
+    }
+
+    // Set ownership to the user who invoked sudo (if SUDO_USER is set)
+    if let Ok(sudo_user) = std::env::var("SUDO_USER") {
+        info!("Setting ownership to {}", sudo_user);
+        let status = Command::new("chown")
+            .arg("-R")
+            .arg(format!("{}:{}", sudo_user, sudo_user))
+            .arg(&mount_point)
+            .status()
+            .context("executing chown")?;
+
+        if !status.success() {
+            // Non-fatal, just warn
+            tracing::warn!("Failed to set ownership to {}", sudo_user);
+        }
+    }
+
+    info!(
+        "✓ btrfs storage ready at {} ({}GB)",
+        mount_point.display(),
+        DEFAULT_SIZE_GB
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- **Eliminates manual `make setup-btrfs` step** - `sudo fcvm setup` now auto-creates btrfs loopback filesystem
- **Streamlines Quick Start to 3 commands** - build, setup, run
- **Reorganizes README** - moves advanced content (Nested Virtualization) to end

## Changes

### Auto-btrfs creation (`src/setup/storage.rs`)
- New `ensure_storage()` function creates 60GB btrfs loopback at configured `assets_dir`
- Reads path from config (no hardcoded fallbacks)
- Creates required subdirectories (kernels, rootfs, initrd, etc.)
- Sets ownership to SUDO_USER after root operations

### Code fixes
- Setup command now handles its own path initialization (fixes OnceLock issue)
- Fixed hardcoded path in snapshot.rs error message

### README restructure
- Quick Start: 3 commands (was ~70 lines with explanations)
- New "Examples" section with common usage patterns
- New "How It Works" section with setup details and networking modes
- Nested Virtualization moved from after Prerequisites to before License

## Test plan
- [x] Existing btrfs detected and not recreated
- [x] Without sudo: helpful error message with configured path
- [x] With sudo: creates btrfs loopback correctly
- [x] Custom `--config` path respected
- [x] Sanity tests pass (3/3): rootless, bridged, ftrace