### PR TITLE
Use custom Firecracker fork with diff snapshot fix

### DIFF
--- a/kernel/btrfs-x86.conf
+++ b/kernel/btrfs-x86.conf
@@ -1,9 +1,6 @@
 # fcvm btrfs kernel config fragment (x86_64)
 #
-# This fragment is applied on top of Firecracker's microvm kernel config
-# to enable FUSE (for fuse-pipe volumes).
-# CONFIG_BTRFS_FS is added automatically by the build script.
-#
+# This fragment is applied on top of Firecracker's microvm kernel config.
 # x86-specific: includes PCI/MMIO configs needed for Firecracker's IRQ infrastructure.
 
 # PCI support (required for GENERIC_MSI_IRQ which virtio needs for IRQ handling)
@@ -18,3 +15,7 @@ CONFIG_VIRTIO_MMIO_CMDLINE_DEVICES=y
 
 # FUSE support for passthrough filesystem
 CONFIG_FUSE_FS=y
+
+# btrfs filesystem with POSIX ACL support (container tools need file ACLs)
+CONFIG_BTRFS_FS=y
+CONFIG_BTRFS_FS_POSIX_ACL=y

--- a/kernel/btrfs.conf
+++ b/kernel/btrfs.conf
@@ -1,8 +1,10 @@
 # fcvm btrfs kernel config fragment
 #
-# This fragment is applied on top of Firecracker's microvm kernel config
-# to enable FUSE (for fuse-pipe volumes).
-# CONFIG_BTRFS_FS is added automatically by the build script.
+# This fragment is applied on top of Firecracker's microvm kernel config.
 
 # FUSE support for passthrough filesystem
 CONFIG_FUSE_FS=y
+
+# btrfs filesystem with POSIX ACL support (container tools need file ACLs)
+CONFIG_BTRFS_FS=y
+CONFIG_BTRFS_FS_POSIX_ACL=y

--- a/rootfs-config.toml
+++ b/rootfs-config.toml
@@ -181,10 +181,10 @@ patches_dir = "kernel/patches-arm64"
 # Base config for VM kernel (Firecracker's microvm config)
 base_config_url = "https://raw.githubusercontent.com/firecracker-microvm/firecracker/main/resources/guest_configs/microvm-kernel-ci-aarch64-6.1.config"
 
-# Firecracker NV2 fork with --enable-nv2 support
-# Binary is content-addressed: assets_dir/firecracker/firecracker-nested-{sha}.bin
+# Firecracker fork: diff snapshot fix + NV2 nested virt (ARM64)
+# PR: https://github.com/firecracker-microvm/firecracker/pull/5696
 firecracker_repo = "ejc3/firecracker"
-firecracker_branch = "nv2-vhe-mode"
+firecracker_branch = "nv2-on-main"
 firecracker_args = "--enable-nv2"
 
 # Boot args for nested KVM
@@ -276,3 +276,8 @@ kernel_config = "kernel/btrfs-x86.conf"
 # No patches_dir — no FUSE patches needed for btrfs profile
 
 base_config_url = "https://raw.githubusercontent.com/firecracker-microvm/firecracker/main/resources/guest_configs/microvm-kernel-ci-x86_64-6.1.config"
+
+# Firecracker fork with diff snapshot fix for multi-slot VMs (>3GB RAM).
+# PR: https://github.com/firecracker-microvm/firecracker/pull/5696
+firecracker_repo = "ejc3/firecracker"
+firecracker_branch = "fix-dump-dirty-multi-slot-cursor"

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -366,6 +366,17 @@ pub async fn cleanup_vm(
         warn!("failed to delete state file: {}", e);
     }
 
