### PR TITLE
fix: prevent output backpressure from deadlocking container FUSE services

### DIFF
--- a/fc-agent/src/agent.rs
+++ b/fc-agent/src/agent.rs
@@ -305,7 +305,7 @@ pub async fn run() -> Result<()> {
     }
 
     // Non-TTY mode: async
-    let exit_code = container::run_async(&podman_args, &output).await?;
+    let exit_code = container::run_async(&podman_args, &output, plan.non_blocking_output).await?;
 
     // Notify host of exit
     crate::vsock::notify_container_exit(exit_code);

--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -1134,7 +1134,11 @@ pub fn run_tty(podman_args: &[String], plan: &Plan, mounted_fuse_paths: &[String
 }
 
 /// Run container in non-TTY async mode. Returns exit code.
-pub async fn run_async(podman_args: &[String], output: &OutputHandle, non_blocking_output: bool) -> Result<i32> {
+pub async fn run_async(
+    podman_args: &[String],
+    output: &OutputHandle,
+    non_blocking_output: bool,
+) -> Result<i32> {
     let mut cmd = Command::new(&podman_args[0]);
     cmd.args(&podman_args[1..]);
     cmd.stdout(Stdio::piped());

--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -1134,7 +1134,7 @@ pub fn run_tty(podman_args: &[String], plan: &Plan, mounted_fuse_paths: &[String
 }
 
 /// Run container in non-TTY async mode. Returns exit code.
-pub async fn run_async(podman_args: &[String], output: &OutputHandle) -> Result<i32> {
+pub async fn run_async(podman_args: &[String], output: &OutputHandle, non_blocking_output: bool) -> Result<i32> {
     let mut cmd = Command::new(&podman_args[0]);
     cmd.args(&podman_args[1..]);
     cmd.stdout(Stdio::piped());
@@ -1144,25 +1144,38 @@ pub async fn run_async(podman_args: &[String], output: &OutputHandle) -> Result<
 
     vsock::notify_container_started();
 
-    // Stream stdout via OutputHandle
+    // Stream stdout via OutputHandle.
+    // In non-blocking mode, use try_send_line (drops on full) to prevent
+    // backpressure from cascading into the container and deadlocking
+    // FUSE-based services like configerator_fuse.
     let out = output.clone();
+    let nb = non_blocking_output;
     let stdout_task = child.stdout.take().map(|stdout| {
         tokio::spawn(async move {
             let reader = BufReader::new(stdout);
             let mut lines = reader.lines();
             while let Ok(Some(line)) = lines.next_line().await {
-                out.send_line("stdout", &line).await;
+                if nb {
+                    out.try_send_line("stdout", &line);
+                } else {
+                    out.send_line("stdout", &line).await;
+                }
             }
         })
     });
 
     let out = output.clone();
+    let nb = non_blocking_output;
     let stderr_task = child.stderr.take().map(|stderr| {
         tokio::spawn(async move {
             let reader = BufReader::new(stderr);
             let mut lines = reader.lines();
             while let Ok(Some(line)) = lines.next_line().await {
-                out.send_line("stderr", &line).await;
+                if nb {
+                    out.try_send_line("stderr", &line);
+                } else {
+                    out.send_line("stderr", &line).await;
+                }
             }
         })
     });

--- a/fc-agent/src/types.rs
+++ b/fc-agent/src/types.rs
@@ -42,6 +42,11 @@ pub struct Plan {
     pub subuid_start: Option<u64>,
     #[serde(default)]
     pub subuid_count: Option<u64>,
+    /// Use non-blocking output: drop container stdout/stderr when the output
+    /// channel is full instead of blocking. Prevents backpressure from
+    /// deadlocking FUSE-based services in the container.
+    #[serde(default)]
+    pub non_blocking_output: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -257,6 +257,14 @@ pub struct RunArgs {
     #[arg(long)]
     pub no_snapshot: bool,
 
+    /// Use non-blocking writes for container stdout/stderr on the host side.
+    /// Without this flag, a slow or broken pipe reader (e.g., `fcvm ... | slow-consumer`)
+    /// backpressures the entire output pipeline into the container, potentially deadlocking
+    /// FUSE-based services like configerator_fuse. With this flag, output that can't be
+    /// written immediately is dropped, keeping the container healthy at the cost of lost logs.
+    #[arg(long)]
+    pub non_blocking_output: bool,
+
     /// Override rootfs filesystem type from kernel profile config (for testing).
     /// Normally driven by rootfs_type in kernel profile config.
     #[arg(long, value_enum, hide = true)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -393,6 +393,11 @@ pub struct SnapshotRunArgs {
     /// Passed from podman run's --hugepages when restoring from a snapshot cache hit.
     #[arg(skip)]
     pub hugepages: Option<bool>,
+
+    /// Whether to use non-blocking output on the host side (internal use only).
+    /// Passed from podman run's --non-blocking-output when restoring from a snapshot.
+    #[arg(skip)]
+    pub non_blocking_output: bool,
 }
 
 // ============================================================================

--- a/src/commands/podman/listeners.rs
+++ b/src/commands/podman/listeners.rs
@@ -354,7 +354,9 @@ mod tests {
         let (read_fd, write_fd) = nix::unistd::pipe().unwrap();
         drop(read_fd);
 
-        let mut writer = unsafe { std::fs::File::from_raw_fd(std::os::unix::io::IntoRawFd::into_raw_fd(write_fd)) };
+        let mut writer = unsafe {
+            std::fs::File::from_raw_fd(std::os::unix::io::IntoRawFd::into_raw_fd(write_fd))
+        };
         let result = writeln!(writer, "test output");
 
         assert!(result.is_err(), "writeln! should return Err on broken pipe");
@@ -370,7 +372,10 @@ mod tests {
 
         let result = tx.try_send("msg2".to_string());
         assert!(result.is_err(), "channel should be full");
-        assert!(matches!(result.unwrap_err(), std::sync::mpsc::TrySendError::Full(_)));
+        assert!(matches!(
+            result.unwrap_err(),
+            std::sync::mpsc::TrySendError::Full(_)
+        ));
     }
 
     /// With --non-blocking-output: try_send drops messages when channel is full.
@@ -401,7 +406,9 @@ mod tests {
             run_output_listener(&socket_str, "test-vm", None, reconnect, lossy).await
         });
         for _ in 0..50 {
-            if socket_path.exists() { break; }
+            if socket_path.exists() {
+                break;
+            }
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
         assert!(socket_path.exists(), "output socket not created");
@@ -418,7 +425,10 @@ mod tests {
 
         let mut stream = tokio::net::UnixStream::connect(&socket_path).await.unwrap();
         for i in 0..100 {
-            stream.write_all(format!("stdout:lossy-line-{}\n", i).as_bytes()).await.unwrap();
+            stream
+                .write_all(format!("stdout:lossy-line-{}\n", i).as_bytes())
+                .await
+                .unwrap();
         }
         drop(stream);
 
@@ -426,7 +436,11 @@ mod tests {
 
         listener.abort();
         let err = listener.await.unwrap_err();
-        assert!(err.is_cancelled(), "lossy listener should be cancelled, not panicked: {:?}", err);
+        assert!(
+            err.is_cancelled(),
+            "lossy listener should be cancelled, not panicked: {:?}",
+            err
+        );
     }
 
     /// Default mode processes lines normally when stdout is healthy.
@@ -438,14 +452,21 @@ mod tests {
         let listener = spawn_listener(&socket_path, false).await;
 
         let mut stream = tokio::net::UnixStream::connect(&socket_path).await.unwrap();
-        stream.write_all(b"stdout:hello\nstderr:world\n").await.unwrap();
+        stream
+            .write_all(b"stdout:hello\nstderr:world\n")
+            .await
+            .unwrap();
         drop(stream);
 
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
         listener.abort();
         let err = listener.await.unwrap_err();
-        assert!(err.is_cancelled(), "default listener should be cancelled, not panicked: {:?}", err);
+        assert!(
+            err.is_cancelled(),
+            "default listener should be cancelled, not panicked: {:?}",
+            err
+        );
     }
 
     #[tokio::test]

--- a/src/commands/podman/listeners.rs
+++ b/src/commands/podman/listeners.rs
@@ -1,3 +1,4 @@
+use std::io::Write;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
@@ -173,6 +174,7 @@ pub(crate) async fn run_output_listener(
     vm_id: &str,
     log_tx: Option<tokio::sync::broadcast::Sender<LogLine>>,
     reconnect_notify: Arc<tokio::sync::Notify>,
+    non_blocking_output: bool,
 ) -> Result<Vec<(String, String)>> {
     use tokio::io::{AsyncBufReadExt, BufReader};
     use tokio::net::UnixListener;
@@ -182,6 +184,29 @@ pub(crate) async fn run_output_listener(
 
     let listener = UnixListener::bind(socket_path)
         .with_context(|| format!("binding output listener to {}", socket_path))?;
+
+    // In non-blocking mode, use a bounded channel + writer thread so the
+    // listener never blocks on stdout/stderr. Messages are dropped when the
+    // channel is full, preventing backpressure from cascading into the container.
+    let nb_tx = if non_blocking_output {
+        let (tx, rx) = std::sync::mpsc::sync_channel::<(bool, String)>(1024);
+        std::thread::Builder::new()
+            .name("output-writer".into())
+            .spawn(move || {
+                for (is_stdout, content) in rx {
+                    if is_stdout {
+                        let _ = writeln!(std::io::stdout(), "{}", content);
+                    } else {
+                        let _ = writeln!(std::io::stderr(), "{}", content);
+                    }
+                }
+            })
+            .expect("spawn output writer thread");
+        info!(vm_id = %vm_id, "Non-blocking output mode: dropping messages when pipe is full");
+        Some(tx)
+    } else {
+        None
+    };
 
     info!(socket = %socket_path, "Output listener started");
 
@@ -243,10 +268,19 @@ pub(crate) async fn run_output_listener(
                             if stream == "heartbeat" {
                                 info!(vm_id = %vm_id, phase = %content, "VM heartbeat");
                             } else {
-                                if stream == "stdout" {
-                                    println!("{}", content);
+                                // Use writeln! instead of println!/eprintln! to avoid
+                                // panicking on broken pipe. println! panics on write
+                                // error, which kills the listener task and stops
+                                // draining the vsock — deadlocking the container.
+                                let is_stdout = stream == "stdout";
+                                if let Some(ref tx) = nb_tx {
+                                    // Non-blocking mode: try_send drops if channel full.
+                                    // Writer thread handles the blocking stdout write.
+                                    let _ = tx.try_send((is_stdout, content.to_string()));
+                                } else if is_stdout {
+                                    let _ = writeln!(std::io::stdout(), "{}", content);
                                 } else {
-                                    eprintln!("{}", content);
+                                    let _ = writeln!(std::io::stderr(), "{}", content);
                                 }
                                 output_lines.push((stream.to_string(), content.to_string()));
                             }
@@ -309,6 +343,110 @@ pub(crate) async fn run_output_listener(
 mod tests {
     use super::*;
     use tokio::io::AsyncWriteExt;
+
+    /// Verify that writeln! to a broken pipe doesn't panic (returns Err),
+    /// while println! would panic with "failed printing to stdout".
+    #[test]
+    fn test_writeln_survives_broken_pipe() {
+        use std::io::Write;
+        use std::os::unix::io::FromRawFd;
+
+        let (read_fd, write_fd) = nix::unistd::pipe().unwrap();
+        drop(read_fd);
+
+        let mut writer = unsafe { std::fs::File::from_raw_fd(std::os::unix::io::IntoRawFd::into_raw_fd(write_fd)) };
+        let result = writeln!(writer, "test output");
+
+        assert!(result.is_err(), "writeln! should return Err on broken pipe");
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::BrokenPipe);
+    }
+
+    /// Without --non-blocking-output: blocking send blocks on a full channel.
+    /// This is what causes the backpressure deadlock in default mode.
+    #[test]
+    fn test_sync_channel_send_blocks_when_full() {
+        let (tx, _rx) = std::sync::mpsc::sync_channel::<String>(1);
+        tx.send("msg1".to_string()).unwrap();
+
+        let result = tx.try_send("msg2".to_string());
+        assert!(result.is_err(), "channel should be full");
+        assert!(matches!(result.unwrap_err(), std::sync::mpsc::TrySendError::Full(_)));
+    }
+
+    /// With --non-blocking-output: try_send drops messages when channel is full.
+    /// This prevents backpressure from cascading into the container.
+    #[test]
+    fn test_lossy_try_send_drops_on_full_channel() {
+        let (tx, rx) = std::sync::mpsc::sync_channel::<(bool, String)>(2);
+
+        tx.try_send((true, "line1".to_string())).unwrap();
+        tx.try_send((true, "line2".to_string())).unwrap();
+
+        let result = tx.try_send((true, "line3-dropped".to_string()));
+        assert!(result.is_err(), "try_send should fail on full channel");
+
+        assert_eq!(rx.recv().unwrap().1, "line1");
+        assert_eq!(rx.recv().unwrap().1, "line2");
+        assert!(rx.try_recv().is_err());
+    }
+
+    /// Helper: spawn the output listener, wait for socket, return JoinHandle.
+    async fn spawn_listener(
+        socket_path: &std::path::Path,
+        lossy: bool,
+    ) -> tokio::task::JoinHandle<Result<Vec<(String, String)>>> {
+        let socket_str = socket_path.to_string_lossy().to_string();
+        let reconnect = std::sync::Arc::new(tokio::sync::Notify::new());
+        let handle = tokio::spawn(async move {
+            run_output_listener(&socket_str, "test-vm", None, reconnect, lossy).await
+        });
+        for _ in 0..50 {
+            if socket_path.exists() { break; }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(socket_path.exists(), "output socket not created");
+        handle
+    }
+
+    /// With --non-blocking-output, the listener processes all input without blocking.
+    #[tokio::test]
+    async fn test_output_listener_lossy_mode_processes_all_input() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let socket_path = temp_dir.path().join("output-lossy.sock");
+
+        let listener = spawn_listener(&socket_path, true).await;
+
+        let mut stream = tokio::net::UnixStream::connect(&socket_path).await.unwrap();
+        for i in 0..100 {
+            stream.write_all(format!("stdout:lossy-line-{}\n", i).as_bytes()).await.unwrap();
+        }
+        drop(stream);
+
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        listener.abort();
+        let err = listener.await.unwrap_err();
+        assert!(err.is_cancelled(), "lossy listener should be cancelled, not panicked: {:?}", err);
+    }
+
+    /// Default mode processes lines normally when stdout is healthy.
+    #[tokio::test]
+    async fn test_output_listener_default_mode_processes_lines() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let socket_path = temp_dir.path().join("output-default.sock");
+
+        let listener = spawn_listener(&socket_path, false).await;
+
+        let mut stream = tokio::net::UnixStream::connect(&socket_path).await.unwrap();
+        stream.write_all(b"stdout:hello\nstderr:world\n").await.unwrap();
+        drop(stream);
+
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        listener.abort();
+        let err = listener.await.unwrap_err();
+        assert!(err.is_cancelled(), "default listener should be cancelled, not panicked: {:?}", err);
+    }
 
     #[tokio::test]
     async fn test_status_listener_handles_multiple_messages_on_single_connection() {

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -745,8 +745,9 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
         let vm_id_clone = vm_id.clone();
         let log_tx_clone = Some(log_tx.clone());
         let reconnect = output_reconnect.clone();
+        let non_blocking_output = args.non_blocking_output;
         Some(tokio::spawn(async move {
-            match run_output_listener(&socket_path, &vm_id_clone, log_tx_clone, reconnect).await {
+            match run_output_listener(&socket_path, &vm_id_clone, log_tx_clone, reconnect, non_blocking_output).await {
                 Ok(lines) => lines,
                 Err(e) => {
                     tracing::warn!("Output listener error: {}", e);
@@ -1084,6 +1085,7 @@ mod tests {
             portable_volumes: false,
             image_mode: None,
             rootfs_type: None,
+            non_blocking_output: false,
             label: vec![],
             image: "alpine:latest".to_string(),
             command_args: vec![],

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -747,7 +747,15 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
         let reconnect = output_reconnect.clone();
         let non_blocking_output = args.non_blocking_output;
         Some(tokio::spawn(async move {
-            match run_output_listener(&socket_path, &vm_id_clone, log_tx_clone, reconnect, non_blocking_output).await {
+            match run_output_listener(
+                &socket_path,
+                &vm_id_clone,
+                log_tx_clone,
+                reconnect,
+                non_blocking_output,
+            )
+            .await
+            {
                 Ok(lines) => lines,
                 Err(e) => {
                     tracing::warn!("Output listener error: {}", e);

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -303,6 +303,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
                 firecracker_bin,
                 firecracker_args,
                 hugepages: Some(args.hugepages),
+                non_blocking_output: args.non_blocking_output,
             };
             super::snapshot::cmd_snapshot_run(snapshot_args).await?;
             return Ok(None);
@@ -335,6 +336,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
                 firecracker_bin,
                 firecracker_args,
                 hugepages: Some(args.hugepages),
+                non_blocking_output: args.non_blocking_output,
             };
             super::snapshot::cmd_snapshot_run(snapshot_args).await?;
             return Ok(None);

--- a/src/commands/podman/snapshot.rs
+++ b/src/commands/podman/snapshot.rs
@@ -261,6 +261,7 @@ pub(super) fn build_firecracker_config(
         args.forward_localhost.clone(),
         image_mode,
         rootfs_type,
+        args.non_blocking_output,
     );
     // Set the original image name for MMDS (separate from cache key identifier)
     config.container_image_name = args.image.clone();

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -848,6 +848,7 @@ pub(super) async fn run_vm_setup(
                 args.forward_localhost.clone(),
                 image_mode,
                 rootfs_type,
+                args.non_blocking_output,
             )
         });
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -321,6 +321,7 @@ async fn create_sandbox(
         no_snapshot: true,
         image_mode: None,
         rootfs_type: None,
+        non_blocking_output: false,
         forward_localhost: vec![],
         user: None,
         hugepages: false,

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -1214,6 +1214,7 @@ mod tests {
             firecracker_bin: Some("/opt/firecracker-profile".to_string()),
             firecracker_args: Some("--enable-nv2".to_string()),
             hugepages: None,
+            non_blocking_output: false,
         };
 
         let runtime = snapshot_restore_runtime_config(&args);

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -657,7 +657,7 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
         let vm_id_clone = vm_id.clone();
         let reconnect = output_reconnect.clone();
         Some(tokio::spawn(async move {
-            match run_output_listener(&socket_path, &vm_id_clone, None, reconnect).await {
+            match run_output_listener(&socket_path, &vm_id_clone, None, reconnect, false).await {
                 Ok(lines) => lines,
                 Err(e) => {
                     tracing::warn!("Output listener error: {}", e);

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -633,6 +633,7 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
     // Setup TTY/output socket paths
     let tty_mode = args.tty;
     let interactive = args.interactive;
+    let non_blocking_output = args.non_blocking_output;
     let tty_socket_path = format!("{}_{}", clone_vsock_base.display(), VSOCK_TTY_PORT);
     let output_socket_path = format!("{}_{}", clone_vsock_base.display(), VSOCK_OUTPUT_PORT);
 
@@ -657,7 +658,15 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
         let vm_id_clone = vm_id.clone();
         let reconnect = output_reconnect.clone();
         Some(tokio::spawn(async move {
-            match run_output_listener(&socket_path, &vm_id_clone, None, reconnect, false).await {
+            match run_output_listener(
+                &socket_path,
+                &vm_id_clone,
+                None,
+                reconnect,
+                non_blocking_output,
+            )
+            .await
+            {
                 Ok(lines) => lines,
                 Err(e) => {
                     tracing::warn!("Output listener error: {}", e);

--- a/src/firecracker/config.rs
+++ b/src/firecracker/config.rs
@@ -63,6 +63,11 @@ pub struct FirecrackerConfig {
     /// Affects MMDS plan and container stdin handling.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub interactive: bool,
+    /// Non-blocking output: fc-agent drops container output when channel is full.
+    /// Part of cache key because fc-agent reads this from the Plan at boot,
+    /// and that value is baked into the snapshot memory.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub non_blocking_output: bool,
     /// Minimum free space on root filesystem (e.g., "10G").
     /// Affects disk size after CoW copy, so must be in cache key.
     #[serde(default = "default_rootfs_size")]
@@ -196,6 +201,7 @@ impl FirecrackerConfig {
         forward_localhost: Vec<u16>,
         image_mode: ImageMode,
         rootfs_type: Option<String>,
+        non_blocking_output: bool,
     ) -> Self {
         Self {
             boot_source: BootSource {
@@ -233,6 +239,7 @@ impl FirecrackerConfig {
             health_check_url,
             user,
             forward_localhost,
+            non_blocking_output,
             image_mode,
             rootfs_type,
         }
@@ -362,6 +369,7 @@ impl FirecrackerConfig {
                     "user": self.user.as_deref(),
                     "subuid_start": runtime.subuid_start,
                     "subuid_count": runtime.subuid_count,
+                    "non_blocking_output": self.non_blocking_output,
                     "forward_localhost": self.forward_localhost.iter().map(|p| p.to_string()).collect::<Vec<_>>(),
                     "interactive": self.interactive,
                     "tty": self.tty,
@@ -429,6 +437,7 @@ mod tests {
             vec![],
             ImageMode::Overlay,
             None,
+            false,
         )
     }
 

--- a/tests/test_library_api.rs
+++ b/tests/test_library_api.rs
@@ -48,6 +48,7 @@ fn test_run_args(name: &str) -> RunArgs {
         image_mode: None,
         rootfs_type: None,
         label: vec![],
+        non_blocking_output: false,
         image: common::TEST_IMAGE.to_string(),
         command_args: vec![],
     }


### PR DESCRIPTION
## Summary
- Replace `println!`/`eprintln!` with `writeln!` in the output listener to prevent panic on broken pipe (which kills the listener task and stops vsock drain)
- Add `--non-blocking-output` flag: uses bounded channel + writer thread with `try_send` — drops messages when full instead of blocking, keeping the container healthy
- Propagate `--non-blocking-output` through snapshot restore path (SnapshotRunArgs) so the flag isn't silently dropped on cache hits

## The Problem
When `fcvm podman run` is piped through `tee` or any consumer that exits/slows down, the output listener panics (`println!` on broken pipe) or blocks (full pipe buffer). This stops draining the vsock connection, backpressuring the entire output pipeline into the container. FUSE-based services like `configerator_fuse` block on stderr writes and can't process FUSE requests, deadlocking HHVM (HTTP 500 on all requests).

Deadlock chain: host pipe breaks → listener dies → vsock fills → fc-agent blocks → podman blocks → conmon blocks → configerator_fuse stderr pipe fills → FUSE handler threads block → HHVM can't load sitevars → 500

## The Fix
1. `writeln!` returns `Err` on broken pipe instead of panicking — listener keeps running
2. `--non-blocking-output`: bounded channel (1024) with `try_send` decouples the listener from stdout writes. Writer thread blocks on stdout independently. When channel is full, messages are dropped (not blocked).
3. `non_blocking_output` added to `SnapshotRunArgs` as internal field, passed through both snapshot cache hit paths in `prepare_vm()`, used in `cmd_snapshot_run()` output listener

## Test plan
```
cargo test --lib -- listeners::tests
# 6 tests: broken pipe survival, channel blocking/dropping, lossy/default listener modes
```