### PR TITLE
refactor: replace long parameter lists with structs

### DIFF
--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -316,6 +316,16 @@ pub async fn save_vm_state_with_network(
     Ok(())
 }
 
+/// Owned resources for VM cleanup that can be moved into the cleanup call.
+pub struct CleanupContext {
+    pub vm_id: String,
+    pub volume_server_handles: Vec<JoinHandle<()>>,
+    pub data_dir: PathBuf,
+    pub health_cancel_token: Option<tokio_util::sync::CancellationToken>,
+    pub health_monitor_handle: Option<JoinHandle<()>>,
+    pub output_listener_handle: Option<JoinHandle<Vec<(String, String)>>>,
+}
+
 /// Cleanup resources for a VM (used by both podman and snapshot commands)
 ///
 /// This function handles the complete cleanup sequence:
@@ -326,19 +336,21 @@ pub async fn save_vm_state_with_network(
 /// 5. Cleanup network resources
 /// 6. Delete state file
 /// 7. Remove data directory
-#[allow(clippy::too_many_arguments)]
 pub async fn cleanup_vm(
-    vm_id: &str,
+    ctx: CleanupContext,
     vm_manager: &mut VmManager,
     holder_child: &mut Option<tokio::process::Child>,
-    volume_server_handles: Vec<JoinHandle<()>>,
     network: &mut dyn NetworkManager,
     state_manager: &StateManager,
-    data_dir: &Path,
-    health_cancel_token: Option<tokio_util::sync::CancellationToken>,
-    health_monitor_handle: Option<JoinHandle<()>>,
-    output_listener_handle: Option<JoinHandle<Vec<(String, String)>>>,
 ) {
+    let CleanupContext {
+        vm_id,
+        volume_server_handles,
+        data_dir,
+        health_cancel_token,
+        health_monitor_handle,
+        output_listener_handle,
+    } = ctx;
     info!("cleaning up resources");
 
     // Signal health monitor to stop gracefully, then wait briefly for it
@@ -384,7 +396,7 @@ pub async fn cleanup_vm(
     }
 
     // Delete state file
-    if let Err(e) = state_manager.delete_state(vm_id).await {
+    if let Err(e) = state_manager.delete_state(&vm_id).await {
         warn!("failed to delete state file: {}", e);
     }
 
@@ -400,7 +412,7 @@ pub async fn cleanup_vm(
     }
 
     // Cleanup VM data directory (includes disks, sockets, etc.)
-    if let Err(e) = tokio::fs::remove_dir_all(data_dir).await {
+    if let Err(e) = tokio::fs::remove_dir_all(&data_dir).await {
         warn!(vm_id = %vm_id, error = %e, "failed to cleanup VM data directory");
     } else {
         info!(vm_id = %vm_id, "cleaned up VM data directory");

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -449,9 +449,6 @@ pub struct SnapshotRestoreConfig {
     pub snapshot_dir: Option<PathBuf>,
 }
 
-/// Restore a VM from a snapshot
-///
-/// This is the core snapshot restore logic shared by:
 /// Parameters for snapshot restore, grouping the many read-only inputs.
 pub struct RestoreParams<'a> {
     pub vm_id: &'a str,
@@ -463,6 +460,9 @@ pub struct RestoreParams<'a> {
     pub network_config: &'a NetworkConfig,
 }
 
+/// Restore a VM from a snapshot.
+///
+/// This is the core snapshot restore logic shared by:
 /// - `fcvm snapshot run` (clone with UFFD memory sharing)
 /// - `fcvm podman run` with cache hit (direct file load)
 ///

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -452,25 +452,38 @@ pub struct SnapshotRestoreConfig {
 /// Restore a VM from a snapshot
 ///
 /// This is the core snapshot restore logic shared by:
+/// Parameters for snapshot restore, grouping the many read-only inputs.
+pub struct RestoreParams<'a> {
+    pub vm_id: &'a str,
+    pub vm_name: &'a str,
+    pub data_dir: &'a Path,
+    pub socket_path: &'a Path,
+    pub runtime_config: &'a RuntimeConfig,
+    pub restore_config: &'a SnapshotRestoreConfig,
+    pub network_config: &'a NetworkConfig,
+}
+
 /// - `fcvm snapshot run` (clone with UFFD memory sharing)
 /// - `fcvm podman run` with cache hit (direct file load)
 ///
 /// Both paths use identical Firecracker setup, the only differences are:
 /// - Memory backend: UFFD vs File
 /// - Snapshot source: snapshots/{name} vs podman-cache/{hash}
-#[allow(clippy::too_many_arguments)]
 pub async fn restore_from_snapshot(
-    vm_id: &str,
-    vm_name: &str,
-    data_dir: &Path,
-    socket_path: &Path,
-    runtime_config: &RuntimeConfig,
-    restore_config: &SnapshotRestoreConfig,
-    network_config: &NetworkConfig,
+    params: RestoreParams<'_>,
     network: &mut dyn NetworkManager,
     state_manager: &StateManager,
     vm_state: &mut VmState,
 ) -> Result<(VmManager, Option<tokio::process::Child>)> {
+    let RestoreParams {
+        vm_id,
+        vm_name,
+        data_dir,
+        socket_path,
+        runtime_config,
+        restore_config,
+        network_config,
+    } = params;
     let vm_dir = data_dir.join("disks");
 
     // Configure namespace isolation if network provides one

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -22,7 +22,10 @@ pub(crate) use listeners::run_output_listener;
 use listeners::run_status_listener;
 
 use snapshot::{build_firecracker_config, snapshot_run_firecracker_overrides};
-pub use snapshot::{check_podman_snapshot, create_snapshot_interruptible, startup_snapshot_key};
+pub use snapshot::{
+    check_podman_snapshot, create_snapshot_interruptible, startup_snapshot_key,
+    CreateSnapshotParams,
+};
 use vm_config::{cleanup_nfs_exports, run_vm_setup, VmSetupParams};
 
 use crate::cli::{NetworkMode, PodmanArgs, PodmanCommands, RunArgs};
@@ -915,12 +918,17 @@ pub async fn run_vm_loop(ctx: &mut VmContext, cancel: CancellationToken) -> Resu
 
                     let mut params = SnapshotCreationParams::from_run_args(&ctx.args);
                     params.extra_disks = ctx.image_extra_disks.clone();
-                    match create_snapshot_interruptible(
-                        &ctx.vm_manager, key, &ctx.vm_id, &params, &ctx.disk_path,
-                        &ctx.network_config, &ctx.volume_configs,
-                        None, // Pre-start is the first snapshot, no parent
-                        &cancel,
-                    ).await {
+                    let snap = CreateSnapshotParams {
+                        vm_manager: &ctx.vm_manager,
+                        snapshot_key: key,
+                        vm_id: &ctx.vm_id,
+                        params: &params,
+                        disk_path: &ctx.disk_path,
+                        network_config: &ctx.network_config,
+                        volume_configs: &ctx.volume_configs,
+                        parent_snapshot_key: None, // Pre-start is the first snapshot, no parent
+                    };
+                    match create_snapshot_interruptible(&snap, &cancel).await {
                         SnapshotOutcome::Interrupted => {
                             return Ok(None);
                         }
@@ -968,13 +976,18 @@ pub async fn run_vm_loop(ctx: &mut VmContext, cancel: CancellationToken) -> Resu
                         // This is safe: startup snapshots are optional (just caching), so
                         // if the VM is paused mid-snapshot when we cancel, cleanup will
                         // kill the VM anyway via vm_manager.kill().
+                        let snap = CreateSnapshotParams {
+                            vm_manager: &ctx.vm_manager,
+                            snapshot_key: &startup_key,
+                            vm_id: &ctx.vm_id,
+                            params: &params,
+                            disk_path: &ctx.disk_path,
+                            network_config: &ctx.network_config,
+                            volume_configs: &ctx.volume_configs,
+                            parent_snapshot_key: Some(key.as_str()), // Parent is pre-start snapshot
+                        };
                         tokio::select! {
-                            outcome = create_snapshot_interruptible(
-                                &ctx.vm_manager, &startup_key, &ctx.vm_id, &params, &ctx.disk_path,
-                                &ctx.network_config, &ctx.volume_configs,
-                                Some(key.as_str()), // Parent is pre-start snapshot
-                                &cancel,
-                            ) => {
+                            outcome = create_snapshot_interruptible(&snap, &cancel) => {
                                 match outcome {
                                     SnapshotOutcome::Interrupted => {
                                         return Ok(None);

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -23,7 +23,7 @@ use listeners::run_status_listener;
 
 use snapshot::{build_firecracker_config, snapshot_run_firecracker_overrides};
 pub use snapshot::{check_podman_snapshot, create_snapshot_interruptible, startup_snapshot_key};
-use vm_config::{cleanup_nfs_exports, run_vm_setup};
+use vm_config::{cleanup_nfs_exports, run_vm_setup, VmSetupParams};
 
 use crate::cli::{NetworkMode, PodmanArgs, PodmanCommands, RunArgs};
 use crate::commands::common::{
@@ -771,23 +771,25 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
 
     // Run the main VM setup in a helper to ensure cleanup on error
     let setup_result = run_vm_setup(
-        &args,
-        &vm_id,
-        &data_dir,
-        &base_rootfs,
-        &socket_path,
-        &kernel_path,
-        &initrd_path,
-        &network_config,
+        VmSetupParams {
+            args: &args,
+            vm_id: &vm_id,
+            data_dir: &data_dir,
+            base_rootfs: &base_rootfs,
+            socket_path: &socket_path,
+            kernel_path: &kernel_path,
+            initrd_path: &initrd_path,
+            network_config: &network_config,
+            cmd_args,
+            volume_mappings: &volume_mappings,
+            vsock_socket_path: &vsock_socket_path,
+            image_disk_path: image_disk_path.as_deref(),
+            fc_config,
+            runtime_config: &runtime_config,
+        },
         network.as_mut(),
-        cmd_args,
         &state_manager,
         &mut vm_state,
-        &volume_mappings,
-        &vsock_socket_path,
-        image_disk_path.as_deref(),
-        fc_config,
-        &runtime_config,
     )
     .await;
 
@@ -1012,16 +1014,18 @@ pub async fn cleanup_vm_context(mut ctx: VmContext) {
 
     // Cleanup common resources
     super::common::cleanup_vm(
-        &ctx.vm_id,
+        super::common::CleanupContext {
+            vm_id: ctx.vm_id,
+            volume_server_handles: ctx.volume_server_handles,
+            data_dir: ctx.data_dir,
+            health_cancel_token: Some(ctx.health_cancel_token),
+            health_monitor_handle: Some(ctx.health_monitor_handle),
+            output_listener_handle: ctx.output_handle,
+        },
         &mut ctx.vm_manager,
         &mut ctx.holder_child,
-        ctx.volume_server_handles,
         ctx.network.as_mut(),
         &ctx.state_manager,
-        &ctx.data_dir,
-        Some(ctx.health_cancel_token),
-        Some(ctx.health_monitor_handle),
-        ctx.output_handle,
     )
     .await;
 }

--- a/src/commands/podman/snapshot.rs
+++ b/src/commands/podman/snapshot.rs
@@ -208,9 +208,7 @@ pub(super) fn build_firecracker_config(
     // image_identifier is the digest for localhost images (content-addressed cache key).
     // args.image is the original name (what the guest uses to find the image).
     // FirecrackerConfig stores both: container_image for cache key, container_image_name for MMDS.
-    use crate::firecracker::{
-        BootSource, Drive, FcNetworkMode, FirecrackerConfig, MachineConfig,
-    };
+    use crate::firecracker::{BootSource, Drive, FcNetworkMode, FirecrackerConfig, MachineConfig};
 
     let network_mode = match args.network {
         crate::cli::args::NetworkMode::Bridged => FcNetworkMode::Bridged,

--- a/src/commands/podman/snapshot.rs
+++ b/src/commands/podman/snapshot.rs
@@ -30,6 +30,18 @@ pub fn startup_snapshot_key(base_key: &str) -> String {
     format!("{}-startup", base_key)
 }
 
+/// Parameters for snapshot creation, grouping the many read-only inputs.
+pub struct CreateSnapshotParams<'a> {
+    pub vm_manager: &'a VmManager,
+    pub snapshot_key: &'a str,
+    pub vm_id: &'a str,
+    pub params: &'a SnapshotCreationParams,
+    pub disk_path: &'a Path,
+    pub network_config: &'a NetworkConfig,
+    pub volume_configs: &'a [VolumeConfig],
+    pub parent_snapshot_key: Option<&'a str>,
+}
+
 /// Create a podman snapshot from a running VM.
 ///
 /// This pauses the VM, creates a Firecracker snapshot, copies the disk,
@@ -40,17 +52,17 @@ pub fn startup_snapshot_key(base_key: &str) -> String {
 ///
 /// If `parent_snapshot_key` is provided, the parent's memory.bin will be copied
 /// (via reflink) as a base, enabling diff snapshots for new directories.
-#[allow(clippy::too_many_arguments)]
-pub async fn create_podman_snapshot(
-    vm_manager: &VmManager,
-    snapshot_key: &str,
-    vm_id: &str,
-    params: &SnapshotCreationParams,
-    disk_path: &Path,
-    network_config: &NetworkConfig,
-    volume_configs: &[VolumeConfig],
-    parent_snapshot_key: Option<&str>,
-) -> Result<()> {
+pub async fn create_podman_snapshot(snap: &CreateSnapshotParams<'_>) -> Result<()> {
+    let CreateSnapshotParams {
+        vm_manager,
+        snapshot_key,
+        vm_id,
+        params,
+        disk_path,
+        network_config,
+        volume_configs,
+        parent_snapshot_key,
+    } = snap;
     // Snapshots stored in snapshot_dir with snapshot_key as name
     let snapshot_dir = paths::snapshot_dir().join(snapshot_key);
 
@@ -117,7 +129,7 @@ pub async fn create_podman_snapshot(
             image: params.image.clone(),
             vcpu: params.vcpu,
             memory_mib: params.memory_mib,
-            network_config: network_config.clone(),
+            network_config: (*network_config).clone(),
             volumes: snapshot_volumes,
             health_check_url: params.health_check_url.clone(),
             hugepages: params.hugepages,
@@ -146,16 +158,8 @@ pub async fn create_podman_snapshot(
 ///
 /// Returns `SnapshotOutcome::Interrupted` if a signal is received - caller
 /// should break their event loop and proceed to cleanup.
-#[allow(clippy::too_many_arguments)]
 pub async fn create_snapshot_interruptible(
-    vm_manager: &VmManager,
-    snapshot_key: &str,
-    vm_id: &str,
-    params: &SnapshotCreationParams,
-    disk_path: &Path,
-    network_config: &NetworkConfig,
-    volume_configs: &[VolumeConfig],
-    parent_snapshot_key: Option<&str>,
+    snap: &CreateSnapshotParams<'_>,
     cancel: &CancellationToken,
 ) -> SnapshotOutcome {
     // CRITICAL: Do NOT use tokio::select! to interrupt the snapshot future.
@@ -170,18 +174,7 @@ pub async fn create_snapshot_interruptible(
 
     // Run snapshot to completion. create_snapshot_core always resumes the VM
     // before returning, even on error, so this is safe.
-    match create_podman_snapshot(
-        vm_manager,
-        snapshot_key,
-        vm_id,
-        params,
-        disk_path,
-        network_config,
-        volume_configs,
-        parent_snapshot_key,
-    )
-    .await
-    {
+    match create_podman_snapshot(snap).await {
         Ok(()) => {
             if cancel.is_cancelled() {
                 // Snapshot succeeded but we're shutting down

--- a/src/commands/podman/snapshot.rs
+++ b/src/commands/podman/snapshot.rs
@@ -215,7 +215,9 @@ pub(super) fn build_firecracker_config(
     // image_identifier is the digest for localhost images (content-addressed cache key).
     // args.image is the original name (what the guest uses to find the image).
     // FirecrackerConfig stores both: container_image for cache key, container_image_name for MMDS.
-    use crate::firecracker::{FcNetworkMode, FirecrackerConfig};
+    use crate::firecracker::{
+        BootSource, Drive, FcNetworkMode, FirecrackerConfig, MachineConfig,
+    };
 
     let network_mode = match args.network {
         crate::cli::args::NetworkMode::Bridged => FcNetworkMode::Bridged,
@@ -229,43 +231,47 @@ pub(super) fn build_firecracker_config(
     extra_disks.extend(args.disk_dir.iter().cloned());
     extra_disks.extend(args.nfs.iter().cloned());
 
-    // Collect env vars for cache key (affects container behavior)
-    let env_vars: Vec<String> = args.env.to_vec();
-
-    // Collect volume mounts for cache key (affects MMDS plan)
-    let volume_mounts: Vec<String> = args.map.to_vec();
-
-    // Resolve rootfs_type for cache key
-    let rootfs_type = super::resolve_rootfs_type(args);
-
-    let mut config = FirecrackerConfig::new(
-        kernel_path.to_path_buf(),
-        initrd_path.to_path_buf(),
-        rootfs_path.to_path_buf(),
-        image_identifier.to_string(),
-        cmd_args,
-        args.cpu,
-        args.mem,
+    FirecrackerConfig {
+        boot_source: BootSource {
+            kernel_image_path: kernel_path.to_path_buf(),
+            initrd_path: initrd_path.to_path_buf(),
+            ..Default::default()
+        },
+        machine_config: MachineConfig {
+            vcpu_count: args.cpu,
+            mem_size_mib: args.mem,
+            huge_pages: if args.hugepages {
+                Some("2M".to_string())
+            } else {
+                None
+            },
+        },
+        drives: vec![Drive {
+            drive_id: "rootfs".to_string(),
+            path_on_host: rootfs_path.to_path_buf(),
+            is_root_device: true,
+            is_read_only: false,
+        }],
+        container_image: image_identifier.to_string(),
+        // Set the original image name for MMDS (separate from cache key identifier)
+        container_image_name: args.image.clone(),
+        container_cmd: cmd_args,
         network_mode,
-        crate::paths::data_dir(),
+        data_dir: crate::paths::data_dir(),
         extra_disks,
-        env_vars,
-        volume_mounts,
-        args.privileged,
-        args.tty,
-        args.interactive,
-        args.rootfs_size.clone(),
-        args.health_check.clone(),
-        args.hugepages,
-        args.user.clone(),
-        args.forward_localhost.clone(),
+        env_vars: args.env.to_vec(),
+        volume_mounts: args.map.to_vec(),
+        privileged: args.privileged,
+        tty: args.tty,
+        interactive: args.interactive,
+        rootfs_size: args.rootfs_size.clone(),
+        health_check_url: args.health_check.clone(),
+        user: args.user.clone(),
+        forward_localhost: args.forward_localhost.clone(),
         image_mode,
-        rootfs_type,
-        args.non_blocking_output,
-    );
-    // Set the original image name for MMDS (separate from cache key identifier)
-    config.container_image_name = args.image.clone();
-    config
+        non_blocking_output: args.non_blocking_output,
+        rootfs_type: super::resolve_rootfs_type(args),
+    }
 }
 
 /// Extract Firecracker binary path and args from RuntimeConfig for snapshot restore.

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -683,29 +683,49 @@ pub(super) async fn cleanup_nfs_exports(vm_id: &str) {
     }
 }
 
+/// Parameters for VM setup, grouping the many read-only inputs.
+pub(super) struct VmSetupParams<'a> {
+    pub args: &'a RunArgs,
+    pub vm_id: &'a str,
+    pub data_dir: &'a std::path::Path,
+    pub base_rootfs: &'a std::path::Path,
+    pub socket_path: &'a std::path::Path,
+    pub kernel_path: &'a std::path::Path,
+    pub initrd_path: &'a std::path::Path,
+    pub network_config: &'a crate::network::NetworkConfig,
+    pub cmd_args: Option<Vec<String>>,
+    pub volume_mappings: &'a [VolumeMapping],
+    pub vsock_socket_path: &'a std::path::Path,
+    pub image_disk_path: Option<&'a std::path::Path>,
+    pub fc_config: Option<crate::firecracker::FirecrackerConfig>,
+    pub runtime_config: &'a crate::commands::common::RuntimeConfig,
+}
+
 /// Helper function that runs VM setup and returns VmManager on success.
 /// This allows the caller to cleanup network resources on error.
 /// For rootless mode, also returns the holder process that keeps the namespace alive.
-#[allow(clippy::too_many_arguments)]
 pub(super) async fn run_vm_setup(
-    args: &RunArgs,
-    vm_id: &str,
-    data_dir: &std::path::Path,
-    base_rootfs: &std::path::Path,
-    socket_path: &std::path::Path,
-    kernel_path: &std::path::Path,
-    initrd_path: &std::path::Path,
-    network_config: &crate::network::NetworkConfig,
+    params: VmSetupParams<'_>,
     network: &mut dyn NetworkManager,
-    cmd_args: Option<Vec<String>>,
     state_manager: &StateManager,
     vm_state: &mut VmState,
-    volume_mappings: &[VolumeMapping],
-    vsock_socket_path: &std::path::Path,
-    image_disk_path: Option<&std::path::Path>,
-    fc_config: Option<crate::firecracker::FirecrackerConfig>,
-    runtime_config: &crate::commands::common::RuntimeConfig,
 ) -> Result<(VmManager, Option<tokio::process::Child>)> {
+    let VmSetupParams {
+        args,
+        vm_id,
+        data_dir,
+        base_rootfs,
+        socket_path,
+        kernel_path,
+        initrd_path,
+        network_config,
+        cmd_args,
+        volume_mappings,
+        vsock_socket_path,
+        image_disk_path,
+        fc_config,
+        runtime_config,
+    } = params;
     // Setup storage - just need CoW copy (fc-agent is injected via initrd at boot)
     let vm_dir = data_dir.join("disks");
     let disk_manager =
@@ -809,7 +829,9 @@ pub(super) async fn run_vm_setup(
     let launch_config = fc_config
         .map(|config| config.with_rootfs_path(rootfs_path.to_path_buf()))
         .unwrap_or_else(|| {
-            use crate::firecracker::FcNetworkMode;
+            use crate::firecracker::{
+                BootSource, Drive, FcNetworkMode, FirecrackerConfig, MachineConfig,
+            };
             let network_mode = match args.network {
                 crate::cli::args::NetworkMode::Bridged => FcNetworkMode::Bridged,
                 crate::cli::args::NetworkMode::Rootless => FcNetworkMode::Rootless,
@@ -819,37 +841,47 @@ pub(super) async fn run_vm_setup(
             extra_disks.extend(args.disk.iter().cloned());
             extra_disks.extend(args.disk_dir.iter().cloned());
             extra_disks.extend(args.nfs.iter().cloned());
-            // Collect env vars and volume mounts for cache key
-            let env_vars: Vec<String> = args.env.to_vec();
-            let volume_mounts: Vec<String> = args.map.to_vec();
-            let image_mode = super::resolve_image_mode(args);
-            let rootfs_type = super::resolve_rootfs_type(args);
 
-            crate::firecracker::FirecrackerConfig::new(
-                kernel_path.to_path_buf(),
-                initrd_path.to_path_buf(),
-                rootfs_path.to_path_buf(),
-                args.image.clone(),
-                cmd_args.clone(),
-                args.cpu,
-                args.mem,
+            FirecrackerConfig {
+                boot_source: BootSource {
+                    kernel_image_path: kernel_path.to_path_buf(),
+                    initrd_path: initrd_path.to_path_buf(),
+                    ..Default::default()
+                },
+                machine_config: MachineConfig {
+                    vcpu_count: args.cpu,
+                    mem_size_mib: args.mem,
+                    huge_pages: if args.hugepages {
+                        Some("2M".to_string())
+                    } else {
+                        None
+                    },
+                },
+                drives: vec![Drive {
+                    drive_id: "rootfs".to_string(),
+                    path_on_host: rootfs_path.to_path_buf(),
+                    is_root_device: true,
+                    is_read_only: false,
+                }],
+                container_image_name: args.image.clone(),
+                container_image: args.image.clone(),
+                container_cmd: cmd_args.clone(),
                 network_mode,
-                crate::paths::data_dir(),
+                data_dir: crate::paths::data_dir(),
                 extra_disks,
-                env_vars,
-                volume_mounts,
-                args.privileged,
-                args.tty,
-                args.interactive,
-                args.rootfs_size.clone(),
-                args.health_check.clone(),
-                args.hugepages,
-                args.user.clone(),
-                args.forward_localhost.clone(),
-                image_mode,
-                rootfs_type,
-                args.non_blocking_output,
-            )
+                env_vars: args.env.to_vec(),
+                volume_mounts: args.map.to_vec(),
+                privileged: args.privileged,
+                tty: args.tty,
+                interactive: args.interactive,
+                non_blocking_output: args.non_blocking_output,
+                rootfs_size: args.rootfs_size.clone(),
+                health_check_url: args.health_check.clone(),
+                user: args.user.clone(),
+                forward_localhost: args.forward_localhost.clone(),
+                image_mode: super::resolve_image_mode(args),
+                rootfs_type: super::resolve_rootfs_type(args),
+            }
         });
 
     // Build runtime boot args and apply FirecrackerConfig

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -979,16 +979,18 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
         implicit_uffd_cancel.cancel();
 
         super::common::cleanup_vm(
-            &vm_id,
+            super::common::CleanupContext {
+                vm_id: vm_id.clone(),
+                volume_server_handles,
+                data_dir: data_dir.clone(),
+                health_cancel_token: None, // no health monitor in exec path
+                health_monitor_handle: None,
+                output_listener_handle: output_handle, // abort output listener task
+            },
             &mut vm_manager,
             &mut holder_child,
-            volume_server_handles,
             network.as_mut(),
             &state_manager,
-            &data_dir,
-            None, // no health monitor in exec path
-            None,
-            output_handle, // abort output listener task
         )
         .await;
 
@@ -1125,16 +1127,18 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
 
     // Cleanup common resources
     super::common::cleanup_vm(
-        &vm_id,
+        super::common::CleanupContext {
+            vm_id: vm_id.clone(),
+            volume_server_handles,
+            data_dir: data_dir.clone(),
+            health_cancel_token: Some(health_cancel_token),
+            health_monitor_handle: Some(health_monitor_handle),
+            output_listener_handle: output_handle, // abort output listener task
+        },
         &mut vm_manager,
         &mut holder_child,
-        volume_server_handles,
         network.as_mut(),
         &state_manager,
-        &data_dir,
-        Some(health_cancel_token),
-        Some(health_monitor_handle),
-        output_handle, // abort output listener task
     )
     .await;
 

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -7,7 +7,7 @@ use tracing::{debug, info, warn};
 
 use super::podman::{
     check_podman_snapshot, create_snapshot_interruptible, startup_snapshot_key,
-    SnapshotCreationParams, SnapshotOutcome,
+    CreateSnapshotParams, SnapshotCreationParams, SnapshotOutcome,
 };
 use crate::cli::{
     NetworkMode, SnapshotArgs, SnapshotCommands, SnapshotCreateArgs, SnapshotRunArgs,
@@ -23,7 +23,8 @@ use crate::uffd::UffdServer;
 use crate::volume::{spawn_volume_servers, VolumeConfig};
 
 use super::common::{
-    MemoryBackend, RuntimeConfig, SnapshotRestoreConfig, VSOCK_OUTPUT_PORT, VSOCK_TTY_PORT,
+    MemoryBackend, RestoreParams, RuntimeConfig, SnapshotRestoreConfig, VSOCK_OUTPUT_PORT,
+    VSOCK_TTY_PORT,
 };
 use super::podman::run_output_listener;
 
@@ -851,14 +852,17 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
     };
 
     // Run clone setup using shared restore function
+    let restore_params = RestoreParams {
+        vm_id: &vm_id,
+        vm_name: &vm_name,
+        data_dir: &data_dir,
+        socket_path: &socket_path,
+        runtime_config: &runtime_config,
+        restore_config: &restore_config,
+        network_config: &network_config,
+    };
     let setup_result = super::common::restore_from_snapshot(
-        &vm_id,
-        &vm_name,
-        &data_dir,
-        &socket_path,
-        &runtime_config,
-        &restore_config,
-        &network_config,
+        restore_params,
         network.as_mut(),
         &state_manager,
         &mut vm_state,
@@ -1089,13 +1093,18 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
                         // Use select! so SIGTERM can abort startup snapshot immediately.
                         // Startup snapshots are optional (just caching), so if the VM is
                         // paused mid-snapshot, cleanup will kill it via vm_manager.kill().
+                        let snap = CreateSnapshotParams {
+                            vm_manager: &vm_manager,
+                            snapshot_key: &startup_key,
+                            vm_id: &vm_id,
+                            params: &params,
+                            disk_path: &disk_path,
+                            network_config: &network_config,
+                            volume_configs: &volume_configs,
+                            parent_snapshot_key: Some(base_key.as_str()), // Parent is pre-start snapshot
+                        };
                         tokio::select! {
-                            outcome = create_snapshot_interruptible(
-                                &vm_manager, &startup_key, &vm_id, &params, &disk_path,
-                                &network_config, &volume_configs,
-                                Some(base_key.as_str()), // Parent is pre-start snapshot
-                                &cancel,
-                            ) => {
+                            outcome = create_snapshot_interruptible(&snap, &cancel) => {
                                 match outcome {
                                     SnapshotOutcome::Interrupted => {
                                         container_exit_code = None;

--- a/src/firecracker/config.rs
+++ b/src/firecracker/config.rs
@@ -96,6 +96,34 @@ pub struct FirecrackerConfig {
     pub rootfs_type: Option<String>,
 }
 
+impl Default for FirecrackerConfig {
+    fn default() -> Self {
+        Self {
+            boot_source: BootSource::default(),
+            machine_config: MachineConfig::default(),
+            drives: Vec::new(),
+            container_image: String::new(),
+            container_image_name: String::new(),
+            container_cmd: None,
+            network_mode: NetworkMode::default(),
+            data_dir: PathBuf::new(),
+            extra_disks: Vec::new(),
+            env_vars: Vec::new(),
+            volume_mounts: Vec::new(),
+            privileged: false,
+            tty: false,
+            interactive: false,
+            non_blocking_output: false,
+            rootfs_size: "10G".to_string(),
+            health_check_url: None,
+            user: None,
+            forward_localhost: Vec::new(),
+            image_mode: ImageMode::Overlay,
+            rootfs_type: None,
+        }
+    }
+}
+
 fn default_image_mode() -> ImageMode {
     ImageMode::Overlay
 }
@@ -114,7 +142,17 @@ pub struct BootSource {
     pub boot_args: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+impl Default for BootSource {
+    fn default() -> Self {
+        Self {
+            kernel_image_path: PathBuf::new(),
+            initrd_path: PathBuf::new(),
+            boot_args: static_boot_args().to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct MachineConfig {
     pub vcpu_count: u8,
     pub mem_size_mib: u32,
@@ -132,19 +170,21 @@ pub struct Drive {
     pub is_read_only: bool,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum NetworkMode {
     Bridged,
+    #[default]
     Rootless,
 }
 
 /// How localhost container images are delivered to the guest VM.
 /// Part of snapshot cache key — different modes produce different VM states.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum ImageMode {
     /// Pre-built overlay storage image as additionalImageStore (read-only, instant)
+    #[default]
     Overlay,
     /// Pre-built btrfs storage image with real subvolumes as graphroot (read-write, instant)
     Btrfs,
@@ -176,75 +216,6 @@ pub fn static_boot_args() -> &'static str {
 }
 
 impl FirecrackerConfig {
-    /// Create a new Firecracker config for a podman VM.
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        kernel_path: PathBuf,
-        initrd_path: PathBuf,
-        rootfs_path: PathBuf,
-        container_image: String,
-        container_cmd: Option<Vec<String>>,
-        cpu: u8,
-        mem: u32,
-        network_mode: NetworkMode,
-        data_dir: PathBuf,
-        extra_disks: Vec<String>,
-        env_vars: Vec<String>,
-        volume_mounts: Vec<String>,
-        privileged: bool,
-        tty: bool,
-        interactive: bool,
-        rootfs_size: String,
-        health_check_url: Option<String>,
-        hugepages: bool,
-        user: Option<String>,
-        forward_localhost: Vec<u16>,
-        image_mode: ImageMode,
-        rootfs_type: Option<String>,
-        non_blocking_output: bool,
-    ) -> Self {
-        Self {
-            boot_source: BootSource {
-                kernel_image_path: kernel_path,
-                initrd_path,
-                boot_args: static_boot_args().to_string(),
-            },
-            machine_config: MachineConfig {
-                vcpu_count: cpu,
-                mem_size_mib: mem,
-                huge_pages: if hugepages {
-                    Some("2M".to_string())
-                } else {
-                    None
-                },
-            },
-            drives: vec![Drive {
-                drive_id: "rootfs".to_string(),
-                path_on_host: rootfs_path,
-                is_root_device: true,
-                is_read_only: false,
-            }],
-            container_image_name: container_image.clone(),
-            container_image,
-            container_cmd,
-            network_mode,
-            data_dir,
-            extra_disks,
-            env_vars,
-            volume_mounts,
-            privileged,
-            tty,
-            interactive,
-            rootfs_size,
-            health_check_url,
-            user,
-            forward_localhost,
-            non_blocking_output,
-            image_mode,
-            rootfs_type,
-        }
-    }
-
     /// Compute snapshot key by hashing the JSON representation.
     pub fn snapshot_key(&self) -> String {
         use crate::setup::rootfs::compute_sha256;
@@ -414,31 +385,29 @@ mod tests {
 
     /// Helper to create a default test config with optional overrides
     fn test_config() -> FirecrackerConfig {
-        FirecrackerConfig::new(
-            "/mnt/fcvm-btrfs/kernels/vmlinux-abc123.bin".into(),
-            "/mnt/fcvm-btrfs/initrd/fc-agent-def456.initrd".into(),
-            "/mnt/fcvm-btrfs/rootfs/layer2-789abc.raw".into(),
-            "nginx:alpine".to_string(),
-            None,
-            2,
-            2048,
-            NetworkMode::Bridged,
-            "/mnt/fcvm-btrfs".into(),
-            vec![],
-            vec![],
-            vec![],
-            false,
-            false,
-            false,
-            "10G".to_string(),
-            None,
-            false,
-            None,
-            vec![],
-            ImageMode::Overlay,
-            None,
-            false,
-        )
+        FirecrackerConfig {
+            boot_source: BootSource {
+                kernel_image_path: "/mnt/fcvm-btrfs/kernels/vmlinux-abc123.bin".into(),
+                initrd_path: "/mnt/fcvm-btrfs/initrd/fc-agent-def456.initrd".into(),
+                ..Default::default()
+            },
+            machine_config: MachineConfig {
+                vcpu_count: 2,
+                mem_size_mib: 2048,
+                ..Default::default()
+            },
+            drives: vec![Drive {
+                drive_id: "rootfs".to_string(),
+                path_on_host: "/mnt/fcvm-btrfs/rootfs/layer2-789abc.raw".into(),
+                is_root_device: true,
+                is_read_only: false,
+            }],
+            container_image: "nginx:alpine".to_string(),
+            container_image_name: "nginx:alpine".to_string(),
+            network_mode: NetworkMode::Bridged,
+            data_dir: "/mnt/fcvm-btrfs".into(),
+            ..Default::default()
+        }
     }
 
     #[test]

--- a/src/firecracker/mod.rs
+++ b/src/firecracker/mod.rs
@@ -3,5 +3,8 @@ pub mod config;
 pub mod vm;
 
 pub use api::FirecrackerClient;
-pub use config::{FirecrackerConfig, ImageMode, MmdsRuntime, NetworkMode as FcNetworkMode};
+pub use config::{
+    BootSource, Drive, FirecrackerConfig, ImageMode, MachineConfig, MmdsRuntime,
+    NetworkMode as FcNetworkMode,
+};
 pub use vm::VmManager;


### PR DESCRIPTION
## Summary

- Delete `FirecrackerConfig::new()` (23 positional params), replace all 3 call sites with struct literals using `..Default::default()`
- Add custom `Default` impl for `FirecrackerConfig` (sets `rootfs_size = "10G"` matching serde default), derive `Default` for `BootSource`, `MachineConfig`, `NetworkMode`, `ImageMode`
- Create `VmSetupParams` struct grouping 14 read-only params, reducing `run_vm_setup()` from 17 params to 4
- Create `CleanupContext` struct grouping 6 owned fields, reducing `cleanup_vm()` from 10 params to 5
- Create `CreateSnapshotParams` struct, reducing `create_podman_snapshot()` from 8 params to 1 and `create_snapshot_interruptible()` from 9 params to 2
- Create `RestoreParams` struct, reducing `restore_from_snapshot()` from 10 params to 4
- Re-export `BootSource`, `Drive`, `MachineConfig` from `crate::firecracker`
- Zero `#[allow(clippy::too_many_arguments)]` suppressions remain in src/

## Test plan

- [x] `cargo build --release` passes
- [x] `cargo clippy --all-targets -- -D warnings` clean (zero warnings)
- [x] `cargo test --lib -p fcvm` — 87/87 unit tests pass
- [ ] CI integration tests