### PR TITLE
Containerize btrfs image build for EL9 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ The mode is auto-detected from the kernel profile (btrfs profile → btrfs mode)
 ./fcvm podman run --name web --image-mode archive nginx:alpine
 ```
 
-**Btrfs mode** is designed for rootless podman with `--user`. It builds the btrfs storage image as the target user on the host, so file ownership matches what rootless podman expects — no chown needed at boot:
+**Btrfs mode** is designed for rootless podman with `--user`. It builds the btrfs storage image inside an Ubuntu Noble container (for host OS compatibility), so file ownership matches what rootless podman expects — no chown needed at boot:
 
 ```bash
 # Rootless podman in VM with btrfs storage (no sudo needed)
@@ -254,7 +254,7 @@ The mode is auto-detected from the kernel profile (btrfs profile → btrfs mode)
 
 **How btrfs mode works:**
 1. Host exports container as Docker archive (`podman save`)
-2. Host loads archive into a temp btrfs storage root (`podman --root <tmp> --storage-driver btrfs load`)
+2. Containerized `podman load` into a temp btrfs storage root (runs inside Ubuntu Noble for EL9 compatibility)
 3. Host packages the storage tree as a btrfs image (`mkfs.btrfs --rootdir --subvol`)
 4. Per-VM: btrfs reflink copy of the image (instant, read-write)
 5. Guest mounts the btrfs image as podman's graphroot — container is ready immediately

--- a/scripts/build-btrfs-progs.sh
+++ b/scripts/build-btrfs-progs.sh
@@ -3,7 +3,9 @@
 #
 # btrfs-progs 6.12+ includes mkfs.btrfs --rootdir --subvol which creates
 # btrfs images from directories containing btrfs subvolumes — without root.
-# Ubuntu 24.04 ships btrfs-progs 6.6.3 which lacks this feature.
+#
+# Builds inside an Ubuntu Noble container to work on any host OS (EL9, Ubuntu, etc.).
+# Uses the same proxy pattern as fcvm's rootfs package download.
 #
 # Usage: ./scripts/build-btrfs-progs.sh [output_dir]
 #        Output defaults to /mnt/fcvm-btrfs/deps/bin/
@@ -13,25 +15,11 @@ set -euo pipefail
 BTRFS_PROGS_VERSION="6.12"
 OUTPUT_DIR="${1:-/mnt/fcvm-btrfs/deps/bin}"
 
-# Source URL
-BTRFS_PROGS_URL="https://github.com/kdave/btrfs-progs/archive/refs/tags/v${BTRFS_PROGS_VERSION}.tar.gz"
-
-# Build directory
-BUILD_DIR="/tmp/btrfs-progs-build-$$"
-PREFIX="$BUILD_DIR/install"
-
-cleanup() {
-    if [[ -d "$BUILD_DIR" ]]; then
-        rm -rf "$BUILD_DIR"
-    fi
-}
-trap cleanup EXIT
-
 echo "=== Building btrfs-progs ${BTRFS_PROGS_VERSION} ==="
 echo "Output: $OUTPUT_DIR/mkfs.btrfs"
 echo ""
 
-# Check if already built
+# Check if already built and runnable
 if [[ -x "$OUTPUT_DIR/mkfs.btrfs" ]]; then
     EXISTING_VERSION=$("$OUTPUT_DIR/mkfs.btrfs" --version 2>/dev/null | grep -oP '[\d.]+' || echo "0")
     MAJOR=$(echo "$EXISTING_VERSION" | cut -d. -f1)
@@ -43,93 +31,97 @@ if [[ -x "$OUTPUT_DIR/mkfs.btrfs" ]]; then
     fi
 fi
 
-mkdir -p "$BUILD_DIR" "$PREFIX"
-cd "$BUILD_DIR"
+mkdir -p "$OUTPUT_DIR"
 
-# Check and install build dependencies
-echo "Checking build dependencies..."
-MISSING_PKGS=""
-
-for pkg in uuid-dev libblkid-dev liblzo2-dev libzstd-dev zlib1g-dev libext2fs-dev libudev-dev; do
-    if ! dpkg -s "$pkg" &>/dev/null; then
-        MISSING_PKGS="$MISSING_PKGS $pkg"
+# Build proxy args for podman (same pattern as fcvm rootfs download)
+PROXY_ARGS=()
+for var in http_proxy https_proxy HTTP_PROXY HTTPS_PROXY; do
+    if [[ -n "${!var:-}" ]]; then
+        PROXY_ARGS+=("-e" "${var}=${!var}")
     fi
 done
 
