### PR TITLE
fix: give namespace holder full retry deadline instead of kill+respawn

### DIFF
--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -72,6 +72,56 @@ pub fn mount_overlay_image(
         mount_path, conf_path
     );
 
+    // Discover the actual image reference in the overlay store.
+    // The overlay cache is keyed by digest (content-addressed), but the image
+    // inside is tagged with the name from the original `podman save`. When the
+    // same content is built under a different name, the cached overlay has the
+    // old name. We ask podman what's actually there instead of trusting the
+    // expected name from the Plan.
+    let discover_output = if let Some(name) = username {
+        let user_pw = nix::unistd::User::from_name(name).ok().flatten();
+        let uid = user_pw.map(|u| u.uid.as_raw()).unwrap_or(0);
+        std::process::Command::new("env")
+            .args([
+                &format!("HOME=/home/{}", name),
+                &format!("XDG_RUNTIME_DIR=/run/user/{}", uid),
+                "runuser",
+                "-u",
+                name,
+                "--",
+                "podman",
+                "images",
+                "--format",
+                "{{.Repository}}:{{.Tag}}",
+            ])
+            .output()
+    } else {
+        std::process::Command::new("podman")
+            .args(["images", "--format", "{{.Repository}}:{{.Tag}}"])
+            .output()
+    };
+
+    if let Ok(output) = discover_output {
+        if output.status.success() {
+            let images_out = String::from_utf8_lossy(&output.stdout);
+            // Find first image that isn't <none>
+            if let Some(actual_ref) = images_out
+                .lines()
+                .find(|line| !line.contains("<none>") && !line.trim().is_empty())
+            {
+                let actual_ref = actual_ref.trim().to_string();
+                if actual_ref != image_name {
+                    eprintln!(
+                        "[fc-agent] overlay store contains '{}' (expected '{}'), using discovered name",
+                        actual_ref, image_name
+                    );
+                }
+                return Ok(actual_ref);
+            }
+        }
+    }
+
+    // Fallback: return expected name (downstream will fail with clear error if wrong)
     Ok(image_name.to_string())
 }
 

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -91,7 +91,12 @@ pub async fn spawn_namespace_holder(
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::piped())
             .spawn()
