### PR TITLE
fix: stop splitting flag values on commas and surface Firecracker launch failures

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -138,8 +138,8 @@ pub struct RunArgs {
     #[arg(long, default_value = "10G")]
     pub rootfs_size: String,
 
-    /// Volume mapping(s): HOST:GUEST[:ro] (repeat or comma-separated)
-    #[arg(long, action = clap::ArgAction::Append, value_delimiter=',')]
+    /// Volume mapping(s): HOST:GUEST[:ro] (repeat for multiple)
+    #[arg(long, action = clap::ArgAction::Append)]
     pub map: Vec<String>,
 
     /// Use portable inode numbering for FUSE volumes.
@@ -148,35 +148,35 @@ pub struct RunArgs {
     #[arg(long)]
     pub portable_volumes: bool,
 
-    /// Extra disk(s): HOST_PATH:GUEST_MOUNT[:ro] (repeat or comma-separated)
+    /// Extra disk(s): HOST_PATH:GUEST_MOUNT[:ro] (repeat for multiple)
     /// Disks appear as /dev/vdb, /dev/vdc, etc. in order specified.
     /// Mounted at GUEST_MOUNT in both VM and container.
     /// Read-only disks (:ro) can be used with snapshots/clones.
     /// Read-write disks block snapshot/clone operations.
     /// Example: --disk /data.raw:/data --disk /scratch.raw:/scratch:ro
-    #[arg(long, action = clap::ArgAction::Append, value_delimiter=',')]
+    #[arg(long, action = clap::ArgAction::Append)]
     pub disk: Vec<String>,
 
     /// Create disk image from directory: HOST_DIR:GUEST_MOUNT[:ro]
     /// Creates an ext4 image from HOST_DIR contents and mounts at GUEST_MOUNT.
     /// Image is stored in VM's data directory and cleaned up on exit.
     /// Example: --disk-dir ./mydata:/data:ro
-    #[arg(long, action = clap::ArgAction::Append, value_delimiter=',')]
+    #[arg(long, action = clap::ArgAction::Append)]
     pub disk_dir: Vec<String>,
 
     /// Share directory via NFS: HOST_DIR:GUEST_MOUNT[:ro]
     /// Starts NFS server on host, VM mounts via network.
     /// Requires NFS kernel support (use --kernel-profile nested or --build-kernels).
     /// Example: --nfs /data:/mnt/data:ro
-    #[arg(long, action = clap::ArgAction::Append, value_delimiter=',')]
+    #[arg(long, action = clap::ArgAction::Append)]
     pub nfs: Vec<String>,
 
-    /// Environment vars KEY=VALUE (repeat or comma-separated)
-    #[arg(long, action = clap::ArgAction::Append, value_delimiter=',')]
+    /// Environment vars KEY=VALUE (repeat for multiple; values may contain commas)
+    #[arg(long, action = clap::ArgAction::Append)]
     pub env: Vec<String>,
 
-    /// Labels KEY=VALUE for tagging VMs (repeat or comma-separated)
-    #[arg(long, action = clap::ArgAction::Append, value_delimiter=',')]
+    /// Labels KEY=VALUE for tagging VMs (repeat for multiple)
+    #[arg(long, action = clap::ArgAction::Append)]
     pub label: Vec<String>,
 
     /// Command to run inside container
@@ -612,5 +612,62 @@ fn parse_cpu(s: &str) -> Result<u8, String> {
                 s
             )
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    /// Parse a `fcvm podman run` command line and return the RunArgs.
+    fn parse_run(extra: &[&str]) -> RunArgs {
+        let mut argv = vec!["fcvm", "podman", "run", "--name", "test"];
+        argv.extend_from_slice(extra);
+        let cli = Cli::try_parse_from(argv).expect("CLI should parse");
+        match cli.cmd {
+            Commands::Podman(podman) => match podman.cmd {
+                PodmanCommands::Run(run) => run,
+            },
+            _ => panic!("expected `podman run` command"),
+        }
+    }
+
+    #[test]
+    fn env_value_with_comma_is_not_split() {
+        let run = parse_run(&["--env", "FLAGS=a,b", "nginx:alpine"]);
+        assert_eq!(run.env, vec!["FLAGS=a,b"]);
+    }
+
+    #[test]
+    fn repeated_env_flags_append() {
+        let run = parse_run(&["--env", "A=1", "--env", "B=2", "nginx:alpine"]);
+        assert_eq!(run.env, vec!["A=1", "B=2"]);
+    }
+
+    #[test]
+    fn label_and_map_values_with_commas_are_not_split() {
+        let run = parse_run(&[
+            "--label",
+            "notes=a,b",
+            "--map",
+            "/host/dir,with-comma:/guest",
+            "nginx:alpine",
+        ]);
+        assert_eq!(run.label, vec!["notes=a,b"]);
+        assert_eq!(run.map, vec!["/host/dir,with-comma:/guest"]);
+    }
+
+    #[test]
+    fn publish_and_forward_localhost_split_on_commas() {
+        let run = parse_run(&[
+            "--publish",
+            "8080:80,8443:443",
+            "--forward-localhost",
+            "1421,9099",
+            "nginx:alpine",
+        ]);
+        assert_eq!(run.publish, vec!["8080:80", "8443:443"]);
+        assert_eq!(run.forward_localhost, vec![1421u16, 9099]);
     }
 }

--- a/src/firecracker/vm.rs
+++ b/src/firecracker/vm.rs
@@ -1,5 +1,7 @@
 use anyhow::{anyhow, bail, Context, Result};
+use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
@@ -13,6 +15,12 @@ use super::FirecrackerClient;
 /// Socket/device wait timeout (total wait time = RETRY_COUNT * RETRY_DELAY)
 const SOCKET_WAIT_RETRY_COUNT: u32 = 500;
 const SOCKET_WAIT_RETRY_DELAY: Duration = Duration::from_millis(10);
+
+/// Number of recent Firecracker stderr lines kept for error reporting.
+const STDERR_TAIL_LINES: usize = 10;
+/// How long to let the async stderr reader drain the pipe after Firecracker
+/// exits, so the failure error can include what it actually printed.
+const STDERR_DRAIN_DELAY: Duration = Duration::from_millis(200);
 
 /// Manages a Firecracker VM process
 ///
@@ -41,6 +49,7 @@ pub struct VmManager {
     net_namespace_path: Option<PathBuf>, // Net namespace path for rootless clones (enter via setns in pre_exec)
     mount_redirects: Option<(Vec<PathBuf>, PathBuf)>, // (baseline_dirs, clone_dir) for mount namespace isolation
     process: Option<Child>,
+    stderr_tail: Arc<Mutex<VecDeque<String>>>, // last few Firecracker stderr lines, for launch failure errors
     client: Option<FirecrackerClient>,
 }
 
@@ -57,6 +66,7 @@ impl VmManager {
             net_namespace_path: None,
             mount_redirects: None,
             process: None,
+            stderr_tail: Arc::new(Mutex::new(VecDeque::new())),
             client: None,
         }
     }
