### PR TITLE
Improve setup flow: SUDO_USER config lookup and flexible btrfs paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,14 @@ sudo iptables -P FORWARD ACCEPT
 # 1. Build
 cargo build --release --workspace
 
-# 2. First-time setup (5-10 min, creates btrfs + downloads kernel + builds rootfs)
+# 2. Generate config (customize ~/.config/fcvm/rootfs-config.toml if needed)
+fcvm setup --generate-config
+
+# 3. First-time setup (5-10 min, downloads kernel + builds rootfs)
+#    Use sudo if btrfs needs to be created; skip sudo if path is already btrfs
 sudo fcvm setup
 
-# 3. Run a container
+# 4. Run a container
 fcvm podman run --name test alpine:latest echo "hello world"
 ```
 
@@ -246,6 +250,21 @@ sudo fcvm podman run --name full \
 5. **Creates fc-agent initrd** for guest agent injection
 
 Everything is cached by content hash - subsequent runs are instant.
+
+**Alternative: Manual btrfs setup (no sudo for fcvm)**
+
+If you prefer to create the loopback yourself:
+```bash
+truncate -s 60G /mnt/fcvm-btrfs.img
+sudo mkfs.btrfs /mnt/fcvm-btrfs.img
+sudo mount -o loop /mnt/fcvm-btrfs.img /mnt/fcvm-btrfs
+sudo chown $USER:$USER /mnt/fcvm-btrfs
+
+# Then setup without sudo (btrfs already exists)
+fcvm setup
+```
+
+Or just point `assets_dir` in your config to any existing btrfs path.
 
 **Alternative: Auto-setup on first run (rootless only)**
 ```bash

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -14,7 +14,7 @@ pub async fn cmd_setup(args: SetupArgs) -> Result<()> {
         let config_path = generate_config(args.force)?;
         println!("Generated config at: {}", config_path.display());
         println!("\nCustomize the config file, then run:");
-        println!("  fcvm setup");
+        println!("  sudo fcvm setup");
         return Ok(());
     }
 

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -647,12 +647,10 @@ pub fn find_config_file(explicit_path: Option<&str>) -> Result<PathBuf> {
     // 2. SUDO_USER's config (when running with sudo)
     if let Ok(sudo_user) = std::env::var("SUDO_USER") {
         // Get the invoking user's home directory
-        if let Ok(passwd) = nix::unistd::User::from_name(&sudo_user) {
-            if let Some(user) = passwd {
-                let p = user.dir.join(".config/fcvm").join(CONFIG_FILE);
-                if p.exists() {
-                    return Ok(p);
-                }
+        if let Some(user) = nix::unistd::User::from_name(&sudo_user).ok().flatten() {
+            let p = user.dir.join(".config/fcvm").join(CONFIG_FILE);
+            if p.exists() {
+                return Ok(p);
             }
         }
     }

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -647,10 +647,18 @@ pub fn find_config_file(explicit_path: Option<&str>) -> Result<PathBuf> {
     // 2. SUDO_USER's config (when running with sudo)
     if let Ok(sudo_user) = std::env::var("SUDO_USER") {
         // Get the invoking user's home directory
-        if let Some(user) = nix::unistd::User::from_name(&sudo_user).ok().flatten() {
-            let p = user.dir.join(".config/fcvm").join(CONFIG_FILE);
-            if p.exists() {
-                return Ok(p);
+        match nix::unistd::User::from_name(&sudo_user) {
+            Ok(Some(user)) => {
+                let p = user.dir.join(".config/fcvm").join(CONFIG_FILE);
+                if p.exists() {
+                    return Ok(p);
+                }
+            }
+            Ok(None) => {
+                tracing::debug!("SUDO_USER '{}' not found in passwd database", sudo_user);
+            }
+            Err(e) => {
+                tracing::debug!("Failed to lookup SUDO_USER '{}': {}", sudo_user, e);
             }
         }
     }

--- a/src/setup/storage.rs
+++ b/src/setup/storage.rs
@@ -107,6 +107,12 @@ pub fn ensure_storage(config_path: Option<&str>) -> Result<()> {
 
     // Create loopback image if it doesn't exist
     if !loopback_image.exists() {
+        // Ensure parent directory exists
+        if let Some(parent) = loopback_image.parent() {
+            std::fs::create_dir_all(parent)
+                .context("creating loopback image parent directory")?;
+        }
+
         info!(
             "Creating {}GB loopback image at {}",
             DEFAULT_SIZE_GB,

--- a/src/setup/storage.rs
+++ b/src/setup/storage.rs
@@ -51,7 +51,7 @@ fn get_storage_paths(config_path: Option<&str>) -> Result<(PathBuf, PathBuf)> {
     let (config, _, _) = load_config(config_path)?;
     let mount_point = PathBuf::from(&config.paths.assets_dir);
     // Loopback image is a sibling of mount point (e.g., /mnt/fcvm-btrfs -> /mnt/fcvm-btrfs.img)
-    let loopback_image = mount_point.with_extension("img");
+    let loopback_image = PathBuf::from(format!("{}.img", mount_point.display()));
     Ok((mount_point, loopback_image))
 }
 


### PR DESCRIPTION
## Summary

- Look up config from invoking user's home when running with `sudo` (via SUDO_USER)
- Change loopback image path to be sibling of mount point (user-configurable)
- Skip root requirement if btrfs already exists at configured path

## Changes

- `src/setup/rootfs.rs`: Add SUDO_USER config lookup before $HOME
- `src/setup/storage.rs`: Loopback path follows mount point, early return if btrfs exists
- Fix `with_extension()` to append `.img` instead of replacing extension