### PR TITLE
Health check: configurable timeout, Host header, skip podman healthcheck with URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Both snapshots are full memory dumps — startup snapshots do not use diff-based
 
 The startup snapshot is triggered by `--health-check <url>`.
 After the check passes, fcvm creates a full snapshot of the initialized app.
+The URL hostname is sent as the Host header. Use `--health-check-timeout <seconds>` to adjust the per-request timeout (default: 5s).
 Second run restores from that snapshot and skips container initialization.
 
 ```bash
@@ -824,7 +825,7 @@ See [DESIGN.md](DESIGN.md#networking) for architecture details.
 
 - **Exit codes**: Container exit code forwarded to host via vsock
 - **Logs**: Container stdout goes to host stdout, stderr to host stderr (clean output for scripting)
-- **Health**: Default uses vsock ready signal; optional `--health-check` for HTTP
+- **Health**: Default uses vsock ready signal; optional `--health-check` for HTTP (timeout configurable via `--health-check-timeout`, default 5s)
 
 See [DESIGN.md](DESIGN.md#guest-agent) for details.
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -199,9 +199,14 @@ pub struct RunArgs {
     pub network: NetworkMode,
 
     /// HTTP health check URL. If not specified, health is based on container running status.
-    /// Example: --health-check http://localhost/health
+    /// The URL hostname is sent as the Host header; the connection goes to the guest IP.
+    /// Example: --health-check http://myapp.example.com/status
     #[arg(long)]
     pub health_check: Option<String>,
+
+    /// Timeout in seconds for HTTP health check requests. Default: 5.
+    #[arg(long, default_value = "5")]
+    pub health_check_timeout: u64,
 
     /// Run container as USER:GROUP (e.g., --user 1000:1000)
     /// Equivalent to podman run --userns=keep-id on the host

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -1068,6 +1068,7 @@ pub fn build_snapshot_config(
             network_config: vm_state.config.network.clone(),
             volumes,
             health_check_url: vm_state.config.health_check_url.clone(),
+            health_check_timeout: vm_state.config.health_check_timeout,
             hugepages: vm_state.config.hugepages,
             extra_disks,
             username: vm_state.config.username.clone(),

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -572,6 +572,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
     vm_state.name = Some(vm_name.clone());
     vm_state.config.volumes = args.map.clone();
     vm_state.config.health_check_url = args.health_check.clone();
+    vm_state.config.health_check_timeout = args.health_check_timeout;
     vm_state.config.hugepages = args.hugepages;
     vm_state.config.portable_volumes = args.portable_volumes;
     vm_state.config.port_mappings = port_mappings.clone();
@@ -1088,6 +1089,7 @@ mod tests {
             balloon: None,
             network: NetworkMode::Rootless,
             health_check: None,
+            health_check_timeout: 5,
             privileged: false,
             interactive: false,
             tty: false,

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -310,6 +310,7 @@ async fn create_sandbox(
         balloon: None,
         network: crate::cli::NetworkMode::Rootless,
         health_check: None,
+        health_check_timeout: 5,
         privileged: false,
         interactive: false,
         tty: false,

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -664,6 +664,7 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
     // Health check URL comes from snapshot metadata — it's a property of the VM image.
     // The cache key includes health_check_url, so each config gets its own snapshot.
     vm_state.config.health_check_url = snapshot_config.metadata.health_check_url.clone();
+    vm_state.config.health_check_timeout = snapshot_config.metadata.health_check_timeout;
     vm_state.config.hugepages = args.hugepages.unwrap_or(snapshot_config.metadata.hugepages);
     // Restore username for rootless health checks (runuser -u <username>).
     vm_state.config.username = snapshot_config.metadata.username.clone();

--- a/src/health.rs
+++ b/src/health.rs
@@ -11,15 +11,17 @@ use crate::paths;
 use crate::state::{truncate_id, HealthStatus, StateManager};
 
 /// Health check polling intervals.
-/// Startup interval is 5s (not 100ms) because nsenter health checks through
-/// slirp4netns can take 1-3s each.
-const HEALTH_POLL_STARTUP_INTERVAL: Duration = Duration::from_secs(5);
+/// During startup, the interval adapts to match how long each check takes
+/// (minimum 100ms). Fast checks (podman inspect ~100ms) poll fast; slow
+/// checks (nsenter+curl ~1-3s) poll slower to avoid hammering.
+const HEALTH_POLL_MIN_INTERVAL: Duration = Duration::from_millis(100);
+const HEALTH_POLL_MAX_INTERVAL: Duration = Duration::from_secs(5);
 const HEALTH_POLL_HEALTHY_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Spawn a background health monitoring task for a VM
 ///
 /// The task polls the VM process health at adaptive intervals:
-/// - 5s during startup (until healthy)
+/// - Adaptive during startup (matches check duration, min 100ms)
 /// - 10s after VM is healthy
 ///
 /// Health check tests HTTP connectivity using reqwest to the guest IP.
@@ -70,15 +72,16 @@ pub fn spawn_health_monitor_full(
                 .clone()
                 .unwrap_or_else(|| truncate_id(&vm_id, 8).to_string())
         } else {
-            truncate_id(&vm_id, 8).to_string() // Fallback to short vm_id
+            truncate_id(&vm_id, 8).to_string()
         };
 
         // vm_name is already in the hierarchical target, so don't duplicate
         let _ = (&vm_name, &vm_id); // suppress unused warning
         info!(target: "health-monitor", pid = ?pid, "starting health monitor");
 
-        // Adaptive polling: fast during startup, slow after healthy
-        let mut poll_interval = HEALTH_POLL_STARTUP_INTERVAL;
+        // Adaptive polling: during startup, wait as long as the check took
+        // (min 100ms). Once healthy, switch to 10s.
+        let mut poll_interval = HEALTH_POLL_MIN_INTERVAL;
         let mut is_healthy = false;
 
         // Oneshot channel for startup snapshot notification (can only fire once)
@@ -118,6 +121,7 @@ pub fn spawn_health_monitor_full(
                 }
             }
 
+            let check_start = Instant::now();
             let health_status = match update_health_status_once(
                 &state_manager,
                 &vm_id,
@@ -133,8 +137,11 @@ pub fn spawn_health_monitor_full(
                     HealthStatus::Unknown
                 }
             };
+            let check_duration = check_start.elapsed();
 
-            // Adaptive polling: fast when unhealthy, slow when healthy
+            // Adaptive polling: once healthy use 10s. During startup, wait as
+            // long as the check took (min 100ms) — fast checks poll fast, slow
+            // checks (nsenter+curl) poll slower to avoid hammering.
             if health_status == HealthStatus::Healthy {
                 if !is_healthy {
                     is_healthy = true;
@@ -148,10 +155,15 @@ pub fn spawn_health_monitor_full(
                     }
                 }
             } else if is_healthy {
-                // VM was healthy but is no longer — revert to fast polling
+                // VM was healthy but is no longer — revert to adaptive polling
                 is_healthy = false;
-                poll_interval = HEALTH_POLL_STARTUP_INTERVAL;
-                warn!(target: "health-monitor", "VM no longer healthy, reverting to {:?} polling", HEALTH_POLL_STARTUP_INTERVAL);
+                poll_interval =
+                    check_duration.clamp(HEALTH_POLL_MIN_INTERVAL, HEALTH_POLL_MAX_INTERVAL);
+                warn!(target: "health-monitor", "VM no longer healthy, reverting to {:?} polling", poll_interval);
+            } else {
+                // Still unhealthy — adapt interval to check duration
+                poll_interval =
+                    check_duration.clamp(HEALTH_POLL_MIN_INTERVAL, HEALTH_POLL_MAX_INTERVAL);
             }
 
             // Stop monitoring if container has stopped

--- a/src/health.rs
+++ b/src/health.rs
@@ -12,6 +12,7 @@ use crate::state::{truncate_id, HealthStatus, StateManager};
 
 /// Health check polling intervals.
 /// Startup interval is 5s (not 100ms) because nsenter health checks through
+/// slirp4netns can take 1-3s each.
 const HEALTH_POLL_STARTUP_INTERVAL: Duration = Duration::from_secs(5);
 const HEALTH_POLL_HEALTHY_INTERVAL: Duration = Duration::from_secs(10);
 
@@ -541,7 +542,7 @@ async fn update_health_status_once(
                     // We override the connection IP with the guest IP but send
                     // the original hostname as the Host header.
                     let url_host = url.host_str();
-                    let health_timeout = state.config.health_check_timeout;
+                    let health_timeout = state.config.health_check_timeout.max(1);
 
                     // Rootless mode with holder_pid: use nsenter to curl guest directly
                     // This bypasses the complexity of slirp4netns port forwarding

--- a/src/health.rs
+++ b/src/health.rs
@@ -10,8 +10,9 @@ use tracing::{debug, info, warn};
 use crate::paths;
 use crate::state::{truncate_id, HealthStatus, StateManager};
 
-/// Health check polling intervals
-const HEALTH_POLL_STARTUP_INTERVAL: Duration = Duration::from_millis(100);
+/// Health check polling intervals.
+/// Startup interval is 5s (not 100ms) because nsenter health checks through
+const HEALTH_POLL_STARTUP_INTERVAL: Duration = Duration::from_secs(5);
 const HEALTH_POLL_HEALTHY_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Spawn a background health monitoring task for a VM
@@ -540,6 +541,7 @@ async fn update_health_status_once(
                     // We override the connection IP with the guest IP but send
                     // the original hostname as the Host header.
                     let url_host = url.host_str();
+                    let health_timeout = state.config.health_check_timeout;
 
                     // Rootless mode with holder_pid: use nsenter to curl guest directly
                     // This bypasses the complexity of slirp4netns port forwarding
@@ -559,6 +561,7 @@ async fn update_health_status_once(
                             port,
                             health_path,
                             url_host,
+                            health_timeout,
                         )
                         .await
                         {
@@ -608,7 +611,7 @@ async fn update_health_status_once(
 
                         debug!(target: "health-monitor", original_url = %url_str, effective_url = %effective_url, veth = ?veth_device, "HTTP health check via veth");
 
-                        match check_http_health_bridged(&effective_url, veth_device, url_host).await
+                        match check_http_health_bridged(&effective_url, veth_device, url_host, health_timeout).await
                         {
                             Ok(true) => {
                                 debug!(target: "health-monitor", "health check passed");
@@ -712,6 +715,7 @@ async fn check_http_health_nsenter(
     port: u16,
     health_path: &str,
     host_header: Option<&str>,
+    timeout_secs: u64,
 ) -> Result<bool> {
     let url = format!("http://{}:{}{}", guest_ip, port, health_path);
 
@@ -719,7 +723,7 @@ async fn check_http_health_nsenter(
 
     // Use nsenter to enter the namespace and curl the guest directly
     // --preserve-credentials keeps UID/GID mapping
-    let nsenter_args = build_nsenter_curl_args(holder_pid, &url, host_header);
+    let nsenter_args = build_nsenter_curl_args(holder_pid, &url, host_header, timeout_secs);
 
     let output = tokio::process::Command::new("nsenter")
         .args(&nsenter_args)
@@ -789,9 +793,10 @@ async fn check_http_health_bridged(
     url: &str,
     veth_device: Option<&str>,
     host_header: Option<&str>,
+    timeout_secs: u64,
 ) -> Result<bool> {
     // Build a reqwest client, optionally bound to the veth device
-    let mut builder = reqwest::Client::builder().timeout(Duration::from_secs(1));
+    let mut builder = reqwest::Client::builder().timeout(Duration::from_secs(timeout_secs));
 
     if let Some(veth) = veth_device {
         builder = builder.interface(veth);
@@ -844,7 +849,12 @@ async fn check_http_health_bridged(
 /// Build the nsenter + curl argument list for rootless health checks.
 ///
 /// Separated from check_http_health_nsenter for testability.
-fn build_nsenter_curl_args(holder_pid: u32, url: &str, host_header: Option<&str>) -> Vec<String> {
+fn build_nsenter_curl_args(
+    holder_pid: u32,
+    url: &str,
+    host_header: Option<&str>,
+    timeout_secs: u64,
+) -> Vec<String> {
     let mut curl_args = vec![
         "curl".to_string(),
         "-s".to_string(),
@@ -853,7 +863,7 @@ fn build_nsenter_curl_args(holder_pid: u32, url: &str, host_header: Option<&str>
         "-w".to_string(),
         "%{http_code}".to_string(),
         "--max-time".to_string(),
-        "1".to_string(),
+        timeout_secs.to_string(),
     ];
     // Add Host header if specified (needed for servers that route by Host)
     if let Some(host) = host_header {
@@ -881,13 +891,13 @@ mod tests {
 
     #[test]
     fn test_nsenter_curl_args_without_host_header() {
-        let args = build_nsenter_curl_args(12345, "http://10.0.2.100:80/health", None);
-        // Find --max-time and verify "1" immediately follows it
+        let args = build_nsenter_curl_args(12345, "http://10.0.2.100:80/health", None, 5);
+        // Find --max-time and verify "5" immediately follows it
         let max_time_pos = args.iter().position(|a| a == "--max-time").unwrap();
         assert_eq!(
             args[max_time_pos + 1],
-            "1",
-            "\"1\" must immediately follow \"--max-time\", got {:?}",
+            "5",
+            "\"5\" must immediately follow \"--max-time\", got {:?}",
             &args[max_time_pos..]
         );
     }
@@ -895,14 +905,14 @@ mod tests {
     #[test]
     fn test_nsenter_curl_args_with_host_header() {
         let args =
-            build_nsenter_curl_args(12345, "http://10.0.2.100:80/health", Some("myapp.local"));
+            build_nsenter_curl_args(12345, "http://10.0.2.100:80/health", Some("myapp.local"), 5);
 
-        // --max-time must be immediately followed by "1"
+        // --max-time must be immediately followed by "5"
         let max_time_pos = args.iter().position(|a| a == "--max-time").unwrap();
         assert_eq!(
             args[max_time_pos + 1],
-            "1",
-            "\"1\" must immediately follow \"--max-time\", but got {:?}",
+            "5",
+            "\"5\" must immediately follow \"--max-time\", but got {:?}",
             &args[max_time_pos..]
         );
 

--- a/src/health.rs
+++ b/src/health.rs
@@ -18,7 +18,7 @@ const HEALTH_POLL_HEALTHY_INTERVAL: Duration = Duration::from_secs(10);
 /// Spawn a background health monitoring task for a VM
 ///
 /// The task polls the VM process health at adaptive intervals:
-/// - 100ms during startup (until healthy)
+/// - 5s during startup (until healthy)
 /// - 10s after VM is healthy
 ///
 /// Health check tests HTTP connectivity using reqwest to the guest IP.
@@ -849,7 +849,11 @@ async fn check_http_health_bridged(
         }
         Err(e) => {
             if e.is_timeout() {
-                anyhow::bail!("Health check timed out after 1 second via {}", iface_str)
+                anyhow::bail!(
+                    "Health check timed out after {}s via {}",
+                    timeout_secs,
+                    iface_str
+                )
             } else if e.is_connect() {
                 anyhow::bail!("Connection refused to {} via {}", url, iface_str)
             } else {

--- a/src/health.rs
+++ b/src/health.rs
@@ -611,7 +611,13 @@ async fn update_health_status_once(
 
                         debug!(target: "health-monitor", original_url = %url_str, effective_url = %effective_url, veth = ?veth_device, "HTTP health check via veth");
 
-                        match check_http_health_bridged(&effective_url, veth_device, url_host, health_timeout).await
+                        match check_http_health_bridged(
+                            &effective_url,
+                            veth_device,
+                            url_host,
+                            health_timeout,
+                        )
+                        .await
                         {
                             Ok(true) => {
                                 debug!(target: "health-monitor", "health check passed");
@@ -641,8 +647,15 @@ async fn update_health_status_once(
             };
 
             // If base health check passed, also check podman healthcheck (AND logic)
-            // Skip if we already know the container has no healthcheck
-            let final_status = if status == HealthStatus::Healthy && !*skip_podman_healthcheck {
+            // Skip if we already know the container has no healthcheck.
+            // Also skip when health_check_url is provided — the user explicitly specified
+            // their health check, and podman's internal HEALTHCHECK may not work (e.g.,
+            // rootless podman in VM without systemd can't schedule healthcheck timers).
+            let has_http_check = state.config.health_check_url.is_some();
+            let final_status = if status == HealthStatus::Healthy
+                && !*skip_podman_healthcheck
+                && !has_http_check
+            {
                 match check_podman_healthcheck(
                     pid,
                     state.config.username.as_deref(),

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -88,6 +88,10 @@ pub struct NfsShare {
     pub read_only: bool,
 }
 
+fn default_health_check_timeout() -> u64 {
+    5
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VmConfig {
     pub image: String,
@@ -105,6 +109,9 @@ pub struct VmConfig {
     pub nfs_shares: Vec<NfsShare>,
     /// HTTP health check URL. None means check container running status via fc-agent.
     pub health_check_url: Option<String>,
+    /// Timeout in seconds for HTTP health check requests.
+    #[serde(default = "default_health_check_timeout")]
+    pub health_check_timeout: u64,
     /// Which snapshot this process is serving or was cloned from
     pub snapshot_name: Option<String>,
     /// Process type: vm (podman run), serve (snapshot serve), clone (snapshot run)
@@ -168,6 +175,7 @@ impl VmState {
                 extra_disks: Vec::new(),
                 nfs_shares: Vec::new(),
                 health_check_url: None,
+                health_check_timeout: 5,
                 snapshot_name: None,
                 process_type: Some(ProcessType::Vm),
                 serve_pid: None,

--- a/src/storage/snapshot.rs
+++ b/src/storage/snapshot.rs
@@ -6,6 +6,10 @@ use tracing::info;
 
 use crate::network::NetworkConfig;
 
+fn default_health_check_timeout() -> u64 {
+    5
+}
+
 /// Type of snapshot - distinguishes user-created from system-generated
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub enum SnapshotType {
@@ -61,6 +65,9 @@ pub struct SnapshotMetadata {
     /// Health check URL from the baseline VM (None = no HTTP health check)
     #[serde(default)]
     pub health_check_url: Option<String>,
+    /// Health check timeout in seconds (default 5)
+    #[serde(default = "default_health_check_timeout")]
+    pub health_check_timeout: u64,
     /// Whether VM uses 2MB hugepage-backed memory
     #[serde(default)]
     pub hugepages: bool,
@@ -245,6 +252,7 @@ mod tests {
                 },
                 volumes: vec![],
                 health_check_url: None,
+                health_check_timeout: 5,
                 hugepages: false,
                 extra_disks: vec![],
                 username: None,
@@ -362,6 +370,7 @@ mod tests {
                 },
                 volumes: vec![],
                 health_check_url: None,
+                health_check_timeout: 5,
                 hugepages: false,
                 extra_disks: vec![],
                 username: None,
@@ -423,6 +432,7 @@ mod tests {
                     },
                     volumes: vec![],
                     health_check_url: None,
+                    health_check_timeout: 5,
                     hugepages: false,
                     extra_disks: vec![],
                     username: None,
@@ -471,6 +481,7 @@ mod tests {
                 },
                 volumes: vec![],
                 health_check_url: None,
+                health_check_timeout: 5,
                 hugepages: false,
                 extra_disks: vec![],
                 username: None,
@@ -570,6 +581,7 @@ mod tests {
                 },
                 volumes: vec![],
                 health_check_url: None,
+                health_check_timeout: 5,
                 hugepages: false,
                 extra_disks: vec![],
                 username: None,

--- a/tests/test_health_monitor.rs
+++ b/tests/test_health_monitor.rs
@@ -83,6 +83,7 @@ async fn test_health_monitor_behaviors() {
             portable_volumes: false,
             user: None,
             username: None,
+            health_check_timeout: 5,
         },
     };
 

--- a/tests/test_library_api.rs
+++ b/tests/test_library_api.rs
@@ -49,6 +49,7 @@ fn test_run_args(name: &str) -> RunArgs {
         rootfs_type: None,
         label: vec![],
         non_blocking_output: false,
+        health_check_timeout: 5,
         image: common::TEST_IMAGE.to_string(),
         command_args: vec![],
     }

--- a/tests/test_state_manager.rs
+++ b/tests/test_state_manager.rs
@@ -56,6 +56,7 @@ async fn test_state_persistence() {
             portable_volumes: false,
             user: None,
             username: None,
+            health_check_timeout: 5,
         },
     };
 
@@ -128,6 +129,7 @@ async fn test_list_vms() {
                 portable_volumes: false,
                 user: None,
                 username: None,
+                health_check_timeout: 5,
             },
         };
         manager.save_state(&state).await.unwrap();
@@ -184,6 +186,7 @@ async fn test_load_state_by_name_duplicate_detection() {
                 portable_volumes: false,
                 user: None,
                 username: None,
+                health_check_timeout: 5,
             },
         };
         manager.save_state(&state).await.unwrap();
@@ -234,6 +237,7 @@ async fn test_load_state_by_name_duplicate_detection() {
             portable_volumes: false,
             user: None,
             username: None,
+            health_check_timeout: 5,
         },
     };
     manager.save_state(&state).await.unwrap();


### PR DESCRIPTION
## Summary
- Add `--health-check-timeout` flag (default 5s) for configurable HTTP health check timeouts
- Extract Host header from health check URL so virtual-host-based routing works (e.g., `--health-check http://myapp.example.com/status` sends `Host: myapp.example.com`)
- Skip podman's internal HEALTHCHECK when `--health-check` URL is provided — rootless podman in VM without systemd user session can't schedule healthcheck timers, causing health to stay "starting" forever
- Propagate `health_check_timeout` through snapshot metadata so it persists across snapshot create/restore
- Clamp timeout to minimum 1s to prevent `curl --max-time 0` from blocking indefinitely
- Adaptive health check polling: interval matches how long each check takes (min 100ms, max 5s). Fast checks (podman inspect ~100ms) poll fast; slow checks (nsenter+curl ~1-3s) poll slower
- Document `--health-check-timeout` in README

## Test plan
- `make test-root FILTER=health_monitor` — health monitor unit tests pass
- `make test-root FILTER=rootless_podman_healthcheck` — podman healthcheck integration passes
- Full CI suite