@@ -452,11 +462,21 @@ impl VmManager {
         }
 
         // Spawn process with streaming output
-        let child = spawn_streaming(cmd, |line, is_stderr| {
+        let stderr_tail = Arc::clone(&self.stderr_tail);
+        let child = spawn_streaming(cmd, move |line, is_stderr| {
             let clean = strip_firecracker_prefix(line);
             // fc-agent and container output at INFO/WARN, everything else at DEBUG
             let is_important = clean.contains("fc-agent") || clean.contains("[ctr:");
             if is_stderr {
+                // Keep the last few stderr lines so launch failures can report
+                // what Firecracker actually printed (its errors only appear at
+                // DEBUG level in the normal log stream).
+                if let Ok(mut tail) = stderr_tail.lock() {
+                    if tail.len() >= STDERR_TAIL_LINES {
+                        tail.pop_front();
+                    }
+                    tail.push_back(clean.to_string());
+                }
                 if is_important {
                     warn!(target: "firecracker", "{}", clean);
                 } else {
@@ -482,13 +502,29 @@ impl VmManager {
     }
 
     /// Wait for Firecracker socket to be ready
-    async fn wait_for_socket(&self) -> Result<()> {
+    ///
+    /// Also polls the Firecracker child process: if it exits before the API
+    /// socket appears, fail immediately with its exit status and recent stderr
+    /// output instead of timing out with a generic socket error.
+    async fn wait_for_socket(&mut self) -> Result<()> {
         use tokio::time::sleep;
 
         for _ in 0..SOCKET_WAIT_RETRY_COUNT {
             if self.socket_path.exists() {
                 return Ok(());
             }
+
+            if let Some(status) = self.try_wait()? {
+                // Give the async stderr reader a moment to drain the pipe so
+                // the error includes what Firecracker actually printed.
+                sleep(STDERR_DRAIN_DELAY).await;
+                bail!(
+                    "Firecracker exited with {} before its API socket became ready{}",
+                    status,
+                    self.stderr_tail_message()
+                );
+            }
+
             sleep(SOCKET_WAIT_RETRY_DELAY).await;
         }
 
@@ -498,6 +534,21 @@ impl VmManager {
             "Firecracker socket not ready after {} seconds",
             timeout_secs
         )
+    }
+
+    /// Render the captured Firecracker stderr tail for error messages.
+    fn stderr_tail_message(&self) -> String {
+        let lines: Vec<String> = self
+            .stderr_tail
+            .lock()
+            .map(|tail| tail.iter().cloned().collect())
+            .unwrap_or_default();
+        if lines.is_empty() {
+            "; no stderr output captured (run with RUST_LOG=debug for full Firecracker output)"
+                .to_string()
+        } else {
+            format!("; last stderr output:\n  {}", lines.join("\n  "))
+        }
     }
 
     /// Get the API client
@@ -615,5 +666,50 @@ impl Drop for VmManager {
         if self.socket_path.exists() {
             let _ = std::fs::remove_file(&self.socket_path);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    /// A Firecracker process that exits before creating its API socket must fail
+    /// `start()` with its exit status and stderr output, not the generic
+    /// "socket not ready after 5 seconds" timeout.
+    #[tokio::test]
+    async fn start_reports_immediate_firecracker_exit() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+
+        let fake_fc = dir.path().join("fake-firecracker.sh");
+        std::fs::write(
+            &fake_fc,
+            "#!/bin/sh\necho 'boom: bad firecracker argument' >&2\nexit 2\n",
+        )
+        .expect("write fake firecracker");
+        std::fs::set_permissions(&fake_fc, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake firecracker");
+
+        let socket_path = dir.path().join("api.sock");
+        let mut vm = VmManager::new("test-vm".to_string(), socket_path, None);
+
+        let err = vm
+            .start(&fake_fc, None, None)
+            .await
+            .expect_err("start should fail when Firecracker exits immediately");
+        let msg = format!("{:#}", err);
+
+        assert!(
+            msg.contains("Firecracker exited with"),
+            "error should report the child exit status, got: {msg}"
+        );
+        assert!(
+            msg.contains("boom: bad firecracker argument"),
+            "error should include Firecracker's stderr output, got: {msg}"
+        );
+        assert!(
+            !msg.contains("socket not ready"),
+            "launch failure must not be reported as a socket timeout, got: {msg}"
+        );
     }
 }

--- a/src/health.rs
+++ b/src/health.rs
@@ -211,29 +211,27 @@ pub fn spawn_health_monitor_with_state_dir(
 }
 
 /// Find the fcvm binary for exec commands.
+///
+/// The health monitor runs inside the fcvm process that manages the VM, so the
+/// running executable is the binary that wrote the state files the exec
+/// subcommand reads. Prefer it over install or build locations to avoid
+/// exec'ing a different (possibly stale) fcvm binary.
 fn find_fcvm_binary() -> Option<std::path::PathBuf> {
-    // Try several possible locations
-    // ./target/release/fcvm first for development/tests where we run from repo root
-    let candidates = [
-        std::path::PathBuf::from("./target/release/fcvm"),
-        std::path::PathBuf::from("/usr/local/bin/fcvm"),
-        std::path::PathBuf::from("/usr/bin/fcvm"),
-    ];
-
-    for path in candidates {
-        if path.exists() {
-            return Some(path);
-        }
-    }
-
-    // Fall back to current exe if it looks like fcvm
     if let Ok(exe) = std::env::current_exe() {
         if exe.file_name().map(|n| n == "fcvm").unwrap_or(false) {
             return Some(exe);
         }
     }
 
-    None
+    // Fallbacks for callers whose current_exe is not fcvm (e.g. test binaries):
+    // repo build output first, then install locations.
+    let candidates = [
+        std::path::PathBuf::from("./target/release/fcvm"),
+        std::path::PathBuf::from("/usr/local/bin/fcvm"),
+        std::path::PathBuf::from("/usr/bin/fcvm"),
+    ];
+
+    candidates.into_iter().find(|path| path.exists())
 }
 
 /// Timeout for exec-based health checks (5 seconds)


### PR DESCRIPTION
CLI and diagnostics fixes from review:

- --env, --label, --map, --disk, --disk-dir, and --nfs no longer split a
  single value on commas, so values like --env FLAGS=a,b are passed
  through intact; repeat the flag for multiple values. --publish and
  --forward-localhost keep their comma-separated port lists.
- wait_for_socket polls the Firecracker child while waiting for the API
  socket and reports the exit status plus recent stderr when it dies at
  launch, instead of a generic five-second socket timeout.
- Health-check exec resolves the running fcvm executable first instead of
  a CWD-relative target/release path, so probes always run the same
  binary that manages the VM.

Tested: cargo fmt and clippy clean; make test-unit passes, including new
parsing tests for the delimiter behavior and a launch-failure test that
runs Firecracker as a stub binary.
