### PR TITLE
Fix 8 review findings (status framing, snapshot serve, DNS/proxy, fuse-pipe fail-fast)

### DIFF
--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -415,21 +415,6 @@ async fn cmd_snapshot_serve(args: SnapshotServeArgs) -> Result<()> {
         info!("deleted serve state");
     }
 
-    // Delete snapshot directory (memory.bin, disk.raw, vmstate.bin, config.json)
-    let snapshot_dir = paths::snapshot_dir().join(&args.snapshot_name);
-    if snapshot_dir.exists() {
-        println!("Cleaning up snapshot directory...");
-        if let Err(e) = std::fs::remove_dir_all(&snapshot_dir) {
-            warn!(
-                "failed to remove snapshot directory {}: {}",
-                snapshot_dir.display(),
-                e
-            );
-        } else {
-            info!("removed snapshot directory: {}", snapshot_dir.display());
-        }
-    }
-
     println!("Memory server stopped");
 
     Ok(())


### PR DESCRIPTION
**Stacked on:** review-wave4 (PR #288)

Fixes all 8 findings from `/home/ubuntu/CODEX-REVIEW.md` with root-cause changes and regression tests.

## What changed
- Fixed rootless retry state propagation so `holder_pid` and nsenter wiring use the live retry holder after recovery.
- Reworked status listener to line-oriented framing so coalesced/partial messages are handled correctly (`cache-ready`, `ready`, `exit`).
- Stopped `snapshot serve` from deleting snapshot artifacts on shutdown.
- Fixed FORWARD iptables cleanup conversion (`-A` to `-D`) for rules at string start and mid-string.
- Hardened DNS parsing (`split_whitespace`) and filtered loopback resolvers including `::1`.
- Fixed proxy URL resolution for no-port URLs by using scheme default ports and preserving auth/path/query/fragment.
- Removed TOCTOU port race in test helpers by binding to port `0` and then reading `local_addr().port()`.
- Made fuse-pipe deserialize corruption fail fast:
  - server reader returns error on bad request frames
  - client reader fails all pending requests and exits on bad response frames

## Regression tests added
- `commands::podman::tests::test_rebuild_proxy_url_preserves_auth_and_query`
- `commands::podman::tests::test_resolve_proxy_url_applies_default_port`
- `commands::podman::tests::test_status_listener_handles_multiple_messages_on_single_connection`
- `network::portmap::tests::test_delete_rule_conversion`
- `network::tests::test_nameserver_parsing_and_loopback_filtering`
- `client::multiplexer::tests::test_deserialize_failure_fails_pending_request`
- `server::pipelined::tests::test_request_reader_exits_on_deserialize_failure`

## Test evidence
```bash
$ make test-unit
Summary [ 100.881s] 144 tests run: 144 passed, 0 skipped

$ make test-root FILTER=sanity STREAM=1
Summary [  23.900s] 3 tests run: 3 passed, 318 skipped
```
