### PR TITLE
Rename cache feature to snapshot for clarity

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -561,6 +561,18 @@ fcvm exec --pid <PID> -c -- wget -q -O - --timeout=10 http://ifconfig.me
 
 Exception: For **forked libraries** (like fuse-backend-rs), we maintain compatibility with upstream to enable merging upstream changes.
 
+### File Operations
+
+**Always use `git mv` when renaming files.** This preserves git history.
+
+```bash
+# CORRECT - preserves history
+git mv old_name.rs new_name.rs
+
+# WRONG - loses history
+mv old_name.rs new_name.rs
+```
+
 ### Development Workflow (PR-Based)
 
 **Main branch is protected. All changes MUST go through pull requests.**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,9 +281,9 @@ jobs:
           key: ${{ env.CACHE_KEY_HOST }}-${{ runner.os }}-${{ runner.arch }}
 
   # Runner 1b: Host-Root (bare metal with KVM)
-  # Runs: test-root with matrix for cache testing modes
-  # - NoCache: FCVM_NO_CACHE=1, runs once (tests bypass path)
-  # - Cache: no env var, runs twice (cache miss then cache hit)
+  # Runs: test-root with matrix for snapshot testing modes
+  # - NoSnapshot: FCVM_NO_SNAPSHOT=1, runs once (tests bypass path)
+  # - Snapshot: no env var, runs twice (snapshot miss then snapshot hit)
   host-root:
     name: Host-Root-${{ matrix.mode }}
     if: ${{ github.event.inputs.job != 'container' }}
@@ -292,14 +292,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - mode: NoCache
-            fcvm_no_cache: "1"
+          - mode: NoSnapshot
+            fcvm_no_snapshot: "1"
             test_runs: "1"
-          - mode: Cache
-            fcvm_no_cache: ""
+          - mode: Snapshot
+            fcvm_no_snapshot: ""
             test_runs: "2"
     env:
-      FCVM_NO_CACHE: ${{ matrix.fcvm_no_cache }}
+      FCVM_NO_SNAPSHOT: ${{ matrix.fcvm_no_snapshot }}
     steps:
       # Clean up root-owned files from previous test runs before checkout
       - name: Clean workspace (pre-checkout)

--- a/README.md
+++ b/README.md
@@ -163,10 +163,10 @@ fcvm automatically caches container images after the first pull. On subsequent r
 
 # Second run: restores from cache (~540ms)
 ./fcvm podman run --name web2 nginx:alpine
-# → Restored from cache
+# → Restored from snapshot
 
-# Disable cache for testing
-./fcvm podman run --name web3 --no-cache nginx:alpine
+# Disable snapshot for testing
+./fcvm podman run --name web3 --no-snapshot nginx:alpine
 ```
 
 **How it works:**
@@ -744,7 +744,7 @@ See [DESIGN.md](DESIGN.md#cli-interface) for architecture and design decisions.
 -i, --interactive   Keep stdin open (for piping input)
 -t, --tty           Allocate pseudo-TTY (for vim, colors, etc.)
 --setup             Auto-setup if kernel/rootfs missing (rootless only)
---no-cache          Disable container image cache (for testing)
+--no-snapshot       Disable automatic snapshot creation (for testing)
 ```
 
 **`fcvm exec`** - Execute in VM/container:
