### PR TITLE
Skip Claude workflows if non-member has commented on PR

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -48,11 +48,19 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
         run: |
-          # Check if any non-member has commented (prompt injection risk)
-          NON_MEMBER=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
-            --jq '[.[] | select(.author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
-          if [ "$NON_MEMBER" -gt 0 ]; then
-            echo "::warning::Skipping Claude - $NON_MEMBER comment(s) from non-members detected"
+          PR_NUM="${{ github.event.pull_request.number }}"
+
+          # Check issue comments (general PR comments) - allow members and bots
+          ISSUE_COMMENTS=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments \
+            --jq '[.[] | select(.user.type != "Bot" and .author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
+
+          # Check review comments (inline code comments) - allow members and bots
+          REVIEW_COMMENTS=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM/comments \
+            --jq '[.[] | select(.user.type != "Bot" and .author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
+
+          TOTAL=$((ISSUE_COMMENTS + REVIEW_COMMENTS))
+          if [ "$TOTAL" -gt 0 ]; then
+            echo "::warning::Skipping Claude - $TOTAL comment(s) from non-members detected (issue: $ISSUE_COMMENTS, review: $REVIEW_COMMENTS)"
             echo "safe=false" >> $GITHUB_OUTPUT
           else
             echo "safe=true" >> $GITHUB_OUTPUT
@@ -125,10 +133,19 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
         run: |
