### PR TITLE
Create fix branch from PR branch, not main

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -183,7 +183,13 @@ jobs:
           BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
           RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: cd scripts/claude-assistant && pnpm exec tsx index.ts
+        run: |
+          cd scripts/claude-assistant && pnpm exec tsx index.ts 2>&1 | tee /tmp/claude-output.log
+          # Verify completion marker exists (detects if process was killed mid-execution)
+          if ! grep -q "CLAUDE_ASSISTANT_COMPLETE" /tmp/claude-output.log; then
+            echo "ERROR: Claude assistant did not complete - process may have been killed"
+            exit 1
+          fi
 
   # Manual review via /claude-review comment
   manual-review:
@@ -247,7 +253,12 @@ jobs:
           BASE_BRANCH: ${{ steps.pr.outputs.base_branch }}
           RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: cd scripts/claude-assistant && pnpm exec tsx index.ts
+        run: |
+          cd scripts/claude-assistant && pnpm exec tsx index.ts 2>&1 | tee /tmp/claude-output.log
+          if ! grep -q "CLAUDE_ASSISTANT_COMPLETE" /tmp/claude-output.log; then
+            echo "ERROR: Claude assistant did not complete - process may have been killed"
+            exit 1
+          fi
 
   # Respond to @claude mentions
   respond:
@@ -318,7 +329,12 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           COMMENT_BODY: ${{ github.event.comment.body }}
-        run: cd scripts/claude-assistant && pnpm exec tsx index.ts
+        run: |
+          cd scripts/claude-assistant && pnpm exec tsx index.ts 2>&1 | tee /tmp/claude-output.log
+          if ! grep -q "CLAUDE_ASSISTANT_COMPLETE" /tmp/claude-output.log; then
+            echo "ERROR: Claude assistant did not complete - process may have been killed"
+            exit 1
+          fi
 
   # Auto-fix CI failures
   ci-fix:
@@ -376,4 +392,9 @@ jobs:
           FAILED_RUN_ID: ${{ github.event.workflow_run.id }}
           FAILED_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
-        run: cd scripts/claude-assistant && pnpm exec tsx index.ts
+        run: |
+          cd scripts/claude-assistant && pnpm exec tsx index.ts 2>&1 | tee /tmp/claude-output.log
+          if ! grep -q "CLAUDE_ASSISTANT_COMPLETE" /tmp/claude-output.log; then
+            echo "ERROR: Claude assistant did not complete - process may have been killed"
+            exit 1
+          fi

--- a/scripts/claude-assistant/index.ts
+++ b/scripts/claude-assistant/index.ts
@@ -697,6 +697,9 @@ async function main(): Promise<void> {
   }
 
   await runClaude(prompt);
+
+  // Print completion marker - if this doesn't appear in logs, the job was truncated/killed
+  console.log("\n=== CLAUDE_ASSISTANT_COMPLETE ===\n");
 }
 
 main().catch((e) => {

--- a/scripts/claude-assistant/index.ts
+++ b/scripts/claude-assistant/index.ts
@@ -122,7 +122,7 @@ function setupFixBranch(ctx: Context): void {
   }
 
   // Fetch latest to ensure we have the PR branch
-  git("fetch", "origin", ctx.headBranch);
+  gitOrFail("fetch", "origin", ctx.headBranch);
 
   // Check if branch already exists
   if (branchExists(ctx.fixBranch)) {

--- a/scripts/claude-assistant/index.ts
+++ b/scripts/claude-assistant/index.ts
@@ -121,13 +121,18 @@ function setupFixBranch(ctx: Context): void {
     gitOrFail("config", "user.email", "claude[bot]@users.noreply.github.com");
   }
 
+  // Fetch latest to ensure we have the PR branch
+  git("fetch", "origin", ctx.headBranch);
+
   // Check if branch already exists
   if (branchExists(ctx.fixBranch)) {
     log(`Branch ${ctx.fixBranch} already exists, checking out`);
     gitOrFail("checkout", ctx.fixBranch);
   } else {
-    log(`Creating new branch ${ctx.fixBranch}`);
-    gitOrFail("checkout", "-b", ctx.fixBranch);
+    // Create fix branch FROM the PR branch, not from main
+    // This ensures Claude can read PR files locally with the Read tool
+    log(`Creating new branch ${ctx.fixBranch} from origin/${ctx.headBranch}`);
+    gitOrFail("checkout", "-b", ctx.fixBranch, `origin/${ctx.headBranch}`);
   }
 }
 
@@ -206,7 +211,8 @@ function reviewPrompt(ctx: Context): string {
 | **Run URL** | ${ctx.runUrl} |
 
 You are reviewing **PR #${ctx.prNumber}** in **${ctx.repository}**.
-Your current branch is \`${ctx.fixBranch}\`, branched from \`${ctx.headBranch}\`.
+Your current branch is \`${ctx.fixBranch}\`, branched from \`origin/${ctx.headBranch}\`.
+**The PR's code is already checked out locally** - you can use the Read tool directly on any file.
 
 ### Open PRs (from members/bots only)
 \`\`\`
@@ -246,7 +252,7 @@ git diff origin/${ctx.baseBranch}...origin/${ctx.headBranch}
 ### 1e. If diff output is large or appears truncated
 The diff output may be truncated for large changes. If the diff ends mid-line or seems incomplete:
 - Use \`git diff --stat\` to see which files changed
-- Read individual files directly with the Read tool to verify their actual content
+- Read individual files directly with the Read tool (PR code is checked out locally)
 - **NEVER assume a file is incomplete based on truncated diff output**
 
 ## STEP 2: CHECK PREVIOUS REVIEWS

--- a/scripts/claude-assistant/index.ts
+++ b/scripts/claude-assistant/index.ts
@@ -126,8 +126,9 @@ function setupFixBranch(ctx: Context): void {
 
   // Check if branch already exists
   if (branchExists(ctx.fixBranch)) {
-    log(`Branch ${ctx.fixBranch} already exists, checking out`);
+    log(`Branch ${ctx.fixBranch} already exists, checking out and updating`);
     gitOrFail("checkout", ctx.fixBranch);
+    gitOrFail("reset", "--hard", `origin/${ctx.headBranch}`);
   } else {
     // Create fix branch FROM the PR branch, not from main
     // This ensures Claude can read PR files locally with the Read tool


### PR DESCRIPTION
## Summary

Fixes the Claude review agent getting lost trying to read files that don't exist locally.

**Problem**: The agent was wasting many turns doing:
```
[driver] Tool: Read  (file not found)
The files don't exist on my current branch. Let me check them out...
[driver] Tool: Bash  (git checkout)
Let me view these files from the origin branch directly...
[driver] Tool: Bash  (git show origin/...)
```

**Root cause**: Workflow checks out `main`, then `setupFixBranch` creates the fix branch from `main`. But the PR code is on `origin/${headBranch}`.

**Fix**: Create fix branch from `origin/${headBranch}`:
```javascript
gitOrFail("checkout", "-b", ctx.fixBranch, `origin/${ctx.headBranch}`);
```

Now the PR code is checked out locally and the Read tool works directly.

## Test plan

- [ ] Push to trigger Claude review on a PR
- [ ] Verify agent can Read files directly without workarounds
- [ ] Verify agent doesn't waste turns on git checkout/show commands

---
**Stacked on:** ci-log-truncation-check (PR #109)