### PR TITLE
Add --hugepages flag for 2MB hugepage-backed VM memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,6 +408,10 @@ jobs:
           sudo ./target/release/fcvm setup --generate-config --force
           # Build nested kernel locally (don't rely on GitHub releases)
           sudo ./target/release/fcvm setup --kernel-profile nested --build-kernels
+      - name: Allocate hugepages
+        run: |
+          echo 512 | sudo tee /proc/sys/vm/nr_hugepages
+          echo "Allocated $(cat /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages) hugepages"
       - name: test-root
         working-directory: fcvm
         run: |

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -122,6 +122,13 @@ pub struct RunArgs {
     #[arg(long, default_value = "2048", value_parser = parse_mem)]
     pub mem: u32,
 
+    /// Enable 2MB hugepage-backed VM memory for improved TLB performance.
+    /// Requires pre-allocated hugepage pool on the host.
+    /// Memory size (--mem) must be divisible by 2 when using hugepages.
+    /// Snapshot restore uses UFFD page fault handler automatically.
+    #[arg(long)]
+    pub hugepages: bool,
+
     /// Minimum free space on root filesystem (default: 10G).
     /// Disk is expanded after CoW copy if free space is below this threshold.
     #[arg(long, default_value = "10G")]
@@ -352,6 +359,11 @@ pub struct SnapshotRunArgs {
     /// Passed from podman run runtime config when restoring from a snapshot cache hit.
     #[arg(skip)]
     pub firecracker_args: Option<String>,
+
+    /// Whether hugepages are enabled (internal use only).
+    /// Passed from podman run's --hugepages when restoring from a snapshot cache hit.
+    #[arg(skip)]
+    pub hugepages: Option<bool>,
 }
 
 // ============================================================================

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -321,6 +321,7 @@ async fn create_sandbox(
         no_snapshot: true,
         forward_localhost: vec![],
         user: None,
+        hugepages: false,
         image,
         command_args: vec![],
     };

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -893,6 +893,9 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
         // Cleanup resources (exec path has no health monitor)
         info!("exec completed with exit code {}, cleaning up", exit_code);
 
+        // Stop implicit UFFD server if running (hugepage cache restore)
+        implicit_uffd_cancel.cancel();
+
         super::common::cleanup_vm(
             &vm_id,
             &mut vm_manager,

--- a/src/firecracker/api.rs
+++ b/src/firecracker/api.rs
@@ -205,6 +205,9 @@ pub struct MachineConfig {
     pub cpu_template: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub track_dirty_pages: Option<bool>,
+    /// Enable 2MB hugepage-backed guest memory ("2M" or None)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub huge_pages: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -2097,6 +2097,7 @@ async fn boot_vm_for_setup(disk_path: &Path, initrd_path: &Path) -> Result<()> {
             smt: Some(false),
             cpu_template: None,
             track_dirty_pages: None,
+            huge_pages: None,
         })
         .await?;
 

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -123,6 +123,9 @@ pub struct VmConfig {
     /// User-defined labels for tagging/filtering VMs
     #[serde(default)]
     pub labels: HashMap<String, String>,
+    /// Whether VM uses 2MB hugepage-backed memory
+    #[serde(default)]
+    pub hugepages: bool,
 }
 
 impl VmState {
@@ -154,6 +157,7 @@ impl VmState {
                 original_vsock_vm_id: None,
                 port_mappings: Vec::new(),
                 labels: HashMap::new(),
+                hugepages: false,
             },
         }
     }

--- a/src/storage/snapshot.rs
+++ b/src/storage/snapshot.rs
@@ -61,6 +61,9 @@ pub struct SnapshotMetadata {
     /// Health check URL from the baseline VM (None = no HTTP health check)
     #[serde(default)]
     pub health_check_url: Option<String>,
+    /// Whether VM uses 2MB hugepage-backed memory
+    #[serde(default)]
+    pub hugepages: bool,
 }
 
 /// Volume configuration saved in snapshot metadata.
@@ -216,6 +219,7 @@ mod tests {
                 },
                 volumes: vec![],
                 health_check_url: None,
+                hugepages: false,
             },
         };
 
@@ -329,6 +333,7 @@ mod tests {
                 },
                 volumes: vec![],
                 health_check_url: None,
+                hugepages: false,
             },
         };
 