-# Also need python3 for documentation/autogen (python3-setuptools for sphinx)
-if ! command -v python3 &>/dev/null; then
-    MISSING_PKGS="$MISSING_PKGS python3"
+# Determine curl proxy flag from http_proxy
+CURL_PROXY=""
+if [[ -n "${http_proxy:-}" ]]; then
+    CURL_PROXY="-x $http_proxy"
+elif [[ -n "${HTTPS_PROXY:-}" ]]; then
+    CURL_PROXY="-x $HTTPS_PROXY"
 fi
 
-if ! command -v autoconf &>/dev/null; then
-    MISSING_PKGS="$MISSING_PKGS autoconf"
+echo "Building in Ubuntu Noble container..."
+podman run --rm --cgroups=disabled --network=host \
+    "${PROXY_ARGS[@]}" \
+    -v "$OUTPUT_DIR:/output:Z" \
+    ubuntu:noble bash -c "
+set -e
+# Configure apt proxy (same as fcvm rootfs download)
+echo 'APT::Sandbox::User \"root\";' > /etc/apt/apt.conf.d/10sandbox
+if [ -n \"\${http_proxy:-}\" ]; then
+    echo \"Acquire::http::Proxy \\\"\$http_proxy\\\";\" > /etc/apt/apt.conf.d/99proxy
+    echo \"Acquire::https::Proxy \\\"\$http_proxy\\\";\" >> /etc/apt/apt.conf.d/99proxy
+fi
+echo 'Acquire::Retries \"3\";' > /etc/apt/apt.conf.d/80retries
+
+echo '  Installing build deps...'
+apt-get update -qq >/dev/null 2>&1
+apt-get install -y --no-install-recommends >/dev/null 2>&1 \
+    curl ca-certificates build-essential autoconf automake pkg-config \
+    uuid-dev libblkid-dev liblzo2-dev libzstd-dev zlib1g-dev libext2fs-dev libudev-dev
+
+echo '  Downloading btrfs-progs ${BTRFS_PROGS_VERSION}...'
+cd /tmp
+curl ${CURL_PROXY} -sL https://github.com/kdave/btrfs-progs/archive/refs/tags/v${BTRFS_PROGS_VERSION}.tar.gz | tar xz
+cd btrfs-progs-${BTRFS_PROGS_VERSION}
+
+echo '  Configuring...'
+./autogen.sh >/dev/null 2>&1
+./configure --disable-documentation --disable-python >/dev/null 2>&1
+
+echo '  Compiling...'
+make -j\$(nproc) >/dev/null 2>&1
+
+# Copy the binary AND its required shared libraries so it runs on any host
+echo '  Bundling binary + libraries...'
+mkdir -p /output/lib
+cp mkfs.btrfs /output/mkfs.btrfs.bin
+chmod +x /output/mkfs.btrfs.bin
+
+# Copy required shared libraries
+for lib in \$(ldd mkfs.btrfs | awk '/=>/ {print \$3}'); do
+    cp \"\$lib\" /output/lib/ 2>/dev/null || true
+done
+# Copy the dynamic linker (architecture-dependent)
+ARCH=\$(uname -m)
+if [ \"\$ARCH\" = \"aarch64\" ]; then
+    cp /lib/ld-linux-aarch64.so.1 /output/lib/ 2>/dev/null || true
+else
+    cp /lib64/ld-linux-x86-64.so.2 /output/lib/ 2>/dev/null || \
+        cp /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 /output/lib/ 2>/dev/null || true
 fi
 
-if ! command -v automake &>/dev/null; then
-    MISSING_PKGS="$MISSING_PKGS automake"
-fi
-
-if ! command -v pkg-config &>/dev/null; then
-    MISSING_PKGS="$MISSING_PKGS pkg-config"
-fi
-
-if [[ -n "$MISSING_PKGS" ]]; then
-    echo "Installing missing build dependencies:$MISSING_PKGS"
-    sudo apt-get update -qq
-    sudo apt-get install -y --no-install-recommends $MISSING_PKGS
-fi
-
-# Download and extract
-echo ""
-echo "=== Downloading btrfs-progs ${BTRFS_PROGS_VERSION} ==="
-curl -sL "$BTRFS_PROGS_URL" | tar xz
-cd "btrfs-progs-${BTRFS_PROGS_VERSION}"
-
-# Generate configure script
-echo ""
-echo "=== Running autogen ==="
-./autogen.sh
-
-# Configure - disable documentation (requires sphinx) and python bindings
-echo ""
-echo "=== Configuring ==="
-./configure \
-    --prefix="$PREFIX" \
-    --disable-documentation \
-    --disable-python
-
-# Build
-echo ""
-echo "=== Building ==="
-make -j"$(nproc)"
-
-# Verify the build
-echo ""
-echo "=== Verifying build ==="
+echo '  Done!'
 ./mkfs.btrfs --version
+"
 
-# Check that --rootdir is supported (mkfs.btrfs has had -r/--rootdir since 4.x)
-# Verify by checking the version is >= 6.12
-BUILT_VERSION=$(./mkfs.btrfs --version 2>/dev/null | grep -oP '[\d.]+' || echo "0")
-echo "Built version: $BUILT_VERSION"
-BUILT_MAJOR=$(echo "$BUILT_VERSION" | cut -d. -f1)
-BUILT_MINOR=$(echo "$BUILT_VERSION" | cut -d. -f2)
-if [[ "$BUILT_MAJOR" -lt 6 ]] || [[ "$BUILT_MAJOR" -eq 6 && "$BUILT_MINOR" -lt 12 ]]; then
-    echo "ERROR: built mkfs.btrfs version $BUILT_VERSION is too old (need >= 6.12 for --rootdir --subvol)"
-    exit 1
+# Create wrapper script that uses bundled libraries
+cat > "$OUTPUT_DIR/mkfs.btrfs" << 'WRAPPER'
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ARCH=$(uname -m)
+if [ "$ARCH" = "aarch64" ]; then
+    LINKER="$DIR/lib/ld-linux-aarch64.so.1"
+else
+    LINKER="$DIR/lib/ld-linux-x86-64.so.2"
 fi
-
-# Install to output directory
-echo ""
-echo "=== Installing to $OUTPUT_DIR ==="
-mkdir -p "$OUTPUT_DIR"
-cp -v mkfs.btrfs "$OUTPUT_DIR/mkfs.btrfs"
+exec "$LINKER" --library-path "$DIR/lib" "$DIR/mkfs.btrfs.bin" "$@"
+WRAPPER
 chmod +x "$OUTPUT_DIR/mkfs.btrfs"
+
+echo ""
+echo "=== Verifying ==="
+"$OUTPUT_DIR/mkfs.btrfs" --version
 
 echo ""
 echo "=== Success! ==="
 echo "Binary: $OUTPUT_DIR/mkfs.btrfs"
-VERSION=$("$OUTPUT_DIR/mkfs.btrfs" --version 2>/dev/null || echo "unknown")
-echo "Version: $VERSION"
-echo ""
-echo "Test with: $OUTPUT_DIR/mkfs.btrfs --version"

--- a/src/commands/podman/image.rs
+++ b/src/commands/podman/image.rs
@@ -229,7 +229,15 @@ pub(super) async fn build_storage_image(
     // Remove podman state files that contain hardcoded paths from the temp dir.
     // Keep only image/layer data directories. When the guest mounts this read-only
     // at a different path, stale state files cause "database graph driver does not match".
-    clean_podman_state(&tmp_dir, &["overlay", "overlay-images", "overlay-layers"]).await;
+    let keep = &["overlay", "overlay-images", "overlay-layers"];
+    clean_podman_state(&tmp_dir, keep).await;
+
+    // Remove .has-mount-program marker from kept directories. This marker causes
+    // podman to create a broken database with driver="" when no existing db.sql exists.
+    for dir_name in keep {
+        let marker = tmp_dir.join(dir_name).join(".has-mount-program");
+        tokio::fs::remove_file(&marker).await.ok();
+    }
 
     // Package the storage tree as an ext4 image using the existing helper.
     // NOTE: Can't use with_extension() here because output_path ends in .storage.img
@@ -322,25 +330,108 @@ fn find_mkfs_btrfs() -> Result<PathBuf> {
     )
 }
 
+/// Load a Docker archive into a btrfs podman storage root using a containerized podman.
+///
+/// Runs inside an Ubuntu Noble container with `--privileged` because:
+/// 1. Host podman may lack the btrfs storage driver (EL9 RPM excludes it)
+/// 2. Rootless podman load needs user namespace support (`newuidmap`)
+///
+/// The btrfs temp dirs are bind-mounted so subvolumes are created on the host filesystem.
+/// For rootless builds (`build_uid`), creates a user inside the container with matching UID.
+async fn podman_btrfs_load_in_container(
+    archive_path: &Path,
+    tmp_dir: &Path,
+    tmp_runroot: &Path,
+) -> Result<()> {
+    info!("Running podman btrfs load inside ubuntu:noble container");
+
+    // Always run podman load as root inside the container. In rootless podman with
+    // --privileged, container uid 0 maps to the host user's uid via the user namespace.
+    // Files created as root inside the container are owned by the host uid on the
+    // bind-mounted btrfs, which is exactly the ownership we want for --user builds.
+    let inner_script = r#"set -e
+# Configure apt proxy from any proxy env var
+PROXY="${http_proxy:-${HTTPS_PROXY:-${https_proxy:-}}}"
+echo 'APT::Sandbox::User "root";' > /etc/apt/apt.conf.d/10sandbox
+if [ -n "$PROXY" ]; then
+    echo "Acquire::http::Proxy \"$PROXY\";" > /etc/apt/apt.conf.d/99proxy
+    echo "Acquire::https::Proxy \"$PROXY\";" >> /etc/apt/apt.conf.d/99proxy
+fi
+echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries
+apt-get update -qq
+apt-get install -y -qq podman
+podman --root /btrfs-root --runroot /btrfs-runroot --storage-driver btrfs load -i /archive.tar"#
+        .to_string();
+
+    let mut podman_args = vec![
+        "run".to_string(),
+        "--rm".to_string(),
+        "--privileged".to_string(),
+        "--cgroups=disabled".to_string(),
+        "--network=host".to_string(),
+    ];
+
+    // Pass through proxy environment variables (same pattern as rootfs.rs download_packages)
+    for var in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"] {
+        if let Ok(val) = std::env::var(var) {
+            podman_args.push("-e".to_string());
+            podman_args.push(format!("{}={}", var, val));
+        }
+    }
+
+    podman_args.extend([
+        "-v".to_string(),
+        format!("{}:/btrfs-root", tmp_dir.display()),
+        "-v".to_string(),
+        format!("{}:/btrfs-runroot", tmp_runroot.display()),
+        "-v".to_string(),
+        format!("{}:/archive.tar:ro", archive_path.display()),
+        "ubuntu:noble".to_string(),
+        "bash".to_string(),
+        "-c".to_string(),
+        inner_script,
+    ]);
+
+    let output = tokio::process::Command::new("podman")
+        .args(&podman_args)
+        .output()
+        .await
+        .context("running containerized podman btrfs load")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        bail!(
+            "containerized podman btrfs load failed:\nstdout: {}\nstderr: {}",
+            stdout.trim(),
+            stderr.trim()
+        );
+    }
+
+    let msg = String::from_utf8_lossy(&output.stdout);
+    info!("podman btrfs load output: {}", msg.trim());
+    Ok(())
+}
+
 /// Build a btrfs storage image from a Docker archive.
 ///
 /// Loads the archive into a temporary podman storage root on btrfs (creating real
