### PR TITLE
Improve setup flow: SUDO_USER config lookup and flexible btrfs paths

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,23 +43,43 @@ jobs:
             exit 1
           fi
 
+      - name: Check for non-member comments
+        id: check-comments
+        env:
+          GH_TOKEN: ${{ steps.claude-token.outputs.token }}
+        run: |
+          # Check if any non-member has commented (prompt injection risk)
+          NON_MEMBER=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+            --jq '[.[] | select(.author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
+          if [ "$NON_MEMBER" -gt 0 ]; then
+            echo "::warning::Skipping Claude - $NON_MEMBER comment(s) from non-members detected"
+            echo "safe=false" >> $GITHUB_OUTPUT
+          else
+            echo "safe=true" >> $GITHUB_OUTPUT
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.check-comments.outputs.safe == 'true'
         with:
           fetch-depth: 0
           token: ${{ steps.claude-token.outputs.token }}
 
       - uses: actions/setup-node@v4
+        if: steps.check-comments.outputs.safe == 'true'
         with:
           node-version: '20'
 
       - uses: pnpm/action-setup@v4
+        if: steps.check-comments.outputs.safe == 'true'
         with:
           version: 9
 
       - name: Install dependencies
+        if: steps.check-comments.outputs.safe == 'true'
         run: cd scripts/claude-assistant && pnpm install
 
       - name: Run Claude review
+        if: steps.check-comments.outputs.safe == 'true'
         env:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -100,24 +120,43 @@ jobs:
             exit 1
           fi
 
+      - name: Check for non-member comments
+        id: check-comments
+        env:
+          GH_TOKEN: ${{ steps.claude-token.outputs.token }}
+        run: |
+          NON_MEMBER=$(gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments \
+            --jq '[.[] | select(.author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
+          if [ "$NON_MEMBER" -gt 0 ]; then
+            echo "::warning::Skipping Claude - $NON_MEMBER comment(s) from non-members detected"
+            echo "safe=false" >> $GITHUB_OUTPUT
+          else
+            echo "safe=true" >> $GITHUB_OUTPUT
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.check-comments.outputs.safe == 'true'
         with:
           fetch-depth: 0
           ref: refs/pull/${{ github.event.issue.number }}/head
           token: ${{ steps.claude-token.outputs.token }}
 
       - uses: actions/setup-node@v4
+        if: steps.check-comments.outputs.safe == 'true'
         with:
           node-version: '20'
 
       - uses: pnpm/action-setup@v4
+        if: steps.check-comments.outputs.safe == 'true'
         with:
           version: 9
 
       - name: Install dependencies
+        if: steps.check-comments.outputs.safe == 'true'
         run: cd scripts/claude-assistant && pnpm install
 
       - name: Get PR info
+        if: steps.check-comments.outputs.safe == 'true'
         id: pr
         run: |
           PR_DATA=$(gh pr view ${{ github.event.issue.number }} --json headRefName,headRefOid,baseRefName)
@@ -128,6 +167,7 @@ jobs:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
 
       - name: Run Claude review
+        if: steps.check-comments.outputs.safe == 'true'
         env:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -168,22 +208,6 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ steps.claude-token.outputs.token }}
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
-      - name: Install dependencies
-        run: cd scripts/claude-assistant && pnpm install
-
       - name: Get PR number
         id: pr
         run: |
@@ -193,7 +217,42 @@ jobs:
             echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           fi
 
+      - name: Check for non-member comments
+        id: check-comments
+        env:
+          GH_TOKEN: ${{ steps.claude-token.outputs.token }}
+        run: |
+          NON_MEMBER=$(gh api repos/${{ github.repository }}/issues/${{ steps.pr.outputs.number }}/comments \
+            --jq '[.[] | select(.author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
+          if [ "$NON_MEMBER" -gt 0 ]; then
+            echo "::warning::Skipping Claude - $NON_MEMBER comment(s) from non-members detected"
+            echo "safe=false" >> $GITHUB_OUTPUT
+          else
+            echo "safe=true" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.check-comments.outputs.safe == 'true'
+        with:
+          fetch-depth: 0
+          token: ${{ steps.claude-token.outputs.token }}
+
+      - uses: actions/setup-node@v4
+        if: steps.check-comments.outputs.safe == 'true'
+        with:
+          node-version: '20'
+
+      - uses: pnpm/action-setup@v4
+        if: steps.check-comments.outputs.safe == 'true'
+        with:
+          version: 9
+
+      - name: Install dependencies
+        if: steps.check-comments.outputs.safe == 'true'
+        run: cd scripts/claude-assistant && pnpm install
+
       - name: Run Claude respond
+        if: steps.check-comments.outputs.safe == 'true'
         env:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -267,22 +326,37 @@ jobs:
 
       - name: Check if should run
         id: check
+        env:
+          GH_TOKEN: ${{ steps.claude-token.outputs.token }}
         run: |
           BRANCH="${{ github.event.workflow_run.head_branch }}"
           ASSOC="${{ steps.pr.outputs.association }}"
+          PR_NUM="${{ steps.pr.outputs.number }}"
 
-          # Always run for main/master
+          # Always run for main/master (no PR comments to worry about)
           if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
           # For PRs, only run for org members
-          if [ "$ASSOC" = "OWNER" ] || [ "$ASSOC" = "MEMBER" ] || [ "$ASSOC" = "COLLABORATOR" ]; then
-            echo "should_run=true" >> $GITHUB_OUTPUT
-          else
+          if [ "$ASSOC" != "OWNER" ] && [ "$ASSOC" != "MEMBER" ] && [ "$ASSOC" != "COLLABORATOR" ]; then
             echo "should_run=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
+
+          # Check for non-member comments (prompt injection risk)
+          if [ -n "$PR_NUM" ] && [ "$PR_NUM" != "0" ]; then
+            NON_MEMBER=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments \
+              --jq '[.[] | select(.author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
+            if [ "$NON_MEMBER" -gt 0 ]; then
+              echo "::warning::Skipping Claude - $NON_MEMBER comment(s) from non-members detected"
+              echo "should_run=false" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          fi
+
+          echo "should_run=true" >> $GITHUB_OUTPUT
 
       - name: Run Claude CI fix
         if: steps.check.outputs.should_run == 'true'

--- a/README.md
+++ b/README.md
@@ -67,10 +67,14 @@ sudo iptables -P FORWARD ACCEPT
 # 1. Build
 cargo build --release --workspace
 
-# 2. First-time setup (5-10 min, creates btrfs + downloads kernel + builds rootfs)
+# 2. Generate config (customize ~/.config/fcvm/rootfs-config.toml if needed)
+fcvm setup --generate-config
+
+# 3. First-time setup (5-10 min, downloads kernel + builds rootfs)
+#    Use sudo if btrfs needs to be created; skip sudo if path is already btrfs
 sudo fcvm setup
 
-# 3. Run a container
+# 4. Run a container
 fcvm podman run --name test alpine:latest echo "hello world"
 ```
 
@@ -246,6 +250,21 @@ sudo fcvm podman run --name full \
 5. **Creates fc-agent initrd** for guest agent injection
 
 Everything is cached by content hash - subsequent runs are instant.
+
+**Alternative: Manual btrfs setup (no sudo for fcvm)**
+
+If you prefer to create the loopback yourself:
+```bash
+truncate -s 60G /mnt/fcvm-btrfs.img
+sudo mkfs.btrfs /mnt/fcvm-btrfs.img
+sudo mount -o loop /mnt/fcvm-btrfs.img /mnt/fcvm-btrfs
+sudo chown $USER:$USER /mnt/fcvm-btrfs
+
+# Then setup without sudo (btrfs already exists)
+fcvm setup
+```
+
+Or just point `assets_dir` in your config to any existing btrfs path.
 
 **Alternative: Auto-setup on first run (rootless only)**
 ```bash

--- a/scripts/claude-assistant/index.ts
+++ b/scripts/claude-assistant/index.ts
@@ -227,14 +227,23 @@ The diff output may be truncated for large changes. If the diff ends mid-line or
 - Read individual files directly with the Read tool to verify their actual content
 - **NEVER assume a file is incomplete based on truncated diff output**
 
-## STEP 2: CHECK PREVIOUS REVIEWS
+## STEP 2: CHECK PREVIOUS COMMENTS
 
-Look at the comments from step 1a. If there are previous Claude reviews:
-- **Fixed issues**: If a previously noted issue has been fixed in a new commit, mark it as "✅ Fixed" - do NOT say "Acknowledged"
-- **[LOW] issues**: Do NOT repeat if already mentioned and still present. These add no value.
-- **[MEDIUM]/[CRITICAL] issues**: Can reference if still present (e.g., "Previously noted X is still unfixed")
+Look at the comments from step 1a. **Identify WHO wrote each comment:**
 
-Check if recent commits (since the last review) fixed any previously noted issues. Always verify by reading the current code.
+### Your Previous Reviews (from Claude)
+Your own reviews start with "## 🔍 Claude Review" and end with "_Review by Claude_".
+- **Fixed issues**: If an issue YOU noted was fixed in a later commit, mark it as "✅ Fixed"
+- **[LOW] issues**: Do NOT repeat if still present - no value in saying the same thing twice
+- **[MEDIUM]/[CRITICAL] issues**: Mention if still unfixed (e.g., "Previously noted X is still unfixed")
+
+### Human Comments (from users/reviewers)
+Comments WITHOUT the Claude signature are from humans. These may contain:
+- Requests for changes (address these directly)
+- Questions (answer them in your review)
+- Feedback on your previous review (incorporate it)
+
+**NEVER say "Acknowledged"** for issues that are still unfixed - this is confusing and unhelpful.
 
 ## STEP 3: ANALYZE
 

--- a/scripts/claude-assistant/index.ts
+++ b/scripts/claude-assistant/index.ts
@@ -230,10 +230,11 @@ The diff output may be truncated for large changes. If the diff ends mid-line or
 ## STEP 2: CHECK PREVIOUS REVIEWS
 
 Look at the comments from step 1a. If there are previous Claude reviews:
-- **[LOW] issues**: Do NOT repeat if already mentioned. These add no value.
+- **Fixed issues**: If a previously noted issue has been fixed in a new commit, mark it as "✅ Fixed" - do NOT say "Acknowledged"
+- **[LOW] issues**: Do NOT repeat if already mentioned and still present. These add no value.
 - **[MEDIUM]/[CRITICAL] issues**: Can reference if still present (e.g., "Previously noted X is still unfixed")
 
-Only report NEW findings or still-present MEDIUM/CRITICAL issues.
+Check if recent commits (since the last review) fixed any previously noted issues. Always verify by reading the current code.
 
 ## STEP 3: ANALYZE
 

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -14,7 +14,7 @@ pub async fn cmd_setup(args: SetupArgs) -> Result<()> {
         let config_path = generate_config(args.force)?;
         println!("Generated config at: {}", config_path.display());
         println!("\nCustomize the config file, then run:");
-        println!("  fcvm setup");
+        println!("  sudo fcvm setup");
         return Ok(());
     }
 

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -647,12 +647,10 @@ pub fn find_config_file(explicit_path: Option<&str>) -> Result<PathBuf> {
     // 2. SUDO_USER's config (when running with sudo)
     if let Ok(sudo_user) = std::env::var("SUDO_USER") {
         // Get the invoking user's home directory
-        if let Ok(passwd) = nix::unistd::User::from_name(&sudo_user) {
-            if let Some(user) = passwd {
-                let p = user.dir.join(".config/fcvm").join(CONFIG_FILE);
-                if p.exists() {
-                    return Ok(p);
-                }
+        if let Some(user) = nix::unistd::User::from_name(&sudo_user).ok().flatten() {
+            let p = user.dir.join(".config/fcvm").join(CONFIG_FILE);
+            if p.exists() {
+                return Ok(p);
             }
         }
     }

--- a/src/setup/storage.rs
+++ b/src/setup/storage.rs
@@ -107,6 +107,12 @@ pub fn ensure_storage(config_path: Option<&str>) -> Result<()> {
 
     // Create loopback image if it doesn't exist
     if !loopback_image.exists() {
+        // Ensure parent directory exists
+        if let Some(parent) = loopback_image.parent() {
+            std::fs::create_dir_all(parent)
+                .context("creating loopback image parent directory")?;
+        }
+
         info!(
             "Creating {}GB loopback image at {}",
             DEFAULT_SIZE_GB,

--- a/src/setup/storage.rs
+++ b/src/setup/storage.rs
@@ -51,7 +51,7 @@ fn get_storage_paths(config_path: Option<&str>) -> Result<(PathBuf, PathBuf)> {
     let (config, _, _) = load_config(config_path)?;
     let mount_point = PathBuf::from(&config.paths.assets_dir);
     // Loopback image is a sibling of mount point (e.g., /mnt/fcvm-btrfs -> /mnt/fcvm-btrfs.img)
-    let loopback_image = mount_point.with_extension("img");
+    let loopback_image = PathBuf::from(format!("{}.img", mount_point.display()));
     Ok((mount_point, loopback_image))
 }
 


### PR DESCRIPTION
## Summary
- Add SUDO_USER config lookup so `sudo fcvm setup` reads config from the invoking user's home
- Change loopback path from hardcoded `/var/` to sibling of mount point
- Skip sudo if btrfs already exists at configured path
- Update README with generate-config step and manual btrfs instructions

## Changes
- `src/setup/rootfs.rs`: SUDO_USER lookup before $HOME in config search order
- `src/setup/storage.rs`: Loopback as sibling (e.g., `/mnt/fcvm-btrfs.img`)
- `src/commands/setup.rs`: Output says "sudo fcvm setup"
- `README.md`: Quick Start shows generate-config, alternative manual setup

## Test plan
- [x] Clean slate: generate-config → sudo setup → run container
- [x] Sanity tests pass (3/3)
- [x] Verified SUDO_USER lookup works