### PR TITLE
Add fcvm serve — ComputeSDK gateway server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,21 @@ jobs:
       - name: test-fast
         working-directory: fcvm
         run: make test-fast
+      - name: test-serve-sdk
+        working-directory: fcvm
+        run: |
+          # SDK test requires computesdk package (sibling repo)
+          # On CI, check if it's available; on dev machines, always available
+          COMPUTESDK_DIR="${{ github.workspace }}/computesdk"
+          if [ ! -d "$COMPUTESDK_DIR/packages/computesdk" ]; then
+            echo "⚠ Skipping SDK E2E test (computesdk not checked out)"
+            echo "  To run locally: cd tests && npm install && cd .. && npx tsx tests/test_serve_sdk.ts"
+            exit 0
+          fi
+          # Install Node.js if not available
+          which node || { echo "⚠ Skipping SDK test (Node.js not available)"; exit 0; }
+          cd tests && npm install && cd ..
+          npx tsx tests/test_serve_sdk.ts
       - name: Upload test logs
         if: always()
         uses: actions/upload-artifact@v6

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ sync-test/
 cargo-home/
 .local/
 scripts/claude-assistant/node_modules/
+tests/node_modules/
 
 # Local repo symlink (from Quick Start)
 /fcvm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "base64 0.22.1",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +521,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +659,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "chrono",
  "clap",
  "clap_complete",
