### PR TITLE
Enable Firecracker seccomp by default

### DIFF
--- a/src/firecracker/vm.rs
+++ b/src/firecracker/vm.rs
@@ -193,8 +193,12 @@ impl VmManager {
             cmd.arg("--show-log-origin");
         }
 
-        // Disable seccomp for now (can enable later for production)
-        cmd.arg("--no-seccomp");
+        // Seccomp is enabled by default (Firecracker's security boundary).
+        // Set FCVM_NO_SECCOMP=1 to disable for debugging.
+        if std::env::var("FCVM_NO_SECCOMP").is_ok() {
+            warn!("Seccomp disabled via FCVM_NO_SECCOMP - reduced security");
+            cmd.arg("--no-seccomp");
+        }
 
         // Additional firecracker args from environment (caller controls)
         if let Ok(extra) = std::env::var("FCVM_FIRECRACKER_ARGS") {


### PR DESCRIPTION
**Stacked on:** review-wave3 (PR pending)

## Summary
- Remove hardcoded `--no-seccomp` flag from Firecracker launch
- Seccomp now enabled by default (Firecracker's security boundary)
- `FCVM_NO_SECCOMP=1` env var available as escape hatch for debugging

## Test plan
```
cargo check -p fcvm  # compiles clean
```

CI will validate whether seccomp causes any issues with standard and nested VM paths.
If NV2 fork's seccomp filter doesn't cover its custom syscalls, CI will fail loudly (SIGSYS).