### PR TITLE
Show HOST_ADDR instead of TAP_DEVICE in fcvm ls

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1035,8 +1035,8 @@ fuse-pipe/benches/
    - **Performance**: Original VM + 2 clones = ~512MB RAM total (not 1.5GB!)
 
 3. **True Rootless Networking** (2025-11-25)
-   - `--network bridged` (default): Network namespace + iptables, requires root
-   - `--network rootless`: slirp4netns, no root required
+   - `--network rootless` (default): slirp4netns, no root required
+   - `--network bridged`: Network namespace + iptables, requires root
    - User namespace via `unshare --user --map-root-user --net`
    - Health checks use unique loopback IPs (127.x.y.z) per VM
 
@@ -1073,8 +1073,8 @@ fuse-pipe/benches/
 
 | Mode | Flag | Requires Root | Performance | Port Forwarding |
 |------|------|---------------|-------------|-----------------|
+| Rootless (default) | `--network rootless` | No | Good | slirp4netns API |
 | Bridged | `--network bridged` | Yes | Better | iptables DNAT |
-| Rootless | `--network rootless` | No | Good | slirp4netns API |
 
 **Rootless Architecture:**
 - Firecracker starts with `unshare --user --map-root-user --net`

--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -68,8 +68,8 @@ pub async fn cmd_ls(args: LsArgs) -> Result<()> {
             "PID",
             "STATUS",
             "HEALTH",
+            "HOST_ADDR",
             "GUEST_IP",
-            "TAP_DEVICE",
             "IMAGE",
             "MEM(MB)",
             "STALE"
@@ -84,12 +84,15 @@ pub async fn cmd_ls(args: LsArgs) -> Result<()> {
                 .name
                 .as_deref()
                 .unwrap_or_else(|| truncate_id(&vm.vm_id, 8));
+            // HOST_ADDR: loopback_ip for rootless, host_ip for bridged
+            let host_addr = vm
+                .config
+                .network
+                .loopback_ip
+                .as_deref()
+                .or(vm.config.network.host_ip.as_deref())
+                .unwrap_or("-");
             let guest_ip = vm.config.network.guest_ip.as_deref().unwrap_or("-");
-            let tap_device = if vm.config.network.tap_device.is_empty() {
-                "-"
-            } else {
-                &vm.config.network.tap_device
-            };
             let image = vm
                 .config
                 .image
@@ -105,8 +108,8 @@ pub async fn cmd_ls(args: LsArgs) -> Result<()> {
                 pid_str,
                 status,
                 health,
+                host_addr,
                 guest_ip,
-                tap_device,
                 image,
                 vm.config.memory_mib,
                 stale_marker

--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -64,15 +64,7 @@ pub async fn cmd_ls(args: LsArgs) -> Result<()> {
         // Table output
         println!(
             "{:<20} {:<10} {:<12} {:<12} {:<15} {:<15} {:<12} {:<8} {:<6}",
-            "NAME",
-            "PID",
-            "STATUS",
-            "HEALTH",
-            "HOST_ADDR",
-            "GUEST_IP",
-            "IMAGE",
-            "MEM(MB)",
-            "STALE"
+            "NAME", "PID", "STATUS", "HEALTH", "HOST_ADDR", "GUEST_IP", "IMAGE", "MEM(MB)", "STALE"
         );
         println!("{}", "-".repeat(120));
 


### PR DESCRIPTION
Replace the TAP_DEVICE column (debugging info only) with HOST_ADDR which
shows the IP address users need to connect to for port forwarding:
- Rootless mode: loopback_ip (127.x.y.z)
- Bridged mode: host_ip

Before: Users had to dig through state JSON to find the loopback IP
After: `fcvm ls` shows HOST_ADDR column with the connectable IP
