### PR TITLE
Add FCVM_NO_CACHE env var and split CI cache testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,12 +281,25 @@ jobs:
           key: ${{ env.CACHE_KEY_HOST }}-${{ runner.os }}-${{ runner.arch }}
 
   # Runner 1b: Host-Root (bare metal with KVM)
-  # Runs: test-root (privileged tests with nested kernel)
-  # Parallel with Host job for faster CI
+  # Runs: test-root with matrix for cache testing modes
+  # - NoCache: FCVM_NO_CACHE=1, runs once (tests bypass path)
+  # - Cache: no env var, runs twice (cache miss then cache hit)
   host-root:
-    name: Host-Root
+    name: Host-Root-${{ matrix.mode }}
     if: ${{ github.event.inputs.job != 'container' }}
     runs-on: [self-hosted, Linux, ARM64]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - mode: NoCache
+            fcvm_no_cache: "1"
+            test_runs: "1"
+          - mode: Cache
+            fcvm_no_cache: ""
+            test_runs: "2"
+    env:
+      FCVM_NO_CACHE: ${{ matrix.fcvm_no_cache }}
     steps:
       # Clean up root-owned files from previous test runs before checkout
       - name: Clean workspace (pre-checkout)
@@ -386,7 +399,11 @@ jobs:
           sudo ./target/release/fcvm setup --kernel-profile nested --build-kernels
       - name: test-root
         working-directory: fcvm
-        run: make test-root
+        run: |
+          for i in $(seq 1 ${{ matrix.test_runs }}); do
+            echo "=== Test run $i of ${{ matrix.test_runs }} ==="
+            make test-root
+          done
       - name: Capture kernel logs
         if: always()
         run: |
@@ -395,7 +412,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: test-logs-host-root
+          name: test-logs-host-root-${{ matrix.mode }}
           path: /tmp/fcvm-test-logs/
           if-no-files-found: ignore
           retention-days: 14

--- a/tests/test_podman_cache.rs
+++ b/tests/test_podman_cache.rs
@@ -35,6 +35,11 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
+/// Check if caching is disabled via FCVM_NO_CACHE environment variable
+fn cache_disabled_by_env() -> bool {
+    std::env::var("FCVM_NO_CACHE").is_ok()
+}
+
 /// Get the cache directory path (cache entries are stored as snapshots via SnapshotManager)
 fn cache_dir() -> PathBuf {
     let data_dir = std::env::var("FCVM_DATA_DIR")
@@ -91,6 +96,10 @@ fn cache_entry_exists(cache_key: &str) -> bool {
 /// Uses rootless network mode for this test
 #[tokio::test]
 async fn test_podman_cache_miss_creates_cache() -> Result<()> {
+    if cache_disabled_by_env() {
+        println!("Skipping test: FCVM_NO_CACHE is set");
+        return Ok(());
+    }
     println!("\ntest_podman_cache_miss_creates_cache");
     println!("=====================================");
 
@@ -145,6 +154,10 @@ async fn test_podman_cache_miss_creates_cache() -> Result<()> {
 /// Uses rootless network mode - tests may share cache, that's OK
 #[tokio::test]
 async fn test_podman_cache_hit_restores_fast() -> Result<()> {
+    if cache_disabled_by_env() {
+        println!("Skipping test: FCVM_NO_CACHE is set");
+        return Ok(());
+    }
     println!("\ntest_podman_cache_hit_restores_fast");
     println!("====================================");
 
@@ -215,6 +228,10 @@ async fn test_podman_cache_hit_restores_fast() -> Result<()> {
 /// Test that different network modes create different cache entries
 #[tokio::test]
 async fn test_podman_cache_different_network_modes() -> Result<()> {
+    if cache_disabled_by_env() {
+        println!("Skipping test: FCVM_NO_CACHE is set");
+        return Ok(());
+    }
     println!("\ntest_podman_cache_different_network_modes");
     println!("==========================================");
 
@@ -351,6 +368,10 @@ async fn test_podman_cache_no_cache_flag() -> Result<()> {
 /// Test that incomplete cache (missing files) is treated as miss
 #[tokio::test]
 async fn test_podman_cache_incomplete_treated_as_miss() -> Result<()> {
+    if cache_disabled_by_env() {
+        println!("Skipping test: FCVM_NO_CACHE is set");
+        return Ok(());
+    }
     println!("\ntest_podman_cache_incomplete_treated_as_miss");
     println!("=============================================");
 
@@ -380,6 +401,10 @@ async fn test_podman_cache_incomplete_treated_as_miss() -> Result<()> {
 /// Test long-running container works with cache
 #[tokio::test]
 async fn test_podman_cache_long_running_container() -> Result<()> {
+    if cache_disabled_by_env() {
+        println!("Skipping test: FCVM_NO_CACHE is set");
+        return Ok(());
+    }
     println!("\ntest_podman_cache_long_running_container");
     println!("=========================================");
 


### PR DESCRIPTION
## Summary

- Add `FCVM_NO_CACHE` environment variable to disable cache globally
- Split Host-Root CI job into two variants for thorough cache testing

## Changes

### New Environment Variable
`FCVM_NO_CACHE=1` disables cache lookup and creation, equivalent to `--no-cache` flag on every run.

### CI Split
- **Host-Root-NoCache**: Runs with `FCVM_NO_CACHE=1` - tests the non-cached code path
- **Host-Root-Cache**: Runs tests TWICE without the env var:
  - First run: cache miss → creates cache entries  
  - Second run: cache hit → uses cached entries

### Test Skipping
Cache-specific tests automatically skip when `FCVM_NO_CACHE` is set (they'd be no-ops anyway). The `test_podman_cache_no_cache_flag` test still runs since it tests the flag behavior itself.

## Test plan
- [x] `make lint` passes
- [x] `FCVM_NO_CACHE=1 make test-root FILTER=cache_miss` correctly skips
- [ ] CI passes with both Host-Root variants