### PR TITLE
Unify default kernel into kernel profiles

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1679,11 +1679,17 @@ The fuse-pipe library passes the pjdfstest POSIX compliance suite. Tests run via
 
 ## Kernel Profiles
 
-fcvm supports named kernel profiles for custom kernel configurations, defined in `rootfs-config.toml`.
+Every kernel in fcvm is delivered through a profile. The `[kernel]` config section is synthesized into a `"default"` profile at load time, so all code paths use profiles uniformly. Named profiles (e.g., `nested`, `btrfs`) can build custom kernels from source or download from GitHub releases.
+
+A profile delivers a kernel in one of three ways:
+1. **URL-based** (default profile): Downloads a pre-built kernel archive (e.g., Kata release)
+2. **Custom build**: Builds from source using `kernel_version`/`kernel_repo`
+3. **Inherited**: Uses the default profile's kernel, adding only runtime overrides (boot_args, firecracker_args, etc.)
 
 ### Configuration Reference
 
 ```toml
+# Custom kernel profile (build from source)
 [kernel_profiles.minimal.amd64]
 description = "Minimal kernel for fast boot"
 kernel_version = "6.12"
@@ -1698,10 +1704,14 @@ patches_dir = "kernel/patches"
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `kernel_version` | Yes | Kernel version (e.g., "6.18.3") |
-| `kernel_repo` | Yes | GitHub repo for releases |
-| `build_inputs` | Yes | Files to hash for kernel SHA (supports globs) |
-| `kernel_config` | No | Kernel .config file path |
+| `kernel_url` | URL-based | URL to kernel archive (e.g., Kata release tarball) |
+| `kernel_archive_path` | URL-based | Path within the archive to extract the kernel binary |
+| `kernel_local_path` | No | Local filesystem path to kernel binary (overrides URL) |
+| `kernel_version` | Custom | Kernel version (e.g., "6.18.3") |
+| `kernel_repo` | Custom | GitHub repo for releases |
+| `build_inputs` | Custom | Files to hash for kernel SHA (supports globs) |
+| `base_config_url` | Custom | Base kernel .config URL (e.g., Firecracker's microvm config) |
+| `kernel_config` | No | Kernel config fragment file path (applied on top of base) |
 | `patches_dir` | No | Directory containing kernel patches |
 | `firecracker_bin` | No | Custom Firecracker binary path |
 | `firecracker_args` | No | Extra Firecracker CLI args |

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -40,7 +40,10 @@ use tokio_util::sync::CancellationToken;
 ///
 /// Priority: explicit `--rootfs-type` CLI flag > kernel profile config > None (ext4).
 fn resolve_rootfs_type(args: &RunArgs) -> Option<String> {
-    crate::setup::resolve_rootfs_type(args.rootfs_type.as_ref(), args.kernel_profile.as_deref())
+    crate::setup::resolve_rootfs_type(
+        args.rootfs_type.as_ref(),
+        args.kernel_profile.as_deref().unwrap_or("default"),
+    )
 }
 
 /// Resolve the image delivery mode from CLI args and kernel profile.
@@ -208,7 +211,8 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
     }
 
     // Get kernel path
-    // Priority: --kernel (explicit) > --kernel-profile (computed) > default
+    // Priority: --kernel (explicit) > profile (named or "default")
+    let kernel_profile_name = args.kernel_profile.as_deref().unwrap_or("default");
     let kernel_path = if let Some(custom_kernel) = &args.kernel {
         // Explicit kernel path - use directly
         let path = PathBuf::from(custom_kernel);
@@ -217,21 +221,9 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
         }
         info!(kernel = %path.display(), "using custom kernel");
         path
-    } else if let Some(ref profile_name) = args.kernel_profile {
-        // Compute kernel path from profile
-        let kernel = crate::setup::get_kernel_path(Some(profile_name))?;
-        if !kernel.exists() {
-            bail!(
-                "Profile '{}' kernel not found at {}.\nRun: fcvm setup --kernel-profile {}",
-                profile_name,
-                kernel.display(),
-                profile_name
-            );
-        }
-        kernel
     } else {
-        // Default kernel (downloads if --setup is set)
-        crate::setup::ensure_kernel(None, args.setup, false)
+        // Profile kernel (named or "default")
+        crate::setup::ensure_kernel(kernel_profile_name, args.setup, false)
             .await
             .context("setting up kernel")?
     };

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -40,7 +40,7 @@ pub async fn cmd_setup(args: SetupArgs) -> Result<()> {
 
         // Build the profile kernel
         let profile_kernel_path =
-            crate::setup::ensure_kernel(Some(profile_name), true, args.build_kernels)
+            crate::setup::ensure_kernel(profile_name, true, args.build_kernels)
                 .await
                 .context("building profile kernel")?;
         println!("  ✓ Kernel built: {}", profile_kernel_path.display());
@@ -65,7 +65,7 @@ pub async fn cmd_setup(args: SetupArgs) -> Result<()> {
     println!("Setting up fcvm (this may take 5-10 minutes on first run)...");
 
     // Ensure default kernel exists (downloads from [kernel] section if missing)
-    let kernel_path = crate::setup::ensure_kernel(None, true, false)
+    let kernel_path = crate::setup::ensure_kernel("default", true, false)
         .await
         .context("setting up kernel")?;
     println!("  ✓ Kernel ready: {}", kernel_path.display());
@@ -84,7 +84,7 @@ pub async fn cmd_setup(args: SetupArgs) -> Result<()> {
 
         // Download or build the profile kernel
         let profile_kernel_path =
-            crate::setup::ensure_kernel(Some(profile_name), true, args.build_kernels)
+            crate::setup::ensure_kernel(profile_name, true, args.build_kernels)
                 .await
                 .context("setting up profile kernel")?;
         println!(
@@ -101,7 +101,7 @@ pub async fn cmd_setup(args: SetupArgs) -> Result<()> {
     // Resolve rootfs type: CLI override > kernel profile config > default (ext4)
     let rootfs_type = crate::setup::resolve_rootfs_type(
         args.rootfs_type.as_ref(),
-        args.kernel_profile.as_deref(),
+        args.kernel_profile.as_deref().unwrap_or("default"),
     );
 
     // Ensure rootfs exists (creates Layer 2 if missing)

--- a/src/setup/kernel.rs
+++ b/src/setup/kernel.rs
@@ -46,6 +46,12 @@ pub async fn ensure_kernel(
 
     if profile.inherits_kernel() {
         // Runtime-only profile — uses default kernel
+        if profile_name == "default" {
+            bail!(
+                "'default' kernel profile must define kernel_url or \
+                 kernel_version/kernel_repo — cannot inherit from itself"
+            );
+        }
         debug!(profile = %profile_name, "profile inherits kernel from default");
         return Box::pin(ensure_kernel("default", allow_create, allow_build)).await;
     }
@@ -66,6 +72,12 @@ pub fn get_kernel_path(profile_name: &str) -> Result<PathBuf> {
         .ok_or_else(|| anyhow::anyhow!("kernel profile '{}' not found in config", profile_name))?;
 
     if profile.inherits_kernel() {
+        if profile_name == "default" {
+            bail!(
+                "'default' kernel profile must define kernel_url or \
+                 kernel_version/kernel_repo — cannot inherit from itself"
+            );
+        }
         return get_kernel_path("default");
     }
 
@@ -80,11 +92,16 @@ pub fn get_kernel_path(profile_name: &str) -> Result<PathBuf> {
 /// For URL-based profiles, this is the URL hash.
 /// Used to include in Layer 2 SHA calculation.
 pub fn get_kernel_url_hash(profile_name: &str) -> Result<String> {
-    let profile = get_kernel_profile(profile_name)?.ok_or_else(|| {
-        anyhow::anyhow!("kernel profile '{}' not found in config", profile_name)
-    })?;
+    let profile = get_kernel_profile(profile_name)?
+        .ok_or_else(|| anyhow::anyhow!("kernel profile '{}' not found in config", profile_name))?;
 
     if profile.inherits_kernel() {
+        if profile_name == "default" {
+            bail!(
+                "'default' kernel profile must define kernel_url or \
+                 kernel_version/kernel_repo — cannot inherit from itself"
+            );
+        }
         return get_kernel_url_hash("default");
     }
 
@@ -119,10 +136,9 @@ async fn ensure_url_kernel(profile: &KernelProfile, allow_create: bool) -> Resul
         return Ok(path);
     }
 
-    let url = profile
-        .kernel_url
-        .as_ref()
-        .ok_or_else(|| anyhow::anyhow!("kernel profile must specify kernel_url or kernel_local_path"))?;
+    let url = profile.kernel_url.as_ref().ok_or_else(|| {
+        anyhow::anyhow!("kernel profile must specify kernel_url or kernel_local_path")
+    })?;
     let archive_path = profile
         .kernel_archive_path
         .as_ref()

--- a/src/setup/kernel.rs
+++ b/src/setup/kernel.rs
@@ -8,7 +8,7 @@ use tokio::process::Command;
 use tracing::{debug, info, warn};
 
 use crate::paths;
-use crate::setup::rootfs::{get_kernel_profile, load_plan, KernelProfile};
+use crate::setup::rootfs::{get_kernel_profile, KernelProfile};
 use crate::utils::run_streaming;
 
 /// Compute SHA256 of bytes, return hex string (first 12 chars)
@@ -25,19 +25,35 @@ fn compute_sha256_short(data: &[u8]) -> String {
 
 /// Ensure kernel exists, downloading or building if needed.
 ///
-/// - If `profile` is None: uses default kernel from [kernel] section
-/// - If `profile` is Some("name"): uses [kernel_profiles.name] section
+/// Every kernel is a profile: "default" is the Kata kernel (URL-based),
+/// named profiles (nested, btrfs) build from source.
 ///
 /// If `allow_create` is false, bails if kernel doesn't exist.
 /// If `allow_build` is true, falls back to local build for custom profiles.
 pub async fn ensure_kernel(
-    profile: Option<&str>,
+    profile_name: &str,
     allow_create: bool,
     allow_build: bool,
 ) -> Result<PathBuf> {
-    match profile {
-        None => ensure_default_kernel(allow_create).await,
-        Some(name) => ensure_profile_kernel(name, allow_create, allow_build).await,
+    let profile = get_kernel_profile(profile_name)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "kernel profile '{}' not found in config. \
+             Add [kernel_profiles.{}] section to rootfs-config.toml",
+            profile_name,
+            profile_name
+        )
+    })?;
+
+    if profile.inherits_kernel() {
+        // Runtime-only profile — uses default kernel
+        debug!(profile = %profile_name, "profile inherits kernel from default");
+        return Box::pin(ensure_kernel("default", allow_create, allow_build)).await;
+    }
+
+    if profile.is_url_based() {
+        ensure_url_kernel(&profile, allow_create).await
+    } else {
+        ensure_custom_kernel(&profile, profile_name, allow_create, allow_build).await
     }
 }
 
@@ -45,38 +61,56 @@ pub async fn ensure_kernel(
 ///
 /// Returns the path where the kernel should exist.
 /// Used to check existence before running VM.
-pub fn get_kernel_path(profile: Option<&str>) -> Result<PathBuf> {
-    match profile {
-        None => get_default_kernel_path(),
-        Some(name) => get_profile_kernel_path(name),
+pub fn get_kernel_path(profile_name: &str) -> Result<PathBuf> {
+    let profile = get_kernel_profile(profile_name)?
+        .ok_or_else(|| anyhow::anyhow!("kernel profile '{}' not found in config", profile_name))?;
+
+    if profile.inherits_kernel() {
+        return get_kernel_path("default");
+    }
+
+    if profile.is_url_based() {
+        get_url_kernel_path(&profile)
+    } else {
+        get_custom_kernel_path(&profile, profile_name)
     }
 }
 
-/// Get the kernel URL hash for the default kernel.
-/// This is used to include in Layer 2 SHA calculation.
-pub fn get_kernel_url_hash() -> Result<String> {
-    let (plan, _, _) = load_plan()?;
-    let kernel_config = plan.kernel.current_arch()?;
-    Ok(compute_sha256_short(kernel_config.url.as_bytes()))
+/// Get the kernel identity hash for a profile.
+/// For URL-based profiles, this is the URL hash.
+/// Used to include in Layer 2 SHA calculation.
+pub fn get_kernel_url_hash(profile_name: &str) -> Result<String> {
+    let profile = get_kernel_profile(profile_name)?.ok_or_else(|| {
+        anyhow::anyhow!("kernel profile '{}' not found in config", profile_name)
+    })?;
+
+    if profile.inherits_kernel() {
+        return get_kernel_url_hash("default");
+    }
+
+    if let Some(ref url) = profile.kernel_url {
+        Ok(compute_sha256_short(url.as_bytes()))
+    } else {
+        Ok(compute_profile_kernel_sha(&profile))
+    }
 }
 
 // ============================================================================
-// Default Kernel (from [kernel] section)
+// URL-Based Kernel (default profile — Kata releases)
 // ============================================================================
 
-fn get_default_kernel_path() -> Result<PathBuf> {
-    let (plan, _, _) = load_plan()?;
-    let kernel_config = plan.kernel.current_arch()?;
-    let url_hash = compute_sha256_short(kernel_config.url.as_bytes());
+fn get_url_kernel_path(profile: &KernelProfile) -> Result<PathBuf> {
+    let url = profile
+        .kernel_url
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("kernel profile missing kernel_url"))?;
+    let url_hash = compute_sha256_short(url.as_bytes());
     Ok(paths::kernel_dir().join(format!("vmlinux-{}.bin", url_hash)))
 }
 
-async fn ensure_default_kernel(allow_create: bool) -> Result<PathBuf> {
-    let (plan, _, _) = load_plan()?;
-    let kernel_config = plan.kernel.current_arch()?;
-
+async fn ensure_url_kernel(profile: &KernelProfile, allow_create: bool) -> Result<PathBuf> {
     // Check for local path first
-    if let Some(local_path) = &kernel_config.local_path {
+    if let Some(ref local_path) = profile.kernel_local_path {
         let path = PathBuf::from(local_path);
         if !path.exists() {
             bail!("Kernel local_path not found: {}", path.display());
@@ -85,12 +119,21 @@ async fn ensure_default_kernel(allow_create: bool) -> Result<PathBuf> {
         return Ok(path);
     }
 
-    if kernel_config.url.is_empty() {
-        bail!("Kernel config must specify 'url' or 'local_path'");
+    let url = profile
+        .kernel_url
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("kernel profile must specify kernel_url or kernel_local_path"))?;
+    let archive_path = profile
+        .kernel_archive_path
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("kernel profile must specify kernel_archive_path"))?;
+
+    if url.is_empty() {
+        bail!("Kernel config must specify 'kernel_url' or 'kernel_local_path'");
     }
 
     let kernel_dir = paths::kernel_dir();
-    let url_hash = compute_sha256_short(kernel_config.url.as_bytes());
+    let url_hash = compute_sha256_short(url.as_bytes());
     let kernel_path = kernel_dir.join(format!("vmlinux-{}.bin", url_hash));
 
     // Fast path: already exists
@@ -131,7 +174,7 @@ async fn ensure_default_kernel(allow_create: bool) -> Result<PathBuf> {
 
     // Download
     println!("⚙️  Downloading kernel...");
-    info!(url = %kernel_config.url, path_in_archive = %kernel_config.path, "downloading kernel");
+    info!(url = %url, path_in_archive = %archive_path, "downloading kernel");
 
     let cache_dir = paths::cache_dir();
     tokio::fs::create_dir_all(&cache_dir).await?;
@@ -146,7 +189,7 @@ async fn ensure_default_kernel(allow_create: bool) -> Result<PathBuf> {
         let _ = tokio::fs::remove_file(&tarball_temp).await;
 
         let output = Command::new("curl")
-            .args(["-fSL", &kernel_config.url, "-o"])
+            .args(["-fSL", url, "-o"])
             .arg(&tarball_temp)
             .output()
             .await
@@ -173,7 +216,7 @@ async fn ensure_default_kernel(allow_create: bool) -> Result<PathBuf> {
     let _ = tokio::fs::remove_dir_all(&extract_temp).await;
     tokio::fs::create_dir_all(&extract_temp).await?;
 
-    let extract_path = format!("./{}", kernel_config.path);
+    let extract_path = format!("./{}", archive_path);
     let output = Command::new("tar")
         .args(["--use-compress-program=zstd", "-xf"])
         .arg(&tarball_path)
@@ -194,7 +237,7 @@ async fn ensure_default_kernel(allow_create: bool) -> Result<PathBuf> {
     }
 
     // Move to final location
-    let extracted_path = extract_temp.join(&kernel_config.path);
+    let extracted_path = extract_temp.join(archive_path);
     if !extracted_path.exists() {
         let _ = tokio::fs::remove_dir_all(&extract_temp).await;
         let _ = flock.unlock();
@@ -219,47 +262,22 @@ async fn ensure_default_kernel(allow_create: bool) -> Result<PathBuf> {
 }
 
 // ============================================================================
-// Profile Kernel (from [kernel_profiles] section)
+// Custom Kernel (built from source — named profiles like nested, btrfs)
 // ============================================================================
 
-fn get_profile_kernel_path(profile_name: &str) -> Result<PathBuf> {
-    let profile = get_kernel_profile(profile_name)?
-        .ok_or_else(|| anyhow::anyhow!("kernel profile '{}' not found in config", profile_name))?;
-
-    // If profile doesn't specify custom kernel, use the default kernel
-    // This allows runtime-only profiles (boot_args, firecracker_args, etc.)
-    if !profile.is_custom() {
-        debug!(profile = %profile_name, "profile uses default kernel (no custom kernel configured)");
-        return get_default_kernel_path();
-    }
-
-    let sha = compute_profile_kernel_sha(&profile);
+fn get_custom_kernel_path(profile: &KernelProfile, profile_name: &str) -> Result<PathBuf> {
+    let sha = compute_profile_kernel_sha(profile);
     let filename = custom_kernel_filename(profile_name, &profile.kernel_version, &sha);
     Ok(paths::kernel_dir().join(filename))
 }
 
-async fn ensure_profile_kernel(
+async fn ensure_custom_kernel(
+    profile: &KernelProfile,
     profile_name: &str,
     allow_create: bool,
     allow_build: bool,
 ) -> Result<PathBuf> {
-    let profile = get_kernel_profile(profile_name)?.ok_or_else(|| {
-        anyhow::anyhow!(
-            "kernel profile '{}' not found in config. \
-             Add [kernel_profiles.{}] section to rootfs-config.toml",
-            profile_name,
-            profile_name
-        )
-    })?;
-
-    // If profile doesn't specify custom kernel, use the default kernel
-    // This allows runtime-only profiles (boot_args, firecracker_args, etc.)
-    if !profile.is_custom() {
-        info!(profile = %profile_name, "profile uses default kernel");
-        return ensure_default_kernel(allow_create).await;
-    }
-
-    let sha = compute_profile_kernel_sha(&profile);
+    let sha = compute_profile_kernel_sha(profile);
     let filename = custom_kernel_filename(profile_name, &profile.kernel_version, &sha);
     let kernel_dir = paths::kernel_dir();
     let kernel_path = kernel_dir.join(&filename);
@@ -341,7 +359,7 @@ async fn ensure_profile_kernel(
 
             if allow_build {
                 println!("  → Building locally (may take 10-20 minutes)...");
-                build_kernel_locally(&profile, profile_name, &kernel_path).await?;
+                build_kernel_locally(profile, profile_name, &kernel_path).await?;
                 println!("  ✓ Kernel built (profile: {})", profile_name);
                 flock.unlock().map_err(|(_, err)| err)?;
                 Ok(kernel_path)

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -43,8 +43,9 @@ pub struct Plan {
 
 /// Kernel profile configuration
 ///
-/// Profiles override the default [kernel] section for special use cases.
-/// Custom kernels are built from source or downloaded from GitHub releases.
+/// Every kernel is delivered through a profile. The `[kernel]` config section
+/// is synthesized into a `"default"` profile at load time. Custom profiles
+/// (nested, btrfs) build kernels from source or download from GitHub releases.
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct KernelProfile {
     /// Human-readable description
@@ -55,6 +56,17 @@ pub struct KernelProfile {
     /// When "btrfs", the rootfs is converted from ext4 to btrfs before setup VM boot.
     #[serde(default)]
     pub rootfs_type: Option<String>,
+
+    // ========== URL-based kernel delivery (synthesized "default" profile) ==========
+    /// URL to kernel archive (e.g., Kata release tarball)
+    #[serde(default)]
+    pub kernel_url: Option<String>,
+    /// Path within the archive to extract the kernel binary
+    #[serde(default)]
+    pub kernel_archive_path: Option<String>,
+    /// Local filesystem path to kernel binary (overrides URL)
+    #[serde(default)]
+    pub kernel_local_path: Option<String>,
 
     // ========== Custom kernel (build from source) ==========
     /// Kernel version (e.g., "6.18")
@@ -135,9 +147,19 @@ pub struct HostKernelConfig {
 }
 
 impl KernelProfile {
-    /// Check if this profile has a custom kernel configured
+    /// Check if this profile builds a custom kernel from source
     pub fn is_custom(&self) -> bool {
         !self.kernel_version.is_empty() && !self.kernel_repo.is_empty()
+    }
+
+    /// Check if this profile uses URL-based kernel download
+    pub fn is_url_based(&self) -> bool {
+        self.kernel_url.is_some()
+    }
+
+    /// This profile doesn't define its own kernel — it inherits from "default"
+    pub fn inherits_kernel(&self) -> bool {
+        !self.is_custom() && !self.is_url_based()
     }
 }
 
@@ -796,8 +818,12 @@ pub fn load_config(explicit_path: Option<&str>) -> Result<(Plan, String, String)
     let config_sha = compute_sha256(config_content.as_bytes());
     let config_sha_short = config_sha[..12].to_string();
 
-    let config: Plan = toml::from_str(&config_content)
+    let mut config: Plan = toml::from_str(&config_content)
         .with_context(|| format!("parsing config file: {}", config_path.display()))?;
+
+    // Synthesize a "default" profile from the [kernel] section so all code
+    // paths use profiles uniformly — no more None vs Some branching.
+    synthesize_default_profile(&mut config);
 
     info!(
         config_file = %config_path.display(),
@@ -806,6 +832,29 @@ pub fn load_config(explicit_path: Option<&str>) -> Result<(Plan, String, String)
     );
 
     Ok((config, config_sha, config_sha_short))
+}
+
+/// Create a synthetic "default" kernel profile from the [kernel] config section.
+///
+/// This allows all kernel code to work with profiles uniformly. The [kernel]
+/// section in rootfs-config.toml stays as-is for backward compatibility.
+/// If a user explicitly defines [kernel_profiles.default], their definition wins.
+fn synthesize_default_profile(plan: &mut Plan) {
+    let arch = config_arch();
+    if let Ok(kernel_config) = plan.kernel.current_arch() {
+        let default_profile = KernelProfile {
+            description: "Default kernel (Kata Containers)".into(),
+            kernel_url: Some(kernel_config.url.clone()),
+            kernel_archive_path: Some(kernel_config.path.clone()),
+            kernel_local_path: kernel_config.local_path.clone(),
+            ..Default::default()
+        };
+        plan.kernel_profiles
+            .entry("default".into())
+            .or_default()
+            .entry(arch.into())
+            .or_insert(default_profile);
+    }
 }
 
 /// Legacy alias for load_config (for backward compatibility during migration)
@@ -842,7 +891,7 @@ pub fn get_kernel_profile(name: &str) -> Result<Option<KernelProfile>> {
 /// Used by both `setup` and `podman run` commands.
 pub fn resolve_rootfs_type(
     cli_rootfs_type: Option<&crate::cli::RootfsType>,
-    kernel_profile_name: Option<&str>,
+    kernel_profile_name: &str,
 ) -> Option<String> {
     // CLI override wins
     if let Some(rt) = cli_rootfs_type {
@@ -853,10 +902,8 @@ pub fn resolve_rootfs_type(
     }
 
     // Read from kernel profile config
-    if let Some(profile_name) = kernel_profile_name {
-        if let Ok(Some(profile)) = get_kernel_profile(profile_name) {
-            return profile.rootfs_type;
-        }
+    if let Ok(Some(profile)) = get_kernel_profile(kernel_profile_name) {
+        return profile.rootfs_type;
     }
 
     None
@@ -2051,11 +2098,11 @@ async fn boot_vm_for_setup(
     // Create log file (Firecracker requires it to exist)
     std::fs::File::create(&log_path).context("creating Firecracker log file")?;
 
-    // Find kernel - use btrfs profile kernel if rootfs is btrfs (needs CONFIG_BTRFS_FS),
-    // otherwise use default Kata kernel.
-    // The rootfs_type value ("btrfs") matches the kernel profile name by convention.
-    let kernel_profile = rootfs_type;
-    let kernel_path = crate::setup::kernel::ensure_kernel(kernel_profile, true, false).await?;
+    // Find kernel — rootfs_type ("btrfs") matches the kernel profile name by convention.
+    // Falls back to "default" profile for ext4 rootfs.
+    let kernel_profile_name = rootfs_type.unwrap_or("default");
+    let kernel_path =
+        crate::setup::kernel::ensure_kernel(kernel_profile_name, true, false).await?;
 
     // Create serial console output file
     let serial_path = temp_dir.join("serial.log");

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -2101,8 +2101,7 @@ async fn boot_vm_for_setup(
     // Find kernel — rootfs_type ("btrfs") matches the kernel profile name by convention.
     // Falls back to "default" profile for ext4 rootfs.
     let kernel_profile_name = rootfs_type.unwrap_or("default");
-    let kernel_path =
-        crate::setup::kernel::ensure_kernel(kernel_profile_name, true, false).await?;
+    let kernel_path = crate::setup::kernel::ensure_kernel(kernel_profile_name, true, false).await?;
 
     // Create serial console output file
     let serial_path = temp_dir.join("serial.log");

--- a/tests/test_kvm.rs
+++ b/tests/test_kvm.rs
@@ -626,7 +626,7 @@ except OSError as e:
 
     // Get the nested kernel path for the nesting script
     let nested_kernel =
-        fcvm::setup::get_kernel_path(Some("nested")).context("getting nested kernel path")?;
+        fcvm::setup::get_kernel_path("nested").context("getting nested kernel path")?;
     let kernel_path_str = nested_kernel.to_string_lossy();
 
     // The nesting script is baked into the container at /usr/local/bin/nested
@@ -1247,7 +1247,7 @@ async fn run_nested_n_levels(
     // This is needed because inside L1, the kernel build inputs don't exist
     // so the SHA computation would fail
     let nested_kernel =
-        fcvm::setup::get_kernel_path(Some("nested")).context("getting nested kernel path")?;
+        fcvm::setup::get_kernel_path("nested").context("getting nested kernel path")?;
     let nested_kernel_path = nested_kernel.to_string_lossy();
 
     // Get the digest of localhost/nested-test


### PR DESCRIPTION
**Stacked on:** btrfs-rootfs (PR #375)

## Summary
- Eliminates the dual "default kernel" vs "kernel profile" code paths by synthesizing a `"default"` profile from the `[kernel]` config section at load time
- Changes `ensure_kernel`/`get_kernel_path` from `Option<&str>` to `&str` — all callers now pass a profile name (e.g. `"default"`, `"btrfs"`, `"nested"`)
- Collapses the triple-branch kernel resolution in `prepare_vm()` (explicit / profile / default) to a double-branch (explicit / profile, where "default" is just a profile)

## What changed

**`src/setup/rootfs.rs`**: Added `kernel_url`, `kernel_archive_path`, `kernel_local_path` fields to `KernelProfile`. Added `is_url_based()`, `inherits_kernel()` methods. Added `synthesize_default_profile()` called from `load_config()`. Updated `resolve_rootfs_type()` signature from `Option<&str>` to `&str`.

**`src/setup/kernel.rs`**: Changed `ensure_kernel`/`get_kernel_path`/`get_kernel_url_hash` from `Option<&str>` to `&str`. Renamed `ensure_default_kernel` → `ensure_url_kernel` and `ensure_profile_kernel` → `ensure_custom_kernel` (both take `&KernelProfile` instead of reading config internally). Dispatch logic: `is_url_based()` → download, `is_custom()` → build from source, `inherits_kernel()` → delegate to default.

**`src/commands/setup.rs`**: `ensure_kernel("default", ...)`, removed `Some()` wrapping.

**`src/commands/podman/mod.rs`**: `unwrap_or("default")` for profile name, collapsed triple-branch to double-branch.

**`tests/test_kvm.rs`**: `get_kernel_path("nested")` (removed `Some()` wrapping).

## What does NOT change
- `rootfs-config.toml` format — `[kernel]` section stays
- CLI interface — `--kernel-profile` still optional, `--kernel` still overrides
- Kernel file naming / snapshot cache keys

## Test plan
- [x] `make build` — compiles clean (no warnings)
- [x] 82 unit tests pass
- [x] `make test-root FILTER=sanity` — 3 passed
- [x] `make test-root FILTER=btrfs_storage` — 2 passed (native + ext4)
- [x] `make test-root FILTER=btrfs_keepid` — 2 passed (native + ext4)