### PR TITLE
Change default health check to container running state

### DIFF
--- a/tests/test_port_forward.rs
+++ b/tests/test_port_forward.rs
@@ -34,6 +34,7 @@ fn test_port_forward_bridged() -> Result<()> {
     let host_port: u16 = 8080;
 
     // Start VM with port forwarding
+    // Use --health-check to wait for nginx to be ready (not just container running)
     let mut fcvm = Command::new(&fcvm_path)
         .args([
             "podman",
@@ -44,6 +45,8 @@ fn test_port_forward_bridged() -> Result<()> {
             "bridged",
             "--publish",
             "8080:80",
+            "--health-check",
+            "http://localhost/",
             common::TEST_IMAGE,
         ])
         .spawn()
@@ -179,6 +182,7 @@ fn test_port_forward_rootless() -> Result<()> {
 
     // Start VM with rootless networking and port forwarding
     // Rootless uses unique loopback IPs (127.x.y.z) per VM, so port 8080 is fine
+    // Use --health-check to wait for nginx to be ready (not just container running)
     let mut fcvm = Command::new(&fcvm_path)
         .args([
             "podman",
@@ -189,6 +193,8 @@ fn test_port_forward_rootless() -> Result<()> {
             "rootless",
             "--publish",
             "8080:80",
+            "--health-check",
+            "http://localhost/",
             common::TEST_IMAGE,
         ])
         .spawn()


### PR DESCRIPTION
## Summary
- Change default health check from file-based (container-ready file) to polling `podman inspect` for container running state
- The previous approach was triggered too early - right when podman process spawned, before the container was actually running
- Tests that need HTTP readiness (e.g., port forwarding) now explicitly use `--health-check http://localhost/`

## Changes
- `src/health.rs`: Add `check_container_running()` function, use it as default health check
- `tests/test_port_forward.rs`: Add `--health-check` flag for nginx tests  
- `tests/test_readme_examples.rs`: Add `--health-check` flag for custom command test

## Test plan
- [x] `make test-root FILTER=port_forward` - 4 passed
- [x] `make test-root FILTER=sanity` - 3 passed
- [x] `make test-root FILTER=custom_command` - 1 passed