### PR TITLE
fix: fall back to the build-time manifest dir in find_repo_root()

### DIFF
--- a/src/setup/kernel.rs
+++ b/src/setup/kernel.rs
@@ -413,6 +413,16 @@ fn find_repo_root() -> Option<PathBuf> {
         }
     }
 
+    // Try the repo path baked in at build time. This keeps locally-built
+    // binaries working when invoked from another directory while target/ is a
+    // symlink outside the repo (then /proc/self/exe resolves outside the repo
+    // and the executable-path fallback below cannot find Cargo.toml).
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    if manifest_dir.join("Cargo.toml").exists() && manifest_dir.join("rootfs-config.toml").exists()
+    {
+        return Some(manifest_dir);
+    }
+
     // Try relative to executable
     if let Ok(exe) = std::env::current_exe() {
         if let Some(exe_dir) = exe.parent() {


### PR DESCRIPTION
## Summary

`find_repo_root()` walks up from the CWD and then falls back to the executable's path to locate `rootfs-config.toml`. When a locally-built fcvm is invoked from outside the repository and `target/` is a symlink whose resolved path is also outside the repository, both lookups fail. Setup then computes an all-zero kernel SHA and tries to download a kernel asset that does not exist:

```
ERROR ... kernels/vmlinux-btrfs-6.18.3-x86_64-000000000000.bin ... 404
```

This adds a fallback to the `CARGO_MANIFEST_DIR` baked in at build time, used only when that directory still contains both `Cargo.toml` and `rootfs-config.toml`. Installed release binaries are unaffected (their manifest dir no longer exists, so the existing fallbacks still apply).

## Test Results

Reproduced by running `fcvm setup --kernel-profile btrfs` from another directory with `target/` symlinked outside the repo: before the change the kernel SHA was all zeros and the download 404'd; with the change the same invocation resolves `vmlinux-btrfs-6.18.3-x86_64-012d1387868b.bin` (the correct content-addressed name) and setup proceeds.

```
$ cargo fmt --check && cargo clippy --all-targets -- -D warnings   # clean
$ make test-unit
Summary [  50.499s] 253 tests run: 253 passed, 0 skipped
```

**Stacked on:** deps-security-updates (PR #568)
