### PR TITLE
Don't create fix PRs that are essentially reverts

### DIFF
--- a/scripts/claude-assistant/index.ts
+++ b/scripts/claude-assistant/index.ts
@@ -333,7 +333,37 @@ SEVERITY: <critical|medium|low|none>
 _Review by Claude | [Run](${ctx.runUrl})_"
 \`\`\`
 
-## STEP 5: FIX (only if [MEDIUM] or [CRITICAL] issues found)
+## STEP 5: DECIDE WHETHER TO FIX OR BLOCK
+
+When you find [MEDIUM] or [CRITICAL] issues, decide:
+
+### Option A: BLOCK (if fix would revert the PR's changes)
+
+If fixing the issue means undoing/reverting what the PR did, **do NOT create a fix PR**.
+Instead, comment that the PR should not be merged:
+
+\`\`\`bash
+gh pr comment ${ctx.prNumber} --repo ${ctx.repository} --body "## ⛔ Do Not Merge
+
+This PR has critical issues that require changes by the author before merging.
+
+### Issues Requiring Author Action
+<list the issues>
+
+### Why No Auto-Fix
+The fix would essentially revert this PR's changes. The author should address these issues directly.
+
+---
+_Review by Claude | [Run](${ctx.runUrl})_"
+\`\`\`
+
+Then **STOP** - do not create any fix PR.
+
+### Option B: FIX (if you're adding improvements on top)
+
+Only create a fix PR if you're **adding to** the PR's changes, not undoing them.
+Good examples: adding missing error handling, fixing a typo, adding a missing test.
+Bad examples: reverting a permission change, removing a feature the PR added.
 
 ### 5a. Edit files
 Make the minimum changes needed to fix the issues.


### PR DESCRIPTION
When Claude reviews a PR and finds critical issues, it should only create
a fix PR if the fix adds something on top of the PR's changes. If the "fix"
would essentially revert/undo the PR's changes, that's pointless - we'd end
up with: bad code → revert of bad code.

Instead, when the fix would be a revert:
- Comment "Do Not Merge" with the issues
- Tell the author to fix it themselves
- Do NOT create any fix PR

Good fix examples: adding missing error handling, fixing a typo
Bad fix examples: reverting a permission change, removing a feature