@@ -613,6 +675,7 @@ dependencies = [
  "libc",
  "memmap2",
  "nix 0.29.0",
+ "percent-encoding",
  "rand 0.8.5",
  "regex",
  "reqwest 0.12.28",
@@ -627,6 +690,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+ "tower-http",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
@@ -1045,6 +1109,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1387,6 +1452,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -2230,6 +2301,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2273,6 +2355,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2580,6 +2673,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2676,6 +2781,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2714,6 +2820,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2789,6 +2896,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.17",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2842,6 +2966,12 @@ dependencies = [
  "cc",
  "cfg-if",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,9 @@ shell-words = "1"
 fuse-pipe = { path = "fuse-pipe", default-features = false }
 exec-proto = { path = "exec-proto" }
 url = "2"
+axum = { version = "0.8", features = ["ws"] }
+tower-http = { version = "0.6", features = ["cors"] }
+percent-encoding = "2"
 tokio-util = "0.7"
 regex = "1.12.2"
 fs2 = "0.4.3"

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ CONTAINER_RUN := podman run --rm --privileged \
 	_test-unit _test-fast _test-all _test-root _setup-fcvm _bench \
 	container-build container-test container-test-unit container-test-fast container-test-all \
 	container-setup-fcvm container-shell container-clean container-bench \
-	setup-btrfs setup-fcvm setup-pjdfstest bench lint fmt ssh
+	setup-btrfs setup-fcvm setup-pjdfstest bench lint fmt ssh test-serve-sdk
 
 all: build
 
@@ -169,6 +169,9 @@ help:
 	@echo "  kernel-patch-create PROFILE=nested NAME=0004-fix FILE=fs/fuse/dir.c"
 	@echo "  kernel-patch-edit PROFILE=nested PATCH=0002"
 	@echo "  kernel-patch-validate PROFILE=nested"
+	@echo ""
+	@echo "SDK:"
+	@echo "  test-serve-sdk     Run ComputeSDK E2E test (requires computesdk sibling repo)"
 	@echo ""
 	@echo "Other:"
 	@echo "  bench              Run fuse-pipe benchmarks"
@@ -377,6 +380,17 @@ _setup-fcvm:
 	sudo ./target/release/fcvm setup --generate-config --force
 	sudo ./target/release/fcvm setup
 	sudo ./target/release/fcvm setup --kernel-profile nested --build-kernels
+
+# SDK E2E test — requires computesdk package as sibling repo and Node.js
+test-serve-sdk: build
+	@echo "==> Running ComputeSDK E2E test..."
+	@if [ ! -d "$(CURDIR)/../computesdk/packages/computesdk" ]; then \
+		echo "ERROR: computesdk not found at ../computesdk"; \
+		echo "Clone it: git clone <computesdk-repo> ../computesdk && cd ../computesdk && pnpm install && pnpm build"; \
+		exit 1; \
+	fi
+	cd tests && npm install --silent
+	npx tsx tests/test_serve_sdk.ts
 
 bench: build
 	@echo "==> Running benchmarks..."

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -30,6 +30,8 @@ pub enum Commands {
     Exec(ExecArgs),
     /// Setup kernel and rootfs (kernel ~15MB download, rootfs ~10GB creation, takes 5-10 minutes)
     Setup(SetupArgs),
+    /// Run HTTP/WebSocket API server for ComputeSDK integration
+    Serve(ServeArgs),
     /// Generate shell completions
     Completions(CompletionsArgs),
 }
@@ -66,6 +68,17 @@ pub struct SetupArgs {
     /// Requires --kernel-profile flag. After setup, reboot to activate.
     #[arg(long, requires = "kernel_profile")]
     pub install_host_kernel: bool,
+}
+
+// ============================================================================
+// Serve Command
+// ============================================================================
+
+#[derive(Args, Debug)]
+pub struct ServeArgs {
+    /// Port to listen on
+    #[arg(long, default_value_t = 8090)]
+    pub port: u16,
 }
 
 // ============================================================================

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod completions;
 pub mod exec;
 pub mod ls;
 pub mod podman;
+pub mod serve;
 pub mod setup;
 pub mod snapshot;
 pub mod snapshots;
@@ -16,6 +17,7 @@ pub use podman::cmd_podman;
 pub use podman::{
     cleanup_vm_context, prepare_vm, run_vm_loop, start_vm, LogLine, VmContext, VmHandle,
 };
+pub use serve::cmd_serve;
 pub use setup::cmd_setup;
 pub use snapshot::cmd_snapshot;
 pub use snapshots::cmd_snapshots;

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -1,0 +1,1076 @@
+//! HTTP/WebSocket API server for ComputeSDK integration.
+//!
+//! `fcvm serve` acts as both the ComputeSDK gateway (sandbox CRUD) and sandbox daemon
+//! (exec, files, terminal). The standard `computesdk` TypeScript package connects via
+//! gateway mode — no custom TypeScript SDK needed.
+//!
+//! Gateway endpoints: `/v1/sandboxes/*`
+//! Sandbox daemon endpoints: `/s/{id}/*`
+
+use crate::cli::ServeArgs;
+use crate::commands::exec::run_exec_in_vm_captured;
+use crate::commands::podman::{start_vm, VmHandle};
+use crate::state::{HealthStatus, StateManager};
+use anyhow::{Context, Result};
+use axum::extract::{Path, Query, State, WebSocketUpgrade};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tower_http::cors::CorsLayer;
+use tracing::{error, info, warn};
+
+// ============================================================================
+// Server state
+// ============================================================================
+
+struct SandboxEntry {
+    handle: VmHandle,
+    runtime: Option<String>,
+    created_at: DateTime<Utc>,
+    timeout_ms: Option<u64>,
+}
+
+struct AppState {
+    sandboxes: RwLock<HashMap<String, SandboxEntry>>,
+    port: u16,
+}
+
+type SharedState = Arc<AppState>;
+
+// ============================================================================
+// Request/Response types
+// ============================================================================
+
+#[derive(Deserialize)]
+struct CreateSandboxRequest {
+    runtime: Option<String>,
+    image: Option<String>,
+    name: Option<String>,
+    cpu: Option<u8>,
+    #[serde(alias = "memoryMib")]
+    memory_mib: Option<u32>,
+    timeout_ms: Option<u64>,
+    env: Option<HashMap<String, String>>,
+    labels: Option<HashMap<String, String>>,
+}
+
+#[derive(Serialize)]
+struct GatewayResponse<T: Serialize> {
+    success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<T>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+impl<T: Serialize> GatewayResponse<T> {
+    fn ok(data: T) -> Json<Self> {
+        Json(Self {
+            success: true,
+            data: Some(data),
+            error: None,
+        })
+    }
+}
+
+fn gateway_error(status: StatusCode, msg: impl Into<String>) -> Response {
+    let body = serde_json::json!({
+        "success": false,
+        "error": msg.into(),
+    });
+    (status, Json(body)).into_response()
+}
+
+#[derive(Serialize)]
+struct SandboxInfo {
+    #[serde(rename = "sandboxId")]
+    sandbox_id: String,
+    url: String,
+    token: String,
+    provider: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct RunCodeRequest {
+    code: String,
+    language: Option<String>,
+}
+
+#[derive(Serialize)]
+struct RunCodeResponse {
+    data: RunCodeData,
+}
+
+#[derive(Serialize)]
+struct RunCodeData {
+    output: String,
+    exit_code: i32,
+    language: String,
+}
+
+#[derive(Deserialize)]
+struct RunCommandRequest {
+    command: String,
+    cwd: Option<String>,
+    env: Option<HashMap<String, String>>,
+}
+
+#[derive(Serialize)]
+struct RunCommandResponse {
+    message: String,
+    data: RunCommandData,
+}
+
+#[derive(Serialize)]
+struct RunCommandData {
+    command: String,
+    stdout: String,
+    stderr: String,
+    exit_code: i32,
+    duration_ms: u64,
+}
+
+#[derive(Deserialize)]
+struct FilesQuery {
+    path: Option<String>,
+}
+
+#[derive(Serialize)]
+struct FileInfo {
+    name: String,
+    #[serde(rename = "type")]
+    file_type: String,
+    is_dir: bool,
+    size: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    modified_at: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct CreateFileRequest {
+    path: String,
+    content: String,
+    #[serde(default)]
+    encoding: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct CreateTerminalRequest {
+    #[allow(dead_code)]
+    shell: Option<String>,
+}
+
+// ============================================================================
+// Runtime mapping
+// ============================================================================
+
+fn runtime_to_image(runtime: &str) -> &str {
+    match runtime {
+        "python" | "python3" => "python:3.12-slim",
+        "node" | "nodejs" => "node:22-slim",
+        "ruby" => "ruby:3.3-slim",
+        "go" | "golang" => "golang:1.23-alpine",
+        other => other,
+    }
+}
+
+fn runtime_to_language(runtime: &str) -> &str {
+    match runtime {
+        "python" | "python3" => "python",
+        "node" | "nodejs" => "javascript",
+        "ruby" => "ruby",
+        "go" | "golang" => "go",
+        other => other,
+    }
+}
+
+fn language_to_run_command(language: &str, code: &str) -> Vec<String> {
+    match language {
+        "python" | "python3" => vec!["python3".into(), "-c".into(), code.into()],
+        "javascript" | "node" | "nodejs" => vec!["node".into(), "-e".into(), code.into()],
+        "ruby" => vec!["ruby".into(), "-e".into(), code.into()],
+        _ => vec!["sh".into(), "-c".into(), code.into()],
+    }
+}
+
+// ============================================================================
+// Helper: get sandbox + vsock path
+// ============================================================================
+
+async fn get_vsock_path(
+    state: &SharedState,
+    id: &str,
+) -> std::result::Result<std::path::PathBuf, Response> {
+    let sandboxes = state.sandboxes.read().await;
+    let entry = sandboxes
+        .get(id)
+        .ok_or_else(|| gateway_error(StatusCode::NOT_FOUND, format!("Sandbox {} not found", id)))?;
+    Ok(entry.handle.vsock_socket_path())
+}
+
+fn sandbox_url(port: u16, id: &str) -> String {
+    format!("http://localhost:{}/s/{}", port, id)
+}
+
+// ============================================================================
+// Gateway handlers
+// ============================================================================
+
+async fn create_sandbox(
+    State(state): State<SharedState>,
+    Json(req): Json<CreateSandboxRequest>,
+) -> Response {
+    let image = match (&req.runtime, &req.image) {
+        (Some(runtime), _) => runtime_to_image(runtime).to_string(),
+        (_, Some(image)) => image.clone(),
+        (None, None) => "python:3.12-slim".to_string(), // default to python
+    };
+
+    let runtime = req.runtime.clone().or_else(|| Some("python".to_string()));
+    let name = req
+        .name
+        .unwrap_or_else(|| format!("csdk-{}", &uuid::Uuid::new_v4().to_string()[..8]));
+
+    // Build RunArgs for start_vm
+    let args = crate::cli::RunArgs {
+        name: name.clone(),
+        cpu: req.cpu.unwrap_or(2),
+        mem: req.memory_mib.unwrap_or(2048),
+        rootfs_size: "10G".to_string(),
+        map: vec![],
+        disk: vec![],
+        disk_dir: vec![],
+        nfs: vec![],
+        env: req
+            .env
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect(),
+        label: req
+            .labels
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect(),
+        cmd: Some("sh -c 'while :; do sleep 3600; done'".to_string()),
+        publish: vec![],
+        balloon: None,
+        network: crate::cli::NetworkMode::Rootless,
+        health_check: None,
+        privileged: false,
+        interactive: false,
+        tty: false,
+        strace_agent: false,
+        setup: true,
+        kernel: None,
+        kernel_profile: None,
+        vsock_dir: None,
+        no_snapshot: true,
+        image,
+        command_args: vec![],
+    };
+
+    info!(name = %name, "Creating sandbox");
+
+    let handle = match start_vm(args).await {
+        Ok(h) => h,
+        Err(e) => {
+            error!(error = %e, "Failed to start VM");
+            return gateway_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to create sandbox: {}", e),
+            );
+        }
+    };
+
+    let sandbox_id = handle.vm_id.clone();
+
+    // Wait for healthy status (max 120s)
+    let healthy = wait_for_healthy(&handle, std::time::Duration::from_secs(120)).await;
+    if !healthy {
+        warn!(sandbox_id = %sandbox_id, "Sandbox did not become healthy within timeout");
+        // Don't fail — the SDK will poll /health itself
+    }
+
+    let url = sandbox_url(state.port, &sandbox_id);
+
+    let entry = SandboxEntry {
+        handle,
+        runtime,
+        created_at: Utc::now(),
+        timeout_ms: req.timeout_ms,
+    };
+
+    state
+        .sandboxes
+        .write()
+        .await
+        .insert(sandbox_id.clone(), entry);
+
+    info!(sandbox_id = %sandbox_id, "Sandbox created");
+
+    let info = SandboxInfo {
+        sandbox_id,
+        url,
+        token: "local".to_string(),
+        provider: "fcvm".to_string(),
+        status: Some("ready".to_string()),
+        name: Some(name),
+    };
+
+    GatewayResponse::ok(info).into_response()
+}
+
+async fn wait_for_healthy(handle: &VmHandle, timeout: std::time::Duration) -> bool {
+    let start = std::time::Instant::now();
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
+    loop {
+        interval.tick().await;
+        if start.elapsed() > timeout {
+            return false;
+        }
+        match handle.state().await {
+            Ok(s) if s.health_status == HealthStatus::Healthy => return true,
+            Ok(s) if s.health_status == HealthStatus::Stopped => return false,
+            _ => {}
+        }
+    }
+}
+
+async fn list_sandboxes(State(state): State<SharedState>) -> Response {
+    let sandboxes = state.sandboxes.read().await;
+    let list: Vec<SandboxInfo> = sandboxes
+        .iter()
+        .map(|(id, entry)| SandboxInfo {
+            sandbox_id: id.clone(),
+            url: sandbox_url(state.port, id),
+            token: "local".to_string(),
+            provider: "fcvm".to_string(),
+            status: None,
+            name: Some(entry.handle.name.clone()),
+        })
+        .collect();
+    GatewayResponse::ok(list).into_response()
+}
+
+async fn get_sandbox(State(state): State<SharedState>, Path(id): Path<String>) -> Response {
+    let sandboxes = state.sandboxes.read().await;
+    let entry = match sandboxes.get(&id) {
+        Some(e) => e,
+        None => return gateway_error(StatusCode::NOT_FOUND, format!("Sandbox {} not found", id)),
+    };
+
+    let status = match entry.handle.state().await {
+        Ok(s) => format!("{:?}", s.health_status).to_lowercase(),
+        Err(_) => "unknown".to_string(),
+    };
+
+    let info = SandboxInfo {
+        sandbox_id: id.clone(),
+        url: sandbox_url(state.port, &id),
+        token: "local".to_string(),
+        provider: "fcvm".to_string(),
+        status: Some(status),
+        name: Some(entry.handle.name.clone()),
+    };
+
+    GatewayResponse::ok(info).into_response()
+}
+
+async fn destroy_sandbox(State(state): State<SharedState>, Path(id): Path<String>) -> Response {
+    let mut entry = match state.sandboxes.write().await.remove(&id) {
+        Some(e) => e,
+        None => return gateway_error(StatusCode::NOT_FOUND, format!("Sandbox {} not found", id)),
+    };
+
+    info!(sandbox_id = %id, "Destroying sandbox");
+
+    if let Err(e) = entry.handle.stop().await {
+        warn!(sandbox_id = %id, error = %e, "Error stopping sandbox");
+    }
+
+    let body = serde_json::json!({ "success": true });
+    Json(body).into_response()
+}
+
+// ============================================================================
+// Sandbox daemon handlers
+// ============================================================================
+
+async fn health(State(state): State<SharedState>, Path(id): Path<String>) -> Response {
+    let sandboxes = state.sandboxes.read().await;
+    if !sandboxes.contains_key(&id) {
+        return gateway_error(StatusCode::NOT_FOUND, format!("Sandbox {} not found", id));
+    }
+
+    let body = serde_json::json!({
+        "status": "ok",
+        "timestamp": Utc::now().to_rfc3339(),
+    });
+    Json(body).into_response()
+}
+
+async fn ready(State(state): State<SharedState>, Path(id): Path<String>) -> Response {
+    let sandboxes = state.sandboxes.read().await;
+    let entry = match sandboxes.get(&id) {
+        Some(e) => e,
+        None => return gateway_error(StatusCode::NOT_FOUND, format!("Sandbox {} not found", id)),
+    };
+
+    let healthy = match entry.handle.state().await {
+        Ok(s) => s.health_status == HealthStatus::Healthy,
+        Err(_) => false,
+    };
+
+    let body = serde_json::json!({
+        "ready": healthy,
+        "healthy": healthy,
+        "servers": [],
+        "overlays": [],
+    });
+    Json(body).into_response()
+}
+
+async fn run_code(
+    State(state): State<SharedState>,
+    Path(id): Path<String>,
+    Json(req): Json<RunCodeRequest>,
+) -> Response {
+    let (vsock_path, language) = {
+        let sandboxes = state.sandboxes.read().await;
+        let entry = match sandboxes.get(&id) {
+            Some(e) => e,
+            None => {
+                return gateway_error(StatusCode::NOT_FOUND, format!("Sandbox {} not found", id))
+            }
+        };
+        let lang = req.language.clone().unwrap_or_else(|| {
+            entry
+                .runtime
+                .as_deref()
+                .map(runtime_to_language)
+                .unwrap_or("python")
+                .to_string()
+        });
+        (entry.handle.vsock_socket_path(), lang)
+    };
+
+    let cmd = language_to_run_command(&language, &req.code);
+
+    let output = match run_exec_in_vm_captured(&vsock_path, &cmd, true).await {
+        Ok(o) => o,
+        Err(e) => {
+            return gateway_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Exec failed: {}", e),
+            );
+        }
+    };
+
+    let combined = if output.stderr.is_empty() {
+        output.stdout.clone()
+    } else if output.stdout.is_empty() {
+        output.stderr.clone()
+    } else {
+        format!("{}{}", output.stdout, output.stderr)
+    };
+
+    let resp = RunCodeResponse {
+        data: RunCodeData {
+            output: combined,
+            exit_code: output.exit_code,
+            language,
+        },
+    };
+    Json(resp).into_response()
+}
+
+async fn run_command(
+    State(state): State<SharedState>,
+    Path(id): Path<String>,
+    Json(req): Json<RunCommandRequest>,
+) -> Response {
+    let vsock_path = match get_vsock_path(&state, &id).await {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+
+    let shell_cmd = build_shell_command(&req.command, req.cwd.as_deref(), req.env.as_ref());
+    let start = std::time::Instant::now();
+
+    let output = match run_exec_in_vm_captured(&vsock_path, &shell_cmd, true).await {
+        Ok(o) => o,
+        Err(e) => {
+            return gateway_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Exec failed: {}", e),
+            );
+        }
+    };
+
+    let duration_ms = start.elapsed().as_millis() as u64;
+
+    let resp = RunCommandResponse {
+        message: "Command executed".to_string(),
+        data: RunCommandData {
+            command: req.command,
+            stdout: output.stdout,
+            stderr: output.stderr,
+            exit_code: output.exit_code,
+            duration_ms,
+        },
+    };
+    Json(resp).into_response()
+}
+
+fn build_shell_command(
+    command: &str,
+    cwd: Option<&str>,
+    env: Option<&HashMap<String, String>>,
+) -> Vec<String> {
+    let mut parts = String::new();
+    if let Some(dir) = cwd {
+        parts.push_str(&format!("cd '{}' && ", dir.replace('\'', "'\\''")));
+    }
+    if let Some(vars) = env {
+        for (k, v) in vars {
+            parts.push_str(&format!("export {}='{}'; ", k, v.replace('\'', "'\\''")));
+        }
+    }
+    parts.push_str(command);
+    vec!["sh".into(), "-c".into(), parts]
+}
+
+// ============================================================================
+// File operation handlers
+// ============================================================================
+
+async fn list_files(
+    State(state): State<SharedState>,
+    Path(id): Path<String>,
+    Query(query): Query<FilesQuery>,
+) -> Response {
+    let vsock_path = match get_vsock_path(&state, &id).await {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+
+    let path = query.path.as_deref().unwrap_or("/");
+
+    // Use stat to get file info in a parseable format
+    // Use printf to produce real tab characters (stat --format doesn't interpret \t)
+    let cmd = vec![
+        "sh".into(),
+        "-c".into(),
+        format!(
+            "for f in '{}'/*; do [ -e \"$f\" ] && stat --printf='%n\\t%F\\t%s\\t%Y\\n' \"$f\" 2>/dev/null; done",
+            path.replace('\'', "'\\''")
+        ),
+    ];
+
+    let output = match run_exec_in_vm_captured(&vsock_path, &cmd, true).await {
+        Ok(o) => o,
+        Err(e) => {
+            return gateway_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to list files: {}", e),
+            );
+        }
+    };
+
+    let files: Vec<FileInfo> = output
+        .stdout
+        .lines()
+        .filter_map(|line| {
+            let parts: Vec<&str> = line.split('\t').collect();
+            if parts.len() >= 4 {
+                let name = std::path::Path::new(parts[0])
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_else(|| parts[0].to_string());
+                let is_dir = parts[1].contains("directory");
+                let file_type = if is_dir { "directory" } else { "file" }.to_string();
+                let size = parts[2].parse().unwrap_or(0);
+                let modified_at = parts[3]
+                    .parse::<i64>()
+                    .ok()
+                    .and_then(|ts| chrono::DateTime::from_timestamp(ts, 0))
+                    .map(|dt| dt.to_rfc3339());
+                Some(FileInfo {
+                    name,
+                    file_type,
+                    is_dir,
+                    size,
+                    modified_at,
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let body = serde_json::json!({
+        "message": "Files listed",
+        "data": {
+            "files": files,
+            "path": path,
+        }
+    });
+    Json(body).into_response()
+}
+
+async fn create_file(
+    State(state): State<SharedState>,
+    Path(id): Path<String>,
+    Json(req): Json<CreateFileRequest>,
+) -> Response {
+    let vsock_path = match get_vsock_path(&state, &id).await {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+
+    // Create parent directory and write file
+    let dir = std::path::Path::new(&req.path)
+        .parent()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|| "/".to_string());
+
+    let is_base64 = req.encoding.as_deref() == Some("base64");
+
+    let write_cmd = if is_base64 {
+        format!(
+            "mkdir -p '{}' && echo '{}' | base64 -d > '{}'",
+            dir.replace('\'', "'\\''"),
+            req.content.replace('\'', "'\\''"),
+            req.path.replace('\'', "'\\''"),
+        )
+    } else {
+        format!(
+            "mkdir -p '{}' && cat > '{}' << 'FCVM_EOF'\n{}\nFCVM_EOF",
+            dir.replace('\'', "'\\''"),
+            req.path.replace('\'', "'\\''"),
+            req.content,
+        )
+    };
+
+    let cmd = vec!["sh".into(), "-c".into(), write_cmd];
+
+    if let Err(e) = run_exec_in_vm_captured(&vsock_path, &cmd, true).await {
+        return gateway_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to write file: {}", e),
+        );
+    }
+
+    let body = serde_json::json!({
+        "message": "File created",
+        "data": {
+            "file": {
+                "name": std::path::Path::new(&req.path).file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_default(),
+                "type": "file",
+                "path": req.path,
+            }
+        }
+    });
+    (StatusCode::CREATED, Json(body)).into_response()
+}
+
+async fn read_file(
+    State(state): State<SharedState>,
+    Path((id, file_path)): Path<(String, String)>,
+) -> Response {
+    let vsock_path = match get_vsock_path(&state, &id).await {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+
+    let decoded_path = percent_encoding::percent_decode_str(&file_path).decode_utf8_lossy();
+    let abs_path = if decoded_path.starts_with('/') {
+        decoded_path.to_string()
+    } else {
+        format!("/{}", decoded_path)
+    };
+
+    let cmd = vec![
+        "sh".into(),
+        "-c".into(),
+        format!("cat '{}'", abs_path.replace('\'', "'\\''")),
+    ];
+
+    let output = match run_exec_in_vm_captured(&vsock_path, &cmd, true).await {
+        Ok(o) => o,
+        Err(e) => {
+            return gateway_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to read file: {}", e),
+            );
+        }
+    };
+
+    if output.exit_code != 0 {
+        return gateway_error(
+            StatusCode::NOT_FOUND,
+            format!("File not found: {}", abs_path),
+        );
+    }
+
+    let body = serde_json::json!({
+        "message": "File read",
+        "data": {
+            "content": output.stdout,
+            "path": abs_path,
+            "encoding": "utf-8",
+        }
+    });
+    Json(body).into_response()
+}
+
+async fn file_exists(
+    State(state): State<SharedState>,
+    Path((id, file_path)): Path<(String, String)>,
+) -> Response {
+    let vsock_path = match get_vsock_path(&state, &id).await {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+
+    let decoded_path = percent_encoding::percent_decode_str(&file_path).decode_utf8_lossy();
+    let abs_path = if decoded_path.starts_with('/') {
+        decoded_path.to_string()
+    } else {
+        format!("/{}", decoded_path)
+    };
+
+    let cmd = vec![
+        "sh".into(),
+        "-c".into(),
+        format!("test -e '{}'", abs_path.replace('\'', "'\\''")),
+    ];
+
+    let output = match run_exec_in_vm_captured(&vsock_path, &cmd, true).await {
+        Ok(o) => o,
+        Err(_) => return StatusCode::NOT_FOUND.into_response(),
+    };
+
+    if output.exit_code == 0 {
+        StatusCode::OK.into_response()
+    } else {
+        StatusCode::NOT_FOUND.into_response()
+    }
+}
+
+async fn delete_file(
+    State(state): State<SharedState>,
+    Path((id, file_path)): Path<(String, String)>,
+) -> Response {
+    let vsock_path = match get_vsock_path(&state, &id).await {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+
+    let decoded_path = percent_encoding::percent_decode_str(&file_path).decode_utf8_lossy();
+    let abs_path = if decoded_path.starts_with('/') {
+        decoded_path.to_string()
+    } else {
+        format!("/{}", decoded_path)
+    };
+
+    let cmd = vec![
+        "sh".into(),
+        "-c".into(),
+        format!("rm -rf '{}'", abs_path.replace('\'', "'\\''")),
+    ];
+
+    if let Err(e) = run_exec_in_vm_captured(&vsock_path, &cmd, true).await {
+        return gateway_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to delete file: {}", e),
+        );
+    }
+
+    StatusCode::NO_CONTENT.into_response()
+}
+
+// ============================================================================
+// Terminal handlers
+// ============================================================================
+
+async fn create_terminal(
+    State(state): State<SharedState>,
+    Path(id): Path<String>,
+    Json(_req): Json<CreateTerminalRequest>,
+) -> Response {
+    let sandboxes = state.sandboxes.read().await;
+    if !sandboxes.contains_key(&id) {
+        return gateway_error(StatusCode::NOT_FOUND, format!("Sandbox {} not found", id));
+    }
+
+    let terminal_id = uuid::Uuid::new_v4().to_string();
+
+    let body = serde_json::json!({
+        "message": "Terminal created",
+        "data": {
+            "id": terminal_id,
+            "pty": true,
+            "status": "running",
+        }
+    });
+    (StatusCode::CREATED, Json(body)).into_response()
+}
+
+async fn ws_terminal(
+    State(state): State<SharedState>,
+    Path(id): Path<String>,
+    ws: WebSocketUpgrade,
+) -> Response {
+    let vsock_path = {
+        let sandboxes = state.sandboxes.read().await;
+        match sandboxes.get(&id) {
+            Some(entry) => entry.handle.vsock_socket_path(),
+            None => {
+                return gateway_error(StatusCode::NOT_FOUND, format!("Sandbox {} not found", id));
+            }
+        }
+    };
+
+    ws.on_upgrade(move |socket| ws_terminal_handler(socket, vsock_path))
+}
+
+async fn ws_terminal_handler(mut ws: axum::extract::ws::WebSocket, vsock_path: std::path::PathBuf) {
+    use axum::extract::ws::Message as WsMessage;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    // Connect to exec server
+    let stream = match crate::commands::exec::connect_to_exec_server_async(&vsock_path).await {
+        Ok(s) => s,
+        Err(e) => {
+            error!(error = %e, "Failed to connect to exec server for terminal");
+            let _ = ws
+                .send(WsMessage::Close(Some(axum::extract::ws::CloseFrame {
+                    code: 1011,
+                    reason: format!("Failed to connect: {}", e).into(),
+                })))
+                .await;
+            return;
+        }
+    };
+
+    // Send exec request for interactive bash
+    let exec_req = crate::commands::exec::ExecRequest {
+        command: vec!["/bin/bash".into()],
+        in_container: true,
+        interactive: true,
+        tty: true,
+    };
+    let (mut vsock_read, mut vsock_write) = stream.into_split();
+
+    // Write the exec request as JSON line
+    let req_json = match serde_json::to_string(&exec_req) {
+        Ok(j) => j,
+        Err(e) => {
+            error!(error = %e, "Failed to serialize exec request");
+            return;
+        }
+    };
+    if let Err(e) = vsock_write
+        .write_all(format!("{}\n", req_json).as_bytes())
+        .await
+    {
+        error!(error = %e, "Failed to send exec request");
+        return;
+    }
+
+    // Bridge WS ↔ vsock
+    // Use a channel for vsock→WS since we can't hold &mut to both ws and vsock in select!
+    let (vsock_tx, mut vsock_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(32);
+
+    // Spawn task to read from vsock and send to channel
+    tokio::spawn(async move {
+        let mut buf = vec![0u8; 8192];
+        loop {
+            match vsock_read.read(&mut buf).await {
+                Ok(0) => break,
+                Ok(n) => {
+                    if vsock_tx.send(buf[..n].to_vec()).await.is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    // Main loop: read from WS and from vsock channel
+    loop {
+        tokio::select! {
+            Some(data) = vsock_rx.recv() => {
+                if ws.send(WsMessage::Binary(data.into())).await.is_err() {
+                    break;
+                }
+            }
+            result = ws.recv() => {
+                match result {
+                    Some(Ok(WsMessage::Binary(data))) => {
+                        if vsock_write.write_all(&data).await.is_err() {
+                            break;
+                        }
+                    }
+                    Some(Ok(WsMessage::Text(text))) => {
+                        // Text frames: encode as exec-proto stdin message
+                        let mut buf = Vec::new();
+                        if exec_proto::write_stdin(&mut buf, text.as_bytes()).is_err() {
+                            break;
+                        }
+                        if vsock_write.write_all(&buf).await.is_err() {
+                            break;
+                        }
+                    }
+                    Some(Ok(WsMessage::Close(_))) | None => break,
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Cleanup
+// ============================================================================
+
+async fn cleanup_orphans() {
+    let state_dir = crate::paths::state_dir();
+    let mgr = StateManager::new(state_dir);
+
+    if let Ok(vms) = mgr.list_vms().await {
+        for vm in vms {
+            if let Some(pid) = vm.pid {
+                // Check if process is still alive
+                if nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid as i32), None).is_ok() {
+                    warn!(pid = pid, vm_id = %vm.vm_id, "Killing orphaned VM");
+                    let _ = nix::sys::signal::kill(
+                        nix::unistd::Pid::from_raw(pid as i32),
+                        nix::sys::signal::Signal::SIGTERM,
+                    );
+                }
+            }
+            let _ = mgr.delete_state(&vm.vm_id).await;
+        }
+    }
+}
+
+async fn reaper_task(state: SharedState) {
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(10));
+    loop {
+        interval.tick().await;
+        let now = Utc::now();
+        let mut expired = Vec::new();
+
+        {
+            let sandboxes = state.sandboxes.read().await;
+            for (id, entry) in sandboxes.iter() {
+                if let Some(timeout_ms) = entry.timeout_ms {
+                    let elapsed = (now - entry.created_at).num_milliseconds();
+                    if elapsed > timeout_ms as i64 {
+                        expired.push(id.clone());
+                    }
+                }
+            }
+        }
+
+        for id in expired {
+            if let Some(mut entry) = state.sandboxes.write().await.remove(&id) {
+                info!(sandbox_id = %id, "Sandbox expired, destroying");
+                let _ = entry.handle.stop().await;
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Main entry point
+// ============================================================================
+
+pub async fn cmd_serve(args: ServeArgs) -> Result<()> {
+    info!(port = args.port, "Starting fcvm serve");
+
+    // Clean up orphaned VMs from previous runs
+    cleanup_orphans().await;
+
+    let state = Arc::new(AppState {
+        sandboxes: RwLock::new(HashMap::new()),
+        port: args.port,
+    });
+
+    // Spawn idle timeout reaper
+    tokio::spawn(reaper_task(state.clone()));
+
+    let app = Router::new()
+        // Gateway endpoints
+        .route("/v1/sandboxes", post(create_sandbox).get(list_sandboxes))
+        .route(
+            "/v1/sandboxes/{id}",
+            get(get_sandbox).delete(destroy_sandbox),
+        )
+        // Sandbox daemon endpoints
+        .route("/s/{id}/health", get(health))
+        .route("/s/{id}/ready", get(ready))
+        .route("/s/{id}/run/code", post(run_code))
+        .route("/s/{id}/run/command", post(run_command))
+        .route("/s/{id}/files", get(list_files).post(create_file))
+        .route(
+            "/s/{id}/files/{*path}",
+            get(read_file).head(file_exists).delete(delete_file),
+        )
+        .route("/s/{id}/terminals", post(create_terminal))
+        .route("/s/{id}", get(ws_terminal))
+        .layer(CorsLayer::permissive())
+        .with_state(state.clone());
+
+    let addr = std::net::SocketAddr::from(([0, 0, 0, 0], args.port));
+    info!(addr = %addr, "Listening");
+
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .context("Failed to bind to port")?;
+
+    // Graceful shutdown on SIGTERM/SIGINT
+    let shutdown_state = state.clone();
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async move {
+            let ctrl_c = tokio::signal::ctrl_c();
+            let mut sigterm =
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                    .expect("install SIGTERM handler");
+
+            tokio::select! {
+                _ = ctrl_c => info!("Received SIGINT"),
+                _ = sigterm.recv() => info!("Received SIGTERM"),
+            }
+
+            info!("Shutting down — stopping all sandboxes");
+            let mut sandboxes = shutdown_state.sandboxes.write().await;
+            for (id, entry) in sandboxes.drain() {
+                info!(sandbox_id = %id, "Stopping sandbox");
+                let mut handle = entry.handle;
+                let _ = handle.stop().await;
+            }
+        })
+        .await
+        .context("Server error")?;
+
+    info!("Server stopped");
+    Ok(())
+}

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -656,11 +656,15 @@ async fn create_file(
             req.path.replace('\'', "'\\''"),
         )
     } else {
+        // Use a randomized heredoc delimiter to prevent content injection
+        let delimiter = format!("FCVM_EOF_{}", uuid::Uuid::new_v4().simple());
         format!(
-            "mkdir -p '{}' && cat > '{}' << 'FCVM_EOF'\n{}\nFCVM_EOF",
+            "mkdir -p '{}' && cat > '{}' << '{}'\n{}\n{}",
             dir.replace('\'', "'\\''"),
             req.path.replace('\'', "'\\''"),
+            delimiter,
             req.content,
+            delimiter,
         )
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,7 @@ async fn main() -> Result<()> {
         Commands::Snapshot(args) => commands::cmd_snapshot(args).await,
         Commands::Snapshots(args) => commands::cmd_snapshots(args).await,
         Commands::Exec(args) => commands::cmd_exec(args).await,
+        Commands::Serve(args) => commands::cmd_serve(args).await,
         Commands::Setup(args) => commands::cmd_setup(args).await,
         Commands::Completions(args) => {
             commands::cmd_completions(args);

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -1,0 +1,544 @@
+{
+  "name": "tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "computesdk": "file:../../computesdk/packages/computesdk",
+        "tsx": "^4"
+      }
+    },
+    "../../computesdk/packages/computesdk": {
+      "version": "2.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "@computesdk/cmd": "workspace:*"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@vitest/coverage-v8": "^1.0.0",
+        "eslint": "^8.37.0",
+        "rimraf": "^5.0.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^1.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/computesdk": {
+      "resolved": "../../computesdk/packages/computesdk",
+      "link": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    }
+  }
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "computesdk": "file:../../computesdk/packages/computesdk",
+    "tsx": "^4"
+  }
+}

--- a/tests/test_serve.rs
+++ b/tests/test_serve.rs
@@ -1,0 +1,315 @@
+//! Integration tests for `fcvm serve` HTTP API.
+//!
+//! Tests start the server on a random port, create sandboxes, run code/commands,
+//! read/write files, and destroy sandboxes — exercising the full gateway + daemon pipeline.
+
+mod common;
+
+use std::time::Duration;
+
+#[cfg(feature = "integration-slow")]
+#[tokio::test]
+async fn test_serve_create_run_destroy() {
+    let logger = common::TestLogger::new("test_serve_create_run_destroy");
+
+    // Find fcvm binary
+    let fcvm_path = common::find_fcvm_binary().expect("find fcvm binary");
+    logger.info(&format!("Using fcvm binary: {:?}", fcvm_path));
+
+    // Start fcvm serve on a random port
+    let port = 18090 + (std::process::id() % 1000) as u16;
+    logger.info(&format!("Starting fcvm serve on port {}", port));
+
+    let mut serve_child = tokio::process::Command::new(&fcvm_path)
+        .args(["serve", "--port", &port.to_string()])
+        .env("RUST_LOG", "info")
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
+        .spawn()
+        .expect("spawn fcvm serve");
+
+    let serve_pid = serve_child.id().expect("serve process has PID");
+    logger.info(&format!("fcvm serve started with PID {}", serve_pid));
+
+    // Wait for server to be ready
+    let base_url = format!("http://localhost:{}", port);
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("build HTTP client");
+
+    // Poll until server accepts connections (max 10s)
+    let mut ready = false;
+    for _ in 0..20 {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let url = format!("{}/v1/sandboxes", base_url);
+        if client.get(url).send().await.is_ok() {
+            ready = true;
+            break;
+        }
+    }
+    assert!(ready, "Server failed to start within 10s");
+    logger.info("Server is ready");
+
+    // ===== Test 1: List sandboxes (empty) =====
+    logger.info("Test 1: List sandboxes (empty)");
+    let resp = client
+        .get(format!("{}/v1/sandboxes", base_url))
+        .send()
+        .await
+        .expect("list sandboxes");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.expect("parse JSON");
+    assert_eq!(body["success"], true);
+    assert_eq!(body["data"].as_array().expect("data is array").len(), 0);
+
+    // ===== Test 2: Create sandbox =====
+    logger.info("Test 2: Create sandbox with python runtime");
+    let create_body = serde_json::json!({
+        "runtime": "python",
+        "name": "serve-test",
+        "cpu": 1,
+        "memory_mib": 512,
+    });
+    let resp = client
+        .post(format!("{}/v1/sandboxes", base_url))
+        .json(&create_body)
+        .timeout(Duration::from_secs(180))
+        .send()
+        .await
+        .expect("create sandbox");
+
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.expect("parse create response");
+    logger.info(&format!(
+        "Create response: {}",
+        serde_json::to_string_pretty(&body).unwrap()
+    ));
+    assert_eq!(status, 200, "Create failed: {:?}", body);
+    assert_eq!(body["success"], true);
+
+    let sandbox_id = body["data"]["sandboxId"]
+        .as_str()
+        .expect("sandboxId in response")
+        .to_string();
+    let sandbox_url = body["data"]["url"]
+        .as_str()
+        .expect("url in response")
+        .to_string();
+    logger.info(&format!(
+        "Created sandbox: {} at {}",
+        sandbox_id, sandbox_url
+    ));
+
+    // ===== Test 3: Health check =====
+    logger.info("Test 3: Health check");
+    let resp = client
+        .get(format!("{}/health", sandbox_url))
+        .send()
+        .await
+        .expect("health check");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.expect("parse health");
+    assert_eq!(body["status"], "ok");
+    logger.info(&format!("Health: {}", body));
+
+    // ===== Test 4: Ready check =====
+    logger.info("Test 4: Ready check");
+    let resp = client
+        .get(format!("{}/ready", sandbox_url))
+        .send()
+        .await
+        .expect("ready check");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.expect("parse ready");
+    assert_eq!(body["ready"], true);
+    assert_eq!(body["healthy"], true);
+
+    // ===== Test 5: Run code =====
+    logger.info("Test 5: Run code (python)");
+    let code_body = serde_json::json!({
+        "code": "print(40 + 2)",
+    });
+    let resp = client
+        .post(format!("{}/run/code", sandbox_url))
+        .json(&code_body)
+        .timeout(Duration::from_secs(30))
+        .send()
+        .await
+        .expect("run code");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.expect("parse run code");
+    logger.info(&format!(
+        "Run code result: {}",
+        serde_json::to_string_pretty(&body).unwrap()
+    ));
+    assert_eq!(body["data"]["exit_code"], 0);
+    assert_eq!(body["data"]["output"].as_str().unwrap().trim(), "42");
+    assert_eq!(body["data"]["language"], "python");
+
+    // ===== Test 6: Run command =====
+    logger.info("Test 6: Run command");
+    let cmd_body = serde_json::json!({
+        "command": "echo hello world",
+    });
+    let resp = client
+        .post(format!("{}/run/command", sandbox_url))
+        .json(&cmd_body)
+        .timeout(Duration::from_secs(30))
+        .send()
+        .await
+        .expect("run command");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.expect("parse run command");
+    logger.info(&format!(
+        "Run command result: {}",
+        serde_json::to_string_pretty(&body).unwrap()
+    ));
+    assert_eq!(body["data"]["exit_code"], 0);
+    assert_eq!(
+        body["data"]["stdout"].as_str().unwrap().trim(),
+        "hello world"
+    );
+    assert!(body["data"]["duration_ms"].as_u64().unwrap() > 0);
+
+    // ===== Test 7: Write file =====
+    logger.info("Test 7: Write file");
+    let write_body = serde_json::json!({
+        "path": "/tmp/test-serve.txt",
+        "content": "hello from serve test",
+    });
+    let resp = client
+        .post(format!("{}/files", sandbox_url))
+        .json(&write_body)
+        .timeout(Duration::from_secs(30))
+        .send()
+        .await
+        .expect("write file");
+    assert_eq!(resp.status(), 201);
+
+    // ===== Test 8: Read file =====
+    logger.info("Test 8: Read file");
+    let resp = client
+        .get(format!("{}/files/tmp/test-serve.txt", sandbox_url))
+        .timeout(Duration::from_secs(30))
+        .send()
+        .await
+        .expect("read file");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.expect("parse read file");
+    assert_eq!(
+        body["content"].as_str().unwrap().trim(),
+        "hello from serve test"
+    );
+
+    // ===== Test 9: File exists (HEAD) =====
+    logger.info("Test 9: File exists check");
+    let resp = client
+        .head(format!("{}/files/tmp/test-serve.txt", sandbox_url))
+        .timeout(Duration::from_secs(30))
+        .send()
+        .await
+        .expect("check file exists");
+    assert_eq!(resp.status(), 200);
+
+    // ===== Test 10: File not exists (HEAD) =====
+    logger.info("Test 10: File not exists check");
+    let resp = client
+        .head(format!("{}/files/tmp/nonexistent-file.txt", sandbox_url))
+        .timeout(Duration::from_secs(30))
+        .send()
+        .await
+        .expect("check file not exists");
+    assert_eq!(resp.status(), 404);
+
+    // ===== Test 11: Delete file =====
+    logger.info("Test 11: Delete file");
+    let resp = client
+        .delete(format!("{}/files/tmp/test-serve.txt", sandbox_url))
+        .timeout(Duration::from_secs(30))
+        .send()
+        .await
+        .expect("delete file");
+    assert_eq!(resp.status(), 204);
+
+    // Verify file is gone
+    let resp = client
+        .head(format!("{}/files/tmp/test-serve.txt", sandbox_url))
+        .timeout(Duration::from_secs(30))
+        .send()
+        .await
+        .expect("verify file deleted");
+    assert_eq!(resp.status(), 404);
+
+    // ===== Test 12: List files =====
+    logger.info("Test 12: List files");
+    let resp = client
+        .get(format!("{}/files?path=/tmp", sandbox_url))
+        .timeout(Duration::from_secs(30))
+        .send()
+        .await
+        .expect("list files");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.expect("parse list files");
+    assert!(body["data"]["files"].is_array());
+
+    // ===== Test 13: Get sandbox =====
+    logger.info("Test 13: Get sandbox details");
+    let resp = client
+        .get(format!("{}/v1/sandboxes/{}", base_url, sandbox_id))
+        .send()
+        .await
+        .expect("get sandbox");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.expect("parse get sandbox");
+    assert_eq!(body["success"], true);
+    assert_eq!(body["data"]["sandboxId"], sandbox_id);
+
+    // ===== Test 14: List sandboxes (1 present) =====
+    logger.info("Test 14: List sandboxes (1 present)");
+    let resp = client
+        .get(format!("{}/v1/sandboxes", base_url))
+        .send()
+        .await
+        .expect("list sandboxes");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.expect("parse list");
+    assert_eq!(body["data"].as_array().expect("data array").len(), 1);
+
+    // ===== Test 15: Destroy sandbox =====
+    logger.info("Test 15: Destroy sandbox");
+    let resp = client
+        .delete(format!("{}/v1/sandboxes/{}", base_url, sandbox_id))
+        .timeout(Duration::from_secs(60))
+        .send()
+        .await
+        .expect("destroy sandbox");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.expect("parse destroy");
+    assert_eq!(body["success"], true);
+
+    // ===== Test 16: Verify sandbox is gone =====
+    logger.info("Test 16: Verify sandbox is gone");
+    let resp = client
+        .get(format!("{}/v1/sandboxes/{}", base_url, sandbox_id))
+        .send()
+        .await
+        .expect("get deleted sandbox");
+    assert_eq!(resp.status(), 404);
+
+    // ===== Test 17: Destroy non-existent (404) =====
+    logger.info("Test 17: Destroy non-existent sandbox");
+    let resp = client
+        .delete(format!("{}/v1/sandboxes/nonexistent", base_url))
+        .send()
+        .await
+        .expect("destroy nonexistent");
+    assert_eq!(resp.status(), 404);
+
+    // Clean up: kill the serve process
+    logger.info("Cleaning up: killing serve process");
+    common::kill_process(serve_pid).await;
+    let _ = serve_child.wait().await;
+
+    logger.finish(true);
+}

--- a/tests/test_serve.rs
+++ b/tests/test_serve.rs
@@ -198,7 +198,7 @@ async fn test_serve_create_run_destroy() {
     assert_eq!(resp.status(), 200);
     let body: serde_json::Value = resp.json().await.expect("parse read file");
     assert_eq!(
-        body["content"].as_str().unwrap().trim(),
+        body["data"]["content"].as_str().unwrap().trim(),
         "hello from serve test"
     );
 

--- a/tests/test_serve_sdk.ts
+++ b/tests/test_serve_sdk.ts
@@ -1,0 +1,470 @@
+/**
+ * Comprehensive E2E test for fcvm serve using the public ComputeSDK API.
+ *
+ * This test is fully self-contained: it starts `fcvm serve` on a random port,
+ * runs all tests using the standard `computesdk` package, then cleans up.
+ *
+ * Usage:
+ *   npx tsx tests/test_serve_sdk.ts
+ */
+
+import { compute, Sandbox } from 'computesdk';
+import { spawn, ChildProcess } from 'child_process';
+import * as net from 'net';
+import * as path from 'path';
+import * as fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Find a free port by binding to port 0 */
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('Could not get port'));
+        return;
+      }
+      const port = addr.port;
+      server.close(() => resolve(port));
+    });
+    server.on('error', reject);
+  });
+}
+
+/** Find the fcvm binary */
+function findFcvmBinary(): string {
+  // Check relative to project root
+  const candidates = [
+    path.join(process.cwd(), 'target/release/fcvm'),
+    path.join(__dirname, '..', 'target/release/fcvm'),
+  ];
+  for (const p of candidates) {
+    if (fs.existsSync(p)) return p;
+  }
+  // Fall back to PATH
+  return 'fcvm';
+}
+
+/** Wait for server to accept connections */
+async function waitForServer(url: string, timeoutMs: number = 30000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const resp = await fetch(`${url}/v1/sandboxes`);
+      if (resp.ok) return;
+    } catch {
+      // Server not ready yet
+    }
+    await new Promise(r => setTimeout(r, 500));
+  }
+  throw new Error(`Server at ${url} did not start within ${timeoutMs}ms`);
+}
+
+let passed = 0;
+let failed = 0;
+
+function pass(name: string) {
+  passed++;
+  console.log(`  ✓ ${name}`);
+}
+
+function fail(name: string, err: any) {
+  failed++;
+  console.error(`  ✗ ${name}: ${err}`);
+}
+
+function assert(condition: boolean, message: string) {
+  if (!condition) throw new Error(`Assertion failed: ${message}`);
+}
+
+function assertEqual(actual: any, expected: any, message: string) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+// ============================================================================
+// Main Test Suite
+// ============================================================================
+
+async function main() {
+  console.log('=== fcvm serve — ComputeSDK E2E Integration Test ===\n');
+
+  // 1. Find fcvm binary and start server
+  const fcvmPath = findFcvmBinary();
+  console.log(`Binary: ${fcvmPath}`);
+
+  const port = await findFreePort();
+  const gatewayUrl = `http://localhost:${port}`;
+  console.log(`Port: ${port}`);
+  console.log(`Gateway: ${gatewayUrl}\n`);
+
+  const serveProcess: ChildProcess = spawn(fcvmPath, ['serve', '--port', port.toString()], {
+    stdio: ['ignore', 'inherit', 'inherit'],
+    env: { ...process.env, RUST_LOG: 'info' },
+  });
+
+  // Ensure cleanup on exit
+  const cleanup = () => {
+    if (serveProcess.pid) {
+      try { process.kill(serveProcess.pid, 'SIGTERM'); } catch {}
+    }
+  };
+  process.on('exit', cleanup);
+  process.on('SIGINT', cleanup);
+  process.on('SIGTERM', cleanup);
+
+  try {
+    // Wait for server
+    console.log('Waiting for server...');
+    await waitForServer(gatewayUrl);
+    console.log('Server ready.\n');
+
+    // 2. Configure ComputeSDK
+    compute.setConfig({
+      provider: 'fcvm',
+      computesdkApiKey: 'local',
+      gatewayUrl,
+      fcvm: { apiKey: 'local' },
+    });
+
+    // =====================================================================
+    // Test: Create Sandbox
+    // =====================================================================
+    console.log('--- Sandbox Lifecycle ---');
+    let sandbox: Sandbox;
+    try {
+      sandbox = await compute.sandbox.create();
+      assert(!!sandbox.sandboxId, 'sandboxId should be set');
+      pass(`create sandbox (id=${sandbox.sandboxId})`);
+    } catch (err) {
+      fail('create sandbox', err);
+      throw err; // Can't continue without a sandbox
+    }
+
+    // =====================================================================
+    // Test: Health Check
+    // =====================================================================
+    try {
+      const health = await sandbox.health();
+      assert(health.status === 'ok', `health status should be "ok", got "${health.status}"`);
+      pass('health check');
+    } catch (err) {
+      fail('health check', err);
+    }
+
+    // =====================================================================
+    // Test: Ready Check
+    // =====================================================================
+    try {
+      const ready = await sandbox.ready();
+      assert(ready.ready === true, 'ready should be true');
+      pass('ready check');
+    } catch (err) {
+      fail('ready check', err);
+    }
+
+    // =====================================================================
+    // Test: Run Code (Python)
+    // =====================================================================
+    console.log('\n--- Code Execution ---');
+    try {
+      const result = await sandbox.runCode('print(40 + 2)');
+      assertEqual(result.output.trim(), '42', 'runCode output');
+      assertEqual(result.exitCode, 0, 'runCode exitCode');
+      assertEqual(result.language, 'python', 'runCode language');
+      pass('runCode (python arithmetic)');
+    } catch (err) {
+      fail('runCode (python arithmetic)', err);
+    }
+
+    // Test: Run code with multi-line output
+    try {
+      const result = await sandbox.runCode('for i in range(3): print(f"line {i}")');
+      const lines = result.output.trim().split('\n');
+      assertEqual(lines.length, 3, 'multi-line output line count');
+      assertEqual(lines[0], 'line 0', 'first line');
+      assertEqual(lines[2], 'line 2', 'last line');
+      pass('runCode (multi-line output)');
+    } catch (err) {
+      fail('runCode (multi-line output)', err);
+    }
+
+    // Test: Run code with non-zero exit
+    try {
+      const result = await sandbox.runCode('import sys; sys.exit(42)');
+      assertEqual(result.exitCode, 42, 'non-zero exit code');
+      pass('runCode (non-zero exit)');
+    } catch (err) {
+      fail('runCode (non-zero exit)', err);
+    }
+
+    // Test: Run code with stderr
+    try {
+      const result = await sandbox.runCode('import sys; print("err", file=sys.stderr)');
+      assert(result.output.includes('err'), 'stderr should be in output');
+      pass('runCode (stderr)');
+    } catch (err) {
+      fail('runCode (stderr)', err);
+    }
+
+    // =====================================================================
+    // Test: Run Command
+    // =====================================================================
+    console.log('\n--- Command Execution ---');
+    try {
+      const result = await sandbox.runCommand('echo hello world');
+      assertEqual(result.stdout.trim(), 'hello world', 'runCommand stdout');
+      assertEqual(result.exitCode, 0, 'runCommand exitCode');
+      assert(result.durationMs >= 0, 'durationMs should be >= 0');
+      pass('runCommand (echo)');
+    } catch (err) {
+      fail('runCommand (echo)', err);
+    }
+
+    // Test: Run command with env vars
+    try {
+      const result = await sandbox.runCommand('echo $MY_VAR', { env: { MY_VAR: 'test_value' } });
+      assertEqual(result.stdout.trim(), 'test_value', 'env var in command');
+      pass('runCommand (env vars)');
+    } catch (err) {
+      fail('runCommand (env vars)', err);
+    }
+
+    // Test: Run command with cwd
+    try {
+      const result = await sandbox.runCommand('pwd', { cwd: '/tmp' });
+      assertEqual(result.stdout.trim(), '/tmp', 'cwd in command');
+      pass('runCommand (cwd)');
+    } catch (err) {
+      fail('runCommand (cwd)', err);
+    }
+
+    // Test: Run command with non-zero exit
+    try {
+      const result = await sandbox.runCommand('exit 7');
+      assertEqual(result.exitCode, 7, 'non-zero exit code');
+      pass('runCommand (non-zero exit)');
+    } catch (err) {
+      fail('runCommand (non-zero exit)', err);
+    }
+
+    // =====================================================================
+    // Test: Filesystem Operations
+    // =====================================================================
+    console.log('\n--- Filesystem ---');
+
+    // Write file
+    try {
+      await sandbox.filesystem.writeFile('/tmp/sdk-test.txt', 'hello from computesdk');
+      pass('filesystem.writeFile');
+    } catch (err) {
+      fail('filesystem.writeFile', err);
+    }
+
+    // Read file
+    try {
+      const content = await sandbox.filesystem.readFile('/tmp/sdk-test.txt');
+      assertEqual(content.trim(), 'hello from computesdk', 'readFile content');
+      pass('filesystem.readFile');
+    } catch (err) {
+      fail('filesystem.readFile', err);
+    }
+
+    // File exists
+    try {
+      const exists = await sandbox.filesystem.exists('/tmp/sdk-test.txt');
+      assertEqual(exists, true, 'exists for existing file');
+      pass('filesystem.exists (true)');
+    } catch (err) {
+      fail('filesystem.exists (true)', err);
+    }
+
+    // File not exists
+    try {
+      const exists = await sandbox.filesystem.exists('/tmp/does-not-exist-xyz.txt');
+      assertEqual(exists, false, 'exists for missing file');
+      pass('filesystem.exists (false)');
+    } catch (err) {
+      fail('filesystem.exists (false)', err);
+    }
+
+    // Mkdir
+    try {
+      await sandbox.filesystem.mkdir('/tmp/sdk-test-dir/nested');
+      const result = await sandbox.runCommand('test -d /tmp/sdk-test-dir/nested && echo yes');
+      assertEqual(result.stdout.trim(), 'yes', 'mkdir created directory');
+      pass('filesystem.mkdir');
+    } catch (err) {
+      fail('filesystem.mkdir', err);
+    }
+
+    // Write file in new directory
+    try {
+      await sandbox.filesystem.writeFile('/tmp/sdk-test-dir/nested/file.txt', 'nested content');
+      const content = await sandbox.filesystem.readFile('/tmp/sdk-test-dir/nested/file.txt');
+      assertEqual(content.trim(), 'nested content', 'nested file content');
+      pass('filesystem.writeFile + readFile (nested)');
+    } catch (err) {
+      fail('filesystem.writeFile + readFile (nested)', err);
+    }
+
+    // Readdir
+    try {
+      // Create some files for listing
+      await sandbox.filesystem.writeFile('/tmp/sdk-list-test/a.txt', 'a');
+      await sandbox.filesystem.writeFile('/tmp/sdk-list-test/b.txt', 'b');
+      const entries = await sandbox.filesystem.readdir('/tmp/sdk-list-test');
+      assert(entries.length >= 2, `readdir should return >= 2 entries, got ${entries.length}`);
+      const names = entries.map(e => e.name).sort();
+      assert(names.includes('a.txt'), 'readdir should include a.txt');
+      assert(names.includes('b.txt'), 'readdir should include b.txt');
+      pass('filesystem.readdir');
+    } catch (err) {
+      fail('filesystem.readdir', err);
+    }
+
+    // Remove file
+    try {
+      await sandbox.filesystem.remove('/tmp/sdk-test.txt');
+      const exists = await sandbox.filesystem.exists('/tmp/sdk-test.txt');
+      assertEqual(exists, false, 'file should be removed');
+      pass('filesystem.remove');
+    } catch (err) {
+      fail('filesystem.remove', err);
+    }
+
+    // =====================================================================
+    // Test: Low-level file API
+    // =====================================================================
+    console.log('\n--- File API (low-level) ---');
+
+    // createFile
+    try {
+      await sandbox.createFile('/tmp/lowlevel.txt', 'low-level content');
+      pass('createFile');
+    } catch (err) {
+      fail('createFile', err);
+    }
+
+    // readFile (low-level)
+    try {
+      const content = await sandbox.readFile('/tmp/lowlevel.txt');
+      assertEqual(content.trim(), 'low-level content', 'readFile content');
+      pass('readFile');
+    } catch (err) {
+      fail('readFile', err);
+    }
+
+    // checkFileExists
+    try {
+      const exists = await sandbox.checkFileExists('/tmp/lowlevel.txt');
+      assertEqual(exists, true, 'checkFileExists');
+      pass('checkFileExists (true)');
+    } catch (err) {
+      fail('checkFileExists (true)', err);
+    }
+
+    // listFiles
+    try {
+      const result = await sandbox.listFiles('/tmp');
+      assert(result.data.files.length > 0, 'listFiles should return files');
+      pass('listFiles');
+    } catch (err) {
+      fail('listFiles', err);
+    }
+
+    // deleteFile
+    try {
+      await sandbox.deleteFile('/tmp/lowlevel.txt');
+      const exists = await sandbox.checkFileExists('/tmp/lowlevel.txt');
+      assertEqual(exists, false, 'file should be deleted');
+      pass('deleteFile');
+    } catch (err) {
+      fail('deleteFile', err);
+    }
+
+    // =====================================================================
+    // Test: Run namespace (sandbox.run.code / sandbox.run.command)
+    // =====================================================================
+    console.log('\n--- Run Namespace ---');
+
+    try {
+      const result = await sandbox.run.code('print("via run namespace")');
+      assertEqual(result.output.trim(), 'via run namespace', 'run.code output');
+      pass('sandbox.run.code');
+    } catch (err) {
+      fail('sandbox.run.code', err);
+    }
+
+    try {
+      const result = await sandbox.run.command('echo via run namespace');
+      assertEqual(result.stdout.trim(), 'via run namespace', 'run.command stdout');
+      pass('sandbox.run.command');
+    } catch (err) {
+      fail('sandbox.run.command', err);
+    }
+
+    // =====================================================================
+    // Test: Get sandbox by ID
+    // =====================================================================
+    console.log('\n--- Sandbox Management ---');
+    try {
+      const found = await compute.sandbox.getById(sandbox.sandboxId);
+      assert(found !== null, 'getById should find sandbox');
+      assertEqual(found!.sandboxId, sandbox.sandboxId, 'getById sandboxId');
+      pass('compute.sandbox.getById');
+    } catch (err) {
+      fail('compute.sandbox.getById', err);
+    }
+
+    // =====================================================================
+    // Test: Destroy Sandbox
+    // =====================================================================
+    try {
+      await sandbox.destroy();
+      pass('sandbox.destroy');
+    } catch (err) {
+      fail('sandbox.destroy', err);
+    }
+
+    // Verify sandbox is gone
+    try {
+      const gone = await compute.sandbox.getById(sandbox.sandboxId);
+      assertEqual(gone, null, 'destroyed sandbox should not be found');
+      pass('verify sandbox destroyed');
+    } catch (err) {
+      fail('verify sandbox destroyed', err);
+    }
+
+    // =====================================================================
+    // Summary
+    // =====================================================================
+    console.log(`\n${'='.repeat(50)}`);
+    console.log(`Results: ${passed} passed, ${failed} failed`);
+    console.log('='.repeat(50));
+
+    if (failed > 0) {
+      process.exit(1);
+    }
+  } finally {
+    cleanup();
+    // Wait a bit for server to shut down
+    await new Promise(r => setTimeout(r, 1000));
+  }
+
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Implements `fcvm serve --port 8090` — an axum HTTP/WebSocket server that speaks the standard ComputeSDK gateway + sandbox daemon protocol. The existing TypeScript `computesdk` npm package connects directly without any custom SDK code.

```typescript
import { compute } from 'computesdk';

compute.setConfig({ provider: 'fcvm', computesdkApiKey: 'local', gatewayUrl: 'http://localhost:8090', fcvm: { apiKey: 'local' } });
const sandbox = await compute.sandbox.create();
const result = await sandbox.runCode('print(42)');  // → { output: "42\n", exitCode: 0 }
await sandbox.destroy();
```

**Stacked on:** refactor-podman-run-library-api (PR #291)

## Changes

### Server implementation (`src/commands/serve.rs`, ~1080 lines)

**Gateway endpoints:**
- `POST /v1/sandboxes` — create sandbox (start_vm with keepalive container, defaults to python:3.12-slim)
- `GET /v1/sandboxes` — list all sandboxes
- `GET /v1/sandboxes/{id}` — get sandbox by ID
- `DELETE /v1/sandboxes/{id}` — destroy sandbox (stop VM + cleanup)

**Sandbox daemon endpoints:**
- `GET /s/{id}/health` — health check
- `GET /s/{id}/ready` — readiness check
- `POST /s/{id}/run/code` — execute code (python3/node, auto-detected)
- `POST /s/{id}/run/command` — run shell command with env vars and cwd
- `GET /s/{id}/files` — list files with stat metadata
- `POST /s/{id}/files` — create file (mkdir -p + heredoc write)
- `GET /s/{id}/files/*path` — read file content
- `HEAD /s/{id}/files/*path` — check file existence
- `DELETE /s/{id}/files/*path` — delete file/directory

### CLI integration
- `Cargo.toml` — Added axum 0.8 (ws), tower-http 0.6 (cors), percent-encoding 2
- `src/cli/args.rs` — Added `Serve(ServeArgs)` with `--port` (default 8090)
- `src/main.rs` — Wired `Commands::Serve => cmd_serve`

### Tests
- `tests/test_serve.rs` — Rust integration test (17 sub-tests, gated with integration-slow)
- `tests/test_serve_sdk.ts` — TypeScript SDK E2E test (29 tests, self-contained: starts server, runs tests, cleans up)
- `tests/package.json` — npm deps for SDK test (computesdk + tsx)

### CI and build
- `.github/workflows/ci.yml` — Added test-serve-sdk step to host job
- `Makefile` — Added `test-serve-sdk` target
- `.gitignore` — Added tests/node_modules/

## Test Results

```
=== fcvm serve — ComputeSDK E2E Integration Test ===

--- Sandbox Lifecycle ---
  ✓ create sandbox
  ✓ health check
  ✓ ready check

--- Code Execution ---
  ✓ runCode (python arithmetic)
  ✓ runCode (multi-line output)
  ✓ runCode (non-zero exit)
  ✓ runCode (stderr)

--- Command Execution ---
  ✓ runCommand (echo)
  ✓ runCommand (env vars)
  ✓ runCommand (cwd)
  ✓ runCommand (non-zero exit)

--- Filesystem ---
  ✓ filesystem.writeFile
  ✓ filesystem.readFile
  ✓ filesystem.exists (true)
  ✓ filesystem.exists (false)
  ✓ filesystem.mkdir
  ✓ filesystem.writeFile + readFile (nested)
  ✓ filesystem.readdir
  ✓ filesystem.remove

--- File API (low-level) ---
  ✓ createFile
  ✓ readFile
  ✓ checkFileExists (true)
  ✓ listFiles
  ✓ deleteFile

--- Run Namespace ---
  ✓ sandbox.run.code
  ✓ sandbox.run.command

--- Sandbox Management ---
  ✓ compute.sandbox.getById
  ✓ sandbox.destroy
  ✓ verify sandbox destroyed

Results: 29 passed, 0 failed
```

Unit tests: 144/144 pass. `cargo fmt` and `cargo clippy` clean.

## Test plan
- [x] All 29 SDK E2E tests pass locally (rootless mode, no sudo)
- [x] All 144 unit tests pass
- [x] cargo fmt and clippy clean
- [ ] CI passes on PR