### PR TITLE
fix: report exec failures as failures and decode the WebSocket terminal stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,6 +652,9 @@ dependencies = [
 [[package]]
 name = "exec-proto"
 version = "0.1.0"
+dependencies = [
+ "tokio",
+]
 
 [[package]]
 name = "fastrand"

--- a/exec-proto/Cargo.toml
+++ b/exec-proto/Cargo.toml
@@ -5,3 +5,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+tokio = { version = "1", features = ["io-util"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["io-util", "macros", "rt"] }

--- a/exec-proto/src/lib.rs
+++ b/exec-proto/src/lib.rs
@@ -14,6 +14,10 @@
 
 use std::io::{self, Read, Write};
 
+/// Maximum payload size for a single message (1MB, plenty for TTY data).
+/// This prevents DoS via large length values.
+const MAX_MESSAGE_SIZE: usize = 1024 * 1024;
+
 /// Message types for the TTY exec protocol
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -98,20 +102,7 @@ impl Message {
         // Read length (4 bytes big-endian)
         let mut len_buf = [0u8; 4];
         reader.read_exact(&mut len_buf)?;
-        let len = u32::from_be_bytes(len_buf) as usize;
-
-        // Sanity check: limit message size to 1MB (plenty for TTY data)
-        // This prevents DoS via large length values
-        const MAX_MESSAGE_SIZE: usize = 1024 * 1024;
-        if len > MAX_MESSAGE_SIZE {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "message too large: {} bytes (max {})",
-                    len, MAX_MESSAGE_SIZE
-                ),
-            ));
-        }
+        let len = validate_len(u32::from_be_bytes(len_buf))?;
 
         // Read payload progressively to avoid allocating large buffers upfront
         // This prevents memory exhaustion if sender disconnects mid-transfer
@@ -126,7 +117,46 @@ impl Message {
             remaining -= to_read;
         }
 
-        // Parse based on type
+        Self::from_parts(msg_type, payload)
+    }
+
+    /// Read a message from an async reader using the binary protocol.
+    ///
+    /// Async equivalent of [`Message::read_from`], for bridging the framed
+    /// exec stream into async contexts (e.g. WebSocket terminal sessions).
+    pub async fn read_from_async<R>(reader: &mut R) -> io::Result<Self>
+    where
+        R: tokio::io::AsyncRead + Unpin,
+    {
+        use tokio::io::AsyncReadExt;
+
+        // Read type byte
+        let mut type_buf = [0u8; 1];
+        reader.read_exact(&mut type_buf).await?;
+        let msg_type = MessageType::from_u8(type_buf[0])?;
+
+        // Read length (4 bytes big-endian)
+        let mut len_buf = [0u8; 4];
+        reader.read_exact(&mut len_buf).await?;
+        let len = validate_len(u32::from_be_bytes(len_buf))?;
+
+        // Read payload progressively to avoid allocating large buffers upfront
+        let mut payload = Vec::with_capacity(len.min(64 * 1024)); // Start with at most 64KB
+        let mut remaining = len;
+        let mut chunk = [0u8; 8192]; // Read in 8KB chunks
+
+        while remaining > 0 {
+            let to_read = remaining.min(chunk.len());
+            reader.read_exact(&mut chunk[..to_read]).await?;
+            payload.extend_from_slice(&chunk[..to_read]);
+            remaining -= to_read;
+        }
+
+        Self::from_parts(msg_type, payload)
+    }
+
+    /// Build a message from its decoded type byte and payload.
+    fn from_parts(msg_type: MessageType, payload: Vec<u8>) -> io::Result<Self> {
         match msg_type {
             MessageType::Data => Ok(Message::Data(payload)),
             MessageType::Exit => {
@@ -148,6 +178,21 @@ impl Message {
             MessageType::Stdin => Ok(Message::Stdin(payload)),
         }
     }
+}
+
+/// Validate a payload length against the maximum message size.
+fn validate_len(len: u32) -> io::Result<usize> {
+    let len = len as usize;
+    if len > MAX_MESSAGE_SIZE {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "message too large: {} bytes (max {})",
+                len, MAX_MESSAGE_SIZE
+            ),
+        ));
+    }
+    Ok(len)
 }
 
 /// Write a Data message directly (convenience function for high-frequency writes)
