### PR TITLE
feat: add proper HEALTHCHECK support for containers

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -590,6 +590,12 @@ mv old_name.rs new_name.rs
 
 ### Development Workflow (PR-Based)
 
+**IMPORTANT: Use `/pr-workflow` skill for ALL PR operations.** This includes:
+- Creating, checking, or merging PRs (`gh pr create`, `gh pr checks`, `gh pr merge`)
+- Checking CI status
+- Fixing lint/clippy/format errors
+- Running `cargo fmt` or `cargo clippy`
+
 **Main branch is protected. All changes MUST go through pull requests.**
 
 #### Creating a PR

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -88,6 +88,21 @@ When a kernel, rootfs, or binary doesn't build correctly:
 
 If `fcvm setup` produces wrong output, the bug is in fcvm or build.sh. Fix it there.
 
+## Test Helper Functions (tests/common/mod.rs)
+
+| Function | Purpose |
+|----------|---------|
+| `spawn_fcvm(&args)` | Spawn fcvm process, returns `(child, pid)` |
+| `spawn_fcvm_with_logs(&args, name)` | Same + debug log file |
+| `poll_health_by_pid(pid, timeout)` | Wait for VM healthy status |
+| `poll_health_status_by_pid(pid, expected, timeout)` | Wait for specific health status |
+| `poll_health(&child, timeout)` | Wait healthy (checks process exit) |
+| `kill_process(pid)` | SIGTERM then SIGKILL if needed |
+| `unique_names(prefix)` | Generate unique `(name, clone, snap, serve)` |
+| `find_fcvm_binary()` | Locate `./target/release/fcvm` |
+| `exec_in_vm(pid, &cmd)` | Run command in VM via exec |
+| `exec_in_container(pid, &cmd)` | Run command in container via exec |
+
 ## Nested Test Architecture
 
 Tests use `localhost/nested-test` container image built from `Containerfile.nested`.

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -47,28 +47,48 @@ make test-root FILTER=sanity
    # All checks must show "pass" before proceeding
    ```
 
-## Before Merging ANY Pull Request
+## MANDATORY: Read PR Comments Before ANY PR Operation
 
-### CRITICAL: Read ALL Review Comments First
+**YOU MUST READ ALL PR COMMENTS** before:
+- Checking PR status
+- Pushing new commits
+- Merging
+- Closing
+- ANY interaction with the PR
+
+This is NOT optional. Comments contain critical information.
+
+### Step 1: ALWAYS Read Comments First
 
 ```bash
