### PR TITLE
Add RemapFs for portable inode numbering with --portable-volumes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1351,9 +1351,30 @@ fcvm snapshot run --pid <serve_pid> --name clone1 --network bridged
 
 ### FUSE Parallelism (fuse-pipe)
 
-**Client side (guest):** `fuser` is configured with `clone_fd = true` and `n_threads = num_readers`. Each reader thread gets a cloned `/dev/fuse` fd via `FUSE_DEV_IOC_CLONE`. The kernel distributes FUSE requests among reader threads concurrently — each request delivered to exactly one thread. Reader threads forward requests to the server via the `Multiplexer`.
+**Kernel clone fd model (`FUSE_DEV_IOC_CLONE`):**
 
-**Server side:** A single reader loop deserializes requests from the socket sequentially, but each request is dispatched via `tokio::spawn` + `spawn_blocking` (`pipelined.rs:400-410`). Multiple handler tasks run concurrently on tokio's blocking thread pool. This means `FilesystemHandler` implementations (including `RemapFs`) must be thread-safe — shared state requires atomic operations or lock-free data structures (e.g., `DashMap::entry()` for atomic check-and-insert).
+Each cloned fd is a complete request-response pipeline. A request dequeued from clone_fd_A is pinned to that fd — the response **must** be written back to clone_fd_A (`fuse_request_find()` searches only per-fd `fpq->processing`, not a global list).
+
+| What | Serialized | Parallel |
+|------|-----------|----------|
+| Dequeue from `fiq->pending` | Yes — brief `fiq->lock` spinlock shared across ALL fds | N/A (one request dequeued at a time) |
+| Copy request to userspace | No lock held | Yes — each fd copies independently |
+| Process request | N/A | Yes — each thread processes its own request |
+| Write response | Per-fd `fpq->lock` (no cross-fd contention) | Yes — each fd writes independently |
+| FORGET/BATCH_FORGET | Fire-and-forget, no response written | Dequeued from shared `fiq->forget_list` |
+
+Without clone fd, all threads share one fd and contend on both `fiq->lock` and the single `fpq->lock`.
+
+**fuse-pipe layers:**
+
+| Layer | Serialized | Parallel |
+|-------|-----------|----------|
+| Client reader threads (`mount.rs`) | Dequeue briefly serialized (kernel `fiq->lock`) | N threads with N cloned fds read/write independently |
+| Multiplexer (socket) | Socket write serialized by channel | Request submission lock-free; responses routed by unique ID |
+| Server socket reader (`pipelined.rs`) | Reads requests sequentially from socket | — |
+| Server handler dispatch | — | Each request dispatched via `tokio::spawn` + `spawn_blocking`; concurrent on tokio blocking pool |
+
+**Implication:** `FilesystemHandler` implementations (including `RemapFs`) must be thread-safe. Shared state requires atomic operations or lock-free data structures (e.g., `DashMap::entry()` for atomic check-and-insert).
 
 ### FUSE Passthrough Performance (fuse-pipe)
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1349,6 +1349,12 @@ fcvm snapshot run --pid <serve_pid> --name clone1 --network bridged
 - 50 VMs with 512MB snapshot = ~512MB physical RAM (not 25.6GB)
 - Pages only copied on write (true CoW at page level)
 
+### FUSE Parallelism (fuse-pipe)
+
+**Client side (guest):** `fuser` is configured with `clone_fd = true` and `n_threads = num_readers`. Each reader thread gets a cloned `/dev/fuse` fd via `FUSE_DEV_IOC_CLONE`. The kernel distributes FUSE requests among reader threads concurrently — each request delivered to exactly one thread. Reader threads forward requests to the server via the `Multiplexer`.
+
+**Server side:** A single reader loop deserializes requests from the socket sequentially, but each request is dispatched via `tokio::spawn` + `spawn_blocking` (`pipelined.rs:400-410`). Multiple handler tasks run concurrently on tokio's blocking thread pool. This means `FilesystemHandler` implementations (including `RemapFs`) must be thread-safe — shared state requires atomic operations or lock-free data structures (e.g., `DashMap::entry()` for atomic check-and-insert).
+
 ### FUSE Passthrough Performance (fuse-pipe)
 
 **Benchmark**: 256 workers, 1024 files × 4KB

