### PR TITLE
feat: fuser rebase with clone_fd support and networking fixes

### DIFF
--- a/.github/actions/checkout-deps/action.yml
+++ b/.github/actions/checkout-deps/action.yml
@@ -1,0 +1,21 @@
+name: Checkout Dependencies
+description: Checkout fuser and fuse-backend-rs dependencies
+
+# UPDATE BRANCHES HERE - this is the single source of truth
+# fuser: https://github.com/ejc3/fuser
+# fuse-backend-rs: https://github.com/ejc3/fuse-backend-rs
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v6
+      with:
+        repository: ejc3/fuse-backend-rs
+        ref: master
+        path: fuse-backend-rs
+
+    - uses: actions/checkout@v6
+      with:
+        repository: ejc3/fuser
+        ref: remap-file-range-on-clone-fd
+        path: fuser

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,8 +224,6 @@ jobs:
           echo ""
           sudo chmod 666 /dev/kvm
           sudo mkdir -p /var/run/netns
-          sudo iptables -P FORWARD ACCEPT
-          sudo iptables -t nat -A POSTROUTING -s 172.30.0.0/16 -o eth0 -j MASQUERADE || true
           if [ ! -e /dev/userfaultfd ]; then
             sudo mknod /dev/userfaultfd c 10 126
           fi
@@ -361,8 +359,6 @@ jobs:
         run: |
           sudo chmod 666 /dev/kvm
           sudo mkdir -p /var/run/netns
-          sudo iptables -P FORWARD ACCEPT
-          sudo iptables -t nat -A POSTROUTING -s 172.30.0.0/16 -o eth0 -j MASQUERADE || true
           if [ ! -e /dev/userfaultfd ]; then
             sudo mknod /dev/userfaultfd c 10 126
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,16 +51,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           path: fcvm
-      - uses: actions/checkout@v6
-        with:
-          repository: ejc3/fuse-backend-rs
-          ref: master
-          path: fuse-backend-rs
-      - uses: actions/checkout@v6
-        with:
-          repository: ejc3/fuser
-          ref: master
-          path: fuser
+      - uses: ./fcvm/.github/actions/checkout-deps
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -107,16 +98,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           path: fcvm
-      - uses: actions/checkout@v6
-        with:
-          repository: ejc3/fuse-backend-rs
-          ref: master
-          path: fuse-backend-rs
-      - uses: actions/checkout@v6
-        with:
-          repository: ejc3/fuser
-          ref: master
-          path: fuser
+      - uses: ./fcvm/.github/actions/checkout-deps
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Get dependency SHAs
@@ -159,16 +141,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           path: fcvm
-      - uses: actions/checkout@v6
-        with:
-          repository: ejc3/fuse-backend-rs
-          ref: master
-          path: fuse-backend-rs
-      - uses: actions/checkout@v6
-        with:
-          repository: ejc3/fuser
-          ref: master
-          path: fuser
+      - uses: ./fcvm/.github/actions/checkout-deps
       - name: Install Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -339,16 +312,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           path: fcvm
-      - uses: actions/checkout@v6
-        with:
-          repository: ejc3/fuse-backend-rs
-          ref: master
-          path: fuse-backend-rs
-      - uses: actions/checkout@v6
-        with:
-          repository: ejc3/fuser
-          ref: master
-          path: fuser
+      - uses: ./fcvm/.github/actions/checkout-deps
       - name: Install Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -491,16 +455,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           path: fcvm
-      - uses: actions/checkout@v6
-        with:
-          repository: ejc3/fuse-backend-rs
-          ref: master
-          path: fuse-backend-rs
-      - uses: actions/checkout@v6
-        with:
-          repository: ejc3/fuser
-          ref: master
-          path: fuser
+      - uses: ./fcvm/.github/actions/checkout-deps
       - name: Setup KVM and rootless podman
         run: |
           sudo chmod 666 /dev/kvm

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -161,17 +161,7 @@ jobs:
           token: ${{ steps.claude-token.outputs.token }}
           path: fcvm
 
