### PR TITLE
Fix hugepage diff snapshots: enable KVM dirty tracking

### DIFF
--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -41,7 +41,28 @@ make test-root FILTER=sanity
    gh pr create --fill
    ```
 
-3. **Wait for CI** - Do NOT proceed until all checks pass:
+3. **Verify PR description matches commits** (also do this after pushing new commits):
+   ```bash
+   # Read ALL commits in the branch
+   git log --oneline origin/main..HEAD
+
+   # Read the current PR description
+   gh pr view <pr-number> --json body --jq '.body'
+
+   # Compare: every commit's changes must be reflected in the description
+   # If commits were added/removed since the PR was created, UPDATE the description
+   gh pr edit <pr-number> --body "$(cat <<'EOF'
+   ...updated description covering ALL commits...
+   EOF
+   )"
+   ```
+   **Anti-patterns to catch:**
+   - Description only mentions the first or last commit (ignores the rest)
+   - Description mentions changes that were reverted or amended away
+   - Description claims functionality that no commit actually implements
+   - Stacked PR description includes parent branch commits (only describe YOUR commits)
+
+4. **Wait for CI** - Do NOT proceed until all checks pass:
    ```bash
    gh pr checks <pr-number>
    # All checks must show "pass" before proceeding

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,51 @@ env:
   CACHE_KEY_HOST: cargo-tools-nextest-0.9.115-audit-0.22.0-deny-0.18.9
 
 jobs:
+  # Skip expensive CI jobs on main pushes when the tree SHA already passed on a PR.
+  # When a PR merges via fast-forward or rebase, the merge commit has the same tree
+  # SHA as the PR tip. Re-running all tests on self-hosted runners is wasteful.
+  skip-check:
+    name: Skip Check
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 20
+      - name: Check if tree SHA already passed CI
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "push" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Not a push event, running CI"
+            exit 0
+          fi
+
+          TREE_SHA=$(git rev-parse HEAD^{tree})
+          echo "Current tree SHA: $TREE_SHA"
+
+          # Check recent successful CI runs on PRs for the same tree SHA
+          # Look at the last 20 commits on main to find PR branch tips
+          SKIP=false
+          for sha in $(git log --format=%H -20 HEAD^ 2>/dev/null || true); do
+            COMMIT_TREE=$(git rev-parse "$sha^{tree}" 2>/dev/null || true)
+            if [ "$COMMIT_TREE" = "$TREE_SHA" ] && [ "$sha" != "$(git rev-parse HEAD)" ]; then
+              # Found a commit with the same tree — check if it passed CI
+              STATUS=$(gh api "repos/${{ github.repository }}/commits/$sha/status" --jq '.state' 2>/dev/null || echo "unknown")
+              echo "Commit $sha has same tree SHA, CI status: $STATUS"
+              if [ "$STATUS" = "success" ]; then
+                SKIP=true
+                echo "Tree SHA $TREE_SHA already passed CI on commit $sha"
+                break
+              fi
+            fi
+          done
+
+          echo "skip=$SKIP" >> "$GITHUB_OUTPUT"
+
   # Runner 0: Lint (default GitHub runner, no KVM needed)
   # Fast checks: fmt, clippy, audit, deny
   lint:
@@ -124,7 +169,8 @@ jobs:
   # Self-hosted runners with nested virtualization (ARM64: c7g.metal, x86: c5.metal)
   host:
     name: Host-${{ matrix.arch }}
-    if: ${{ github.event.inputs.job != 'container' }}
+    needs: [skip-check]
+    if: ${{ github.event.inputs.job != 'container' && needs.skip-check.outputs.skip != 'true' }}
     runs-on: [self-hosted, Linux, '${{ matrix.arch }}']
     strategy:
       fail-fast: false
@@ -305,7 +351,8 @@ jobs:
   #   This validates the full snapshot lifecycle: create -> persist -> restore
   host-root:
     name: Host-Root-${{ matrix.arch }}-${{ matrix.mode }}
