### PR TITLE
fix: fail the boot on guest mount errors and harden warm-start/egress ordering

### DIFF
--- a/fc-agent/src/agent.rs
+++ b/fc-agent/src/agent.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use tokio::time::{sleep, Duration};
 
 use crate::{container, exec, lock_test, mmds, mounts, network, output, proxy, system};
@@ -134,19 +134,15 @@ pub async fn run() -> Result<()> {
         Err(_) => eprintln!("[fc-agent] WARNING: exec server did not become ready within 5s"),
     }
 
-    // Mount filesystems
+    // Mount filesystems. Mount failures are fatal: the container would otherwise
+    // start with a plain empty directory bind-mounted where the volume should be,
+    // write into the ephemeral rootfs, and the VM would still report healthy.
+    // Propagating the error makes main() report container exit 1 and shut down.
     let mounted_fuse_paths = if !plan.volumes.is_empty() {
         eprintln!("[fc-agent] mounting {} FUSE volume(s)", plan.volumes.len());
-        match mounts::mount_fuse_volumes(&plan.volumes) {
-            Ok(paths) => {
-                eprintln!("[fc-agent] FUSE volumes mounted successfully");
-                paths
-            }
-            Err(e) => {
-                eprintln!("[fc-agent] ERROR: failed to mount FUSE volumes: {:?}", e);
-                Vec::new()
-            }
-        }
+        let paths = mounts::mount_fuse_volumes(&plan.volumes).context("mounting FUSE volumes")?;
+        eprintln!("[fc-agent] FUSE volumes mounted successfully");
+        paths
     } else {
         Vec::new()
     };
@@ -162,26 +158,17 @@ pub async fn run() -> Result<()> {
             "[fc-agent] mounting {} extra disk(s)",
             plan.extra_disks.len()
         );
-        match mounts::mount_extra_disks(&plan.extra_disks) {
-            Ok(paths) => {
-                eprintln!("[fc-agent] extra disks mounted successfully");
-                paths
-            }
-            Err(e) => {
-                eprintln!("[fc-agent] ERROR: failed to mount extra disks: {:?}", e);
-                Vec::new()
-            }
-        }
+        let paths = mounts::mount_extra_disks(&plan.extra_disks).context("mounting extra disks")?;
+        eprintln!("[fc-agent] extra disks mounted successfully");
+        paths
     } else {
         Vec::new()
     };
 
     if !plan.nfs_mounts.is_empty() {
         eprintln!("[fc-agent] mounting {} NFS share(s)", plan.nfs_mounts.len());
-        match mounts::mount_nfs_shares(&plan.nfs_mounts) {
-            Ok(_) => eprintln!("[fc-agent] NFS shares mounted successfully"),
-            Err(e) => eprintln!("[fc-agent] ERROR: failed to mount NFS shares: {:?}", e),
-        }
+        mounts::mount_nfs_shares(&plan.nfs_mounts).context("mounting NFS shares")?;
+        eprintln!("[fc-agent] NFS shares mounted successfully");
     }
 
     // Start lock test watcher if shared volume exists
