### PR TITLE
fix: prevent exec server rebind signal loss in tokio::select! race

### DIFF
--- a/fc-agent/src/agent.rs
+++ b/fc-agent/src/agent.rs
@@ -66,22 +66,34 @@ pub async fn run() -> Result<()> {
 
     // Exec server rebind signal — shared by restore-epoch watcher and cache-ready handshake.
     // After vsock transport reset, the listener's AsyncFd epoll becomes stale.
+    // We use BOTH Notify (to wake the select loop) and AtomicBool (to persist the signal).
+    // tokio::select! can lose Notify permits when accept() and notified() are both Ready
+    // simultaneously — the AtomicBool flag catches this race.
     let exec_rebind = std::sync::Arc::new(tokio::sync::Notify::new());
+    let exec_rebind_needed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
 
     // Start restore-epoch watcher
     let watcher_output = output.clone();
     let watcher_restore_flag = restore_flag.clone();
     let watcher_exec_rebind = exec_rebind.clone();
+    let watcher_exec_rebind_needed = exec_rebind_needed.clone();
     tokio::spawn(async move {
         eprintln!("[fc-agent] starting restore-epoch watcher");
-        mmds::watch_restore_epoch(watcher_output, watcher_restore_flag, watcher_exec_rebind).await;
+        mmds::watch_restore_epoch(
+            watcher_output,
+            watcher_restore_flag,
+            watcher_exec_rebind,
+            watcher_exec_rebind_needed,
+        )
+        .await;
     });
 
     // Start exec server with rebind signal for vsock transport reset recovery
     let (exec_ready_tx, exec_ready_rx) = tokio::sync::oneshot::channel();
     let exec_rebind_clone = exec_rebind.clone();
+    let exec_rebind_needed_clone = exec_rebind_needed.clone();
     tokio::spawn(async move {
-        exec::run_server(exec_ready_tx, exec_rebind_clone).await;
+        exec::run_server(exec_ready_tx, exec_rebind_clone, exec_rebind_needed_clone).await;
     });
 
     match tokio::time::timeout(Duration::from_secs(5), exec_ready_rx).await {
@@ -223,7 +235,9 @@ pub async fn run() -> Result<()> {
                 // Pre-start snapshot was taken and we've been restored into a new
                 // Firecracker instance. The vsock transport was reset, which
                 // invalidates the exec server's listener socket (stale AsyncFd epoll).
-                // Signal it to re-bind.
+                // Signal it to re-bind. Set flag BEFORE notify to prevent race where
+                // select! drops the Notified future (see exec.rs doc comment).
+                exec_rebind_needed.store(true, std::sync::atomic::Ordering::Release);
                 exec_rebind.notify_one();
             } else {
                 eprintln!("[fc-agent] WARNING: cache-ready handshake failed, continuing");

--- a/fc-agent/src/exec.rs
+++ b/fc-agent/src/exec.rs
@@ -1,4 +1,5 @@
 use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use tokio::io::unix::AsyncFd;
@@ -10,14 +11,27 @@ use crate::vsock;
 
 /// Run the exec server. Sends ready signal when listening.
 ///
-/// The `rebind_signal` handles vsock transport reset after snapshot restore.
-/// When Firecracker creates a snapshot and restores, the vsock transport is reset
-/// (VIRTIO_VSOCK_EVENT_TRANSPORT_RESET). The listener's AsyncFd epoll registration
-/// becomes stale — accept() hangs forever because tokio never delivers readability
-/// events for incoming connections. On signal, re-registers the epoll via
-/// `VsockListener::re_register()` (extracts fd, re-wraps in new AsyncFd) without
-/// closing or rebinding the socket. Falls back to full rebind if re-register fails.
-pub async fn run_server(ready_tx: tokio::sync::oneshot::Sender<()>, rebind_signal: Arc<Notify>) {
+/// The `rebind_signal` + `rebind_needed` handle vsock transport reset after
+/// snapshot restore. When Firecracker creates a snapshot and restores, the vsock
+/// transport is reset (VIRTIO_VSOCK_EVENT_TRANSPORT_RESET). The listener's AsyncFd
+/// epoll registration becomes stale — accept() hangs forever because tokio never
+/// delivers readability events for incoming connections. On signal, re-registers
+/// the epoll via `VsockListener::re_register()` (extracts fd, re-wraps in new
+/// AsyncFd) without closing or rebinding the socket. Falls back to full rebind
+/// if re-register fails.
+///
+/// CRITICAL: We use both a `Notify` (to wake up the select loop) and an `AtomicBool`
+/// flag (to persist the rebind request). `tokio::select!` polls all branches
+/// concurrently — if both `accept()` and `notified()` return Ready simultaneously,
+/// `select!` picks one and drops the other. The `Notified` future consumes the
+/// permit during `poll()`, so if `accept()` wins, the notification is permanently
+/// lost and `re_register()` never runs. The `AtomicBool` flag survives this race:
+/// it's checked at the top of each loop iteration, catching any lost notifications.
+pub async fn run_server(
+    ready_tx: tokio::sync::oneshot::Sender<()>,
+    rebind_signal: Arc<Notify>,
+    rebind_needed: Arc<AtomicBool>,
+) {
     eprintln!(
         "[fc-agent] starting exec server on vsock port {}",
         vsock::EXEC_PORT
@@ -40,6 +54,18 @@ pub async fn run_server(ready_tx: tokio::sync::oneshot::Sender<()>, rebind_signa
     let _ = ready_tx.send(());
 
     loop {
+        // Check flag before polling — catches notifications lost due to select! races.
+        // When both accept() and notified() are Ready simultaneously, select! picks one
+        // and drops the other. If accept() wins, the Notified future's permit was already
+        // consumed during poll() but the re_register branch never executed. The flag
+        // persists across this race and is checked here on the next iteration.
+        if rebind_needed.swap(false, Ordering::AcqRel) {
+            eprintln!(
+                "[fc-agent] exec server: vsock transport reset (flag), re-registering listener"
+            );
+            listener = do_re_register(listener).await;
+        }
+
         tokio::select! {
             result = listener.accept() => {
                 match result {
@@ -52,37 +78,57 @@ pub async fn run_server(ready_tx: tokio::sync::oneshot::Sender<()>, rebind_signa
                 }
             }
             _ = rebind_signal.notified() => {
-                eprintln!("[fc-agent] exec server: vsock transport reset, re-registering listener");
-                // Re-register the AsyncFd (epoll) without closing the socket.
-                // Drop+rebind fails when accepted connections keep the port bound.
-                match listener.re_register() {
+                // Clear the flag (we're handling it now).
+                rebind_needed.store(false, Ordering::Release);
+                eprintln!("[fc-agent] exec server: vsock transport reset (notify), re-registering listener");
+                listener = do_re_register(listener).await;
+            }
+        }
+    }
+}
+
+/// Re-register or rebind the vsock listener after transport reset.
+async fn do_re_register(listener: vsock::VsockListener) -> vsock::VsockListener {
+    match listener.re_register() {
+        Ok(l) => {
+            eprintln!(
+                "[fc-agent] exec server: re-registered on vsock port {}",
+                vsock::EXEC_PORT
+            );
+            l
+        }
+        Err(e) => {
+            // re_register consumed the listener; socket is closed.
+            eprintln!(
+                "[fc-agent] exec server: re-register failed: {}, trying full rebind",
+                e
+            );
+            let mut retries = 0;
+            loop {
+                match vsock::VsockListener::bind(vsock::EXEC_PORT) {
                     Ok(l) => {
-                        listener = l;
-                        eprintln!("[fc-agent] exec server: re-registered on vsock port {}", vsock::EXEC_PORT);
+                        eprintln!(
+                            "[fc-agent] exec server: re-bound to vsock port {}",
+                            vsock::EXEC_PORT
+                        );
+                        return l;
                     }
-                    Err(e) => {
-                        // re_register consumed the listener; socket is closed.
-                        eprintln!("[fc-agent] exec server: re-register failed: {}, trying full rebind", e);
-                        let mut retries = 0;
-                        loop {
-                            match vsock::VsockListener::bind(vsock::EXEC_PORT) {
-                                Ok(l) => {
-                                    listener = l;
-                                    eprintln!("[fc-agent] exec server: re-bound to vsock port {}", vsock::EXEC_PORT);
-                                    break;
-                                }
-                                Err(e2) => {
-                                    retries += 1;
-                                    if retries >= 50 {
-                                        eprintln!("[fc-agent] exec server: re-bind failed after {} retries: {}", retries, e2);
-                                        eprintln!("[fc-agent] exec server: giving up, exec will be unavailable");
-                                        return;
-                                    }
-                                    eprintln!("[fc-agent] exec server: re-bind failed: {}, retrying ({}/50)", e2, retries);
-                                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                                }
-                            }
+                    Err(e2) => {
+                        retries += 1;
+                        if retries >= 50 {
+                            eprintln!(
+                                "[fc-agent] exec server: re-bind failed after {} retries: {}",
+                                retries, e2
+                            );
+                            // Fatal: exec server is unavailable. Panic to make the
+                            // failure visible rather than silently hanging.
+                            panic!("exec server: re-bind failed after 50 retries");
                         }
+                        eprintln!(
+                            "[fc-agent] exec server: re-bind failed: {}, retrying ({}/50)",
+                            e2, retries
+                        );
+                        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                     }
                 }
             }

--- a/fc-agent/src/mmds.rs
+++ b/fc-agent/src/mmds.rs
@@ -138,6 +138,7 @@ pub async fn watch_restore_epoch(
     output: OutputHandle,
     restore_flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
     exec_rebind: std::sync::Arc<tokio::sync::Notify>,
+    exec_rebind_needed: std::sync::Arc<std::sync::atomic::AtomicBool>,
 ) {
     let mut last_epoch: Option<String> = None;
 
@@ -166,13 +167,23 @@ pub async fn watch_restore_epoch(
                     // Must be set BEFORE handle_clone_restore so the poll loop
                     // exits before output reconnect changes vsock state.
                     restore_flag.store(true, std::sync::atomic::Ordering::Release);
-                    crate::restore::handle_clone_restore(&output, &exec_rebind).await;
+                    crate::restore::handle_clone_restore(
+                        &output,
+                        &exec_rebind,
+                        &exec_rebind_needed,
+                    )
+                    .await;
                     last_epoch = metadata.restore_epoch;
                 }
                 Some(prev) if prev != current => {
                     eprintln!("[fc-agent] restore-epoch changed: {} -> {}", prev, current,);
                     restore_flag.store(true, std::sync::atomic::Ordering::Release);
-                    crate::restore::handle_clone_restore(&output, &exec_rebind).await;
+                    crate::restore::handle_clone_restore(
+                        &output,
+                        &exec_rebind,
+                        &exec_rebind_needed,
+                    )
+                    .await;
                     last_epoch = metadata.restore_epoch;
                 }
                 _ => {}

--- a/fc-agent/src/restore.rs
+++ b/fc-agent/src/restore.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use tokio::sync::Notify;
@@ -10,7 +11,11 @@ use crate::output::OutputHandle;
 /// FUSE volumes are NOT remounted here. The reconnectable multiplexer
 /// detects the dead vsock and auto-reconnects to the clone's VolumeServer.
 /// The kernel FUSE session stays alive — processes see a brief hang, not errors.
-pub async fn handle_clone_restore(output: &OutputHandle, exec_rebind: &Arc<Notify>) {
+pub async fn handle_clone_restore(
+    output: &OutputHandle,
+    exec_rebind: &Arc<Notify>,
+    exec_rebind_needed: &Arc<AtomicBool>,
+) {
     network::kill_stale_tcp_connections().await;
     network::flush_arp_cache().await;
     network::send_gratuitous_arp().await;
@@ -20,6 +25,9 @@ pub async fn handle_clone_restore(output: &OutputHandle, exec_rebind: &Arc<Notif
     output.reconnect();
 
     // Re-bind exec server listener (AsyncFd epoll stale after transport reset).
+    // Set flag BEFORE notify to prevent race where select! drops the Notified future
+    // (see exec.rs doc comment for detailed explanation).
+    exec_rebind_needed.store(true, Ordering::Release);
     exec_rebind.notify_one();
 
     eprintln!("[fc-agent] signaled output + exec vsock reconnect after restore");


### PR DESCRIPTION
## Summary

Fix a race condition where the exec server's vsock rebind signal is permanently lost after snapshot restore, causing all subsequent exec commands to hang.

## The Problem

After snapshot restore, the vsock transport resets and the exec server's AsyncFd epoll registration becomes stale. The MMDS watcher detects the restore and sends a rebind signal via `tokio::sync::Notify::notify_one()`. However, `tokio::select!` polls **all** branches concurrently — if both `accept()` and `notified()` return `Ready` in the same poll cycle, `select!` randomly picks one and drops the other.

The `Notified` future consumes the Notify permit during `poll()` (transitioning from NOTIFIED → EMPTY atomically). When `select!` picks `accept()` and drops the `Notified` future in `Done` state, the permit is permanently consumed but the re_register branch never executes. This is documented behavior: [tokio#3825](https://github.com/tokio-rs/tokio/issues/3825).

**Effect:** The exec server handles exactly one connection after restore, then hangs forever — the stale AsyncFd never delivers readability events for new connections.

**Observed in CI:** Container-x64 runner i-012893bec30733041 failed `test_localhost_rootless_btrfs_snapshot_restore` 3/3 retries. First exec at t=9ms succeeded, second exec at t=5009ms timed out. MMDS watcher detects restore ~100ms after resume, so both branches can be Ready simultaneously.

## The Fix

Add an `AtomicBool` flag alongside the `Notify`:
- Flag is set **before** `notify_one()` at all signal sites (restore.rs, agent.rs cache-ready)
- Flag is checked at the **top of each loop iteration** in the exec server
- Even if `select!` drops the `Notified` future after consuming the permit, the flag persists
- The `Notify` still serves its purpose: waking up the select loop from a pending state

Also extracted the re_register/rebind logic into `do_re_register()` helper to avoid duplication.

## Test plan

- [ ] CI passes on Container-x64 (the previously flaky runner)
- [ ] `test_localhost_rootless_btrfs_snapshot_restore` passes consistently
- [ ] All snapshot-based tests pass (snapshot create/restore, clone, diff snapshot)