### PR TITLE
Fix claude.yml: add working-directory for gh pr view

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -278,6 +278,7 @@ jobs:
 
       - name: Get PR info
         id: pr
+        working-directory: fcvm
         run: |
           PR_DATA=$(gh pr view ${{ github.event.issue.number }} --json headRefName,headRefOid,baseRefName)
           echo "head_branch=$(echo $PR_DATA | jq -r .headRefName)" >> $GITHUB_OUTPUT
@@ -370,6 +371,7 @@ jobs:
 
       - name: Get PR info
         id: pr
+        working-directory: fcvm
         env:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
         run: |


### PR DESCRIPTION
## Summary
- Fix `gh pr view` failing with "fatal: not a git repository"
- The checkout uses `path: fcvm` subdirectory, but `gh pr view` was running in root directory
- Added `working-directory: fcvm` to both "Get PR info" steps

Fixes: https://github.com/ejc3/fcvm/actions/runs/20739452274/job/59543204198