### PR TITLE
Fix flaky test_sigterm_cleanup_rootless

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,9 @@ container-build:
 	@sudo mkdir -p /mnt/fcvm-btrfs 2>/dev/null || true
 	@mkdir -p /tmp/fcvm-container-target
 	podman build -t $(CONTAINER_TAG) -f Containerfile --build-arg ARCH=$(CONTAINER_ARCH) \
-		--layers --cache-from $(CONTAINER_CACHE_REPO) $(CACHE_TO_FLAG) .
+		--layers --cache-from $(CONTAINER_CACHE_REPO) $(CACHE_TO_FLAG) . \
+	|| podman build -t $(CONTAINER_TAG) -f Containerfile --build-arg ARCH=$(CONTAINER_ARCH) \
+		--layers --cache-from $(CONTAINER_CACHE_REPO) .
 
 container-shell: container-build
 	$(CONTAINER_RUN) -it $(CONTAINER_TAG) bash

--- a/tests/test_signal_cleanup.rs
+++ b/tests/test_signal_cleanup.rs
@@ -107,10 +107,10 @@ fn test_sigint_kills_firecracker_bridged() -> Result<()> {
     println!("Sending SIGINT to fcvm (PID {})", fcvm_pid);
     send_signal(fcvm_pid, "INT").context("sending SIGINT to fcvm")?;
 
-    // Wait for fcvm to exit (max 10 seconds)
+    // Wait for fcvm to exit (max 30 seconds — cleanup can be slow under CI load)
     let start = std::time::Instant::now();
     let mut exited = false;
-    while start.elapsed() < Duration::from_secs(10) {
+    while start.elapsed() < Duration::from_secs(30) {
         match fcvm.try_wait() {
             Ok(Some(status)) => {
                 println!("fcvm exited with status: {:?}", status);
@@ -133,8 +133,14 @@ fn test_sigint_kills_firecracker_bridged() -> Result<()> {
         let _ = fcvm.wait();
     }
 
-    // Give a moment for cleanup
-    std::thread::sleep(common::POLL_INTERVAL);
+    // Poll for firecracker cleanup (max 5 seconds)
+    let start = std::time::Instant::now();
+    while start.elapsed() < Duration::from_secs(5) {
+        if !process_exists(fc_pid) {
+            break;
+        }
+        std::thread::sleep(common::POLL_INTERVAL);
+    }
 
     // Check if our specific firecracker is still running
     let still_running = process_exists(fc_pid);
@@ -235,12 +241,14 @@ fn test_sigterm_kills_firecracker_bridged() -> Result<()> {
     println!("Sending SIGTERM to fcvm (PID {})", fcvm_pid);
     send_signal(fcvm_pid, "TERM").context("sending SIGTERM to fcvm")?;
 
-    // Wait for fcvm to exit (max 10 seconds)
+    // Wait for fcvm to exit (max 30 seconds — cleanup can be slow under CI load)
     let start = std::time::Instant::now();
-    while start.elapsed() < Duration::from_secs(10) {
+    let mut exited = false;
+    while start.elapsed() < Duration::from_secs(30) {
         match fcvm.try_wait() {
             Ok(Some(status)) => {
                 println!("fcvm exited with status: {:?}", status);
+                exited = true;
                 break;
             }
             Ok(None) => {
@@ -250,8 +258,20 @@ fn test_sigterm_kills_firecracker_bridged() -> Result<()> {
         }
     }
 
-    // Give a moment for cleanup
-    std::thread::sleep(common::POLL_INTERVAL);
+    if !exited {
+        println!("fcvm didn't exit after SIGTERM, killing forcefully");
+        let _ = fcvm.kill();
+        let _ = fcvm.wait();
+    }
+
+    // Poll for firecracker cleanup (max 5 seconds)
+    let start = std::time::Instant::now();
+    while start.elapsed() < Duration::from_secs(5) {
+        if !process_exists(fc_pid) {
+            break;
+        }
+        std::thread::sleep(common::POLL_INTERVAL);
+    }
 
     // Check if our specific firecracker is still running
     let still_running = process_exists(fc_pid);
@@ -354,12 +374,14 @@ fn test_sigterm_cleanup_rootless() -> Result<()> {
     println!("Sending SIGTERM to fcvm (PID {})", fcvm_pid);
     send_signal(fcvm_pid, "TERM").context("sending SIGTERM to fcvm")?;
 
-    // Wait for fcvm to exit (max 10 seconds)
+    // Wait for fcvm to exit (max 30 seconds — cleanup can be slow under CI load)
     let start = std::time::Instant::now();
-    while start.elapsed() < Duration::from_secs(10) {
+    let mut exited = false;
+    while start.elapsed() < Duration::from_secs(30) {
         match fcvm.try_wait() {
             Ok(Some(status)) => {
                 println!("fcvm exited with status: {:?}", status);
+                exited = true;
                 break;
             }
             Ok(None) => {
@@ -369,8 +391,22 @@ fn test_sigterm_cleanup_rootless() -> Result<()> {
         }
     }
 
-    // Give a moment for cleanup
-    std::thread::sleep(common::POLL_INTERVAL);
+    if !exited {
+        println!("fcvm didn't exit after SIGTERM, killing forcefully");
+        let _ = fcvm.kill();
+        let _ = fcvm.wait();
+    }
+
+    // Poll for child process cleanup (max 5 seconds)
+    let start = std::time::Instant::now();
+    while start.elapsed() < Duration::from_secs(5) {
+        let fc_alive = our_fc_pid.is_some_and(process_exists);
+        let slirp_alive = our_slirp_pid.is_some_and(process_exists);
+        if !fc_alive && !slirp_alive {
+            break;
+        }
+        std::thread::sleep(common::POLL_INTERVAL);
+    }
 
     // Verify our SPECIFIC processes are cleaned up
     if let Some(fc_pid) = our_fc_pid {
@@ -584,12 +620,14 @@ fn test_sigterm_cleanup_bridged() -> Result<()> {
     println!("Sending SIGTERM to fcvm (PID {})", fcvm_pid);
     send_signal(fcvm_pid, "TERM").context("sending SIGTERM to fcvm")?;
 
-    // Wait for exit
+    // Wait for fcvm to exit (max 30 seconds — cleanup can be slow under CI load)
     let start = std::time::Instant::now();
-    while start.elapsed() < Duration::from_secs(10) {
+    let mut exited = false;
+    while start.elapsed() < Duration::from_secs(30) {
         match fcvm.try_wait() {
             Ok(Some(status)) => {
                 println!("fcvm exited with status: {:?}", status);
+                exited = true;
                 break;
             }
             Ok(None) => std::thread::sleep(common::POLL_INTERVAL),
@@ -597,7 +635,21 @@ fn test_sigterm_cleanup_bridged() -> Result<()> {
         }
     }
 
-    std::thread::sleep(common::POLL_INTERVAL);
+    if !exited {
+        println!("fcvm didn't exit after SIGTERM, killing forcefully");
+        let _ = fcvm.kill();
+        let _ = fcvm.wait();
+    }
+
+    // Poll for child process cleanup (max 5 seconds)
+    let start = std::time::Instant::now();
+    while start.elapsed() < Duration::from_secs(5) {
+        let fc_alive = our_fc_pid.is_some_and(process_exists);
+        if !fc_alive {
+            break;
+        }
+        std::thread::sleep(common::POLL_INTERVAL);
+    }
 
     // Verify our SPECIFIC processes are cleaned up
     if let Some(fc_pid) = our_fc_pid {


### PR DESCRIPTION
## Fix flaky signal cleanup tests + container build resilience

### Signal cleanup tests

`test_sigterm_cleanup_rootless` consistently fails TRY 1 on CI (Container-arm64 and Container-x64 on main), sometimes all 3 retries.

**The Problem:** After sending SIGTERM to fcvm, the test waited only 10s for fcvm to exit, then fell through **without force-killing** and asserted firecracker was dead after a single 100ms sleep. Under CI load (parallel tests, I/O contention), fcvm cleanup sometimes exceeded 10s, so firecracker was still alive when the assertion fired.

Three of the four signal tests (`test_sigterm_kills_firecracker_bridged`, `test_sigterm_cleanup_rootless`, `test_sigterm_cleanup_bridged`) were missing the force-kill fallback that `test_sigint_kills_firecracker_bridged` already had.

**The Fix:** Applied to all 4 signal cleanup tests:
- Increase exit wait timeout from 10s to 30s
- Add `if !exited { fcvm.kill(); fcvm.wait(); }` fallback to the three tests missing it
- Replace single 100ms sleep with a polling loop (max 5s) for child process death

### Container build cache-push resilience

**The Problem:** `podman build --cache-to ghcr.io/ejc3/fcvm-cache` can fail with transient `permission_denied: write_package` errors from ghcr.io, even though the container image was built successfully from cached layers.

**The Fix:** Retry the build without `--cache-to` on failure, since cache pushing is an optimization, not a requirement.

## Test plan
- [ ] CI passes — signal cleanup tests should no longer flake
- [ ] Container builds succeed even when ghcr.io cache push fails