### PR TITLE
Remove output listener read timeout for large image imports

### DIFF
--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -290,6 +290,7 @@ pub async fn cleanup_vm(
     data_dir: &Path,
     health_cancel_token: Option<tokio_util::sync::CancellationToken>,
     health_monitor_handle: Option<JoinHandle<()>>,
+    output_listener_handle: Option<JoinHandle<Vec<(String, String)>>>,
 ) {
     info!("cleaning up resources");
 
@@ -304,6 +305,11 @@ pub async fn cleanup_vm(
                 debug!("health monitor didn't stop in time, continuing cleanup");
             }
         }
+    }
+
+    // Abort output listener task if still running
+    if let Some(handle) = output_listener_handle {
+        handle.abort();
     }
 
     // Cancel VolumeServer tasks

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -1424,7 +1424,7 @@ async fn cmd_podman_run(args: RunArgs) -> Result<()> {
     };
 
     // For non-TTY mode, use async output listener
-    let _output_handle = if !tty_mode {
+    let output_handle = if !tty_mode {
         let socket_path = output_socket_path.clone();
         let vm_id_clone = vm_id.clone();
         Some(tokio::spawn(async move {
@@ -1636,6 +1636,7 @@ async fn cmd_podman_run(args: RunArgs) -> Result<()> {
         &data_dir,
         Some(health_cancel_token),
         Some(health_monitor_handle),
+        output_handle, // abort output listener task
     )
     .await;
 

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -854,21 +854,17 @@ pub(crate) async fn run_output_listener(
         None
     };
 
-    // Read lines until connection closes
+    // Read lines until connection closes (no read timeout — large image imports
+    // can take 10+ minutes during which fc-agent produces no output)
     loop {
         line_buf.clear();
-        match tokio::time::timeout(
-            std::time::Duration::from_secs(300), // 5 min read timeout
-            reader.read_line(&mut line_buf),
-        )
-        .await
-        {
-            Ok(Ok(0)) => {
+        match reader.read_line(&mut line_buf).await {
+            Ok(0) => {
                 // EOF - connection closed
                 debug!(vm_id = %vm_id, "Output connection closed");
                 break;
             }
-            Ok(Ok(_)) => {
+            Ok(_) => {
                 // Parse raw line format: stream:content
                 let line = line_buf.trim_end();
                 if let Some((stream, content)) = line.split_once(':') {
@@ -886,13 +882,8 @@ pub(crate) async fn run_output_listener(
                     let _ = w.write_all(b"ack\n").await;
                 }
             }
-            Ok(Err(e)) => {
+            Err(e) => {
                 warn!(vm_id = %vm_id, error = %e, "Error reading output");
-                break;
-            }
-            Err(_) => {
-                // Read timeout
-                debug!(vm_id = %vm_id, "Output read timeout");
                 break;
             }
         }

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -604,7 +604,7 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
     };
 
     // For non-TTY mode, use async output listener
-    let _output_handle = if !tty_mode {
+    let output_handle = if !tty_mode {
         let socket_path = output_socket_path.clone();
         let vm_id_clone = vm_id.clone();
         Some(tokio::spawn(async move {
@@ -856,6 +856,7 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
             &data_dir,
             None, // no health monitor in exec path
             None,
+            output_handle, // abort output listener task
         )
         .await;
 
@@ -983,6 +984,7 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
         &data_dir,
         Some(health_cancel_token),
         Some(health_monitor_handle),
+        output_handle, // abort output listener task
     )
     .await;
 


### PR DESCRIPTION
## Summary

The 5-minute read timeout on the container output vsock caused the listener to exit during long image imports (10+ min for 26GB images). Container stdout/stderr was lost.

## Fix

Remove the read timeout. The listener stays alive until EOF (connection closed by fc-agent) or VM exit. 6 lines added, 15 removed.

## Test plan

```
make test-root FILTER=sanity_rootless
make test-root FILTER=localhost
```