### PR TITLE
fc-mock: namespace networking, rootless support, and CI

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1169,7 +1169,7 @@ fuse-pipe/benches/
 3. **True Rootless Networking** (2025-11-25)
    - `--network rootless` (default): slirp4netns, no root required
    - `--network bridged`: Network namespace + iptables, requires root
-   - User namespace via `unshare --user --map-root-user --net`
+   - User namespace via `unshare --user --net` with external UID/GID mappings
    - Health checks use unique loopback IPs (127.x.y.z) per VM
 
 4. **Hierarchical Logging** (2025-11-15)
@@ -1209,7 +1209,7 @@ fuse-pipe/benches/
 | Bridged | `--network bridged` | Yes | Better | iptables DNAT |
 
 **Rootless Architecture:**
-- Firecracker starts with `unshare --user --map-root-user --net`
+- Holder process starts with `unshare --user --net`, UID/GID mappings written externally
 - Linux bridge (br0) connects slirp0 and tap-fc for L2 forwarding
 - Bridge preserves MAC addresses for proper slirp4netns ARP/NDP learning
 - Namespace IP (10.0.2.1) on bridge enables health checks via nsenter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,57 @@ jobs:
         working-directory: fcvm
         run: ./scripts/test-packaging.sh ./target/release/fcvm
 
+  # Runner 0c: fc-mock (default GitHub runner, no KVM needed)
+  # Tests fc-mock (Firecracker mock) which runs containers via podman
+  # instead of real Firecracker VMs. No KVM or btrfs required.
+  fc-mock:
+    name: fc-mock
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          path: fcvm
+      - uses: ./fcvm/.github/actions/checkout-deps
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Get dependency SHAs
+        id: deps
+        run: |
+          echo "fuser=$(git -C fuser rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "fuse-backend-rs=$(git -C fuse-backend-rs rev-parse HEAD)" >> $GITHUB_OUTPUT
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: fcvm -> target
+          shared-key: deps-${{ steps.deps.outputs.fuser }}-${{ steps.deps.outputs.fuse-backend-rs }}
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y libfuse3-dev libclang-dev clang podman
+      - name: Setup podman
+        run: |
+          # Disable AppArmor restriction on unprivileged user namespaces
+          # (needed for rootless podman on Ubuntu 24.04+)
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 2>/dev/null || true
+      - name: Cache cargo tools
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin
+          key: cargo-nextest-0.9.115-${{ runner.os }}-${{ runner.arch }}
+      - name: Install cargo-nextest
+        run: which cargo-nextest || cargo install cargo-nextest@0.9.115 --locked
+      - name: Build fc-mock
+        working-directory: fcvm
+        run: |
+          cargo build --release -p fc-mock
+          sudo install -m 755 target/release/fc-mock /usr/local/bin/fc-mock
+      - name: Test fc-mock
+        working-directory: fcvm
+        env:
+          FCVM_FIRECRACKER_BIN: /usr/local/bin/fc-mock
+          RUST_LOG: "fcvm=debug,health-monitor=info,fuser=warn,fuse_backend_rs=warn,passthrough=warn"
+        run: |
+          cargo nextest run --release -p fcvm --profile fc-mock \
+            --features privileged-tests \
+            -E 'package(fcvm) & (test(/fc_mock/) | test(/state_manager/) | test(/health_monitor/) | test(/no_sudo/)) & not test(=test_fc_mock_sanity) & not test(=test_fc_mock_container_launch)'
+
   # Runner 1a: Host (bare metal with KVM)
   # Runs: test-unit → test-fast (quick tests, no privileged)
   # Self-hosted runners with nested virtualization (ARM64: c7g.metal, x86: c5.metal)
@@ -626,7 +677,7 @@ jobs:
   # Final summary job - runs after all test jobs
   summary:
     name: Summary
