### PR TITLE
Fix rootless podman in VM: subuid passthrough, pipe deadlock, duplicate name detection

### DIFF
--- a/fc-agent/src/agent.rs
+++ b/fc-agent/src/agent.rs
@@ -132,7 +132,12 @@ pub async fn run() -> Result<()> {
             .get("USER")
             .map(|s| s.as_str())
             .unwrap_or("fcvm-user");
-        let (username, _uid, runtime_dir) = container::create_vm_user(user_spec, desired_name);
+        let subuid_range = plan
+            .subuid_start
+            .zip(plan.subuid_count)
+            .or_else(|| plan.subuid_start.map(|s| (s, 65536)));
+        let (username, _uid, runtime_dir) =
+            container::create_vm_user(user_spec, desired_name, subuid_range);
         Some((username, runtime_dir))
     } else {
         None
@@ -149,7 +154,8 @@ pub async fn run() -> Result<()> {
 
     // Prepare image (mount storage, import archive, or pull from registry)
     let image_ref = if let Some(storage_device) = &plan.image_storage_device {
-        container::mount_storage_image(storage_device, &plan.image)?
+        let username = user_info.as_ref().map(|(name, _)| name.as_str());
+        container::mount_storage_image(storage_device, &plan.image, username)?
     } else if let Some(archive_path) = &plan.image_archive {
         container::import_image(archive_path, &plan.image, &output, &cmd_prefix).await?
     } else {

--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -16,7 +16,11 @@ use crate::vsock;
 /// The storage image is an ext4 filesystem containing a podman overlay storage tree
 /// (overlay/, overlay-images/, overlay-layers/). It is mounted read-only and podman
 /// finds the image there without needing `podman load`.
-pub fn mount_storage_image(device: &str, image_name: &str) -> Result<String> {
+pub fn mount_storage_image(
+    device: &str,
+    image_name: &str,
+    username: Option<&str>,
+) -> Result<String> {
     eprintln!("[fc-agent] mounting pre-built storage image: {}", device);
 
     let mount_path = "/mnt/image-store";
@@ -54,22 +58,59 @@ pub fn mount_storage_image(device: &str, image_name: &str) -> Result<String> {
         );
     }
 
+    // Configure podman to use this as an additional image store.
+    // For rootless podman (--user mode), write to the user's config dir.
+    // For root podman, write to /etc/containers/.
+    let (conf_path, runroot, graphroot) = if let Some(name) = username {
+        // Rootless: user's home directory config
+        let home = format!("/home/{}", name);
+        let config_dir = format!("{}/.config", home);
+        let conf_dir = format!("{}/containers", config_dir);
+        let _ = std::fs::create_dir_all(&conf_dir);
+        // Chown .config and children so podman can create subdirs (cni, etc.)
+        if let Ok(Some(pw)) = nix::unistd::User::from_name(name) {
+            let _ = nix::unistd::chown(config_dir.as_str(), Some(pw.uid), Some(pw.gid));
+            let _ = nix::unistd::chown(conf_dir.as_str(), Some(pw.uid), Some(pw.gid));
+        }
+        (
+            format!("{}/storage.conf", conf_dir),
+            format!(
+                "/run/user/{}/containers",
+                nix::unistd::User::from_name(name)
+                    .ok()
+                    .flatten()
+                    .map(|u| u.uid.as_raw())
+                    .unwrap_or(0)
+            ),
+            format!("{}/.local/share/containers/storage", home),
+        )
+    } else {
+        (
+            "/etc/containers/storage.conf".to_string(),
+            "/run/containers/storage".to_string(),
+            "/var/lib/containers/storage".to_string(),
+        )
+    };
+
     // Detect if btrfs storage was already configured (by setup_btrfs_storage_if_available).
-    let graphroot = "/var/lib/containers/storage";
+    // Check the ROOT storage path — for rootless users, setup_user_btrfs_storage() creates
+    // subdirs under the root btrfs mount, but the per-user graphroot uses a different path.
     let is_btrfs = std::process::Command::new("findmnt")
-        .args(["-n", "-o", "FSTYPE", graphroot])
+        .args(["-n", "-o", "FSTYPE", "/var/lib/containers/storage"])
         .output()
         .map(|o| String::from_utf8_lossy(&o.stdout).trim() == "btrfs")
         .unwrap_or(false);
 
     if is_btrfs {
         // btrfs driver doesn't support overlay-format additionalimagestores.
-        // Import the image from the mounted overlay store into btrfs via save/load.
-        let storage_conf = format!(
-            "[storage]\ndriver = \"btrfs\"\nrunroot = \"/run/containers/storage\"\ngraphroot = \"{graphroot}\"\n"
-        );
-        std::fs::write("/etc/containers/storage.conf", storage_conf)
-            .context("writing storage.conf")?;
+        // For rootless users, setup_user_btrfs_storage() already wrote the correct
+        // storage.conf — don't overwrite it. For root, write a minimal btrfs config.
+        if username.is_none() {
+            let storage_conf = format!(
+                "[storage]\ndriver = \"btrfs\"\nrunroot = \"{runroot}\"\ngraphroot = \"{graphroot}\"\n"
+            );
+            std::fs::write(&conf_path, &storage_conf).context("writing storage.conf")?;
+        }
 
         eprintln!(
             "[fc-agent] btrfs driver: importing image from overlay store at {}",
@@ -96,11 +137,34 @@ pub fn mount_storage_image(device: &str, image_name: &str) -> Result<String> {
             anyhow::bail!("podman save from overlay store failed: {}", stderr);
         }
 
-        // Load the image into the btrfs store
-        let load_output = std::process::Command::new("podman")
-            .args(["load", "-i", "/tmp/image-import.tar"])
-            .output()
-            .context("running podman load into btrfs store")?;
+        // Load the image into the btrfs store.
+        // For rootless users, use runuser so podman reads the user's storage.conf.
+        let load_output = if let Some(name) = username {
+            let uid_str = nix::unistd::User::from_name(name)
+                .ok()
+                .flatten()
+                .map(|u| u.uid.as_raw().to_string())
+                .unwrap_or_default();
+            std::process::Command::new("env")
+                .args([
+                    &format!("XDG_RUNTIME_DIR=/run/user/{}", uid_str),
+                    "runuser",
+                    "-u",
+                    name,
+                    "--",
+                    "podman",
+                    "load",
+                    "-i",
+                    "/tmp/image-import.tar",
+                ])
+                .output()
+                .context("running podman load as user into btrfs store")?
+        } else {
+            std::process::Command::new("podman")
+                .args(["load", "-i", "/tmp/image-import.tar"])
+                .output()
+                .context("running podman load into btrfs store")?
+        };
 
         if !load_output.status.success() {
             let stderr = String::from_utf8_lossy(&load_output.stderr);
@@ -117,14 +181,13 @@ pub fn mount_storage_image(device: &str, image_name: &str) -> Result<String> {
     } else {
         // overlay driver: use additionalimagestores for instant image access
         let storage_conf = format!(
-            "[storage]\ndriver = \"overlay\"\nrunroot = \"/run/containers/storage\"\ngraphroot = \"{graphroot}\"\n\n[storage.options]\nadditionalimagestores = [\"{mount_path}\"]\n"
+            "[storage]\ndriver = \"overlay\"\nrunroot = \"{runroot}\"\ngraphroot = \"{graphroot}\"\n\n[storage.options]\nadditionalimagestores = [\"{mount_path}\"]\n"
         );
-        std::fs::write("/etc/containers/storage.conf", storage_conf)
-            .context("writing storage.conf")?;
+        std::fs::write(&conf_path, &storage_conf).context("writing storage.conf")?;
 
         eprintln!(
-            "[fc-agent] storage image mounted at {}, configured as additional image store",
-            mount_path
+            "[fc-agent] storage image mounted at {}, configured as additional image store (conf: {})",
+            mount_path, conf_path
         );
     }
 
@@ -710,7 +773,16 @@ pub fn build_podman_args(
 /// Create the VM user and set up rootless podman prerequisites.
 /// Call this BEFORE importing images so podman load runs as the target user.
 /// Returns (username, uid, runtime_dir) for use by run_as_user_prefix().
-pub fn create_vm_user(user_spec: &str, desired_name: &str) -> (String, String, String) {
+///
+/// `subuid_range`: optional (start, count) from the host's /etc/subuid.
+/// When the storage image is built by rootless podman on the host, it contains
+/// files with UIDs from the host's subuid range. The VM must use the same range
+/// so those UIDs are valid in the VM's user namespace.
+pub fn create_vm_user(
+    user_spec: &str,
+    desired_name: &str,
+    subuid_range: Option<(u64, u64)>,
+) -> (String, String, String) {
     let parts: Vec<&str> = user_spec.split(':').collect();
     let uid = parts[0].to_string();
     let gid = parts.get(1).unwrap_or(&"100").to_string();
@@ -728,7 +800,14 @@ pub fn create_vm_user(user_spec: &str, desired_name: &str) -> (String, String, S
         .args(["-u", &uid, "-g", &gid, "-m", "-s", "/bin/sh", &username])
         .output();
 
-    let subuid_entry = format!("{}:100000:65536\n", username);
+    // Use host's subuid range if provided (matches storage image UIDs),
+    // otherwise fall back to a default range.
+    let (subuid_start, subuid_count) = subuid_range.unwrap_or((100000, 65536));
+    let subuid_entry = format!("{}:{}:{}\n", username, subuid_start, subuid_count);
+    eprintln!(
+        "[fc-agent] subuid/subgid: {}:{}",
+        subuid_start, subuid_count
+    );
     let _ = std::fs::write("/etc/subuid", &subuid_entry);
     let _ = std::fs::write("/etc/subgid", &subuid_entry);
 

--- a/fc-agent/src/main.rs
+++ b/fc-agent/src/main.rs
@@ -20,7 +20,7 @@ async fn main() {
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| EnvFilter::new("info,fuse_pipe=debug")),
+                .unwrap_or_else(|_| EnvFilter::new("info,fuse_pipe=warn")),
         )
         .with_target(true)
         .with_ansi(false)

--- a/fc-agent/src/types.rs
+++ b/fc-agent/src/types.rs
@@ -33,6 +33,13 @@ pub struct Plan {
     pub https_proxy: Option<String>,
     #[serde(default)]
     pub no_proxy: Option<String>,
+    /// Host user's subordinate UID range start (from /etc/subuid).
+    /// When set, the VM user is created with the same subuid range so that
+    /// the storage image (built by rootless podman on the host) has valid UIDs.
+    #[serde(default)]
+    pub subuid_start: Option<u64>,
+    #[serde(default)]
+    pub subuid_count: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -1043,4 +1043,36 @@ mod tests {
         assert!(resolved_https.contains(":443"));
         assert!(resolved_https.contains("/proxy"));
     }
+
+    #[test]
+    fn test_parse_subid_file_finds_current_user() {
+        let username = std::env::var("USER").expect("USER env var must be set");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("subuid");
+        std::fs::write(
+            &path,
+            format!(
+                "nobody:100000:65536\n{}:1879048192:65536\nother:200000:65536\n",
+                username
+            ),
+        )
+        .unwrap();
+        let result = parse_subid_file(path.to_str().unwrap());
+        assert_eq!(result, Some((1879048192, 65536)));
+    }
+
+    #[test]
+    fn test_parse_subid_file_returns_none_for_missing_user() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("subuid");
+        std::fs::write(&path, "nobody:100000:65536\nother:200000:65536\n").unwrap();
+        let result = parse_subid_file(path.to_str().unwrap());
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_parse_subid_file_returns_none_for_missing_file() {
+        let result = parse_subid_file("/tmp/nonexistent-subuid-test-file");
+        assert_eq!(result, None);
+    }
 }

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -15,6 +15,41 @@ use super::types::VolumeMapping;
 
 use crate::commands::common::VSOCK_VOLUME_PORT_BASE;
 
+/// Read the current user's subordinate UID range start from /etc/subuid.
+/// Returns None if the file doesn't exist or the user has no entry.
+fn get_host_subuid_start() -> Option<u64> {
+    parse_subid_file("/etc/subuid").map(|(start, _)| start)
+}
+
+/// Read the current user's subordinate UID range count from /etc/subuid.
+fn get_host_subuid_count() -> Option<u64> {
+    parse_subid_file("/etc/subuid").map(|(_, count)| count)
+}
+
+/// Parse /etc/subuid or /etc/subgid for the current user.
+/// Format: username:start:count
+fn parse_subid_file(path: &str) -> Option<(u64, u64)> {
+    let username = std::env::var("USER")
+        .or_else(|_| {
+            nix::unistd::User::from_uid(nix::unistd::getuid())
+                .ok()
+                .flatten()
+                .map(|u| u.name)
+                .ok_or(())
+        })
+        .ok()?;
+    let content = std::fs::read_to_string(path).ok()?;
+    for line in content.lines() {
+        let parts: Vec<&str> = line.split(':').collect();
+        if parts.len() >= 3 && parts[0] == username {
+            let start = parts[1].parse().ok()?;
+            let count = parts[2].parse().ok()?;
+            return Some((start, count));
+        }
+    }
+    None
+}
+
 /// Resolve a proxy URL's hostname to an IP address.
 ///
 /// VMs using slirp4netns with --enable-ipv6 can reach both IPv4 (via 10.0.2.2 gateway)
@@ -563,6 +598,14 @@ pub(super) async fn build_and_send_mmds(
         http_proxy,
         https_proxy,
         no_proxy,
+        subuid_start: launch_config
+            .user
+            .as_ref()
+            .and_then(|_| get_host_subuid_start()),
+        subuid_count: launch_config
+            .user
+            .as_ref()
+            .and_then(|_| get_host_subuid_count()),
         host_time: chrono::Utc::now().timestamp().to_string(),
     };
 

--- a/src/firecracker/config.rs
+++ b/src/firecracker/config.rs
@@ -315,6 +315,8 @@ impl FirecrackerConfig {
                     "image_storage_device": runtime.image_storage_device,
                     "privileged": self.privileged,
                     "user": self.user.as_deref(),
+                    "subuid_start": runtime.subuid_start,
+                    "subuid_count": runtime.subuid_count,
                     "forward_localhost": self.forward_localhost.iter().map(|p| p.to_string()).collect::<Vec<_>>(),
                     "interactive": self.interactive,
                     "tty": self.tty,
@@ -347,6 +349,10 @@ pub struct MmdsRuntime {
     pub https_proxy: Option<String>,
     /// NO_PROXY value from environment
     pub no_proxy: Option<String>,
+    /// Host user's subordinate UID range start (from /etc/subuid)
+    pub subuid_start: Option<u64>,
+    /// Host user's subordinate UID range count
+    pub subuid_count: Option<u64>,
     /// Host timestamp (UTC epoch seconds)
     pub host_time: String,
 }

--- a/src/state/manager.rs
+++ b/src/state/manager.rs
@@ -257,9 +257,30 @@ impl StateManager {
     /// Load VM state by name
     pub async fn load_state_by_name(&self, name: &str) -> Result<VmState> {
         let vms = self.list_vms().await?;
-        vms.into_iter()
-            .find(|vm| vm.name.as_deref() == Some(name))
-            .ok_or_else(|| anyhow::anyhow!("VM not found: {}", name))
+        let matches: Vec<_> = vms
+            .into_iter()
+            .filter(|vm| vm.name.as_deref() == Some(name))
+            .collect();
+        match matches.len() {
+            0 => anyhow::bail!("VM not found: {}", name),
+            1 => Ok(matches.into_iter().next().unwrap()),
+            n => {
+                let pids: Vec<String> = matches
+                    .iter()
+                    .map(|vm| {
+                        vm.pid
+                            .map(|p| p.to_string())
+                            .unwrap_or_else(|| "none".to_string())
+                    })
+                    .collect();
+                anyhow::bail!(
+                    "Multiple VMs named '{}' ({}). Use --pid to specify: {}",
+                    name,
+                    n,
+                    pids.join(", ")
+                )
+            }
+        }
     }
 
     /// Load VM state by PID

--- a/tests/test_state_manager.rs
+++ b/tests/test_state_manager.rs
@@ -143,3 +143,100 @@ async fn test_list_vms() {
     assert!(vm_ids.contains(&"vm-2".to_string()));
     assert!(vm_ids.contains(&"vm-3".to_string()));
 }
+
+#[tokio::test]
+async fn test_load_state_by_name_duplicate_detection() {
+    let temp_dir = TempDir::new().unwrap();
+    let manager = StateManager::new(temp_dir.path().to_path_buf());
+    manager.init().await.unwrap();
+
+    let now = Utc::now();
+
+    // Save two VMs with the same name but different vm_ids and PIDs
+    for (i, pid) in [(1u32, 5000u32), (2, 5001)] {
+        let state = VmState {
+            schema_version: 1,
+            vm_id: format!("vm-dup-{}", i),
+            name: Some("duplicate-name".to_string()),
+            status: VmStatus::Running,
+            health_status: HealthStatus::Healthy,
+            exit_code: None,
+            pid: Some(pid),
+            holder_pid: None,
+            created_at: now,
+            last_updated: now,
+            config: VmConfig {
+                image: "nginx:alpine".to_string(),
+                vcpu: 1,
+                memory_mib: 256,
+                network: NetworkConfig::default(),
+                volumes: vec![],
+                extra_disks: vec![],
+                nfs_shares: vec![],
+                health_check_url: None,
+                snapshot_name: None,
+                process_type: Some(ProcessType::Vm),
+                serve_pid: None,
+                original_vsock_vm_id: None,
+                port_mappings: vec![],
+                labels: std::collections::HashMap::new(),
+                hugepages: false,
+                portable_volumes: false,
+                user: None,
+                username: None,
+            },
+        };
+        manager.save_state(&state).await.unwrap();
+    }
+
+    // Looking up the duplicate name should error with both PIDs listed
+    let err = manager
+        .load_state_by_name("duplicate-name")
+        .await
+        .expect_err("should fail with duplicate names");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Multiple VMs"),
+        "error should mention multiple VMs: {}",
+        msg
+    );
+    assert!(msg.contains("5000"), "error should list PID 5000: {}", msg);
+    assert!(msg.contains("5001"), "error should list PID 5001: {}", msg);
+
+    // Looking up a unique name should still work
+    let state = VmState {
+        schema_version: 1,
+        vm_id: "vm-unique".to_string(),
+        name: Some("unique-name".to_string()),
+        status: VmStatus::Running,
+        health_status: HealthStatus::Healthy,
+        exit_code: None,
+        pid: Some(6000),
+        holder_pid: None,
+        created_at: now,
+        last_updated: now,
+        config: VmConfig {
+            image: "nginx:alpine".to_string(),
+            vcpu: 1,
+            memory_mib: 256,
+            network: NetworkConfig::default(),
+            volumes: vec![],
+            extra_disks: vec![],
+            nfs_shares: vec![],
+            health_check_url: None,
+            snapshot_name: None,
+            process_type: Some(ProcessType::Vm),
+            serve_pid: None,
+            original_vsock_vm_id: None,
+            port_mappings: vec![],
+            labels: std::collections::HashMap::new(),
+            hugepages: false,
+            portable_volumes: false,
+            user: None,
+            username: None,
+        },
+    };
+    manager.save_state(&state).await.unwrap();
+    let found = manager.load_state_by_name("unique-name").await.unwrap();
+    assert_eq!(found.pid, Some(6000));
+}


### PR DESCRIPTION
**Stacked on:** mmds-from-config (PR #348)

## Summary
- Pass host's `/etc/subuid` range through MMDS so VM user namespace matches the storage image UIDs built by rootless podman on the host
- Write `storage.conf` to `~/.config/containers/` for rootless mode (instead of `/etc/containers/`), chown `.config` so podman can create subdirs
- Fix pipe deadlock: `fuse_pipe=debug` flooded vsock with thousands of FUSE mux log lines/sec, filling the 64KB pipe buffer and blocking entrypoint stdout. Changed to `fuse_pipe=warn`.
- Detect duplicate VM names in `exec --name` and return error with PID list instead of silently picking one

## Tests added
- `test_parse_subid_file_finds_current_user`: verifies correct user lookup from temp subuid file
- `test_parse_subid_file_returns_none_for_missing_user`: graceful when user not in file
- `test_parse_subid_file_returns_none_for_missing_file`: graceful on nonexistent file
- `test_load_state_by_name_duplicate_detection`: errors with PID list for duplicate names, succeeds for unique names

## Test plan
- `make build` compiles cleanly
- VM boots with correct subuid range (`[fc-agent] subuid/subgid: 1879048192:65536`)
- Entrypoint no longer hangs from pipe deadlock
- `fcvm exec --name www` errors when multiple VMs share the name
- Unit tests pass: `cargo test parse_subid` and `cargo test state_manager`