### PR TITLE
Containerize btrfs image build for host compatibility

### DIFF
--- a/scripts/build-btrfs-progs.sh
+++ b/scripts/build-btrfs-progs.sh
@@ -3,7 +3,9 @@
 #
 # btrfs-progs 6.12+ includes mkfs.btrfs --rootdir --subvol which creates
 # btrfs images from directories containing btrfs subvolumes — without root.
-# Ubuntu 24.04 ships btrfs-progs 6.6.3 which lacks this feature.
+#
+# Builds inside an Ubuntu Noble container to work on any host OS (EL9, Ubuntu, etc.).
+# Uses the same proxy pattern as fcvm's rootfs package download.
 #
 # Usage: ./scripts/build-btrfs-progs.sh [output_dir]
 #        Output defaults to /mnt/fcvm-btrfs/deps/bin/
@@ -13,25 +15,11 @@ set -euo pipefail
 BTRFS_PROGS_VERSION="6.12"
 OUTPUT_DIR="${1:-/mnt/fcvm-btrfs/deps/bin}"
 
-# Source URL
-BTRFS_PROGS_URL="https://github.com/kdave/btrfs-progs/archive/refs/tags/v${BTRFS_PROGS_VERSION}.tar.gz"
-
-# Build directory
-BUILD_DIR="/tmp/btrfs-progs-build-$$"
-PREFIX="$BUILD_DIR/install"
-
-cleanup() {
-    if [[ -d "$BUILD_DIR" ]]; then
-        rm -rf "$BUILD_DIR"
-    fi
-}
-trap cleanup EXIT
-
 echo "=== Building btrfs-progs ${BTRFS_PROGS_VERSION} ==="
 echo "Output: $OUTPUT_DIR/mkfs.btrfs"
 echo ""
 
-# Check if already built
+# Check if already built and runnable
 if [[ -x "$OUTPUT_DIR/mkfs.btrfs" ]]; then
     EXISTING_VERSION=$("$OUTPUT_DIR/mkfs.btrfs" --version 2>/dev/null | grep -oP '[\d.]+' || echo "0")
     MAJOR=$(echo "$EXISTING_VERSION" | cut -d. -f1)
@@ -43,93 +31,85 @@ if [[ -x "$OUTPUT_DIR/mkfs.btrfs" ]]; then
     fi
 fi
 
-mkdir -p "$BUILD_DIR" "$PREFIX"
-cd "$BUILD_DIR"
+mkdir -p "$OUTPUT_DIR"
 
-# Check and install build dependencies
-echo "Checking build dependencies..."
-MISSING_PKGS=""
-
-for pkg in uuid-dev libblkid-dev liblzo2-dev libzstd-dev zlib1g-dev libext2fs-dev libudev-dev; do
-    if ! dpkg -s "$pkg" &>/dev/null; then
-        MISSING_PKGS="$MISSING_PKGS $pkg"
+# Build proxy args for podman (same pattern as fcvm rootfs download)
+PROXY_ARGS=()
+for var in http_proxy https_proxy HTTP_PROXY HTTPS_PROXY; do
+    if [[ -n "${!var:-}" ]]; then
+        PROXY_ARGS+=("-e" "${var}=${!var}")
     fi
 done
 
-# Also need python3 for documentation/autogen (python3-setuptools for sphinx)
-if ! command -v python3 &>/dev/null; then
-    MISSING_PKGS="$MISSING_PKGS python3"
+# Determine curl proxy flag from http_proxy
+CURL_PROXY=""
+if [[ -n "${http_proxy:-}" ]]; then
+    CURL_PROXY="-x $http_proxy"
+elif [[ -n "${HTTPS_PROXY:-}" ]]; then
+    CURL_PROXY="-x $HTTPS_PROXY"
 fi
 
