### PR TITLE
Native btrfs image build with correct UID ownership

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,6 +11,18 @@
 
 This is non-negotiable. A test failure means the CODE is broken - fix the code, not the test.
 
+## VERIFY PLAN AND RUN NEW TESTS LOCALLY
+
+**Before committing, ALWAYS:**
+
+1. **Re-read the plan** — check every numbered step and verification item against what was implemented
+2. **Run new tests locally** — don't just compile them, actually execute them and verify output
+3. **Check for dead code** — search for old function/field names that should have been removed
+
+Writing tests without running them is pointless. Compilation does not equal correctness. A test that passes `--no-run` might fail at runtime due to logic bugs, missing `-T` flags, wrong paths, etc.
+
+**Anti-pattern:** "All 85 unit tests pass" + never ran the integration tests that actually exercise the new code paths.
+
 ## STACKED PRs BY DEFAULT
 
 **All work goes in stacked PRs.** Each new PR should be based on the previous one, not main.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,6 +307,9 @@ jobs:
           sudo ./target/release/fcvm setup --generate-config --force
           # Build btrfs kernel locally (needed for test_localhost_rootless tests)
           sudo ./target/release/fcvm setup --kernel-profile btrfs --build-kernels
+      - name: Build btrfs-progs
+        working-directory: fcvm
+        run: ./scripts/build-btrfs-progs.sh
       - name: test-packaging-e2e
         working-directory: fcvm
         run: ./scripts/test-packaging-e2e.sh ./target/release/fcvm
@@ -475,6 +478,9 @@ jobs:
         run: |
           # Build btrfs kernel locally (needed for test_localhost_rootless tests)
           sudo ./target/release/fcvm setup --kernel-profile btrfs --build-kernels
+      - name: Build btrfs-progs
+        working-directory: fcvm
+        run: ./scripts/build-btrfs-progs.sh
       - name: Allocate hugepages
         run: |
           echo 512 | sudo tee /proc/sys/vm/nr_hugepages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,8 @@ jobs:
       - name: Build btrfs-progs
         working-directory: fcvm
         run: ./scripts/build-btrfs-progs.sh
+      - name: Refresh KVM permissions
+        run: sudo chmod 666 /dev/kvm
       - name: test-packaging-e2e
         working-directory: fcvm
         run: ./scripts/test-packaging-e2e.sh ./target/release/fcvm
@@ -481,6 +483,8 @@ jobs:
       - name: Build btrfs-progs
         working-directory: fcvm
         run: ./scripts/build-btrfs-progs.sh
+      - name: Refresh KVM permissions
+        run: sudo chmod 666 /dev/kvm
       - name: Allocate hugepages
         run: |
           echo 512 | sudo tee /proc/sys/vm/nr_hugepages

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,10 @@ integration-slow = []        # Slow VM tests, > 30s each (clone, snapshot, fuse 
 # Privileged tests require sudo (bridged networking, pjdfstest, iptables)
 privileged-tests = []
 
+# Bare-metal tests require host user namespace (not nested inside a container).
+# e.g. btrfs --user builds need newuidmap which fails under nested user namespaces.
+bare-metal = []
+
 # libfuse remap_file_range container test (requires pre-built container)
 libfuse-test = []
 

--- a/Containerfile
+++ b/Containerfile
@@ -33,6 +33,7 @@ RUN echo "user_allow_other" >> /etc/fuse.conf \
     && useradd -m -s /bin/bash testuser \
     && usermod -aG fuse,kvm testuser \
     && echo "testuser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
+    && sed -i '/^testuser:/d' /etc/subuid /etc/subgid \
     && echo "testuser:100000:65536" >> /etc/subuid \
     && echo "testuser:100000:65536" >> /etc/subgid
 

--- a/Makefile
+++ b/Makefile
@@ -261,24 +261,32 @@ test-packaging: build
 clean:
 	sudo rm -rf target
 
+# Bare-metal feature: tests that need host user namespace (not nested in a container).
+# Set BARE_METAL=1 to include these tests (host targets set this automatically).
+ifeq ($(BARE_METAL),1)
+BARE_METAL_FEATURES := ,bare-metal
+else
+BARE_METAL_FEATURES :=
+endif
+
 # Run-only targets (no setup deps, used by container)
 _test-unit:
 	$(NEXTEST) --no-default-features
 
 _test-fast:
 	RUST_LOG="$(TEST_LOG)" \
-	./scripts/no-sudo.sh $(NEXTEST) $(NEXTEST_CAPTURE) $(NEXTEST_RETRIES) --no-default-features --features integration-fast $(FILTER)
+	./scripts/no-sudo.sh $(NEXTEST) $(NEXTEST_CAPTURE) $(NEXTEST_RETRIES) --no-default-features --features integration-fast$(BARE_METAL_FEATURES) $(FILTER)
 
 _test-all:
 	RUST_LOG="$(TEST_LOG)" \
-	./scripts/no-sudo.sh $(NEXTEST) $(NEXTEST_CAPTURE) $(NEXTEST_RETRIES) $(FILTER)
+	./scripts/no-sudo.sh $(NEXTEST) $(NEXTEST_CAPTURE) $(NEXTEST_RETRIES) --features default$(BARE_METAL_FEATURES) $(FILTER)
 
 _test-root:
 	@RUST_LOG="$(TEST_LOG)" \
 	FCVM_DATA_DIR=$(ROOT_DATA_DIR) \
 	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
 	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
-	$(NEXTEST) $(NEXTEST_CAPTURE) $(NEXTEST_IGNORED) $(NEXTEST_RETRIES) --features privileged-tests $(IPV6_FILTER) $(FILTER) || \
+	$(NEXTEST) $(NEXTEST_CAPTURE) $(NEXTEST_IGNORED) $(NEXTEST_RETRIES) --features privileged-tests,bare-metal $(IPV6_FILTER) $(FILTER) || \
 	{ echo ""; \
 	  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"; \
 	  echo "TEST FAILED - Check debug logs for root cause:"; \
@@ -288,9 +296,12 @@ _test-root:
 	  exit 1; }
 
 # Host targets (with setup, check-disk first to fail fast if disk is full)
+# BARE_METAL=1 enables tests that need host user namespace (not container)
 test-unit: show-notes check-disk build _test-unit
-test-fast: show-notes check-disk setup-fcvm _test-fast
-test-all: show-notes check-disk setup-fcvm _test-all
+test-fast: show-notes check-disk setup-fcvm
+	$(MAKE) _test-fast BARE_METAL=1
+test-all: show-notes check-disk setup-fcvm
+	$(MAKE) _test-all BARE_METAL=1
 test-root: show-notes check-disk setup-fcvm setup-pjdfstest setup-hugepages _test-root
 test: test-root
 

--- a/Makefile
+++ b/Makefile
@@ -415,6 +415,7 @@ _setup-fcvm:
 	sudo ./target/release/fcvm setup
 	sudo ./target/release/fcvm setup --kernel-profile nested --build-kernels
 	sudo ./target/release/fcvm setup --kernel-profile btrfs --build-kernels
+	./scripts/build-btrfs-progs.sh
 
 # SDK E2E test — requires computesdk package as sibling repo and Node.js
 test-serve-sdk: build

--- a/README.md
+++ b/README.md
@@ -219,6 +219,50 @@ Second run restores from that snapshot and skips container initialization.
 
 Clone snapshots automatically use their source as parent, enabling diff-based optimization across the chain.
 
