### PR TITLE
fix: trigger podman healthcheck in rootless mode without systemd

### DIFF
--- a/src/health.rs
+++ b/src/health.rs
@@ -382,8 +382,70 @@ async fn check_podman_healthcheck(
         "healthy" => Some(true),
         "" => None, // No healthcheck defined - skip future checks
         "unhealthy" => Some(false),
-        "starting" => Some(false), // Still starting, keep polling
-        _ => Some(true),           // Unknown status, assume healthy
+        "starting" => {
+            // Rootless podman without a systemd user session doesn't run the
+            // periodic healthcheck timer. Trigger it manually.
+            debug!(target: "health-monitor", "podman health is 'starting', triggering healthcheck run");
+            run_podman_healthcheck(pid, username, user_spec).await;
+            Some(false)
+        }
+        _ => Some(true), // Unknown status, assume healthy
+    }
+}
+
+/// Trigger `podman healthcheck run` inside the VM.
+/// Rootless podman without systemd doesn't auto-run healthchecks.
+async fn run_podman_healthcheck(
+    pid: u32,
+    username: Option<&str>,
+    user_spec: Option<&str>,
+) {
+    let exe = match find_fcvm_binary() {
+        Some(e) => e,
+        None => return,
+    };
+
+    let mut cmd_args: Vec<String> = vec![
+        "exec".into(),
+        "--pid".into(),
+        pid.to_string(),
+        "--vm".into(),
+        "--".into(),
+    ];
+    if let Some(name) = username {
+        cmd_args.extend(user_cmd_prefix(name, user_spec));
+    }
+    cmd_args.extend([
+        "podman".into(),
+        "healthcheck".into(),
+        "run".into(),
+        "fcvm-container".into(),
+    ]);
+
+    let child = match tokio::process::Command::new(&exe)
+        .args(&cmd_args)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            debug!(target: "health-monitor", error = %e, "podman healthcheck run spawn failed");
+            return;
+        }
+    };
+
+    match tokio::time::timeout(HEALTH_CHECK_EXEC_TIMEOUT, child.wait_with_output()).await {
+        Ok(Ok(o)) => {
+            debug!(target: "health-monitor", exit = %o.status, "podman healthcheck run completed");
+        }
+        Ok(Err(e)) => {
+            debug!(target: "health-monitor", error = %e, "podman healthcheck run exec failed");
+        }
+        Err(_) => {
+            debug!(target: "health-monitor", "podman healthcheck run timed out");
+        }
     }
 }
 

