### PR TITLE
Improve CI snapshot test documentation and job naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,9 +281,19 @@ jobs:
           key: ${{ env.CACHE_KEY_HOST }}-${{ runner.os }}-${{ runner.arch }}
 
   # Runner 1b: Host-Root (bare metal with KVM)
-  # Runs: test-root with matrix for snapshot testing modes
-  # - NoSnapshot: FCVM_NO_SNAPSHOT=1, runs once (tests bypass path)
-  # - Snapshot: no env var, runs twice (snapshot miss then snapshot hit)
+  # Runs test-root with matrix for snapshot testing modes.
+  # IMPORTANT: Both matrix entries run on the SAME self-hosted runner to test
+  # snapshot persistence across runs.
+  #
+  # Matrix modes:
+  # - SnapshotDisabled: FCVM_NO_SNAPSHOT=1, runs once
+  #   Tests the code path where snapshot feature is explicitly disabled.
+  #   Verifies --no-snapshot flag and FCVM_NO_SNAPSHOT env var work correctly.
+  #
+  # - SnapshotEnabled: No env var, runs TWICE on same runner
+  #   Run 1: Snapshot miss - creates snapshots for container images
+  #   Run 2: Snapshot hit - reuses snapshots from Run 1 (should be faster)
+  #   This validates the full snapshot lifecycle: create -> persist -> restore
   host-root:
     name: Host-Root-${{ matrix.mode }}
     if: ${{ github.event.inputs.job != 'container' }}
@@ -292,10 +302,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - mode: NoSnapshot
+          - mode: SnapshotDisabled
             fcvm_no_snapshot: "1"
             test_runs: "1"
-          - mode: Snapshot
+          - mode: SnapshotEnabled
             fcvm_no_snapshot: ""
             test_runs: "2"
     env:
@@ -400,9 +410,23 @@ jobs:
       - name: test-root
         working-directory: fcvm
         run: |
+          SNAPSHOT_DIR="${FCVM_DATA_DIR:-/mnt/fcvm-btrfs/root}/snapshots"
           for i in $(seq 1 ${{ matrix.test_runs }}); do
-            echo "=== Test run $i of ${{ matrix.test_runs }} ==="
+            echo ""
+            echo "╔══════════════════════════════════════════════════════════════════╗"
+            echo "║ Test Run $i of ${{ matrix.test_runs }} (${{ matrix.mode }} mode)"
+            echo "╚══════════════════════════════════════════════════════════════════╝"
+            echo ""
+            BEFORE=$(sudo find "$SNAPSHOT_DIR" -maxdepth 1 -type d 2>/dev/null | wc -l)
+            echo "📦 Snapshot entries before run $i: $((BEFORE - 1))"
+            echo ""
             make test-root
+            AFTER=$(sudo find "$SNAPSHOT_DIR" -maxdepth 1 -type d 2>/dev/null | wc -l)
+            echo ""
+            echo "📦 Snapshot entries after run $i: $((AFTER - 1))"
+            if [ "$i" -eq 2 ] && [ "${{ matrix.mode }}" = "SnapshotEnabled" ]; then
+              echo "✓ Run 2 complete - snapshot hit paths tested"
+            fi
           done
       - name: Capture kernel logs
         if: always()

--- a/README.md
+++ b/README.md
@@ -877,13 +877,20 @@ RUST_LOG=debug make test-root FILTER=test_exec_basic STREAM=1
 
 ### CI Workflow
 
-Tests run automatically on PRs and pushes to main. Three parallel jobs:
+Tests run automatically on PRs and pushes to main:
 
 | Job | Runner | Tests |
 |-----|--------|-------|
 | **Host** | Self-hosted ARM64 | Unit tests, quick VM tests (rootless) |
-| **Host-Root** | Self-hosted ARM64 | Privileged tests, pjdfstest, nested KVM |
+| **Host-Root-SnapshotDisabled** | Self-hosted ARM64 | Privileged tests with `FCVM_NO_SNAPSHOT=1` |
+| **Host-Root-SnapshotEnabled** | Self-hosted ARM64 | Privileged tests run **twice** to verify snapshot hit |
 | **Container** | Self-hosted ARM64 | All tests in container |
+
+The **SnapshotEnabled** job runs the full test suite twice on the same runner:
+- **Run 1**: Creates snapshots (cache miss path)
+- **Run 2**: Uses existing snapshots (cache hit path - should be faster)
+
+This validates the complete snapshot lifecycle: creation, persistence, and restoration.
 
 Latest results: [CI Workflow](.github/workflows/ci.yml) → Actions tab
 


### PR DESCRIPTION
## Summary

- Rename CI matrix modes to be clearer: `NoSnapshot` → `SnapshotDisabled`, `Snapshot` → `SnapshotEnabled`
- Add detailed comments explaining what each mode tests
- Add snapshot count logging before/after each test run
- Update README with new job names and explanation

## What Each Job Tests

| Job | Purpose |
|-----|---------|
| **Host-Root-SnapshotDisabled** | Tests with `FCVM_NO_SNAPSHOT=1` - verifies snapshot feature can be disabled |
| **Host-Root-SnapshotEnabled** | Runs test-root **twice** on same runner to verify snapshot lifecycle |

## SnapshotEnabled Dual-Run Logic

The SnapshotEnabled job runs the test suite twice:

1. **Run 1 (Cache Miss)**: Snapshots cleared, tests create new snapshots
2. **Run 2 (Cache Hit)**: Snapshots preserved from Run 1, tests reuse them

This validates the full snapshot lifecycle:
- Snapshots are created correctly
- Snapshots persist on disk
- Snapshots are found and restored correctly

## Test Plan

- [ ] CI passes with new job names
- [ ] SnapshotEnabled shows snapshot counts before/after each run
- [ ] Run 2 uses snapshots from Run 1 (visible in logs)