-            .with_context(|| format!("spawning namespace holder (attempt {}): {:?}", attempt, holder_cmd))?;
+            .with_context(|| {
+                format!(
+                    "spawning namespace holder (attempt {}): {:?}",
+                    attempt, holder_cmd
+                )
+            })?;
 
         let holder_pid = child.id().context("getting holder process PID")?;
         if attempt > 1 {
@@ -117,9 +122,8 @@ pub async fn spawn_namespace_holder(
                     tokio::time::sleep(HOLDER_RETRY_INTERVAL).await;
                     continue;
                 } else {
-                    let max_user_ns =
-                        std::fs::read_to_string("/proc/sys/user/max_user_namespaces")
-                            .unwrap_or_else(|_| "unknown".to_string());
+                    let max_user_ns = std::fs::read_to_string("/proc/sys/user/max_user_namespaces")
+                        .unwrap_or_else(|_| "unknown".to_string());
                     anyhow::bail!(
                         "namespace holder died and no time remaining to retry \
                          (attempt {}, holder PID {}, max_user_namespaces={})",

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -58,17 +58,96 @@ const MIN_FIRECRACKER_VERSION: (u32, u32, u32) = (1, 13, 1);
 /// Timeout for namespace holder creation retries
 pub const HOLDER_RETRY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
-/// Timeout for waiting for namespace to be ready
-pub const NAMESPACE_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(500);
-
 /// Maximum wait time for namespace setup via nsenter
 pub const NSENTER_MAX_WAIT: std::time::Duration = std::time::Duration::from_millis(1000);
 
 /// Poll interval for namespace setup retries
 pub const NSENTER_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(5);
 
-/// Retry interval between holder creation attempts
+/// Retry interval between holder creation attempts (only used when holder dies)
 pub const HOLDER_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// Spawn a namespace holder process and wait for it to be ready.
+///
+/// Spawns `unshare --user --map-root-user --net -- sleep infinity` and waits for the
+/// namespace to become ready (uid_map/gid_map written, nsenter probe succeeds).
+///
+/// Key design: gives the first holder the FULL retry deadline. Only spawns a new
+/// holder if the current one dies. Under heavy load, the `unshare` parent process
+/// may be slow to write uid_map due to CPU scheduling pressure — killing and
+/// respawning wastes time since the new holder faces the same pressure.
+pub async fn spawn_namespace_holder(
+    holder_cmd: &[String],
+) -> anyhow::Result<(tokio::process::Child, u32)> {
+    let deadline = std::time::Instant::now() + HOLDER_RETRY_TIMEOUT;
+    let mut attempt = 0u32;
+
+    loop {
+        attempt += 1;
+
+        let child = tokio::process::Command::new(&holder_cmd[0])
+            .args(&holder_cmd[1..])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .with_context(|| format!("spawning namespace holder (attempt {}): {:?}", attempt, holder_cmd))?;
+
+        let holder_pid = child.id().context("getting holder process PID")?;
+        if attempt > 1 {
+            info!(holder_pid, attempt, "namespace holder started (retry)");
+        } else {
+            info!(holder_pid, "namespace holder started");
+        }
+
+        // Give this holder the FULL remaining time to become ready.
+        // Don't kill on timeout — if it times out, the deadline is exceeded anyway.
+        let result = crate::utils::wait_for_namespace_ready(holder_pid, deadline).await;
+
+        match result {
+            crate::utils::NamespaceReadyResult::Ready => {
+                return Ok((child, holder_pid));
+            }
+            crate::utils::NamespaceReadyResult::HolderDied => {
+                if std::time::Instant::now() < deadline {
+                    warn!(
+                        holder_pid,
+                        attempt, "holder died before namespace ready, retrying..."
+                    );
+                    tokio::time::sleep(HOLDER_RETRY_INTERVAL).await;
+                    continue;
+                } else {
+                    let max_user_ns =
+                        std::fs::read_to_string("/proc/sys/user/max_user_namespaces")
+                            .unwrap_or_else(|_| "unknown".to_string());
+                    anyhow::bail!(
+                        "namespace holder died and no time remaining to retry \
+                         (attempt {}, holder PID {}, max_user_namespaces={})",
+                        attempt,
+                        holder_pid,
+                        max_user_ns.trim()
+                    );
+                }
+            }
+            crate::utils::NamespaceReadyResult::TimedOut => {
+                // Holder is alive but maps not written within deadline.
+                // No point killing and retrying — deadline is exceeded.
+                let _ = nix::sys::signal::kill(
+                    nix::unistd::Pid::from_raw(holder_pid as i32),
+                    nix::sys::signal::Signal::SIGKILL,
+                );
+                anyhow::bail!(
+                    "namespace not ready within {:?} (holder PID {} alive, \
+                     uid_map not written — likely CPU scheduling pressure \
+                     with many concurrent VMs). Attempt {}.",
+                    HOLDER_RETRY_TIMEOUT,
+                    holder_pid,
+                    attempt
+                );
+            }
+        }
+    }
+}
 
 /// Merge a diff snapshot onto a base memory file.
 ///
@@ -533,55 +612,7 @@ pub async fn restore_from_snapshot(
         let holder_cmd = slirp_net.build_holder_command();
         info!(cmd = ?holder_cmd, "spawning namespace holder for rootless networking");
 
-        let retry_deadline = std::time::Instant::now() + HOLDER_RETRY_TIMEOUT;
-        let mut attempt = 0u32;
-
-        let (mut child, holder_pid) = loop {
-            attempt += 1;
-
-            let mut child = tokio::process::Command::new(&holder_cmd[0])
-                .args(&holder_cmd[1..])
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .spawn()
-                .context("spawning namespace holder process")?;
-
-            let holder_pid = child.id().context("getting holder process PID")?;
-            if attempt > 1 {
-                info!(
-                    holder_pid = holder_pid,
-                    attempt = attempt,
-                    "namespace holder started (retry)"
-                );
-            } else {
-                info!(holder_pid = holder_pid, "namespace holder started");
-            }
-
-            // Wait for namespace to be ready by checking uid_map
-            let namespace_ready =
-                crate::utils::wait_for_namespace_ready(holder_pid, NAMESPACE_READY_TIMEOUT).await;
-
-            if namespace_ready {
-                break (child, holder_pid);
-            }
-
-            // Namespace not ready, kill holder and retry
-            let _ = child.kill().await;
-            if std::time::Instant::now() < retry_deadline {
-                warn!(
-                    holder_pid = holder_pid,
-                    attempt = attempt,
-                    "namespace not ready, retrying holder creation..."
-                );
-                tokio::time::sleep(HOLDER_RETRY_INTERVAL).await;
-            } else {
-                anyhow::bail!(
-                    "namespace not ready after {} attempts (holder PID {})",
-                    attempt,
-                    holder_pid
-                );
-            }
-        };
+        let (mut child, holder_pid) = spawn_namespace_holder(&holder_cmd).await?;
 
         // Step 2: Run disk creation and network setup IN PARALLEL
         let setup_script = slirp_net.build_setup_script();

--- a/src/commands/podman/namespace.rs
+++ b/src/commands/podman/namespace.rs
@@ -16,155 +16,16 @@ pub(super) async fn setup_rootless_namespace(
     vm_state: &mut VmState,
 ) -> Result<tokio::process::Child> {
     // Step 1: Spawn holder process (keeps namespace alive)
-    // Retry for up to 5 seconds if holder dies (transient failures under load)
+    // Uses shared function that gives the holder the full retry deadline,
+    // only respawning if the holder actually dies (not on timeout).
     let holder_cmd = slirp_net.build_holder_command();
     info!(cmd = ?holder_cmd, "spawning namespace holder for rootless networking");
 
-    let retry_deadline = std::time::Instant::now() + crate::commands::common::HOLDER_RETRY_TIMEOUT;
-    let mut attempt = 0;
+    let (mut child, mut holder_pid) =
+        crate::commands::common::spawn_namespace_holder(&holder_cmd).await?;
 
-    let (mut child, mut holder_pid, mut holder_stderr) = loop {
-        attempt += 1;
-
-        // Spawn holder with piped stderr to capture errors if it fails
-        let mut child = tokio::process::Command::new(&holder_cmd[0])
-            .args(&holder_cmd[1..])
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::piped())
-            .spawn()
-            .with_context(|| format!("failed to spawn holder: {:?}", holder_cmd))?;
-
-        let holder_pid = child.id().context("getting holder process PID")?;
-        if attempt > 1 {
-            info!(
-                holder_pid = holder_pid,
-                attempt = attempt,
-                "namespace holder started (retry)"
-            );
-        } else {
-            info!(holder_pid = holder_pid, "namespace holder started");
-        }
-
-        // Wait for namespace to be ready by checking uid_map
-        let namespace_ready = crate::utils::wait_for_namespace_ready(
-            holder_pid,
-            crate::commands::common::NAMESPACE_READY_TIMEOUT,
-        )
-        .await;
-
-        // If namespace didn't become ready, kill holder and retry
-        if !namespace_ready {
-            let _ = child.kill().await;
-
-            if std::time::Instant::now() < retry_deadline {
-                warn!(
-                    holder_pid = holder_pid,
-                    attempt = attempt,
-                    "namespace not ready, retrying holder creation..."
-                );
-                tokio::time::sleep(crate::commands::common::HOLDER_RETRY_INTERVAL).await;
-                continue;
-            } else {
-                bail!(
-                    "namespace not ready after {} attempts (holder PID {})",
-                    attempt,
-                    holder_pid
-                );
-            }
-        }
-
-        // Take stderr pipe - we'll use it for diagnostics if holder dies later
-        let mut holder_stderr = child.stderr.take();
-
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                // Holder exited - capture stderr to see why
-                let stderr = if let Some(ref mut pipe) = holder_stderr {
-                    use tokio::io::AsyncReadExt;
-                    let mut buf = String::new();
-                    let _ = pipe.read_to_string(&mut buf).await;
-                    buf
-                } else {
-                    String::new()
-                };
-
-                if std::time::Instant::now() < retry_deadline {
-                    warn!(
-                        holder_pid = holder_pid,
-                        attempt = attempt,
-                        status = %status,
-                        stderr = %stderr.trim(),
-                        "holder died, retrying..."
-                    );
-                    tokio::time::sleep(crate::commands::common::HOLDER_RETRY_INTERVAL).await;
-                    continue;
-                } else {
-                    bail!(
-                        "holder process exited immediately after {} attempts: status={}, stderr={}, cmd={:?}",
-                        attempt,
-                        status,
-                        stderr.trim(),
-                        holder_cmd
-                    );
-                }
-            }
-            Ok(None) => {
-                debug!(holder_pid = holder_pid, "holder running");
-            }
-            Err(e) => {
-                warn!(holder_pid = holder_pid, error = ?e, "failed to check holder status");
-            }
-        }
-
-        // Check if holder is still alive before proceeding
-        if !crate::utils::is_process_alive(holder_pid) {
-            // Try to capture stderr from the dead holder process
-            let holder_stderr_content = if let Some(ref mut pipe) = holder_stderr {
-                use tokio::io::AsyncReadExt;
-                let mut buf = String::new();
-                match tokio::time::timeout(
-                    std::time::Duration::from_millis(100),
-                    pipe.read_to_string(&mut buf),
-                )
-                .await
-                {
-                    Ok(Ok(_)) => buf,
-                    _ => String::new(),
-                }
-            } else {
-                String::new()
-            };
-
-            let _ = child.kill().await;
-
-            if std::time::Instant::now() < retry_deadline {
-                warn!(
-                    holder_pid = holder_pid,
-                    attempt = attempt,
-                    holder_stderr = %holder_stderr_content.trim(),
-                    "holder died after initial check, retrying..."
-                );
-                tokio::time::sleep(crate::commands::common::HOLDER_RETRY_INTERVAL).await;
-                continue;
-            } else {
-                let max_user_ns = std::fs::read_to_string("/proc/sys/user/max_user_namespaces")
-                    .unwrap_or_else(|_| "unknown".to_string());
-                bail!(
-                    "holder process (PID {}) died after {} attempts. \
-                     stderr='{}', max_user_namespaces={}. \
-                     This may indicate resource exhaustion or namespace limit reached.",
-                    holder_pid,
-                    attempt,
-                    holder_stderr_content.trim(),
-                    max_user_ns.trim()
-                );
-            }
-        }
-
-        // Holder is alive - break out of retry loop
-        break (child, holder_pid, holder_stderr);
-    };
+    // Take stderr pipe for diagnostics if holder dies during nsenter
+    let mut holder_stderr = child.stderr.take();
 
     // Step 2: Run setup script via nsenter (creates TAPs, iptables, etc.)
     // This is also inside retry logic - if holder dies during nsenter, retry everything
@@ -222,64 +83,19 @@ pub(super) async fn setup_rootless_namespace(
         let ns_net_exists = std::path::Path::new(&ns_net).exists();
 
         // If holder died during nsenter, this is a retryable error
-        if !holder_alive && std::time::Instant::now() < retry_deadline {
-            // Holder died during nsenter - retry the whole thing
-            let holder_stderr_content = if let Some(ref mut pipe) = holder_stderr {
-                use tokio::io::AsyncReadExt;
-                let mut buf = String::new();
-                match tokio::time::timeout(
-                    std::time::Duration::from_millis(100),
-                    pipe.read_to_string(&mut buf),
-                )
-                .await
-                {
-                    Ok(Ok(_)) => buf,
-                    _ => String::new(),
-                }
-            } else {
-                String::new()
-            };
-
+        if !holder_alive {
             let _ = child.kill().await;
 
             warn!(
                 holder_pid = holder_pid,
-                attempt = attempt,
-                holder_stderr = %holder_stderr_content.trim(),
                 nsenter_stderr = %stderr.trim(),
-                "holder died during nsenter, retrying..."
+                "holder died during nsenter, spawning new holder..."
             );
 
-            // Jump back to the retry loop by recursing into this block
-            // We need to restructure - for now just retry once more inline
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-
-            // Retry: spawn new holder
-            attempt += 1;
-            let mut retry_child = tokio::process::Command::new(&holder_cmd[0])
-                .args(&holder_cmd[1..])
-                .stdin(std::process::Stdio::null())
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::piped())
-                .spawn()
-                .with_context(|| format!("failed to spawn holder on retry: {:?}", holder_cmd))?;
-
-            let retry_holder_pid = retry_child.id().context("getting retry holder PID")?;
-            info!(
-                holder_pid = retry_holder_pid,
-                attempt = attempt,
-                "namespace holder started (retry after nsenter failure)"
-            );
-
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-
-            if !crate::utils::is_process_alive(retry_holder_pid) {
-                let _ = retry_child.kill().await;
-                bail!(
-                    "holder died on retry after nsenter failure (attempt {})",
-                    attempt
-                );
-            }
+            // Use spawn_namespace_holder for the retry — it handles its own
+            // deadline and readiness waiting
+            let (retry_child, retry_holder_pid) =
+                crate::commands::common::spawn_namespace_holder(&holder_cmd).await?;
 
             // Retry nsenter with new holder
             let retry_nsenter_prefix = slirp_net.build_nsenter_prefix(retry_holder_pid);
@@ -294,11 +110,13 @@ pub(super) async fn setup_rootless_namespace(
 
             if !retry_output.status.success() {
                 let retry_stderr = String::from_utf8_lossy(&retry_output.stderr);
-                let _ = retry_child.kill().await;
+                let _ = nix::sys::signal::kill(
+                    nix::unistd::Pid::from_raw(retry_holder_pid as i32),
+                    nix::sys::signal::Signal::SIGKILL,
+                );
                 bail!(
-                    "network setup failed on retry: {} (attempt {})",
+                    "network setup failed on retry: {}",
                     retry_stderr.trim(),
-                    attempt
                 );
             }
 
@@ -308,7 +126,6 @@ pub(super) async fn setup_rootless_namespace(
             nsenter_prefix = slirp_net.build_nsenter_prefix(holder_pid);
             info!(
                 holder_pid = holder_pid,
-                attempts = attempt,
                 "network setup succeeded after retry"
             );
         } else {
@@ -351,10 +168,9 @@ pub(super) async fn setup_rootless_namespace(
 
             if !holder_alive {
                 bail!(
-                    "network setup failed: holder died during nsenter after {} attempts. \
+                    "network setup failed: holder died during nsenter. \
                      nsenter_stderr='{}', holder_stderr='{}', \
                      (tun={}, ns_user={}, ns_net={})",
-                    attempt,
                     stderr.trim(),
                     holder_stderr_content.trim(),
                     tun_exists,
@@ -372,14 +188,6 @@ pub(super) async fn setup_rootless_namespace(
                 );
             }
         }
-    }
-
-    if attempt > 1 {
-        info!(
-            holder_pid = holder_pid,
-            attempts = attempt,
-            "namespace setup succeeded after retries"
-        );
     }
 
     info!(holder_pid = holder_pid, "network setup complete");

--- a/src/commands/podman/namespace.rs
+++ b/src/commands/podman/namespace.rs
@@ -114,10 +114,7 @@ pub(super) async fn setup_rootless_namespace(
                     nix::unistd::Pid::from_raw(retry_holder_pid as i32),
                     nix::sys::signal::Signal::SIGKILL,
                 );
-                bail!(
-                    "network setup failed on retry: {}",
-                    retry_stderr.trim(),
-                );
+                bail!("network setup failed on retry: {}", retry_stderr.trim(),);
             }
 
             // Success on retry - update variables for rest of function

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -228,9 +228,7 @@ pub async fn wait_for_namespace_ready(
                     .unwrap_or_default();
                 let gid_trimmed = gid_map.trim();
 
-                if !trimmed.is_empty()
-                    && !gid_trimmed.is_empty()
-                    && !content.contains("4294967295")
+                if !trimmed.is_empty() && !gid_trimmed.is_empty() && !content.contains("4294967295")
                 {
                     // Maps are written - now verify nsenter actually works
                     // Some kernel states require additional settling time

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -171,6 +171,17 @@ pub async fn run_streaming(
     Ok(child.wait().await?)
 }
 
+/// Result of waiting for namespace readiness.
+#[derive(Debug, PartialEq)]
+pub enum NamespaceReadyResult {
+    /// Namespace is ready (uid_map/gid_map written, nsenter probe succeeded)
+    Ready,
+    /// Holder process died while waiting
+    HolderDied,
+    /// Deadline expired while holder was still alive
+    TimedOut,
+}
+
 /// Wait for a user namespace to be ready by checking uid_map.
 ///
 /// When `unshare --map-root-user` creates a namespace, the uid_map initially has
@@ -178,18 +189,21 @@ pub async fn run_streaming(
 /// setns() fails with EINVAL until the real mapping (e.g., "0 1000 1") is written.
 ///
 /// This function polls uid_map until it no longer contains the identity mapping,
-/// which is more efficient than repeatedly spawning nsenter processes.
+/// then verifies nsenter works. It checks holder liveness on each iteration to
+/// short-circuit if the holder dies.
 ///
 /// # Arguments
 /// * `holder_pid` - PID of the namespace holder process
-/// * `timeout` - Maximum time to wait for namespace readiness
+/// * `deadline` - Absolute deadline for readiness
 ///
 /// # Returns
-/// `true` if namespace became ready, `false` on timeout or error
-pub async fn wait_for_namespace_ready(holder_pid: u32, timeout: Duration) -> bool {
+/// `NamespaceReadyResult` indicating ready, holder died, or timed out
+pub async fn wait_for_namespace_ready(
+    holder_pid: u32,
+    deadline: std::time::Instant,
+) -> NamespaceReadyResult {
     use tracing::{debug, info, warn};
 
-    let deadline = std::time::Instant::now() + timeout;
     let uid_map_path = format!("/proc/{}/uid_map", holder_pid);
     let mut iterations = 0u32;
 
@@ -214,7 +228,9 @@ pub async fn wait_for_namespace_ready(holder_pid: u32, timeout: Duration) -> boo
                     .unwrap_or_default();
                 let gid_trimmed = gid_map.trim();
 
-                if !trimmed.is_empty() && !gid_trimmed.is_empty() && !content.contains("4294967295")
+                if !trimmed.is_empty()
+                    && !gid_trimmed.is_empty()
+                    && !content.contains("4294967295")
                 {
                     // Maps are written - now verify nsenter actually works
                     // Some kernel states require additional settling time
@@ -240,7 +256,7 @@ pub async fn wait_for_namespace_ready(holder_pid: u32, timeout: Duration) -> boo
                                 gid_map = %gid_trimmed,
                                 "namespace ready (nsenter probe succeeded)"
                             );
-                            return true;
+                            return NamespaceReadyResult::Ready;
                         }
                         Ok(output) => {
                             // nsenter failed even though maps are written - continue waiting
@@ -254,7 +270,7 @@ pub async fn wait_for_namespace_ready(holder_pid: u32, timeout: Duration) -> boo
                         }
                         Err(e) => {
                             warn!(holder_pid = holder_pid, error = %e, "nsenter probe spawn failed");
-                            return false;
+                            return NamespaceReadyResult::HolderDied;
                         }
                     }
                 }
@@ -272,18 +288,18 @@ pub async fn wait_for_namespace_ready(holder_pid: u32, timeout: Duration) -> boo
                 }
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                // Process might have died, check if still alive
+                // Process died — /proc/{pid} gone
                 if !is_process_alive(holder_pid) {
                     debug!(
                         holder_pid = holder_pid,
                         "holder process died while waiting for uid_map"
                     );
-                    return false;
+                    return NamespaceReadyResult::HolderDied;
                 }
             }
             Err(e) => {
                 warn!(holder_pid = holder_pid, error = %e, "failed to read uid_map");
-                return false;
+                return NamespaceReadyResult::HolderDied;
             }
         }
 
@@ -291,10 +307,9 @@ pub async fn wait_for_namespace_ready(holder_pid: u32, timeout: Duration) -> boo
             warn!(
                 holder_pid = holder_pid,
                 iterations = iterations,
-                "namespace not ready after {:?}",
-                timeout
+                "namespace not ready, deadline expired"
             );
-            return false;
+            return NamespaceReadyResult::TimedOut;
         }
         tokio::time::sleep(Duration::from_millis(1)).await;
     }


### PR DESCRIPTION
## Summary

Two fixes for rootless mode reliability:

- **Namespace readiness**: Give the first namespace holder the full 5s retry deadline instead of killing and respawning after 500ms. Under load (parallel CI), the holder process is alive but the kernel hasn't finished writing uid_map/gid_map. The old 500ms timeout caused unnecessary kill+respawn cycles. Now uses `NamespaceReadyResult` enum (`Ready`/`HolderDied`/`TimedOut`) and shared `spawn_namespace_holder()` function.

- **Overlay image name mismatch**: The overlay storage cache is keyed by content digest, but the image inside is tagged with the name from the original `podman save`. When the same content is built under a different name (e.g., PID-based test names across CI retries), the cached overlay has the old name → "image not known" exit 125. Fix: after mounting overlay, run `podman images` to discover the actual image reference instead of trusting the expected name.

## Test plan

- [x] `make test-fast FILTER=rootless STREAM=1` — 11/11 pass
- [x] `make test-fast FILTER=rootless_podman_healthcheck STREAM=1` — passes with overlay name discovery
- [x] CI: Host-Root-x64-SnapshotEnabled passes (namespace readiness fix)
- [ ] CI: all jobs pass (overlay image discovery fix)