+    // Save Firecracker log before cleanup (for debugging snapshot restore failures)
+    let fc_log = data_dir.join("firecracker.log");
+    if fc_log.exists() {
+        let dest = std::path::PathBuf::from(format!("/tmp/fcvm-firecracker-{}.log", vm_id));
+        if let Err(e) = tokio::fs::copy(&fc_log, &dest).await {
+            debug!(vm_id = %vm_id, error = %e, "could not save firecracker log");
+        } else {
+            info!(vm_id = %vm_id, log = %dest.display(), "saved firecracker log");
+        }
+    }
+
     // Cleanup VM data directory (includes disks, sockets, etc.)
     if let Err(e) = tokio::fs::remove_dir_all(data_dir).await {
         warn!(vm_id = %vm_id, error = %e, "failed to cleanup VM data directory");
@@ -431,7 +442,12 @@ pub async fn restore_from_snapshot(
     // Configure namespace isolation if network provides one
     let mut holder_child: Option<tokio::process::Child> = None;
     let mut holder_pid_for_post_start: Option<u32> = None;
-    let mut vm_manager = VmManager::new(vm_id.to_string(), socket_path.to_path_buf(), None);
+    let fc_log_path = data_dir.join("firecracker.log");
+    let mut vm_manager = VmManager::new(
+        vm_id.to_string(),
+        socket_path.to_path_buf(),
+        Some(fc_log_path),
+    );
     vm_manager.set_vm_name(vm_name.to_string());
 
     // rootfs_path is set by either the bridged or rootless branch
@@ -1113,8 +1129,8 @@ pub async fn create_snapshot_core(
                 .context("diff merge task panicked")?
                 .context("merging diff snapshot")?;
 
-        // Clean up the diff file - we only need the merged memory.bin
-        let _ = tokio::fs::remove_file(&diff_file_path).await;
+        // Keep the diff file for debugging (renamed to memory.diff in final dir)
+        // The full-debug file (if present) is also preserved for comparison.
 
         info!(
             snapshot = %snapshot_config.name,

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -798,6 +798,24 @@ pub async fn restore_from_snapshot(
         "signaled fc-agent to flush ARP via MMDS"
     );
 
+    // FCVM_KVM_TRACE: enable KVM ftrace around VM resume for debugging snapshot restore.
+    // Captures KVM exit reasons (NPF, shutdown, etc.) to /tmp/fcvm-kvm-trace-{vm_id}.log.
+    // Requires: sudo access (ftrace needs debugfs). Safe to set without sudo — just skips.
+    let kvm_trace = if std::env::var("FCVM_KVM_TRACE").is_ok() {
+        match crate::kvm_trace::KvmTrace::start(&vm_state.vm_id) {
+            Ok(t) => {
+                info!("KVM trace started for VM resume");
+                Some(t)
+            }
+            Err(e) => {
+                warn!("FCVM_KVM_TRACE: could not start KVM trace: {}", e);
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     // Timing instrumentation: measure VM resume operation
     let resume_start = std::time::Instant::now();
     client
@@ -812,6 +830,16 @@ pub async fn restore_from_snapshot(
         total_snapshot_ms = (load_duration + patch_duration + resume_duration).as_millis(),
         "VM resume completed"
     );
+
+    // Stop KVM trace and dump results (captures resume + early VM execution)
+    if let Some(trace) = kvm_trace {
+        // Brief delay to capture initial KVM exits after resume
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        match trace.stop_and_dump() {
+            Ok(path) => info!("KVM trace saved to {}", path),
+            Err(e) => warn!("FCVM_KVM_TRACE: failed to save: {}", e),
+        }
+    }
 
     // Store fcvm process PID (not Firecracker PID)
     vm_state.pid = Some(std::process::id());

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -776,47 +776,51 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
         MemoryBackend::Uffd {
             socket_path: uffd_socket_path.clone(),
         }
-    } else if hugepages {
-        // Implicit UFFD mode: hugepages require UFFD, start in-process server
-        let implicit_socket_path = data_dir.join("uffd.sock");
-        info!(
-            target: "uffd",
-            socket = %implicit_socket_path.display(),
-            "starting implicit UFFD server for hugepage snapshot restore"
-        );
-
-        let server = UffdServer::new_with_path(
-            format!("implicit-{}", truncate_id(&vm_id, 8)),
-            &snapshot_config.memory_path,
-            &implicit_socket_path,
-        )
-        .await
-        .context("creating implicit UFFD server for hugepages")?;
-
-        let cancel = implicit_uffd_cancel.clone();
-        tokio::spawn(async move {
-            if let Err(e) = server.run(cancel).await {
-                tracing::error!(target: "uffd", error = ?e, "implicit UFFD server error");
-            }
-        });
-
-        // Poll for socket to appear (server binds it asynchronously)
-        for i in 0..100 {
-            if implicit_socket_path.exists() {
-                break;
-            }
-            if i == 99 {
-                bail!("implicit UFFD server did not bind socket within 5s");
-            }
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
-
-        MemoryBackend::Uffd {
-            socket_path: implicit_socket_path,
-        }
     } else {
-        MemoryBackend::File {
-            memory_path: snapshot_config.memory_path.clone(),
+        // Use file-backed restore by default.
+        // Note: Firecracker v1.14.0 has a bug where file-backed restore of VMs >= 4GB
+        // causes a triple fault (guest page tables for memory above the MMIO gap at 3GB
+        // are invalid). Fixed in v1.15.0+. If /dev/userfaultfd is accessible (chmod 666),
+        // UFFD can be used as a workaround via FCVM_FORCE_UFFD=1.
+        if std::env::var("FCVM_FORCE_UFFD").is_ok() {
+            let implicit_socket_path = data_dir.join("uffd.sock");
+            info!(
+                socket = %implicit_socket_path.display(),
+                "starting implicit UFFD server for snapshot restore (FCVM_FORCE_UFFD)"
+            );
+
+            let server = UffdServer::new_with_path(
+                format!("implicit-{}", truncate_id(&vm_id, 8)),
+                &snapshot_config.memory_path,
+                &implicit_socket_path,
+            )
+            .await
+            .context("creating implicit UFFD server")?;
+
+            let cancel = implicit_uffd_cancel.clone();
+            tokio::spawn(async move {
+                if let Err(e) = server.run(cancel).await {
+                    tracing::error!(target: "uffd", error = ?e, "implicit UFFD server error");
+                }
+            });
+
+            for i in 0..100 {
+                if implicit_socket_path.exists() {
+                    break;
+                }
+                if i == 99 {
+                    bail!("implicit UFFD server did not bind socket within 5s");
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+
+            MemoryBackend::Uffd {
+                socket_path: implicit_socket_path,
+            }
+        } else {
+            MemoryBackend::File {
+                memory_path: snapshot_config.memory_path.clone(),
+            }
         }
     };
 
@@ -887,30 +891,18 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
 
     let (mut vm_manager, mut holder_child) = setup_result.unwrap();
 
-    // Determine actual memory mode: use_uffd covers explicit UFFD (serve PID),
-    // but hugepages also use implicit UFFD without a serve process.
-    let actual_uffd = use_uffd || hugepages;
-    if actual_uffd {
-        info!(
-            vm_id = %vm_id,
-            vm_name = %vm_name,
-            "VM cloned successfully with UFFD memory sharing!"
-        );
-        println!(
-            "✓ VM '{}' cloned from snapshot '{}' (UFFD mode)",
-            vm_name, snapshot_name
-        );
-        println!("  Memory pages shared via UFFD server");
+    let is_uffd = use_uffd || std::env::var("FCVM_FORCE_UFFD").is_ok() || hugepages;
+    if is_uffd {
+        info!(vm_id = %vm_id, vm_name = %vm_name, "VM cloned with UFFD memory");
+        println!("✓ VM '{}' cloned from snapshot '{}' (UFFD mode)", vm_name, snapshot_name);
+        if use_uffd {
+            println!("  Memory pages shared via UFFD serve process");
+        } else {
+            println!("  Memory pages served on-demand from snapshot file");
+        }
     } else {
-        info!(
-            vm_id = %vm_id,
-            vm_name = %vm_name,
-            "VM cloned successfully from snapshot files!"
-        );
-        println!(
-            "✓ VM '{}' cloned from snapshot '{}' (direct mode)",
-            vm_name, snapshot_name
-        );
+        info!(vm_id = %vm_id, vm_name = %vm_name, "VM cloned from snapshot files");
+        println!("✓ VM '{}' cloned from snapshot '{}' (direct mode)", vm_name, snapshot_name);
         println!("  Memory loaded from file");
     }
     println!("  Disk uses CoW overlay");

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -894,7 +894,10 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
     let is_uffd = use_uffd || std::env::var("FCVM_FORCE_UFFD").is_ok() || hugepages;
     if is_uffd {
         info!(vm_id = %vm_id, vm_name = %vm_name, "VM cloned with UFFD memory");
-        println!("✓ VM '{}' cloned from snapshot '{}' (UFFD mode)", vm_name, snapshot_name);
+        println!(
+            "✓ VM '{}' cloned from snapshot '{}' (UFFD mode)",
+            vm_name, snapshot_name
+        );
         if use_uffd {
             println!("  Memory pages shared via UFFD serve process");
         } else {
@@ -902,7 +905,10 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
         }
     } else {
         info!(vm_id = %vm_id, vm_name = %vm_name, "VM cloned from snapshot files");
-        println!("✓ VM '{}' cloned from snapshot '{}' (direct mode)", vm_name, snapshot_name);
+        println!(
+            "✓ VM '{}' cloned from snapshot '{}' (direct mode)",
+            vm_name, snapshot_name
+        );
         println!("  Memory loaded from file");
     }
     println!("  Disk uses CoW overlay");

--- a/src/firecracker/vm.rs
+++ b/src/firecracker/vm.rs
@@ -211,6 +211,41 @@ impl VmManager {
             }
         }
 
+        // FCVM_STRACE_FC: wrap Firecracker with strace for debugging.
+        // Output goes to /tmp/fcvm-strace-fc-{vm_id}.log on the host.
+        // Traces ioctl, mmap, and signal syscalls by default.
+        // Set FCVM_STRACE_FC=all for full trace.
+        if let Ok(trace_filter) = std::env::var("FCVM_STRACE_FC") {
+            let strace_log = format!("/tmp/fcvm-strace-fc-{}.log", &self.vm_id);
+            let filter = if trace_filter == "all" {
+                String::new()
+            } else if trace_filter.contains('=') || trace_filter.contains(',') {
+                // Custom filter like "ioctl,mmap" or "trace=ioctl"
+                format!("-e {}", trace_filter)
+            } else {
+                "-e trace=ioctl,mmap,madvise,mprotect".to_string()
+            };
+            warn!(
+                strace_log = %strace_log,
+                filter = %filter,
+                "FCVM_STRACE_FC: wrapping Firecracker with strace"
+            );
+            // Prepend strace to the command
+            let program = cmd.as_std().get_program().to_owned();
+            let args: Vec<_> = cmd.as_std().get_args().map(|a| a.to_owned()).collect();
+            cmd = Command::new("strace");
+            cmd.arg("-f").arg("-tt").arg("-o").arg(&strace_log);
+            if !filter.is_empty() {
+                for part in filter.split_whitespace() {
+                    cmd.arg(part);
+                }
+            }
+            cmd.arg(program);
+            for arg in args {
+                cmd.arg(arg);
+            }
+        }
+
         // Setup namespace isolation if specified (network namespace and/or mount namespace)
         // We need to handle these in a single pre_exec because it can only be called once
         let ns_id_clone = self.namespace_id.clone();

--- a/src/kvm_trace.rs
+++ b/src/kvm_trace.rs
@@ -1,0 +1,145 @@
+//! KVM ftrace helper for debugging snapshot restore.
+//!
+//! Enable with `FCVM_KVM_TRACE=1`. Requires debugfs access (typically root).
+//! Captures KVM exit events during VM resume to diagnose issues like
+//! triple faults, NPF storms, or unexpected shutdown exits.
+//!
+//! Output: /tmp/fcvm-kvm-trace-{vm_id}.log
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const TRACING_DIR: &str = "/sys/kernel/debug/tracing";
+
+pub struct KvmTrace {
+    vm_id: String,
+    output_path: PathBuf,
+}
+
+impl KvmTrace {
+    /// Start KVM tracing. Enables kvm_exit and kvm_userspace_exit events.
+    pub fn start(vm_id: &str) -> Result<Self> {
+        let tracing = Path::new(TRACING_DIR);
+        if !tracing.exists() {
+            anyhow::bail!("debugfs tracing not available at {}", TRACING_DIR);
+        }
+
+        // Stop any existing trace
+        write_tracing("tracing_on", "0")?;
+
+        // Clear buffer
+        write_tracing("trace", "")?;
+
+        // Set buffer size (256MB to handle burst of KVM exits)
+        write_tracing("buffer_size_kb", "262144")?;
+
+        // Enable KVM exit events
+        enable_event("kvm/kvm_exit", true)?;
+        enable_event("kvm/kvm_userspace_exit", true)?;
+
+        // Enable signal events (to catch SIGABRT delivery)
+        enable_event("signal/signal_generate", true)?;
+        enable_event("signal/signal_deliver", true)?;
+
+        // Start tracing
+        write_tracing("tracing_on", "1")?;
+
+        let output_path = PathBuf::from(format!("/tmp/fcvm-kvm-trace-{}.log", vm_id));
+        eprintln!(
+            "[fcvm] KVM trace started (kvm_exit + signals) → {}",
+            output_path.display()
+        );
+
+        Ok(Self {
+            vm_id: vm_id.to_string(),
+            output_path,
+        })
+    }
+
+    /// Stop tracing and dump captured events to file.
+    pub fn stop_and_dump(self) -> Result<String> {
+        // Stop tracing
+        write_tracing("tracing_on", "0")?;
+
+        // Disable events
+        let _ = enable_event("kvm/kvm_exit", false);
+        let _ = enable_event("kvm/kvm_userspace_exit", false);
+        let _ = enable_event("signal/signal_generate", false);
+        let _ = enable_event("signal/signal_deliver", false);
+
+        // Read trace buffer
+        let trace_path = Path::new(TRACING_DIR).join("trace");
+        let raw = fs::read_to_string(&trace_path).context("reading trace buffer")?;
+
+        // Filter for relevant events (fc_vcpu threads, firecracker signals)
+        let mut output = String::new();
+        output.push_str(&format!(
+            "# KVM trace for VM {} (captured by FCVM_KVM_TRACE)\n",
+            self.vm_id
+        ));
+        output.push_str("#\n");
+
+        let mut kvm_exit_count = 0;
+        let mut shutdown_count = 0;
+        let mut signal_count = 0;
+
+        for line in raw.lines() {
+            if line.starts_with('#') {
+                continue;
+            }
+            let dominated_by_fc =
+                line.contains("fc_vcpu") || line.contains("firecracker") || line.contains("fcvm");
+            let is_kvm = line.contains("kvm_exit") || line.contains("kvm_userspace_exit");
+            let is_signal = line.contains("signal_generate") || line.contains("signal_deliver");
+
+            if dominated_by_fc && (is_kvm || is_signal) {
+                output.push_str(line);
+                output.push('\n');
+
+                if is_kvm {
+                    kvm_exit_count += 1;
+                }
+                if line.contains("shutdown") || line.contains("SHUTDOWN") {
+                    shutdown_count += 1;
+                }
+                if is_signal {
+                    signal_count += 1;
+                }
+            }
+        }
+
+        output.push_str(&format!(
+            "\n# Summary: {} KVM exits, {} shutdowns, {} signals\n",
+            kvm_exit_count, shutdown_count, signal_count
+        ));
+
+        // Write to file
+        fs::write(&self.output_path, &output).context("writing KVM trace output")?;
+
+        // Clear trace buffer
+        let _ = write_tracing("trace", "");
+
+        let path_str = self.output_path.display().to_string();
+        eprintln!(
+            "[fcvm] KVM trace: {} exits, {} shutdowns, {} signals → {}",
+            kvm_exit_count, shutdown_count, signal_count, path_str
+        );
+
+        Ok(path_str)
+    }
+}
+
+fn write_tracing(file: &str, value: &str) -> Result<()> {
+    let path = Path::new(TRACING_DIR).join(file);
+    fs::write(&path, value).with_context(|| format!("writing to {}", path.display()))
+}
+
+fn enable_event(event: &str, enable: bool) -> Result<()> {
+    let path = Path::new(TRACING_DIR)
+        .join("events")
+        .join(event)
+        .join("enable");
+    let value = if enable { "1" } else { "0" };
+    fs::write(&path, value).with_context(|| format!("enabling event {}", event))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod cli;
 pub mod commands;
 pub mod firecracker;
 pub mod health;
+pub mod kvm_trace;
 pub mod network;
 pub mod paths;
 pub mod setup;

--- a/src/setup/kernel.rs
+++ b/src/setup/kernel.rs
@@ -651,9 +651,6 @@ curl -fSL "$BASE_CONFIG_URL" -o .config
 # Apply options from config fragment
 {apply_config_fragment}
 
-# Always enable BTRFS
-./scripts/config --enable CONFIG_BTRFS_FS
-
 # Update config with defaults for new options
 make ARCH="$KERNEL_ARCH" olddefconfig
 

--- a/target
+++ b/target
@@ -1,1 +1,0 @@
-/mnt/fcvm-btrfs/cargo-target

--- a/target
+++ b/target
@@ -1,0 +1,1 @@
+/mnt/fcvm-btrfs/cargo-target


### PR DESCRIPTION
## Summary

Point kernel profiles at ejc3/firecracker fork with the dump_dirty cursor alignment fix.

**Bug**: Firecracker's `dump_dirty` doesn't seek past trailing clean pages at the end of a KVM memory slot. For VMs >3GB (two slots due to x86 MMIO gap), this misaligns all data for the second slot, corrupting ~47K pages in diff snapshots.

Upstream PR: https://github.com/firecracker-microvm/firecracker/pull/5696

**Config**:
- btrfs x86: `fix-dump-dirty-multi-slot-cursor` (fix only)
- nested ARM64: `nv2-on-main` (fix + NV2 patches, rebased to 1.15)

**Debug tools**: FCVM_STRACE_FC, FCVM_KVM_TRACE, FCVM_FORCE_UFFD, FC log capture

## Test Plan
4GB: 1.0s warm start PASSED
8GB: 2.0s warm start PASSED