### PR TITLE
Optimize container import: direct image mount via additionalImageStore

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -100,3 +100,9 @@ jobs:
           FUSE_BACKEND_RS: ${{ github.workspace }}/fuse-backend-rs
           FUSER: ${{ github.workspace }}/fuser
         run: make bench-hugepages-test
+      - name: Run container import benchmark
+        working-directory: fcvm
+        env:
+          FUSE_BACKEND_RS: ${{ github.workspace }}/fuse-backend-rs
+          FUSER: ${{ github.workspace }}/fuser
+        run: make bench-container-import

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,3 +112,7 @@ harness = false
 [[bench]]
 name = "hugepages"
 harness = false
+
+[[bench]]
+name = "container_import"
+harness = false

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,7 @@ CONTAINER_RUN := $(CONTAINER_RUN_BASE) --ulimit nproc=65536:65536 --pids-limit=6
 	container-build container-test container-test-unit container-test-fast container-test-all \
 	container-setup-fcvm container-shell container-clean container-bench \
 	setup-btrfs setup-fcvm setup-pjdfstest bench bench-vm bench-hugepages bench-hugepages-test \
+	bench-container-import \
 	lint fmt ssh test-serve-sdk
 
 all: build
@@ -183,6 +184,7 @@ help:
 	@echo "  bench-vm           Run VM benchmarks (exec, clone)"
 	@echo "  bench-hugepages    Run hugepages benchmark (32GB VM, 16GB dirty)"
 	@echo "  bench-hugepages-test  Run hugepages benchmark (2GB VM, 256MB dirty)"
+	@echo "  bench-container-import  Compare podman load vs direct image mount"
 	@echo ""
 	@echo "Other:"
 	@echo "  lint               Run linting (auto-installs tools if needed)"
@@ -454,6 +456,10 @@ bench-hugepages-test: build setup-fcvm
 	echo "==> Releasing hugepage pool..."; \
 	sudo sh -c 'echo 0 > /proc/sys/vm/nr_hugepages'; \
 	exit $$RC
+
+bench-container-import: build setup-fcvm
+	@echo "==> Running container import benchmark..."
+	$(CARGO) bench --bench container_import
 
 # Container benchmark target (used by nightly CI)
 # Uses CONTAINER_RUN_BASE (no --ulimit nproc) to avoid EPERM on GHA ubuntu-latest

--- a/benches/container_import.rs
+++ b/benches/container_import.rs
@@ -59,17 +59,13 @@ fn graceful_kill(pid: u32, timeout_ms: u64) {
 
     let start = Instant::now();
     loop {
-        let status = Command::new("kill")
-            .args(["-0", &pid.to_string()])
-            .output();
+        let status = Command::new("kill").args(["-0", &pid.to_string()]).output();
         match status {
             Ok(o) if !o.status.success() => return,
             _ => {}
         }
         if start.elapsed() > Duration::from_millis(timeout_ms) {
-            let _ = Command::new("kill")
-                .args(["-9", &pid.to_string()])
-                .output();
+            let _ = Command::new("kill").args(["-9", &pid.to_string()]).output();
             return;
         }
         std::thread::sleep(Duration::from_millis(100));
@@ -273,7 +269,10 @@ fn run_mode(mode: &str, no_direct_image_mount: bool, iterations: u32) -> BenchRe
 fn print_comparison(legacy: &BenchResult, direct: &BenchResult, iterations: u32) {
     eprintln!();
     println!("=================================================================");
-    println!("  Container Import Benchmark ({} iterations each)", iterations);
+    println!(
+        "  Container Import Benchmark ({} iterations each)",
+        iterations
+    );
     println!("=================================================================");
     println!();
     println!(

--- a/benches/container_import.rs
+++ b/benches/container_import.rs
@@ -1,0 +1,322 @@
+//! Container import benchmark: compares legacy `podman load` vs direct image mount.
+//!
+//! Measures cold start time for localhost/ container images using two strategies:
+//!   - Legacy: Docker archive attached as block device, fc-agent runs `podman load`
+//!   - Direct mount: Pre-built podman storage mounted as additionalImageStore
+//!
+//! Both modes are tested without snapshot cache (--no-snapshot) to isolate the
+//! import step from snapshot restore performance.
+//!
+//! Run with: make bench-container-import
+
+use serde::Deserialize;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+const BENCH_IMAGE: &str = "localhost/bench-container-import";
+
+const BENCH_DOCKERFILE: &[u8] = b"FROM public.ecr.aws/nginx/nginx:alpine\n\
+    RUN dd if=/dev/urandom of=/data1.bin bs=1M count=100 2>/dev/null\n\
+    RUN dd if=/dev/urandom of=/data2.bin bs=1M count=100 2>/dev/null\n\
+    RUN dd if=/dev/urandom of=/data3.bin bs=1M count=100 2>/dev/null\n\
+    RUN dd if=/dev/urandom of=/data4.bin bs=1M count=100 2>/dev/null\n\
+    RUN dd if=/dev/urandom of=/data5.bin bs=1M count=100 2>/dev/null\n\
+    CMD [\"nginx\", \"-g\", \"daemon off;\"]\n";
+
+/// VM state from fcvm ls --json
+#[derive(Deserialize)]
+struct VmLsEntry {
+    health_status: String,
+}
+
+struct BenchResult {
+    cold_start_secs: f64,
+}
+
+/// Find the fcvm binary
+fn find_fcvm_binary() -> PathBuf {
+    let candidates = [
+        "./target/release/fcvm",
+        "./target/debug/fcvm",
+        "/usr/local/bin/fcvm",
+    ];
+    for path in candidates {
+        let p = PathBuf::from(path);
+        if p.exists() {
+            return p;
+        }
+    }
+    panic!("fcvm binary not found - run: cargo build --release");
+}
+
+/// Kill a process gracefully (SIGTERM, then SIGKILL after timeout)
+fn graceful_kill(pid: u32, timeout_ms: u64) {
+    let _ = Command::new("kill")
+        .args(["-TERM", &pid.to_string()])
+        .output();
+
+    let start = Instant::now();
+    loop {
+        let status = Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .output();
+        match status {
+            Ok(o) if !o.status.success() => return,
+            _ => {}
+        }
+        if start.elapsed() > Duration::from_millis(timeout_ms) {
+            let _ = Command::new("kill")
+                .args(["-9", &pid.to_string()])
+                .output();
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+/// Wait for a VM to become healthy, polling fcvm ls --json --pid.
+/// Uses try_wait() on the Child to detect early exit (avoids zombie false-positive
+/// from kill -0).
+fn poll_health(fcvm: &Path, child: &mut Child, timeout_secs: u64) -> Duration {
+    let pid = child.id();
+    let start = Instant::now();
+    let timeout = Duration::from_secs(timeout_secs);
+    loop {
+        if start.elapsed() > timeout {
+            panic!(
+                "VM (PID {}) failed to become healthy within {}s",
+                pid, timeout_secs
+            );
+        }
+
+        // Check if the child process has exited
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                panic!(
+                    "VM process (PID {}) exited with {} after {:.1}s - check /tmp/fcvm-bench-*.log",
+                    pid,
+                    status,
+                    start.elapsed().as_secs_f64()
+                );
+            }
+            Ok(None) => {} // still running
+            Err(e) => {
+                panic!("Failed to check VM process (PID {}): {}", pid, e);
+            }
+        }
+
+        let output = Command::new(fcvm)
+            .args(["ls", "--json", "--pid", &pid.to_string()])
+            .output()
+            .expect("failed to run fcvm ls");
+
+        if output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            if let Ok(vms) = serde_json::from_str::<Vec<VmLsEntry>>(&stdout) {
+                if vms
+                    .first()
+                    .map(|v| v.health_status == "healthy")
+                    .unwrap_or(false)
+                {
+                    return start.elapsed();
+                }
+            }
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+}
+
+/// RAII guard that kills a process on drop
+struct ProcessGuard {
+    pid: u32,
+    child: Child,
+}
+
+impl Drop for ProcessGuard {
+    fn drop(&mut self) {
+        graceful_kill(self.pid, 5000);
+        let _ = self.child.wait();
+    }
+}
+
+/// Delete cached storage images so the next run is a true cold start
+fn clear_image_cache() {
+    eprintln!("    Clearing image cache...");
+    let _ = Command::new("sh")
+        .args(["-c", "rm -f /mnt/fcvm-btrfs/image-cache/*.storage.img"])
+        .output();
+}
+
+/// Delete benchmark snapshots
+fn prune_bench_snapshots(fcvm: &Path) {
+    let output = Command::new(fcvm)
+        .args([
+            "snapshots",
+            "prune",
+            "--all",
+            "--image",
+            BENCH_IMAGE,
+            "--force",
+        ])
+        .output()
+        .expect("failed to run fcvm snapshots prune");
+
+    if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout.lines() {
+            eprintln!("    {}", line);
+        }
+    }
+}
+
+/// Build the benchmark container image. Always runs podman build and relies on
+/// podman's layer cache — a no-op rebuild if the Dockerfile hasn't changed.
+fn build_image() {
+    eprintln!("==> Building benchmark container image...");
+
+    let status = Command::new("podman")
+        .args(["build", "-t", BENCH_IMAGE, "-f", "-", "."])
+        .stdin(Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                stdin.write_all(BENCH_DOCKERFILE)?;
+            }
+            child.wait()
+        })
+        .expect("failed to run podman build");
+
+    if !status.success() {
+        panic!("podman build failed");
+    }
+    eprintln!("    Image built successfully");
+}
+
+/// Run one mode through a cold start cycle (no snapshot cache)
+fn run_mode(mode: &str, no_direct_image_mount: bool, iterations: u32) -> BenchResult {
+    let fcvm = find_fcvm_binary();
+    let pid_suffix = std::process::id();
+
+    eprintln!("\n--- {} ---", mode);
+
+    let mut total_secs = 0.0;
+
+    for i in 1..=iterations {
+        // Clean state for each iteration
+        prune_bench_snapshots(&fcvm);
+        if !no_direct_image_mount {
+            // Clear cached storage images to measure full build + mount time
+            clear_image_cache();
+        }
+
+        let name = format!("bench-import-{}-{}-{}", mode, i, pid_suffix);
+        eprintln!("  [{}/{}] Cold start: {}", i, iterations, name);
+
+        let log_path = format!("/tmp/fcvm-bench-{}.log", name);
+        let log_file = File::create(&log_path).expect("create log file");
+        let log_err = log_file.try_clone().expect("clone log file");
+
+        let mut args = vec![
+            "podman",
+            "run",
+            "--name",
+            &name,
+            "--no-snapshot",
+            "--health-check",
+            "http://localhost:80/",
+        ];
+        if no_direct_image_mount {
+            args.push("--no-direct-image-mount");
+        }
+        args.push(BENCH_IMAGE);
+
+        let t = Instant::now();
+        let child = Command::new(&fcvm)
+            .args(&args)
+            .env("RUST_LOG", "debug")
+            .stdout(Stdio::from(log_file))
+            .stderr(Stdio::from(log_err))
+            .spawn()
+            .expect("failed to spawn VM");
+
+        let pid = child.id();
+        let mut guard = ProcessGuard { pid, child };
+        eprintln!("    Log: {}", log_path);
+
+        let health_elapsed = poll_health(&fcvm, &mut guard.child, 300);
+        let elapsed = t.elapsed().as_secs_f64();
+        eprintln!(
+            "    Healthy after {:.1}s (total {:.1}s)",
+            health_elapsed.as_secs_f64(),
+            elapsed
+        );
+
+        total_secs += elapsed;
+
+        eprintln!("    Killing VM...");
+        drop(guard);
+        std::thread::sleep(Duration::from_secs(2));
+    }
+
+    let cold_start_secs = total_secs / iterations as f64;
+    eprintln!("  Average cold start: {:.1}s", cold_start_secs);
+
+    BenchResult { cold_start_secs }
+}
+
+fn print_comparison(legacy: &BenchResult, direct: &BenchResult, iterations: u32) {
+    eprintln!();
+    println!("=================================================================");
+    println!("  Container Import Benchmark ({} iterations each)", iterations);
+    println!("=================================================================");
+    println!();
+    println!(
+        "{:<24} {:>17} {:>17} {:>8}",
+        "Metric", "podman load", "direct mount", "Speedup"
+    );
+    println!("{}", "-".repeat(68));
+    println!(
+        "{:<24} {:>16.1}s {:>16.1}s {:>7.2}x",
+        "Cold Start (avg)",
+        legacy.cold_start_secs,
+        direct.cold_start_secs,
+        legacy.cold_start_secs / direct.cold_start_secs.max(0.001)
+    );
+    println!("{}", "-".repeat(68));
+    println!();
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let iterations: u32 = args
+        .iter()
+        .position(|a| a == "--iterations")
+        .and_then(|i| args.get(i + 1))
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(3);
+
+    eprintln!(
+        "=== Container Import Benchmark ({} iterations) ===",
+        iterations
+    );
+
+    // Build container image
+    build_image();
+
+    // Run legacy mode (podman load)
+    let legacy_result = run_mode("podman-load", true, iterations);
+
+    // Run direct mount mode
+    let direct_result = run_mode("direct-mount", false, iterations);
+
+    // Print comparison
+    print_comparison(&legacy_result, &direct_result, iterations);
+
+    // Clean up
+    eprintln!("==> Cleaning up...");
+    let fcvm = find_fcvm_binary();
+    prune_bench_snapshots(&fcvm);
+}

--- a/benches/container_import.rs
+++ b/benches/container_import.rs
@@ -141,11 +141,16 @@ impl Drop for ProcessGuard {
     }
 }
 
-/// Delete cached storage images so the next run is a true cold start
+/// Delete cached image artifacts so the next run is a true cold start.
+/// Removes both .storage.img (direct mount) and .docker.tar (legacy) to ensure
+/// symmetric benchmarking — both modes pay the full export + build cost.
 fn clear_image_cache() {
     eprintln!("    Clearing image cache...");
     let _ = Command::new("sh")
-        .args(["-c", "rm -f /mnt/fcvm-btrfs/image-cache/*.storage.img"])
+        .args([
+            "-c",
+            "rm -f /mnt/fcvm-btrfs/image-cache/*.storage.img /mnt/fcvm-btrfs/image-cache/*.docker.tar",
+        ])
         .output();
 }
 
@@ -207,10 +212,8 @@ fn run_mode(mode: &str, no_direct_image_mount: bool, iterations: u32) -> BenchRe
     for i in 1..=iterations {
         // Clean state for each iteration
         prune_bench_snapshots(&fcvm);
-        if !no_direct_image_mount {
-            // Clear cached storage images to measure full build + mount time
-            clear_image_cache();
-        }
+        // Clear cached image artifacts so both modes measure full cold start
+        clear_image_cache();
 
         let name = format!("bench-import-{}-{}-{}", mode, i, pid_suffix);
         eprintln!("  [{}/{}] Cold start: {}", i, iterations, name);

--- a/benches/hugepages.rs
+++ b/benches/hugepages.rs
@@ -196,31 +196,13 @@ fn extract_diff_bytes(log_path: &str) -> u64 {
     0
 }
 
-/// Build the benchmark container image with the specified data size
+/// Build the benchmark container image with the specified data size.
+/// Always runs podman build and relies on podman's layer cache.
 fn build_image(data_mb: u32) {
     eprintln!(
         "==> Building benchmark container image ({} MB data)...",
         data_mb
     );
-
-    // Check if image already exists with correct data size
-    let inspect = Command::new("podman")
-        .args([
-            "inspect",
-            BENCH_IMAGE,
-            "--format",
-            "{{.Config.Labels.data_size_mb}}",
-        ])
-        .output();
-    if let Ok(output) = inspect {
-        if output.status.success() {
-            let label = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if label == data_mb.to_string() {
-                eprintln!("    Image already exists with correct data size, skipping build");
-                return;
-            }
-        }
-    }
 
     // Set TMPDIR to btrfs volume to avoid tmpfs overflow during large image builds.
     // The overlay commit step creates tar archives that can exceed /run/user tmpfs (13GB).
@@ -236,8 +218,6 @@ fn build_image(data_mb: u32) {
             "Containerfile.bench-hugepages",
             "--build-arg",
             &format!("DATA_SIZE_MB={}", data_mb),
-            "--label",
-            &format!("data_size_mb={}", data_mb),
             ".",
         ])
         .env("TMPDIR", tmpdir)

--- a/fc-agent/src/agent.rs
+++ b/fc-agent/src/agent.rs
@@ -119,8 +119,10 @@ pub async fn run() -> Result<()> {
         });
     }
 
-    // Prepare image (import archive or pull from registry)
-    let image_ref = if let Some(archive_path) = &plan.image_archive {
+    // Prepare image (mount storage, import archive, or pull from registry)
+    let image_ref = if let Some(storage_device) = &plan.image_storage_device {
+        container::mount_storage_image(storage_device, &plan.image)?
+    } else if let Some(archive_path) = &plan.image_archive {
         container::import_image(archive_path, &plan.image, &output).await?
     } else {
         container::pull_image(&plan).await?
@@ -174,6 +176,9 @@ pub async fn run() -> Result<()> {
         sleep(Duration::from_millis(100)).await;
     }
     mounts::unmount_disks(&mounted_disk_paths);
+    if plan.image_storage_device.is_some() {
+        mounts::unmount_paths(&["/mnt/image-store".to_string()], "image store");
+    }
 
     // Shutdown output writer
     output.shutdown().await;

--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -10,6 +10,65 @@ use crate::output::OutputHandle;
 use crate::types::Plan;
 use crate::vsock;
 
+/// Mount a pre-built podman storage image and configure as additionalImageStore.
+///
+/// The storage image is an ext4 filesystem containing a podman overlay storage tree
+/// (overlay/, overlay-images/, overlay-layers/). It is mounted read-only and podman
+/// finds the image there without needing `podman load`.
+pub fn mount_storage_image(device: &str, image_name: &str) -> Result<String> {
+    eprintln!("[fc-agent] mounting pre-built storage image: {}", device);
+
+    let mount_path = "/mnt/image-store";
+    std::fs::create_dir_all(mount_path)
+        .context("creating image store mount point")?;
+
+    // Wait for device to appear
+    let device_path = std::path::Path::new(device);
+    for attempt in 1..=10 {
+        if device_path.exists() {
+            break;
+        }
+        if attempt == 10 {
+            anyhow::bail!("Device {} not found after 10 attempts", device);
+        }
+        eprintln!(
+            "[fc-agent] waiting for device {} (attempt {}/10)",
+            device, attempt
+        );
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+
+    // Mount read-only
+    let output = std::process::Command::new("mount")
+        .args(["-o", "ro", device, mount_path])
+        .output()
+        .context("mounting storage image")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "Failed to mount storage image {} at {}: {}",
+            device, mount_path, stderr
+        );
+    }
+
+    // Configure podman to use this as an additional image store.
+    // Write a complete storage.conf with runroot/graphroot (required when
+    // storage.options is present) but omit "driver" to let podman auto-detect
+    // — setting it explicitly causes "database graph driver mismatch" errors.
+    let storage_conf = format!(
+        "[storage]\nrunroot = \"/run/containers/storage\"\ngraphroot = \"/var/lib/containers/storage\"\n\n[storage.options]\nadditionalimagestores = [\"{mount_path}\"]\n"
+    );
+    std::fs::write("/etc/containers/storage.conf", storage_conf)
+        .context("writing storage.conf")?;
+
+    eprintln!(
+        "[fc-agent] storage image mounted at {}, configured as additional image store",
+        mount_path
+    );
+    Ok(image_name.to_string())
+}
+
 /// Import a Docker archive into podman storage. Returns image reference.
 pub async fn import_image(
     archive_path: &str,

--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -19,8 +19,7 @@ pub fn mount_storage_image(device: &str, image_name: &str) -> Result<String> {
     eprintln!("[fc-agent] mounting pre-built storage image: {}", device);
 
     let mount_path = "/mnt/image-store";
-    std::fs::create_dir_all(mount_path)
-        .context("creating image store mount point")?;
+    std::fs::create_dir_all(mount_path).context("creating image store mount point")?;
 
     // Wait for device to appear
     let device_path = std::path::Path::new(device);
@@ -48,7 +47,9 @@ pub fn mount_storage_image(device: &str, image_name: &str) -> Result<String> {
         let stderr = String::from_utf8_lossy(&output.stderr);
         anyhow::bail!(
             "Failed to mount storage image {} at {}: {}",
-            device, mount_path, stderr
+            device,
+            mount_path,
+            stderr
         );
     }
 
@@ -59,8 +60,7 @@ pub fn mount_storage_image(device: &str, image_name: &str) -> Result<String> {
     let storage_conf = format!(
         "[storage]\nrunroot = \"/run/containers/storage\"\ngraphroot = \"/var/lib/containers/storage\"\n\n[storage.options]\nadditionalimagestores = [\"{mount_path}\"]\n"
     );
-    std::fs::write("/etc/containers/storage.conf", storage_conf)
-        .context("writing storage.conf")?;
+    std::fs::write("/etc/containers/storage.conf", storage_conf).context("writing storage.conf")?;
 
     eprintln!(
         "[fc-agent] storage image mounted at {}, configured as additional image store",

--- a/fc-agent/src/types.rs
+++ b/fc-agent/src/types.rs
@@ -16,6 +16,8 @@ pub struct Plan {
     #[serde(default)]
     pub image_archive: Option<String>,
     #[serde(default)]
+    pub image_storage_device: Option<String>,
+    #[serde(default)]
     pub user: Option<String>,
     #[serde(default)]
     pub forward_localhost: Vec<String>,
@@ -127,6 +129,21 @@ mod tests {
         assert!(!plan.volumes[0].read_only);
         assert!(plan.tty);
         assert!(plan.privileged);
+    }
+
+    #[test]
+    fn test_plan_with_storage_device() {
+        let json = r#"{
+            "image": "localhost/myapp",
+            "image_storage_device": "/dev/vdb"
+        }"#;
+        let plan: Plan = serde_json::from_str(json).unwrap();
+        assert_eq!(plan.image, "localhost/myapp");
+        assert_eq!(
+            plan.image_storage_device.as_deref(),
+            Some("/dev/vdb")
+        );
+        assert!(plan.image_archive.is_none());
     }
 
     #[test]

--- a/fc-agent/src/types.rs
+++ b/fc-agent/src/types.rs
@@ -139,10 +139,7 @@ mod tests {
         }"#;
         let plan: Plan = serde_json::from_str(json).unwrap();
         assert_eq!(plan.image, "localhost/myapp");
-        assert_eq!(
-            plan.image_storage_device.as_deref(),
-            Some("/dev/vdb")
-        );
+        assert_eq!(plan.image_storage_device.as_deref(), Some("/dev/vdb"));
         assert!(plan.image_archive.is_none());
     }
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -247,6 +247,12 @@ pub struct RunArgs {
     #[arg(long)]
     pub no_snapshot: bool,
 
+    /// Disable direct image mount and fall back to podman load for localhost images.
+    /// By default, fcvm pre-builds podman overlay storage on the host and mounts it
+    /// read-only in the guest, bypassing podman load for faster container startup.
+    #[arg(long)]
+    pub no_direct_image_mount: bool,
+
     /// Container image (e.g., nginx:alpine or localhost/myimage)
     pub image: String,
 

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -810,10 +810,7 @@ async fn build_storage_image(
     if !load_output.status.success() {
         let stderr = String::from_utf8_lossy(&load_output.stderr);
         tokio::fs::remove_dir_all(&tmp_dir).await.ok();
-        bail!(
-            "podman load into storage root failed: {}",
-            stderr
-        );
+        bail!("podman load into storage root failed: {}", stderr);
     }
 
     let loaded_msg = String::from_utf8_lossy(&load_output.stdout);
@@ -841,10 +838,7 @@ async fn build_storage_image(
         return Err(e).context("renaming storage image to final path");
     }
 
-    info!(
-        "Built storage image: {}",
-        output_path.display()
-    );
+    info!("Built storage image: {}", output_path.display());
     Ok(())
 }
 

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -771,7 +771,12 @@ async fn build_storage_image(
     archive_path: &std::path::Path,
     output_path: &std::path::Path,
 ) -> Result<()> {
-    let tmp_dir = PathBuf::from(format!("/tmp/fcvm-storage-{}", std::process::id()));
+    // Use output_path's parent (the image-cache dir on btrfs) for temp storage,
+    // not /tmp which may be tmpfs with limited space.
+    let cache_dir = output_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("output_path has no parent directory"))?;
+    let tmp_dir = cache_dir.join(format!("tmp-storage-{}", std::process::id()));
 
     // Clean up any stale temp dir from a previous interrupted run
     if tmp_dir.exists() {
@@ -823,12 +828,18 @@ async fn build_storage_image(
     // Clean up temp storage dir regardless of result
     tokio::fs::remove_dir_all(&tmp_dir).await.ok();
 
-    result.context("creating ext4 image from storage dir")?;
+    if let Err(e) = result {
+        // Clean up partial .tmp image file on failure
+        tokio::fs::remove_file(&tmp_img).await.ok();
+        return Err(e).context("creating ext4 image from storage dir");
+    }
 
     // Atomic rename to final path
-    tokio::fs::rename(&tmp_img, output_path)
-        .await
-        .context("renaming storage image to final path")?;
+    if let Err(e) = tokio::fs::rename(&tmp_img, output_path).await {
+        // Clean up .tmp image file if rename fails
+        tokio::fs::remove_file(&tmp_img).await.ok();
+        return Err(e).context("renaming storage image to final path");
+    }
 
     info!(
         "Built storage image: {}",

--- a/src/commands/podman.rs
+++ b/src/commands/podman.rs
@@ -699,8 +699,6 @@ async fn create_disk_from_dir(
     source_dir: &std::path::Path,
     output_path: &std::path::Path,
 ) -> Result<()> {
-    use std::process::Stdio;
-
     // Calculate directory size (add 20% overhead for ext4 metadata, min 16MB)
     let dir_size = tokio::process::Command::new("du")
         .args(["-sb", source_dir.to_str().unwrap()])
@@ -739,66 +737,103 @@ async fn create_disk_from_dir(
         );
     }
 
-    // Format as ext4
+    // Format as ext4 and populate from source directory in one step.
+    // Uses mkfs.ext4 -d which doesn't require root (no mount/loop device needed).
     let mkfs = tokio::process::Command::new("mkfs.ext4")
-        .args(["-q", "-F", output_path.to_str().unwrap()])
+        .args([
+            "-q",
+            "-F",
+            "-d",
+            source_dir.to_str().unwrap(),
+            output_path.to_str().unwrap(),
+        ])
         .output()
         .await
-        .context("formatting as ext4")?;
+        .context("formatting as ext4 with directory contents")?;
 
     if !mkfs.status.success() {
         bail!(
-            "mkfs.ext4 failed: {}",
+            "mkfs.ext4 -d failed: {}",
             String::from_utf8_lossy(&mkfs.stderr)
         );
     }
 
-    // Mount and copy contents
-    let mount_dir = format!("/tmp/fcvm-disk-dir-{}", std::process::id());
-    tokio::fs::create_dir_all(&mount_dir).await?;
-
-    let mount = tokio::process::Command::new("mount")
-        .args([output_path.to_str().unwrap(), &mount_dir])
-        .output()
-        .await
-        .context("mounting image")?;
-
-    if !mount.status.success() {
-        tokio::fs::remove_dir(&mount_dir).await.ok();
-        bail!("mount failed: {}", String::from_utf8_lossy(&mount.stderr));
-    }
-
-    // Copy directory contents (use rsync for reliability)
-    let copy = tokio::process::Command::new("rsync")
-        .args([
-            "-a",
-            &format!("{}/", source_dir.display()),
-            &format!("{}/", mount_dir),
-        ])
-        .stderr(Stdio::piped())
-        .output()
-        .await
-        .context("copying directory contents")?;
-
-    // Always unmount
-    let umount = tokio::process::Command::new("umount")
-        .arg(&mount_dir)
-        .output()
-        .await;
-
-    tokio::fs::remove_dir(&mount_dir).await.ok();
-
-    if !copy.status.success() {
-        bail!("rsync failed: {}", String::from_utf8_lossy(&copy.stderr));
-    }
-
-    if let Ok(u) = umount {
-        if !u.status.success() {
-            warn!("umount warning: {}", String::from_utf8_lossy(&u.stderr));
-        }
-    }
-
     info!("Created disk image: {}", output_path.display());
+    Ok(())
+}
+
+/// Build a podman storage image from a Docker archive.
+///
+/// Loads the archive into a temporary podman storage root using the overlay driver,
+/// then packages the result as an ext4 image. The guest can mount this read-only
+/// and use it as an `additionalImageStore`, eliminating the need for `podman load`.
+async fn build_storage_image(
+    archive_path: &std::path::Path,
+    output_path: &std::path::Path,
+) -> Result<()> {
+    let tmp_dir = PathBuf::from(format!("/tmp/fcvm-storage-{}", std::process::id()));
+
+    // Clean up any stale temp dir from a previous interrupted run
+    if tmp_dir.exists() {
+        tokio::fs::remove_dir_all(&tmp_dir).await.ok();
+    }
+    tokio::fs::create_dir_all(&tmp_dir)
+        .await
+        .context("creating temp storage dir")?;
+
+    // Load the docker archive into a custom podman storage root
+    info!(
+        "Loading archive into podman storage: {} -> {}",
+        archive_path.display(),
+        tmp_dir.display()
+    );
+
+    let load_output = tokio::process::Command::new("podman")
+        .args([
+            "--root",
+            tmp_dir.to_str().unwrap(),
+            "--storage-driver",
+            "overlay",
+            "load",
+            "-i",
+            archive_path.to_str().unwrap(),
+        ])
+        .output()
+        .await
+        .context("running podman load into storage root")?;
+
+    if !load_output.status.success() {
+        let stderr = String::from_utf8_lossy(&load_output.stderr);
+        tokio::fs::remove_dir_all(&tmp_dir).await.ok();
+        bail!(
+            "podman load into storage root failed: {}",
+            stderr
+        );
+    }
+
+    let loaded_msg = String::from_utf8_lossy(&load_output.stdout);
+    info!("podman load output: {}", loaded_msg.trim());
+
+    // Package the storage tree as an ext4 image using the existing helper.
+    // NOTE: Can't use with_extension() here because output_path ends in .storage.img
+    // — with_extension replaces after the last dot, producing a double "storage".
+    let tmp_img = PathBuf::from(format!("{}.tmp", output_path.display()));
+    let result = create_disk_from_dir(&tmp_dir, &tmp_img).await;
+
+    // Clean up temp storage dir regardless of result
+    tokio::fs::remove_dir_all(&tmp_dir).await.ok();
+
+    result.context("creating ext4 image from storage dir")?;
+
+    // Atomic rename to final path
+    tokio::fs::rename(&tmp_img, output_path)
+        .await
+        .context("renaming storage image to final path")?;
+
+    info!(
+        "Built storage image: {}",
+        output_path.display()
+    );
     Ok(())
 }
 
@@ -1518,12 +1553,27 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
             info!(path = %archive_path.display(), "Image exported as Docker archive");
         }
 
+        let disk_path = if !args.no_direct_image_mount {
+            // Direct image mount: pre-build podman storage as ext4 image.
+            // Guest mounts this as additionalImageStore — no podman load needed.
+            let storage_img_path = cache_dir.with_extension("storage.img");
+            if !storage_img_path.exists() {
+                info!(image = %args.image, digest = %digest, "Building podman storage image");
+                build_storage_image(&archive_path, &storage_img_path).await?;
+            } else {
+                info!(image = %args.image, digest = %digest, "Using cached storage image");
+            }
+            storage_img_path
+        } else {
+            // Legacy path: attach docker archive as raw block device.
+            // fc-agent reads docker-archive:/dev/vdX via podman load.
+            archive_path
+        };
+
         // Lock released when lock_file is dropped
         drop(lock_file);
 
-        // Attach the tar directly as a Firecracker block device (read-only).
-        // fc-agent reads docker-archive:/dev/vdX — no FUSE, no ext4, no mount.
-        Some(archive_path)
+        Some(disk_path)
     } else {
         None
     };
@@ -2389,7 +2439,8 @@ async fn build_and_send_mmds(
                 "volumes": volume_mounts,
                 "extra_disks": extra_disk_mounts,
                 "nfs_mounts": nfs_mounts,
-                "image_archive": image_device,
+                "image_archive": if args.no_direct_image_mount { image_device.clone() } else { None::<String> },
+                "image_storage_device": if !args.no_direct_image_mount { image_device } else { None::<String> },
                 "privileged": args.privileged,
                 "user": args.user.as_deref(),
                 "forward_localhost": args.forward_localhost.iter().map(|p| p.to_string()).collect::<Vec<_>>(),
@@ -2864,12 +2915,19 @@ async fn run_vm_setup(
         .context("creating CoW disk")?;
 
     // Estimate space needed for container image extraction inside VM.
+    // When using direct image mount (storage image), layers live on a separate read-only
+    // block device and are NOT extracted onto the rootfs, so no extra space is needed.
+    // When using legacy podman load, the archive is extracted onto the rootfs.
     // podman load extracts layers to /var/tmp first, then copies to overlay storage,
-    // so we need ~2x the archive size (temp + final). Use 3x for safety margin.
-    let image_overhead = if let Some(disk_path) = image_disk_path {
-        match tokio::fs::metadata(disk_path).await {
-            Ok(meta) => meta.len() * 3,
-            Err(_) => 0,
+    // so we need ~3x the archive size for safety margin.
+    let image_overhead = if args.no_direct_image_mount {
+        if let Some(disk_path) = image_disk_path {
+            match tokio::fs::metadata(disk_path).await {
+                Ok(meta) => meta.len() * 3,
+                Err(_) => 0,
+            }
+        } else {
+            0
         }
     } else {
         0

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -319,6 +319,7 @@ async fn create_sandbox(
         kernel_profile: None,
         vsock_dir: None,
         no_snapshot: true,
+        no_direct_image_mount: false,
         forward_localhost: vec![],
         user: None,
         hugepages: false,

--- a/tests/test_library_api.rs
+++ b/tests/test_library_api.rs
@@ -44,6 +44,7 @@ fn test_run_args(name: &str) -> RunArgs {
         user: None,
         forward_localhost: vec![],
         hugepages: false,
+        no_direct_image_mount: false,
         label: vec![],
         image: common::TEST_IMAGE.to_string(),
         command_args: vec![],

--- a/tests/test_localhost_image.rs
+++ b/tests/test_localhost_image.rs
@@ -1,8 +1,8 @@
 //! Integration test for localhost/ container images
 //!
-//! This test verifies that locally-built container images can be run inside VMs.
-//! The image is exported from the host using `podman save`, mounted into the VM via FUSE,
-//! and then imported by fc-agent using `podman load` before running with podman.
+//! Tests both import paths:
+//! - Default (direct mount): Pre-built podman storage mounted as additionalImageStore
+//! - Legacy (--no-direct-image-mount): Docker archive imported via podman load
 
 #![cfg(feature = "integration-fast")]
 
@@ -13,25 +13,56 @@ use std::process::Stdio;
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, BufReader};
 
-/// Test that a localhost/ container image can be built and run in a VM (rootless)
+/// Test with default direct image mount path
 #[tokio::test]
 async fn test_localhost_hello_world() -> Result<()> {
-    println!("\nLocalhost Image Test");
+    run_localhost_test(false).await
+}
+
+/// Test with legacy podman load path (--no-direct-image-mount)
+#[tokio::test]
+async fn test_localhost_hello_world_legacy_import() -> Result<()> {
+    run_localhost_test(true).await
+}
+
+async fn run_localhost_test(no_direct_image_mount: bool) -> Result<()> {
+    let mode = if no_direct_image_mount {
+        "legacy (podman load)"
+    } else {
+        "direct mount (additionalImageStore)"
+    };
+
+    println!("\nLocalhost Image Test ({})", mode);
     println!("====================");
-    println!("Testing that localhost/ container images work via podman save/load");
 
     // Find fcvm binary
     let fcvm_path = common::find_fcvm_binary()?;
-    let (vm_name, _, _, _) = common::unique_names("localhost-hello");
+    let suffix = if no_direct_image_mount {
+        "localhost-legacy"
+    } else {
+        "localhost-direct"
+    };
+    let (vm_name, _, _, _) = common::unique_names(suffix);
 
     // Step 1: Build a test container image on the host
     println!("Step 1: Building test container image localhost/test-hello...");
     build_test_image().await?;
 
     // Step 2: Start VM with localhost image (rootless mode)
-    println!("Step 2: Starting VM with localhost/test-hello image...");
+    println!("Step 2: Starting VM with localhost/test-hello image ({})...", mode);
+    let mut args = vec![
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+    ];
+    if no_direct_image_mount {
+        args.push("--no-direct-image-mount");
+    }
+    args.push("localhost/test-hello");
+
     let mut child = tokio::process::Command::new(&fcvm_path)
-        .args(["podman", "run", "--name", &vm_name, "localhost/test-hello"])
+        .args(&args)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
@@ -107,19 +138,17 @@ async fn test_localhost_hello_world() -> Result<()> {
 
     // Check results - verify we got the container output
     if found_hello {
-        println!("\n✅ LOCALHOST IMAGE TEST PASSED!");
-        println!("  - Image exported via podman save on host");
-        println!("  - Image imported via podman load in guest");
+        println!("\n  LOCALHOST IMAGE TEST PASSED! ({})", mode);
         println!("  - Container ran and printed: Hello from localhost container!");
         if container_exited_zero {
             println!("  - Container exited with code 0");
         }
         Ok(())
     } else {
-        println!("\n❌ LOCALHOST IMAGE TEST FAILED!");
+        println!("\n  LOCALHOST IMAGE TEST FAILED! ({})", mode);
         println!("  - Did not find expected output: 'Hello from localhost container!'");
         println!("  - Check logs above for error details");
-        anyhow::bail!("Localhost image test failed")
+        anyhow::bail!("Localhost image test failed ({})", mode)
     }
 }
 

--- a/tests/test_localhost_image.rs
+++ b/tests/test_localhost_image.rs
@@ -49,13 +49,11 @@ async fn run_localhost_test(no_direct_image_mount: bool) -> Result<()> {
     build_test_image().await?;
 
     // Step 2: Start VM with localhost image (rootless mode)
-    println!("Step 2: Starting VM with localhost/test-hello image ({})...", mode);
-    let mut args = vec![
-        "podman",
-        "run",
-        "--name",
-        &vm_name,
-    ];
+    println!(
+        "Step 2: Starting VM with localhost/test-hello image ({})...",
+        mode
+    );
+    let mut args = vec!["podman", "run", "--name", &vm_name];
     if no_direct_image_mount {
         args.push("--no-direct-image-mount");
     }


### PR DESCRIPTION
## Summary

- Pre-build podman overlay storage on the host and mount it read-only in the guest as an `additionalImageStore`, eliminating `podman load` on cold start
- Default ON, opt-out with `--no-direct-image-mount` (matches `--no-snapshot` pattern)
- Benchmarks show **1.27x speedup** (6.4s → 5.1s) with a 500MB multi-layer image

## How it works

**Host-side:** `podman load` into a temp storage root → `mkfs.ext4 -d` to package as ext4 image → cache at `{digest}.storage.img` → attach as block device

**Guest-side:** Mount block device read-only → write `storage.conf` with `additionalimagestores` → podman finds image immediately, no extraction needed

## Changes

**Host (`src/commands/podman.rs`):**
- `build_storage_image()`: loads archive into temp podman root, packages as ext4 via `mkfs.ext4 -d`
- Temp storage uses image-cache dir (not `/tmp`) to avoid ENOSPC on tmpfs hosts
- Clean up `.tmp` image file on error (both `create_disk_from_dir` failure and rename failure)
- Branch on `--no-direct-image-mount` flag in image caching logic
- Set `image_storage_device` (not `image_archive`) in MMDS for the new path
- Set `image_overhead=0` for direct mount (layers on separate block device)
- Replace `mount`/`rsync`/`umount` in `create_disk_from_dir` with `mkfs.ext4 -d` (rootless, no loop device needed)

**Guest (`fc-agent/src/`):**
- `mount_storage_image()`: mount device ro, write `storage.conf` with `additionalimagestores`
- Dispatch: `image_storage_device` → mount, `image_archive` → podman load
- Unmount `/mnt/image-store` on shutdown

**Benchmarks & CI:**
- New `benches/container_import.rs` comparing podman load vs direct mount
- Symmetric cache clearing: both `.docker.tar` and `.storage.img` removed before each iteration
- `make bench-container-import` target
- Added to nightly CI workflow
- Remove stale `podman inspect` skip-build checks from hugepages benchmark

**Tests:**
- Matrix `test_localhost_image.rs` to cover both import paths
- Add missing `no_direct_image_mount` field to `test_library_api.rs`

## Benchmark results (500MB image, 3 iterations)

```
Metric                         podman load      direct mount  Speedup
--------------------------------------------------------------------
Cold Start (avg)                      6.4s              5.1s    1.27x
```

## Test plan

- [x] `cargo fmt --check` and `cargo clippy --all-targets` clean
- [x] `cargo test -p fc-agent` passes (9/9 including new storage device test)
- [x] Integration tests pass: both `test_localhost_hello_world` (direct mount) and `test_localhost_hello_world_legacy_import` (podman load)
- [x] Benchmark runs end-to-end: `make bench-container-import`
- [ ] Nightly CI runs container import benchmark

**Stacked on:** `hugepages-dirty-tracking` (PR #329)