-          NON_MEMBER=$(gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments \
-            --jq '[.[] | select(.author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
-          if [ "$NON_MEMBER" -gt 0 ]; then
-            echo "::warning::Skipping Claude - $NON_MEMBER comment(s) from non-members detected"
+          PR_NUM="${{ github.event.issue.number }}"
+
+          # Check issue comments (general PR comments) - allow members and bots
+          ISSUE_COMMENTS=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments \
+            --jq '[.[] | select(.user.type != "Bot" and .author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
+
+          # Check review comments (inline code comments) - allow members and bots
+          REVIEW_COMMENTS=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM/comments \
+            --jq '[.[] | select(.user.type != "Bot" and .author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
+
+          TOTAL=$((ISSUE_COMMENTS + REVIEW_COMMENTS))
+          if [ "$TOTAL" -gt 0 ]; then
+            echo "::warning::Skipping Claude - $TOTAL comment(s) from non-members detected (issue: $ISSUE_COMMENTS, review: $REVIEW_COMMENTS)"
             echo "safe=false" >> $GITHUB_OUTPUT
           else
             echo "safe=true" >> $GITHUB_OUTPUT
@@ -211,10 +228,15 @@ jobs:
       - name: Get PR number
         id: pr
         run: |
-          if [ "${{ github.event.issue.pull_request }}" != "" ]; then
+          # issue_comment on a PR: github.event.issue.number
+          # pull_request_review_comment: github.event.pull_request.number
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
             echo "number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
-          else
+          elif [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
             echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          else
+            echo "::error::Unknown event type for respond job"
+            exit 1
           fi
 
       - name: Check for non-member comments
@@ -222,10 +244,19 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
         run: |
-          NON_MEMBER=$(gh api repos/${{ github.repository }}/issues/${{ steps.pr.outputs.number }}/comments \
-            --jq '[.[] | select(.author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
-          if [ "$NON_MEMBER" -gt 0 ]; then
-            echo "::warning::Skipping Claude - $NON_MEMBER comment(s) from non-members detected"
+          PR_NUM="${{ steps.pr.outputs.number }}"
+
+          # Check issue comments (general PR comments) - allow members and bots
+          ISSUE_COMMENTS=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments \
+            --jq '[.[] | select(.user.type != "Bot" and .author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
+
+          # Check review comments (inline code comments) - allow members and bots
+          REVIEW_COMMENTS=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM/comments \
+            --jq '[.[] | select(.user.type != "Bot" and .author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
+
+          TOTAL=$((ISSUE_COMMENTS + REVIEW_COMMENTS))
+          if [ "$TOTAL" -gt 0 ]; then
+            echo "::warning::Skipping Claude - $TOTAL comment(s) from non-members detected (issue: $ISSUE_COMMENTS, review: $REVIEW_COMMENTS)"
             echo "safe=false" >> $GITHUB_OUTPUT
           else
             echo "safe=true" >> $GITHUB_OUTPUT
@@ -347,10 +378,17 @@ jobs:
 
           # Check for non-member comments (prompt injection risk)
           if [ -n "$PR_NUM" ] && [ "$PR_NUM" != "0" ]; then
-            NON_MEMBER=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments \
-              --jq '[.[] | select(.author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
-            if [ "$NON_MEMBER" -gt 0 ]; then
-              echo "::warning::Skipping Claude - $NON_MEMBER comment(s) from non-members detected"
+            # Check issue comments (general PR comments) - allow members and bots
+            ISSUE_COMMENTS=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments \
+              --jq '[.[] | select(.user.type != "Bot" and .author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
+
+            # Check review comments (inline code comments) - allow members and bots
+            REVIEW_COMMENTS=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM/comments \
+              --jq '[.[] | select(.user.type != "Bot" and .author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
+
+            TOTAL=$((ISSUE_COMMENTS + REVIEW_COMMENTS))
+            if [ "$TOTAL" -gt 0 ]; then
+              echo "::warning::Skipping Claude - $TOTAL comment(s) from non-members detected (issue: $ISSUE_COMMENTS, review: $REVIEW_COMMENTS)"
               echo "should_run=false" >> $GITHUB_OUTPUT
               exit 0
             fi

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,12 +21,13 @@ env:
 # Required: CLAUDE_APP_ID (variable), CLAUDE_APP_PRIVATE_KEY (secret)
 
 jobs:
-  # Check for non-member comments before running any Claude job
+  # Gatekeeper: Check for non-member comments and author association
   safety-check:
     runs-on: ubuntu-latest
     outputs:
       safe: ${{ steps.check.outputs.safe }}
       pr_number: ${{ steps.get-pr.outputs.number }}
+      author_ok: ${{ steps.author.outputs.ok }}
     steps:
       - name: Generate token
         id: token
@@ -47,10 +48,40 @@ jobs:
           elif [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
             echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" = "workflow_run" ]; then
-            PR_NUM=$(gh pr list --repo ${{ github.repository }} --head ${{ github.event.workflow_run.head_branch }} --json number --jq '.[0].number // 0')
-            echo "number=$PR_NUM" >> $GITHUB_OUTPUT
+            BRANCH="${{ github.event.workflow_run.head_branch }}"
+            if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+              echo "number=0" >> $GITHUB_OUTPUT
+            else
+              PR_NUM=$(gh pr list --repo ${{ github.repository }} --head "$BRANCH" --json number --jq '.[0].number // 0')
+              echo "number=$PR_NUM" >> $GITHUB_OUTPUT
+            fi
           else
             echo "number=0" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get PR author association
+        id: get-author
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          PR_NUM="${{ steps.get-pr.outputs.number }}"
+          if [ -z "$PR_NUM" ] || [ "$PR_NUM" = "0" ]; then
+            # No PR (e.g., main branch CI) - treat as owner
+            echo "assoc=OWNER" >> $GITHUB_OUTPUT
+          else
+            ASSOC=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM --jq '.author_association')
+            echo "assoc=$ASSOC" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check author is member
+        id: author
+        run: |
+          ASSOC="${{ steps.get-author.outputs.assoc }}"
+          if [ "$ASSOC" = "OWNER" ] || [ "$ASSOC" = "MEMBER" ] || [ "$ASSOC" = "COLLABORATOR" ]; then
+            echo "ok=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::Blocking Claude - PR author association is $ASSOC (not member)"
+            echo "ok=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Check for non-member comments
@@ -78,8 +109,8 @@ jobs:
     needs: safety-check
     if: |
       needs.safety-check.outputs.safe == 'true' &&
+      needs.safety-check.outputs.author_ok == 'true' &&
       github.event_name == 'pull_request' &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) &&
       !startsWith(github.event.pull_request.head.ref, 'claude/fix-')
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -129,10 +160,10 @@ jobs:
     needs: safety-check
     if: |
       needs.safety-check.outputs.safe == 'true' &&
+      needs.safety-check.outputs.author_ok == 'true' &&
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/claude-review') &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      contains(github.event.comment.body, '/claude-review')
     runs-on: ubuntu-latest
     timeout-minutes: 45
     concurrency:
@@ -192,7 +223,7 @@ jobs:
     needs: safety-check
     if: |
       needs.safety-check.outputs.safe == 'true' &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+      needs.safety-check.outputs.author_ok == 'true' &&
       !contains(github.event.comment.body, '/claude-review') &&
       ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')))
@@ -245,6 +276,7 @@ jobs:
     needs: safety-check
     if: |
       needs.safety-check.outputs.safe == 'true' &&
+      needs.safety-check.outputs.author_ok == 'true' &&
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'failure' &&
       !startsWith(github.event.workflow_run.head_branch, 'claude/fix-') &&
@@ -279,34 +311,7 @@ jobs:
       - name: Install dependencies
         run: cd scripts/claude-assistant && pnpm install
 
-      - name: Check PR author association
-        id: check
-        env:
-          GH_TOKEN: ${{ steps.claude-token.outputs.token }}
-        run: |
-          BRANCH="${{ github.event.workflow_run.head_branch }}"
-          PR_NUM="${{ needs.safety-check.outputs.pr_number }}"
-
-          # Always run for main/master
-          if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
-            echo "should_run=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          # For PRs, check author is org member
-          if [ -n "$PR_NUM" ] && [ "$PR_NUM" != "0" ]; then
-            ASSOC=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM --jq '.author_association')
-            if [ "$ASSOC" = "OWNER" ] || [ "$ASSOC" = "MEMBER" ] || [ "$ASSOC" = "COLLABORATOR" ]; then
-              echo "should_run=true" >> $GITHUB_OUTPUT
-            else
-              echo "should_run=false" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "should_run=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Run Claude CI fix
-        if: steps.check.outputs.should_run == 'true'
         env:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -288,6 +288,23 @@ jobs:
       - name: Install dependencies
         run: cd scripts/claude-assistant && pnpm install
 
+      - name: Get PR info
+        id: pr
+        env:
+          GH_TOKEN: ${{ steps.claude-token.outputs.token }}
+        run: |
+          PR_NUM="${{ needs.safety-check.outputs.pr_number }}"
+          if [ -n "$PR_NUM" ] && [ "$PR_NUM" != "0" ]; then
+            PR_DATA=$(gh pr view $PR_NUM --json headRefName,headRefOid,baseRefName)
+            echo "head_branch=$(echo $PR_DATA | jq -r .headRefName)" >> $GITHUB_OUTPUT
+            echo "head_sha=$(echo $PR_DATA | jq -r .headRefOid)" >> $GITHUB_OUTPUT
+            echo "base_branch=$(echo $PR_DATA | jq -r .baseRefName)" >> $GITHUB_OUTPUT
+          else
+            echo "head_branch=" >> $GITHUB_OUTPUT
+            echo "head_sha=" >> $GITHUB_OUTPUT
+            echo "base_branch=" >> $GITHUB_OUTPUT
+          fi
+
       - name: Run Claude respond
         env:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
@@ -295,9 +312,9 @@ jobs:
           MODE: respond
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ needs.safety-check.outputs.pr_number }}
-          HEAD_BRANCH: ${{ github.head_ref }}
-          HEAD_SHA: ${{ github.sha }}
-          BASE_BRANCH: ${{ github.base_ref }}
+          HEAD_BRANCH: ${{ steps.pr.outputs.head_branch }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          BASE_BRANCH: ${{ steps.pr.outputs.base_branch }}
           RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           COMMENT_BODY: ${{ github.event.comment.body }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,13 +21,14 @@ env:
 # Required: CLAUDE_APP_ID (variable), CLAUDE_APP_PRIVATE_KEY (secret)
 
 jobs:
-  # Gatekeeper: Check for non-member comments and author association
+  # Gatekeeper: Check for non-member commits, comments, and author association
   safety-check:
     runs-on: ubuntu-latest
     outputs:
       safe: ${{ steps.check.outputs.safe }}
       pr_number: ${{ steps.get-pr.outputs.number }}
       author_ok: ${{ steps.author.outputs.ok }}
+      commits_ok: ${{ steps.commits.outputs.ok }}
     steps:
       - name: Generate token
         id: token
@@ -84,6 +85,33 @@ jobs:
             echo "ok=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Check for non-member commits
+        id: commits
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          PR_NUM="${{ steps.get-pr.outputs.number }}"
+          if [ -z "$PR_NUM" ] || [ "$PR_NUM" = "0" ]; then
+            echo "ok=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          # Check each commit author's association
+          NON_MEMBER=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM/commits --jq \
+            '[.[] | select(.author.type != "Bot" and .author.login != null) | .author.login] | unique | .[]' | while read -r LOGIN; do
+            if [ -n "$LOGIN" ]; then
+              ASSOC=$(gh api repos/${{ github.repository }}/collaborators/$LOGIN/permission --jq '.permission' 2>/dev/null || echo "none")
+              if [ "$ASSOC" != "admin" ] && [ "$ASSOC" != "write" ] && [ "$ASSOC" != "maintain" ]; then
+                echo "$LOGIN"
+              fi
+            fi
+          done | head -1)
+          if [ -n "$NON_MEMBER" ]; then
+            echo "::warning::Blocking Claude - non-member commit author: $NON_MEMBER"
+            echo "ok=false" >> $GITHUB_OUTPUT
+          else
+            echo "ok=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Check for non-member comments
         id: check
         env:
@@ -110,6 +138,7 @@ jobs:
     if: |
       needs.safety-check.outputs.safe == 'true' &&
       needs.safety-check.outputs.author_ok == 'true' &&
+      needs.safety-check.outputs.commits_ok == 'true' &&
       github.event_name == 'pull_request' &&
       !startsWith(github.event.pull_request.head.ref, 'claude/fix-')
     runs-on: ubuntu-latest
@@ -161,6 +190,7 @@ jobs:
     if: |
       needs.safety-check.outputs.safe == 'true' &&
       needs.safety-check.outputs.author_ok == 'true' &&
+      needs.safety-check.outputs.commits_ok == 'true' &&
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '/claude-review')
@@ -224,6 +254,7 @@ jobs:
     if: |
       needs.safety-check.outputs.safe == 'true' &&
       needs.safety-check.outputs.author_ok == 'true' &&
