### PR TITLE
ci: add x86_64 architecture support to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,15 +48,15 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: fcvm
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ejc3/fuse-backend-rs
           ref: master
           path: fuse-backend-rs
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ejc3/fuser
           ref: master
@@ -104,15 +104,15 @@ jobs:
     name: Packaging
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: fcvm
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ejc3/fuse-backend-rs
           ref: master
           path: fuse-backend-rs
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ejc3/fuser
           ref: master
@@ -156,15 +156,15 @@ jobs:
           # Fix cargo advisory-db permissions (can become read-only from previous runs)
           sudo chmod -R u+w ~/.cargo/advisory-db* 2>/dev/null || true
           sudo chown -R $USER:$USER ~/.cargo/advisory-db* 2>/dev/null || true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: fcvm
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ejc3/fuse-backend-rs
           ref: master
           path: fuse-backend-rs
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ejc3/fuser
           ref: master
@@ -283,7 +283,7 @@ jobs:
         run: make test-fast
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-logs-host-${{ matrix.arch }}
           path: /tmp/fcvm-test-logs/
@@ -336,15 +336,15 @@ jobs:
           # Fix cargo advisory-db permissions (can become read-only from previous runs)
           sudo chmod -R u+w ~/.cargo/advisory-db* 2>/dev/null || true
           sudo chown -R $USER:$USER ~/.cargo/advisory-db* 2>/dev/null || true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: fcvm
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ejc3/fuse-backend-rs
           ref: master
           path: fuse-backend-rs
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ejc3/fuser
           ref: master
@@ -452,7 +452,7 @@ jobs:
           sudo dmesg | grep -iE 'userfault|uffd|kvm|firecracker|oom|killed|segfault|page.fault' > /tmp/fcvm-test-logs/dmesg-filtered.log || true
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-logs-host-root-${{ matrix.arch }}-${{ matrix.mode }}
           path: /tmp/fcvm-test-logs/
@@ -488,15 +488,15 @@ jobs:
           # Fix cargo advisory-db permissions (can become read-only from previous runs)
           sudo chmod -R u+w ~/.cargo/advisory-db* 2>/dev/null || true
           sudo chown -R $USER:$USER ~/.cargo/advisory-db* 2>/dev/null || true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: fcvm
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ejc3/fuse-backend-rs
           ref: master
           path: fuse-backend-rs
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ejc3/fuser
           ref: master
@@ -550,7 +550,7 @@ jobs:
           sudo dmesg | grep -iE 'userfault|uffd|kvm|firecracker|oom|killed|segfault|page.fault' > /tmp/fcvm-test-logs/dmesg-filtered.log || true
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-logs-container-${{ matrix.arch }}
           path: /tmp/fcvm-test-logs/
@@ -564,9 +564,9 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: /tmp/ci-artifacts
       - name: Analyze CI run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [arm64, x64]
+        mode: [SnapshotDisabled, SnapshotEnabled]
         include:
           - mode: SnapshotDisabled
             fcvm_no_snapshot: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ env:
   CARGO_TERM_COLOR: always
   FUSE_BACKEND_RS: ${{ github.workspace }}/fuse-backend-rs
   FUSER: ${{ github.workspace }}/fuser
-  CONTAINER_ARCH: aarch64
   # Cache keys for cargo tools (update versions here when bumping)
   CACHE_KEY_LINT: cargo-tools-audit-0.22.0-deny-0.18.9
   CACHE_KEY_HOST: cargo-tools-nextest-0.9.115-audit-0.22.0-deny-0.18.9
@@ -140,11 +139,15 @@ jobs:
 
   # Runner 1a: Host (bare metal with KVM)
   # Runs: test-unit → test-fast (quick tests, no privileged)
-  # Self-hosted ARM64 runner with nested virtualization (c7g.metal)
+  # Self-hosted runners with nested virtualization (ARM64: c7g.metal, x86: c5.metal)
   host:
-    name: Host
+    name: Host-${{ matrix.arch }}
     if: ${{ github.event.inputs.job != 'container' }}
-    runs-on: [self-hosted, Linux, ARM64]
+    runs-on: [self-hosted, Linux, '${{ matrix.arch }}']
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [arm64, x64]
     steps:
       # Clean up root-owned files from previous test runs before checkout
       - name: Clean workspace (pre-checkout)
@@ -224,13 +227,26 @@ jobs:
           cat /proc/cmdline
           echo ""
           echo "=== KVM Capabilities ==="
-          cat /sys/module/kvm/parameters/mode 2>/dev/null || echo "kvm mode param not available"
-          # Check if nested virt is available (NV2 on ARM64)
-          if grep -q "kvm-arm.mode=nested" /proc/cmdline; then
-            echo "✓ Nested virtualization ENABLED (kvm-arm.mode=nested)"
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "aarch64" ]; then
+            cat /sys/module/kvm/parameters/mode 2>/dev/null || echo "kvm mode param not available"
+            # Check if nested virt is available (NV2 on ARM64)
+            if grep -q "kvm-arm.mode=nested" /proc/cmdline; then
+              echo "✓ Nested virtualization ENABLED (kvm-arm.mode=nested)"
+            else
+              echo "⚠ Nested virtualization NOT enabled in kernel cmdline"
+              echo "  Nested virtualization tests will fail - add kvm-arm.mode=nested to GRUB_CMDLINE_LINUX"
+            fi
           else
