### PR TITLE
fix: revert destructive podman reset, add container build lock

### DIFF
--- a/fc-agent/src/agent.rs
+++ b/fc-agent/src/agent.rs
@@ -162,6 +162,12 @@ pub async fn run() -> Result<()> {
     // Store prefix globally so exec server and health checks can use it
     container::set_podman_cmd_prefix(cmd_prefix.clone());
 
+    // Reset podman state to match storage.conf before the first real podman operation.
+    // By this point, storage setup is complete (btrfs loopback mounted, storage.conf
+    // written with correct driver). Reset ensures db.sql matches storage.conf even if
+    // concurrent health monitor `podman inspect` created stale state during setup.
+    container::reset_podman_state();
+
     // Prepare image based on delivery mode
     let image_ref = match (plan.image_mode.as_deref(), &plan.image_device) {
         (Some("overlay"), Some(device)) => {

--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -356,6 +356,37 @@ pub fn setup_btrfs_storage_if_available() {
     );
 }
 
+/// Reset podman state to match the current storage.conf.
+///
+/// Must be called after storage.conf is written (by btrfs/overlay setup) and
+/// immediately before the first real podman operation (pull/load/run).
+///
+/// This fixes "database graph driver does not match" errors caused by:
+/// 1. Stale db.sql from rootfs build (apt post-install creates it with driver="")
+/// 2. Concurrent health monitor `podman inspect` recreating db.sql during setup
+///
+/// `podman system reset --force` atomically drops and recreates all podman state
+/// to match the current storage.conf, eliminating any driver mismatch.
+pub fn reset_podman_state() {
+    match std::process::Command::new("podman")
+        .args(["system", "reset", "--force"])
+        .output()
+    {
+        Ok(o) if o.status.success() => {
+            eprintln!("[fc-agent] podman state reset to match storage.conf");
+        }
+        Ok(o) => {
+            eprintln!(
+                "[fc-agent] WARNING: podman system reset failed: {}",
+                String::from_utf8_lossy(&o.stderr).trim()
+            );
+        }
+        Err(e) => {
+            eprintln!("[fc-agent] WARNING: podman system reset error: {}", e);
+        }
+    }
+}
+
 /// Import a Docker archive into podman storage. Returns image reference.
 /// If cmd_prefix is provided, prepend it to the podman command (e.g., for runuser).
 pub async fn import_image(


### PR DESCRIPTION
## Summary

- Revert `reset_podman_state()` which ran `podman system reset --force` as root, destroying `/var/lib/containers/storage/user-1000` and breaking all rootless user tests
- Add file locking to `ensure_nested_container()` to prevent concurrent `podman build` race on x64

## What changed

**fc-agent/src/agent.rs**: Remove `reset_podman_state()` call  
**fc-agent/src/container.rs**: Remove `reset_podman_state()` function  
**tests/common/mod.rs**: Add file-based locking around `podman build` with early-exit when image already exists

## Why

The `podman system reset --force` as root wiped the user-1000 btrfs storage directory, causing permission denied errors on `podman load`. The existing resets in `setup_btrfs_storage_if_available()` (root-level) and `create_vm_user()` (user-level) already handle the db.sql mismatch.

The container build lock prevents multiple nextest processes from concurrently calling `podman build`, which races on overlay unmount on x64.

## Test plan

- [ ] CI passes (rootless btrfs keepid tests no longer fail with permission denied)
- [ ] Nested tests don't race on container build