+      needs.safety-check.outputs.commits_ok == 'true' &&
       !contains(github.event.comment.body, '/claude-review') &&
       ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')))
@@ -277,6 +308,7 @@ jobs:
     if: |
       needs.safety-check.outputs.safe == 'true' &&
       needs.safety-check.outputs.author_ok == 'true' &&
+      needs.safety-check.outputs.commits_ok == 'true' &&
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'failure' &&
       !startsWith(github.event.workflow_run.head_branch, 'claude/fix-') &&

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,6 +11,10 @@ on:
     workflows: ["CI"]
     types: [completed]
 
+# Filter to find non-member, non-bot comments (for prompt injection prevention)
+env:
+  NONMEMBER_FILTER: '[.[] | select(.user.type != "Bot" and .author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length'
+
 # Note: We use a GitHub App token instead of GITHUB_TOKEN so that:
 # 1. All actions appear as "Claude" bot
 # 2. PRs created by Claude can trigger CI workflows
@@ -49,18 +53,11 @@ jobs:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
         run: |
           PR_NUM="${{ github.event.pull_request.number }}"
-
-          # Check issue comments (general PR comments) - allow members and bots
-          ISSUE_COMMENTS=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments \
-            --jq '[.[] | select(.user.type != "Bot" and .author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
-
-          # Check review comments (inline code comments) - allow members and bots
-          REVIEW_COMMENTS=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM/comments \
-            --jq '[.[] | select(.user.type != "Bot" and .author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
-
-          TOTAL=$((ISSUE_COMMENTS + REVIEW_COMMENTS))
+          ISSUE=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments --jq "$NONMEMBER_FILTER")
+          REVIEW=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM/comments --jq "$NONMEMBER_FILTER")
+          TOTAL=$((ISSUE + REVIEW))
           if [ "$TOTAL" -gt 0 ]; then
