### PR TITLE
fix: limit concurrent snapshot creation to prevent dirty_ratio throttling

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -122,8 +122,8 @@ pub struct RunArgs {
     #[arg(long, default_value = "2", value_parser = parse_cpu)]
     pub cpu: u8,
 
-    /// Memory in MiB, or "unlimited" to use all host memory (default: 2048)
-    #[arg(long, default_value = "2048", value_parser = parse_mem)]
+    /// Memory in MiB, or "unlimited" to use all host memory (default: 1024)
+    #[arg(long, default_value = "1024", value_parser = parse_mem)]
     pub mem: u32,
 
     /// Enable 2MB hugepage-backed VM memory for improved TLB performance.

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -5,7 +5,7 @@
 
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
-use std::sync::LazyLock;
+use std::sync::OnceLock;
 
 use anyhow::{Context, Result};
 use nix::sys::uio::{pread, pwrite};
@@ -948,21 +948,25 @@ pub(crate) async fn reflink_copy(source: &Path, dest: &Path) -> Result<()> {
 
 /// Limit concurrent snapshot creation to prevent dirty_ratio writeback throttling.
 ///
-/// Each Full snapshot writes ~2GB (the VM's entire configured memory) to page cache.
+/// Each Full snapshot writes the VM's entire configured memory to page cache.
 /// The Linux kernel throttles ALL writers when dirty pages exceed `dirty_ratio` (typically
-/// 20% of RAM). On a 125GB machine, that's 25GB — just 12 concurrent Full snapshots.
-/// When 150 VMs snapshot simultaneously (CI SnapshotEnabled mode), 300GB of dirty pages
-/// causes the kernel to force synchronous writeback, stalling each snapshot for 100+ seconds.
+/// 20% of RAM). On a 125GB machine with default dirty_ratio=20%, that's 25GB.
+/// When 150 VMs snapshot simultaneously (CI SnapshotEnabled mode), total dirty pages
+/// cause the kernel to force synchronous writeback, stalling each snapshot for 100+ seconds.
 ///
-/// With a semaphore of 10, peak dirty pages stay at ~20GB (under the 25GB threshold),
-/// and each snapshot completes in ~3.5 seconds without throttling.
-static SNAPSHOT_SEMAPHORE: LazyLock<Semaphore> = LazyLock::new(|| {
-    let permits = std::env::var("FCVM_SNAPSHOT_CONCURRENCY")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(10);
-    Semaphore::new(permits)
-});
+/// With a semaphore of 10, peak dirty pages stay low enough that snapshots complete
+/// at memory speed (~1s each) without triggering kernel writeback throttling.
+static SNAPSHOT_SEMAPHORE: OnceLock<Semaphore> = OnceLock::new();
+
+fn snapshot_semaphore() -> &'static Semaphore {
+    SNAPSHOT_SEMAPHORE.get_or_init(|| {
+        let permits = std::env::var("FCVM_SNAPSHOT_CONCURRENCY")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(10);
+        Semaphore::new(permits)
+    })
+}
 
 /// # Arguments
 /// * `client` - Firecracker API client for the running VM
@@ -982,7 +986,7 @@ pub async fn create_snapshot_core(
 
     // Acquire snapshot concurrency permit BEFORE pausing the VM.
     // This prevents dirty_ratio throttling when many VMs snapshot simultaneously.
-    let _permit = SNAPSHOT_SEMAPHORE
+    let _permit = snapshot_semaphore()
         .acquire()
         .await
         .map_err(|e| anyhow::anyhow!("snapshot semaphore closed: {}", e))?;

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -5,10 +5,12 @@
 
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
+use std::sync::LazyLock;
 
 use anyhow::{Context, Result};
 use nix::sys::uio::{pread, pwrite};
 use nix::unistd::{lseek, Whence};
+use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 
@@ -944,6 +946,24 @@ pub(crate) async fn reflink_copy(source: &Path, dest: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Limit concurrent snapshot creation to prevent dirty_ratio writeback throttling.
+///
+/// Each Full snapshot writes ~2GB (the VM's entire configured memory) to page cache.
+/// The Linux kernel throttles ALL writers when dirty pages exceed `dirty_ratio` (typically
+/// 20% of RAM). On a 125GB machine, that's 25GB — just 12 concurrent Full snapshots.
+/// When 150 VMs snapshot simultaneously (CI SnapshotEnabled mode), 300GB of dirty pages
+/// causes the kernel to force synchronous writeback, stalling each snapshot for 100+ seconds.
+///
+/// With a semaphore of 10, peak dirty pages stay at ~20GB (under the 25GB threshold),
+/// and each snapshot completes in ~3.5 seconds without throttling.
+static SNAPSHOT_SEMAPHORE: LazyLock<Semaphore> = LazyLock::new(|| {
+    let permits = std::env::var("FCVM_SNAPSHOT_CONCURRENCY")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(10);
+    Semaphore::new(permits)
+});
+
 /// # Arguments
 /// * `client` - Firecracker API client for the running VM
 /// * `snapshot_config` - Pre-built config with FINAL paths (after atomic rename)
@@ -959,6 +979,13 @@ pub async fn create_snapshot_core(
     parent_snapshot_dir: Option<&Path>,
 ) -> Result<()> {
     use crate::firecracker::api::{SnapshotCreate, VmState as ApiVmState};
+
+    // Acquire snapshot concurrency permit BEFORE pausing the VM.
+    // This prevents dirty_ratio throttling when many VMs snapshot simultaneously.
+    let _permit = SNAPSHOT_SEMAPHORE
+        .acquire()
+        .await
+        .map_err(|e| anyhow::anyhow!("snapshot semaphore closed: {}", e))?;
 
     // Derive directories from snapshot config (memory_path's parent is the snapshot dir)
     let snapshot_dir = snapshot_config

--- a/tests/test_library_api.rs
+++ b/tests/test_library_api.rs
@@ -20,7 +20,7 @@ fn test_run_args(name: &str) -> RunArgs {
     RunArgs {
         name: name.to_string(),
         cpu: 2,
-        mem: 2048,
+        mem: 1024,
         rootfs_size: "10G".to_string(),
         map: vec![],
         disk: vec![],


### PR DESCRIPTION
## Summary

- Add `tokio::sync::Semaphore` (10 permits) in `create_snapshot_core` to limit concurrent snapshot creation
- Reduce default VM memory from 2GB to 1GB (halves snapshot size)
- Combined with infra changes (PR ejc3/aws#8): RAID0 NVMe + dirty_ratio=80%

## The Problem

In CI SnapshotEnabled Run 1, 150+ tests create Full snapshots simultaneously. Each writes the VM's entire configured memory to the page cache. With 150 × 2GB = 300GB of dirty pages and `dirty_ratio=20%` (25GB threshold), the kernel forces synchronous writeback, stalling each snapshot for 100+ seconds.

## Evidence (fio benchmarks on c7gd.metal, 125GB RAM)

| Scenario | Throughput | Time |
|---|---|---|
| 150 × 1GB, dirty_ratio=20% (current) | 1.3 GB/s | 117s |
| 150 × 1GB, dirty_ratio=80% (infra fix) | 2.4 GB/s | 68s |
| Semaphore(10) × 1GB, dirty_ratio=80% (both) | 8.5 GB/s | ~18s |

## Changes

### 1. Semaphore in `create_snapshot_core` (src/commands/common.rs)
- Global `tokio::sync::Semaphore(10)` gates concurrent snapshot creation
- With 10 × 1GB = 10GB per batch, stays well under dirty_ratio threshold
- Configurable via `FCVM_SNAPSHOT_CONCURRENCY` env var

### 2. Default memory 2GB → 1GB (src/cli/args.rs)
- Halves snapshot size from 2GB to 1GB per VM
- 1GB sufficient for Podman + containers (tested: sanity, exec, snapshot workflows)
- Tests needing more (nested VMs) already set `--mem` explicitly

### Infrastructure (separate PR: ejc3/aws#8)
- RAID0 both NVMe drives (~2x write throughput)
- dirty_ratio=80%, dirty_background_ratio=50%

## Test plan

- [x] `cargo check` — compiles clean
- [x] `make test-root FILTER=sanity` — 3/3 pass with 1GB
- [x] `make test-root FILTER=test_exec_bridged` — passes with 1GB
- [x] `make test-root FILTER=test_snapshot_run_direct_rootless` — passes
- [x] Snapshot size confirmed 1.0GB (was 2.0GB)
- [x] Single-VM snapshot: 1.1s (was 3.5s)
- [ ] CI SnapshotEnabled run should show no timeout failures