### PR TITLE
Derive MMDS plan from FirecrackerConfig, not CLI args

### DIFF
--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -109,6 +109,11 @@ Comments may contain:
 - **CI failure analysis** - Re-run if infra issue, fix if code issue
 - **Security concerns** - Must address before merge
 
+**Fix ALL severity levels.** Low-severity findings (naming inconsistencies, minor
+code quality issues, pattern mismatches) should still be fixed before merging.
+They're quick to address and prevent technical debt from accumulating. Only skip
+a finding if you have a concrete reason to disagree with it — not because it's low severity.
+
 **CRITICAL: Never Apply Skip Conditions!**
 
 When reviewing auto-fix PRs or suggested fixes:
@@ -284,3 +289,87 @@ sudo make test-root FILTER=<test_name> STREAM=1 2>&1 | tee /tmp/test.log
 - Runners may be busy with CI jobs - check `busy=` status first
 - Don't interfere with running CI jobs on busy runners
 - Tests on runners may cause resource contention with concurrent CI runs
+
+## CI Not Starting? Check Your Branch Base
+
+If CI checks don't start automatically after pushing a PR, it likely means the PR branch
+is not based on main (or its target base branch). GitHub Actions CI triggers are configured
+to run on PRs targeting specific branches.
+
+**Common causes:**
+- Branch was created from an old commit, not from current main
+- Branch diverged significantly and GitHub can't compute the diff
+- PR targets a non-default base branch that doesn't have CI workflows
+
+**How to fix:**
+```bash
+# 1. Check what branch your PR targets
+gh pr view <pr-number> --json baseRefName
+
+# 2. Check if your branch is actually based on that branch
+git log --oneline origin/main..HEAD | tail -5   # Should show only YOUR commits
+
+# 3. If the branch is stale or incorrectly based, rebase onto main
+git fetch origin
+git rebase origin/main
+git push --force-with-lease
+
+# 4. If the PR targets wrong base, update it
+gh pr edit <pr-number> --base main
+```
+
+**Prevention:** Always create branches from current main:
+```bash
+git fetch origin
+git checkout origin/main -b my-feature
+```
+
+## Investigating CI Failures with Test Log Artifacts
+
+CI uploads test logs to `/tmp/fcvm-test-logs/` as artifacts (14 day retention). When tests fail,
+**always download and read the full logs** before drawing conclusions.
+
+### Download Artifacts
+
+```bash
+# 1. Find the run ID for the failing CI run
+gh run list --branch <branch-name> --limit 5 --json databaseId,conclusion,startedTime \
+  --jq '.[] | "\(.databaseId) \(.conclusion) \(.startedTime)"'
+
+# 2. List artifacts for that run
+gh api "repos/{owner}/{repo}/actions/runs/{run_id}/artifacts" \
+  --jq '.artifacts[] | "\(.id) \(.name) \(.size_in_bytes)"'
+
+# 3. Download a specific artifact (e.g., test-logs-host-root-arm64-SnapshotDisabled)
+gh api "repos/{owner}/{repo}/actions/runs/{run_id}/artifacts/{artifact_id}/zip" > /tmp/artifact.zip
+unzip -o /tmp/artifact.zip -d /tmp/ci-logs/
+
+# 4. Read the full debug logs
+ls /tmp/ci-logs/
+cat /tmp/ci-logs/<test-name>-*.log
+```
+
+### Quick Artifact Download Script
+
+```bash
+# Download ALL test log artifacts for a run
+RUN_ID=<run_id>
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+for artifact in $(gh api "repos/$REPO/actions/runs/$RUN_ID/artifacts" \
+  --jq '.artifacts[] | select(.name | startswith("test-logs")) | "\(.id):\(.name)"'); do
+  ID=${artifact%%:*}
+  NAME=${artifact#*:}
+  echo "Downloading $NAME..."
+  gh api "repos/$REPO/actions/runs/$RUN_ID/artifacts/$ID/zip" > "/tmp/$NAME.zip"
+  mkdir -p "/tmp/ci-logs/$NAME"
+  unzip -o "/tmp/$NAME.zip" -d "/tmp/ci-logs/$NAME"
+done
+echo "All logs in /tmp/ci-logs/"
+```
+
+### What to Look For
+
+- **Full error messages**: CI test output truncates stderr; the log files have everything
+- **Timestamps**: Compare failing vs passing test timings to identify contention
+- **Boot sequence**: fc-agent logs show exactly where startup stalled
+- **dmesg**: `dmesg-filtered.log` artifact has KVM/UFFD/OOM kernel messages

