### PR TITLE
Add --user, --forward-localhost flags and improve image import

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,8 @@ See [DESIGN.md](DESIGN.md#cli-interface) for architecture and design decisions.
 -t, --tty           Allocate pseudo-TTY (for vim, colors, etc.)
 --setup             Auto-setup if kernel/rootfs missing (rootless only)
 --no-snapshot       Disable automatic snapshot creation (for testing)
+--forward-localhost <PORTS>  Forward localhost ports to host (e.g., 1421,9099)
+--rootfs-size <SIZE> Minimum free space on rootfs (default: 10G)
 ```
 
 **`fcvm exec`** - Execute in VM/container:

--- a/fc-agent/src/main.rs
+++ b/fc-agent/src/main.rs
@@ -2606,6 +2606,13 @@ async fn run_agent() -> Result<()> {
     let image_ref = if let Some(archive_path) = &plan.image_archive {
         eprintln!("[fc-agent] importing Docker archive: {}", archive_path);
 
+        // Make block device readable by non-root (needed with --userns=keep-id)
+        if archive_path.starts_with("/dev/") {
+            let _ = std::process::Command::new("chmod")
+                .args(["444", archive_path])
+                .output();
+        }
+
         // Import into podman storage so the pre-start snapshot captures the loaded image.
         // Without this, every snapshot restore would re-read the entire tar from /dev/vdb.
         let output = Command::new("podman")

--- a/fc-agent/src/main.rs
+++ b/fc-agent/src/main.rs
@@ -2904,7 +2904,7 @@ async fn run_agent() -> Result<()> {
         let parts: Vec<&str> = user_spec.split(':').collect();
         let uid = parts[0];
         let gid = parts.get(1).unwrap_or(&"100");
-        let username = format!("fcvm-user");
+        let username = "fcvm-user".to_string();
 
         eprintln!(
             "[fc-agent] setting up user mapping: uid={} gid={}",

--- a/rootfs-config.toml
+++ b/rootfs-config.toml
@@ -57,7 +57,7 @@ path = "opt/kata/share/kata-containers/vmlinux-6.12.47-173"
 
 [packages]
 # Container runtime
-runtime = ["podman", "crun", "fuse-overlayfs", "skopeo"]
+runtime = ["podman", "crun", "fuse-overlayfs", "skopeo", "uidmap"]
 
 # FUSE support for overlay filesystem
 fuse = ["fuse3"]

--- a/rootfs-config.toml
+++ b/rootfs-config.toml
@@ -63,10 +63,10 @@ runtime = ["podman", "crun", "fuse-overlayfs", "skopeo", "uidmap"]
 fuse = ["fuse3"]
 
 # System services and disk/filesystem tools for nested --disk-dir and --nfs
-system = ["haveged", "chrony", "rsync", "nfs-common"]
+system = ["haveged", "chrony", "rsync", "nfs-common", "iptables"]
 
-# Debugging tools
-debug = ["strace"]
+# Debugging and networking tools
+debug = ["strace", "netcat-openbsd"]
 
 [services]
 # Services to enable

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -186,6 +186,11 @@ pub struct RunArgs {
     #[arg(long)]
     pub health_check: Option<String>,
 
+    /// Run container as USER:GROUP (e.g., --user 1000:1000)
+    /// Equivalent to podman run --userns=keep-id on the host
+    #[arg(long)]
+    pub user: Option<String>,
+
     /// Run container in privileged mode (allows mknod, device access, etc.)
     /// Use for POSIX compliance tests that need full filesystem capabilities
     #[arg(long)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -492,10 +492,14 @@ pub struct ExecArgs {
 /// Parse --mem value: either an integer (MiB) or "unlimited" (all host memory).
 fn parse_mem(s: &str) -> Result<u32, String> {
     if s.eq_ignore_ascii_case("unlimited") {
-        crate::host_memory_mib().ok_or_else(|| "failed to read host memory from /proc/meminfo".to_string())
+        crate::host_memory_mib()
+            .ok_or_else(|| "failed to read host memory from /proc/meminfo".to_string())
     } else {
         s.parse::<u32>().map_err(|_| {
-            format!("invalid --mem value '{}': expected integer (MiB) or 'unlimited'", s)
+            format!(
+                "invalid --mem value '{}': expected integer (MiB) or 'unlimited'",
+                s
+            )
         })
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -114,12 +114,12 @@ pub struct RunArgs {
     #[arg(long)]
     pub name: String,
 
-    /// vCPUs
-    #[arg(long, default_value_t = 2)]
+    /// vCPUs (0 = all host CPUs)
+    #[arg(long, default_value_t = 0)]
     pub cpu: u8,
 
-    /// Memory (MiB)
-    #[arg(long, default_value_t = 2048)]
+    /// Memory in MiB (0 = all host memory)
+    #[arg(long, default_value_t = 0)]
     pub mem: u32,
 
     /// Minimum free space on root filesystem (default: 10G).
@@ -190,6 +190,12 @@ pub struct RunArgs {
     /// Equivalent to podman run --userns=keep-id on the host
     #[arg(long)]
     pub user: Option<String>,
+
+    /// Forward specific localhost ports to the host gateway via iptables DNAT.
+    /// Enables containers to reach host-only services via localhost.
+    /// Comma-separated port list, e.g., --forward-localhost 1421,9099
+    #[arg(long, value_delimiter = ',')]
+    pub forward_localhost: Vec<u16>,
 
     /// Run container in privileged mode (allows mknod, device access, etc.)
     /// Use for POSIX compliance tests that need full filesystem capabilities

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -10,7 +10,7 @@ use anyhow::{Context, Result};
 use nix::sys::uio::{pread, pwrite};
 use nix::unistd::{lseek, Whence};
 use tokio::task::JoinHandle;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use std::path::PathBuf;
 
@@ -877,6 +877,32 @@ pub async fn create_snapshot_core(
 
     let snapshot_type = if has_base { "Diff" } else { "Full" };
 
+    // Check available disk space before attempting snapshot.
+    // A full snapshot dumps all VM memory; a diff snapshot is smaller but still needs space.
+    // Failing ENOSPC mid-snapshot corrupts the VM (Firecracker can't resume properly).
+    {
+        let memory_bytes = (snapshot_config.metadata.memory_mib as u64) * 1024 * 1024;
+        // For full snapshots, need ~memory_mib. For diff, need ~10% as buffer.
+        let required_bytes = if has_base {
+            memory_bytes / 10
+        } else {
+            memory_bytes
+        };
+        if let Ok(stat) = nix::sys::statvfs::statvfs(snapshot_dir) {
+            let available_bytes = stat.blocks_available() * stat.fragment_size() as u64;
+            if available_bytes < required_bytes {
+                anyhow::bail!(
+                    "Not enough disk space for {} snapshot: need {} MiB, have {} MiB free on {}. \
+                     Use --mem to limit VM memory, or increase btrfs_size in rootfs-config.toml.",
+                    snapshot_type.to_lowercase(),
+                    required_bytes / (1024 * 1024),
+                    available_bytes / (1024 * 1024),
+                    snapshot_dir.display()
+                );
+            }
+        }
+    }
+
     info!(
         snapshot = %snapshot_config.name,
         snapshot_type = snapshot_type,
@@ -900,17 +926,27 @@ pub async fn create_snapshot_core(
     };
     let temp_vmstate_path = temp_snapshot_dir.join("vmstate.bin");
 
-    // Pause VM before snapshotting (required by Firecracker)
+    // Pause timeout: should be fast (just pauses vCPU threads). 30s is generous.
+    // Snapshot timeout: depends on memory size (32GB at ~500MB/s = ~64s). 5 min is generous.
+    let pause_client = client.with_timeout(std::time::Duration::from_secs(30));
+    let snapshot_client = client.with_timeout(std::time::Duration::from_secs(300));
+
+    // Pause VM before snapshotting (required by Firecracker).
+    // If Pause fails/times out, the VM is NOT paused — no resume needed.
     info!(snapshot = %snapshot_config.name, "pausing VM for snapshot");
-    client
+    if let Err(e) = pause_client
         .patch_vm_state(ApiVmState {
             state: "Paused".to_string(),
         })
         .await
-        .context("pausing VM for snapshot")?;
+    {
+        let _ = tokio::fs::remove_dir_all(&temp_snapshot_dir).await;
+        return Err(e).context("pausing VM for snapshot (VM still running, no data loss)");
+    }
 
-    // Create Firecracker snapshot (Full or Diff based on whether base exists)
-    let snapshot_result = client
+    // VM is now paused — we MUST resume it before returning, no matter what.
+    // Use a closure-like pattern to ensure resume always runs.
+    let snapshot_result = snapshot_client
         .create_snapshot(SnapshotCreate {
             snapshot_type: Some(snapshot_type.to_string()),
             snapshot_path: temp_vmstate_path.display().to_string(),
@@ -918,19 +954,22 @@ pub async fn create_snapshot_core(
         })
         .await;
 
-    // Resume VM immediately (always, regardless of snapshot result)
-    // This minimizes pause time - diff merge happens after resume
-    let resume_result = client
+    // Resume VM immediately (ALWAYS, regardless of snapshot result).
+    // This minimizes pause time — diff merge happens after resume.
+    let resume_result = snapshot_client
         .patch_vm_state(ApiVmState {
             state: "Resumed".to_string(),
         })
         .await;
 
     if let Err(e) = &resume_result {
-        warn!(snapshot = %snapshot_config.name, error = %e, "failed to resume VM after snapshot");
+        // Resume failure is critical — VM may be stuck paused.
+        // Log prominently so the operator knows.
+        error!(snapshot = %snapshot_config.name, error = %e,
+            "CRITICAL: failed to resume VM after snapshot — VM may be paused!");
     }
 
-    // Check if snapshot succeeded - clean up temp dir on failure
+    // Check if snapshot succeeded — clean up temp dir on failure
     if let Err(e) = snapshot_result {
         let _ = tokio::fs::remove_dir_all(&temp_snapshot_dir).await;
         return Err(e).context("creating Firecracker snapshot");

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -889,7 +889,7 @@ pub async fn create_snapshot_core(
             memory_bytes
         };
         if let Ok(stat) = nix::sys::statvfs::statvfs(snapshot_dir) {
-            let available_bytes = stat.blocks_available() * stat.fragment_size() as u64;
+            let available_bytes = stat.blocks_available() * stat.fragment_size();
             if available_bytes < required_bytes {
                 anyhow::bail!(
                     "Not enough disk space for {} snapshot: need {} MiB, have {} MiB free on {}. \

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -2360,6 +2360,7 @@ async fn build_and_send_mmds(
                 "nfs_mounts": nfs_mounts,
                 "image_archive": image_device,
                 "privileged": args.privileged,
+                "user": args.user.as_deref(),
                 "interactive": args.interactive,
                 "tty": args.tty,
                 // Use network-provided proxy, or fall back to environment variables.

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -1064,104 +1064,117 @@ pub(crate) async fn run_output_listener(
 
     let mut output_lines: Vec<(String, String)> = Vec::new();
 
-    // Accept connection from fc-agent (no timeout - image import can take 10+ min)
-    let (stream, _) = match listener.accept().await {
-        Ok(conn) => conn,
-        Err(e) => {
-            warn!(vm_id = %vm_id, error = %e, "Error accepting output connection");
-            let _ = std::fs::remove_file(socket_path);
-            return Ok(output_lines);
-        }
-    };
-
-    debug!(vm_id = %vm_id, "Output connection established");
-
-    let (reader, writer) = stream.into_split();
-    let mut reader = BufReader::new(reader);
-    let writer = std::sync::Arc::new(tokio::sync::Mutex::new(writer));
-    let mut line_buf = String::new();
-
-    // Spawn stdin forwarder if interactive mode
-    let stdin_task = if interactive {
-        let writer = writer.clone();
-        Some(tokio::spawn(async move {
-            let stdin = tokio::io::stdin();
-            let mut stdin = BufReader::new(stdin);
-            let mut line = String::new();
-            loop {
-                line.clear();
-                match stdin.read_line(&mut line).await {
-                    Ok(0) => break, // EOF
-                    Ok(_) => {
-                        // Forward to container: "stdin:content\n"
-                        let msg = format!("stdin:{}", line.trim_end());
-                        let mut w = writer.lock().await;
-                        if w.write_all(msg.as_bytes()).await.is_err() {
-                            break;
-                        }
-                        if w.write_all(b"\n").await.is_err() {
-                            break;
-                        }
-                    }
-                    Err(_) => break,
-                }
-            }
-        }))
-    } else {
-        None
-    };
-
-    // Read lines until connection closes (no read timeout — large image imports
-    // can take 10+ minutes during which fc-agent produces no output)
-    loop {
-        line_buf.clear();
-        match reader.read_line(&mut line_buf).await {
-            Ok(0) => {
-                // EOF - connection closed
-                debug!(vm_id = %vm_id, "Output connection closed");
-                break;
-            }
-            Ok(_) => {
-                // Parse raw line format: stream:content
-                let line = line_buf.trim_end();
-                if let Some((stream, content)) = line.split_once(':') {
-                    if stream == "heartbeat" {
-                        // Heartbeat from fc-agent during long operations (image import/pull)
-                        info!(vm_id = %vm_id, phase = %content, "VM heartbeat");
-                    } else {
-                        // Print container output directly (stdout to stdout, stderr to stderr)
-                        // No prefix - clean output for scripting
-                        if stream == "stdout" {
-                            println!("{}", content);
-                        } else {
-                            eprintln!("{}", content);
-                        }
-                        output_lines.push((stream.to_string(), content.to_string()));
-                    }
-
-                    // Forward to broadcast channel for library consumers
-                    if let Some(ref tx) = log_tx {
-                        let _ = tx.send(LogLine {
-                            stream: stream.to_string(),
-                            content: content.to_string(),
-                        });
-                    }
-
-                    // Send ack back (bidirectional)
-                    let mut w = writer.lock().await;
-                    let _ = w.write_all(b"ack\n").await;
-                }
-            }
+    // Accept connections from fc-agent in a loop. The first connection may be closed
+    // by a snapshot (VIRTIO_VSOCK_EVENT_TRANSPORT_RESET closes all vsock connections).
+    // When that happens, fc-agent reconnects, so we need to accept again.
+    'accept_loop: loop {
+        let (stream, _) = match listener.accept().await {
+            Ok(conn) => conn,
             Err(e) => {
-                warn!(vm_id = %vm_id, error = %e, "Error reading output");
-                break;
+                warn!(vm_id = %vm_id, error = %e, "Error accepting output connection");
+                let _ = std::fs::remove_file(socket_path);
+                return Ok(output_lines);
+            }
+        };
+
+        debug!(vm_id = %vm_id, "Output connection established");
+
+        let (reader, writer) = stream.into_split();
+        let mut reader = BufReader::new(reader);
+        let writer = std::sync::Arc::new(tokio::sync::Mutex::new(writer));
+        let mut line_buf = String::new();
+        let mut got_output = false;
+
+        // Spawn stdin forwarder if interactive mode (only on first connection)
+        let stdin_task = if interactive {
+            let writer = writer.clone();
+            Some(tokio::spawn(async move {
+                let stdin = tokio::io::stdin();
+                let mut stdin = BufReader::new(stdin);
+                let mut line = String::new();
+                loop {
+                    line.clear();
+                    match stdin.read_line(&mut line).await {
+                        Ok(0) => break, // EOF
+                        Ok(_) => {
+                            // Forward to container: "stdin:content\n"
+                            let msg = format!("stdin:{}", line.trim_end());
+                            let mut w = writer.lock().await;
+                            if w.write_all(msg.as_bytes()).await.is_err() {
+                                break;
+                            }
+                            if w.write_all(b"\n").await.is_err() {
+                                break;
+                            }
+                        }
+                        Err(_) => break,
+                    }
+                }
+            }))
+        } else {
+            None
+        };
+
+        // Read lines until connection closes (no read timeout — large image imports
+        // can take 10+ minutes during which fc-agent produces no output)
+        loop {
+            line_buf.clear();
+            match reader.read_line(&mut line_buf).await {
+                Ok(0) => {
+                    // EOF - connection closed
+                    debug!(vm_id = %vm_id, "Output connection closed");
+                    break;
+                }
+                Ok(_) => {
+                    // Parse raw line format: stream:content
+                    let line = line_buf.trim_end();
+                    if let Some((stream, content)) = line.split_once(':') {
+                        if stream == "heartbeat" {
+                            // Heartbeat from fc-agent during long operations (image import/pull)
+                            info!(vm_id = %vm_id, phase = %content, "VM heartbeat");
+                        } else {
+                            // Print container output directly (stdout to stdout, stderr to stderr)
+                            // No prefix - clean output for scripting
+                            got_output = true;
+                            if stream == "stdout" {
+                                println!("{}", content);
+                            } else {
+                                eprintln!("{}", content);
+                            }
+                            output_lines.push((stream.to_string(), content.to_string()));
+                        }
+
+                        // Forward to broadcast channel for library consumers
+                        if let Some(ref tx) = log_tx {
+                            let _ = tx.send(LogLine {
+                                stream: stream.to_string(),
+                                content: content.to_string(),
+                            });
+                        }
+
+                        // Send ack back (bidirectional)
+                        let mut w = writer.lock().await;
+                        let _ = w.write_all(b"ack\n").await;
+                    }
+                }
+                Err(e) => {
+                    warn!(vm_id = %vm_id, error = %e, "Error reading output");
+                    break;
+                }
             }
         }
-    }
 
-    // Abort stdin task if it's still running
-    if let Some(task) = stdin_task {
-        task.abort();
+        // Abort stdin task if it's still running
+        if let Some(task) = stdin_task {
+            task.abort();
+        }
+
+        // If we received actual output, we're done. If we only got heartbeats or
+        // nothing (snapshot reset closed the connection), re-accept for the reconnect.
+        if got_output {
+            break 'accept_loop;
+        }
+        debug!(vm_id = %vm_id, "No output received, re-accepting (snapshot reset?)");
     }
 
     // Clean up

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -319,6 +319,8 @@ async fn create_sandbox(
         kernel_profile: None,
         vsock_dir: None,
         no_snapshot: true,
+        forward_localhost: vec![],
+        user: None,
         image,
         command_args: vec![],
     };

--- a/src/firecracker/api.rs
+++ b/src/firecracker/api.rs
@@ -29,6 +29,16 @@ impl FirecrackerClient {
         })
     }
 
+    /// Return a clone with a different request timeout.
+    /// Use for long-running operations like snapshot create/load.
+    pub fn with_timeout(&self, timeout: Duration) -> Self {
+        Self {
+            socket_path: self.socket_path.clone(),
+            client: self.client.clone(),
+            request_timeout: timeout,
+        }
+    }
+
     /// Build Unix socket URI for Firecracker API
     fn uri(&self, path: &str) -> hyper::Uri {
         UnixUri::new(&self.socket_path, path).into()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,14 @@ pub mod storage;
 pub mod uffd;
 pub mod utils;
 pub mod volume;
+
+/// Get total host memory in MiB from /proc/meminfo.
+pub fn host_memory_mib() -> Option<u32> {
+    std::fs::read_to_string("/proc/meminfo").ok().and_then(|s| {
+        s.lines()
+            .find(|l| l.starts_with("MemTotal:"))
+            .and_then(|l| l.split_whitespace().nth(1))
+            .and_then(|kb| kb.parse::<u64>().ok())
+            .map(|kb| (kb / 1024) as u32)
+    })
+}

--- a/tests/test_forward_localhost.rs
+++ b/tests/test_forward_localhost.rs
@@ -1,0 +1,92 @@
+//! Test --forward-localhost flag: VM localhost reaches host services.
+//!
+//! Starts a TCP server on host 127.0.0.1, runs a VM with --forward-localhost
+//! that connects to localhost:port from inside the container.
+
+#![cfg(feature = "integration-fast")]
+
+mod common;
+
+use anyhow::{Context, Result};
+use std::io::Write;
+use std::net::TcpListener;
+
+/// Test that --forward-localhost makes container's 127.0.0.1 reach host services.
+#[tokio::test]
+async fn test_forward_localhost() -> Result<()> {
+    println!("\nTest --forward-localhost");
+    println!("========================");
+
+    // Start a TCP server on host 127.0.0.1 (only reachable via loopback)
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    println!("  Host server on 127.0.0.1:{}", port);
+
+    // Accept one connection in background (with timeout)
+    let accept_handle = std::thread::spawn(move || -> bool {
+        listener.set_nonblocking(false).expect("set_nonblocking");
+        // 15s accept timeout
+        unsafe {
+            let tv = libc::timeval {
+                tv_sec: 15,
+                tv_usec: 0,
+            };
+            libc::setsockopt(
+                std::os::unix::io::AsRawFd::as_raw_fd(&listener) as i32,
+                libc::SOL_SOCKET,
+                libc::SO_RCVTIMEO,
+                &tv as *const _ as *const libc::c_void,
+                std::mem::size_of_val(&tv) as u32,
+            );
+        }
+        match listener.accept() {
+            Ok((mut conn, _)) => {
+                let _ = conn.write_all(b"HELLO_FROM_HOST\n");
+                true
+            }
+            Err(_) => false,
+        }
+    });
+
+    let port_str = port.to_string();
+    let (vm_name, _, _, _) = common::unique_names("fwd-localhost");
+
+    // Run container command that connects to localhost:port
+    // This matches the exact manual test that works
+    let fcvm_path = common::find_fcvm_binary()?;
+    let output = tokio::process::Command::new(&fcvm_path)
+        .args([
+            "podman",
+            "run",
+            "--name",
+            &vm_name,
+            "--forward-localhost",
+            &port_str,
+            "--no-snapshot",
+            common::TEST_IMAGE,
+            "--",
+            "sh",
+            "-c",
+            &format!("nc -w5 127.0.0.1 {} 2>&1 || echo FAILED", port),
+        ])
+        .output()
+        .await
+        .context("running fcvm")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    println!("  stdout: {}", stdout.trim());
+
+    let accepted = accept_handle.join().unwrap_or(false);
+    println!("  server accepted: {}", accepted);
+
+    assert!(
+        stdout.contains("HELLO_FROM_HOST"),
+        "VM localhost should reach host (got stdout={}, stderr={})",
+        stdout.trim(),
+        &stderr[..std::cmp::min(200, stderr.len())]
+    );
+
+    println!("✅ FORWARD LOCALHOST TEST PASSED!");
+    Ok(())
+}

--- a/tests/test_forward_localhost.rs
+++ b/tests/test_forward_localhost.rs
@@ -32,7 +32,7 @@ async fn test_forward_localhost() -> Result<()> {
                 tv_usec: 0,
             };
             libc::setsockopt(
-                std::os::unix::io::AsRawFd::as_raw_fd(&listener) as i32,
+                std::os::unix::io::AsRawFd::as_raw_fd(&listener),
                 libc::SOL_SOCKET,
                 libc::SO_RCVTIMEO,
                 &tv as *const _ as *const libc::c_void,

--- a/tests/test_library_api.rs
+++ b/tests/test_library_api.rs
@@ -41,6 +41,8 @@ fn test_run_args(name: &str) -> RunArgs {
         kernel_profile: None,
         vsock_dir: None,
         no_snapshot: true,
+        user: None,
+        forward_localhost: vec![],
         label: vec![],
         image: common::TEST_IMAGE.to_string(),
         command_args: vec![],


### PR DESCRIPTION
## Summary

New fc-agent and host-side features for better container ergonomics and reliability.

**Stacked on:** main

### `--user` flag for rootless podman in VM
- Replicates host podman behavior: creates user in VM, sets up subuid/subgid, delegates cgroup
- Runs podman as target user with `--userns=keep-id` (container sees same UID as host)
- Adds `uidmap` package to rootfs for user namespace support
- Chmod block device for docker-archive access under userns

### `--forward-localhost` flag
- Opt-in iptables DNAT rule redirecting `127.0.0.0/8` in the VM to host gateway (`10.0.2.2`)
- Allows containers to reach host-only services via localhost
- Includes integration test (`test_forward_localhost.rs`)

### vCPU cap at 32
- Firecracker allows max 32 vCPUs; cap `available_parallelism()` to 32
- Atomic podman save: temp file + rename to avoid corrupt archives

### Image import reliability
- Connect output vsock early so host tracks progress during long imports
- Send heartbeats every 30s during `podman load`
- Remove output listener timeout (was 2min, imports can take 10+)
- Fix archive tmp path double-extension bug
- Skip btrfs loopback when parent is already btrfs

## Test plan
- [ ] `make test-root FILTER=sanity` passes
- [ ] `make test-root FILTER=forward_localhost` passes