@@ -386,6 +391,7 @@ mod tests {
                     },
                     volumes: vec![],
                     health_check_url: None,
+                    hugepages: false,
                 },
             };
             manager.save_snapshot(config).await.unwrap();
@@ -430,6 +436,7 @@ mod tests {
                 },
                 volumes: vec![],
                 health_check_url: None,
+                hugepages: false,
             },
         };
         manager.save_snapshot(config).await.unwrap();
@@ -525,6 +532,7 @@ mod tests {
                 },
                 volumes: vec![],
                 health_check_url: None,
+                hugepages: false,
             },
         };
 

--- a/tests/test_health_monitor.rs
+++ b/tests/test_health_monitor.rs
@@ -79,6 +79,7 @@ async fn test_health_monitor_behaviors() {
             original_vsock_vm_id: None,
             port_mappings: vec![],
             labels: std::collections::HashMap::new(),
+            hugepages: false,
         },
     };
 

--- a/tests/test_hugepages.rs
+++ b/tests/test_hugepages.rs
@@ -1,0 +1,373 @@
+//! Integration tests for hugepage-backed VMs.
+//!
+//! These tests verify:
+//! - VM boots with --hugepages flag
+//! - Snapshot cache creates hugepage-backed snapshots
+//! - Cache restore implicitly starts UFFD server (required for hugepage snapshots)
+//! - Snapshot/clone workflow works with hugepages
+//! - Memory alignment validation
+//!
+//! Requires pre-allocated hugepage pool on host:
+//!   echo 512 | sudo tee /proc/sys/vm/nr_hugepages
+
+#![cfg(feature = "privileged-tests")]
+
+mod common;
+
+use anyhow::{Context, Result};
+use std::time::Duration;
+
+/// Ensure hugepages are available, fail the test if not
+async fn ensure_hugepages() -> Result<()> {
+    let nr = tokio::fs::read_to_string("/sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages")
+        .await
+        .context("reading nr_hugepages")?;
+    let count: u64 = nr.trim().parse().context("parsing nr_hugepages")?;
+    anyhow::ensure!(
+        count > 0,
+        "No hugepages allocated. Run: echo 512 | sudo tee /proc/sys/vm/nr_hugepages"
+    );
+    println!("  Hugepages available: {}", count);
+    Ok(())
+}
+
+/// Test that a VM boots successfully with --hugepages flag
+///
+/// Verifies:
+/// - huge_pages: "2M" is accepted by Firecracker's PUT /machine-config
+/// - VM reaches healthy status
+/// - Exec works in the container
+#[tokio::test]
+async fn test_hugepage_vm_boot() -> Result<()> {
+    println!("\nHugepage VM boot test");
+    println!("=====================");
+    ensure_hugepages().await?;
+
+    let (vm_name, _, _, _) = common::unique_names("hugepages-boot");
+
+    // Use --mem 512 (even number, 2MB aligned) with --hugepages
+    let (mut child, fcvm_pid) = common::spawn_fcvm(&[
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--network",
+        "bridged",
+        "--hugepages",
+        "--mem",
+        "512",
+        common::TEST_IMAGE,
+    ])
+    .await
+    .context("spawning fcvm with --hugepages")?;
+
+    println!("  fcvm PID: {}", fcvm_pid);
+    println!("  Waiting for VM to become healthy...");
+
+    let health_result = tokio::time::timeout(
+        Duration::from_secs(300),
+        common::poll_health_by_pid(fcvm_pid, 300),
+    )
+    .await;
+
+    match &health_result {
+        Ok(Ok(_)) => println!("  VM is healthy with hugepages!"),
+        Ok(Err(e)) => println!("  Health check failed: {}", e),
+        Err(_) => println!("  Health check timed out"),
+    }
+
+    // Run exec to verify container is functional
+    if health_result.is_ok() && health_result.as_ref().unwrap().is_ok() {
+        println!("  Running exec in hugepage VM...");
+        let exec_output = common::exec_in_container(fcvm_pid, &["echo", "hugepages-ok"]).await?;
+        assert!(
+            exec_output.contains("hugepages-ok"),
+            "exec output should contain 'hugepages-ok', got: {}",
+            exec_output
+        );
+        println!("  Exec output: {}", exec_output.trim());
+    }
+
+    // Cleanup
+    println!("  Stopping VM...");
+    common::kill_process(fcvm_pid).await;
+    let _ = child.wait().await;
+
+    health_result
+        .map_err(|_| anyhow::anyhow!("health check timed out"))?
+        .context("health check failed")?;
+
+    println!("  PASSED: hugepage VM boots and exec works");
+    Ok(())
+}
+
+/// Test that cache restore with hugepages uses UFFD (not File backend).
+///
+/// Firecracker rejects File backend for hugepage snapshots, so cache restore
+/// must implicitly start a UFFD server. This test verifies:
+/// 1. First run: VM boots with --hugepages, snapshot cache is created
+/// 2. Second run: same args hit cache, VM still boots (proves UFFD restore worked)
+///    (If File backend were used, Firecracker would return an error)
+#[tokio::test]
+async fn test_hugepage_cache_restore_uses_uffd() -> Result<()> {
+    println!("\nHugepage cache restore test");
+    println!("===========================");
+    ensure_hugepages().await?;
+
+    // Use unique env var so we get a unique cache key
+    let test_id = format!("TEST_ID=hp-cache-{}", std::process::id());
+
+    // First run: creates snapshot cache
+    println!("  First run: creating hugepage snapshot cache...");
+    let (vm_name1, _, _, _) = common::unique_names("hp-cache-1");
+    let (mut child1, pid1) = common::spawn_fcvm(&[
+        "podman",
+        "run",
+        "--name",
+        &vm_name1,
+        "--network",
+        "bridged",
+        "--hugepages",
+        "--mem",
+        "512",
+        "--env",
+        &test_id,
+        common::TEST_IMAGE,
+    ])
+    .await
+    .context("spawning first hugepage VM")?;
+
+    println!("  First VM PID: {}", pid1);
+    common::poll_health_by_pid(pid1, 300).await?;
+    println!("  First VM healthy, waiting for snapshot cache creation...");
+
+    // Wait for snapshot cache to be created (happens after health check)
+    tokio::time::sleep(Duration::from_secs(10)).await;
+
+    // Kill first VM
+    common::kill_process(pid1).await;
+    let _ = child1.wait().await;
+    println!("  First VM stopped");
+
+    // Second run: should hit cache and use implicit UFFD server
+    println!("  Second run: should hit hugepage cache...");
+    let (vm_name2, _, _, _) = common::unique_names("hp-cache-2");
+    let (mut child2, pid2) = common::spawn_fcvm(&[
+        "podman",
+        "run",
+        "--name",
+        &vm_name2,
+        "--network",
+        "bridged",
+        "--hugepages",
+        "--mem",
+        "512",
+        "--env",
+        &test_id,
+        common::TEST_IMAGE,
+    ])
+    .await
+    .context("spawning second hugepage VM (cache hit)")?;
+
+    println!("  Second VM PID: {}", pid2);
+
+    let health_result = tokio::time::timeout(
+        Duration::from_secs(300),
+        common::poll_health_by_pid(pid2, 300),
+    )
+    .await;
+
+    match &health_result {
+        Ok(Ok(_)) => println!("  Second VM healthy (UFFD restore worked!)"),
+        Ok(Err(e)) => println!("  Second VM health check failed: {}", e),
+        Err(_) => println!("  Second VM health check timed out"),
+    }
+
+    // Cleanup
+    common::kill_process(pid2).await;
+    let _ = child2.wait().await;
+
+    health_result
+        .map_err(|_| anyhow::anyhow!("cache restore health check timed out"))?
+        .context("cache restore health check failed")?;
+
+    println!("  PASSED: hugepage cache restore with implicit UFFD server works");
+    Ok(())
+}
+
+/// Test full snapshot/clone workflow with hugepages.
+///
+/// 1. Boot VM with --hugepages
+/// 2. Create user snapshot
+/// 3. Start serve process
+/// 4. Spawn clone from serve
+/// 5. Verify clone is healthy and functional
+#[tokio::test]
+async fn test_hugepage_snapshot_clone() -> Result<()> {
+    println!("\nHugepage snapshot/clone test");
+    println!("============================");
+    ensure_hugepages().await?;
+
+    let (baseline_name, clone_name, snap_name, serve_name) = common::unique_names("hp-snap-clone");
+
+    let fcvm_path = common::find_fcvm_binary()?;
+
+    // 1. Boot baseline VM with hugepages
+    println!("  Starting baseline VM with --hugepages...");
+    let (mut baseline, baseline_pid) = common::spawn_fcvm(&[
+        "podman",
+        "run",
+        "--name",
+        &baseline_name,
+        "--network",
+        "bridged",
+        "--hugepages",
+        "--mem",
+        "512",
+        common::TEST_IMAGE,
+    ])
+    .await
+    .context("spawning baseline hugepage VM")?;
+
+    common::poll_health_by_pid(baseline_pid, 300).await?;
+    println!("  Baseline VM healthy (PID: {})", baseline_pid);
+
+    // 2. Create snapshot (no sudo — CARGO_RUNNER handles that)
+    println!("  Creating snapshot '{}'...", snap_name);
+    let snap_output = tokio::process::Command::new(&fcvm_path)
+        .args([
+            "snapshot",
+            "create",
+            "--pid",
+            &baseline_pid.to_string(),
+            "--tag",
+            &snap_name,
+        ])
+        .output()
+        .await
+        .context("creating snapshot")?;
+
+    if !snap_output.status.success() {
+        let stderr = String::from_utf8_lossy(&snap_output.stderr);
+        // Kill baseline before bailing
+        common::kill_process(baseline_pid).await;
+        let _ = baseline.wait().await;
+        anyhow::bail!("snapshot create failed: {}", stderr);
+    }
+    println!("  Snapshot created");
+
+    // Kill baseline (no longer needed)
+    common::kill_process(baseline_pid).await;
+    let _ = baseline.wait().await;
+
+    // 3. Start serve
+    println!("  Starting serve for '{}'...", snap_name);
+    let (mut serve_child, serve_pid) =
+        common::spawn_fcvm_with_logs(&["snapshot", "serve", &snap_name], &serve_name)
+            .await
+            .context("starting serve")?;
+
+    // Give serve a moment to start
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    println!("  Serve started (PID: {})", serve_pid);
+
+    // 4. Spawn clone
+    println!("  Spawning clone from serve...");
+    let (mut clone_child, clone_pid) = common::spawn_fcvm(&[
+        "snapshot",
+        "run",
+        "--pid",
+        &serve_pid.to_string(),
+        "--name",
+        &clone_name,
+        "--network",
+        "bridged",
+    ])
+    .await
+    .context("spawning clone")?;
+
+    println!("  Clone PID: {}", clone_pid);
+
+    let health_result = tokio::time::timeout(
+        Duration::from_secs(120),
+        common::poll_health_by_pid(clone_pid, 120),
+    )
+    .await;
+
+    match &health_result {
+        Ok(Ok(_)) => {
+            println!("  Clone healthy! Running exec...");
+            let exec_output =
+                common::exec_in_container(clone_pid, &["echo", "hugepage-clone-ok"]).await?;
+            assert!(
+                exec_output.contains("hugepage-clone-ok"),
+                "exec output should contain 'hugepage-clone-ok', got: {}",
+                exec_output
+            );
+            println!("  Clone exec: {}", exec_output.trim());
+        }
+        Ok(Err(e)) => println!("  Clone health failed: {}", e),
+        Err(_) => println!("  Clone health timed out"),
+    }
+
+    // Cleanup (kill clone, serve)
+    common::kill_process(clone_pid).await;
+    let _ = clone_child.wait().await;
+    common::kill_process(serve_pid).await;
+    let _ = serve_child.wait().await;
+
+    health_result
+        .map_err(|_| anyhow::anyhow!("clone health timed out"))?
+        .context("clone health failed")?;
+
+    println!("  PASSED: hugepage snapshot/clone workflow works");
+    Ok(())
+}
+
+/// Test that --hugepages with odd memory value is rejected.
+///
+/// Hugepages require 2MB-aligned memory, so mem_size_mib must be even.
+#[tokio::test]
+async fn test_hugepage_mem_validation() -> Result<()> {
+    println!("\nHugepage memory validation test");
+    println!("================================");
+
+    let (vm_name, _, _, _) = common::unique_names("hp-validate");
+
+    // Try to run with --hugepages --mem 2049 (odd MiB)
+    println!("  Testing --hugepages --mem 2049 (should fail)...");
+    let fcvm = common::find_fcvm_binary()?;
+    let output = tokio::process::Command::new(&fcvm)
+        .args([
+            "podman",
+            "run",
+            "--name",
+            &vm_name,
+            "--network",
+            "bridged",
+            "--hugepages",
+            "--mem",
+            "2049",
+            common::TEST_IMAGE,
+        ])
+        .output()
+        .await
+        .context("running fcvm with odd mem + hugepages")?;
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    println!("  Exit status: {}", output.status);
+    println!("  stderr: {}", stderr.trim());
+
+    assert!(
+        !output.status.success(),
+        "fcvm should fail with odd memory + hugepages"
+    );
+    assert!(
+        stderr.contains("not divisible by 2") || stderr.contains("hugepages"),
+        "error should mention memory alignment, got: {}",
+        stderr
+    );
+
+    println!("  PASSED: odd memory with hugepages correctly rejected");
+    Ok(())
+}

