### PR TITLE
Fix inaccurate speed claims in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,8 +254,6 @@ Validated with 10 sequential clones from the same memory server:
 
 Individual clone times: 631, 599, 611, 611, 615, 618, 618, 622, 587, 599ms
 
-**Key findings**: Very low variance across clones. UFFD memory serving is consistent and reliable.
-
 #### 10-Clone Parallel Test Results
 
 All 10 clones launched simultaneously:
@@ -266,7 +264,11 @@ All 10 clones launched simultaneously:
 | **Snapshot load (UFFD)** | 9-11ms (consistent under load) |
 | **Individual clone times** | 743-1024ms |
 
-The core VM restore (~10ms) stays consistent even under parallel load. Total wall clock time is only slightly longer than a single clone because all 10 VMs share the same UFFD memory server.
+**Key findings**:
+- **Core restore is fast**: ~10ms regardless of sequential or parallel execution
+- **UFFD scales well**: Single memory server handles 10 concurrent clones with minimal overhead
+- **Parallelism works**: 10 VMs in 1.03s (not 10× sequential time)
+- **Bottleneck is cleanup**: Network teardown and state deletion add latency under contention
 
 **Demo: Time a clone cycle**
 


### PR DESCRIPTION
## Summary

The README contained significantly overstated speed claims that didn't match actual measurements. This PR updates them with verified numbers and adds a detailed timing breakdown.

### Speed Claim Corrections

| Metric | Old Claim | Actual Measured |
|--------|-----------|-----------------|
| Clone startup | ~3ms | ~670ms full cycle |
| VM restore | (not stated) | ~10ms (UFFD + resume) |
| VM boot | ~50ms | ~5s |
| 50 VMs scale-out | ~150ms | ~3.1s |

### New: Clone Speed Breakdown Table

Added per-step timing breakdown showing where the 670ms goes:

| Step | Time | Description |
|------|------|-------------|
| State lookup | ~1ms | Find serve process |
| Namespace spawn | ~6ms | unshare --user --map-root-user --net |
| CoW disk reflink | ~31ms | btrfs instant copy |
| Network setup | ~35ms | TAP device, iptables rules |
| Firecracker spawn | ~6ms | Start VM process |
| **Snapshot load (UFFD)** | **~9ms** | Load memory from server |
| Disk patch | <1ms | Point to CoW disk |
| **VM resume** | **<1ms** | Resume vCPUs |
| fc-agent recovery | ~100ms | ARP flush, kill stale TCP |
| Exec connect | ~20ms | Connect to guest vsock |
| Command + cleanup | ~300ms | Run echo + shutdown |
| **Total** | **~670ms** | Full clone cycle with exec |

This shows the **core VM restore (UFFD + resume) is just ~10ms** - the rest is network setup, guest agent recovery, and cleanup.

### Test Methodology

**Clone timing breakdown:**
```bash
RUST_LOG=debug fcvm snapshot run --pid <pid> --exec "echo ready"
# Parsed timestamps from debug output
```

**Clone time:**
```bash
time fcvm snapshot run --pid 444015 --exec "echo ready"
# Results: 0.67s - 0.80s across multiple runs
```

**VM boot time:**
```bash
time fcvm podman run --name boot-test alpine:latest -- echo "hello"
# Results: 5.1s - 5.5s
```

### Wording Changes

- "Instant VM cloning" → "Fast VM cloning"
- Added link from CI summary to Clone Speed Breakdown section

The updated numbers are still impressive (clones are 7x faster than cold boots, core restore is 10ms), but they're now accurate.

## Test Plan

- [x] Verified clone timing breakdown with RUST_LOG=debug
- [x] Verified clone timing: ~670ms
- [x] Verified VM boot timing: ~5s  
- [x] Verified 50 VM parallel scaling: ~3.1s
- [ ] CI passes (documentation change only)