-            echo "⚠ Nested virtualization NOT enabled in kernel cmdline"
-            echo "  Nested virtualization tests will fail - add kvm-arm.mode=nested to GRUB_CMDLINE_LINUX"
+            # x86: Check for Intel VT-x or AMD-V nested virtualization
+            cat /sys/module/kvm_intel/parameters/nested 2>/dev/null && echo "Intel VT-x nested support" || true
+            cat /sys/module/kvm_amd/parameters/nested 2>/dev/null && echo "AMD-V nested support" || true
+            if grep -E "^Y|^1" /sys/module/kvm_intel/parameters/nested 2>/dev/null || \
+               grep -E "^Y|^1" /sys/module/kvm_amd/parameters/nested 2>/dev/null; then
+              echo "✓ Nested virtualization ENABLED"
+            else
+              echo "⚠ Nested virtualization may not be enabled"
+            fi
           fi
           echo ""
           sudo chmod 666 /dev/kvm
@@ -269,7 +285,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: test-logs-host
+          name: test-logs-host-${{ matrix.arch }}
           path: /tmp/fcvm-test-logs/
           if-no-files-found: ignore
           retention-days: 14
@@ -281,8 +297,8 @@ jobs:
           key: ${{ env.CACHE_KEY_HOST }}-${{ runner.os }}-${{ runner.arch }}
 
   # Runner 1b: Host-Root (bare metal with KVM)
-  # Runs test-root with matrix for snapshot testing modes.
-  # IMPORTANT: Both matrix entries run on the SAME self-hosted runner to test
+  # Runs test-root with matrix for snapshot testing modes and architectures.
+  # IMPORTANT: Both snapshot mode entries run on the SAME self-hosted runner to test
   # snapshot persistence across runs.
   #
   # Matrix modes:
@@ -295,12 +311,13 @@ jobs:
   #   Run 2: Snapshot hit - reuses snapshots from Run 1 (should be faster)
   #   This validates the full snapshot lifecycle: create -> persist -> restore
   host-root:
-    name: Host-Root-${{ matrix.mode }}
+    name: Host-Root-${{ matrix.arch }}-${{ matrix.mode }}
     if: ${{ github.event.inputs.job != 'container' }}
-    runs-on: [self-hosted, Linux, ARM64]
+    runs-on: [self-hosted, Linux, '${{ matrix.arch }}']
     strategy:
       fail-fast: false
       matrix:
+        arch: [arm64, x64]
         include:
           - mode: SnapshotDisabled
             fcvm_no_snapshot: "1"
@@ -436,7 +453,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: test-logs-host-root-${{ matrix.mode }}
+          name: test-logs-host-root-${{ matrix.arch }}-${{ matrix.mode }}
           path: /tmp/fcvm-test-logs/
           if-no-files-found: ignore
           retention-days: 14
@@ -451,11 +468,17 @@ jobs:
   # Runs same tests as Host but inside a container
   # Needs KVM for VM tests (container mounts /dev/kvm)
   container:
-    name: Container
+    name: Container-${{ matrix.arch }}
     if: ${{ github.event.inputs.job != 'host' }}
-    runs-on: [self-hosted, Linux, ARM64]
+    runs-on: [self-hosted, Linux, '${{ matrix.arch }}']
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [arm64, x64]
     permissions:
       packages: write
+    env:
+      CONTAINER_ARCH: ${{ matrix.arch == 'arm64' && 'aarch64' || 'x86_64' }}
     steps:
       # Clean up root-owned files from previous test runs before checkout
       - name: Clean workspace (pre-checkout)
@@ -528,7 +551,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: test-logs-container
+          name: test-logs-container-${{ matrix.arch }}
           path: /tmp/fcvm-test-logs/
           if-no-files-found: ignore
           retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,15 +48,15 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           path: fcvm
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           repository: ejc3/fuse-backend-rs
           ref: master
           path: fuse-backend-rs
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           repository: ejc3/fuser
           ref: master
@@ -104,15 +104,15 @@ jobs:
     name: Packaging
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           path: fcvm
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           repository: ejc3/fuse-backend-rs
           ref: master
           path: fuse-backend-rs
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           repository: ejc3/fuser
           ref: master
@@ -156,15 +156,15 @@ jobs:
           # Fix cargo advisory-db permissions (can become read-only from previous runs)
           sudo chmod -R u+w ~/.cargo/advisory-db* 2>/dev/null || true
           sudo chown -R $USER:$USER ~/.cargo/advisory-db* 2>/dev/null || true
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           path: fcvm
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           repository: ejc3/fuse-backend-rs
           ref: master
           path: fuse-backend-rs
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           repository: ejc3/fuser
           ref: master
