### PR TITLE
ci: fix coverage gaps and stale-state hazards in the workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ on:
   pull_request:
     branches: [main]
     paths-ignore:
-      - 'kernel/**'
       - 'scripts/claude-assistant/**'
       - '.github/workflows/claude*.yml'
       - '.claude/**'
@@ -58,8 +57,6 @@ jobs:
       skip: ${{ steps.check.outputs.skip }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 20
       - name: Check if tree SHA already passed CI
         id: check
         env:
@@ -74,20 +71,24 @@ jobs:
           TREE_SHA=$(git rev-parse HEAD^{tree})
           echo "Current tree SHA: $TREE_SHA"
 
-          # Check recent successful CI runs on PRs for the same tree SHA
-          # Look at the last 20 commits on main to find PR branch tips
+          # GitHub Actions results are check runs, not commit statuses, so the
+          # legacy status API never reports them. Look for a successful run of
+          # this CI workflow on a PR whose head commit has the same tree SHA.
           SKIP=false
-          for sha in $(git log --format=%H -20 HEAD^ 2>/dev/null || true); do
-            COMMIT_TREE=$(git rev-parse "$sha^{tree}" 2>/dev/null || true)
-            if [ "$COMMIT_TREE" = "$TREE_SHA" ] && [ "$sha" != "$(git rev-parse HEAD)" ]; then
-              # Found a commit with the same tree — check if it passed CI
-              STATUS=$(gh api "repos/${{ github.repository }}/commits/$sha/status" --jq '.state' 2>/dev/null || echo "unknown")
-              echo "Commit $sha has same tree SHA, CI status: $STATUS"
-              if [ "$STATUS" = "success" ]; then
-                SKIP=true
-                echo "Tree SHA $TREE_SHA already passed CI on commit $sha"
-                break
-              fi
+          if ! HEAD_SHAS=$(gh run list --repo "${{ github.repository }}" --workflow ci.yml \
+              --event pull_request --status success --limit 30 --json headSha --jq '.[].headSha'); then
+            echo "Could not list workflow runs, running CI"
+            HEAD_SHAS=""
+          fi
+          for sha in $HEAD_SHAS; do
+            if ! COMMIT_TREE=$(gh api "repos/${{ github.repository }}/git/commits/$sha" --jq '.tree.sha'); then
+              echo "Could not look up commit $sha, ignoring it"
+              continue
+            fi
+            if [ "$COMMIT_TREE" = "$TREE_SHA" ]; then
+              SKIP=true
+              echo "Tree SHA $TREE_SHA already passed CI on PR commit $sha"
+              break
             fi
           done
 
@@ -385,21 +386,6 @@ jobs:
       - name: test-fast
         working-directory: fcvm
         run: make test-fast
-      - name: test-serve-sdk
-        working-directory: fcvm
-        run: |
-          # SDK test requires computesdk package (sibling repo)
-          # On CI, check if it's available; on dev machines, always available
-          COMPUTESDK_DIR="${{ github.workspace }}/computesdk"
-          if [ ! -d "$COMPUTESDK_DIR/packages/computesdk" ]; then
-            echo "⚠ Skipping SDK E2E test (computesdk not checked out)"
-            echo "  To run locally: cd tests && npm install && cd .. && npx tsx tests/test_serve_sdk.ts"
-            exit 0
-          fi
-          # Install Node.js if not available
-          which node || { echo "⚠ Skipping SDK test (Node.js not available)"; exit 0; }
-          cd tests && npm install && cd ..
-          npx tsx tests/test_serve_sdk.ts
       - name: Upload test logs
         if: always()
         uses: actions/upload-artifact@v6
@@ -676,8 +662,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/cargo-cache
-          key: container-cargo-${{ hashFiles('fcvm/Cargo.lock') }}
-          restore-keys: container-cargo-
+          key: container-cargo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('fcvm/Cargo.lock') }}
+          restore-keys: container-cargo-${{ runner.os }}-${{ runner.arch }}-
       - name: Create test log directory
         run: sudo rm -rf /tmp/fcvm-test-logs && mkdir -p /tmp/fcvm-test-logs
       - name: Clean test data

