### PR TITLE
Fix FUSE mount race: poll for readiness

### DIFF
--- a/fc-agent/src/main.rs
+++ b/fc-agent/src/main.rs
@@ -1704,7 +1704,7 @@ fn mount_fuse_volumes(volumes: &[VolumeMount]) -> Result<Vec<String>> {
                     "[fc-agent] ✓ mount {} ready ({} entries, {}ms)",
                     vol.guest_path,
                     count,
-                    attempt * 500
+                    (attempt - 1) * 500
                 );
                 ready = true;
                 break;
@@ -1712,10 +1712,10 @@ fn mount_fuse_volumes(volumes: &[VolumeMount]) -> Result<Vec<String>> {
             std::thread::sleep(std::time::Duration::from_millis(500));
         }
         if !ready {
-            eprintln!(
-                "[fc-agent] ✗ mount {} NOT accessible after 30s",
+            return Err(anyhow::anyhow!(
+                "mount {} not accessible after 30s",
                 vol.guest_path
-            );
+            ));
         }
     }
 


### PR DESCRIPTION
## Summary

Replace the fixed 500ms sleep for FUSE mount initialization with a proper poll loop. Waits up to 30s for each mount to become accessible via `read_dir` before starting the container. Returns error if mount fails (previously silently continued with broken mounts).

## Problem

The entrypoint symlink was dangling when the container launched because the FUSE mount wasn't ready after only 500ms.

## Test plan

```
make test-root FILTER=localhost
make test-root FILTER=sanity_rootless
```