-    needs: [skip-check, lint, packaging, host, host-root, container]
+    needs: [skip-check, lint, packaging, fc-mock, host, host-root, container]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -399,7 +399,7 @@ Each VM has:
 
 **Topology**:
 ```
-Host                     │ User Namespace (unshare --user --map-root-user --net)
+Host                     │ User Namespace (unshare --user --net)
                          │
 slirp4netns <────────────┼── slirp0 ─┐
   (userspace NAT)        │           │
@@ -419,7 +419,7 @@ slirp4netns <────────────┼── slirp0 ─┐
 - Bridge also enables IPv6 with proper NDP neighbor discovery
 
 **Setup Sequence** (3-phase with nsenter):
-1. Spawn holder process: `unshare --user --map-root-user --net -- sleep infinity`
+1. Spawn holder process: `unshare --user --net -- sleep infinity` (UID/GID mappings written externally)
 2. Run setup via nsenter: create bridge, TAPs, add namespace IP
 3. Start slirp4netns attached to holder's namespace (connects to slirp0)
 4. Run Firecracker via nsenter: `nsenter -t HOLDER_PID -U -n -- firecracker ...`

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ CONTAINER_RUN := $(CONTAINER_RUN_BASE) --ulimit nproc=65536:65536 --pids-limit=6
 .PHONY: all help build clean clean-test-data check-disk \
 	test test-unit test-fast test-all test-root test-packaging \
 	_test-unit _test-fast _test-all _test-root _setup-fcvm _bench \
-	container-build container-test container-test-unit container-test-fast container-test-all \
+	container-build container-test container-test-unit container-test-fast container-test-all container-test-fc-mock \
 	container-setup-fcvm container-shell container-clean container-bench \
 	setup-btrfs setup-default setup-fcvm setup-pjdfstest setup-hugepages bench bench-vm bench-hugepages bench-hugepages-test \
 	bench-container-import \
@@ -161,6 +161,7 @@ help:
 	@echo "  container-test-unit    Unit tests in container"
 	@echo "  container-test-fast    + quick VM tests in container"
 	@echo "  container-test-all, container-test  + slow VM tests in container"
+	@echo "  container-test-fc-mock  fc-mock tests in container (no KVM)"
 	@echo ""
 	@echo "Container:"
 	@echo "  container-build    Build test container"
@@ -310,11 +311,11 @@ test: test-root
 # fc-mock: container-mode tests (no KVM required)
 # Uses fc-mock binary instead of Firecracker.
 # Only runs tests known to work with fc-mock (no KVM, no real Firecracker).
-FC_MOCK_FILTER := package(fcvm) & (test(=test_sanity_bridged) | test(/fc_mock/) | test(/state_manager/) | test(/health_monitor/) | test(/no_sudo/))
+FC_MOCK_FILTER := package(fcvm) & (test(=test_sanity_bridged) | test(=test_sanity_rootless) | test(/fc_mock/) | test(/state_manager/) | test(/health_monitor/) | test(/no_sudo/))
 _test-fc-mock:
 	@FCVM_FIRECRACKER_BIN=/usr/local/bin/fc-mock \
 	RUST_LOG="$(TEST_LOG)" \
-	FCVM_DATA_DIR=$(ROOT_DATA_DIR) \
+	FCVM_DATA_DIR=$${FCVM_DATA_DIR:-$(ROOT_DATA_DIR)} \
 	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
 	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
 	$(NEXTEST) $(NEXTEST_CAPTURE) --profile fc-mock --features privileged-tests -E '$(FC_MOCK_FILTER)' $(FILTER) || \
@@ -326,6 +327,20 @@ test-fc-mock: show-notes check-disk build build-fc-mock setup-fcvm _test-fc-mock
 # Container targets (setup on host where needed, run-only in container)
 # Container uses shadowed target/ mount to avoid permission conflicts
 # check-disk runs on host before container tests start
+
+# fc-mock in container (subset — networking tests excluded)
+# Rootless podman containers can't create nested user namespaces or TAP devices,
+# so only fc-mock unit tests run here. Full fc-mock tests run on bare metal (test-fc-mock).
+FC_MOCK_CONTAINER_FILTER := package(fcvm) & (test(/fc_mock/) | test(/state_manager/) | test(/health_monitor/) | test(/no_sudo/)) & not test(=test_fc_mock_sanity) & not test(=test_fc_mock_container_launch)
+container-test-fc-mock: check-disk container-build setup-btrfs
+	@echo "==> Running fc-mock tests in container (unit tests only)..."
+	$(CONTAINER_RUN) $(CONTAINER_TAG) bash -c '\
+		make build build-fc-mock && \
+		FCVM_FIRECRACKER_BIN=/usr/local/bin/fc-mock \
+		RUST_LOG="$(TEST_LOG)" \
+		$(NEXTEST) $(NEXTEST_CAPTURE) --profile fc-mock --features privileged-tests -E "$(FC_MOCK_CONTAINER_FILTER)" $(FILTER) || \
+		{ echo "TEST FAILED (fc-mock container mode)"; exit 1; }'
+
 container-test-unit: check-disk container-build
 	@echo "==> Running unit tests in container..."
 	$(CONTAINER_RUN) $(CONTAINER_TAG) make build _test-unit

--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ Clone timing measured on c7g.metal ARM64 with `RUST_LOG=debug`:
 | Step | Time | Description |
 |------|------|-------------|
 | State lookup | ~1ms | Find serve process |
-| Namespace spawn | ~6ms | `unshare --user --map-root-user --net` |
+| Namespace spawn | ~6ms | `unshare --user --net` + UID/GID mappings |
 | CoW disk reflink | ~31ms | btrfs instant copy |
 | Network setup | ~35ms | TAP device, iptables rules |
 | Firecracker spawn | ~6ms | Start VM process |

--- a/fc-mock/src/api_server.rs
+++ b/fc-mock/src/api_server.rs
@@ -20,6 +20,8 @@ struct MockState {
     mmds_data: Option<serde_json::Value>,
     /// Vsock config (contains uds_path)
     vsock_uds_path: Option<String>,
+    /// Boot args from PUT /boot-source (contains IP config, DNS)
+    boot_args: Option<String>,
     /// Whether InstanceStart has been called
     started: bool,
     /// Shutdown notifier (triggers when container exits)
@@ -31,6 +33,7 @@ impl SharedState {
         Self(Arc::new(Mutex::new(MockState {
             mmds_data: None,
             vsock_uds_path: None,
+            boot_args: None,
             started: false,
             shutdown: None,
         })))
@@ -110,8 +113,22 @@ async fn handle_request(
     let body_bytes = hyper::body::to_bytes(req.into_body()).await?;
 
     let result: Result<(), String> = match (method, path.as_str()) {
-        // Config endpoints - store and return 204
-        (Method::PUT, "/boot-source") => Ok(()),
+        // Boot source - extract boot_args for network config
+        (Method::PUT, "/boot-source") => {
+            #[derive(serde::Deserialize)]
+            struct BootSource {
+                #[serde(default)]
+                boot_args: Option<String>,
+            }
+            if let Ok(bs) = serde_json::from_slice::<BootSource>(&body_bytes) {
+                if let Some(args) = bs.boot_args {
+                    let mut s = state.0.lock().await;
+                    s.boot_args = Some(args);
+                    debug!("boot_args stored");
+                }
+            }
+            Ok(())
+        }
         (Method::PUT, "/machine-config") => Ok(()),
         (Method::PUT, p) if p.starts_with("/drives/") => Ok(()),
         (Method::PUT, p) if p.starts_with("/network-interfaces/") => Ok(()),
@@ -175,6 +192,7 @@ async fn handle_request(
 
                     let mmds_data = s.mmds_data.clone();
                     let vsock_uds_path = s.vsock_uds_path.clone();
+                    let boot_args = s.boot_args.clone();
                     let shutdown = s.shutdown.clone();
                     drop(s); // Release lock before spawning
 
@@ -182,6 +200,7 @@ async fn handle_request(
                         if let Err(e) = crate::container::launch_container(
                             mmds_data,
                             vsock_uds_path,
+                            boot_args,
                             shutdown.clone(),
                         )
                         .await

--- a/fc-mock/src/container.rs
+++ b/fc-mock/src/container.rs
@@ -13,18 +13,28 @@ use tracing::{debug, info, warn};
 /// Container name used by fcvm's health monitor (hardcoded in health.rs)
 const CONTAINER_NAME: &str = "fcvm-container";
 
+/// Network config parsed from kernel boot args.
+struct NetworkConfig {
+    guest_ip: String,
+    netmask: String,
+    gateway: String,
+    dns_servers: Vec<String>,
+}
+
 /// Launch a container from the MMDS plan and manage its lifecycle.
 ///
 /// 1. Parse MMDS container-plan
-/// 2. Start vsock exec listener
-/// 3. Launch container via podman
-/// 4. Connect to status socket → send "ready"
-/// 5. Connect to output socket → forward stdout/stderr
-/// 6. Wait for container exit → send "exit:{code}"
-/// 7. Signal shutdown so fc-mock exits
+/// 2. Configure namespace networking (IP on br0, default route)
+/// 3. Start vsock exec listener
+/// 4. Launch container via podman with --network host
+/// 5. Connect to status socket → send "ready"
+/// 6. Connect to output socket → forward stdout/stderr
+/// 7. Wait for container exit → send "exit:{code}"
+/// 8. Signal shutdown so fc-mock exits
 pub async fn launch_container(
     mmds_data: Option<serde_json::Value>,
     vsock_uds_path: Option<String>,
+    boot_args: Option<String>,
     shutdown: Option<Arc<Notify>>,
 ) -> Result<()> {
     let mmds = mmds_data.context("no MMDS data stored (PUT /mmds not called)")?;
@@ -68,6 +78,17 @@ pub async fn launch_container(
         "parsed container plan"
     );
 
+    // Parse boot args and configure namespace networking
+    let net_config = boot_args.as_deref().and_then(parse_boot_args);
+    if let Some(ref nc) = net_config {
+        if let Err(e) = configure_namespace_networking(nc).await {
+            warn!(
+                "failed to configure namespace networking: {} (container may lack internet)",
+                e
+            );
+        }
+    }
+
     // Start vsock exec listener BEFORE anything else so health checks can connect
     let exec_handle = crate::vsock_exec::start_exec_listener(&vsock_path).await?;
 
@@ -80,7 +101,23 @@ pub async fn launch_container(
         "--name".to_string(),
         CONTAINER_NAME.to_string(),
         "--rm".to_string(),
+        // Share the namespace's network stack (mirrors fc-agent's --network=host)
+        "--network".to_string(),
+        "host".to_string(),
     ];
+
+    // DNS from boot args
+    if let Some(ref nc) = net_config {
+        for dns in &nc.dns_servers {
+            podman_args.push("--dns".to_string());
+            podman_args.push(dns.clone());
+        }
+    }
+
+    // Rootless storage fix: use overlay+fuse-overlayfs on tmpfs to avoid btrfs
+    // remount failure. fuse-overlayfs works in user namespaces and handles chown errors.
+    let storage_args = rootless_storage_args();
+    podman_args.extend(storage_args.clone());
 
     for (key, val) in &env {
         podman_args.push("-e".to_string());
@@ -109,12 +146,15 @@ pub async fn launch_container(
     info!(args = ?podman_args, "launching container");
 
     // Spawn podman with piped stdout/stderr
-    let mut child = tokio::process::Command::new("podman")
-        .args(&podman_args)
+    let mut cmd = tokio::process::Command::new("podman");
+    cmd.args(&podman_args)
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .context("spawning podman")?;
+        .stderr(std::process::Stdio::piped());
+
+    // In user namespaces, HOME and XDG_RUNTIME_DIR may be inaccessible.
+    apply_user_ns_env(&mut cmd);
+
+    let mut child = cmd.spawn().context("spawning podman")?;
 
     let stdout = child.stdout.take().context("no stdout")?;
     let stderr = child.stderr.take().context("no stderr")?;
@@ -211,15 +251,266 @@ pub async fn launch_container(
     Ok(())
 }
 
+/// Parse kernel boot args for network configuration.
+///
+/// Extracts:
+/// - `ip=GUEST_IP::GATEWAY:NETMASK::eth0:off` → guest_ip, gateway
+/// - `fcvm_dns=X.X.X.X|Y.Y.Y.Y` → DNS servers
+fn parse_boot_args(boot_args: &str) -> Option<NetworkConfig> {
+    let mut guest_ip = None;
+    let mut netmask = None;
+    let mut gateway = None;
+    let mut dns_servers = Vec::new();
+
+    for arg in boot_args.split_whitespace() {
+        if let Some(ip_arg) = arg.strip_prefix("ip=") {
+            // Format: ip=CLIENT::GATEWAY:NETMASK::DEVICE:AUTOCONF
+            let parts: Vec<&str> = ip_arg.split(':').collect();
+            if !parts.is_empty() && !parts[0].is_empty() {
+                guest_ip = Some(parts[0].to_string());
+            }
+            // Gateway is after two colons (empty server-ip field)
+            // Parts: [CLIENT, "", GATEWAY, NETMASK, "", DEVICE, AUTOCONF]
+            if parts.len() >= 3 && !parts[2].is_empty() {
+                gateway = Some(parts[2].to_string());
+            }
+            if parts.len() >= 4 && !parts[3].is_empty() {
+                netmask = Some(parts[3].to_string());
+            }
+        } else if let Some(dns_arg) = arg.strip_prefix("fcvm_dns=") {
+            // Format: fcvm_dns=X.X.X.X|Y.Y.Y.Y (pipe-separated)
+            dns_servers = dns_arg.split('|').map(String::from).collect();
+        }
+    }
+
+    match (guest_ip, gateway) {
+        (Some(ip), Some(gw)) => {
+            let mask = netmask.unwrap_or_else(|| "255.255.255.0".to_string());
+            info!(guest_ip = %ip, netmask = %mask, gateway = %gw, dns = ?dns_servers, "parsed network config from boot args");
+            Some(NetworkConfig {
+                guest_ip: ip,
+                netmask: mask,
+                gateway: gw,
+                dns_servers,
+            })
+        }
+        _ => {
+            debug!("no network config found in boot args");
+            None
+        }
+    }
+}
+
+/// Configure the namespace's network so containers can use it.
+///
+/// Assigns guest IP to br0 and adds a default route via the gateway.
+/// This makes the namespace's network stack usable with --network host.
+async fn configure_namespace_networking(config: &NetworkConfig) -> Result<()> {
+    let prefix_len = netmask_to_prefix(&config.netmask);
+
+    // Assign guest IP to br0
+    let output = tokio::process::Command::new("ip")
+        .args([
+            "addr",
+            "add",
+            &format!("{}/{}", config.guest_ip, prefix_len),
+            "dev",
+            "br0",
+        ])
+        .output()
+        .await
+        .context("running ip addr add")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // RTNETLINK: File exists means IP already assigned — that's fine
+        if !stderr.contains("File exists") {
+            bail!("ip addr add failed: {}", stderr.trim());
+        }
+    }
+    info!(ip = %config.guest_ip, "assigned IP to br0");
+
+    // Add default route via gateway
+    let output = tokio::process::Command::new("ip")
+        .args([
+            "route",
+            "add",
+            "default",
+            "via",
+            &config.gateway,
+            "dev",
+            "br0",
+        ])
+        .output()
+        .await
+        .context("running ip route add")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.contains("File exists") {
+            bail!("ip route add failed: {}", stderr.trim());
+        }
+    }
+    info!(gateway = %config.gateway, "added default route");
+
+    // Fix DNS: In network namespaces, /etc/resolv.conf often points to
+    // 127.0.0.53 (systemd-resolved) which is unreachable. If we have DNS
+    // servers from boot args and are in a mount namespace (set up in main),
+    // bind-mount a custom resolv.conf so podman can resolve registry names.
+    if !config.dns_servers.is_empty() {
+        fix_namespace_dns(&config.dns_servers);
+    }
+
+    Ok(())
+}
+
+/// Fix DNS in the namespace by bind-mounting a custom resolv.conf.
+///
+/// In network namespaces, /etc/resolv.conf typically points to 127.0.0.53
+/// (systemd-resolved) which only listens in the initial network namespace.
+/// This replaces it with the real DNS servers from boot args.
+///
+/// Requires a private mount namespace (set up in main.rs before tokio).
+fn fix_namespace_dns(dns_servers: &[String]) {
+    // Check if fix is needed
+    if let Ok(content) = std::fs::read_to_string("/etc/resolv.conf") {
+        if !content.contains("127.0.0.53") {
+            debug!("resolv.conf doesn't use systemd-resolved stub, no fix needed");
+            return;
+        }
+    }
+
+    // Write custom resolv.conf
+    let resolv_path = "/tmp/fc-mock-resolv.conf";
+    let content: String = dns_servers
+        .iter()
+        .map(|s| format!("nameserver {}", s))
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+
+    if let Err(e) = std::fs::write(resolv_path, &content) {
+        warn!("failed to write custom resolv.conf: {}", e);
+        return;
+    }
+
+    // Bind mount over /etc/resolv.conf
+    let source = std::ffi::CString::new(resolv_path).unwrap();
+    let target = std::ffi::CString::new("/etc/resolv.conf").unwrap();
+    let ret = unsafe {
+        libc::mount(
+            source.as_ptr(),
+            target.as_ptr(),
+            std::ptr::null(),
+            libc::MS_BIND,
+            std::ptr::null(),
+        )
+    };
+
+    if ret != 0 {
+        warn!(
+            "failed to bind mount resolv.conf: {} (DNS may not work for image pulls)",
+            std::io::Error::last_os_error()
+        );
+    } else {
+        info!(dns = ?dns_servers, "bind-mounted custom resolv.conf for namespace DNS");
+    }
+}
+
+/// Convert a dotted-decimal netmask to CIDR prefix length.
+/// Falls back to 24 if the netmask can't be parsed.
+fn netmask_to_prefix(netmask: &str) -> u32 {
+    netmask
+        .parse::<std::net::Ipv4Addr>()
+        .map(|ip| u32::from(ip).count_ones())
+        .unwrap_or(24)
+}
+
+/// Return extra podman args for rootless storage if in a user namespace.
+///
+/// In user namespaces, podman can't remount btrfs storage and native overlay
+/// fails. Use overlay driver with fuse-overlayfs on tmpfs instead.
+/// fuse-overlayfs works in user namespaces and the overlay driver properly
+/// handles chown errors during image layer extraction (unlike vfs).
+pub fn rootless_storage_args() -> Vec<String> {
+    if !in_user_namespace() {
+        return Vec::new();
+    }
+    let storage_root = format!("/tmp/fc-mock-podman-{}", std::process::id());
+    debug!(storage_root = %storage_root, "using overlay+fuse-overlayfs storage (user namespace)");
+    vec![
+        "--root".to_string(),
+        storage_root,
+        "--storage-driver".to_string(),
+        "overlay".to_string(),
+        "--storage-opt".to_string(),
+        "overlay.mount_program=/usr/bin/fuse-overlayfs".to_string(),
+        // In user namespaces with limited UID/GID mappings (e.g., only 0→0),
+        // image layer extraction fails on lchown for unmapped IDs (like GID 42).
+        // This tells the overlay driver to silently ignore chown errors.
+        "--storage-opt".to_string(),
+        "overlay.ignore_chown_errors=true".to_string(),
+    ]
+}
+
+/// Apply environment fixes needed for podman in user namespaces.
+///
+/// In user namespaces, HOME and XDG_RUNTIME_DIR may point to directories
+/// with restrictive permissions (e.g., /home/ubuntu with 750 or /run/user/1000),
+/// causing podman to fail reading config and auth files.
+///
+/// Also sets _CONTAINERS_USERNS_CONFIGURED so containers/storage treats the
+/// process as rootless. This enables automatic chown error tolerance during
+/// image layer extraction, since the user namespace only maps UID/GID 0.
+pub fn apply_user_ns_env(cmd: &mut tokio::process::Command) {
+    if !in_user_namespace() {
+        return;
+    }
+    let runtime_dir = format!("/tmp/fc-mock-runtime-{}", std::process::id());
+    let _ = std::fs::create_dir_all(&runtime_dir);
+    cmd.env("HOME", "/tmp");
+    cmd.env("XDG_RUNTIME_DIR", &runtime_dir);
+    // Tell containers/storage we're in a user namespace so it ignores
+    // chown errors during image layer extraction (only UID/GID 0 is mapped).
+    cmd.env("_CONTAINERS_USERNS_CONFIGURED", "1");
+}
+
+/// Detect if we're running inside a user namespace.
+///
+/// Checks /proc/self/uid_map: identity mapping (0 0 4294967295) means
+/// no user namespace. Any other mapping means we're in one.
+pub fn in_user_namespace() -> bool {
+    match std::fs::read_to_string("/proc/self/uid_map") {
+        Ok(content) => {
+            let line = content.trim();
+            // Identity mapping = not in user namespace
+            // Format: "         0          0 4294967295" (with variable whitespace)
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            !(parts.len() == 3 && parts[0] == "0" && parts[1] == "0" && parts[2] == "4294967295")
+        }
+        Err(_) => false,
+    }
+}
+
 /// Clean up any existing container with our name.
 pub async fn cleanup_container() {
     debug!("cleaning up container {}", CONTAINER_NAME);
-    let output = tokio::process::Command::new("podman")
-        .args(["rm", "-f", "-t", "0", CONTAINER_NAME])
+    let storage_args = rootless_storage_args();
+    let mut args = storage_args;
+    args.extend(
+        ["rm", "-f", "-t", "0", CONTAINER_NAME]
+            .iter()
+            .map(|s| s.to_string()),
+    );
+
+    let mut cmd = tokio::process::Command::new("podman");
+    cmd.args(&args)
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .output()
-        .await;
+        .stderr(std::process::Stdio::null());
+
+    apply_user_ns_env(&mut cmd);
+
+    let output = cmd.output().await;
     if let Ok(o) = output {
         if o.status.success() {
             debug!("removed existing container {}", CONTAINER_NAME);

--- a/fc-mock/src/main.rs
+++ b/fc-mock/src/main.rs
@@ -39,6 +39,15 @@ fn main() -> Result<()> {
 
     tracing::info!("fc-mock starting (api-sock: {})", api_sock);
 
+    // In user namespaces, create a private mount namespace so we can bind-mount
+    // a custom resolv.conf later. This must happen while single-threaded (before
+    // tokio spawns worker threads). Without this, podman can't resolve DNS for
+    // image pulls because /etc/resolv.conf points to 127.0.0.53 (systemd-resolved)
+    // which is unreachable in the new network namespace.
+    if container::in_user_namespace() {
+        setup_private_mount_namespace();
+    }
+
     // Run the async runtime
     let rt = tokio::runtime::Runtime::new().context("creating tokio runtime")?;
     rt.block_on(run(PathBuf::from(api_sock)))
@@ -93,4 +102,39 @@ fn parse_arg(args: &[String], name: &str) -> Option<String> {
         .position(|a| a == name)
         .and_then(|i| args.get(i + 1))
         .cloned()
+}
+
+/// Create a private mount namespace so we can later bind-mount a custom
+/// resolv.conf without affecting the host.
+fn setup_private_mount_namespace() {
+    // unshare(CLONE_NEWNS) must be called while single-threaded
+    let ret = unsafe { libc::unshare(libc::CLONE_NEWNS) };
+    if ret != 0 {
+        tracing::warn!(
+            "failed to create mount namespace: {} (DNS may not work for image pulls)",
+            std::io::Error::last_os_error()
+        );
+        return;
+    }
+
+    // Make all mounts private so bind mounts don't propagate to host
+    let root = std::ffi::CString::new("/").unwrap();
+    let ret = unsafe {
+        libc::mount(
+            std::ptr::null(),
+            root.as_ptr(),
+            std::ptr::null(),
+            libc::MS_REC | libc::MS_PRIVATE,
+            std::ptr::null(),
+        )
+    };
+    if ret != 0 {
+        tracing::warn!(
+            "failed to set mount propagation: {}",
+            std::io::Error::last_os_error()
+        );
+        return;
+    }
+
+    tracing::info!("created private mount namespace for DNS fix");
 }

--- a/fc-mock/src/vsock_exec.rs
+++ b/fc-mock/src/vsock_exec.rs
@@ -112,12 +112,15 @@ async fn handle_connection(stream: tokio::net::UnixStream) -> Result<()> {
     // Build the actual command to run
     let (program, args) = if request.in_container {
         // Run inside the container via podman exec
-        let mut exec_args = vec!["exec".to_string(), CONTAINER_NAME.to_string()];
+        // Include rootless storage args so podman can find the container
+        let storage_args = crate::container::rootless_storage_args();
+        let mut exec_args = storage_args;
+        exec_args.push("exec".to_string());
+        exec_args.push(CONTAINER_NAME.to_string());
         exec_args.extend(request.command.clone());
         ("podman".to_string(), exec_args)
     } else {
         // Run directly on the host (VM-level exec)
-        // First arg is the program, rest are arguments
         if request.command.is_empty() {
             let resp = ExecResponse::Error("empty command".to_string());
             let json = serde_json::to_string(&resp)?;
@@ -125,20 +128,33 @@ async fn handle_connection(stream: tokio::net::UnixStream) -> Result<()> {
             write_half.write_all(b"\n").await?;
             return Ok(());
         }
+        // If the command is podman, prepend rootless storage args
         let program = request.command[0].clone();
-        let args = request.command[1..].to_vec();
+        let args = if program == "podman" {
+            let mut storage_args = crate::container::rootless_storage_args();
+            storage_args.extend(request.command[1..].to_vec());
+            storage_args
+        } else {
+            request.command[1..].to_vec()
+        };
         (program, args)
     };
 
     debug!(program = %program, args = ?args, "executing command");
 
     // Spawn the command
-    let result = tokio::process::Command::new(&program)
-        .args(&args)
+    let mut cmd = tokio::process::Command::new(&program);
+    cmd.args(&args)
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .output()
-        .await;
+        .stderr(std::process::Stdio::piped());
+
+    // In user namespaces, podman needs HOME and XDG_RUNTIME_DIR overrides
+    // to avoid permission errors reading config/auth from the original user's dirs.
+    if program == "podman" {
+        crate::container::apply_user_ns_env(&mut cmd);
+    }
+
+    let result = cmd.output().await;
 
     match result {
         Ok(output) => {

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -67,15 +67,84 @@ pub const NSENTER_POLL_INTERVAL: std::time::Duration = std::time::Duration::from
 /// Retry interval between holder creation attempts (only used when holder dies)
 pub const HOLDER_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
 
+/// Set up UID/GID mappings for a process in a new user namespace.
+///
+/// Tries extended mappings (UIDs 0-65535) via newuidmap/newgidmap first, which
+/// enables OCI runtimes (crun) to mount devpts inside containers (needed by fc-mock).
+/// Falls back to single-UID mapping (like --map-root-user) when the helpers aren't
+/// available or lack permissions (e.g., inside containers).
+async fn setup_namespace_mappings(pid: u32) -> anyhow::Result<()> {
+    use std::os::unix::fs::MetadataExt;
+
+    let uid = nix::unistd::getuid().as_raw();
+    let gid = nix::unistd::getgid().as_raw();
+    let pid_s = pid.to_string();
+    let uid_s = uid.to_string();
+    let gid_s = gid.to_string();
+
+    // Wait for unshare(2) to create the new user namespace.
+    // The namespace exists once /proc/PID/ns/user has a different inode than ours.
+    let self_ino = std::fs::metadata("/proc/self/ns/user")
+        .context("reading own user namespace inode")?
+        .ino();
+    let ns_deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        if std::fs::metadata(format!("/proc/{pid}/ns/user"))
+            .map(|m| m.ino() != self_ino)
+            .unwrap_or(false)
+        {
+            break;
+        }
+        if std::time::Instant::now() >= ns_deadline {
+            anyhow::bail!("timed out waiting for user namespace (PID {pid})");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+    }
+
+    // Try extended mappings (0-65535) via newuidmap/newgidmap (setuid helpers).
+    // These read /etc/subuid and /etc/subgid to authorize the mapping range.
+    let uid_ok = tokio::process::Command::new("newuidmap")
+        .args([&pid_s, "0", &uid_s, "1", "1", "100000", "65535"])
+        .output()
+        .await
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    let gid_ok = uid_ok
+        && tokio::process::Command::new("newgidmap")
+            .args([&pid_s, "0", &gid_s, "1", "1", "100000", "65535"])
+            .output()
+            .await
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+
+    if uid_ok && gid_ok {
+        info!(pid, "extended UID/GID mappings (0-65535)");
+        return Ok(());
+    }
+
+    // Fallback: write mappings directly (equivalent to --map-root-user).
+    // Must deny setgroups before writing gid_map as unprivileged user.
+    std::fs::write(format!("/proc/{pid}/setgroups"), "deny").context("denying setgroups")?;
+    if !uid_ok {
+        std::fs::write(format!("/proc/{pid}/uid_map"), format!("0 {uid} 1\n"))
+            .context("writing uid_map")?;
+    }
+    std::fs::write(format!("/proc/{pid}/gid_map"), format!("0 {gid} 1\n"))
+        .context("writing gid_map")?;
+    info!(pid, "single UID/GID mapping (fallback)");
+
+    Ok(())
+}
+
 /// Spawn a namespace holder process and wait for it to be ready.
 ///
-/// Spawns `unshare --user --map-root-user --net -- sleep infinity` and waits for the
-/// namespace to become ready (uid_map/gid_map written, nsenter probe succeeds).
+/// Spawns `unshare --user --net -- sleep infinity`, writes UID/GID mappings
+/// (extended if possible, single otherwise), and waits for nsenter to work.
 ///
 /// Key design: gives the first holder the FULL retry deadline. Only spawns a new
-/// holder if the current one dies. Under heavy load, the `unshare` parent process
-/// may be slow to write uid_map due to CPU scheduling pressure — killing and
-/// respawning wastes time since the new holder faces the same pressure.
+/// holder if the current one dies. Under heavy load, mapping setup may be slow
+/// due to CPU scheduling pressure — killing and respawning wastes time since
+/// the new holder faces the same pressure.
 pub async fn spawn_namespace_holder(
     holder_cmd: &[String],
 ) -> anyhow::Result<(tokio::process::Child, u32)> {
@@ -103,6 +172,21 @@ pub async fn spawn_namespace_holder(
             info!(holder_pid, attempt, "namespace holder started (retry)");
         } else {
             info!(holder_pid, "namespace holder started");
+        }
+
+        // Write UID/GID mappings for the new user namespace.
+        // Must happen before wait_for_namespace_ready which checks uid_map.
+        if let Err(e) = setup_namespace_mappings(holder_pid).await {
+            warn!(holder_pid, error = %e, "failed to set up namespace mappings");
+            let _ = nix::sys::signal::kill(
+                nix::unistd::Pid::from_raw(holder_pid as i32),
+                nix::sys::signal::Signal::SIGKILL,
+            );
+            if std::time::Instant::now() < deadline {
+                tokio::time::sleep(HOLDER_RETRY_INTERVAL).await;
+                continue;
+            }
+            return Err(e).context("setting up namespace mappings");
         }
 
         // Give this holder the FULL remaining time to become ready.

--- a/src/firecracker/vm.rs
+++ b/src/firecracker/vm.rs
@@ -77,12 +77,13 @@ impl VmManager {
     /// Set namespace holder PID for rootless networking
     ///
     /// When set, Firecracker will be launched inside an existing user+net namespace
-    /// via nsenter. The holder process (created by `unshare --user --map-root-user --net -- cat`)
+    /// via nsenter. The holder process (created by `unshare --user --net -- sleep infinity`)
     /// keeps the namespace alive while Firecracker runs.
     ///
-    /// With `--map-root-user`, the current user (UID 1000) is mapped to UID 0 inside the
-    /// namespace. Combined with `--preserve-credentials` when using nsenter, no chmod
-    /// is needed on sockets or files - the user has access both inside and outside.
+    /// UID/GID mappings are written externally by `setup_namespace_mappings()`, which
+    /// maps the current user (UID 1000) to UID 0 inside the namespace. Combined with
+    /// `--preserve-credentials` when using nsenter, no chmod is needed on sockets or
+    /// files - the user has access both inside and outside.
     pub fn set_holder_pid(&mut self, pid: u32) {
         self.holder_pid = Some(pid);
     }
@@ -342,8 +343,9 @@ impl VmManager {
 
                     // Step 0: Enter user namespace if specified (for rootless clones)
                     // This MUST be done first to get CAP_SYS_ADMIN for mount operations.
-                    // The user namespace was created by the holder process with --map-root-user,
-                    // so entering it gives us UID 0 with full capabilities inside the namespace.
+                    // The user namespace was created by the holder process (unshare --user --net)
+                    // with external UID/GID mappings, so entering it gives us UID 0 with full
+                    // capabilities inside the namespace.
                     if let Some(ref user_ns_path) = user_ns_cstr {
                         let ns_fd_raw = open(
                             user_ns_path.as_c_str(),

--- a/src/network/slirp.rs
+++ b/src/network/slirp.rs
@@ -53,7 +53,7 @@ fn find_slirp4netns() -> String {
 ///
 /// Architecture (L2 Bridge - no NAT required):
 /// ```text
