### PR TITLE
Add timeouts and fix UDP DNAT for clone networking

### DIFF
--- a/src/network/veth.rs
+++ b/src/network/veth.rs
@@ -616,36 +616,39 @@ pub async fn setup_in_namespace_nat(
         anyhow::bail!("failed to add MASQUERADE rule in namespace: {}", stderr);
     }
 
-    // Step 8: Add DNAT rule for incoming traffic to reach the guest
+    // Step 8: Add DNAT rules for incoming traffic to reach the guest
     // This allows health checks from host to reach the guest via the veth IP
     // Host connects to veth_ip:80 → DNAT to guest_ip:80
+    // We add rules for both TCP and UDP so port forwarding works for all protocols
     let veth_ip = config
         .veth_ip_cidr
         .split('/')
         .next()
         .unwrap_or(&config.veth_ip_cidr);
-    let output = exec_in_namespace(
-        ns_name,
-        &[
-            "iptables",
-            "-t",
-            "nat",
-            "-A",
-            "PREROUTING",
-            "-d",
-            veth_ip,
-            "-p",
-            "tcp",
-            "-j",
-            "DNAT",
-            "--to-destination",
-            &config.guest_ip,
-        ],
-    )
-    .await?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("failed to add DNAT rule in namespace: {}", stderr);
+    for proto in ["tcp", "udp"] {
+        let output = exec_in_namespace(
+            ns_name,
+            &[
+                "iptables",
+                "-t",
+                "nat",
+                "-A",
+                "PREROUTING",
+                "-d",
+                veth_ip,
+                "-p",
+                proto,
+                "-j",
+                "DNAT",
+                "--to-destination",
+                &config.guest_ip,
+            ],
+        )
+        .await?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("failed to add {} DNAT rule in namespace: {}", proto, stderr);
+        }
     }
 
     info!(

--- a/tests/test_extra_disks.rs
+++ b/tests/test_extra_disks.rs
@@ -57,7 +57,13 @@ async fn create_test_disk(path: &Path) -> Result<()> {
         .await?;
 
     // Mount temporarily, write test file, unmount
-    let mount_dir = format!("/tmp/fcvm-disk-{}", std::process::id());
+    // Use path-derived name to avoid collisions when tests run in parallel
+    let mount_dir = format!("/tmp/fcvm-disk-{:x}", {
+        use std::hash::{Hash, Hasher};
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        path.hash(&mut h);
+        h.finish()
+    });
     tokio::fs::create_dir_all(&mount_dir).await?;
     tokio::process::Command::new("mount")
         .args([path.to_str().unwrap(), &mount_dir])


### PR DESCRIPTION
**Stacked on:** review-blocking-io (PR #286)

## Summary
- **API timeout (#43):** Add 30s timeout to Firecracker API put/patch requests via `tokio::time::timeout`, preventing indefinite hangs when Firecracker is stuck.
- **UDP DNAT (#37):** Add UDP DNAT rule alongside TCP for clone port forwarding. Previously only TCP was forwarded, so UDP services (DNS, etc.) were unreachable on clones.
- **Test mount dir collision (T4):** Use path-derived hash for temp mount directory in `test_extra_disks.rs` instead of PID, preventing collisions when tests run in parallel.

## Test plan
```
cargo check --workspace
cargo clippy --workspace
cargo fmt -p fcvm -p fuse-pipe -p fc-agent -- --check
cargo test --lib -p fcvm  # 49/49 pass
```