--- a/tests/test_library_api.rs
+++ b/tests/test_library_api.rs
@@ -43,6 +43,7 @@ fn test_run_args(name: &str) -> RunArgs {
         no_snapshot: true,
         user: None,
         forward_localhost: vec![],
+        hugepages: false,
         label: vec![],
         image: common::TEST_IMAGE.to_string(),
         command_args: vec![],

--- a/tests/test_state_manager.rs
+++ b/tests/test_state_manager.rs
@@ -52,6 +52,7 @@ async fn test_state_persistence() {
             original_vsock_vm_id: None,
             port_mappings: vec![],
             labels: std::collections::HashMap::new(),
+            hugepages: false,
         },
     };
 
@@ -120,6 +121,7 @@ async fn test_list_vms() {
                 original_vsock_vm_id: None,
                 port_mappings: vec![],
                 labels: std::collections::HashMap::new(),
+                hugepages: false,
             },
         };
         manager.save_state(&state).await.unwrap();


### PR DESCRIPTION
## Summary

- Adds `--hugepages` flag to `fcvm podman run` enabling Firecracker's 2MB hugepage guest memory
- UFFD server reads `page_size` from Firecracker handshake instead of hardcoding 4096 — supports 4K, 2MB, and future 16K pages
- When restoring from snapshot cache with hugepages, starts an implicit in-process UFFD server (Firecracker rejects File backend for hugepage snapshots)
- Snapshot creation timeout scales with memory size: `max(300, mem_gib * 5)` seconds
- Validates `--mem` is divisible by 2 when `--hugepages` is used

