### PR TITLE
Add --rootfs-size flag and simplify btrfs storage

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1256,7 +1256,7 @@ fuse-pipe/benches/
 **Performance: ~1.5ms disk copy (560x faster than standard copy)**
 
 **Architecture:**
-- All data under `/mnt/fcvm-btrfs/` (btrfs filesystem)
+- All data under `/mnt/fcvm-btrfs/` — native btrfs used directly if host is btrfs, otherwise a loopback image is created (size from `paths.btrfs_size` in rootfs-config.toml, default 60G)
 - Base rootfs: `/mnt/fcvm-btrfs/rootfs/layer2-{sha}.raw` (~10GB raw disk with Ubuntu 24.04 + Podman)
 - VM disks: `/mnt/fcvm-btrfs/vm-disks/{vm_id}/disks/rootfs.raw` (sparse, expanded per `--rootfs-size`)
 - Initrd: `/mnt/fcvm-btrfs/initrd/fc-agent-{sha}.initrd` (injects fc-agent at boot)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A Rust implementation that launches Firecracker microVMs to run Podman container
 - For building rootfs: qemu-utils, e2fsprogs
 
 **Storage**
-- btrfs filesystem at `/mnt/fcvm-btrfs` (for CoW disk snapshots)
+- btrfs filesystem at `/mnt/fcvm-btrfs` (native btrfs used directly; loopback created on non-btrfs hosts)
 - Kernel auto-downloaded from Kata Containers release on first run
 
 ---

--- a/rootfs-config.toml
+++ b/rootfs-config.toml
@@ -13,6 +13,10 @@ data_dir = "/mnt/fcvm-btrfs"
 # All nesting levels share this for deduplication via btrfs reflinks
 assets_dir = "/mnt/fcvm-btrfs"
 
+# Size of the btrfs loopback filesystem (sparse file, only written blocks use real space)
+# Only used when creating a new loopback; ignored if already mounted
+btrfs_size = "60G"
+
 # Rootfs Modification Plan
 #
 # The SHA256 of the generated setup script determines the image name: layer2-{sha}.raw

--- a/rootfs-config.toml
+++ b/rootfs-config.toml
@@ -14,7 +14,8 @@ data_dir = "/mnt/fcvm-btrfs"
 assets_dir = "/mnt/fcvm-btrfs"
 
 # Size of the btrfs loopback filesystem (sparse file, only written blocks use real space)
-# Only used when creating a new loopback; ignored if already mounted
+# Only used on non-btrfs hosts where a loopback image must be created.
+# Ignored if the host filesystem is already btrfs.
 btrfs_size = "60G"
 
 # Rootfs Modification Plan

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -109,6 +109,11 @@ pub struct RunArgs {
     #[arg(long, default_value_t = 2048)]
     pub mem: u32,
 
+    /// Minimum free space on root filesystem (default: 10G).
+    /// Disk is expanded after CoW copy if free space is below this threshold.
+    #[arg(long, default_value = "10G")]
+    pub rootfs_size: String,
+
     /// Volume mapping(s): HOST:GUEST[:ro] (repeat or comma-separated)
     #[arg(long, action = clap::ArgAction::Append, value_delimiter=',')]
     pub map: Vec<String>,

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -297,6 +297,7 @@ fn build_firecracker_config(
         args.privileged,
         args.tty,
         args.interactive,
+        args.rootfs_size.clone(),
     )
 }
 
@@ -1695,6 +1696,11 @@ async fn run_vm_setup(
         .await
         .context("creating CoW disk")?;
 
+    // Ensure minimum free space (from --rootfs-size, stored in FirecrackerConfig)
+    crate::storage::disk::ensure_free_space(&rootfs_path, &args.rootfs_size)
+        .await
+        .context("ensuring rootfs free space")?;
+
     info!(rootfs = %rootfs_path.display(), "disk prepared (fc-agent baked into Layer 2)");
 
     let vm_name = args.name.clone();
@@ -2170,6 +2176,7 @@ async fn run_vm_setup(
                 args.privileged,
                 args.tty,
                 args.interactive,
+                args.rootfs_size.clone(),
             )
         });
 

