### PR TITLE
Rename repo references from firepod to fcvm

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1162,7 +1162,7 @@ sudo fcvm podman run --name my-vm --network bridged \
 Key config fields in `[kernel_profiles.nested.arm64]`:
 ```toml
 kernel_version = "6.18.3"              # Version to download/build
-kernel_repo = "ejc3/firepod"           # GitHub repo for releases
+kernel_repo = "ejc3/fcvm"           # GitHub repo for releases
 build_inputs = ["kernel/nested.conf", "kernel/patches/*.patch"]  # Files for SHA
 kernel_config = "kernel/nested.conf"   # Kernel .config
 patches_dir = "kernel/patches"         # Directory with patches

--- a/README.md
+++ b/README.md
@@ -617,7 +617,7 @@ boot_args = "quiet"
 | Field | Required | Description |
 |-------|----------|-------------|
 | `kernel_version` | Yes | Kernel version (e.g., "6.18.3") |
-| `kernel_repo` | Yes | GitHub repo for releases (e.g., "ejc3/firepod") |
+| `kernel_repo` | Yes | GitHub repo for releases (e.g., "ejc3/fcvm") |
 | `build_inputs` | Yes | Files to hash for kernel SHA (supports globs) |
 | `kernel_config` | No | Kernel .config file path |
 | `patches_dir` | No | Directory containing kernel patches |

--- a/rootfs-config.toml
+++ b/rootfs-config.toml
@@ -149,7 +149,7 @@ remove_dirs = [
 [kernel_profiles.nested.arm64]
 description = "Nested virtualization support for running VMs inside VMs"
 kernel_version = "6.18.3"
-kernel_repo = "ejc3/firepod"
+kernel_repo = "ejc3/fcvm"
 
 # Build configuration - these files determine when kernel needs rebuilding
 # SHA is computed from contents of all files matching these patterns
@@ -197,7 +197,7 @@ build_inputs = [
 [kernel_profiles.nested.amd64]
 description = "Nested virtualization support for running VMs inside VMs (x86_64)"
 kernel_version = "6.18.3"
-kernel_repo = "ejc3/firepod"
+kernel_repo = "ejc3/fcvm"
 
 # Build configuration - these files determine when kernel needs rebuilding
 build_inputs = [

--- a/scripts/build-ami.sh
+++ b/scripts/build-ami.sh
@@ -107,11 +107,11 @@ export HOME=/root
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 source /root/.cargo/env
 
-# Clone firepod and its dependencies
-git clone --depth 1 https://github.com/ejc3/firepod.git /tmp/firepod
+# Clone fcvm and its dependencies
+git clone --depth 1 https://github.com/ejc3/fcvm.git /tmp/fcvm
 git clone --depth 1 https://github.com/ejc3/fuse-backend-rs.git /tmp/fuse-backend-rs
 git clone --depth 1 https://github.com/ejc3/fuser.git /tmp/fuser
-cd /tmp/firepod
+cd /tmp/fcvm
 cargo build --release
 
 # Use repo's config which has nested profile defined
@@ -340,13 +340,13 @@ main() {
 
   # Create AMI
   timestamp=$(date +%Y%m%d-%H%M)
-  ami_name="firepod-runner-${kernel_version}-${timestamp}"
+  ami_name="fcvm-runner-${kernel_version}-${timestamp}"
 
   ami_id=$(aws ec2 create-image \
     --region "$REGION" \
     --instance-id "$instance_id" \
     --name "$ami_name" \
-    --description "Firepod CI runner with kernel ${kernel_version}-nested" \
+    --description "fcvm CI runner with kernel ${kernel_version}-nested" \
     --query 'ImageId' --output text)
   echo "Created AMI: $ami_id ($ami_name)"
 

--- a/scripts/setup-runner.sh
+++ b/scripts/setup-runner.sh
@@ -14,13 +14,13 @@ if [ ! -f "$MARKER" ]; then
   apt-get install -y curl jq
 
   # Find the latest host kernel release
-  RELEASE_TAG=$(curl -s https://api.github.com/repos/ejc3/firepod/releases | \
+  RELEASE_TAG=$(curl -s https://api.github.com/repos/ejc3/fcvm/releases | \
     jq -r '.[] | select(.tag_name | startswith("host-kernel-")) | .tag_name' | head -1)
 
   if [ -n "$RELEASE_TAG" ]; then
     echo "Found kernel release: $RELEASE_TAG"
 
-    KERNEL_URL=$(curl -s "https://api.github.com/repos/ejc3/firepod/releases/tags/$RELEASE_TAG" | \
+    KERNEL_URL=$(curl -s "https://api.github.com/repos/ejc3/fcvm/releases/tags/$RELEASE_TAG" | \
       jq -r '.assets[] | select(.name | startswith("linux-image-")) | .browser_download_url')
 
     if [ -n "$KERNEL_URL" ]; then
@@ -39,7 +39,7 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/bash -c 'curl -fsSL https://raw.githubusercontent.com/ejc3/firepod/main/scripts/setup-runner.sh | bash'
+ExecStart=/bin/bash -c 'curl -fsSL https://raw.githubusercontent.com/ejc3/fcvm/main/scripts/setup-runner.sh | bash'
 RemainAfterExit=yes
 StandardOutput=journal+console
 StandardError=journal+console
@@ -122,8 +122,8 @@ chown -R ubuntu:ubuntu /opt/actions-runner
 PAT=$(aws ssm get-parameter --name /github-runner/pat --with-decryption --query 'Parameter.Value' --output text --region us-west-1 2>/dev/null || echo "")
 if [ -n "$PAT" ] && [ "$PAT" != "placeholder" ]; then
   TOKEN=$(curl -s -X POST -H "Authorization: token $PAT" \
-    https://api.github.com/repos/ejc3/firepod/actions/runners/registration-token | jq -r '.token')
-  sudo -u ubuntu ./config.sh --url https://github.com/ejc3/firepod --token "$TOKEN" \
+    https://api.github.com/repos/ejc3/fcvm/actions/runners/registration-token | jq -r '.token')
+  sudo -u ubuntu ./config.sh --url https://github.com/ejc3/fcvm --token "$TOKEN" \
     --name "runner-$INSTANCE_ID" --labels self-hosted,Linux,ARM64 --unattended
   ./svc.sh install ubuntu
   ./svc.sh start

--- a/src/setup/storage.rs
+++ b/src/setup/storage.rs
@@ -54,13 +54,15 @@ fn get_storage_paths(config_path: Option<&str>) -> Result<(PathBuf, PathBuf)> {
     // Canonicalize the mount point to resolve .., ., and symlinks
     // If it doesn't exist yet, canonicalize as much as possible
     let canonical_mount = if mount_point.exists() {
-        mount_point.canonicalize()
+        mount_point
+            .canonicalize()
             .context("canonicalizing mount point path")?
     } else {
         // For non-existent paths, try to canonicalize the parent
         if let Some(parent) = mount_point.parent() {
             let canonical_parent = if parent.exists() {
-                parent.canonicalize()
+                parent
+                    .canonicalize()
                     .context("canonicalizing mount point parent")?
             } else {
                 parent.to_path_buf()
@@ -74,7 +76,8 @@ fn get_storage_paths(config_path: Option<&str>) -> Result<(PathBuf, PathBuf)> {
     // Loopback image is a sibling of mount point (e.g., /mnt/fcvm-btrfs -> /mnt/fcvm-btrfs.img)
     // Use the canonical path and proper PathBuf API to construct the loopback path
     let mut loopback_image = canonical_mount.clone();
-    let current_name = loopback_image.file_name()
+    let current_name = loopback_image
+        .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or("fcvm-btrfs");
     loopback_image.set_file_name(format!("{}.img", current_name));
@@ -96,13 +99,12 @@ pub fn ensure_storage(config_path: Option<&str>) -> Result<()> {
     if is_btrfs_mount(&mount_point) {
         for dir in REQUIRED_DIRS {
             let path = mount_point.join(dir);
-            std::fs::create_dir_all(&path)
-                .with_context(|| {
-                    format!(
-                        "creating directory {} (if mount was unmounted, run 'sudo fcvm setup' again)",
-                        path.display()
-                    )
-                })?;
+            std::fs::create_dir_all(&path).with_context(|| {
+                format!(
+                    "creating directory {} (if mount was unmounted, run 'sudo fcvm setup' again)",
+                    path.display()
+                )
+            })?;
         }
         return Ok(());
     }
@@ -141,8 +143,7 @@ pub fn ensure_storage(config_path: Option<&str>) -> Result<()> {
     if !loopback_image.exists() {
         // Ensure parent directory exists
         if let Some(parent) = loopback_image.parent() {
-            std::fs::create_dir_all(parent)
-                .context("creating loopback image parent directory")?;
+            std::fs::create_dir_all(parent).context("creating loopback image parent directory")?;
         }
 
         info!(


### PR DESCRIPTION
Updates all references from ejc3/firepod to ejc3/fcvm after repo rename.

Changed files:
- rootfs-config.toml (kernel_repo)
- README.md (documentation)
- .claude/CLAUDE.md (documentation)
- scripts/build-ami.sh (clone URL, AMI names)
- scripts/setup-runner.sh (API URLs, config)