--- a/src/commands/podman/snapshot.rs
+++ b/src/commands/podman/snapshot.rs
@@ -249,6 +249,7 @@ pub(super) fn build_firecracker_config(
         args.health_check.clone(),
         args.hugepages,
         args.user.clone(),
+        args.forward_localhost.clone(),
     )
 }
 

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -467,20 +467,20 @@ pub(super) async fn attach_extra_disks(
 
 /// Build MMDS data (container plan) and send it to Firecracker.
 ///
-/// Includes volume/disk/NFS mount info, container plan, proxy config, and host time.
-#[allow(clippy::too_many_arguments)]
+/// User-input fields come from `launch_config` (part of snapshot cache key).
+/// Runtime-only values (network, proxies, timestamps) are computed here.
 pub(super) async fn build_and_send_mmds(
-    args: &RunArgs,
+    launch_config: &crate::firecracker::FirecrackerConfig,
     client: &crate::firecracker::FirecrackerClient,
     network_config: &crate::network::NetworkConfig,
     vm_state: &VmState,
     volume_mappings: &[VolumeMapping],
-    cmd_args: &Option<Vec<String>>,
     image_device: Option<String>,
+    no_direct_image_mount: bool,
 ) -> Result<()> {
     // Build volume mount info for MMDS
     // Format: { guest_path, vsock_port, read_only }
-    let volume_mounts: Vec<serde_json::Value> = volume_mappings
+    let volumes: Vec<serde_json::Value> = volume_mappings
         .iter()
         .enumerate()
         .map(|(idx, v)| {
@@ -495,7 +495,7 @@ pub(super) async fn build_and_send_mmds(
     // Build extra disk info for MMDS
     // Format: { device, mount_path, read_only }
     // Disks are added as /dev/vdb, /dev/vdc, etc.
-    let extra_disk_mounts: Vec<serde_json::Value> = vm_state
+    let extra_disks: Vec<serde_json::Value> = vm_state
         .config
         .extra_disks
         .iter()
@@ -525,48 +525,48 @@ pub(super) async fn build_and_send_mmds(
         })
         .collect();
 
-    // MMDS data (container plan) - nested under "latest" for V2 compatibility
-    // Include host timestamp so guest can set clock immediately (avoiding slow NTP sync)
-    // Format without subsecond precision for Alpine `date` compatibility
-    let mmds_data = serde_json::json!({
-        "latest": {
-            "container-plan": {
-                "image": args.image,
-                "env": args.env.iter().map(|e| {
-                    let parts: Vec<&str> = e.splitn(2, '=').collect();
-                    (parts[0], parts.get(1).copied().unwrap_or(""))
-                }).collect::<std::collections::HashMap<_, _>>(),
-                "cmd": cmd_args,
-                "volumes": volume_mounts,
-                "extra_disks": extra_disk_mounts,
-                "nfs_mounts": nfs_mounts,
-                "image_archive": if args.no_direct_image_mount { image_device.clone() } else { None::<String> },
-                "image_storage_device": if !args.no_direct_image_mount { image_device } else { None::<String> },
-                "privileged": args.privileged,
-                "user": args.user.as_deref(),
-                "forward_localhost": args.forward_localhost.iter().map(|p| p.to_string()).collect::<Vec<_>>(),
-                "interactive": args.interactive,
-                "tty": args.tty,
-                // Use network-provided proxy, or fall back to environment variables.
-                // Resolve hostname to IPv4 since slirp VMs can only reach IPv4 addresses.
-                "http_proxy": network_config.http_proxy.clone()
-                    .or_else(|| std::env::var("http_proxy").ok())
-                    .or_else(|| std::env::var("HTTP_PROXY").ok())
-                    .and_then(|url| resolve_proxy_url(&url)),
-                "https_proxy": network_config.http_proxy.clone()
-                    .or_else(|| std::env::var("https_proxy").ok())
-                    .or_else(|| std::env::var("HTTPS_PROXY").ok())
-                    .or_else(|| std::env::var("http_proxy").ok())
-                    .or_else(|| std::env::var("HTTP_PROXY").ok())
-                    .and_then(|url| resolve_proxy_url(&url)),
-                "no_proxy": std::env::var("no_proxy")
-                    .or_else(|_| std::env::var("NO_PROXY"))
-                    .ok(),
-            },
-            "host-time": chrono::Utc::now().timestamp().to_string(),
-        }
-    });
+    // Resolve proxy URLs — runtime behavior, not part of cache key.
+    // Use network-provided proxy, or fall back to environment variables.
+    // Resolve hostname to IPv4 since slirp VMs can only reach IPv4 addresses.
+    let http_proxy = network_config
+        .http_proxy
+        .clone()
+        .or_else(|| std::env::var("http_proxy").ok())
+        .or_else(|| std::env::var("HTTP_PROXY").ok())
+        .and_then(|url| resolve_proxy_url(&url));
+    let https_proxy = network_config
+        .http_proxy
+        .clone()
+        .or_else(|| std::env::var("https_proxy").ok())
+        .or_else(|| std::env::var("HTTPS_PROXY").ok())
+        .or_else(|| std::env::var("http_proxy").ok())
+        .or_else(|| std::env::var("HTTP_PROXY").ok())
+        .and_then(|url| resolve_proxy_url(&url));
+    let no_proxy = std::env::var("no_proxy")
+        .or_else(|_| std::env::var("NO_PROXY"))
+        .ok();
 
+    let runtime = crate::firecracker::MmdsRuntime {
+        volumes,
+        extra_disks,
+        nfs_mounts,
+        image_archive: if no_direct_image_mount {
+            image_device.clone()
+        } else {
+            None
+        },
+        image_storage_device: if !no_direct_image_mount {
+            image_device
+        } else {
+            None
+        },
+        http_proxy,
+        https_proxy,
+        no_proxy,
+        host_time: chrono::Utc::now().timestamp().to_string(),
+    };
+
+    let mmds_data = launch_config.to_mmds_json(runtime);
     client.put_mmds(mmds_data).await?;
     Ok(())
 }
@@ -811,6 +811,7 @@ pub(super) async fn run_vm_setup(
                 args.health_check.clone(),
                 args.hugepages,
                 args.user.clone(),
+                args.forward_localhost.clone(),
             )
         });
 
@@ -937,13 +938,13 @@ pub(super) async fn run_vm_setup(
 
     // Build and send MMDS data (container plan)
     build_and_send_mmds(
-        args,
+        &launch_config,
         client,
         network_config,
         vm_state,
         volume_mappings,
-        &cmd_args,
         image_device,
+        args.no_direct_image_mount,
     )
     .await?;
 

--- a/src/firecracker/config.rs
+++ b/src/firecracker/config.rs
@@ -72,6 +72,10 @@ pub struct FirecrackerConfig {
     /// it changes how podman sets up user namespaces and storage.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
+    /// Ports to forward from guest localhost to host localhost.
+    /// Affects fc-agent's iptables setup, must be in cache key.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub forward_localhost: Vec<u16>,
 }
 
 fn default_rootfs_size() -> String {
@@ -149,6 +153,7 @@ impl FirecrackerConfig {
         health_check_url: Option<String>,
         hugepages: bool,
         user: Option<String>,
+        forward_localhost: Vec<u16>,
     ) -> Self {
         Self {
             boot_source: BootSource {
@@ -184,6 +189,7 @@ impl FirecrackerConfig {
             rootfs_size,
             health_check_url,
             user,
+            forward_localhost,
         }
     }
 
@@ -279,6 +285,70 @@ impl FirecrackerConfig {
     pub fn to_json(&self) -> String {
         serde_json::to_string_pretty(self).expect("FirecrackerConfig serialization failed")
     }
+
+    /// Build the MMDS container-plan JSON.
+    ///
+    /// User-input fields come from `self` (part of snapshot key).
+    /// Runtime parameters are values that legitimately differ between launches
+    /// using the same snapshot (network config, resolved proxies, timestamps).
+    pub fn to_mmds_json(&self, runtime: MmdsRuntime) -> serde_json::Value {
+        // Parse env vars from "KEY=value" format to HashMap
+        let env: std::collections::HashMap<&str, &str> = self
+            .env_vars
+            .iter()
+            .map(|e| {
+                let parts: Vec<&str> = e.splitn(2, '=').collect();
+                (parts[0], parts.get(1).copied().unwrap_or(""))
+            })
+            .collect();
+
+        serde_json::json!({
+            "latest": {
+                "container-plan": {
+                    "image": self.container_image,
+                    "env": env,
+                    "cmd": self.container_cmd,
+                    "volumes": runtime.volumes,
+                    "extra_disks": runtime.extra_disks,
+                    "nfs_mounts": runtime.nfs_mounts,
+                    "image_archive": runtime.image_archive,
+                    "image_storage_device": runtime.image_storage_device,
+                    "privileged": self.privileged,
+                    "user": self.user.as_deref(),
+                    "forward_localhost": self.forward_localhost.iter().map(|p| p.to_string()).collect::<Vec<_>>(),
+                    "interactive": self.interactive,
+                    "tty": self.tty,
+                    "http_proxy": runtime.http_proxy,
+                    "https_proxy": runtime.https_proxy,
+                    "no_proxy": runtime.no_proxy,
+                },
+                "host-time": runtime.host_time,
+            }
+        })
+    }
+}
+
+/// Runtime-only MMDS parameters that differ between launches using the same snapshot.
+/// These are NOT part of the cache key.
+pub struct MmdsRuntime {
+    /// Volume mount details with assigned vsock ports
+    pub volumes: Vec<serde_json::Value>,
+    /// Extra disk device assignments (e.g., /dev/vdb)
+    pub extra_disks: Vec<serde_json::Value>,
+    /// NFS mount details with host IP
+    pub nfs_mounts: Vec<serde_json::Value>,
+    /// Device path for image archive (localhost images, no-direct-image-mount mode)
+    pub image_archive: Option<String>,
+    /// Device path for image storage (direct-image-mount mode)
+    pub image_storage_device: Option<String>,
+    /// Resolved HTTP proxy URL (IP, not hostname)
+    pub http_proxy: Option<String>,
+    /// Resolved HTTPS proxy URL
+    pub https_proxy: Option<String>,
+    /// NO_PROXY value from environment
+    pub no_proxy: Option<String>,
+    /// Host timestamp (UTC epoch seconds)
+    pub host_time: String,
 }
 
 #[cfg(test)]
@@ -307,6 +377,7 @@ mod tests {
             None,
             false,
             None,
+            vec![],
         )
     }
 
@@ -412,6 +483,14 @@ mod tests {
         let config1 = test_config();
         let mut config2 = test_config();
         config2.user = Some("1000:1000".to_string());
+        assert_ne!(config1.snapshot_key(), config2.snapshot_key());
+    }
+
+    #[test]
+    fn test_snapshot_key_changes_with_forward_localhost() {
+        let config1 = test_config();
+        let mut config2 = test_config();
+        config2.forward_localhost = vec![8080];
         assert_ne!(config1.snapshot_key(), config2.snapshot_key());
     }
 }

--- a/src/firecracker/mod.rs
+++ b/src/firecracker/mod.rs
@@ -3,5 +3,5 @@ pub mod config;
 pub mod vm;
 
 pub use api::FirecrackerClient;
-pub use config::{FirecrackerConfig, NetworkMode as FcNetworkMode};
+pub use config::{FirecrackerConfig, MmdsRuntime, NetworkMode as FcNetworkMode};
 pub use vm::VmManager;


### PR DESCRIPTION
**Stacked on:** btrfs-local-container (PR #347)

## Summary

Make `FirecrackerConfig` the single source of truth for all user-input fields in the MMDS plan. Previously, `build_and_send_mmds()` read fields directly from CLI args, meaning a field could be in the MMDS plan without being in the snapshot cache key. `forward_localhost` was the concrete example: changing `--forward-localhost` reused the same stale snapshot.

## Changes

### `src/firecracker/config.rs`
- Add `forward_localhost: Vec<u16>` to `FirecrackerConfig` (now part of snapshot cache key)
- Add `MmdsRuntime` struct for runtime-only MMDS values (proxies, timestamps, volume/disk assignments)
- Add `to_mmds_json(&self, runtime: MmdsRuntime)` method — builds MMDS JSON from config fields + runtime values
- Add `test_snapshot_key_changes_with_forward_localhost` test

### `src/commands/podman/vm_config.rs`
- Refactor `build_and_send_mmds()` to take `&FirecrackerConfig` instead of `&RunArgs`
- Remove `cmd_args` parameter (now read from config)
- Build `MmdsRuntime` from runtime locals (proxy resolution, volume ports, disk devices)
- Pass `forward_localhost` to `FirecrackerConfig::new()` call

### `src/commands/podman/snapshot.rs`
- Pass `forward_localhost` to `FirecrackerConfig::new()` call

### `.claude/skills/pr-workflow/SKILL.md`
- Add CI artifact download instructions for investigating test failures
- Add troubleshooting guide for CI not auto-starting (branch not based on main)