@@ -306,10 +293,24 @@ pub async fn run() -> Result<()> {
                 container::CacheResult::WarmStart => {
                     eprintln!("[fc-agent] cache ready: warm start (snapshot restore detected)");
                     // Vsock IS dead (VIRTIO_VSOCK_EVENT_TRANSPORT_RESET on restore).
-                    // Reconnect output before starting the container — for fast-exit
-                    // containers (echo + exit in ~200ms), output must be live or the
-                    // container's stdout/stderr goes to the dead vsock.
-                    output.reconnect();
+                    // The restore-epoch watcher runs handle_clone_restore concurrently, and
+                    // the host treats the first output connection as the readiness signal:
+                    // it must not arrive before the exec server has re-registered and the
+                    // egress proxy has reconnected (same ordering handle_clone_restore
+                    // enforces). Wait on the exec_rebind_done flag rather than its Notify —
+                    // exec.rs uses notify_one() and the restore handler must win that
+                    // notification.
+                    let rebind_wait = std::time::Instant::now();
+                    while !exec_rebind_done.load(std::sync::atomic::Ordering::Acquire) {
+                        if rebind_wait.elapsed() > std::time::Duration::from_secs(10) {
+                            eprintln!(
+                                "[fc-agent] WARNING: exec re-register not confirmed within 10s, \
+                                 reconnecting output anyway"
+                            );
+                            break;
+                        }
+                        sleep(Duration::from_millis(25)).await;
+                    }
                     // No explicit signal to proxy needed — it detects the dead vsock fd
                     // natively via Interest::ERROR (EPOLLERR fires instantly after restore).
                     // Just wait for the watch channel to confirm reconnection.
@@ -322,6 +323,10 @@ pub async fn run() -> Result<()> {
                         )
                         .await;
                     }
+                    // Reconnect output before starting the container — for fast-exit
+                    // containers (echo + exit in ~200ms), output must be live or the
+                    // container's stdout/stderr goes to the dead vsock.
+                    output.reconnect();
                 }
                 container::CacheResult::Failed => {
                     eprintln!("[fc-agent] WARNING: cache-ready handshake failed, continuing");

--- a/fc-agent/src/proxy.rs
+++ b/fc-agent/src/proxy.rs
@@ -130,15 +130,11 @@ impl ProxyState {
 /// EPOLLERR on all vsock fds. `VsockStream::wait_for_error()` detects this via
 /// `Interest::ERROR`, which fires the select! arm and ends the session naturally.
 pub async fn run_egress_proxy(gen_tx: watch::Sender<u64>) {
-    if !setup_iptables_redirect() {
-        eprintln!(
-            "[fc-agent] WARNING: failed to set up iptables REDIRECT rules, egress proxy disabled"
-        );
-        return;
-    }
-
     // Bind on both IPv4 and IPv6 loopback so we catch redirected traffic from both stacks.
     // ip6tables REDIRECT sends IPv6 traffic to [::1]:PROXY_LISTEN_PORT.
+    //
+    // Bind BEFORE installing any REDIRECT rule: a rule pointing at a port nothing
+    // listens on turns every redirected guest connection into an immediate refusal.
     //
     // Use TcpSocket to set a large listen backlog (8192 instead of default 128).
     // With 8000+ concurrent connections, the default backlog causes accept queue
@@ -153,12 +149,19 @@ pub async fn run_egress_proxy(gen_tx: watch::Sender<u64>) {
         }
         Err(e) => {
             eprintln!(
-                "[fc-agent] WARNING: failed to bind egress proxy on 127.0.0.1:{}: {}",
+                "[fc-agent] WARNING: failed to bind egress proxy on 127.0.0.1:{}: {} (egress proxy disabled)",
                 PROXY_LISTEN_PORT, e
             );
             return;
         }
     };
+
+    if !setup_iptables_redirect_v4() {
+        eprintln!(
+            "[fc-agent] WARNING: failed to set up iptables REDIRECT rules, egress proxy disabled"
+        );
+        return;
+    }
 
     let listener_v6 = match bind_with_backlog("::1", PROXY_LISTEN_PORT, true).await {
         Ok(l) => {
@@ -166,6 +169,8 @@ pub async fn run_egress_proxy(gen_tx: watch::Sender<u64>) {
                 "[fc-agent] egress proxy listening on [::1]:{} (backlog=8192)",
                 PROXY_LISTEN_PORT
             );
+            // Only redirect IPv6 once its listener exists; failure leaves IPv6 unproxied.
+            setup_ip6tables_redirect();
             Some(l)
         }
         Err(e) => {
@@ -486,8 +491,8 @@ async fn bind_with_backlog(
     socket.listen(LISTEN_BACKLOG)
 }
 
-/// Set up iptables and ip6tables NAT OUTPUT REDIRECT rules.
-fn setup_iptables_redirect() -> bool {
+/// Set up iptables (IPv4) NAT OUTPUT REDIRECT rules.
+fn setup_iptables_redirect_v4() -> bool {
     let port_str = PROXY_LISTEN_PORT.to_string();
 
     // IPv4 rules
@@ -565,8 +570,15 @@ fn setup_iptables_redirect() -> bool {
         }
     }
     eprintln!("[fc-agent] iptables REDIRECT rules configured for egress proxy");
+    true
+}
 
-    // IPv6 rules — best-effort (ip6tables may not be available)
+/// Set up ip6tables NAT OUTPUT REDIRECT rules — best-effort (ip6tables may not be available).
+/// Only called once the IPv6 proxy listener is bound, so a failure here leaves IPv6
+/// egress unproxied rather than redirected to a dead port.
+fn setup_ip6tables_redirect() -> bool {
+    let port_str = PROXY_LISTEN_PORT.to_string();
+
     let v6_rules: &[&[&str]] = &[
         // Don't redirect localhost traffic (proxy listens on [::1])
         &[
@@ -623,14 +635,14 @@ fn setup_iptables_redirect() -> bool {
                     "[fc-agent] WARNING: ip6tables rule {:?} failed: {} (IPv6 proxy disabled)",
                     rule, stderr
                 );
-                return true; // IPv4 still works
+                return false;
             }
             Err(e) => {
                 eprintln!(
                     "[fc-agent] WARNING: ip6tables not available: {} (IPv6 proxy disabled)",
                     e
                 );
-                return true; // IPv4 still works
+                return false;
             }
         }
     }


### PR DESCRIPTION
Three fc-agent failure-handling fixes:

- Mount failures are now fatal. FUSE volume, extra-disk, and NFS mount
  errors were logged and discarded, so the container started with a plain
  empty directory bind-mounted where the volume should be, wrote into the
  ephemeral rootfs, and the VM still reported healthy. The errors now
  propagate out of agent::run(), which reports container exit 1 to the
  host and shuts the VM down.

- Warm-start output reconnect now waits for the exec server re-register
  and the egress proxy reconnect before connecting, matching the ordering
  handle_clone_restore enforces. The host treats the first output
  connection as the clone readiness signal, so the previous immediate
  reconnect could let health checks reach a stale exec listener.

- The egress proxy binds its listeners before installing iptables/ip6tables
  REDIRECT rules, and only installs the IPv6 rules once the IPv6 listener
  exists. Previously a bind failure left REDIRECT rules pointing at a dead
  port, silently refusing all guest egress while the VM reported healthy.

Tested: cargo fmt and clippy clean; make test-unit passes. The mount and
restore orderings are exercised by the existing volume and snapshot-clone
end-to-end suites in CI.
