### PR TITLE
Detect incomplete Claude assistant runs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -184,6 +184,7 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          set -o pipefail
           cd scripts/claude-assistant && pnpm exec tsx index.ts 2>&1 | tee /tmp/claude-output.log
           # Verify completion marker exists (detects if process was killed mid-execution)
           if ! grep -q "CLAUDE_ASSISTANT_COMPLETE" /tmp/claude-output.log; then
@@ -254,6 +255,7 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          set -o pipefail
           cd scripts/claude-assistant && pnpm exec tsx index.ts 2>&1 | tee /tmp/claude-output.log
           if ! grep -q "CLAUDE_ASSISTANT_COMPLETE" /tmp/claude-output.log; then
             echo "ERROR: Claude assistant did not complete - process may have been killed"
@@ -330,6 +332,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
+          set -o pipefail
           cd scripts/claude-assistant && pnpm exec tsx index.ts 2>&1 | tee /tmp/claude-output.log
           if ! grep -q "CLAUDE_ASSISTANT_COMPLETE" /tmp/claude-output.log; then
             echo "ERROR: Claude assistant did not complete - process may have been killed"
@@ -393,6 +396,7 @@ jobs:
           FAILED_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
         run: |
+          set -o pipefail
           cd scripts/claude-assistant && pnpm exec tsx index.ts 2>&1 | tee /tmp/claude-output.log
           if ! grep -q "CLAUDE_ASSISTANT_COMPLETE" /tmp/claude-output.log; then
             echo "ERROR: Claude assistant did not complete - process may have been killed"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -183,7 +183,13 @@ jobs:
           BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
           RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: cd scripts/claude-assistant && pnpm exec tsx index.ts
+        run: |
+          cd scripts/claude-assistant && pnpm exec tsx index.ts 2>&1 | tee /tmp/claude-output.log
+          # Verify completion marker exists (detects if process was killed mid-execution)
+          if ! grep -q "CLAUDE_ASSISTANT_COMPLETE" /tmp/claude-output.log; then
+            echo "ERROR: Claude assistant did not complete - process may have been killed"
+            exit 1
+          fi
 
   # Manual review via /claude-review comment
   manual-review:
@@ -247,7 +253,12 @@ jobs:
           BASE_BRANCH: ${{ steps.pr.outputs.base_branch }}
           RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: cd scripts/claude-assistant && pnpm exec tsx index.ts
+        run: |
+          cd scripts/claude-assistant && pnpm exec tsx index.ts 2>&1 | tee /tmp/claude-output.log
+          if ! grep -q "CLAUDE_ASSISTANT_COMPLETE" /tmp/claude-output.log; then
+            echo "ERROR: Claude assistant did not complete - process may have been killed"
+            exit 1
+          fi
 
   # Respond to @claude mentions
   respond:
@@ -318,7 +329,12 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           COMMENT_BODY: ${{ github.event.comment.body }}
-        run: cd scripts/claude-assistant && pnpm exec tsx index.ts
+        run: |
+          cd scripts/claude-assistant && pnpm exec tsx index.ts 2>&1 | tee /tmp/claude-output.log
+          if ! grep -q "CLAUDE_ASSISTANT_COMPLETE" /tmp/claude-output.log; then
+            echo "ERROR: Claude assistant did not complete - process may have been killed"
+            exit 1
+          fi
 
   # Auto-fix CI failures
   ci-fix:
@@ -376,4 +392,9 @@ jobs:
           FAILED_RUN_ID: ${{ github.event.workflow_run.id }}
           FAILED_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
-        run: cd scripts/claude-assistant && pnpm exec tsx index.ts
+        run: |
+          cd scripts/claude-assistant && pnpm exec tsx index.ts 2>&1 | tee /tmp/claude-output.log
+          if ! grep -q "CLAUDE_ASSISTANT_COMPLETE" /tmp/claude-output.log; then
+            echo "ERROR: Claude assistant did not complete - process may have been killed"
+            exit 1
+          fi

--- a/scripts/claude-assistant/index.ts
+++ b/scripts/claude-assistant/index.ts
@@ -697,6 +697,9 @@ async function main(): Promise<void> {
   }
 
   await runClaude(prompt);
+
+  // Print completion marker - if this doesn't appear in logs, the job was truncated/killed
+  console.log("\n=== CLAUDE_ASSISTANT_COMPLETE ===\n");
 }
 
 main().catch((e) => {


### PR DESCRIPTION
## Summary

Fixes a bug where Claude assistant jobs show "success" even when killed mid-execution.

**Root cause**: When GitHub cancels a job (e.g., via `cancel-in-progress`), the Claude process receives SIGTERM and exits. The async iterator in `runClaude()` stops yielding, the function returns normally, and the process exits with code 0. GitHub sees exit code 0 and marks the job as "success".

**Evidence**: Run [#20726814304](https://github.com/ejc3/fcvm/actions/runs/20726814304/job/59504328021) shows "success" but logs show Claude was mid-execution when "Post job cleanup" started.

## Changes

- Add `CLAUDE_ASSISTANT_COMPLETE` marker after `runClaude()` finishes in `index.ts`
- Verify marker exists in all workflow steps before declaring success
- Applies to: review, manual-review, respond, ci-fix jobs

## Test plan

- [ ] Push to trigger Claude review
- [ ] Verify completion marker appears in successful runs
- [ ] Verify cancelled runs fail instead of showing success

---
**Stacked on:** tty-interactive-mode (PR #108)