### PR TITLE
Remove data dirs from ensure_storage(), create lazily instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,16 +327,18 @@ setup-btrfs:
 		fi && \
 		sudo mkdir -p /mnt/fcvm-btrfs && \
 		sudo mount -o loop /var/fcvm-btrfs.img /mnt/fcvm-btrfs && \
-		sudo mkdir -p /mnt/fcvm-btrfs/{kernels,rootfs,initrd,state,snapshots,vm-disks,cache,image-cache} && \
+		sudo mkdir -p /mnt/fcvm-btrfs/{kernels,rootfs,initrd,cache,image-cache} && \
 		sudo chown -R $$(id -un):$$(id -gn) /mnt/fcvm-btrfs && \
 		echo '==> btrfs ready at /mnt/fcvm-btrfs'; \
 	fi
 	@# Ensure image-cache exists with correct permissions (may be missing on older setups)
 	@sudo mkdir -p /mnt/fcvm-btrfs/image-cache && sudo chown $$(id -un):$$(id -gn) /mnt/fcvm-btrfs/image-cache
-	@# Create per-mode data directories
-	@# ROOT_DATA_DIR: owned by root (tests run with sudo)
-	@# CONTAINER_DATA_DIR: owned by user (podman rootless maps to subordinate UIDs)
+	@# Create per-mode data directories (state, snapshots, vm-disks)
+	@# Default: owned by current user (test-fast runs as ubuntu)
+	@mkdir -p /mnt/fcvm-btrfs/{state,snapshots,vm-disks}
+	@# ROOT_DATA_DIR: owned by root (test-root runs with sudo)
 	@sudo mkdir -p $(ROOT_DATA_DIR)/{state,snapshots,vm-disks}
+	@# CONTAINER_DATA_DIR: owned by current user (podman rootless maps to subordinate UIDs)
 	@sudo mkdir -p $(CONTAINER_DATA_DIR)/{state,snapshots,vm-disks}
 	@sudo chown -R $$(id -un):$$(id -gn) $(CONTAINER_DATA_DIR)
 

--- a/src/setup/storage.rs
+++ b/src/setup/storage.rs
@@ -5,17 +5,10 @@ use tracing::info;
 
 use crate::setup::rootfs::load_config;
 
-/// Required subdirectories under the btrfs mount
-const REQUIRED_DIRS: &[&str] = &[
-    "kernels",
-    "rootfs",
-    "initrd",
-    "state",
-    "snapshots",
-    "vm-disks",
-    "cache",
-    "image-cache",
-];
+/// Required asset subdirectories under the btrfs mount.
+/// Data dirs (state, snapshots, vm-disks) are created lazily by the code
+/// that uses them, allowing FCVM_DATA_DIR to point elsewhere.
+const REQUIRED_DIRS: &[&str] = &["kernels", "rootfs", "initrd", "cache", "image-cache"];
 
 /// Unmount a path, ignoring errors
 fn cleanup_mount(path: &Path) {


### PR DESCRIPTION
## Summary

- Remove `state`, `snapshots`, `vm-disks` from `REQUIRED_DIRS` in `ensure_storage()` — these are data dirs, not asset dirs
- They were being created as root by `sudo fcvm setup`, which caused the loopback-ip.lock permission error on shared CI runners (root-owned state dir + non-root test)
- Data dirs are already created lazily by `StateManager::init()`, `cmd_podman()`, and `cmd_snapshot()`
- Update Makefile `setup-btrfs` to create default data dirs as current user (not via sudo)

**Root cause of `feca7cd`**: Before commit `1a6662e` split data dirs, root and non-root tests shared `/mnt/fcvm-btrfs/state/`. After the split, `sudo fcvm setup` still created data dirs under assets_dir via `ensure_storage()`, and `clean-test-data` only cleaned `*.json` not `*.lock`. The stale root-owned lock file caused permission denied for non-root tests.

## Test plan

- [x] Deleted `/mnt/fcvm-btrfs/root/{state,snapshots,vm-disks}`, ran `make test-root FILTER=sanity` — all 3 passed, dirs recreated lazily
- [x] Reverted lock file mode to 0o600 on main (`f973b66`)