### PR TITLE
fix: make routed network setup failures recoverable and stop swallowing errors

### DIFF
--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -698,7 +698,21 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
         }
     };
 
-    let network_config = network.setup().await.context("setting up network")?;
+    // network.setup() may fail partway through (it tears nothing down itself),
+    // so any error from here until the run_vm_setup error handler below must
+    // run network.cleanup() to remove partially-created host network state.
+    let network_config = match network.setup().await.context("setting up network") {
+        Ok(config) => config,
+        Err(e) => {
+            if let Err(cleanup_err) = network.cleanup().await {
+                warn!(
+                    "failed to cleanup network after setup error: {}",
+                    cleanup_err
+                );
+            }
+            return Err(e);
+        }
+    };
 
     info!(tap = %network_config.tap_device, mac = %network_config.guest_mac, "network configured");
 
@@ -707,9 +721,18 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
     // Use custom vsock_dir if provided (for predictable socket paths)
     let vsock_socket_path = if let Some(ref vsock_dir) = args.vsock_dir {
         let vsock_dir = std::path::PathBuf::from(vsock_dir);
-        tokio::fs::create_dir_all(&vsock_dir)
+        if let Err(e) = tokio::fs::create_dir_all(&vsock_dir)
             .await
-            .with_context(|| format!("creating vsock dir: {:?}", vsock_dir))?;
+            .with_context(|| format!("creating vsock dir: {:?}", vsock_dir))
+        {
+            if let Err(cleanup_err) = network.cleanup().await {
+                warn!(
+                    "failed to cleanup network after setup error: {}",
+                    cleanup_err
+                );
+            }
+            return Err(e);
+        }
         vsock_dir.join("vsock.sock")
     } else {
         data_dir.join("vsock.sock")
@@ -730,9 +753,21 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
         })
         .collect();
 
-    let volume_servers = spawn_volume_servers(&volume_configs, &vsock_socket_path)
+    let volume_servers = match spawn_volume_servers(&volume_configs, &vsock_socket_path)
         .await
-        .context("spawning VolumeServers")?;
+        .context("spawning VolumeServers")
+    {
+        Ok(servers) => servers,
+        Err(e) => {
+            if let Err(cleanup_err) = network.cleanup().await {
+                warn!(
+                    "failed to cleanup network after setup error: {}",
+                    cleanup_err
+                );
+            }
+            return Err(e);
+        }
+    };
 
     // Create snapshot channel for snapshot-ready notifications
     // Skip snapshot creation when:

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -763,7 +763,21 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
         }
     };
 
-    let network_config = network.setup().await.context("setting up network")?;
+    // network.setup() may fail partway through (it tears nothing down itself),
+    // so any error from here until the restore_from_snapshot error handler below
+    // must run network.cleanup() to remove partially-created host network state.
+    let network_config = match network.setup().await.context("setting up network") {
+        Ok(config) => config,
+        Err(e) => {
+            if let Err(cleanup_err) = network.cleanup().await {
+                warn!(
+                    "failed to cleanup network after setup error: {}",
+                    cleanup_err
+                );
+            }
+            return Err(e);
+        }
+    };
 
     // For routed mode clones: the snapshot's guest IPv6 (baked into boot params) is shared
     // across all clones. After restore, fc-agent will be told to swap it to the unique
@@ -859,13 +873,25 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
                 "starting implicit UFFD server for snapshot restore"
             );
 