-if ! command -v autoconf &>/dev/null; then
-    MISSING_PKGS="$MISSING_PKGS autoconf"
+echo "Building in Ubuntu Noble container..."
+podman run --rm --cgroups=disabled --network=host \
+    "${PROXY_ARGS[@]}" \
+    -v "$OUTPUT_DIR:/output:Z" \
+    ubuntu:noble bash -c "
+set -e
+# Configure apt proxy (same as fcvm rootfs download)
+echo 'APT::Sandbox::User \"root\";' > /etc/apt/apt.conf.d/10sandbox
+if [ -n \"\${http_proxy:-}\" ]; then
+    echo \"Acquire::http::Proxy \\\"\$http_proxy\\\";\" > /etc/apt/apt.conf.d/99proxy
+    echo \"Acquire::https::Proxy \\\"\$http_proxy\\\";\" >> /etc/apt/apt.conf.d/99proxy
 fi
+echo 'Acquire::Retries \"3\";' > /etc/apt/apt.conf.d/80retries
 
-if ! command -v automake &>/dev/null; then
-    MISSING_PKGS="$MISSING_PKGS automake"
-fi
+echo '  Installing build deps...'
+apt-get update -qq >/dev/null 2>&1
+apt-get install -y --no-install-recommends >/dev/null 2>&1 \
+    curl ca-certificates build-essential autoconf automake pkg-config \
+    uuid-dev libblkid-dev liblzo2-dev libzstd-dev zlib1g-dev libext2fs-dev libudev-dev
 
-if ! command -v pkg-config &>/dev/null; then
-    MISSING_PKGS="$MISSING_PKGS pkg-config"
-fi
+echo '  Downloading btrfs-progs ${BTRFS_PROGS_VERSION}...'
+cd /tmp
+curl ${CURL_PROXY} -sL https://github.com/kdave/btrfs-progs/archive/refs/tags/v${BTRFS_PROGS_VERSION}.tar.gz | tar xz
+cd btrfs-progs-${BTRFS_PROGS_VERSION}
 
-if [[ -n "$MISSING_PKGS" ]]; then
-    echo "Installing missing build dependencies:$MISSING_PKGS"
-    sudo apt-get update -qq
-    sudo apt-get install -y --no-install-recommends $MISSING_PKGS
-fi
+echo '  Configuring...'
+./autogen.sh >/dev/null 2>&1
+./configure --disable-documentation --disable-python >/dev/null 2>&1
 
-# Download and extract
-echo ""
-echo "=== Downloading btrfs-progs ${BTRFS_PROGS_VERSION} ==="
-curl -sL "$BTRFS_PROGS_URL" | tar xz
-cd "btrfs-progs-${BTRFS_PROGS_VERSION}"
+echo '  Compiling...'
+make -j\$(nproc) >/dev/null 2>&1
 
-# Generate configure script
-echo ""
-echo "=== Running autogen ==="
-./autogen.sh
+# Copy the binary AND its required shared libraries so it runs on any host
+echo '  Bundling binary + libraries...'
+mkdir -p /output/lib
+cp mkfs.btrfs /output/mkfs.btrfs.bin
+chmod +x /output/mkfs.btrfs.bin
 
-# Configure - disable documentation (requires sphinx) and python bindings
-echo ""
-echo "=== Configuring ==="
-./configure \
-    --prefix="$PREFIX" \
-    --disable-documentation \
-    --disable-python
+# Copy required shared libraries
+for lib in \$(ldd mkfs.btrfs | awk '/=>/ {print \$3}'); do
+    cp \"\$lib\" /output/lib/ 2>/dev/null || true
+done
+cp /lib64/ld-linux-x86-64.so.2 /output/lib/ 2>/dev/null || \
+    cp /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 /output/lib/ 2>/dev/null || true
 
-# Build
-echo ""
-echo "=== Building ==="
-make -j"$(nproc)"
-
-# Verify the build
-echo ""
-echo "=== Verifying build ==="
+echo '  Done!'
 ./mkfs.btrfs --version
+"
 
-# Check that --rootdir is supported (mkfs.btrfs has had -r/--rootdir since 4.x)
-# Verify by checking the version is >= 6.12
-BUILT_VERSION=$(./mkfs.btrfs --version 2>/dev/null | grep -oP '[\d.]+' || echo "0")
-echo "Built version: $BUILT_VERSION"
-BUILT_MAJOR=$(echo "$BUILT_VERSION" | cut -d. -f1)
-BUILT_MINOR=$(echo "$BUILT_VERSION" | cut -d. -f2)
-if [[ "$BUILT_MAJOR" -lt 6 ]] || [[ "$BUILT_MAJOR" -eq 6 && "$BUILT_MINOR" -lt 12 ]]; then
-    echo "ERROR: built mkfs.btrfs version $BUILT_VERSION is too old (need >= 6.12 for --rootdir --subvol)"
-    exit 1
-fi
-
-# Install to output directory
-echo ""
-echo "=== Installing to $OUTPUT_DIR ==="
-mkdir -p "$OUTPUT_DIR"
-cp -v mkfs.btrfs "$OUTPUT_DIR/mkfs.btrfs"
+# Create wrapper script that uses bundled libraries
+cat > "$OUTPUT_DIR/mkfs.btrfs" << 'WRAPPER'
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$DIR/lib/ld-linux-x86-64.so.2" --library-path "$DIR/lib" "$DIR/mkfs.btrfs.bin" "$@"
+WRAPPER
 chmod +x "$OUTPUT_DIR/mkfs.btrfs"
+
+echo ""
+echo "=== Verifying ==="
+"$OUTPUT_DIR/mkfs.btrfs" --version
 
 echo ""
 echo "=== Success! ==="
 echo "Binary: $OUTPUT_DIR/mkfs.btrfs"
-VERSION=$("$OUTPUT_DIR/mkfs.btrfs" --version 2>/dev/null || echo "unknown")
-echo "Version: $VERSION"
-echo ""
-echo "Test with: $OUTPUT_DIR/mkfs.btrfs --version"

--- a/src/commands/podman/image.rs
+++ b/src/commands/podman/image.rs
@@ -322,25 +322,108 @@ fn find_mkfs_btrfs() -> Result<PathBuf> {
     )
 }
 
+/// Load a Docker archive into a btrfs podman storage root using a containerized podman.
+///
+/// Runs inside an Ubuntu Noble container with `--privileged` because:
+/// 1. Host podman may lack the btrfs storage driver (EL9 RPM excludes it)
+/// 2. Rootless podman load needs user namespace support (`newuidmap`)
+///
+/// The btrfs temp dirs are bind-mounted so subvolumes are created on the host filesystem.
+/// For rootless builds (`build_uid`), creates a user inside the container with matching UID.
+async fn podman_btrfs_load_in_container(
+    archive_path: &Path,
+    tmp_dir: &Path,
+    tmp_runroot: &Path,
+) -> Result<()> {
+    info!("Running podman btrfs load inside ubuntu:noble container");
+
+    // Always run podman load as root inside the container. In rootless podman with
+    // --privileged, container uid 0 maps to the host user's uid via the user namespace.
+    // Files created as root inside the container are owned by the host uid on the
+    // bind-mounted btrfs, which is exactly the ownership we want for --user builds.
+    let inner_script = r#"set -e
+# Configure apt proxy from any proxy env var
+PROXY="${http_proxy:-${HTTPS_PROXY:-${https_proxy:-}}}"
+echo 'APT::Sandbox::User "root";' > /etc/apt/apt.conf.d/10sandbox
+if [ -n "$PROXY" ]; then
+    echo "Acquire::http::Proxy \"$PROXY\";" > /etc/apt/apt.conf.d/99proxy
+    echo "Acquire::https::Proxy \"$PROXY\";" >> /etc/apt/apt.conf.d/99proxy
+fi
+echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries
+apt-get update -qq
+apt-get install -y -qq podman
+podman --root /btrfs-root --runroot /btrfs-runroot --storage-driver btrfs load -i /archive.tar"#
+        .to_string();
+
+    let mut podman_args = vec![
+        "run".to_string(),
+        "--rm".to_string(),
+        "--privileged".to_string(),
+        "--cgroups=disabled".to_string(),
+        "--network=host".to_string(),
+    ];
+
+    // Pass through proxy environment variables (same pattern as rootfs.rs download_packages)
+    for var in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"] {
+        if let Ok(val) = std::env::var(var) {
+            podman_args.push("-e".to_string());
+            podman_args.push(format!("{}={}", var, val));
+        }
+    }
+
+    podman_args.extend([
+        "-v".to_string(),
+        format!("{}:/btrfs-root", tmp_dir.display()),
+        "-v".to_string(),
+        format!("{}:/btrfs-runroot", tmp_runroot.display()),
+        "-v".to_string(),
+        format!("{}:/archive.tar:ro", archive_path.display()),
+        "ubuntu:noble".to_string(),
+        "bash".to_string(),
+        "-c".to_string(),
+        inner_script,
+    ]);
+
+    let output = tokio::process::Command::new("podman")
+        .args(&podman_args)
+        .output()
+        .await
+        .context("running containerized podman btrfs load")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        bail!(
+            "containerized podman btrfs load failed:\nstdout: {}\nstderr: {}",
+            stdout.trim(),
+            stderr.trim()
+        );
+    }
+
+    let msg = String::from_utf8_lossy(&output.stdout);
+    info!("podman btrfs load output: {}", msg.trim());
+    Ok(())
+}
+
 /// Build a btrfs storage image from a Docker archive.
 ///
 /// Loads the archive into a temporary podman storage root on btrfs (creating real
-/// btrfs subvolumes), then packages the result as a btrfs image using
-/// `mkfs.btrfs --rootdir --subvol`. The guest mounts this directly as its
+/// btrfs subvolumes via a containerized podman), then packages the result as a btrfs
+/// image using `mkfs.btrfs --rootdir --subvol`. The guest mounts this directly as its
 /// podman graphroot — no podman load needed, instant startup.
 ///
-/// When `build_uid` is set, runs `podman load` as that user (rootless podman).
-/// This creates storage with the correct UID ownership for rootless use in the guest,
-/// matching how rootless podman works on a physical host. When None, builds as root.
+/// The podman load step runs inside an Ubuntu Noble container because the host
+/// podman may lack the btrfs storage driver (e.g., EL9). The mkfs.btrfs step
+/// runs on the host using a bundled binary with libraries.
 ///
 /// Requires:
 /// - The temp dir must be on a btrfs filesystem (for real subvolumes)
 /// - mkfs.btrfs >= 6.12 (for --rootdir --subvol support)
-/// - Kernel 5.18+ (for unprivileged btrfs subvolume creation)
 pub(super) async fn build_btrfs_storage_image(
     archive_path: &Path,
     output_path: &Path,
     build_uid: Option<u32>,
+    rootfs_size: &str,
 ) -> Result<()> {
     // Find mkfs.btrfs with --rootdir --subvol support
     let mkfs_btrfs = find_mkfs_btrfs()?;
@@ -385,91 +468,55 @@ pub(super) async fn build_btrfs_storage_image(
         .await
         .context("creating temp btrfs runroot dir")?;
 
-    // For user builds: find username and chown temp dirs so rootless podman can use them.
-    // Skip runuser if we're already running as the target uid (rootless fcvm, no sudo).
-    let build_username = if let Some(uid) = build_uid {
-        let current_uid = nix::unistd::getuid().as_raw();
-        if current_uid == uid {
-            // Already running as the target user — no runuser needed
-            info!("Building btrfs image as current user (uid {})", uid);
-            None
-        } else {
-            let user = nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))
-                .context("looking up build user")?
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "no user with uid {} on host (needed for rootless btrfs image build)",
-                        uid
-                    )
-                })?;
-            let nix_uid = nix::unistd::Uid::from_raw(uid);
-            let nix_gid = nix::unistd::Gid::from_raw(user.gid.as_raw());
-            nix::unistd::chown(tmp_dir.as_path(), Some(nix_uid), Some(nix_gid))
-                .context("chowning temp dir to build user")?;
-            nix::unistd::chown(tmp_runroot.as_path(), Some(nix_uid), Some(nix_gid))
-                .context("chowning temp runroot to build user")?;
-            info!("Building btrfs image as user {} (uid {})", user.name, uid);
-            Some(user.name)
-        }
-    } else {
-        None
-    };
+    // For user builds: chown temp dirs so the containerized rootless podman can use them.
+    if let Some(uid) = build_uid {
+        let user = nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))
+            .context("looking up build user")?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no user with uid {} on host (needed for rootless btrfs image build)",
+                    uid
+                )
+            })?;
+        let nix_uid = nix::unistd::Uid::from_raw(uid);
+        let nix_gid = nix::unistd::Gid::from_raw(user.gid.as_raw());
+        nix::unistd::chown(tmp_dir.as_path(), Some(nix_uid), Some(nix_gid))
+            .context("chowning temp dir to build user")?;
+        nix::unistd::chown(tmp_runroot.as_path(), Some(nix_uid), Some(nix_gid))
+            .context("chowning temp runroot to build user")?;
+        info!("Building btrfs image for uid {}", uid);
+    }
 
     // Load the docker archive into a custom podman storage root on btrfs.
     // This creates real btrfs subvolumes for each layer.
-    // For user builds, `runuser -u <username>` runs rootless podman, creating
-    // storage with correct UID ownership — matching a physical host.
+    // Runs inside an Ubuntu Noble container because the host podman may not have
+    // the btrfs storage driver (e.g., EL9 RPM excludes it).
     info!(
         "Loading archive into btrfs podman storage: {} -> {}",
         archive_path.display(),
         tmp_dir.display()
     );
 
-    let mut cmd_args: Vec<String> = Vec::new();
-    if let Some(ref username) = build_username {
-        cmd_args.extend(
-            ["runuser", "-u", username, "--"]
-                .iter()
-                .map(|s| s.to_string()),
-        );
-    }
-    cmd_args.extend(
-        [
-            "podman",
-            "--root",
-            tmp_dir.to_str().unwrap(),
-            "--runroot",
-            tmp_runroot.to_str().unwrap(),
-            "--storage-driver",
-            "btrfs",
-            "load",
-            "-i",
-            archive_path.to_str().unwrap(),
-        ]
-        .iter()
-        .map(|s| s.to_string()),
-    );
-
-    let load_output = tokio::process::Command::new(&cmd_args[0])
-        .args(&cmd_args[1..])
-        .output()
-        .await
-        .context("running podman load into btrfs storage root")?;
-
-    if !load_output.status.success() {
-        let stderr = String::from_utf8_lossy(&load_output.stderr);
+    if let Err(e) =
+        podman_btrfs_load_in_container(archive_path, &tmp_dir, &tmp_runroot).await
+    {
         cleanup_btrfs_tmp(&tmp_dir).await;
         tokio::fs::remove_dir_all(&tmp_runroot).await.ok();
-        bail!("podman load into btrfs storage root failed: {}", stderr);
+        return Err(e);
     }
 
-    let loaded_msg = String::from_utf8_lossy(&load_output.stdout);
-    info!("podman load output: {}", loaded_msg.trim());
-
-    // Remove podman state files that contain hardcoded paths from the temp dir.
-    // Keep only image/layer data directories. When the guest mounts the image at a
-    // different path, stale state causes "database graph driver does not match".
-    clean_podman_state(&tmp_dir, &["btrfs", "btrfs-images", "btrfs-layers"]).await;
+    // Remove podman database files — they contain hardcoded paths from the temp dir.
+    // When the guest mounts the image at a different path, podman would complain about
+    // "database static dir does not match". Deleting them forces podman to recreate
+    // the database at the correct mount path.
+    for db_file in ["db.sql", "libpod", "storage.lock"] {
+        let path = tmp_dir.join(db_file);
+        if path.is_dir() {
+            tokio::fs::remove_dir_all(&path).await.ok();
+        } else if path.is_file() {
+            tokio::fs::remove_file(&path).await.ok();
+        }
+    }
 
     // Enumerate btrfs subvolumes in the temp dir for --subvol flags.
     // Btrfs subvolumes always have inode 256 — this detects them without root.
@@ -498,7 +545,13 @@ pub(super) async fn build_btrfs_storage_image(
         mkfs_args.push("--subvol".to_string());
         mkfs_args.push(format!("rw:{}", subvol_path));
     }
-    mkfs_args.push("--shrink".to_string());
+    // Create a sparse btrfs image sized to match --rootfs-size (same as ext4 rootfs).
+    // Only used blocks take real host disk space. Without this, --shrink creates a
+    // minimal image with no free space for container runtime writes.
+    let size_bytes = crate::storage::disk::parse_size(rootfs_size)
+        .context("parsing rootfs_size for btrfs image")?;
+    mkfs_args.push("--byte-count".to_string());
+    mkfs_args.push(size_bytes.to_string());
     mkfs_args.push(tmp_img.to_str().unwrap().to_string());
 
     let mkfs_output = tokio::process::Command::new(&mkfs_btrfs)

--- a/src/commands/podman/image.rs
+++ b/src/commands/podman/image.rs
@@ -497,9 +497,7 @@ pub(super) async fn build_btrfs_storage_image(
         tmp_dir.display()
     );
 
-    if let Err(e) =
-        podman_btrfs_load_in_container(archive_path, &tmp_dir, &tmp_runroot).await
-    {
+    if let Err(e) = podman_btrfs_load_in_container(archive_path, &tmp_dir, &tmp_runroot).await {
         cleanup_btrfs_tmp(&tmp_dir).await;
         tokio::fs::remove_dir_all(&tmp_runroot).await.ok();
         return Err(e);
@@ -530,6 +528,10 @@ pub(super) async fn build_btrfs_storage_image(
     // Create btrfs image from the storage tree using mkfs.btrfs --rootdir --subvol.
     // Each subvolume is passed as --subvol rw:<relative-path> to preserve it as a
     // real subvolume in the output image.
+    //
+    // Runs inside a --privileged container because the podman load (also containerized)
+    // creates files with their original permissions (e.g. /etc/gshadow mode 000).
+    // The host user can't read these, but container root can.
     let tmp_img = PathBuf::from(format!("{}.tmp", output_path.display()));
     info!(
         "Creating btrfs image: {} -> {}",
@@ -537,28 +539,68 @@ pub(super) async fn build_btrfs_storage_image(
         tmp_img.display()
     );
 
-    let mut mkfs_args = vec![
-        "--rootdir".to_string(),
-        tmp_dir.to_str().unwrap().to_string(),
-    ];
-    for subvol_path in &subvol_args {
-        mkfs_args.push("--subvol".to_string());
-        mkfs_args.push(format!("rw:{}", subvol_path));
-    }
-    // Create a sparse btrfs image sized to match --rootfs-size (same as ext4 rootfs).
-    // Only used blocks take real host disk space. Without this, --shrink creates a
-    // minimal image with no free space for container runtime writes.
     let size_bytes = crate::storage::disk::parse_size(rootfs_size)
         .context("parsing rootfs_size for btrfs image")?;
-    mkfs_args.push("--byte-count".to_string());
-    mkfs_args.push(size_bytes.to_string());
-    mkfs_args.push(tmp_img.to_str().unwrap().to_string());
 
-    let mkfs_output = tokio::process::Command::new(&mkfs_btrfs)
-        .args(&mkfs_args)
+    // Build mkfs.btrfs command line for inside the container.
+    // The source tree is mounted at /btrfs-src, output dir at /btrfs-out.
+    let tmp_img_name = tmp_img
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("tmp_img has no filename"))?
+        .to_string_lossy();
+    let output_dir = tmp_img
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("tmp_img has no parent directory"))?;
+
+    let mut mkfs_cmd_parts = vec!["--rootdir".to_string(), "/btrfs-src".to_string()];
+    for subvol_path in &subvol_args {
+        mkfs_cmd_parts.push("--subvol".to_string());
+        mkfs_cmd_parts.push(format!("rw:{}", subvol_path));
+    }
+    mkfs_cmd_parts.push("--byte-count".to_string());
+    mkfs_cmd_parts.push(size_bytes.to_string());
+    mkfs_cmd_parts.push(format!("/btrfs-out/{}", tmp_img_name));
+
+    // The mkfs.btrfs wrapper script uses ld-linux to load bundled libs.
+    // Inside the container, mount the deps dir and invoke via bundled ld-linux.
+    let mkfs_dir = mkfs_btrfs
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("mkfs.btrfs has no parent directory"))?;
+    let mkfs_bin = mkfs_dir.join("mkfs.btrfs.bin");
+    let mkfs_lib = mkfs_dir.join("lib");
+
+    let inner_cmd = if mkfs_bin.exists() && mkfs_lib.exists() {
+        format!(
+            "/mkfs-bin/lib/ld-linux-x86-64.so.2 --library-path /mkfs-bin/lib /mkfs-bin/mkfs.btrfs.bin {}",
+            mkfs_cmd_parts.join(" ")
+        )
+    } else {
+        // System mkfs.btrfs (if >= 6.12 is available in the container)
+        format!("{} {}", mkfs_btrfs.display(), mkfs_cmd_parts.join(" "))
+    };
+
+    info!("Running mkfs.btrfs inside privileged container");
+    let mkfs_output = tokio::process::Command::new("podman")
+        .args([
+            "run",
+            "--rm",
+            "--privileged",
+            "--cgroups=disabled",
+            "--network=none",
+            "-v",
+            &format!("{}:/btrfs-src:ro", tmp_dir.display()),
+            "-v",
+            &format!("{}:/btrfs-out", output_dir.display()),
+            "-v",
+            &format!("{}:/mkfs-bin:ro", mkfs_dir.display()),
+            "ubuntu:noble",
+            "bash",
+            "-c",
+            &inner_cmd,
+        ])
         .output()
         .await
-        .context("running mkfs.btrfs --rootdir --subvol")?;
+        .context("running containerized mkfs.btrfs --rootdir --subvol")?;
 
     // Clean up temp storage dir (contains btrfs subvolumes, needs special handling)
     cleanup_btrfs_tmp(&tmp_dir).await;
@@ -566,8 +608,13 @@ pub(super) async fn build_btrfs_storage_image(
 
     if !mkfs_output.status.success() {
         let stderr = String::from_utf8_lossy(&mkfs_output.stderr);
+        let stdout = String::from_utf8_lossy(&mkfs_output.stdout);
         tokio::fs::remove_file(&tmp_img).await.ok();
-        bail!("mkfs.btrfs --rootdir --subvol failed: {}", stderr);
+        bail!(
+            "mkfs.btrfs --rootdir --subvol failed:\nstdout: {}\nstderr: {}",
+            stdout.trim(),
+            stderr.trim()
+        );
     }
 
     // Atomic rename to final path
@@ -627,42 +674,60 @@ fn enumerate_subvolumes_recursive(
 /// Clean up a temporary btrfs storage directory.
 ///
 /// btrfs subvolumes can't be removed with regular rm -rf.
-/// Use `podman --root <dir> system reset --force` to clean up properly,
-/// then remove the directory.
+/// The containerized podman load creates files as root (inside --privileged),
+/// so the host user may not have permission to delete them.
+/// Run cleanup inside a privileged container to handle both issues.
 async fn cleanup_btrfs_tmp(tmp_dir: &Path) {
-    // First try podman system reset to properly clean up subvolumes
-    let reset = tokio::process::Command::new("podman")
+    // Use a privileged container to delete everything — it has root access
+    // to both btrfs subvolume operations and root-owned files.
+    let cleanup_script = "set -e\n\
+        # Delete all btrfs subvolumes first (can't rm -rf a subvolume)\n\
+        if command -v btrfs >/dev/null 2>&1; then\n\
+            btrfs subvolume list -o /cleanup 2>/dev/null | awk '{print $NF}' | while read sv; do\n\
+                btrfs subvolume delete \"/cleanup/$sv\" 2>/dev/null || true\n\
+            done\n\
+        fi\n\
+        # Then remove everything\n\
+        rm -rf /cleanup/*\n\
+        rm -rf /cleanup/.[!.]* 2>/dev/null || true";
+
+    let result = tokio::process::Command::new("podman")
         .args([
-            "--root",
-            tmp_dir.to_str().unwrap_or(""),
-            "--storage-driver",
-            "btrfs",
-            "system",
-            "reset",
-            "--force",
+            "run",
+            "--rm",
+            "--privileged",
+            "--cgroups=disabled",
+            "--network=none",
+            "-v",
+            &format!("{}:/cleanup", tmp_dir.display()),
+            "ubuntu:noble",
+            "bash",
+            "-c",
+            cleanup_script,
         ])
         .output()
         .await;
 
-    if let Err(e) = &reset {
-        warn!("podman system reset for tmp dir failed: {}", e);
-    }
-
-    // Then try btrfs subvolume delete on any remaining subvolumes
-    if let Ok(entries) = std::fs::read_dir(tmp_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() {
-                // Try btrfs subvolume delete (ignores errors on non-subvolumes)
-                let _ = tokio::process::Command::new("btrfs")
-                    .args(["subvolume", "delete", path.to_str().unwrap_or("")])
-                    .output()
-                    .await;
-            }
+    match &result {
+        Ok(output) if output.status.success() => {}
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            warn!(
+                "containerized cleanup of {} had errors: {}",
+                tmp_dir.display(),
+                stderr.trim()
+            );
+        }
+        Err(e) => {
+            warn!(
+                "containerized cleanup of {} failed: {}",
+                tmp_dir.display(),
+                e
+            );
         }
     }
 
-    // Finally remove the directory tree
+    // Try to remove the now-empty directory
     if let Err(e) = tokio::fs::remove_dir_all(tmp_dir).await {
         warn!("Failed to remove temp dir {}: {}", tmp_dir.display(), e);
     }

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -517,15 +517,27 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
                     .and_then(|user_spec| user_spec.split(':').next()?.parse::<u32>().ok());
                 // Cache key includes UID and rootfs_size — different sizes need different images
                 let btrfs_img_path = match build_uid {
-                    Some(uid) => {
-                        PathBuf::from(format!("{}.btrfs-uid{}-{}.img", cache_dir.display(), uid, args.rootfs_size))
-                    }
-                    None => PathBuf::from(format!("{}.btrfs-{}.img", cache_dir.display(), args.rootfs_size)),
+                    Some(uid) => PathBuf::from(format!(
+                        "{}.btrfs-uid{}-{}.img",
+                        cache_dir.display(),
+                        uid,
+                        args.rootfs_size
+                    )),
+                    None => PathBuf::from(format!(
+                        "{}.btrfs-{}.img",
+                        cache_dir.display(),
+                        args.rootfs_size
+                    )),
                 };
                 if !btrfs_img_path.exists() {
                     info!(image = %args.image, digest = %digest, uid = ?build_uid, "Building btrfs storage image");
-                    image::build_btrfs_storage_image(&archive_path, &btrfs_img_path, build_uid, &args.rootfs_size)
-                        .await?;
+                    image::build_btrfs_storage_image(
+                        &archive_path,
+                        &btrfs_img_path,
+                        build_uid,
+                        &args.rootfs_size,
+                    )
+                    .await?;
                 } else {
                     info!(image = %args.image, digest = %digest, "Using cached btrfs storage image");
                 }

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -515,27 +515,16 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
                     .user
                     .as_ref()
                     .and_then(|user_spec| user_spec.split(':').next()?.parse::<u32>().ok());
-                // Format version for btrfs image cache. Bump when the build process
-                // changes in a way that invalidates previously-cached images.
-                // v2: host-side cleanup of podman state files before mkfs.btrfs
-                const BTRFS_CACHE_VERSION: u32 = 2;
-
+                // Cache key includes UID and rootfs_size — different sizes need different images
                 let btrfs_img_path = match build_uid {
-                    Some(uid) => PathBuf::from(format!(
-                        "{}.btrfs-v{}-uid{}.img",
-                        cache_dir.display(),
-                        BTRFS_CACHE_VERSION,
-                        uid
-                    )),
-                    None => PathBuf::from(format!(
-                        "{}.btrfs-v{}.img",
-                        cache_dir.display(),
-                        BTRFS_CACHE_VERSION
-                    )),
+                    Some(uid) => {
+                        PathBuf::from(format!("{}.btrfs-uid{}-{}.img", cache_dir.display(), uid, args.rootfs_size))
+                    }
+                    None => PathBuf::from(format!("{}.btrfs-{}.img", cache_dir.display(), args.rootfs_size)),
                 };
                 if !btrfs_img_path.exists() {
                     info!(image = %args.image, digest = %digest, uid = ?build_uid, "Building btrfs storage image");
-                    image::build_btrfs_storage_image(&archive_path, &btrfs_img_path, build_uid)
+                    image::build_btrfs_storage_image(&archive_path, &btrfs_img_path, build_uid, &args.rootfs_size)
                         .await?;
                 } else {
                     info!(image = %args.image, digest = %digest, "Using cached btrfs storage image");


### PR DESCRIPTION
**Stacked on:** btrfs-native-image (PR #363)

## Summary
- Run `podman load --storage-driver btrfs` inside an Ubuntu Noble container instead of on the host, so it works on hosts without the btrfs podman driver (e.g. EL9)
- `build-btrfs-progs.sh` detects ARM64 vs x86-64 for the dynamic linker
- `cleanup_btrfs_tmp` uses recursive subvolume enumeration instead of depth-1 walk
- Restore `BTRFS_CACHE_VERSION` (v3) for cache invalidation
- Remove `.has-mount-program` marker from overlay storage images and rootfs
- `build_uid` uses numeric UID directly instead of `/etc/passwd` lookup
- Use whitelist cleanup (`clean_podman_state`) for btrfs storage, not blocklist
- Update README to reflect containerized build approach

## Test plan
- [ ] CI passes (lint, clippy, all test jobs)
- [ ] btrfs keepid permission issue needs separate investigation