-# Get all review comments
-gh pr view <pr-number> --json comments --jq '.comments[] | .body'
-
-# Get review status
-gh pr view <pr-number> --json reviews --jq '.reviews[] | {author: .author.login, state: .state, body: .body}'
-
-# Check for auto-generated fix PRs
-gh pr list --search "base:<your-branch>"
+# MANDATORY - Run this FIRST before any other PR operation
+gh pr view <pr-number> --json comments --jq '.comments[] | "---\n" + .body'
 ```
 
-Review comments may contain:
-- Required changes from reviewers
-- Auto-fix PRs from CI (cherry-pick or close if outdated)
-- Suggestions for improvement
-- Security concerns
+### Step 2: Check for Auto-Fix PRs
 
-### Verify CI is Green
+CI may have created fix PRs targeting your branch. You MUST handle these:
+
+```bash
+# Check for fix PRs
+gh pr list --search "base:<your-branch>"
+
+# If fix PRs exist:
+# 1. Review the fix
+# 2. Cherry-pick: git cherry-pick <commit>
+# 3. Push to your branch
+# 4. Close the fix PR: gh pr close <fix-pr> --comment "Cherry-picked into PR #<your-pr>"
+```
+
+### Step 3: Address Review Findings
+
+Comments may contain:
+- **Code review findings** - Fix these before merging
+- **Auto-fix PRs** - Cherry-pick or close if outdated
+- **CI failure analysis** - Re-run if infra issue, fix if code issue
+- **Security concerns** - Must address before merge
+
+### Step 4: Verify CI is Green
 
 ```bash
 gh pr checks <pr-number>

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: pr-workflow
+description: "ALWAYS USE THIS SKILL when: creating PRs, checking PR status, reviewing PRs, merging PRs, checking CI status, fixing lint/clippy errors, running cargo fmt, or any gh pr command. Invoke with /pr-workflow"
+allowed-tools: Bash, Read, Grep, Glob
+user-invocable: true
+---
+
+# Pull Request Workflow for Rust Projects
+
+Follow this workflow when creating, updating, or merging pull requests.
+
+## Before Creating/Pushing ANY Code
+
+Run these checks locally - CI is for validation, not discovery:
+
+```bash
+# 1. Format check (REQUIRED)
+cargo fmt --check
+# If it fails: cargo fmt
+
+# 2. Lint check (REQUIRED)
+cargo clippy --all-targets -- -D warnings
+
+# 3. Sanity tests (RECOMMENDED)
+make test-root FILTER=sanity
+# Or run tests relevant to your changes
+```
+
+## Creating a Pull Request
+
+1. **Review your changes first**:
+   ```bash
+   git diff --stat              # What files changed
+   git diff                     # Actual changes
+   git log main..HEAD --oneline # All commits in this branch
+   ```
+
+2. **Push and create PR**:
+   ```bash
+   git push -u origin <branch-name>
+   gh pr create --fill
+   ```
+
+3. **Wait for CI** - Do NOT proceed until all checks pass:
+   ```bash
+   gh pr checks <pr-number>
+   # All checks must show "pass" before proceeding
+   ```
+
+## Before Merging ANY Pull Request
+
+### CRITICAL: Read ALL Review Comments First
+
+```bash
+# Get all review comments
+gh pr view <pr-number> --json comments --jq '.comments[] | .body'
+
+# Get review status
+gh pr view <pr-number> --json reviews --jq '.reviews[] | {author: .author.login, state: .state, body: .body}'
+
+# Check for auto-generated fix PRs
+gh pr list --search "base:<your-branch>"
+```
+
+Review comments may contain:
+- Required changes from reviewers
+- Auto-fix PRs from CI (cherry-pick or close if outdated)
+- Suggestions for improvement
+- Security concerns
+
+### Verify CI is Green
+
+```bash
+gh pr checks <pr-number>
+# ALL checks must show "pass"
+# If Lint fails: run cargo fmt && cargo clippy, commit, push
+```
+
+### Then Merge
+
+```bash
+gh pr merge <pr-number> --merge --delete-branch
+```
+
+## Stacked PRs (Branch of Branch)
+
+When your work builds on an unmerged PR:
+
+```bash
+# Create PR #2 based on PR #1's branch (not main!)
+git checkout pr1-branch
+git checkout -b pr2-branch
+# ... make changes ...
+git push -u origin pr2-branch
+gh pr create --base pr1-branch  # Target the parent branch!
+
+# Verify the chain
+git log --oneline origin/main..HEAD  # Should show both PR's commits
+```
+
+**After PR #1 merges:**
+1. Wait for GitHub to update PR #2's base to main
+2. Verify: `gh pr view 2 --json baseRefName`
+3. Only then merge PR #2
+
+## Rust Code Quality Checklist
+
+Before considering code "done":
+
+- [ ] No `unwrap()` in production code (use `?` or proper error handling)
+- [ ] No `clone()` without justification (prefer references)
+- [ ] Feature-gated tests have matching `#[cfg(feature = "...")]` on imports
+- [ ] Test names are descriptive: `test_<what>_<scenario>`
+- [ ] Error messages include context (use `.context("what failed")`)
+- [ ] No `println!` in library code (use `tracing::debug!` etc.)
+- [ ] Public APIs have doc comments
+
+## When Tests Fail
+
+**NEVER skip, ignore, or weaken assertions.** Find and fix the root cause.
+
+1. Read the error message completely
+2. Check test logs: `/tmp/fcvm-test-logs/*.log`
+3. Run the specific test with more output:
+   ```bash
+   RUST_LOG=debug make test-root FILTER=<failing_test> STREAM=1
+   ```
+4. Fix the CODE, not the test

--- a/Containerfile.test
+++ b/Containerfile.test
@@ -1,0 +1,11 @@
+# Test container with proper HEALTHCHECK
+# Based on nginx:alpine but with health verification
+
+FROM public.ecr.aws/nginx/nginx:alpine
+
+# Install curl for healthcheck
+RUN apk add --no-cache curl
+
+# Add healthcheck that verifies nginx is actually responding
+HEALTHCHECK --interval=2s --timeout=5s --start-period=5s --retries=3 \
+    CMD curl -sf http://localhost/ || exit 1

--- a/Containerfile.unhealthy
+++ b/Containerfile.unhealthy
@@ -1,0 +1,8 @@
+# Test container with HEALTHCHECK that always fails
+# Used to verify unhealthy containers are detected correctly
+
+FROM public.ecr.aws/nginx/nginx:alpine
+
+# Healthcheck that always fails
+HEALTHCHECK --interval=1s --timeout=1s --start-period=1s --retries=1 \
+    CMD exit 1