@@ -783,7 +783,7 @@ See [DESIGN.md](DESIGN.md#guest-agent) for details.
 |----------|---------|-------------|
 | `FCVM_BASE_DIR` | `/mnt/fcvm-btrfs` | Base directory for all data |
 | `RUST_LOG` | `warn` | Logging level (quiet by default; use `info` or `debug` for verbose) |
-| `FCVM_NO_CACHE` | unset | Set to `1` to disable container image cache (same as `--no-cache` flag) |
+| `FCVM_NO_SNAPSHOT` | unset | Set to `1` to disable automatic snapshot creation (same as `--no-snapshot` flag) |
 | `FCVM_NO_WRITEBACK_CACHE` | unset | Set to `1` to disable FUSE writeback cache (see below) |
 | `FCVM_NO_XATTR_FASTPATH` | unset | Set to `1` to disable security.capability xattr fast path |
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -202,10 +202,10 @@ pub struct RunArgs {
     #[arg(long)]
     pub vsock_dir: Option<String>,
 
-    /// Disable automatic podman cache (bypass cache lookup and creation).
-    /// By default, fcvm caches "container-loaded" VM snapshots for fast subsequent launches.
+    /// Disable automatic snapshot cache (bypass snapshot lookup and creation).
+    /// By default, fcvm creates snapshots after container image pull for fast subsequent launches.
     #[arg(long)]
-    pub no_cache: bool,
+    pub no_snapshot: bool,
 
     /// Container image (e.g., nginx:alpine or localhost/myimage)
     pub image: String,

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -1178,7 +1178,9 @@ async fn cmd_podman_run(args: RunArgs) -> Result<()> {
     // Note: no_snapshot and is_localhost_image are already defined above
     let skip_snapshot_creation = no_snapshot || !args.map.is_empty() || is_localhost_image;
     if !args.map.is_empty() && !no_snapshot {
-        info!("Skipping snapshot creation: volumes specified (FUSE doesn't survive snapshot pause)");
+        info!(
+            "Skipping snapshot creation: volumes specified (FUSE doesn't survive snapshot pause)"
+        );
     }
     let (cache_tx, mut cache_rx): (
         Option<mpsc::Sender<CacheRequest>>,

--- a/src/firecracker/config.rs
+++ b/src/firecracker/config.rs
@@ -154,8 +154,8 @@ impl FirecrackerConfig {
         }
     }
 
-    /// Compute cache key by hashing the JSON representation.
-    pub fn cache_key(&self) -> String {
+    /// Compute snapshot key by hashing the JSON representation.
+    pub fn snapshot_key(&self) -> String {
         use crate::setup::rootfs::compute_sha256;
         let json = serde_json::to_string(self).expect("FirecrackerConfig serialization failed");
         compute_sha256(json.as_bytes())[..12].to_string()
@@ -163,7 +163,7 @@ impl FirecrackerConfig {
 
     /// Return a copy of this config with the rootfs path replaced.
     ///
-    /// This is used when launching a VM: the cache key is computed using the
+    /// This is used when launching a VM: the snapshot key is computed using the
     /// content-addressed base rootfs path, but the actual launch uses a
     /// per-instance CoW copy path.
     pub fn with_rootfs_path(&self, new_rootfs_path: PathBuf) -> Self {

--- a/src/firecracker/config.rs
+++ b/src/firecracker/config.rs
@@ -264,83 +264,83 @@ mod tests {
     }
 
     #[test]
-    fn test_cache_key_deterministic() {
+    fn test_snapshot_key_deterministic() {
         let config1 = test_config();
         let config2 = test_config();
-        assert_eq!(config1.cache_key(), config2.cache_key());
+        assert_eq!(config1.snapshot_key(), config2.snapshot_key());
     }
 
     #[test]
-    fn test_cache_key_changes_with_config() {
+    fn test_snapshot_key_changes_with_config() {
         let config1 = test_config();
         let mut config2 = test_config();
         config2.network_mode = NetworkMode::Rootless;
-        assert_ne!(config1.cache_key(), config2.cache_key());
+        assert_ne!(config1.snapshot_key(), config2.snapshot_key());
     }
 
     #[test]
-    fn test_cache_key_changes_with_cmd() {
+    fn test_snapshot_key_changes_with_cmd() {
         let config1 = test_config();
         let mut config2 = test_config();
         config2.container_cmd = Some(vec!["true".to_string()]);
-        assert_ne!(config1.cache_key(), config2.cache_key());
+        assert_ne!(config1.snapshot_key(), config2.snapshot_key());
     }
 
     #[test]
-    fn test_cache_key_changes_with_extra_disks() {
+    fn test_snapshot_key_changes_with_extra_disks() {
         let config1 = test_config();
         let mut config2 = test_config();
         config2.extra_disks = vec!["/tmp/data:/mydata:ro".to_string()];
-        assert_ne!(config1.cache_key(), config2.cache_key());
+        assert_ne!(config1.snapshot_key(), config2.snapshot_key());
     }
 
     #[test]
-    fn test_cache_key_changes_with_env_vars() {
+    fn test_snapshot_key_changes_with_env_vars() {
         let config1 = test_config();
         let mut config2 = test_config();
         config2.env_vars = vec!["MY_VAR=test_value".to_string()];
-        assert_ne!(config1.cache_key(), config2.cache_key());
+        assert_ne!(config1.snapshot_key(), config2.snapshot_key());
     }
 
     #[test]
-    fn test_cache_key_changes_with_volumes() {
+    fn test_snapshot_key_changes_with_volumes() {
         let config1 = test_config();
         let mut config2 = test_config();
         config2.volume_mounts = vec!["/tmp/data:/data:ro".to_string()];
-        assert_ne!(config1.cache_key(), config2.cache_key());
+        assert_ne!(config1.snapshot_key(), config2.snapshot_key());
     }
 
     #[test]
-    fn test_cache_key_changes_with_privileged() {
+    fn test_snapshot_key_changes_with_privileged() {
         let config1 = test_config();
         let mut config2 = test_config();
         config2.privileged = true;
-        assert_ne!(config1.cache_key(), config2.cache_key());
+        assert_ne!(config1.snapshot_key(), config2.snapshot_key());
     }
 
     #[test]
-    fn test_cache_key_changes_with_tty() {
+    fn test_snapshot_key_changes_with_tty() {
         let config1 = test_config();
         let mut config2 = test_config();
         config2.tty = true;
-        assert_ne!(config1.cache_key(), config2.cache_key());
+        assert_ne!(config1.snapshot_key(), config2.snapshot_key());
     }
 
     #[test]
-    fn test_cache_key_changes_with_interactive() {
+    fn test_snapshot_key_changes_with_interactive() {
         let config1 = test_config();
         let mut config2 = test_config();
         config2.interactive = true;
-        assert_ne!(config1.cache_key(), config2.cache_key());
+        assert_ne!(config1.snapshot_key(), config2.snapshot_key());
     }
 
     #[test]
-    fn test_cache_key_changes_with_data_dir() {
-        // Different data_dirs must produce different cache keys
-        // This ensures root and non-root caches don't collide
+    fn test_snapshot_key_changes_with_data_dir() {
+        // Different data_dirs must produce different snapshot keys
+        // This ensures root and non-root snapshots don't collide
         let config1 = test_config();
         let mut config2 = test_config();
         config2.data_dir = "/mnt/fcvm-btrfs/root".into();
-        assert_ne!(config1.cache_key(), config2.cache_key());
+        assert_ne!(config1.snapshot_key(), config2.snapshot_key());
     }
 }

--- a/tests/test_podman_snapshot.rs
+++ b/tests/test_podman_snapshot.rs
@@ -70,7 +70,10 @@ fn list_snapshot_entries() -> HashSet<String> {
 }
 
 /// Wait for a new snapshot entry to appear (returns the new key)
-async fn wait_for_new_snapshot_entry(before: &HashSet<String>, timeout_secs: u64) -> Option<String> {
+async fn wait_for_new_snapshot_entry(
+    before: &HashSet<String>,
+    timeout_secs: u64,
+) -> Option<String> {
     let start = Instant::now();
     while start.elapsed() < Duration::from_secs(timeout_secs) {
         let current = list_snapshot_entries();

--- a/tests/test_podman_snapshot.rs
+++ b/tests/test_podman_snapshot.rs
@@ -1,26 +1,26 @@
-//! Podman cache integration tests
+//! Podman snapshot integration tests
 //!
-//! Tests the container-layer caching feature that caches VM state after
+//! Tests the snapshot caching feature that snapshots VM state after
 //! container image is loaded, enabling fast subsequent launches.
 //!
-//! ## Cache Storage
+//! ## Snapshot Storage
 //!
-//! Cache entries are stored via SnapshotManager in the snapshots directory
-//! (`paths::snapshot_dir()`). The cache key becomes the snapshot name.
+//! Snapshot entries are stored via SnapshotManager in the snapshots directory
+//! (`paths::snapshot_dir()`). The snapshot key becomes the snapshot name.
 //!
-//! ## Cache Key Model
+//! ## Snapshot Key Model
 //!
-//! Cache keys are computed from FirecrackerConfig JSON which includes:
+//! Snapshot keys are computed from FirecrackerConfig JSON which includes:
 //! - kernel_path, initrd_path, rootfs_path (content-addressed with SHA)
 //! - container_image, container_cmd, cpu, mem, network_mode
 //!
-//! Cache keys do NOT include runtime-only values: env vars, ports, volumes.
-//! This means VMs with same image+cmd+cpu+mem+network_mode share the same cache.
+//! Snapshot keys do NOT include runtime-only values: env vars, ports, volumes.
+//! This means VMs with same image+cmd+cpu+mem+network_mode share the same snapshot.
 //!
 //! ## Test Isolation
 //!
-//! Tests use different network modes (bridged vs rootless) for cache isolation
-//! since network mode IS part of the cache key.
+//! Tests use different network modes (bridged vs rootless) for snapshot isolation
+//! since network mode IS part of the snapshot key.
 //!
 //! ## Root Required
 //!
@@ -35,27 +35,27 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-/// Check if caching is disabled via FCVM_NO_CACHE environment variable
-fn cache_disabled_by_env() -> bool {
-    std::env::var("FCVM_NO_CACHE").is_ok()
+/// Check if snapshot is disabled via FCVM_NO_SNAPSHOT environment variable
+fn snapshot_disabled_by_env() -> bool {
+    std::env::var("FCVM_NO_SNAPSHOT").is_ok()
 }
 
-/// Get the cache directory path (cache entries are stored as snapshots via SnapshotManager)
-fn cache_dir() -> PathBuf {
+/// Get the snapshot directory path
+fn snapshot_dir() -> PathBuf {
     let data_dir = std::env::var("FCVM_DATA_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(|_| PathBuf::from("/mnt/fcvm-btrfs/root"));
     data_dir.join("snapshots")
 }
 
-/// List all cache entries (directory names that contain complete cache files)
-fn list_cache_entries() -> HashSet<String> {
+/// List all snapshot entries (directory names that contain complete snapshot files)
+fn list_snapshot_entries() -> HashSet<String> {
     let mut entries = HashSet::new();
-    if let Ok(dir) = std::fs::read_dir(cache_dir()) {
+    if let Ok(dir) = std::fs::read_dir(snapshot_dir()) {
         for entry in dir.flatten() {
             if let Ok(name) = entry.file_name().into_string() {
                 let path = entry.path();
-                // Check if this is a complete cache entry
+                // Check if this is a complete snapshot entry
                 if path.join("memory.bin").exists()
                     && path.join("vmstate.bin").exists()
                     && path.join("disk.raw").exists()
@@ -69,11 +69,11 @@ fn list_cache_entries() -> HashSet<String> {
     entries
 }
 
-/// Wait for a new cache entry to appear (returns the new key)
-async fn wait_for_new_cache_entry(before: &HashSet<String>, timeout_secs: u64) -> Option<String> {
+/// Wait for a new snapshot entry to appear (returns the new key)
+async fn wait_for_new_snapshot_entry(before: &HashSet<String>, timeout_secs: u64) -> Option<String> {
     let start = Instant::now();
     while start.elapsed() < Duration::from_secs(timeout_secs) {
-        let current = list_cache_entries();
+        let current = list_snapshot_entries();
         let new_entries: Vec<_> = current.difference(before).collect();
         if !new_entries.is_empty() {
             return Some(new_entries[0].clone());
@@ -83,36 +83,36 @@ async fn wait_for_new_cache_entry(before: &HashSet<String>, timeout_secs: u64) -
     None
 }
 
-/// Check if a specific cache entry exists and is complete
-fn cache_entry_exists(cache_key: &str) -> bool {
-    let path = cache_dir().join(cache_key);
+/// Check if a specific snapshot entry exists and is complete
+fn snapshot_entry_exists(snapshot_key: &str) -> bool {
+    let path = snapshot_dir().join(snapshot_key);
     path.join("memory.bin").exists()
         && path.join("vmstate.bin").exists()
         && path.join("disk.raw").exists()
         && path.join("config.json").exists()
 }
 
-/// Test that first run creates a cache entry
+/// Test that first run creates a snapshot entry
 /// Uses rootless network mode for this test
 #[tokio::test]
-async fn test_podman_cache_miss_creates_cache() -> Result<()> {
-    if cache_disabled_by_env() {
-        println!("Skipping test: FCVM_NO_CACHE is set");
+async fn test_podman_snapshot_miss_creates_snapshot() -> Result<()> {
+    if snapshot_disabled_by_env() {
+        println!("Skipping test: FCVM_NO_SNAPSHOT is set");
         return Ok(());
     }
-    println!("\ntest_podman_cache_miss_creates_cache");
-    println!("=====================================");
+    println!("\ntest_podman_snapshot_miss_creates_snapshot");
+    println!("==========================================");
 
-    // Record cache entries before test
-    let before = list_cache_entries();
-    println!("Cache entries before: {}", before.len());
+    // Record snapshot entries before test
+    let before = list_snapshot_entries();
+    println!("Snapshot entries before: {}", before.len());
 
-    // Run container with a UNIQUE command that won't be in any existing cache.
-    // Since container_cmd is now part of the cache key, using a timestamp ensures
-    // this test always creates a new cache entry (cache miss).
-    let (vm_name, _, _, _) = common::unique_names("cache-miss");
+    // Run container with a UNIQUE command that won't be in any existing snapshot.
+    // Since container_cmd is now part of the snapshot key, using a timestamp ensures
+    // this test always creates a new snapshot entry (snapshot miss).
+    let (vm_name, _, _, _) = common::unique_names("snapshot-miss");
     let unique_msg = format!(
-        "cache-miss-{}",
+        "snapshot-miss-{}",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
@@ -141,28 +141,28 @@ async fn test_podman_cache_miss_creates_cache() -> Result<()> {
     let _ = common::poll_health_by_pid(pid, 180).await;
     let _ = tokio::time::timeout(Duration::from_secs(120), child.wait()).await;
 
-    // Verify at least one new cache entry was created
-    let new_key = wait_for_new_cache_entry(&before, 10).await;
-    assert!(new_key.is_some(), "A cache entry should be created");
-    println!("New cache entry: {}", new_key.unwrap());
+    // Verify at least one new snapshot entry was created
+    let new_key = wait_for_new_snapshot_entry(&before, 10).await;
+    assert!(new_key.is_some(), "A snapshot entry should be created");
+    println!("New snapshot entry: {}", new_key.unwrap());
 
     println!("Test passed");
     Ok(())
 }
 
-/// Test that second run with same config hits cache and is faster
-/// Uses rootless network mode - tests may share cache, that's OK
+/// Test that second run with same config hits snapshot and is faster
+/// Uses rootless network mode - tests may share snapshot, that's OK
 #[tokio::test]
-async fn test_podman_cache_hit_restores_fast() -> Result<()> {
-    if cache_disabled_by_env() {
-        println!("Skipping test: FCVM_NO_CACHE is set");
+async fn test_podman_snapshot_hit_restores_fast() -> Result<()> {
+    if snapshot_disabled_by_env() {
+        println!("Skipping test: FCVM_NO_SNAPSHOT is set");
         return Ok(());
     }
-    println!("\ntest_podman_cache_hit_restores_fast");
-    println!("====================================");
+    println!("\ntest_podman_snapshot_hit_restores_fast");
+    println!("======================================");
 
-    // First run - may create cache or use existing
-    let (vm_name1, _, _, _) = common::unique_names("cache-hit-1");
+    // First run - may create snapshot or use existing
+    let (vm_name1, _, _, _) = common::unique_names("snapshot-hit-1");
     println!("First run: {}", vm_name1);
 
     let start1 = Instant::now();
@@ -184,12 +184,12 @@ async fn test_podman_cache_hit_restores_fast() -> Result<()> {
     child1.kill().await?;
     let _ = child1.wait().await;
 
-    // Wait a moment for cache to be written
+    // Wait a moment for snapshot to be written
     tokio::time::sleep(Duration::from_secs(2)).await;
 
-    // Second run - should hit cache (same image+cpu+mem+network)
-    let (vm_name2, _, _, _) = common::unique_names("cache-hit-2");
-    println!("Second run (should be cache hit): {}", vm_name2);
+    // Second run - should hit snapshot (same image+cpu+mem+network)
+    let (vm_name2, _, _, _) = common::unique_names("snapshot-hit-2");
+    println!("Second run (should be snapshot hit): {}", vm_name2);
 
     let start2 = Instant::now();
     let (mut child2, pid2) = common::spawn_fcvm(&[
@@ -211,33 +211,33 @@ async fn test_podman_cache_hit_restores_fast() -> Result<()> {
     let _ = child2.wait().await;
 
     // Second run should be faster (or at least not much slower)
-    // Cache hit skips image pull which saves significant time
+    // Snapshot hit skips image pull which saves significant time
     if duration1 > Duration::from_secs(5) {
         let speedup = duration1.as_secs_f64() / duration2.as_secs_f64();
         println!("Speedup: {:.1}x", speedup);
-        // Cache should provide at least some speedup
-        assert!(speedup > 1.0, "Cache hit should be faster than miss");
+        // Snapshot should provide at least some speedup
+        assert!(speedup > 1.0, "Snapshot hit should be faster than miss");
     } else {
-        println!("First run was too fast to measure speedup (likely already cached)");
+        println!("First run was too fast to measure speedup (likely already has snapshot)");
     }
 
     println!("Test passed");
     Ok(())
 }
 
-/// Test that different network modes create different cache entries
+/// Test that different network modes create different snapshot entries
 #[tokio::test]
-async fn test_podman_cache_different_network_modes() -> Result<()> {
-    if cache_disabled_by_env() {
-        println!("Skipping test: FCVM_NO_CACHE is set");
+async fn test_podman_snapshot_different_network_modes() -> Result<()> {
+    if snapshot_disabled_by_env() {
+        println!("Skipping test: FCVM_NO_SNAPSHOT is set");
         return Ok(());
     }
-    println!("\ntest_podman_cache_different_network_modes");
-    println!("==========================================");
+    println!("\ntest_podman_snapshot_different_network_modes");
+    println!("=============================================");
 
-    // Record cache entries before
-    let before = list_cache_entries();
-    println!("Cache entries before: {}", before.len());
+    // Record snapshot entries before
+    let before = list_snapshot_entries();
+    println!("Snapshot entries before: {}", before.len());
 
     // Run with rootless
     let (vm_name1, _, _, _) = common::unique_names("net-rootless");
@@ -257,10 +257,10 @@ async fn test_podman_cache_different_network_modes() -> Result<()> {
     let _ = common::poll_health_by_pid(pid1, 180).await;
     let _ = tokio::time::timeout(Duration::from_secs(120), child1.wait()).await;
 
-    // Wait for cache
+    // Wait for snapshot
     tokio::time::sleep(Duration::from_secs(2)).await;
-    let after_rootless = list_cache_entries();
-    println!("Cache entries after rootless: {}", after_rootless.len());
+    let after_rootless = list_snapshot_entries();
+    println!("Snapshot entries after rootless: {}", after_rootless.len());
 
     // Run with bridged (requires sudo, handled by test harness)
     let (vm_name2, _, _, _) = common::unique_names("net-bridged");
@@ -280,13 +280,13 @@ async fn test_podman_cache_different_network_modes() -> Result<()> {
     let _ = common::poll_health_by_pid(pid2, 180).await;
     let _ = tokio::time::timeout(Duration::from_secs(120), child2.wait()).await;
 
-    // Wait for cache
+    // Wait for snapshot
     tokio::time::sleep(Duration::from_secs(2)).await;
-    let after_bridged = list_cache_entries();
-    println!("Cache entries after bridged: {}", after_bridged.len());
+    let after_bridged = list_snapshot_entries();
+    println!("Snapshot entries after bridged: {}", after_bridged.len());
 
-    // Should have created different cache entries for different network modes
-    // (If either was already cached, count might not increase but that's OK)
+    // Should have created different snapshot entries for different network modes
+    // (If either was already snapshotted, count might not increase but that's OK)
     let new_after_rootless: HashSet<_> = after_rootless.difference(&before).collect();
     let new_after_bridged: HashSet<_> = after_bridged.difference(&after_rootless).collect();
 
@@ -298,15 +298,15 @@ async fn test_podman_cache_different_network_modes() -> Result<()> {
     Ok(())
 }
 
-/// Test that --no-cache flag prevents cache creation
+/// Test that --no-snapshot flag prevents snapshot creation
 #[tokio::test]
-async fn test_podman_cache_no_cache_flag() -> Result<()> {
-    println!("\ntest_podman_cache_no_cache_flag");
-    println!("================================");
+async fn test_podman_no_snapshot_flag() -> Result<()> {
+    println!("\ntest_podman_no_snapshot_flag");
+    println!("============================");
 
-    // Use a unique command so we can verify OUR cache wasn't created
+    // Use a unique command so we can verify OUR snapshot wasn't created
     let unique_msg = format!(
-        "no-cache-test-{}",
+        "no-snapshot-test-{}",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
@@ -314,12 +314,12 @@ async fn test_podman_cache_no_cache_flag() -> Result<()> {
     );
     println!("Using unique message: {}", unique_msg);
 
-    // Record cache entries before
-    let before = list_cache_entries();
-    println!("Cache entries before: {}", before.len());
+    // Record snapshot entries before
+    let before = list_snapshot_entries();
+    println!("Snapshot entries before: {}", before.len());
 
-    // Run with --no-cache
-    let (vm_name, _, _, _) = common::unique_names("no-cache");
+    // Run with --no-snapshot
+    let (vm_name, _, _, _) = common::unique_names("no-snapshot");
     let (mut child, pid) = common::spawn_fcvm(&[
         "podman",
         "run",
@@ -327,7 +327,7 @@ async fn test_podman_cache_no_cache_flag() -> Result<()> {
         &vm_name,
         "--network",
         "rootless",
-        "--no-cache",
+        "--no-snapshot",
         "alpine:latest",
         "echo",
         &unique_msg,
@@ -337,76 +337,76 @@ async fn test_podman_cache_no_cache_flag() -> Result<()> {
     let _ = common::poll_health_by_pid(pid, 180).await;
     let _ = tokio::time::timeout(Duration::from_secs(60), child.wait()).await;
 
-    // Wait extra time for cache creation (if it were to happen)
+    // Wait extra time for snapshot creation (if it were to happen)
     tokio::time::sleep(Duration::from_secs(5)).await;
 
-    // Check for new cache entries
-    let after = list_cache_entries();
+    // Check for new snapshot entries
+    let after = list_snapshot_entries();
     let new_entries: Vec<_> = after.difference(&before).cloned().collect();
     println!(
-        "Cache entries after: {} (new: {})",
+        "Snapshot entries after: {} (new: {})",
         after.len(),
         new_entries.len()
     );
 
     // Verify no new entry contains our unique message in its config
     for entry in &new_entries {
-        let config_path = cache_dir().join(entry).join("config.json");
+        let config_path = snapshot_dir().join(entry).join("config.json");
         if let Ok(config) = std::fs::read_to_string(&config_path) {
             assert!(
                 !config.contains(&unique_msg),
-                "--no-cache flag failed: cache entry {} was created for our command",
+                "--no-snapshot flag failed: snapshot entry {} was created for our command",
                 entry
             );
         }
     }
 
-    println!("Test passed (--no-cache prevented cache creation)");
+    println!("Test passed (--no-snapshot prevented snapshot creation)");
     Ok(())
 }
 
-/// Test that incomplete cache (missing files) is treated as miss
+/// Test that incomplete snapshot (missing files) is treated as miss
 #[tokio::test]
-async fn test_podman_cache_incomplete_treated_as_miss() -> Result<()> {
-    if cache_disabled_by_env() {
-        println!("Skipping test: FCVM_NO_CACHE is set");
+async fn test_podman_snapshot_incomplete_treated_as_miss() -> Result<()> {
+    if snapshot_disabled_by_env() {
+        println!("Skipping test: FCVM_NO_SNAPSHOT is set");
         return Ok(());
     }
-    println!("\ntest_podman_cache_incomplete_treated_as_miss");
-    println!("=============================================");
+    println!("\ntest_podman_snapshot_incomplete_treated_as_miss");
+    println!("================================================");
 
-    // Create an incomplete cache entry with a known key
+    // Create an incomplete snapshot entry with a known key
     let incomplete_key = "incomplete-test-entry";
-    let cache_path = cache_dir().join(incomplete_key);
+    let path = snapshot_dir().join(incomplete_key);
 
-    // Clean and create empty directory (incomplete cache)
-    let _ = std::fs::remove_dir_all(&cache_path);
-    std::fs::create_dir_all(&cache_path)?;
-    println!("Created incomplete cache directory: {}", incomplete_key);
+    // Clean and create empty directory (incomplete snapshot)
+    let _ = std::fs::remove_dir_all(&path);
+    std::fs::create_dir_all(&path)?;
+    println!("Created incomplete snapshot directory: {}", incomplete_key);
 
     // Verify it's incomplete (exists but missing required files)
-    assert!(cache_path.exists(), "Directory should exist");
+    assert!(path.exists(), "Directory should exist");
     assert!(
-        !cache_entry_exists(incomplete_key),
+        !snapshot_entry_exists(incomplete_key),
         "Should be incomplete (missing files)"
     );
 
     // Clean up
-    let _ = std::fs::remove_dir_all(&cache_path);
+    let _ = std::fs::remove_dir_all(&path);
 
     println!("Test passed");
     Ok(())
 }
 
-/// Test long-running container works with cache
+/// Test long-running container works with snapshot
 #[tokio::test]
-async fn test_podman_cache_long_running_container() -> Result<()> {
-    if cache_disabled_by_env() {
-        println!("Skipping test: FCVM_NO_CACHE is set");
+async fn test_podman_snapshot_long_running_container() -> Result<()> {
+    if snapshot_disabled_by_env() {
+        println!("Skipping test: FCVM_NO_SNAPSHOT is set");
         return Ok(());
     }
-    println!("\ntest_podman_cache_long_running_container");
-    println!("=========================================");
+    println!("\ntest_podman_snapshot_long_running_container");
+    println!("============================================");
 
     // First run
     let (vm_name1, _, _, _) = common::unique_names("long-1");
@@ -427,10 +427,10 @@ async fn test_podman_cache_long_running_container() -> Result<()> {
     child1.kill().await?;
     let _ = child1.wait().await;
 
-    // Wait for cache
+    // Wait for snapshot
     tokio::time::sleep(Duration::from_secs(2)).await;
 
-    // Second run - from cache
+    // Second run - from snapshot
     let (vm_name2, _, _, _) = common::unique_names("long-2");
     let (mut child2, pid2) = common::spawn_fcvm(&[
         "podman",


### PR DESCRIPTION
The "cache" terminology was confusing since this feature creates Firecracker
snapshots after container image pull. Rename throughout:

CLI:
- --no-cache → --no-snapshot
- FCVM_NO_CACHE → FCVM_NO_SNAPSHOT

Code:
- cache_key → snapshot_key
- check_podman_cache() → check_podman_snapshot()
- create_podman_cache() → create_podman_snapshot()
- no_cache variable → no_snapshot
- skip_cache_creation → skip_snapshot_creation

Tests:
- test_podman_cache.rs → test_podman_snapshot.rs (via git mv)
- Updated all test names and comments

CI:
- Host-Root-NoCache → Host-Root-NoSnapshot
- Host-Root-Cache → Host-Root-Snapshot
- fcvm_no_cache matrix var → fcvm_no_snapshot

Also added git mv guidance to CLAUDE.md.
