### PR TITLE
test: add vsock CONNECT lifecycle stress test

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,33 +191,28 @@ fcvm uses a two-tier snapshot system to reduce startup time:
 | Snapshot | When Created | Content | Size |
 |----------|--------------|---------|------|
 | **Pre-start** | After image pull, before container runs | VM with image loaded | Full (~1GB) |
-| **Startup** | After HTTP health check passes | VM with container fully initialized | Diff (~50MB) |
+| **Startup** | After HTTP health check passes | VM with container fully initialized | Full (~512MB) |
 
-**How diff snapshots work:**
-1. **First snapshot (pre-start)**: Creates a full memory snapshot (~1GB)
-2. **Subsequent snapshots (startup)**: Reflink-copy parent `memory.bin`, create a diff, then merge
-3. **Result**: Each snapshot ends up with a complete `memory.bin`, equivalent to a full snapshot
-
-There are no persistent diff chains.
-Reflink copy is instant (btrfs CoW), and the diff is typically ~2% of pages.
-Merge produces a complete `memory.bin` with no parent dependency.
+Both snapshots are full memory dumps — startup snapshots do not use diff-based tracking.
+(KVM dirty page tracking is unreliable on x86_64, reporting only ~90KB of dirty pages when
+60-97MB are actually dirty, producing corrupt snapshots that triple-fault on restore.)
 
 The startup snapshot is triggered by `--health-check <url>`.
-After the check passes, fcvm creates a diff snapshot of the initialized app.
+After the check passes, fcvm creates a full snapshot of the initialized app.
 Second run restores from that snapshot and skips container initialization.
 
 ```bash
-# First run: Creates pre-start (full) + startup (diff, merged)
+# First run: Creates pre-start (full) + startup (full)
 ./fcvm podman run --name web --health-check http://localhost/ nginx:alpine
-# → Pre-start snapshot: 1024MB (full)
-# → Startup snapshot: ~50MB (diff) → merged onto base
+# → Pre-start snapshot: ~1024MB (full)
+# → Startup snapshot: ~512MB (full)
 
 # Second run: Restores from startup snapshot
 ./fcvm podman run --name web2 --health-check http://localhost/ nginx:alpine
 # → Restored from startup snapshot (application already running)
 ```
 
-Clone snapshots automatically use their source as parent, enabling diff-based optimization across the chain.
+Clone snapshots use their source as parent for diff-based optimization across the clone chain.
 
 ### Image Delivery Modes
 
@@ -348,22 +343,16 @@ sudo sh -c 'echo 0 > /proc/sys/vm/nr_hugepages'
 
 **How it works with snapshots:**
 
-The snapshot cache flow creates two snapshots on the initial VM:
+The snapshot cache flow creates two full snapshots on the initial VM:
 1. **Pre-start (Full)**: After container image import
-2. **Startup (Diff)**: After container is healthy
+2. **Startup (Full)**: After container is healthy
 
-KVM dirty page tracking is enabled on the initial VM so the startup diff snapshot
-captures only the pages that changed between pre-start and startup (~100MB for a
-typical nginx container, vs dumping the entire VM memory).
-
-Dirty tracking requires KVM to split ARM64 Stage 2 block mappings from 2MB to 4KB
-entries. This only affects the initial VM (runs once for cache creation). Restored
-VMs (clones) do not enable dirty tracking, so they get full 2MB Stage 2 block
-mappings and the TLB benefit of hugepages.
+Both are full memory dumps. Restored VMs (clones) with hugepages disabled
+enable KVM dirty page tracking for clone-of-clone diff snapshots.
 
 | VM role | Dirty tracking | Stage 2 mapping | Runs |
 |---------|---------------|-----------------|------|
-| Initial (cache creation) | Enabled | 4KB (split for tracking) | Once |
+| Initial (cache creation) | Disabled | 2MB blocks | Once |
 | Clone (hugepage) | Disabled | 2MB blocks (full TLB benefit) | Many times |
 | Clone (non-hugepage) | Enabled | 4KB (no hugepages anyway) | Many times |
 

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -970,7 +970,12 @@ pub async fn run_vm_loop(ctx: &mut VmContext, cancel: CancellationToken) -> Resu
                             vm_state: &ctx.vm_state,
                             disk_path: &ctx.disk_path,
                             volume_configs: &ctx.volume_configs,
