### PR TITLE
Fix snapshot ENOSPC, output vsock reconnect, channel-based writer

### DIFF
--- a/fc-agent/src/main.rs
+++ b/fc-agent/src/main.rs
@@ -1619,12 +1619,13 @@ fn send_output_line(stream: &str, line: &str) {
     }
     // Raw format: stream:line\n
     let data = format!("{}:{}\n", stream, line);
-    let result = unsafe {
-        libc::write(fd, data.as_ptr() as *const libc::c_void, data.len())
-    };
+    let result = unsafe { libc::write(fd, data.as_ptr() as *const libc::c_void, data.len()) };
     if result < 0 {
         let err = std::io::Error::last_os_error();
-        eprintln!("[fc-agent] WARNING: output vsock write failed: {} (fd={})", err, fd);
+        eprintln!(
+            "[fc-agent] WARNING: output vsock write failed: {} (fd={})",
+            err, fd
+        );
     }
 }
 
@@ -3126,9 +3127,7 @@ async fn run_agent() -> Result<()> {
             if fd < 0 {
                 continue;
             }
-            let result = unsafe {
-                libc::write(fd, msg.as_ptr() as *const libc::c_void, msg.len())
-            };
+            let result = unsafe { libc::write(fd, msg.as_ptr() as *const libc::c_void, msg.len()) };
             if result < 0 {
                 let err = std::io::Error::last_os_error();
                 eprintln!(

--- a/fc-agent/src/main.rs
+++ b/fc-agent/src/main.rs
@@ -439,7 +439,20 @@ async fn handle_clone_restore(volumes: &[VolumeMount]) {
     // Note: Interface bounce (ip link down/up) is NOT needed - ss -K handles socket cleanup
     // more effectively by directly destroying sockets rather than hoping they notice ENETDOWN.
 
-    // 4. Remount FUSE volumes if any
+    // 4. Reconnect output vsock (broken by snapshot vsock reset)
+    let old_fd = OUTPUT_VSOCK_FD.load(std::sync::atomic::Ordering::Relaxed);
+    if old_fd >= 0 {
+        unsafe { libc::close(old_fd) };
+    }
+    let new_fd = create_output_vsock();
+    OUTPUT_VSOCK_FD.store(new_fd, std::sync::atomic::Ordering::Release);
+    if new_fd >= 0 {
+        eprintln!("[fc-agent] ✓ output vsock reconnected after restore");
+    } else {
+        eprintln!("[fc-agent] WARNING: failed to reconnect output vsock after restore");
+    }
+
+    // 5. Remount FUSE volumes if any
     if !volumes.is_empty() {
         eprintln!(
             "[fc-agent] clone has {} volume(s) to remount",
@@ -1070,6 +1083,10 @@ const OUTPUT_VSOCK_PORT: u32 = 4997;
 /// Host CID for vsock (always 2)
 const HOST_CID: u32 = 2;
 
+/// Global output vsock fd, shared between output streaming tasks and restore-epoch watcher.
+/// Updated atomically when reconnecting after snapshot restore.
+static OUTPUT_VSOCK_FD: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(-1);
+
 /// Request from host to execute a command
 #[derive(Debug, Deserialize)]
 struct ExecRequest {
@@ -1590,14 +1607,24 @@ fn create_output_vsock() -> i32 {
 
 /// Send a line of container output to host via vsock.
 /// Format: stdout:line or stderr:line (raw, no JSON)
-fn send_output_line(fd: i32, stream: &str, line: &str) {
+/// Reads the fd from the global OUTPUT_VSOCK_FD (updated on snapshot restore reconnect).
+///
+/// After snapshot restore, the old fd is closed by handle_clone_restore() and
+/// the write returns EBADF immediately (no blocking). The restore-epoch watcher
+/// then reconnects and stores the new fd. Subsequent writes use the new fd.
+fn send_output_line(stream: &str, line: &str) {
+    let fd = OUTPUT_VSOCK_FD.load(std::sync::atomic::Ordering::Acquire);
     if fd < 0 {
         return;
     }
     // Raw format: stream:line\n
     let data = format!("{}:{}\n", stream, line);
-    unsafe {
-        libc::write(fd, data.as_ptr() as *const libc::c_void, data.len());
+    let result = unsafe {
+        libc::write(fd, data.as_ptr() as *const libc::c_void, data.len())
+    };
+    if result < 0 {
+        let err = std::io::Error::last_os_error();
+        eprintln!("[fc-agent] WARNING: output vsock write failed: {} (fd={})", err, fd);
     }
 }
 
@@ -2640,13 +2667,17 @@ async fn run_agent() -> Result<()> {
     }
 
     // Connect output vsock early so host can track our progress during long operations
-    // (image import can take 10+ minutes for large images)
-    let mut output_fd = create_output_vsock();
-    if output_fd >= 0 {
-        eprintln!(
-            "[fc-agent] output vsock connected early (port {})",
-            OUTPUT_VSOCK_PORT
-        );
+    // (image import can take 10+ minutes for large images).
+    // Store in global OUTPUT_VSOCK_FD so it can be reconnected after snapshot restore.
+    {
+        let fd = create_output_vsock();
+        OUTPUT_VSOCK_FD.store(fd, std::sync::atomic::Ordering::Release);
+        if fd >= 0 {
+            eprintln!(
+                "[fc-agent] output vsock connected early (port {})",
+                OUTPUT_VSOCK_PORT
+            );
+        }
     }
 
     // Determine the image reference for podman run
@@ -2678,7 +2709,7 @@ async fn run_agent() -> Result<()> {
                     break result.context("waiting for podman load")?;
                 }
                 _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
-                    send_output_line(output_fd, "heartbeat", "importing image");
+                    send_output_line("heartbeat", "importing image");
                     eprintln!("[fc-agent] heartbeat: still importing image...");
                 }
             }
@@ -2840,17 +2871,7 @@ async fn run_agent() -> Result<()> {
 
     // After cache-ready handshake, Firecracker may have created a pre-start snapshot.
     // Snapshot creation resets all vsock connections (VIRTIO_VSOCK_EVENT_TRANSPORT_RESET),
-    // which breaks FUSE mounts and the output vsock. Reconnect the output vsock and
-    // check if FUSE mounts are still healthy.
-    if output_fd >= 0 {
-        unsafe { libc::close(output_fd) };
-    }
-    output_fd = create_output_vsock();
-    if output_fd >= 0 {
-        eprintln!("[fc-agent] output vsock reconnected after snapshot");
-    }
-
-    // Check if FUSE mounts are still healthy and remount if needed.
+    // which breaks FUSE mounts. Check if mounts are still healthy and remount if needed.
     if !mounted_fuse_paths.is_empty() {
         let mut broken = false;
         for path in &mounted_fuse_paths {
@@ -3083,8 +3104,7 @@ async fn run_agent() -> Result<()> {
     let mut cmd = Command::new(&podman_args[0]);
     cmd.args(&podman_args[1..]);
 
-    // Spawn container with piped stdin/stdout/stderr for bidirectional I/O
-    cmd.stdin(Stdio::piped());
+    // Pipe stdout/stderr so we can stream them to host via vsock
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
 
@@ -3094,95 +3114,86 @@ async fn run_agent() -> Result<()> {
     // The host listens on vsock.sock_4999 for status messages
     notify_container_started();
 
-    // Stream stdout via vsock (wrapped in Arc for sharing across tasks)
-    let output_fd_arc = std::sync::Arc::new(std::sync::atomic::AtomicI32::new(output_fd));
+    // Channel-based output: decouple container output reading from vsock writing.
+    // A dedicated writer thread handles the blocking libc::write() to the vsock,
+    // keeping tokio worker threads free for async I/O.
+    let (output_tx, output_rx) = std::sync::mpsc::sync_channel::<String>(4096);
+
+    // Dedicated writer thread for vsock output
+    let writer_thread = std::thread::spawn(move || {
+        for msg in output_rx {
+            let fd = OUTPUT_VSOCK_FD.load(std::sync::atomic::Ordering::Acquire);
+            if fd < 0 {
+                continue;
+            }
+            let result = unsafe {
+                libc::write(fd, msg.as_ptr() as *const libc::c_void, msg.len())
+            };
+            if result < 0 {
+                let err = std::io::Error::last_os_error();
+                eprintln!(
+                    "[fc-agent] WARNING: output vsock write failed: {} (fd={})",
+                    err, fd
+                );
+            }
+        }
+    });
+
+    // Stream stdout via channel → writer thread → vsock
+    let stdout_tx = output_tx.clone();
     let stdout_task = if let Some(stdout) = child.stdout.take() {
-        let fd = output_fd_arc.clone();
         Some(tokio::spawn(async move {
             let reader = BufReader::new(stdout);
             let mut lines = reader.lines();
             while let Ok(Some(line)) = lines.next_line().await {
-                send_output_line(
-                    fd.load(std::sync::atomic::Ordering::Relaxed),
-                    "stdout",
-                    &line,
-                );
+                let msg = format!("stdout:{}\n", line);
+                if stdout_tx.send(msg).is_err() {
+                    break; // Writer thread exited
+                }
             }
         }))
     } else {
         None
     };
 
-    // Stream stderr via vsock
+    // Stream stderr via channel → writer thread → vsock
+    let stderr_tx = output_tx.clone();
     let stderr_task = if let Some(stderr) = child.stderr.take() {
-        let fd = output_fd_arc.clone();
         Some(tokio::spawn(async move {
             let reader = BufReader::new(stderr);
             let mut lines = reader.lines();
             while let Ok(Some(line)) = lines.next_line().await {
-                send_output_line(
-                    fd.load(std::sync::atomic::Ordering::Relaxed),
-                    "stderr",
-                    &line,
-                );
+                let msg = format!("stderr:{}\n", line);
+                if stderr_tx.send(msg).is_err() {
+                    break; // Writer thread exited
+                }
             }
         }))
     } else {
         None
     };
 
-    // Read stdin from vsock and forward to container (bidirectional I/O)
-    let stdin_task = if output_fd >= 0 {
-        if let Some(mut stdin) = child.stdin.take() {
-            // Duplicate the fd for reading (original used for writing)
-            let read_fd = unsafe { libc::dup(output_fd) };
-            if read_fd >= 0 {
-                Some(tokio::spawn(async move {
-                    use std::os::unix::io::FromRawFd;
-                    use tokio::io::AsyncWriteExt;
-                    // Convert to async file for reading
-                    let file = unsafe { std::fs::File::from_raw_fd(read_fd) };
-                    let file = tokio::fs::File::from_std(file);
-                    let reader = BufReader::new(file);
-                    let mut lines = reader.lines();
-                    while let Ok(Some(line)) = lines.next_line().await {
-                        // Parse stdin:content format
-                        if let Some(content) = line.strip_prefix("stdin:") {
-                            // Write to container stdin
-                            if stdin.write_all(content.as_bytes()).await.is_err() {
-                                break;
-                            }
-                            if stdin.write_all(b"\n").await.is_err() {
-                                break;
-                            }
-                        }
-                    }
-                }))
-            } else {
-                None
-            }
-        } else {
-            None
-        }
-    } else {
-        None
-    };
+    // Drop our copy of the sender (stdout/stderr tasks hold their own clones)
+    drop(output_tx);
 
     // Wait for container to exit
     let status = child.wait().await?;
     let exit_code = status.code().unwrap_or(1);
 
-    // Abort stdin task (container exited, no more input needed)
-    if let Some(task) = stdin_task {
-        task.abort();
-    }
-
-    // Wait for output streams to complete before closing vsock
+    // Wait for output streams to drain, then writer thread to finish
     if let Some(task) = stdout_task {
         let _ = task.await;
     }
     if let Some(task) = stderr_task {
         let _ = task.await;
+    }
+    // All senders dropped → writer_thread recv() returns Err → thread exits
+    let _ = writer_thread.join();
+
+    // Close output vsock
+    let final_fd = OUTPUT_VSOCK_FD.swap(-1, std::sync::atomic::Ordering::Release);
+    if final_fd >= 0 {
+        unsafe { libc::close(final_fd) };
     }
 
     if status.success() {
@@ -3207,14 +3218,14 @@ async fn run_agent() -> Result<()> {
                     eprintln!("[fc-agent] === podman logs (stdout) ===");
                     for line in stdout.lines() {
                         eprintln!("[fc-agent] {}", line);
-                        send_output_line(output_fd, "stdout", line);
+                        send_output_line("stdout", line);
                     }
                 }
                 if !stderr.is_empty() {
                     eprintln!("[fc-agent] === podman logs (stderr) ===");
                     for line in stderr.lines() {
                         eprintln!("[fc-agent] {}", line);
-                        send_output_line(output_fd, "stderr", line);
+                        send_output_line("stderr", line);
                     }
                 }
                 if stdout.is_empty() && stderr.is_empty() {
@@ -3225,11 +3236,6 @@ async fn run_agent() -> Result<()> {
                 eprintln!("[fc-agent] failed to get podman logs: {}", e);
             }
         }
-    }
-
-    // Close output vsock after all output (including failure logs) has been sent
-    if output_fd >= 0 {
-        unsafe { libc::close(output_fd) };
     }
 
     // Clean up the container (we don't use --rm so we can capture logs on failure)

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -513,8 +513,10 @@ fn parse_cpu(s: &str) -> Result<u8, String> {
         Ok(cpus)
     } else {
         s.parse::<u8>().map_err(|_| {
-            format!("invalid --cpu value '{}': expected integer or 'unlimited'", s)
+            format!(
+                "invalid --cpu value '{}': expected integer or 'unlimited'",
+                s
+            )
         })
     }
 }
-

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -114,8 +114,8 @@ pub struct RunArgs {
     #[arg(long)]
     pub name: String,
 
-    /// vCPUs (0 = all host CPUs)
-    #[arg(long, default_value_t = 0)]
+    /// vCPUs, or "unlimited" to use all host CPUs (default: 2, max: 32)
+    #[arg(long, default_value = "2", value_parser = parse_cpu)]
     pub cpu: u8,
 
     /// Memory in MiB, or "unlimited" to use all host memory (default: 2048)
@@ -503,3 +503,18 @@ fn parse_mem(s: &str) -> Result<u32, String> {
         })
     }
 }
+
+/// Parse --cpu value: either an integer or "unlimited" (all host CPUs, capped at 32).
+fn parse_cpu(s: &str) -> Result<u8, String> {
+    if s.eq_ignore_ascii_case("unlimited") {
+        let cpus = std::thread::available_parallelism()
+            .map(|n| n.get().min(32) as u8)
+            .unwrap_or(2);
+        Ok(cpus)
+    } else {
+        s.parse::<u8>().map_err(|_| {
+            format!("invalid --cpu value '{}': expected integer or 'unlimited'", s)
+        })
+    }
+}
+

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -605,7 +605,14 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
         let socket_path = output_socket_path.clone();
         let vm_id_clone = vm_id.clone();
         Some(tokio::spawn(async move {
-            match run_output_listener(&socket_path, &vm_id_clone, None, std::sync::Arc::new(tokio::sync::Notify::new())).await {
+            match run_output_listener(
+                &socket_path,
+                &vm_id_clone,
+                None,
+                std::sync::Arc::new(tokio::sync::Notify::new()),
+            )
+            .await
+            {
                 Ok(lines) => lines,
                 Err(e) => {
                     tracing::warn!("Output listener error: {}", e);

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -605,7 +605,7 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
         let socket_path = output_socket_path.clone();
         let vm_id_clone = vm_id.clone();
         Some(tokio::spawn(async move {
-            match run_output_listener(&socket_path, &vm_id_clone, interactive, None).await {
+            match run_output_listener(&socket_path, &vm_id_clone, None, std::sync::Arc::new(tokio::sync::Notify::new())).await {
                 Ok(lines) => lines,
                 Err(e) => {
                     tracing::warn!("Output listener error: {}", e);


### PR DESCRIPTION
Stacked on fc-agent-features (PR 308). Fixes: snapshot ENOSPC (default --mem to 2048 MiB), output vsock reconnect after snapshot reset, channel-based writer to prevent output loss.