### PR TITLE
fix: download pinned passt tarball from snapshot.debian.org

### DIFF
--- a/scripts/build-passt.sh
+++ b/scripts/build-passt.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
-# Build passt/pasta from source using Debian source tarball.
-# Pinned to commit 386b5f5 (2025-01-20) from https://passt.top/passt
-# Debian tarball: reliable CDN, no dependency on passt.top uptime.
+# Build passt/pasta from source using a pinned Debian source tarball.
+# Pinned to commit 386b5f5 (2026-01-20) from https://passt.top/passt
+# Served from snapshot.debian.org: deb.debian.org drops superseded versions
+# from its pool (which 404'd the previous pin), while snapshot.debian.org
+# archives every version permanently. The checksum guards the pin.
 set -euo pipefail
 
-PASST_DEBIAN_TARBALL="http://deb.debian.org/debian/pool/main/p/passt/passt_0.0~git20260120.386b5f5.orig.tar.xz"
+PASST_TARBALL_URL="https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/p/passt/passt_0.0~git20260120.386b5f5.orig.tar.xz"
+PASST_TARBALL_SHA256="cc0a86b0ac28e1e5b2a4243bcf7fa84b14dd91c7dc883a78896060111e12d105"
 BUILD_DIR="${BUILD_DIR:-/tmp/passt-build}"
 
 echo "==> Building passt from Debian source tarball (commit 386b5f5)..."
@@ -12,7 +15,9 @@ echo "==> Building passt from Debian source tarball (commit 386b5f5)..."
 if [ ! -f "$BUILD_DIR/Makefile" ]; then
     rm -rf "$BUILD_DIR"
     mkdir -p "$BUILD_DIR"
-    curl -fsSL "$PASST_DEBIAN_TARBALL" | tar -xJ -C "$BUILD_DIR" --strip-components=1
+    curl -fsSL -o "$BUILD_DIR/passt.orig.tar.xz" "$PASST_TARBALL_URL"
+    echo "$PASST_TARBALL_SHA256  $BUILD_DIR/passt.orig.tar.xz" | sha256sum -c -
+    tar -xJf "$BUILD_DIR/passt.orig.tar.xz" -C "$BUILD_DIR" --strip-components=1
 fi
 
 cd "$BUILD_DIR"


### PR DESCRIPTION
## The Problem

`scripts/build-passt.sh` downloads the pinned passt source from deb.debian.org. Debian drops superseded versions from that pool, and the pinned `passt_0.0~git20260120.386b5f5.orig.tar.xz` now returns 404:

```
$ curl -sI "http://deb.debian.org/debian/pool/main/p/passt/passt_0.0~git20260120.386b5f5.orig.tar.xz" | head -1
HTTP/1.1 404 Not Found
```

Any runner without a cached `/tmp/passt-build` fails at "Build passt from source": the nightly VM benchmark jobs have failed on this every night since 2026-05-22 (e.g. run 26737178481), and CI Host jobs hit the same step on a cold runner.

## The Solution

Download the same pinned tarball from snapshot.debian.org, which archives every version permanently, and verify its sha256 before extracting so the pin is also integrity-checked.

## Test Results

```
$ curl -fsSL -o passt.orig.tar.xz "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/p/passt/passt_0.0~git20260120.386b5f5.orig.tar.xz"
$ sha256sum passt.orig.tar.xz
cc0a86b0ac28e1e5b2a4243bcf7fa84b14dd91c7dc883a78896060111e12d105  passt.orig.tar.xz
$ tar -xJf passt.orig.tar.xz --strip-components=1 && make -j8 && echo BUILD OK
BUILD OK
```

The install step (atomic rename into /usr/local/bin) is unchanged.

**Stacked on:** deps-security-updates (PR #568)
