### PR TITLE
fix: enable IP forwarding for podman container networking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,10 @@ jobs:
           sudo sysctl -w vm.unprivileged_userfaultfd=1
           # Disable AppArmor restriction on unprivileged user namespaces (needed for rootless networking on newer Ubuntu)
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 2>/dev/null || true
+          # Enable IP forwarding for all interfaces (including future ones like podman0)
+          # This fixes podman container networking - without this, containers can't reach the internet
+          sudo sysctl -w net.ipv4.conf.all.forwarding=1
+          sudo sysctl -w net.ipv4.conf.default.forwarding=1
           # Enable FUSE allow_other for tests
           echo "user_allow_other" | sudo tee /etc/fuse.conf
           # Reset podman state if corrupted from previous runs
@@ -366,6 +370,10 @@ jobs:
           sudo sysctl -w vm.unprivileged_userfaultfd=1
           # Disable AppArmor restriction on unprivileged user namespaces (needed for rootless networking on newer Ubuntu)
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 2>/dev/null || true
+          # Enable IP forwarding for all interfaces (including future ones like podman0)
+          # This fixes podman container networking - without this, containers can't reach the internet
+          sudo sysctl -w net.ipv4.conf.all.forwarding=1
+          sudo sysctl -w net.ipv4.conf.default.forwarding=1
           echo "user_allow_other" | sudo tee /etc/fuse.conf
           podman system migrate || true
           # Install iperf3 for network benchmarks
@@ -459,6 +467,10 @@ jobs:
           sudo sysctl -w vm.unprivileged_userfaultfd=1
           # Disable AppArmor restriction on unprivileged user namespaces (needed for rootless networking on newer Ubuntu)
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 2>/dev/null || true
+          # Enable IP forwarding for all interfaces (including future ones like podman0)
+          # This fixes podman container networking - without this, containers can't reach the internet
+          sudo sysctl -w net.ipv4.conf.all.forwarding=1
+          sudo sysctl -w net.ipv4.conf.default.forwarding=1
           # Configure rootless podman to use cgroupfs (no systemd session on CI)
           mkdir -p ~/.config/containers
           printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n' > ~/.config/containers/containers.conf

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ echo "user_allow_other" | sudo tee -a /etc/fuse.conf
 # Ubuntu 24.04+: allow unprivileged user namespaces
 sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
+# IP forwarding for container networking (e.g., podman builds)
+sudo sysctl -w net.ipv4.conf.all.forwarding=1
+sudo sysctl -w net.ipv4.conf.default.forwarding=1
+
 # Bridged networking only (not needed for --network rootless):
 sudo mkdir -p /var/run/netns
 sudo iptables -P FORWARD ACCEPT


### PR DESCRIPTION
## Problem

Container builds (like pjdfstest) hang indefinitely during `apt-get update` because the container can't reach external networks.

## Root Cause

When podman creates the `podman0` bridge interface, it inherits the default forwarding setting:
- `net.ipv4.conf.default.forwarding = 0` → `net.ipv4.conf.podman0.forwarding = 0`

Even though global `ip_forward=1`, the per-interface `forwarding=0` blocks packet routing through that interface.

**Packet flow that was broken:**
```
Container (10.88.x.x) → podman0 → [BLOCKED - forwarding=0] → enP1s33 → internet
```

## Fix

Enable forwarding for all interfaces BEFORE podman creates the bridge:
```bash
sudo sysctl -w net.ipv4.conf.all.forwarding=1
sudo sysctl -w net.ipv4.conf.default.forwarding=1
```

## Verification

On the broken runner:
```bash
# Before fix
$ ping -c 1 8.8.8.8  # from container
100% packet loss

$ sysctl net.ipv4.conf.podman0.forwarding
net.ipv4.conf.podman0.forwarding = 0

# After fix
$ sudo sysctl -w net.ipv4.conf.podman0.forwarding=1
$ ping -c 1 8.8.8.8  # from container
64 bytes from 8.8.8.8: icmp_seq=1 ttl=117 time=0.774 ms
```