@@ -283,7 +283,7 @@ jobs:
         run: make test-fast
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v4
         with:
           name: test-logs-host-${{ matrix.arch }}
           path: /tmp/fcvm-test-logs/
@@ -335,15 +335,15 @@ jobs:
           # Fix cargo advisory-db permissions (can become read-only from previous runs)
           sudo chmod -R u+w ~/.cargo/advisory-db* 2>/dev/null || true
           sudo chown -R $USER:$USER ~/.cargo/advisory-db* 2>/dev/null || true
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           path: fcvm
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           repository: ejc3/fuse-backend-rs
           ref: master
           path: fuse-backend-rs
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           repository: ejc3/fuser
           ref: master
@@ -451,7 +451,7 @@ jobs:
           sudo dmesg | grep -iE 'userfault|uffd|kvm|firecracker|oom|killed|segfault|page.fault' > /tmp/fcvm-test-logs/dmesg-filtered.log || true
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v4
         with:
           name: test-logs-host-root-${{ matrix.arch }}-${{ matrix.mode }}
           path: /tmp/fcvm-test-logs/
@@ -487,15 +487,15 @@ jobs:
           # Fix cargo advisory-db permissions (can become read-only from previous runs)
           sudo chmod -R u+w ~/.cargo/advisory-db* 2>/dev/null || true
           sudo chown -R $USER:$USER ~/.cargo/advisory-db* 2>/dev/null || true
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           path: fcvm
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           repository: ejc3/fuse-backend-rs
           ref: master
           path: fuse-backend-rs
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           repository: ejc3/fuser
           ref: master
@@ -549,7 +549,7 @@ jobs:
           sudo dmesg | grep -iE 'userfault|uffd|kvm|firecracker|oom|killed|segfault|page.fault' > /tmp/fcvm-test-logs/dmesg-filtered.log || true
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v4
         with:
           name: test-logs-container-${{ matrix.arch }}
           path: /tmp/fcvm-test-logs/
@@ -563,9 +563,9 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - name: Download all artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v4
         with:
           path: /tmp/ci-artifacts
       - name: Analyze CI run

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1029,7 +1029,8 @@ pub struct Ftrace {
 }
 
 impl Ftrace {
-    /// Low-noise events for PSCI/shutdown debugging
+    /// Low-noise events for PSCI/shutdown debugging (ARM64)
+    #[cfg(target_arch = "aarch64")]
     pub const EVENTS_PSCI: &'static [&'static str] = &[
         "kvm:kvm_userspace_exit",
         "kvm:kvm_hvc_arm64",
@@ -1037,7 +1038,17 @@ impl Ftrace {
         "kvm:kvm_wfx_arm64",
     ];
 
-    /// Medium-noise events including interrupts
+    /// Low-noise events for shutdown debugging (x86)
+    #[cfg(target_arch = "x86_64")]
+    pub const EVENTS_PSCI: &'static [&'static str] = &[
+        "kvm:kvm_userspace_exit",
+        "kvm:kvm_hypercall",
+        "kvm:kvm_vcpu_wakeup",
+        "kvm:kvm_hlt",
+    ];
+
+    /// Medium-noise events including interrupts (ARM64)
+    #[cfg(target_arch = "aarch64")]
     pub const EVENTS_INTERRUPTS: &'static [&'static str] = &[
         "kvm:kvm_userspace_exit",
         "kvm:kvm_set_irq",
@@ -1046,7 +1057,17 @@ impl Ftrace {
         "kvm:vgic_update_irq_pending",
     ];
 
-    /// High-noise events for detailed VM tracing
+    /// Medium-noise events including interrupts (x86)
+    #[cfg(target_arch = "x86_64")]
+    pub const EVENTS_INTERRUPTS: &'static [&'static str] = &[
+        "kvm:kvm_userspace_exit",
+        "kvm:kvm_set_irq",
+        "kvm:kvm_vcpu_wakeup",
+        "kvm:kvm_apic",
+        "kvm:kvm_inj_virq",
+    ];
+
+    /// High-noise events for detailed VM tracing (arch-independent)
     pub const EVENTS_DETAILED: &'static [&'static str] =
         &["kvm:kvm_exit", "kvm:kvm_entry", "kvm:kvm_userspace_exit"];
 


### PR DESCRIPTION
## Summary
Adds x86_64 architecture support to the CI pipeline, enabling tests to run on both ARM64 (c7g.metal) and x86 (c5.metal) self-hosted runners.

## Changes
- Add `arch: [arm64, x64]` matrix to Host, Host-Root, and Container jobs
- Make KVM capability check architecture-aware:
  - ARM64: checks for `kvm-arm.mode=nested` and FEAT_NV2
  - x86: checks for Intel VT-x / AMD-V nested support (`nested=1`)
- Update artifact names to include architecture suffix for disambiguation
- Add x86-specific ftrace events for KVM debugging in `tests/common/mod.rs`
- Update KVM test documentation to mention x86 nested virtualization requirements

## Test plan
- [x] `make test-root FILTER=sanity` passes (3/3)
- [ ] CI runs on both ARM64 and x86 runners