-            let server = UffdServer::new_with_path(
+            let server = match UffdServer::new_with_path(
                 format!("implicit-{}", truncate_id(&vm_id, 8)),
                 &snapshot_config.memory_path,
                 &implicit_socket_path,
             )
             .await
-            .context("creating implicit UFFD server")?;
+            .context("creating implicit UFFD server")
+            {
+                Ok(server) => server,
+                Err(e) => {
+                    if let Err(cleanup_err) = network.cleanup().await {
+                        warn!(
+                            "failed to cleanup network after setup error: {}",
+                            cleanup_err
+                        );
+                    }
+                    return Err(e);
+                }
+            };
 
             let cancel = implicit_uffd_cancel.clone();
             tokio::spawn(async move {
@@ -879,6 +905,12 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
                     break;
                 }
                 if i == 99 {
+                    if let Err(cleanup_err) = network.cleanup().await {
+                        warn!(
+                            "failed to cleanup network after setup error: {}",
+                            cleanup_err
+                        );
+                    }
                     bail!("implicit UFFD server did not bind socket within 5s");
                 }
                 tokio::time::sleep(Duration::from_millis(50)).await;

--- a/src/network/namespace.rs
+++ b/src/network/namespace.rs
@@ -82,6 +82,26 @@ pub async fn exec_in_namespace(ns_name: &str, command: &[&str]) -> Result<std::p
     Ok(output)
 }
 
+/// Executes a command inside a network namespace and fails on non-zero exit.
+///
+/// Like [`exec_in_namespace`], but bails with the command, exit status, and
+/// stderr when the inner command exits non-zero. Use for configuration
+/// commands whose failure must not be silently ignored. Callers that need to
+/// inspect the output themselves should use [`exec_in_namespace`] directly.
+pub async fn exec_in_namespace_checked(ns_name: &str, command: &[&str]) -> Result<()> {
+    let output = exec_in_namespace(ns_name, command).await?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "command {:?} in namespace {} failed ({}): {}",
+            command,
+            ns_name,
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
 /// Lists all network namespaces
 #[allow(dead_code)]
 pub async fn list_namespaces() -> Result<Vec<String>> {

--- a/src/network/routed.rs
+++ b/src/network/routed.rs
@@ -5,7 +5,7 @@ use super::namespace;
 use super::tcp_proxy;
 use super::types::generate_mac;
 use super::veth;
-use super::{NetworkConfig, NetworkManager, PortMapping};
+use super::{NetworkConfig, NetworkManager, PortMapping, Protocol};
 use crate::state::truncate_id;
 
 /// Guest network addressing (same as pasta/bridged for Firecracker compatibility)
@@ -144,6 +144,15 @@ impl RoutedNetwork {
             anyhow::bail!(
                 "routed networking requires root (creates network namespaces and veth pairs). \
                  Run with sudo or use --network rootless instead."
+            );
+        }
+
+        // Routed-mode port forwarding is a TCP relay (tcp_proxy::start_port_forwards),
+        // so UDP mappings would be silently set up as useless TCP listeners.
+        if self.port_mappings.iter().any(|m| m.proto == Protocol::Udp) {
+            anyhow::bail!(
+                "routed networking does not support UDP port mappings (--publish .../udp); \
+                 use bridged or rootless networking for UDP"
             );
         }
 
@@ -370,6 +379,9 @@ impl NetworkManager for RoutedNetwork {
             }
             candidate
         };
+        // Record state as soon as it's known so cleanup() can tear down a
+        // partially-completed setup if a later step fails.
+        self.vm_ipv6 = Some(vm_ipv6.clone());
         info!(
             host_ipv6 = %host_ipv6,
             vm_ipv6 = %vm_ipv6,
@@ -379,9 +391,11 @@ impl NetworkManager for RoutedNetwork {
 
         // 1. Create network namespace
         namespace::create_namespace(&ns_name).await?;
+        self.namespace_id = Some(ns_name.clone());
 
         // 2. Create veth pair and move guest side to namespace
         veth::create_veth_pair(&host_veth, &guest_veth, &ns_name).await?;
+        self.host_veth = Some(host_veth.clone());
 
         // 3. Create TAP in namespace
         veth::create_tap_in_ns(&ns_name, &self.tap_device).await?;
@@ -392,14 +406,18 @@ impl NetworkManager for RoutedNetwork {
         //    IPv6 for external destinations traverses the bridge to the veth peer on the host.
         veth::connect_tap_to_veth(&ns_name, &self.tap_device, &guest_veth).await?;
         // Bring up all interfaces (connect_tap_to_veth only brings up the bridge)
-        namespace::exec_in_namespace(&ns_name, &["ip", "link", "set", "lo", "up"]).await?;
-        namespace::exec_in_namespace(&ns_name, &["ip", "link", "set", &self.tap_device, "up"])
+        namespace::exec_in_namespace_checked(&ns_name, &["ip", "link", "set", "lo", "up"]).await?;
+        namespace::exec_in_namespace_checked(
+            &ns_name,
+            &["ip", "link", "set", &self.tap_device, "up"],
+        )
+        .await?;
+        namespace::exec_in_namespace_checked(&ns_name, &["ip", "link", "set", &guest_veth, "up"])
             .await?;
-        namespace::exec_in_namespace(&ns_name, &["ip", "link", "set", &guest_veth, "up"]).await?;
 
         // 5. Assign gateway IPs to bridge (VM connects here via TAP)
         let gw_cidr = format!("{}/24", GUEST_GATEWAY);
-        namespace::exec_in_namespace(
+        namespace::exec_in_namespace_checked(
             &ns_name,
             &["ip", "addr", "add", &gw_cidr, "dev", BRIDGE_DEVICE],
         )
@@ -407,7 +425,7 @@ impl NetworkManager for RoutedNetwork {
         // nodad: skip Duplicate Address Detection so the address is usable immediately.
         // Without nodad, the address stays "tentative" for ~1-3s and the kernel silently
         // drops all IPv6 packets to it — breaking the VM's default route via fd00::1.
-        namespace::exec_in_namespace(
+        namespace::exec_in_namespace_checked(
             &ns_name,
             &[
                 "ip",
@@ -434,15 +452,18 @@ impl NetworkManager for RoutedNetwork {
         }
         // 7. Enable IPv6 forwarding on the host veth only (not all.forwarding —
         //    that prevents link-local auto-assignment on future interfaces).
-        let _ = tokio::process::Command::new("sysctl")
-            .args(["-w", &format!("net.ipv6.conf.{}.forwarding=1", host_veth)])
-            .output()
-            .await;
+        run_host_command(
+            "enabling IPv6 forwarding on host veth",
+            "sysctl",
+            &["-w", &format!("net.ipv6.conf.{}.forwarding=1", host_veth)],
+        )
+        .await;
 
         // Detect default interface early — used for sysctl checks AND proxy NDP below.
         let default_iface = detect_default_ipv6_interface()
             .await
             .unwrap_or_else(|| "eth0".to_string());
+        self.default_iface = Some(default_iface.clone());
 
         // Verify host routing is set up correctly. These sysctls are the user's
         // responsibility (host sysctl configuration), not fcvm's — but warn
@@ -489,8 +510,10 @@ impl NetworkManager for RoutedNetwork {
             .await
             .context("failed to generate link-local for host veth")?;
         let host_ll_cidr = format!("{}/64", host_ll);
-        let _ = tokio::process::Command::new("ip")
-            .args([
+        if run_host_command(
+            "assigning link-local to host veth",
+            "ip",
+            &[
                 "-6",
                 "addr",
                 "add",
@@ -500,16 +523,18 @@ impl NetworkManager for RoutedNetwork {
                 "scope",
                 "link",
                 "nodad",
-            ])
-            .output()
-            .await;
-        info!(host_ll = %host_ll, "assigned link-local to host veth");
+            ],
+        )
+        .await
+        {
+            info!(host_ll = %host_ll, "assigned link-local to host veth");
+        }
 
         // 9. In namespace: default IPv6 route goes through bridge → veth → host.
         //     The bridge forwards L2 frames from br0 to veth (bridge member).
         //     The host veth receives them and the host kernel routes to eth0.
         //     Use the host veth's link-local as nexthop (reachable via NDP on bridge).
-        namespace::exec_in_namespace(
+        namespace::exec_in_namespace_checked(
             &ns_name,
             &[
                 "ip",
@@ -526,7 +551,7 @@ impl NetworkManager for RoutedNetwork {
         .await?;
 
         // 10. Enable IPv6 forwarding in namespace (for VM traffic forwarding)
-        namespace::exec_in_namespace(
+        namespace::exec_in_namespace_checked(
             &ns_name,
             &["sysctl", "-w", "net.ipv6.conf.all.forwarding=1"],
         )
@@ -538,24 +563,30 @@ impl NetworkManager for RoutedNetwork {
 
         // 11. On host: route VM's IPv6 back through veth to the namespace (per-VM, no collision)
         let vm_route = format!("{}/128", vm_ipv6);
-        let _ = tokio::process::Command::new("ip")
-            .args(["-6", "route", "replace", &vm_route, "dev", &host_veth])
-            .output()
-            .await;
+        run_host_command(
+            "adding host return route for VM IPv6",
+            "ip",
+            &["-6", "route", "replace", &vm_route, "dev", &host_veth],
+        )
+        .await;
 
         // 12. Add proxy NDP so the network fabric routes VM's IPv6 to this host
         // (default_iface already detected above)
         // Enable proxy NDP on the interface so the kernel actually responds
         // to neighbor solicitations for our proxy entries.
-        let _ = tokio::process::Command::new("sysctl")
-            .args([
+        run_host_command(
+            "enabling proxy NDP on default interface",
+            "sysctl",
+            &[
                 "-w",
                 &format!("net.ipv6.conf.{}.proxy_ndp=1", default_iface),
-            ])
-            .output()
-            .await;
-        let _ = tokio::process::Command::new("ip")
-            .args([
+            ],
+        )
+        .await;
+        if run_host_command(
+            "adding proxy NDP entry",
+            "ip",
+            &[
                 "-6",
                 "neigh",
                 "add",
@@ -563,10 +594,12 @@ impl NetworkManager for RoutedNetwork {
                 &vm_ipv6,
                 "dev",
                 &default_iface,
-            ])
-            .output()
-            .await;
-        info!(vm_ipv6 = %vm_ipv6, iface = %default_iface, "added proxy NDP");
+            ],
+        )
+        .await
+        {
+            info!(vm_ipv6 = %vm_ipv6, iface = %default_iface, "added proxy NDP");
+        }
 
         // 13. MASQUERADE outbound IPv6 traffic from the namespace.
         //     On AWS, source/dest check drops packets with unassigned source IPs.
@@ -576,22 +609,24 @@ impl NetworkManager for RoutedNetwork {
         //     and the VM's source IP matches the cert's IP SANs.
         if self.ipv6_prefix.is_some() {
             info!(iface = %default_iface, "skipping MASQUERADE (--ipv6-prefix is routable)");
-        } else {
-            let _ = tokio::process::Command::new("ip6tables")
-                .args([
-                    "-t",
-                    "nat",
-                    "-A",
-                    "POSTROUTING",
-                    "-o",
-                    &default_iface,
-                    "-s",
-                    &format!("{}/128", vm_ipv6),
-                    "-j",
-                    "MASQUERADE",
-                ])
-                .output()
-                .await;
+        } else if run_host_command(
+            "adding IPv6 MASQUERADE rule",
+            "ip6tables",
+            &[
+                "-t",
+                "nat",
+                "-A",
+                "POSTROUTING",
+                "-o",
+                &default_iface,
+                "-s",
+                &format!("{}/128", vm_ipv6),
+                "-j",
+                "MASQUERADE",
+            ],
+        )
+        .await
+        {
             info!(iface = %default_iface, "added IPv6 MASQUERADE for outbound traffic");
         }
 
@@ -623,19 +658,12 @@ impl NetworkManager for RoutedNetwork {
         //     127.0.0.1:<port> from the host namespace.
         if !self.forward_localhost.is_empty() {
             let alias_cidr = format!("{}/32", HOST_LOOPBACK_ALIAS);
-            let output = namespace::exec_in_namespace(
+            namespace::exec_in_namespace_checked(
                 &ns_name,
                 &["ip", "addr", "add", &alias_cidr, "dev", BRIDGE_DEVICE],
             )
-            .await?;
-            if !output.status.success() {
-                anyhow::bail!(
-                    "failed to assign host loopback alias {} to {}: {}",
-                    alias_cidr,
-                    BRIDGE_DEVICE,
-                    String::from_utf8_lossy(&output.stderr).trim()
-                );
-            }
+            .await
+            .context("assigning host loopback alias for --forward-localhost")?;
 
             let handles = tcp_proxy::start_localhost_forwards(
                 &ns_name,
@@ -676,12 +704,6 @@ impl NetworkManager for RoutedNetwork {
 
         let guest_mac = generate_mac();
         let guest_ip = format!("{}/{}", GUEST_IP, "24");
-
-        // Store state for cleanup
-        self.namespace_id = Some(ns_name);
-        self.host_veth = Some(host_veth);
-        self.vm_ipv6 = Some(vm_ipv6.clone());
-        self.default_iface = Some(default_iface);
 
         Ok(NetworkConfig {
             tap_device: self.tap_device.clone(),
@@ -820,6 +842,34 @@ impl NetworkManager for RoutedNetwork {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+}
+
+/// Run a host-namespace command, returning whether it succeeded.
+///
+/// Failures are logged with the command's stderr instead of bailing — some of
+/// these commands legitimately fail on re-runs (e.g. a stale proxy-NDP entry
+/// left by a previous VM). Callers should only log success messages when this
+/// returns true.
+async fn run_host_command(what: &str, program: &str, args: &[&str]) -> bool {
+    match tokio::process::Command::new(program)
+        .args(args)
+        .output()
+        .await
+    {
+        Ok(output) if output.status.success() => true,
+        Ok(output) => {
+            warn!(
+                stderr = %String::from_utf8_lossy(&output.stderr).trim(),
+                "{} failed",
+                what
+            );
+            false
+        }
+        Err(e) => {
+            warn!(error = %e, "{} failed to run", what);
+            false
+        }
     }
 }
 

--- a/src/network/tcp_proxy.rs
+++ b/src/network/tcp_proxy.rs
@@ -120,8 +120,14 @@ where
                     });
                 }
                 Err(e) => {
-                    warn!(error = %e, "{label} accept error");
-                    break;
+                    // accept() can fail transiently (ECONNABORTED, EMFILE/ENFILE
+                    // under fd pressure). The listener is owned by this loop and
+                    // never closed externally, so back off briefly and keep
+                    // accepting instead of silently killing the relay for the
+                    // VM's lifetime.
+                    warn!(error = %e, "{label} accept error, retrying");
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    continue;
                 }
             }
         }


### PR DESCRIPTION
Routed mode robustness fixes from review:

- setup() records the namespace, veth, per-VM IPv6, and default interface
  into the manager as soon as each exists, and prepare_vm / snapshot run
  call network.cleanup() when setup (or the steps right after it) fail, so
  a partial setup no longer leaks the netns, veth pair, /128 route, proxy
  NDP entry, and MASQUERADE rule on the host.
- namespace configuration commands (link up, gateway addresses, default
  route, forwarding sysctl, the forward-localhost alias) now fail setup
  with the command's stderr instead of silently succeeding via an
  unchecked exit status (new exec_in_namespace_checked helper).
- host-side route/NDP/MASQUERADE/sysctl commands are no longer discarded
  with let _ =; failures are logged with stderr and the success log lines
  only fire when the command succeeded.
- relay accept loops retry transient accept() errors instead of silently
  ending port forwarding for the VM's lifetime.
- routed preflight rejects UDP --publish mappings, which were silently set
  up as TCP relays; bridged and rootless modes still handle UDP.

Tested: cargo fmt and clippy clean; make test-unit passes 253/253. Routed
end-to-end coverage runs in the Host-Root CI jobs.
