### PR TITLE
fix: nightly CI benchmark failures (15+ days broken)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -90,6 +90,17 @@ jobs:
           podman system migrate || true
           # Fix lock file permissions from previous sudo runs (bench-vm runs as root)
           sudo chmod 666 /mnt/fcvm-btrfs/state/*.lock 2>/dev/null || true
+      - name: Clean stale state
+        run: |
+          # Kill any leftover fcvm processes from crashed previous runs
+          sudo pkill -9 -f "fcvm (podman|snapshot)" 2>/dev/null || true
+          sudo pkill -9 -f firecracker 2>/dev/null || true
+          sleep 2
+          # Remove stale state files and snapshots from previous benchmark runs
+          sudo rm -f /mnt/fcvm-btrfs/state/vm-*.json 2>/dev/null || true
+          sudo rm -rf /mnt/fcvm-btrfs/snapshots/bench-* 2>/dev/null || true
+          # Clean up old benchmark VM disks
+          sudo rm -rf /mnt/fcvm-btrfs/vm-disks/vm-* 2>/dev/null || true
       - name: Run VM benchmarks
         working-directory: fcvm
         env:

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,8 @@ CONTAINER_RUN_BASE := podman run --rm --privileged \
 	$(TARGET_MOUNT) \
 	-v $(FUSE_BACKEND_RS):/workspace/fuse-backend-rs -v $(FUSER):/workspace/fuser \
 	--device /dev/fuse -v /dev/kvm:/dev/kvm -v /dev/userfaultfd:/dev/userfaultfd \
-	--ulimit nofile=65536:65536 -v /mnt/fcvm-btrfs:/mnt/fcvm-btrfs \
+	--ulimit nofile=65536:65536 --ulimit nproc=-1:-1 \
+	-v /mnt/fcvm-btrfs:/mnt/fcvm-btrfs \
 	-v $(TEST_LOG_DIR):$(TEST_LOG_DIR) $(CARGO_CACHE_MOUNT) \
 	-e FCVM_DATA_DIR=$(CONTAINER_DATA_DIR)
 
@@ -135,7 +136,7 @@ CONTAINER_RUN := $(CONTAINER_RUN_BASE) --ulimit nproc=65536:65536 --pids-limit=6
 	_test-unit _test-fast _test-all _test-root _setup-fcvm _bench \
 	container-build container-test container-test-unit container-test-fast container-test-all \
 	container-setup-fcvm container-shell container-clean container-bench \
-	setup-btrfs setup-fcvm setup-pjdfstest setup-hugepages bench bench-vm bench-hugepages bench-hugepages-test \
+	setup-btrfs setup-default setup-fcvm setup-pjdfstest setup-hugepages bench bench-vm bench-hugepages bench-hugepages-test \
 	bench-container-import \
 	lint fmt ssh test-serve-sdk
 
@@ -385,14 +386,16 @@ setup-btrfs:
 	@sudo mkdir -p $(CONTAINER_DATA_DIR)/{state,snapshots,vm-disks}
 	@sudo chown -R $$(id -un):$$(id -gn) $(CONTAINER_DATA_DIR)
 
-setup-fcvm: build setup-btrfs
+setup-default: build setup-btrfs
 	@FREE_GB=$$(df -BG /mnt/fcvm-btrfs 2>/dev/null | awk 'NR==2 {gsub("G",""); print $$4}'); \
 	if [ -n "$$FREE_GB" ] && [ "$$FREE_GB" -lt 15 ]; then \
 		echo "ERROR: Need 15GB on /mnt/fcvm-btrfs (have $${FREE_GB}GB)"; \
 		exit 1; \
 	fi
-	@echo "==> Running fcvm setup..."
+	@echo "==> Running fcvm setup (default kernel)..."
 	./target/release/fcvm setup
+
+setup-fcvm: setup-default
 	@echo "==> Running fcvm setup --kernel-profile nested..."
 	./target/release/fcvm setup --kernel-profile nested --build-kernels
 	@echo "==> Running fcvm setup --kernel-profile btrfs..."
@@ -441,7 +444,7 @@ bench: build
 	$(CARGO) bench -p fuse-pipe --bench protocol
 
 # VM benchmarks (exec, clone) - require KVM, Firecracker, setup
-bench-vm: build setup-fcvm
+bench-vm: build setup-default
 	@echo "==> Running VM benchmarks..."
 	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
 	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
@@ -456,7 +459,7 @@ bench-vm: build setup-fcvm
 HUGEPAGE_POOL_FULL := 17000
 HUGEPAGE_POOL_TEST := 1200
 
-bench-hugepages: build setup-fcvm
+bench-hugepages: build setup-default
 	@echo "==> Allocating hugepage pool ($(HUGEPAGE_POOL_FULL) pages = $$(( $(HUGEPAGE_POOL_FULL) * 2 ))MB)..."
 	sudo sh -c 'echo $(HUGEPAGE_POOL_FULL) > /proc/sys/vm/nr_hugepages'
 	@echo "==> Running hugepages benchmark (full)..."
@@ -466,7 +469,7 @@ bench-hugepages: build setup-fcvm
 	sudo sh -c 'echo 0 > /proc/sys/vm/nr_hugepages'; \
 	exit $$RC
 
-bench-hugepages-test: build setup-fcvm
+bench-hugepages-test: build setup-default
 	@echo "==> Allocating hugepage pool ($(HUGEPAGE_POOL_TEST) pages = $$(( $(HUGEPAGE_POOL_TEST) * 2 ))MB)..."
 	sudo sh -c 'echo $(HUGEPAGE_POOL_TEST) > /proc/sys/vm/nr_hugepages'
 	@echo "==> Running hugepages benchmark (test)..."
@@ -476,7 +479,7 @@ bench-hugepages-test: build setup-fcvm
 	sudo sh -c 'echo 0 > /proc/sys/vm/nr_hugepages'; \
 	exit $$RC
 
-bench-container-import: build setup-fcvm
+bench-container-import: build setup-default
 	@echo "==> Running container import benchmark..."
 	$(CARGO) bench --bench container_import
 

--- a/benches/exec.rs
+++ b/benches/exec.rs
@@ -500,7 +500,22 @@ impl CloneFixture {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            panic!("clone exec failed: {}", stderr);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            // Dump serve log for diagnostics
+            let serve_log = "/tmp/fcvm-bench-serve-clone-exec.log";
+            if let Ok(logs) = std::fs::read_to_string(serve_log) {
+                let tail: Vec<&str> = logs.lines().rev().take(30).collect();
+                eprintln!("=== Last 30 lines of serve log ===");
+                for line in tail.into_iter().rev() {
+                    eprintln!("{}", line);
+                }
+            }
+            panic!(
+                "clone exec failed after {:.1}s:\nstderr: {}\nstdout: {}",
+                elapsed.as_secs_f64(),
+                stderr,
+                stdout
+            );
         }
 
         elapsed

--- a/benches/hugepages.rs
+++ b/benches/hugepages.rs
@@ -428,6 +428,14 @@ fn run_mode(mode: &str, mem_mb: u32, data_mb: u32, hugepages: bool) -> BenchResu
     let clone_elapsed = match poll_health(&fcvm, &mut child2, clone_timeout) {
         Ok(elapsed) => elapsed,
         Err(e) => {
+            // Dump log file for diagnostics before panicking
+            if let Ok(logs) = std::fs::read_to_string(&log_path2) {
+                let tail: Vec<&str> = logs.lines().rev().take(50).collect();
+                eprintln!("=== Last 50 lines of {} ===", log_path2);
+                for line in tail.into_iter().rev() {
+                    eprintln!("{}", line);
+                }
+            }
             graceful_kill(pid2, 5000);
             let _ = child2.wait();
             panic!("Clone failed: {}", e);


### PR DESCRIPTION
## Summary

Fix three distinct issues causing nightly benchmark CI to fail for 15+ consecutive days (Feb 6-20).

### Changes

1. **Container benchmark RLIMIT_NPROC** (`Makefile`): crun fails with `EPERM` when setting `RLIMIT_NPROC` on GHA ubuntu-latest runners. Added `--ulimit nproc=-1:-1` to `CONTAINER_RUN_BASE` to suppress the default limit.

2. **Setup-fcvm blocking benchmarks** (`Makefile`): Benchmark targets depended on `setup-fcvm` which tries to download nested/btrfs kernels from GitHub releases — but no x86_64 releases exist, causing 404 failures. Created `setup-default` target that only installs the default Kata kernel, and changed all benchmark targets (`bench-vm`, `bench-hugepages`, `bench-hugepages-test`, `bench-container-import`) to depend on `setup-default` instead.

3. **Stale state from crashed runs** (`nightly.yml`): Leftover state files, snapshots, and VM disks from crashed previous nightly runs interfere with subsequent runs. Added "Clean stale state" step that kills orphaned fcvm/firecracker processes and removes stale files before benchmarks start.

4. **Benchmark diagnostics** (`benches/exec.rs`, `benches/hugepages.rs`): Added log file dumps on failure for easier debugging of future issues — serve log dump on clone exec failure, and clone log dump on hugepages warm start failure.

## Test Results

All benchmarks pass locally (arm64) and on remote CI runner (arm64):

```
# bench-vm: all exec/clone tests pass
exec_latency/{bridged,rootless}/{echo,echo_vm} - Success
exec_data/{bridged,rootless}/{1kb,4kb,16kb} - Success
exec_throughput/{bridged,rootless}/10_commands - Success
clone_exec/rootless/echo - Success
clone_http/rootless/nginx - Success

# bench-hugepages-test: cold + warm start pass
Standard: cold=8.1s, clone=0.5s
Hugepages: cold=4.6s, clone=0.5s

# bench-container-import: archive + overlay pass
Archive avg: 8.8s, Overlay avg: 5.1s
```