--- a/fc-agent/src/main.rs
+++ b/fc-agent/src/main.rs
@@ -2016,8 +2016,8 @@ async fn run_agent() -> Result<()> {
             }
         }
     } else {
-        // OCI archive - notify with image name as identifier
-        eprintln!("[fc-agent] using OCI archive, notifying cache-ready with image name");
+        // Docker archive - notify with image name as identifier
+        eprintln!("[fc-agent] using Docker archive, notifying cache-ready with image name");
         if notify_cache_ready_and_wait(&plan.image) {
             eprintln!("[fc-agent] ✓ cache ready notification acknowledged");
         } else {

--- a/tests/test_podman_healthcheck.rs
+++ b/tests/test_podman_healthcheck.rs
@@ -7,6 +7,7 @@
 
 mod common;
 
+#[cfg(feature = "privileged-tests")]
 use anyhow::{Context, Result};
 
 /// Test that a container with a passing HEALTHCHECK becomes healthy
@@ -129,12 +130,8 @@ async fn test_podman_healthcheck_unhealthy() -> Result<()> {
     // The unhealthy container has: --interval=1s --retries=1
     // So it should fail within a few seconds of the healthcheck running
     println!("  Polling health status (looking for Unhealthy)...");
-    let result = common::poll_health_status_by_pid(
-        fcvm_pid,
-        fcvm::state::HealthStatus::Unhealthy,
-        60,
-    )
-    .await;
+    let result =
+        common::poll_health_status_by_pid(fcvm_pid, fcvm::state::HealthStatus::Unhealthy, 60).await;
 
     // Kill the VM
     println!("  Stopping VM...");
@@ -190,7 +187,10 @@ async fn test_podman_healthcheck_none() -> Result<()> {
             Ok(())
         }
         Err(e) => {
-            anyhow::bail!("Health check failed for container without HEALTHCHECK: {}", e);
+            anyhow::bail!(
+                "Health check failed for container without HEALTHCHECK: {}",
+                e
+            );
         }
     }
 }

--- a/tests/test_podman_healthcheck.rs
+++ b/tests/test_podman_healthcheck.rs
@@ -1,0 +1,196 @@
+//! Tests for podman HEALTHCHECK integration
+//!
+//! Verifies that containers with HEALTHCHECK are properly monitored
+//! and that unhealthy containers are detected.
+
+#![cfg(feature = "integration-fast")]
+
+mod common;
+
+use anyhow::{Context, Result};
+
+/// Test that a container with a passing HEALTHCHECK becomes healthy
+#[cfg(feature = "privileged-tests")]
+#[tokio::test]
+async fn test_podman_healthcheck_healthy() -> Result<()> {
+    println!("\nTest: podman healthcheck (healthy container)");
+    println!("=============================================");
+
+    // Build the test-healthy image with docker format (preserves HEALTHCHECK)
+    println!("Building localhost/test-healthy image...");
+    let build_output = tokio::process::Command::new("sudo")
+        .args([
+            "podman",
+            "build",
+            "--format=docker",
+            "-t",
+            "localhost/test-healthy",
+            "-f",
+            "Containerfile.test",
+            ".",
+        ])
+        .output()
+        .await
+        .context("building test-healthy image")?;
+
+    if !build_output.status.success() {
+        let stderr = String::from_utf8_lossy(&build_output.stderr);
+        anyhow::bail!("Failed to build test-healthy image: {}", stderr);
+    }
+    println!("  Image built successfully");
+
+    // Start the VM with the healthy container
+    let (vm_name, _, _, _) = common::unique_names("healthcheck-ok");
+    println!("Starting VM with healthy container: {}", vm_name);
+
+    let (mut child, fcvm_pid) = common::spawn_fcvm(&[
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--network",
+        "bridged",
+        "localhost/test-healthy",
+    ])
+    .await
+    .context("spawning fcvm podman run")?;
+
+    println!("  fcvm process started (PID: {})", fcvm_pid);
+    println!("  Waiting for VM to become healthy (includes podman healthcheck)...");
+
+    // Wait for health with 120s timeout (container needs to start + healthcheck must pass)
+    let health_result = common::poll_health_by_pid(fcvm_pid, 120).await;
+
+    // Kill the VM
+    println!("  Stopping VM...");
+    common::kill_process(fcvm_pid).await;
+    let _ = child.wait().await;
+
+    match health_result {
+        Ok(()) => {
+            println!("  Container became healthy (HTTP + podman healthcheck both passed)");
+            Ok(())
+        }
+        Err(e) => {
+            anyhow::bail!("Health check failed: {}", e);
+        }
+    }
+}
+
+/// Test that a container with a failing HEALTHCHECK stays unhealthy
+#[cfg(feature = "privileged-tests")]
+#[tokio::test]
+async fn test_podman_healthcheck_unhealthy() -> Result<()> {
+    println!("\nTest: podman healthcheck (unhealthy container)");
+    println!("===============================================");
+
+    // Build the test-unhealthy image with docker format
+    println!("Building localhost/test-unhealthy image...");
+    let build_output = tokio::process::Command::new("sudo")
+        .args([
+            "podman",
+            "build",
+            "--format=docker",
+            "-t",
+            "localhost/test-unhealthy",
+            "-f",
+            "Containerfile.unhealthy",
+            ".",
+        ])
+        .output()
+        .await
+        .context("building test-unhealthy image")?;
+
+    if !build_output.status.success() {
+        let stderr = String::from_utf8_lossy(&build_output.stderr);
+        anyhow::bail!("Failed to build test-unhealthy image: {}", stderr);
+    }
+    println!("  Image built successfully");
+
+    // Start the VM with the unhealthy container
+    let (vm_name, _, _, _) = common::unique_names("healthcheck-fail");
+    println!("Starting VM with unhealthy container: {}", vm_name);
+
+    let (mut child, fcvm_pid) = common::spawn_fcvm(&[
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--network",
+        "bridged",
+        "localhost/test-unhealthy",
+    ])
+    .await
+    .context("spawning fcvm podman run")?;
+
+    println!("  fcvm process started (PID: {})", fcvm_pid);
+
+    // Poll health status until we see unhealthy or timeout
+    // The unhealthy container has: --interval=1s --retries=1
+    // So it should fail within a few seconds of the healthcheck running
+    println!("  Polling health status (looking for Unhealthy)...");
+    let result = common::poll_health_status_by_pid(
+        fcvm_pid,
+        fcvm::state::HealthStatus::Unhealthy,
+        60,
+    )
+    .await;
+
+    // Kill the VM
+    println!("  Stopping VM...");
+    common::kill_process(fcvm_pid).await;
+    let _ = child.wait().await;
+
+    match result {
+        Ok(()) => {
+            println!("  Container correctly detected as unhealthy");
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Test that a container WITHOUT HEALTHCHECK still works (backwards compat)
+#[cfg(feature = "privileged-tests")]
+#[tokio::test]
+async fn test_podman_healthcheck_none() -> Result<()> {
+    println!("\nTest: podman healthcheck (no HEALTHCHECK defined)");
+    println!("==================================================");
+
+    // Use standard nginx:alpine which has no HEALTHCHECK
+    let (vm_name, _, _, _) = common::unique_names("healthcheck-none");
+    println!("Starting VM with container (no HEALTHCHECK): {}", vm_name);
+
+    let (mut child, fcvm_pid) = common::spawn_fcvm(&[
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--network",
+        "bridged",
+        common::TEST_IMAGE,
+    ])
+    .await
+    .context("spawning fcvm podman run")?;
+
+    println!("  fcvm process started (PID: {})", fcvm_pid);
+    println!("  Waiting for VM to become healthy (HTTP check only)...");
+
+    // Should become healthy based on HTTP check alone
+    let health_result = common::poll_health_by_pid(fcvm_pid, 120).await;
+
+    // Kill the VM
+    println!("  Stopping VM...");
+    common::kill_process(fcvm_pid).await;
+    let _ = child.wait().await;
+
+    match health_result {
+        Ok(()) => {
+            println!("  Container without HEALTHCHECK became healthy (backwards compat OK)");
+            Ok(())
+        }
+        Err(e) => {
+            anyhow::bail!("Health check failed for container without HEALTHCHECK: {}", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Combine podman HEALTHCHECK with existing HTTP health check using AND logic. If container has a HEALTHCHECK defined, both must pass for container to be considered healthy.

## Changes

- **fc-agent**: Name container `fcvm-container` for healthcheck reference
- **fc-agent**: Use `docker-archive` format (OCI format doesn't preserve HEALTHCHECK)
- **podman.rs**: Export localhost images as `docker-archive`
- **health.rs**: Add `check_podman_healthcheck()` that exec's into VM to query status
- **health.rs**: Combine with base health check - both must pass

## Behavior

| Scenario | Result |
|----------|--------|
| No HEALTHCHECK defined | Healthy (doesn't block) |
| HEALTHCHECK returns "healthy" | Healthy |
| HEALTHCHECK returns "unhealthy" | Unhealthy |
| Exec fails during startup | Healthy (doesn't block startup) |

## Test plan

- [x] `make test-root FILTER=sanity` (3/3 passed)
- [ ] CI tests