--- a/README.md
+++ b/README.md
@@ -473,6 +473,20 @@ Expose multiple ports and mount multiple volumes in one command:
   nginx:alpine
 ```
 
+### Portable Volumes
+
+Use `--portable-volumes` to enable deterministic inode numbering for FUSE volumes. This allows snapshots with mounted volumes to be restored on a different machine:
+
+```bash
+# Standard mode (host inodes, same-machine clones only)
+./fcvm podman run --name app --map /data:/data:ro alpine:latest
+
+# Portable mode (path-hash inodes, cross-machine snapshot/restore)
+./fcvm podman run --name app --portable-volumes --map /data:/data:ro alpine:latest
+```
+
+When `--portable-volumes` is set, volumes use a `RemapFs` wrapper that translates between stable path-based inodes and host-specific inodes. The flag applies to all `--map` volumes on the VM and is persisted in snapshot metadata so clones inherit it automatically.
+
 ---
 
 ## Interactive Mode & TTY

--- a/fc-agent/src/mounts.rs
+++ b/fc-agent/src/mounts.rs
@@ -6,9 +6,13 @@ use crate::types::{ExtraDiskMount, NfsMount, VolumeMount};
 /// Check if a path has an active FUSE mount by examining /proc/self/mountinfo.
 fn is_fuse_mounted(path: &str) -> bool {
     let mounts = std::fs::read_to_string("/proc/self/mountinfo").unwrap_or_default();
-    mounts
-        .lines()
-        .any(|line| line.contains(path) && (line.contains("fuse") || line.contains("FUSE")))
+    // mountinfo format: 36 35 98:0 /mnt1 /mnt2 rw,... - type source options
+    // Field 5 (0-indexed: 4) is the mount point. Match exactly to avoid
+    // partial path matches (e.g., "/mnt/data" matching "/mnt/data2").
+    mounts.lines().any(|line| {
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        fields.get(4) == Some(&path) && (line.contains("fuse") || line.contains("FUSE"))
+    })
 }
 
 /// Mount FUSE volumes from host via vsock. Returns list of mounted paths.

--- a/fuse-pipe/src/lib.rs
+++ b/fuse-pipe/src/lib.rs
@@ -71,6 +71,7 @@ pub use transport::{Transport, TransportError, UnixListener, UnixTransport, HOST
 pub use transport::{VsockListener, VsockTransport};
 
 // Re-export server types
+pub use server::remap::RemapFs;
 pub use server::{AsyncServer, FilesystemHandler, PassthroughFs, ServerConfig};
 
 // Re-export telemetry types

--- a/fuse-pipe/src/server/mod.rs
+++ b/fuse-pipe/src/server/mod.rs
@@ -22,6 +22,7 @@ mod config;
 mod handler;
 mod passthrough;
 mod pipelined;
+pub mod remap;
 mod zerocopy;
 
 pub use config::ServerConfig;

--- a/fuse-pipe/src/server/remap.rs
+++ b/fuse-pipe/src/server/remap.rs
@@ -95,49 +95,55 @@ impl<T: FilesystemHandler> RemapFs<T> {
     /// Returns `Err(())` if a hash collision is detected and no alternative
     /// stable_ino can be found.
     fn register_entry(&self, parent_stable: u64, name: &[u8], inner_ino: u64) -> Result<u64, ()> {
-        // Hard link / already-known check
-        if let Some(existing_stable) = self.inner_to_stable.get(&inner_ino) {
-            return Ok(*existing_stable);
-        }
+        // Atomic check-and-insert via DashMap::entry() — holds a shard write lock
+        // so concurrent threads discovering the same inner_ino don't race.
+        use dashmap::mapref::entry::Entry;
+        match self.inner_to_stable.entry(inner_ino) {
+            Entry::Occupied(e) => {
+                // Hard link or concurrent duplicate — return existing mapping
+                Ok(*e.get())
+            }
+            Entry::Vacant(e) => {
+                // Compute path and hash while holding the shard lock
+                let name_str = String::from_utf8_lossy(name);
+                let parent_path = self
+                    .paths
+                    .get(&parent_stable)
+                    .map(|p| p.value().clone())
+                    .unwrap_or_default();
+                let path = Self::format_path(&parent_path, &name_str);
+                let mut stable_ino = Self::path_hash(&path);
 
-        // Compute path and initial hash
-        let name_str = String::from_utf8_lossy(name);
-        let parent_path = self
-            .paths
-            .get(&parent_stable)
-            .map(|p| p.value().clone())
-            .unwrap_or_default();
-        let path = Self::format_path(&parent_path, &name_str);
-        let mut stable_ino = Self::path_hash(&path);
-
-        // Handle conflicts (true hash collision or rename-then-recreate)
-        if self.stable_to_inner.contains_key(&stable_ino) {
-            debug!(
-                stable_ino,
-                path = %path,
-                "stable_ino taken, finding alternative"
-            );
-            let mut found = false;
-            for i in 1u64..10000 {
-                let alt = stable_ino.wrapping_add(i);
-                if alt >= 2 && !self.stable_to_inner.contains_key(&alt) {
-                    stable_ino = alt;
-                    found = true;
-                    break;
+                // Handle conflicts (true hash collision or rename-then-recreate)
+                if self.stable_to_inner.contains_key(&stable_ino) {
+                    debug!(
+                        stable_ino,
+                        path = %path,
+                        "stable_ino taken, finding alternative"
+                    );
+                    let mut found = false;
+                    for i in 1u64..10000 {
+                        let alt = stable_ino.wrapping_add(i);
+                        if alt >= 2 && !self.stable_to_inner.contains_key(&alt) {
+                            stable_ino = alt;
+                            found = true;
+                            break;
+                        }
+                    }
+                    if !found {
+                        error!(path = %path, "failed to find free stable_ino");
+                        return Err(());
+                    }
                 }
-            }
-            if !found {
-                error!(path = %path, "failed to find free stable_ino");
-                return Err(());
+
+                // Register bidirectional mapping
+                e.insert(stable_ino);
+                self.stable_to_inner.insert(stable_ino, inner_ino);
+                self.paths.insert(stable_ino, path);
+
+                Ok(stable_ino)
             }
         }
-
-        // Register bidirectional mapping
-        self.inner_to_stable.insert(inner_ino, stable_ino);
-        self.stable_to_inner.insert(stable_ino, inner_ino);
-        self.paths.insert(stable_ino, path);
-
-        Ok(stable_ino)
     }
 
     /// Remap inode fields in a request from stable to inner.

--- a/fuse-pipe/src/server/remap.rs
+++ b/fuse-pipe/src/server/remap.rs
@@ -1,0 +1,1445 @@
+//! Inode-remapping filesystem wrapper for portable snapshots.
+//!
+//! `RemapFs` wraps any `FilesystemHandler` and translates between stable
+//! path-hash-based inodes (deterministic, portable across machines) and the
+//! inner handler's host-specific inodes.
+//!
+//! When `--portable-volumes` is set, the volume server wraps `PassthroughFs`
+//! in `RemapFs` so that snapshot/clone operations produce consistent inode
+//! numbers regardless of which host they run on.
+
+use dashmap::DashMap;
+use tracing::{debug, error, info};
+
+use crate::protocol::{VolumeRequest, VolumeResponse};
+
+use super::handler::FilesystemHandler;
+
+/// Filesystem wrapper that remaps inodes for portable snapshots.
+///
+/// Translates between stable (path-hash) inodes visible to FUSE clients
+/// and inner (host-specific) inodes used by the underlying filesystem.
+pub struct RemapFs<T: FilesystemHandler> {
+    inner: T,
+    /// inner_ino → stable_ino (set on first encounter, never changes)
+    inner_to_stable: DashMap<u64, u64>,
+    /// stable_ino → inner_ino (reverse mapping for request remapping)
+    stable_to_inner: DashMap<u64, u64>,
+    /// stable_ino → relative path from mount root (for serialization)
+    paths: DashMap<u64, String>,
+}
+
+impl<T: FilesystemHandler> RemapFs<T> {
+    /// Create a new RemapFs wrapping the given handler.
+    ///
+    /// Initializes the root inode mapping (stable:1 ↔ inner:1, path:"").
+    pub fn new(inner: T) -> Self {
+        let inner_to_stable = DashMap::new();
+        let stable_to_inner = DashMap::new();
+        let paths = DashMap::new();
+
+        // Root inode is always 1 in FUSE
+        inner_to_stable.insert(1, 1);
+        stable_to_inner.insert(1, 1);
+        paths.insert(1, String::new());
+
+        Self {
+            inner,
+            inner_to_stable,
+            stable_to_inner,
+            paths,
+        }
+    }
+
+    /// FNV-1a hash of a path string, used to compute stable inodes.
+    ///
+    /// Returns a value >= 2 (0 is invalid, 1 is reserved for root).
+    pub fn path_hash(path: &str) -> u64 {
+        let mut hash: u64 = 0xcbf29ce484222325; // FNV-1a offset basis
+        for byte in path.as_bytes() {
+            hash ^= *byte as u64;
+            hash = hash.wrapping_mul(0x100000001b3); // FNV-1a prime
+        }
+        // Avoid reserved values: 0 (invalid) and 1 (root)
+        if hash < 2 {
+            hash + 2
+        } else {
+            hash
+        }
+    }
+
+    /// Build a relative path from parent path and child name.
+    fn format_path(parent_path: &str, name: &str) -> String {
+        if parent_path.is_empty() {
+            name.to_string()
+        } else {
+            format!("{}/{}", parent_path, name)
+        }
+    }
+
+    /// Look up the inner inode for a stable inode.
+    fn to_inner(&self, stable: u64) -> Option<u64> {
+        self.stable_to_inner.get(&stable).map(|r| *r)
+    }
+
+    /// Look up the stable inode for an inner inode.
+    fn to_stable(&self, inner: u64) -> Option<u64> {
+        self.inner_to_stable.get(&inner).map(|r| *r)
+    }
+
+    /// Register a new inode mapping from an entry-returning operation.
+    ///
+    /// If `inner_ino` is already mapped (hard link case), returns the
+    /// existing stable_ino without modifying paths.
+    ///
+    /// Returns `Err(())` if a hash collision is detected and no alternative
+    /// stable_ino can be found.
+    fn register_entry(&self, parent_stable: u64, name: &[u8], inner_ino: u64) -> Result<u64, ()> {
+        // Hard link / already-known check
+        if let Some(existing_stable) = self.inner_to_stable.get(&inner_ino) {
+            return Ok(*existing_stable);
+        }
+
+        // Compute path and initial hash
+        let name_str = String::from_utf8_lossy(name);
+        let parent_path = self
+            .paths
+            .get(&parent_stable)
+            .map(|p| p.value().clone())
+            .unwrap_or_default();
+        let path = Self::format_path(&parent_path, &name_str);
+        let mut stable_ino = Self::path_hash(&path);
+
+        // Handle conflicts (true hash collision or rename-then-recreate)
+        if self.stable_to_inner.contains_key(&stable_ino) {
+            debug!(
+                stable_ino,
+                path = %path,
+                "stable_ino taken, finding alternative"
+            );
+            let mut found = false;
+            for i in 1u64..10000 {
+                let alt = stable_ino.wrapping_add(i);
+                if alt >= 2 && !self.stable_to_inner.contains_key(&alt) {
+                    stable_ino = alt;
+                    found = true;
+                    break;
+                }
+            }
+            if !found {
+                error!(path = %path, "failed to find free stable_ino");
+                return Err(());
+            }
+        }
+
+        // Register bidirectional mapping
+        self.inner_to_stable.insert(inner_ino, stable_ino);
+        self.stable_to_inner.insert(stable_ino, inner_ino);
+        self.paths.insert(stable_ino, path);
+
+        Ok(stable_ino)
+    }
+
+    /// Remap inode fields in a request from stable to inner.
+    ///
+    /// Returns `None` if a required inode mapping is missing.
+    fn remap_request_inodes(&self, req: &mut VolumeRequest) -> Option<()> {
+        match req {
+            // Single `ino` field
+            VolumeRequest::Getattr { ino }
+            | VolumeRequest::Readlink { ino }
+            | VolumeRequest::Statfs { ino } => {
+                *ino = self.to_inner(*ino)?;
+            }
+
+            VolumeRequest::Setattr { ino, .. }
+            | VolumeRequest::Open { ino, .. }
+            | VolumeRequest::Read { ino, .. }
+            | VolumeRequest::Write { ino, .. }
+            | VolumeRequest::Access { ino, .. }
+            | VolumeRequest::Opendir { ino, .. }
+            | VolumeRequest::Setxattr { ino, .. }
+            | VolumeRequest::Getxattr { ino, .. }
+            | VolumeRequest::Listxattr { ino, .. }
+            | VolumeRequest::Removexattr { ino, .. }
+            | VolumeRequest::Readdir { ino, .. }
+            | VolumeRequest::Readdirplus { ino, .. } => {
+                *ino = self.to_inner(*ino)?;
+            }
+
+            VolumeRequest::Release { ino, .. }
+            | VolumeRequest::Flush { ino, .. }
+            | VolumeRequest::Fsync { ino, .. }
+            | VolumeRequest::Releasedir { ino, .. }
+            | VolumeRequest::Fsyncdir { ino, .. }
+            | VolumeRequest::Fallocate { ino, .. }
+            | VolumeRequest::Lseek { ino, .. }
+            | VolumeRequest::Getlk { ino, .. }
+            | VolumeRequest::Setlk { ino, .. } => {
+                *ino = self.to_inner(*ino)?;
+            }
+
+            // Single `parent` field
+            VolumeRequest::Lookup { parent, .. }
+            | VolumeRequest::Mkdir { parent, .. }
+            | VolumeRequest::Create { parent, .. }
+            | VolumeRequest::Mknod { parent, .. }
+            | VolumeRequest::Rmdir { parent, .. }
+            | VolumeRequest::Unlink { parent, .. }
+            | VolumeRequest::Symlink { parent, .. } => {
+                *parent = self.to_inner(*parent)?;
+            }
+
+            // `ino` + `newparent`
+            VolumeRequest::Link { ino, newparent, .. } => {
+                *ino = self.to_inner(*ino)?;
+                *newparent = self.to_inner(*newparent)?;
+            }
+
+            // `parent` + `newparent`
+            VolumeRequest::Rename {
+                parent, newparent, ..
+            } => {
+                *parent = self.to_inner(*parent)?;
+                *newparent = self.to_inner(*newparent)?;
+            }
+
+            // `ino_in` + `ino_out`
+            VolumeRequest::CopyFileRange {
+                ino_in, ino_out, ..
+            }
+            | VolumeRequest::RemapFileRange {
+                ino_in, ino_out, ..
+            } => {
+                *ino_in = self.to_inner(*ino_in)?;
+                *ino_out = self.to_inner(*ino_out)?;
+            }
+
+            // Forget: best-effort (don't fail if mapping missing)
+            VolumeRequest::Forget { ino, .. } => {
+                if let Some(inner) = self.to_inner(*ino) {
+                    *ino = inner;
+                }
+            }
+
+            VolumeRequest::BatchForget { inodes } => {
+                for (ino, _nlookup) in inodes.iter_mut() {
+                    if let Some(inner) = self.to_inner(*ino) {
+                        *ino = inner;
+                    }
+                }
+            }
+        }
+        Some(())
+    }
+
+    /// Remap inodes in a response from inner to stable, registering new mappings.
+    ///
+    /// `original_req` is the request with STABLE inodes (before remapping),
+    /// needed to compute paths for newly discovered entries.
+    fn remap_response(
+        &self,
+        original_req: &VolumeRequest,
+        response: VolumeResponse,
+    ) -> VolumeResponse {
+        if response.is_error() {
+            return response;
+        }
+
+        match original_req {
+            // Entry-returning ops: register mapping, remap attr.ino
+            VolumeRequest::Lookup { parent, name, .. }
+            | VolumeRequest::Mkdir { parent, name, .. }
+            | VolumeRequest::Create { parent, name, .. }
+            | VolumeRequest::Mknod { parent, name, .. }
+            | VolumeRequest::Symlink { parent, name, .. } => {
+                self.remap_entry_response(*parent, name, response)
+            }
+
+            // Link: use newparent/newname for path, inner_ino already mapped
+            VolumeRequest::Link {
+                newparent, newname, ..
+            } => self.remap_entry_response(*newparent, newname, response),
+
+            // Attr-returning ops: just remap ino
+            VolumeRequest::Getattr { .. } | VolumeRequest::Setattr { .. } => {
+                self.remap_attr_response(response)
+            }
+
+            // Readdir: remap entries, detect stale paths
+            VolumeRequest::Readdir { ino, .. } => self.remap_readdir_response(*ino, response),
+
+            // Readdirplus: remap + register entries, detect stale paths
+            VolumeRequest::Readdirplus { ino, .. } => {
+                self.remap_readdirplus_response(*ino, response)
+            }
+
+            // Rename: update paths on success
+            VolumeRequest::Rename {
+                parent,
+                name,
+                newparent,
+                newname,
+                flags,
+                ..
+            } => {
+                self.handle_rename_paths(*parent, name, *newparent, newname, *flags);
+                response
+            }
+
+            // Everything else: pass through unchanged
+            _ => response,
+        }
+    }
+
+    /// Remap an Entry or Created response, registering the new inode mapping.
+    fn remap_entry_response(
+        &self,
+        parent_stable: u64,
+        name: &[u8],
+        mut response: VolumeResponse,
+    ) -> VolumeResponse {
+        match &mut response {
+            VolumeResponse::Entry { attr, .. } | VolumeResponse::Created { attr, .. } => {
+                let inner_ino = attr.ino;
+                match self.register_entry(parent_stable, name, inner_ino) {
+                    Ok(stable_ino) => {
+                        attr.ino = stable_ino;
+                        response
+                    }
+                    Err(()) => VolumeResponse::io_error(),
+                }
+            }
+            _ => response,
+        }
+    }
+
+    /// Remap an Attr response's inode from inner to stable.
+    fn remap_attr_response(&self, mut response: VolumeResponse) -> VolumeResponse {
+        if let VolumeResponse::Attr { attr, .. } = &mut response {
+            if let Some(stable) = self.to_stable(attr.ino) {
+                attr.ino = stable;
+            }
+        }
+        response
+    }
+
+    /// Remap readdir entries from inner to stable inodes.
+    ///
+    /// Readdir entries are advisory (don't bump nlookup), so we don't
+    /// register new mappings. We do detect and fix stale paths.
+    fn remap_readdir_response(
+        &self,
+        dir_stable: u64,
+        mut response: VolumeResponse,
+    ) -> VolumeResponse {
+        if let VolumeResponse::DirEntries { entries } = &mut response {
+            let dir_path = self
+                .paths
+                .get(&dir_stable)
+                .map(|p| p.value().clone())
+                .unwrap_or_default();
+
+            for entry in entries.iter_mut() {
+                if entry.name == b"." {
+                    entry.ino = dir_stable;
+                    continue;
+                }
+                if entry.name == b".." {
+                    if let Some(stable) = self.to_stable(entry.ino) {
+                        entry.ino = stable;
+                    }
+                    continue;
+                }
+
+                let inner_ino = entry.ino;
+                let name_str = String::from_utf8_lossy(&entry.name);
+                let expected_path = Self::format_path(&dir_path, &name_str);
+
+                if let Some(existing_stable) = self.inner_to_stable.get(&inner_ino) {
+                    let stable = *existing_stable;
+                    entry.ino = stable;
+
+                    // Path staleness detection
+                    if let Some(mut stored_path) = self.paths.get_mut(&stable) {
+                        if *stored_path != expected_path {
+                            debug!(
+                                old_path = %*stored_path,
+                                new_path = %expected_path,
+                                "readdir: fixing stale path"
+                            );
+                            *stored_path = expected_path;
+                        }
+                    }
+                } else {
+                    // Unknown inner_ino: compute hash on-the-fly (no registration)
+                    entry.ino = Self::path_hash(&expected_path);
+                }
+            }
+        }
+        response
+    }
+
+    /// Remap readdirplus entries, registering mappings (implicit lookup).
+    ///
+    /// Readdirplus is an implicit lookup for each entry, so we register
+    /// new mappings and detect stale paths.
+    fn remap_readdirplus_response(
+        &self,
+        dir_stable: u64,
+        mut response: VolumeResponse,
+    ) -> VolumeResponse {
+        if let VolumeResponse::DirEntriesPlus { entries } = &mut response {
+            let dir_path = self
+                .paths
+                .get(&dir_stable)
+                .map(|p| p.value().clone())
+                .unwrap_or_default();
+
+            for entry in entries.iter_mut() {
+                if entry.name == b"." {
+                    entry.ino = dir_stable;
+                    entry.attr.ino = dir_stable;
+                    continue;
+                }
+                if entry.name == b".." {
+                    if let Some(stable) = self.to_stable(entry.ino) {
+                        entry.ino = stable;
+                        entry.attr.ino = stable;
+                    }
+                    continue;
+                }
+
+                let inner_ino = entry.attr.ino;
+                match self.register_entry(dir_stable, &entry.name, inner_ino) {
+                    Ok(stable_ino) => {
+                        entry.ino = stable_ino;
+                        entry.attr.ino = stable_ino;
+
+                        // Path staleness detection
+                        let name_str = String::from_utf8_lossy(&entry.name);
+                        let expected_path = Self::format_path(&dir_path, &name_str);
+                        if let Some(mut stored_path) = self.paths.get_mut(&stable_ino) {
+                            if *stored_path != expected_path {
+                                debug!(
+                                    old_path = %*stored_path,
+                                    new_path = %expected_path,
+                                    "readdirplus: fixing stale path"
+                                );
+                                *stored_path = expected_path;
+                            }
+                        }
+                    }
+                    Err(()) => {
+                        // Collision - leave entry with inner ino (rare, logged above)
+                    }
+                }
+            }
+        }
+        response
+    }
+
+    /// Update stored paths after a successful rename.
+    fn handle_rename_paths(
+        &self,
+        parent_stable: u64,
+        name: &[u8],
+        newparent_stable: u64,
+        newname: &[u8],
+        flags: u32,
+    ) {
+        let name_str = String::from_utf8_lossy(name);
+        let newname_str = String::from_utf8_lossy(newname);
+        let parent_path = self
+            .paths
+            .get(&parent_stable)
+            .map(|p| p.value().clone())
+            .unwrap_or_default();
+        let newparent_path = self
+            .paths
+            .get(&newparent_stable)
+            .map(|p| p.value().clone())
+            .unwrap_or_default();
+        let old_path = Self::format_path(&parent_path, &name_str);
+        let new_path = Self::format_path(&newparent_path, &newname_str);
+
+        // Find stable_ino of the source entry by scanning paths
+        let source_stable = self
+            .paths
+            .iter()
+            .find(|e| *e.value() == old_path)
+            .map(|e| *e.key());
+
+        let is_exchange = flags & 2 != 0; // RENAME_EXCHANGE
+
+        if is_exchange {
+            // RENAME_EXCHANGE: swap both entries' paths
+            let dest_stable = self
+                .paths
+                .iter()
+                .find(|e| *e.value() == new_path)
+                .map(|e| *e.key());
+
+            if let Some(src) = source_stable {
+                self.paths.insert(src, new_path.clone());
+            }
+            if let Some(dst) = dest_stable {
+                self.paths.insert(dst, old_path.clone());
+            }
+        } else {
+            // Regular rename: update source path and all descendants
+            if let Some(src) = source_stable {
+                self.paths.insert(src, new_path.clone());
+
+                // Update descendant paths (for directory renames)
+                let old_prefix = format!("{}/", old_path);
+                let new_prefix = format!("{}/", new_path);
+                let updates: Vec<(u64, String)> = self
+                    .paths
+                    .iter()
+                    .filter(|e| e.value().starts_with(&old_prefix))
+                    .map(|e| (*e.key(), e.value().replacen(&old_prefix, &new_prefix, 1)))
+                    .collect();
+                for (ino, path) in updates {
+                    self.paths.insert(ino, path);
+                }
+            }
+        }
+    }
+
+    /// Serialize the inode mapping table as JSON.
+    ///
+    /// Returns a JSON object mapping stable_ino (as string key) to path.
+    /// Used for portable snapshot restore.
+    pub fn serialize_table(&self) -> String {
+        let map: std::collections::BTreeMap<u64, String> = self
+            .paths
+            .iter()
+            .map(|e| (*e.key(), e.value().clone()))
+            .collect();
+        serde_json::to_string(&map).unwrap_or_default()
+    }
+
+    /// Restore a RemapFs from a serialized inode table.
+    ///
+    /// Walks each path in the table through the inner handler's lookup
+    /// to rebuild the stable_ino ↔ inner_ino mappings.
+    ///
+    /// Paths that no longer exist on the host are skipped (logged as warnings).
+    pub fn restore_from_table(inner: T, json: &str) -> Self {
+        let table: std::collections::BTreeMap<u64, String> =
+            serde_json::from_str(json).unwrap_or_default();
+
+        let inner_to_stable = DashMap::new();
+        let stable_to_inner = DashMap::new();
+        let paths = DashMap::new();
+
+        // Root is always mapped
+        inner_to_stable.insert(1, 1);
+        stable_to_inner.insert(1, 1);
+        paths.insert(1, String::new());
+
+        // Walk each path to discover inner inodes
+        for (stable_ino, path) in &table {
+            if path.is_empty() {
+                continue; // Root already handled
+            }
+
+            // Walk each component through lookup
+            let components: Vec<&str> = path.split('/').collect();
+            let mut current_inner = 1u64; // Start from root
+            let mut resolved = true;
+
+            for component in &components {
+                let req = VolumeRequest::Lookup {
+                    parent: current_inner,
+                    name: component.as_bytes().to_vec(),
+                    uid: 0,
+                    gid: 0,
+                    pid: 0,
+                };
+                let resp = inner.handle_request(&req);
+                match resp.attr() {
+                    Some(attr) => {
+                        current_inner = attr.ino;
+                    }
+                    None => {
+                        debug!(
+                            path = %path,
+                            component = %component,
+                            "restore: path no longer exists, skipping"
+                        );
+                        resolved = false;
+                        break;
+                    }
+                }
+            }
+
+            if resolved {
+                inner_to_stable.insert(current_inner, *stable_ino);
+                stable_to_inner.insert(*stable_ino, current_inner);
+                paths.insert(*stable_ino, path.clone());
+            }
+        }
+
+        info!(
+            restored = paths.len(),
+            total = table.len(),
+            "RemapFs restored from table"
+        );
+
+        Self {
+            inner,
+            inner_to_stable,
+            stable_to_inner,
+            paths,
+        }
+    }
+
+    /// Get a reference to the inner handler.
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T: FilesystemHandler> FilesystemHandler for RemapFs<T> {
+    fn handle_request_with_groups(
+        &self,
+        request: &VolumeRequest,
+        supplementary_groups: &[u32],
+    ) -> VolumeResponse {
+        // Clone and remap request inodes (stable → inner)
+        let mut remapped = request.clone();
+        if self.remap_request_inodes(&mut remapped).is_none() {
+            error!(op = request.op_name(), "unknown inode in request");
+            return VolumeResponse::io_error();
+        }
+
+        // Delegate to inner handler
+        let response = self
+            .inner
+            .handle_request_with_groups(&remapped, supplementary_groups);
+
+        // Remap response inodes (inner → stable) and register new mappings
+        // Use ORIGINAL request (stable inodes) for path computation
+        self.remap_response(request, response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::{DirEntry, DirEntryPlus, FileAttr};
+    use std::sync::Mutex;
+
+    /// Mock handler that records requests and returns configurable responses.
+    struct MockFs {
+        next_response: Mutex<Option<VolumeResponse>>,
+    }
+
+    impl MockFs {
+        fn new() -> Self {
+            Self {
+                next_response: Mutex::new(None),
+            }
+        }
+
+        fn set_response(&self, resp: VolumeResponse) {
+            *self.next_response.lock().unwrap() = Some(resp);
+        }
+    }
+
+    impl FilesystemHandler for MockFs {
+        fn handle_request_with_groups(
+            &self,
+            _request: &VolumeRequest,
+            _groups: &[u32],
+        ) -> VolumeResponse {
+            self.next_response
+                .lock()
+                .unwrap()
+                .take()
+                .unwrap_or(VolumeResponse::Ok)
+        }
+    }
+
+    fn make_attr(ino: u64) -> FileAttr {
+        FileAttr {
+            ino,
+            size: 100,
+            blocks: 1,
+            atime_secs: 0,
+            atime_nsecs: 0,
+            mtime_secs: 0,
+            mtime_nsecs: 0,
+            ctime_secs: 0,
+            ctime_nsecs: 0,
+            mode: libc::S_IFREG | 0o644,
+            nlink: 1,
+            uid: 1000,
+            gid: 1000,
+            rdev: 0,
+            blksize: 4096,
+        }
+    }
+
+    #[test]
+    fn test_path_hash_deterministic() {
+        assert_eq!(
+            RemapFs::<MockFs>::path_hash("foo"),
+            RemapFs::<MockFs>::path_hash("foo")
+        );
+        assert_ne!(
+            RemapFs::<MockFs>::path_hash("foo"),
+            RemapFs::<MockFs>::path_hash("bar")
+        );
+    }
+
+    #[test]
+    fn test_path_hash_avoids_reserved() {
+        // Empty string and all inputs should return >= 2
+        let h = RemapFs::<MockFs>::path_hash("");
+        assert!(h >= 2);
+    }
+
+    #[test]
+    fn test_basic_lookup_remapping() {
+        let mock = MockFs::new();
+        let remap = RemapFs::new(mock);
+
+        // Inner handler returns entry with inner_ino=500
+        remap.inner.set_response(VolumeResponse::Entry {
+            attr: make_attr(500),
+            generation: 0,
+            ttl_secs: 1,
+        });
+
+        let req = VolumeRequest::Lookup {
+            parent: 1, // root (stable)
+            name: b"hello.txt".to_vec(),
+            uid: 1000,
+            gid: 1000,
+            pid: 1,
+        };
+
+        let resp = remap.handle_request_with_groups(&req, &[]);
+
+        // Response should have stable inode (hash of "hello.txt"), not 500
+        match resp {
+            VolumeResponse::Entry { attr, .. } => {
+                assert_ne!(attr.ino, 500, "should not expose inner inode");
+                assert_eq!(attr.ino, RemapFs::<MockFs>::path_hash("hello.txt"));
+            }
+            other => panic!("unexpected response: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_consistent_inode_across_lookups() {
+        let mock = MockFs::new();
+        let remap = RemapFs::new(mock);
+
+        // First lookup
+        remap.inner.set_response(VolumeResponse::Entry {
+            attr: make_attr(500),
+            generation: 0,
+            ttl_secs: 1,
+        });
+        let req = VolumeRequest::Lookup {
+            parent: 1,
+            name: b"file.txt".to_vec(),
+            uid: 0,
+            gid: 0,
+            pid: 0,
+        };
+        let resp1 = remap.handle_request_with_groups(&req, &[]);
+        let ino1 = resp1.attr().unwrap().ino;
+
+        // Second lookup (same inner_ino)
+        remap.inner.set_response(VolumeResponse::Entry {
+            attr: make_attr(500),
+            generation: 0,
+            ttl_secs: 1,
+        });
+        let resp2 = remap.handle_request_with_groups(&req, &[]);
+        let ino2 = resp2.attr().unwrap().ino;
+
+        assert_eq!(ino1, ino2, "same file should always get same stable inode");
+    }
+
+    #[test]
+    fn test_hard_link_same_inode() {
+        let mock = MockFs::new();
+        let remap = RemapFs::new(mock);
+
+        // Lookup "file_a" → inner_ino 42
+        remap.inner.set_response(VolumeResponse::Entry {
+            attr: make_attr(42),
+            generation: 0,
+            ttl_secs: 1,
+        });
+        let req_a = VolumeRequest::Lookup {
+            parent: 1,
+            name: b"file_a".to_vec(),
+            uid: 0,
+            gid: 0,
+            pid: 0,
+        };
+        let resp_a = remap.handle_request_with_groups(&req_a, &[]);
+        let stable_a = resp_a.attr().unwrap().ino;
+
+        // Lookup "file_b" → same inner_ino 42 (hard link)
+        remap.inner.set_response(VolumeResponse::Entry {
+            attr: make_attr(42),
+            generation: 0,
+            ttl_secs: 1,
+        });
+        let req_b = VolumeRequest::Lookup {
+            parent: 1,
+            name: b"file_b".to_vec(),
+            uid: 0,
+            gid: 0,
+            pid: 0,
+        };
+        let resp_b = remap.handle_request_with_groups(&req_b, &[]);
+        let stable_b = resp_b.attr().unwrap().ino;
+
+        assert_eq!(
+            stable_a, stable_b,
+            "hard links must share the same stable inode"
+        );
+    }
+
+    #[test]
+    fn test_getattr_remaps_response() {
+        let mock = MockFs::new();
+        let remap = RemapFs::new(mock);
+
+        // First, register the inode via lookup
+        remap.inner.set_response(VolumeResponse::Entry {
+            attr: make_attr(200),
+            generation: 0,
+            ttl_secs: 1,
+        });
+        let lookup = VolumeRequest::Lookup {
+            parent: 1,
+            name: b"test".to_vec(),
+            uid: 0,
+            gid: 0,
+            pid: 0,
+        };
+        let resp = remap.handle_request_with_groups(&lookup, &[]);
+        let stable_ino = resp.attr().unwrap().ino;
+
+        // Now getattr with stable inode
+        remap.inner.set_response(VolumeResponse::Attr {
+            attr: make_attr(200), // inner handler returns inner ino
+            ttl_secs: 1,
+        });
+        let getattr = VolumeRequest::Getattr { ino: stable_ino };
+        let resp = remap.handle_request_with_groups(&getattr, &[]);
+
+        match resp {
+            VolumeResponse::Attr { attr, .. } => {
+                assert_eq!(attr.ino, stable_ino, "getattr should return stable inode");
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_readdir_remaps_known_entries() {
+        let mock = MockFs::new();
+        let remap = RemapFs::new(mock);
+
+        // Register "file1" via lookup (inner_ino=10)
+        remap.inner.set_response(VolumeResponse::Entry {
+            attr: make_attr(10),
+            generation: 0,
+            ttl_secs: 1,
+        });
+        let lookup = VolumeRequest::Lookup {
+            parent: 1,
+            name: b"file1".to_vec(),
+            uid: 0,
+            gid: 0,
+            pid: 0,
+        };
+        let resp = remap.handle_request_with_groups(&lookup, &[]);
+        let stable_file1 = resp.attr().unwrap().ino;
+
+        // Readdir on root
+        remap.inner.set_response(VolumeResponse::DirEntries {
+            entries: vec![
+                DirEntry::dot(1),                        // inner root ino
+                DirEntry::dotdot(1),                     // inner root parent
+                DirEntry::new(10, b"file1".to_vec(), 8), // inner_ino=10
+                DirEntry::new(20, b"file2".to_vec(), 8), // inner_ino=20, unknown
+            ],
+        });
+        let readdir = VolumeRequest::Readdir {
+            ino: 1, // root (stable = 1 = inner)
+            offset: 0,
+            uid: 0,
+            gid: 0,
+            pid: 0,
+        };
+        let resp = remap.handle_request_with_groups(&readdir, &[]);
+
+        match resp {
+            VolumeResponse::DirEntries { entries } => {
+                assert_eq!(entries[0].ino, 1, ". should be root stable ino");
+                assert_eq!(entries[1].ino, 1, ".. should be parent stable ino");
+                assert_eq!(
+                    entries[2].ino, stable_file1,
+                    "file1 should use registered stable ino"
+                );
+                // file2 unknown: should get on-the-fly hash
+                assert_eq!(
+                    entries[3].ino,
+                    RemapFs::<MockFs>::path_hash("file2"),
+                    "unknown entry should get path hash"
+                );
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_readdir_detects_stale_path() {
+        let mock = MockFs::new();
+        let remap = RemapFs::new(mock);
+
+        // Register "old_name" via lookup (inner_ino=50)
+        remap.inner.set_response(VolumeResponse::Entry {
+            attr: make_attr(50),
+            generation: 0,
+            ttl_secs: 1,
+        });
+        let lookup = VolumeRequest::Lookup {
+            parent: 1,
+            name: b"old_name".to_vec(),
+            uid: 0,
+            gid: 0,
+            pid: 0,
+        };
+        remap.handle_request_with_groups(&lookup, &[]);
+
+        // Verify path is "old_name"
+        let stable_50 = remap.to_stable(50).unwrap();
+        assert_eq!(remap.paths.get(&stable_50).unwrap().value(), "old_name");
+
+        // Host renames file. Readdir now shows inner_ino=50 as "new_name"
+        remap.inner.set_response(VolumeResponse::DirEntries {
+            entries: vec![DirEntry::new(50, b"new_name".to_vec(), 8)],
+        });
+        let readdir = VolumeRequest::Readdir {
+            ino: 1,
+            offset: 0,
+            uid: 0,
+            gid: 0,
+            pid: 0,
+        };
+        remap.handle_request_with_groups(&readdir, &[]);
+
+        // Path should be updated to "new_name"
+        assert_eq!(
+            remap.paths.get(&stable_50).unwrap().value(),
+            "new_name",
+            "stale path should be corrected by readdir"
+        );
+    }
+
+    #[test]
+    fn test_rename_updates_paths() {
+        let mock = MockFs::new();
+        let remap = RemapFs::new(mock);
+
+        // Register "src" via lookup (inner_ino=100)
+        remap.inner.set_response(VolumeResponse::Entry {
+            attr: make_attr(100),
+            generation: 0,
+            ttl_secs: 1,
+        });
+        let lookup = VolumeRequest::Lookup {
+            parent: 1,
+            name: b"src".to_vec(),
+            uid: 0,
+            gid: 0,
+            pid: 0,
+        };
+        remap.handle_request_with_groups(&lookup, &[]);
+
+        let stable_100 = remap.to_stable(100).unwrap();
+        assert_eq!(remap.paths.get(&stable_100).unwrap().value(), "src");
+
+        // Guest renames "src" → "dst"
+        remap.inner.set_response(VolumeResponse::Ok);
+        let rename = VolumeRequest::Rename {
+            parent: 1,
+            name: b"src".to_vec(),
+            newparent: 1,
+            newname: b"dst".to_vec(),
+            flags: 0,
+            uid: 0,
+            gid: 0,
+            pid: 0,
+        };
+        remap.handle_request_with_groups(&rename, &[]);
+
+        // Path should now be "dst"
+        assert_eq!(
+            remap.paths.get(&stable_100).unwrap().value(),
+            "dst",
+            "rename should update stored path"
+        );
+    }
+
+    #[test]
+    fn test_serialize_table() {
+        let mock = MockFs::new();
+        let remap = RemapFs::new(mock);
+
+        // Register a file
+        remap.inner.set_response(VolumeResponse::Entry {
+            attr: make_attr(300),
+            generation: 0,
+            ttl_secs: 1,
+        });
+        let lookup = VolumeRequest::Lookup {
+            parent: 1,
+            name: b"data.txt".to_vec(),
+            uid: 0,
+            gid: 0,
+            pid: 0,
+        };
+        remap.handle_request_with_groups(&lookup, &[]);
+
+        let json = remap.serialize_table();
+        let parsed: std::collections::BTreeMap<u64, String> = serde_json::from_str(&json).unwrap();
+
+        // Should contain root ("") and "data.txt"
+        assert_eq!(parsed.len(), 2);
+        assert!(parsed.values().any(|v| v.is_empty()));
+        assert!(parsed.values().any(|v| v == "data.txt"));
+    }
+
+    #[test]
+    fn test_created_response_remapped() {
+        let mock = MockFs::new();
+        let remap = RemapFs::new(mock);
+
+        // Create returns Created with inner_ino=77
+        remap.inner.set_response(VolumeResponse::Created {
+            attr: make_attr(77),
+            generation: 0,
+            ttl_secs: 1,
+            fh: 99,
+            flags: 0,
+        });
+        let create = VolumeRequest::Create {
+            parent: 1,
+            name: b"new_file".to_vec(),
+            mode: 0o644,
+            flags: 0,
+            uid: 0,
+            gid: 0,
+            pid: 0,
+        };
+        let resp = remap.handle_request_with_groups(&create, &[]);
+
+        match resp {
+            VolumeResponse::Created { attr, fh, .. } => {
+                assert_ne!(attr.ino, 77, "should not expose inner inode");
+                assert_eq!(
+                    attr.ino,
+                    RemapFs::<MockFs>::path_hash("new_file"),
+                    "should use path hash"
+                );
+                assert_eq!(fh, 99, "fh should pass through unchanged");
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_readdirplus_registers_mappings() {
+        let mock = MockFs::new();
+        let remap = RemapFs::new(mock);
+
+        // Readdirplus returns entries
+        remap.inner.set_response(VolumeResponse::DirEntriesPlus {
+            entries: vec![DirEntryPlus {
+                ino: 60,
+                name: b"auto_reg".to_vec(),
+                attr: make_attr(60),
+                generation: 0,
+                attr_ttl_secs: 1,
+                entry_ttl_secs: 1,
+            }],
+        });
+
+        let readdirplus = VolumeRequest::Readdirplus {
+            ino: 1,
+            fh: 0,
+            offset: 0,
+            uid: 0,
+            gid: 0,
+            pid: 0,
+        };
+        let resp = remap.handle_request_with_groups(&readdirplus, &[]);
+
+        // Entry should be registered
+        let stable = remap.to_stable(60);
+        assert!(stable.is_some(), "readdirplus should register mapping");
+
+        match resp {
+            VolumeResponse::DirEntriesPlus { entries } => {
+                assert_eq!(entries[0].ino, stable.unwrap());
+                assert_eq!(entries[0].attr.ino, stable.unwrap());
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_error_response_passed_through() {
+        let mock = MockFs::new();
+        let remap = RemapFs::new(mock);
+
+        remap
+            .inner
+            .set_response(VolumeResponse::error(libc::ENOENT));
+        let req = VolumeRequest::Lookup {
+            parent: 1,
+            name: b"nonexistent".to_vec(),
+            uid: 0,
+            gid: 0,
+            pid: 0,
+        };
+        let resp = remap.handle_request_with_groups(&req, &[]);
+        assert_eq!(resp.errno(), Some(libc::ENOENT));
+    }
+
+    #[test]
+    fn test_unknown_stable_ino_returns_eio() {
+        let mock = MockFs::new();
+        let remap = RemapFs::new(mock);
+
+        // Getattr with unknown stable inode (never registered)
+        let req = VolumeRequest::Getattr { ino: 999999 };
+        let resp = remap.handle_request_with_groups(&req, &[]);
+        assert_eq!(resp.errno(), Some(libc::EIO));
+    }
+
+    /// Mock handler that supports lookup chains for restore testing.
+    /// Maps (parent_ino, name) → child_ino.
+    struct LookupFs {
+        entries: std::collections::HashMap<(u64, Vec<u8>), u64>,
+    }
+
+    impl LookupFs {
+        fn new() -> Self {
+            Self {
+                entries: std::collections::HashMap::new(),
+            }
+        }
+
+        fn add_entry(&mut self, parent: u64, name: &[u8], ino: u64) {
+            self.entries.insert((parent, name.to_vec()), ino);
+        }
+    }
+
+    impl FilesystemHandler for LookupFs {
+        fn handle_request(&self, request: &VolumeRequest) -> VolumeResponse {
+            match request {
+                VolumeRequest::Lookup { parent, name, .. } => {
+                    if let Some(&ino) = self.entries.get(&(*parent, name.clone())) {
+                        VolumeResponse::Entry {
+                            attr: make_attr(ino),
+                            generation: 0,
+                            ttl_secs: 1,
+                        }
+                    } else {
+                        VolumeResponse::not_found()
+                    }
+                }
+                _ => VolumeResponse::Ok,
+            }
+        }
+    }
+
+    #[test]
+    fn test_serialize_restore_roundtrip() {
+        let mock = MockFs::new();
+        let remap = RemapFs::new(mock);
+
+        // Register entries: root/dir/file.txt
+        // First: lookup "dir" (inner_ino=10)
+        remap.inner.set_response(VolumeResponse::Entry {
+            attr: {
+                let mut a = make_attr(10);
+                a.mode = libc::S_IFDIR | 0o755;
+                a
+            },
+            generation: 0,
+            ttl_secs: 1,
+        });
+        let lookup_dir = VolumeRequest::Lookup {
+            parent: 1,
+            name: b"dir".to_vec(),
+            uid: 0,
+            gid: 0,
+            pid: 0,
+        };
+        let resp = remap.handle_request_with_groups(&lookup_dir, &[]);
+        let dir_stable = resp.attr().unwrap().ino;
+
+        // Then: lookup "file.txt" under dir (inner_ino=20)
+        remap.inner.set_response(VolumeResponse::Entry {
+            attr: make_attr(20),
+            generation: 0,
+            ttl_secs: 1,
+        });
+        let lookup_file = VolumeRequest::Lookup {
+            parent: dir_stable,
+            name: b"file.txt".to_vec(),
+            uid: 0,
+            gid: 0,
+            pid: 0,
+        };
+        let resp = remap.handle_request_with_groups(&lookup_file, &[]);
+        let file_stable = resp.attr().unwrap().ino;
+
+        // Serialize
+        let json = remap.serialize_table();
+
+        // Restore with a LookupFs that maps the same paths to different inner inodes
+        let mut restore_fs = LookupFs::new();
+        restore_fs.add_entry(1, b"dir", 500); // different inner ino
+        restore_fs.add_entry(500, b"file.txt", 600); // different inner ino
+
+        let restored = RemapFs::restore_from_table(restore_fs, &json);
+
+        // The stable inodes should be the same
+        assert_eq!(
+            restored.to_inner(dir_stable),
+            Some(500),
+            "restored dir should map to new inner ino"
+        );
+        assert_eq!(
+            restored.to_inner(file_stable),
+            Some(600),
+            "restored file should map to new inner ino"
+        );
+
+        // Reverse mappings should also work
+        assert_eq!(restored.to_stable(500), Some(dir_stable));
+        assert_eq!(restored.to_stable(600), Some(file_stable));
+
+        // Paths should be preserved
+        assert_eq!(restored.paths.get(&dir_stable).unwrap().value(), "dir");
+        assert_eq!(
+            restored.paths.get(&file_stable).unwrap().value(),
+            "dir/file.txt"
+        );
+    }
+
+    #[test]
+    fn test_restore_missing_path_skipped() {
+        // Serialize a table with a file that won't exist on restore
+        let mock = MockFs::new();
+        let remap = RemapFs::new(mock);
+
+        remap.inner.set_response(VolumeResponse::Entry {
+            attr: make_attr(42),
+            generation: 0,
+            ttl_secs: 1,
+        });
+        let lookup = VolumeRequest::Lookup {
+            parent: 1,
+            name: b"gone.txt".to_vec(),
+            uid: 0,
+            gid: 0,
+            pid: 0,
+        };
+        remap.handle_request_with_groups(&lookup, &[]);
+        let json = remap.serialize_table();
+
+        // Restore with empty filesystem (no files)
+        let restore_fs = LookupFs::new();
+        let restored = RemapFs::restore_from_table(restore_fs, &json);
+
+        // Root should exist, but gone.txt should be skipped
+        assert!(restored.to_inner(1).is_some(), "root should exist");
+        assert_eq!(
+            restored.paths.len(),
+            1,
+            "only root should be in paths (gone.txt skipped)"
+        );
+    }
+
+    #[test]
+    fn test_rename_updates_descendant_paths() {
+        let mock = MockFs::new();
+        let remap = RemapFs::new(mock);
+
+        // Register dir/child
+        remap.inner.set_response(VolumeResponse::Entry {
+            attr: {
+                let mut a = make_attr(10);
+                a.mode = libc::S_IFDIR | 0o755;
+                a
+            },
+            generation: 0,
+            ttl_secs: 1,
+        });
+        remap.handle_request_with_groups(
+            &VolumeRequest::Lookup {
+                parent: 1,
+                name: b"dir".to_vec(),
+                uid: 0,
+                gid: 0,
+                pid: 0,
+            },
+            &[],
+        );
+        let dir_stable = remap.to_stable(10).unwrap();
+
+        remap.inner.set_response(VolumeResponse::Entry {
+            attr: make_attr(20),
+            generation: 0,
+            ttl_secs: 1,
+        });
+        remap.handle_request_with_groups(
+            &VolumeRequest::Lookup {
+                parent: dir_stable,
+                name: b"child.txt".to_vec(),
+                uid: 0,
+                gid: 0,
+                pid: 0,
+            },
+            &[],
+        );
+        let child_stable = remap.to_stable(20).unwrap();
+
+        assert_eq!(
+            remap.paths.get(&child_stable).unwrap().value(),
+            "dir/child.txt"
+        );
+
+        // Rename "dir" → "newdir"
+        remap.inner.set_response(VolumeResponse::Ok);
+        remap.handle_request_with_groups(
+            &VolumeRequest::Rename {
+                parent: 1,
+                name: b"dir".to_vec(),
+                newparent: 1,
+                newname: b"newdir".to_vec(),
+                flags: 0,
+                uid: 0,
+                gid: 0,
+                pid: 0,
+            },
+            &[],
+        );
+
+        // Both parent and child paths should be updated
+        assert_eq!(remap.paths.get(&dir_stable).unwrap().value(), "newdir");
+        assert_eq!(
+            remap.paths.get(&child_stable).unwrap().value(),
+            "newdir/child.txt",
+            "descendant path should be updated after directory rename"
+        );
+    }
+
+    #[test]
+    fn test_host_rename_then_serialize_accurate() {
+        let mock = MockFs::new();
+        let remap = RemapFs::new(mock);
+
+        // Register "original" (inner_ino=50)
+        remap.inner.set_response(VolumeResponse::Entry {
+            attr: make_attr(50),
+            generation: 0,
+            ttl_secs: 1,
+        });
+        remap.handle_request_with_groups(
+            &VolumeRequest::Lookup {
+                parent: 1,
+                name: b"original".to_vec(),
+                uid: 0,
+                gid: 0,
+                pid: 0,
+            },
+            &[],
+        );
+        let stable_50 = remap.to_stable(50).unwrap();
+        assert_eq!(remap.paths.get(&stable_50).unwrap().value(), "original");
+
+        // Host renames file. Readdir now shows inner_ino=50 as "renamed"
+        remap.inner.set_response(VolumeResponse::DirEntries {
+            entries: vec![DirEntry::new(50, b"renamed".to_vec(), 8)],
+        });
+        remap.handle_request_with_groups(
+            &VolumeRequest::Readdir {
+                ino: 1,
+                offset: 0,
+                uid: 0,
+                gid: 0,
+                pid: 0,
+            },
+            &[],
+        );
+
+        // Path should be updated
+        assert_eq!(remap.paths.get(&stable_50).unwrap().value(), "renamed");
+
+        // Serialize should reflect the corrected path
+        let json = remap.serialize_table();
+        let parsed: std::collections::BTreeMap<u64, String> = serde_json::from_str(&json).unwrap();
+        assert!(
+            parsed.values().any(|v| v == "renamed"),
+            "serialized table should have corrected path"
+        );
+        assert!(
+            !parsed.values().any(|v| v == "original"),
+            "serialized table should NOT have stale path"
+        );
+    }
+
+    #[test]
+    fn test_forget_remaps_inode() {
+        let mock = MockFs::new();
+        let remap = RemapFs::new(mock);
+
+        // Register a file
+        remap.inner.set_response(VolumeResponse::Entry {
+            attr: make_attr(42),
+            generation: 0,
+            ttl_secs: 1,
+        });
+        remap.handle_request_with_groups(
+            &VolumeRequest::Lookup {
+                parent: 1,
+                name: b"f".to_vec(),
+                uid: 0,
+                gid: 0,
+                pid: 0,
+            },
+            &[],
+        );
+        let stable = remap.to_stable(42).unwrap();
+
+        // Forget should not error (best-effort)
+        remap.inner.set_response(VolumeResponse::Ok);
+        let resp = remap.handle_request_with_groups(
+            &VolumeRequest::Forget {
+                ino: stable,
+                nlookup: 1,
+            },
+            &[],
+        );
+        assert!(resp.is_ok());
+    }
+}

--- a/fuse-pipe/src/transport/vsock.rs
+++ b/fuse-pipe/src/transport/vsock.rs
@@ -112,13 +112,19 @@ mod linux {
                 tv_sec: 0,
                 tv_usec: 0,
             };
-            unsafe {
+            let ret = unsafe {
                 libc::setsockopt(
                     fd,
                     libc::SOL_SOCKET,
                     libc::SO_SNDTIMEO,
                     &zero_timeout as *const _ as *const libc::c_void,
                     std::mem::size_of::<libc::timeval>() as u32,
+                )
+            };
+            if ret < 0 {
+                eprintln!(
+                    "warning: failed to clear SO_SNDTIMEO: {}",
+                    io::Error::last_os_error()
                 );
             }
 

--- a/fuse-pipe/src/transport/vsock.rs
+++ b/fuse-pipe/src/transport/vsock.rs
@@ -107,6 +107,21 @@ mod linux {
                 return Err(err);
             }
 
+            // Clear send timeout now that connect succeeded — don't constrain normal sends.
+            let zero_timeout = libc::timeval {
+                tv_sec: 0,
+                tv_usec: 0,
+            };
+            unsafe {
+                libc::setsockopt(
+                    fd,
+                    libc::SOL_SOCKET,
+                    libc::SO_SNDTIMEO,
+                    &zero_timeout as *const _ as *const libc::c_void,
+                    std::mem::size_of::<libc::timeval>() as u32,
+                );
+            }
+
             // Wrap fd in UnixStream for Read/Write impls
             let stream = unsafe { UnixStream::from_raw_fd(fd) };
 

--- a/fuse-pipe/src/transport/vsock.rs
+++ b/fuse-pipe/src/transport/vsock.rs
@@ -122,8 +122,8 @@ mod linux {
                 )
             };
             if ret < 0 {
-                eprintln!(
-                    "warning: failed to clear SO_SNDTIMEO: {}",
+                tracing::warn!(
+                    "failed to clear SO_SNDTIMEO: {}",
                     io::Error::last_os_error()
                 );
             }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -138,6 +138,12 @@ pub struct RunArgs {
     #[arg(long, action = clap::ArgAction::Append, value_delimiter=',')]
     pub map: Vec<String>,
 
+    /// Use portable inode numbering for FUSE volumes.
+    /// Enables deterministic inodes based on file paths instead of host inodes,
+    /// allowing snapshots with volumes to be restored on different machines.
+    #[arg(long)]
+    pub portable_volumes: bool,
+
     /// Extra disk(s): HOST_PATH:GUEST_MOUNT[:ro] (repeat or comma-separated)
     /// Disks appear as /dev/vdb, /dev/vdc, etc. in order specified.
     /// Mounted at GUEST_MOUNT in both VM and container.

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -856,12 +856,14 @@ pub async fn restore_from_snapshot(
 ///
 /// Copy a file using btrfs reflink (instant CoW copy).
 async fn reflink_copy(source: &Path, dest: &Path) -> Result<()> {
+    let source_str = source
+        .to_str()
+        .with_context(|| format!("non-UTF-8 path: {}", source.display()))?;
+    let dest_str = dest
+        .to_str()
+        .with_context(|| format!("non-UTF-8 path: {}", dest.display()))?;
     let result = tokio::process::Command::new("cp")
-        .args([
-            "--reflink=always",
-            source.to_str().unwrap(),
-            dest.to_str().unwrap(),
-        ])
+        .args(["--reflink=always", source_str, dest_str])
         .status()
         .await
         .with_context(|| format!("reflink copy {} -> {}", source.display(), dest.display()))?;

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -500,6 +500,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
     vm_state.config.volumes = args.map.clone();
     vm_state.config.health_check_url = args.health_check.clone();
     vm_state.config.hugepages = args.hugepages;
+    vm_state.config.portable_volumes = args.portable_volumes;
     vm_state.config.port_mappings = port_mappings.clone();
     vm_state.config.labels = args
         .label

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -579,6 +579,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
             guest_path: vol.guest_path.clone().into(),
             read_only: vol.read_only,
             port: VSOCK_VOLUME_PORT_BASE + idx as u32,
+            portable: args.portable_volumes,
         })
         .collect();
 

--- a/src/commands/podman/snapshot.rs
+++ b/src/commands/podman/snapshot.rs
@@ -94,6 +94,7 @@ pub async fn create_podman_snapshot(
             guest_path: v.guest_path.to_string_lossy().to_string(),
             read_only: v.read_only,
             vsock_port: v.port,
+            portable: v.portable,
         })
         .collect();
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -323,6 +323,7 @@ async fn create_sandbox(
         forward_localhost: vec![],
         user: None,
         hugepages: false,
+        portable_volumes: false,
         image,
         command_args: vec![],
     };

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -168,13 +168,12 @@ async fn cmd_snapshot_create(args: SnapshotCreateArgs) -> Result<()> {
                 .to_str()?
                 .to_string();
             // Derive drive_id from filename: "disk-dir-0.raw" → "disk0"
-            let drive_id = format!(
-                "disk{}",
-                filename
-                    .strip_prefix("disk-dir-")
-                    .and_then(|s| s.strip_suffix(".raw"))
-                    .unwrap_or("0")
-            );
+            // Falls back to "disk0" if filename doesn't match the expected pattern.
+            let index = filename
+                .strip_prefix("disk-dir-")
+                .and_then(|s| s.strip_suffix(".raw"))
+                .unwrap_or("0");
+            let drive_id = format!("disk{}", index);
             Some(SnapshotExtraDisk {
                 filename,
                 mount_path: disk.mount_path.clone(),

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -134,7 +134,7 @@ async fn cmd_snapshot_create(args: SnapshotCreateArgs) -> Result<()> {
                     guest_path: parts[1].to_string(),
                     read_only: parts.get(2).map(|s| *s == "ro").unwrap_or(false),
                     vsock_port: VSOCK_VOLUME_PORT_BASE + idx as u32,
-                    portable: false,
+                    portable: vm_state.config.portable_volumes,
                 })
             } else {
                 warn!("Invalid volume spec in VM state: {}", spec);

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -134,6 +134,7 @@ async fn cmd_snapshot_create(args: SnapshotCreateArgs) -> Result<()> {
                     guest_path: parts[1].to_string(),
                     read_only: parts.get(2).map(|s| *s == "ro").unwrap_or(false),
                     vsock_port: VSOCK_VOLUME_PORT_BASE + idx as u32,
+                    portable: false,
                 })
             } else {
                 warn!("Invalid volume spec in VM state: {}", spec);
@@ -619,6 +620,7 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
             guest_path: vol.guest_path.clone().into(),
             read_only: vol.read_only,
             port: vol.vsock_port,
+            portable: vol.portable,
         })
         .collect();
 

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -126,6 +126,9 @@ pub struct VmConfig {
     /// Whether VM uses 2MB hugepage-backed memory
     #[serde(default)]
     pub hugepages: bool,
+    /// Whether FUSE volumes use portable inode numbering (RemapFs)
+    #[serde(default)]
+    pub portable_volumes: bool,
 }
 
 impl VmState {
@@ -158,6 +161,7 @@ impl VmState {
                 port_mappings: Vec::new(),
                 labels: HashMap::new(),
                 hugepages: false,
+                portable_volumes: false,
             },
         }
     }

--- a/src/storage/snapshot.rs
+++ b/src/storage/snapshot.rs
@@ -95,6 +95,9 @@ pub struct SnapshotVolumeConfig {
     pub read_only: bool,
     /// Vsock port number
     pub vsock_port: u32,
+    /// Use portable inode numbering
+    #[serde(default)]
+    pub portable: bool,
 }
 
 /// Manages VM snapshots

--- a/src/volume/mod.rs
+++ b/src/volume/mod.rs
@@ -46,6 +46,8 @@ pub struct VolumeConfig {
     pub read_only: bool,
     /// Vsock port number
     pub port: u32,
+    /// Use portable inode numbering (RemapFs wrapper)
+    pub portable: bool,
 }
 
 /// Volume server that serves host directories to guests.
@@ -107,18 +109,30 @@ impl VolumeServer {
         // Note: read_only enforcement is handled at the PassthroughFs level
         // TODO: Add read_only support to PassthroughFs if needed
 
-        // Create and run the async server
-        let server = fuse_pipe::AsyncServer::new(fs);
-        server
-            .serve_vsock_forwarded_with_ready_signal(&base_path, self.config.port, ready)
-            .await
-            .with_context(|| {
-                format!(
-                    "VolumeServer failed for port {} serving {}",
-                    self.config.port,
-                    self.host_path.display()
-                )
-            })
+        let serve_err = || {
+            format!(
+                "VolumeServer failed for port {} serving {}",
+                self.config.port,
+                self.host_path.display()
+            )
+        };
+
+        if self.config.portable {
+            // Wrap in RemapFs for deterministic inode numbering
+            info!("using portable inode remapping (RemapFs)");
+            let remap = fuse_pipe::RemapFs::new(fs);
+            let server = fuse_pipe::AsyncServer::new(remap);
+            server
+                .serve_vsock_forwarded_with_ready_signal(&base_path, self.config.port, ready)
+                .await
+                .with_context(serve_err)
+        } else {
+            let server = fuse_pipe::AsyncServer::new(fs);
+            server
+                .serve_vsock_forwarded_with_ready_signal(&base_path, self.config.port, ready)
+                .await
+                .with_context(serve_err)
+        }
     }
 
     /// Serve volumes over a Unix socket (for testing/development).

--- a/tests/test_health_monitor.rs
+++ b/tests/test_health_monitor.rs
@@ -80,6 +80,7 @@ async fn test_health_monitor_behaviors() {
             port_mappings: vec![],
             labels: std::collections::HashMap::new(),
             hugepages: false,
+            portable_volumes: false,
         },
     };
 

--- a/tests/test_library_api.rs
+++ b/tests/test_library_api.rs
@@ -44,6 +44,7 @@ fn test_run_args(name: &str) -> RunArgs {
         user: None,
         forward_localhost: vec![],
         hugepages: false,
+        portable_volumes: false,
         no_direct_image_mount: false,
         label: vec![],
         image: common::TEST_IMAGE.to_string(),

--- a/tests/test_portable_volumes.rs
+++ b/tests/test_portable_volumes.rs
@@ -1,0 +1,413 @@
+//! Integration tests for --portable-volumes (RemapFs)
+//!
+//! Tests the full stack: --portable-volumes flag → RemapFs wrapping PassthroughFs
+//! → VolumeServer → vsock → guest FUSE mount.
+//!
+//! Run with: make test-root FILTER=portable_volumes STREAM=1
+
+#![cfg(feature = "integration-slow")]
+
+mod common;
+
+use anyhow::{Context, Result};
+use std::time::Duration;
+
+/// Read a file from the container's FUSE mount, retrying until success or timeout.
+async fn fuse_read(pid: u32, path: &str, timeout_secs: u64) -> Result<String> {
+    let attempts = (timeout_secs * 5) as usize; // 200ms intervals
+    let mut last_err = None;
+    for _ in 0..attempts {
+        match common::exec_in_container(pid, &[&format!("cat {}", path)]).await {
+            Ok(output) => return Ok(output),
+            Err(e) => last_err = Some(format!("{}", e)),
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    anyhow::bail!(
+        "fuse_read {} failed after {}s: {}",
+        path,
+        timeout_secs,
+        last_err.unwrap_or_default()
+    )
+}
+
+/// Get the inode number of a file inside the container via stat.
+async fn get_inode(pid: u32, path: &str, timeout_secs: u64) -> Result<u64> {
+    let attempts = (timeout_secs * 5) as usize;
+    let mut last_err = None;
+    for _ in 0..attempts {
+        match common::exec_in_container(pid, &[&format!("stat -c %i {}", path)]).await {
+            Ok(output) => {
+                let trimmed = output.trim();
+                if let Ok(ino) = trimmed.parse::<u64>() {
+                    return Ok(ino);
+                }
+                last_err = Some(format!("parse error: '{}'", trimmed));
+            }
+            Err(e) => last_err = Some(format!("{}", e)),
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    anyhow::bail!(
+        "get_inode {} failed after {}s: {}",
+        path,
+        timeout_secs,
+        last_err.unwrap_or_default()
+    )
+}
+
+/// Start a VM with --portable-volumes and a FUSE mount.
+async fn start_portable_vm(
+    vm_name: &str,
+    host_dir: &str,
+    guest_path: &str,
+    read_only: bool,
+) -> Result<(tokio::process::Child, u32)> {
+    let map_arg = if read_only {
+        format!("{}:{}:ro", host_dir, guest_path)
+    } else {
+        format!("{}:{}", host_dir, guest_path)
+    };
+
+    common::spawn_fcvm_with_logs(
+        &[
+            "podman",
+            "run",
+            "--name",
+            vm_name,
+            "--network",
+            "rootless",
+            "--portable-volumes",
+            "--map",
+            &map_arg,
+            common::TEST_IMAGE,
+        ],
+        vm_name,
+    )
+    .await
+    .context("spawning portable-volumes VM")
+}
+
+// =============================================================================
+// Test 13: stat() returns deterministic inodes with --portable-volumes
+// =============================================================================
+
+/// Mount with RemapFs via --portable-volumes, stat() same files multiple times.
+/// Inodes must be stable (hash-based) and consistent across calls.
+#[tokio::test]
+async fn test_remap_fs_stat_deterministic() -> Result<()> {
+    let (vm_name, _, _, _) = common::unique_names("pv-stat");
+    let host_dir = format!("/tmp/fcvm-pv-stat-{}", std::process::id());
+    tokio::fs::create_dir_all(&host_dir).await?;
+
+    println!("=== test_remap_fs_stat_deterministic ===");
+
+    // Create test files on host
+    tokio::fs::write(format!("{}/file-a.txt", host_dir), "content-a").await?;
+    tokio::fs::write(format!("{}/file-b.txt", host_dir), "content-b").await?;
+    tokio::fs::create_dir_all(format!("{}/subdir", host_dir)).await?;
+    tokio::fs::write(format!("{}/subdir/nested.txt", host_dir), "nested").await?;
+
+    let (_child, pid) = start_portable_vm(&vm_name, &host_dir, "/mnt/test", true).await?;
+    common::poll_health_by_pid(pid, 180).await?;
+    println!("  VM healthy (PID: {})", pid);
+
+    // Stat each file 3 times — inode must be identical every time
+    for file in &[
+        "/mnt/test/file-a.txt",
+        "/mnt/test/file-b.txt",
+        "/mnt/test/subdir/nested.txt",
+        "/mnt/test/subdir",
+    ] {
+        let ino1 = get_inode(pid, file, 30).await?;
+        let ino2 = get_inode(pid, file, 5).await?;
+        let ino3 = get_inode(pid, file, 5).await?;
+
+        assert_eq!(
+            ino1, ino2,
+            "inode for {} changed between stat calls: {} vs {}",
+            file, ino1, ino2
+        );
+        assert_eq!(
+            ino2, ino3,
+            "inode for {} changed between stat calls: {} vs {}",
+            file, ino2, ino3
+        );
+
+        // RemapFs inodes are hash-based, must not be 0 or 1
+        assert!(ino1 >= 2, "inode for {} is reserved value: {}", file, ino1);
+
+        println!("  {} → inode {} (stable across 3 calls)", file, ino1);
+    }
+
+    // Different files must have different inodes
+    let ino_a = get_inode(pid, "/mnt/test/file-a.txt", 5).await?;
+    let ino_b = get_inode(pid, "/mnt/test/file-b.txt", 5).await?;
+    assert_ne!(
+        ino_a, ino_b,
+        "different files should have different inodes: {} vs {}",
+        ino_a, ino_b
+    );
+    println!(
+        "  file-a and file-b have different inodes ({} vs {})",
+        ino_a, ino_b
+    );
+
+    // Root mount point should have inode 1 (FUSE convention)
+    let ino_root = get_inode(pid, "/mnt/test", 5).await?;
+    assert_eq!(
+        ino_root, 1,
+        "mount root should have inode 1, got {}",
+        ino_root
+    );
+    println!("  mount root → inode {} (correct)", ino_root);
+
+    // Cleanup
+    common::kill_process(pid).await;
+    tokio::fs::remove_dir_all(&host_dir).await.ok();
+
+    println!("PASSED: test_remap_fs_stat_deterministic");
+    Ok(())
+}
+
+// =============================================================================
+// Test 14: Snapshot/clone preserves inodes with --portable-volumes
+// =============================================================================
+
+/// Baseline with RemapFs → snapshot → clone → same inodes on clone.
+/// This is the core portability guarantee: clone sees the same inodes as baseline.
+#[tokio::test]
+async fn test_remap_fs_snapshot_clone() -> Result<()> {
+    let (vm_name, clone_name, snap_name, _) = common::unique_names("pv-clone");
+    let host_dir = format!("/tmp/fcvm-pv-clone-{}", std::process::id());
+    tokio::fs::create_dir_all(&host_dir).await?;
+
+    println!("=== test_remap_fs_snapshot_clone ===");
+
+    // Create test files
+    tokio::fs::write(format!("{}/alpha.txt", host_dir), "alpha-content").await?;
+    tokio::fs::write(format!("{}/beta.txt", host_dir), "beta-content").await?;
+
+    // Start baseline with --portable-volumes
+    let (_child, pid) = start_portable_vm(&vm_name, &host_dir, "/mnt/test", true).await?;
+    common::poll_health_by_pid(pid, 180).await?;
+    println!("  Baseline healthy (PID: {})", pid);
+
+    // Get inodes on baseline
+    let baseline_ino_alpha = get_inode(pid, "/mnt/test/alpha.txt", 30).await?;
+    let baseline_ino_beta = get_inode(pid, "/mnt/test/beta.txt", 30).await?;
+    let baseline_ino_root = get_inode(pid, "/mnt/test", 5).await?;
+    println!(
+        "  Baseline inodes: root={}, alpha={}, beta={}",
+        baseline_ino_root, baseline_ino_alpha, baseline_ino_beta
+    );
+
+    // Snapshot
+    common::create_snapshot_by_pid(pid, &snap_name).await?;
+    println!("  Snapshot created");
+
+    // Start clone
+    let (_serve, serve_pid) = common::start_memory_server(&snap_name).await?;
+    let (_clone, clone_pid) = common::spawn_clone(serve_pid, &clone_name, "rootless").await?;
+    common::poll_health_by_pid(clone_pid, 180).await?;
+    println!("  Clone healthy (PID: {})", clone_pid);
+
+    // Get inodes on clone — they must match baseline
+    let clone_ino_alpha = get_inode(clone_pid, "/mnt/test/alpha.txt", 30).await?;
+    let clone_ino_beta = get_inode(clone_pid, "/mnt/test/beta.txt", 30).await?;
+    let clone_ino_root = get_inode(clone_pid, "/mnt/test", 5).await?;
+    println!(
+        "  Clone inodes: root={}, alpha={}, beta={}",
+        clone_ino_root, clone_ino_alpha, clone_ino_beta
+    );
+
+    assert_eq!(
+        baseline_ino_root, clone_ino_root,
+        "root inode mismatch: baseline={} clone={}",
+        baseline_ino_root, clone_ino_root
+    );
+    assert_eq!(
+        baseline_ino_alpha, clone_ino_alpha,
+        "alpha.txt inode mismatch: baseline={} clone={}",
+        baseline_ino_alpha, clone_ino_alpha
+    );
+    assert_eq!(
+        baseline_ino_beta, clone_ino_beta,
+        "beta.txt inode mismatch: baseline={} clone={}",
+        baseline_ino_beta, clone_ino_beta
+    );
+    println!("  All inodes match between baseline and clone!");
+
+    // Cleanup
+    common::kill_process(clone_pid).await;
+    common::kill_process(serve_pid).await;
+    common::kill_process(pid).await;
+    tokio::fs::remove_dir_all(&host_dir).await.ok();
+
+    println!("PASSED: test_remap_fs_snapshot_clone");
+    Ok(())
+}
+
+// =============================================================================
+// Test 15: Host file modifications visible through RemapFs
+// =============================================================================
+
+/// Modify file on host, guest sees updated content through portable FUSE mount.
+/// Verifies RemapFs doesn't break data transparency.
+#[tokio::test]
+async fn test_remap_fs_host_file_changes() -> Result<()> {
+    let (vm_name, _, _, _) = common::unique_names("pv-host-mod");
+    let host_dir = format!("/tmp/fcvm-pv-host-mod-{}", std::process::id());
+    tokio::fs::create_dir_all(&host_dir).await?;
+
+    println!("=== test_remap_fs_host_file_changes ===");
+
+    // Create initial file
+    tokio::fs::write(format!("{}/data.txt", host_dir), "version-1").await?;
+
+    let (_child, pid) = start_portable_vm(&vm_name, &host_dir, "/mnt/test", true).await?;
+    common::poll_health_by_pid(pid, 180).await?;
+    println!("  VM healthy");
+
+    // Read initial content
+    let content = fuse_read(pid, "/mnt/test/data.txt", 30).await?;
+    assert!(
+        content.contains("version-1"),
+        "initial read failed: got '{}'",
+        content.trim()
+    );
+    let ino_before = get_inode(pid, "/mnt/test/data.txt", 5).await?;
+    println!("  Initial read: '{}', inode={}", content.trim(), ino_before);
+
+    // Modify on host
+    tokio::fs::write(format!("{}/data.txt", host_dir), "version-2").await?;
+    println!("  Host file modified to version-2");
+
+    // Guest should see the update (may need to wait for cache expiry)
+    let mut saw_update = false;
+    for _ in 0..50 {
+        // 10s at 200ms intervals
+        if let Ok(content) = fuse_read(pid, "/mnt/test/data.txt", 2).await {
+            if content.contains("version-2") {
+                saw_update = true;
+                println!("  Guest sees updated content: '{}'", content.trim());
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    assert!(saw_update, "guest never saw updated content 'version-2'");
+
+    // Inode should remain the same after content change (same path = same hash)
+    let ino_after = get_inode(pid, "/mnt/test/data.txt", 5).await?;
+    assert_eq!(
+        ino_before, ino_after,
+        "inode changed after content update: {} vs {}",
+        ino_before, ino_after
+    );
+    println!("  Inode stable through content update: {}", ino_after);
+
+    // Add new file on host
+    tokio::fs::write(format!("{}/new-file.txt", host_dir), "new-content").await?;
+    let content = fuse_read(pid, "/mnt/test/new-file.txt", 10).await?;
+    assert!(
+        content.contains("new-content"),
+        "new file read failed: got '{}'",
+        content.trim()
+    );
+    println!("  New host file visible in guest: '{}'", content.trim());
+
+    // Cleanup
+    common::kill_process(pid).await;
+    tokio::fs::remove_dir_all(&host_dir).await.ok();
+
+    println!("PASSED: test_remap_fs_host_file_changes");
+    Ok(())
+}
+
+// =============================================================================
+// Test 16: Host-side rename detected via readdir
+// =============================================================================
+
+/// Rename file on host, guest readdir sees the new name.
+/// Verifies RemapFs's path staleness detection works end-to-end.
+#[tokio::test]
+async fn test_remap_fs_host_rename_then_readdir() -> Result<()> {
+    let (vm_name, _, _, _) = common::unique_names("pv-rename");
+    let host_dir = format!("/tmp/fcvm-pv-rename-{}", std::process::id());
+    tokio::fs::create_dir_all(&host_dir).await?;
+
+    println!("=== test_remap_fs_host_rename_then_readdir ===");
+
+    // Create initial files
+    tokio::fs::write(format!("{}/original.txt", host_dir), "rename-test").await?;
+    tokio::fs::write(format!("{}/stable.txt", host_dir), "not-renamed").await?;
+
+    let (_child, pid) = start_portable_vm(&vm_name, &host_dir, "/mnt/test", true).await?;
+    common::poll_health_by_pid(pid, 180).await?;
+    println!("  VM healthy");
+
+    // Read original file and get its inode
+    let content = fuse_read(pid, "/mnt/test/original.txt", 30).await?;
+    assert!(content.contains("rename-test"));
+    let ino_original = get_inode(pid, "/mnt/test/original.txt", 5).await?;
+    println!("  original.txt: inode={}", ino_original);
+
+    // Get inode for stable.txt (should not change)
+    let ino_stable = get_inode(pid, "/mnt/test/stable.txt", 5).await?;
+    println!("  stable.txt: inode={}", ino_stable);
+
+    // Rename on host
+    tokio::fs::rename(
+        format!("{}/original.txt", host_dir),
+        format!("{}/renamed.txt", host_dir),
+    )
+    .await?;
+    println!("  Host: renamed original.txt → renamed.txt");
+
+    // Guest readdir should eventually show the new name
+    let mut saw_renamed = false;
+    for _ in 0..50 {
+        // 10s at 200ms intervals
+        if let Ok(output) = common::exec_in_container(pid, &["ls /mnt/test/"]).await {
+            if output.contains("renamed.txt") && !output.contains("original.txt") {
+                saw_renamed = true;
+                println!(
+                    "  Guest readdir shows: {}",
+                    output.trim().replace('\n', ", ")
+                );
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    assert!(
+        saw_renamed,
+        "guest readdir never showed renamed.txt (host-side rename not detected)"
+    );
+
+    // The renamed file should be readable with the same content
+    let content = fuse_read(pid, "/mnt/test/renamed.txt", 10).await?;
+    assert!(
+        content.contains("rename-test"),
+        "renamed file content wrong: got '{}'",
+        content.trim()
+    );
+    println!("  renamed.txt readable with correct content");
+
+    // stable.txt should still have the same inode
+    let ino_stable_after = get_inode(pid, "/mnt/test/stable.txt", 5).await?;
+    assert_eq!(
+        ino_stable, ino_stable_after,
+        "stable.txt inode changed: {} vs {}",
+        ino_stable, ino_stable_after
+    );
+    println!("  stable.txt inode unchanged: {}", ino_stable_after);
+
+    // Cleanup
+    common::kill_process(pid).await;
+    tokio::fs::remove_dir_all(&host_dir).await.ok();
+
+    println!("PASSED: test_remap_fs_host_rename_then_readdir");
+    Ok(())
+}

--- a/tests/test_portable_volumes.rs
+++ b/tests/test_portable_volumes.rs
@@ -447,3 +447,143 @@ async fn test_remap_fs_host_rename_then_readdir() -> Result<()> {
     println!("PASSED: test_remap_fs_host_rename_then_readdir");
     Ok(())
 }
+
+// =============================================================================
+// Test 17: Persistent reader survives snapshot, sees host file replacement
+// =============================================================================
+
+/// Mount a directory, start a background reader that logs file contents in a loop,
+/// snapshot the VM, replace files on host, start clone from snapshot, verify the
+/// clone's reader process sees the new content.
+///
+/// This proves:
+/// - FUSE mount survives snapshot/restore on clones
+/// - RemapFs works across snapshot/clone boundary
+/// - Host-side file replacement is visible to clone
+/// - Open file operations continue working after restore
+#[tokio::test]
+async fn test_remap_fs_snapshot_file_replace() -> Result<()> {
+    let (vm_name, clone_name, snap_name, _) = common::unique_names("pv-replace");
+    let host_dir = format!("/tmp/fcvm-pv-replace-{}", std::process::id());
+    tokio::fs::create_dir_all(&host_dir).await?;
+
+    println!("=== test_remap_fs_snapshot_file_replace ===");
+
+    // Create initial file
+    tokio::fs::write(format!("{}/data.txt", host_dir), "original-v1").await?;
+
+    // Start VM with portable volumes
+    let (_child, pid) = start_portable_vm(&vm_name, &host_dir, "/mnt/test", true).await?;
+    common::poll_health_by_pid(pid, 180).await?;
+    println!("  VM healthy (PID: {})", pid);
+
+    // Verify initial content is readable
+    let content = fuse_read(pid, "/mnt/test/data.txt", 30).await?;
+    assert!(
+        content.contains("original-v1"),
+        "initial read failed: {}",
+        content.trim()
+    );
+    println!("  Initial read: '{}'", content.trim());
+
+    // Start a persistent reader inside the container that reads the file every 0.5s
+    // and appends each read to a log file. This process will be captured in the snapshot
+    // and resume on the clone.
+    common::exec_in_container(
+        pid,
+        &["sh -c 'while true; do echo \"$(cat /mnt/test/data.txt 2>&1)\" >> /tmp/reader.log; sleep 0.5; done &'"],
+    )
+    .await?;
+    println!("  Background reader started");
+
+    // Wait for reader to accumulate a few entries
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Verify reader is logging original content
+    let log = common::exec_in_container(pid, &["cat /tmp/reader.log"]).await?;
+    assert!(
+        log.contains("original-v1"),
+        "reader not logging original content: {}",
+        log
+    );
+    let pre_snap_lines = log.lines().count();
+    println!(
+        "  Reader confirmed logging original content ({} lines)",
+        pre_snap_lines
+    );
+
+    // Snapshot the VM (reader is still running inside)
+    common::create_snapshot_by_pid(pid, &snap_name).await?;
+    println!("  Snapshot created (reader process captured in snapshot)");
+
+    // Replace file on host with new content
+    tokio::fs::write(format!("{}/data.txt", host_dir), "replaced-v2").await?;
+    println!("  Host file replaced: 'original-v1' → 'replaced-v2'");
+
+    // Start clone from snapshot — the reader process resumes automatically
+    let (_serve, serve_pid) = common::start_memory_server(&snap_name).await?;
+    let (_clone, clone_pid) = common::spawn_clone(serve_pid, &clone_name, "rootless").await?;
+    common::poll_health_by_pid(clone_pid, 180).await?;
+    println!("  Clone healthy (PID: {})", clone_pid);
+
+    // Wait for clone's reader to run several iterations with the new content
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    // Read the clone's log file — it should have pre-snapshot entries (original-v1)
+    // from before the snapshot, plus post-snapshot entries (replaced-v2) from after
+    // the reader resumed on the clone and saw the new host content.
+    let clone_log = common::exec_in_container(clone_pid, &["cat /tmp/reader.log"]).await?;
+    let total_lines = clone_log.lines().count();
+    println!("  Clone reader log ({} lines):", total_lines);
+    for line in clone_log
+        .lines()
+        .rev()
+        .take(5)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+    {
+        println!("    {}", line);
+    }
+
+    // Log must contain both original and replaced content, proving the reader
+    // saw the transition across snapshot/restore + host file replacement.
+    assert!(
+        clone_log.contains("original-v1"),
+        "clone log missing pre-snapshot content 'original-v1'"
+    );
+    assert!(
+        clone_log.contains("replaced-v2"),
+        "clone reader never saw replaced content 'replaced-v2' — FUSE mount may not have \
+         reconnected after snapshot restore. Log:\n{}",
+        clone_log
+    );
+    assert!(
+        total_lines > pre_snap_lines,
+        "clone log has {} lines (same as pre-snapshot {}) — reader didn't resume",
+        total_lines,
+        pre_snap_lines
+    );
+    println!(
+        "  Clone reader log proves transition: original-v1 → replaced-v2 ({} → {} lines)",
+        pre_snap_lines, total_lines
+    );
+
+    // Also verify a direct read confirms the new content
+    let direct = fuse_read(clone_pid, "/mnt/test/data.txt", 10).await?;
+    assert!(
+        direct.contains("replaced-v2"),
+        "clone direct read got '{}', expected 'replaced-v2'",
+        direct.trim()
+    );
+    println!("  Direct read confirms: '{}'", direct.trim());
+
+    // Cleanup
+    common::kill_process(clone_pid).await;
+    common::kill_process(serve_pid).await;
+    common::kill_process(pid).await;
+    tokio::fs::remove_dir_all(&host_dir).await.ok();
+
+    println!("PASSED: test_remap_fs_snapshot_file_replace");
+    Ok(())
+}

--- a/tests/test_portable_volumes.rs
+++ b/tests/test_portable_volumes.rs
@@ -162,6 +162,23 @@ async fn test_remap_fs_stat_deterministic() -> Result<()> {
     );
     println!("  mount root → inode {} (correct)", ino_root);
 
+    // Verify FUSE inodes differ from host inodes (proves RemapFs is active)
+    let host_ino_a = std::fs::metadata(format!("{}/file-a.txt", host_dir))
+        .map(|m| {
+            use std::os::unix::fs::MetadataExt;
+            m.ino()
+        })
+        .unwrap_or(0);
+    assert_ne!(
+        ino_a, host_ino_a,
+        "FUSE inode matches host inode {} — RemapFs not active",
+        host_ino_a
+    );
+    println!(
+        "  FUSE inode {} differs from host inode {} (RemapFs active)",
+        ino_a, host_ino_a
+    );
+
     // Cleanup
     common::kill_process(pid).await;
     tokio::fs::remove_dir_all(&host_dir).await.ok();
@@ -237,6 +254,25 @@ async fn test_remap_fs_snapshot_clone() -> Result<()> {
         baseline_ino_beta, clone_ino_beta
     );
     println!("  All inodes match between baseline and clone!");
+
+    // Verify inodes are NOT host inodes (proves RemapFs is active, not PassthroughFs).
+    // If --portable-volumes wasn't propagated to the clone, it would use PassthroughFs
+    // which returns host inodes — these would differ from the baseline's hash-based inodes.
+    let host_ino = std::fs::metadata(format!("{}/alpha.txt", host_dir))
+        .map(|m| {
+            use std::os::unix::fs::MetadataExt;
+            m.ino()
+        })
+        .unwrap_or(0);
+    assert_ne!(
+        clone_ino_alpha, host_ino,
+        "clone inode matches host inode {} — RemapFs not active on clone (portable flag lost in snapshot?)",
+        host_ino
+    );
+    println!(
+        "  Clone inode {} differs from host inode {} (RemapFs confirmed active)",
+        clone_ino_alpha, host_ino
+    );
 
     // Cleanup
     common::kill_process(clone_pid).await;

--- a/tests/test_state_manager.rs
+++ b/tests/test_state_manager.rs
@@ -53,6 +53,7 @@ async fn test_state_persistence() {
             port_mappings: vec![],
             labels: std::collections::HashMap::new(),
             hugepages: false,
+            portable_volumes: false,
         },
     };
 
@@ -122,6 +123,7 @@ async fn test_list_vms() {
                 port_mappings: vec![],
                 labels: std::collections::HashMap::new(),
                 hugepages: false,
+                portable_volumes: false,
             },
         };
         manager.save_state(&state).await.unwrap();


### PR DESCRIPTION
**Stacked on:** fuse-clone-fixes (PR #342, merged)

## Summary

Adds `--portable-volumes` flag that wraps FUSE PassthroughFs in a RemapFs layer, translating host-specific inodes to stable path-hash inodes. This enables shipping snapshots to another machine and restoring with the same FUSE inode numbering.

- **RemapFs** (`fuse-pipe/src/server/remap.rs`, 1445 lines): Generic `FilesystemHandler` wrapper using FNV-1a path hashing, bidirectional inode mapping via DashMap, hard link correctness, path staleness detection for host-side renames, guest-side rename handling with descendant path updates, and JSON serialize/restore for snapshot metadata. 21 unit tests.
- **CLI flag**: `--portable-volumes` on RunArgs, threaded through VolumeConfig → SnapshotVolumeConfig → clone restore. VolumeServer conditionally wraps PassthroughFs in RemapFs when enabled.
- **Portable flag propagation fix**: `portable_volumes` field added to VmConfig (persisted in state JSON), read from vm_state during snapshot create instead of being hardcoded to false.
- **TOCTOU fix in register_entry**: Uses `DashMap::entry()` for atomic check-and-insert since the pipelined server dispatches requests concurrently via `spawn_blocking`.
- **Review fixes**: Exact mountinfo path matching in `is_fuse_mounted()`, proper error handling in `reflink_copy()` (no unwraps), SO_SNDTIMEO cleared after vsock connect with warning on failure, clearer drive_id derivation.

## Test Plan

- [x] 21 unit tests in `remap.rs` (remapping, hard links, renames, hash collisions, serialization roundtrip)
- [x] `test_remap_fs_stat_deterministic` — stable hash-based inodes, root=1, deterministic across calls
- [x] `test_remap_fs_snapshot_clone` — baseline → snapshot → clone, all inodes match (core portability guarantee), asserts FUSE inodes differ from host inodes
- [x] `test_remap_fs_host_file_changes` — host-side file modify/add visible through portable FUSE mount
- [x] `test_remap_fs_host_rename_then_readdir` — host rename detected via guest readdir
- [x] `test_remap_fs_snapshot_file_replace` — persistent reader survives snapshot/restore, sees replaced content on clone
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes