### PR TITLE
Fix DNS resolution on IPv6-only hosts

### DIFF
--- a/fc-agent/src/main.rs
+++ b/fc-agent/src/main.rs
@@ -48,6 +48,9 @@ struct Plan {
     /// HTTPS proxy for container registry access
     #[serde(default)]
     https_proxy: Option<String>,
+    /// Hosts/domains that bypass the proxy
+    #[serde(default)]
+    no_proxy: Option<String>,
 }
 
 /// Volume mount configuration from MMDS
@@ -2113,6 +2116,12 @@ fn save_proxy_settings(plan: &Plan) {
         env_vars.push(("https_proxy", proxy.clone()));
         env_vars.push(("HTTPS_PROXY", proxy.clone()));
     }
+    if let Some(ref no_proxy) = plan.no_proxy {
+        content.push_str(&format!("no_proxy={}\n", no_proxy));
+        content.push_str(&format!("NO_PROXY={}\n", no_proxy));
+        env_vars.push(("no_proxy", no_proxy.clone()));
+        env_vars.push(("NO_PROXY", no_proxy.clone()));
+    }
 
     if content.is_empty() {
         eprintln!("[fc-agent] no proxy settings configured");
@@ -2376,6 +2385,10 @@ async fn run_agent() -> Result<()> {
             if let Some(ref proxy) = plan.https_proxy {
                 cmd.env("https_proxy", proxy);
                 cmd.env("HTTPS_PROXY", proxy);
+            }
+            if let Some(ref no_proxy) = plan.no_proxy {
+                cmd.env("no_proxy", no_proxy);
+                cmd.env("NO_PROXY", no_proxy);
             }
             let mut child = cmd
                 .stdout(Stdio::piped())

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -2233,22 +2233,23 @@ async fn run_vm_setup(
         }
         // Use | delimiter since : is part of IPv6 addresses
         runtime_boot_args.push_str(&format!("fcvm_dns={}", dns_servers.join("|")));
-    }
-    // Pass search domains for short hostname resolution
-    if let Ok(content) = std::fs::read_to_string("/run/systemd/resolve/resolv.conf")
-        .or_else(|_| std::fs::read_to_string("/etc/resolv.conf"))
-    {
-        let search: Vec<&str> = content
-            .lines()
-            .filter_map(|l| l.trim().strip_prefix("search "))
-            .next()
-            .map(|s| s.split_whitespace().collect())
-            .unwrap_or_default();
-        if !search.is_empty() {
-            if !runtime_boot_args.is_empty() {
-                runtime_boot_args.push(' ');
+
+        // Pass search domains for short hostname resolution (only when DNS servers are available)
+        if let Ok(content) = std::fs::read_to_string("/run/systemd/resolve/resolv.conf")
+            .or_else(|_| std::fs::read_to_string("/etc/resolv.conf"))
+        {
+            let search: Vec<&str> = content
+                .lines()
+                .filter_map(|l| l.trim().strip_prefix("search "))
+                .next()
+                .map(|s| s.split_whitespace().collect())
+                .unwrap_or_default();
+            if !search.is_empty() {
+                if !runtime_boot_args.is_empty() {
+                    runtime_boot_args.push(' ');
+                }
+                runtime_boot_args.push_str(&format!("fcvm_dns_search={}", search.join("|")));
             }
-            runtime_boot_args.push_str(&format!("fcvm_dns_search={}", search.join("|")));
         }
     }
 

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -2632,6 +2632,9 @@ async fn run_vm_setup(
                     .or_else(|| std::env::var("http_proxy").ok())
                     .or_else(|| std::env::var("HTTP_PROXY").ok())
                     .and_then(|url| resolve_proxy_url(&url)),
+                "no_proxy": std::env::var("no_proxy")
+                    .or_else(|_| std::env::var("NO_PROXY"))
+                    .ok(),
             },
             "host-time": chrono::Utc::now().timestamp().to_string(),
         }

--- a/tests/test_host_dns.rs
+++ b/tests/test_host_dns.rs
@@ -1,0 +1,84 @@
+//! Test that host DNS servers are passed to the guest for direct resolution.
+//!
+//! On IPv6-only hosts, slirp4netns's built-in DNS proxy (10.0.2.3) can't
+//! forward to IPv6 nameservers. This test verifies that fc-agent writes
+//! the host's real nameservers into /etc/resolv.conf via the fcvm_dns=
+//! boot parameter.
+
+#![cfg(feature = "privileged-tests")]
+
+mod common;
+
+use anyhow::{Context, Result};
+
+/// Verify the guest gets the host's real DNS servers (not slirp's 10.0.2.3)
+/// and can resolve hostnames directly through them.
+#[tokio::test]
+async fn test_guest_has_host_dns_servers() -> Result<()> {
+    println!("\nTest host DNS servers passed to guest");
+    println!("======================================");
+
+    // Read host's DNS servers for comparison
+    let host_resolv = std::fs::read_to_string("/run/systemd/resolve/resolv.conf")
+        .or_else(|_| std::fs::read_to_string("/etc/resolv.conf"))
+        .context("reading host resolv.conf")?;
+
+    let host_nameservers: Vec<&str> = host_resolv
+        .lines()
+        .filter_map(|l| l.trim().strip_prefix("nameserver "))
+        .filter(|s| !s.starts_with("127."))
+        .collect();
+
+    println!("  Host nameservers: {:?}", host_nameservers);
+
+    if host_nameservers.is_empty() {
+        println!("  SKIP: no non-localhost nameservers on host");
+        return Ok(());
+    }
+
+    let (vm_name, _, _, _) = common::unique_names("host-dns");
+
+    let (_, pid) = common::spawn_fcvm(&[
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--no-snapshot",
+        common::TEST_IMAGE,
+    ])
+    .await
+    .context("spawning fcvm")?;
+
+    common::poll_health_by_pid(pid, 300).await?;
+    println!("  VM healthy");
+
+    // Check guest's resolv.conf
+    let guest_resolv = common::exec_in_vm(pid, &["cat", "/etc/resolv.conf"]).await?;
+    println!("  Guest resolv.conf:\n{}", guest_resolv.trim());
+
+    // Verify guest has the host's nameservers (not 10.0.2.3)
+    assert!(
+        !guest_resolv.contains("10.0.2.3"),
+        "Guest should have host DNS servers, not slirp's 10.0.2.3"
+    );
+
+    for ns in &host_nameservers {
+        assert!(
+            guest_resolv.contains(ns),
+            "Guest resolv.conf missing host nameserver: {}",
+            ns
+        );
+    }
+
+    // Verify DNS actually works by resolving a hostname
+    let result = common::exec_in_vm(pid, &["nslookup", "facebook.com"]).await;
+    println!("  nslookup facebook.com: {:?}", result);
+    assert!(
+        result.is_ok(),
+        "DNS resolution should work with host nameservers"
+    );
+
+    common::kill_process(pid).await;
+    println!("✅ HOST DNS TEST PASSED!");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Pass host's real DNS servers to guest instead of relying on slirp4netns's built-in DNS proxy (10.0.2.3), which can't forward to IPv6 nameservers with libslirp < 4.8.0.

## Changes

**Host DNS passthrough** (`src/commands/podman.rs`, `fc-agent/src/main.rs`):
- Pass host nameservers via `fcvm_dns=` kernel boot param (pipe-separated for IPv6 compat)
- Pass search domains via `fcvm_dns_search=` boot param
- fc-agent parses both and writes full `/etc/resolv.conf` with real nameservers + search domains
- Guest resolves hostnames directly through slirp's IPv6 gateway, bypassing slirp's DNS proxy

**Better slirp4netns error reporting** (`src/network/slirp.rs`):
- Capture stderr via `wait_with_output()` when slirp4netns exits before becoming ready
- Previously: "slirp4netns exited before becoming ready" (no reason)
- Now: includes the actual error message

## Why

On IPv6-only hosts, internal hostnames (e.g., harbor.thefacebook.com) that bypass the proxy via `no_proxy` need direct DNS resolution. Slirp's `10.0.2.3` can't forward to IPv6 nameservers, so we pass the host's real DNS servers directly.

## Test plan

```
make test-root FILTER=host_dns  # verifies guest gets host nameservers and can resolve
```

Test output:
```
Guest resolv.conf:
  search 01.cco0.facebook.com cco0.facebook.com facebook.com tfbnw.net
  nameserver 2401:db00:eef0:a53::
  nameserver 2401:db00:eef0:b53::

nslookup facebook.com → 57.144.216.1, 2a03:2880:f36c:1:face:b00c:0:25de
```