-      - uses: actions/checkout@v4
-        with:
-          repository: ejc3/fuse-backend-rs
-          ref: master
-          path: fuse-backend-rs
-
-      - uses: actions/checkout@v4
-        with:
-          repository: ejc3/fuser
-          ref: master
-          path: fuser
+      - uses: ./fcvm/.github/actions/checkout-deps
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -245,17 +235,7 @@ jobs:
           token: ${{ steps.claude-token.outputs.token }}
           path: fcvm
 
-      - uses: actions/checkout@v4
-        with:
-          repository: ejc3/fuse-backend-rs
-          ref: master
-          path: fuse-backend-rs
-
-      - uses: actions/checkout@v4
-        with:
-          repository: ejc3/fuser
-          ref: master
-          path: fuser
+      - uses: ./fcvm/.github/actions/checkout-deps
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -338,17 +318,7 @@ jobs:
           token: ${{ steps.claude-token.outputs.token }}
           path: fcvm
 
-      - uses: actions/checkout@v4
-        with:
-          repository: ejc3/fuse-backend-rs
-          ref: master
-          path: fuse-backend-rs
-
-      - uses: actions/checkout@v4
-        with:
-          repository: ejc3/fuser
-          ref: master
-          path: fuser
+      - uses: ./fcvm/.github/actions/checkout-deps
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -441,17 +411,7 @@ jobs:
           token: ${{ steps.claude-token.outputs.token }}
           path: fcvm
 
-      - uses: actions/checkout@v4
-        with:
-          repository: ejc3/fuse-backend-rs
-          ref: master
-          path: fuse-backend-rs
-
-      - uses: actions/checkout@v4
-        with:
-          repository: ejc3/fuser
-          ref: master
-          path: fuser
+      - uses: ./fcvm/.github/actions/checkout-deps
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/kernels.yml
+++ b/.github/workflows/kernels.yml
@@ -33,17 +33,7 @@ jobs:
         with:
           path: fcvm
 
-      - uses: actions/checkout@v4
-        with:
-          repository: ejc3/fuse-backend-rs
-          ref: master
-          path: fuse-backend-rs
-
-      - uses: actions/checkout@v4
-        with:
-          repository: ejc3/fuser
-          ref: master
-          path: fuser
+      - uses: ./fcvm/.github/actions/checkout-deps
 
       - name: Install Rust
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,16 +16,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           path: fcvm
-      - uses: actions/checkout@v6
-        with:
-          repository: ejc3/fuse-backend-rs
-          ref: master
-          path: fuse-backend-rs
-      - uses: actions/checkout@v6
-        with:
-          repository: ejc3/fuser
-          ref: master
-          path: fuser
+      - uses: ./fcvm/.github/actions/checkout-deps
       - name: Run benchmarks (container)
         working-directory: fcvm
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,12 +713,15 @@ dependencies = [
 name = "fuser"
 version = "0.16.0"
 dependencies = [
+ "bitflags 2.10.0",
  "libc",
  "log",
  "memchr",
- "nix 0.29.0",
+ "nix 0.30.1",
+ "num_enum",
  "page_size",
  "pkg-config",
+ "ref-cast",
  "smallvec",
  "zerocopy",
 ]
@@ -1484,6 +1487,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.1",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1509,6 +1525,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1662,6 +1700,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -1861,6 +1908,26 @@ dependencies = [
  "getrandom 0.2.16",
  "libredox",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2498,8 +2565,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -2512,6 +2579,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2520,8 +2596,29 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
  "winnow",
 ]
 