-    if: ${{ github.event.inputs.job != 'container' }}
+    needs: [skip-check]
+    if: ${{ github.event.inputs.job != 'container' && needs.skip-check.outputs.skip != 'true' }}
     runs-on: [self-hosted, Linux, '${{ matrix.arch }}']
     strategy:
       fail-fast: false
@@ -469,7 +516,8 @@ jobs:
   # Needs KVM for VM tests (container mounts /dev/kvm)
   container:
     name: Container-${{ matrix.arch }}
-    if: ${{ github.event.inputs.job != 'host' }}
+    needs: [skip-check]
+    if: ${{ github.event.inputs.job != 'host' && needs.skip-check.outputs.skip != 'true' }}
     runs-on: [self-hosted, Linux, '${{ matrix.arch }}']
     strategy:
       fail-fast: false
@@ -554,10 +602,13 @@ jobs:
   # Final summary job - runs after all test jobs
   summary:
     name: Summary
-    needs: [lint, packaging, host, host-root, container]
+    needs: [skip-check, lint, packaging, host, host-root, container]
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: Report skipped
+        if: needs.skip-check.outputs.skip == 'true'
+        run: echo "::notice::Skipped self-hosted tests — tree SHA already passed CI on a PR branch"
       - uses: actions/checkout@v6
       - name: Download all artifacts
         uses: actions/download-artifact@v7

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -718,7 +718,7 @@ curl http://172.30.x.1:8080
                  ▼
 ┌─────────────────────────────────────────────────────────┐
 │ 4. Load snapshot via Firecracker API                    │
-│    - enable_diff_snapshots = true                       │
+│    - track_dirty_pages = !hugepages                     │
 │    - resume_vm = true                                   │
 └────────────────┬────────────────────────────────────────┘
                  ▼

--- a/README.md
+++ b/README.md
@@ -287,6 +287,64 @@ sudo ./fcvm snapshot run --pid <serve_pid> --network bridged --exec "curl localh
 sudo ./fcvm snapshot run --snapshot nginx-warm --network bridged --exec "curl localhost"
 ```
 
+### Hugepages (2MB Pages)
+
+Use `--hugepages` to back VM memory with 2MB hugepages instead of 4KB pages.
+Hugepages reduce TLB pressure for memory-intensive workloads by mapping guest memory
+with 2MB Stage 2 block entries instead of 4KB page table entries.
+
+```bash
+# Allocate hugepage pool (must cover VM memory)
+sudo sh -c 'echo 1200 > /proc/sys/vm/nr_hugepages'  # 2400MB for a 2GB VM
+
+# Run with hugepages
+./fcvm podman run --name web --hugepages --health-check http://localhost/ nginx:alpine
+
+# Release hugepage pool when done
+sudo sh -c 'echo 0 > /proc/sys/vm/nr_hugepages'
+```
+
+**How it works with snapshots:**
+
+The snapshot cache flow creates two snapshots on the initial VM:
+1. **Pre-start (Full)**: After container image import
+2. **Startup (Diff)**: After container is healthy
+
+KVM dirty page tracking is enabled on the initial VM so the startup diff snapshot
+captures only the pages that changed between pre-start and startup (~100MB for a
+typical nginx container, vs dumping the entire VM memory).
+
+Dirty tracking requires KVM to split ARM64 Stage 2 block mappings from 2MB to 4KB
+entries. This only affects the initial VM (runs once for cache creation). Restored
+VMs (clones) do not enable dirty tracking, so they get full 2MB Stage 2 block
+mappings and the TLB benefit of hugepages.
+
+| VM role | Dirty tracking | Stage 2 mapping | Runs |
+|---------|---------------|-----------------|------|
+| Initial (cache creation) | Enabled | 4KB (split for tracking) | Once |
+| Clone (hugepage) | Disabled | 2MB blocks (full TLB benefit) | Many times |
+| Clone (non-hugepage) | Enabled | 4KB (no hugepages anyway) | Many times |
+
+**Benchmark results** (c7gd.metal ARM64, 2GB VM, 256MB dirty data):
+
+```
+Phase                       Standard (4KB)   Hugepages (2MB)    Ratio
+--------------------------------------------------------------------
+First Run (cold)                     10.1s              8.6s    0.85x
+Diff Size (dirty)                   95 MB              98 MB    1.03x
+Clone Restore                        0.5s              1.0s    1.99x
+```
+
+**Limitations:**
+- Hugepage pool must be pre-allocated (`/proc/sys/vm/nr_hugepages`)
+- Hugepage VMs require UFFD for snapshot restore (file-based restore is not supported by Firecracker with hugepages)
+- Clone restore is ~2x slower with hugepages due to UFFD page fault handling at 2MB granularity
+- Diff snapshots from hugepage clones use `mincore(2)` fallback (reports in-core pages, not dirty pages), so they may be larger than necessary
+
+**When to use hugepages:** Workloads where the TLB benefit of 2MB mappings on clones
+outweighs the ~2x slower clone restore. Best for long-running VMs with large working sets
+where TLB misses dominate performance.
+
 ---
 
 ## Examples
@@ -546,6 +604,7 @@ See [DESIGN.md](DESIGN.md#cli-interface) for architecture and design decisions.
 -t, --tty           Allocate pseudo-TTY (for vim, colors, etc.)
 --setup             Auto-setup if kernel/rootfs missing (rootless only)
 --no-snapshot       Disable automatic snapshot creation (for testing)
+--hugepages         Use 2MB hugepages for VM memory (requires pre-allocated pool)
 --forward-localhost <PORTS>  Forward localhost ports to host (e.g., 1421,9099)
 --rootfs-size <SIZE> Minimum free space on rootfs (default: 10G)
 ```