## Changes

| File | Change |
|------|--------|
| `src/cli/args.rs` | `--hugepages` flag on RunArgs, internal field on SnapshotRunArgs |
| `src/firecracker/config.rs` | `huge_pages` in MachineConfig (auto cache key), disables `track_dirty_pages` |
| `src/firecracker/api.rs` | `huge_pages` in API MachineConfig |
| `src/uffd/server.rs` | Parse `page_size` from handshake, dynamic page alignment/copy, heap-allocate zero buffers |
| `src/commands/podman.rs` | Plumb hugepages through build/validate/cache-hit/snapshot paths |
| `src/commands/snapshot.rs` | Implicit UFFD server on hugepage cache restore via CancellationToken |
| `src/commands/common.rs` | Scale snapshot timeout with memory size |
| `src/storage/snapshot.rs` | `hugepages` in SnapshotMetadata |
| `src/state/types.rs` | `hugepages` in VmConfig |
| `.github/workflows/ci.yml` | Allocate 512 hugepages before test-root |
| `tests/test_hugepages.rs` | 4 integration tests for hugepage flows |

## Test plan

- [x] `make test` — 67 unit tests pass (snapshot key, page_size parsing, validation)
- [x] `make test-root FILTER=hugepage` — 6 tests pass:
  - `test_hugepage_vm_boot`: VM boots with `--hugepages`, exec works
  - `test_hugepage_cache_restore_uses_uffd`: Cache hit starts implicit UFFD server
  - `test_hugepage_snapshot_clone`: Full snapshot/serve/clone with hugepages
  - `test_hugepage_mem_validation`: Odd mem values rejected
  - `test_snapshot_key_changes_with_hugepages`: Different cache key
  - `test_mapping_contains_with_hugepage_alignment`: 2MB alignment