### PR TITLE
Fix pull_image to use rootless podman prefix in --user mode

### DIFF
--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -176,8 +176,18 @@ pub async fn pull_image(plan: &Plan) -> Result<String> {
             plan.image, attempt, MAX_RETRIES
         );
 
-        let mut cmd = Command::new("podman");
-        cmd.arg("pull").arg(&plan.image);
+        let prefix = podman_cmd_prefix();
+        let mut cmd = if prefix.is_empty() {
+            let mut c = Command::new("podman");
+            c.arg("pull");
+            c
+        } else {
+            let mut c = Command::new(&prefix[0]);
+            c.args(&prefix[1..]);
+            c.arg("podman").arg("pull");
+            c
+        };
+        cmd.arg(&plan.image);
         if let Some(ref proxy) = plan.http_proxy {
             cmd.env("http_proxy", proxy).env("HTTP_PROXY", proxy);
         }

--- a/tests/test_user_mode_pull.rs
+++ b/tests/test_user_mode_pull.rs
@@ -1,0 +1,96 @@
+//! Test that --user mode pulls registry images into rootless storage.
+//!
+//! Registry images (non-localhost/) are always pulled inside the VM via `podman pull`.
+//! With --user, this must run as the target user so the image ends up in rootless
+//! podman storage. (localhost/ images go through host-side export/archive instead.)
+
+#![cfg(feature = "integration-fast")]
+
+mod common;
+
+use anyhow::{Context, Result};
+
+/// Test that --user pulls registry images into rootless storage (not root's).
+/// This verifies pull_image() uses the rootless podman prefix.
+#[tokio::test]
+async fn test_user_mode_pull_image_into_rootless_storage() -> Result<()> {
+    println!("\nUser mode test: registry image pulled into rootless storage");
+    println!("===========================================================");
+
+    let (vm_name, _, _, _) = common::unique_names("user-pull");
+    let uid = 1000;
+    let gid = 1000;
+    let username = nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))
+        .ok()
+        .flatten()
+        .map(|u| u.name)
+        .unwrap_or_else(|| format!("u{}", uid));
+
+    println!(
+        "  Starting VM with --user {}:{} (username={})...",
+        uid, gid, username
+    );
+    let (mut _child, fcvm_pid) = common::spawn_fcvm(&[
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--network",
+        "rootless",
+        "--user",
+        &format!("{}:{}", uid, gid),
+        common::ALPINE_IMAGE,
+        "sleep",
+        "120",
+    ])
+    .await
+    .context("spawning fcvm with --user")?;
+
+    println!("  fcvm PID: {}", fcvm_pid);
+    println!("  Waiting for VM to become healthy...");
+
+    common::poll_health_by_pid(fcvm_pid, 300).await?;
+    println!("  VM is healthy");
+
+    // Verify the image was pulled into rootless storage (not root's storage)
+    println!("  Checking image is in rootless storage...");
+    let images_output = common::exec_in_vm(
+        fcvm_pid,
+        &[
+            "runuser",
+            "-u",
+            &username,
+            "--",
+            "podman",
+            "images",
+            "--format",
+            "{{.Repository}}:{{.Tag}}",
+        ],
+    )
+    .await?;
+    println!("  Rootless images: {}", images_output.trim());
+    assert!(
+        images_output.contains("alpine"),
+        "Alpine image should be in rootless storage, got: {}",
+        images_output.trim()
+    );
+
+    // Verify root's storage does NOT have the image (it should be rootless-only)
+    let root_images = common::exec_in_vm(
+        fcvm_pid,
+        &["podman", "images", "--format", "{{.Repository}}:{{.Tag}}"],
+    )
+    .await?;
+    println!("  Root images: {}", root_images.trim());
+    assert!(
+        !root_images.contains("alpine"),
+        "Alpine image should NOT be in root's storage, got: {}",
+        root_images.trim()
+    );
+
+    println!("  Stopping VM...");
+    common::kill_process(fcvm_pid).await;
+
+    println!("  PASSED!");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

`pull_image()` in fc-agent ran `podman pull` directly as root. With `--user` mode, the image ended up in root's storage while the container expected it in the user's rootless storage. Now uses `podman_cmd_prefix()` like all other podman commands.

Registry images (non-`localhost/`) always go through `pull_image()` inside the VM — the host doesn't export them. This was the only podman command path missing the rootless prefix.

Identified during review of PR #344.

## What Changed

- **fc-agent/src/container.rs**: `pull_image()` now uses `podman_cmd_prefix()` to run `podman pull` as the target user when in `--user` mode.
- **tests/test_user_mode_pull.rs**: New integration test verifying the image lands in rootless storage (not root's) when using `--user`.

## Test Plan

- [x] `test_user_mode_pull_image_into_rootless_storage`: Verifies image in user's storage, NOT in root's
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean