### PR TITLE
Add native btrfs rootfs option

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1184,7 +1184,7 @@ fuse-pipe/benches/
 
 ### Firecracker Requirements
 - **Kernel**: vmlinux or bzImage, boot args: `console=ttyS0 reboot=k panic=1 pci=off`
-- **Rootfs**: ext4 with Ubuntu 24.04, systemd, Podman, iproute2, fc-agent at `/usr/local/bin/fc-agent`
+- **Rootfs**: ext4 or btrfs (via `--rootfs-type`) with Ubuntu 24.04, systemd, Podman, iproute2, fc-agent injected at boot via initrd
 
 ### Network Modes
 
@@ -1218,7 +1218,7 @@ fuse-pipe/benches/
 
 **Per-VM Disk Sizing (`--rootfs-size`):**
 - Default: `10G` — ensures at least 10G free space on root filesystem
-- After btrfs reflink copy, `dumpe2fs` checks free space; if below threshold, expands with `truncate` + `resize2fs`
+- After btrfs reflink copy, `ensure_free_space()` auto-detects filesystem type: ext4 uses `dumpe2fs` + `truncate` + `resize2fs`; btrfs uses `btrfs dump-super` + `truncate` (guest resizes btrfs at boot)
 - Sparse files: only written blocks use real disk space (50G file with 2G content uses ~2G)
 - Included in `FirecrackerConfig.rootfs_size` → affects snapshot cache key (different sizes = different snapshots)
 - Clones inherit parent's disk size naturally (reflink copies the already-resized file)
@@ -1241,8 +1241,8 @@ This ensures packages match the target Ubuntu version (Noble/24.04), not the hos
 The `codename` is specified in `rootfs-config.toml`.
 
 **Setup Verification:**
-Layer 2 setup writes a marker file `/etc/fcvm-setup-complete` on successful completion.
-After the setup VM exits, fcvm mounts the rootfs and verifies this marker exists.
+Layer 2 setup writes a marker file `/etc/fcvm-setup-complete` and prints `FCVM_SETUP_COMPLETE` to serial console on successful completion.
+After the setup VM exits, fcvm checks the serial console output for the completion marker.
 If missing, setup fails with a clear error.
 
 The initrd contains a statically-linked busybox and fc-agent binary, injected at boot before systemd.

--- a/Containerfile
+++ b/Containerfile
@@ -14,7 +14,7 @@ RUN cargo install cargo-nextest cargo-audit cargo-deny --locked
 # Install system dependencies (including kernel build tools: flex, bison, bc, libelf-dev, libssl-dev)
 RUN apt-get update && apt-get install -y \
     fuse3 libfuse3-dev autoconf automake libtool perl libclang-dev clang cmake \
-    musl-tools iproute2 iptables slirp4netns dnsmasq qemu-utils e2fsprogs \
+    musl-tools iproute2 iptables slirp4netns dnsmasq qemu-utils e2fsprogs btrfs-progs \
     parted fdisk podman skopeo git curl sudo procps zstd busybox-static cpio uidmap \
     flex bison bc libelf-dev libssl-dev libseccomp-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/Containerfile.nested
+++ b/Containerfile.nested
@@ -17,7 +17,7 @@ FROM ubuntu:24.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     iproute2 iptables podman python3 kmod procps fuse3 curl nginx \
-    fuse-overlayfs sudo iperf3 rsync \
+    fuse-overlayfs sudo iperf3 rsync btrfs-progs \
     && rm -rf /var/lib/apt/lists/*
 
 # Configure podman to use fuse-overlayfs (required for nested containers)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1706,6 +1706,7 @@ patches_dir = "kernel/patches"
 | `firecracker_bin` | No | Custom Firecracker binary path |
 | `firecracker_args` | No | Extra Firecracker CLI args |
 | `boot_args` | No | Extra kernel boot parameters |
+| `rootfs_type` | No | Root filesystem type: `"ext4"` (default) or `"btrfs"` (converts via btrfs-convert) |
 
 ### How It Works
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ The mode is auto-detected from the kernel profile (btrfs profile → btrfs mode)
 **How btrfs mode works:**
 1. Host exports container as Docker archive (`podman save`)
 2. Docker archive is attached to the VM as a read-only block device
-3. VM creates a btrfs loopback on the rootfs and runs `podman load` from the archive device
+3. VM rootfs is natively btrfs — fc-agent runs `podman load` directly on the btrfs root filesystem (no loopback)
 4. Snapshot caches the post-load state for instant subsequent boots
 
 **Requirements for btrfs mode:**

--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -215,10 +215,23 @@ pub fn setup_btrfs_storage_if_available() {
         .unwrap_or(false);
 
     if root_is_btrfs {
-        let _ = std::process::Command::new("btrfs")
+        match std::process::Command::new("btrfs")
             .args(["filesystem", "resize", "max", "/"])
-            .output();
-        eprintln!("[fc-agent] root filesystem is btrfs, resized to fill disk");
+            .output()
+        {
+            Ok(output) if output.status.success() => {
+                eprintln!("[fc-agent] root filesystem is btrfs, resized to fill disk");
+            }
+            Ok(output) => {
+                eprintln!(
+                    "[fc-agent] WARNING: btrfs resize failed: {}",
+                    String::from_utf8_lossy(&output.stderr).trim()
+                );
+            }
+            Err(e) => {
+                eprintln!("[fc-agent] WARNING: btrfs resize command failed: {}", e);
+            }
+        }
         let storage_dir = "/var/lib/containers/storage";
         let _ = std::fs::create_dir_all(storage_dir);
         write_btrfs_storage_conf(

--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -206,10 +206,33 @@ pub fn setup_btrfs_storage_if_available() {
         return;
     }
 
+    // If root filesystem is natively btrfs, resize to fill disk and skip loopback.
+    // The host may have expanded the sparse file for --rootfs-size.
+    let root_is_btrfs = std::process::Command::new("findmnt")
+        .args(["-n", "-o", "FSTYPE", "/"])
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim() == "btrfs")
+        .unwrap_or(false);
+
+    if root_is_btrfs {
+        let _ = std::process::Command::new("btrfs")
+            .args(["filesystem", "resize", "max", "/"])
+            .output();
+        eprintln!("[fc-agent] root filesystem is btrfs, resized to fill disk");
+        let storage_dir = "/var/lib/containers/storage";
+        let _ = std::fs::create_dir_all(storage_dir);
+        write_btrfs_storage_conf(
+            "/etc/containers/storage.conf",
+            storage_dir,
+            "/run/containers/storage",
+        );
+        return;
+    }
+
     let storage_dir = "/var/lib/containers/storage";
     let loopback_path = "/var/lib/containers/btrfs.img";
 
-    // Skip if already mounted as btrfs
+    // Skip if already btrfs (either native btrfs root or pre-existing loopback mount)
     let already_btrfs = std::process::Command::new("findmnt")
         .args(["-n", "-o", "FSTYPE", storage_dir])
         .output()

--- a/rootfs-config.toml
+++ b/rootfs-config.toml
@@ -247,6 +247,7 @@ build_inputs = [
 # When the kernel supports btrfs, fc-agent auto-detects it and configures
 # podman to use btrfs instead of overlay (avoids idmapped mount issues).
 [kernel_profiles.btrfs.arm64]
+rootfs_type = "btrfs"
 description = "Kernel with FUSE and btrfs support for efficient container storage"
 kernel_version = "6.18.3"
 kernel_repo = "ejc3/fcvm"
@@ -262,6 +263,7 @@ base_config_url = "https://raw.githubusercontent.com/firecracker-microvm/firecra
 
 # x86_64 btrfs profile (FUSE + btrfs, no KVM/nested)
 [kernel_profiles.btrfs.amd64]
+rootfs_type = "btrfs"
 description = "Kernel with FUSE and btrfs support for efficient container storage (x86_64)"
 kernel_version = "6.18.3"
 kernel_repo = "ejc3/fcvm"

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -64,6 +64,10 @@ pub struct SetupArgs {
     #[arg(long)]
     pub build_kernels: bool,
 
+    /// Override rootfs filesystem type from kernel profile config (for testing).
+    #[arg(long, value_enum, hide = true)]
+    pub rootfs_type: Option<RootfsType>,
+
     /// Install kernel as the host kernel and configure GRUB.
     /// Requires --kernel-profile flag. After setup, reboot to activate.
     #[arg(long, requires = "kernel_profile")]
@@ -252,6 +256,11 @@ pub struct RunArgs {
     /// By default, fcvm creates snapshots after container image pull for fast subsequent launches.
     #[arg(long)]
     pub no_snapshot: bool,
+
+    /// Override rootfs filesystem type from kernel profile config (for testing).
+    /// Normally driven by rootfs_type in kernel profile config.
+    #[arg(long, value_enum, hide = true)]
+    pub rootfs_type: Option<RootfsType>,
 
     /// Image delivery mode for localhost images (default: auto-detect from kernel profile).
     /// overlay: pre-built overlay storage (instant), btrfs: pre-built btrfs image (instant),
@@ -465,6 +474,18 @@ pub enum NetworkMode {
     Bridged,
     /// True rootless networking using slirp4netns (no sudo required)
     Rootless,
+}
+
+/// Root filesystem type for the VM.
+///
+/// Controls whether the rootfs is ext4 (default) or btrfs.
+/// Normally driven by the kernel profile config; this enum enables CLI override for testing.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, ValueEnum)]
+pub enum RootfsType {
+    /// Standard ext4 rootfs (default)
+    Ext4,
+    /// btrfs rootfs (converted from ext4 via btrfs-convert)
+    Btrfs,
 }
 
 /// Image delivery mode for localhost container images.

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -40,22 +40,7 @@ use tokio_util::sync::CancellationToken;
 ///
 /// Priority: explicit `--rootfs-type` CLI flag > kernel profile config > None (ext4).
 fn resolve_rootfs_type(args: &RunArgs) -> Option<String> {
-    // CLI override wins
-    if let Some(ref rt) = args.rootfs_type {
-        return match rt {
-            crate::cli::RootfsType::Btrfs => Some("btrfs".to_string()),
-            crate::cli::RootfsType::Ext4 => None,
-        };
-    }
-
-    // Read from kernel profile config
-    if let Some(ref profile_name) = args.kernel_profile {
-        if let Ok(Some(profile)) = crate::setup::get_kernel_profile(profile_name) {
-            return profile.rootfs_type;
-        }
-    }
-
-    None
+    crate::setup::resolve_rootfs_type(args.rootfs_type.as_ref(), args.kernel_profile.as_deref())
 }
 
 /// Resolve the image delivery mode from CLI args and kernel profile.

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -36,6 +36,28 @@ use crate::volume::{spawn_volume_servers, VolumeConfig};
 use image::{build_storage_image, get_image_identifier, validate_docker_archive};
 use tokio_util::sync::CancellationToken;
 
+/// Resolve the rootfs filesystem type from CLI args and kernel profile config.
+///
+/// Priority: explicit `--rootfs-type` CLI flag > kernel profile config > None (ext4).
+fn resolve_rootfs_type(args: &RunArgs) -> Option<String> {
+    // CLI override wins
+    if let Some(ref rt) = args.rootfs_type {
+        return match rt {
+            crate::cli::RootfsType::Btrfs => Some("btrfs".to_string()),
+            crate::cli::RootfsType::Ext4 => None,
+        };
+    }
+
+    // Read from kernel profile config
+    if let Some(ref profile_name) = args.kernel_profile {
+        if let Ok(Some(profile)) = crate::setup::get_kernel_profile(profile_name) {
+            return profile.rootfs_type;
+        }
+    }
+
+    None
+}
+
 /// Resolve the image delivery mode from CLI args and kernel profile.
 ///
 /// Priority: explicit `--image-mode` > auto-detect from kernel profile.
@@ -229,7 +251,10 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
             .context("setting up kernel")?
     };
 
-    let base_rootfs = crate::setup::ensure_rootfs(args.setup)
+    // Resolve rootfs type: CLI override > kernel profile config > default (ext4)
+    let rootfs_type = resolve_rootfs_type(&args);
+
+    let base_rootfs = crate::setup::ensure_rootfs(args.setup, rootfs_type.as_deref())
         .await
         .context("setting up rootfs")?;
     let initrd_path = crate::setup::ensure_fc_agent_initrd(args.setup)
@@ -1063,6 +1088,7 @@ mod tests {
             hugepages: false,
             portable_volumes: false,
             image_mode: None,
+            rootfs_type: None,
             label: vec![],
             image: "alpine:latest".to_string(),
             command_args: vec![],

--- a/src/commands/podman/snapshot.rs
+++ b/src/commands/podman/snapshot.rs
@@ -234,6 +234,9 @@ pub(super) fn build_firecracker_config(
     // Collect volume mounts for cache key (affects MMDS plan)
     let volume_mounts: Vec<String> = args.map.to_vec();
 
+    // Resolve rootfs_type for cache key
+    let rootfs_type = super::resolve_rootfs_type(args);
+
     let mut config = FirecrackerConfig::new(
         kernel_path.to_path_buf(),
         initrd_path.to_path_buf(),
@@ -256,6 +259,7 @@ pub(super) fn build_firecracker_config(
         args.user.clone(),
         args.forward_localhost.clone(),
         image_mode,
+        rootfs_type,
     );
     // Set the original image name for MMDS (separate from cache key identifier)
     config.container_image_name = args.image.clone();

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -823,6 +823,7 @@ pub(super) async fn run_vm_setup(
             let env_vars: Vec<String> = args.env.to_vec();
             let volume_mounts: Vec<String> = args.map.to_vec();
             let image_mode = super::resolve_image_mode(args);
+            let rootfs_type = super::resolve_rootfs_type(args);
 
             crate::firecracker::FirecrackerConfig::new(
                 kernel_path.to_path_buf(),
@@ -846,6 +847,7 @@ pub(super) async fn run_vm_setup(
                 args.user.clone(),
                 args.forward_localhost.clone(),
                 image_mode,
+                rootfs_type,
             )
         });
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -320,6 +320,7 @@ async fn create_sandbox(
         vsock_dir: None,
         no_snapshot: true,
         image_mode: None,
+        rootfs_type: None,
         forward_localhost: vec![],
         user: None,
         hugepages: false,

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -71,17 +71,10 @@ pub async fn cmd_setup(args: SetupArgs) -> Result<()> {
     println!("  ✓ Kernel ready: {}", kernel_path.display());
 
     // Resolve rootfs type: CLI override > kernel profile config > default (ext4)
-    let rootfs_type = if let Some(ref rt) = args.rootfs_type {
-        match rt {
-            crate::cli::RootfsType::Btrfs => Some("btrfs".to_string()),
-            crate::cli::RootfsType::Ext4 => None,
-        }
-    } else if let Some(ref profile_name) = args.kernel_profile {
-        get_kernel_profile(profile_name)?
-            .and_then(|p| p.rootfs_type)
-    } else {
-        None
-    };
+    let rootfs_type = crate::setup::resolve_rootfs_type(
+        args.rootfs_type.as_ref(),
+        args.kernel_profile.as_deref(),
+    );
 
     // Ensure rootfs exists (creates Layer 2 if missing)
     let rootfs_path = crate::setup::ensure_rootfs(true, rootfs_type.as_deref())

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -70,25 +70,8 @@ pub async fn cmd_setup(args: SetupArgs) -> Result<()> {
         .context("setting up kernel")?;
     println!("  ✓ Kernel ready: {}", kernel_path.display());
 
-    // Resolve rootfs type: CLI override > kernel profile config > default (ext4)
-    let rootfs_type = crate::setup::resolve_rootfs_type(
-        args.rootfs_type.as_ref(),
-        args.kernel_profile.as_deref(),
-    );
-
-    // Ensure rootfs exists (creates Layer 2 if missing)
-    let rootfs_path = crate::setup::ensure_rootfs(true, rootfs_type.as_deref())
-        .await
-        .context("setting up rootfs")?;
-    println!("  ✓ Rootfs ready: {}", rootfs_path.display());
-
-    // Ensure fc-agent initrd exists
-    let initrd_path = crate::setup::ensure_fc_agent_initrd(true)
-        .await
-        .context("setting up fc-agent initrd")?;
-    println!("  ✓ Initrd ready: {}", initrd_path.display());
-
-    // Setup kernel profile if requested (e.g., "nested" for nested virtualization)
+    // Setup kernel profile if requested — must happen BEFORE rootfs creation
+    // because btrfs rootfs needs the profile kernel to boot the setup VM
     if let Some(profile_name) = &args.kernel_profile {
         let profile = get_kernel_profile(profile_name)?.ok_or_else(|| {
             anyhow::anyhow!("kernel profile '{}' not found in config", profile_name)
@@ -113,7 +96,28 @@ pub async fn cmd_setup(args: SetupArgs) -> Result<()> {
         crate::setup::ensure_profile_firecracker(&profile, profile_name)
             .await
             .context("setting up profile firecracker")?;
+    }
 
+    // Resolve rootfs type: CLI override > kernel profile config > default (ext4)
+    let rootfs_type = crate::setup::resolve_rootfs_type(
+        args.rootfs_type.as_ref(),
+        args.kernel_profile.as_deref(),
+    );
+
+    // Ensure rootfs exists (creates Layer 2 if missing)
+    let rootfs_path = crate::setup::ensure_rootfs(true, rootfs_type.as_deref())
+        .await
+        .context("setting up rootfs")?;
+    println!("  ✓ Rootfs ready: {}", rootfs_path.display());
+
+    // Ensure fc-agent initrd exists
+    let initrd_path = crate::setup::ensure_fc_agent_initrd(true)
+        .await
+        .context("setting up fc-agent initrd")?;
+    println!("  ✓ Initrd ready: {}", initrd_path.display());
+
+    if args.kernel_profile.is_some() {
+        let profile_name = args.kernel_profile.as_ref().unwrap();
         println!("\nFor '{}' profile, use:", profile_name);
         println!(
             "  fcvm podman run --kernel-profile {} --privileged ...",

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -70,8 +70,21 @@ pub async fn cmd_setup(args: SetupArgs) -> Result<()> {
         .context("setting up kernel")?;
     println!("  ✓ Kernel ready: {}", kernel_path.display());
 
+    // Resolve rootfs type: CLI override > kernel profile config > default (ext4)
+    let rootfs_type = if let Some(ref rt) = args.rootfs_type {
+        match rt {
+            crate::cli::RootfsType::Btrfs => Some("btrfs".to_string()),
+            crate::cli::RootfsType::Ext4 => None,
+        }
+    } else if let Some(ref profile_name) = args.kernel_profile {
+        get_kernel_profile(profile_name)?
+            .and_then(|p| p.rootfs_type)
+    } else {
+        None
+    };
+
     // Ensure rootfs exists (creates Layer 2 if missing)
-    let rootfs_path = crate::setup::ensure_rootfs(true)
+    let rootfs_path = crate::setup::ensure_rootfs(true, rootfs_type.as_deref())
         .await
         .context("setting up rootfs")?;
     println!("  ✓ Rootfs ready: {}", rootfs_path.display());

--- a/src/firecracker/config.rs
+++ b/src/firecracker/config.rs
@@ -85,6 +85,10 @@ pub struct FirecrackerConfig {
     /// Affects whether guest mounts overlay store, btrfs store, or runs podman load.
     #[serde(default = "default_image_mode")]
     pub image_mode: ImageMode,
+    /// Root filesystem type ("ext4" or "btrfs").
+    /// Different rootfs types produce different VM states and must not share snapshots.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rootfs_type: Option<String>,
 }
 
 fn default_image_mode() -> ImageMode {
@@ -191,6 +195,7 @@ impl FirecrackerConfig {
         user: Option<String>,
         forward_localhost: Vec<u16>,
         image_mode: ImageMode,
+        rootfs_type: Option<String>,
     ) -> Self {
         Self {
             boot_source: BootSource {
@@ -229,6 +234,7 @@ impl FirecrackerConfig {
             user,
             forward_localhost,
             image_mode,
+            rootfs_type,
         }
     }
 
@@ -422,6 +428,7 @@ mod tests {
             None,
             vec![],
             ImageMode::Overlay,
+            None,
         )
     }
 
@@ -549,5 +556,13 @@ mod tests {
         config3.image_mode = ImageMode::Archive;
         assert_ne!(config1.snapshot_key(), config3.snapshot_key());
         assert_ne!(config2.snapshot_key(), config3.snapshot_key());
+    }
+
+    #[test]
+    fn test_snapshot_key_changes_with_rootfs_type() {
+        let config1 = test_config();
+        let mut config2 = test_config();
+        config2.rootfs_type = Some("btrfs".to_string());
+        assert_ne!(config1.snapshot_key(), config2.snapshot_key());
     }
 }

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -6,5 +6,7 @@ pub use kernel::{
     ensure_kernel, ensure_profile_firecracker, get_firecracker_for_profile, get_kernel_path,
     get_kernel_url_hash, get_profile_firecracker_path, install_host_kernel,
 };
-pub use rootfs::{ensure_fc_agent_initrd, ensure_rootfs, get_kernel_profile, KernelProfile};
+pub use rootfs::{
+    ensure_fc_agent_initrd, ensure_rootfs, get_kernel_profile, resolve_rootfs_type, KernelProfile,
+};
 pub use storage::ensure_storage;

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -1503,6 +1503,11 @@ fn find_busybox() -> Result<PathBuf> {
 /// Requires a clean ext4 filesystem (runs e2fsck first).
 /// btrfs-convert works on image files, not just block devices.
 async fn convert_to_btrfs(image_path: &Path) -> Result<()> {
+    // Verify btrfs-convert is available (from btrfs-progs package)
+    if which::which("btrfs-convert").is_err() {
+        bail!("btrfs-convert not found — install btrfs-progs: apt-get install btrfs-progs");
+    }
+
     // e2fsck first — btrfs-convert requires a clean ext4 filesystem
     let e2fsck_output = Command::new("e2fsck")
         .args(["-f", "-y", path_to_str(image_path)?])

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -836,6 +836,32 @@ pub fn get_kernel_profile(name: &str) -> Result<Option<KernelProfile>> {
         .cloned())
 }
 
+/// Resolve rootfs filesystem type from CLI override and kernel profile name.
+///
+/// Priority: explicit CLI `--rootfs-type` flag > kernel profile config > None (ext4 default).
+/// Used by both `setup` and `podman run` commands.
+pub fn resolve_rootfs_type(
+    cli_rootfs_type: Option<&crate::cli::RootfsType>,
+    kernel_profile_name: Option<&str>,
+) -> Option<String> {
+    // CLI override wins
+    if let Some(rt) = cli_rootfs_type {
+        return match rt {
+            crate::cli::RootfsType::Btrfs => Some("btrfs".to_string()),
+            crate::cli::RootfsType::Ext4 => None,
+        };
+    }
+
+    // Read from kernel profile config
+    if let Some(profile_name) = kernel_profile_name {
+        if let Ok(Some(profile)) = get_kernel_profile(profile_name) {
+            return profile.rootfs_type;
+        }
+    }
+
+    None
+}
+
 /// Detect kernel profile from kernel path.
 ///
 /// Checks if the kernel filename matches a configured profile name.
@@ -1017,8 +1043,14 @@ pub async fn ensure_rootfs(allow_create: bool, rootfs_type: Option<&str>) -> Res
     let temp_rootfs_path = rootfs_path.with_extension("raw.tmp");
     let _ = tokio::fs::remove_file(&temp_rootfs_path).await;
 
-    let result =
-        create_layer2_rootless(&plan, script_sha_short, &setup_script, &temp_rootfs_path, rootfs_type).await;
+    let result = create_layer2_rootless(
+        &plan,
+        script_sha_short,
+        &setup_script,
+        &temp_rootfs_path,
+        rootfs_type,
+    )
+    .await;
 
     if result.is_ok() {
         tokio::fs::rename(&temp_rootfs_path, &rootfs_path)
@@ -2014,8 +2046,7 @@ async fn boot_vm_for_setup(
     } else {
         None
     };
-    let kernel_path =
-        crate::setup::kernel::ensure_kernel(kernel_profile, true, false).await?;
+    let kernel_path = crate::setup::kernel::ensure_kernel(kernel_profile, true, false).await?;
 
     // Create serial console output file
     let serial_path = temp_dir.join("serial.log");

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -51,6 +51,11 @@ pub struct KernelProfile {
     #[serde(default)]
     pub description: String,
 
+    /// Root filesystem type: "ext4" (default) or "btrfs"
+    /// When "btrfs", the rootfs is converted from ext4 to btrfs before setup VM boot.
+    #[serde(default)]
+    pub rootfs_type: Option<String>,
+
     // ========== Custom kernel (build from source) ==========
     /// Kernel version (e.g., "6.18")
     #[serde(default)]
@@ -403,6 +408,12 @@ if [ $? -ne 0 ]; then
     echo 1 > /proc/sys/kernel/sysrq 2>/dev/null || true
     echo o > /proc/sysrq-trigger 2>/dev/null || poweroff -f
 fi
+
+# Fix fstab: remove entries for partitions that don't exist in microVM.
+# Ubuntu cloud images have LABEL=BOOT and LABEL=UEFI entries that cause
+# systemd to enter emergency mode when these partitions are missing.
+echo "FCVM Layer 2 Setup: Fixing fstab..."
+sed -i '/LABEL=BOOT/d;/LABEL=UEFI/d' /newroot/etc/fstab 2>/dev/null || true
 
 # Copy embedded packages from initrd to rootfs
 # Packages are in /packages directory inside the initrd (loaded in RAM)
@@ -902,7 +913,7 @@ pub fn compute_sha256(data: &[u8]) -> String {
 /// Layer 2 only contains packages (podman, crun, etc.).
 ///
 /// If `allow_create` is false, bail if rootfs doesn't exist.
-pub async fn ensure_rootfs(allow_create: bool) -> Result<PathBuf> {
+pub async fn ensure_rootfs(allow_create: bool, rootfs_type: Option<&str>) -> Result<PathBuf> {
     let (plan, _plan_sha_full, _plan_sha_short) = load_plan()?;
 
     // Generate all scripts and compute hash of the complete init script
@@ -915,11 +926,12 @@ pub async fn ensure_rootfs(allow_create: bool) -> Result<PathBuf> {
     let kernel_config = plan.kernel.current_arch()?;
     let kernel_url = &kernel_config.url;
 
-    // Hash the complete init script + kernel URL + download script
+    // Hash the complete init script + kernel URL + download script + rootfs_type
     // Any change to:
     // - init logic, install script, or setup script
     // - kernel URL (different kernel version/release)
     // - download method (podman image, codename, packages)
+    // - rootfs filesystem type (ext4 vs btrfs)
     // invalidates the cache
     let mut combined = init_script.clone();
     combined.push_str("\n# KERNEL_URL: ");
@@ -930,11 +942,20 @@ pub async fn ensure_rootfs(allow_create: bool) -> Result<PathBuf> {
     combined.push_str(FC_AGENT_SERVICE);
     combined.push_str("\n# FC_AGENT_SERVICE_STRACE:\n");
     combined.push_str(FC_AGENT_SERVICE_STRACE);
+    if let Some(fs_type) = rootfs_type {
+        combined.push_str("\n# ROOTFS_TYPE: ");
+        combined.push_str(fs_type);
+    }
     let script_sha = compute_sha256(combined.as_bytes());
     let script_sha_short = &script_sha[..12];
 
     let rootfs_dir = paths::rootfs_dir();
-    let rootfs_path = rootfs_dir.join(format!("layer2-{}.raw", script_sha_short));
+    // Different rootfs types use different cache filenames
+    let rootfs_path = if rootfs_type == Some("btrfs") {
+        rootfs_dir.join(format!("layer2-{}-btrfs.raw", script_sha_short))
+    } else {
+        rootfs_dir.join(format!("layer2-{}.raw", script_sha_short))
+    };
     let lock_file = rootfs_dir.join(".rootfs-creation.lock");
 
     // If rootfs exists for this script, return it
@@ -997,7 +1018,7 @@ pub async fn ensure_rootfs(allow_create: bool) -> Result<PathBuf> {
     let _ = tokio::fs::remove_file(&temp_rootfs_path).await;
 
     let result =
-        create_layer2_rootless(&plan, script_sha_short, &setup_script, &temp_rootfs_path).await;
+        create_layer2_rootless(&plan, script_sha_short, &setup_script, &temp_rootfs_path, rootfs_type).await;
 
     if result.is_ok() {
         tokio::fs::rename(&temp_rootfs_path, &rootfs_path)
@@ -1445,15 +1466,35 @@ fn find_busybox() -> Result<PathBuf> {
 // Layer 2 Creation (Rootless)
 // ============================================================================
 
-/// Create Layer 2 rootfs without requiring root
+/// Convert an ext4 image file to btrfs in-place using btrfs-convert.
 ///
-/// 1. Download cloud image (qcow2, cached)
-/// 2. Convert to raw with qemu-img (no root)
-/// 3. Expand to 10GB (no root)
-/// 4. Download .deb packages on host (has network)
-/// 5. Create initrd with embedded packages
-/// 6. Boot VM with initrd to install packages (no network needed)
-/// 7. Wait for VM to shut down
+/// Requires a clean ext4 filesystem (runs e2fsck first).
+/// btrfs-convert works on image files, not just block devices.
+async fn convert_to_btrfs(image_path: &Path) -> Result<()> {
+    // e2fsck first — btrfs-convert requires a clean ext4 filesystem
+    let _ = Command::new("e2fsck")
+        .args(["-f", "-y", path_to_str(image_path)?])
+        .output()
+        .await
+        .context("e2fsck before btrfs-convert")?;
+
+    let output = Command::new("btrfs-convert")
+        .arg(path_to_str(image_path)?)
+        .output()
+        .await
+        .context("running btrfs-convert")?;
+
+    if !output.status.success() {
+        bail!(
+            "btrfs-convert failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    info!("rootfs converted from ext4 to btrfs");
+    Ok(())
+}
+
+/// Create Layer 2 rootfs without requiring root
 ///
 /// NOTE: fc-agent is NOT included - it will be injected per-VM at boot time.
 async fn create_layer2_rootless(
@@ -1461,6 +1502,7 @@ async fn create_layer2_rootless(
     script_sha_short: &str,
     script: &str,
     output_path: &Path,
+    rootfs_type: Option<&str>,
 ) -> Result<()> {
     // Step 1: Download cloud image (cached by URL)
     let cloud_image = download_cloud_image(plan).await?;
@@ -1599,10 +1641,11 @@ async fn create_layer2_rootless(
         );
     }
 
-    // Step 4b: Fix /etc/fstab to remove BOOT and UEFI entries
-    // This MUST happen before booting - systemd reads fstab before cloud-init runs
-    info!("fixing /etc/fstab to remove non-existent partition entries");
-    fix_fstab_in_image(&partition_path).await?;
+    // Step 4b: Convert ext4 to btrfs if requested (before setup VM boot)
+    if rootfs_type == Some("btrfs") {
+        info!("converting rootfs from ext4 to btrfs");
+        convert_to_btrfs(&partition_path).await?;
+    }
 
     // Step 5: Download packages on host (host has network!)
     let packages_dir = download_packages(plan, script_sha_short).await?;
@@ -1619,15 +1662,15 @@ async fn create_layer2_rootless(
 
     let setup_initrd = create_layer2_setup_initrd(&install_script, script, &packages_dir).await?;
 
-    // Step 7: Boot VM with initrd to run setup (no cloud-init needed!)
-    // Now we boot a pure ext4 partition (no GPT), so root=/dev/vda works
-    // Only one disk needed - packages are in the initrd
+    // Step 7: Boot VM with initrd to run setup
+    // Boots a partition (ext4 or btrfs) with root=/dev/vda
+    // Uses btrfs kernel profile when rootfs is btrfs (needs CONFIG_BTRFS_FS)
     info!(
         script_sha = %script_sha_short,
         "booting VM with setup initrd (packages embedded)"
     );
 
-    boot_vm_for_setup(&partition_path, &setup_initrd).await?;
+    boot_vm_for_setup(&partition_path, &setup_initrd, rootfs_type).await?;
 
     // Step 8: Rename to final path
     tokio::fs::rename(&partition_path, output_path)
@@ -1635,97 +1678,6 @@ async fn create_layer2_rootless(
         .context("renaming partition to output path")?;
 
     info!("Layer 2 creation complete (packages embedded in initrd)");
-    Ok(())
-}
-
-/// Fix /etc/fstab in an ext4 image to remove BOOT and UEFI partition entries
-///
-/// The Ubuntu cloud image has fstab entries for LABEL=BOOT and LABEL=UEFI
-/// which cause systemd to enter emergency mode when these partitions don't exist.
-/// We use debugfs to modify fstab directly in the ext4 image without mounting.
-async fn fix_fstab_in_image(image_path: &Path) -> Result<()> {
-    // Read current fstab using debugfs
-    let output = Command::new("debugfs")
-        .args(["-R", "cat /etc/fstab", path_to_str(image_path)?])
-        .output()
-        .await
-        .context("reading fstab with debugfs")?;
-
-    if !output.status.success() {
-        bail!(
-            "debugfs read failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    let fstab_content = String::from_utf8_lossy(&output.stdout);
-
-    // Filter out BOOT and UEFI entries
-    let new_fstab: String = fstab_content
-        .lines()
-        .filter(|line| !line.contains("LABEL=BOOT") && !line.contains("LABEL=UEFI"))
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    debug!("new fstab content:\n{}", new_fstab);
-
-    // Write new fstab to a temp file
-    let temp_fstab = std::env::temp_dir().join("fstab.new");
-    tokio::fs::write(&temp_fstab, format!("{}\n", new_fstab))
-        .await
-        .context("writing temp fstab")?;
-
-    // Write the new fstab back using debugfs -w
-    // debugfs command: rm /etc/fstab; write /tmp/fstab.new /etc/fstab
-    let output = Command::new("debugfs")
-        .args(["-w", "-R", "rm /etc/fstab", path_to_str(image_path)?])
-        .output()
-        .await
-        .context("removing old fstab with debugfs")?;
-
-    // rm might fail if file doesn't exist, that's OK
-    if !output.status.success() {
-        debug!(
-            "debugfs rm fstab (might be expected): {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    let output = Command::new("debugfs")
-        .args([
-            "-w",
-            "-R",
-            &format!("write {} /etc/fstab", temp_fstab.display()),
-            path_to_str(image_path)?,
-        ])
-        .output()
-        .await
-        .context("writing new fstab with debugfs")?;
-
-    if !output.status.success() {
-        bail!(
-            "debugfs write failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    // Cleanup temp file
-    let _ = tokio::fs::remove_file(&temp_fstab).await;
-
-    // Verify the change
-    let output = Command::new("debugfs")
-        .args(["-R", "cat /etc/fstab", path_to_str(image_path)?])
-        .output()
-        .await
-        .context("verifying fstab with debugfs")?;
-
-    let new_content = String::from_utf8_lossy(&output.stdout);
-    if new_content.contains("LABEL=BOOT") || new_content.contains("LABEL=UEFI") {
-        warn!("fstab still contains BOOT/UEFI entries after fix - VM may enter emergency mode");
-    } else {
-        info!("fstab fixed - removed BOOT and UEFI entries");
-    }
-
     Ok(())
 }
 
@@ -2034,7 +1986,11 @@ async fn download_cloud_image(plan: &Plan) -> Result<PathBuf> {
 ///
 /// Only one disk is needed - packages are embedded in the initrd.
 /// This allows using Kata's kernel which has FUSE but no ISO9660/SquashFS.
-async fn boot_vm_for_setup(disk_path: &Path, initrd_path: &Path) -> Result<()> {
+async fn boot_vm_for_setup(
+    disk_path: &Path,
+    initrd_path: &Path,
+    rootfs_type: Option<&str>,
+) -> Result<()> {
     use std::time::Duration;
     use tokio::time::timeout;
 
@@ -2051,9 +2007,15 @@ async fn boot_vm_for_setup(disk_path: &Path, initrd_path: &Path) -> Result<()> {
     // Create log file (Firecracker requires it to exist)
     std::fs::File::create(&log_path).context("creating Firecracker log file")?;
 
-    // Find kernel - downloaded from Kata release if needed
-    // Use default kernel (None profile), allow_create=true, allow_build=false
-    let kernel_path = crate::setup::kernel::ensure_kernel(None, true, false).await?;
+    // Find kernel - use btrfs profile kernel if rootfs is btrfs (needs CONFIG_BTRFS_FS),
+    // otherwise use default Kata kernel
+    let kernel_profile = if rootfs_type == Some("btrfs") {
+        Some("btrfs")
+    } else {
+        None
+    };
+    let kernel_path =
+        crate::setup::kernel::ensure_kernel(kernel_profile, true, false).await?;
 
     // Create serial console output file
     let serial_path = temp_dir.join("serial.log");
@@ -2095,9 +2057,9 @@ async fn boot_vm_for_setup(disk_path: &Path, initrd_path: &Path) -> Result<()> {
     // Configure VM via API
     let client = crate::firecracker::api::FirecrackerClient::new(api_socket.clone())?;
 
-    // Set boot source - boot from raw ext4 partition (no GPT)
+    // Set boot source - boot from raw partition (ext4 or btrfs, no GPT)
     // The disk IS the filesystem, so use root=/dev/vda directly
-    // No cloud-init needed - scripts are injected via debugfs and run by rc.local
+    // No cloud-init needed - scripts are injected via initrd
     client
         .set_boot_source(crate::firecracker::api::BootSource {
             kernel_image_path: kernel_path.display().to_string(),
@@ -2108,7 +2070,7 @@ async fn boot_vm_for_setup(disk_path: &Path, initrd_path: &Path) -> Result<()> {
         })
         .await?;
 
-    // Add root drive (raw ext4 filesystem, no partition table)
+    // Add root drive (raw filesystem, no partition table)
     client
         .add_drive(
             "rootfs",
@@ -2208,23 +2170,6 @@ async fn boot_vm_for_setup(disk_path: &Path, initrd_path: &Path) -> Result<()> {
                 }
                 let _ = tokio::fs::remove_dir_all(&temp_dir).await;
                 bail!("Layer 2 setup failed (no FCVM_SETUP_COMPLETE marker found)");
-            }
-
-            // Verify marker file exists in the rootfs using debugfs (no root needed)
-            let debugfs_output = Command::new("debugfs")
-                .args([
-                    "-R",
-                    "stat /etc/fcvm-setup-complete",
-                    path_to_str(disk_path)?,
-                ])
-                .output()
-                .await?;
-            let marker_exists = debugfs_output.status.success()
-                && !String::from_utf8_lossy(&debugfs_output.stdout).contains("not found");
-            if !marker_exists {
-                warn!("Setup failed! Serial console output:\n{}", serial_content);
-                let _ = tokio::fs::remove_dir_all(&temp_dir).await;
-                bail!("Layer 2 setup failed: marker file /etc/fcvm-setup-complete not found in rootfs");
             }
 
             let _ = tokio::fs::remove_dir_all(&temp_dir).await;

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -2052,12 +2052,9 @@ async fn boot_vm_for_setup(
     std::fs::File::create(&log_path).context("creating Firecracker log file")?;
 
     // Find kernel - use btrfs profile kernel if rootfs is btrfs (needs CONFIG_BTRFS_FS),
-    // otherwise use default Kata kernel
-    let kernel_profile = if rootfs_type == Some("btrfs") {
-        Some("btrfs")
-    } else {
-        None
-    };
+    // otherwise use default Kata kernel.
+    // The rootfs_type value ("btrfs") matches the kernel profile name by convention.
+    let kernel_profile = rootfs_type;
     let kernel_path = crate::setup::kernel::ensure_kernel(kernel_profile, true, false).await?;
 
     // Create serial console output file

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -1504,11 +1504,18 @@ fn find_busybox() -> Result<PathBuf> {
 /// btrfs-convert works on image files, not just block devices.
 async fn convert_to_btrfs(image_path: &Path) -> Result<()> {
     // e2fsck first — btrfs-convert requires a clean ext4 filesystem
-    let _ = Command::new("e2fsck")
+    let e2fsck_output = Command::new("e2fsck")
         .args(["-f", "-y", path_to_str(image_path)?])
         .output()
         .await
         .context("e2fsck before btrfs-convert")?;
+    // e2fsck exit codes: 0=clean, 1=corrected, 2=corrected+reboot needed, >=4=uncorrectable
+    if e2fsck_output.status.code().unwrap_or(255) >= 4 {
+        bail!(
+            "e2fsck found uncorrectable errors: {}",
+            String::from_utf8_lossy(&e2fsck_output.stderr)
+        );
+    }
 
     let output = Command::new("btrfs-convert")
         .arg(path_to_str(image_path)?)

--- a/src/storage/disk.rs
+++ b/src/storage/disk.rs
@@ -124,8 +124,9 @@ impl DiskManager {
     }
 }
 
-/// Ensure the ext4 filesystem has at least `min_free + extra_bytes` of free space.
+/// Ensure the filesystem has at least `min_free + extra_bytes` of free space.
 /// `extra_bytes` accounts for content that will be written after boot (e.g., container image layers).
+/// Auto-detects filesystem type (ext4 or btrfs) and uses the appropriate tools.
 pub async fn ensure_free_space(
     disk_path: &Path,
     min_free_str: &str,
@@ -139,6 +140,32 @@ pub async fn ensure_free_space(
         return Ok(());
     }
 
+    let fs_type = detect_filesystem_type(disk_path).await?;
+    match fs_type.as_str() {
+        "btrfs" => ensure_free_space_btrfs(disk_path, min_free).await,
+        _ => ensure_free_space_ext4(disk_path, min_free).await,
+    }
+}
+
+/// Detect filesystem type of an image file using blkid.
+async fn detect_filesystem_type(path: &Path) -> Result<String> {
+    let output = tokio::process::Command::new("blkid")
+        .args(["-o", "value", "-s", "TYPE", path.to_string_lossy().as_ref()])
+        .output()
+        .await
+        .context("running blkid")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "blkid failed for {}: {}",
+            path.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Ensure ext4 filesystem has sufficient free space by expanding and resizing.
+async fn ensure_free_space_ext4(disk_path: &Path, min_free: u64) -> Result<()> {
     // Get current free space via dumpe2fs
     let output = tokio::process::Command::new("dumpe2fs")
         .args(["-h", disk_path.to_string_lossy().as_ref()])
@@ -174,7 +201,7 @@ pub async fn ensure_free_space(
         free_bytes,
         min_free,
         expand_by,
-        "expanding rootfs to ensure minimum free space"
+        "expanding ext4 rootfs to ensure minimum free space"
     );
 
     // Expand the sparse file
@@ -225,8 +252,91 @@ pub async fn ensure_free_space(
         );
     }
 
-    info!(disk = %disk_path.display(), "rootfs expanded successfully");
+    info!(disk = %disk_path.display(), "ext4 rootfs expanded successfully");
     Ok(())
+}
+
+/// Ensure btrfs filesystem has sufficient free space by expanding the sparse file.
+/// The guest resizes the btrfs filesystem at boot via `btrfs filesystem resize max /`.
+async fn ensure_free_space_btrfs(disk_path: &Path, min_free: u64) -> Result<()> {
+    // Parse btrfs superblock to get size info (no mount needed)
+    let output = tokio::process::Command::new("btrfs")
+        .args([
+            "inspect-internal",
+            "dump-super",
+            disk_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .await
+        .context("running btrfs dump-super")?;
+
+    if !output.status.success() {
+        bail!(
+            "btrfs dump-super failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let total_bytes = parse_dump_super_value(&stdout, "total_bytes")?;
+    let bytes_used = parse_dump_super_value(&stdout, "bytes_used")?;
+    let free_bytes = total_bytes.saturating_sub(bytes_used);
+
+    if free_bytes >= min_free {
+        debug!(
+            disk = %disk_path.display(),
+            free_bytes,
+            min_free,
+            "btrfs disk already has sufficient free space"
+        );
+        return Ok(());
+    }
+
+    let expand_by = min_free - free_bytes;
+    info!(
+        disk = %disk_path.display(),
+        free_bytes,
+        min_free,
+        expand_by,
+        "expanding btrfs rootfs sparse file"
+    );
+
+    // Expand sparse file — fc-agent resizes btrfs at boot
+    let output = tokio::process::Command::new("truncate")
+        .args([
+            "-s",
+            &format!("+{}", expand_by),
+            disk_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .await
+        .context("expanding btrfs sparse file")?;
+
+    if !output.status.success() {
+        bail!(
+            "truncate failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    info!(disk = %disk_path.display(), "btrfs rootfs sparse file expanded");
+    Ok(())
+}
+
+/// Parse a value from `btrfs inspect-internal dump-super` output.
+/// Format: "total_bytes\t\t10737418240" or "bytes_used\t\t2147483648"
+fn parse_dump_super_value(output: &str, key: &str) -> Result<u64> {
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with(key) {
+            if let Some(value) = trimmed.split_whitespace().last() {
+                return value
+                    .parse::<u64>()
+                    .with_context(|| format!("parsing {} value '{}'", key, value));
+            }
+        }
+    }
+    bail!("'{}' not found in btrfs dump-super output", key)
 }
 
 /// Parse a value from dumpe2fs -h output (e.g., "Block size:          4096")

--- a/tests/test_btrfs_rootfs.rs
+++ b/tests/test_btrfs_rootfs.rs
@@ -54,10 +54,9 @@ async fn test_btrfs_rootfs_native() -> Result<()> {
 
     // Step 3: Verify root filesystem is btrfs
     println!("\n3. Checking root filesystem type...");
-    let root_fstype =
-        common::exec_in_vm(fcvm_pid, &["findmnt", "-n", "-o", "FSTYPE", "/"])
-            .await
-            .context("checking root fstype")?;
+    let root_fstype = common::exec_in_vm(fcvm_pid, &["findmnt", "-n", "-o", "FSTYPE", "/"])
+        .await
+        .context("checking root fstype")?;
     let root_fstype = root_fstype.trim();
     println!("  / fstype: {}", root_fstype);
     assert_eq!(
@@ -70,7 +69,17 @@ async fn test_btrfs_rootfs_native() -> Result<()> {
     println!("\n4. Checking that no btrfs loopback file exists...");
     let loopback_check = common::exec_in_vm(
         fcvm_pid,
-        &["test", "-f", "/var/lib/containers/btrfs.img", "&&", "echo", "exists", "||", "echo", "absent"],
+        &[
+            "test",
+            "-f",
+            "/var/lib/containers/btrfs.img",
+            "&&",
+            "echo",
+            "exists",
+            "||",
+            "echo",
+            "absent",
+        ],
     )
     .await
     .context("checking loopback file")?;
@@ -163,10 +172,9 @@ async fn test_btrfs_rootfs_keepid() -> Result<()> {
 
     // Step 3: Verify root is btrfs
     println!("\n3. Checking root filesystem type...");
-    let root_fstype =
-        common::exec_in_vm(fcvm_pid, &["findmnt", "-n", "-o", "FSTYPE", "/"])
-            .await
-            .context("checking root fstype")?;
+    let root_fstype = common::exec_in_vm(fcvm_pid, &["findmnt", "-n", "-o", "FSTYPE", "/"])
+        .await
+        .context("checking root fstype")?;
     let root_fstype = root_fstype.trim();
     println!("  / fstype: {}", root_fstype);
     assert_eq!(root_fstype, "btrfs", "Root should be btrfs");
@@ -178,7 +186,11 @@ async fn test_btrfs_rootfs_keepid() -> Result<()> {
         .context("checking uid in container")?;
     let uid = uid.trim();
     println!("  Container UID: {}", uid);
-    assert_eq!(uid, "1000", "Container should run as UID 1000, got: {}", uid);
+    assert_eq!(
+        uid, "1000",
+        "Container should run as UID 1000, got: {}",
+        uid
+    );
 
     // Cleanup
     println!("\n5. Cleaning up...");
@@ -228,10 +240,9 @@ async fn test_btrfs_rootfs_ext4_loopback() -> Result<()> {
 
     // Step 3: Verify root filesystem is ext4
     println!("\n3. Checking root filesystem type...");
-    let root_fstype =
-        common::exec_in_vm(fcvm_pid, &["findmnt", "-n", "-o", "FSTYPE", "/"])
-            .await
-            .context("checking root fstype")?;
+    let root_fstype = common::exec_in_vm(fcvm_pid, &["findmnt", "-n", "-o", "FSTYPE", "/"])
+        .await
+        .context("checking root fstype")?;
     let root_fstype = root_fstype.trim();
     println!("  / fstype: {}", root_fstype);
     assert_eq!(
@@ -244,7 +255,17 @@ async fn test_btrfs_rootfs_ext4_loopback() -> Result<()> {
     println!("\n4. Checking btrfs loopback file...");
     let loopback_check = common::exec_in_vm(
         fcvm_pid,
-        &["test", "-f", "/var/lib/containers/btrfs.img", "&&", "echo", "exists", "||", "echo", "absent"],
+        &[
+            "test",
+            "-f",
+            "/var/lib/containers/btrfs.img",
+            "&&",
+            "echo",
+            "exists",
+            "||",
+            "echo",
+            "absent",
+        ],
     )
     .await
     .context("checking loopback file")?;

--- a/tests/test_btrfs_rootfs.rs
+++ b/tests/test_btrfs_rootfs.rs
@@ -1,0 +1,316 @@
+//! Integration tests for btrfs root filesystem support.
+//!
+//! Tests two modes:
+//! 1. **Native btrfs rootfs** (--rootfs-type btrfs): Root filesystem is btrfs,
+//!    no loopback needed. fc-agent resizes btrfs at boot and uses it directly.
+//! 2. **ext4 rootfs + btrfs loopback** (--rootfs-type ext4 or default): Root
+//!    filesystem is ext4, fc-agent creates a btrfs loopback for container storage.
+//!
+//! Both modes use --kernel-profile btrfs (kernel with btrfs support).
+
+#![cfg(feature = "integration-fast")]
+
+mod common;
+
+use anyhow::{Context, Result};
+
+/// Native btrfs rootfs — root is btrfs, no loopback file.
+///
+/// Verifies:
+/// - Root filesystem (/) is btrfs
+/// - No loopback file at /var/lib/containers/btrfs.img
+/// - Podman uses btrfs storage driver
+/// - Container runs successfully
+#[tokio::test]
+async fn test_btrfs_rootfs_native() -> Result<()> {
+    println!("\nNative Btrfs Rootfs Test");
+    println!("========================");
+
+    // Step 1: Start VM with btrfs kernel and btrfs rootfs
+    println!("\n1. Starting VM (rootless, --kernel-profile btrfs --rootfs-type btrfs)...");
+    let (vm_name, _, _, _) = common::unique_names("btrfs-rootfs");
+
+    let (mut _child, fcvm_pid) = common::spawn_fcvm(&[
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--kernel-profile",
+        "btrfs",
+        "--rootfs-type",
+        "btrfs",
+        "nginx:alpine",
+    ])
+    .await
+    .context("spawning fcvm")?;
+    println!("  fcvm PID: {}", fcvm_pid);
+
+    // Step 2: Wait for healthy
+    println!("\n2. Waiting for VM to become healthy...");
+    common::poll_health_by_pid(fcvm_pid, 300)
+        .await
+        .context("VM failed to become healthy")?;
+    println!("  VM is healthy");
+
+    // Step 3: Verify root filesystem is btrfs
+    println!("\n3. Checking root filesystem type...");
+    let root_fstype =
+        common::exec_in_vm(fcvm_pid, &["findmnt", "-n", "-o", "FSTYPE", "/"])
+            .await
+            .context("checking root fstype")?;
+    let root_fstype = root_fstype.trim();
+    println!("  / fstype: {}", root_fstype);
+    assert_eq!(
+        root_fstype, "btrfs",
+        "Root filesystem should be btrfs, got: {}",
+        root_fstype
+    );
+
+    // Step 4: Verify no loopback file exists
+    println!("\n4. Checking that no btrfs loopback file exists...");
+    let loopback_check = common::exec_in_vm(
+        fcvm_pid,
+        &["test", "-f", "/var/lib/containers/btrfs.img", "&&", "echo", "exists", "||", "echo", "absent"],
+    )
+    .await
+    .context("checking loopback file")?;
+    let loopback_check = loopback_check.trim();
+    println!("  btrfs.img: {}", loopback_check);
+    assert_eq!(
+        loopback_check, "absent",
+        "Loopback file should not exist on native btrfs root, got: {}",
+        loopback_check
+    );
+
+    // Step 5: Verify btrfs storage driver
+    println!("\n5. Checking podman storage driver...");
+    let driver = common::exec_in_vm(
+        fcvm_pid,
+        &["podman", "info", "--format", "{{.Store.GraphDriverName}}"],
+    )
+    .await
+    .context("checking storage driver")?;
+    let driver = driver.trim();
+    println!("  GraphDriverName: {}", driver);
+    assert_eq!(
+        driver, "btrfs",
+        "Expected btrfs storage driver, got: {}",
+        driver
+    );
+
+    // Step 6: Verify container ran
+    println!("\n6. Checking container execution...");
+    let ps_output = common::exec_in_vm(fcvm_pid, &["podman", "ps", "-a", "--format", "{{.Names}}"])
+        .await
+        .context("checking container status")?;
+    println!("  Container names: {}", ps_output.trim());
+    assert!(
+        ps_output.contains("fcvm-container"),
+        "Container should have run: {}",
+        ps_output
+    );
+
+    // Cleanup
+    println!("\n7. Cleaning up...");
+    common::kill_process(fcvm_pid).await;
+
+    println!("\n  NATIVE BTRFS ROOTFS TEST PASSED");
+    println!("  - Root filesystem is btrfs (no ext4)");
+    println!("  - No loopback file created");
+    println!("  - btrfs storage driver auto-configured");
+    println!("  - Container ran successfully");
+
+    Ok(())
+}
+
+/// Native btrfs rootfs with --user (keep-id).
+///
+/// Verifies that user namespace mapping works on native btrfs root.
+#[tokio::test]
+async fn test_btrfs_rootfs_keepid() -> Result<()> {
+    println!("\nNative Btrfs Rootfs + Keep-ID Test");
+    println!("===================================");
+
+    // Step 1: Start VM with btrfs rootfs and user mapping
+    println!("\n1. Starting VM (rootless, --kernel-profile btrfs --rootfs-type btrfs --user 1000:1000)...");
+    let (vm_name, _, _, _) = common::unique_names("btrfs-rootfs-kid");
+
+    let (mut _child, fcvm_pid) = common::spawn_fcvm(&[
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--kernel-profile",
+        "btrfs",
+        "--rootfs-type",
+        "btrfs",
+        "--user",
+        "1000:1000",
+        "alpine:latest",
+        "sleep",
+        "3600",
+    ])
+    .await
+    .context("spawning fcvm")?;
+    println!("  fcvm PID: {}", fcvm_pid);
+
+    // Step 2: Wait for healthy
+    println!("\n2. Waiting for VM to become healthy...");
+    common::poll_health_by_pid(fcvm_pid, 300)
+        .await
+        .context("VM failed to become healthy")?;
+    println!("  VM is healthy");
+
+    // Step 3: Verify root is btrfs
+    println!("\n3. Checking root filesystem type...");
+    let root_fstype =
+        common::exec_in_vm(fcvm_pid, &["findmnt", "-n", "-o", "FSTYPE", "/"])
+            .await
+            .context("checking root fstype")?;
+    let root_fstype = root_fstype.trim();
+    println!("  / fstype: {}", root_fstype);
+    assert_eq!(root_fstype, "btrfs", "Root should be btrfs");
+
+    // Step 4: Verify container runs as UID 1000
+    println!("\n4. Checking container UID...");
+    let uid = common::exec_in_container(fcvm_pid, &["id", "-u"])
+        .await
+        .context("checking uid in container")?;
+    let uid = uid.trim();
+    println!("  Container UID: {}", uid);
+    assert_eq!(uid, "1000", "Container should run as UID 1000, got: {}", uid);
+
+    // Cleanup
+    println!("\n5. Cleaning up...");
+    common::kill_process(fcvm_pid).await;
+
+    println!("\n  BTRFS ROOTFS + KEEP-ID TEST PASSED");
+    println!("  - Root filesystem is btrfs");
+    println!("  - Container runs as UID 1000");
+
+    Ok(())
+}
+
+/// Explicit ext4 rootfs with btrfs kernel — uses loopback (contrast test).
+///
+/// Verifies the existing behavior: even with btrfs kernel, when rootfs_type is
+/// explicitly ext4, fc-agent creates a btrfs loopback for container storage.
+#[tokio::test]
+async fn test_btrfs_rootfs_ext4_loopback() -> Result<()> {
+    println!("\nExt4 Rootfs + Btrfs Loopback Test (contrast)");
+    println!("=============================================");
+
+    // Step 1: Start VM with btrfs kernel but ext4 rootfs
+    println!("\n1. Starting VM (rootless, --kernel-profile btrfs --rootfs-type ext4)...");
+    let (vm_name, _, _, _) = common::unique_names("btrfs-rootfs-ext4");
+
+    let (mut _child, fcvm_pid) = common::spawn_fcvm(&[
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--kernel-profile",
+        "btrfs",
+        "--rootfs-type",
+        "ext4",
+        "nginx:alpine",
+    ])
+    .await
+    .context("spawning fcvm")?;
+    println!("  fcvm PID: {}", fcvm_pid);
+
+    // Step 2: Wait for healthy
+    println!("\n2. Waiting for VM to become healthy...");
+    common::poll_health_by_pid(fcvm_pid, 300)
+        .await
+        .context("VM failed to become healthy")?;
+    println!("  VM is healthy");
+
+    // Step 3: Verify root filesystem is ext4
+    println!("\n3. Checking root filesystem type...");
+    let root_fstype =
+        common::exec_in_vm(fcvm_pid, &["findmnt", "-n", "-o", "FSTYPE", "/"])
+            .await
+            .context("checking root fstype")?;
+    let root_fstype = root_fstype.trim();
+    println!("  / fstype: {}", root_fstype);
+    assert_eq!(
+        root_fstype, "ext4",
+        "Root filesystem should be ext4, got: {}",
+        root_fstype
+    );
+
+    // Step 4: Verify btrfs loopback exists
+    println!("\n4. Checking btrfs loopback file...");
+    let loopback_check = common::exec_in_vm(
+        fcvm_pid,
+        &["test", "-f", "/var/lib/containers/btrfs.img", "&&", "echo", "exists", "||", "echo", "absent"],
+    )
+    .await
+    .context("checking loopback file")?;
+    let loopback_check = loopback_check.trim();
+    println!("  btrfs.img: {}", loopback_check);
+    assert_eq!(
+        loopback_check, "exists",
+        "Loopback file should exist on ext4 root, got: {}",
+        loopback_check
+    );
+
+    // Step 5: Verify btrfs storage at storage dir (via loopback mount)
+    println!("\n5. Checking btrfs mount at storage dir...");
+    let storage_fstype = common::exec_in_vm(
+        fcvm_pid,
+        &[
+            "findmnt",
+            "-n",
+            "-o",
+            "FSTYPE",
+            "/var/lib/containers/storage",
+        ],
+    )
+    .await
+    .context("checking storage fstype")?;
+    let storage_fstype = storage_fstype.trim();
+    println!("  /var/lib/containers/storage fstype: {}", storage_fstype);
+    assert_eq!(
+        storage_fstype, "btrfs",
+        "Storage should be btrfs via loopback, got: {}",
+        storage_fstype
+    );
+
+    // Step 6: Verify btrfs storage driver
+    println!("\n6. Checking podman storage driver...");
+    let driver = common::exec_in_vm(
+        fcvm_pid,
+        &["podman", "info", "--format", "{{.Store.GraphDriverName}}"],
+    )
+    .await
+    .context("checking storage driver")?;
+    let driver = driver.trim();
+    println!("  GraphDriverName: {}", driver);
+    assert_eq!(driver, "btrfs", "Expected btrfs driver, got: {}", driver);
+
+    // Step 7: Verify container ran
+    println!("\n7. Checking container execution...");
+    let ps_output = common::exec_in_vm(fcvm_pid, &["podman", "ps", "-a", "--format", "{{.Names}}"])
+        .await
+        .context("checking container status")?;
+    println!("  Container names: {}", ps_output.trim());
+    assert!(
+        ps_output.contains("fcvm-container"),
+        "Container should have run: {}",
+        ps_output
+    );
+
+    // Cleanup
+    println!("\n8. Cleaning up...");
+    common::kill_process(fcvm_pid).await;
+
+    println!("\n  EXT4 + BTRFS LOOPBACK TEST PASSED");
+    println!("  - Root filesystem is ext4");
+    println!("  - btrfs loopback created at /var/lib/containers/btrfs.img");
+    println!("  - Storage mounted as btrfs via loopback");
+    println!("  - Container ran successfully");
+
+    Ok(())
+}

--- a/tests/test_library_api.rs
+++ b/tests/test_library_api.rs
@@ -46,6 +46,7 @@ fn test_run_args(name: &str) -> RunArgs {
         hugepages: false,
         portable_volumes: false,
         image_mode: None,
+        rootfs_type: None,
         label: vec![],
         image: common::TEST_IMAGE.to_string(),
         command_args: vec![],

--- a/tests/test_localhost_rootless.rs
+++ b/tests/test_localhost_rootless.rs
@@ -70,7 +70,10 @@ async fn test_localhost_rootless_btrfs_storage_ext4() -> Result<()> {
 /// Verifies btrfs storage driver is active and container runs successfully.
 async fn run_btrfs_storage_test(rootfs_type: Option<&str>) -> Result<()> {
     let label = rootfs_type.unwrap_or("default (btrfs from profile)");
-    println!("\nRootless Localhost + Btrfs Storage Test (rootfs: {})", label);
+    println!(
+        "\nRootless Localhost + Btrfs Storage Test (rootfs: {})",
+        label
+    );
     println!("===================================================");
 
     // Step 1: Build test image
@@ -78,7 +81,10 @@ async fn run_btrfs_storage_test(rootfs_type: Option<&str>) -> Result<()> {
     build_test_image().await?;
 
     // Step 2: Start VM in rootless mode with btrfs kernel
-    println!("\n2. Starting VM (rootless, --kernel-profile btrfs, rootfs: {})...", label);
+    println!(
+        "\n2. Starting VM (rootless, --kernel-profile btrfs, rootfs: {})...",
+        label
+    );
     let suffix = format!("btrfs-{}", rootfs_type.unwrap_or("native"));
     let (vm_name, _, _, _) = common::unique_names(&suffix);
 
@@ -96,9 +102,7 @@ async fn run_btrfs_storage_test(rootfs_type: Option<&str>) -> Result<()> {
     }
     args.push("localhost/test-btrfs-rootless");
 
-    let (mut _child, fcvm_pid) = common::spawn_fcvm(&args)
-        .await
-        .context("spawning fcvm")?;
+    let (mut _child, fcvm_pid) = common::spawn_fcvm(&args).await.context("spawning fcvm")?;
     println!("  fcvm PID: {}", fcvm_pid);
 
     // Step 3: Wait for healthy
@@ -165,7 +169,10 @@ async fn run_btrfs_storage_test(rootfs_type: Option<&str>) -> Result<()> {
     println!("\n7. Cleaning up...");
     common::kill_process(fcvm_pid).await;
 
-    println!("\n  ROOTLESS + BTRFS STORAGE TEST PASSED (rootfs: {})", label);
+    println!(
+        "\n  ROOTLESS + BTRFS STORAGE TEST PASSED (rootfs: {})",
+        label
+    );
     println!("  - localhost image built and loaded in rootless mode");
     println!("  - btrfs storage driver auto-detected and configured");
     println!("  - Container ran successfully on btrfs storage");
@@ -382,7 +389,10 @@ async fn test_localhost_rootless_btrfs_keepid_ext4() -> Result<()> {
 /// With btrfs, user namespaces work natively — no chown fallback needed.
 async fn run_btrfs_keepid_test(rootfs_type: Option<&str>) -> Result<()> {
     let label = rootfs_type.unwrap_or("default (btrfs from profile)");
-    println!("\nRootless Localhost + Btrfs + keep-id Test (rootfs: {})", label);
+    println!(
+        "\nRootless Localhost + Btrfs + keep-id Test (rootfs: {})",
+        label
+    );
     println!("=========================================================");
 
     // Step 1: Build test image (same image, snapshot key includes --user)
@@ -390,7 +400,10 @@ async fn run_btrfs_keepid_test(rootfs_type: Option<&str>) -> Result<()> {
     build_test_image().await?;
 
     // Step 2: Start VM with --user 1000:1000 (triggers keep-id in fc-agent)
-    println!("\n2. Starting VM (rootless, --kernel-profile btrfs, --user 1000:1000, rootfs: {})...", label);
+    println!(
+        "\n2. Starting VM (rootless, --kernel-profile btrfs, --user 1000:1000, rootfs: {})...",
+        label
+    );
     let suffix = format!("btrfs-kid-{}", rootfs_type.unwrap_or("native"));
     let (vm_name, _, _, _) = common::unique_names(&suffix);
 
@@ -408,9 +421,7 @@ async fn run_btrfs_keepid_test(rootfs_type: Option<&str>) -> Result<()> {
     }
     args.extend_from_slice(&["--user", "1000:1000", "localhost/test-btrfs-rootless"]);
 
-    let (mut _child, fcvm_pid) = common::spawn_fcvm(&args)
-        .await
-        .context("spawning fcvm")?;
+    let (mut _child, fcvm_pid) = common::spawn_fcvm(&args).await.context("spawning fcvm")?;
     println!("  fcvm PID: {}", fcvm_pid);
 
     // Step 3: Wait for VM health and resolve the VM username for UID 1000.
@@ -564,7 +575,10 @@ async fn run_btrfs_keepid_test(rootfs_type: Option<&str>) -> Result<()> {
     println!("\n9. Cleaning up...");
     common::kill_process(fcvm_pid).await;
 
-    println!("\n  ROOTLESS + BTRFS + KEEP-ID TEST PASSED (rootfs: {})", label);
+    println!(
+        "\n  ROOTLESS + BTRFS + KEEP-ID TEST PASSED (rootfs: {})",
+        label
+    );
     println!("  - localhost image with --user 1000:1000 (keep-id mode)");
     println!("  - btrfs storage driver avoids storage-chown-by-maps fallback");
     println!("  - Container ran successfully with user namespace mapping");

--- a/tests/test_localhost_rootless.rs
+++ b/tests/test_localhost_rootless.rs
@@ -52,35 +52,53 @@ CMD ["sh", "-c", "echo 'btrfs-rootless-test-ok' && sleep 600"]"#
     Ok(())
 }
 
-/// Test rootless localhost container with btrfs kernel profile
-///
-/// Uses --kernel-profile btrfs to get a kernel with CONFIG_BTRFS_FS=y.
-/// fc-agent detects btrfs support at runtime and auto-configures podman
-/// to use the btrfs storage driver via a loopback filesystem.
+/// Test rootless btrfs storage with native btrfs rootfs (profile default).
 #[tokio::test]
 async fn test_localhost_rootless_btrfs_storage() -> Result<()> {
-    println!("\nRootless Localhost + Btrfs Storage Test");
-    println!("=======================================");
+    run_btrfs_storage_test(None).await
+}
+
+/// Test rootless btrfs storage with ext4 rootfs + loopback.
+#[tokio::test]
+async fn test_localhost_rootless_btrfs_storage_ext4() -> Result<()> {
+    run_btrfs_storage_test(Some("ext4")).await
+}
+
+/// Shared btrfs storage test — works with any rootfs type.
+///
+/// Uses --kernel-profile btrfs to get a kernel with CONFIG_BTRFS_FS=y.
+/// Verifies btrfs storage driver is active and container runs successfully.
+async fn run_btrfs_storage_test(rootfs_type: Option<&str>) -> Result<()> {
+    let label = rootfs_type.unwrap_or("default (btrfs from profile)");
+    println!("\nRootless Localhost + Btrfs Storage Test (rootfs: {})", label);
+    println!("===================================================");
 
     // Step 1: Build test image
     println!("\n1. Building test container image...");
     build_test_image().await?;
 
     // Step 2: Start VM in rootless mode with btrfs kernel
-    println!("\n2. Starting VM (rootless, --kernel-profile btrfs)...");
-    let (vm_name, _, _, _) = common::unique_names("btrfs-rootless");
+    println!("\n2. Starting VM (rootless, --kernel-profile btrfs, rootfs: {})...", label);
+    let suffix = format!("btrfs-{}", rootfs_type.unwrap_or("native"));
+    let (vm_name, _, _, _) = common::unique_names(&suffix);
 
-    let (mut _child, fcvm_pid) = common::spawn_fcvm(&[
+    let mut args = vec![
         "podman",
         "run",
         "--name",
         &vm_name,
         "--kernel-profile",
         "btrfs",
-        "localhost/test-btrfs-rootless",
-    ])
-    .await
-    .context("spawning fcvm")?;
+    ];
+    if let Some(rt) = rootfs_type {
+        args.push("--rootfs-type");
+        args.push(rt);
+    }
+    args.push("localhost/test-btrfs-rootless");
+
+    let (mut _child, fcvm_pid) = common::spawn_fcvm(&args)
+        .await
+        .context("spawning fcvm")?;
     println!("  fcvm PID: {}", fcvm_pid);
 
     // Step 3: Wait for healthy
@@ -106,8 +124,10 @@ async fn test_localhost_rootless_btrfs_storage() -> Result<()> {
         driver
     );
 
-    // Step 5: Verify btrfs mount
-    println!("\n5. Checking btrfs mount...");
+    // Step 5: Verify btrfs at storage path (works with both native btrfs root and loopback)
+    // Use -T (target) flag so findmnt finds the mount containing the path,
+    // not just exact mount points. On native btrfs, storage is under / (no separate mount).
+    println!("\n5. Checking btrfs at storage path...");
     let fstype = common::exec_in_vm(
         fcvm_pid,
         &[
@@ -115,11 +135,12 @@ async fn test_localhost_rootless_btrfs_storage() -> Result<()> {
             "-n",
             "-o",
             "FSTYPE",
+            "--target",
             "/var/lib/containers/storage",
         ],
     )
     .await
-    .context("checking btrfs mount")?;
+    .context("checking btrfs at storage path")?;
     let fstype = fstype.trim();
     println!("  /var/lib/containers/storage fstype: {}", fstype);
     assert_eq!(
@@ -144,7 +165,7 @@ async fn test_localhost_rootless_btrfs_storage() -> Result<()> {
     println!("\n7. Cleaning up...");
     common::kill_process(fcvm_pid).await;
 
-    println!("\n  ROOTLESS + BTRFS STORAGE TEST PASSED");
+    println!("\n  ROOTLESS + BTRFS STORAGE TEST PASSED (rootfs: {})", label);
     println!("  - localhost image built and loaded in rootless mode");
     println!("  - btrfs storage driver auto-detected and configured");
     println!("  - Container ran successfully on btrfs storage");
@@ -343,51 +364,56 @@ async fn test_localhost_rootless_btrfs_snapshot_restore() -> Result<()> {
     Ok(())
 }
 
-/// Test rootless localhost container with --user (keep-id) and btrfs storage
-///
-/// This is the critical path that triggered the original issue:
-/// - --user 1000:1000 causes fc-agent to run podman with --userns=keep-id
-/// - With overlay, checkAndRecordIDMappedSupport() returns false for rootless
-/// - This forces storage-chown-by-maps (expensive chown-copy of every layer)
-/// - With btrfs, user namespaces work natively — no chown fallback needed
-///
-/// Note: --user causes fc-agent to run podman as fcvm-user (rootless).
-/// Root's `podman inspect` can't see rootless containers, so the standard
-/// health monitor can't detect container health. We poll btrfs readiness
-/// and use `runuser -u fcvm-user` for podman queries.
-///
-/// VM-side btrfs loading: no host-side rootless podman needed, so this runs everywhere.
+/// Test rootless btrfs + keep-id with native btrfs rootfs (profile default).
 #[tokio::test]
 async fn test_localhost_rootless_btrfs_keepid() -> Result<()> {
-    println!("\nRootless Localhost + Btrfs + keep-id Test");
-    println!("==========================================");
+    run_btrfs_keepid_test(None).await
+}
+
+/// Test rootless btrfs + keep-id with ext4 rootfs + loopback.
+#[tokio::test]
+async fn test_localhost_rootless_btrfs_keepid_ext4() -> Result<()> {
+    run_btrfs_keepid_test(Some("ext4")).await
+}
+
+/// Shared btrfs keep-id test — works with any rootfs type.
+///
+/// Tests --user 1000:1000 (keep-id) with btrfs storage.
+/// With btrfs, user namespaces work natively — no chown fallback needed.
+async fn run_btrfs_keepid_test(rootfs_type: Option<&str>) -> Result<()> {
+    let label = rootfs_type.unwrap_or("default (btrfs from profile)");
+    println!("\nRootless Localhost + Btrfs + keep-id Test (rootfs: {})", label);
+    println!("=========================================================");
 
     // Step 1: Build test image (same image, snapshot key includes --user)
     println!("\n1. Building test container image...");
     build_test_image().await?;
 
     // Step 2: Start VM with --user 1000:1000 (triggers keep-id in fc-agent)
-    println!("\n2. Starting VM (rootless, --kernel-profile btrfs, --user 1000:1000)...");
-    let (vm_name, _, _, _) = common::unique_names("btrfs-keepid");
+    println!("\n2. Starting VM (rootless, --kernel-profile btrfs, --user 1000:1000, rootfs: {})...", label);
+    let suffix = format!("btrfs-kid-{}", rootfs_type.unwrap_or("native"));
+    let (vm_name, _, _, _) = common::unique_names(&suffix);
 
-    let (mut _child, fcvm_pid) = common::spawn_fcvm(&[
+    let mut args = vec![
         "podman",
         "run",
         "--name",
         &vm_name,
         "--kernel-profile",
         "btrfs",
-        "--user",
-        "1000:1000",
-        "localhost/test-btrfs-rootless",
-    ])
-    .await
-    .context("spawning fcvm")?;
+    ];
+    if let Some(rt) = rootfs_type {
+        args.push("--rootfs-type");
+        args.push(rt);
+    }
+    args.extend_from_slice(&["--user", "1000:1000", "localhost/test-btrfs-rootless"]);
+
+    let (mut _child, fcvm_pid) = common::spawn_fcvm(&args)
+        .await
+        .context("spawning fcvm")?;
     println!("  fcvm PID: {}", fcvm_pid);
 
     // Step 3: Wait for VM health and resolve the VM username for UID 1000.
-    // The host resolves UID 1000 via /etc/passwd (e.g., "ubuntu") and passes it as
-    // USER env var. The guest creates a user with that name, not "fcvm-user".
     println!("\n3. Waiting for VM to become healthy...");
     common::poll_health_by_pid(fcvm_pid, 120).await?;
     println!("  VM is healthy");
@@ -460,10 +486,8 @@ async fn test_localhost_rootless_btrfs_keepid() -> Result<()> {
         driver
     );
 
-    // Step 6: Verify btrfs mount at root graphroot (loopback).
-    // With VM-side btrfs loading, the loopback btrfs is mounted at
-    // /var/lib/containers/storage. The user's graphroot is a subdirectory there.
-    println!("\n6. Checking btrfs mount...");
+    // Step 6: Verify btrfs at storage path (works with both native btrfs root and loopback)
+    println!("\n6. Checking btrfs at storage path...");
     let fstype = common::exec_in_vm(
         fcvm_pid,
         &[
@@ -471,11 +495,12 @@ async fn test_localhost_rootless_btrfs_keepid() -> Result<()> {
             "-n",
             "-o",
             "FSTYPE",
+            "--target",
             "/var/lib/containers/storage",
         ],
     )
     .await
-    .context("checking btrfs mount")?;
+    .context("checking btrfs at storage path")?;
     let fstype = fstype.trim();
     println!("  /var/lib/containers/storage fstype: {}", fstype);
     assert_eq!(
@@ -539,7 +564,7 @@ async fn test_localhost_rootless_btrfs_keepid() -> Result<()> {
     println!("\n9. Cleaning up...");
     common::kill_process(fcvm_pid).await;
 
-    println!("\n  ROOTLESS + BTRFS + KEEP-ID TEST PASSED");
+    println!("\n  ROOTLESS + BTRFS + KEEP-ID TEST PASSED (rootfs: {})", label);
     println!("  - localhost image with --user 1000:1000 (keep-id mode)");
     println!("  - btrfs storage driver avoids storage-chown-by-maps fallback");
     println!("  - Container ran successfully with user namespace mapping");


### PR DESCRIPTION
## Summary

Add native btrfs root filesystem option (`--rootfs-type btrfs`) as alternative to the default ext4 rootfs with btrfs loopback.

- **Config-driven**: `rootfs_type = "btrfs"` in kernel profile auto-selects btrfs rootfs
- **CLI override**: Hidden `--rootfs-type` flag for testing both modes
- **btrfs-convert**: Converts ext4→btrfs in-place during rootfs creation (~2 seconds)
- **fc-agent**: Detects native btrfs root, resizes to fill disk, skips loopback creation
- **Disk sizing**: `ensure_free_space()` auto-detects fs type (btrfs uses `dump-super`, ext4 uses `dumpe2fs`)
- **Cache separation**: Different rootfs types use different cache keys (`layer2-{sha}-btrfs.raw`)

### Two modes (both work with `--kernel-profile btrfs`)

| Mode | Trigger | Root FS | Container storage | Loopback? |
|------|---------|---------|-------------------|-----------|
| ext4+loopback (default) | no `rootfs_type` in profile | ext4 | btrfs via loopback | Yes |
| native btrfs | `rootfs_type = "btrfs"` in profile | btrfs | btrfs on root | No |

### Files changed

| File | Change |
|------|--------|
| `rootfs-config.toml` | Add `rootfs_type = "btrfs"` to btrfs kernel profiles |
| `src/setup/rootfs.rs` | `KernelProfile.rootfs_type`, `convert_to_btrfs()`, `resolve_rootfs_type()`, fstab fix in init script, remove debugfs verification |
| `src/storage/disk.rs` | `detect_filesystem_type()`, `ensure_free_space_btrfs()` |
| `src/firecracker/config.rs` | `rootfs_type` in cache key |
| `src/commands/podman/mod.rs` | Resolve rootfs_type from profile, pass through |
| `src/commands/setup.rs` | Resolve rootfs_type, pass to `ensure_rootfs()`. Profile kernel built BEFORE rootfs (btrfs needs btrfs kernel for setup VM) |
| `src/cli/args.rs` | Hidden `--rootfs-type` CLI flag |
| `fc-agent/src/container.rs` | Detect btrfs root, resize to fill disk, skip loopback |
| `Containerfile.nested` | Add `btrfs-progs` for btrfs-convert in CI |
| `DESIGN.md` | Document `rootfs_type` kernel profile field |
| `tests/test_btrfs_rootfs.rs` | 3 tests: native btrfs, keepid, ext4 contrast |

## Test plan

- [ ] `make test-root FILTER=btrfs_rootfs` — 3 new tests (native btrfs, keepid, ext4 contrast)
- [ ] `make test-root FILTER=sanity` — existing sanity tests still pass
- [ ] `make test-root FILTER=btrfs_storage` — existing ext4+loopback tests still pass
- [ ] CI: all 8 jobs pass (host + container, arm64 + x86)