### PR TITLE
Enable snapshot caching for localhost images

### DIFF
--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -1374,7 +1374,7 @@ async fn cmd_podman_run(args: RunArgs) -> Result<()> {
 
     // Create startup snapshot channel for health-triggered snapshot creation
     // Only create startup snapshots if:
-    // - Not skipping snapshots (no --no-snapshot, no volumes, not localhost image)
+    // - Not skipping snapshots (no --no-snapshot, no volumes)
     // - Have a snapshot key
     // - Have a health_check URL configured (HTTP health check, not just container-ready)
     let (startup_tx, mut startup_rx): (


### PR DESCRIPTION
## Summary

Localhost images were excluded from snapshot caching because the FUSE volume path wouldn't exist on restore. Now that images are attached as raw block devices (#253), the CAS-cached path is stable. This enables instant snapshot restore instead of re-loading all blobs every startup.

Also adds Known Limitations section to DESIGN.md documenting FUSE cache coherency, NV2 constraints, and snapshot + FUSE interaction.

## Impact

First run: full boot + image load (~2-3 min for large images).
Subsequent runs: instant snapshot restore.

## Test plan

```
make test-root FILTER=localhost
```