-            echo "::warning::Skipping Claude - $TOTAL comment(s) from non-members detected (issue: $ISSUE_COMMENTS, review: $REVIEW_COMMENTS)"
+            echo "::warning::Skipping - $TOTAL non-member comment(s) detected"
             echo "safe=false" >> $GITHUB_OUTPUT
           else
             echo "safe=true" >> $GITHUB_OUTPUT
@@ -134,18 +131,11 @@ jobs:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
         run: |
           PR_NUM="${{ github.event.issue.number }}"
-
-          # Check issue comments (general PR comments) - allow members and bots
-          ISSUE_COMMENTS=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments \
-            --jq '[.[] | select(.user.type != "Bot" and .author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
-
-          # Check review comments (inline code comments) - allow members and bots
-          REVIEW_COMMENTS=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM/comments \
-            --jq '[.[] | select(.user.type != "Bot" and .author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
-
-          TOTAL=$((ISSUE_COMMENTS + REVIEW_COMMENTS))
+          ISSUE=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments --jq "$NONMEMBER_FILTER")
+          REVIEW=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM/comments --jq "$NONMEMBER_FILTER")
+          TOTAL=$((ISSUE + REVIEW))
           if [ "$TOTAL" -gt 0 ]; then
-            echo "::warning::Skipping Claude - $TOTAL comment(s) from non-members detected (issue: $ISSUE_COMMENTS, review: $REVIEW_COMMENTS)"
+            echo "::warning::Skipping - $TOTAL non-member comment(s) detected"
             echo "safe=false" >> $GITHUB_OUTPUT
           else
             echo "safe=true" >> $GITHUB_OUTPUT
@@ -245,18 +235,11 @@ jobs:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
         run: |
           PR_NUM="${{ steps.pr.outputs.number }}"
-
-          # Check issue comments (general PR comments) - allow members and bots
-          ISSUE_COMMENTS=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments \
-            --jq '[.[] | select(.user.type != "Bot" and .author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
-
-          # Check review comments (inline code comments) - allow members and bots
-          REVIEW_COMMENTS=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM/comments \
-            --jq '[.[] | select(.user.type != "Bot" and .author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
-
-          TOTAL=$((ISSUE_COMMENTS + REVIEW_COMMENTS))
+          ISSUE=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments --jq "$NONMEMBER_FILTER")
+          REVIEW=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM/comments --jq "$NONMEMBER_FILTER")
+          TOTAL=$((ISSUE + REVIEW))
           if [ "$TOTAL" -gt 0 ]; then
-            echo "::warning::Skipping Claude - $TOTAL comment(s) from non-members detected (issue: $ISSUE_COMMENTS, review: $REVIEW_COMMENTS)"
+            echo "::warning::Skipping - $TOTAL non-member comment(s) detected"
             echo "safe=false" >> $GITHUB_OUTPUT
           else
             echo "safe=true" >> $GITHUB_OUTPUT
@@ -378,17 +361,11 @@ jobs:
 
           # Check for non-member comments (prompt injection risk)
           if [ -n "$PR_NUM" ] && [ "$PR_NUM" != "0" ]; then
-            # Check issue comments (general PR comments) - allow members and bots
-            ISSUE_COMMENTS=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments \
-              --jq '[.[] | select(.user.type != "Bot" and .author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
-
-            # Check review comments (inline code comments) - allow members and bots
-            REVIEW_COMMENTS=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM/comments \
-              --jq '[.[] | select(.user.type != "Bot" and .author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
-
-            TOTAL=$((ISSUE_COMMENTS + REVIEW_COMMENTS))
+            ISSUE=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments --jq "$NONMEMBER_FILTER")
+            REVIEW=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM/comments --jq "$NONMEMBER_FILTER")
+            TOTAL=$((ISSUE + REVIEW))
             if [ "$TOTAL" -gt 0 ]; then