--- a/fuse-pipe/src/client/fuse.rs
+++ b/fuse-pipe/src/client/fuse.rs
@@ -222,11 +222,7 @@ fn protocol_file_type_to_fuser(ft: u8) -> FileType {
 const DEFAULT_FUSE_MAX_WRITE: u32 = 0;
 
 impl Filesystem for FuseClient {
-    fn init(
-        &mut self,
-        _req: &Request,
-        config: &mut fuser::KernelConfig,
-    ) -> Result<(), io::Error> {
+    fn init(&mut self, _req: &Request, config: &mut fuser::KernelConfig) -> Result<(), io::Error> {
         // Enable writeback cache for better write performance (kernel batches writes).
         // Can be disabled via FCVM_NO_WRITEBACK_CACHE=1 for debugging.
         let enable_writeback = std::env::var("FCVM_NO_WRITEBACK_CACHE").is_err();
@@ -561,7 +557,9 @@ impl Filesystem for FuseClient {
         });
 
         match response {
-            VolumeResponse::Opened { fh, flags } => reply.opened(FileHandle(fh), FopenFlags::from_bits_truncate(flags)),
+            VolumeResponse::Opened { fh, flags } => {
+                reply.opened(FileHandle(fh), FopenFlags::from_bits_truncate(flags))
+            }
             VolumeResponse::Error { errno } => reply.error(Errno::from_i32(errno)),
             _ => reply.error(Errno::EIO),
         }
@@ -634,7 +632,10 @@ impl Filesystem for FuseClient {
         _flush: bool,
         reply: ReplyEmpty,
     ) {
-        let response = self.send_request_sync(VolumeRequest::Release { ino: ino.into(), fh: fh.into() });
+        let response = self.send_request_sync(VolumeRequest::Release {
+            ino: ino.into(),
+            fh: fh.into(),
+        });
 
         match response {
             VolumeResponse::Ok => reply.ok(),
@@ -643,8 +644,18 @@ impl Filesystem for FuseClient {
         }
     }
 
-    fn flush(&self, _req: &Request, ino: INodeNo, fh: FileHandle, _lock_owner: LockOwner, reply: ReplyEmpty) {
-        let response = self.send_request_sync(VolumeRequest::Flush { ino: ino.into(), fh: fh.into() });
+    fn flush(
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        fh: FileHandle,
+        _lock_owner: LockOwner,
+        reply: ReplyEmpty,
+    ) {
+        let response = self.send_request_sync(VolumeRequest::Flush {
+            ino: ino.into(),
+            fh: fh.into(),
+        });
 
         match response {
             VolumeResponse::Ok => reply.ok(),
@@ -653,8 +664,19 @@ impl Filesystem for FuseClient {
         }
     }
 
-    fn fsync(&self, _req: &Request, ino: INodeNo, fh: FileHandle, datasync: bool, reply: ReplyEmpty) {
-        let response = self.send_request_sync(VolumeRequest::Fsync { ino: ino.into(), fh: fh.into(), datasync });
+    fn fsync(
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        fh: FileHandle,
+        datasync: bool,
+        reply: ReplyEmpty,
+    ) {
+        let response = self.send_request_sync(VolumeRequest::Fsync {
+            ino: ino.into(),
+            fh: fh.into(),
+            datasync,
+        });
 
         match response {
             VolumeResponse::Ok => reply.ok(),
@@ -910,8 +932,18 @@ impl Filesystem for FuseClient {
         }
     }
 
-    fn releasedir(&self, _req: &Request, ino: INodeNo, fh: FileHandle, _flags: OpenFlags, reply: ReplyEmpty) {
-        let response = self.send_request_sync(VolumeRequest::Releasedir { ino: ino.into(), fh: fh.into() });
+    fn releasedir(
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        fh: FileHandle,
+        _flags: OpenFlags,
+        reply: ReplyEmpty,
+    ) {
+        let response = self.send_request_sync(VolumeRequest::Releasedir {
+            ino: ino.into(),
+            fh: fh.into(),
+        });
 
         match response {
             VolumeResponse::Ok => reply.ok(),
@@ -920,8 +952,19 @@ impl Filesystem for FuseClient {
         }
     }
 
-    fn fsyncdir(&self, _req: &Request, ino: INodeNo, fh: FileHandle, datasync: bool, reply: ReplyEmpty) {
-        let response = self.send_request_sync(VolumeRequest::Fsyncdir { ino: ino.into(), fh: fh.into(), datasync });
+    fn fsyncdir(
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        fh: FileHandle,
+        datasync: bool,
+        reply: ReplyEmpty,
+    ) {
+        let response = self.send_request_sync(VolumeRequest::Fsyncdir {
+            ino: ino.into(),
+            fh: fh.into(),
+            datasync,
+        });
 
         match response {
             VolumeResponse::Ok => reply.ok(),

--- a/src/network/portmap.rs
+++ b/src/network/portmap.rs
@@ -259,7 +259,10 @@ pub async fn ensure_global_nat(vm_subnet: &str, outbound_iface: &str) -> Result<
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        warn!("failed to enable forwarding on {}: {}", outbound_iface, stderr);
+        warn!(
+            "failed to enable forwarding on {}: {}",
+            outbound_iface, stderr
+        );
     }
 
     // Check if MASQUERADE rule already exists

--- a/src/network/portmap.rs
+++ b/src/network/portmap.rs
@@ -236,7 +236,7 @@ pub async fn ensure_global_nat(vm_subnet: &str, outbound_iface: &str) -> Result<
         "ensuring global NAT configuration"
     );
 
-    // Enable IP forwarding
+    // Enable IP forwarding globally
     let output = Command::new("sysctl")
         .args(["-w", "net.ipv4.ip_forward=1"])
         .output()
@@ -246,6 +246,20 @@ pub async fn ensure_global_nat(vm_subnet: &str, outbound_iface: &str) -> Result<
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         warn!("failed to enable IP forwarding: {}", stderr);
+    }
+
+    // Enable forwarding on the outbound interface specifically
+    // (per-interface forwarding may be disabled even when global ip_forward=1)
+    let iface_forwarding = format!("net.ipv4.conf.{}.forwarding=1", outbound_iface);
+    let output = Command::new("sysctl")
+        .args(["-w", &iface_forwarding])
+        .output()
+        .await
+        .with_context(|| format!("enabling forwarding on {}", outbound_iface))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        warn!("failed to enable forwarding on {}: {}", outbound_iface, stderr);
     }
 
     // Check if MASQUERADE rule already exists

--- a/src/network/slirp.rs
+++ b/src/network/slirp.rs
@@ -173,7 +173,13 @@ ip link set {fc_tap} up
 ip link set lo up
 
 # Enable IP forwarding (required for NAT to work)
+# Must enable both global and per-interface forwarding.
+# The host's net.ipv4.conf.default.forwarding=0 means new interfaces
+# inherit forwarding=0 even when ip_forward=1.
 sysctl -w net.ipv4.ip_forward=1
+sysctl -w net.ipv4.conf.all.forwarding=1
+sysctl -w net.ipv4.conf.{slirp_dev}.forwarding=1
+sysctl -w net.ipv4.conf.{fc_tap}.forwarding=1
 
 # Set default route via slirp gateway (10.0.2.2 is slirp4netns internal gateway)
 ip route add default via 10.0.2.2 dev {slirp_dev}


### PR DESCRIPTION
## Summary

- Update fuse-pipe to use fuser with `clone_fd()` and `remap_file_range` support
- Fix bridged VM networking by enabling per-interface forwarding
- Consolidate GitHub workflow dependency management into a single composite action

## Changes

### Fuser Rebase (ffd5152)
Updates fuse-pipe to use `ejc3/fuser` branch `remap-file-range-on-clone-fd`:
- `clone_fd()` support for multi-reader FUSE (from PR #421)
- `from_fd_initialized()` for session sharing between readers
- `remap_file_range` for FICLONE/FICLONERANGE ioctls

### Bridged Networking Fix (fe6e807)
Bridged VMs failed with DNS timeout because per-interface forwarding was disabled even when global `ip_forward=1`. Linux requires both:
- `net.ipv4.ip_forward=1` (global master switch)
- `net.ipv4.conf.{interface}.forwarding=1` (per-interface control)

Fixed by explicitly enabling forwarding on:
- The outbound interface (e.g., enP1s33) in `ensure_global_nat()`
- Each veth interface we create in `setup_host_veth()`

This is more targeted than setting global defaults - we only enable forwarding on fcvm-managed interfaces.

### CI Consolidation (4e595a2, 4359964)
- Created `.github/actions/checkout-deps` composite action as single source of truth for dependency branches
- Removed redundant `iptables -P FORWARD ACCEPT` and MASQUERADE rules from CI setup (fcvm now handles this per-interface)

## Test plan
- [x] `make test-root` - 275 passed, 14 skipped
- [x] Manual bridged VM test with DNS resolution