@@ -278,5 +323,56 @@ mod tests {
             Message::Data(data) => assert_eq!(data, binary),
             _ => panic!("wrong message type"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_async_read_decodes_data_then_exit() {
+        // Stream as written by the guest: terminal output frames followed by Exit
+        let mut buf = Vec::new();
+        write_data(&mut buf, b"terminal output").unwrap();
+        write_exit(&mut buf, 3).unwrap();
+
+        let mut reader = buf.as_slice();
+        match Message::read_from_async(&mut reader).await.unwrap() {
+            Message::Data(data) => assert_eq!(data, b"terminal output"),
+            other => panic!("expected Data, got {:?}", other),
+        }
+        match Message::read_from_async(&mut reader).await.unwrap() {
+            Message::Exit(code) => assert_eq!(code, 3),
+            other => panic!("expected Exit(3), got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_async_read_error_message() {
+        let mut buf = Vec::new();
+        write_error(&mut buf, "spawn failed").unwrap();
+
+        let mut reader = buf.as_slice();
+        match Message::read_from_async(&mut reader).await.unwrap() {
+            Message::Error(msg) => assert_eq!(msg, "spawn failed"),
+            other => panic!("expected Error, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_async_read_eof() {
+        let mut reader: &[u8] = &[];
+        let err = Message::read_from_async(&mut reader).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[tokio::test]
+    async fn test_async_read_truncated_frame() {
+        // Frame header claims 16 bytes but the stream ends after 4, as if
+        // the connection dropped mid-message.
+        let mut buf = Vec::new();
+        buf.push(MessageType::Data as u8);
+        buf.extend_from_slice(&16u32.to_be_bytes());
+        buf.extend_from_slice(b"oops");
+
+        let mut reader = buf.as_slice();
+        let err = Message::read_from_async(&mut reader).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
     }
 }

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -140,6 +140,9 @@ pub fn connect_to_exec_server_with_retry(vsock_socket: &Path) -> Result<UnixStre
 /// For CLI use, see `cmd_exec`.
 ///
 /// Returns the command's exit code.
+///
+/// The blocking vsock I/O is offloaded to a blocking thread pool so this
+/// function is safe to call from async contexts without starving the runtime.
 pub async fn run_exec_in_vm(
     vsock_socket: &Path,
     command: &[String],
@@ -152,31 +155,38 @@ pub async fn run_exec_in_vm(
         "executing command in VM"
     );
 
-    // Connect to the exec server with retry logic
-    let mut stream = connect_to_exec_server_with_retry(vsock_socket)?;
+    let vsock_socket = vsock_socket.to_path_buf();
+    let command = command.to_vec();
 
-    // Long timeout — commands like phps cookie gen can take >10 min.
-    // Use 1 hour as a safety net against permanent hangs (not None/infinite).
-    stream.set_read_timeout(Some(Duration::from_secs(3600)))?;
-    stream.set_write_timeout(Some(Duration::from_secs(10)))?;
+    tokio::task::spawn_blocking(move || {
+        // Connect to the exec server with retry logic
+        let mut stream = connect_to_exec_server_with_retry(&vsock_socket)?;
 
-    debug!("connected to guest exec server");
+        // Long timeout — commands like phps cookie gen can take >10 min.
+        // Use 1 hour as a safety net against permanent hangs (not None/infinite).
+        stream.set_read_timeout(Some(Duration::from_secs(3600)))?;
+        stream.set_write_timeout(Some(Duration::from_secs(10)))?;
 
-    // Build the exec request (non-interactive, no TTY)
-    let request = ExecRequest {
-        command: command.to_vec(),
-        in_container,
-        interactive: false,
-        tty: false,
-    };
+        debug!("connected to guest exec server");
 
-    // Send request as JSON followed by newline
-    let request_json = serde_json::to_string(&request)?;
-    writeln!(stream, "{}", request_json)?;
-    stream.flush()?;
+        // Build the exec request (non-interactive, no TTY)
+        let request = ExecRequest {
+            command,
+            in_container,
+            interactive: false,
+            tty: false,
+        };
 
-    // Run in line mode and capture exit code
-    run_line_mode_with_exit_code(stream)
+        // Send request as JSON followed by newline
+        let request_json = serde_json::to_string(&request)?;
+        writeln!(stream, "{}", request_json)?;
+        stream.flush()?;
+
+        // Run in line mode and capture exit code
+        run_line_mode_with_exit_code(stream)
+    })
+    .await
+    .context("exec task panicked")?
 }
 
 pub async fn cmd_exec(args: ExecArgs) -> Result<()> {
@@ -300,37 +310,49 @@ pub async fn cmd_exec(args: ExecArgs) -> Result<()> {
     }
 }
 
-/// Run in line-buffered mode (non-TTY), returns exit code
-fn run_line_mode_with_exit_code(stream: UnixStream) -> Result<i32> {
-    let reader = BufReader::new(stream);
-    let mut exit_code = 0i32;
-
+/// Read JSON-line exec responses until an Exit (or Error) message arrives.
+///
+/// Stdout/stderr payloads are passed to the provided callbacks. Returns the
+/// command's exit code (Error messages map to exit code 1).
+///
+/// If the stream ends before an Exit message is received (fc-agent crash, VM
+/// reboot, vsock reset), the command's outcome is unknown, so this returns an
+/// error rather than reporting success.
+fn read_exec_responses<R: BufRead>(
+    reader: R,
+    mut on_stdout: impl FnMut(&str),
+    mut on_stderr: impl FnMut(&str),
+) -> Result<i32> {
     for line in reader.lines() {
         let line = line.context("reading from exec socket")?;
 
-        // Parse the line as JSON
-        if let Ok(response) = serde_json::from_str::<ExecResponse>(&line) {
-            match response {
-                ExecResponse::Stdout(data) => {
-                    print!("{}", data);
-                }
-                ExecResponse::Stderr(data) => {
-                    eprint!("{}", data);
-                }
-                ExecResponse::Exit(code) => {
-                    exit_code = code;
-                    break;
-                }
-                ExecResponse::Error(msg) => {
-                    eprintln!("Error: {}", msg);
-                    exit_code = 1;
-                    break;
-                }
+        // Parse the line as JSON; skip lines that aren't valid responses
+        let Ok(response) = serde_json::from_str::<ExecResponse>(&line) else {
+            continue;
+        };
+
+        match response {
+            ExecResponse::Stdout(data) => on_stdout(&data),
+            ExecResponse::Stderr(data) => on_stderr(&data),
+            ExecResponse::Exit(code) => return Ok(code),
+            ExecResponse::Error(msg) => {
+                on_stderr(&format!("Error: {}\n", msg));
+                return Ok(1);
             }
         }
     }
 
-    Ok(exit_code)
+    bail!("exec connection closed before an exit status was received")
+}
+
+/// Run in line-buffered mode (non-TTY), returns exit code
+fn run_line_mode_with_exit_code(stream: UnixStream) -> Result<i32> {
+    let reader = BufReader::new(stream);
+    read_exec_responses(
+        reader,
+        |data| print!("{}", data),
+        |data| eprint!("{}", data),
+    )
 }
 
 /// Run in line-buffered mode (non-TTY)
@@ -423,27 +445,11 @@ pub async fn run_exec_in_vm_captured(
         let reader = BufReader::new(stream);
         let mut stdout = String::new();
         let mut stderr = String::new();
-        let mut exit_code = 0i32;
-
-        for line in reader.lines() {
-            let line = line.context("reading from exec socket")?;
-
-            if let Ok(response) = serde_json::from_str::<ExecResponse>(&line) {
-                match response {
-                    ExecResponse::Stdout(data) => stdout.push_str(&data),
-                    ExecResponse::Stderr(data) => stderr.push_str(&data),
-                    ExecResponse::Exit(code) => {
-                        exit_code = code;
-                        break;
-                    }
-                    ExecResponse::Error(msg) => {
-                        stderr.push_str(&format!("Error: {}\n", msg));
-                        exit_code = 1;
-                        break;
-                    }
-                }
-            }
-        }
+        let exit_code = read_exec_responses(
+            reader,
+            |data| stdout.push_str(data),
+            |data| stderr.push_str(data),
+        )?;
 
         Ok(ExecOutput {
             stdout,
@@ -469,4 +475,71 @@ pub async fn connect_to_exec_server_async(vsock_socket: &Path) -> Result<tokio::
             .context("connect task panicked")??;
     std_stream.set_nonblocking(true)?;
     tokio::net::UnixStream::from_std(std_stream).context("converting to tokio UnixStream")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn response_line(response: &ExecResponse) -> String {
+        format!("{}\n", serde_json::to_string(response).unwrap())
+    }
+
+    #[test]
+    fn read_exec_responses_returns_exit_code() {
+        let mut input = String::new();
+        input.push_str(&response_line(&ExecResponse::Stdout("hello\n".into())));
+        input.push_str(&response_line(&ExecResponse::Stderr("warning\n".into())));
+        input.push_str(&response_line(&ExecResponse::Exit(7)));
+
+        let mut stdout = String::new();
+        let mut stderr = String::new();
+        let code = read_exec_responses(
+            input.as_bytes(),
+            |d| stdout.push_str(d),
+            |d| stderr.push_str(d),
+        )
+        .unwrap();
+
+        assert_eq!(code, 7);
+        assert_eq!(stdout, "hello\n");
+        assert_eq!(stderr, "warning\n");
+    }
+
+    #[test]
+    fn read_exec_responses_error_message_yields_exit_one() {
+        let input = response_line(&ExecResponse::Error("spawn failed".into()));
+
+        let mut stderr = String::new();
+        let code = read_exec_responses(input.as_bytes(), |_| {}, |d| stderr.push_str(d)).unwrap();
+
+        assert_eq!(code, 1);
+        assert_eq!(stderr, "Error: spawn failed\n");
+    }
+
+    #[test]
+    fn read_exec_responses_eof_without_exit_is_an_error() {
+        // Connection dropped after some output but before the Exit message:
+        // the command's outcome is unknown, so this must not report success.
+        let input = response_line(&ExecResponse::Stdout("partial output\n".into()));
+
+        let err = read_exec_responses(input.as_bytes(), |_| {}, |_| {}).unwrap_err();
+        assert!(
+            err.to_string().contains("before an exit status"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn read_exec_responses_truncated_final_line_is_an_error() {
+        // A connection drop mid-message leaves a partial JSON line and no Exit.
+        let mut input = response_line(&ExecResponse::Stdout("ok\n".into()));
+        input.push_str("{\"type\":\"exit\",\"da");
+
+        let err = read_exec_responses(input.as_bytes(), |_| {}, |_| {}).unwrap_err();
+        assert!(
+            err.to_string().contains("before an exit status"),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -932,8 +932,8 @@ async fn ws_terminal(
 }
 
 async fn ws_terminal_handler(mut ws: axum::extract::ws::WebSocket, vsock_path: std::path::PathBuf) {
-    use axum::extract::ws::Message as WsMessage;
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use axum::extract::ws::{CloseFrame, Message as WsMessage};
+    use tokio::io::AsyncWriteExt;
 
     // Connect to exec server
     let stream = match crate::commands::exec::connect_to_exec_server_async(&vsock_path).await {
@@ -941,7 +941,7 @@ async fn ws_terminal_handler(mut ws: axum::extract::ws::WebSocket, vsock_path: s
         Err(e) => {
             error!(error = %e, "Failed to connect to exec server for terminal");
             let _ = ws
-                .send(WsMessage::Close(Some(axum::extract::ws::CloseFrame {
+                .send(WsMessage::Close(Some(CloseFrame {
                     code: 1011,
                     reason: format!("Failed to connect: {}", e).into(),
                 })))
@@ -977,20 +977,32 @@ async fn ws_terminal_handler(mut ws: axum::extract::ws::WebSocket, vsock_path: s
 
     // Bridge WS ↔ vsock
     // Use a channel for vsock→WS since we can't hold &mut to both ws and vsock in select!
-    let (vsock_tx, mut vsock_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(32);
+    //
+    // The guest speaks the framed exec protocol (see exec-proto): terminal output
+    // arrives as Data frames and the session ends with an Exit (or Error) frame.
+    // Decode frames here and forward only payload bytes to the WebSocket client,
+    // so frame headers and control messages never reach the terminal stream.
+    let (vsock_tx, mut vsock_rx) = tokio::sync::mpsc::channel::<exec_proto::Message>(32);
 
-    // Spawn task to read from vsock and send to channel
+    // Spawn task to decode exec-proto frames from the vsock and send them to the channel
     let reader_task = tokio::spawn(async move {
-        let mut buf = vec![0u8; 8192];
         loop {
-            match vsock_read.read(&mut buf).await {
-                Ok(0) => break,
-                Ok(n) => {
-                    if vsock_tx.send(buf[..n].to_vec()).await.is_err() {
+            match exec_proto::Message::read_from_async(&mut vsock_read).await {
+                Ok(msg) => {
+                    let session_ended = matches!(
+                        msg,
+                        exec_proto::Message::Exit(_) | exec_proto::Message::Error(_)
+                    );
+                    if vsock_tx.send(msg).await.is_err() || session_ended {
                         break;
                     }
                 }
-                Err(_) => break,
+                Err(e) => {
+                    if e.kind() != std::io::ErrorKind::UnexpectedEof {
+                        warn!(error = %e, "terminal vsock protocol error");
+                    }
+                    break;
+                }
             }
         }
     });
@@ -998,9 +1010,43 @@ async fn ws_terminal_handler(mut ws: axum::extract::ws::WebSocket, vsock_path: s
     // Main loop: read from WS and from vsock channel
     loop {
         tokio::select! {
-            Some(data) = vsock_rx.recv() => {
-                if ws.send(WsMessage::Binary(data.into())).await.is_err() {
-                    break;
+            msg = vsock_rx.recv() => {
+                match msg {
+                    Some(exec_proto::Message::Data(data)) => {
+                        if ws.send(WsMessage::Binary(data.into())).await.is_err() {
+                            break;
+                        }
+                    }
+                    Some(exec_proto::Message::Exit(code)) => {
+                        let _ = ws
+                            .send(WsMessage::Close(Some(CloseFrame {
+                                code: 1000,
+                                reason: format!("exit code {}", code).into(),
+                            })))
+                            .await;
+                        break;
+                    }
+                    Some(exec_proto::Message::Error(msg)) => {
+                        let _ = ws
+                            .send(WsMessage::Close(Some(CloseFrame {
+                                code: 1011,
+                                reason: format!("terminal error: {}", msg).into(),
+                            })))
+                            .await;
+                        break;
+                    }
+                    // The guest never sends Stdin frames; ignore if one arrives
+                    Some(exec_proto::Message::Stdin(_)) => {}
+                    // vsock closed without an Exit frame
+                    None => {
+                        let _ = ws
+                            .send(WsMessage::Close(Some(CloseFrame {
+                                code: 1011,
+                                reason: "terminal closed before exit status".to_string().into(),
+                            })))
+                            .await;
+                        break;
+                    }
                 }
             }
             result = ws.recv() => {


### PR DESCRIPTION
Exec/serve fixes from review:

- Non-TTY exec no longer reports exit code 0 when the connection drops
  before an Exit message arrives. The shared response reader returns an
  error on EOF-without-exit (and maps protocol Error messages to exit 1),
  so `fcvm exec`, the serve API, and `snapshot run --exec` propagate real
  failures instead of success.
- The serve WebSocket terminal decodes exec-proto frames (new async frame
  reader in exec-proto) and forwards only payload bytes, closing the
  socket with the exit status instead of dumping frame headers into the
  terminal stream.
- run_exec_in_vm wraps its blocking connect/read loop in spawn_blocking
  instead of blocking the async runtime for up to an hour.

Tested: cargo fmt and clippy clean; make test-unit passes (includes new
unit tests for the exec response reader and the async exec-proto frame
reader). Exec end-to-end coverage runs in the Host-Root CI jobs.
