### PR TITLE
docs: update memory references from 2GB to 1GB

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1407,7 +1407,7 @@ This ensures automatic cache invalidation when any component changes.
   "config": {
     "image": "nginx:alpine",
     "vcpu": 2,
-    "memory_mib": 2048,
+    "memory_mib": 1024,
     "network": {
       "tap_device": "tap-abc123",
       "guest_ip": "172.16.29.2",

--- a/README.md
+++ b/README.md
@@ -190,11 +190,11 @@ fcvm uses a two-tier snapshot system to reduce startup time:
 
 | Snapshot | When Created | Content | Size |
 |----------|--------------|---------|------|
-| **Pre-start** | After image pull, before container runs | VM with image loaded | Full (~2GB) |
+| **Pre-start** | After image pull, before container runs | VM with image loaded | Full (~1GB) |
 | **Startup** | After HTTP health check passes | VM with container fully initialized | Diff (~50MB) |
 
 **How diff snapshots work:**
-1. **First snapshot (pre-start)**: Creates a full memory snapshot (~2GB)
+1. **First snapshot (pre-start)**: Creates a full memory snapshot (~1GB)
 2. **Subsequent snapshots (startup)**: Reflink-copy parent `memory.bin`, create a diff, then merge
 3. **Result**: Each snapshot ends up with a complete `memory.bin`, equivalent to a full snapshot
 
@@ -209,7 +209,7 @@ Second run restores from that snapshot and skips container initialization.
 ```bash
 # First run: Creates pre-start (full) + startup (diff, merged)
 ./fcvm podman run --name web --health-check http://localhost/ nginx:alpine
-# → Pre-start snapshot: 2048MB (full)
+# → Pre-start snapshot: 1024MB (full)
 # → Startup snapshot: ~50MB (diff) → merged onto base
 
 # Second run: Restores from startup snapshot
@@ -849,6 +849,7 @@ See [DESIGN.md](DESIGN.md#guest-agent) for details.
 | `RUST_LOG` | `warn` | Logging level (quiet by default; use `info` or `debug` for verbose) |
 | `FCVM_NO_SNAPSHOT` | unset | Set to `1` to disable automatic snapshot creation (same as `--no-snapshot` flag) |
 | `FCVM_NO_WRITEBACK_CACHE` | unset | Set to `1` to disable FUSE writeback cache (see below) |
+| `FCVM_SNAPSHOT_CONCURRENCY` | `10` | Max concurrent snapshot creations (prevents dirty_ratio throttling) |
 
 
 ### FUSE Writeback Cache

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -973,7 +973,7 @@ pub(crate) async fn reflink_copy(source: &Path, dest: &Path) -> Result<()> {
 
 /// Limit concurrent snapshot creation to prevent dirty_ratio writeback throttling.
 ///
-/// Each Full snapshot writes the VM's entire configured memory to page cache.
+/// Each full snapshot writes the VM's entire configured memory (default 1GB) to page cache.
 /// The Linux kernel throttles ALL writers when dirty pages exceed `dirty_ratio` (typically
 /// 20% of RAM). On a 125GB machine with default dirty_ratio=20%, that's 25GB.
 /// When 150 VMs snapshot simultaneously (CI SnapshotEnabled mode), total dirty pages


### PR DESCRIPTION
## Summary
- Update snapshot size references in README.md from 2GB/2048MB to 1GB/1024MB (default memory was reduced in #425)
- Add `FCVM_SNAPSHOT_CONCURRENCY` env var to README's Environment Variables table
- Update DESIGN.md example `memory_mib` from 2048 to 1024
- Fix doc comment on `SNAPSHOT_SEMAPHORE` constant

Addresses review findings from PR #425.