### PR TITLE
Enable clone_fd for true parallel FUSE request processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,9 +184,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "caps"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "fuser"
 version = "0.16.0"
-source = "git+https://github.com/ejc3/fuser.git?branch=remap-on-627#baf714e91781568aac3971c5c8458210b65ba32a"
+source = "git+https://github.com/ejc3/fuser.git?branch=remap-file-range-on-clone-fd#283f574504d3954cda1157d8468820e76bffab4f"
 dependencies = [
  "bitflags 2.10.0",
  "libc",

--- a/fuse-pipe/Cargo.toml
+++ b/fuse-pipe/Cargo.toml
@@ -39,8 +39,8 @@ tracing-log = "0.2"  # Bridge log crate to tracing
 fuse-backend-rs = { path = "../../fuse-backend-rs", default-features = false, features = ["fusedev"] }
 
 # FUSE client (fork with clone_fd for true parallel readers + remap_file_range)
-# Based on upstream PR #627 (stepancheg's multi-threaded approach)
-fuser = { git = "https://github.com/ejc3/fuser.git", branch = "remap-on-627", features = ["abi-7-28"] }
+# Based on upstream PR #636 (clone_fd for parallel processing) + remap_file_range
+fuser = { git = "https://github.com/ejc3/fuser.git", branch = "remap-file-range-on-clone-fd", features = ["abi-7-28"] }
 
 # Concurrent data structures
 dashmap = "5.5"

--- a/fuse-pipe/src/client/mount.rs
+++ b/fuse-pipe/src/client/mount.rs
@@ -290,8 +290,9 @@ fn mount_internal<P: AsRef<Path>>(
     let mut config = fuser::Config::default();
     config.mount_options = options;
     config.acl = acl;
-    // Use fuser's built-in multi-threading with clone_fd
+    // Use fuser's built-in multi-threading with clone_fd for true parallel request processing
     config.n_threads = Some(num_readers);
+    config.clone_fd = true; // Opt-in to FUSE_DEV_IOC_CLONE for parallel requests
 
     // Shared flag set by FuseClient::destroy() when kernel sends FUSE_DESTROY.
     let destroyed = Arc::new(AtomicBool::new(false));
@@ -448,8 +449,9 @@ pub fn mount_vsock_with_options<P: AsRef<Path>>(
     let mut config = fuser::Config::default();
     config.mount_options = options;
     config.acl = acl;
-    // Use fuser's built-in multi-threading with clone_fd
+    // Use fuser's built-in multi-threading with clone_fd for true parallel request processing
     config.n_threads = Some(num_readers);
+    config.clone_fd = true; // Opt-in to FUSE_DEV_IOC_CLONE for parallel requests
 
     // Shared flag set by FuseClient::destroy() when kernel sends FUSE_DESTROY.
     let destroyed = Arc::new(AtomicBool::new(false));


### PR DESCRIPTION
## Summary
- Switch fuser dependency to `remap-file-range-on-clone-fd` branch (based on upstream PR #636)
- Add explicit `config.clone_fd = true` to opt-in to FUSE_DEV_IOC_CLONE for parallel requests

## Changes
- **fuser branch**: `remap-on-627` → `remap-file-range-on-clone-fd`
- **mount.rs**: Added `config.clone_fd = true` in both:
  - `mount_internal()` - Unix socket mounts (tests, local mounts)
  - `mount_vsock_with_options()` - vsock mounts (fc-agent in VMs)

## Why
The clone_fd feature uses FUSE_DEV_IOC_CLONE to create per-thread /dev/fuse file descriptors, enabling true parallel request processing instead of serializing through a single fd.

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -p fuse-pipe --all-targets` passes
- [x] `cargo test -p fuse-pipe --lib` passes (42 tests)
- [x] Integration test passes (`cargo test -p fuse-pipe --test integration basic`)
- [ ] CI passes