-              echo "::warning::Skipping Claude - $TOTAL comment(s) from non-members detected (issue: $ISSUE_COMMENTS, review: $REVIEW_COMMENTS)"
+              echo "::warning::Skipping - $TOTAL non-member comment(s) detected"
               echo "should_run=false" >> $GITHUB_OUTPUT
               exit 0
             fi

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,23 +43,43 @@ jobs:
             exit 1
           fi
 
+      - name: Check for non-member comments
+        id: check-comments
+        env:
+          GH_TOKEN: ${{ steps.claude-token.outputs.token }}
+        run: |
+          # Check if any non-member has commented (prompt injection risk)
+          NON_MEMBER=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+            --jq '[.[] | select(.author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
+          if [ "$NON_MEMBER" -gt 0 ]; then
+            echo "::warning::Skipping Claude - $NON_MEMBER comment(s) from non-members detected"
+            echo "safe=false" >> $GITHUB_OUTPUT
+          else
+            echo "safe=true" >> $GITHUB_OUTPUT
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.check-comments.outputs.safe == 'true'
         with:
           fetch-depth: 0
           token: ${{ steps.claude-token.outputs.token }}
 
       - uses: actions/setup-node@v4
+        if: steps.check-comments.outputs.safe == 'true'
         with:
           node-version: '20'
 
       - uses: pnpm/action-setup@v4
+        if: steps.check-comments.outputs.safe == 'true'
         with:
           version: 9
 
       - name: Install dependencies
+        if: steps.check-comments.outputs.safe == 'true'
         run: cd scripts/claude-assistant && pnpm install
 
       - name: Run Claude review
+        if: steps.check-comments.outputs.safe == 'true'
         env:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -100,24 +120,43 @@ jobs:
             exit 1
           fi
 
+      - name: Check for non-member comments
+        id: check-comments
+        env:
+          GH_TOKEN: ${{ steps.claude-token.outputs.token }}
+        run: |
+          NON_MEMBER=$(gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments \
+            --jq '[.[] | select(.author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
+          if [ "$NON_MEMBER" -gt 0 ]; then
+            echo "::warning::Skipping Claude - $NON_MEMBER comment(s) from non-members detected"
+            echo "safe=false" >> $GITHUB_OUTPUT
+          else
+            echo "safe=true" >> $GITHUB_OUTPUT
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.check-comments.outputs.safe == 'true'
         with:
           fetch-depth: 0
           ref: refs/pull/${{ github.event.issue.number }}/head
           token: ${{ steps.claude-token.outputs.token }}
 
       - uses: actions/setup-node@v4
+        if: steps.check-comments.outputs.safe == 'true'
         with:
           node-version: '20'
 
       - uses: pnpm/action-setup@v4
+        if: steps.check-comments.outputs.safe == 'true'
         with:
           version: 9
 
       - name: Install dependencies
+        if: steps.check-comments.outputs.safe == 'true'
         run: cd scripts/claude-assistant && pnpm install
 
       - name: Get PR info
+        if: steps.check-comments.outputs.safe == 'true'
         id: pr
         run: |
           PR_DATA=$(gh pr view ${{ github.event.issue.number }} --json headRefName,headRefOid,baseRefName)
@@ -128,6 +167,7 @@ jobs:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
 
       - name: Run Claude review
+        if: steps.check-comments.outputs.safe == 'true'
         env:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -168,22 +208,6 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ steps.claude-token.outputs.token }}
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
-      - name: Install dependencies
-        run: cd scripts/claude-assistant && pnpm install
-
       - name: Get PR number
         id: pr
         run: |
@@ -193,7 +217,42 @@ jobs:
             echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           fi
 