-/// btrfs subvolumes), then packages the result as a btrfs image using
-/// `mkfs.btrfs --rootdir --subvol`. The guest mounts this directly as its
+/// btrfs subvolumes via a containerized podman), then packages the result as a btrfs
+/// image using `mkfs.btrfs --rootdir --subvol`. The guest mounts this directly as its
 /// podman graphroot — no podman load needed, instant startup.
 ///
-/// When `build_uid` is set, runs `podman load` as that user (rootless podman).
-/// This creates storage with the correct UID ownership for rootless use in the guest,
-/// matching how rootless podman works on a physical host. When None, builds as root.
+/// The podman load step runs inside an Ubuntu Noble container because the host
+/// podman may lack the btrfs storage driver (e.g., EL9). The mkfs.btrfs step
+/// runs on the host using a bundled binary with libraries.
 ///
 /// Requires:
 /// - The temp dir must be on a btrfs filesystem (for real subvolumes)
 /// - mkfs.btrfs >= 6.12 (for --rootdir --subvol support)
-/// - Kernel 5.18+ (for unprivileged btrfs subvolume creation)
 pub(super) async fn build_btrfs_storage_image(
     archive_path: &Path,
     output_path: &Path,
     build_uid: Option<u32>,
+    rootfs_size: &str,
 ) -> Result<()> {
     // Find mkfs.btrfs with --rootdir --subvol support
     let mkfs_btrfs = find_mkfs_btrfs()?;
@@ -385,86 +476,34 @@ pub(super) async fn build_btrfs_storage_image(
         .await
         .context("creating temp btrfs runroot dir")?;
 
-    // For user builds: find username and chown temp dirs so rootless podman can use them.
-    // Skip runuser if we're already running as the target uid (rootless fcvm, no sudo).
-    let build_username = if let Some(uid) = build_uid {
-        let current_uid = nix::unistd::getuid().as_raw();
-        if current_uid == uid {
-            // Already running as the target user — no runuser needed
-            info!("Building btrfs image as current user (uid {})", uid);
-            None
-        } else {
-            let user = nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))
-                .context("looking up build user")?
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "no user with uid {} on host (needed for rootless btrfs image build)",
-                        uid
-                    )
-                })?;
-            let nix_uid = nix::unistd::Uid::from_raw(uid);
-            let nix_gid = nix::unistd::Gid::from_raw(user.gid.as_raw());
-            nix::unistd::chown(tmp_dir.as_path(), Some(nix_uid), Some(nix_gid))
-                .context("chowning temp dir to build user")?;
-            nix::unistd::chown(tmp_runroot.as_path(), Some(nix_uid), Some(nix_gid))
-                .context("chowning temp runroot to build user")?;
-            info!("Building btrfs image as user {} (uid {})", user.name, uid);
-            Some(user.name)
-        }
-    } else {
-        None
-    };
+    // For user builds: chown temp dirs so the containerized rootless podman can use them.
+    // Use uid directly without /etc/passwd lookup — the UID may not exist on the host
+    // (common in CI containers), and we only need numeric ownership, not username.
+    if let Some(uid) = build_uid {
+        let nix_uid = nix::unistd::Uid::from_raw(uid);
+        let nix_gid = nix::unistd::Gid::from_raw(uid); // Use uid as gid (matches --user uid:uid)
+        nix::unistd::chown(tmp_dir.as_path(), Some(nix_uid), Some(nix_gid))
+            .context("chowning temp dir to build user")?;
+        nix::unistd::chown(tmp_runroot.as_path(), Some(nix_uid), Some(nix_gid))
+            .context("chowning temp runroot to build user")?;
+        info!("Building btrfs image for uid {}", uid);
+    }
 
     // Load the docker archive into a custom podman storage root on btrfs.
     // This creates real btrfs subvolumes for each layer.
-    // For user builds, `runuser -u <username>` runs rootless podman, creating
-    // storage with correct UID ownership — matching a physical host.
+    // Runs inside an Ubuntu Noble container because the host podman may not have
+    // the btrfs storage driver (e.g., EL9 RPM excludes it).
     info!(
         "Loading archive into btrfs podman storage: {} -> {}",
         archive_path.display(),
         tmp_dir.display()
     );
 
-    let mut cmd_args: Vec<String> = Vec::new();
-    if let Some(ref username) = build_username {
-        cmd_args.extend(
-            ["runuser", "-u", username, "--"]
-                .iter()
-                .map(|s| s.to_string()),
-        );
-    }
-    cmd_args.extend(
-        [
-            "podman",
-            "--root",
-            tmp_dir.to_str().unwrap(),
-            "--runroot",
-            tmp_runroot.to_str().unwrap(),
-            "--storage-driver",
-            "btrfs",
-            "load",
-            "-i",
-            archive_path.to_str().unwrap(),
-        ]
-        .iter()
-        .map(|s| s.to_string()),
-    );
-
-    let load_output = tokio::process::Command::new(&cmd_args[0])
-        .args(&cmd_args[1..])
-        .output()
-        .await
-        .context("running podman load into btrfs storage root")?;
-
-    if !load_output.status.success() {
-        let stderr = String::from_utf8_lossy(&load_output.stderr);
+    if let Err(e) = podman_btrfs_load_in_container(archive_path, &tmp_dir, &tmp_runroot).await {
         cleanup_btrfs_tmp(&tmp_dir).await;
         tokio::fs::remove_dir_all(&tmp_runroot).await.ok();
-        bail!("podman load into btrfs storage root failed: {}", stderr);
+        return Err(e);
     }
-
-    let loaded_msg = String::from_utf8_lossy(&load_output.stdout);
-    info!("podman load output: {}", loaded_msg.trim());
 
     // Remove podman state files that contain hardcoded paths from the temp dir.
     // Keep only image/layer data directories. When the guest mounts the image at a
@@ -498,7 +537,13 @@ pub(super) async fn build_btrfs_storage_image(
         mkfs_args.push("--subvol".to_string());
         mkfs_args.push(format!("rw:{}", subvol_path));
     }
-    mkfs_args.push("--shrink".to_string());
+    // Create a sparse btrfs image sized to match --rootfs-size (same as ext4 rootfs).
+    // Only used blocks take real host disk space. Without this, --shrink creates a
+    // minimal image with no free space for container runtime writes.
+    let size_bytes = crate::storage::disk::parse_size(rootfs_size)
+        .context("parsing rootfs_size for btrfs image")?;
+    mkfs_args.push("--byte-count".to_string());
+    mkfs_args.push(size_bytes.to_string());
     mkfs_args.push(tmp_img.to_str().unwrap().to_string());
 
     let mkfs_output = tokio::process::Command::new(&mkfs_btrfs)
@@ -573,43 +618,26 @@ fn enumerate_subvolumes_recursive(
 
 /// Clean up a temporary btrfs storage directory.
 ///
-/// btrfs subvolumes can't be removed with regular rm -rf.
-/// Use `podman --root <dir> system reset --force` to clean up properly,
-/// then remove the directory.
+/// btrfs subvolumes can't be removed with regular rm -rf. We use
+/// `enumerate_btrfs_subvolumes` to find all nested subvolumes (e.g.
+/// `btrfs/subvolumes/<layer-hash>` at depth 2+), delete them with
+/// `btrfs subvolume delete`, then remove the directory tree.
 async fn cleanup_btrfs_tmp(tmp_dir: &Path) {
-    // First try podman system reset to properly clean up subvolumes
-    let reset = tokio::process::Command::new("podman")
-        .args([
-            "--root",
-            tmp_dir.to_str().unwrap_or(""),
-            "--storage-driver",
-            "btrfs",
-            "system",
-            "reset",
-            "--force",
-        ])
-        .output()
-        .await;
-
-    if let Err(e) = &reset {
-        warn!("podman system reset for tmp dir failed: {}", e);
-    }
-
-    // Then try btrfs subvolume delete on any remaining subvolumes
-    if let Ok(entries) = std::fs::read_dir(tmp_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() {
-                // Try btrfs subvolume delete (ignores errors on non-subvolumes)
-                let _ = tokio::process::Command::new("btrfs")
-                    .args(["subvolume", "delete", path.to_str().unwrap_or("")])
-                    .output()
-                    .await;
-            }
+    // Find all btrfs subvolumes recursively (inode 256 detection)
+    if let Ok(subvolumes) = enumerate_btrfs_subvolumes(tmp_dir) {
+        // Delete deepest subvolumes first (reverse sort by path depth)
+        let mut sorted = subvolumes;
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.matches('/').count()));
+        for subvol in &sorted {
+            let path = tmp_dir.join(subvol);
+            let _ = tokio::process::Command::new("btrfs")
+                .args(["subvolume", "delete", path.to_str().unwrap_or("")])
+                .output()
+                .await;
         }
     }
 
-    // Finally remove the directory tree
+    // Remove the directory tree
     if let Err(e) = tokio::fs::remove_dir_all(tmp_dir).await {
         warn!("Failed to remove temp dir {}: {}", tmp_dir.display(), e);
     }

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -490,7 +490,8 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
                 // Format version for overlay image cache. Bump when the build process
                 // changes in a way that invalidates previously-cached images.
                 // v2: host-side cleanup of podman state files before ext4 packaging
-                const OVERLAY_CACHE_VERSION: u32 = 2;
+                // v3: also remove .has-mount-program marker from overlay dir
+                const OVERLAY_CACHE_VERSION: u32 = 3;
                 let storage_img_path = PathBuf::from(format!(
                     "{}.storage-v{}.img",
                     cache_dir.display(),
@@ -518,25 +519,34 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
                 // Format version for btrfs image cache. Bump when the build process
                 // changes in a way that invalidates previously-cached images.
                 // v2: host-side cleanup of podman state files before mkfs.btrfs
-                const BTRFS_CACHE_VERSION: u32 = 2;
+                // v3: containerized podman load, explicit db file cleanup
+                const BTRFS_CACHE_VERSION: u32 = 3;
 
+                // Cache key includes version, UID, and rootfs_size
                 let btrfs_img_path = match build_uid {
                     Some(uid) => PathBuf::from(format!(
-                        "{}.btrfs-v{}-uid{}.img",
+                        "{}.btrfs-v{}-uid{}-{}.img",
                         cache_dir.display(),
                         BTRFS_CACHE_VERSION,
-                        uid
+                        uid,
+                        args.rootfs_size
                     )),
                     None => PathBuf::from(format!(
-                        "{}.btrfs-v{}.img",
+                        "{}.btrfs-v{}-{}.img",
                         cache_dir.display(),
-                        BTRFS_CACHE_VERSION
+                        BTRFS_CACHE_VERSION,
+                        args.rootfs_size
                     )),
                 };
                 if !btrfs_img_path.exists() {
                     info!(image = %args.image, digest = %digest, uid = ?build_uid, "Building btrfs storage image");
-                    image::build_btrfs_storage_image(&archive_path, &btrfs_img_path, build_uid)
-                        .await?;
+                    image::build_btrfs_storage_image(
+                        &archive_path,
+                        &btrfs_img_path,
+                        build_uid,
+                        &args.rootfs_size,
+                    )
+                    .await?;
                 } else {
                     info!(image = %args.image, digest = %digest, "Using cached btrfs storage image");
                 }

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -628,7 +628,9 @@ pub fn generate_setup_script(plan: &Plan) -> String {
     // be busy from postinst).
     s.push_str("# Remove podman state files created by apt post-install scripts\n");
     s.push_str("rm -f /var/lib/containers/storage/db.sql /var/lib/containers/storage/storage.lock /var/lib/containers/storage/userns.lock /var/lib/containers/storage/defaultNetworkBackend 2>/dev/null || true\n");
-    s.push_str("rm -rf /var/lib/containers/storage/libpod /var/lib/containers/storage/overlay-containers /var/lib/containers/storage/overlay-images 2>/dev/null || true\n\n");
+    s.push_str("rm -rf /var/lib/containers/storage/libpod /var/lib/containers/storage/overlay-containers /var/lib/containers/storage/overlay-images 2>/dev/null || true\n");
+    s.push_str("# Remove .has-mount-program marker — causes podman to create broken db.sql with driver=\"\"\n");
+    s.push_str("rm -f /var/lib/containers/storage/overlay/.has-mount-program 2>/dev/null || true\n\n");
 
     // Cleanup
     if !plan.cleanup.remove_dirs.is_empty() {


### PR DESCRIPTION
## Summary
- Run `podman --storage-driver btrfs load` inside Ubuntu Noble container (EL9's podman lacks btrfs driver)
- `build-btrfs-progs.sh` builds mkfs.btrfs 6.12 in container with bundled shared libs (works on any host glibc)
- Btrfs image sized to `--rootfs-size` (sparse — 50G image uses 132MB actual disk)
- Cache key includes rootfs_size to avoid wrong-sized cached images

**Stacked on:** btrfs-native-image (PR #363)

## Test plan
Tested on EL9 devserver (podman 5.6.0 without btrfs driver):
```
Cold start:  56.7s
Warm start:  1.0s
Speedup:     55.4x
```
50G sparse btrfs image: 132MB actual disk, full writable space for container.