### PR TITLE
fix: disable FUSE writeback cache for ctime-sensitive pjdfstest categories

### DIFF
--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -2279,6 +2279,14 @@ async fn run_vm_setup(
         runtime_boot_args.push_str(&format!("fuse_max_write={}", max_write));
     }
 
+    // Pass FUSE writeback cache disable flag to fc-agent via kernel command line.
+    if std::env::var("FCVM_NO_WRITEBACK_CACHE").is_ok() {
+        if !runtime_boot_args.is_empty() {
+            runtime_boot_args.push(' ');
+        }
+        runtime_boot_args.push_str("no_writeback_cache=1");
+    }
+
     // Apply FirecrackerConfig to client (boot_source, machine_config, rootfs drive)
     // This ensures the same config used for cache key is used for launch
     launch_config.apply(client, &runtime_boot_args).await?;


### PR DESCRIPTION
## Summary

- Propagate `FCVM_NO_WRITEBACK_CACHE` env var from host through kernel boot params to fc-agent inside the guest VM
- Disable writeback cache for 4 pjdfstest categories (chmod, ftruncate, link, truncate) whose ctime assertions fail intermittently under parallel load
- Other categories keep writeback cache enabled for write performance

## The Problem

The kernel's FUSE writeback cache (`FUSE_WRITEBACK_CACHE`) suppresses server-side ctime updates through `fuse_get_cache_mask()` returning `STATX_CTIME`. Even though the fuse-pipe server correctly updates ctime on the host filesystem, the kernel discards the server's response and uses a stale local value. This causes POSIX ctime assertions to fail intermittently when the 1-second attribute cache TTL aligns with test timing.

Failures appeared on 2026-02-06 when additional parallel test VMs increased load past a threshold on ARM64 CI.

## Changes

- `src/commands/podman.rs`: Pass `no_writeback_cache=1` boot param when `FCVM_NO_WRITEBACK_CACHE` is set
- `fc-agent/src/fuse/mod.rs`: Read `no_writeback_cache=1` from `/proc/cmdline` and set env var for fuse-pipe
- `tests/test_fuse_in_vm_matrix.rs`: Set `FCVM_NO_WRITEBACK_CACHE=1` for chmod, ftruncate, link, truncate categories

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `make test-root FILTER=pjdfstest_vm_truncate` — 84/84 tests pass (including previously failing test 15)
- [ ] CI: all pjdfstest VM categories pass