### PR TITLE
Fix nightly hugepages benchmark failure

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -88,6 +88,8 @@ jobs:
           mkdir -p ~/.config/containers
           printf '[storage]\ndriver = "overlay"\ngraphroot = "/mnt/fcvm-btrfs/containers/storage"\n' > ~/.config/containers/storage.conf
           podman system migrate || true
+          # Fix lock file permissions from previous sudo runs (bench-vm runs as root)
+          sudo chmod 666 /mnt/fcvm-btrfs/state/*.lock 2>/dev/null || true
       - name: Run VM benchmarks
         working-directory: fcvm
         env:

--- a/benches/hugepages.rs
+++ b/benches/hugepages.rs
@@ -425,8 +425,14 @@ fn run_mode(mode: &str, mem_mb: u32, data_mb: u32, hugepages: bool) -> BenchResu
     eprintln!("    Log: {}", log_path2);
 
     let clone_timeout = if data_mb > 1000 { 300 } else { 120 };
-    let clone_elapsed = poll_health(&fcvm, &mut child2, clone_timeout)
-        .unwrap_or_else(|e| panic!("Clone failed: {}", e));
+    let clone_elapsed = match poll_health(&fcvm, &mut child2, clone_timeout) {
+        Ok(elapsed) => elapsed,
+        Err(e) => {
+            graceful_kill(pid2, 5000);
+            let _ = child2.wait();
+            panic!("Clone failed: {}", e);
+        }
+    };
     let _guard2 = ProcessGuard {
         pid: pid2,
         child: child2,

--- a/benches/hugepages.rs
+++ b/benches/hugepages.rs
@@ -79,18 +79,10 @@ fn graceful_kill(pid: u32, timeout_ms: u64) {
     }
 }
 
-/// Check if a process is still alive
-fn is_process_alive(pid: u32) -> bool {
-    Command::new("kill")
-        .args(["-0", &pid.to_string()])
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-}
-
 /// Wait for a VM to become healthy, polling fcvm ls --json --pid.
 /// Detects early process death to avoid waiting the full timeout.
-fn poll_health(fcvm: &Path, pid: u32, timeout_secs: u64) -> Result<Duration, String> {
+fn poll_health(fcvm: &Path, child: &mut Child, timeout_secs: u64) -> Result<Duration, String> {
+    let pid = child.id();
     let start = Instant::now();
     let timeout = Duration::from_secs(timeout_secs);
     loop {
@@ -101,13 +93,23 @@ fn poll_health(fcvm: &Path, pid: u32, timeout_secs: u64) -> Result<Duration, Str
             ));
         }
 
-        // Detect early process death
-        if !is_process_alive(pid) {
-            return Err(format!(
-                "VM process (PID {}) died after {:.1}s — check /tmp/fcvm-bench-*.log",
-                pid,
-                start.elapsed().as_secs_f64()
-            ));
+        // Detect early process death using try_wait (reaps zombies properly)
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                return Err(format!(
+                    "VM process (PID {}) exited with {} after {:.1}s — check /tmp/fcvm-bench-*.log",
+                    pid,
+                    status,
+                    start.elapsed().as_secs_f64()
+                ));
+            }
+            Ok(None) => {} // Still running
+            Err(e) => {
+                return Err(format!(
+                    "Failed to check VM process (PID {}): {} — check /tmp/fcvm-bench-*.log",
+                    pid, e
+                ));
+            }
         }
 
         let output = Command::new(fcvm)
@@ -292,7 +294,7 @@ fn run_mode(mode: &str, mem_mb: u32, data_mb: u32, hugepages: bool) -> BenchResu
         }
         args1.push(BENCH_IMAGE);
 
-        let child1 = Command::new(&fcvm)
+        let mut child1 = Command::new(&fcvm)
             .args(&args1)
             .env("RUST_LOG", "debug")
             .stdout(Stdio::from(log_file1))
@@ -301,22 +303,23 @@ fn run_mode(mode: &str, mem_mb: u32, data_mb: u32, hugepages: bool) -> BenchResu
             .expect("failed to spawn cold start VM");
 
         let pid1 = child1.id();
-        let guard1 = ProcessGuard {
-            pid: pid1,
-            child: child1,
-        };
         eprintln!("    Log: {}", log_path1);
 
-        match poll_health(&fcvm, pid1, healthy_timeout) {
+        match poll_health(&fcvm, &mut child1, healthy_timeout) {
             Ok(elapsed) => {
                 health_elapsed = elapsed;
-                cold_guard = Some(guard1);
+                cold_guard = Some(ProcessGuard {
+                    pid: pid1,
+                    child: child1,
+                });
                 cold_log_path = log_path1;
                 break;
             }
             Err(e) => {
                 eprintln!("    Cold start failed: {}", e);
-                drop(guard1); // Kill the failed VM
+                // Kill the failed VM
+                graceful_kill(pid1, 5000);
+                let _ = child1.wait();
                 if cold_attempt == max_cold_attempts {
                     panic!(
                         "Cold start failed after {} attempts: {}",
@@ -410,7 +413,7 @@ fn run_mode(mode: &str, mem_mb: u32, data_mb: u32, hugepages: bool) -> BenchResu
     args2.push(BENCH_IMAGE);
 
     let t2 = Instant::now();
-    let child2 = Command::new(&fcvm)
+    let mut child2 = Command::new(&fcvm)
         .args(&args2)
         .env("RUST_LOG", "debug")
         .stdout(Stdio::from(log_file2))
@@ -419,15 +422,15 @@ fn run_mode(mode: &str, mem_mb: u32, data_mb: u32, hugepages: bool) -> BenchResu
         .expect("failed to spawn warm start VM");
 
     let pid2 = child2.id();
+    eprintln!("    Log: {}", log_path2);
+
+    let clone_timeout = if data_mb > 1000 { 300 } else { 120 };
+    let clone_elapsed = poll_health(&fcvm, &mut child2, clone_timeout)
+        .unwrap_or_else(|e| panic!("Clone failed: {}", e));
     let _guard2 = ProcessGuard {
         pid: pid2,
         child: child2,
     };
-    eprintln!("    Log: {}", log_path2);
-
-    let clone_timeout = if data_mb > 1000 { 300 } else { 120 };
-    let clone_elapsed =
-        poll_health(&fcvm, pid2, clone_timeout).unwrap_or_else(|e| panic!("Clone failed: {}", e));
     let clone_secs = clone_elapsed.as_secs_f64();
     eprintln!("    Clone healthy after {:.1}s", clone_secs);
 

--- a/src/state/manager.rs
+++ b/src/state/manager.rs
@@ -1,8 +1,24 @@
 use anyhow::{Context, Result};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::fs;
 
 use super::types::VmState;
+
+/// Open or create a lock file with world-readable/writable permissions.
+/// Uses fchmod after creation to ensure permissions are set regardless of umask.
+/// This allows both root and non-root processes to coordinate via flock.
+fn open_lock_file(path: &Path) -> Result<std::fs::File> {
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .mode(0o666)
+        .open(path)?;
+    // Force permissions regardless of umask (only effective if we own the file or are root)
+    let _ = file.set_permissions(std::fs::Permissions::from_mode(0o666));
+    Ok(file)
+}
 
 /// Manages VM state persistence
 ///
@@ -63,14 +79,7 @@ impl StateManager {
         let lock_file = self.state_dir.join(format!("{}.json.lock", state.vm_id));
 
         // Create/open lock file for exclusive locking
-        use std::os::unix::fs::OpenOptionsExt;
-        let lock_fd = std::fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .mode(0o666)
-            .open(&lock_file)
-            .context("opening lock file")?;
+        let lock_fd = open_lock_file(&lock_file).context("opening lock file")?;
 
         // Acquire exclusive lock (blocks if another process has lock).
         // NOTE: Flock::lock() is technically blocking I/O in an async context, but
@@ -426,14 +435,7 @@ impl StateManager {
         let lock_file = self.state_dir.join(format!("{}.json.lock", vm_id));
 
         // Create/open lock file for exclusive locking
-        use std::os::unix::fs::OpenOptionsExt;
-        let lock_fd = std::fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .mode(0o666)
-            .open(&lock_file)
-            .context("opening lock file for health update")?;
+        let lock_fd = open_lock_file(&lock_file).context("opening lock file for health update")?;
 
         // Acquire exclusive lock (blocks if another process has lock)
         use nix::fcntl::{Flock, FlockArg};
@@ -511,14 +513,7 @@ impl StateManager {
         let lock_file = self.state_dir.join("loopback-ip.lock");
 
         // Create/open lock file for exclusive locking
-        use std::os::unix::fs::OpenOptionsExt;
-        let lock_fd = std::fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .mode(0o666)
-            .open(&lock_file)
-            .context("opening loopback IP lock file")?;
+        let lock_fd = open_lock_file(&lock_file).context("opening loopback IP lock file")?;
 
         // Acquire exclusive lock (blocks if another process has lock)
         use nix::fcntl::{Flock, FlockArg};

--- a/src/state/manager.rs
+++ b/src/state/manager.rs
@@ -68,7 +68,7 @@ impl StateManager {
             .create(true)
             .write(true)
             .truncate(true)
-            .mode(0o600)
+            .mode(0o666)
             .open(&lock_file)
             .context("opening lock file")?;
 
@@ -431,7 +431,7 @@ impl StateManager {
             .create(true)
             .write(true)
             .truncate(true)
-            .mode(0o600)
+            .mode(0o666)
             .open(&lock_file)
             .context("opening lock file for health update")?;
 
@@ -516,7 +516,7 @@ impl StateManager {
             .create(true)
             .write(true)
             .truncate(true)
-            .mode(0o600)
+            .mode(0o666)
             .open(&lock_file)
             .context("opening loopback IP lock file")?;
 


### PR DESCRIPTION
## Summary

Fixes the hugepages benchmark that has been failing on ARM64 nightly CI for ~2 weeks (since the benchmark was added).

**Root cause:** The `bench-vm` step runs as root (via `CARGO_TARGET_*_RUNNER='sudo -E'`), creating `/mnt/fcvm-btrfs/state/loopback-ip.lock` with mode `0600 root:root`. The hugepages benchmark runs as the `ubuntu` user and gets `Permission denied (os error 13)` when trying to open the lock file. The fcvm process exits immediately, but `poll_health` used `kill -0` which returns `true` for zombie processes (the parent hasn't called `wait()`), masking the instant failure as a 300s timeout.

**Confirmed via SSH to the ARM64 runner:**
```
$ ls -la /mnt/fcvm-btrfs/state/loopback-ip.lock
-rw------- 1 root root 0 Feb 17 04:46 loopback-ip.lock

$ head -20 /tmp/fcvm-bench-bench-hp-standard-cold-57486-1.log
... 
ERROR fcvm: Error: allocating loopback IP: opening loopback IP lock file: Permission denied (os error 13)
```

## Changes

- **`src/state/manager.rs`**: Change lock file mode from `0600` to `0666` — these files are only used for `flock()` coordination, no sensitive data
- **`benches/hugepages.rs`**: Replace `kill -0` (zombie-blind) with `child.try_wait()` which properly reaps and detects exited processes
- **`.github/workflows/nightly.yml`**: `chmod 666` existing lock files before hugepages step to handle runners with stale root-owned lock files

## Test plan

- [x] `cargo check --all-targets` passes
- [ ] Nightly CI passes on ARM64 with hugepages benchmark