--- a/.github/workflows/kernels.yml
+++ b/.github/workflows/kernels.yml
@@ -47,18 +47,26 @@ jobs:
 
       - name: Build fcvm and fc-agent
         working-directory: fcvm
-        run: cargo build --release -p fcvm -p fc-agent
+        run: |
+          cargo build --release -p fcvm -p fc-agent
+          # Sync the checkout's embedded config to the runner user's config dir so the
+          # kernel build below uses this checkout, not stale per-runner state.
+          ./target/release/fcvm setup --generate-config --force
 
       - name: Compute kernel version and SHA
         id: kernel
         working-directory: fcvm
         run: |
-          # Get kernel info from fcvm (reads from rootfs-config.toml)
-          # SHA is computed from build_inputs: kernel/nested.conf + kernel/patches/*.patch
-          SHA=$(cat kernel/nested.conf kernel/patches/*.patch 2>/dev/null | sha256sum | cut -c1-12)
+          # SHA must match fcvm's content-addressed kernel naming:
+          # build_inputs for kernel_profiles.nested.arm64 in rootfs-config.toml
+          SHA=$(cat kernel/nested.conf kernel/patches-arm64/*.patch | sha256sum | cut -c1-12)
 
-          # Version from config
-          VERSION=$(grep 'kernel_version' ~/.config/fcvm/rootfs-config.toml | grep -oE '"[0-9]+\.[0-9]+\.[0-9]+"' | head -1 | tr -d '"' || echo "6.18.3")
+          # Version from the checked-out repo config (the source of truth)
+          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('rootfs-config.toml','rb'))['kernel_profiles']['nested']['arm64']['kernel_version'])")
+          if [ -z "$VERSION" ]; then
+            echo "ERROR: kernel_version not found for kernel_profiles.nested.arm64 in rootfs-config.toml"
+            exit 1
+          fi
 
           ARCH=$(uname -m)
 
@@ -115,16 +123,12 @@ jobs:
           # Build the nested kernel using fcvm
           sudo ./target/release/fcvm setup --kernel-profile nested --build-kernels
 
-          # Find the built kernel and copy to expected location
+          # The built kernel must match the exact version/arch/SHA we publish under
           KERNEL_PATH="/tmp/${{ steps.kernel.outputs.filename }}"
-          SHA="${{ steps.kernel.outputs.sha }}"
-          VERSION="${{ steps.kernel.outputs.version }}"
+          BUILT_KERNEL="/mnt/fcvm-btrfs/kernels/${{ steps.kernel.outputs.filename }}"
 
-          # The kernel is at /mnt/fcvm-btrfs/kernels/vmlinux-nested-{version}-{arch}-{sha}.bin
-          BUILT_KERNEL=$(find /mnt/fcvm-btrfs/kernels -name "vmlinux-nested-*-${SHA}.bin" | head -1)
-
-          if [ -z "$BUILT_KERNEL" ] || [ ! -f "$BUILT_KERNEL" ]; then
-            echo "ERROR: Built kernel not found"
+          if [ ! -f "$BUILT_KERNEL" ]; then
+            echo "ERROR: Built kernel not found at $BUILT_KERNEL"
             ls -la /mnt/fcvm-btrfs/kernels/ || true
             exit 1
           fi
@@ -231,16 +235,27 @@ jobs:
 
       - name: Build fcvm and fc-agent
         working-directory: fcvm
-        run: cargo build --release -p fcvm -p fc-agent
+        run: |
+          cargo build --release -p fcvm -p fc-agent
+          # Sync the checkout's embedded config to the runner user's config dir so the
+          # kernel build below uses this checkout, not stale per-runner state.
+          ./target/release/fcvm setup --generate-config --force
 
       - name: Compute kernel version and SHA
         id: kernel
         working-directory: fcvm
         run: |
-          # SHA is computed from build_inputs: kernel/btrfs.conf only (no patches)
+          # SHA must match fcvm's content-addressed kernel naming:
+          # build_inputs for kernel_profiles.btrfs.arm64 in rootfs-config.toml (no patches)
           SHA=$(cat kernel/btrfs.conf | sha256sum | cut -c1-12)
 
-          VERSION="6.18.3"
+          # Version from the checked-out repo config (the source of truth)
+          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('rootfs-config.toml','rb'))['kernel_profiles']['btrfs']['arm64']['kernel_version'])")
+          if [ -z "$VERSION" ]; then
+            echo "ERROR: kernel_version not found for kernel_profiles.btrfs.arm64 in rootfs-config.toml"
+            exit 1
+          fi
+
           ARCH=$(uname -m)
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -296,15 +311,12 @@ jobs:
           # Build the btrfs kernel using fcvm
           sudo ./target/release/fcvm setup --kernel-profile btrfs --build-kernels
 
-          # Find the built kernel and copy to expected location
+          # The built kernel must match the exact version/arch/SHA we publish under
           KERNEL_PATH="/tmp/${{ steps.kernel.outputs.filename }}"
-          SHA="${{ steps.kernel.outputs.sha }}"
+          BUILT_KERNEL="/mnt/fcvm-btrfs/kernels/${{ steps.kernel.outputs.filename }}"
 
-          # The kernel is at /mnt/fcvm-btrfs/kernels/vmlinux-btrfs-{version}-{arch}-{sha}.bin
-          BUILT_KERNEL=$(find /mnt/fcvm-btrfs/kernels -name "vmlinux-btrfs-*-${SHA}.bin" | head -1)
-
-          if [ -z "$BUILT_KERNEL" ] || [ ! -f "$BUILT_KERNEL" ]; then
-            echo "ERROR: Built kernel not found"
+          if [ ! -f "$BUILT_KERNEL" ]; then
+            echo "ERROR: Built kernel not found at $BUILT_KERNEL"
             ls -la /mnt/fcvm-btrfs/kernels/ || true
             exit 1
           fi

--- a/Makefile
+++ b/Makefile
@@ -70,13 +70,6 @@ else
 IPV6_FILTER :=
 endif
 
-# Disable retries when FILTER is set (debugging specific tests)
-ifdef FILTER
-NEXTEST_RETRIES :=
-else
-NEXTEST_RETRIES := --retries 2
-endif
-
 # Default log level: fcvm debug, suppress FUSE spam
 # Override with: RUST_LOG=debug make test-root
 TEST_LOG ?= fcvm=debug,health-monitor=info,fuser=warn,fuse_backend_rs=warn,passthrough=warn
@@ -321,11 +314,11 @@ _test-unit:
 
 _test-fast:
 	RUST_LOG="$(TEST_LOG)" \
-	./scripts/no-sudo.sh $(NEXTEST) $(NEXTEST_CAPTURE) $(NEXTEST_RETRIES) --no-default-features --features integration-fast $(FILTER)
+	./scripts/no-sudo.sh $(NEXTEST) $(NEXTEST_CAPTURE) --no-default-features --features integration-fast $(FILTER)
 
 _test-all:
 	RUST_LOG="$(TEST_LOG)" \
-	./scripts/no-sudo.sh $(NEXTEST) $(NEXTEST_CAPTURE) $(NEXTEST_RETRIES) $(FILTER)
+	./scripts/no-sudo.sh $(NEXTEST) $(NEXTEST_CAPTURE) $(FILTER)
 
 _test-root:
 	@if find target/ -user root -print -quit 2>/dev/null | grep -q .; then \
@@ -336,7 +329,7 @@ _test-root:
 	FCVM_DATA_DIR=$(ROOT_DATA_DIR) \
 	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
 	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
-	$(NEXTEST) $(NEXTEST_CAPTURE) $(NEXTEST_IGNORED) $(NEXTEST_RETRIES) --features privileged-tests $(IPV6_FILTER) $(FILTER) || \
+	$(NEXTEST) $(NEXTEST_CAPTURE) $(NEXTEST_IGNORED) --features privileged-tests $(IPV6_FILTER) $(FILTER) || \
 	{ echo ""; \
 	  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"; \
 	  echo "TEST FAILED - Check debug logs for root cause:"; \

--- a/scripts/test-packaging-e2e.sh
+++ b/scripts/test-packaging-e2e.sh
@@ -110,8 +110,9 @@ for i in $(seq 1 $TIMEOUT); do
     # Check if VM is healthy via ls command (use jq to parse JSON properly)
     LS_OUTPUT=$(sudo "$FCVM" ls --json 2>/dev/null || echo "[]")
 
-    # Find healthy VM using jq
-    HEALTHY_VM=$(echo "$LS_OUTPUT" | jq -r '.[] | select(.health_status == "healthy") | .pid' 2>/dev/null | head -1)
+    # Find the VM we started (by name) and check it is healthy
+    HEALTHY_VM=$(echo "$LS_OUTPUT" | jq -r --arg name "$VM_NAME" \
+        '.[] | select(.name == $name and .health_status == "healthy") | .pid' | head -1)
 
     if [[ -n "$HEALTHY_VM" ]]; then
         HEALTHY=true
@@ -121,8 +122,9 @@ for i in $(seq 1 $TIMEOUT); do
 
     # Debug: show status every 10 seconds
     if [[ $((i % 10)) -eq 0 ]]; then
-        STATUS=$(echo "$LS_OUTPUT" | jq -r '.[0] | "\(.name): \(.health_status)"' 2>/dev/null || echo "no VMs yet")
-        echo "  [$i s] $STATUS"
+        STATUS=$(echo "$LS_OUTPUT" | jq -r --arg name "$VM_NAME" \
+            '.[] | select(.name == $name) | "\(.name): \(.health_status)"' | head -1)
+        echo "  [$i s] ${STATUS:-$VM_NAME not registered yet}"
     fi
 
     # Check if background process exited (VM failed)
@@ -148,11 +150,15 @@ echo "PASS: VM is healthy (PID: $FCVM_PID)"
 echo ""
 echo "Step 3: Execute command in VM"
 # Run a simple command to verify exec works (use sh -c for portability)
-OUTPUT=$(sudo "$FCVM" exec --pid "$FCVM_PID" -- sh -c "echo hello" 2>/dev/null || true)
+if ! OUTPUT=$(sudo "$FCVM" exec --pid "$FCVM_PID" -- sh -c "echo hello"); then
+    echo "FAIL: Exec command failed"
+    exit 1
+fi
 if [[ "$OUTPUT" == *"hello"* ]]; then
     echo "PASS: Exec works"
 else
-    echo "WARN: Exec output unexpected: $OUTPUT"
+    echo "FAIL: Exec output unexpected: $OUTPUT"
+    exit 1
 fi
 
 echo ""


### PR DESCRIPTION
CI fixes from review:

- Pull requests touching kernel/ now run CI (the paths-ignore skip stays
  for pushes, which defer to the Build Kernels workflow).
- The skip-check job compares tree SHAs against successful Actions runs
  via the Actions API; the previous commit-status query could never match
  a passing run and would have trusted any stray status.
- Removed the test-serve-sdk CI step, which always silently skipped
  because its SDK dependency is never checked out; the Makefile target
  remains for local use.
- Build Kernels reads the kernel version from the checked-out
  rootfs-config.toml (per profile), regenerates the runner config from
  the checkout, looks up the built kernel by exact name, and hashes the
  same patch directory the profile's build_inputs declare, instead of
  trusting stale per-runner config and wildcard lookups.
- Container job cargo caches are keyed by runner arch, packaging E2E
  failures are no longer downgraded to warnings (and the script verifies
  the VM it started rather than any healthy VM), and the default
  --retries 2 for CI test runs is removed so flaky tests fail instead of
  silently passing on retry.

Tested: scripts/test-packaging-e2e.sh passes bash -n and shellcheck (one
pre-existing SC2024 warning); make test-unit passes with the Makefile
change. The workflow edits follow the existing file structure and are
exercised by the CI runs on this PR stack.