--- a/benches/hugepages.rs
+++ b/benches/hugepages.rs
@@ -337,7 +337,10 @@ fn run_mode(mode: &str, mem_mb: u32, data_mb: u32, hugepages: bool) -> BenchResu
     // Extract the actual diff size from the debug log (bytes_merged in diff merge)
     let diff_bytes = extract_diff_bytes(&log_path1);
     let diff_size_mb = diff_bytes / (1024 * 1024);
-    eprintln!("    Memory snapshot size: {} MB (diff: {} MB)", snapshot_size_mb, diff_size_mb);
+    eprintln!(
+        "    Memory snapshot size: {} MB (diff: {} MB)",
+        snapshot_size_mb, diff_size_mb
+    );
 
     let first_run_secs = t1.elapsed().as_secs_f64();
 

--- a/benches/hugepages.rs
+++ b/benches/hugepages.rs
@@ -38,6 +38,7 @@ struct SnapshotLsEntry {
 struct BenchResult {
     first_run_secs: f64,
     snapshot_size_mb: u64,
+    diff_size_mb: u64,
     clone_secs: f64,
 }
 
@@ -178,6 +179,23 @@ fn wait_for_startup_snapshot(fcvm: &Path, timeout_secs: u64) -> Option<SnapshotL
     }
 }
 
+/// Extract bytes_merged from the debug log to get the actual diff snapshot size.
+/// Searches for "diff merge complete" log line which contains bytes_merged=N.
+fn extract_diff_bytes(log_path: &str) -> u64 {
+    let content = std::fs::read_to_string(log_path).unwrap_or_default();
+    for line in content.lines().rev() {
+        if line.contains("diff merge complete") {
+            // Format: ... bytes_merged=99524608
+            if let Some(pos) = line.find("bytes_merged=") {
+                let after = &line[pos + "bytes_merged=".len()..];
+                let num_str: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
+                return num_str.parse().unwrap_or(0);
+            }
+        }
+    }
+    0
+}
+
 /// Build the benchmark container image with the specified data size
 fn build_image(data_mb: u32) {
     eprintln!(
@@ -316,7 +334,10 @@ fn run_mode(mode: &str, mem_mb: u32, data_mb: u32, hugepages: bool) -> BenchResu
             0
         }
     };
