### PR TITLE
fix: upgrade snapshot epoch bump to hard error

### DIFF
--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -1444,14 +1444,17 @@ pub async fn create_snapshot_core(
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
-    client
+    if let Err(e) = client
         .patch_mmds(serde_json::json!({
             "latest": {
                 "restore-epoch": restore_epoch.to_string()
             }
         }))
         .await
-        .context("bumping restore-epoch in MMDS after snapshot")?;
+    {
+        let _ = tokio::fs::remove_dir_all(&temp_snapshot_dir).await;
+        return Err(e).context("bumping restore-epoch in MMDS after snapshot");
+    }
 
     if has_base {
         // Diff snapshot: copy base to temp, merge diff onto it, then atomic rename

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -1436,21 +1436,22 @@ pub async fn create_snapshot_core(
 
     // Firecracker resets all vsock connections during snapshot creation
     // (VIRTIO_VSOCK_EVENT_TRANSPORT_RESET). Bump restore-epoch in MMDS so fc-agent's
-    // background watcher detects this and remounts FUSE volumes.
+    // background watcher detects this and triggers handle_clone_restore() which
+    // re-registers the exec server's AsyncFd (stale after transport reset) and
+    // reconnects the output vsock. This MUST succeed — if the epoch isn't bumped,
+    // the exec server stays stale and health checks hang for ~60s.
     let restore_epoch = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
-    if let Err(e) = client
+    client
         .patch_mmds(serde_json::json!({
             "latest": {
                 "restore-epoch": restore_epoch.to_string()
             }
         }))
         .await
-    {
-        warn!(error = %e, "failed to bump restore-epoch after snapshot (FUSE remount may be delayed)");
-    }
+        .context("bumping restore-epoch in MMDS after snapshot")?;
 
     if has_base {
         // Diff snapshot: copy base to temp, merge diff onto it, then atomic rename


### PR DESCRIPTION
## Fix: upgrade snapshot epoch bump to hard error + cleanup

Found by code review on PR #468 (inline comment on `fc-agent/src/agent.rs:237`).

### The Problem

In `create_snapshot_core()`, the restore-epoch MMDS update was best-effort:
```rust
if let Err(e) = client.patch_mmds(...).await {
    warn!("failed to bump restore-epoch after snapshot");
}
```

The entire exec rebind chain from PR #468 depends on this succeeding:
```
patch_mmds → epoch watcher → handle_clone_restore() → exec re_register → output reconnect
```

If `patch_mmds` fails silently, the epoch watcher never fires, `handle_clone_restore()` is never called, and the exec server's AsyncFd epoll stays stale after vsock transport reset — causing health checks to hang for ~60s.

The **clone** path already uses hard error (`put_mmds().context("...")?`). The baseline pre-start snapshot path was the only weak link.

### Changes

1. **Upgrade `patch_mmds` to hard error** — if MMDS is unreachable after VM resume, the snapshot fails rather than leaving the exec server silently broken.

2. **Clean up `temp_snapshot_dir` on failure** — the new error path removes the `.creating` directory (memory snapshot files) before returning, matching all other early-return error paths in the function. Prevents ENOSPC from orphaned snapshot data.

### Test Results

```
make test-root FILTER=localhost_rootless_btrfs_snapshot_restore STREAM=1
  First run: snapshot created, patch_mmds succeeds
  Second run: restored from snapshot, VM healthy in <1s
  Exec stress: 10 parallel calls completed in 14.0ms (max 13.1ms)
  PASSED
```