-/// Host                    | User Namespace (unshare --user --map-root-user --net)
+/// Host                    | User Namespace (unshare --user --net)
 ///                         |
 /// slirp4netns <-----------+-- slirp0 --+
 ///   (userspace NAT)       |            |
@@ -68,7 +68,8 @@ fn find_slirp4netns() -> String {
 /// The bridge forwards Ethernet frames directly, preserving MAC addresses.
 ///
 /// Setup sequence (3-phase with nsenter):
-/// 1. Spawn holder process: `unshare --user --map-root-user --net -- sleep infinity`
+/// 1. Spawn holder process: `unshare --user --net -- sleep infinity`
+///    (UID/GID mappings written externally by spawn_namespace_holder)
 /// 2. Run setup via nsenter: create bridge, TAPs, add TAPs to bridge
 /// 3. Start slirp4netns attached to holder's namespace
 /// 4. Run Firecracker via nsenter: `nsenter -t HOLDER_PID -U -n -- firecracker ...`
@@ -135,18 +136,16 @@ impl SlirpNetwork {
     ///
     /// Returns command to spawn a holder process that keeps the namespace alive.
     /// The holder runs `sleep infinity` which blocks forever until killed.
-    /// Note: We use sleep instead of cat because cat requires stdin management.
     ///
-    /// Uses --map-root-user for simple 1:1 UID mapping (current user → UID 0 inside namespace).
-    /// This works for both root and unprivileged users.
-    ///
-    /// Note: --map-auto was considered but it maps to subordinate UIDs (100000+) which doesn't
-    /// include the current user's UID, causing permission issues with KVM and file access.
+    /// UID/GID mappings are NOT set here — they're written externally by
+    /// spawn_namespace_holder() after the namespace is created. This allows
+    /// trying extended mappings (0-65535) via newuidmap/newgidmap first,
+    /// which OCI runtimes (crun) need to mount devpts inside containers.
+    /// Falls back to single-UID mapping if the helpers aren't available.
     pub fn build_holder_command(&self) -> Vec<String> {
         vec![
             "unshare".to_string(),
             "--user".to_string(),
-            "--map-root-user".to_string(),
             "--net".to_string(),
             "--".to_string(),
             "sleep".to_string(),
@@ -217,7 +216,7 @@ ip addr add {namespace_ip}/24 dev {bridge}
 
     /// Get a human-readable representation of the rootless networking flow
     pub fn rootless_flow_string(&self) -> String {
-        "holder(unshare --map-root-user) + nsenter for setup/firecracker".to_string()
+        "holder(unshare --user --net) + nsenter for setup/firecracker".to_string()
     }
 
     /// Detect host's global IPv6 address for slirp4netns outbound traffic

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -184,8 +184,9 @@ pub enum NamespaceReadyResult {
 
 /// Wait for a user namespace to be ready by checking uid_map.
 ///
-/// When `unshare --map-root-user` creates a namespace, the uid_map initially has
-/// an identity mapping "0 0 4294967295" before the actual mapping is written.
+/// When `unshare --user` creates a namespace, the uid_map initially has
+/// an identity mapping "0 0 4294967295" before the actual mapping is written
+/// (externally by `setup_namespace_mappings()` or by `--map-root-user`).
 /// setns() fails with EINVAL until the real mapping (e.g., "0 1000 1") is written.
 ///
 /// This function polls uid_map until it no longer contains the identity mapping,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -186,7 +186,7 @@ pub enum NamespaceReadyResult {
 ///
 /// When `unshare --user` creates a namespace, the uid_map initially has
 /// an identity mapping "0 0 4294967295" before the actual mapping is written
-/// (externally by `setup_namespace_mappings()` or by `--map-root-user`).
+/// (externally by `setup_namespace_mappings()`).
 /// setns() fails with EINVAL until the real mapping (e.g., "0 1000 1") is written.
 ///
 /// This function polls uid_map until it no longer contains the identity mapping,


### PR DESCRIPTION
## Summary

Wire fc-mock (container-based Firecracker replacement) into fcvm's networking stack so it works with both rootless and bridged modes.

### Namespace UID/GID mapping (production code)
- Remove `--map-root-user` from unshare command (uid_map is write-once, can't extend after)
- Add `setup_namespace_mappings()`: tries `newuidmap`/`newgidmap` for extended range (0-65535), falls back to single mapping for container environments
- Extended UIDs enable OCI runtimes (crun) to mount devpts — required for fc-mock's podman
- Wait for namespace creation via `/proc/PID/ns/user` inode comparison before writing mappings

### fc-mock networking and rootless support
- Wire fc-mock container launch through fcvm's namespace networking (bridged + rootless)
- Parse `boot_args` from Firecracker API for DNS/network config
- Add rootless storage (overlay+fuse-overlayfs) for user namespaces
- Add DNS resolution from kernel cmdline parameters

### CI and testing
- Add `fc-mock` job on `ubuntu-latest` (no KVM needed, cheap runners)
- Isolate snapshot cache key by `firecracker_bin` path (fc-mock vs real Firecracker)
- Add missing `test_snapshot_key_changes_with_firecracker_bin` test
- Fix stale comments (vfs→overlay+fuse-overlayfs, --map-root-user references)

## Test plan
- [x] `test_sanity_rootless` with real Firecracker: PASS (extended mappings confirmed in logs)
- [x] fc-mock CI tests (API, exec protocol, version): 3/3 PASS
- [x] Scratch test: namespace creation + newuidmap + nsenter verified
- [x] All 17 snapshot_key unit tests: PASS
- [x] CI: fc-mock job on ubuntu-latest
- [x] CI: Container tests (single-mapping fallback path)
- [x] CI: Host tests (extended mappings path)