--- a/src/health.rs
+++ b/src/health.rs
@@ -395,11 +395,7 @@ async fn check_podman_healthcheck(
 
 /// Trigger `podman healthcheck run` inside the VM.
 /// Rootless podman without systemd doesn't auto-run healthchecks.
-async fn run_podman_healthcheck(
-    pid: u32,
-    username: Option<&str>,
-    user_spec: Option<&str>,
-) {
+async fn run_podman_healthcheck(pid: u32, username: Option<&str>, user_spec: Option<&str>) {
     let exe = match find_fcvm_binary() {
         Some(e) => e,
         None => return,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1085,7 +1085,10 @@ pub async fn ensure_nested_container(image_name: &str, containerfile: &str) -> a
             .context("copying firecracker to artifacts/")?;
     }
 
-    // Always build - podman handles layer caching
+    // Build with podman layer caching. If the build fails due to overlay
+    // storage corruption (e.g., "error unmounting container: directory not empty"),
+    // the corrupted intermediate layers stay cached and all retries reuse them.
+    // Detect this and rebuild with --no-cache to recover.
     println!("Building {}...", image_name);
     let output = tokio::process::Command::new("podman")
         .args(["build", "-t", image_name, "-f", containerfile, "."])
@@ -1094,9 +1097,53 @@ pub async fn ensure_nested_container(image_name: &str, containerfile: &str) -> a
         .context("running podman build")?;
 
     if !output.status.success() {
-        drop(lock_file);
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("Failed to build {}: {}", image_name, stderr);
+
+        // Overlay corruption leaves broken cached layers. Clean them and retry
+        // with --no-cache so the next attempt starts from scratch.
+        if stderr.contains("error unmounting") || stderr.contains("directory not empty") {
+            println!(
+                "Build failed with overlay corruption, cleaning cache and retrying: {}",
+                image_name
+            );
+            // Remove the partially-built image (may not exist)
+            let _ = tokio::process::Command::new("podman")
+                .args(["rmi", "-f", image_name])
+                .output()
+                .await;
+            // Prune dangling build layers left by the failed build
+            let _ = tokio::process::Command::new("podman")
+                .args(["system", "prune", "-f"])
+                .output()
+                .await;
+
+            let retry = tokio::process::Command::new("podman")
+                .args([
+                    "build",
+                    "--no-cache",
+                    "-t",
+                    image_name,
+                    "-f",
+                    containerfile,
+                    ".",
+                ])
+                .output()
+                .await
+                .context("running podman build (retry after overlay cleanup)")?;
+
+            if !retry.status.success() {
+                drop(lock_file);
+                let retry_stderr = String::from_utf8_lossy(&retry.stderr);
+                anyhow::bail!(
+                    "Failed to build {} (retry after overlay cleanup): {}",
+                    image_name,
+                    retry_stderr
+                );
+            }
+        } else {
+            drop(lock_file);
+            anyhow::bail!("Failed to build {}: {}", image_name, stderr);
+        }
     }
 
     // Export to CAS cache so nested VMs can access it

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1055,16 +1055,17 @@ pub async fn ensure_nested_container(image_name: &str, containerfile: &str) -> a
     let fcvm_path = find_fcvm_binary()?;
     let fcvm_dir = fcvm_path.parent().unwrap();
 
-    // Serialize concurrent builds with a file lock. Multiple nextest processes
-    // may call this simultaneously; without locking, concurrent `podman build`
-    // races on overlay unmount and corrupts the build cache (x64-specific).
-    let lock_name = image_name.replace('/', "-");
-    let lock_path = format!("/tmp/fcvm-build-{}.lock", lock_name);
+    // Serialize ALL concurrent podman builds with a single global file lock.
+    // Per-image locks are insufficient: different images (e.g., localhost/nested-test
+    // and localhost/pjdfstest) share base layers (FROM ubuntu:24.04) in the same
+    // overlay storage. Concurrent builds race on shared layer cleanup, causing
+    // "error unmounting container: directory not empty" on x64.
+    let lock_path = "/tmp/fcvm-podman-build.lock";
     let lock_file = std::fs::OpenOptions::new()
         .create(true)
         .write(true)
         .truncate(false)
-        .open(&lock_path)
+        .open(lock_path)
         .context("creating build lock file")?;
     lock_file.lock_exclusive().context("acquiring build lock")?;
 

--- a/tests/test_rootless_healthcheck.rs
+++ b/tests/test_rootless_healthcheck.rs
@@ -1,0 +1,106 @@
+//! Verifies that podman HEALTHCHECK works in rootless mode (no systemd).
+//!
+//! Root cause of the original bug: rootless podman without a systemd user session
+//! doesn't run the periodic healthcheck timer. The container health stays "starting"
+//! forever. fcvm's health monitor sees "starting" and reports Unhealthy.
+//!
+//! Fix: when fcvm's health monitor sees podman health "starting", it manually
+//! triggers `podman healthcheck run` to kick the check.
+//!
+//! This test builds a container with a HEALTHCHECK that passes immediately,
+//! runs it in rootless mode, and verifies fcvm reports Healthy.
+
+#![cfg(feature = "integration-fast")]
+
+mod common;
+
+use anyhow::{Context, Result};
+
+#[tokio::test]
+async fn test_rootless_podman_healthcheck_becomes_healthy() -> Result<()> {
+    println!("\nTest: rootless podman healthcheck trigger");
+    println!("==========================================");
+
+    // Build a container image with a HEALTHCHECK defined.
+    // The healthcheck passes immediately (exit 0).
+    // Use --format=docker to preserve HEALTHCHECK instruction.
+    let image_name = format!(
+        "localhost/test-rootless-hc-{}",
+        std::process::id() % 10000
+    );
+
+    println!("  Building image with HEALTHCHECK: {}", image_name);
+    let tmpdir = tempfile::tempdir()?;
+    let containerfile = tmpdir.path().join("Containerfile");
+    std::fs::write(
+        &containerfile,
+        format!(
+            "FROM {}\nHEALTHCHECK --interval=2s --timeout=2s --retries=1 CMD exit 0\nCMD [\"sleep\", \"120\"]\n",
+            common::ALPINE_IMAGE
+        ),
+    )?;
+
+    let build = tokio::process::Command::new("podman")
+        .args([
+            "build",
+            "--format=docker",
+            "-t",
+            &image_name,
+            "-f",
+            &containerfile.to_string_lossy(),
+            &tmpdir.path().to_string_lossy(),
+        ])
+        .output()
+        .await
+        .context("building test image")?;
+
+    if !build.status.success() {
+        let stderr = String::from_utf8_lossy(&build.stderr);
+        anyhow::bail!("Image build failed: {}", stderr);
+    }
+    println!("  Image built");
+
+    // Run the container in rootless mode (no --network bridged, no sudo).
+    // The VM doesn't have a systemd user session, so podman's healthcheck
+    // timer won't run automatically. fcvm's health monitor must trigger it.
+    let (vm_name, _, _, _) = common::unique_names("rootless-hc");
+    println!("  Starting rootless VM: {}", vm_name);
+
+    let (mut child, fcvm_pid) = common::spawn_fcvm(&[
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        &image_name,
+    ])
+    .await
+    .context("spawning fcvm")?;
+
+    println!("  fcvm PID: {}", fcvm_pid);
+    println!("  Waiting for Healthy (fcvm must trigger podman healthcheck)...");
+
+    // Without the fix, this would time out because podman health stays "starting".
+    // With the fix, fcvm triggers `podman healthcheck run` when it sees "starting",
+    // podman runs the check (exit 0), marks container healthy, fcvm sees "healthy".
+    let health_result = common::poll_health_by_pid(fcvm_pid, 180).await;
+
+    // Cleanup
+    println!("  Stopping VM...");
+    common::kill_process(fcvm_pid).await;
+    let _ = child.wait().await;
+
+    match health_result {
+        Ok(()) => {
+            println!("  PASSED: rootless container became Healthy");
+            println!("  (fcvm triggered podman healthcheck in VM without systemd)");
+            Ok(())
+        }
+        Err(e) => {
+            anyhow::bail!(
+                "Container never became Healthy — fcvm failed to trigger \
+                 podman healthcheck in rootless mode: {}",
+                e
+            );
+        }
+    }
+}

--- a/tests/test_rootless_healthcheck.rs
+++ b/tests/test_rootless_healthcheck.rs
@@ -24,10 +24,7 @@ async fn test_rootless_podman_healthcheck_becomes_healthy() -> Result<()> {
     // Build a container image with a HEALTHCHECK defined.
     // The healthcheck passes immediately (exit 0).
     // Use --format=docker to preserve HEALTHCHECK instruction.
-    let image_name = format!(
-        "localhost/test-rootless-hc-{}",
-        std::process::id() % 10000
-    );
+    let image_name = format!("localhost/test-rootless-hc-{}", std::process::id() % 10000);
 
     println!("  Building image with HEALTHCHECK: {}", image_name);
     let tmpdir = tempfile::tempdir()?;
@@ -66,15 +63,10 @@ async fn test_rootless_podman_healthcheck_becomes_healthy() -> Result<()> {
     let (vm_name, _, _, _) = common::unique_names("rootless-hc");
     println!("  Starting rootless VM: {}", vm_name);
 
-    let (mut child, fcvm_pid) = common::spawn_fcvm(&[
-        "podman",
-        "run",
-        "--name",
-        &vm_name,
-        &image_name,
-    ])
-    .await
-    .context("spawning fcvm")?;
+    let (mut child, fcvm_pid) =
+        common::spawn_fcvm(&["podman", "run", "--name", &vm_name, &image_name])
+            .await
+            .context("spawning fcvm")?;
 
     println!("  fcvm PID: {}", fcvm_pid);
     println!("  Waiting for Healthy (fcvm must trigger podman healthcheck)...");


### PR DESCRIPTION
## Summary
- When the health monitor sees podman health "starting", trigger `podman healthcheck run` manually
- Rootless podman without systemd user session doesn't run the periodic healthcheck timer
- Without this fix, containers stay "Unhealthy" forever even when serving correctly
- Also adds overlay corruption recovery and global podman build lock to test infrastructure

## The Problem
In VM mode, podman runs rootless without a systemd user session. Podman's healthcheck timer
(which periodically runs `HEALTHCHECK CMD`) relies on systemd. Without it, the health status
stays "starting" indefinitely. fcvm's health monitor reads this and reports Unhealthy.

## The Fix
`check_podman_healthcheck()` in health.rs: when status is "starting", call
`run_podman_healthcheck()` which executes `podman healthcheck run fcvm-container` inside the VM.
On the next health poll, podman reports "healthy" and fcvm transitions to Healthy.

## Additional Changes
- **Overlay corruption recovery** (test infra): detect `"error unmounting"` / `"directory not empty"` in podman build stderr, clean corrupted layers with `podman rmi -f` + `podman system prune -f`, rebuild with `--no-cache`
- **Global podman build lock**: changed from per-image lock to global lock (`/tmp/fcvm-podman-build.lock`) to prevent concurrent podman builds from triggering kernel overlayfs race conditions
- **Formatting**: applied `cargo fmt` to health.rs and test_rootless_healthcheck.rs

## Test plan
```
make test-fast FILTER=rootless_podman_healthcheck STREAM=1
# 1 test, passes in ~13s
```

Test builds a container with `HEALTHCHECK --interval=2s CMD exit 0`, runs rootless,
verifies fcvm reports Healthy. Without the fix, it would timeout at 180s.