-                            parent_snapshot_key: Some(key.as_str()), // Parent is pre-start snapshot
+                            // Always use FULL snapshots for startup snapshots.
+                            // Diff snapshots rely on KVM dirty page tracking, which
+                            // is broken on x86_64: KVM reports only ~90KB of dirty
+                            // pages when 60-97MB are actually dirty, producing a
+                            // corrupt snapshot that triple-faults on restore.
+                            parent_snapshot_key: None,
                         };
                         tokio::select! {
                             outcome = create_snapshot_interruptible(&snap, &cancel) => {

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -1019,7 +1019,12 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
                             vm_state: &vm_state,
                             disk_path: &disk_path,
                             volume_configs: &volume_configs,
-                            parent_snapshot_key: Some(base_key.as_str()), // Parent is pre-start snapshot
+                            // Always use FULL snapshots for startup snapshots.
+                            // Diff snapshots rely on KVM dirty page tracking, which
+                            // is broken on x86_64: KVM reports only ~90KB of dirty
+                            // pages when 60-97MB are actually dirty, producing a
+                            // corrupt snapshot that triple-faults on restore.
+                            parent_snapshot_key: None,
                         };
                         tokio::select! {
                             outcome = create_snapshot_interruptible(&snap, &cancel) => {

--- a/tests/test_vsock_connect_stress.rs
+++ b/tests/test_vsock_connect_stress.rs
@@ -1,0 +1,307 @@
+//! Vsock CONNECT reliability stress test
+//!
+//! Proves that `fcvm exec` (which uses vsock CONNECT to reach the guest exec server)
+//! works 100% reliably and stays flat/fast through every lifecycle stage:
+//!
+//! 1. Baseline VM (direct boot)
+//! 2. Clone from snapshot (snapshot restore)
+//! 3. Clone of clone (double snapshot restore)
+//! 4. Parallel clones from same serve
+//! 5. Clone surviving sibling death
+//!
+//! Also tests kill-on-drop resilience: killing an exec mid-flight must not
+//! break subsequent execs.
+
+#![cfg(feature = "integration-slow")]
+
+mod common;
+
+use anyhow::{Context, Result};
+use std::time::{Duration, Instant};
+
+/// Number of sequential exec iterations per stress round
+const EXEC_ITERATIONS: usize = 20;
+
+/// Maximum acceptable time for a single exec (milliseconds)
+const MAX_EXEC_MS: u128 = 2000;
+
+/// Number of kill-on-drop iterations per round
+const KILL_ON_DROP_ITERATIONS: usize = 5;
+
+/// Run rapid sequential execs against a VM, assert all succeed and are fast.
+///
+/// Returns (success_count, avg_ms, max_ms).
+async fn exec_stress(pid: u32, label: &str) -> Result<(usize, f64, f64)> {
+    let fcvm_path = common::find_fcvm_binary()?;
+    let pid_str = pid.to_string();
+    let mut times_ms = Vec::with_capacity(EXEC_ITERATIONS);
+
+    println!(
+        "\n  --- Exec stress: {} ({} iterations) ---",
+        label, EXEC_ITERATIONS
+    );
+
+    for i in 0..EXEC_ITERATIONS {
+        let t0 = Instant::now();
+        let output = tokio::time::timeout(
+            Duration::from_secs(5),
+            tokio::process::Command::new(&fcvm_path)
+                .args(["exec", "--pid", &pid_str, "--vm", "--", "echo", "ok"])
+                .output(),
+        )
+        .await;
+
+        let elapsed_ms = t0.elapsed().as_millis() as f64;
+
+        match output {
+            Ok(Ok(out)) if out.status.success() => {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                assert!(
+                    stdout.trim() == "ok",
+                    "exec #{} returned unexpected output: {:?}",
+                    i,
+                    stdout.trim()
+                );
+                if elapsed_ms > 500.0 {
+                    println!("    SLOW #{}: {:.0}ms", i, elapsed_ms);
+                }
+                times_ms.push(elapsed_ms);
+            }
+            Ok(Ok(out)) => {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                panic!(
+                    "exec #{} failed: rc={} stderr={} ({:.0}ms)",
+                    i,
+                    out.status.code().unwrap_or(-1),
+                    &stderr[..stderr.len().min(200)],
+                    elapsed_ms
+                );
+            }
+            Ok(Err(e)) => {
+                panic!("exec #{} spawn error: {} ({:.0}ms)", i, e, elapsed_ms);
+            }
+            Err(_) => {
+                panic!("exec #{} TIMEOUT after {:.0}ms", i, elapsed_ms);
+            }
+        }
+
+        assert!(
+            (elapsed_ms as u128) < MAX_EXEC_MS,
+            "exec #{} took {:.0}ms (max {}ms)",
+            i,
+            elapsed_ms,
+            MAX_EXEC_MS
+        );
+    }
+
+    let avg = times_ms.iter().sum::<f64>() / times_ms.len() as f64;
+    let max = times_ms.iter().cloned().fold(0.0_f64, f64::max);
+    let min = times_ms.iter().cloned().fold(f64::MAX, f64::min);
+    println!(
+        "  Results: {}/{} OK  min={:.0}ms  avg={:.0}ms  max={:.0}ms",
+        times_ms.len(),
+        EXEC_ITERATIONS,
+        min,
+        avg,
+        max
+    );
+
+    Ok((times_ms.len(), avg, max))
+}
+
+/// Simulate health monitor kill_on_drop: start exec, kill after 100ms, verify next exec works.
+async fn kill_on_drop_stress(pid: u32, label: &str) -> Result<()> {
+    let fcvm_path = common::find_fcvm_binary()?;
+    let pid_str = pid.to_string();
+
+    println!(
+        "\n  --- Kill-on-drop: {} ({} iterations) ---",
+        label, KILL_ON_DROP_ITERATIONS
+    );
+
+    for i in 0..KILL_ON_DROP_ITERATIONS {
+        // Start a long-running exec, then kill it after 100ms
+        let mut child = tokio::process::Command::new(&fcvm_path)
+            .args(["exec", "--pid", &pid_str, "--vm", "--", "sleep", "10"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+            .context("spawning long exec")?;
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let _ = child.kill().await;
+        let _ = child.wait().await;
+
+        // Verify a normal exec still works immediately after
+        let t0 = Instant::now();
+        let output = tokio::time::timeout(
+            Duration::from_secs(5),
+            tokio::process::Command::new(&fcvm_path)
+                .args(["exec", "--pid", &pid_str, "--vm", "--", "echo", "ok"])
+                .output(),
+        )
+        .await;
+
+        let elapsed_ms = t0.elapsed().as_millis();
+
+        match output {
+            Ok(Ok(out)) if out.status.success() => {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                assert!(
+                    stdout.trim() == "ok",
+                    "post-kill exec #{} returned unexpected output: {:?}",
+                    i,
+                    stdout.trim()
+                );
+            }
+            Ok(Ok(out)) => {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                panic!(
+                    "post-kill exec #{} failed: stderr={} ({:.0}ms)",
+                    i,
+                    &stderr[..stderr.len().min(200)],
+                    elapsed_ms
+                );
+            }
+            Ok(Err(e)) => panic!("post-kill exec #{} error: {}", i, e),
+            Err(_) => panic!("post-kill exec #{} TIMEOUT after {}ms", i, elapsed_ms),
+        }
+    }
+
+    println!("  All {} post-kill execs OK", KILL_ON_DROP_ITERATIONS);
+    Ok(())
+}
+
+/// Full lifecycle stress test for vsock CONNECT reliability.
+///
+/// Tests exec through: baseline → clone → clone-of-clone → parallel clones → sibling death.
+/// Every exec must succeed and complete in under 2 seconds.
+#[cfg(feature = "privileged-tests")]
+#[tokio::test]
+async fn test_vsock_connect_lifecycle_stress_bridged() -> Result<()> {
+    vsock_connect_lifecycle_stress("bridged").await
+}
+
+#[tokio::test]
+async fn test_vsock_connect_lifecycle_stress_rootless() -> Result<()> {
+    vsock_connect_lifecycle_stress("rootless").await
+}
+
+async fn vsock_connect_lifecycle_stress(network: &str) -> Result<()> {
+    let (baseline_name, clone1_name, snapshot_name, _serve_name) =
+        common::unique_names(&format!("vsock-{}", network));
+    let clone2_name = format!("{}-c2", clone1_name);
+    let clone3_name = format!("{}-c3", clone1_name);
+
+    println!("\n╔═══════════════════════════════════════════════════════════════╗");
+    println!(
+        "║     Vsock CONNECT Lifecycle Stress Test ({:8})            ║",
+        network
+    );
+    println!("╚═══════════════════════════════════════════════════════════════╝");
+
+    // ========================================================================
+    // STAGE 1: Baseline VM
+    // ========================================================================
+    println!("\n=== STAGE 1: Baseline VM ===");
+    let (_baseline_child, baseline_pid) = common::spawn_fcvm_with_logs(
+        &[
+            "podman",
+            "run",
+            "--name",
+            &baseline_name,
+            "--network",
+            network,
+            "--health-check",
+            "http://localhost/",
+            common::TEST_IMAGE,
+        ],
+        &baseline_name,
+    )
+    .await
+    .context("spawning baseline VM")?;
+
+    common::poll_health_by_pid(baseline_pid, 120).await?;
+    println!("  Baseline healthy (PID: {})", baseline_pid);
+
+    exec_stress(baseline_pid, "baseline").await?;
+    kill_on_drop_stress(baseline_pid, "baseline").await?;
+
+    // ========================================================================
+    // STAGE 2: Snapshot + Clone
+    // ========================================================================
+    println!("\n=== STAGE 2: Snapshot baseline + Clone ===");
+    common::create_snapshot_by_pid(baseline_pid, &snapshot_name).await?;
+    println!("  Snapshot created: {}", snapshot_name);
+
+    let (_serve_child, serve_pid) = common::start_memory_server(&snapshot_name).await?;
+    println!("  Memory server ready (PID: {})", serve_pid);
+
+    let (_clone1_child, clone1_pid) = common::spawn_clone(serve_pid, &clone1_name, network).await?;
+    common::poll_health_by_pid(clone1_pid, 120).await?;
+    println!("  Clone1 healthy (PID: {})", clone1_pid);
+
+    exec_stress(clone1_pid, "clone1").await?;
+    kill_on_drop_stress(clone1_pid, "clone1").await?;
+
+    // ========================================================================
+    // STAGE 3: Clone of Clone
+    // ========================================================================
+    println!("\n=== STAGE 3: Snapshot clone1 + Clone-of-clone ===");
+    let snap2_name = format!("{}-snap2", snapshot_name);
+    common::create_snapshot_by_pid(clone1_pid, &snap2_name).await?;
+    println!("  Snapshot of clone created: {}", snap2_name);
+
+    let (_serve2_child, serve2_pid) = common::start_memory_server(&snap2_name).await?;
+    println!("  Memory server 2 ready (PID: {})", serve2_pid);
+
+    let (_clone2_child, clone2_pid) =
+        common::spawn_clone(serve2_pid, &clone2_name, network).await?;
+    common::poll_health_by_pid(clone2_pid, 120).await?;
+    println!("  Clone-of-clone healthy (PID: {})", clone2_pid);
+
+    exec_stress(clone2_pid, "clone-of-clone").await?;
+    kill_on_drop_stress(clone2_pid, "clone-of-clone").await?;
+
+    // ========================================================================
+    // STAGE 4: Parallel clone from same serve
+    // ========================================================================
+    println!("\n=== STAGE 4: Parallel clone from same serve ===");
+    let (_clone3_child, clone3_pid) = common::spawn_clone(serve_pid, &clone3_name, network).await?;
+    common::poll_health_by_pid(clone3_pid, 120).await?;
+    println!("  Clone3 healthy (PID: {})", clone3_pid);
+
+    exec_stress(clone3_pid, "parallel-clone3").await?;
+
+    // Verify clone1 still works while clone3 is alive
+    exec_stress(clone1_pid, "clone1-concurrent").await?;
+
+    // ========================================================================
+    // STAGE 5: Kill a clone, verify sibling survives
+    // ========================================================================
+    println!("\n=== STAGE 5: Kill clone1, verify clone3 survives ===");
+    common::kill_process(clone1_pid).await;
+    println!("  Clone1 killed");
+
+    // Brief pause for cleanup
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    exec_stress(clone3_pid, "clone3-after-sibling-killed").await?;
+
+    // ========================================================================
+    // Cleanup
+    // ========================================================================
+    println!("\n--- Cleanup ---");
+    common::kill_process(clone3_pid).await;
+    common::kill_process(clone2_pid).await;
+    common::kill_process(serve2_pid).await;
+    common::kill_process(serve_pid).await;
+    common::kill_process(baseline_pid).await;
+
+    println!("\n╔═══════════════════════════════════════════════════════════════╗");
+    println!("║     ALL VSOCK CONNECT LIFECYCLE STRESS TESTS PASSED         ║");
+    println!("╚═══════════════════════════════════════════════════════════════╝");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- **Full startup snapshots**: Switch startup snapshots from diff to full snapshots to avoid corrupt memory from broken KVM dirty page tracking on x86_64. Both `podman/mod.rs` and `snapshot.rs` now set `parent_snapshot_key: None`.
- **Vsock CONNECT stress test**: New `test_vsock_connect_stress` that exercises rapid vsock connect/disconnect cycles to validate lifecycle handling under load.
- **README update**: Documentation now correctly describes startup snapshots as Full (~512MB) with explanation of the KVM dirty page tracking issue.

## Test plan

- [x] `make test-root FILTER=vsock_connect_stress` passes
- [x] CI: all 12 jobs green