### PR TITLE
Refactor cmd_podman_run into composable library API

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -145,6 +145,10 @@ pub struct RunArgs {
     #[arg(long, action = clap::ArgAction::Append, value_delimiter=',')]
     pub env: Vec<String>,
 
+    /// Labels KEY=VALUE for tagging VMs (repeat or comma-separated)
+    #[arg(long, action = clap::ArgAction::Append, value_delimiter=',')]
+    pub label: Vec<String>,
+
     /// Command to run inside container
     ///
     /// Example: --cmd "nginx -g 'daemon off;'"

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -381,6 +381,9 @@ pub struct ExecOutput {
 ///
 /// Unlike `run_exec_in_vm` which prints to stdout/stderr directly,
 /// this returns the output as strings for programmatic use.
+///
+/// The blocking vsock I/O is offloaded to a blocking thread pool so this
+/// function is safe to call from async contexts without starving the runtime.
 pub async fn run_exec_in_vm_captured(
     vsock_socket: &Path,
     command: &[String],
@@ -393,60 +396,74 @@ pub async fn run_exec_in_vm_captured(
         "executing command in VM (captured)"
     );
 
-    let mut stream = connect_to_exec_server_with_retry(vsock_socket)?;
+    let vsock_socket = vsock_socket.to_path_buf();
+    let command = command.to_vec();
 
-    stream.set_read_timeout(Some(Duration::from_secs(300)))?;
-    stream.set_write_timeout(Some(Duration::from_secs(10)))?;
+    tokio::task::spawn_blocking(move || {
+        let mut stream = connect_to_exec_server_with_retry(&vsock_socket)?;
 
-    let request = ExecRequest {
-        command: command.to_vec(),
-        in_container,
-        interactive: false,
-        tty: false,
-    };
+        stream.set_read_timeout(Some(Duration::from_secs(300)))?;
+        stream.set_write_timeout(Some(Duration::from_secs(10)))?;
 
-    let request_json = serde_json::to_string(&request)?;
-    writeln!(stream, "{}", request_json)?;
-    stream.flush()?;
+        let request = ExecRequest {
+            command,
+            in_container,
+            interactive: false,
+            tty: false,
+        };
 
-    // Read lines and capture into strings instead of printing
-    let reader = BufReader::new(stream);
-    let mut stdout = String::new();
-    let mut stderr = String::new();
-    let mut exit_code = 0i32;
+        let request_json = serde_json::to_string(&request)?;
+        writeln!(stream, "{}", request_json)?;
+        stream.flush()?;
 
-    for line in reader.lines() {
-        let line = line.context("reading from exec socket")?;
+        // Read lines and capture into strings instead of printing
+        let reader = BufReader::new(stream);
+        let mut stdout = String::new();
+        let mut stderr = String::new();
+        let mut exit_code = 0i32;
 
-        if let Ok(response) = serde_json::from_str::<ExecResponse>(&line) {
-            match response {
-                ExecResponse::Stdout(data) => stdout.push_str(&data),
-                ExecResponse::Stderr(data) => stderr.push_str(&data),
-                ExecResponse::Exit(code) => {
-                    exit_code = code;
-                    break;
-                }
-                ExecResponse::Error(msg) => {
-                    stderr.push_str(&format!("Error: {}\n", msg));
-                    exit_code = 1;
-                    break;
+        for line in reader.lines() {
+            let line = line.context("reading from exec socket")?;
+
+            if let Ok(response) = serde_json::from_str::<ExecResponse>(&line) {
+                match response {
+                    ExecResponse::Stdout(data) => stdout.push_str(&data),
+                    ExecResponse::Stderr(data) => stderr.push_str(&data),
+                    ExecResponse::Exit(code) => {
+                        exit_code = code;
+                        break;
+                    }
+                    ExecResponse::Error(msg) => {
+                        stderr.push_str(&format!("Error: {}\n", msg));
+                        exit_code = 1;
+                        break;
+                    }
                 }
             }
         }
-    }
 
-    Ok(ExecOutput {
-        stdout,
-        stderr,
-        exit_code,
+        Ok(ExecOutput {
+            stdout,
+            stderr,
+            exit_code,
+        })
     })
+    .await
+    .context("exec task panicked")?
 }
 
 /// Connect to the exec server and return a tokio async UnixStream.
 ///
 /// Useful for building WebSocket↔vsock bridges (terminal sessions).
+///
+/// The blocking connection/retry logic is offloaded to a blocking thread pool
+/// so this function is safe to call from async contexts.
 pub async fn connect_to_exec_server_async(vsock_socket: &Path) -> Result<tokio::net::UnixStream> {
-    let std_stream = connect_to_exec_server_with_retry(vsock_socket)?;
+    let vsock_socket = vsock_socket.to_path_buf();
+    let std_stream =
+        tokio::task::spawn_blocking(move || connect_to_exec_server_with_retry(&vsock_socket))
+            .await
+            .context("connect task panicked")??;
     std_stream.set_nonblocking(true)?;
     tokio::net::UnixStream::from_std(std_stream).context("converting to tokio UnixStream")
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub use completions::cmd_completions;
 pub use exec::cmd_exec;
 pub use ls::cmd_ls;
 pub use podman::cmd_podman;
+pub use podman::{cleanup_vm_context, prepare_vm, run_vm_loop, VmContext};
 pub use setup::cmd_setup;
 pub use snapshot::cmd_snapshot;
 pub use snapshots::cmd_snapshots;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -13,7 +13,7 @@ pub use completions::cmd_completions;
 pub use exec::cmd_exec;
 pub use ls::cmd_ls;
 pub use podman::cmd_podman;
-pub use podman::{cleanup_vm_context, prepare_vm, run_vm_loop, VmContext};
+pub use podman::{cleanup_vm_context, prepare_vm, run_vm_loop, start_vm, VmContext, VmHandle};
 pub use setup::cmd_setup;
 pub use snapshot::cmd_snapshot;
 pub use snapshots::cmd_snapshots;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -13,7 +13,9 @@ pub use completions::cmd_completions;
 pub use exec::cmd_exec;
 pub use ls::cmd_ls;
 pub use podman::cmd_podman;
-pub use podman::{cleanup_vm_context, prepare_vm, run_vm_loop, start_vm, VmContext, VmHandle};
+pub use podman::{
+    cleanup_vm_context, prepare_vm, run_vm_loop, start_vm, LogLine, VmContext, VmHandle,
+};
 pub use setup::cmd_setup;
 pub use snapshot::cmd_snapshot;
 pub use snapshots::cmd_snapshots;

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -1745,545 +1745,16 @@ async fn cmd_podman_run(args: RunArgs) -> Result<()> {
     Ok(())
 }
 
-/// Helper function that runs VM setup and returns VmManager on success.
-/// This allows the caller to cleanup network resources on error.
-/// For rootless mode, also returns the holder process that keeps the namespace alive.
-#[allow(clippy::too_many_arguments)]
-async fn run_vm_setup(
+/// Build runtime boot arguments for the kernel command line.
+///
+/// These are per-instance values NOT included in the snapshot cache key:
+/// network IP config, IPv6, DNS, strace, profile boot args, FUSE tuning.
+fn build_runtime_boot_args(
     args: &RunArgs,
-    vm_id: &str,
-    data_dir: &std::path::Path,
-    base_rootfs: &std::path::Path,
-    socket_path: &std::path::Path,
-    kernel_path: &std::path::Path,
-    initrd_path: &std::path::Path,
     network_config: &crate::network::NetworkConfig,
-    network: &mut dyn NetworkManager,
-    cmd_args: Option<Vec<String>>,
-    state_manager: &StateManager,
-    vm_state: &mut VmState,
-    volume_mappings: &[VolumeMapping],
-    vsock_socket_path: &std::path::Path,
-    image_disk_path: Option<&std::path::Path>,
-    fc_config: Option<crate::firecracker::FirecrackerConfig>,
     runtime_config: &super::common::RuntimeConfig,
-) -> Result<(VmManager, Option<tokio::process::Child>)> {
-    // Setup storage - just need CoW copy (fc-agent is injected via initrd at boot)
-    let vm_dir = data_dir.join("disks");
-    let disk_manager =
-        DiskManager::new(vm_id.to_string(), base_rootfs.to_path_buf(), vm_dir.clone());
-
-    let rootfs_path = disk_manager
-        .create_cow_disk()
-        .await
-        .context("creating CoW disk")?;
-
-    // Estimate space needed for container image extraction inside VM.
-    // The archive is loaded via podman load which extracts layers onto the rootfs.
-    let image_overhead = if let Some(disk_path) = image_disk_path {
-        match tokio::fs::metadata(disk_path).await {
-            Ok(meta) => meta.len(),
-            Err(_) => 0,
-        }
-    } else {
-        0
-    };
-
-    // Ensure minimum free space (from --rootfs-size) plus room for the container image
-    crate::storage::disk::ensure_free_space(&rootfs_path, &args.rootfs_size, image_overhead)
-        .await
-        .context("ensuring rootfs free space")?;
-
-    info!(rootfs = %rootfs_path.display(), "disk prepared (fc-agent baked into Layer 2)");
-
-    let vm_name = args.name.clone();
-    info!(vm_name = %vm_name, vm_id = %vm_id, "creating VM manager");
-    let mut vm_manager = VmManager::new(vm_id.to_string(), socket_path.to_path_buf(), None);
-
-    // Set VM name for logging
-    vm_manager.set_vm_name(vm_name);
-
-    // Configure namespace isolation based on network type
-    let holder_child: Option<tokio::process::Child>;
-
-    if let Some(bridged_net) = network.as_any().downcast_ref::<BridgedNetwork>() {
-        // Bridged mode: use pre-created network namespace
-        holder_child = None;
-        if let Some(ns_id) = bridged_net.namespace_id() {
-            info!(namespace = %ns_id, "configuring VM to run in network namespace");
-            vm_manager.set_namespace(ns_id.to_string());
-        }
-    } else if let Some(slirp_net) = network.as_any().downcast_ref::<SlirpNetwork>() {
-        // Rootless mode: spawn holder process and set up namespace via nsenter
-        // This is fully rootless - no sudo required!
-
-        // Step 1: Spawn holder process (keeps namespace alive)
-        // Retry for up to 5 seconds if holder dies (transient failures under load)
-        let holder_cmd = slirp_net.build_holder_command();
-        info!(cmd = ?holder_cmd, "spawning namespace holder for rootless networking");
-
-        let retry_deadline = std::time::Instant::now() + super::common::HOLDER_RETRY_TIMEOUT;
-        let mut attempt = 0;
-
-        let (mut child, mut holder_pid, mut holder_stderr) = loop {
-            attempt += 1;
-
-            // Spawn holder with piped stderr to capture errors if it fails
-            let mut child = tokio::process::Command::new(&holder_cmd[0])
-                .args(&holder_cmd[1..])
-                .stdin(std::process::Stdio::null())
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::piped())
-                .spawn()
-                .with_context(|| format!("failed to spawn holder: {:?}", holder_cmd))?;
-
-            let holder_pid = child.id().context("getting holder process PID")?;
-            if attempt > 1 {
-                info!(
-                    holder_pid = holder_pid,
-                    attempt = attempt,
-                    "namespace holder started (retry)"
-                );
-            } else {
-                info!(holder_pid = holder_pid, "namespace holder started");
-            }
-
-            // Wait for namespace to be ready by checking uid_map
-            let namespace_ready = crate::utils::wait_for_namespace_ready(
-                holder_pid,
-                super::common::NAMESPACE_READY_TIMEOUT,
-            )
-            .await;
-
-            // If namespace didn't become ready, kill holder and retry
-            if !namespace_ready {
-                let _ = child.kill().await;
-
-                if std::time::Instant::now() < retry_deadline {
-                    warn!(
-                        holder_pid = holder_pid,
-                        attempt = attempt,
-                        "namespace not ready, retrying holder creation..."
-                    );
-                    tokio::time::sleep(super::common::HOLDER_RETRY_INTERVAL).await;
-                    continue;
-                } else {
-                    bail!(
-                        "namespace not ready after {} attempts (holder PID {})",
-                        attempt,
-                        holder_pid
-                    );
-                }
-            }
-
-            // Take stderr pipe - we'll use it for diagnostics if holder dies later
-            let mut holder_stderr = child.stderr.take();
-
-            match child.try_wait() {
-                Ok(Some(status)) => {
-                    // Holder exited - capture stderr to see why
-                    let stderr = if let Some(ref mut pipe) = holder_stderr {
-                        use tokio::io::AsyncReadExt;
-                        let mut buf = String::new();
-                        let _ = pipe.read_to_string(&mut buf).await;
-                        buf
-                    } else {
-                        String::new()
-                    };
-
-                    if std::time::Instant::now() < retry_deadline {
-                        warn!(
-                            holder_pid = holder_pid,
-                            attempt = attempt,
-                            status = %status,
-                            stderr = %stderr.trim(),
-                            "holder died, retrying..."
-                        );
-                        tokio::time::sleep(super::common::HOLDER_RETRY_INTERVAL).await;
-                        continue;
-                    } else {
-                        bail!(
-                            "holder process exited immediately after {} attempts: status={}, stderr={}, cmd={:?}",
-                            attempt,
-                            status,
-                            stderr.trim(),
-                            holder_cmd
-                        );
-                    }
-                }
-                Ok(None) => {
-                    debug!(holder_pid = holder_pid, "holder running");
-                }
-                Err(e) => {
-                    warn!(holder_pid = holder_pid, error = ?e, "failed to check holder status");
-                }
-            }
-
-            // Check if holder is still alive before proceeding
-            if !crate::utils::is_process_alive(holder_pid) {
-                // Try to capture stderr from the dead holder process
-                let holder_stderr_content = if let Some(ref mut pipe) = holder_stderr {
-                    use tokio::io::AsyncReadExt;
-                    let mut buf = String::new();
-                    match tokio::time::timeout(
-                        std::time::Duration::from_millis(100),
-                        pipe.read_to_string(&mut buf),
-                    )
-                    .await
-                    {
-                        Ok(Ok(_)) => buf,
-                        _ => String::new(),
-                    }
-                } else {
-                    String::new()
-                };
-
-                let _ = child.kill().await;
-
-                if std::time::Instant::now() < retry_deadline {
-                    warn!(
-                        holder_pid = holder_pid,
-                        attempt = attempt,
-                        holder_stderr = %holder_stderr_content.trim(),
-                        "holder died after initial check, retrying..."
-                    );
-                    tokio::time::sleep(super::common::HOLDER_RETRY_INTERVAL).await;
-                    continue;
-                } else {
-                    let max_user_ns = std::fs::read_to_string("/proc/sys/user/max_user_namespaces")
-                        .unwrap_or_else(|_| "unknown".to_string());
-                    bail!(
-                        "holder process (PID {}) died after {} attempts. \
-                         stderr='{}', max_user_namespaces={}. \
-                         This may indicate resource exhaustion or namespace limit reached.",
-                        holder_pid,
-                        attempt,
-                        holder_stderr_content.trim(),
-                        max_user_ns.trim()
-                    );
-                }
-            }
-
-            // Holder is alive - break out of retry loop
-            break (child, holder_pid, holder_stderr);
-        };
-
-        // Step 2: Run setup script via nsenter (creates TAPs, iptables, etc.)
-        // This is also inside retry logic - if holder dies during nsenter, retry everything
-        let setup_script = slirp_net.build_setup_script();
-        let mut nsenter_prefix = slirp_net.build_nsenter_prefix(holder_pid);
-
-        // Debug: Check if holder is still alive and namespace files exist
-        let proc_dir = format!("/proc/{}", holder_pid);
-        let ns_user = format!("/proc/{}/ns/user", holder_pid);
-        let ns_net = format!("/proc/{}/ns/net", holder_pid);
-        debug!(
-            holder_pid = holder_pid,
-            proc_exists = std::path::Path::new(&proc_dir).exists(),
-            ns_user_exists = std::path::Path::new(&ns_user).exists(),
-            ns_net_exists = std::path::Path::new(&ns_net).exists(),
-            "checking holder process before nsenter"
-        );
-
-        // Check for required devices before attempting network setup
-        let tun_exists = std::path::Path::new("/dev/net/tun").exists();
-        debug!(
-            holder_pid = holder_pid,
-            tun_exists = tun_exists,
-            "checking /dev/net/tun availability"
-        );
-        if !tun_exists {
-            warn!("/dev/net/tun not available - TAP device creation will fail");
-        }
-
-        info!(holder_pid = holder_pid, "running network setup via nsenter");
-
-        // Log the setup script for debugging
-        debug!(
-            holder_pid = holder_pid,
-            script = %setup_script.lines().filter(|l| !l.trim().is_empty() && !l.trim().starts_with('#')).collect::<Vec<_>>().join("; "),
-            "network setup script"
-        );
-
-        let setup_output = tokio::process::Command::new(&nsenter_prefix[0])
-            .args(&nsenter_prefix[1..])
-            .arg("bash")
-            .arg("-c")
-            .arg(&setup_script)
-            .output()
-            .await
-            .context("running network setup via nsenter")?;
-
-        if !setup_output.status.success() {
-            let stderr = String::from_utf8_lossy(&setup_output.stderr);
-            let stdout = String::from_utf8_lossy(&setup_output.stdout);
-
-            // Re-check state for diagnostics
-            let holder_alive = std::path::Path::new(&proc_dir).exists();
-            let ns_user_exists = std::path::Path::new(&ns_user).exists();
-            let ns_net_exists = std::path::Path::new(&ns_net).exists();
-
-            // If holder died during nsenter, this is a retryable error
-            if !holder_alive && std::time::Instant::now() < retry_deadline {
-                // Holder died during nsenter - retry the whole thing
-                let holder_stderr_content = if let Some(ref mut pipe) = holder_stderr {
-                    use tokio::io::AsyncReadExt;
-                    let mut buf = String::new();
-                    match tokio::time::timeout(
-                        std::time::Duration::from_millis(100),
-                        pipe.read_to_string(&mut buf),
-                    )
-                    .await
-                    {
-                        Ok(Ok(_)) => buf,
-                        _ => String::new(),
-                    }
-                } else {
-                    String::new()
-                };
-
-                let _ = child.kill().await;
-
-                warn!(
-                    holder_pid = holder_pid,
-                    attempt = attempt,
-                    holder_stderr = %holder_stderr_content.trim(),
-                    nsenter_stderr = %stderr.trim(),
-                    "holder died during nsenter, retrying..."
-                );
-
-                // Jump back to the retry loop by recursing into this block
-                // We need to restructure - for now just retry once more inline
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-
-                // Retry: spawn new holder
-                attempt += 1;
-                let mut retry_child = tokio::process::Command::new(&holder_cmd[0])
-                    .args(&holder_cmd[1..])
-                    .stdin(std::process::Stdio::null())
-                    .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::piped())
-                    .spawn()
-                    .with_context(|| {
-                        format!("failed to spawn holder on retry: {:?}", holder_cmd)
-                    })?;
-
-                let retry_holder_pid = retry_child.id().context("getting retry holder PID")?;
-                info!(
-                    holder_pid = retry_holder_pid,
-                    attempt = attempt,
-                    "namespace holder started (retry after nsenter failure)"
-                );
-
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-
-                if !crate::utils::is_process_alive(retry_holder_pid) {
-                    let _ = retry_child.kill().await;
-                    bail!(
-                        "holder died on retry after nsenter failure (attempt {})",
-                        attempt
-                    );
-                }
-
-                // Retry nsenter with new holder
-                let retry_nsenter_prefix = slirp_net.build_nsenter_prefix(retry_holder_pid);
-                let retry_output = tokio::process::Command::new(&retry_nsenter_prefix[0])
-                    .args(&retry_nsenter_prefix[1..])
-                    .arg("bash")
-                    .arg("-c")
-                    .arg(&setup_script)
-                    .output()
-                    .await
-                    .context("running network setup via nsenter (retry)")?;
-
-                if !retry_output.status.success() {
-                    let retry_stderr = String::from_utf8_lossy(&retry_output.stderr);
-                    let _ = retry_child.kill().await;
-                    bail!(
-                        "network setup failed on retry: {} (attempt {})",
-                        retry_stderr.trim(),
-                        attempt
-                    );
-                }
-
-                // Success on retry - update variables for rest of function
-                child = retry_child;
-                holder_pid = retry_holder_pid;
-                nsenter_prefix = slirp_net.build_nsenter_prefix(holder_pid);
-                info!(
-                    holder_pid = holder_pid,
-                    attempts = attempt,
-                    "network setup succeeded after retry"
-                );
-            } else {
-                // If holder died, try to capture its stderr for more context
-                let holder_stderr_content = if !holder_alive {
-                    if let Some(ref mut pipe) = holder_stderr {
-                        use tokio::io::AsyncReadExt;
-                        let mut buf = String::new();
-                        match tokio::time::timeout(
-                            std::time::Duration::from_millis(100),
-                            pipe.read_to_string(&mut buf),
-                        )
-                        .await
-                        {
-                            Ok(Ok(_)) => buf,
-                            _ => String::new(),
-                        }
-                    } else {
-                        String::new()
-                    }
-                } else {
-                    String::new()
-                };
-
-                // Kill holder before bailing
-                let _ = child.kill().await;
-
-                // Log comprehensive error info at ERROR level (always visible)
-                warn!(
-                    holder_pid = holder_pid,
-                    holder_alive = holder_alive,
-                    holder_stderr = %holder_stderr_content.trim(),
-                    tun_exists = tun_exists,
-                    ns_user_exists = ns_user_exists,
-                    ns_net_exists = ns_net_exists,
-                    nsenter_stderr = %stderr.trim(),
-                    nsenter_stdout = %stdout.trim(),
-                    "network setup failed - diagnostics"
-                );
-
-                if !holder_alive {
-                    bail!(
-                        "network setup failed: holder died during nsenter after {} attempts. \
-                         nsenter_stderr='{}', holder_stderr='{}', \
-                         (tun={}, ns_user={}, ns_net={})",
-                        attempt,
-                        stderr.trim(),
-                        holder_stderr_content.trim(),
-                        tun_exists,
-                        ns_user_exists,
-                        ns_net_exists
-                    );
-                } else {
-                    bail!(
-                        "network setup failed: {} (tun={}, holder_alive={}, ns_user={}, ns_net={})",
-                        stderr.trim(),
-                        tun_exists,
-                        holder_alive,
-                        ns_user_exists,
-                        ns_net_exists
-                    );
-                }
-            }
-        }
-
-        if attempt > 1 {
-            info!(
-                holder_pid = holder_pid,
-                attempts = attempt,
-                "namespace setup succeeded after retries"
-            );
-        }
-
-        info!(holder_pid = holder_pid, "network setup complete");
-
-        // Verify TAP device was created successfully
-        let tap_device = &network_config.tap_device;
-        let verify_output = tokio::process::Command::new(&nsenter_prefix[0])
-            .args(&nsenter_prefix[1..])
-            .arg("ip")
-            .arg("link")
-            .arg("show")
-            .arg(tap_device)
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .await
-            .context("verifying TAP device")?;
-
-        if !verify_output.success() {
-            let _ = child.kill().await;
-            bail!(
-                "TAP device '{}' not found after network setup - setup may have failed silently",
-                tap_device
-            );
-        }
-        debug!(tap_device = %tap_device, "TAP device verified");
-
-        // Step 3: Set holder_pid so VmManager uses nsenter
-        vm_manager.set_holder_pid(holder_pid);
-
-        // Store holder_pid in state for health checks and cleanup
-        vm_state.holder_pid = Some(holder_pid);
-
-        holder_child = Some(child);
-    } else {
-        holder_child = None;
-    }
-
-    let firecracker_bin = super::common::find_firecracker(runtime_config)?;
-
-    vm_manager
-        .start(
-            &firecracker_bin,
-            None,
-            runtime_config.firecracker_args.as_deref(),
-        )
-        .await
-        .context("starting Firecracker")?;
-
-    let vm_pid = vm_manager.pid()?;
-    let client = vm_manager.client()?;
-
-    // Configure VM via API
-    info!("configuring VM via Firecracker API");
-
-    // Build FirecrackerConfig for launch (single source of truth for VM config)
-    // Use fc_config from cache check if available, otherwise build fresh.
-    // IMPORTANT: fc_config uses content-addressed base_rootfs path for cache key,
-    // but launch must use per-instance CoW copy path (rootfs_path).
-    let launch_config = fc_config
-        .map(|config| config.with_rootfs_path(rootfs_path.to_path_buf()))
-        .unwrap_or_else(|| {
-            use crate::firecracker::FcNetworkMode;
-            let network_mode = match args.network {
-                crate::cli::args::NetworkMode::Bridged => FcNetworkMode::Bridged,
-                crate::cli::args::NetworkMode::Rootless => FcNetworkMode::Rootless,
-            };
-            // Collect extra disk specifications
-            let mut extra_disks: Vec<String> = Vec::new();
-            extra_disks.extend(args.disk.iter().cloned());
-            extra_disks.extend(args.disk_dir.iter().cloned());
-            extra_disks.extend(args.nfs.iter().cloned());
-            // Collect env vars and volume mounts for cache key
-            let env_vars: Vec<String> = args.env.to_vec();
-            let volume_mounts: Vec<String> = args.map.to_vec();
-
-            crate::firecracker::FirecrackerConfig::new(
-                kernel_path.to_path_buf(),
-                initrd_path.to_path_buf(),
-                rootfs_path.to_path_buf(),
-                args.image.clone(),
-                cmd_args.clone(),
-                args.cpu,
-                args.mem,
-                network_mode,
-                crate::paths::data_dir(),
-                extra_disks,
-                env_vars,
-                volume_mounts,
-                args.privileged,
-                args.tty,
-                args.interactive,
-                args.rootfs_size.clone(),
-                args.health_check.clone(),
-            )
-        });
-
-    // Build runtime boot args (per-instance values NOT in cache key)
-    // These are added to the static boot_args from FirecrackerConfig
-    let mut runtime_boot_args = String::new();
+) -> String {
+    let mut boot_args = String::new();
 
     // Network configuration via kernel cmdline
     // Format: ip=<client-ip>:<server-ip>:<gw-ip>:<netmask>:<hostname>:<device>:<autoconf>:<dns0>
@@ -2296,7 +1767,7 @@ async fn run_vm_setup(
             .map(|dns| format!(":{}", dns))
             .unwrap_or_default();
         // Use /24 netmask for slirp4netns (10.0.2.0/24) or bridged (172.30.x.0/24)
-        runtime_boot_args.push_str(&format!(
+        boot_args.push_str(&format!(
             "ip={}::{}:255.255.255.0::eth0:off{}",
             guest_ip_clean, host_ip_clean, dns_suffix
         ));
@@ -2308,20 +1779,20 @@ async fn run_vm_setup(
     if let (Some(guest_ipv6), Some(host_ipv6)) =
         (&network_config.guest_ipv6, &network_config.host_ipv6)
     {
-        if !runtime_boot_args.is_empty() {
-            runtime_boot_args.push(' ');
+        if !boot_args.is_empty() {
+            boot_args.push(' ');
         }
-        runtime_boot_args.push_str(&format!("ipv6={}|{}", guest_ipv6, host_ipv6));
+        boot_args.push_str(&format!("ipv6={}|{}", guest_ipv6, host_ipv6));
     }
 
     // Pass host DNS servers to guest for direct resolution (bypasses slirp's DNS proxy)
     // This is needed on IPv6-only hosts where slirp's 10.0.2.3 can't forward to IPv6 nameservers
     if let Ok(dns_servers) = crate::network::get_host_dns_servers() {
-        if !runtime_boot_args.is_empty() {
-            runtime_boot_args.push(' ');
+        if !boot_args.is_empty() {
+            boot_args.push(' ');
         }
         // Use | delimiter since : is part of IPv6 addresses
-        runtime_boot_args.push_str(&format!("fcvm_dns={}", dns_servers.join("|")));
+        boot_args.push_str(&format!("fcvm_dns={}", dns_servers.join("|")));
 
         // Pass search domains for short hostname resolution (only when DNS servers are available)
         if let Ok(content) = std::fs::read_to_string("/run/systemd/resolve/resolv.conf")
@@ -2334,29 +1805,29 @@ async fn run_vm_setup(
                 .map(|s| s.split_whitespace().collect())
                 .unwrap_or_default();
             if !search.is_empty() {
-                if !runtime_boot_args.is_empty() {
-                    runtime_boot_args.push(' ');
+                if !boot_args.is_empty() {
+                    boot_args.push(' ');
                 }
-                runtime_boot_args.push_str(&format!("fcvm_dns_search={}", search.join("|")));
+                boot_args.push_str(&format!("fcvm_dns_search={}", search.join("|")));
             }
         }
     }
 
     // Enable fc-agent strace debugging if requested
     if args.strace_agent {
-        if !runtime_boot_args.is_empty() {
-            runtime_boot_args.push(' ');
+        if !boot_args.is_empty() {
+            boot_args.push(' ');
         }
-        runtime_boot_args.push_str("fc_agent_strace=1");
+        boot_args.push_str("fc_agent_strace=1");
         info!("fc-agent strace debugging enabled - output will be in /tmp/fc-agent.strace");
     }
 
     // Additional boot args from RuntimeConfig (kernel profile)
     if let Some(ref extra) = runtime_config.boot_args {
-        if !runtime_boot_args.is_empty() {
-            runtime_boot_args.push(' ');
+        if !boot_args.is_empty() {
+            boot_args.push(' ');
         }
-        runtime_boot_args.push_str(extra);
+        boot_args.push_str(extra);
     }
 
     // Pass FUSE reader count to fc-agent via kernel command line (from RuntimeConfig or env)
@@ -2365,43 +1836,53 @@ async fn run_vm_setup(
         .map(|r| r.to_string())
         .or_else(|| std::env::var("FCVM_FUSE_READERS").ok());
     if let Some(readers) = fuse_readers {
-        if !runtime_boot_args.is_empty() {
-            runtime_boot_args.push(' ');
+        if !boot_args.is_empty() {
+            boot_args.push(' ');
         }
-        runtime_boot_args.push_str(&format!("fuse_readers={}", readers));
+        boot_args.push_str(&format!("fuse_readers={}", readers));
     }
 
     // Pass FUSE trace rate to fc-agent via kernel command line.
     if let Ok(rate) = std::env::var("FCVM_FUSE_TRACE_RATE") {
-        if !runtime_boot_args.is_empty() {
-            runtime_boot_args.push(' ');
+        if !boot_args.is_empty() {
+            boot_args.push(' ');
         }
-        runtime_boot_args.push_str(&format!("fuse_trace_rate={}", rate));
+        boot_args.push_str(&format!("fuse_trace_rate={}", rate));
     }
 
     // Pass FUSE max_write to fc-agent via kernel command line.
     if let Ok(max_write) = std::env::var("FCVM_FUSE_MAX_WRITE") {
-        if !runtime_boot_args.is_empty() {
-            runtime_boot_args.push(' ');
+        if !boot_args.is_empty() {
+            boot_args.push(' ');
         }
-        runtime_boot_args.push_str(&format!("fuse_max_write={}", max_write));
+        boot_args.push_str(&format!("fuse_max_write={}", max_write));
     }
 
     // Pass FUSE writeback cache disable flag to fc-agent via kernel command line.
     if std::env::var("FCVM_NO_WRITEBACK_CACHE").is_ok() {
-        if !runtime_boot_args.is_empty() {
-            runtime_boot_args.push(' ');
+        if !boot_args.is_empty() {
+            boot_args.push(' ');
         }
-        runtime_boot_args.push_str("no_writeback_cache=1");
+        boot_args.push_str("no_writeback_cache=1");
     }
 
-    // Apply FirecrackerConfig to client (boot_source, machine_config, rootfs drive)
-    // This ensures the same config used for cache key is used for launch
-    launch_config.apply(client, &runtime_boot_args).await?;
+    boot_args
+}
+
+/// Attach extra disks (--disk, --disk-dir, image archive) to the VM.
+///
+/// Returns the list of extra disks and optionally the image archive device path.
+#[allow(clippy::too_many_arguments)]
+async fn attach_extra_disks(
+    args: &RunArgs,
+    client: &crate::firecracker::FirecrackerClient,
+    data_dir: &std::path::Path,
+    image_disk_path: Option<&std::path::Path>,
+) -> Result<(Vec<crate::state::types::ExtraDisk>, Option<String>)> {
+    let mut extra_disks = Vec::new();
 
     // Extra disks (appear as /dev/vdb, /dev/vdc, etc.)
     // Parse format: HOST_PATH:GUEST_MOUNT[:ro]
-    let mut extra_disks = Vec::new();
     for (i, disk_spec) in args.disk.iter().enumerate() {
         // Check for :ro suffix
         let (spec_without_ro, read_only) = if disk_spec.ends_with(":ro") {
@@ -2544,6 +2025,7 @@ async fn run_vm_setup(
             )
             .await?;
     }
+
     // Attach image archive as a raw read-only block device.
     // fc-agent reads docker-archive:/dev/vdX directly — no FUSE, no mount.
     let image_device = if let Some(disk_path) = image_disk_path {
@@ -2574,6 +2056,665 @@ async fn run_vm_setup(
         None
     };
 
+    Ok((extra_disks, image_device))
+}
+
+/// Build MMDS data (container plan) and send it to Firecracker.
+///
+/// Includes volume/disk/NFS mount info, container plan, proxy config, and host time.
+#[allow(clippy::too_many_arguments)]
+async fn build_and_send_mmds(
+    args: &RunArgs,
+    client: &crate::firecracker::FirecrackerClient,
+    network_config: &crate::network::NetworkConfig,
+    vm_state: &VmState,
+    volume_mappings: &[VolumeMapping],
+    cmd_args: &Option<Vec<String>>,
+    image_device: Option<String>,
+) -> Result<()> {
+    // Build volume mount info for MMDS
+    // Format: { guest_path, vsock_port, read_only }
+    let volume_mounts: Vec<serde_json::Value> = volume_mappings
+        .iter()
+        .enumerate()
+        .map(|(idx, v)| {
+            serde_json::json!({
+                "guest_path": v.guest_path,
+                "vsock_port": VSOCK_VOLUME_PORT_BASE + idx as u32,
+                "read_only": v.read_only,
+            })
+        })
+        .collect();
+
+    // Build extra disk info for MMDS
+    // Format: { device, mount_path, read_only }
+    // Disks are added as /dev/vdb, /dev/vdc, etc.
+    let extra_disk_mounts: Vec<serde_json::Value> = vm_state
+        .config
+        .extra_disks
+        .iter()
+        .enumerate()
+        .map(|(idx, disk)| {
+            serde_json::json!({
+                "device": format!("/dev/vd{}", (b'b' + idx as u8) as char),
+                "mount_path": &disk.mount_path,
+                "read_only": disk.read_only,
+            })
+        })
+        .collect();
+
+    // NFS mounts for guest
+    // Format: { host_ip, host_path, mount_path, read_only }
+    let nfs_mounts: Vec<serde_json::Value> = vm_state
+        .config
+        .nfs_shares
+        .iter()
+        .map(|share| {
+            serde_json::json!({
+                "host_ip": network_config.host_ip.as_ref().unwrap_or(&"".to_string()),
+                "host_path": &share.host_path,
+                "mount_path": &share.mount_path,
+                "read_only": share.read_only,
+            })
+        })
+        .collect();
+
+    // MMDS data (container plan) - nested under "latest" for V2 compatibility
+    // Include host timestamp so guest can set clock immediately (avoiding slow NTP sync)
+    // Format without subsecond precision for Alpine `date` compatibility
+    let mmds_data = serde_json::json!({
+        "latest": {
+            "container-plan": {
+                "image": args.image,
+                "env": args.env.iter().map(|e| {
+                    let parts: Vec<&str> = e.splitn(2, '=').collect();
+                    (parts[0], parts.get(1).copied().unwrap_or(""))
+                }).collect::<std::collections::HashMap<_, _>>(),
+                "cmd": cmd_args,
+                "volumes": volume_mounts,
+                "extra_disks": extra_disk_mounts,
+                "nfs_mounts": nfs_mounts,
+                "image_archive": image_device,
+                "privileged": args.privileged,
+                "interactive": args.interactive,
+                "tty": args.tty,
+                // Use network-provided proxy, or fall back to environment variables.
+                // Resolve hostname to IPv4 since slirp VMs can only reach IPv4 addresses.
+                "http_proxy": network_config.http_proxy.clone()
+                    .or_else(|| std::env::var("http_proxy").ok())
+                    .or_else(|| std::env::var("HTTP_PROXY").ok())
+                    .and_then(|url| resolve_proxy_url(&url)),
+                "https_proxy": network_config.http_proxy.clone()
+                    .or_else(|| std::env::var("https_proxy").ok())
+                    .or_else(|| std::env::var("HTTPS_PROXY").ok())
+                    .or_else(|| std::env::var("http_proxy").ok())
+                    .or_else(|| std::env::var("HTTP_PROXY").ok())
+                    .and_then(|url| resolve_proxy_url(&url)),
+                "no_proxy": std::env::var("no_proxy")
+                    .or_else(|_| std::env::var("NO_PROXY"))
+                    .ok(),
+            },
+            "host-time": chrono::Utc::now().timestamp().to_string(),
+        }
+    });
+
+    client.put_mmds(mmds_data).await?;
+    Ok(())
+}
+
+/// Set up rootless namespace for VM networking.
+///
+/// Spawns a holder process with retry logic, runs network setup via nsenter,
+/// and verifies TAP device creation. Returns the holder child process and PID.
+async fn setup_rootless_namespace(
+    slirp_net: &SlirpNetwork,
+    network_config: &crate::network::NetworkConfig,
+    vm_manager: &mut VmManager,
+    vm_state: &mut VmState,
+) -> Result<tokio::process::Child> {
+    // Step 1: Spawn holder process (keeps namespace alive)
+    // Retry for up to 5 seconds if holder dies (transient failures under load)
+    let holder_cmd = slirp_net.build_holder_command();
+    info!(cmd = ?holder_cmd, "spawning namespace holder for rootless networking");
+
+    let retry_deadline = std::time::Instant::now() + super::common::HOLDER_RETRY_TIMEOUT;
+    let mut attempt = 0;
+
+    let (mut child, mut holder_pid, mut holder_stderr) = loop {
+        attempt += 1;
+
+        // Spawn holder with piped stderr to capture errors if it fails
+        let mut child = tokio::process::Command::new(&holder_cmd[0])
+            .args(&holder_cmd[1..])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .with_context(|| format!("failed to spawn holder: {:?}", holder_cmd))?;
+
+        let holder_pid = child.id().context("getting holder process PID")?;
+        if attempt > 1 {
+            info!(
+                holder_pid = holder_pid,
+                attempt = attempt,
+                "namespace holder started (retry)"
+            );
+        } else {
+            info!(holder_pid = holder_pid, "namespace holder started");
+        }
+
+        // Wait for namespace to be ready by checking uid_map
+        let namespace_ready = crate::utils::wait_for_namespace_ready(
+            holder_pid,
+            super::common::NAMESPACE_READY_TIMEOUT,
+        )
+        .await;
+
+        // If namespace didn't become ready, kill holder and retry
+        if !namespace_ready {
+            let _ = child.kill().await;
+
+            if std::time::Instant::now() < retry_deadline {
+                warn!(
+                    holder_pid = holder_pid,
+                    attempt = attempt,
+                    "namespace not ready, retrying holder creation..."
+                );
+                tokio::time::sleep(super::common::HOLDER_RETRY_INTERVAL).await;
+                continue;
+            } else {
+                bail!(
+                    "namespace not ready after {} attempts (holder PID {})",
+                    attempt,
+                    holder_pid
+                );
+            }
+        }
+
+        // Take stderr pipe - we'll use it for diagnostics if holder dies later
+        let mut holder_stderr = child.stderr.take();
+
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                // Holder exited - capture stderr to see why
+                let stderr = if let Some(ref mut pipe) = holder_stderr {
+                    use tokio::io::AsyncReadExt;
+                    let mut buf = String::new();
+                    let _ = pipe.read_to_string(&mut buf).await;
+                    buf
+                } else {
+                    String::new()
+                };
+
+                if std::time::Instant::now() < retry_deadline {
+                    warn!(
+                        holder_pid = holder_pid,
+                        attempt = attempt,
+                        status = %status,
+                        stderr = %stderr.trim(),
+                        "holder died, retrying..."
+                    );
+                    tokio::time::sleep(super::common::HOLDER_RETRY_INTERVAL).await;
+                    continue;
+                } else {
+                    bail!(
+                        "holder process exited immediately after {} attempts: status={}, stderr={}, cmd={:?}",
+                        attempt,
+                        status,
+                        stderr.trim(),
+                        holder_cmd
+                    );
+                }
+            }
+            Ok(None) => {
+                debug!(holder_pid = holder_pid, "holder running");
+            }
+            Err(e) => {
+                warn!(holder_pid = holder_pid, error = ?e, "failed to check holder status");
+            }
+        }
+
+        // Check if holder is still alive before proceeding
+        if !crate::utils::is_process_alive(holder_pid) {
+            // Try to capture stderr from the dead holder process
+            let holder_stderr_content = if let Some(ref mut pipe) = holder_stderr {
+                use tokio::io::AsyncReadExt;
+                let mut buf = String::new();
+                match tokio::time::timeout(
+                    std::time::Duration::from_millis(100),
+                    pipe.read_to_string(&mut buf),
+                )
+                .await
+                {
+                    Ok(Ok(_)) => buf,
+                    _ => String::new(),
+                }
+            } else {
+                String::new()
+            };
+
+            let _ = child.kill().await;
+
+            if std::time::Instant::now() < retry_deadline {
+                warn!(
+                    holder_pid = holder_pid,
+                    attempt = attempt,
+                    holder_stderr = %holder_stderr_content.trim(),
+                    "holder died after initial check, retrying..."
+                );
+                tokio::time::sleep(super::common::HOLDER_RETRY_INTERVAL).await;
+                continue;
+            } else {
+                let max_user_ns = std::fs::read_to_string("/proc/sys/user/max_user_namespaces")
+                    .unwrap_or_else(|_| "unknown".to_string());
+                bail!(
+                    "holder process (PID {}) died after {} attempts. \
+                     stderr='{}', max_user_namespaces={}. \
+                     This may indicate resource exhaustion or namespace limit reached.",
+                    holder_pid,
+                    attempt,
+                    holder_stderr_content.trim(),
+                    max_user_ns.trim()
+                );
+            }
+        }
+
+        // Holder is alive - break out of retry loop
+        break (child, holder_pid, holder_stderr);
+    };
+
+    // Step 2: Run setup script via nsenter (creates TAPs, iptables, etc.)
+    // This is also inside retry logic - if holder dies during nsenter, retry everything
+    let setup_script = slirp_net.build_setup_script();
+    let mut nsenter_prefix = slirp_net.build_nsenter_prefix(holder_pid);
+
+    // Debug: Check if holder is still alive and namespace files exist
+    let proc_dir = format!("/proc/{}", holder_pid);
+    let ns_user = format!("/proc/{}/ns/user", holder_pid);
+    let ns_net = format!("/proc/{}/ns/net", holder_pid);
+    debug!(
+        holder_pid = holder_pid,
+        proc_exists = std::path::Path::new(&proc_dir).exists(),
+        ns_user_exists = std::path::Path::new(&ns_user).exists(),
+        ns_net_exists = std::path::Path::new(&ns_net).exists(),
+        "checking holder process before nsenter"
+    );
+
+    // Check for required devices before attempting network setup
+    let tun_exists = std::path::Path::new("/dev/net/tun").exists();
+    debug!(
+        holder_pid = holder_pid,
+        tun_exists = tun_exists,
+        "checking /dev/net/tun availability"
+    );
+    if !tun_exists {
+        warn!("/dev/net/tun not available - TAP device creation will fail");
+    }
+
+    info!(holder_pid = holder_pid, "running network setup via nsenter");
+
+    // Log the setup script for debugging
+    debug!(
+        holder_pid = holder_pid,
+        script = %setup_script.lines().filter(|l| !l.trim().is_empty() && !l.trim().starts_with('#')).collect::<Vec<_>>().join("; "),
+        "network setup script"
+    );
+
+    let setup_output = tokio::process::Command::new(&nsenter_prefix[0])
+        .args(&nsenter_prefix[1..])
+        .arg("bash")
+        .arg("-c")
+        .arg(&setup_script)
+        .output()
+        .await
+        .context("running network setup via nsenter")?;
+
+    if !setup_output.status.success() {
+        let stderr = String::from_utf8_lossy(&setup_output.stderr);
+        let stdout = String::from_utf8_lossy(&setup_output.stdout);
+
+        // Re-check state for diagnostics
+        let holder_alive = std::path::Path::new(&proc_dir).exists();
+        let ns_user_exists = std::path::Path::new(&ns_user).exists();
+        let ns_net_exists = std::path::Path::new(&ns_net).exists();
+
+        // If holder died during nsenter, this is a retryable error
+        if !holder_alive && std::time::Instant::now() < retry_deadline {
+            // Holder died during nsenter - retry the whole thing
+            let holder_stderr_content = if let Some(ref mut pipe) = holder_stderr {
+                use tokio::io::AsyncReadExt;
+                let mut buf = String::new();
+                match tokio::time::timeout(
+                    std::time::Duration::from_millis(100),
+                    pipe.read_to_string(&mut buf),
+                )
+                .await
+                {
+                    Ok(Ok(_)) => buf,
+                    _ => String::new(),
+                }
+            } else {
+                String::new()
+            };
+
+            let _ = child.kill().await;
+
+            warn!(
+                holder_pid = holder_pid,
+                attempt = attempt,
+                holder_stderr = %holder_stderr_content.trim(),
+                nsenter_stderr = %stderr.trim(),
+                "holder died during nsenter, retrying..."
+            );
+
+            // Jump back to the retry loop by recursing into this block
+            // We need to restructure - for now just retry once more inline
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+            // Retry: spawn new holder
+            attempt += 1;
+            let mut retry_child = tokio::process::Command::new(&holder_cmd[0])
+                .args(&holder_cmd[1..])
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::piped())
+                .spawn()
+                .with_context(|| format!("failed to spawn holder on retry: {:?}", holder_cmd))?;
+
+            let retry_holder_pid = retry_child.id().context("getting retry holder PID")?;
+            info!(
+                holder_pid = retry_holder_pid,
+                attempt = attempt,
+                "namespace holder started (retry after nsenter failure)"
+            );
+
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+            if !crate::utils::is_process_alive(retry_holder_pid) {
+                let _ = retry_child.kill().await;
+                bail!(
+                    "holder died on retry after nsenter failure (attempt {})",
+                    attempt
+                );
+            }
+
+            // Retry nsenter with new holder
+            let retry_nsenter_prefix = slirp_net.build_nsenter_prefix(retry_holder_pid);
+            let retry_output = tokio::process::Command::new(&retry_nsenter_prefix[0])
+                .args(&retry_nsenter_prefix[1..])
+                .arg("bash")
+                .arg("-c")
+                .arg(&setup_script)
+                .output()
+                .await
+                .context("running network setup via nsenter (retry)")?;
+
+            if !retry_output.status.success() {
+                let retry_stderr = String::from_utf8_lossy(&retry_output.stderr);
+                let _ = retry_child.kill().await;
+                bail!(
+                    "network setup failed on retry: {} (attempt {})",
+                    retry_stderr.trim(),
+                    attempt
+                );
+            }
+
+            // Success on retry - update variables for rest of function
+            child = retry_child;
+            holder_pid = retry_holder_pid;
+            nsenter_prefix = slirp_net.build_nsenter_prefix(holder_pid);
+            info!(
+                holder_pid = holder_pid,
+                attempts = attempt,
+                "network setup succeeded after retry"
+            );
+        } else {
+            // If holder died, try to capture its stderr for more context
+            let holder_stderr_content = if !holder_alive {
+                if let Some(ref mut pipe) = holder_stderr {
+                    use tokio::io::AsyncReadExt;
+                    let mut buf = String::new();
+                    match tokio::time::timeout(
+                        std::time::Duration::from_millis(100),
+                        pipe.read_to_string(&mut buf),
+                    )
+                    .await
+                    {
+                        Ok(Ok(_)) => buf,
+                        _ => String::new(),
+                    }
+                } else {
+                    String::new()
+                }
+            } else {
+                String::new()
+            };
+
+            // Kill holder before bailing
+            let _ = child.kill().await;
+
+            // Log comprehensive error info at ERROR level (always visible)
+            warn!(
+                holder_pid = holder_pid,
+                holder_alive = holder_alive,
+                holder_stderr = %holder_stderr_content.trim(),
+                tun_exists = tun_exists,
+                ns_user_exists = ns_user_exists,
+                ns_net_exists = ns_net_exists,
+                nsenter_stderr = %stderr.trim(),
+                nsenter_stdout = %stdout.trim(),
+                "network setup failed - diagnostics"
+            );
+
+            if !holder_alive {
+                bail!(
+                    "network setup failed: holder died during nsenter after {} attempts. \
+                     nsenter_stderr='{}', holder_stderr='{}', \
+                     (tun={}, ns_user={}, ns_net={})",
+                    attempt,
+                    stderr.trim(),
+                    holder_stderr_content.trim(),
+                    tun_exists,
+                    ns_user_exists,
+                    ns_net_exists
+                );
+            } else {
+                bail!(
+                    "network setup failed: {} (tun={}, holder_alive={}, ns_user={}, ns_net={})",
+                    stderr.trim(),
+                    tun_exists,
+                    holder_alive,
+                    ns_user_exists,
+                    ns_net_exists
+                );
+            }
+        }
+    }
+
+    if attempt > 1 {
+        info!(
+            holder_pid = holder_pid,
+            attempts = attempt,
+            "namespace setup succeeded after retries"
+        );
+    }
+
+    info!(holder_pid = holder_pid, "network setup complete");
+
+    // Verify TAP device was created successfully
+    let tap_device = &network_config.tap_device;
+    let verify_output = tokio::process::Command::new(&nsenter_prefix[0])
+        .args(&nsenter_prefix[1..])
+        .arg("ip")
+        .arg("link")
+        .arg("show")
+        .arg(tap_device)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .await
+        .context("verifying TAP device")?;
+
+    if !verify_output.success() {
+        let _ = child.kill().await;
+        bail!(
+            "TAP device '{}' not found after network setup - setup may have failed silently",
+            tap_device
+        );
+    }
+    debug!(tap_device = %tap_device, "TAP device verified");
+
+    // Set holder_pid so VmManager uses nsenter
+    vm_manager.set_holder_pid(holder_pid);
+
+    // Store holder_pid in state for health checks and cleanup
+    vm_state.holder_pid = Some(holder_pid);
+
+    Ok(child)
+}
+
+/// Helper function that runs VM setup and returns VmManager on success.
+/// This allows the caller to cleanup network resources on error.
+/// For rootless mode, also returns the holder process that keeps the namespace alive.
+#[allow(clippy::too_many_arguments)]
+async fn run_vm_setup(
+    args: &RunArgs,
+    vm_id: &str,
+    data_dir: &std::path::Path,
+    base_rootfs: &std::path::Path,
+    socket_path: &std::path::Path,
+    kernel_path: &std::path::Path,
+    initrd_path: &std::path::Path,
+    network_config: &crate::network::NetworkConfig,
+    network: &mut dyn NetworkManager,
+    cmd_args: Option<Vec<String>>,
+    state_manager: &StateManager,
+    vm_state: &mut VmState,
+    volume_mappings: &[VolumeMapping],
+    vsock_socket_path: &std::path::Path,
+    image_disk_path: Option<&std::path::Path>,
+    fc_config: Option<crate::firecracker::FirecrackerConfig>,
+    runtime_config: &super::common::RuntimeConfig,
+) -> Result<(VmManager, Option<tokio::process::Child>)> {
+    // Setup storage - just need CoW copy (fc-agent is injected via initrd at boot)
+    let vm_dir = data_dir.join("disks");
+    let disk_manager =
+        DiskManager::new(vm_id.to_string(), base_rootfs.to_path_buf(), vm_dir.clone());
+
+    let rootfs_path = disk_manager
+        .create_cow_disk()
+        .await
+        .context("creating CoW disk")?;
+
+    // Estimate space needed for container image extraction inside VM.
+    // The archive is loaded via podman load which extracts layers onto the rootfs.
+    let image_overhead = if let Some(disk_path) = image_disk_path {
+        match tokio::fs::metadata(disk_path).await {
+            Ok(meta) => meta.len(),
+            Err(_) => 0,
+        }
+    } else {
+        0
+    };
+
+    // Ensure minimum free space (from --rootfs-size) plus room for the container image
+    crate::storage::disk::ensure_free_space(&rootfs_path, &args.rootfs_size, image_overhead)
+        .await
+        .context("ensuring rootfs free space")?;
+
+    info!(rootfs = %rootfs_path.display(), "disk prepared (fc-agent baked into Layer 2)");
+
+    let vm_name = args.name.clone();
+    info!(vm_name = %vm_name, vm_id = %vm_id, "creating VM manager");
+    let mut vm_manager = VmManager::new(vm_id.to_string(), socket_path.to_path_buf(), None);
+
+    // Set VM name for logging
+    vm_manager.set_vm_name(vm_name);
+
+    // Configure namespace isolation based on network type
+    let holder_child: Option<tokio::process::Child>;
+
+    if let Some(bridged_net) = network.as_any().downcast_ref::<BridgedNetwork>() {
+        // Bridged mode: use pre-created network namespace
+        holder_child = None;
+        if let Some(ns_id) = bridged_net.namespace_id() {
+            info!(namespace = %ns_id, "configuring VM to run in network namespace");
+            vm_manager.set_namespace(ns_id.to_string());
+        }
+    } else if let Some(slirp_net) = network.as_any().downcast_ref::<SlirpNetwork>() {
+        holder_child = Some(
+            setup_rootless_namespace(slirp_net, network_config, &mut vm_manager, vm_state).await?,
+        );
+    } else {
+        holder_child = None;
+    }
+
+    let firecracker_bin = super::common::find_firecracker(runtime_config)?;
+
+    vm_manager
+        .start(
+            &firecracker_bin,
+            None,
+            runtime_config.firecracker_args.as_deref(),
+        )
+        .await
+        .context("starting Firecracker")?;
+
+    let vm_pid = vm_manager.pid()?;
+    let client = vm_manager.client()?;
+
+    // Configure VM via API
+    info!("configuring VM via Firecracker API");
+
+    // Build FirecrackerConfig for launch (single source of truth for VM config)
+    // Use fc_config from cache check if available, otherwise build fresh.
+    // IMPORTANT: fc_config uses content-addressed base_rootfs path for cache key,
+    // but launch must use per-instance CoW copy path (rootfs_path).
+    let launch_config = fc_config
+        .map(|config| config.with_rootfs_path(rootfs_path.to_path_buf()))
+        .unwrap_or_else(|| {
+            use crate::firecracker::FcNetworkMode;
+            let network_mode = match args.network {
+                crate::cli::args::NetworkMode::Bridged => FcNetworkMode::Bridged,
+                crate::cli::args::NetworkMode::Rootless => FcNetworkMode::Rootless,
+            };
+            // Collect extra disk specifications
+            let mut extra_disks: Vec<String> = Vec::new();
+            extra_disks.extend(args.disk.iter().cloned());
+            extra_disks.extend(args.disk_dir.iter().cloned());
+            extra_disks.extend(args.nfs.iter().cloned());
+            // Collect env vars and volume mounts for cache key
+            let env_vars: Vec<String> = args.env.to_vec();
+            let volume_mounts: Vec<String> = args.map.to_vec();
+
+            crate::firecracker::FirecrackerConfig::new(
+                kernel_path.to_path_buf(),
+                initrd_path.to_path_buf(),
+                rootfs_path.to_path_buf(),
+                args.image.clone(),
+                cmd_args.clone(),
+                args.cpu,
+                args.mem,
+                network_mode,
+                crate::paths::data_dir(),
+                extra_disks,
+                env_vars,
+                volume_mounts,
+                args.privileged,
+                args.tty,
+                args.interactive,
+                args.rootfs_size.clone(),
+                args.health_check.clone(),
+            )
+        });
+
+    // Build runtime boot args and apply FirecrackerConfig
+    let runtime_boot_args = build_runtime_boot_args(args, network_config, runtime_config);
+    launch_config.apply(client, &runtime_boot_args).await?;
+
+    // Attach extra disks and image archive
+    let (extra_disks, image_device) =
+        attach_extra_disks(args, client, data_dir, image_disk_path).await?;
     vm_state.config.extra_disks = extra_disks;
 
     // Process --nfs: export directories via NFS for guest to mount
@@ -2686,93 +2827,17 @@ async fn run_vm_setup(
         })
         .await?;
 
-    // Build volume mount info for MMDS
-    // Format: { guest_path, vsock_port, read_only }
-    let volume_mounts: Vec<serde_json::Value> = volume_mappings
-        .iter()
-        .enumerate()
-        .map(|(idx, v)| {
-            serde_json::json!({
-                "guest_path": v.guest_path,
-                "vsock_port": VSOCK_VOLUME_PORT_BASE + idx as u32,
-                "read_only": v.read_only,
-            })
-        })
-        .collect();
-
-    // Build extra disk info for MMDS
-    // Format: { device, mount_path, read_only }
-    // Disks are added as /dev/vdb, /dev/vdc, etc.
-    let extra_disk_mounts: Vec<serde_json::Value> = vm_state
-        .config
-        .extra_disks
-        .iter()
-        .enumerate()
-        .map(|(idx, disk)| {
-            serde_json::json!({
-                "device": format!("/dev/vd{}", (b'b' + idx as u8) as char),
-                "mount_path": &disk.mount_path,
-                "read_only": disk.read_only,
-            })
-        })
-        .collect();
-
-    // NFS mounts for guest
-    // Format: { host_ip, host_path, mount_path, read_only }
-    let nfs_mounts: Vec<serde_json::Value> = vm_state
-        .config
-        .nfs_shares
-        .iter()
-        .map(|share| {
-            serde_json::json!({
-                "host_ip": network_config.host_ip.as_ref().unwrap_or(&"".to_string()),
-                "host_path": &share.host_path,
-                "mount_path": &share.mount_path,
-                "read_only": share.read_only,
-            })
-        })
-        .collect();
-
-    // MMDS data (container plan) - nested under "latest" for V2 compatibility
-    // Include host timestamp so guest can set clock immediately (avoiding slow NTP sync)
-    // Format without subsecond precision for Alpine `date` compatibility
-    let mmds_data = serde_json::json!({
-        "latest": {
-            "container-plan": {
-                "image": args.image,
-                "env": args.env.iter().map(|e| {
-                    let parts: Vec<&str> = e.splitn(2, '=').collect();
-                    (parts[0], parts.get(1).copied().unwrap_or(""))
-                }).collect::<std::collections::HashMap<_, _>>(),
-                "cmd": cmd_args,
-                "volumes": volume_mounts,
-                "extra_disks": extra_disk_mounts,
-                "nfs_mounts": nfs_mounts,
-                "image_archive": image_device.clone(),
-                "privileged": args.privileged,
-                "interactive": args.interactive,
-                "tty": args.tty,
-                // Use network-provided proxy, or fall back to environment variables.
-                // Resolve hostname to IPv4 since slirp VMs can only reach IPv4 addresses.
-                "http_proxy": network_config.http_proxy.clone()
-                    .or_else(|| std::env::var("http_proxy").ok())
-                    .or_else(|| std::env::var("HTTP_PROXY").ok())
-                    .and_then(|url| resolve_proxy_url(&url)),
-                "https_proxy": network_config.http_proxy.clone()
-                    .or_else(|| std::env::var("https_proxy").ok())
-                    .or_else(|| std::env::var("HTTPS_PROXY").ok())
-                    .or_else(|| std::env::var("http_proxy").ok())
-                    .or_else(|| std::env::var("HTTP_PROXY").ok())
-                    .and_then(|url| resolve_proxy_url(&url)),
-                "no_proxy": std::env::var("no_proxy")
-                    .or_else(|_| std::env::var("NO_PROXY"))
-                    .ok(),
-            },
-            "host-time": chrono::Utc::now().timestamp().to_string(),
-        }
-    });
-
-    client.put_mmds(mmds_data).await?;
+    // Build and send MMDS data (container plan)
+    build_and_send_mmds(
+        args,
+        client,
+        network_config,
+        vm_state,
+        volume_mappings,
+        &cmd_args,
+        image_device,
+    )
+    .await?;
 
     // Configure entropy device (virtio-rng) for better random number generation
     client

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -183,6 +183,11 @@ impl VmHandle {
         self.cancel.clone()
     }
 
+    /// Get the vsock socket path for this VM (used for exec/terminal connections).
+    pub fn vsock_socket_path(&self) -> PathBuf {
+        crate::paths::vm_runtime_dir(&self.vm_id).join("vsock.sock")
+    }
+
     /// Gracefully stop the VM and wait for cleanup to complete.
     /// Returns the container exit code (None if the container didn't exit naturally).
     pub async fn stop(self) -> Result<Option<i32>> {

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -593,7 +593,7 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
         let socket_path = output_socket_path.clone();
         let vm_id_clone = vm_id.clone();
         Some(tokio::spawn(async move {
-            match run_output_listener(&socket_path, &vm_id_clone, interactive).await {
+            match run_output_listener(&socket_path, &vm_id_clone, interactive, None).await {
                 Ok(lines) => lines,
                 Err(e) => {
                     tracing::warn!("Output listener error: {}", e);

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -884,8 +884,8 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
     let cancel = tokio_util::sync::CancellationToken::new();
     let cancel_clone = cancel.clone();
     tokio::spawn(async move {
-        let mut sigterm = signal(SignalKind::terminate()).unwrap();
-        let mut sigint = signal(SignalKind::interrupt()).unwrap();
+        let mut sigterm = signal(SignalKind::terminate()).expect("SIGTERM handler");
+        let mut sigint = signal(SignalKind::interrupt()).expect("SIGINT handler");
         tokio::select! {
             _ = sigterm.recv() => { info!("received SIGTERM, shutting down VM"); }
             _ = sigint.recv() => { info!("received SIGINT, shutting down VM"); }

--- a/src/firecracker/vm.rs
+++ b/src/firecracker/vm.rs
@@ -126,10 +126,14 @@ impl VmManager {
     }
 
     /// Start the Firecracker process
+    ///
+    /// `firecracker_args` provides extra CLI arguments (e.g., "--enable-nv2") passed
+    /// explicitly from RuntimeConfig instead of reading the FCVM_FIRECRACKER_ARGS env var.
     pub async fn start(
         &mut self,
         firecracker_bin: &Path,
         config_override: Option<&Path>,
+        firecracker_args: Option<&str>,
     ) -> Result<()> {
         if let Some(ref name) = self.vm_name {
             info!(target: "vm", vm_name = %name, vm_id = %self.vm_id, "starting Firecracker process");
@@ -200,8 +204,8 @@ impl VmManager {
             cmd.arg("--no-seccomp");
         }
 
-        // Additional firecracker args from environment (caller controls)
-        if let Ok(extra) = std::env::var("FCVM_FIRECRACKER_ARGS") {
+        // Additional firecracker args from RuntimeConfig (passed explicitly by caller)
+        if let Some(extra) = firecracker_args {
             for arg in extra.split_whitespace() {
                 cmd.arg(arg);
             }

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -37,7 +37,7 @@ pub struct NetworkConfig {
     pub http_proxy: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PortMapping {
     pub host_ip: Option<String>,
     pub host_port: u16,
@@ -45,7 +45,8 @@ pub struct PortMapping {
     pub proto: Protocol,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Protocol {
     Tcp,
     Udp,

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
-use crate::network::NetworkConfig;
+use crate::network::{NetworkConfig, PortMapping};
 
 /// Safely truncate a string to at most `max_len` characters.
 /// Returns a string slice without panicking for short inputs.
@@ -115,6 +117,12 @@ pub struct VmConfig {
     /// to preserve this original_vm_id for clones to use the correct redirect.
     #[serde(default)]
     pub original_vsock_vm_id: Option<String>,
+    /// Published port mappings (host:guest)
+    #[serde(default)]
+    pub port_mappings: Vec<PortMapping>,
+    /// User-defined labels for tagging/filtering VMs
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
 }
 
 impl VmState {
@@ -144,6 +152,8 @@ impl VmState {
                 process_type: Some(ProcessType::Vm),
                 serve_pid: None,
                 original_vsock_vm_id: None,
+                port_mappings: Vec::new(),
+                labels: HashMap::new(),
             },
         }
     }

--- a/tests/test_health_monitor.rs
+++ b/tests/test_health_monitor.rs
@@ -77,6 +77,8 @@ async fn test_health_monitor_behaviors() {
             process_type: Some(ProcessType::Vm),
             serve_pid: None,
             original_vsock_vm_id: None,
+            port_mappings: vec![],
+            labels: std::collections::HashMap::new(),
         },
     };
 

--- a/tests/test_library_api.rs
+++ b/tests/test_library_api.rs
@@ -1,0 +1,150 @@
+//! Library API integration tests — exercise start_vm, exec captured, and async connection
+//!
+//! These tests call fcvm's library API directly (in-process), not via subprocess.
+//! Each test boots a full VM, so they take ~30-60s each.
+//!
+//! Uses multi_thread runtime because prepare_vm() does blocking I/O
+//! (spawning processes, setting up namespaces) that needs concurrent task execution.
+
+#![cfg(feature = "integration-fast")]
+
+mod common;
+
+use anyhow::Result;
+use fcvm::cli::{NetworkMode, RunArgs};
+use fcvm::commands::{exec, start_vm};
+
+/// Build a minimal RunArgs for testing (rootless, no snapshot).
+/// Uses nginx:alpine (long-running daemon) — alpine:latest exits immediately without TTY.
+fn test_run_args(name: &str) -> RunArgs {
+    RunArgs {
+        name: name.to_string(),
+        cpu: 2,
+        mem: 2048,
+        rootfs_size: "10G".to_string(),
+        map: vec![],
+        disk: vec![],
+        disk_dir: vec![],
+        nfs: vec![],
+        env: vec![],
+        cmd: None,
+        publish: vec![],
+        balloon: None,
+        network: NetworkMode::Rootless,
+        health_check: None,
+        privileged: false,
+        interactive: false,
+        tty: false,
+        strace_agent: false,
+        setup: false,
+        kernel: None,
+        kernel_profile: None,
+        vsock_dir: None,
+        no_snapshot: true,
+        image: common::TEST_IMAGE.to_string(),
+        command_args: vec![],
+    }
+}
+
+/// Test: start_vm returns a valid VmHandle, VM becomes healthy, stop works
+#[tokio::test(flavor = "multi_thread")]
+async fn test_library_api_start_vm_and_stop() -> Result<()> {
+    let (vm_name, _, _, _) = common::unique_names("api-start");
+    let args = test_run_args(&vm_name);
+    let handle = start_vm(args).await?;
+
+    println!(
+        "start_vm returned: vm_id={}, name={}, pid={}",
+        handle.vm_id, handle.name, handle.pid
+    );
+
+    assert!(!handle.vm_id.is_empty(), "vm_id should not be empty");
+    assert_eq!(handle.name, vm_name);
+    assert!(handle.pid > 0, "pid should be positive");
+
+    // Wait for VM to become healthy
+    common::poll_health_by_pid(handle.pid, 300).await?;
+    println!("VM is healthy!");
+
+    // Stop gracefully
+    let exit_code = handle.stop().await?;
+    assert!(
+        exit_code.is_none(),
+        "expected None exit code on cancel, got {:?}",
+        exit_code
+    );
+
+    println!("VM stopped successfully");
+    Ok(())
+}
+
+/// Test: run_exec_in_vm_captured returns captured stdout/stderr
+#[tokio::test(flavor = "multi_thread")]
+async fn test_library_api_exec_captured() -> Result<()> {
+    let (vm_name, _, _, _) = common::unique_names("api-exec");
+    let args = test_run_args(&vm_name);
+
+    let handle = start_vm(args).await?;
+    println!("VM started: vm_id={}, pid={}", handle.vm_id, handle.pid);
+
+    common::poll_health_by_pid(handle.pid, 300).await?;
+    println!("VM healthy");
+
+    let vsock = handle.vsock_socket_path();
+
+    // Run a command that produces stdout
+    let output = exec::run_exec_in_vm_captured(
+        &vsock,
+        &["echo".into(), "hello-api".into()],
+        true, // in_container
+    )
+    .await?;
+
+    assert_eq!(output.exit_code, 0, "echo should exit 0");
+    assert!(
+        output.stdout.contains("hello-api"),
+        "stdout should contain 'hello-api', got: {:?}",
+        output.stdout
+    );
+
+    // Run a command that produces stderr and non-zero exit
+    let output = exec::run_exec_in_vm_captured(
+        &vsock,
+        &["sh".into(), "-c".into(), "echo errmsg >&2; exit 42".into()],
+        true,
+    )
+    .await?;
+
+    assert_eq!(output.exit_code, 42, "should exit 42");
+    assert!(
+        output.stderr.contains("errmsg"),
+        "stderr should contain 'errmsg', got: {:?}",
+        output.stderr
+    );
+
+    handle.stop().await?;
+    Ok(())
+}
+
+/// Test: connect_to_exec_server_async returns a usable tokio stream
+#[tokio::test(flavor = "multi_thread")]
+async fn test_library_api_async_connection() -> Result<()> {
+    let (vm_name, _, _, _) = common::unique_names("api-conn");
+    let args = test_run_args(&vm_name);
+
+    let handle = start_vm(args).await?;
+    println!("VM started: vm_id={}, pid={}", handle.vm_id, handle.pid);
+
+    common::poll_health_by_pid(handle.pid, 300).await?;
+    println!("VM healthy");
+
+    let vsock = handle.vsock_socket_path();
+
+    // Get async stream (for WS bridge use case)
+    let stream = exec::connect_to_exec_server_async(&vsock).await?;
+    // If we got here without error, the async connection works
+    drop(stream);
+
+    handle.stop().await?;
+    Ok(())
+}

--- a/tests/test_library_api.rs
+++ b/tests/test_library_api.rs
@@ -41,6 +41,7 @@ fn test_run_args(name: &str) -> RunArgs {
         kernel_profile: None,
         vsock_dir: None,
         no_snapshot: true,
+        label: vec![],
         image: common::TEST_IMAGE.to_string(),
         command_args: vec![],
     }

--- a/tests/test_library_api.rs
+++ b/tests/test_library_api.rs
@@ -51,7 +51,7 @@ fn test_run_args(name: &str) -> RunArgs {
 async fn test_library_api_start_vm_and_stop() -> Result<()> {
     let (vm_name, _, _, _) = common::unique_names("api-start");
     let args = test_run_args(&vm_name);
-    let handle = start_vm(args).await?;
+    let mut handle = start_vm(args).await?;
 
     println!(
         "start_vm returned: vm_id={}, name={}, pid={}",
@@ -84,7 +84,7 @@ async fn test_library_api_exec_captured() -> Result<()> {
     let (vm_name, _, _, _) = common::unique_names("api-exec");
     let args = test_run_args(&vm_name);
 
-    let handle = start_vm(args).await?;
+    let mut handle = start_vm(args).await?;
     println!("VM started: vm_id={}, pid={}", handle.vm_id, handle.pid);
 
     common::poll_health_by_pid(handle.pid, 300).await?;
@@ -132,7 +132,7 @@ async fn test_library_api_async_connection() -> Result<()> {
     let (vm_name, _, _, _) = common::unique_names("api-conn");
     let args = test_run_args(&vm_name);
 
-    let handle = start_vm(args).await?;
+    let mut handle = start_vm(args).await?;
     println!("VM started: vm_id={}, pid={}", handle.vm_id, handle.pid);
 
     common::poll_health_by_pid(handle.pid, 300).await?;

--- a/tests/test_state_manager.rs
+++ b/tests/test_state_manager.rs
@@ -50,6 +50,8 @@ async fn test_state_persistence() {
             process_type: Some(ProcessType::Vm),
             serve_pid: None,
             original_vsock_vm_id: None,
+            port_mappings: vec![],
+            labels: std::collections::HashMap::new(),
         },
     };
 
@@ -116,6 +118,8 @@ async fn test_list_vms() {
                 process_type: Some(ProcessType::Vm),
                 serve_pid: None,
                 original_vsock_vm_id: None,
+                port_mappings: vec![],
+                labels: std::collections::HashMap::new(),
             },
         };
         manager.save_state(&state).await.unwrap();


### PR DESCRIPTION
## Summary

Decomposes the monolithic `cmd_podman_run` (~750 lines) and `run_vm_setup` (~1000 lines) into composable pieces with a clean library API, enabling `fcvm serve` (an async HTTP server managing multiple VMs concurrently).

After this refactoring:
```rust
let handle = start_vm(args).await?;
// handle.vm_id, handle.name, handle.pid available immediately

let state = handle.state().await?;          // health, IP, ports, labels
let mut logs = handle.subscribe_logs();     // broadcast::Receiver<LogLine>

let output = run_exec_in_vm_captured(&handle.vsock_socket_path(), &cmd, true).await?;
let stream = connect_to_exec_server_async(&handle.vsock_socket_path()).await?;

let exit_code = handle.stop().await?; // graceful shutdown
// Or just drop — Drop impl cancels the VM automatically
```

## Changes

### Step 1: RuntimeConfig (647ef02)
- New `RuntimeConfig` struct replaces 4 `set_var()` calls (firecracker_bin, firecracker_args, boot_args, fuse_readers)
- `find_firecracker()` and `VmManager::start()` accept config parameters instead of reading env vars
- Eliminates process-global state that would race with concurrent VMs

### Step 2: Decompose run_vm_setup (21c1080)
- Extracts 4 focused functions from the 1000-line `run_vm_setup()`:
  - `setup_rootless_namespace()` (~420 lines) — holder process spawn, nsenter setup
  - `build_runtime_boot_args()` (~100 lines) — pure function, no side effects
  - `attach_extra_disks()` (~175 lines) — --disk, --disk-dir handling
  - `build_and_send_mmds()` (~100 lines) — metadata service configuration
- `run_vm_setup()` reduced to ~200 lines of glue

### Step 3: VmContext + prepare_vm/run_vm_loop (cf5cc31)
- `VmContext` struct bundles all running VM state (15+ fields)
- `prepare_vm(args)` — sets up all resources, returns `VmContext`
- `run_vm_loop(ctx, cancel)` — event loop using `CancellationToken` instead of signal handlers
- `cleanup_vm_context(ctx)` — resource cleanup
- `cmd_podman_run` reduced to ~20 lines

### Step 4: VmHandle + start_vm (b41463d)
- `VmHandle` — public handle with vm_id, name, pid + stop()/wait()
- `start_vm(args)` — spawns background task, returns handle immediately
- `ExecOutput` + `run_exec_in_vm_captured()` for programmatic command execution
- `connect_to_exec_server_async()` for WebSocket terminal bridge

### Step 5: vsock_socket_path convenience (d70bd5d)
- `VmHandle::vsock_socket_path()` for exec/terminal connections

### Step 6: Library API integration tests (17c0c8a)
- 3 in-process tests exercising the new public API directly:
  - `test_library_api_start_vm_and_stop` — VmHandle lifecycle
  - `test_library_api_exec_captured` — stdout/stderr/exit code capture
  - `test_library_api_async_connection` — tokio UnixStream for WS bridge

### Step 7: Drop safety + signal handler fix (8f93e86)
- `Drop` impl on `VmHandle` — cancels the VM automatically if handle is dropped without calling `stop()`
- Replaced `.unwrap()` with `.expect()` on signal handler registration in spawned tasks

### Step 8: Labels, port mappings, state query, log streaming (0620aba)
- `--label key=value` CLI flag (repeatable, comma-separated) stored in `VmConfig.labels`
- `PortMapping` and `Protocol` made `Serialize, Deserialize`, stored in `VmConfig.port_mappings`
- `VmHandle::state()` — queries `StateManager` for full `VmState` (health, IP, ports, labels)
- `LogLine` type + `broadcast::channel` in `run_output_listener()` for live container output
- `VmHandle::subscribe_logs()` — returns `broadcast::Receiver<LogLine>`

### Step 9: Restore env var fallbacks (8cf2d66)
- `FCVM_BOOT_ARGS` and `FCVM_FIRECRACKER_ARGS` env var fallbacks restored (used by `nested.sh`)
- RuntimeConfig takes priority, env var is fallback

## Public API Surface

| API | Purpose |
|-----|---------|
| `start_vm(RunArgs) -> VmHandle` | Start VM, returns handle |
| `VmHandle::stop() -> Option<i32>` | Graceful shutdown |
| `VmHandle::wait() -> Option<i32>` | Wait for natural exit |
| `VmHandle::state() -> VmState` | Query health, IP, ports, labels |
| `VmHandle::subscribe_logs() -> Receiver<LogLine>` | Live container output |
| `VmHandle::vsock_socket_path()` | Socket path for exec |
| `run_exec_in_vm_captured(vsock, cmd, in_container) -> ExecOutput` | Captured exec |
| `connect_to_exec_server_async(vsock) -> UnixStream` | Async stream for WS bridge |
| `prepare_vm(RunArgs) -> Option<VmContext>` | Low-level: setup resources |
| `run_vm_loop(VmContext, CancellationToken) -> Option<i32>` | Low-level: event loop |
| `cleanup_vm_context(VmContext)` | Low-level: cleanup |

## Test Results

```
make test-root FILTER=library_api  # 3 passed
make test-root FILTER=sanity       # 3 passed, no regression
make test-root FILTER=exec         # 7 passed, no regression
cargo clippy --all-targets -- -D warnings  # clean
cargo fmt --check                          # clean
```

## Test plan

- [x] Library API tests pass (start_vm, exec captured, async connection)
- [x] Sanity tests pass (bridged + rootless)
- [x] Exec tests pass (bridged + rootless snapshot/clone exec)
- [x] No `set_var` calls remain in podman.rs
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] Review findings addressed (Drop impl, signal unwrap, env var fallbacks)