+### Image Delivery Modes
+
+fcvm supports three modes for delivering container images to VMs:
+
+| Mode | Flag | Description | Speed |
+|------|------|-------------|-------|
+| **Overlay** (default) | `--image-mode overlay` | Pre-built ext4 image, mounted read-only as `additionalImageStore` | Fast (~540ms cached) |
+| **Btrfs** | `--image-mode btrfs` | Pre-built btrfs image with native subvolumes, reflink-copied per VM | Fast (~540ms cached) |
+| **Archive** | `--image-mode archive` | Docker tar archive, `podman load` at boot | Slow (~3s) |
+
+The mode is auto-detected from the kernel profile (btrfs profile → btrfs mode) or can be set explicitly:
+
+```bash
+# Auto-detect from kernel profile
+./fcvm podman run --name web --kernel-profile btrfs nginx:alpine
+
+# Explicit mode
+./fcvm podman run --name web --image-mode btrfs nginx:alpine
+
+# Archive mode (fallback, no pre-built image needed)
+./fcvm podman run --name web --image-mode archive nginx:alpine
+```
+
+**Btrfs mode** is designed for rootless podman with `--user`. It builds the btrfs storage image as the target user on the host, so file ownership matches what rootless podman expects — no chown needed at boot:
+
+```bash
+# Rootless podman in VM with btrfs storage (no sudo needed)
+./fcvm podman run --name app \
+    --user 1000:1000 \
+    --kernel-profile btrfs \
+    localhost/myimage
+```
+
+**How btrfs mode works:**
+1. Host exports container as Docker archive (`podman save`)
+2. Host loads archive into a temp btrfs storage root (`podman --root <tmp> --storage-driver btrfs load`)
+3. Host packages the storage tree as a btrfs image (`mkfs.btrfs --rootdir --subvol`)
+4. Per-VM: btrfs reflink copy of the image (instant, read-write)
+5. Guest mounts the btrfs image as podman's graphroot — container is ready immediately
+
+**Requirements for btrfs mode:**
+- btrfs-progs >= 6.12 (for `--rootdir --subvol` support). Build from source: `./scripts/build-btrfs-progs.sh`
+- A btrfs kernel profile with `CONFIG_BTRFS_FS=y`: `./fcvm setup --kernel-profile btrfs --build-kernels`
+
 ### More Options
 
 ```bash

--- a/benches/container_import.rs
+++ b/benches/container_import.rs
@@ -197,7 +197,7 @@ fn build_image() {
 }
 
 /// Run one mode through a cold start cycle (no snapshot cache)
-fn run_mode(mode: &str, no_direct_image_mount: bool, iterations: u32) -> BenchResult {
+fn run_mode(mode: &str, image_mode: Option<&str>, iterations: u32) -> BenchResult {
     let fcvm = find_fcvm_binary();
     let pid_suffix = std::process::id();
 
@@ -227,8 +227,9 @@ fn run_mode(mode: &str, no_direct_image_mount: bool, iterations: u32) -> BenchRe
             "--health-check",
             "http://localhost:80/",
         ];
-        if no_direct_image_mount {
-            args.push("--no-direct-image-mount");
+        if let Some(im) = image_mode {
+            args.push("--image-mode");
+            args.push(im);
         }
         args.push(BENCH_IMAGE);
 
@@ -308,11 +309,11 @@ fn main() {
     // Build container image
     build_image();
 
-    // Run legacy mode (podman load)
-    let legacy_result = run_mode("podman-load", true, iterations);
+    // Run archive mode (podman load)
+    let legacy_result = run_mode("archive", Some("archive"), iterations);
 
-    // Run direct mount mode
-    let direct_result = run_mode("direct-mount", false, iterations);
+    // Run overlay mode (direct mount)
+    let direct_result = run_mode("overlay", None, iterations);
 
     // Print comparison
     print_comparison(&legacy_result, &direct_result, iterations);

--- a/fc-agent/src/agent.rs
+++ b/fc-agent/src/agent.rs
@@ -196,10 +196,10 @@ pub async fn run() -> Result<()> {
             container::mount_overlay_image(device, &plan.image, username)?
         }
         (Some("btrfs"), Some(_device)) => {
-            // Device was already mounted in Phase 1 (before user creation).
-            // setup_btrfs_storage_if_available() wrote root storage.conf.
-            // setup_user_btrfs_storage() created user subdirs (if --user).
-            // Just return the image name — it's already in the store.
+            // Device was already mounted in Phase 1 (before user creation):
+            // - Root mode: mount_btrfs_device() + write_btrfs_storage_conf()
+            // - User mode: mount_btrfs_for_user() (mounts at user graphroot)
+            // Image is already in the btrfs store — just return the name.
             plan.image.clone()
         }
         (Some("archive"), Some(device)) => {

--- a/fc-agent/src/agent.rs
+++ b/fc-agent/src/agent.rs
@@ -119,8 +119,27 @@ pub async fn run() -> Result<()> {
     }
 
     // Set up btrfs storage if kernel supports it (avoids overlay idmap issues).
-    // Must happen before any podman operations (import_image, pull_image, etc.)
-    container::setup_btrfs_storage_if_available();
+    // Skip for overlay/btrfs modes — they manage their own storage.
+    // For archive/pull: creates loopback btrfs if kernel supports it.
+    match plan.image_mode.as_deref() {
+        Some("overlay") => {
+            eprintln!("[fc-agent] skipping btrfs loopback setup (image_mode=overlay)");
+        }
+        Some("btrfs") => {
+            // Pre-built btrfs image — mount it directly, no loopback needed.
+            // For root mode: mount at /var/lib/containers/storage now.
+            // For user mode: mount at user's default rootless path after user creation.
+            if plan.user.is_none() {
+                if let Some(ref device) = plan.image_device {
+                    container::mount_btrfs_device(device, "/var/lib/containers/storage")?;
+                    container::write_btrfs_storage_conf("/etc/containers/storage.conf", "/var/lib/containers/storage", "/run/containers/storage");
+                }
+            }
+        }
+        _ => {
+            container::setup_btrfs_storage_if_available();
+        }
+    }
 
     // If --user is specified, create the VM user BEFORE image import so
     // podman load runs as the target user (rootless podman has separate storage).
@@ -137,11 +156,21 @@ pub async fn run() -> Result<()> {
             .zip(plan.subuid_count)
             .or_else(|| plan.subuid_start.map(|s| (s, 65536)));
         let (username, _uid, runtime_dir) =
-            container::create_vm_user(user_spec, desired_name, subuid_range);
+            container::create_vm_user(user_spec, desired_name, subuid_range, plan.image_mode.as_deref());
         Some((username, runtime_dir))
     } else {
         None
     };
+
+    // For btrfs image mode + user: mount at the user's standard rootless graphroot.
+    // This happens AFTER user creation so we know the home directory.
+    // Podman finds btrfs at its default path — no custom graphroot needed.
+    if plan.image_mode.as_deref() == Some("btrfs") && plan.user.is_some() {
+        if let Some(ref device) = plan.image_device {
+            let (username, _) = user_info.as_ref().unwrap();
+            container::mount_btrfs_for_user(device, username)?;
+        }
+    }
 
     // Build the command prefix for running commands as the target user
     let cmd_prefix: Vec<String> = match &user_info {
@@ -158,9 +187,12 @@ pub async fn run() -> Result<()> {
             let username = user_info.as_ref().map(|(name, _)| name.as_str());
             container::mount_overlay_image(device, &plan.image, username)?
         }
-        (Some("btrfs"), Some(device)) => {
-            let username = user_info.as_ref().map(|(name, _)| name.as_str());
-            container::mount_btrfs_image(device, &plan.image, username)?
+        (Some("btrfs"), Some(_device)) => {
+            // Device was already mounted in Phase 1 (before user creation).
+            // setup_btrfs_storage_if_available() wrote root storage.conf.
+            // setup_user_btrfs_storage() created user subdirs (if --user).
+            // Just return the image name — it's already in the store.
+            plan.image.clone()
         }
         (Some("archive"), Some(device)) => {
             container::import_image(device, &plan.image, &output, &cmd_prefix).await?
@@ -277,10 +309,13 @@ pub async fn run() -> Result<()> {
             mounts::unmount_paths(&["/mnt/image-store".to_string()], "image store");
         }
         Some("btrfs") => {
-            mounts::unmount_paths(
-                &["/var/lib/containers/storage".to_string()],
-                "btrfs image store",
-            );
+            // Btrfs image is mounted at either root graphroot or user graphroot
+            let btrfs_mount = if let Some((username, _)) = &user_info {
+                format!("/home/{}/.local/share/containers/storage", username)
+            } else {
+                "/var/lib/containers/storage".to_string()
+            };
+            mounts::unmount_paths(&[btrfs_mount], "btrfs image store");
         }
         _ => {}
     }

--- a/fc-agent/src/agent.rs
+++ b/fc-agent/src/agent.rs
@@ -132,7 +132,11 @@ pub async fn run() -> Result<()> {
             if plan.user.is_none() {
                 if let Some(ref device) = plan.image_device {
                     container::mount_btrfs_device(device, "/var/lib/containers/storage")?;
-                    container::write_btrfs_storage_conf("/etc/containers/storage.conf", "/var/lib/containers/storage", "/run/containers/storage");
+                    container::write_btrfs_storage_conf(
+                        "/etc/containers/storage.conf",
+                        "/var/lib/containers/storage",
+                        "/run/containers/storage",
+                    );
                 }
             }
         }
@@ -155,8 +159,12 @@ pub async fn run() -> Result<()> {
             .subuid_start
             .zip(plan.subuid_count)
             .or_else(|| plan.subuid_start.map(|s| (s, 65536)));
-        let (username, _uid, runtime_dir) =
-            container::create_vm_user(user_spec, desired_name, subuid_range, plan.image_mode.as_deref());
+        let (username, _uid, runtime_dir) = container::create_vm_user(
+            user_spec,
+            desired_name,
+            subuid_range,
+            plan.image_mode.as_deref(),
+        );
         Some((username, runtime_dir))
     } else {
         None

--- a/fc-agent/src/agent.rs
+++ b/fc-agent/src/agent.rs
@@ -152,14 +152,29 @@ pub async fn run() -> Result<()> {
     // Store prefix globally so exec server and health checks can use it
     container::set_podman_cmd_prefix(cmd_prefix.clone());
 
-    // Prepare image (mount storage, import archive, or pull from registry)
-    let image_ref = if let Some(storage_device) = &plan.image_storage_device {
-        let username = user_info.as_ref().map(|(name, _)| name.as_str());
-        container::mount_storage_image(storage_device, &plan.image, username)?
-    } else if let Some(archive_path) = &plan.image_archive {
-        container::import_image(archive_path, &plan.image, &output, &cmd_prefix).await?
-    } else {
-        container::pull_image(&plan).await?
+    // Prepare image based on delivery mode
+    let image_ref = match (plan.image_mode.as_deref(), &plan.image_device) {
+        (Some("overlay"), Some(device)) => {
+            let username = user_info.as_ref().map(|(name, _)| name.as_str());
+            container::mount_overlay_image(device, &plan.image, username)?
+        }
+        (Some("btrfs"), Some(device)) => {
+            let username = user_info.as_ref().map(|(name, _)| name.as_str());
+            container::mount_btrfs_image(device, &plan.image, username)?
+        }
+        (Some("archive"), Some(device)) => {
+            container::import_image(device, &plan.image, &output, &cmd_prefix).await?
+        }
+        (None, None) => {
+            // Remote image — pull from registry
+            container::pull_image(&plan).await?
+        }
+        (Some(mode), _) => {
+            anyhow::bail!("unknown image_mode: {}", mode);
+        }
+        (None, Some(_)) => {
+            anyhow::bail!("image_device set but image_mode is missing");
+        }
     };
 
     // Notify host for cache snapshot
@@ -257,8 +272,17 @@ pub async fn run() -> Result<()> {
         sleep(Duration::from_millis(100)).await;
     }
     mounts::unmount_disks(&mounted_disk_paths);
-    if plan.image_storage_device.is_some() {
-        mounts::unmount_paths(&["/mnt/image-store".to_string()], "image store");
+    match plan.image_mode.as_deref() {
+        Some("overlay") => {
+            mounts::unmount_paths(&["/mnt/image-store".to_string()], "image store");
+        }
+        Some("btrfs") => {
+            mounts::unmount_paths(
+                &["/var/lib/containers/storage".to_string()],
+                "btrfs image store",
+            );
+        }
+        _ => {}
     }
 
     // Shutdown output writer

--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -50,10 +50,24 @@ pub fn mount_overlay_image(
     // Configure podman to use this as an additional image store.
     let (conf_path, runroot, graphroot) = storage_paths(username);
 
+    // Clear any stale podman database that might have a different driver.
+    // The rootfs may have a pre-existing database from setup that conflicts
+    // with our explicit driver="overlay" setting.
+    clear_podman_database(&graphroot);
+
     let storage_conf = format!(
         "[storage]\ndriver = \"overlay\"\nrunroot = \"{runroot}\"\ngraphroot = \"{graphroot}\"\n\n[storage.options]\nadditionalimagestores = [\"{mount_path}\"]\n"
     );
     std::fs::write(&conf_path, &storage_conf).context("writing storage.conf")?;
+
+    // Write containers.conf to disable netavark (VM uses --network=host)
+    let containers_conf_path = if username.is_some() {
+        // User-level containers.conf lives alongside storage.conf
+        conf_path.replace("storage.conf", "containers.conf")
+    } else {
+        "/etc/containers/containers.conf".to_string()
+    };
+    write_containers_conf(&containers_conf_path);
 
     eprintln!(
         "[fc-agent] overlay image mounted at {}, configured as additional image store (conf: {})",
@@ -63,59 +77,57 @@ pub fn mount_overlay_image(
     Ok(image_name.to_string())
 }
 
-/// Mount a pre-built btrfs storage image directly as the podman graphroot.
+/// Mount a btrfs device at the given path (Phase 1: before user creation).
 ///
-/// The btrfs image contains real btrfs subvolumes with podman's storage tree.
-/// It is mounted read-write at `/var/lib/containers/storage` so podman uses it
-/// as the primary graphroot — no podman load or import needed.
-///
-/// When `setup_btrfs_storage_if_available()` runs later, it detects btrfs is already
-/// mounted at this path and skips loopback creation.
-pub fn mount_btrfs_image(
-    device: &str,
-    image_name: &str,
-    username: Option<&str>,
-) -> Result<String> {
-    eprintln!(
-        "[fc-agent] mounting btrfs storage image: {}",
-        device
-    );
+/// This is the early mount step for btrfs image mode. The device is mounted read-write
+/// so that `setup_btrfs_storage_if_available()` detects btrfs and writes storage.conf,
+/// and `setup_user_btrfs_storage()` creates user subdirs on it.
+pub fn mount_btrfs_device(device: &str, mount_path: &str) -> Result<()> {
+    std::fs::create_dir_all(mount_path).context("creating mount point")?;
 
-    let mount_path = "/var/lib/containers/storage";
-    std::fs::create_dir_all(mount_path).context("creating graphroot mount point")?;
+    // Ensure parent directories are traversable by non-root users.
+    // /var/lib/containers is typically 0700 root:root (podman default),
+    // but rootless podman needs to traverse it to reach the graphroot.
+    if let Some(parent) = std::path::Path::new(mount_path).parent() {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o755));
+    }
 
     wait_for_device(device)?;
 
-    // Mount read-write (podman needs to create container subvolumes)
     let output = std::process::Command::new("mount")
         .args(["-t", "btrfs", device, mount_path])
         .output()
-        .context("mounting btrfs storage image")?;
+        .context("mounting btrfs device")?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         anyhow::bail!(
-            "Failed to mount btrfs storage image {} at {}: {}",
+            "Failed to mount btrfs device {} at {}: {}",
             device,
             mount_path,
             stderr
         );
     }
 
-    // Configure podman to use btrfs driver with this graphroot.
-    let (conf_path, runroot, _graphroot) = storage_paths(username);
+    // The btrfs image's root directory may have mode 0700 (podman graphroot default
+    // from mkfs.btrfs --rootdir). Set to 0755 so rootless podman's user namespace
+    // can traverse it (real root maps to "nobody" in user namespaces).
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(mount_path, std::fs::Permissions::from_mode(0o755));
+    }
 
-    let storage_conf = format!(
-        "[storage]\ndriver = \"btrfs\"\nrunroot = \"{runroot}\"\ngraphroot = \"{mount_path}\"\n"
-    );
-    std::fs::write(&conf_path, &storage_conf).context("writing storage.conf")?;
+    // Clear stale podman database AFTER mounting so we clean the actual btrfs content.
+    // The cached .btrfs.img may have stale db/containers from previous VM runs
+    // (btrfs image disk is read-write, so previous runs' container creates persist).
+    clear_podman_database(mount_path);
 
     eprintln!(
-        "[fc-agent] btrfs image mounted at {}, configured as graphroot (conf: {})",
-        mount_path, conf_path
+        "[fc-agent] btrfs device {} mounted at {} (early mount)",
+        device, mount_path
     );
-
-    Ok(image_name.to_string())
+    Ok(())
 }
 
 /// Wait for a block device to appear (up to 5 seconds).
@@ -170,6 +182,49 @@ fn storage_paths(username: Option<&str>) -> (String, String, String) {
     }
 }
 
+/// Clear stale podman database files that might have a mismatched driver.
+///
+/// Podman stores its graph driver in the database. If we write a storage.conf
+/// with a different driver, podman refuses to start ("database graph driver X
+/// does not match our graph driver Y"). Clearing the database lets podman
+/// recreate it with the correct driver.
+fn clear_podman_database(graphroot: &str) {
+    let graphroot_path = std::path::Path::new(graphroot);
+    for entry in ["libpod", "db.sql", "btrfs-containers", "overlay-containers"] {
+        let path = graphroot_path.join(entry);
+        if path.is_dir() {
+            if let Err(e) = std::fs::remove_dir_all(&path) {
+                eprintln!("[fc-agent] WARNING: failed to remove {}: {}", path.display(), e);
+            }
+        } else if path.is_file() {
+            if let Err(e) = std::fs::remove_file(&path) {
+                eprintln!("[fc-agent] WARNING: failed to remove {}: {}", path.display(), e);
+            }
+        }
+    }
+}
+
+/// Write containers.conf to disable netavark requirement.
+///
+/// The VM always uses `--network=host` for containers, so podman never needs
+/// netavark for container networking. However, podman 4.x checks for netavark
+/// at startup even with `--network=host`. The rootfs may not have netavark
+/// installed (it's not required for our use case), so we configure podman to
+/// skip the check by setting `network_backend = "cni"`.
+fn write_containers_conf(conf_path: &str) {
+    let containers_conf = "[network]\nnetwork_backend = \"cni\"\n";
+    let conf_dir = std::path::Path::new(conf_path).parent();
+    if let Some(dir) = conf_dir {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    if let Err(e) = std::fs::write(conf_path, containers_conf) {
+        eprintln!(
+            "[fc-agent] WARNING: failed to write containers.conf at {}: {}",
+            conf_path, e
+        );
+    }
+}
+
 /// Global command prefix for running podman commands as the target user.
 /// Set once during setup, used by exec server and health checks.
 /// Empty when running as root (no user mapping).
@@ -183,6 +238,85 @@ pub fn set_podman_cmd_prefix(prefix: Vec<String>) {
 /// Get the command prefix (empty vec if running as root).
 pub fn podman_cmd_prefix() -> &'static [String] {
     PODMAN_CMD_PREFIX.get().map(|v| v.as_slice()).unwrap_or(&[])
+}
+
+/// Mount a pre-built btrfs image at the user's standard rootless graphroot.
+///
+/// Mounts at ~/.local/share/containers/storage — the default rootless graphroot.
+/// The btrfs image was built by rootless podman on the host (uid 1000), so all
+/// storage files already have correct ownership. No chown needed — just mount
+/// and configure, matching how rootless podman works on a physical host.
+pub fn mount_btrfs_for_user(device: &str, username: &str) -> Result<()> {
+    let home = format!("/home/{}", username);
+    let storage_dir = format!("{}/.local/share/containers/storage", home);
+
+    // Create the directory chain to the mount point
+    std::fs::create_dir_all(&storage_dir).context("creating user graphroot")?;
+
+    let pw = nix::unistd::User::from_name(username)?
+        .ok_or_else(|| anyhow::anyhow!("user not found: {}", username))?;
+    let uid = pw.uid.as_raw();
+    let gid = pw.gid.as_raw();
+    let owner = format!("{}:{}", uid, gid);
+
+    // Chown only the directory chain leading to the mount point (non-recursive).
+    // These are empty directories created by root; the user needs to traverse them.
+    let _ = std::process::Command::new("chown")
+        .args([
+            &owner,
+            &format!("{}/.local", home),
+            &format!("{}/.local/share", home),
+            &format!("{}/.local/share/containers", home),
+            &storage_dir,
+        ])
+        .output();
+
+    mount_btrfs_device(device, &storage_dir)?;
+
+    // Write user storage.conf with just driver = "btrfs".
+    // No custom graphroot needed — podman uses ~/.local/share/containers/storage by default.
+    let user_config_dir = format!("{}/.config/containers", home);
+    let _ = std::fs::create_dir_all(&user_config_dir);
+    let user_runroot = format!("/run/user/{}/containers", uid);
+    let _ = std::fs::create_dir_all(&user_runroot);
+    let _ = std::process::Command::new("chown")
+        .args([&owner, &user_runroot])
+        .output();
+
+    let storage_conf = format!(
+        "[storage]\ndriver = \"btrfs\"\nrunroot = \"{}\"\n",
+        user_runroot
+    );
+    std::fs::write(format!("{}/storage.conf", user_config_dir), &storage_conf)
+        .context("writing user storage.conf")?;
+    write_containers_conf(&format!("{}/containers.conf", user_config_dir));
+
+    // Chown config dir to user (tiny tree — just 2 config files)
+    let _ = std::process::Command::new("chown")
+        .args(["-R", &owner, &format!("{}/.config", home)])
+        .output();
+
+    eprintln!(
+        "[fc-agent] btrfs image mounted at user graphroot {} (uid={})",
+        storage_dir, uid
+    );
+    Ok(())
+}
+
+/// Write a btrfs storage.conf for root podman.
+pub fn write_btrfs_storage_conf(conf_path: &str, graphroot: &str, runroot: &str) {
+    let _ = std::fs::create_dir_all(
+        std::path::Path::new(conf_path).parent().unwrap_or(std::path::Path::new("/etc/containers")),
+    );
+    let storage_conf = format!(
+        "[storage]\ndriver = \"btrfs\"\nrunroot = \"{}\"\ngraphroot = \"{}\"\n",
+        runroot, graphroot
+    );
+    if let Err(e) = std::fs::write(conf_path, &storage_conf) {
+        eprintln!("[fc-agent] WARNING: failed to write storage.conf at {}: {}", conf_path, e);
+    }
+    let containers_conf = conf_path.replace("storage.conf", "containers.conf");
+    write_containers_conf(&containers_conf);
 }
 
 /// Get the total size of the filesystem containing `path` in bytes.
@@ -233,6 +367,7 @@ pub fn setup_btrfs_storage_if_available() {
             "[fc-agent] btrfs storage already mounted at {}",
             storage_dir
         );
+        write_btrfs_storage_conf("/etc/containers/storage.conf", storage_dir, "/run/containers/storage");
         return;
     }
 
@@ -299,16 +434,7 @@ pub fn setup_btrfs_storage_if_available() {
         }
     }
 
-    // Write storage.conf for root podman with explicit paths.
-    // runroot is required by podman when driver is set explicitly.
-    let storage_conf = format!(
-        "[storage]\ndriver = \"btrfs\"\nrunroot = \"/run/containers/storage\"\ngraphroot = \"{}\"\n",
-        storage_dir
-    );
-    let _ = std::fs::create_dir_all("/etc/containers");
-    if let Err(e) = std::fs::write("/etc/containers/storage.conf", storage_conf) {
-        eprintln!("[fc-agent] WARNING: failed to write storage.conf: {}", e);
-    }
+    write_btrfs_storage_conf("/etc/containers/storage.conf", storage_dir, "/run/containers/storage");
 
     eprintln!(
         "[fc-agent] btrfs storage configured at {} ({} sparse loopback)",
@@ -754,10 +880,15 @@ pub fn build_podman_args(
 /// When the storage image is built by rootless podman on the host, it contains
 /// files with UIDs from the host's subuid range. The VM must use the same range
 /// so those UIDs are valid in the VM's user namespace.
+///
+/// `image_mode`: the image delivery mode ("overlay", "btrfs", "archive", or None).
+/// When "btrfs", the pre-built btrfs image is mounted at the root graphroot and
+/// the user's graphroot points directly there (btrfs doesn't support additionalImageStores).
 pub fn create_vm_user(
     user_spec: &str,
     desired_name: &str,
     subuid_range: Option<(u64, u64)>,
+    image_mode: Option<&str>,
 ) -> (String, String, String) {
     let parts: Vec<&str> = user_spec.split(':').collect();
     let uid = parts[0].to_string();
@@ -796,8 +927,10 @@ pub fn create_vm_user(
     // Clean stale podman storage from previous VM runs. The run root may have
     // changed between runs (e.g., /tmp vs /run/user), causing "database
     // configuration mismatch" errors.
+    // HOME is set so podman finds user-level config (if it exists at this point).
     let _ = std::process::Command::new("env")
         .args([
+            &format!("HOME=/home/{}", username),
             &format!("XDG_RUNTIME_DIR={}", runtime_dir),
             "runuser",
             "-u",
@@ -833,17 +966,25 @@ pub fn create_vm_user(
     }
 
     // Set up user-level btrfs storage if root btrfs is available
-    setup_user_btrfs_storage(&uid, &gid, &username);
+    setup_user_btrfs_storage(&uid, &gid, &username, image_mode);
 
     (username, uid, runtime_dir)
 }
 
-/// Set up btrfs storage for a rootless user by creating a subdirectory
-/// under the root btrfs mount and writing a user-level storage.conf.
-fn setup_user_btrfs_storage(uid: &str, gid: &str, username: &str) {
+/// Set up btrfs storage for a rootless user (loopback mode only).
+///
+/// For btrfs image mode, `mount_btrfs_for_user()` handles everything.
+/// This function creates a user-specific subdirectory on the loopback btrfs mount
+/// for archive/pull modes where no pre-built image is provided.
+fn setup_user_btrfs_storage(uid: &str, gid: &str, username: &str, image_mode: Option<&str>) {
+    // Btrfs image mode is handled by mount_btrfs_for_user() in agent.rs
+    if image_mode == Some("btrfs") {
+        return;
+    }
+
     let root_mnt = "/var/lib/containers/storage";
 
-    // Check if root btrfs storage is mounted
+    // Check if root btrfs storage is mounted (loopback from setup_btrfs_storage_if_available)
     let is_btrfs = std::process::Command::new("findmnt")
         .args(["-n", "-o", "FSTYPE", root_mnt])
         .output()
@@ -854,7 +995,7 @@ fn setup_user_btrfs_storage(uid: &str, gid: &str, username: &str) {
         return;
     }
 
-    // Create user-specific subdirectory on the btrfs mount
+    // Loopback mode: create user-specific subdirectory
     let user_graphroot = format!("{}/user-{}", root_mnt, uid);
     let _ = std::fs::create_dir_all(&user_graphroot);
     let _ = std::process::Command::new("chown")
@@ -882,6 +1023,7 @@ fn setup_user_btrfs_storage(uid: &str, gid: &str, username: &str) {
         );
         return;
     }
+    write_containers_conf(&format!("{}/containers.conf", user_config_dir));
     // Ensure the user owns their config
     let _ = std::process::Command::new("chown")
         .args([
@@ -898,9 +1040,13 @@ fn setup_user_btrfs_storage(uid: &str, gid: &str, username: &str) {
 }
 
 /// Build the env + runuser prefix for running commands as the VM user.
+///
+/// Sets HOME so podman finds user-level config at ~/.config/containers/,
+/// and XDG_RUNTIME_DIR for the user's runtime state.
 pub fn run_as_user_prefix(username: &str, runtime_dir: &str) -> Vec<String> {
     vec![
         "env".to_string(),
+        format!("HOME=/home/{}", username),
         format!("XDG_RUNTIME_DIR={}", runtime_dir),
         "runuser".to_string(),
         "-u".to_string(),

--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -115,9 +115,10 @@ pub fn mount_btrfs_device(device: &str, mount_path: &str) -> Result<()> {
         let _ = std::fs::set_permissions(mount_path, std::fs::Permissions::from_mode(0o755));
     }
 
-    // Clear stale podman database AFTER mounting so we clean the actual btrfs content.
-    // The cached .btrfs.img may have stale db/containers from previous VM runs
-    // (btrfs image disk is read-write, so previous runs' container creates persist).
+    // Clean podman state files from the mounted image. The host-side build removes
+    // these before mkfs.btrfs, but they can reappear: btrfs metadata operations or
+    // podman initialization may recreate db.sql with graph_driver="" before we write
+    // storage.conf with driver="btrfs", causing a mismatch error.
     clear_podman_database(mount_path);
 
     eprintln!(
@@ -219,22 +220,17 @@ fn clear_podman_database(graphroot: &str) {
             Ok(ft) => ft,
             Err(_) => continue,
         };
-        if ft.is_dir() {
-            if let Err(e) = std::fs::remove_dir_all(&path) {
-                eprintln!(
-                    "[fc-agent] WARNING: failed to remove {}: {}",
-                    path.display(),
-                    e
-                );
-            }
+        let result = if ft.is_dir() {
+            std::fs::remove_dir_all(&path)
         } else {
-            if let Err(e) = std::fs::remove_file(&path) {
-                eprintln!(
-                    "[fc-agent] WARNING: failed to remove {}: {}",
-                    path.display(),
-                    e
-                );
-            }
+            std::fs::remove_file(&path)
+        };
+        if let Err(e) = result {
+            eprintln!(
+                "[fc-agent] WARNING: failed to remove {}: {}",
+                path.display(),
+                e
+            );
         }
     }
 }

--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -21,10 +21,7 @@ pub fn mount_overlay_image(
     image_name: &str,
     username: Option<&str>,
 ) -> Result<String> {
-    eprintln!(
-        "[fc-agent] mounting overlay storage image: {}",
-        device
-    );
+    eprintln!("[fc-agent] mounting overlay storage image: {}", device);
 
     let mount_path = "/mnt/image-store";
     std::fs::create_dir_all(mount_path).context("creating image store mount point")?;
@@ -156,21 +153,16 @@ fn storage_paths(username: Option<&str>) -> (String, String, String) {
         let config_dir = format!("{}/.config", home);
         let conf_dir = format!("{}/containers", config_dir);
         let _ = std::fs::create_dir_all(&conf_dir);
-        // Chown .config and children so podman can create subdirs (cni, etc.)
-        if let Ok(Some(pw)) = nix::unistd::User::from_name(name) {
+        // Look up user once and reuse for chown and UID extraction
+        let user_pw = nix::unistd::User::from_name(name).ok().flatten();
+        if let Some(ref pw) = user_pw {
             let _ = nix::unistd::chown(config_dir.as_str(), Some(pw.uid), Some(pw.gid));
             let _ = nix::unistd::chown(conf_dir.as_str(), Some(pw.uid), Some(pw.gid));
         }
+        let uid = user_pw.map(|u| u.uid.as_raw()).unwrap_or(0);
         (
             format!("{}/storage.conf", conf_dir),
-            format!(
-                "/run/user/{}/containers",
-                nix::unistd::User::from_name(name)
-                    .ok()
-                    .flatten()
-                    .map(|u| u.uid.as_raw())
-                    .unwrap_or(0)
-            ),
+            format!("/run/user/{}/containers", uid),
             format!("{}/.local/share/containers/storage", home),
         )
     } else {
@@ -194,11 +186,19 @@ fn clear_podman_database(graphroot: &str) {
         let path = graphroot_path.join(entry);
         if path.is_dir() {
             if let Err(e) = std::fs::remove_dir_all(&path) {
-                eprintln!("[fc-agent] WARNING: failed to remove {}: {}", path.display(), e);
+                eprintln!(
+                    "[fc-agent] WARNING: failed to remove {}: {}",
+                    path.display(),
+                    e
+                );
             }
         } else if path.is_file() {
             if let Err(e) = std::fs::remove_file(&path) {
-                eprintln!("[fc-agent] WARNING: failed to remove {}: {}", path.display(), e);
+                eprintln!(
+                    "[fc-agent] WARNING: failed to remove {}: {}",
+                    path.display(),
+                    e
+                );
             }
         }
     }
@@ -306,14 +306,19 @@ pub fn mount_btrfs_for_user(device: &str, username: &str) -> Result<()> {
 /// Write a btrfs storage.conf for root podman.
 pub fn write_btrfs_storage_conf(conf_path: &str, graphroot: &str, runroot: &str) {
     let _ = std::fs::create_dir_all(
-        std::path::Path::new(conf_path).parent().unwrap_or(std::path::Path::new("/etc/containers")),
+        std::path::Path::new(conf_path)
+            .parent()
+            .unwrap_or(std::path::Path::new("/etc/containers")),
     );
     let storage_conf = format!(
         "[storage]\ndriver = \"btrfs\"\nrunroot = \"{}\"\ngraphroot = \"{}\"\n",
         runroot, graphroot
     );
     if let Err(e) = std::fs::write(conf_path, &storage_conf) {
-        eprintln!("[fc-agent] WARNING: failed to write storage.conf at {}: {}", conf_path, e);
+        eprintln!(
+            "[fc-agent] WARNING: failed to write storage.conf at {}: {}",
+            conf_path, e
+        );
     }
     let containers_conf = conf_path.replace("storage.conf", "containers.conf");
     write_containers_conf(&containers_conf);
@@ -367,7 +372,11 @@ pub fn setup_btrfs_storage_if_available() {
             "[fc-agent] btrfs storage already mounted at {}",
             storage_dir
         );
-        write_btrfs_storage_conf("/etc/containers/storage.conf", storage_dir, "/run/containers/storage");
+        write_btrfs_storage_conf(
+            "/etc/containers/storage.conf",
+            storage_dir,
+            "/run/containers/storage",
+        );
         return;
     }
 
@@ -434,7 +443,11 @@ pub fn setup_btrfs_storage_if_available() {
         }
     }
 
-    write_btrfs_storage_conf("/etc/containers/storage.conf", storage_dir, "/run/containers/storage");
+    write_btrfs_storage_conf(
+        "/etc/containers/storage.conf",
+        storage_dir,
+        "/run/containers/storage",
+    );
 
     eprintln!(
         "[fc-agent] btrfs storage configured at {} ({} sparse loopback)",

--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -11,36 +11,25 @@ use crate::output::OutputHandle;
 use crate::types::Plan;
 use crate::vsock;
 
-/// Mount a pre-built podman storage image and configure as additionalImageStore.
+/// Mount a pre-built overlay storage image and configure as additionalImageStore.
 ///
 /// The storage image is an ext4 filesystem containing a podman overlay storage tree
 /// (overlay/, overlay-images/, overlay-layers/). It is mounted read-only and podman
 /// finds the image there without needing `podman load`.
-pub fn mount_storage_image(
+pub fn mount_overlay_image(
     device: &str,
     image_name: &str,
     username: Option<&str>,
 ) -> Result<String> {
-    eprintln!("[fc-agent] mounting pre-built storage image: {}", device);
+    eprintln!(
+        "[fc-agent] mounting overlay storage image: {}",
+        device
+    );
 
     let mount_path = "/mnt/image-store";
     std::fs::create_dir_all(mount_path).context("creating image store mount point")?;
 
-    // Wait for device to appear
-    let device_path = std::path::Path::new(device);
-    for attempt in 1..=10 {
-        if device_path.exists() {
-            break;
-        }
-        if attempt == 10 {
-            anyhow::bail!("Device {} not found after 10 attempts", device);
-        }
-        eprintln!(
-            "[fc-agent] waiting for device {} (attempt {}/10)",
-            device, attempt
-        );
-        std::thread::sleep(std::time::Duration::from_millis(500));
-    }
+    wait_for_device(device)?;
 
     // Mount read-only
     let output = std::process::Command::new("mount")
@@ -51,7 +40,7 @@ pub fn mount_storage_image(
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         anyhow::bail!(
-            "Failed to mount storage image {} at {}: {}",
+            "Failed to mount overlay storage image {} at {}: {}",
             device,
             mount_path,
             stderr
@@ -59,10 +48,98 @@ pub fn mount_storage_image(
     }
 
     // Configure podman to use this as an additional image store.
-    // For rootless podman (--user mode), write to the user's config dir.
-    // For root podman, write to /etc/containers/.
-    let (conf_path, runroot, graphroot) = if let Some(name) = username {
-        // Rootless: user's home directory config
+    let (conf_path, runroot, graphroot) = storage_paths(username);
+
+    let storage_conf = format!(
+        "[storage]\ndriver = \"overlay\"\nrunroot = \"{runroot}\"\ngraphroot = \"{graphroot}\"\n\n[storage.options]\nadditionalimagestores = [\"{mount_path}\"]\n"
+    );
+    std::fs::write(&conf_path, &storage_conf).context("writing storage.conf")?;
+
+    eprintln!(
+        "[fc-agent] overlay image mounted at {}, configured as additional image store (conf: {})",
+        mount_path, conf_path
+    );
+
+    Ok(image_name.to_string())
+}
+
+/// Mount a pre-built btrfs storage image directly as the podman graphroot.
+///
+/// The btrfs image contains real btrfs subvolumes with podman's storage tree.
+/// It is mounted read-write at `/var/lib/containers/storage` so podman uses it
+/// as the primary graphroot — no podman load or import needed.
+///
+/// When `setup_btrfs_storage_if_available()` runs later, it detects btrfs is already
+/// mounted at this path and skips loopback creation.
+pub fn mount_btrfs_image(
+    device: &str,
+    image_name: &str,
+    username: Option<&str>,
+) -> Result<String> {
+    eprintln!(
+        "[fc-agent] mounting btrfs storage image: {}",
+        device
+    );
+
+    let mount_path = "/var/lib/containers/storage";
+    std::fs::create_dir_all(mount_path).context("creating graphroot mount point")?;
+
+    wait_for_device(device)?;
+
+    // Mount read-write (podman needs to create container subvolumes)
+    let output = std::process::Command::new("mount")
+        .args(["-t", "btrfs", device, mount_path])
+        .output()
+        .context("mounting btrfs storage image")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "Failed to mount btrfs storage image {} at {}: {}",
+            device,
+            mount_path,
+            stderr
+        );
+    }
+
+    // Configure podman to use btrfs driver with this graphroot.
+    let (conf_path, runroot, _graphroot) = storage_paths(username);
+
+    let storage_conf = format!(
+        "[storage]\ndriver = \"btrfs\"\nrunroot = \"{runroot}\"\ngraphroot = \"{mount_path}\"\n"
+    );
+    std::fs::write(&conf_path, &storage_conf).context("writing storage.conf")?;
+
+    eprintln!(
+        "[fc-agent] btrfs image mounted at {}, configured as graphroot (conf: {})",
+        mount_path, conf_path
+    );
+
+    Ok(image_name.to_string())
+}
+
+/// Wait for a block device to appear (up to 5 seconds).
+fn wait_for_device(device: &str) -> Result<()> {
+    let device_path = std::path::Path::new(device);
+    for attempt in 1..=10 {
+        if device_path.exists() {
+            return Ok(());
+        }
+        if attempt == 10 {
+            anyhow::bail!("Device {} not found after 10 attempts", device);
+        }
+        eprintln!(
+            "[fc-agent] waiting for device {} (attempt {}/10)",
+            device, attempt
+        );
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+    Ok(())
+}
+
+/// Get storage.conf path, runroot, and graphroot for the given user.
+fn storage_paths(username: Option<&str>) -> (String, String, String) {
+    if let Some(name) = username {
         let home = format!("/home/{}", name);
         let config_dir = format!("{}/.config", home);
         let conf_dir = format!("{}/containers", config_dir);
@@ -90,108 +167,7 @@ pub fn mount_storage_image(
             "/run/containers/storage".to_string(),
             "/var/lib/containers/storage".to_string(),
         )
-    };
-
-    // Detect if btrfs storage was already configured (by setup_btrfs_storage_if_available).
-    // Check the ROOT storage path — for rootless users, setup_user_btrfs_storage() creates
-    // subdirs under the root btrfs mount, but the per-user graphroot uses a different path.
-    let is_btrfs = std::process::Command::new("findmnt")
-        .args(["-n", "-o", "FSTYPE", "/var/lib/containers/storage"])
-        .output()
-        .map(|o| String::from_utf8_lossy(&o.stdout).trim() == "btrfs")
-        .unwrap_or(false);
-
-    if is_btrfs {
-        // btrfs driver doesn't support overlay-format additionalimagestores.
-        // For rootless users, setup_user_btrfs_storage() already wrote the correct
-        // storage.conf — don't overwrite it. For root, write a minimal btrfs config.
-        if username.is_none() {
-            let storage_conf = format!(
-                "[storage]\ndriver = \"btrfs\"\nrunroot = \"{runroot}\"\ngraphroot = \"{graphroot}\"\n"
-            );
-            std::fs::write(&conf_path, &storage_conf).context("writing storage.conf")?;
-        }
-
-        eprintln!(
-            "[fc-agent] btrfs driver: importing image from overlay store at {}",
-            mount_path
-        );
-
-        // Save the image from the overlay store to a tar archive
-        let save_output = std::process::Command::new("podman")
-            .args([
-                "--root",
-                mount_path,
-                "--storage-driver",
-                "overlay",
-                "save",
-                "-o",
-                "/tmp/image-import.tar",
-                image_name,
-            ])
-            .output()
-            .context("running podman save from overlay store")?;
-
-        if !save_output.status.success() {
-            let stderr = String::from_utf8_lossy(&save_output.stderr);
-            anyhow::bail!("podman save from overlay store failed: {}", stderr);
-        }
-
-        // Load the image into the btrfs store.
-        // For rootless users, use runuser so podman reads the user's storage.conf.
-        let load_output = if let Some(name) = username {
-            let uid_str = nix::unistd::User::from_name(name)
-                .ok()
-                .flatten()
-                .map(|u| u.uid.as_raw().to_string())
-                .unwrap_or_default();
-            std::process::Command::new("env")
-                .args([
-                    &format!("XDG_RUNTIME_DIR=/run/user/{}", uid_str),
-                    "runuser",
-                    "-u",
-                    name,
-                    "--",
-                    "podman",
-                    "load",
-                    "-i",
-                    "/tmp/image-import.tar",
-                ])
-                .output()
-                .context("running podman load as user into btrfs store")?
-        } else {
-            std::process::Command::new("podman")
-                .args(["load", "-i", "/tmp/image-import.tar"])
-                .output()
-                .context("running podman load into btrfs store")?
-        };
-
-        if !load_output.status.success() {
-            let stderr = String::from_utf8_lossy(&load_output.stderr);
-            anyhow::bail!("podman load into btrfs store failed: {}", stderr);
-        }
-
-        // Clean up temp archive
-        let _ = std::fs::remove_file("/tmp/image-import.tar");
-
-        eprintln!(
-            "[fc-agent] image imported into btrfs store: {}",
-            String::from_utf8_lossy(&load_output.stdout).trim()
-        );
-    } else {
-        // overlay driver: use additionalimagestores for instant image access
-        let storage_conf = format!(
-            "[storage]\ndriver = \"overlay\"\nrunroot = \"{runroot}\"\ngraphroot = \"{graphroot}\"\n\n[storage.options]\nadditionalimagestores = [\"{mount_path}\"]\n"
-        );
-        std::fs::write(&conf_path, &storage_conf).context("writing storage.conf")?;
-
-        eprintln!(
-            "[fc-agent] storage image mounted at {}, configured as additional image store (conf: {})",
-            mount_path, conf_path
-        );
     }
-
-    Ok(image_name.to_string())
 }
 
 /// Global command prefix for running podman commands as the target user.

--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -47,11 +47,6 @@ pub fn mount_overlay_image(
     // Configure podman to use this as an additional image store.
     let (conf_path, runroot, graphroot) = storage_paths(username);
 
-    // Clear any stale podman database that might have a different driver.
-    // The rootfs may have a pre-existing database from setup that conflicts
-    // with our explicit driver="overlay" setting.
-    clear_podman_database(&graphroot);
-
     let storage_conf = format!(
         "[storage]\ndriver = \"overlay\"\nrunroot = \"{runroot}\"\ngraphroot = \"{graphroot}\"\n\n[storage.options]\nadditionalimagestores = [\"{mount_path}\"]\n"
     );
@@ -115,12 +110,6 @@ pub fn mount_btrfs_device(device: &str, mount_path: &str) -> Result<()> {
         let _ = std::fs::set_permissions(mount_path, std::fs::Permissions::from_mode(0o755));
     }
 
-    // Clean podman state files from the mounted image. The host-side build removes
-    // these before mkfs.btrfs, but they can reappear: btrfs metadata operations or
-    // podman initialization may recreate db.sql with graph_driver="" before we write
-    // storage.conf with driver="btrfs", causing a mismatch error.
-    clear_podman_database(mount_path);
-
     eprintln!(
         "[fc-agent] btrfs device {} mounted at {} (early mount)",
         device, mount_path
@@ -172,66 +161,6 @@ fn storage_paths(username: Option<&str>) -> (String, String, String) {
             "/run/containers/storage".to_string(),
             "/var/lib/containers/storage".to_string(),
         )
-    }
-}
-
-/// Clear ALL podman state files, keeping only image/layer data.
-///
-/// Podman stores its graph driver in the database (db.sql, libpod/).
-/// If we write a storage.conf with a different driver, podman refuses to start:
-/// "database graph driver X does not match our graph driver Y".
-///
-/// Instead of maintaining a list of files to delete (which misses new state files
-/// added in newer podman versions), we keep only the directories containing
-/// actual image/layer data and delete everything else.
-fn clear_podman_database(graphroot: &str) {
-    let graphroot_path = std::path::Path::new(graphroot);
-
-    // Directories containing actual image/layer data — keep these.
-    // All other files/dirs are state/database/locks that must be recreated.
-    let keep = [
-        "btrfs",
-        "btrfs-images",
-        "btrfs-layers",
-        "overlay",
-        "overlay-images",
-        "overlay-layers",
-    ];
-
-    let entries = match std::fs::read_dir(graphroot_path) {
-        Ok(entries) => entries,
-        Err(e) => {
-            eprintln!(
-                "[fc-agent] WARNING: cannot read graphroot {}: {}",
-                graphroot, e
-            );
-            return;
-        }
-    };
-
-    for entry in entries.flatten() {
-        let name = entry.file_name();
-        let name_str = name.to_string_lossy();
-        if keep.iter().any(|&k| k == name_str.as_ref()) {
-            continue;
-        }
-        let path = entry.path();
-        let ft = match entry.file_type() {
-            Ok(ft) => ft,
-            Err(_) => continue,
-        };
-        let result = if ft.is_dir() {
-            std::fs::remove_dir_all(&path)
-        } else {
-            std::fs::remove_file(&path)
-        };
-        if let Err(e) = result {
-            eprintln!(
-                "[fc-agent] WARNING: failed to remove {}: {}",
-                path.display(),
-                e
-            );
-        }
     }
 }
 

--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -174,17 +174,52 @@ fn storage_paths(username: Option<&str>) -> (String, String, String) {
     }
 }
 
-/// Clear stale podman database files that might have a mismatched driver.
+/// Clear ALL podman state files, keeping only image/layer data.
 ///
-/// Podman stores its graph driver in the database. If we write a storage.conf
-/// with a different driver, podman refuses to start ("database graph driver X
-/// does not match our graph driver Y"). Clearing the database lets podman
-/// recreate it with the correct driver.
+/// Podman stores its graph driver in the database (db.sql, libpod/).
+/// If we write a storage.conf with a different driver, podman refuses to start:
+/// "database graph driver X does not match our graph driver Y".
+///
+/// Instead of maintaining a list of files to delete (which misses new state files
+/// added in newer podman versions), we keep only the directories containing
+/// actual image/layer data and delete everything else.
 fn clear_podman_database(graphroot: &str) {
     let graphroot_path = std::path::Path::new(graphroot);
-    for entry in ["libpod", "db.sql", "btrfs-containers", "overlay-containers"] {
-        let path = graphroot_path.join(entry);
-        if path.is_dir() {
+
+    // Directories containing actual image/layer data — keep these.
+    // All other files/dirs are state/database/locks that must be recreated.
+    let keep = [
+        "btrfs",
+        "btrfs-images",
+        "btrfs-layers",
+        "overlay",
+        "overlay-images",
+        "overlay-layers",
+    ];
+
+    let entries = match std::fs::read_dir(graphroot_path) {
+        Ok(entries) => entries,
+        Err(e) => {
+            eprintln!(
+                "[fc-agent] WARNING: cannot read graphroot {}: {}",
+                graphroot, e
+            );
+            return;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if keep.iter().any(|&k| k == name_str.as_ref()) {
+            continue;
+        }
+        let path = entry.path();
+        let ft = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(_) => continue,
+        };
+        if ft.is_dir() {
             if let Err(e) = std::fs::remove_dir_all(&path) {
                 eprintln!(
                     "[fc-agent] WARNING: failed to remove {}: {}",
@@ -192,7 +227,7 @@ fn clear_podman_database(graphroot: &str) {
                     e
                 );
             }
-        } else if path.is_file() {
+        } else {
             if let Err(e) = std::fs::remove_file(&path) {
                 eprintln!(
                     "[fc-agent] WARNING: failed to remove {}: {}",

--- a/fc-agent/src/types.rs
+++ b/fc-agent/src/types.rs
@@ -13,10 +13,12 @@ pub struct Plan {
     pub extra_disks: Vec<ExtraDiskMount>,
     #[serde(default)]
     pub nfs_mounts: Vec<NfsMount>,
+    /// Device path for localhost image (e.g., "/dev/vdb")
     #[serde(default)]
-    pub image_archive: Option<String>,
+    pub image_device: Option<String>,
+    /// Image delivery mode: "overlay", "btrfs", or "archive"
     #[serde(default)]
-    pub image_storage_device: Option<String>,
+    pub image_mode: Option<String>,
     #[serde(default)]
     pub user: Option<String>,
     #[serde(default)]
@@ -139,15 +141,40 @@ mod tests {
     }
 
     #[test]
-    fn test_plan_with_storage_device() {
+    fn test_plan_with_overlay_image() {
         let json = r#"{
             "image": "localhost/myapp",
-            "image_storage_device": "/dev/vdb"
+            "image_device": "/dev/vdb",
+            "image_mode": "overlay"
         }"#;
         let plan: Plan = serde_json::from_str(json).unwrap();
         assert_eq!(plan.image, "localhost/myapp");
-        assert_eq!(plan.image_storage_device.as_deref(), Some("/dev/vdb"));
-        assert!(plan.image_archive.is_none());
+        assert_eq!(plan.image_device.as_deref(), Some("/dev/vdb"));
+        assert_eq!(plan.image_mode.as_deref(), Some("overlay"));
+    }
+
+    #[test]
+    fn test_plan_with_btrfs_image() {
+        let json = r#"{
+            "image": "localhost/myapp",
+            "image_device": "/dev/vdb",
+            "image_mode": "btrfs"
+        }"#;
+        let plan: Plan = serde_json::from_str(json).unwrap();
+        assert_eq!(plan.image_device.as_deref(), Some("/dev/vdb"));
+        assert_eq!(plan.image_mode.as_deref(), Some("btrfs"));
+    }
+
+    #[test]
+    fn test_plan_with_archive_image() {
+        let json = r#"{
+            "image": "localhost/myapp",
+            "image_device": "/dev/vdb",
+            "image_mode": "archive"
+        }"#;
+        let plan: Plan = serde_json::from_str(json).unwrap();
+        assert_eq!(plan.image_device.as_deref(), Some("/dev/vdb"));
+        assert_eq!(plan.image_mode.as_deref(), Some("archive"));
     }
 
     #[test]

--- a/rootfs-config.toml
+++ b/rootfs-config.toml
@@ -80,12 +80,21 @@ enable = [
 ]
 
 # Services to disable
+# podman services race with fc-agent: they run `podman start --all` at boot,
+# which initializes db.sql before fc-agent writes storage.conf, causing
+# "database graph driver does not match" errors.
 disable = [
     "multipathd",
     "snapd",
     "cloud-init",
     "cloud-config",
     "cloud-final",
+    "podman.service",
+    "podman.socket",
+    "podman-restart.service",
+    "podman-auto-update.service",
+    "podman-auto-update.timer",
+    "podman-clean-transient.service",
 ]
 
 [files]

--- a/scripts/build-btrfs-progs.sh
+++ b/scripts/build-btrfs-progs.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Build btrfs-progs >= 6.12 for --rootdir --subvol support.
+#
+# btrfs-progs 6.12+ includes mkfs.btrfs --rootdir --subvol which creates
+# btrfs images from directories containing btrfs subvolumes — without root.
+# Ubuntu 24.04 ships btrfs-progs 6.6.3 which lacks this feature.
+#
+# Usage: ./scripts/build-btrfs-progs.sh [output_dir]
+#        Output defaults to /mnt/fcvm-btrfs/deps/bin/
+
+set -euo pipefail
+
+BTRFS_PROGS_VERSION="6.12"
+OUTPUT_DIR="${1:-/mnt/fcvm-btrfs/deps/bin}"
+
+# Source URL
+BTRFS_PROGS_URL="https://github.com/kdave/btrfs-progs/archive/refs/tags/v${BTRFS_PROGS_VERSION}.tar.gz"
+
+# Build directory
+BUILD_DIR="/tmp/btrfs-progs-build-$$"
+PREFIX="$BUILD_DIR/install"
+
+cleanup() {
+    if [[ -d "$BUILD_DIR" ]]; then
+        rm -rf "$BUILD_DIR"
+    fi
+}
+trap cleanup EXIT
+
+echo "=== Building btrfs-progs ${BTRFS_PROGS_VERSION} ==="
+echo "Output: $OUTPUT_DIR/mkfs.btrfs"
+echo ""
+
+# Check if already built
+if [[ -x "$OUTPUT_DIR/mkfs.btrfs" ]]; then
+    EXISTING_VERSION=$("$OUTPUT_DIR/mkfs.btrfs" --version 2>/dev/null | grep -oP '[\d.]+' || echo "0")
+    MAJOR=$(echo "$EXISTING_VERSION" | cut -d. -f1)
+    MINOR=$(echo "$EXISTING_VERSION" | cut -d. -f2)
+    if [[ "$MAJOR" -gt 6 ]] || [[ "$MAJOR" -eq 6 && "$MINOR" -ge 12 ]]; then
+        echo "mkfs.btrfs $EXISTING_VERSION already exists at $OUTPUT_DIR/mkfs.btrfs (>= 6.12)"
+        echo "Delete it to force rebuild."
+        exit 0
+    fi
+fi
+
+mkdir -p "$BUILD_DIR" "$PREFIX"
+cd "$BUILD_DIR"
+
+# Check and install build dependencies
+echo "Checking build dependencies..."
+MISSING_PKGS=""
+
+for pkg in uuid-dev libblkid-dev liblzo2-dev libzstd-dev zlib1g-dev libext2fs-dev libudev-dev; do
+    if ! dpkg -s "$pkg" &>/dev/null; then
+        MISSING_PKGS="$MISSING_PKGS $pkg"
+    fi
+done
+
+# Also need python3 for documentation/autogen (python3-setuptools for sphinx)
+if ! command -v python3 &>/dev/null; then
+    MISSING_PKGS="$MISSING_PKGS python3"
+fi
+
+if ! command -v autoconf &>/dev/null; then
+    MISSING_PKGS="$MISSING_PKGS autoconf"
+fi
+
+if ! command -v automake &>/dev/null; then
+    MISSING_PKGS="$MISSING_PKGS automake"
+fi
+
+if ! command -v pkg-config &>/dev/null; then
+    MISSING_PKGS="$MISSING_PKGS pkg-config"
+fi
+
+if [[ -n "$MISSING_PKGS" ]]; then
+    echo "Installing missing build dependencies:$MISSING_PKGS"
+    sudo apt-get update -qq
+    sudo apt-get install -y --no-install-recommends $MISSING_PKGS
+fi
+
+# Download and extract
+echo ""
+echo "=== Downloading btrfs-progs ${BTRFS_PROGS_VERSION} ==="
+curl -sL "$BTRFS_PROGS_URL" | tar xz
+cd "btrfs-progs-${BTRFS_PROGS_VERSION}"
+
+# Generate configure script
+echo ""
+echo "=== Running autogen ==="
+./autogen.sh
+
+# Configure - disable documentation (requires sphinx) and python bindings
+echo ""
+echo "=== Configuring ==="
+./configure \
+    --prefix="$PREFIX" \
+    --disable-documentation \
+    --disable-python
+
+# Build
+echo ""
+echo "=== Building ==="
+make -j"$(nproc)"
+
+# Verify the build
+echo ""
+echo "=== Verifying build ==="
+./mkfs.btrfs --version
+
+# Check that --rootdir is supported (mkfs.btrfs has had -r/--rootdir since 4.x)
+# Verify by checking the version is >= 6.12
+BUILT_VERSION=$(./mkfs.btrfs --version 2>/dev/null | grep -oP '[\d.]+' || echo "0")
+echo "Built version: $BUILT_VERSION"
+BUILT_MAJOR=$(echo "$BUILT_VERSION" | cut -d. -f1)
+BUILT_MINOR=$(echo "$BUILT_VERSION" | cut -d. -f2)
+if [[ "$BUILT_MAJOR" -lt 6 ]] || [[ "$BUILT_MAJOR" -eq 6 && "$BUILT_MINOR" -lt 12 ]]; then
+    echo "ERROR: built mkfs.btrfs version $BUILT_VERSION is too old (need >= 6.12 for --rootdir --subvol)"
+    exit 1
+fi
+
+# Install to output directory
+echo ""
+echo "=== Installing to $OUTPUT_DIR ==="
+mkdir -p "$OUTPUT_DIR"
+cp -v mkfs.btrfs "$OUTPUT_DIR/mkfs.btrfs"
+chmod +x "$OUTPUT_DIR/mkfs.btrfs"
+
+echo ""
+echo "=== Success! ==="
+echo "Binary: $OUTPUT_DIR/mkfs.btrfs"
+VERSION=$("$OUTPUT_DIR/mkfs.btrfs" --version 2>/dev/null || echo "unknown")
+echo "Version: $VERSION"
+echo ""
+echo "Test with: $OUTPUT_DIR/mkfs.btrfs --version"

--- a/scripts/claude-assistant/index.ts
+++ b/scripts/claude-assistant/index.ts
@@ -293,15 +293,24 @@ Every commit's changes must be reflected in the description. Flag as [MEDIUM] if
 
 ### 3b. Check code/documentation consistency
 
-When a PR modifies both code and documentation (README.md, CLAUDE.md, comments, doc strings),
-verify they are consistent:
+**When a PR modifies code**, check if related documentation needs updating.
+The project has three doc files — README.md (user-facing), DESIGN.md (architecture), CLAUDE.md (dev guide):
+- New or renamed CLI flags/options → update README.md usage sections
+- Changed behavior or defaults → update relevant docs, DESIGN.md, and CLAUDE.md
+- New features or modes → check if README.md and DESIGN.md tables/lists need new entries
+- Renamed functions/fields/types → check if CLAUDE.md and DESIGN.md reference the old names
+- Architecture changes (new modules, changed data flow) → update DESIGN.md
+- Changed error messages or output format → update examples in docs
+
+**When a PR modifies both code and docs**, verify they are consistent:
 - Function/field names in docs match actual code names
 - CLI flags and options documented match what the code accepts
 - Described behavior matches the implementation
 - Examples in docs use correct syntax and current API
 - Tables or lists of modes/options are complete (no missing or stale entries)
 
-Flag mismatches as [MEDIUM] - stale docs are worse than no docs because they actively mislead.
+Flag mismatches or missing doc updates as [MEDIUM] - stale docs are worse than no docs
+because they actively mislead.
 
 ### 3c. Categorize code issues
 

--- a/scripts/claude-assistant/index.ts
+++ b/scripts/claude-assistant/index.ts
@@ -291,11 +291,23 @@ Every commit's changes must be reflected in the description. Flag as [MEDIUM] if
 - Description mentions reverted or amended-away changes
 - For stacked PRs: description includes parent branch changes instead of just this branch's commits
 
-### 3b. Categorize code issues
+### 3b. Check code/documentation consistency
+
+When a PR modifies both code and documentation (README.md, CLAUDE.md, comments, doc strings),
+verify they are consistent:
+- Function/field names in docs match actual code names
+- CLI flags and options documented match what the code accepts
+- Described behavior matches the implementation
+- Examples in docs use correct syntax and current API
+- Tables or lists of modes/options are complete (no missing or stale entries)
+
+Flag mismatches as [MEDIUM] - stale docs are worse than no docs because they actively mislead.
+
+### 3c. Categorize code issues
 
 Categorize issues:
 - \`[CRITICAL]\` - Security holes, data loss, crashes, breaking changes
-- \`[MEDIUM]\` - Bugs, logic errors, race conditions, missing validation
+- \`[MEDIUM]\` - Bugs, logic errors, race conditions, missing validation, code/docs mismatches
 - \`[LOW]\` - Style, naming, minor improvements (only if not previously mentioned)
 
 ## STEP 4: POST REVIEW

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -253,11 +253,11 @@ pub struct RunArgs {
     #[arg(long)]
     pub no_snapshot: bool,
 
-    /// Disable direct image mount and fall back to podman load for localhost images.
-    /// By default, fcvm pre-builds podman overlay storage on the host and mounts it
-    /// read-only in the guest, bypassing podman load for faster container startup.
-    #[arg(long)]
-    pub no_direct_image_mount: bool,
+    /// Image delivery mode for localhost images (default: auto-detect from kernel profile).
+    /// overlay: pre-built overlay storage (instant), btrfs: pre-built btrfs image (instant),
+    /// archive: docker archive via podman load (slow).
+    #[arg(long, value_enum)]
+    pub image_mode: Option<ImageMode>,
 
     /// Container image (e.g., nginx:alpine or localhost/myimage)
     pub image: String,
@@ -465,6 +465,20 @@ pub enum NetworkMode {
     Bridged,
     /// True rootless networking using slirp4netns (no sudo required)
     Rootless,
+}
+
+/// Image delivery mode for localhost container images.
+///
+/// Controls how pre-built container images are delivered to the guest VM.
+/// Auto-detected from kernel profile if not specified.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, ValueEnum)]
+pub enum ImageMode {
+    /// Pre-built overlay storage image mounted as additionalImageStore (read-only, instant)
+    Overlay,
+    /// Pre-built btrfs storage image with real subvolumes, reflink-copied as graphroot (read-write, instant)
+    Btrfs,
+    /// Docker archive loaded via podman at boot (slow, works with any storage driver)
+    Archive,
 }
 
 // ============================================================================

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -855,7 +855,7 @@ pub async fn restore_from_snapshot(
 /// - Result is always a complete memory.bin
 ///
 /// Copy a file using btrfs reflink (instant CoW copy).
-async fn reflink_copy(source: &Path, dest: &Path) -> Result<()> {
+pub(crate) async fn reflink_copy(source: &Path, dest: &Path) -> Result<()> {
     let source_str = source
         .to_str()
         .with_context(|| format!("non-UTF-8 path: {}", source.display()))?;

--- a/src/commands/podman/image.rs
+++ b/src/commands/podman/image.rs
@@ -256,7 +256,7 @@ fn find_mkfs_btrfs() -> Result<PathBuf> {
             // Parse version from "mkfs.btrfs, part of btrfs-progs v6.12"
             if let Some(version) = version_str
                 .split('v')
-                .last()
+                .next_back()
                 .and_then(|s| s.trim().split_once('.'))
             {
                 let major: u32 = version.0.parse().unwrap_or(0);
@@ -368,9 +368,12 @@ pub(super) async fn build_btrfs_storage_image(
         } else {
             let user = nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))
                 .context("looking up build user")?
-                .ok_or_else(|| anyhow::anyhow!(
-                    "no user with uid {} on host (needed for rootless btrfs image build)", uid
-                ))?;
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "no user with uid {} on host (needed for rootless btrfs image build)",
+                        uid
+                    )
+                })?;
             let nix_uid = nix::unistd::Uid::from_raw(uid);
             let nix_gid = nix::unistd::Gid::from_raw(user.gid.as_raw());
             nix::unistd::chown(tmp_dir.as_path(), Some(nix_uid), Some(nix_gid))
@@ -396,15 +399,28 @@ pub(super) async fn build_btrfs_storage_image(
 
     let mut cmd_args: Vec<String> = Vec::new();
     if let Some(ref username) = build_username {
-        cmd_args.extend(["runuser", "-u", username, "--"].iter().map(|s| s.to_string()));
+        cmd_args.extend(
+            ["runuser", "-u", username, "--"]
+                .iter()
+                .map(|s| s.to_string()),
+        );
     }
-    cmd_args.extend([
-        "podman",
-        "--root", tmp_dir.to_str().unwrap(),
-        "--runroot", tmp_runroot.to_str().unwrap(),
-        "--storage-driver", "btrfs",
-        "load", "-i", archive_path.to_str().unwrap(),
-    ].iter().map(|s| s.to_string()));
+    cmd_args.extend(
+        [
+            "podman",
+            "--root",
+            tmp_dir.to_str().unwrap(),
+            "--runroot",
+            tmp_runroot.to_str().unwrap(),
+            "--storage-driver",
+            "btrfs",
+            "load",
+            "-i",
+            archive_path.to_str().unwrap(),
+        ]
+        .iter()
+        .map(|s| s.to_string()),
+    );
 
     let load_output = tokio::process::Command::new(&cmd_args[0])
         .args(&cmd_args[1..])
@@ -575,10 +591,6 @@ async fn cleanup_btrfs_tmp(tmp_dir: &Path) {
 
     // Finally remove the directory tree
     if let Err(e) = tokio::fs::remove_dir_all(tmp_dir).await {
-        warn!(
-            "Failed to remove temp dir {}: {}",
-            tmp_dir.display(),
-            e
-        );
+        warn!("Failed to remove temp dir {}: {}", tmp_dir.display(), e);
     }
 }

--- a/src/commands/podman/image.rs
+++ b/src/commands/podman/image.rs
@@ -3,6 +3,29 @@ use std::path::{Path, PathBuf};
 use anyhow::{bail, Context, Result};
 use tracing::{debug, info, warn};
 
+/// Remove podman state files from a storage root, keeping only image/layer data.
+///
+/// `podman load` creates state files (db.sql, storage.lock, libpod/, etc.) that
+/// contain hardcoded paths. When the storage root is mounted at a different path
+/// in the guest, these stale files cause "database graph driver does not match".
+async fn clean_podman_state(dir: &Path, keep: &[&str]) {
+    if let Ok(mut entries) = tokio::fs::read_dir(dir).await {
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if keep.iter().any(|&k| k == name_str.as_ref()) {
+                continue;
+            }
+            let path = entry.path();
+            if path.is_dir() {
+                tokio::fs::remove_dir_all(&path).await.ok();
+            } else {
+                tokio::fs::remove_file(&path).await.ok();
+            }
+        }
+    }
+}
+
 /// Validate that a Docker archive contains manifest.json.
 ///
 /// Docker archive format requires manifest.json to be loadable.
@@ -202,6 +225,11 @@ pub(super) async fn build_storage_image(
 
     let loaded_msg = String::from_utf8_lossy(&load_output.stdout);
     info!("podman load output: {}", loaded_msg.trim());
+
+    // Remove podman state files that contain hardcoded paths from the temp dir.
+    // Keep only image/layer data directories. When the guest mounts this read-only
+    // at a different path, stale state files cause "database graph driver does not match".
+    clean_podman_state(&tmp_dir, &["overlay", "overlay-images", "overlay-layers"]).await;
 
     // Package the storage tree as an ext4 image using the existing helper.
     // NOTE: Can't use with_extension() here because output_path ends in .storage.img
@@ -438,26 +466,10 @@ pub(super) async fn build_btrfs_storage_image(
     let loaded_msg = String::from_utf8_lossy(&load_output.stdout);
     info!("podman load output: {}", loaded_msg.trim());
 
-    // Remove ALL podman state files — they contain hardcoded paths from the temp dir.
-    // Keep only image/layer data directories (btrfs/, btrfs-images/, btrfs-layers/).
-    // When the guest mounts the image at a different path, stale state causes
-    // "database graph driver does not match" or "database static dir does not match".
-    let keep = ["btrfs", "btrfs-images", "btrfs-layers"];
-    if let Ok(mut entries) = tokio::fs::read_dir(&tmp_dir).await {
-        while let Ok(Some(entry)) = entries.next_entry().await {
-            let name = entry.file_name();
-            let name_str = name.to_string_lossy();
-            if keep.iter().any(|&k| k == name_str.as_ref()) {
-                continue;
-            }
-            let path = entry.path();
-            if path.is_dir() {
-                tokio::fs::remove_dir_all(&path).await.ok();
-            } else {
-                tokio::fs::remove_file(&path).await.ok();
-            }
-        }
-    }
+    // Remove podman state files that contain hardcoded paths from the temp dir.
+    // Keep only image/layer data directories. When the guest mounts the image at a
+    // different path, stale state causes "database graph driver does not match".
+    clean_podman_state(&tmp_dir, &["btrfs", "btrfs-images", "btrfs-layers"]).await;
 
     // Enumerate btrfs subvolumes in the temp dir for --subvol flags.
     // Btrfs subvolumes always have inode 256 — this detects them without root.

--- a/src/commands/podman/image.rs
+++ b/src/commands/podman/image.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 /// Validate that a Docker archive contains manifest.json.
 ///
@@ -227,4 +227,238 @@ pub(super) async fn build_storage_image(
 
     info!("Built storage image: {}", output_path.display());
     Ok(())
+}
+
+/// Find mkfs.btrfs with version >= 6.12 (needed for --rootdir --subvol).
+///
+/// Checks PATH first, then the build-from-source location at
+/// `/mnt/fcvm-btrfs/deps/bin/mkfs.btrfs`.
+fn find_mkfs_btrfs() -> Result<PathBuf> {
+    let candidates = [
+        // Check PATH first
+        which::which("mkfs.btrfs").ok(),
+        // Then check the build-from-source location
+        Some(PathBuf::from("/mnt/fcvm-btrfs/deps/bin/mkfs.btrfs")),
+    ];
+
+    for candidate in candidates.into_iter().flatten() {
+        if !candidate.exists() {
+            continue;
+        }
+
+        // Check version >= 6.12
+        let output = std::process::Command::new(&candidate)
+            .arg("--version")
+            .output();
+
+        if let Ok(output) = output {
+            let version_str = String::from_utf8_lossy(&output.stdout);
+            // Parse version from "mkfs.btrfs, part of btrfs-progs v6.12"
+            if let Some(version) = version_str
+                .split('v')
+                .last()
+                .and_then(|s| s.trim().split_once('.'))
+            {
+                let major: u32 = version.0.parse().unwrap_or(0);
+                let minor: u32 = version
+                    .1
+                    .chars()
+                    .take_while(|c| c.is_ascii_digit())
+                    .collect::<String>()
+                    .parse()
+                    .unwrap_or(0);
+
+                if major > 6 || (major == 6 && minor >= 12) {
+                    info!(
+                        "Found mkfs.btrfs {}.{} at {}",
+                        major,
+                        minor,
+                        candidate.display()
+                    );
+                    return Ok(candidate);
+                }
+                debug!(
+                    "mkfs.btrfs at {} is v{}.{} (need >= 6.12)",
+                    candidate.display(),
+                    major,
+                    minor
+                );
+            }
+        }
+    }
+
+    bail!(
+        "mkfs.btrfs >= 6.12 not found.\n\
+         Install with: scripts/build-btrfs-progs.sh\n\
+         Ubuntu 24.04 ships 6.6.3 which lacks --rootdir --subvol support."
+    )
+}
+
+/// Build a btrfs storage image from a Docker archive.
+///
+/// Loads the archive into a temporary podman storage root on btrfs (creating real
+/// btrfs subvolumes), then packages the result as a btrfs image using
+/// `mkfs.btrfs --rootdir --subvol`. The guest mounts this directly as its
+/// podman graphroot — no podman load needed, instant startup.
+///
+/// Requires:
+/// - The temp dir must be on a btrfs filesystem (for real subvolumes)
+/// - mkfs.btrfs >= 6.12 (for --rootdir --subvol support)
+/// - Kernel 5.18+ (for unprivileged btrfs subvolume creation)
+pub(super) async fn build_btrfs_storage_image(
+    archive_path: &Path,
+    output_path: &Path,
+) -> Result<()> {
+    // Find mkfs.btrfs with --rootdir --subvol support
+    let mkfs_btrfs = find_mkfs_btrfs()?;
+
+    // Use the image-cache directory on btrfs for temp storage.
+    // This MUST be on a btrfs filesystem so podman creates real btrfs subvolumes.
+    let cache_dir = output_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("output_path has no parent directory"))?;
+
+    // Verify cache_dir is on btrfs
+    let findmnt = std::process::Command::new("findmnt")
+        .args(["-n", "-o", "FSTYPE", cache_dir.to_str().unwrap()])
+        .output()
+        .context("checking filesystem type of cache directory")?;
+    let fstype = String::from_utf8_lossy(&findmnt.stdout).trim().to_string();
+    if fstype != "btrfs" {
+        bail!(
+            "Image cache directory {} is on {} (need btrfs).\n\
+             btrfs mode requires /mnt/fcvm-btrfs to be a btrfs filesystem.",
+            cache_dir.display(),
+            fstype
+        );
+    }
+
+    let tmp_dir = cache_dir.join(format!("tmp-btrfs-{}", std::process::id()));
+
+    // Clean up any stale temp dir from a previous interrupted run
+    if tmp_dir.exists() {
+        cleanup_btrfs_tmp(&tmp_dir).await;
+    }
+    tokio::fs::create_dir_all(&tmp_dir)
+        .await
+        .context("creating temp btrfs storage dir")?;
+
+    // Load the docker archive into a custom podman storage root on btrfs.
+    // This creates real btrfs subvolumes for each layer.
+    info!(
+        "Loading archive into btrfs podman storage: {} -> {}",
+        archive_path.display(),
+        tmp_dir.display()
+    );
+
+    let load_output = tokio::process::Command::new("podman")
+        .args([
+            "--root",
+            tmp_dir.to_str().unwrap(),
+            "--storage-driver",
+            "btrfs",
+            "load",
+            "-i",
+            archive_path.to_str().unwrap(),
+        ])
+        .output()
+        .await
+        .context("running podman load into btrfs storage root")?;
+
+    if !load_output.status.success() {
+        let stderr = String::from_utf8_lossy(&load_output.stderr);
+        cleanup_btrfs_tmp(&tmp_dir).await;
+        bail!("podman load into btrfs storage root failed: {}", stderr);
+    }
+
+    let loaded_msg = String::from_utf8_lossy(&load_output.stdout);
+    info!("podman load output: {}", loaded_msg.trim());
+
+    // Create btrfs image from the storage tree using mkfs.btrfs --rootdir --subvol.
+    // This preserves btrfs subvolumes from the source directory as real subvolumes
+    // in the output image.
+    let tmp_img = PathBuf::from(format!("{}.tmp", output_path.display()));
+    info!(
+        "Creating btrfs image: {} -> {}",
+        tmp_dir.display(),
+        tmp_img.display()
+    );
+
+    let mkfs_output = tokio::process::Command::new(&mkfs_btrfs)
+        .args([
+            "--rootdir",
+            tmp_dir.to_str().unwrap(),
+            "--subvol",
+            "--shrink",
+            tmp_img.to_str().unwrap(),
+        ])
+        .output()
+        .await
+        .context("running mkfs.btrfs --rootdir --subvol")?;
+
+    // Clean up temp storage dir (contains btrfs subvolumes, needs special handling)
+    cleanup_btrfs_tmp(&tmp_dir).await;
+
+    if !mkfs_output.status.success() {
+        let stderr = String::from_utf8_lossy(&mkfs_output.stderr);
+        tokio::fs::remove_file(&tmp_img).await.ok();
+        bail!("mkfs.btrfs --rootdir --subvol failed: {}", stderr);
+    }
+
+    // Atomic rename to final path
+    if let Err(e) = tokio::fs::rename(&tmp_img, output_path).await {
+        tokio::fs::remove_file(&tmp_img).await.ok();
+        return Err(e).context("renaming btrfs storage image to final path");
+    }
+
+    info!("Built btrfs storage image: {}", output_path.display());
+    Ok(())
+}
+
+/// Clean up a temporary btrfs storage directory.
+///
+/// btrfs subvolumes can't be removed with regular rm -rf.
+/// Use `podman --root <dir> system reset --force` to clean up properly,
+/// then remove the directory.
+async fn cleanup_btrfs_tmp(tmp_dir: &Path) {
+    // First try podman system reset to properly clean up subvolumes
+    let reset = tokio::process::Command::new("podman")
+        .args([
+            "--root",
+            tmp_dir.to_str().unwrap_or(""),
+            "--storage-driver",
+            "btrfs",
+            "system",
+            "reset",
+            "--force",
+        ])
+        .output()
+        .await;
+
+    if let Err(e) = &reset {
+        warn!("podman system reset for tmp dir failed: {}", e);
+    }
+
+    // Then try btrfs subvolume delete on any remaining subvolumes
+    if let Ok(entries) = std::fs::read_dir(tmp_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                // Try btrfs subvolume delete (ignores errors on non-subvolumes)
+                let _ = tokio::process::Command::new("btrfs")
+                    .args(["subvolume", "delete", path.to_str().unwrap_or("")])
+                    .output()
+                    .await;
+            }
+        }
+    }
+
+    // Finally remove the directory tree
+    if let Err(e) = tokio::fs::remove_dir_all(tmp_dir).await {
+        warn!(
+            "Failed to remove temp dir {}: {}",
+            tmp_dir.display(),
+            e
+        );
+    }
 }

--- a/src/commands/podman/image.rs
+++ b/src/commands/podman/image.rs
@@ -301,6 +301,10 @@ fn find_mkfs_btrfs() -> Result<PathBuf> {
 /// `mkfs.btrfs --rootdir --subvol`. The guest mounts this directly as its
 /// podman graphroot — no podman load needed, instant startup.
 ///
+/// When `build_uid` is set, runs `podman load` as that user (rootless podman).
+/// This creates storage with the correct UID ownership for rootless use in the guest,
+/// matching how rootless podman works on a physical host. When None, builds as root.
+///
 /// Requires:
 /// - The temp dir must be on a btrfs filesystem (for real subvolumes)
 /// - mkfs.btrfs >= 6.12 (for --rootdir --subvol support)
@@ -308,6 +312,7 @@ fn find_mkfs_btrfs() -> Result<PathBuf> {
 pub(super) async fn build_btrfs_storage_image(
     archive_path: &Path,
     output_path: &Path,
+    build_uid: Option<u32>,
 ) -> Result<()> {
     // Find mkfs.btrfs with --rootdir --subvol support
     let mkfs_btrfs = find_mkfs_btrfs()?;
@@ -318,9 +323,11 @@ pub(super) async fn build_btrfs_storage_image(
         .parent()
         .ok_or_else(|| anyhow::anyhow!("output_path has no parent directory"))?;
 
-    // Verify cache_dir is on btrfs
+    // Verify cache_dir is on btrfs.
+    // Use -T (target) flag to find the filesystem containing the path,
+    // not just exact mount points.
     let findmnt = std::process::Command::new("findmnt")
-        .args(["-n", "-o", "FSTYPE", cache_dir.to_str().unwrap()])
+        .args(["-n", "-o", "FSTYPE", "-T", cache_dir.to_str().unwrap()])
         .output()
         .context("checking filesystem type of cache directory")?;
     let fstype = String::from_utf8_lossy(&findmnt.stdout).trim().to_string();
@@ -334,33 +341,73 @@ pub(super) async fn build_btrfs_storage_image(
     }
 
     let tmp_dir = cache_dir.join(format!("tmp-btrfs-{}", std::process::id()));
+    let tmp_runroot = cache_dir.join(format!("tmp-btrfs-run-{}", std::process::id()));
 
-    // Clean up any stale temp dir from a previous interrupted run
+    // Clean up any stale temp dirs from a previous interrupted run
     if tmp_dir.exists() {
         cleanup_btrfs_tmp(&tmp_dir).await;
+    }
+    if tmp_runroot.exists() {
+        tokio::fs::remove_dir_all(&tmp_runroot).await.ok();
     }
     tokio::fs::create_dir_all(&tmp_dir)
         .await
         .context("creating temp btrfs storage dir")?;
+    tokio::fs::create_dir_all(&tmp_runroot)
+        .await
+        .context("creating temp btrfs runroot dir")?;
+
+    // For user builds: find username and chown temp dirs so rootless podman can use them.
+    // Skip runuser if we're already running as the target uid (rootless fcvm, no sudo).
+    let build_username = if let Some(uid) = build_uid {
+        let current_uid = nix::unistd::getuid().as_raw();
+        if current_uid == uid {
+            // Already running as the target user — no runuser needed
+            info!("Building btrfs image as current user (uid {})", uid);
+            None
+        } else {
+            let user = nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))
+                .context("looking up build user")?
+                .ok_or_else(|| anyhow::anyhow!(
+                    "no user with uid {} on host (needed for rootless btrfs image build)", uid
+                ))?;
+            let nix_uid = nix::unistd::Uid::from_raw(uid);
+            let nix_gid = nix::unistd::Gid::from_raw(user.gid.as_raw());
+            nix::unistd::chown(tmp_dir.as_path(), Some(nix_uid), Some(nix_gid))
+                .context("chowning temp dir to build user")?;
+            nix::unistd::chown(tmp_runroot.as_path(), Some(nix_uid), Some(nix_gid))
+                .context("chowning temp runroot to build user")?;
+            info!("Building btrfs image as user {} (uid {})", user.name, uid);
+            Some(user.name)
+        }
+    } else {
+        None
+    };
 
     // Load the docker archive into a custom podman storage root on btrfs.
     // This creates real btrfs subvolumes for each layer.
+    // For user builds, `runuser -u <username>` runs rootless podman, creating
+    // storage with correct UID ownership — matching a physical host.
     info!(
         "Loading archive into btrfs podman storage: {} -> {}",
         archive_path.display(),
         tmp_dir.display()
     );
 
-    let load_output = tokio::process::Command::new("podman")
-        .args([
-            "--root",
-            tmp_dir.to_str().unwrap(),
-            "--storage-driver",
-            "btrfs",
-            "load",
-            "-i",
-            archive_path.to_str().unwrap(),
-        ])
+    let mut cmd_args: Vec<String> = Vec::new();
+    if let Some(ref username) = build_username {
+        cmd_args.extend(["runuser", "-u", username, "--"].iter().map(|s| s.to_string()));
+    }
+    cmd_args.extend([
+        "podman",
+        "--root", tmp_dir.to_str().unwrap(),
+        "--runroot", tmp_runroot.to_str().unwrap(),
+        "--storage-driver", "btrfs",
+        "load", "-i", archive_path.to_str().unwrap(),
+    ].iter().map(|s| s.to_string()));
+
+    let load_output = tokio::process::Command::new(&cmd_args[0])
+        .args(&cmd_args[1..])
         .output()
         .await
         .context("running podman load into btrfs storage root")?;
@@ -368,15 +415,38 @@ pub(super) async fn build_btrfs_storage_image(
     if !load_output.status.success() {
         let stderr = String::from_utf8_lossy(&load_output.stderr);
         cleanup_btrfs_tmp(&tmp_dir).await;
+        tokio::fs::remove_dir_all(&tmp_runroot).await.ok();
         bail!("podman load into btrfs storage root failed: {}", stderr);
     }
 
     let loaded_msg = String::from_utf8_lossy(&load_output.stdout);
     info!("podman load output: {}", loaded_msg.trim());
 
+    // Remove podman database files — they contain hardcoded paths from the temp dir.
+    // When the guest mounts the image at a different path, podman would complain about
+    // "database static dir does not match". Deleting them forces podman to recreate
+    // the database at the correct mount path.
+    for db_file in ["db.sql", "libpod", "storage.lock"] {
+        let path = tmp_dir.join(db_file);
+        if path.is_dir() {
+            tokio::fs::remove_dir_all(&path).await.ok();
+        } else if path.is_file() {
+            tokio::fs::remove_file(&path).await.ok();
+        }
+    }
+
+    // Enumerate btrfs subvolumes in the temp dir for --subvol flags.
+    // Btrfs subvolumes always have inode 256 — this detects them without root.
+    // Podman's btrfs driver creates subvolumes at btrfs/subvolumes/<layer-hash>.
+    let subvol_args = enumerate_btrfs_subvolumes(&tmp_dir)?;
+    info!(
+        "Found {} btrfs subvolumes in temp storage",
+        subvol_args.len()
+    );
+
     // Create btrfs image from the storage tree using mkfs.btrfs --rootdir --subvol.
-    // This preserves btrfs subvolumes from the source directory as real subvolumes
-    // in the output image.
+    // Each subvolume is passed as --subvol rw:<relative-path> to preserve it as a
+    // real subvolume in the output image.
     let tmp_img = PathBuf::from(format!("{}.tmp", output_path.display()));
     info!(
         "Creating btrfs image: {} -> {}",
@@ -384,20 +454,26 @@ pub(super) async fn build_btrfs_storage_image(
         tmp_img.display()
     );
 
+    let mut mkfs_args = vec![
+        "--rootdir".to_string(),
+        tmp_dir.to_str().unwrap().to_string(),
+    ];
+    for subvol_path in &subvol_args {
+        mkfs_args.push("--subvol".to_string());
+        mkfs_args.push(format!("rw:{}", subvol_path));
+    }
+    mkfs_args.push("--shrink".to_string());
+    mkfs_args.push(tmp_img.to_str().unwrap().to_string());
+
     let mkfs_output = tokio::process::Command::new(&mkfs_btrfs)
-        .args([
-            "--rootdir",
-            tmp_dir.to_str().unwrap(),
-            "--subvol",
-            "--shrink",
-            tmp_img.to_str().unwrap(),
-        ])
+        .args(&mkfs_args)
         .output()
         .await
         .context("running mkfs.btrfs --rootdir --subvol")?;
 
     // Clean up temp storage dir (contains btrfs subvolumes, needs special handling)
     cleanup_btrfs_tmp(&tmp_dir).await;
+    tokio::fs::remove_dir_all(&tmp_runroot).await.ok();
 
     if !mkfs_output.status.success() {
         let stderr = String::from_utf8_lossy(&mkfs_output.stderr);
@@ -412,6 +488,50 @@ pub(super) async fn build_btrfs_storage_image(
     }
 
     info!("Built btrfs storage image: {}", output_path.display());
+    Ok(())
+}
+
+/// Enumerate btrfs subvolumes in a directory tree.
+///
+/// Returns paths relative to `root_dir`. Detects subvolumes by checking for
+/// inode 256, which is the canonical inode number for btrfs subvolume root
+/// directories. This works without root privileges.
+fn enumerate_btrfs_subvolumes(root_dir: &Path) -> Result<Vec<String>> {
+    let mut subvolumes = Vec::new();
+    enumerate_subvolumes_recursive(root_dir, root_dir, &mut subvolumes)?;
+    Ok(subvolumes)
+}
+
+fn enumerate_subvolumes_recursive(
+    base_dir: &Path,
+    current_dir: &Path,
+    subvolumes: &mut Vec<String>,
+) -> Result<()> {
+    let entries = std::fs::read_dir(current_dir)
+        .with_context(|| format!("reading directory {}", current_dir.display()))?;
+
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        // Check if this directory is a btrfs subvolume (inode 256)
+        let metadata = std::fs::metadata(&path)?;
+        use std::os::unix::fs::MetadataExt;
+        if metadata.ino() == 256 {
+            // Found a subvolume — record its path relative to the base dir
+            if let Ok(rel) = path.strip_prefix(base_dir) {
+                subvolumes.push(rel.to_string_lossy().to_string());
+            }
+            // Don't recurse into subvolumes — mkfs.btrfs handles their contents
+            continue;
+        }
+
+        // Regular directory — recurse to find nested subvolumes
+        enumerate_subvolumes_recursive(base_dir, &path, subvolumes)?;
+    }
     Ok(())
 }
 

--- a/src/commands/podman/image.rs
+++ b/src/commands/podman/image.rs
@@ -438,16 +438,24 @@ pub(super) async fn build_btrfs_storage_image(
     let loaded_msg = String::from_utf8_lossy(&load_output.stdout);
     info!("podman load output: {}", loaded_msg.trim());
 
-    // Remove podman database files — they contain hardcoded paths from the temp dir.
-    // When the guest mounts the image at a different path, podman would complain about
-    // "database static dir does not match". Deleting them forces podman to recreate
-    // the database at the correct mount path.
-    for db_file in ["db.sql", "libpod", "storage.lock"] {
-        let path = tmp_dir.join(db_file);
-        if path.is_dir() {
-            tokio::fs::remove_dir_all(&path).await.ok();
-        } else if path.is_file() {
-            tokio::fs::remove_file(&path).await.ok();
+    // Remove ALL podman state files — they contain hardcoded paths from the temp dir.
+    // Keep only image/layer data directories (btrfs/, btrfs-images/, btrfs-layers/).
+    // When the guest mounts the image at a different path, stale state causes
+    // "database graph driver does not match" or "database static dir does not match".
+    let keep = ["btrfs", "btrfs-images", "btrfs-layers"];
+    if let Ok(mut entries) = tokio::fs::read_dir(&tmp_dir).await {
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if keep.iter().any(|&k| k == name_str.as_ref()) {
+                continue;
+            }
+            let path = entry.path();
+            if path.is_dir() {
+                tokio::fs::remove_dir_all(&path).await.ok();
+            } else {
+                tokio::fs::remove_file(&path).await.ok();
+            }
         }
     }
 

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -503,18 +503,20 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
                 // For --user mode: build as uid 1000 (rootless podman), creating storage
                 // with correct ownership — matching a physical host. Separate cache path
                 // because rootless builds have different UID ownership than root builds.
-                let build_uid = args.user.as_ref().and_then(|user_spec| {
-                    user_spec.split(':').next()?.parse::<u32>().ok()
-                });
+                let build_uid = args
+                    .user
+                    .as_ref()
+                    .and_then(|user_spec| user_spec.split(':').next()?.parse::<u32>().ok());
                 let btrfs_img_path = match build_uid {
-                    Some(uid) => PathBuf::from(format!(
-                        "{}.btrfs-uid{}.img", cache_dir.display(), uid
-                    )),
+                    Some(uid) => {
+                        PathBuf::from(format!("{}.btrfs-uid{}.img", cache_dir.display(), uid))
+                    }
                     None => cache_dir.with_extension("btrfs.img"),
                 };
                 if !btrfs_img_path.exists() {
                     info!(image = %args.image, digest = %digest, uid = ?build_uid, "Building btrfs storage image");
-                    image::build_btrfs_storage_image(&archive_path, &btrfs_img_path, build_uid).await?;
+                    image::build_btrfs_storage_image(&archive_path, &btrfs_img_path, build_uid)
+                        .await?;
                 } else {
                     info!(image = %args.image, digest = %digest, "Using cached btrfs storage image");
                 }
@@ -854,9 +856,9 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
     // Build image extra disk entries for snapshot metadata.
     // For btrfs mode, the per-VM image copy needs to be saved with snapshots
     // so clones get their own isolated copy.
-    let image_extra_disks = if image_disk_path.as_ref().map_or(false, |p| {
+    let image_extra_disks = if image_disk_path.as_ref().is_some_and(|p| {
         p.file_name()
-            .map_or(false, |f| f.to_string_lossy().ends_with(".btrfs"))
+            .is_some_and(|f| f.to_string_lossy().ends_with(".btrfs"))
     }) {
         let disk_idx = args.disk.len() + args.disk_dir.len();
         vec![crate::storage::SnapshotExtraDisk {

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -507,11 +507,23 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
                     .user
                     .as_ref()
                     .and_then(|user_spec| user_spec.split(':').next()?.parse::<u32>().ok());
+                // Format version for btrfs image cache. Bump when the build process
+                // changes in a way that invalidates previously-cached images.
+                // v2: host-side cleanup of podman state files before mkfs.btrfs
+                const BTRFS_CACHE_VERSION: u32 = 2;
+
                 let btrfs_img_path = match build_uid {
-                    Some(uid) => {
-                        PathBuf::from(format!("{}.btrfs-uid{}.img", cache_dir.display(), uid))
-                    }
-                    None => cache_dir.with_extension("btrfs.img"),
+                    Some(uid) => PathBuf::from(format!(
+                        "{}.btrfs-v{}-uid{}.img",
+                        cache_dir.display(),
+                        BTRFS_CACHE_VERSION,
+                        uid
+                    )),
+                    None => PathBuf::from(format!(
+                        "{}.btrfs-v{}.img",
+                        cache_dir.display(),
+                        BTRFS_CACHE_VERSION
+                    )),
                 };
                 if !btrfs_img_path.exists() {
                     info!(image = %args.image, digest = %digest, uid = ?build_uid, "Building btrfs storage image");

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -36,6 +36,39 @@ use crate::volume::{spawn_volume_servers, VolumeConfig};
 use image::{build_storage_image, get_image_identifier, validate_docker_archive};
 use tokio_util::sync::CancellationToken;
 
+/// Resolve the image delivery mode from CLI args and kernel profile.
+///
+/// Priority: explicit `--image-mode` > auto-detect from kernel profile.
+/// Auto-detect: kernel profile name containing "btrfs" → Btrfs, otherwise Overlay.
+fn resolve_image_mode(
+    args: &RunArgs,
+    runtime_config: &super::common::RuntimeConfig,
+) -> crate::firecracker::ImageMode {
+    use crate::firecracker::ImageMode;
+
+    // Explicit CLI flag wins
+    if let Some(ref mode) = args.image_mode {
+        return match mode {
+            crate::cli::ImageMode::Overlay => ImageMode::Overlay,
+            crate::cli::ImageMode::Btrfs => ImageMode::Btrfs,
+            crate::cli::ImageMode::Archive => ImageMode::Archive,
+        };
+    }
+
+    // Auto-detect from kernel profile name
+    if let Some(ref profile_name) = args.kernel_profile {
+        if profile_name.contains("btrfs") {
+            return ImageMode::Btrfs;
+        }
+    }
+
+    // Check if runtime_config suggests btrfs (from boot_args or other hints)
+    let _ = runtime_config;
+
+    // Default: overlay
+    ImageMode::Overlay
+}
+
 /// Start a VM with the given args. Returns a handle to the running VM.
 ///
 /// The VM event loop runs in a background task. The handle's `Drop` impl cancels
@@ -230,6 +263,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
     ) = if !no_snapshot {
         // Get image identifier for cache key computation
         let image_identifier = get_image_identifier(&args.image).await?;
+        let resolved_mode = resolve_image_mode(&args, &runtime_config);
         let config = build_firecracker_config(
             &args,
             &image_identifier,
@@ -237,6 +271,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
             &base_rootfs,
             &initrd_path,
             cmd_args.clone(),
+            resolved_mode,
         );
         let key = config.snapshot_key();
 
@@ -451,21 +486,39 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
             info!(path = %archive_path.display(), "Image exported as Docker archive");
         }
 
-        let disk_path = if !args.no_direct_image_mount {
-            // Direct image mount: pre-build podman storage as ext4 image.
-            // Guest mounts this as additionalImageStore — no podman load needed.
-            let storage_img_path = cache_dir.with_extension("storage.img");
-            if !storage_img_path.exists() {
-                info!(image = %args.image, digest = %digest, "Building podman storage image");
-                build_storage_image(&archive_path, &storage_img_path).await?;
-            } else {
-                info!(image = %args.image, digest = %digest, "Using cached storage image");
+        let resolved_image_mode = resolve_image_mode(&args, &runtime_config);
+        info!(image = %args.image, digest = %digest, mode = %resolved_image_mode, "Image delivery mode");
+
+        let disk_path = match resolved_image_mode {
+            crate::firecracker::ImageMode::Overlay => {
+                // Pre-built overlay storage: ext4 image with podman storage.
+                // Guest mounts this as additionalImageStore — no podman load needed.
+                let storage_img_path = cache_dir.with_extension("storage.img");
+                if !storage_img_path.exists() {
+                    info!(image = %args.image, digest = %digest, "Building overlay storage image");
+                    build_storage_image(&archive_path, &storage_img_path).await?;
+                } else {
+                    info!(image = %args.image, digest = %digest, "Using cached overlay storage image");
+                }
+                storage_img_path
             }
-            storage_img_path
-        } else {
-            // Legacy path: attach docker archive as raw block device.
-            // fc-agent reads docker-archive:/dev/vdX via podman load.
-            archive_path
+            crate::firecracker::ImageMode::Btrfs => {
+                // Pre-built btrfs storage: btrfs image with real subvolumes.
+                // Guest reflink-copies it and mounts as graphroot — no podman load needed.
+                let btrfs_img_path = cache_dir.with_extension("btrfs.img");
+                if !btrfs_img_path.exists() {
+                    info!(image = %args.image, digest = %digest, "Building btrfs storage image");
+                    image::build_btrfs_storage_image(&archive_path, &btrfs_img_path).await?;
+                } else {
+                    info!(image = %args.image, digest = %digest, "Using cached btrfs storage image");
+                }
+                btrfs_img_path
+            }
+            crate::firecracker::ImageMode::Archive => {
+                // Docker archive: attach as raw block device.
+                // fc-agent reads docker-archive:/dev/vdX via podman load at boot.
+                archive_path
+            }
         };
 
         // Lock released when lock_file is dropped
@@ -964,4 +1017,103 @@ async fn cmd_podman_run(args: RunArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::args::{ImageMode as CliImageMode, NetworkMode};
+    use crate::firecracker::ImageMode;
+
+    fn test_args() -> RunArgs {
+        RunArgs {
+            name: "test".to_string(),
+            cpu: 2,
+            mem: 2048,
+            rootfs_size: "10G".to_string(),
+            map: vec![],
+            disk: vec![],
+            disk_dir: vec![],
+            nfs: vec![],
+            env: vec![],
+            cmd: None,
+            publish: vec![],
+            balloon: None,
+            network: NetworkMode::Rootless,
+            health_check: None,
+            privileged: false,
+            interactive: false,
+            tty: false,
+            strace_agent: false,
+            setup: false,
+            kernel: None,
+            kernel_profile: None,
+            vsock_dir: None,
+            no_snapshot: true,
+            user: None,
+            forward_localhost: vec![],
+            hugepages: false,
+            portable_volumes: false,
+            image_mode: None,
+            label: vec![],
+            image: "alpine:latest".to_string(),
+            command_args: vec![],
+        }
+    }
+
+    #[test]
+    fn test_resolve_image_mode_default_is_overlay() {
+        let args = test_args();
+        let rc = super::super::common::RuntimeConfig::default();
+        assert_eq!(resolve_image_mode(&args, &rc), ImageMode::Overlay);
+    }
+
+    #[test]
+    fn test_resolve_image_mode_btrfs_profile_auto_detects() {
+        let mut args = test_args();
+        args.kernel_profile = Some("btrfs".to_string());
+        let rc = super::super::common::RuntimeConfig::default();
+        assert_eq!(resolve_image_mode(&args, &rc), ImageMode::Btrfs);
+    }
+
+    #[test]
+    fn test_resolve_image_mode_btrfs_in_profile_name() {
+        let mut args = test_args();
+        args.kernel_profile = Some("nested-btrfs-test".to_string());
+        let rc = super::super::common::RuntimeConfig::default();
+        assert_eq!(resolve_image_mode(&args, &rc), ImageMode::Btrfs);
+    }
+
+    #[test]
+    fn test_resolve_image_mode_non_btrfs_profile_is_overlay() {
+        let mut args = test_args();
+        args.kernel_profile = Some("nested".to_string());
+        let rc = super::super::common::RuntimeConfig::default();
+        assert_eq!(resolve_image_mode(&args, &rc), ImageMode::Overlay);
+    }
+
+    #[test]
+    fn test_resolve_image_mode_explicit_overrides_profile() {
+        let mut args = test_args();
+        args.kernel_profile = Some("btrfs".to_string());
+        args.image_mode = Some(CliImageMode::Archive);
+        let rc = super::super::common::RuntimeConfig::default();
+        assert_eq!(resolve_image_mode(&args, &rc), ImageMode::Archive);
+    }
+
+    #[test]
+    fn test_resolve_image_mode_explicit_overlay() {
+        let mut args = test_args();
+        args.image_mode = Some(CliImageMode::Overlay);
+        let rc = super::super::common::RuntimeConfig::default();
+        assert_eq!(resolve_image_mode(&args, &rc), ImageMode::Overlay);
+    }
+
+    #[test]
+    fn test_resolve_image_mode_explicit_btrfs_no_profile() {
+        let mut args = test_args();
+        args.image_mode = Some(CliImageMode::Btrfs);
+        let rc = super::super::common::RuntimeConfig::default();
+        assert_eq!(resolve_image_mode(&args, &rc), ImageMode::Btrfs);
+    }
 }

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -487,7 +487,15 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
             crate::firecracker::ImageMode::Overlay => {
                 // Pre-built overlay storage: ext4 image with podman storage.
                 // Guest mounts this as additionalImageStore — no podman load needed.
-                let storage_img_path = cache_dir.with_extension("storage.img");
+                // Format version for overlay image cache. Bump when the build process
+                // changes in a way that invalidates previously-cached images.
+                // v2: host-side cleanup of podman state files before ext4 packaging
+                const OVERLAY_CACHE_VERSION: u32 = 2;
+                let storage_img_path = PathBuf::from(format!(
+                    "{}.storage-v{}.img",
+                    cache_dir.display(),
+                    OVERLAY_CACHE_VERSION
+                ));
                 if !storage_img_path.exists() {
                     info!(image = %args.image, digest = %digest, "Building overlay storage image");
                     build_storage_image(&archive_path, &storage_img_path).await?;

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -40,10 +40,7 @@ use tokio_util::sync::CancellationToken;
 ///
 /// Priority: explicit `--image-mode` > auto-detect from kernel profile.
 /// Auto-detect: kernel profile name containing "btrfs" → Btrfs, otherwise Overlay.
-fn resolve_image_mode(
-    args: &RunArgs,
-    runtime_config: &super::common::RuntimeConfig,
-) -> crate::firecracker::ImageMode {
+fn resolve_image_mode(args: &RunArgs) -> crate::firecracker::ImageMode {
     use crate::firecracker::ImageMode;
 
     // Explicit CLI flag wins
@@ -61,9 +58,6 @@ fn resolve_image_mode(
             return ImageMode::Btrfs;
         }
     }
-
-    // Check if runtime_config suggests btrfs (from boot_args or other hints)
-    let _ = runtime_config;
 
     // Default: overlay
     ImageMode::Overlay
@@ -263,7 +257,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
     ) = if !no_snapshot {
         // Get image identifier for cache key computation
         let image_identifier = get_image_identifier(&args.image).await?;
-        let resolved_mode = resolve_image_mode(&args, &runtime_config);
+        let resolved_mode = resolve_image_mode(&args);
         let config = build_firecracker_config(
             &args,
             &image_identifier,
@@ -486,7 +480,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
             info!(path = %archive_path.display(), "Image exported as Docker archive");
         }
 
-        let resolved_image_mode = resolve_image_mode(&args, &runtime_config);
+        let resolved_image_mode = resolve_image_mode(&args);
         info!(image = %args.image, digest = %digest, mode = %resolved_image_mode, "Image delivery mode");
 
         let disk_path = match resolved_image_mode {
@@ -505,10 +499,22 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
             crate::firecracker::ImageMode::Btrfs => {
                 // Pre-built btrfs storage: btrfs image with real subvolumes.
                 // Guest reflink-copies it and mounts as graphroot — no podman load needed.
-                let btrfs_img_path = cache_dir.with_extension("btrfs.img");
+                //
+                // For --user mode: build as uid 1000 (rootless podman), creating storage
+                // with correct ownership — matching a physical host. Separate cache path
+                // because rootless builds have different UID ownership than root builds.
+                let build_uid = args.user.as_ref().and_then(|user_spec| {
+                    user_spec.split(':').next()?.parse::<u32>().ok()
+                });
+                let btrfs_img_path = match build_uid {
+                    Some(uid) => PathBuf::from(format!(
+                        "{}.btrfs-uid{}.img", cache_dir.display(), uid
+                    )),
+                    None => cache_dir.with_extension("btrfs.img"),
+                };
                 if !btrfs_img_path.exists() {
-                    info!(image = %args.image, digest = %digest, "Building btrfs storage image");
-                    image::build_btrfs_storage_image(&archive_path, &btrfs_img_path).await?;
+                    info!(image = %args.image, digest = %digest, uid = ?build_uid, "Building btrfs storage image");
+                    image::build_btrfs_storage_image(&archive_path, &btrfs_img_path, build_uid).await?;
                 } else {
                     info!(image = %args.image, digest = %digest, "Using cached btrfs storage image");
                 }
@@ -550,6 +556,35 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
     tokio::fs::create_dir_all(&data_dir)
         .await
         .context("creating VM data directory")?;
+
+    // For btrfs mode, reflink copy the image from cache to per-VM directory.
+    // Each VM needs its own read-write copy because:
+    // 1. Btrfs images are read-write (podman creates subvolumes in graphroot)
+    // 2. Snapshot restore needs a pristine copy (not modified by previous VM runs)
+    // 3. Mount namespace redirects vm_runtime_dir paths for clones
+    let image_disk_path = if let Some(cache_path) = image_disk_path {
+        let resolved_mode = resolve_image_mode(&args);
+        if resolved_mode == crate::firecracker::ImageMode::Btrfs {
+            let disks_dir = data_dir.join("disks");
+            tokio::fs::create_dir_all(&disks_dir)
+                .await
+                .context("creating disks directory for btrfs image")?;
+            let per_vm_path = disks_dir.join("image.btrfs");
+            crate::commands::common::reflink_copy(&cache_path, &per_vm_path)
+                .await
+                .context("reflink copying btrfs image to per-VM directory")?;
+            info!(
+                cache = %cache_path.display(),
+                per_vm = %per_vm_path.display(),
+                "reflink copied btrfs image to per-VM directory"
+            );
+            Some(per_vm_path)
+        } else {
+            Some(cache_path)
+        }
+    } else {
+        None
+    };
 
     let socket_path = data_dir.join("firecracker.sock");
 
@@ -816,6 +851,24 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
 
     let disk_path = data_dir.join("disks/rootfs.raw");
 
+    // Build image extra disk entries for snapshot metadata.
+    // For btrfs mode, the per-VM image copy needs to be saved with snapshots
+    // so clones get their own isolated copy.
+    let image_extra_disks = if image_disk_path.as_ref().map_or(false, |p| {
+        p.file_name()
+            .map_or(false, |f| f.to_string_lossy().ends_with(".btrfs"))
+    }) {
+        let disk_idx = args.disk.len() + args.disk_dir.len();
+        vec![crate::storage::SnapshotExtraDisk {
+            filename: "image.btrfs".to_string(),
+            mount_path: String::new(),
+            read_only: false,
+            drive_id: format!("disk{}", disk_idx),
+        }]
+    } else {
+        vec![]
+    };
+
     Ok(Some(VmContext {
         vm_id,
         vm_name,
@@ -839,6 +892,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
         disk_path,
         log_tx,
         output_reconnect,
+        image_extra_disks,
     }))
 }
 
@@ -886,7 +940,8 @@ pub async fn run_vm_loop(ctx: &mut VmContext, cancel: CancellationToken) -> Resu
                 if let Some(ref key) = ctx.snapshot_key {
                     info!(snapshot_key = %key, digest = %cache_request.digest, "Creating pre-start snapshot");
 
-                    let params = SnapshotCreationParams::from_run_args(&ctx.args);
+                    let mut params = SnapshotCreationParams::from_run_args(&ctx.args);
+                    params.extra_disks = ctx.image_extra_disks.clone();
                     match create_snapshot_interruptible(
                         &ctx.vm_manager, key, &ctx.vm_id, &params, &ctx.disk_path,
                         &ctx.network_config, &ctx.volume_configs,
@@ -934,7 +989,8 @@ pub async fn run_vm_loop(ctx: &mut VmContext, cancel: CancellationToken) -> Resu
                     } else {
                         info!(snapshot_key = %startup_key, "Creating startup snapshot (VM healthy)");
 
-                        let params = SnapshotCreationParams::from_run_args(&ctx.args);
+                        let mut params = SnapshotCreationParams::from_run_args(&ctx.args);
+                        params.extra_disks = ctx.image_extra_disks.clone();
                         match create_snapshot_interruptible(
                             &ctx.vm_manager, &startup_key, &ctx.vm_id, &params, &ctx.disk_path,
                             &ctx.network_config, &ctx.volume_configs,
@@ -1064,32 +1120,32 @@ mod tests {
     #[test]
     fn test_resolve_image_mode_default_is_overlay() {
         let args = test_args();
-        let rc = super::super::common::RuntimeConfig::default();
-        assert_eq!(resolve_image_mode(&args, &rc), ImageMode::Overlay);
+
+        assert_eq!(resolve_image_mode(&args), ImageMode::Overlay);
     }
 
     #[test]
     fn test_resolve_image_mode_btrfs_profile_auto_detects() {
         let mut args = test_args();
         args.kernel_profile = Some("btrfs".to_string());
-        let rc = super::super::common::RuntimeConfig::default();
-        assert_eq!(resolve_image_mode(&args, &rc), ImageMode::Btrfs);
+
+        assert_eq!(resolve_image_mode(&args), ImageMode::Btrfs);
     }
 
     #[test]
     fn test_resolve_image_mode_btrfs_in_profile_name() {
         let mut args = test_args();
         args.kernel_profile = Some("nested-btrfs-test".to_string());
-        let rc = super::super::common::RuntimeConfig::default();
-        assert_eq!(resolve_image_mode(&args, &rc), ImageMode::Btrfs);
+
+        assert_eq!(resolve_image_mode(&args), ImageMode::Btrfs);
     }
 
     #[test]
     fn test_resolve_image_mode_non_btrfs_profile_is_overlay() {
         let mut args = test_args();
         args.kernel_profile = Some("nested".to_string());
-        let rc = super::super::common::RuntimeConfig::default();
-        assert_eq!(resolve_image_mode(&args, &rc), ImageMode::Overlay);
+
+        assert_eq!(resolve_image_mode(&args), ImageMode::Overlay);
     }
 
     #[test]
@@ -1097,23 +1153,23 @@ mod tests {
         let mut args = test_args();
         args.kernel_profile = Some("btrfs".to_string());
         args.image_mode = Some(CliImageMode::Archive);
-        let rc = super::super::common::RuntimeConfig::default();
-        assert_eq!(resolve_image_mode(&args, &rc), ImageMode::Archive);
+
+        assert_eq!(resolve_image_mode(&args), ImageMode::Archive);
     }
 
     #[test]
     fn test_resolve_image_mode_explicit_overlay() {
         let mut args = test_args();
         args.image_mode = Some(CliImageMode::Overlay);
-        let rc = super::super::common::RuntimeConfig::default();
-        assert_eq!(resolve_image_mode(&args, &rc), ImageMode::Overlay);
+
+        assert_eq!(resolve_image_mode(&args), ImageMode::Overlay);
     }
 
     #[test]
     fn test_resolve_image_mode_explicit_btrfs_no_profile() {
         let mut args = test_args();
         args.image_mode = Some(CliImageMode::Btrfs);
-        let rc = super::super::common::RuntimeConfig::default();
-        assert_eq!(resolve_image_mode(&args, &rc), ImageMode::Btrfs);
+
+        assert_eq!(resolve_image_mode(&args), ImageMode::Btrfs);
     }
 }

--- a/src/commands/podman/snapshot.rs
+++ b/src/commands/podman/snapshot.rs
@@ -121,7 +121,8 @@ pub async fn create_podman_snapshot(
             volumes: snapshot_volumes,
             health_check_url: params.health_check_url.clone(),
             hugepages: params.hugepages,
-            extra_disks: vec![],
+            extra_disks: params.extra_disks.clone(),
+            username: params.username.clone(),
         },
     };
 
@@ -210,6 +211,9 @@ pub(super) fn build_firecracker_config(
     cmd_args: Option<Vec<String>>,
     image_mode: crate::firecracker::ImageMode,
 ) -> crate::firecracker::FirecrackerConfig {
+    // image_identifier is the digest for localhost images (content-addressed cache key).
+    // args.image is the original name (what the guest uses to find the image).
+    // FirecrackerConfig stores both: container_image for cache key, container_image_name for MMDS.
     use crate::firecracker::{FcNetworkMode, FirecrackerConfig};
 
     let network_mode = match args.network {
@@ -230,7 +234,7 @@ pub(super) fn build_firecracker_config(
     // Collect volume mounts for cache key (affects MMDS plan)
     let volume_mounts: Vec<String> = args.map.to_vec();
 
-    FirecrackerConfig::new(
+    let mut config = FirecrackerConfig::new(
         kernel_path.to_path_buf(),
         initrd_path.to_path_buf(),
         rootfs_path.to_path_buf(),
@@ -252,7 +256,10 @@ pub(super) fn build_firecracker_config(
         args.user.clone(),
         args.forward_localhost.clone(),
         image_mode,
-    )
+    );
+    // Set the original image name for MMDS (separate from cache key identifier)
+    config.container_image_name = args.image.clone();
+    config
 }
 
 /// Extract Firecracker binary path and args from RuntimeConfig for snapshot restore.

--- a/src/commands/podman/snapshot.rs
+++ b/src/commands/podman/snapshot.rs
@@ -208,6 +208,7 @@ pub(super) fn build_firecracker_config(
     rootfs_path: &Path,
     initrd_path: &Path,
     cmd_args: Option<Vec<String>>,
+    image_mode: crate::firecracker::ImageMode,
 ) -> crate::firecracker::FirecrackerConfig {
     use crate::firecracker::{FcNetworkMode, FirecrackerConfig};
 
@@ -250,6 +251,7 @@ pub(super) fn build_firecracker_config(
         args.hugepages,
         args.user.clone(),
         args.forward_localhost.clone(),
+        image_mode,
     )
 }
 

--- a/src/commands/podman/types.rs
+++ b/src/commands/podman/types.rs
@@ -37,6 +37,8 @@ pub struct VmContext {
     /// Notify the output listener to drop its current connection and re-accept.
     /// Triggered after each snapshot (vsock connections reset during snapshot).
     pub output_reconnect: Arc<tokio::sync::Notify>,
+    /// Extra disk entries for the image disk (btrfs mode), included in snapshot metadata.
+    pub image_extra_disks: Vec<crate::storage::SnapshotExtraDisk>,
 }
 
 /// A log line from the VM's container output.
@@ -140,17 +142,30 @@ pub struct SnapshotCreationParams {
     pub health_check_url: Option<String>,
     /// Whether VM uses 2MB hugepage-backed memory
     pub hugepages: bool,
+    /// Username for rootless container health checks
+    pub username: Option<String>,
+    /// Extra disks to include in snapshot (e.g., btrfs image disk)
+    pub extra_disks: Vec<crate::storage::SnapshotExtraDisk>,
 }
 
 impl SnapshotCreationParams {
-    /// Create from RunArgs (for fresh VMs)
+    /// Create from RunArgs (for fresh VMs).
+    /// Note: `extra_disks` must be set separately after VM setup (drive IDs are assigned then).
     pub fn from_run_args(args: &RunArgs) -> Self {
+        // Resolve username from USER= env var (set during podman arg parsing)
+        let username = args
+            .env
+            .iter()
+            .find_map(|s| s.strip_prefix("USER="))
+            .map(|s| s.to_string());
         Self {
             image: args.image.clone(),
             vcpu: args.cpu,
             memory_mib: args.mem,
             health_check_url: args.health_check.clone(),
             hugepages: args.hugepages,
+            username,
+            extra_disks: vec![],
         }
     }
 
@@ -162,6 +177,8 @@ impl SnapshotCreationParams {
             memory_mib: metadata.memory_mib,
             health_check_url: metadata.health_check_url.clone(),
             hugepages: metadata.hugepages,
+            username: metadata.username.clone(),
+            extra_disks: metadata.extra_disks.clone(),
         }
     }
 }

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -726,7 +726,7 @@ pub(super) async fn run_vm_setup(
     // Archive mode extracts layers onto the rootfs via podman load.
     // podman load extracts layers to /var/tmp first, then copies to storage,
     // so we need ~3x the archive size for safety margin.
-    let resolved_mode = super::resolve_image_mode(args, runtime_config);
+    let resolved_mode = super::resolve_image_mode(args);
     let image_overhead = if resolved_mode == crate::firecracker::ImageMode::Archive {
         if let Some(disk_path) = image_disk_path {
             match tokio::fs::metadata(disk_path).await {
@@ -824,7 +824,7 @@ pub(super) async fn run_vm_setup(
             // Collect env vars and volume mounts for cache key
             let env_vars: Vec<String> = args.env.to_vec();
             let volume_mounts: Vec<String> = args.map.to_vec();
-            let image_mode = super::resolve_image_mode(args, runtime_config);
+            let image_mode = super::resolve_image_mode(args);
 
             crate::firecracker::FirecrackerConfig::new(
                 kernel_path.to_path_buf(),

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -15,15 +15,10 @@ use super::types::VolumeMapping;
 
 use crate::commands::common::VSOCK_VOLUME_PORT_BASE;
 
-/// Read the current user's subordinate UID range start from /etc/subuid.
+/// Read the current user's subordinate UID range (start, count) from /etc/subuid.
 /// Returns None if the file doesn't exist or the user has no entry.
-fn get_host_subuid_start() -> Option<u64> {
-    parse_subid_file("/etc/subuid").map(|(start, _)| start)
-}
-
-/// Read the current user's subordinate UID range count from /etc/subuid.
-fn get_host_subuid_count() -> Option<u64> {
-    parse_subid_file("/etc/subuid").map(|(_, count)| count)
+fn get_host_subuid_range() -> Option<(u64, u64)> {
+    parse_subid_file("/etc/subuid")
 }
 
 /// Parse /etc/subuid or /etc/subgid for the current user.
@@ -581,6 +576,12 @@ pub(super) async fn build_and_send_mmds(
         .or_else(|_| std::env::var("NO_PROXY"))
         .ok();
 
+    let subuid_range = if launch_config.user.is_some() {
+        get_host_subuid_range()
+    } else {
+        None
+    };
+
     let runtime = crate::firecracker::MmdsRuntime {
         volumes,
         extra_disks,
@@ -589,14 +590,8 @@ pub(super) async fn build_and_send_mmds(
         http_proxy,
         https_proxy,
         no_proxy,
-        subuid_start: launch_config
-            .user
-            .as_ref()
-            .and_then(|_| get_host_subuid_start()),
-        subuid_count: launch_config
-            .user
-            .as_ref()
-            .and_then(|_| get_host_subuid_count()),
+        subuid_start: subuid_range.map(|(start, _)| start),
+        subuid_count: subuid_range.map(|(_, count)| count),
         host_time: chrono::Utc::now().timestamp().to_string(),
     };
 
@@ -861,8 +856,14 @@ pub(super) async fn run_vm_setup(
     // Btrfs mode needs read-write (podman creates new subvolumes in graphroot).
     // Overlay and archive modes are read-only.
     let image_disk_read_only = launch_config.image_mode != crate::firecracker::ImageMode::Btrfs;
-    let (extra_disks, image_device) =
-        attach_extra_disks(args, client, data_dir, image_disk_path, image_disk_read_only).await?;
+    let (extra_disks, image_device) = attach_extra_disks(
+        args,
+        client,
+        data_dir,
+        image_disk_path,
+        image_disk_read_only,
+    )
+    .await?;
     vm_state.config.extra_disks = extra_disks;
 
     // Process --nfs: export directories via NFS for guest to mount
@@ -1041,7 +1042,13 @@ mod tests {
 
     #[test]
     fn test_parse_subid_file_finds_current_user() {
-        let username = std::env::var("USER").expect("USER env var must be set");
+        let username = std::env::var("USER").ok().unwrap_or_else(|| {
+            nix::unistd::User::from_uid(nix::unistd::getuid())
+                .ok()
+                .flatten()
+                .map(|u| u.name)
+                .expect("could not determine current username")
+        });
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("subuid");
         std::fs::write(

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -319,6 +319,7 @@ pub(super) async fn attach_extra_disks(
     client: &crate::firecracker::FirecrackerClient,
     data_dir: &std::path::Path,
     image_disk_path: Option<&std::path::Path>,
+    image_disk_read_only: bool,
 ) -> Result<(Vec<crate::state::types::ExtraDisk>, Option<String>)> {
     let mut extra_disks = Vec::new();
 
@@ -467,17 +468,17 @@ pub(super) async fn attach_extra_disks(
             .await?;
     }
 
-    // Attach image archive as a raw read-only block device.
-    // fc-agent reads docker-archive:/dev/vdX directly -- no FUSE, no mount.
+    // Attach image disk as a block device.
     let image_device = if let Some(disk_path) = image_disk_path {
         let disk_idx = args.disk.len() + args.disk_dir.len();
         let drive_id = format!("disk{}", disk_idx);
         let device = format!("/dev/vd{}", (b'b' + disk_idx as u8) as char);
 
         info!(
-            "Attaching image archive as block device: {} -> {}",
+            "Attaching image disk as block device: {} -> {} (read_only={})",
             disk_path.display(),
             device,
+            image_disk_read_only,
         );
         client
             .add_drive(
@@ -486,7 +487,7 @@ pub(super) async fn attach_extra_disks(
                     drive_id: drive_id.clone(),
                     path_on_host: disk_path.display().to_string(),
                     is_root_device: false,
-                    is_read_only: true,
+                    is_read_only: image_disk_read_only,
                     partuuid: None,
                     rate_limiter: None,
                 },
@@ -511,7 +512,6 @@ pub(super) async fn build_and_send_mmds(
     vm_state: &VmState,
     volume_mappings: &[VolumeMapping],
     image_device: Option<String>,
-    no_direct_image_mount: bool,
 ) -> Result<()> {
     // Build volume mount info for MMDS
     // Format: { guest_path, vsock_port, read_only }
@@ -585,16 +585,7 @@ pub(super) async fn build_and_send_mmds(
         volumes,
         extra_disks,
         nfs_mounts,
-        image_archive: if no_direct_image_mount {
-            image_device.clone()
-        } else {
-            None
-        },
-        image_storage_device: if !no_direct_image_mount {
-            image_device
-        } else {
-            None
-        },
+        image_device,
         http_proxy,
         https_proxy,
         no_proxy,
@@ -731,12 +722,12 @@ pub(super) async fn run_vm_setup(
         .context("creating CoW disk")?;
 
     // Estimate space needed for container image extraction inside VM.
-    // When using direct image mount (storage image), layers live on a separate read-only
-    // block device and are NOT extracted onto the rootfs, so no extra space is needed.
-    // When using legacy podman load, the archive is extracted onto the rootfs.
-    // podman load extracts layers to /var/tmp first, then copies to overlay storage,
+    // Overlay and btrfs modes use separate block devices — no rootfs impact.
+    // Archive mode extracts layers onto the rootfs via podman load.
+    // podman load extracts layers to /var/tmp first, then copies to storage,
     // so we need ~3x the archive size for safety margin.
-    let image_overhead = if args.no_direct_image_mount {
+    let resolved_mode = super::resolve_image_mode(args, runtime_config);
+    let image_overhead = if resolved_mode == crate::firecracker::ImageMode::Archive {
         if let Some(disk_path) = image_disk_path {
             match tokio::fs::metadata(disk_path).await {
                 Ok(meta) => meta.len() * 3,
@@ -833,6 +824,7 @@ pub(super) async fn run_vm_setup(
             // Collect env vars and volume mounts for cache key
             let env_vars: Vec<String> = args.env.to_vec();
             let volume_mounts: Vec<String> = args.map.to_vec();
+            let image_mode = super::resolve_image_mode(args, runtime_config);
 
             crate::firecracker::FirecrackerConfig::new(
                 kernel_path.to_path_buf(),
@@ -855,6 +847,7 @@ pub(super) async fn run_vm_setup(
                 args.hugepages,
                 args.user.clone(),
                 args.forward_localhost.clone(),
+                image_mode,
             )
         });
 
@@ -864,9 +857,12 @@ pub(super) async fn run_vm_setup(
         .apply(client, &runtime_boot_args, track_dirty_pages)
         .await?;
 
-    // Attach extra disks and image archive
+    // Attach extra disks and image disk.
+    // Btrfs mode needs read-write (podman creates new subvolumes in graphroot).
+    // Overlay and archive modes are read-only.
+    let image_disk_read_only = launch_config.image_mode != crate::firecracker::ImageMode::Btrfs;
     let (extra_disks, image_device) =
-        attach_extra_disks(args, client, data_dir, image_disk_path).await?;
+        attach_extra_disks(args, client, data_dir, image_disk_path, image_disk_read_only).await?;
     vm_state.config.extra_disks = extra_disks;
 
     // Process --nfs: export directories via NFS for guest to mount
@@ -987,7 +983,6 @@ pub(super) async fn run_vm_setup(
         vm_state,
         volume_mappings,
         image_device,
-        args.no_direct_image_mount,
     )
     .await?;
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -319,7 +319,7 @@ async fn create_sandbox(
         kernel_profile: None,
         vsock_dir: None,
         no_snapshot: true,
-        no_direct_image_mount: false,
+        image_mode: None,
         forward_localhost: vec![],
         user: None,
         hugepages: false,

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -223,6 +223,7 @@ async fn cmd_snapshot_create(args: SnapshotCreateArgs) -> Result<()> {
             health_check_url: vm_state.config.health_check_url.clone(),
             hugepages: vm_state.config.hugepages,
             extra_disks: extra_disk_configs,
+            username: vm_state.config.username.clone(),
         },
     };
 
@@ -733,6 +734,8 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
     // The cache key includes health_check_url, so each config gets its own snapshot.
     vm_state.config.health_check_url = snapshot_config.metadata.health_check_url.clone();
     vm_state.config.hugepages = args.hugepages.unwrap_or(snapshot_config.metadata.hugepages);
+    // Restore username for rootless health checks (runuser -u <username>).
+    vm_state.config.username = snapshot_config.metadata.username.clone();
 
     info!(
         tap = %network_config.tap_device,

--- a/src/firecracker/config.rs
+++ b/src/firecracker/config.rs
@@ -23,8 +23,13 @@ pub struct FirecrackerConfig {
     pub machine_config: MachineConfig,
     /// Root drive configuration
     pub drives: Vec<Drive>,
-    /// Container image to pull (for fc-agent)
+    /// Container image identifier (digest for localhost images, name for remote).
+    /// Used in snapshot cache key computation.
     pub container_image: String,
+    /// Original image name for the MMDS plan (what the guest uses to find the image).
+    /// Excluded from cache key — content hash in container_image handles cache correctness.
+    #[serde(skip)]
+    pub container_image_name: String,
     /// Container command (affects what runs after container starts)
     pub container_cmd: Option<Vec<String>>,
     /// Network mode (bridged or rootless)
@@ -208,6 +213,7 @@ impl FirecrackerConfig {
                 is_root_device: true,
                 is_read_only: false,
             }],
+            container_image_name: container_image.clone(),
             container_image,
             container_cmd,
             network_mode,
@@ -338,7 +344,7 @@ impl FirecrackerConfig {
         serde_json::json!({
             "latest": {
                 "container-plan": {
-                    "image": self.container_image,
+                    "image": self.container_image_name,
                     "env": env,
                     "cmd": self.container_cmd,
                     "volumes": runtime.volumes,

--- a/src/firecracker/config.rs
+++ b/src/firecracker/config.rs
@@ -76,6 +76,14 @@ pub struct FirecrackerConfig {
     /// Affects fc-agent's iptables setup, must be in cache key.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub forward_localhost: Vec<u16>,
+    /// How localhost images are delivered to the guest.
+    /// Affects whether guest mounts overlay store, btrfs store, or runs podman load.
+    #[serde(default = "default_image_mode")]
+    pub image_mode: ImageMode,
+}
+
+fn default_image_mode() -> ImageMode {
+    ImageMode::Overlay
 }
 
 fn default_rootfs_size() -> String {
@@ -117,6 +125,29 @@ pub enum NetworkMode {
     Rootless,
 }
 
+/// How localhost container images are delivered to the guest VM.
+/// Part of snapshot cache key — different modes produce different VM states.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ImageMode {
+    /// Pre-built overlay storage image as additionalImageStore (read-only, instant)
+    Overlay,
+    /// Pre-built btrfs storage image with real subvolumes as graphroot (read-write, instant)
+    Btrfs,
+    /// Docker archive loaded via podman at boot (slow, works with any driver)
+    Archive,
+}
+
+impl std::fmt::Display for ImageMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ImageMode::Overlay => write!(f, "overlay"),
+            ImageMode::Btrfs => write!(f, "btrfs"),
+            ImageMode::Archive => write!(f, "archive"),
+        }
+    }
+}
+
 /// Static boot arguments that affect cached VM state.
 /// Does NOT include per-instance values like IP addresses.
 /// Architecture-specific because reboot method differs (ARM64=k, x86=t).
@@ -154,6 +185,7 @@ impl FirecrackerConfig {
         hugepages: bool,
         user: Option<String>,
         forward_localhost: Vec<u16>,
+        image_mode: ImageMode,
     ) -> Self {
         Self {
             boot_source: BootSource {
@@ -190,6 +222,7 @@ impl FirecrackerConfig {
             health_check_url,
             user,
             forward_localhost,
+            image_mode,
         }
     }
 
@@ -311,8 +344,8 @@ impl FirecrackerConfig {
                     "volumes": runtime.volumes,
                     "extra_disks": runtime.extra_disks,
                     "nfs_mounts": runtime.nfs_mounts,
-                    "image_archive": runtime.image_archive,
-                    "image_storage_device": runtime.image_storage_device,
+                    "image_device": runtime.image_device,
+                    "image_mode": runtime.image_device.as_ref().map(|_| self.image_mode.to_string()),
                     "privileged": self.privileged,
                     "user": self.user.as_deref(),
                     "subuid_start": runtime.subuid_start,
@@ -339,10 +372,8 @@ pub struct MmdsRuntime {
     pub extra_disks: Vec<serde_json::Value>,
     /// NFS mount details with host IP
     pub nfs_mounts: Vec<serde_json::Value>,
-    /// Device path for image archive (localhost images, no-direct-image-mount mode)
-    pub image_archive: Option<String>,
-    /// Device path for image storage (direct-image-mount mode)
-    pub image_storage_device: Option<String>,
+    /// Device path for localhost image (e.g., "/dev/vdb"), used by all image modes
+    pub image_device: Option<String>,
     /// Resolved HTTP proxy URL (IP, not hostname)
     pub http_proxy: Option<String>,
     /// Resolved HTTPS proxy URL
@@ -384,6 +415,7 @@ mod tests {
             false,
             None,
             vec![],
+            ImageMode::Overlay,
         )
     }
 
@@ -498,5 +530,18 @@ mod tests {
         let mut config2 = test_config();
         config2.forward_localhost = vec![8080];
         assert_ne!(config1.snapshot_key(), config2.snapshot_key());
+    }
+
+    #[test]
+    fn test_snapshot_key_changes_with_image_mode() {
+        let config1 = test_config();
+        let mut config2 = test_config();
+        config2.image_mode = ImageMode::Btrfs;
+        assert_ne!(config1.snapshot_key(), config2.snapshot_key());
+
+        let mut config3 = test_config();
+        config3.image_mode = ImageMode::Archive;
+        assert_ne!(config1.snapshot_key(), config3.snapshot_key());
+        assert_ne!(config2.snapshot_key(), config3.snapshot_key());
     }
 }

--- a/src/firecracker/mod.rs
+++ b/src/firecracker/mod.rs
@@ -3,5 +3,5 @@ pub mod config;
 pub mod vm;
 
 pub use api::FirecrackerClient;
-pub use config::{FirecrackerConfig, MmdsRuntime, NetworkMode as FcNetworkMode};
+pub use config::{FirecrackerConfig, ImageMode, MmdsRuntime, NetworkMode as FcNetworkMode};
 pub use vm::VmManager;

--- a/src/health.rs
+++ b/src/health.rs
@@ -428,8 +428,12 @@ async fn update_health_status_once(
                 None => {
                     // No HTTP check - check if container is actually running
                     // Uses podman inspect to verify container state (not just process spawned)
-                    let container_running =
-                        check_container_running(pid, state.config.username.as_deref(), state.config.user.as_deref()).await;
+                    let container_running = check_container_running(
+                        pid,
+                        state.config.username.as_deref(),
+                        state.config.user.as_deref(),
+                    )
+                    .await;
                     if container_running {
                         debug!(target: "health-monitor", "container is running");
                         *last_failure_log = None;
@@ -441,9 +445,13 @@ async fn update_health_status_once(
                         // Note: We don't return Unhealthy here because check_podman_healthcheck
                         // returns Some(false) when the container doesn't exist yet (inspect fails)
                         if !*skip_podman_healthcheck
-                            && check_podman_healthcheck(pid, state.config.username.as_deref(), state.config.user.as_deref())
-                                .await
-                                .is_none()
+                            && check_podman_healthcheck(
+                                pid,
+                                state.config.username.as_deref(),
+                                state.config.user.as_deref(),
+                            )
+                            .await
+                            .is_none()
                         {
                             // No healthcheck defined - skip future checks
                             debug!(target: "health-monitor", "no podman healthcheck defined, skipping future checks");
@@ -552,7 +560,13 @@ async fn update_health_status_once(
             // If base health check passed, also check podman healthcheck (AND logic)
             // Skip if we already know the container has no healthcheck
             let final_status = if status == HealthStatus::Healthy && !*skip_podman_healthcheck {
-                match check_podman_healthcheck(pid, state.config.username.as_deref(), state.config.user.as_deref()).await {
+                match check_podman_healthcheck(
+                    pid,
+                    state.config.username.as_deref(),
+                    state.config.user.as_deref(),
+                )
+                .await
+                {
                     Some(true) => {
                         debug!(target: "health-monitor", "all health checks passed");
                         HealthStatus::Healthy

--- a/src/health.rs
+++ b/src/health.rs
@@ -200,12 +200,37 @@ fn find_fcvm_binary() -> Option<std::path::PathBuf> {
 /// Timeout for exec-based health checks (5 seconds)
 const HEALTH_CHECK_EXEC_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Build the env + runuser prefix for health check commands running as a user.
+///
+/// Must mirror fc-agent's `run_as_user_prefix()`: sets HOME and XDG_RUNTIME_DIR
+/// so podman finds user-level config and runtime state.
+fn user_cmd_prefix(name: &str, user_spec: Option<&str>) -> Vec<String> {
+    // Extract UID from user spec (format: "UID:GID" or just "UID")
+    let uid = user_spec
+        .and_then(|s| s.split(':').next())
+        .unwrap_or("1000");
+
+    vec![
+        "env".into(),
+        format!("HOME=/home/{}", name),
+        format!("XDG_RUNTIME_DIR=/run/user/{}", uid),
+        "runuser".into(),
+        "-u".into(),
+        name.to_string(),
+        "--".into(),
+    ]
+}
+
 /// Check if the container is running via podman inspect.
 ///
 /// Returns:
 /// - `true` = container is running
 /// - `false` = container not running yet (or inspect failed)
-async fn check_container_running(pid: u32, username: Option<&str>) -> bool {
+async fn check_container_running(
+    pid: u32,
+    username: Option<&str>,
+    user_spec: Option<&str>,
+) -> bool {
     let exe = match find_fcvm_binary() {
         Some(e) => e,
         None => return false, // Can't find fcvm binary
@@ -221,8 +246,7 @@ async fn check_container_running(pid: u32, username: Option<&str>) -> bool {
         "--".into(),
     ];
     if let Some(name) = username {
-        // Run podman as the target user (rootless podman owner)
-        cmd_args.extend(["runuser".into(), "-u".into(), name.to_string(), "--".into()]);
+        cmd_args.extend(user_cmd_prefix(name, user_spec));
     }
     cmd_args.extend([
         "podman".into(),
@@ -277,7 +301,11 @@ async fn check_container_running(pid: u32, username: Option<&str>) -> bool {
 /// - `Some(true)` = healthcheck exists and is healthy
 /// - `Some(false)` = healthcheck exists and is unhealthy/starting
 /// - `None` = no healthcheck defined (caller should skip future calls)
-async fn check_podman_healthcheck(pid: u32, username: Option<&str>) -> Option<bool> {
+async fn check_podman_healthcheck(
+    pid: u32,
+    username: Option<&str>,
+    user_spec: Option<&str>,
+) -> Option<bool> {
     // Use fcvm exec to run podman inspect inside the VM
     let exe = match find_fcvm_binary() {
         Some(e) => e,
@@ -292,7 +320,7 @@ async fn check_podman_healthcheck(pid: u32, username: Option<&str>) -> Option<bo
         "--".into(),
     ];
     if let Some(name) = username {
-        cmd_args.extend(["runuser".into(), "-u".into(), name.to_string(), "--".into()]);
+        cmd_args.extend(user_cmd_prefix(name, user_spec));
     }
     cmd_args.extend([
         "podman".into(),
@@ -401,7 +429,7 @@ async fn update_health_status_once(
                     // No HTTP check - check if container is actually running
                     // Uses podman inspect to verify container state (not just process spawned)
                     let container_running =
-                        check_container_running(pid, state.config.username.as_deref()).await;
+                        check_container_running(pid, state.config.username.as_deref(), state.config.user.as_deref()).await;
                     if container_running {
                         debug!(target: "health-monitor", "container is running");
                         *last_failure_log = None;
@@ -413,7 +441,7 @@ async fn update_health_status_once(
                         // Note: We don't return Unhealthy here because check_podman_healthcheck
                         // returns Some(false) when the container doesn't exist yet (inspect fails)
                         if !*skip_podman_healthcheck
-                            && check_podman_healthcheck(pid, state.config.username.as_deref())
+                            && check_podman_healthcheck(pid, state.config.username.as_deref(), state.config.user.as_deref())
                                 .await
                                 .is_none()
                         {
@@ -524,7 +552,7 @@ async fn update_health_status_once(
             // If base health check passed, also check podman healthcheck (AND logic)
             // Skip if we already know the container has no healthcheck
             let final_status = if status == HealthStatus::Healthy && !*skip_podman_healthcheck {
-                match check_podman_healthcheck(pid, state.config.username.as_deref()).await {
+                match check_podman_healthcheck(pid, state.config.username.as_deref(), state.config.user.as_deref()).await {
                     Some(true) => {
                         debug!(target: "health-monitor", "all health checks passed");
                         HealthStatus::Healthy

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -599,15 +599,36 @@ pub fn generate_setup_script(plan: &Plan) -> String {
     // Also enable serial console
     s.push_str("systemctl enable serial-getty@ttyS0\n\n");
 
-    // Disable services
+    // Disable services by removing symlinks from target.wants directories.
+    // We run in chroot (no systemd), so `systemctl disable` fails silently.
+    // Manually remove all symlinks that reference these units.
     if !plan.services.disable.is_empty() {
-        s.push_str("# Disable services\n");
-        s.push_str("systemctl disable");
+        s.push_str("# Disable services (remove symlinks from *.target.wants)\n");
         for svc in &plan.services.disable {
-            s.push_str(&format!(" {}", svc));
+            // Bare names like "multipathd" match multipathd.service, multipathd.socket, etc.
+            // Full names like "podman.service" match exactly.
+            let pattern = if svc.contains('.') {
+                svc.to_string()
+            } else {
+                format!("{}.*", svc)
+            };
+            s.push_str(&format!(
+                "find /etc/systemd/system -name '{}' -type l -delete 2>/dev/null || true\n",
+                pattern
+            ));
         }
-        s.push_str(" || true\n\n");
+        s.push('\n');
     }
+
+    // Remove podman state files created during package installation.
+    // apt's post-install scripts initialize /var/lib/containers/storage with an
+    // empty db.sql (driver=""). fc-agent writes storage.conf with the actual
+    // driver at boot, but podman refuses to start if db.sql already exists with
+    // a different driver. Remove state files but not directories (overlay/ may
+    // be busy from postinst).
+    s.push_str("# Remove podman state files created by apt post-install scripts\n");
+    s.push_str("rm -f /var/lib/containers/storage/db.sql /var/lib/containers/storage/storage.lock /var/lib/containers/storage/userns.lock /var/lib/containers/storage/defaultNetworkBackend 2>/dev/null || true\n");
+    s.push_str("rm -rf /var/lib/containers/storage/libpod /var/lib/containers/storage/overlay-containers /var/lib/containers/storage/overlay-images 2>/dev/null || true\n\n");
 
     // Cleanup
     if !plan.cleanup.remove_dirs.is_empty() {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4,6 +4,7 @@ pub mod volume;
 
 pub use disk::{DiskConfig, DiskManager};
 pub use snapshot::{
-    SnapshotConfig, SnapshotManager, SnapshotMetadata, SnapshotType, SnapshotVolumeConfig,
+    SnapshotConfig, SnapshotExtraDisk, SnapshotManager, SnapshotMetadata, SnapshotType,
+    SnapshotVolumeConfig,
 };
 pub use volume::{VolumeManager, VolumeMount};

--- a/src/storage/snapshot.rs
+++ b/src/storage/snapshot.rs
@@ -67,6 +67,9 @@ pub struct SnapshotMetadata {
     /// Extra disk images from the baseline VM (for clone disk-dir support)
     #[serde(default)]
     pub extra_disks: Vec<SnapshotExtraDisk>,
+    /// Username for rootless container health checks (e.g., "ubuntu")
+    #[serde(default)]
+    pub username: Option<String>,
 }
 
 /// Extra disk configuration saved in snapshot metadata.
@@ -241,6 +244,7 @@ mod tests {
                 health_check_url: None,
                 hugepages: false,
                 extra_disks: vec![],
+                username: None,
             },
         };
 
@@ -356,6 +360,7 @@ mod tests {
                 health_check_url: None,
                 hugepages: false,
                 extra_disks: vec![],
+                username: None,
             },
         };
 
@@ -415,6 +420,7 @@ mod tests {
                     health_check_url: None,
                     hugepages: false,
                     extra_disks: vec![],
+                    username: None,
                 },
             };
             manager.save_snapshot(config).await.unwrap();
@@ -461,6 +467,7 @@ mod tests {
                 health_check_url: None,
                 hugepages: false,
                 extra_disks: vec![],
+                username: None,
             },
         };
         manager.save_snapshot(config).await.unwrap();
@@ -558,6 +565,7 @@ mod tests {
                 health_check_url: None,
                 hugepages: false,
                 extra_disks: vec![],
+                username: None,
             },
         };
 

--- a/tests/test_library_api.rs
+++ b/tests/test_library_api.rs
@@ -45,7 +45,7 @@ fn test_run_args(name: &str) -> RunArgs {
         forward_localhost: vec![],
         hugepages: false,
         portable_volumes: false,
-        no_direct_image_mount: false,
+        image_mode: None,
         label: vec![],
         image: common::TEST_IMAGE.to_string(),
         command_args: vec![],

--- a/tests/test_localhost_image.rs
+++ b/tests/test_localhost_image.rs
@@ -26,10 +26,10 @@ async fn test_localhost_archive_mode() -> Result<()> {
     run_localhost_test(Some("archive"), "localhost-archive").await
 }
 
-/// Test with btrfs mode (pre-built btrfs image as graphroot)
+/// Test with btrfs mode (pre-built btrfs image as graphroot, requires btrfs kernel)
 #[tokio::test]
 async fn test_localhost_btrfs_mode() -> Result<()> {
-    run_localhost_test(Some("btrfs"), "localhost-btrfs").await
+    run_localhost_test_with_kernel(Some("btrfs"), Some("btrfs"), "localhost-btrfs").await
 }
 
 /// Test with default mode (auto-detect, should be overlay without btrfs kernel)
@@ -39,6 +39,14 @@ async fn test_localhost_default_mode() -> Result<()> {
 }
 
 async fn run_localhost_test(image_mode: Option<&str>, suffix: &str) -> Result<()> {
+    run_localhost_test_with_kernel(image_mode, None, suffix).await
+}
+
+async fn run_localhost_test_with_kernel(
+    image_mode: Option<&str>,
+    kernel_profile: Option<&str>,
+    suffix: &str,
+) -> Result<()> {
     let mode_label = image_mode.unwrap_or("default (auto-detect)");
 
     println!("\nLocalhost Image Test ({})", mode_label);
@@ -61,6 +69,10 @@ async fn run_localhost_test(image_mode: Option<&str>, suffix: &str) -> Result<()
     if let Some(mode) = image_mode {
         args.push("--image-mode");
         args.push(mode);
+    }
+    if let Some(profile) = kernel_profile {
+        args.push("--kernel-profile");
+        args.push(profile);
     }
     args.push("localhost/test-hello");
 

--- a/tests/test_localhost_image.rs
+++ b/tests/test_localhost_image.rs
@@ -1,8 +1,9 @@
 //! Integration test for localhost/ container images
 //!
-//! Tests both import paths:
-//! - Default (direct mount): Pre-built podman storage mounted as additionalImageStore
-//! - Legacy (--no-direct-image-mount): Docker archive imported via podman load
+//! Tests all three image delivery modes:
+//! - Overlay (default): Pre-built overlay storage mounted as additionalImageStore
+//! - Archive: Docker archive imported via podman load at boot
+//! - Btrfs: Pre-built btrfs image mounted as graphroot (requires btrfs kernel)
 
 #![cfg(feature = "integration-fast")]
 
@@ -13,35 +14,38 @@ use std::process::Stdio;
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, BufReader};
 
-/// Test with default direct image mount path
+/// Test with overlay mode (default, additionalImageStore)
 #[tokio::test]
-async fn test_localhost_hello_world() -> Result<()> {
-    run_localhost_test(false).await
+async fn test_localhost_overlay_mode() -> Result<()> {
+    run_localhost_test(Some("overlay"), "localhost-overlay").await
 }
 
-/// Test with legacy podman load path (--no-direct-image-mount)
+/// Test with archive mode (podman load at boot)
 #[tokio::test]
-async fn test_localhost_hello_world_legacy_import() -> Result<()> {
-    run_localhost_test(true).await
+async fn test_localhost_archive_mode() -> Result<()> {
+    run_localhost_test(Some("archive"), "localhost-archive").await
 }
 
-async fn run_localhost_test(no_direct_image_mount: bool) -> Result<()> {
-    let mode = if no_direct_image_mount {
-        "legacy (podman load)"
-    } else {
-        "direct mount (additionalImageStore)"
-    };
+/// Test with btrfs mode (pre-built btrfs image as graphroot)
+#[tokio::test]
+async fn test_localhost_btrfs_mode() -> Result<()> {
+    run_localhost_test(Some("btrfs"), "localhost-btrfs").await
+}
 
-    println!("\nLocalhost Image Test ({})", mode);
+/// Test with default mode (auto-detect, should be overlay without btrfs kernel)
+#[tokio::test]
+async fn test_localhost_default_mode() -> Result<()> {
+    run_localhost_test(None, "localhost-default").await
+}
+
+async fn run_localhost_test(image_mode: Option<&str>, suffix: &str) -> Result<()> {
+    let mode_label = image_mode.unwrap_or("default (auto-detect)");
+
+    println!("\nLocalhost Image Test ({})", mode_label);
     println!("====================");
 
     // Find fcvm binary
     let fcvm_path = common::find_fcvm_binary()?;
-    let suffix = if no_direct_image_mount {
-        "localhost-legacy"
-    } else {
-        "localhost-direct"
-    };
     let (vm_name, _, _, _) = common::unique_names(suffix);
 
     // Step 1: Build a test container image on the host
@@ -51,11 +55,12 @@ async fn run_localhost_test(no_direct_image_mount: bool) -> Result<()> {
     // Step 2: Start VM with localhost image (rootless mode)
     println!(
         "Step 2: Starting VM with localhost/test-hello image ({})...",
-        mode
+        mode_label
     );
     let mut args = vec!["podman", "run", "--name", &vm_name];
-    if no_direct_image_mount {
-        args.push("--no-direct-image-mount");
+    if let Some(mode) = image_mode {
+        args.push("--image-mode");
+        args.push(mode);
     }
     args.push("localhost/test-hello");
 
@@ -136,17 +141,17 @@ async fn run_localhost_test(no_direct_image_mount: bool) -> Result<()> {
 
     // Check results - verify we got the container output
     if found_hello {
-        println!("\n  LOCALHOST IMAGE TEST PASSED! ({})", mode);
+        println!("\n  LOCALHOST IMAGE TEST PASSED! ({})", mode_label);
         println!("  - Container ran and printed: Hello from localhost container!");
         if container_exited_zero {
             println!("  - Container exited with code 0");
         }
         Ok(())
     } else {
-        println!("\n  LOCALHOST IMAGE TEST FAILED! ({})", mode);
+        println!("\n  LOCALHOST IMAGE TEST FAILED! ({})", mode_label);
         println!("  - Did not find expected output: 'Hello from localhost container!'");
         println!("  - Check logs above for error details");
-        anyhow::bail!("Localhost image test failed ({})", mode)
+        anyhow::bail!("Localhost image test failed ({})", mode_label)
     }
 }
 

--- a/tests/test_localhost_rootless.rs
+++ b/tests/test_localhost_rootless.rs
@@ -196,13 +196,15 @@ async fn test_localhost_rootless_btrfs_snapshot_restore() -> Result<()> {
         println!("  First run: VM is healthy");
 
         // Verify container runs
-        let vm_username = common::exec_in_vm(
-            fcvm_pid,
-            &["getent", "passwd", "1000"],
-        )
-        .await
-        .context("resolving UID 1000 username")?;
-        let vm_username = vm_username.trim().split(':').next().unwrap_or("ubuntu").to_string();
+        let vm_username = common::exec_in_vm(fcvm_pid, &["getent", "passwd", "1000"])
+            .await
+            .context("resolving UID 1000 username")?;
+        let vm_username = vm_username
+            .trim()
+            .split(':')
+            .next()
+            .unwrap_or("ubuntu")
+            .to_string();
 
         // Wait for container to appear
         let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(60);
@@ -212,8 +214,20 @@ async fn test_localhost_rootless_btrfs_snapshot_restore() -> Result<()> {
             }
             if let Ok(ps) = common::exec_in_vm(
                 fcvm_pid,
-                &["runuser", "-u", &vm_username, "--", "podman", "ps", "-a", "--format", "{{.Names}}"],
-            ).await {
+                &[
+                    "runuser",
+                    "-u",
+                    &vm_username,
+                    "--",
+                    "podman",
+                    "ps",
+                    "-a",
+                    "--format",
+                    "{{.Names}}",
+                ],
+            )
+            .await
+            {
                 if ps.contains("fcvm-container") {
                     println!("  First run: container is running as {}", vm_username);
                     break;
@@ -252,13 +266,15 @@ async fn test_localhost_rootless_btrfs_snapshot_restore() -> Result<()> {
         println!("  Second run: VM is healthy (restored from snapshot!)");
 
         // Verify btrfs storage driver
-        let vm_username = common::exec_in_vm(
-            fcvm_pid,
-            &["getent", "passwd", "1000"],
-        )
-        .await
-        .context("resolving UID 1000 username")?;
-        let vm_username = vm_username.trim().split(':').next().unwrap_or("ubuntu").to_string();
+        let vm_username = common::exec_in_vm(fcvm_pid, &["getent", "passwd", "1000"])
+            .await
+            .context("resolving UID 1000 username")?;
+        let vm_username = vm_username
+            .trim()
+            .split(':')
+            .next()
+            .unwrap_or("ubuntu")
+            .to_string();
 
         // Wait for container
         let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(60);
@@ -268,8 +284,20 @@ async fn test_localhost_rootless_btrfs_snapshot_restore() -> Result<()> {
             }
             if let Ok(ps) = common::exec_in_vm(
                 fcvm_pid,
-                &["runuser", "-u", &vm_username, "--", "podman", "ps", "-a", "--format", "{{.Names}}"],
-            ).await {
+                &[
+                    "runuser",
+                    "-u",
+                    &vm_username,
+                    "--",
+                    "podman",
+                    "ps",
+                    "-a",
+                    "--format",
+                    "{{.Names}}",
+                ],
+            )
+            .await
+            {
                 if ps.contains("fcvm-container") {
                     println!("  Second run: container is running as {}", vm_username);
                     break;
@@ -281,11 +309,26 @@ async fn test_localhost_rootless_btrfs_snapshot_restore() -> Result<()> {
         // Verify btrfs driver in restored VM
         let driver = common::exec_in_vm(
             fcvm_pid,
-            &["runuser", "-u", &vm_username, "--", "podman", "info", "--format", "{{.Store.GraphDriverName}}"],
-        ).await.context("checking storage driver")?;
+            &[
+                "runuser",
+                "-u",
+                &vm_username,
+                "--",
+                "podman",
+                "info",
+                "--format",
+                "{{.Store.GraphDriverName}}",
+            ],
+        )
+        .await
+        .context("checking storage driver")?;
         let driver = driver.trim();
         println!("  GraphDriverName: {}", driver);
-        assert_eq!(driver, "btrfs", "Expected btrfs after snapshot restore, got: {}", driver);
+        assert_eq!(
+            driver, "btrfs",
+            "Expected btrfs after snapshot restore, got: {}",
+            driver
+        );
 
         common::kill_process(fcvm_pid).await;
     }
@@ -346,13 +389,15 @@ async fn test_localhost_rootless_btrfs_keepid() -> Result<()> {
     println!("  VM is healthy");
 
     // Resolve the actual username for UID 1000 in the guest
-    let vm_username = common::exec_in_vm(
-        fcvm_pid,
-        &["getent", "passwd", "1000"],
-    )
-    .await
-    .context("resolving UID 1000 username")?;
-    let vm_username = vm_username.trim().split(':').next().unwrap_or("ubuntu").to_string();
+    let vm_username = common::exec_in_vm(fcvm_pid, &["getent", "passwd", "1000"])
+        .await
+        .context("resolving UID 1000 username")?;
+    let vm_username = vm_username
+        .trim()
+        .split(':')
+        .next()
+        .unwrap_or("ubuntu")
+        .to_string();
     println!("  VM user for UID 1000: {}", vm_username);
 
     // Step 4: Wait for container to start by polling rootless podman.
@@ -416,13 +461,7 @@ async fn test_localhost_rootless_btrfs_keepid() -> Result<()> {
     let user_graphroot = format!("/home/{}/.local/share/containers/storage", vm_username);
     let fstype = common::exec_in_vm(
         fcvm_pid,
-        &[
-            "findmnt",
-            "-n",
-            "-o",
-            "FSTYPE",
-            &user_graphroot,
-        ],
+        &["findmnt", "-n", "-o", "FSTYPE", &user_graphroot],
     )
     .await
     .context("checking btrfs mount")?;

--- a/tests/test_localhost_rootless.rs
+++ b/tests/test_localhost_rootless.rs
@@ -161,6 +161,11 @@ async fn test_localhost_rootless_btrfs_storage() -> Result<()> {
 ///
 /// Runs the VM twice with the same args — first creates a snapshot, second restores from it.
 /// The key test is that the second run (from snapshot) also succeeds.
+///
+/// Requires host user namespace: btrfs --user builds need rootless podman on the host,
+/// which calls newuidmap to write /proc/PID/uid_map. Gated behind bare-metal
+/// (newuidmap fails under nested user namespaces in container CI).
+#[cfg(feature = "bare-metal")]
 #[tokio::test]
 async fn test_localhost_rootless_btrfs_snapshot_restore() -> Result<()> {
     println!("\nBtrfs Snapshot Restore Test");
@@ -353,6 +358,11 @@ async fn test_localhost_rootless_btrfs_snapshot_restore() -> Result<()> {
 /// Root's `podman inspect` can't see rootless containers, so the standard
 /// health monitor can't detect container health. We poll btrfs readiness
 /// and use `runuser -u fcvm-user` for podman queries.
+///
+/// Requires host user namespace: btrfs --user builds need rootless podman on the host,
+/// which calls newuidmap to write /proc/PID/uid_map. Gated behind bare-metal
+/// (newuidmap fails under nested user namespaces in container CI).
+#[cfg(feature = "bare-metal")]
 #[tokio::test]
 async fn test_localhost_rootless_btrfs_keepid() -> Result<()> {
     println!("\nRootless Localhost + Btrfs + keep-id Test");

--- a/tests/test_localhost_rootless.rs
+++ b/tests/test_localhost_rootless.rs
@@ -152,6 +152,152 @@ async fn test_localhost_rootless_btrfs_storage() -> Result<()> {
     Ok(())
 }
 
+/// Test btrfs snapshot restore with --user (keep-id mode).
+///
+/// This validates that snapshot clones work correctly when:
+/// 1. The btrfs image is read-write (each clone needs its own copy)
+/// 2. The username is preserved across snapshot/restore for health checks
+/// 3. The container starts correctly in the restored VM
+///
+/// Runs the VM twice with the same args — first creates a snapshot, second restores from it.
+/// The key test is that the second run (from snapshot) also succeeds.
+#[tokio::test]
+async fn test_localhost_rootless_btrfs_snapshot_restore() -> Result<()> {
+    println!("\nBtrfs Snapshot Restore Test");
+    println!("==========================");
+
+    // Step 1: Build test image
+    println!("\n1. Building test container image...");
+    build_test_image().await?;
+
+    // Step 2: First run (creates snapshot cache)
+    println!("\n2. First run (fresh boot, creates snapshot)...");
+    {
+        let (vm_name, _, _, _) = common::unique_names("btrfs-snap-1st");
+
+        let (mut _child, fcvm_pid) = common::spawn_fcvm(&[
+            "podman",
+            "run",
+            "--name",
+            &vm_name,
+            "--kernel-profile",
+            "btrfs",
+            "--user",
+            "1000:1000",
+            "localhost/test-btrfs-rootless",
+        ])
+        .await
+        .context("spawning fcvm (first run)")?;
+        println!("  fcvm PID: {}", fcvm_pid);
+
+        common::poll_health_by_pid(fcvm_pid, 120)
+            .await
+            .context("first run: VM failed to become healthy")?;
+        println!("  First run: VM is healthy");
+
+        // Verify container runs
+        let vm_username = common::exec_in_vm(
+            fcvm_pid,
+            &["getent", "passwd", "1000"],
+        )
+        .await
+        .context("resolving UID 1000 username")?;
+        let vm_username = vm_username.trim().split(':').next().unwrap_or("ubuntu").to_string();
+
+        // Wait for container to appear
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(60);
+        loop {
+            if tokio::time::Instant::now() > deadline {
+                anyhow::bail!("First run: timed out waiting for container");
+            }
+            if let Ok(ps) = common::exec_in_vm(
+                fcvm_pid,
+                &["runuser", "-u", &vm_username, "--", "podman", "ps", "-a", "--format", "{{.Names}}"],
+            ).await {
+                if ps.contains("fcvm-container") {
+                    println!("  First run: container is running as {}", vm_username);
+                    break;
+                }
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+        }
+
+        common::kill_process(fcvm_pid).await;
+        println!("  First run: completed (snapshot should be cached)");
+    }
+
+    // Step 3: Second run (should restore from snapshot)
+    println!("\n3. Second run (snapshot restore)...");
+    {
+        let (vm_name, _, _, _) = common::unique_names("btrfs-snap-2nd");
+
+        let (mut _child, fcvm_pid) = common::spawn_fcvm(&[
+            "podman",
+            "run",
+            "--name",
+            &vm_name,
+            "--kernel-profile",
+            "btrfs",
+            "--user",
+            "1000:1000",
+            "localhost/test-btrfs-rootless",
+        ])
+        .await
+        .context("spawning fcvm (second run)")?;
+        println!("  fcvm PID: {}", fcvm_pid);
+
+        common::poll_health_by_pid(fcvm_pid, 120)
+            .await
+            .context("second run (from snapshot): VM failed to become healthy")?;
+        println!("  Second run: VM is healthy (restored from snapshot!)");
+
+        // Verify btrfs storage driver
+        let vm_username = common::exec_in_vm(
+            fcvm_pid,
+            &["getent", "passwd", "1000"],
+        )
+        .await
+        .context("resolving UID 1000 username")?;
+        let vm_username = vm_username.trim().split(':').next().unwrap_or("ubuntu").to_string();
+
+        // Wait for container
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(60);
+        loop {
+            if tokio::time::Instant::now() > deadline {
+                anyhow::bail!("Second run: timed out waiting for container");
+            }
+            if let Ok(ps) = common::exec_in_vm(
+                fcvm_pid,
+                &["runuser", "-u", &vm_username, "--", "podman", "ps", "-a", "--format", "{{.Names}}"],
+            ).await {
+                if ps.contains("fcvm-container") {
+                    println!("  Second run: container is running as {}", vm_username);
+                    break;
+                }
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+        }
+
+        // Verify btrfs driver in restored VM
+        let driver = common::exec_in_vm(
+            fcvm_pid,
+            &["runuser", "-u", &vm_username, "--", "podman", "info", "--format", "{{.Store.GraphDriverName}}"],
+        ).await.context("checking storage driver")?;
+        let driver = driver.trim();
+        println!("  GraphDriverName: {}", driver);
+        assert_eq!(driver, "btrfs", "Expected btrfs after snapshot restore, got: {}", driver);
+
+        common::kill_process(fcvm_pid).await;
+    }
+
+    println!("\n  BTRFS SNAPSHOT RESTORE TEST PASSED");
+    println!("  - First run: fresh boot, btrfs image, snapshot created");
+    println!("  - Second run: restored from snapshot, btrfs image isolated per-clone");
+    println!("  - Username preserved across snapshot for health checks");
+
+    Ok(())
+}
+
 /// Test rootless localhost container with --user (keep-id) and btrfs storage
 ///
 /// This is the critical path that triggered the original issue:
@@ -192,22 +338,36 @@ async fn test_localhost_rootless_btrfs_keepid() -> Result<()> {
     .context("spawning fcvm")?;
     println!("  fcvm PID: {}", fcvm_pid);
 
-    // Step 3: Wait for container to start by polling btrfs mount and user container.
-    // Standard health monitor uses root's `podman inspect` which can't see rootless
-    // containers, so we poll directly using runuser.
-    println!("\n3. Waiting for container to start...");
-    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(180);
+    // Step 3: Wait for VM health and resolve the VM username for UID 1000.
+    // The host resolves UID 1000 via /etc/passwd (e.g., "ubuntu") and passes it as
+    // USER env var. The guest creates a user with that name, not "fcvm-user".
+    println!("\n3. Waiting for VM to become healthy...");
+    common::poll_health_by_pid(fcvm_pid, 120).await?;
+    println!("  VM is healthy");
+
+    // Resolve the actual username for UID 1000 in the guest
+    let vm_username = common::exec_in_vm(
+        fcvm_pid,
+        &["getent", "passwd", "1000"],
+    )
+    .await
+    .context("resolving UID 1000 username")?;
+    let vm_username = vm_username.trim().split(':').next().unwrap_or("ubuntu").to_string();
+    println!("  VM user for UID 1000: {}", vm_username);
+
+    // Step 4: Wait for container to start by polling rootless podman.
+    println!("\n4. Waiting for container to start...");
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(120);
     loop {
         if tokio::time::Instant::now() > deadline {
             anyhow::bail!("Timed out waiting for container to start");
         }
-        // Check if the container is visible via rootless podman
         if let Ok(ps) = common::exec_in_vm(
             fcvm_pid,
             &[
                 "runuser",
                 "-u",
-                "fcvm-user",
+                &vm_username,
                 "--",
                 "podman",
                 "ps",
@@ -226,14 +386,14 @@ async fn test_localhost_rootless_btrfs_keepid() -> Result<()> {
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
     }
 
-    // Step 4: Verify btrfs storage driver (root's podman info shows system-wide config)
-    println!("\n4. Checking podman storage driver...");
+    // Step 5: Verify btrfs storage driver
+    println!("\n5. Checking podman storage driver...");
     let driver = common::exec_in_vm(
         fcvm_pid,
         &[
             "runuser",
             "-u",
-            "fcvm-user",
+            &vm_username,
             "--",
             "podman",
             "info",
@@ -251,8 +411,9 @@ async fn test_localhost_rootless_btrfs_keepid() -> Result<()> {
         driver
     );
 
-    // Step 5: Verify btrfs mount
-    println!("\n5. Checking btrfs mount...");
+    // Step 6: Verify btrfs mount at user's default rootless graphroot
+    println!("\n6. Checking btrfs mount...");
+    let user_graphroot = format!("/home/{}/.local/share/containers/storage", vm_username);
     let fstype = common::exec_in_vm(
         fcvm_pid,
         &[
@@ -260,27 +421,27 @@ async fn test_localhost_rootless_btrfs_keepid() -> Result<()> {
             "-n",
             "-o",
             "FSTYPE",
-            "/var/lib/containers/storage",
+            &user_graphroot,
         ],
     )
     .await
     .context("checking btrfs mount")?;
     let fstype = fstype.trim();
-    println!("  /var/lib/containers/storage fstype: {}", fstype);
+    println!("  {} fstype: {}", user_graphroot, fstype);
     assert_eq!(
         fstype, "btrfs",
-        "Expected btrfs filesystem at /var/lib/containers/storage, got: {}",
-        fstype
+        "Expected btrfs filesystem at {}, got: {}",
+        user_graphroot, fstype
     );
 
-    // Step 6: Verify container ran with correct user
-    println!("\n6. Checking container execution...");
+    // Step 7: Verify container ran with correct user
+    println!("\n7. Checking container execution...");
     let ps_output = common::exec_in_vm(
         fcvm_pid,
         &[
             "runuser",
             "-u",
-            "fcvm-user",
+            &vm_username,
             "--",
             "podman",
             "ps",
@@ -298,17 +459,14 @@ async fn test_localhost_rootless_btrfs_keepid() -> Result<()> {
         ps_output
     );
 
-    // Step 7: Verify userns=keep-id was used (container process runs as uid 1000)
-    // Note: podman's HostConfig.UsernsMode reports "private" for keep-id (Docker compat
-    // doesn't distinguish the two). Instead, verify the actual behavior: the container
-    // process should run as uid 1000, proving keep-id mapped host UID into the container.
-    println!("\n7. Checking container runs as expected user...");
+    // Step 8: Verify userns=keep-id was used (container process runs as uid 1000)
+    println!("\n8. Checking container runs as expected user...");
     let container_uid = common::exec_in_vm(
         fcvm_pid,
         &[
             "runuser",
             "-u",
-            "fcvm-user",
+            &vm_username,
             "--",
             "podman",
             "exec",
@@ -328,7 +486,7 @@ async fn test_localhost_rootless_btrfs_keepid() -> Result<()> {
     );
 
     // Cleanup
-    println!("\n8. Cleaning up...");
+    println!("\n9. Cleaning up...");
     common::kill_process(fcvm_pid).await;
 
     println!("\n  ROOTLESS + BTRFS + KEEP-ID TEST PASSED");


### PR DESCRIPTION
**Stacked on:** vm-rootless-fixes (PR #352)

## Summary
- Three-mode image delivery: `--image-mode overlay|btrfs|archive` (auto-detected from kernel profile)
- Build btrfs storage images as the target user (uid 1000) via `runuser` so file ownership matches rootless podman expectations — no chown at boot
- Per-VM reflink copy of btrfs image (read-write, instant startup)
- Snapshot/restore support for btrfs mode

## Changes

### Host side
- `ImageMode` enum replaces `--no-direct-image-mount`
- `build_btrfs_storage_image()` runs `podman load` as target user when `--user` specified
- Separate cache paths: `{digest}.btrfs.img` (root) vs `{digest}.btrfs-uid1000.img` (user)
- `mkfs.btrfs --rootdir --subvol` preserves btrfs subvolumes in image (requires btrfs-progs >= 6.12)
- Skip `runuser` when fcvm already runs as target uid (rootless without sudo)

### Guest side (fc-agent)
- Three-way dispatch on `image_mode` in agent.rs
- `mount_btrfs_for_user()`: mount at `~/.local/share/containers/storage` with correct ownership
- No runtime chown of btrfs content — files already correctly owned from host build
- `setup_btrfs_storage_if_available()` and `setup_user_btrfs_storage()` skipped for btrfs image mode

### Code quality (from auto-fix PR review)
- Deduplicate `User::from_name` calls in `storage_paths()`
- Merge `get_host_subuid_start/count` into single `get_host_subuid_range()` (was double-parsing `/etc/subuid`)
- Fix `test_parse_subid_file_finds_current_user` USER env var panic in CI
- cargo fmt + clippy fixes

## Test plan
- [x] 81 unit tests pass
- [x] 9/9 localhost E2E tests pass (run twice locally)
- [ ] CI green on all jobs