-    eprintln!("    Memory snapshot size: {} MB", snapshot_size_mb);
+    // Extract the actual diff size from the debug log (bytes_merged in diff merge)
+    let diff_bytes = extract_diff_bytes(&log_path1);
+    let diff_size_mb = diff_bytes / (1024 * 1024);
+    eprintln!("    Memory snapshot size: {} MB (diff: {} MB)", snapshot_size_mb, diff_size_mb);
 
     let first_run_secs = t1.elapsed().as_secs_f64();
 
@@ -401,6 +422,7 @@ fn run_mode(mode: &str, mem_mb: u32, data_mb: u32, hugepages: bool) -> BenchResu
     BenchResult {
         first_run_secs,
         snapshot_size_mb,
+        diff_size_mb,
         clone_secs: total_clone_secs,
     }
 }
@@ -441,6 +463,13 @@ fn print_comparison(mem_mb: u32, data_mb: u32, std: &BenchResult, hp: &BenchResu
         std.snapshot_size_mb,
         hp.snapshot_size_mb,
         hp.snapshot_size_mb as f64 / std.snapshot_size_mb.max(1) as f64
+    );
+    println!(
+        "{:<24} {:>14} MB {:>14} MB {:>7.2}x",
+        "Diff Size (dirty)",
+        std.diff_size_mb,
+        hp.diff_size_mb,
+        hp.diff_size_mb as f64 / std.diff_size_mb.max(1) as f64
     );
     println!(
         "{:<24} {:>16.1}s {:>16.1}s {:>7.2}x",

--- a/scripts/claude-assistant/index.ts
+++ b/scripts/claude-assistant/index.ts
@@ -282,6 +282,17 @@ Then link to it: "As noted in [previous review](URL), the PATH inconsistency rem
 
 ## STEP 3: ANALYZE
 
+### 3a. Check PR description consistency
+
+Compare the PR description (from step 1a) against the commit list (from step 1b).
+Every commit's changes must be reflected in the description. Flag as [MEDIUM] if:
+- Description only covers some commits (e.g., mentions 3 of 7 commits)
+- Description claims changes that no commit implements
+- Description mentions reverted or amended-away changes
+- For stacked PRs: description includes parent branch changes instead of just this branch's commits
+
+### 3b. Categorize code issues
+
 Categorize issues:
 - \`[CRITICAL]\` - Security holes, data loss, crashes, breaking changes
 - \`[MEDIUM]\` - Bugs, logic errors, race conditions, missing validation

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -396,6 +396,8 @@ pub struct SnapshotRestoreConfig {
     /// This is needed because disk paths are patched during cache restore,
     /// so vmstate.bin has a different VM ID for disk than for vsock.
     pub snapshot_vm_id: Option<String>,
+    /// Whether this VM uses hugepages
+    pub hugepages: bool,
 }
 
 /// Restore a VM from a snapshot
@@ -714,10 +716,11 @@ pub async fn restore_from_snapshot(
         .load_snapshot(SnapshotLoad {
             snapshot_path: restore_config.vmstate_path.display().to_string(),
             mem_backend,
-            // Dirty tracking is not needed on restored VMs — we don't create
-            // diff snapshots from clones. Diff snapshots are created on the initial
-            // VM (which has track_dirty_pages=true via machine config).
-            track_dirty_pages: Some(false),
+            // Enable dirty tracking on non-hugepage VMs so subsequent snapshots
+            // from clones produce accurate diffs. Skip for hugepage VMs because
+            // KVM splits 2MB Stage 2 block mappings to 4K for dirty tracking,
+            // negating the TLB benefit of hugepages.
+            track_dirty_pages: Some(!restore_config.hugepages),
             resume_vm: Some(false), // Update devices before resume
             network_overrides: Some(vec![NetworkOverride {
                 iface_id: "eth0".to_string(),

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -714,12 +714,10 @@ pub async fn restore_from_snapshot(
         .load_snapshot(SnapshotLoad {
             snapshot_path: restore_config.vmstate_path.display().to_string(),
             mem_backend,
-            // NOTE: enable_diff_snapshots is DEPRECATED in Firecracker v1.13.0+
-            // It was for legacy KVM dirty page tracking. Firecracker now uses mincore(2)
-            // to find dirty pages automatically. Enabling this on restored VMs causes
-            // kernel stack corruption ("stack-protector: Kernel stack is corrupted in: do_idle").
-            // Diff snapshots still work via snapshot_type: "Diff" + mincore(2).
-            enable_diff_snapshots: Some(false),
+            // Dirty tracking is not needed on restored VMs — we don't create
+            // diff snapshots from clones. Diff snapshots are created on the initial
+            // VM (which has track_dirty_pages=true via machine config).
+            track_dirty_pages: Some(false),
             resume_vm: Some(false), // Update devices before resume
             network_overrides: Some(vec![NetworkOverride {
                 iface_id: "eth0".to_string(),

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -2931,6 +2931,11 @@ async fn run_vm_setup(
     // Use fc_config from cache check if available, otherwise build fresh.
     // IMPORTANT: fc_config uses content-addressed base_rootfs path for cache key,
     // but launch must use per-instance CoW copy path (rootfs_path).
+    //
+    // Enable dirty page tracking only when snapshots are enabled (fc_config is Some).
+    // With hugepages, dirty tracking splits 2MB Stage 2 block mappings to 4K,
+    // so we avoid it when snapshots are disabled (--no-snapshot / FCVM_NO_SNAPSHOT).
+    let track_dirty_pages = fc_config.is_some();
     let launch_config = fc_config
         .map(|config| config.with_rootfs_path(rootfs_path.to_path_buf()))
         .unwrap_or_else(|| {
@@ -2972,7 +2977,9 @@ async fn run_vm_setup(
 
     // Build runtime boot args and apply FirecrackerConfig
     let runtime_boot_args = build_runtime_boot_args(args, network_config, runtime_config);
-    launch_config.apply(client, &runtime_boot_args).await?;
+    launch_config
+        .apply(client, &runtime_boot_args, track_dirty_pages)
+        .await?;
 
     // Attach extra disks and image archive
     let (extra_disks, image_device) =

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -780,6 +780,7 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
         source_disk_path: snapshot_config.disk_path.clone(),
         original_vm_id,
         snapshot_vm_id,
+        hugepages,
     };
 
     // Run clone setup using shared restore function

--- a/src/firecracker/api.rs
+++ b/src/firecracker/api.rs
@@ -279,7 +279,7 @@ pub struct SnapshotLoad {
     pub snapshot_path: String,
     pub mem_backend: MemBackend,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub enable_diff_snapshots: Option<bool>,
+    pub track_dirty_pages: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resume_vm: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/firecracker/config.rs
+++ b/src/firecracker/config.rs
@@ -228,16 +228,18 @@ impl FirecrackerConfig {
             .await?;
 
         // Set machine config
-        // Hugepages negate dirty page tracking benefits (KVM forces 4K page tables),
-        // but diff snapshots still work via mincore(2) fallback.
-        let track_dirty_pages = self.machine_config.huge_pages.is_none();
+        // Always enable dirty page tracking for accurate diff snapshots.
+        // With hugepages, KVM splits Stage 2 block mappings from 2MB to 4K for
+        // dirty tracking. This only affects the initial VM (cache creation, runs once).
+        // Restored VMs (clones) don't enable dirty tracking, so they get full 2MB
+        // Stage 2 entries and the TLB benefit of hugepages.
         client
             .set_machine_config(super::api::MachineConfig {
                 vcpu_count: self.machine_config.vcpu_count,
                 mem_size_mib: self.machine_config.mem_size_mib,
                 smt: Some(false),
                 cpu_template: None,
-                track_dirty_pages: Some(track_dirty_pages),
+                track_dirty_pages: Some(true),
                 huge_pages: self.machine_config.huge_pages.clone(),
             })
             .await?;

--- a/src/firecracker/config.rs
+++ b/src/firecracker/config.rs
@@ -206,10 +206,16 @@ impl FirecrackerConfig {
     ///
     /// `runtime_boot_args` contains per-instance values (IPs, strace, etc.)
     /// that don't affect cache but are needed for launch.
+    ///
+    /// `track_dirty_pages`: enable KVM dirty page tracking for diff snapshots.
+    /// Should be true when creating a snapshot cache (need accurate diffs),
+    /// false when snapshots are disabled (avoids splitting hugepage 2MB Stage 2
+    /// block mappings to 4K).
     pub async fn apply(
         &self,
         client: &super::api::FirecrackerClient,
         runtime_boot_args: &str,
+        track_dirty_pages: bool,
     ) -> Result<()> {
         // Build full boot args: static (cached) + runtime (per-instance)
         let full_boot_args = if runtime_boot_args.is_empty() {
@@ -228,18 +234,16 @@ impl FirecrackerConfig {
             .await?;
 
         // Set machine config
-        // Always enable dirty page tracking for accurate diff snapshots.
-        // With hugepages, KVM splits Stage 2 block mappings from 2MB to 4K for
-        // dirty tracking. This only affects the initial VM (cache creation, runs once).
-        // Restored VMs (clones) don't enable dirty tracking, so they get full 2MB
-        // Stage 2 entries and the TLB benefit of hugepages.
+        // Dirty page tracking enables diff snapshots but has a cost with hugepages:
+        // KVM splits 2MB Stage 2 block mappings to 4K for per-page tracking.
+        // Only enable when we'll actually create a snapshot (cache miss path).
         client
             .set_machine_config(super::api::MachineConfig {
                 vcpu_count: self.machine_config.vcpu_count,
                 mem_size_mib: self.machine_config.mem_size_mib,
                 smt: Some(false),
                 cpu_template: None,
-                track_dirty_pages: Some(true),
+                track_dirty_pages: Some(track_dirty_pages),
                 huge_pages: self.machine_config.huge_pages.clone(),
             })
             .await?;


### PR DESCRIPTION
## Summary

- Enable KVM dirty page tracking for hugepage VMs via Firecracker's `track_dirty_pages` API (replaces deprecated `enable_diff_snapshots`)
- Enable dirty tracking conditionally on restored VMs: on for standard pages (so subsequent snapshot→clone chains work), off for hugepages (avoids splitting 2MB Stage 2 block mappings to 4K)
- Gate `track_dirty_pages` on snapshot usage for initial VMs: only enable when creating a snapshot cache, disable with `--no-snapshot` to preserve hugepage TLB benefit
- Show diff snapshot size in hugepages benchmark output
- Document hugepages feature in README (usage, dirty tracking tradeoffs, benchmark results, limitations)
- Fix stale `enable_diff_snapshots` reference in DESIGN.md
- Skip redundant CI on main when merge commit tree SHA matches an already-green PR commit
- Add PR description consistency verification step to pr-workflow skill
- Add PR description consistency check to code review bot (step 3a in review prompt)

## Test plan

- [x] `test_user_snapshot_from_clone_uses_parent` — exercises full dirty tracking flow on restored VMs
- [x] All 3 diff snapshot tests pass (`make test-root FILTER=diff_snapshot`)
- [x] `cargo fmt --check` and `cargo clippy` clean
- [x] CI green on PR branch