### PR TITLE
Add TTY and interactive mode support (-it flags)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -499,13 +499,22 @@ See `Containerfile.libfuse-remap` and `Containerfile.pjdfstest` for examples.
 
 **CRITICAL: VM commands BLOCK the terminal.** You MUST use Claude's `run_in_background: true` feature.
 
-```bash
-# WRONG - This blocks forever, wastes context, and times out
-sudo fcvm podman run --name test nginx:alpine
+**PREFER NON-ROOT TESTING**: Run tests without sudo when possible. Rootless networking mode (`--network rootless`, the default) doesn't require sudo. Only use `sudo` for:
+- `--network bridged` tests
+- Operations that explicitly need root (iptables, privileged containers)
 
-# CORRECT - Run VM in background, then use exec to test
+The ubuntu user has KVM access (`kvm` group), so `fcvm podman run` works without sudo in rootless mode.
+
+```bash
+# PREFERRED - Rootless mode (no sudo needed, use run_in_background: true)
+./target/release/fcvm podman run --name test alpine:latest 2>&1 | tee /tmp/vm.log
+# Defaults to --network rootless
+# Get PID from state and use exec:
+ls -t /mnt/fcvm-btrfs/state/*.json | head -1 | xargs cat | jq -r '.pid'
+./target/release/fcvm exec --pid <PID> -- hostname
+
+# ONLY WHEN NEEDED - Bridged mode (requires sudo)
 sudo ./target/release/fcvm podman run --name test --network bridged nginx:alpine 2>&1 | tee /tmp/vm.log
-# Use run_in_background: true in Bash tool call
 # Then sleep and check logs:
 sleep 30
 grep healthy /tmp/vm.log

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -27,6 +27,12 @@ gh pr view 2 --json baseRefName
 
 ## UNDERSTAND BRANCH CHAINS
 
+**ALWAYS fetch before investigating branches:**
+```bash
+git fetch origin
+```
+Branches may already be merged on remote. Don't waste time on stale local state.
+
 **Run before starting work, committing, or opening PRs:**
 
 ```bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ serde_json = "1"
 sha2 = "0.10"
 hex = "0.4"
 toml = "0.8"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "fs", "signal", "io-util", "sync", "time"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "fs", "signal", "io-util", "io-std", "sync", "time"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 which = "6"
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,13 @@ else
 NEXTEST_IGNORED :=
 endif
 
+# Disable retries when FILTER is set (debugging specific tests)
+ifdef FILTER
+NEXTEST_RETRIES :=
+else
+NEXTEST_RETRIES := --retries 2
+endif
+
 # Default log level: fcvm debug, suppress FUSE spam
 # Override with: RUST_LOG=debug make test-root
 TEST_LOG ?= fcvm=debug,health-monitor=info,fuser=warn,fuse_backend_rs=warn,passthrough=warn
@@ -199,7 +206,7 @@ _test-root:
 	FCVM_DATA_DIR=$(ROOT_DATA_DIR) \
 	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E' \
 	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E' \
-	$(NEXTEST) $(NEXTEST_CAPTURE) $(NEXTEST_IGNORED) --retries 2 --features privileged-tests $(FILTER)
+	$(NEXTEST) $(NEXTEST_CAPTURE) $(NEXTEST_IGNORED) $(NEXTEST_RETRIES) --features privileged-tests $(FILTER)
 
 # Host targets (with setup, check-disk first to fail fast if disk is full)
 test-unit: show-notes check-disk build _test-unit

--- a/fc-agent/src/main.rs
+++ b/fc-agent/src/main.rs
@@ -858,9 +858,8 @@ fn handle_exec_connection_blocking(fd: i32) {
         // Use unified TTY handler
         // NOTE: Don't call std::process::exit() here - that would kill the entire fc-agent!
         // run_with_pty_fd already sends the exit code via exec_proto and closes the fd.
-        // We just return and let the spawn_blocking task end naturally.
+        // We just let the spawn_blocking task end naturally.
         let _exit_code = tty::run_with_pty_fd(fd, &command, request.tty, request.interactive);
-        return;
     } else {
         handle_exec_pipe(fd, &request);
     }

--- a/fc-agent/src/tty.rs
+++ b/fc-agent/src/tty.rs
@@ -1,0 +1,409 @@
+//! Unified TTY handling for fc-agent.
+//!
+//! This module provides a single implementation for running commands with PTY support,
+//! used by both `podman run -it` and `exec -it` paths.
+
+use std::io::{Read, Write};
+use std::os::unix::io::FromRawFd;
+
+/// Vsock port for TTY I/O (used by podman run -it)
+pub const TTY_VSOCK_PORT: u32 = 4996;
+
+/// Host CID for vsock connections
+const HOST_CID: u32 = 2;
+
+/// Run a command with PTY, connecting to host first.
+///
+/// Used by `podman run -it` where fc-agent initiates the connection.
+pub fn run_with_pty(command: &[String], tty: bool, interactive: bool) -> i32 {
+    if command.is_empty() {
+        eprintln!("[fc-agent] tty: empty command");
+        return 1;
+    }
+
+    // Connect to host via vsock
+    let vsock_fd = match connect_vsock(TTY_VSOCK_PORT) {
+        Ok(fd) => fd,
+        Err(e) => {
+            eprintln!("[fc-agent] tty: failed to connect vsock: {}", e);
+            return 1;
+        }
+    };
+
+    run_with_pty_fd(vsock_fd, command, tty, interactive)
+}
+
+/// Run a command with PTY using a pre-connected fd.
+///
+/// Used by `exec -it` where the host has already connected to fc-agent.
+/// Also called by `run_with_pty` after connecting.
+pub fn run_with_pty_fd(vsock_fd: i32, command: &[String], tty: bool, interactive: bool) -> i32 {
+    // Allocate PTY or pipes
+    let (master_fd, slave_fd, stdin_read, stdin_write, stdout_read, stdout_write) = if tty {
+        match allocate_pty() {
+            Ok((m, s)) => (m, s, -1, -1, -1, -1),
+            Err(e) => {
+                eprintln!("[fc-agent] tty: failed to allocate PTY: {}", e);
+                unsafe { libc::close(vsock_fd) };
+                return 1;
+            }
+        }
+    } else {
+        match allocate_pipes() {
+            Ok((sr, sw, or, ow)) => (-1, -1, sr, sw, or, ow),
+            Err(e) => {
+                eprintln!("[fc-agent] tty: failed to allocate pipes: {}", e);
+                unsafe { libc::close(vsock_fd) };
+                return 1;
+            }
+        }
+    };
+
+    // Fork
+    let pid = unsafe { libc::fork() };
+    if pid < 0 {
+        eprintln!("[fc-agent] tty: fork failed");
+        cleanup_fds(
+            tty,
+            master_fd,
+            slave_fd,
+            stdin_read,
+            stdin_write,
+            stdout_read,
+            stdout_write,
+        );
+        unsafe { libc::close(vsock_fd) };
+        return 1;
+    }
+
+    if pid == 0 {
+        // Child process
+        unsafe { libc::close(vsock_fd) };
+
+        if tty {
+            setup_child_pty(slave_fd, master_fd);
+        } else {
+            setup_child_pipes(stdin_read, stdin_write, stdout_read, stdout_write);
+        }
+
+        exec_command(command);
+        // exec_command never returns on success
+        eprintln!("[fc-agent] tty: exec failed");
+        unsafe { libc::_exit(127) };
+    }
+
+    // Parent process
+    if tty {
+        unsafe { libc::close(slave_fd) };
+    } else {
+        unsafe {
+            libc::close(stdin_read);
+            libc::close(stdout_write);
+        }
+    }
+
+    // Create File wrappers for I/O
+    let mut vsock = unsafe { std::fs::File::from_raw_fd(vsock_fd) };
+
+    let output_fd = if tty { master_fd } else { stdout_read };
+
+    // Spawn writer thread (only if interactive)
+    let writer_thread = if interactive {
+        let vsock_clone = match vsock.try_clone() {
+            Ok(f) => f,
+            Err(e) => {
+                eprintln!("[fc-agent] tty: failed to clone vsock: {}", e);
+                unsafe {
+                    libc::kill(pid, libc::SIGKILL);
+                    libc::waitpid(pid, std::ptr::null_mut(), 0);
+                }
+                return 1;
+            }
+        };
+
+        // For TTY, duplicate the master fd so we can use it for writing
+        // while the main thread uses it for reading
+        let input_file = if tty {
+            let dup_fd = unsafe { libc::dup(master_fd) };
+            if dup_fd < 0 {
+                eprintln!("[fc-agent] tty: failed to dup master fd");
+                unsafe {
+                    libc::kill(pid, libc::SIGKILL);
+                    libc::waitpid(pid, std::ptr::null_mut(), 0);
+                }
+                return 1;
+            }
+            unsafe { std::fs::File::from_raw_fd(dup_fd) }
+        } else {
+            unsafe { std::fs::File::from_raw_fd(stdin_write) }
+        };
+
+        Some(std::thread::spawn(move || {
+            writer_loop(vsock_clone, input_file);
+        }))
+    } else {
+        // Close stdin pipe if not interactive
+        if !tty && stdin_write >= 0 {
+            unsafe { libc::close(stdin_write) };
+        }
+        None
+    };
+
+    // Reader loop in main thread
+    let output_file = unsafe { std::fs::File::from_raw_fd(output_fd) };
+    let exit_code = reader_loop(output_file, &mut vsock, pid);
+
+    // Send exit message and flush to ensure it's sent before we exit
+    let _ = exec_proto::write_exit(&mut vsock, exit_code);
+    let _ = vsock.flush();
+
+    // Wait for writer thread
+    if let Some(handle) = writer_thread {
+        let _ = handle.join();
+    }
+
+    // Drop vsock explicitly to ensure close is sent before process exits
+    drop(vsock);
+
+    exit_code
+}
+
+/// Connect to host via vsock
+fn connect_vsock(port: u32) -> Result<i32, String> {
+    let fd = unsafe { libc::socket(libc::AF_VSOCK, libc::SOCK_STREAM, 0) };
+    if fd < 0 {
+        return Err("socket creation failed".to_string());
+    }
+
+    let addr = libc::sockaddr_vm {
+        svm_family: libc::AF_VSOCK as u16,
+        svm_reserved1: 0,
+        svm_port: port,
+        svm_cid: HOST_CID,
+        svm_zero: [0u8; 4],
+    };
+
+    let result = unsafe {
+        libc::connect(
+            fd,
+            &addr as *const libc::sockaddr_vm as *const libc::sockaddr,
+            std::mem::size_of::<libc::sockaddr_vm>() as u32,
+        )
+    };
+
+    if result < 0 {
+        unsafe { libc::close(fd) };
+        return Err(format!(
+            "connect failed: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+
+    Ok(fd)
+}
+
+/// Allocate PTY pair
+fn allocate_pty() -> Result<(i32, i32), String> {
+    let mut master: libc::c_int = 0;
+    let mut slave: libc::c_int = 0;
+
+    let result = unsafe {
+        libc::openpty(
+            &mut master,
+            &mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+
+    if result != 0 {
+        return Err("openpty failed".to_string());
+    }
+
+    Ok((master, slave))
+}
+
+/// Allocate stdin/stdout pipes
+fn allocate_pipes() -> Result<(i32, i32, i32, i32), String> {
+    let mut stdin_pipe = [0i32; 2];
+    let mut stdout_pipe = [0i32; 2];
+
+    if unsafe { libc::pipe(stdin_pipe.as_mut_ptr()) } != 0 {
+        return Err("stdin pipe failed".to_string());
+    }
+
+    if unsafe { libc::pipe(stdout_pipe.as_mut_ptr()) } != 0 {
+        unsafe {
+            libc::close(stdin_pipe[0]);
+            libc::close(stdin_pipe[1]);
+        }
+        return Err("stdout pipe failed".to_string());
+    }
+
+    // stdin_pipe[0] = read end (child reads from this)
+    // stdin_pipe[1] = write end (parent writes to this)
+    // stdout_pipe[0] = read end (parent reads from this)
+    // stdout_pipe[1] = write end (child writes to this)
+    Ok((stdin_pipe[0], stdin_pipe[1], stdout_pipe[0], stdout_pipe[1]))
+}
+
+/// Clean up file descriptors on error
+fn cleanup_fds(
+    tty: bool,
+    master_fd: i32,
+    slave_fd: i32,
+    stdin_read: i32,
+    stdin_write: i32,
+    stdout_read: i32,
+    stdout_write: i32,
+) {
+    unsafe {
+        if tty {
+            if master_fd >= 0 {
+                libc::close(master_fd);
+            }
+            if slave_fd >= 0 {
+                libc::close(slave_fd);
+            }
+        } else {
+            if stdin_read >= 0 {
+                libc::close(stdin_read);
+            }
+            if stdin_write >= 0 {
+                libc::close(stdin_write);
+            }
+            if stdout_read >= 0 {
+                libc::close(stdout_read);
+            }
+            if stdout_write >= 0 {
+                libc::close(stdout_write);
+            }
+        }
+    }
+}
+
+/// Set up child process for PTY
+fn setup_child_pty(slave_fd: i32, master_fd: i32) {
+    unsafe {
+        // Create new session and set controlling terminal
+        libc::setsid();
+        libc::ioctl(slave_fd, libc::TIOCSCTTY as _, 0);
+
+        // Redirect stdin/stdout/stderr to PTY slave
+        libc::dup2(slave_fd, 0);
+        libc::dup2(slave_fd, 1);
+        libc::dup2(slave_fd, 2);
+
+        // Close original fds
+        if slave_fd > 2 {
+            libc::close(slave_fd);
+        }
+        libc::close(master_fd);
+    }
+}
+
+/// Set up child process for pipes
+fn setup_child_pipes(stdin_read: i32, stdin_write: i32, stdout_read: i32, stdout_write: i32) {
+    unsafe {
+        // Redirect stdin to read end of stdin pipe
+        libc::dup2(stdin_read, 0);
+        // Redirect stdout/stderr to write end of stdout pipe
+        libc::dup2(stdout_write, 1);
+        libc::dup2(stdout_write, 2);
+
+        // Close original pipe fds
+        libc::close(stdin_read);
+        libc::close(stdin_write);
+        libc::close(stdout_read);
+        libc::close(stdout_write);
+    }
+}
+
+/// Exec the command
+fn exec_command(command: &[String]) {
+    use std::ffi::CString;
+
+    let prog = match CString::new(command[0].as_str()) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    let args: Vec<CString> = command
+        .iter()
+        .filter_map(|s| CString::new(s.as_str()).ok())
+        .collect();
+
+    let arg_ptrs: Vec<*const libc::c_char> = args
+        .iter()
+        .map(|s| s.as_ptr())
+        .chain(std::iter::once(std::ptr::null()))
+        .collect();
+
+    unsafe {
+        libc::execvp(prog.as_ptr(), arg_ptrs.as_ptr());
+    }
+}
+
+/// Writer loop: read STDIN messages from vsock, write to PTY/pipe
+fn writer_loop(mut vsock: std::fs::File, mut target: std::fs::File) {
+    loop {
+        match exec_proto::Message::read_from(&mut vsock) {
+            Ok(exec_proto::Message::Stdin(data)) => {
+                if target.write_all(&data).is_err() {
+                    break;
+                }
+                if target.flush().is_err() {
+                    break;
+                }
+            }
+            Ok(exec_proto::Message::Exit(_)) | Ok(exec_proto::Message::Error(_)) => {
+                break;
+            }
+            Ok(_) => {
+                // Unexpected message type, ignore
+            }
+            Err(_) => {
+                break;
+            }
+        }
+    }
+    // Drop target to close pipe/PTY, signaling EOF to child
+}
+
+/// Reader loop: read from PTY/pipe, send DATA messages via exec_proto
+fn reader_loop(mut source: std::fs::File, vsock: &mut std::fs::File, child_pid: i32) -> i32 {
+    let mut buf = [0u8; 4096];
+
+    loop {
+        match source.read(&mut buf) {
+            Ok(0) => {
+                break;
+            }
+            Ok(n) => {
+                if exec_proto::write_data(vsock, &buf[..n]).is_err() {
+                    break;
+                }
+            }
+            Err(e) => {
+                if e.kind() != std::io::ErrorKind::Interrupted {
+                    break;
+                }
+            }
+        }
+    }
+
+    // Wait for child and get exit code
+    let mut status: libc::c_int = 0;
+    unsafe {
+        libc::waitpid(child_pid, &mut status, 0);
+    }
+
+    if libc::WIFEXITED(status) {
+        libc::WEXITSTATUS(status)
+    } else if libc::WIFSIGNALED(status) {
+        128 + libc::WTERMSIG(status)
+    } else {
+        1
+    }
+}

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -97,14 +97,6 @@ pub enum PodmanCommands {
 
 #[derive(Args, Debug)]
 pub struct RunArgs {
-    /// Container image (e.g., nginx:alpine or localhost/myimage)
-    pub image: String,
-
-    /// Command and arguments to run in container (alternative to --cmd)
-    /// Example: fcvm podman run --name foo --network bridged alpine:latest sh -c "echo hello"
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-    pub command_args: Vec<String>,
-
     /// VM name (required)
     #[arg(long)]
     pub name: String,
@@ -177,6 +169,14 @@ pub struct RunArgs {
     #[arg(long)]
     pub privileged: bool,
 
+    /// Keep STDIN open even if not attached
+    #[arg(short, long)]
+    pub interactive: bool,
+
+    /// Allocate a pseudo-TTY
+    #[arg(short, long)]
+    pub tty: bool,
+
     /// Debug fc-agent with strace (output to /tmp/fc-agent.strace in guest)
     /// Useful for diagnosing fc-agent startup issues
     #[arg(long)]
@@ -201,6 +201,14 @@ pub struct RunArgs {
     /// Example: --vsock-dir /tmp/myvm creates /tmp/myvm/vsock.sock
     #[arg(long)]
     pub vsock_dir: Option<String>,
+
+    /// Container image (e.g., nginx:alpine or localhost/myimage)
+    pub image: String,
+
+    /// Command and arguments to run in container (alternative to --cmd)
+    /// Example: fcvm podman run --name foo --network bridged alpine:latest sh -c "echo hello"
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    pub command_args: Vec<String>,
 }
 
 // ============================================================================
@@ -305,10 +313,6 @@ pub struct LsArgs {
 
 #[derive(Args, Debug)]
 pub struct ExecArgs {
-    /// VM name to exec into (mutually exclusive with --pid)
-    #[arg(conflicts_with = "pid")]
-    pub name: Option<String>,
-
     /// VM PID to exec into (mutually exclusive with name)
     #[arg(long, conflicts_with = "name")]
     pub pid: Option<u32>,
@@ -316,6 +320,10 @@ pub struct ExecArgs {
     /// Execute in the VM instead of inside the container
     #[arg(long)]
     pub vm: bool,
+
+    /// Execute inside container (default, mutually exclusive with --vm)
+    #[arg(short, long)]
+    pub container: bool,
 
     /// Keep STDIN open even if not attached
     #[arg(short, long)]
@@ -329,7 +337,11 @@ pub struct ExecArgs {
     #[arg(short, long)]
     pub quiet: bool,
 
+    /// VM name to exec into (mutually exclusive with --pid)
+    #[arg(long, conflicts_with = "pid")]
+    pub name: Option<String>,
+
     /// Command and arguments to execute
-    #[arg(last = true, required = true)]
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true, required = true)]
     pub command: Vec<String>,
 }

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -21,8 +21,11 @@ pub const VSOCK_VOLUME_PORT_BASE: u32 = 5000;
 /// Vsock port for status channel (fc-agent notifies when container starts)
 pub const VSOCK_STATUS_PORT: u32 = 4999;
 
-/// Vsock port for container output streaming (bidirectional)
+/// Vsock port for container output streaming (bidirectional, line-based)
 pub const VSOCK_OUTPUT_PORT: u32 = 4997;
+
+/// Vsock port for TTY container I/O (binary exec_proto)
+pub const VSOCK_TTY_PORT: u32 = 4996;
 
 /// Minimum required Firecracker version for network_overrides support
 const MIN_FIRECRACKER_VERSION: (u32, u32, u32) = (1, 13, 1);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod podman;
 pub mod setup;
 pub mod snapshot;
 pub mod snapshots;
+pub mod tty;
 
 // Re-export command functions
 pub use completions::cmd_completions;

--- a/src/commands/tty.rs
+++ b/src/commands/tty.rs
@@ -1,0 +1,277 @@
+//! Unified TTY handling for fcvm host side.
+//!
+//! This module provides a single implementation for running TTY sessions,
+//! used by both `podman run -it` and `exec -it` paths.
+
+use std::io::Write;
+use std::os::unix::io::AsRawFd;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use anyhow::{bail, Context, Result};
+use tracing::{debug, info};
+
+/// Run a TTY session by listening on a Unix socket.
+///
+/// Used by `podman run -it` where the host listens and guest connects.
+///
+/// 1. Binds and accepts connection on Unix socket
+/// 2. Delegates to `run_tty_session_connected()` for I/O handling
+/// 3. Cleans up socket on exit
+pub fn run_tty_session(socket_path: &str, tty: bool, interactive: bool) -> Result<i32> {
+    // Remove stale socket if it exists
+    let _ = std::fs::remove_file(socket_path);
+
+    let listener =
+        UnixListener::bind(socket_path).with_context(|| format!("binding to {}", socket_path))?;
+
+    info!(socket = %socket_path, tty, interactive, "TTY session started");
+
+    // Accept connection from guest (blocking)
+    listener
+        .set_nonblocking(false)
+        .context("setting listener to blocking")?;
+    let (stream, _) = listener.accept().context("accepting connection")?;
+
+    debug!("TTY connection established");
+
+    // Run the session with the connected stream
+    let result = run_tty_session_connected(stream, tty, interactive);
+
+    // Clean up socket
+    let _ = std::fs::remove_file(socket_path);
+
+    result
+}
+
+/// Run a TTY session with a pre-connected stream.
+///
+/// Used by `exec -it` where the host has already connected to the guest.
+///
+/// 1. Sets terminal to raw mode if `tty=true`
+/// 2. Spawns reader thread (socket -> stdout)
+/// 3. Spawns writer thread if `interactive=true` (stdin -> socket)
+/// 4. Returns exit code from remote command
+pub fn run_tty_session_connected(stream: UnixStream, tty: bool, interactive: bool) -> Result<i32> {
+    // Set up raw terminal mode if TTY requested
+    let stdin_fd = std::io::stdin().as_raw_fd();
+
+    // Debug: check if stdin is non-blocking
+    let stdin_flags = unsafe { libc::fcntl(stdin_fd, libc::F_GETFL) };
+    let is_nonblocking = (stdin_flags & libc::O_NONBLOCK) != 0;
+    debug!(
+        "run_tty_session_connected: stdin_fd={}, flags=0x{:x}, O_NONBLOCK={}",
+        stdin_fd, stdin_flags, is_nonblocking
+    );
+    let orig_termios = if tty {
+        setup_raw_terminal(stdin_fd)?
+    } else {
+        None
+    };
+
+    // Flag to track completion
+    let done = Arc::new(AtomicBool::new(false));
+
+    // Clone stream for reader/writer
+    let read_stream = stream.try_clone().context("cloning stream for reader")?;
+    let mut write_stream = stream;
+
+    // Spawn reader thread: socket -> stdout
+    let reader_done = done.clone();
+    let reader_thread = std::thread::spawn(move || reader_loop(read_stream, reader_done));
+
+    // Spawn writer thread if interactive: stdin -> socket
+    let writer_thread = if interactive {
+        let writer_done = done.clone();
+        Some(std::thread::spawn(move || {
+            writer_loop(&mut write_stream, writer_done);
+        }))
+    } else {
+        drop(write_stream);
+        None
+    };
+
+    // Wait for reader to finish and get exit code
+    let exit_code = reader_thread.join().ok().flatten().unwrap_or(0);
+
+    // Signal writer to stop
+    done.store(true, Ordering::Relaxed);
+
+    // Restore terminal if we set raw mode
+    if let Some(termios) = orig_termios {
+        restore_terminal(stdin_fd, termios);
+    }
+
+    // Clean up writer thread handle
+    drop(writer_thread);
+
+    Ok(exit_code)
+}
+
+/// Set up raw terminal mode
+fn setup_raw_terminal(stdin_fd: i32) -> Result<Option<libc::termios>> {
+    let is_tty = unsafe { libc::isatty(stdin_fd) == 1 };
+    if !is_tty {
+        bail!("TTY mode requires a terminal. Use without -t for non-interactive mode.");
+    }
+
+    // Ensure stdin is in blocking mode (tokio may have set it non-blocking)
+    unsafe {
+        let flags = libc::fcntl(stdin_fd, libc::F_GETFL);
+        if flags != -1 && (flags & libc::O_NONBLOCK) != 0 {
+            libc::fcntl(stdin_fd, libc::F_SETFL, flags & !libc::O_NONBLOCK);
+            debug!("setup_raw_terminal: cleared O_NONBLOCK from stdin");
+        }
+    }
+
+    // Save original terminal settings
+    let mut termios: libc::termios = unsafe { std::mem::zeroed() };
+    if unsafe { libc::tcgetattr(stdin_fd, &mut termios) } != 0 {
+        bail!("Failed to get terminal attributes");
+    }
+    let orig = termios;
+
+    // Set raw mode
+    unsafe {
+        libc::cfmakeraw(&mut termios);
+    }
+    if unsafe { libc::tcsetattr(stdin_fd, libc::TCSANOW, &termios) } != 0 {
+        bail!("Failed to set raw terminal mode");
+    }
+
+    Ok(Some(orig))
+}
+
+/// Restore terminal to original settings
+fn restore_terminal(stdin_fd: i32, termios: libc::termios) {
+    unsafe {
+        libc::tcsetattr(stdin_fd, libc::TCSANOW, &termios);
+    }
+}
+
+/// Reader loop: read framed messages from socket, write to stdout
+fn reader_loop(mut stream: std::os::unix::net::UnixStream, done: Arc<AtomicBool>) -> Option<i32> {
+    let mut stdout = std::io::stdout().lock();
+    let mut total_read: usize = 0;
+
+    loop {
+        if done.load(Ordering::Relaxed) {
+            debug!("reader_loop: done flag set, exiting");
+            break;
+        }
+
+        match exec_proto::Message::read_from(&mut stream) {
+            Ok(exec_proto::Message::Data(data)) => {
+                total_read += data.len();
+                debug!("reader_loop: received {} bytes (total {})", data.len(), total_read);
+                let _ = stdout.write_all(&data);
+                let _ = stdout.flush();
+            }
+            Ok(exec_proto::Message::Exit(code)) => {
+                debug!("reader_loop: received Exit({})", code);
+                done.store(true, Ordering::Relaxed);
+                return Some(code);
+            }
+            Ok(exec_proto::Message::Error(msg)) => {
+                debug!("reader_loop: received Error({})", msg);
+                let _ = writeln!(stdout, "\r\nError: {}\r", msg);
+                let _ = stdout.flush();
+                done.store(true, Ordering::Relaxed);
+                return Some(1);
+            }
+            Ok(exec_proto::Message::Stdin(_)) => {
+                // Should not receive STDIN from guest, ignore
+            }
+            Err(e) => {
+                if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                    debug!("reader_loop: EOF");
+                    break;
+                }
+                debug!("reader_loop: error: {}", e);
+                eprintln!("\r\nProtocol error: {}\r", e);
+                break;
+            }
+        }
+    }
+    None
+}
+
+/// Writer loop: read from stdin, send STDIN messages to socket
+fn writer_loop(stream: &mut std::os::unix::net::UnixStream, done: Arc<AtomicBool>) {
+    let stdin_fd = std::io::stdin().as_raw_fd();
+    let mut buf = [0u8; 1024];
+    let mut total_written = 0usize;
+
+    debug!(
+        "writer_loop: starting, stdin_fd={}, waiting for stdin data",
+        stdin_fd
+    );
+
+    // Use poll-based loop to avoid blocking forever and see when data arrives
+    let mut poll_count = 0;
+    let mut last_log_time = std::time::Instant::now();
+
+    loop {
+        if done.load(Ordering::Relaxed) {
+            debug!("writer_loop: done flag set, exiting");
+            break;
+        }
+
+        // Poll for 1 second
+        let mut pollfd = libc::pollfd {
+            fd: stdin_fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let poll_result = unsafe { libc::poll(&mut pollfd, 1, 1000) };
+        poll_count += 1;
+
+        // Log every 5 seconds
+        if last_log_time.elapsed() > std::time::Duration::from_secs(5) {
+            debug!(
+                "writer_loop: poll #{}, result={}, revents=0x{:x}",
+                poll_count, poll_result, pollfd.revents
+            );
+            last_log_time = std::time::Instant::now();
+        }
+
+        if poll_result < 0 {
+            let errno = std::io::Error::last_os_error();
+            debug!("writer_loop: poll error: {}", errno);
+            break;
+        } else if poll_result == 0 {
+            // Timeout, no data yet
+            continue;
+        }
+
+        // Data available! Read it
+        debug!(
+            "writer_loop: DATA AVAILABLE! poll_result={}, revents=0x{:x}",
+            poll_result, pollfd.revents
+        );
+
+        let n = unsafe { libc::read(stdin_fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
+
+        if n < 0 {
+            let errno = std::io::Error::last_os_error();
+            debug!("writer_loop: stdin read error: {}", errno);
+            break;
+        } else if n == 0 {
+            debug!("writer_loop: EOF on stdin");
+            break;
+        } else {
+            let n = n as usize;
+            total_written += n;
+            debug!(
+                "writer_loop: read {} bytes from stdin (total {})",
+                n, total_written
+            );
+            if exec_proto::write_stdin(stream, &buf[..n]).is_err() {
+                debug!("writer_loop: write_stdin failed");
+                break;
+            }
+        }
+    }
+    debug!("writer_loop: exiting, total written: {} bytes", total_written);
+}

--- a/src/commands/tty.rs
+++ b/src/commands/tty.rs
@@ -164,7 +164,11 @@ fn reader_loop(mut stream: std::os::unix::net::UnixStream, done: Arc<AtomicBool>
         match exec_proto::Message::read_from(&mut stream) {
             Ok(exec_proto::Message::Data(data)) => {
                 total_read += data.len();
-                debug!("reader_loop: received {} bytes (total {})", data.len(), total_read);
+                debug!(
+                    "reader_loop: received {} bytes (total {})",
+                    data.len(),
+                    total_read
+                );
                 let _ = stdout.write_all(&data);
                 let _ = stdout.flush();
             }
@@ -273,5 +277,8 @@ fn writer_loop(stream: &mut std::os::unix::net::UnixStream, done: Arc<AtomicBool
             }
         }
     }
-    debug!("writer_loop: exiting, total written: {} bytes", total_written);
+    debug!(
+        "writer_loop: exiting, total written: {} bytes",
+        total_written
+    );
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -119,6 +119,8 @@ pub fn spawn_streaming<F>(
 where
     F: Fn(&str, bool) + Send + Sync + Clone + 'static,
 {
+    // Stdin is null to prevent child from competing with parent for terminal input
+    cmd.stdin(Stdio::null());
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -745,7 +745,7 @@ pub async fn exec_in_container(pid: u32, cmd: &[&str]) -> anyhow::Result<String>
     let script = cmd.join(" ");
 
     let output = tokio::process::Command::new(&fcvm_path)
-        .args(["exec", "--pid", &pid.to_string(), "--", "sh", "-c", &script])
+        .args(["exec", "--pid", &pid.to_string(), "sh", "-c", &script])
         .output()
         .await?;
 

--- a/tests/test_exec.rs
+++ b/tests/test_exec.rs
@@ -360,7 +360,7 @@ async fn exec_test_impl(network: &str) -> Result<()> {
     {
         let pid_str = fcvm_pid.to_string();
         let mut child = tokio::process::Command::new(&fcvm_path)
-            .args(["exec", "--pid", &pid_str, "--vm", "-i", "--", "head", "-1"])
+            .args(["exec", "--pid", &pid_str, "--vm", "-i", "head", "-1"])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -391,7 +391,7 @@ async fn exec_test_impl(network: &str) -> Result<()> {
     {
         let pid_str = fcvm_pid.to_string();
         let mut child = tokio::process::Command::new(&fcvm_path)
-            .args(["exec", "--pid", &pid_str, "-i", "--", "head", "-1"])
+            .args(["exec", "--pid", &pid_str, "-i", "head", "-1"])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -482,6 +482,117 @@ async fn exec_test_impl(network: &str) -> Result<()> {
         output
     );
     println!("  ✓ -t without -i correctly ignores stdin (container)");
+
+    // ======================================================================
+    // Tests 25-28: Ctrl-C/Ctrl-D/Ctrl-Z via PTY (proper signal path)
+    // These tests send actual control characters through the PTY to verify
+    // the signal handling works correctly through the terminal layer.
+    // ======================================================================
+
+    // Test 25: Ctrl-C (0x03) via PTY interrupts sleep (VM)
+    // This tests the proper PTY signal path: we write 0x03 to PTY master,
+    // which gets interpreted by the PTY slave's line discipline as SIGINT
+    println!("\nTest 25: Ctrl-C (0x03) via PTY interrupts command (VM -it)");
+    let (exit_code, _, output) = run_exec_with_pty_interrupt(
+        &fcvm_path,
+        fcvm_pid,
+        true,  // in_vm
+        &["sh", "-c", "trap 'echo CAUGHT_SIGINT; exit 130' INT; echo READY; sleep 999"],
+        "READY",
+        0x03, // Ctrl-C
+    )
+    .await?;
+    println!("  exit code: {}", exit_code);
+    println!("  output: {:?}", output);
+    assert!(
+        output.contains("READY"),
+        "should see READY before interrupt, got: {:?}",
+        output
+    );
+    assert!(
+        output.contains("CAUGHT_SIGINT"),
+        "trap should catch SIGINT, got: {:?}",
+        output
+    );
+    assert_eq!(exit_code, 130, "exit code should be 130 (128 + SIGINT)");
+    println!("  ✓ Ctrl-C via PTY works for VM exec");
+
+    // Test 26: Ctrl-C (0x03) via PTY interrupts command (container -it)
+    println!("\nTest 26: Ctrl-C (0x03) via PTY interrupts command (container -it)");
+    let (exit_code, _, output) = run_exec_with_pty_interrupt(
+        &fcvm_path,
+        fcvm_pid,
+        false, // container
+        &["sh", "-c", "trap 'echo CAUGHT_SIGINT; exit 130' INT; echo READY; sleep 999"],
+        "READY",
+        0x03, // Ctrl-C
+    )
+    .await?;
+    println!("  exit code: {}", exit_code);
+    println!("  output: {:?}", output);
+    assert!(
+        output.contains("READY"),
+        "should see READY before interrupt, got: {:?}",
+        output
+    );
+    assert!(
+        output.contains("CAUGHT_SIGINT"),
+        "trap should catch SIGINT, got: {:?}",
+        output
+    );
+    assert_eq!(exit_code, 130, "exit code should be 130 (128 + SIGINT)");
+    println!("  ✓ Ctrl-C via PTY works for container exec");
+
+    // Test 27: Ctrl-D (0x04) via PTY sends EOF (VM -it)
+    // Ctrl-D should close stdin, causing the process to see EOF
+    println!("\nTest 27: Ctrl-D (0x04) via PTY sends EOF (VM -it)");
+    let (exit_code, _, output) = run_exec_with_pty_interrupt(
+        &fcvm_path,
+        fcvm_pid,
+        true, // in_vm
+        &["sh", "-c", "echo READY; cat; echo GOT_EOF"],
+        "READY",
+        0x04, // Ctrl-D
+    )
+    .await?;
+    println!("  exit code: {}", exit_code);
+    println!("  output: {:?}", output);
+    assert!(
+        output.contains("READY"),
+        "should see READY before EOF, got: {:?}",
+        output
+    );
+    assert!(
+        output.contains("GOT_EOF"),
+        "cat should get EOF and script should continue, got: {:?}",
+        output
+    );
+    println!("  ✓ Ctrl-D via PTY works for VM exec");
+
+    // Test 28: Ctrl-D (0x04) via PTY sends EOF (container -it)
+    println!("\nTest 28: Ctrl-D (0x04) via PTY sends EOF (container -it)");
+    let (exit_code, _, output) = run_exec_with_pty_interrupt(
+        &fcvm_path,
+        fcvm_pid,
+        false, // container
+        &["sh", "-c", "echo READY; cat; echo GOT_EOF"],
+        "READY",
+        0x04, // Ctrl-D
+    )
+    .await?;
+    println!("  exit code: {}", exit_code);
+    println!("  output: {:?}", output);
+    assert!(
+        output.contains("READY"),
+        "should see READY before EOF, got: {:?}",
+        output
+    );
+    assert!(
+        output.contains("GOT_EOF"),
+        "cat should get EOF and script should continue, got: {:?}",
+        output
+    );
+    println!("  ✓ Ctrl-D via PTY works for container exec");
 
     // Cleanup
     println!("\nCleaning up...");
@@ -870,6 +981,158 @@ async fn run_exec_with_pty(
     }
 }
 
+/// Run fcvm exec with PTY and send a control character after seeing expected output
+///
+/// This tests the proper PTY signal path:
+/// - Ctrl-C (0x03) should be converted to SIGINT by PTY layer
+/// - Ctrl-D (0x04) should be converted to EOF
+/// - Ctrl-Z (0x1a) should be converted to SIGTSTP
+///
+/// Uses -it mode (interactive + tty) so stdin is forwarded.
+async fn run_exec_with_pty_interrupt(
+    fcvm_path: &std::path::Path,
+    pid: u32,
+    in_vm: bool,
+    cmd: &[&str],
+    wait_for: &str,
+    control_char: u8,
+) -> Result<(i32, Duration, String)> {
+    use nix::pty::openpty;
+    use nix::unistd::{close, dup2, fork, ForkResult};
+    use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
+
+    let pid_str = pid.to_string();
+    let start = std::time::Instant::now();
+
+    // Allocate a PTY pair
+    let pty = openpty(None, None).context("opening PTY")?;
+
+    // Configure PTY slave before forking
+    unsafe {
+        let slave_fd = pty.slave.as_raw_fd();
+        let mut termios: libc::termios = std::mem::zeroed();
+        if libc::tcgetattr(slave_fd, &mut termios) == 0 {
+            // Disable echo but KEEP ISIG enabled so control characters work
+            termios.c_lflag &= !(libc::ECHO | libc::ICANON);
+            // ISIG must be enabled for Ctrl-C → SIGINT conversion in PTY layer
+            libc::tcsetattr(slave_fd, libc::TCSANOW, &termios);
+        }
+    }
+
+    let master_fd = pty.master.into_raw_fd();
+    let slave_fd = pty.slave.into_raw_fd();
+
+    match unsafe { fork() }.context("forking")? {
+        ForkResult::Child => {
+            // Child: set up PTY slave as stdin/stdout/stderr
+            unsafe {
+                libc::setsid();
+                libc::ioctl(slave_fd, libc::TIOCSCTTY as _, 0);
+                dup2(slave_fd, 0).ok();
+                dup2(slave_fd, 1).ok();
+                dup2(slave_fd, 2).ok();
+                if slave_fd > 2 {
+                    close(slave_fd).ok();
+                }
+                close(master_fd).ok();
+            }
+
+            // Build command
+            use std::ffi::CString;
+            let prog = CString::new(fcvm_path.to_str().unwrap()).unwrap();
+            let mut args: Vec<CString> = vec![
+                CString::new(fcvm_path.to_str().unwrap()).unwrap(),
+                CString::new("exec").unwrap(),
+                CString::new("--pid").unwrap(),
+                CString::new(pid_str.as_str()).unwrap(),
+                CString::new("-it").unwrap(), // Always use -it for control char tests
+            ];
+            if in_vm {
+                args.push(CString::new("--vm").unwrap());
+            }
+            args.push(CString::new("--").unwrap());
+            for c in cmd {
+                args.push(CString::new(*c).unwrap());
+            }
+
+            #[allow(unreachable_code)]
+            {
+                nix::unistd::execvp(&prog, &args).expect("execvp failed");
+                std::process::exit(1);
+            }
+        }
+        ForkResult::Parent { child } => {
+            close(slave_fd).ok();
+            let mut master = unsafe { std::fs::File::from_raw_fd(master_fd) };
+
+            // Set non-blocking
+            unsafe {
+                let flags = libc::fcntl(master_fd, libc::F_GETFL);
+                libc::fcntl(master_fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+            }
+
+            let mut output = Vec::new();
+            let mut buf = [0u8; 4096];
+            let deadline = std::time::Instant::now() + Duration::from_secs(30);
+            let mut sent_control = false;
+
+            loop {
+                if std::time::Instant::now() > deadline {
+                    nix::sys::signal::kill(child, nix::sys::signal::Signal::SIGKILL).ok();
+                    anyhow::bail!("timeout waiting for command");
+                }
+
+                use std::io::Read;
+                match master.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        output.extend_from_slice(&buf[..n]);
+
+                        // Check if we should send the control character
+                        if !sent_control {
+                            let output_str = String::from_utf8_lossy(&output);
+                            if output_str.contains(wait_for) {
+                                // Small delay to ensure command is in expected state
+                                std::thread::sleep(Duration::from_millis(100));
+
+                                // Send the control character through PTY
+                                use std::io::Write;
+                                master.write_all(&[control_char]).ok();
+                                master.flush().ok();
+                                sent_control = true;
+                            }
+                        }
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        // Check if child exited
+                        match nix::sys::wait::waitpid(
+                            child,
+                            Some(nix::sys::wait::WaitPidFlag::WNOHANG),
+                        ) {
+                            Ok(nix::sys::wait::WaitStatus::Exited(_, _)) => break,
+                            Ok(nix::sys::wait::WaitStatus::Signaled(_, _, _)) => break,
+                            _ => std::thread::sleep(Duration::from_millis(50)),
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+
+            // Wait for child
+            let status = nix::sys::wait::waitpid(child, None).context("waiting for child")?;
+            let exit_code = match status {
+                nix::sys::wait::WaitStatus::Exited(_, code) => code,
+                _ => -1,
+            };
+
+            let duration = start.elapsed();
+            let output_str = String::from_utf8_lossy(&output).to_string();
+
+            Ok((exit_code, duration, output_str))
+        }
+    }
+}
+
 /// Stress test: Run 100 parallel TTY execs to verify no race conditions
 ///
 /// This test verifies that the TTY stdin fix works under heavy parallel load.
@@ -1008,5 +1271,313 @@ async fn test_exec_parallel_tty_stress() -> Result<()> {
     );
 
     println!("✓ ALL {} PARALLEL TTY EXECS PASSED!", TOTAL_EXECS);
+    Ok(())
+}
+
+// ============================================================================
+// Tests for `fcvm podman run -it` (not exec, but container run with -i/-t)
+// ============================================================================
+
+/// Test `fcvm podman run -t` allocates TTY for container
+///
+/// Uses `tty` command to verify TTY is allocated when -t flag is used.
+#[tokio::test]
+async fn test_podman_run_tty() -> Result<()> {
+    use nix::pty::openpty;
+    use nix::unistd::{close, dup2, fork, ForkResult};
+    use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
+    use std::time::Duration;
+
+    println!("\nTest: fcvm podman run -t (TTY allocation)");
+    println!("==========================================");
+
+    let fcvm_path = common::find_fcvm_binary()?;
+    let (vm_name, _, _, _) = common::unique_names("run-tty");
+
+    // Allocate PTY for test harness (since we don't have a real terminal)
+    let pty = openpty(None, None).context("opening PTY")?;
+
+    // Disable echo before forking
+    unsafe {
+        let slave_fd = pty.slave.as_raw_fd();
+        let mut termios: libc::termios = std::mem::zeroed();
+        if libc::tcgetattr(slave_fd, &mut termios) == 0 {
+            termios.c_lflag &= !(libc::ECHO | libc::ICANON | libc::ISIG);
+            libc::tcsetattr(slave_fd, libc::TCSANOW, &termios);
+        }
+    }
+
+    let master_fd = pty.master.into_raw_fd();
+    let slave_fd = pty.slave.into_raw_fd();
+
+    // Fork to run fcvm with PTY
+    match unsafe { fork() }.context("forking")? {
+        ForkResult::Child => {
+            // Child: set up PTY and exec fcvm
+            unsafe {
+                libc::setsid();
+                libc::ioctl(slave_fd, libc::TIOCSCTTY as _, 0);
+                dup2(slave_fd, 0).ok();
+                dup2(slave_fd, 1).ok();
+                dup2(slave_fd, 2).ok();
+                if slave_fd > 2 {
+                    close(slave_fd).ok();
+                }
+                close(master_fd).ok();
+            }
+
+            // Exec fcvm podman run -t ... tty
+            use std::ffi::CString;
+            let prog = CString::new(fcvm_path.to_str().unwrap()).unwrap();
+            let args = vec![
+                CString::new(fcvm_path.to_str().unwrap()).unwrap(),
+                CString::new("podman").unwrap(),
+                CString::new("run").unwrap(),
+                CString::new("--name").unwrap(),
+                CString::new(vm_name.as_str()).unwrap(),
+                CString::new("-t").unwrap(),
+                CString::new("alpine:latest").unwrap(),
+                CString::new("tty").unwrap(),
+            ];
+            #[allow(unreachable_code)]
+            {
+                nix::unistd::execvp(&prog, &args).expect("execvp failed");
+                std::process::exit(1);
+            }
+        }
+        ForkResult::Parent { child } => {
+            close(slave_fd).ok();
+
+            let mut master = unsafe { std::fs::File::from_raw_fd(master_fd) };
+
+            // Read output with timeout
+            let mut output = Vec::new();
+            let mut buf = [0u8; 4096];
+
+            // Set non-blocking
+            unsafe {
+                let flags = libc::fcntl(master_fd, libc::F_GETFL);
+                libc::fcntl(master_fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+            }
+
+            let deadline = std::time::Instant::now() + Duration::from_secs(120);
+            loop {
+                if std::time::Instant::now() > deadline {
+                    nix::sys::signal::kill(child, nix::sys::signal::Signal::SIGKILL).ok();
+                    break;
+                }
+
+                use std::io::Read;
+                match master.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => output.extend_from_slice(&buf[..n]),
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        match nix::sys::wait::waitpid(
+                            child,
+                            Some(nix::sys::wait::WaitPidFlag::WNOHANG),
+                        ) {
+                            Ok(nix::sys::wait::WaitStatus::Exited(_, _)) => break,
+                            Ok(nix::sys::wait::WaitStatus::Signaled(_, _, _)) => break,
+                            _ => std::thread::sleep(Duration::from_millis(50)),
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+
+            // Wait for child
+            let _ = nix::sys::wait::waitpid(child, None);
+
+            let output_str = String::from_utf8_lossy(&output);
+            println!("  Output: {:?}", output_str);
+
+            // Should see /dev/pts/X
+            assert!(
+                output_str.contains("/dev/pts"),
+                "With -t flag, container should have TTY (/dev/pts), got: {:?}",
+                output_str
+            );
+            println!("✓ fcvm podman run -t correctly allocates TTY");
+        }
+    }
+
+    Ok(())
+}
+
+/// Test `fcvm podman run -it` for interactive container with TTY
+///
+/// Uses `head -1` to verify stdin is forwarded when -i flag is used.
+#[tokio::test]
+async fn test_podman_run_interactive_tty() -> Result<()> {
+    use nix::pty::openpty;
+    use nix::unistd::{close, dup2, fork, ForkResult};
+    use std::io::Write;
+    use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
+    use std::time::Duration;
+
+    println!("\nTest: fcvm podman run -it (interactive + TTY)");
+    println!("==============================================");
+
+    let fcvm_path = common::find_fcvm_binary()?;
+    let (vm_name, _, _, _) = common::unique_names("run-it");
+
+    // Allocate PTY for test harness
+    let pty = openpty(None, None).context("opening PTY")?;
+
+    // Disable echo before forking
+    unsafe {
+        let slave_fd = pty.slave.as_raw_fd();
+        let mut termios: libc::termios = std::mem::zeroed();
+        if libc::tcgetattr(slave_fd, &mut termios) == 0 {
+            termios.c_lflag &= !(libc::ECHO | libc::ICANON | libc::ISIG);
+            libc::tcsetattr(slave_fd, libc::TCSANOW, &termios);
+        }
+    }
+
+    let master_fd = pty.master.into_raw_fd();
+    let slave_fd = pty.slave.into_raw_fd();
+
+    // Fork to run fcvm with PTY
+    match unsafe { fork() }.context("forking")? {
+        ForkResult::Child => {
+            // Child: set up PTY and exec fcvm
+            unsafe {
+                libc::setsid();
+                libc::ioctl(slave_fd, libc::TIOCSCTTY as _, 0);
+                dup2(slave_fd, 0).ok();
+                dup2(slave_fd, 1).ok();
+                dup2(slave_fd, 2).ok();
+                if slave_fd > 2 {
+                    close(slave_fd).ok();
+                }
+                close(master_fd).ok();
+            }
+
+            // Exec fcvm podman run -it ... head -1
+            use std::ffi::CString;
+            let prog = CString::new(fcvm_path.to_str().unwrap()).unwrap();
+            let args = vec![
+                CString::new(fcvm_path.to_str().unwrap()).unwrap(),
+                CString::new("podman").unwrap(),
+                CString::new("run").unwrap(),
+                CString::new("--name").unwrap(),
+                CString::new(vm_name.as_str()).unwrap(),
+                CString::new("-it").unwrap(),
+                CString::new("alpine:latest").unwrap(),
+                CString::new("head").unwrap(),
+                CString::new("-1").unwrap(),
+            ];
+            #[allow(unreachable_code)]
+            {
+                nix::unistd::execvp(&prog, &args).expect("execvp failed");
+                unreachable!();
+            }
+        }
+        ForkResult::Parent { child } => {
+            close(slave_fd).ok();
+
+            let mut master = unsafe { std::fs::File::from_raw_fd(master_fd) };
+
+            // Wait for container to be ready
+            std::thread::sleep(Duration::from_secs(10));
+
+            // Write input to container
+            master
+                .write_all(b"hello-from-stdin\n")
+                .context("writing stdin")?;
+            master.flush()?;
+
+            // Read output with timeout
+            let mut output = Vec::new();
+            let mut buf = [0u8; 4096];
+
+            // Set non-blocking
+            unsafe {
+                let flags = libc::fcntl(master_fd, libc::F_GETFL);
+                libc::fcntl(master_fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+            }
+
+            let deadline = std::time::Instant::now() + Duration::from_secs(120);
+            loop {
+                if std::time::Instant::now() > deadline {
+                    nix::sys::signal::kill(child, nix::sys::signal::Signal::SIGKILL).ok();
+                    break;
+                }
+
+                use std::io::Read;
+                match master.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => output.extend_from_slice(&buf[..n]),
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        match nix::sys::wait::waitpid(
+                            child,
+                            Some(nix::sys::wait::WaitPidFlag::WNOHANG),
+                        ) {
+                            Ok(nix::sys::wait::WaitStatus::Exited(_, _)) => break,
+                            Ok(nix::sys::wait::WaitStatus::Signaled(_, _, _)) => break,
+                            _ => std::thread::sleep(Duration::from_millis(50)),
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+
+            // Wait for child
+            let _ = nix::sys::wait::waitpid(child, None);
+
+            let output_str = String::from_utf8_lossy(&output);
+            println!("  Output: {:?}", output_str);
+
+            // Should see our input echoed back
+            assert!(
+                output_str.contains("hello-from-stdin"),
+                "With -it flags, stdin should be forwarded, got: {:?}",
+                output_str
+            );
+            println!("✓ fcvm podman run -it correctly forwards stdin");
+        }
+    }
+
+    Ok(())
+}
+
+/// Test `fcvm podman run` without -t flag (no TTY)
+///
+/// Verifies that without -t, container does NOT have a TTY.
+#[tokio::test]
+async fn test_podman_run_no_tty() -> Result<()> {
+    use std::time::Duration;
+
+    println!("\nTest: fcvm podman run (no -t = no TTY)");
+    println!("======================================");
+
+    let fcvm_path = common::find_fcvm_binary()?;
+    let (vm_name, _, _, _) = common::unique_names("run-no-tty");
+
+    // Run without -t, check tty command output
+    let output = tokio::time::timeout(
+        Duration::from_secs(120),
+        tokio::process::Command::new(&fcvm_path)
+            .args(["podman", "run", "--name", &vm_name, "alpine:latest", "tty"])
+            .output(),
+    )
+    .await
+    .context("timeout")?
+    .context("running fcvm")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{}{}", stdout, stderr);
+
+    println!("  Output: {:?}", combined.trim());
+
+    // Without -t, should say "not a tty"
+    assert!(
+        combined.contains("not a tty") || combined.contains("not a terminal"),
+        "Without -t flag, container should NOT have TTY, got: {:?}",
+        combined
+    );
+    println!("✓ fcvm podman run (no -t) correctly has no TTY");
+
     Ok(())
 }

--- a/tests/test_exec.rs
+++ b/tests/test_exec.rs
@@ -496,8 +496,12 @@ async fn exec_test_impl(network: &str) -> Result<()> {
     let (exit_code, _, output) = run_exec_with_pty_interrupt(
         &fcvm_path,
         fcvm_pid,
-        true,  // in_vm
-        &["sh", "-c", "trap 'echo CAUGHT_SIGINT; exit 130' INT; echo READY; sleep 999"],
+        true, // in_vm
+        &[
+            "sh",
+            "-c",
+            "trap 'echo CAUGHT_SIGINT; exit 130' INT; echo READY; sleep 999",
+        ],
         "READY",
         0x03, // Ctrl-C
     )
@@ -523,7 +527,11 @@ async fn exec_test_impl(network: &str) -> Result<()> {
         &fcvm_path,
         fcvm_pid,
         false, // container
-        &["sh", "-c", "trap 'echo CAUGHT_SIGINT; exit 130' INT; echo READY; sleep 999"],
+        &[
+            "sh",
+            "-c",
+            "trap 'echo CAUGHT_SIGINT; exit 130' INT; echo READY; sleep 999",
+        ],
         "READY",
         0x03, // Ctrl-C
     )

--- a/tests/test_kvm.rs
+++ b/tests/test_kvm.rs
@@ -318,7 +318,7 @@ async fn test_nested_run_fcvm_inside_vm() -> Result<()> {
     // First, check kernel config and dmesg for KVM-related messages
     let debug_output = tokio::process::Command::new(&fcvm_path)
         .args([
-            "exec", "--pid", &outer_pid.to_string(), "--vm", "--",
+            "exec", "--pid", &outer_pid.to_string(), "--vm",
             "sh", "-c", r#"
 echo "=== Kernel config (KVM/VIRTUALIZATION) ==="
 zcat /proc/config.gz 2>/dev/null | grep -E "^CONFIG_(KVM|VIRTUALIZATION)" || echo "config.gz not available"


### PR DESCRIPTION
## Summary

Implements full PTY/interactive mode support for `fcvm podman run` and `fcvm exec`, matching docker/podman `-i` and `-t` flag semantics.

## Changes

### New Features
- `-i, --interactive`: Keep stdin open (forward user input)
- `-t, --tty`: Allocate pseudo-TTY (colors, line editing, full-screen apps)
- `-it`: Both flags together for interactive shell

### Implementation
- **Host side** (`src/commands/tty.rs`): Raw terminal mode, binary exec_proto framing over vsock
- **Guest side** (`fc-agent/src/tty.rs`): PTY allocation via openpty(), fork with PTY as controlling terminal

### CLI Changes
- Add `-i`/`-t` flags to `fcvm podman run`
- Change exec `name` from positional to `--name` flag (fixes argument conflict)

### Documentation
- Add TTY architecture section to DESIGN.md
- Add Interactive Mode section to README.md  
- Update all CLI examples to use `--name` flag

## Test Plan

- [x] `make test-root FILTER=tty` - 4 TTY tests pass
- [x] `make test-root FILTER=exec` - 6 exec tests pass
- [x] Manual verification of README examples:
  - `fcvm exec --name my-vm -- cat /etc/os-release` ✅
  - `fcvm exec --name my-vm --vm -- hostname` ✅
  - `fcvm exec --pid <PID> -- hostname` ✅
  - `fcvm podman run ... alpine:latest echo "hello"` ✅ (trailing args)