### PR TITLE
Fix chown ctime test failure on x64

### DIFF
--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -247,3 +247,40 @@ Before claiming a test failure is unrelated to your PR:
    ```
 
 **The rule:** Green main + red PR = PR caused it. No exceptions, no excuses.
+
+## SSH into CI Runners
+
+When you need to reproduce a CI failure on the actual runner hardware:
+
+```bash
+# 1. Find runner names and status
+gh api repos/ejc3/fcvm/actions/runners --jq '.runners[] | "\(.name) busy=\(.busy) labels=\(.labels | map(.name) | join(","))"'
+
+# 2. Get runner public IPs (filter by architecture)
+# x64 runners:
+aws ec2 describe-instances \
+  --filters "Name=tag:Name,Values=*runner*" "Name=architecture,Values=x86_64" \
+  --query 'Reservations[*].Instances[*].[InstanceId,PublicIpAddress,State.Name]' \
+  --output text
+
+# arm64 runners:
+aws ec2 describe-instances \
+  --filters "Name=tag:Name,Values=*runner*" "Name=architecture,Values=arm64" \
+  --query 'Reservations[*].Instances[*].[InstanceId,PublicIpAddress,State.Name]' \
+  --output text
+
+# 3. SSH using the runner key
+ssh -i ~/.ssh/runner_key -o StrictHostKeyChecking=no ubuntu@<public-ip>
+
+# 4. On the runner, the repo is at ~/fcvm
+# Build and run specific tests:
+cd ~/fcvm && git fetch && git checkout <branch>
+make build
+sudo make test-root FILTER=<test_name> STREAM=1 2>&1 | tee /tmp/test.log
+```
+
+**Important:**
+- Runner key is at `~/.ssh/runner_key` on the dev machine
+- Runners may be busy with CI jobs - check `busy=` status first
+- Don't interfere with running CI jobs on busy runners
+- Tests on runners may cause resource contention with concurrent CI runs

--- a/tests/test_fuse_in_vm_matrix.rs
+++ b/tests/test_fuse_in_vm_matrix.rs
@@ -23,7 +23,8 @@ const JOBS: usize = 8;
 /// The kernel's FUSE writeback cache suppresses server-side ctime updates via
 /// fuse_get_cache_mask() returning STATX_CTIME, causing these tests to fail
 /// intermittently under parallel load (see DESIGN.md "Known Limitations").
-const WRITEBACK_CACHE_CTIME_CATEGORIES: &[&str] = &["chmod", "ftruncate", "link", "truncate"];
+const WRITEBACK_CACHE_CTIME_CATEGORIES: &[&str] =
+    &["chmod", "chown", "ftruncate", "link", "truncate"];
 
 /// Run a single pjdfstest category inside a VM
 async fn run_category_in_vm(category: &str) -> Result<()> {


### PR DESCRIPTION
## Fix pjdfstest chown ctime failure on x64

### The Problem

`test_pjdfstest_vm_chown` fails on x64 Host-Root-SnapshotDisabled with subtests 903 and 919 consistently failing (3/3 retries). These are `test_check(ctime1 -lt ctime2)` calls in the "successful chown updates ctime" section — they verify that ctime is updated after chown operations on block device file types.

### Root Cause

The kernel's FUSE writeback cache suppresses server-side ctime updates via `fuse_get_cache_mask()` returning `STATX_CTIME`. Under CI parallel load, the cached ctime prevents the test from seeing the updated value.

This is the exact same mechanism that already required disabling writeback cache for chmod, ftruncate, link, and truncate categories. `chown` was simply missing from the exclusion list.

### Investigation

1. Traced regression to PR #330 merge (commit 24a180e2) — main was green before, red after
2. SSHed into x64 runner, built pjdfstest binary, instrumented `test_check()` to print details
3. Confirmed tests 903/919 are ctime comparison checks (`$ctime1 -lt $ctime2`)
4. Test passes in isolation (no parallel load = no writeback cache timing issue)
5. Regression exposed by PR #330's faster container startup (additionalImageStore eliminates `podman load`, changing test timing)

### The Fix

Add `"chown"` to `WRITEBACK_CACHE_CTIME_CATEGORIES`, so `FCVM_NO_WRITEBACK_CACHE=1` is set when running the chown test category.

Also adds runner SSH instructions to the pr-workflow skill for future CI debugging.

## Test plan
- [ ] CI passes on x64 Host-Root-SnapshotDisabled (where chown was failing)