### PR TITLE
Refactor fuse-pipe to use fuser PR #627's spawn() API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,6 +712,7 @@ dependencies = [
 [[package]]
 name = "fuser"
 version = "0.16.0"
+source = "git+https://github.com/ejc3/fuser.git?branch=remap-on-627#baf714e91781568aac3971c5c8458210b65ba32a"
 dependencies = [
  "bitflags 2.10.0",
  "libc",

--- a/fuse-pipe/Cargo.toml
+++ b/fuse-pipe/Cargo.toml
@@ -38,9 +38,9 @@ tracing-log = "0.2"  # Bridge log crate to tracing
 # Using local path for development - synced to EC2 via `make sync`
 fuse-backend-rs = { path = "../../fuse-backend-rs", default-features = false, features = ["fusedev"] }
 
-# FUSE client (local fork with multi-reader support via FUSE_DEV_IOC_CLONE)
-# Using local path for development - synced to EC2 via `make sync`
-fuser = { path = "../../fuser", features = ["abi-7-28"] }
+# FUSE client (fork with clone_fd for true parallel readers + remap_file_range)
+# Based on upstream PR #627 (stepancheg's multi-threaded approach)
+fuser = { git = "https://github.com/ejc3/fuser.git", branch = "remap-on-627", features = ["abi-7-28"] }
 
 # Concurrent data structures
 dashmap = "5.5"

--- a/fuse-pipe/tests/common/mod.rs
+++ b/fuse-pipe/tests/common/mod.rs
@@ -190,6 +190,9 @@ impl FuseMount {
         // Cleanup any stale state
         let _ = fs::remove_file(&socket);
         fs::create_dir_all(data_path).expect("create data dir");
+        // Remove mount_path if it exists (could be file or dir from previous test)
+        let _ = fs::remove_file(mount_path);
+        let _ = fs::remove_dir(mount_path);
         fs::create_dir_all(mount_path).expect("create mount dir");
 
         let socket_path = socket.to_str().unwrap().to_string();
@@ -313,6 +316,10 @@ impl Drop for FuseMount {
 
         debug!(target: TARGET, "Dropping server_guard (shutting down server)");
         drop(self.server_guard.take());
+
+        // Clean up mount directory to prevent stale state for next test
+        debug!(target: TARGET, "Cleaning up mount directory");
+        let _ = fs::remove_dir(&self.mount_dir);
 
         info!(target: TARGET, "FuseMount::drop complete");
     }

--- a/fuse-pipe/tests/test_remap_file_range.rs
+++ b/fuse-pipe/tests/test_remap_file_range.rs
@@ -24,10 +24,7 @@ static BTRFS_TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
 fn unique_btrfs_path(prefix: &str) -> std::path::PathBuf {
     let id = BTRFS_TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
     let pid = std::process::id();
-    std::path::PathBuf::from(format!(
-        "/mnt/fcvm-btrfs/{}-{}-{}",
-        prefix, pid, id
-    ))
+    std::path::PathBuf::from(format!("/mnt/fcvm-btrfs/{}-{}-{}", prefix, pid, id))
 }
 
 /// FICLONE ioctl number: _IOW(0x94, 9, int) = 0x40049409

--- a/fuse-pipe/tests/test_remap_file_range.rs
+++ b/fuse-pipe/tests/test_remap_file_range.rs
@@ -15,6 +15,20 @@ use std::fs::{self, File};
 use std::os::unix::io::AsRawFd;
 
 use common::{cleanup, unique_paths, FuseMount};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Counter for unique btrfs test paths
+static BTRFS_TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Generate a unique path on btrfs for parallel test execution.
+fn unique_btrfs_path(prefix: &str) -> std::path::PathBuf {
+    let id = BTRFS_TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let pid = std::process::id();
+    std::path::PathBuf::from(format!(
+        "/mnt/fcvm-btrfs/{}-{}-{}",
+        prefix, pid, id
+    ))
+}
 
 /// FICLONE ioctl number: _IOW(0x94, 9, int) = 0x40049409
 const FICLONE: libc::c_ulong = 0x40049409;
@@ -120,14 +134,14 @@ fn test_ficlone_whole_file() {
     // Check if backing filesystem is btrfs
     if !is_btrfs(std::path::Path::new("/tmp")) {
         // Try to use /mnt/fcvm-btrfs if available
-        let btrfs_path = std::path::Path::new("/mnt/fcvm-btrfs/test-fuse-ficlone");
         if !is_btrfs(std::path::Path::new("/mnt/fcvm-btrfs")) {
             eprintln!("SKIP: test_ficlone_whole_file requires btrfs backing filesystem");
             eprintln!("      /tmp is not btrfs and /mnt/fcvm-btrfs is not available");
             return;
         }
-        // Use btrfs-backed paths
-        return run_ficlone_test(btrfs_path);
+        // Use unique btrfs-backed path for parallel test safety
+        let btrfs_path = unique_btrfs_path("test-fuse-ficlone");
+        return run_ficlone_test(&btrfs_path);
     }
 
     run_ficlone_test_with_paths(&data_dir, &mount_dir);
@@ -227,12 +241,12 @@ fn test_ficlonerange_partial() {
 
     // Check if backing filesystem is btrfs
     if !is_btrfs(std::path::Path::new("/tmp")) {
-        let btrfs_path = std::path::Path::new("/mnt/fcvm-btrfs/test-fuse-ficlonerange");
         if !is_btrfs(std::path::Path::new("/mnt/fcvm-btrfs")) {
             eprintln!("SKIP: test_ficlonerange_partial requires btrfs backing filesystem");
             return;
         }
-        return run_ficlonerange_test(btrfs_path);
+        let btrfs_path = unique_btrfs_path("test-fuse-ficlonerange");
+        return run_ficlonerange_test(&btrfs_path);
     }
 
     run_ficlonerange_test_with_paths(&data_dir, &mount_dir);
@@ -360,12 +374,12 @@ fn test_cp_reflink_always() {
 
     // Check if backing filesystem is btrfs
     if !is_btrfs(std::path::Path::new("/tmp")) {
-        let btrfs_path = std::path::Path::new("/mnt/fcvm-btrfs/test-fuse-cp-reflink");
         if !is_btrfs(std::path::Path::new("/mnt/fcvm-btrfs")) {
             eprintln!("SKIP: test_cp_reflink_always requires btrfs backing filesystem");
             return;
         }
-        return run_cp_reflink_test(btrfs_path);
+        let btrfs_path = unique_btrfs_path("test-fuse-cp-reflink");
+        return run_cp_reflink_test(&btrfs_path);
     }
 
     run_cp_reflink_test_with_paths(&data_dir, &mount_dir);


### PR DESCRIPTION
## Summary

Simplifies fuse-pipe's multi-reader implementation by using fuser's built-in
multi-threading (PR #627) with clone_fd for true parallel FUSE request processing.

**Key changes:**
- Update fuser to `remap-on-627` branch which combines:
  - Upstream PR #627's multi-threaded event loop architecture
  - `clone_fd()` for true parallel FUSE request processing (via FUSE_DEV_IOC_CLONE ioctl)
  - `remap_file_range` support
- Remove `reader_id` from FuseClient (Multiplexer already routes by unique request ID)
- Simplify mount.rs: use `session.spawn().join()` instead of manual thread management
- Remove manual clone_fd, from_fd_initialized, and secondary reader spawning
- Use fuser's `n_threads` config which handles clone_fd internally

**Why this is cleaner:**
- Uses fuser's public API (`spawn()`) instead of internal `run()`
- Removes ~280 lines of manual thread management code
- Response routing was already by unique_id, reader_id was unnecessary

## Test plan

- [x] fuse-pipe unit tests pass
- [x] fcvm sanity tests pass (bridged + rootless)
- [x] cargo fmt --check passes
- [x] cargo clippy passes