+      - name: Check for non-member comments
+        id: check-comments
+        env:
+          GH_TOKEN: ${{ steps.claude-token.outputs.token }}
+        run: |
+          NON_MEMBER=$(gh api repos/${{ github.repository }}/issues/${{ steps.pr.outputs.number }}/comments \
+            --jq '[.[] | select(.author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
+          if [ "$NON_MEMBER" -gt 0 ]; then
+            echo "::warning::Skipping Claude - $NON_MEMBER comment(s) from non-members detected"
+            echo "safe=false" >> $GITHUB_OUTPUT
+          else
+            echo "safe=true" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.check-comments.outputs.safe == 'true'
+        with:
+          fetch-depth: 0
+          token: ${{ steps.claude-token.outputs.token }}
+
+      - uses: actions/setup-node@v4
+        if: steps.check-comments.outputs.safe == 'true'
+        with:
+          node-version: '20'
+
+      - uses: pnpm/action-setup@v4
+        if: steps.check-comments.outputs.safe == 'true'
+        with:
+          version: 9
+
+      - name: Install dependencies
+        if: steps.check-comments.outputs.safe == 'true'
+        run: cd scripts/claude-assistant && pnpm install
+
       - name: Run Claude respond
+        if: steps.check-comments.outputs.safe == 'true'
         env:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -267,22 +326,37 @@ jobs:
 
       - name: Check if should run
         id: check
+        env:
+          GH_TOKEN: ${{ steps.claude-token.outputs.token }}
         run: |
           BRANCH="${{ github.event.workflow_run.head_branch }}"
           ASSOC="${{ steps.pr.outputs.association }}"
+          PR_NUM="${{ steps.pr.outputs.number }}"
 
-          # Always run for main/master
+          # Always run for main/master (no PR comments to worry about)
           if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
           # For PRs, only run for org members
-          if [ "$ASSOC" = "OWNER" ] || [ "$ASSOC" = "MEMBER" ] || [ "$ASSOC" = "COLLABORATOR" ]; then
-            echo "should_run=true" >> $GITHUB_OUTPUT
-          else
+          if [ "$ASSOC" != "OWNER" ] && [ "$ASSOC" != "MEMBER" ] && [ "$ASSOC" != "COLLABORATOR" ]; then
             echo "should_run=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
+
+          # Check for non-member comments (prompt injection risk)
+          if [ -n "$PR_NUM" ] && [ "$PR_NUM" != "0" ]; then
+            NON_MEMBER=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments \
+              --jq '[.[] | select(.author_association != "OWNER" and .author_association != "MEMBER" and .author_association != "COLLABORATOR")] | length')
+            if [ "$NON_MEMBER" -gt 0 ]; then
+              echo "::warning::Skipping Claude - $NON_MEMBER comment(s) from non-members detected"
+              echo "should_run=false" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          fi
+
+          echo "should_run=true" >> $GITHUB_OUTPUT
 
       - name: Run Claude CI fix
         if: steps.check.outputs.should_run == 'true'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,9 +21,63 @@ env:
 # Required: CLAUDE_APP_ID (variable), CLAUDE_APP_PRIVATE_KEY (secret)
 
 jobs:
+  # Check for non-member comments before running any Claude job
+  safety-check:
+    runs-on: ubuntu-latest
+    outputs:
+      safe: ${{ steps.check.outputs.safe }}
+      pr_number: ${{ steps.get-pr.outputs.number }}
+    steps:
+      - name: Generate token
+        id: token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.CLAUDE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+
+      - name: Get PR number
+        id: get-pr
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "issue_comment" ]; then
+            echo "number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "workflow_run" ]; then
+            PR_NUM=$(gh pr list --repo ${{ github.repository }} --head ${{ github.event.workflow_run.head_branch }} --json number --jq '.[0].number // 0')
+            echo "number=$PR_NUM" >> $GITHUB_OUTPUT
+          else
+            echo "number=0" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for non-member comments
+        id: check
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          PR_NUM="${{ steps.get-pr.outputs.number }}"
+          if [ -z "$PR_NUM" ] || [ "$PR_NUM" = "0" ]; then
+            echo "safe=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          ISSUE=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments --jq "$NONMEMBER_FILTER" 2>/dev/null || echo 0)
+          REVIEW=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM/comments --jq "$NONMEMBER_FILTER" 2>/dev/null || echo 0)
+          TOTAL=$((ISSUE + REVIEW))
+          if [ "$TOTAL" -gt 0 ]; then
+            echo "::warning::Blocking Claude - $TOTAL non-member comment(s) detected"
+            echo "safe=false" >> $GITHUB_OUTPUT
+          else
+            echo "safe=true" >> $GITHUB_OUTPUT
+          fi
+
   # Review PRs from org members, auto-fix medium/critical issues
   review:
+    needs: safety-check
     if: |
+      needs.safety-check.outputs.safe == 'true' &&
       github.event_name == 'pull_request' &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) &&
       !startsWith(github.event.pull_request.head.ref, 'claude/fix-')
@@ -40,51 +94,23 @@ jobs:
           app-id: ${{ vars.CLAUDE_APP_ID }}
           private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
 
-      - name: Validate token
-        run: |
-          if [ -z "${{ steps.claude-token.outputs.token }}" ]; then
-            echo "Error: Failed to generate GitHub App token"
-            exit 1
-          fi
-
-      - name: Check for non-member comments
-        id: check-comments
-        env:
-          GH_TOKEN: ${{ steps.claude-token.outputs.token }}
-        run: |
-          PR_NUM="${{ github.event.pull_request.number }}"
-          ISSUE=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments --jq "$NONMEMBER_FILTER")
-          REVIEW=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM/comments --jq "$NONMEMBER_FILTER")
-          TOTAL=$((ISSUE + REVIEW))
-          if [ "$TOTAL" -gt 0 ]; then
-            echo "::warning::Skipping - $TOTAL non-member comment(s) detected"
-            echo "safe=false" >> $GITHUB_OUTPUT
-          else
-            echo "safe=true" >> $GITHUB_OUTPUT
-          fi
-
       - uses: actions/checkout@v4
-        if: steps.check-comments.outputs.safe == 'true'
         with:
           fetch-depth: 0
           token: ${{ steps.claude-token.outputs.token }}
 
       - uses: actions/setup-node@v4
-        if: steps.check-comments.outputs.safe == 'true'
         with:
           node-version: '20'
 
       - uses: pnpm/action-setup@v4
-        if: steps.check-comments.outputs.safe == 'true'
         with:
           version: 9
 
       - name: Install dependencies
