### PR TITLE
fix: restore CI to green (cargo audit deps + passt tarball URL)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -73,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -598,7 +598,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -646,7 +646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -718,7 +718,7 @@ dependencies = [
  "memmap2",
  "nix 0.29.0",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "reqwest 0.12.28",
  "serde",
@@ -1374,7 +1374,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1643,7 +1643,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1882,14 +1882,14 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -1942,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1953,9 +1953,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -2231,7 +2231,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2260,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2583,9 +2583,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -2602,7 +2602,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3003,7 +3003,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.17",
  "utf-8",
@@ -3282,7 +3282,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/scripts/build-passt.sh
+++ b/scripts/build-passt.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
-# Build passt/pasta from source using Debian source tarball.
-# Pinned to commit 386b5f5 (2025-01-20) from https://passt.top/passt
-# Debian tarball: reliable CDN, no dependency on passt.top uptime.
+# Build passt/pasta from source using a pinned Debian source tarball.
+# Pinned to commit 386b5f5 (2026-01-20) from https://passt.top/passt
+# Served from snapshot.debian.org: deb.debian.org drops superseded versions
+# from its pool (which 404'd the previous pin), while snapshot.debian.org
+# archives every version permanently. The checksum guards the pin.
 set -euo pipefail
 
-PASST_DEBIAN_TARBALL="http://deb.debian.org/debian/pool/main/p/passt/passt_0.0~git20260120.386b5f5.orig.tar.xz"
+PASST_TARBALL_URL="https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/p/passt/passt_0.0~git20260120.386b5f5.orig.tar.xz"
+PASST_TARBALL_SHA256="cc0a86b0ac28e1e5b2a4243bcf7fa84b14dd91c7dc883a78896060111e12d105"
 BUILD_DIR="${BUILD_DIR:-/tmp/passt-build}"
 
 echo "==> Building passt from Debian source tarball (commit 386b5f5)..."
@@ -12,7 +15,9 @@ echo "==> Building passt from Debian source tarball (commit 386b5f5)..."
 if [ ! -f "$BUILD_DIR/Makefile" ]; then
     rm -rf "$BUILD_DIR"
     mkdir -p "$BUILD_DIR"
-    curl -fsSL "$PASST_DEBIAN_TARBALL" | tar -xJ -C "$BUILD_DIR" --strip-components=1
+    curl -fsSL -o "$BUILD_DIR/passt.orig.tar.xz" "$PASST_TARBALL_URL"
+    echo "$PASST_TARBALL_SHA256  $BUILD_DIR/passt.orig.tar.xz" | sha256sum -c -
+    tar -xJf "$BUILD_DIR/passt.orig.tar.xz" -C "$BUILD_DIR" --strip-components=1
 fi
 
 cd "$BUILD_DIR"


### PR DESCRIPTION
## Summary

Two small fixes that restore CI to green. They ship together because neither is green alone: the Lint job needs the lockfile update, and the Host jobs need the passt tarball fix on any runner with a cold `/tmp/passt-build` cache (the arm64 jobs on the first revision of this PR failed exactly there).

**1. Update dependencies flagged by cargo audit** (lockfile-only, semver-compatible):
- quinn-proto 0.11.13 → 0.11.14 (RUSTSEC-2026-0037)
- rustls-webpki 0.103.8 → 0.103.13 (RUSTSEC-2026-0049 / 0098 / 0099 / 0104)
- tar 0.4.44 → 0.4.46 (RUSTSEC-2026-0067 / 0068)
- rand 0.8.5 → 0.8.6, rand 0.9.2 → 0.9.4 (RUSTSEC-2026-0097)

**2. Download the pinned passt tarball from snapshot.debian.org.** deb.debian.org drops superseded versions from its pool, so the pinned `passt_0.0~git20260120.386b5f5.orig.tar.xz` now 404s. The nightly VM benchmark jobs have failed on this since 2026-05-22, and CI Host jobs hit it on cold runners. snapshot.debian.org archives every version permanently; the tarball sha256 is now also verified before extraction.

## Test Results

```
$ cargo audit
warning: 1 allowed warning found        # exit 0 (was: error: 7 vulnerabilities found!)

$ cargo deny check
advisories ok, bans ok, licenses ok, sources ok

$ make lint && make test-unit
Summary [  50.659s] 253 tests run: 253 passed, 0 skipped
```

passt download from the new URL, checksum, and build verified manually:

```
$ curl -fsSL -o passt.orig.tar.xz "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/p/passt/passt_0.0~git20260120.386b5f5.orig.tar.xz"
$ sha256sum passt.orig.tar.xz
cc0a86b0ac28e1e5b2a4243bcf7fa84b14dd91c7dc883a78896060111e12d105  passt.orig.tar.xz
$ tar -xJf passt.orig.tar.xz --strip-components=1 && make -j8 && echo BUILD OK
BUILD OK

$ curl -sI "http://deb.debian.org/debian/pool/main/p/passt/passt_0.0~git20260120.386b5f5.orig.tar.xz" | head -1
HTTP/1.1 404 Not Found                  # the old URL
```
