### PR TITLE
Fix container-bench failing on missing /tmp/fcvm-test-logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,8 @@ help:
 # Disk space check - fails if either root or btrfs is too full
 # Requires 10GB free on root (for cargo target) and 15GB on btrfs (for VMs)
 check-disk:
+	@# Ensure test log directory exists for container mounts
+	@mkdir -p $(TEST_LOG_DIR)
 	@# Fix advisory-db ownership (sudo/non-sudo mixing corrupts it)
 	@sudo chown -R $$(id -u):$$(id -g) "$$HOME/.cargo/advisory-db" 2>/dev/null || true
 	@sudo chown -R $$(id -u):$$(id -g) "$$HOME/.cargo/advisory-dbs" 2>/dev/null || true
@@ -323,7 +325,7 @@ bench: build
 	$(CARGO) bench -p fuse-pipe --bench protocol
 
 # Container benchmark target (used by nightly CI)
-container-bench: container-build
+container-bench: check-disk container-build
 	@echo "==> Running benchmarks in container..."
 	$(CONTAINER_RUN) $(CONTAINER_TAG) make build _bench
 


### PR DESCRIPTION
## Summary

Fix the CI benchmark job failing with:
```
Error: statfs /tmp/fcvm-test-logs: no such file or directory
make: *** [Makefile:319: container-bench] Error 125
```

## Root Cause

The `container-bench` target mounts `/tmp/fcvm-test-logs` into the container via `CONTAINER_RUN`, but the directory wasn't created before the podman run command executed.

## Fix

1. Add `mkdir -p $(TEST_LOG_DIR)` to the `check-disk` target (ensures directory exists)
2. Add `check-disk` as a prerequisite to `container-bench` (matches other container-* targets)

## Test Plan

- [x] Verified locally: `make check-disk` creates `/tmp/fcvm-test-logs`
- [ ] CI benchmark job passes