-        if: steps.check-comments.outputs.safe == 'true'
         run: cd scripts/claude-assistant && pnpm install
 
       - name: Run Claude review
-        if: steps.check-comments.outputs.safe == 'true'
         env:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -100,7 +126,9 @@ jobs:
 
   # Manual review via /claude-review comment
   manual-review:
+    needs: safety-check
     if: |
+      needs.safety-check.outputs.safe == 'true' &&
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '/claude-review') &&
@@ -118,52 +146,24 @@ jobs:
           app-id: ${{ vars.CLAUDE_APP_ID }}
           private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
 
-      - name: Validate token
-        run: |
-          if [ -z "${{ steps.claude-token.outputs.token }}" ]; then
-            echo "Error: Failed to generate GitHub App token"
-            exit 1
-          fi
-
-      - name: Check for non-member comments
-        id: check-comments
-        env:
-          GH_TOKEN: ${{ steps.claude-token.outputs.token }}
-        run: |
-          PR_NUM="${{ github.event.issue.number }}"
-          ISSUE=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments --jq "$NONMEMBER_FILTER")
-          REVIEW=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM/comments --jq "$NONMEMBER_FILTER")
-          TOTAL=$((ISSUE + REVIEW))
-          if [ "$TOTAL" -gt 0 ]; then
-            echo "::warning::Skipping - $TOTAL non-member comment(s) detected"
-            echo "safe=false" >> $GITHUB_OUTPUT
-          else
-            echo "safe=true" >> $GITHUB_OUTPUT
-          fi
-
       - uses: actions/checkout@v4
-        if: steps.check-comments.outputs.safe == 'true'
         with:
           fetch-depth: 0
           ref: refs/pull/${{ github.event.issue.number }}/head
           token: ${{ steps.claude-token.outputs.token }}
 
       - uses: actions/setup-node@v4
-        if: steps.check-comments.outputs.safe == 'true'
         with:
           node-version: '20'
 
       - uses: pnpm/action-setup@v4
-        if: steps.check-comments.outputs.safe == 'true'
         with:
           version: 9
 
       - name: Install dependencies
-        if: steps.check-comments.outputs.safe == 'true'
         run: cd scripts/claude-assistant && pnpm install
 
       - name: Get PR info
-        if: steps.check-comments.outputs.safe == 'true'
         id: pr
         run: |
           PR_DATA=$(gh pr view ${{ github.event.issue.number }} --json headRefName,headRefOid,baseRefName)
@@ -174,7 +174,6 @@ jobs:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
 
       - name: Run Claude review
-        if: steps.check-comments.outputs.safe == 'true'
         env:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -190,7 +189,9 @@ jobs:
 
   # Respond to @claude mentions
   respond:
+    needs: safety-check
     if: |
+      needs.safety-check.outputs.safe == 'true' &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
       !contains(github.event.comment.body, '/claude-review') &&
       ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
@@ -208,71 +209,29 @@ jobs:
           app-id: ${{ vars.CLAUDE_APP_ID }}
           private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
 
-      - name: Validate token
-        run: |
-          if [ -z "${{ steps.claude-token.outputs.token }}" ]; then
-            echo "Error: Failed to generate GitHub App token"
-            exit 1
-          fi
-
-      - name: Get PR number
-        id: pr
-        run: |
-          # issue_comment on a PR: github.event.issue.number
-          # pull_request_review_comment: github.event.pull_request.number
-          if [ "${{ github.event_name }}" = "issue_comment" ]; then
-            echo "number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
-            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          else
-            echo "::error::Unknown event type for respond job"
-            exit 1
-          fi
-
-      - name: Check for non-member comments
-        id: check-comments
-        env:
-          GH_TOKEN: ${{ steps.claude-token.outputs.token }}
-        run: |
-          PR_NUM="${{ steps.pr.outputs.number }}"
-          ISSUE=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments --jq "$NONMEMBER_FILTER")
-          REVIEW=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM/comments --jq "$NONMEMBER_FILTER")
-          TOTAL=$((ISSUE + REVIEW))
-          if [ "$TOTAL" -gt 0 ]; then
-            echo "::warning::Skipping - $TOTAL non-member comment(s) detected"
-            echo "safe=false" >> $GITHUB_OUTPUT
-          else
-            echo "safe=true" >> $GITHUB_OUTPUT
-          fi
-
       - uses: actions/checkout@v4
-        if: steps.check-comments.outputs.safe == 'true'
         with:
           fetch-depth: 0
           token: ${{ steps.claude-token.outputs.token }}
 
       - uses: actions/setup-node@v4
-        if: steps.check-comments.outputs.safe == 'true'
         with:
           node-version: '20'
 
       - uses: pnpm/action-setup@v4
-        if: steps.check-comments.outputs.safe == 'true'
         with:
           version: 9
 
       - name: Install dependencies
-        if: steps.check-comments.outputs.safe == 'true'
         run: cd scripts/claude-assistant && pnpm install
 
       - name: Run Claude respond
