### PR TITLE
Allow snapshot caching with FUSE volume mounts

### DIFF
--- a/fc-agent/src/main.rs
+++ b/fc-agent/src/main.rs
@@ -627,11 +627,9 @@ fn rebind_mount_cross_ns(container_pid: &str, guest_path: &str) -> Result<(), St
     use std::ffi::CString;
     use std::os::unix::io::AsRawFd;
 
-    // Syscall numbers for aarch64
-    #[cfg(target_arch = "aarch64")]
-    const SYS_OPEN_TREE: libc::c_long = 428;
-    #[cfg(target_arch = "aarch64")]
-    const SYS_MOVE_MOUNT: libc::c_long = 429;
+    // libc crate provides these for both aarch64 and x86_64
+    const SYS_OPEN_TREE: libc::c_long = libc::SYS_open_tree;
+    const SYS_MOVE_MOUNT: libc::c_long = libc::SYS_move_mount;
 
     const OPEN_TREE_CLONE: libc::c_ulong = 1;
     const MOVE_MOUNT_F_EMPTY_PATH: libc::c_ulong = 4;

--- a/fc-agent/src/main.rs
+++ b/fc-agent/src/main.rs
@@ -442,68 +442,283 @@ async fn handle_clone_restore(volumes: &[VolumeMount]) {
 /// Remount FUSE volumes after clone restore.
 /// The old vsock connections are broken, so we unmount and remount.
 async fn remount_fuse_volumes(volumes: &[VolumeMount]) {
+    // After snapshot restore, Firecracker places VIRTIO_VSOCK_EVENT_TRANSPORT_RESET
+    // in the guest's virtio event queue. The kernel processes this asynchronously
+    // after resume, killing ALL vsock connections (including newly created ones).
+    // Wait for the transport reset to complete before creating new connections.
+    sleep(Duration::from_millis(500)).await;
+
     for vol in volumes {
-        eprintln!(
-            "[fc-agent] remounting volume at {} (port {})",
-            vol.guest_path, vol.vsock_port
-        );
-
-        // First, try to unmount the old (broken) FUSE mount
-        // Use lazy unmount (-l) in case there are open files
-        let umount_output = Command::new("umount")
-            .args(["-l", &vol.guest_path])
-            .output()
-            .await;
-
-        match umount_output {
-            Ok(o) if o.status.success() => {
-                eprintln!("[fc-agent] unmounted old FUSE mount at {}", vol.guest_path);
-            }
-            Ok(o) => {
-                // Not mounted or error - that's fine, we'll mount fresh
+        // Retry remount: the first attempt may fail if the kernel is still
+        // processing the vsock transport reset from the snapshot.
+        for attempt in 0..3 {
+            if attempt > 0 {
                 eprintln!(
-                    "[fc-agent] umount {} (may not be mounted): {}",
+                    "[fc-agent] retrying remount of {} (attempt {})",
                     vol.guest_path,
-                    String::from_utf8_lossy(&o.stderr).trim()
+                    attempt + 1
+                );
+                sleep(Duration::from_millis(500)).await;
+            }
+
+            eprintln!(
+                "[fc-agent] remounting volume at {} (port {})",
+                vol.guest_path, vol.vsock_port
+            );
+
+            // Unmount the old (broken) FUSE mount
+            // Use lazy unmount (-l) in case there are open files
+            let umount_output = Command::new("umount")
+                .args(["-l", &vol.guest_path])
+                .output()
+                .await;
+
+            match umount_output {
+                Ok(o) if o.status.success() => {
+                    eprintln!("[fc-agent] unmounted old FUSE mount at {}", vol.guest_path);
+                }
+                Ok(o) => {
+                    eprintln!(
+                        "[fc-agent] umount {} (may not be mounted): {}",
+                        vol.guest_path,
+                        String::from_utf8_lossy(&o.stderr).trim()
+                    );
+                }
+                Err(e) => {
+                    eprintln!("[fc-agent] umount error for {}: {}", vol.guest_path, e);
+                }
+            }
+
+            // Small delay to ensure unmount completes
+            sleep(Duration::from_millis(100)).await;
+
+            // Create mount point directory (in case it doesn't exist)
+            if let Err(e) = std::fs::create_dir_all(&vol.guest_path) {
+                eprintln!(
+                    "[fc-agent] ERROR: cannot create mount point {}: {}",
+                    vol.guest_path, e
+                );
+                break;
+            }
+
+            // Mount FUSE filesystem in a background thread using fuse-pipe
+            let mount_path = vol.guest_path.clone();
+            let port = vol.vsock_port;
+
+            thread::spawn(move || {
+                eprintln!("[fc-agent] fuse: starting remount at {}", mount_path);
+                if let Err(e) = fuse::mount_vsock(port, &mount_path) {
+                    eprintln!("[fc-agent] FUSE remount error at {}: {}", mount_path, e);
+                }
+                eprintln!("[fc-agent] fuse: remount at {} exited", mount_path);
+            });
+
+            eprintln!("[fc-agent] volume {} remount initiated", vol.guest_path);
+
+            // Wait for FUSE mount to initialize, then verify it works
+            sleep(Duration::from_millis(500)).await;
+
+            if std::fs::metadata(&vol.guest_path).is_ok() {
+                eprintln!("[fc-agent] ✓ volume {} remount verified", vol.guest_path);
+                break;
+            } else {
+                eprintln!(
+                    "[fc-agent] volume {} mount not accessible after remount",
+                    vol.guest_path
+                );
+            }
+        }
+    }
+
+    if volumes.is_empty() {
+        return;
+    }
+
+    // Rebind new FUSE mounts into the container's mount namespace.
+    // The container has stale bind mounts from before the snapshot — podman's
+    // -v flag creates bind mounts into the container's mount namespace, and
+    // those don't automatically see FUSE remounts in the root namespace.
+    rebind_volumes_in_container(volumes).await;
+
+    eprintln!("[fc-agent] ✓ volume remounts complete");
+}
+
+/// After FUSE remount in root namespace, rebind into the container's mount
+/// namespace so `podman exec` commands see the new FUSE mount instead of
+/// the stale bind mount from before the snapshot.
+///
+/// Uses the new mount API (open_tree + move_mount, Linux 5.2+) because the
+/// traditional mount --bind rejects cross-namespace sources (check_mnt).
+async fn rebind_volumes_in_container(volumes: &[VolumeMount]) {
+    // Get the container's PID (it may not be running yet during initial boot)
+    let pid_output = match Command::new("podman")
+        .args(["inspect", "--format", "{{.State.Pid}}", "fcvm-container"])
+        .output()
+        .await
+    {
+        Ok(o) if o.status.success() => o,
+        Ok(_) => {
+            eprintln!("[fc-agent] container not running, skipping mount rebind");
+            return;
+        }
+        Err(e) => {
+            eprintln!("[fc-agent] podman inspect failed: {}, skipping mount rebind", e);
+            return;
+        }
+    };
+
+    let container_pid = String::from_utf8_lossy(&pid_output.stdout)
+        .trim()
+        .to_string();
+    if container_pid.is_empty() || container_pid == "0" {
+        eprintln!("[fc-agent] container PID is 0, skipping mount rebind");
+        return;
+    }
+
+    for vol in volumes {
+        let pid = container_pid.clone();
+        let path = vol.guest_path.clone();
+
+        let result =
+            tokio::task::spawn_blocking(move || rebind_mount_cross_ns(&pid, &path)).await;
+
+        match result {
+            Ok(Ok(())) => {
+                eprintln!(
+                    "[fc-agent] ✓ volume {} rebound in container namespace",
+                    vol.guest_path
+                );
+            }
+            Ok(Err(e)) => {
+                eprintln!(
+                    "[fc-agent] WARNING: rebind {} in container failed: {}",
+                    vol.guest_path, e
                 );
             }
             Err(e) => {
-                eprintln!("[fc-agent] umount error for {}: {}", vol.guest_path, e);
+                eprintln!(
+                    "[fc-agent] WARNING: rebind task failed for {}: {}",
+                    vol.guest_path, e
+                );
             }
         }
+    }
+}
 
-        // Small delay to ensure unmount completes
-        sleep(Duration::from_millis(100)).await;
+/// Rebind a FUSE mount from the root namespace into a container's mount namespace.
+///
+/// Uses fork + open_tree + move_mount:
+/// 1. open_tree(CLONE) creates a namespace-neutral detached mount clone
+/// 2. Child process enters the container's mount namespace via setns
+/// 3. move_mount places the detached clone at the target path
+///
+/// This avoids the check_mnt restriction that blocks traditional mount --bind
+/// across mount namespace boundaries.
+fn rebind_mount_cross_ns(container_pid: &str, guest_path: &str) -> Result<(), String> {
+    use std::ffi::CString;
+    use std::os::unix::io::AsRawFd;
 
-        // Create mount point directory (in case it doesn't exist)
-        if let Err(e) = std::fs::create_dir_all(&vol.guest_path) {
-            eprintln!(
-                "[fc-agent] ERROR: cannot create mount point {}: {}",
-                vol.guest_path, e
-            );
-            continue;
-        }
+    // Syscall numbers for aarch64
+    #[cfg(target_arch = "aarch64")]
+    const SYS_OPEN_TREE: libc::c_long = 428;
+    #[cfg(target_arch = "aarch64")]
+    const SYS_MOVE_MOUNT: libc::c_long = 429;
 
-        // Mount FUSE filesystem in a background thread using fuse-pipe
-        let mount_path = vol.guest_path.clone();
-        let port = vol.vsock_port;
+    const OPEN_TREE_CLONE: libc::c_ulong = 1;
+    const MOVE_MOUNT_F_EMPTY_PATH: libc::c_ulong = 4;
 
-        thread::spawn(move || {
-            eprintln!("[fc-agent] fuse: starting remount at {}", mount_path);
-            if let Err(e) = fuse::mount_vsock(port, &mount_path) {
-                eprintln!("[fc-agent] FUSE remount error at {}: {}", mount_path, e);
-            }
-            eprintln!("[fc-agent] fuse: remount at {} exited", mount_path);
-        });
+    let path_c = CString::new(guest_path).map_err(|e| format!("invalid path: {}", e))?;
 
-        eprintln!("[fc-agent] volume {} remount initiated", vol.guest_path);
+    // Step 1: Create a detached mount clone of the FUSE mount (from root namespace).
+    // open_tree with OPEN_TREE_CLONE creates a mount that belongs to no namespace,
+    // so it can be moved into any namespace with move_mount.
+    let tree_fd = unsafe {
+        libc::syscall(
+            SYS_OPEN_TREE,
+            libc::AT_FDCWD,
+            path_c.as_ptr(),
+            OPEN_TREE_CLONE,
+        )
+    };
+    if tree_fd < 0 {
+        return Err(format!(
+            "open_tree({}) failed: {}",
+            guest_path,
+            std::io::Error::last_os_error()
+        ));
+    }
+    let tree_fd = tree_fd as libc::c_int;
+
+    // Step 2: Open references for container namespace entry
+    let ns_path = format!("/proc/{}/ns/mnt", container_pid);
+    let root_path = format!("/proc/{}/root", container_pid);
+
+    let ns_file = std::fs::File::open(&ns_path).map_err(|e| {
+        unsafe { libc::close(tree_fd) };
+        format!("open container mount ns: {}", e)
+    })?;
+    let root_file = std::fs::File::open(&root_path).map_err(|e| {
+        unsafe { libc::close(tree_fd) };
+        format!("open container root: {}", e)
+    })?;
+
+    // Step 3: Fork a child to enter container namespace and move the mount.
+    // We fork because setns() changes the calling thread's namespace permanently.
+    // All syscalls in the child are async-signal-safe.
+    let pid = unsafe { libc::fork() };
+    if pid < 0 {
+        unsafe { libc::close(tree_fd) };
+        return Err(format!("fork: {}", std::io::Error::last_os_error()));
     }
 
-    // Give FUSE mounts time to initialize
-    if !volumes.is_empty() {
-        eprintln!("[fc-agent] waiting for FUSE remounts to initialize...");
-        sleep(Duration::from_millis(500)).await;
-        eprintln!("[fc-agent] ✓ volume remounts complete");
+    if pid == 0 {
+        // === Child process ===
+        // Enter container's mount namespace
+        if unsafe { libc::setns(ns_file.as_raw_fd(), libc::CLONE_NEWNS) } != 0 {
+            unsafe { libc::_exit(1) };
+        }
+        // chroot to container's root (so path resolution works after pivot_root)
+        if unsafe { libc::fchdir(root_file.as_raw_fd()) } != 0 {
+            unsafe { libc::_exit(2) };
+        }
+        if unsafe { libc::chroot(c".".as_ptr()) } != 0 {
+            unsafe { libc::_exit(3) };
+        }
+
+        // Unmount the stale bind mount (lazy, ignore errors — may already be gone)
+        unsafe { libc::umount2(path_c.as_ptr(), libc::MNT_DETACH) };
+
+        // Move the detached mount clone into this namespace at guest_path
+        let empty = c"".as_ptr();
+        let ret = unsafe {
+            libc::syscall(
+                SYS_MOVE_MOUNT,
+                tree_fd,
+                empty,
+                libc::AT_FDCWD,
+                path_c.as_ptr(),
+                MOVE_MOUNT_F_EMPTY_PATH,
+            )
+        };
+
+        unsafe { libc::_exit(if ret == 0 { 0 } else { 5 }) };
+    }
+
+    // === Parent process ===
+    unsafe { libc::close(tree_fd) };
+
+    let mut status: libc::c_int = 0;
+    unsafe { libc::waitpid(pid, &mut status, 0) };
+
+    // WIFEXITED: (status & 0x7f) == 0
+    // WEXITSTATUS: (status >> 8) & 0xff
+    let exited = (status & 0x7f) == 0;
+    let exit_code = (status >> 8) & 0xff;
+
+    if exited && exit_code == 0 {
+        Ok(())
+    } else {
+        Err(format!("rebind child failed (exit code {})", exit_code))
     }
 }
 
@@ -2527,6 +2742,26 @@ async fn run_agent() -> Result<()> {
         Err(e) => {
             eprintln!("[fc-agent] WARNING: failed to get image digest: {:?}", e);
             eprintln!("[fc-agent] continuing without cache notification");
+        }
+    }
+
+    // After cache-ready handshake, Firecracker may have created a pre-start snapshot.
+    // Snapshot creation resets all vsock connections (VIRTIO_VSOCK_EVENT_TRANSPORT_RESET),
+    // which breaks FUSE mounts. Check if mounts are still healthy and remount if needed.
+    if !mounted_fuse_paths.is_empty() {
+        let mut broken = false;
+        for path in &mounted_fuse_paths {
+            if std::fs::metadata(path).is_err() {
+                eprintln!(
+                    "[fc-agent] FUSE mount at {} broken after snapshot (vsock reset), will remount",
+                    path
+                );
+                broken = true;
+                break;
+            }
+        }
+        if broken {
+            remount_fuse_volumes(&plan.volumes).await;
         }
     }
 

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -728,22 +728,6 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
         snapshot_vm_id,
     };
 
-    // Build MMDS volume data so fc-agent can remount FUSE after clone restore
-    // (Firecracker resets vsock connections during snapshot, breaking FUSE mounts)
-    let extra_mmds = if !snapshot_config.metadata.volumes.is_empty() {
-        Some(serde_json::json!({
-            "volumes": snapshot_config.metadata.volumes.iter().map(|v| {
-                serde_json::json!({
-                    "guest_path": v.guest_path,
-                    "vsock_port": v.vsock_port,
-                    "read_only": v.read_only,
-                })
-            }).collect::<Vec<_>>()
-        }))
-    } else {
-        None
-    };
-
     // Run clone setup using shared restore function
     let setup_result = super::common::restore_from_snapshot(
         &vm_id,
@@ -756,7 +740,6 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
         network.as_mut(),
         &state_manager,
         &mut vm_state,
-        extra_mmds,
     )
     .await;
 

--- a/tests/test_volume_coherency.rs
+++ b/tests/test_volume_coherency.rs
@@ -137,8 +137,7 @@ async fn test_volume_coherency_clone() -> Result<()> {
 
     // Step 4: Spawn clone (volumes reconstituted from snapshot metadata)
     println!("Step 4: Spawning clone...");
-    let (_clone_child, clone_pid) =
-        common::spawn_clone(serve_pid, &clone_name, "rootless").await?;
+    let (_clone_child, clone_pid) = common::spawn_clone(serve_pid, &clone_name, "rootless").await?;
 
     common::poll_health_by_pid(clone_pid, 120).await?;
     println!("  Clone healthy (PID: {})", clone_pid);

--- a/tests/test_volume_coherency.rs
+++ b/tests/test_volume_coherency.rs
@@ -1,0 +1,191 @@
+//! Volume coherency integration tests
+//!
+//! Verifies that read-only FUSE volume mounts work correctly:
+//! 1. Baseline VM: host writes file, container reads it
+//! 2. Clone VM: after snapshot/restore, host writes file, clone reads it
+
+#![cfg(feature = "integration-slow")]
+
+mod common;
+
+use anyhow::{Context, Result};
+use std::time::Duration;
+
+/// Test read-only volume coherency on a baseline VM.
+///
+/// Host writes a file, container reads it through FUSE mount.
+#[tokio::test]
+async fn test_volume_coherency_baseline() -> Result<()> {
+    let id = std::process::id();
+    let vm_name = format!("vol-baseline-{}", id);
+    let host_dir = format!("/tmp/fcvm-vol-test-{}", id);
+
+    tokio::fs::create_dir_all(&host_dir).await?;
+
+    // Start VM with read-only volume mount
+    let map_arg = format!("{}:/mnt/test:ro", host_dir);
+    let (_child, pid) = common::spawn_fcvm_with_logs(
+        &[
+            "podman",
+            "run",
+            "--name",
+            &vm_name,
+            "--network",
+            "rootless",
+            "--map",
+            &map_arg,
+            common::TEST_IMAGE,
+        ],
+        &vm_name,
+    )
+    .await
+    .context("spawning VM")?;
+
+    println!("Waiting for VM to become healthy...");
+    common::poll_health_by_pid(pid, 180).await?;
+    println!("VM healthy (PID: {})", pid);
+
+    // Write a file on host
+    let test_content = format!("coherency-test-{}", id);
+    tokio::fs::write(format!("{}/test.txt", host_dir), &test_content).await?;
+    println!("Wrote test.txt on host: {}", test_content);
+
+    // Read from container with retry (up to 1s for cache coherency)
+    let mut last_err = None;
+    for attempt in 0..10 {
+        match common::exec_in_container(pid, &["cat", "/mnt/test/test.txt"]).await {
+            Ok(output) => {
+                let trimmed = output.trim().to_string();
+                if trimmed == test_content {
+                    println!("Container read matches host write (attempt {})", attempt);
+                    last_err = None;
+                    break;
+                } else {
+                    last_err = Some(format!(
+                        "content mismatch: expected '{}', got '{}'",
+                        test_content, trimmed
+                    ));
+                }
+            }
+            Err(e) => {
+                last_err = Some(format!("exec failed: {}", e));
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Cleanup
+    common::kill_process(pid).await;
+    let _ = tokio::fs::remove_dir_all(&host_dir).await;
+
+    if let Some(err) = last_err {
+        anyhow::bail!("Volume coherency failed: {}", err);
+    }
+
+    println!("VOLUME COHERENCY BASELINE TEST PASSED!");
+    Ok(())
+}
+
+/// Test read-only volume coherency after snapshot/clone.
+///
+/// 1. Start VM with volume mount
+/// 2. Snapshot it
+/// 3. Clone from snapshot (volumes reconstituted from snapshot metadata)
+/// 4. Host writes new file, clone reads it
+#[tokio::test]
+async fn test_volume_coherency_clone() -> Result<()> {
+    let id = std::process::id();
+    let vm_name = format!("vol-clone-{}", id);
+    let clone_name = format!("vol-clone-c-{}", id);
+    let snapshot_name = format!("vol-snap-{}", id);
+    let host_dir = format!("/tmp/fcvm-vol-clone-{}", id);
+
+    tokio::fs::create_dir_all(&host_dir).await?;
+
+    // Step 1: Start VM with read-only volume mount
+    println!("Step 1: Starting baseline VM with volume...");
+    let map_arg = format!("{}:/mnt/test:ro", host_dir);
+    let (_child, baseline_pid) = common::spawn_fcvm_with_logs(
+        &[
+            "podman",
+            "run",
+            "--name",
+            &vm_name,
+            "--network",
+            "rootless",
+            "--map",
+            &map_arg,
+            common::TEST_IMAGE,
+        ],
+        &vm_name,
+    )
+    .await
+    .context("spawning baseline VM")?;
+
+    common::poll_health_by_pid(baseline_pid, 180).await?;
+    println!("  Baseline VM healthy (PID: {})", baseline_pid);
+
+    // Step 2: Create snapshot
+    println!("Step 2: Creating snapshot...");
+    common::create_snapshot_by_pid(baseline_pid, &snapshot_name).await?;
+    println!("  Snapshot created");
+
+    // Step 3: Start memory server
+    println!("Step 3: Starting memory server...");
+    let (_serve_child, serve_pid) = common::start_memory_server(&snapshot_name).await?;
+    println!("  Memory server ready (PID: {})", serve_pid);
+
+    // Step 4: Spawn clone (volumes reconstituted from snapshot metadata)
+    println!("Step 4: Spawning clone...");
+    let (_clone_child, clone_pid) =
+        common::spawn_clone(serve_pid, &clone_name, "rootless").await?;
+
+    common::poll_health_by_pid(clone_pid, 120).await?;
+    println!("  Clone healthy (PID: {})", clone_pid);
+
+    // Step 5: Write a NEW file on host (after clone started)
+    let test_content = format!("clone-coherency-{}", id);
+    tokio::fs::write(format!("{}/clone_test.txt", host_dir), &test_content).await?;
+    println!("Step 5: Wrote clone_test.txt on host: {}", test_content);
+
+    // Step 6: Read from clone container with retry
+    // FUSE remount after clone restore takes time: watcher polls every 100ms,
+    // then remount involves unmount + vsock reconnect + mount. Allow up to 5s.
+    println!("Step 6: Reading from clone...");
+    let mut last_err = None;
+    for attempt in 0..25 {
+        match common::exec_in_container(clone_pid, &["cat", "/mnt/test/clone_test.txt"]).await {
+            Ok(output) => {
+                let trimmed = output.trim().to_string();
+                if trimmed == test_content {
+                    println!("  Clone read matches host write (attempt {})", attempt);
+                    last_err = None;
+                    break;
+                } else {
+                    last_err = Some(format!(
+                        "content mismatch: expected '{}', got '{}'",
+                        test_content, trimmed
+                    ));
+                }
+            }
+            Err(e) => {
+                last_err = Some(format!("exec failed: {}", e));
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    // Cleanup
+    println!("Cleaning up...");
+    common::kill_process(clone_pid).await;
+    common::kill_process(serve_pid).await;
+    common::kill_process(baseline_pid).await;
+    let _ = tokio::fs::remove_dir_all(&host_dir).await;
+
+    if let Some(err) = last_err {
+        anyhow::bail!("Volume coherency after clone failed: {}", err);
+    }
+
+    println!("VOLUME COHERENCY CLONE TEST PASSED!");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

FUSE-over-vsock mounts broke during snapshot/restore because Firecracker resets all vsock connections (`VIRTIO_VSOCK_EVENT_TRANSPORT_RESET`). This prevented snapshot caching for VMs that use `--map` volume mounts.

This PR makes FUSE mounts survive snapshot/restore:

- Remove `!args.map.is_empty()` guard that blocked snapshot creation when volumes are present
- fc-agent detects broken FUSE mounts after restore via `metadata()` check, triggers remount with retry loop (3 attempts, 500ms vsock reset delay)
- Use `open_tree` + `move_mount` (Linux new mount API) to rebind FUSE mounts into the container's mount namespace — traditional `mount --bind` fails cross-namespace due to kernel `check_mnt` restriction
- Bump restore-epoch via `patch_mmds` in `create_snapshot_core` so fc-agent's watcher detects any snapshot (not just clones)
- Fix two race conditions: use boot volumes instead of MMDS volumes (stale TCP response after restore), ignore `EEXIST` from `create_dir_all` after lazy unmount

## Test plan

- [x] `make test-root FILTER=sanity` — 3/3 passed
- [x] `make test-root FILTER=volume_coherency` — 2/2 passed (baseline + clone volume coherency)