--- a/src/firecracker/config.rs
+++ b/src/firecracker/config.rs
@@ -58,6 +58,14 @@ pub struct FirecrackerConfig {
     /// Affects MMDS plan and container stdin handling.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub interactive: bool,
+    /// Minimum free space on root filesystem (e.g., "10G").
+    /// Affects disk size after CoW copy, so must be in cache key.
+    #[serde(default = "default_rootfs_size")]
+    pub rootfs_size: String,
+}
+
+fn default_rootfs_size() -> String {
+    "10G".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -124,6 +132,7 @@ impl FirecrackerConfig {
         privileged: bool,
         tty: bool,
         interactive: bool,
+        rootfs_size: String,
     ) -> Self {
         Self {
             boot_source: BootSource {
@@ -151,6 +160,7 @@ impl FirecrackerConfig {
             privileged,
             tty,
             interactive,
+            rootfs_size,
         }
     }
 
@@ -260,6 +270,7 @@ mod tests {
             false,
             false,
             false,
+            "10G".to_string(),
         )
     }
 

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -144,6 +144,13 @@ pub struct PathsConfig {
     /// Directory for shared content-addressed assets (kernels, rootfs, initrd, image-cache)
     #[serde(default = "default_base_dir")]
     pub assets_dir: String,
+    /// Size of the btrfs loopback filesystem (e.g., "60G")
+    #[serde(default = "default_btrfs_size")]
+    pub btrfs_size: String,
+}
+
+fn default_btrfs_size() -> String {
+    "60G".to_string()
 }
 
 fn default_base_dir() -> String {
@@ -155,6 +162,7 @@ impl Default for PathsConfig {
         Self {
             data_dir: default_base_dir(),
             assets_dir: default_base_dir(),
+            btrfs_size: default_btrfs_size(),
         }
     }
 }

--- a/src/storage/disk.rs
+++ b/src/storage/disk.rs
@@ -1,7 +1,7 @@
-use anyhow::{Context, Result};
-use std::path::PathBuf;
+use anyhow::{bail, Context, Result};
+use std::path::{Path, PathBuf};
 use tokio::fs;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 /// Configuration for a VM disk
 #[derive(Debug, Clone)]
@@ -122,4 +122,133 @@ impl DiskManager {
 
         Ok(())
     }
+}
+
+/// Ensure the ext4 filesystem has at least `min_free` bytes of free space.
+/// If not, expand the file and resize the filesystem.
+pub async fn ensure_free_space(disk_path: &Path, min_free_str: &str) -> Result<()> {
+    let min_free = parse_size(min_free_str)
+        .with_context(|| format!("parsing rootfs-size '{}'", min_free_str))?;
+
+    if min_free == 0 {
+        return Ok(());
+    }
+
+    // Get current free space via dumpe2fs
+    let output = tokio::process::Command::new("dumpe2fs")
+        .args(["-h", disk_path.to_str().unwrap()])
+        .output()
+        .await
+        .context("running dumpe2fs")?;
+
+    if !output.status.success() {
+        bail!(
+            "dumpe2fs failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let block_size = parse_dumpe2fs_value(&stdout, "Block size")?;
+    let free_blocks = parse_dumpe2fs_value(&stdout, "Free blocks")?;
+    let free_bytes = free_blocks * block_size;
+
+    if free_bytes >= min_free {
+        debug!(
+            disk = %disk_path.display(),
+            free_bytes,
+            min_free,
+            "disk already has sufficient free space"
+        );
+        return Ok(());
+    }
+
+    let expand_by = min_free - free_bytes;
+    info!(
+        disk = %disk_path.display(),
+        free_bytes,
+        min_free,
+        expand_by,
+        "expanding rootfs to ensure minimum free space"
+    );
+
+    // Expand the sparse file
+    let output = tokio::process::Command::new("truncate")
+        .args([
+            "-s",
+            &format!("+{}", expand_by),
+            disk_path.to_str().unwrap(),
+        ])
+        .output()
+        .await
+        .context("expanding disk file")?;
+
+    if !output.status.success() {
+        bail!(
+            "truncate failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    // Check filesystem before resize (required by resize2fs)
+    let _ = tokio::process::Command::new("e2fsck")
+        .args(["-f", "-y", disk_path.to_str().unwrap()])
+        .output()
+        .await;
+
+    // Resize ext4 filesystem to fill the new space
+    let output = tokio::process::Command::new("resize2fs")
+        .arg(disk_path.to_str().unwrap())
+        .output()
+        .await
+        .context("resizing ext4 filesystem")?;
+
+    if !output.status.success() {
+        bail!(
+            "resize2fs failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    info!(disk = %disk_path.display(), "rootfs expanded successfully");
+    Ok(())
+}
+
+/// Parse a value from dumpe2fs -h output (e.g., "Block size:          4096")
+fn parse_dumpe2fs_value(output: &str, key: &str) -> Result<u64> {
+    for line in output.lines() {
+        if line.starts_with(key) {
+            if let Some(value) = line.split(':').nth(1) {
+                return value
+                    .trim()
+                    .parse::<u64>()
+                    .with_context(|| format!("parsing {} value", key));
+            }
+        }
+    }
+    bail!("'{}' not found in dumpe2fs output", key)
+}
+
+/// Parse size strings like "10G", "500M", "1024K", or plain bytes
+pub fn parse_size(s: &str) -> Result<u64> {
+    let s = s.trim();
+    if s.is_empty() {
+        bail!("empty size string");
+    }
+
+    let (num_str, multiplier) = if s.ends_with('G') || s.ends_with('g') {
+        (&s[..s.len() - 1], 1024u64 * 1024 * 1024)
+    } else if s.ends_with('M') || s.ends_with('m') {
+        (&s[..s.len() - 1], 1024u64 * 1024)
+    } else if s.ends_with('K') || s.ends_with('k') {
+        (&s[..s.len() - 1], 1024u64)
+    } else {
+        (s, 1u64)
+    };
+
+    let num: u64 = num_str
+        .parse()
+        .with_context(|| format!("parsing size number '{}'", num_str))?;
+
+    Ok(num * multiplier)
 }

--- a/src/storage/disk.rs
+++ b/src/storage/disk.rs
@@ -124,11 +124,16 @@ impl DiskManager {
     }
 }
 
-/// Ensure the ext4 filesystem has at least `min_free` bytes of free space.
-/// If not, expand the file and resize the filesystem.
-pub async fn ensure_free_space(disk_path: &Path, min_free_str: &str) -> Result<()> {
+/// Ensure the ext4 filesystem has at least `min_free + extra_bytes` of free space.
+/// `extra_bytes` accounts for content that will be written after boot (e.g., container image layers).
+pub async fn ensure_free_space(
+    disk_path: &Path,
+    min_free_str: &str,
+    extra_bytes: u64,
+) -> Result<()> {
     let min_free = parse_size(min_free_str)
-        .with_context(|| format!("parsing rootfs-size '{}'", min_free_str))?;
+        .with_context(|| format!("parsing rootfs-size '{}'", min_free_str))?
+        + extra_bytes;
 
     if min_free == 0 {
         return Ok(());

--- a/tests/test_rootfs_size.rs
+++ b/tests/test_rootfs_size.rs
@@ -1,0 +1,75 @@
+//! Integration test for --rootfs-size flag
+//!
+//! Verifies that the root filesystem is expanded to provide
+//! the requested minimum free space.
+
+#![cfg(feature = "privileged-tests")]
+
+mod common;
+
+use anyhow::{Context, Result};
+
+#[tokio::test]
+async fn test_rootfs_size_50g() -> Result<()> {
+    println!("\nTest --rootfs-size 50G");
+    println!("======================");
+
+    let (vm_name, _, _, _) = common::unique_names("rootfs-size");
+
+    let (_, fcvm_pid) = common::spawn_fcvm(&[
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--rootfs-size",
+        "50G",
+        common::TEST_IMAGE,
+    ])
+    .await
+    .context("spawning fcvm")?;
+
+    println!("  fcvm PID: {}", fcvm_pid);
+    println!("  Waiting for VM to become healthy...");
+
+    common::poll_health_by_pid(fcvm_pid, 300).await?;
+    println!("  VM healthy");
+
+    // Check root filesystem size
+    let df_output = common::exec_in_vm(fcvm_pid, &["df", "-B1", "/"]).await?;
+    println!("  df output: {}", df_output.trim());
+
+    // Parse available bytes from df output (4th column = Available)
+    // Example: "Filesystem     1B-blocks      Used  Available Use% Mounted on"
+    //          "/dev/vda       53151899648 3048108032 50103791616   6% /"
+    let avail_bytes: u64 = df_output
+        .lines()
+        .last()
+        .context("no df output")?
+        .split_whitespace()
+        .nth(3)
+        .context("no Available column in df")?
+        .parse()
+        .context("parsing available bytes")?;
+
+    let fifty_gb = 50u64 * 1024 * 1024 * 1024;
+    // Allow 5% tolerance for ext4 overhead (reserved blocks, journal, etc.)
+    let threshold = (fifty_gb as f64 * 0.95) as u64;
+
+    println!(
+        "  Available: {:.1} GB (need >= {:.1} GB)",
+        avail_bytes as f64 / 1e9,
+        threshold as f64 / 1e9
+    );
+
+    assert!(
+        avail_bytes >= threshold,
+        "Root filesystem should have at least ~50GB available, got {:.1} GB",
+        avail_bytes as f64 / 1e9,
+    );
+
+    println!("  Stopping VM...");
+    common::kill_process(fcvm_pid).await;
+
+    println!("✅ ROOTFS SIZE TEST PASSED!");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Add `--rootfs-size` flag (default 10G) that ensures minimum free space on the root filesystem, and simplify btrfs storage setup to use native btrfs directly when available.

## Changes

**`--rootfs-size` flag** (`src/cli/args.rs`, `src/storage/disk.rs`, `src/commands/podman.rs`):
- After CoW disk copy, check free space via `dumpe2fs`; expand with `truncate` + `resize2fs` if below threshold
- Container image archive size is added on top of the threshold (images are extracted onto rootfs after boot)
- Included in `FirecrackerConfig` snapshot cache key — different sizes produce different snapshots
- Sparse files: only written blocks use real disk space

**Simplify btrfs detection** (`src/setup/storage.rs`):
- Replace `is_btrfs_mount()` (required mountpoint) with `is_btrfs()` (just checks filesystem type)
- If host filesystem is already btrfs, just `mkdir` — no loopback image, no size limit
- Loopback only created on non-btrfs hosts

**Configurable btrfs loopback size** (`rootfs-config.toml`, `src/setup/rootfs.rs`):
- Move hardcoded `DEFAULT_SIZE_GB = 60` to `paths.btrfs_size = "60G"` in config
- Only used on non-btrfs hosts where a loopback must be created

## Test plan

```
make test-root FILTER=sanity_rootless   # default works
make test-root FILTER=rootfs_size       # 50G expansion test
```