### PR TITLE
fix: harden fc-agent I/O paths (image import deadlock, exit-code delivery, exec/output recovery)

### DIFF
--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -531,6 +531,35 @@ pub async fn import_image(
         .spawn()
         .context("spawning podman load")?;
 
+    // Drain stdout/stderr concurrently while waiting (same pattern as pull_image).
+    // podman load can emit per-layer progress lines; if neither pipe is read until
+    // after exit, the child blocks once the 64KB pipe buffer fills and wait() never
+    // returns — the import hangs forever with only heartbeats.
+    let stdout_task = load_child.stdout.take().map(|stdout| {
+        tokio::spawn(async move {
+            let reader = BufReader::new(stdout);
+            let mut lines = reader.lines();
+            let mut captured = Vec::new();
+            while let Ok(Some(line)) = lines.next_line().await {
+                captured.push(line);
+            }
+            captured
+        })
+    });
+
+    let stderr_task = load_child.stderr.take().map(|stderr| {
+        tokio::spawn(async move {
+            let reader = BufReader::new(stderr);
+            let mut lines = reader.lines();
+            let mut captured = Vec::new();
+            while let Ok(Some(line)) = lines.next_line().await {
+                eprintln!("[fc-agent] [podman] {}", line);
+                captured.push(line);
+            }
+            captured
+        })
+    });
+
     let status = loop {
         tokio::select! {
             result = load_child.wait() => {
@@ -543,25 +572,22 @@ pub async fn import_image(
         }
     };
 
+    let stdout_lines = if let Some(task) = stdout_task {
+        task.await.unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    let stderr_lines = if let Some(task) = stderr_task {
+        task.await.unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
     if !status.success() {
-        let stderr = if let Some(mut se) = load_child.stderr.take() {
-            let mut buf = String::new();
-            let _ = tokio::io::AsyncReadExt::read_to_string(&mut se, &mut buf).await;
-            buf
-        } else {
-            String::new()
-        };
-        anyhow::bail!("podman load failed: {}", stderr);
+        anyhow::bail!("podman load failed: {}", stderr_lines.join("\n"));
     }
 
-    let loaded_output = if let Some(mut so) = load_child.stdout.take() {
-        let mut buf = String::new();
-        let _ = tokio::io::AsyncReadExt::read_to_string(&mut so, &mut buf).await;
-        buf
-    } else {
-        String::new()
-    };
-    eprintln!("[fc-agent] podman load: {}", loaded_output.trim());
+    eprintln!("[fc-agent] podman load: {}", stdout_lines.join(" "));
     eprintln!("[fc-agent] image imported as: {}", image_name);
     Ok(image_name.to_string())
 }

--- a/fc-agent/src/exec.rs
+++ b/fc-agent/src/exec.rs
@@ -56,11 +56,12 @@ pub async fn run_server(
     let _ = ready_tx.send(());
 
     loop {
-        // Check flag before polling — catches notifications lost due to select! races.
-        // When both accept() and notified() are Ready simultaneously, select! picks one
-        // and drops the other. If accept() wins, the Notified future's permit was already
-        // consumed during poll() but the re_register branch never executed. The flag
-        // persists across this race and is checked here on the next iteration.
+        // Single rebind path: the AtomicBool flag is the source of truth, the Notify
+        // below is only a wakeup. When both accept() and notified() are Ready
+        // simultaneously, select! picks one and drops the other — if accept() wins,
+        // the Notified permit may already be consumed, but the flag persists and is
+        // handled here on the next iteration. Performing the rebind only here also
+        // guarantees one rebind request produces exactly one rebind_done notification.
         if rebind_needed.swap(false, Ordering::AcqRel) {
             eprintln!(
                 "[fc-agent] exec server: vsock transport reset (flag), re-registering listener"
@@ -82,18 +83,24 @@ pub async fn run_server(
                 }
             }
             _ = rebind_signal.notified() => {
-                // Clear the flag (we're handling it now).
-                rebind_needed.store(false, Ordering::Release);
-                eprintln!("[fc-agent] exec server: vsock transport reset (notify), re-registering listener");
-                listener = do_re_register(listener).await;
-                rebind_done.store(true, Ordering::Release);
-                rebind_done_notify.notify_one();
+                // Wake-up only — the top-of-loop flag check performs the re-register.
+                // Handling the rebind here as well would double-handle a single request
+                // when accept() readiness raced the notification (the flag check wins,
+                // then the stored permit fires this arm), producing a second
+                // rebind_done notification with no waiter. That stale permit would let
+                // a LATER restore proceed before its listener re-register completed.
             }
         }
     }
 }
 
 /// Re-register or rebind the vsock listener after transport reset.
+///
+/// Does not return until a working listener exists. Failures are not fatal: this runs
+/// in a spawned task, so a panic here would only kill the exec-server task while the
+/// rest of fc-agent kept running with no exec listener at all. Instead, bind failures
+/// are logged loudly (visible on the serial console) and retried with backoff — if the
+/// vsock device recovers, the exec server recovers with it.
 async fn do_re_register(listener: vsock::VsockListener) -> vsock::VsockListener {
     match listener.re_register() {
         Ok(l) => {
@@ -109,7 +116,7 @@ async fn do_re_register(listener: vsock::VsockListener) -> vsock::VsockListener 
                 "[fc-agent] exec server: re-register failed: {}, trying full rebind",
                 e
             );
-            let mut retries = 0;
+            let mut retries: u32 = 0;
             loop {
                 match vsock::VsockListener::bind(vsock::EXEC_PORT) {
                     Ok(l) => {
@@ -121,20 +128,18 @@ async fn do_re_register(listener: vsock::VsockListener) -> vsock::VsockListener 
                     }
                     Err(e2) => {
                         retries += 1;
-                        if retries >= 50 {
+                        // Fast retries for the first ~5s (transient EADDRINUSE while
+                        // pre-snapshot connections drain), then back off to 1s and log
+                        // periodically so a broken vsock device stays visible without
+                        // flooding the console.
+                        let delay_ms = if retries < 50 { 100 } else { 1000 };
+                        if retries <= 50 || retries.is_multiple_of(30) {
                             eprintln!(
-                                "[fc-agent] exec server: re-bind failed after {} retries: {}",
-                                retries, e2
+                                "[fc-agent] ERROR: exec re-bind failed (attempt {}): {}, exec unavailable, retrying in {}ms",
+                                retries, e2, delay_ms
                             );
-                            // Fatal: exec server is unavailable. Panic to make the
-                            // failure visible rather than silently hanging.
-                            panic!("exec server: re-bind failed after 50 retries");
                         }
-                        eprintln!(
-                            "[fc-agent] exec server: re-bind failed: {}, retrying ({}/50)",
-                            e2, retries
-                        );
-                        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                        tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
                     }
                 }
             }
@@ -199,9 +204,14 @@ fn write_line_to_fd(fd: i32, data: &str) {
 
 /// Read the request line synchronously (blocking byte-by-byte read).
 /// Returns (ExecRequest, raw_fd) on success, or None if connection closed or parse error.
+///
+/// The request is accumulated as raw bytes and parsed as UTF-8 JSON. The host
+/// serializes ExecRequest with serde_json::to_string, which emits non-ASCII
+/// characters as raw UTF-8 — decoding byte-by-byte (Latin-1) would silently corrupt
+/// multi-byte arguments and paths.
 fn read_request_line(fd: i32) -> Option<(ExecRequest, i32)> {
     const MAX_EXEC_LINE_LENGTH: usize = 1_048_576;
-    let mut line = String::new();
+    let mut line: Vec<u8> = Vec::new();
     let mut buf = [0u8; 1];
     loop {
         let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, 1) };
@@ -220,10 +230,10 @@ fn read_request_line(fd: i32) -> Option<(ExecRequest, i32)> {
             unsafe { libc::close(fd) };
             return None;
         }
-        line.push(buf[0] as char);
+        line.push(buf[0]);
     }
 
-    let request: ExecRequest = match serde_json::from_str(&line) {
+    let request: ExecRequest = match serde_json::from_slice(&line) {
         Ok(r) => r,
         Err(e) => {
             let response = ExecResponse::Error(format!("Invalid request: {}", e));
@@ -402,4 +412,55 @@ async fn handle_pipe_async(raw_fd: i32, request: &ExecRequest) {
     let conn = async_fd.lock().await;
     write_line_async(&conn, &serde_json::to_string(&response).unwrap()).await;
     // fd closed by OwnedFd drop (inside AsyncFd, inside Mutex, inside Arc)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Send `data` over a socketpair and parse it with read_request_line.
+    fn parse_request(data: &[u8]) -> Option<ExecRequest> {
+        let mut fds = [0i32; 2];
+        let rc = unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) };
+        assert_eq!(rc, 0, "socketpair failed");
+        let (server_fd, client_fd) = (fds[0], fds[1]);
+
+        let written = unsafe { libc::write(client_fd, data.as_ptr().cast(), data.len()) };
+        assert_eq!(written, data.len() as isize, "short write to socketpair");
+
+        // read_request_line closes server_fd on error; on success it returns it open.
+        let request = match read_request_line(server_fd) {
+            Some((request, fd)) => {
+                unsafe { libc::close(fd) };
+                Some(request)
+            }
+            None => None,
+        };
+        unsafe { libc::close(client_fd) };
+        request
+    }
+
+    #[test]
+    fn test_read_request_line_preserves_utf8_args() {
+        // The host serializes ExecRequest with serde_json::to_string, which emits
+        // non-ASCII characters as raw UTF-8 bytes — they must round-trip intact.
+        let json = "{\"command\":[\"touch\",\"/data/héllo wörld.txt\"]}\n";
+        let request = parse_request(json.as_bytes()).expect("request should parse");
+        assert_eq!(request.command, vec!["touch", "/data/héllo wörld.txt"]);
+        assert!(!request.in_container);
+        assert!(!request.tty);
+    }
+
+    #[test]
+    fn test_read_request_line_ascii() {
+        let json = "{\"command\":[\"echo\",\"hello\"],\"in_container\":true}\n";
+        let request = parse_request(json.as_bytes()).expect("request should parse");
+        assert_eq!(request.command, vec!["echo", "hello"]);
+        assert!(request.in_container);
+    }
+
+    #[test]
+    fn test_read_request_line_rejects_invalid_json() {
+        assert!(parse_request(b"not json\n").is_none());
+    }
 }

--- a/fc-agent/src/output.rs
+++ b/fc-agent/src/output.rs
@@ -109,6 +109,12 @@ async fn try_reconnect() -> Option<VsockStream> {
 /// The host gates health monitoring on the output connection (snapshot.rs),
 /// so auto-reconnecting before handle_clone_restore finishes ARP/exec setup
 /// causes pasta port forwarding failures in clones.
+///
+/// Once an explicit reconnect HAS been requested, the writer keeps retrying
+/// until it succeeds (like initial startup). The request arrives at most once
+/// per restore epoch — giving up after one ~3s try_reconnect() round would
+/// leave output dead for the VM's lifetime and eventually wedge the container
+/// on a full output channel.
 async fn output_writer(
     mut rx: mpsc::Receiver<OutputMessage>,
     reconnect_signal: Arc<Notify>,
@@ -147,6 +153,14 @@ async fn output_writer(
             stream = try_reconnect().await;
             if stream.is_some() {
                 ever_connected = true;
+            } else {
+                // The explicit reconnect request failed (host listener unreachable
+                // for ~3s). Re-arm the flag and keep retrying — the request comes
+                // at most once per restore epoch, so giving up here would leave
+                // output dead for the VM's lifetime.
+                eprintln!("[fc-agent] output vsock reconnect failed, retrying");
+                reconnect_flag.store(true, std::sync::atomic::Ordering::Release);
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
             }
             continue;
         }
@@ -217,12 +231,11 @@ async fn output_writer(
             // Don't auto-reconnect: the host gates health monitoring on the
             // output connection, so reconnecting before ARP/exec setup
             // completes causes pasta port forwarding failures in clones.
+            // The top-of-loop flag check performs the actual reconnect (and
+            // keeps retrying on failure) — this branch only waits for the wakeup.
             tokio::select! {
                 _ = reconnect_signal.notified() => {}
                 _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {}
-            }
-            if reconnect_flag.swap(false, std::sync::atomic::Ordering::AcqRel) {
-                stream = try_reconnect().await;
             }
         } else {
             // Never connected — initial startup. Auto-reconnect with backoff.

--- a/fc-agent/src/restore.rs
+++ b/fc-agent/src/restore.rs
@@ -101,16 +101,26 @@ pub async fn handle_clone_restore(
 
     // SECOND: Wait for exec server to confirm re-register completed.
     // This ensures accept() works before the host can reach the exec server.
-    match tokio::time::timeout(
-        std::time::Duration::from_secs(5),
-        signals.exec_rebind_done_notify.notified(),
-    )
-    .await
-    {
-        Ok(()) => {
-            eprintln!("[fc-agent] exec re-registered after restore")
+    // Wait on the AtomicBool (the source of truth) and use the Notify only as a
+    // wakeup: a stale stored permit (e.g. left over from a previous restore whose
+    // wait timed out before the rebind finished) must not let this restore proceed
+    // before its own re-register has completed. The flag was reset above, so it only
+    // reads true once the exec server has re-registered for THIS restore.
+    let rebind_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if signals.exec_rebind_done.load(Ordering::Acquire) {
+            eprintln!("[fc-agent] exec re-registered after restore");
+            break;
         }
-        Err(_) => eprintln!("[fc-agent] WARNING: exec re-register timed out (5s)"),
+        if tokio::time::Instant::now() >= rebind_deadline {
+            eprintln!("[fc-agent] WARNING: exec re-register timed out (5s)");
+            break;
+        }
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            signals.exec_rebind_done_notify.notified(),
+        )
+        .await;
     }
 
     // THIRD: Wait for egress proxy to reconnect (watch channel incremented after vsock connect).

--- a/fc-agent/src/vsock.rs
+++ b/fc-agent/src/vsock.rs
@@ -313,16 +313,36 @@ pub fn send_status(message: &[u8]) -> bool {
 }
 
 /// Notify host of container exit status.
+///
+/// The exit message is the host's only signal of how the container finished — if it
+/// is lost, the host treats a missing exit code as success. Retry a bounded number of
+/// times (each attempt is a fresh connection) so a transient vsock failure right
+/// before shutdown doesn't silently drop a non-zero exit code.
 pub fn notify_container_exit(exit_code: i32) {
+    const MAX_ATTEMPTS: u32 = 5;
+    const RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(200);
+
     let msg = format!("exit:{}\n", exit_code);
-    if send_status(msg.as_bytes()) {
-        eprintln!(
-            "[fc-agent] notified host of exit code {} via vsock",
-            exit_code
-        );
-    } else {
-        eprintln!("[fc-agent] WARNING: failed to send exit status to host");
+    for attempt in 1..=MAX_ATTEMPTS {
+        if send_status(msg.as_bytes()) {
+            eprintln!(
+                "[fc-agent] notified host of exit code {} via vsock",
+                exit_code
+            );
+            return;
+        }
+        if attempt < MAX_ATTEMPTS {
+            eprintln!(
+                "[fc-agent] WARNING: failed to send exit status to host (attempt {}/{}), retrying",
+                attempt, MAX_ATTEMPTS
+            );
+            std::thread::sleep(RETRY_DELAY);
+        }
     }
+    eprintln!(
+        "[fc-agent] WARNING: failed to send exit status to host after {} attempts",
+        MAX_ATTEMPTS
+    );
 }
 
 /// Notify host that the container has started.


### PR DESCRIPTION
Guest-agent fixes from review:

- podman load output is drained by reader tasks while the import runs,
  so a verbose load can no longer fill the pipe buffer and hang the
  import forever behind heartbeat messages.
- The container exit notification retries (fresh vsock connection per
  attempt) instead of a single best-effort send, so a transient vsock
  hiccup at shutdown no longer silently drops a non-zero exit code.
- Exec rebind handling after snapshot restore can no longer consume a
  stale completion permit from a previous restore, the rebind failure
  path retries with backoff instead of panicking the exec task, and exec
  request lines are decoded as UTF-8 so non-ASCII arguments survive.
- The output writer keeps retrying its post-restore reconnect instead of
  giving up after ~3 seconds and never delivering container output.

Tested: cargo fmt and clippy clean; make test-unit passes (includes new
exec request decoding tests). Restore and exit-code propagation paths are
exercised by the snapshot-clone and sanity end-to-end suites in CI.
