### PR TITLE
fix: use --no-snapshot for route replacement test baseline VM

### DIFF
--- a/tests/test_snapshot_clone.rs
+++ b/tests/test_snapshot_clone.rs
@@ -578,6 +578,8 @@ async fn test_route_replacement_on_clone_bridged() -> Result<()> {
     let fcvm_path = common::find_fcvm_binary()?;
 
     // Step 1: Start baseline with --health-check so clones inherit HTTP health checking
+    // Use --no-snapshot to ensure a fresh boot (startup snapshot cache may have
+    // stale vsock paths that cause "Address in use" errors on Run 2 in CI)
     println!("Step 1: Starting baseline VM with --health-check...");
     let (_baseline_child, baseline_pid) = common::spawn_fcvm_with_logs(
         &[
@@ -587,6 +589,7 @@ async fn test_route_replacement_on_clone_bridged() -> Result<()> {
             &baseline_name,
             "--network",
             "bridged",
+            "--no-snapshot",
             "--health-check",
             "http://localhost/",
             common::TEST_IMAGE,


### PR DESCRIPTION
## Summary
- Add `--no-snapshot` to the baseline VM in `test_route_replacement_on_clone_bridged`
- Prevents stale vsock socket conflicts on CI Run 2 in SnapshotEnabled mode

## Problem
In SnapshotEnabled CI mode, Run 2 has a startup snapshot cache from Run 1. The baseline VM hits the cache and tries to clone instead of booting fresh, failing with:
```
VsockUnixBackend: Error binding to the host-side Unix socket: Address in use (os error 98)
```

## Test plan
- [x] CI should pass on both arm64 and x64 in SnapshotEnabled mode