### PR TITLE
Convert exec pipe path to fully async tokio

### DIFF
--- a/tests/test_exec.rs
+++ b/tests/test_exec.rs
@@ -1315,8 +1315,12 @@ async fn test_exec_parallel_pipe_stress() -> Result<()> {
     let fcvm_path = common::find_fcvm_binary()?;
     let (vm_name, _, _, _) = common::unique_names("stress-pipe");
 
-    // Expected output: seq 1 100 with newlines stripped = concatenated numbers
-    let expected_output: String = (1..=100).map(|n| n.to_string()).collect();
+    // Expected output: seq 1 100 with trailing newlines preserved
+    let expected_output: String = (1..=100)
+        .map(|n| format!("{}\n", n))
+        .collect::<String>()
+        .trim()
+        .to_string();
 
     // Start VM with nginx (keeps running)
     println!("Starting VM...");
@@ -1390,10 +1394,7 @@ async fn test_exec_parallel_pipe_stress() -> Result<()> {
                         } else {
                             stdout.clone()
                         };
-                        failures.push((
-                            idx,
-                            format!("exit={}, output={:?}", exit_code, preview),
-                        ));
+                        failures.push((idx, format!("exit={}, output={:?}", exit_code, preview)));
                     }
                 }
                 Err(e) => {
@@ -1430,7 +1431,8 @@ async fn test_exec_parallel_pipe_stress() -> Result<()> {
 
     // Assert 100% success
     assert_eq!(
-        success_count, TOTAL_EXECS,
+        success_count,
+        TOTAL_EXECS,
         "Expected 100% success rate, got {}/{} failures: {:?}",
         success_count,
         TOTAL_EXECS,


### PR DESCRIPTION
**Stacked on:** fc-agent-refactor (PR #310)

## Summary
- Replace `std::thread::spawn` with `tokio::spawn` for stdout/stderr pipe readers in exec.rs
- Use `tokio::process::Command` instead of `std::process::Command` for the pipe path
- Use `AsyncFd<OwnedFd>` with writable guard pattern for non-blocking vsock writes
- `Arc<tokio::sync::Mutex<AsyncFd<OwnedFd>>>` for write serialization between stdout/stderr tasks
- `handle_connection` is now fully async with `spawn_blocking` only for request line parsing and TTY dispatch

## What stays blocking
- TTY path: fork/PTY requires blocking OS threads (`spawn_blocking`)
- Request line parsing: fast byte-by-byte read (`spawn_blocking`)
- FUSE mounts and restore: must block forever

## Test plan
- [x] `cargo clippy -p fc-agent` — clean
- [x] All 24 exec subtests pass (bridged + rootless)
- [x] New `test_exec_parallel_pipe_stress`: 100 parallel non-TTY execs at 370 execs/sec
- [x] `grep -n "std::thread::spawn" fc-agent/src/exec.rs` returns nothing
- [x] Sanity tests pass (3/3)