### PR TITLE
Deduplicate Claude review findings with comment links

### DIFF
--- a/scripts/claude-assistant/index.ts
+++ b/scripts/claude-assistant/index.ts
@@ -252,10 +252,17 @@ The diff output may be truncated for large changes. If the diff ends mid-line or
 ## STEP 2: CHECK PREVIOUS REVIEWS
 
 Look at the comments from step 1a. If there are previous Claude reviews:
-- **[LOW] issues**: Do NOT repeat if already mentioned. These add no value.
-- **[MEDIUM]/[CRITICAL] issues**: Can reference if still present (e.g., "Previously noted X is still unfixed")
+- **[LOW] issues**: Do NOT mention again. Skip entirely.
+- **[MEDIUM]/[CRITICAL] issues that are STILL UNFIXED**: Reference with a link, do NOT repeat the analysis.
 
-Only report NEW findings or still-present MEDIUM/CRITICAL issues.
+When referencing a previous comment, get the comment URL:
+\`\`\`bash
+gh api repos/${ctx.repository}/issues/${ctx.prNumber}/comments --jq '.[] | select(.user.login == "claude[bot]") | {id: .id, url: .html_url}'
+\`\`\`
+
+Then link to it: "As noted in [previous review](URL), the PATH inconsistency remains unfixed."
+
+**CRITICAL**: If an issue was already reported, do NOT repeat the full analysis. One-line summary with link only.
 
 ## STEP 3: ANALYZE
 


### PR DESCRIPTION
## Summary
- Claude reviews now link to previous comments instead of repeating findings
- Uses `gh api` to fetch comment URLs for proper markdown links
- Skips [LOW] issues entirely if already reported
- One-line summary with link for still-unfixed [MEDIUM]/[CRITICAL] issues

**Stacked on:** setup-fixup (PR #102)

## Context
PR #102 had duplicate review comments both saying the same PATH inconsistency issue. This teaches Claude to reference the previous comment with a link instead of repeating the full analysis.