-        if: steps.check-comments.outputs.safe == 'true'
         env:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           MODE: respond
           GITHUB_REPOSITORY: ${{ github.repository }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_NUMBER: ${{ needs.safety-check.outputs.pr_number }}
           HEAD_BRANCH: ${{ github.head_ref }}
           HEAD_SHA: ${{ github.sha }}
           BASE_BRANCH: ${{ github.base_ref }}
@@ -283,7 +242,9 @@ jobs:
 
   # Auto-fix CI failures
   ci-fix:
+    needs: safety-check
     if: |
+      needs.safety-check.outputs.safe == 'true' &&
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'failure' &&
       !startsWith(github.event.workflow_run.head_branch, 'claude/fix-') &&
@@ -300,13 +261,6 @@ jobs:
         with:
           app-id: ${{ vars.CLAUDE_APP_ID }}
           private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
-
-      - name: Validate token
-        run: |
-          if [ -z "${{ steps.claude-token.outputs.token }}" ]; then
-            echo "Error: Failed to generate GitHub App token"
-            exit 1
-          fi
 
       - uses: actions/checkout@v4
         with:
@@ -325,53 +279,31 @@ jobs:
       - name: Install dependencies
         run: cd scripts/claude-assistant && pnpm install
 
-      - name: Get PR number
-        id: pr
-        run: |
-          PR_NUM=$(gh pr list --repo ${{ github.repository }} --head ${{ github.event.workflow_run.head_branch }} --json number --jq '.[0].number')
-          echo "number=${PR_NUM:-0}" >> $GITHUB_OUTPUT
-
-          if [ -n "$PR_NUM" ]; then
-            ASSOC=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM --jq '.author_association')
-            echo "association=$ASSOC" >> $GITHUB_OUTPUT
-          fi
-        env:
-          GH_TOKEN: ${{ steps.claude-token.outputs.token }}
-
-      - name: Check if should run
+      - name: Check PR author association
         id: check
         env:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
         run: |
           BRANCH="${{ github.event.workflow_run.head_branch }}"
-          ASSOC="${{ steps.pr.outputs.association }}"
-          PR_NUM="${{ steps.pr.outputs.number }}"
+          PR_NUM="${{ needs.safety-check.outputs.pr_number }}"
 
-          # Always run for main/master (no PR comments to worry about)
+          # Always run for main/master
           if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          # For PRs, only run for org members
-          if [ "$ASSOC" != "OWNER" ] && [ "$ASSOC" != "MEMBER" ] && [ "$ASSOC" != "COLLABORATOR" ]; then
-            echo "should_run=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          # Check for non-member comments (prompt injection risk)
+          # For PRs, check author is org member
           if [ -n "$PR_NUM" ] && [ "$PR_NUM" != "0" ]; then
-            ISSUE=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments --jq "$NONMEMBER_FILTER")
-            REVIEW=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM/comments --jq "$NONMEMBER_FILTER")
-            TOTAL=$((ISSUE + REVIEW))
-            if [ "$TOTAL" -gt 0 ]; then
-              echo "::warning::Skipping - $TOTAL non-member comment(s) detected"
+            ASSOC=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM --jq '.author_association')
+            if [ "$ASSOC" = "OWNER" ] || [ "$ASSOC" = "MEMBER" ] || [ "$ASSOC" = "COLLABORATOR" ]; then
+              echo "should_run=true" >> $GITHUB_OUTPUT
+            else
               echo "should_run=false" >> $GITHUB_OUTPUT
-              exit 0
             fi
+          else
+            echo "should_run=false" >> $GITHUB_OUTPUT
           fi
-
-          echo "should_run=true" >> $GITHUB_OUTPUT
 
       - name: Run Claude CI fix
         if: steps.check.outputs.should_run == 'true'
@@ -380,7 +312,7 @@ jobs:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           MODE: ci-fix
           GITHUB_REPOSITORY: ${{ github.repository }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_NUMBER: ${{ needs.safety-check.outputs.pr_number }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           BASE_BRANCH: main

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -100,7 +100,8 @@ jobs:
             '[.[] | select(.author.type != "Bot" and .author.login != null) | .author.login] | unique | .[]' | while read -r LOGIN; do
             if [ -n "$LOGIN" ]; then
               ASSOC=$(gh api repos/${{ github.repository }}/collaborators/$LOGIN/permission --jq '.permission' 2>/dev/null || echo "none")
-              if [ "$ASSOC" != "admin" ] && [ "$ASSOC" != "write" ] && [ "$ASSOC" != "maintain" ]; then
+              # Block if not a collaborator (permission = none)
+              if [ "$ASSOC" = "none" ]; then
                 echo "$LOGIN"
               fi
             fi


### PR DESCRIPTION
## Summary

Prevents prompt injection attacks by refusing to run Claude workflows when any comment exists from a non-OWNER/MEMBER/COLLABORATOR.

## Changes

All four jobs check for non-member comments before running:
- `review`: Checks `issues/{pr}/comments` API
- `manual-review`: Same check
- `respond`: Same check  
- `ci-fix`: Added to existing "should run" check

If any non-member comment is found, job skips with warning:
```
::warning::Skipping Claude - 1 comment(s) from non-members detected
```