### PR TITLE
fix: stop bridged/NAT cleanup from racing parallel VMs and bound egress proxy buffering

### DIFF
--- a/src/network/bridged.rs
+++ b/src/network/bridged.rs
@@ -144,6 +144,18 @@ impl NetworkManager for BridgedNetwork {
         id_for_subnet.hash(&mut hasher);
         let mut subnet_id = (hasher.finish() % 16384) as u16;
 
+        // Serialize subnet selection through host-IP assignment across fcvm processes.
+        // is_ip_in_use_on_veth() only sees IPs already assigned to veth interfaces, and
+        // the chosen IP is not assigned until setup_host_veth() in step 3 below. Without
+        // a cross-process lock, two concurrently starting VMs could both pass the check
+        // for the same subnet (check-then-act race) and end up with duplicate host IPs
+        // and ambiguous DNAT/return routing. Same pattern as loopback-ip.lock.
+        // Lock ordering: this lock may be held while portmap takes bridged-nat.lock
+        // (cleanup() on the error paths below); the reverse never happens.
+        let subnet_lock = super::acquire_host_network_lock("bridged-subnet.lock")
+            .await
+            .context("acquiring bridged subnet allocation lock")?;
+
         // Check for subnet collisions with live VMs and retry with incremented ID
         let subnet_id = {
             let mut attempts = 0u32;
@@ -268,6 +280,10 @@ impl NetworkManager for BridgedNetwork {
             let _ = self.cleanup().await;
             return Err(e).context("configuring host veth");
         }
+
+        // Host IP is now assigned to the veth, so other processes' collision checks
+        // can see it. The remaining steps don't touch subnet allocation state.
+        drop(subnet_lock);
 
         // Step 4: Create TAP device inside namespace
         if let Err(e) = veth::create_tap_in_ns(&namespace_id, &self.tap_device).await {
@@ -433,10 +449,13 @@ impl NetworkManager for BridgedNetwork {
             }
         }
 
-        // Step 2: Delete host route to guest IP (for clones)
+        // Step 2: Delete host route to guest IP (for clones).
+        // All clones of a snapshot share the same guest IP and the {guest_ip}/32 route
+        // points at whichever clone last set it up. Only delete the route this clone
+        // owns (via its veth_inner_ip) so a surviving clone keeps host -> guest access.
         if self.is_clone {
-            if let Some(ref guest_ip) = self.guest_ip {
-                if let Err(e) = veth::delete_host_route_to_guest(guest_ip).await {
+            if let (Some(guest_ip), Some(veth_inner_ip)) = (&self.guest_ip, &self.veth_inner_ip) {
+                if let Err(e) = veth::delete_host_route_to_guest(guest_ip, veth_inner_ip).await {
                     warn!(vm_id = %self.vm_id, error = %e, "failed to delete host route");
                     errors.push(format!("host route: {}", e));
                 }

--- a/src/network/egress_proxy.rs
+++ b/src/network/egress_proxy.rs
@@ -11,9 +11,18 @@
 //!
 //! Runs OUTSIDE the network namespace, so it has direct internet access.
 //!
-//! Backpressure: The writer channel is bounded. When the vsock is congested,
-//! send_frame().await blocks, which blocks the TCP read loop, which triggers
-//! TCP flow control back to the source. This prevents unbounded memory growth.
+//! Backpressure (both directions are bounded — no unbounded buffering):
+//! - destination → guest: the writer channel is bounded. When the vsock is
+//!   congested, send_frame().await blocks, which blocks the TCP read loop,
+//!   which triggers TCP flow control back to the destination.
+//! - guest → destination: each per-stream channel is bounded. When a stream's
+//!   destination is slower than the guest, the channel fills and the vsock read
+//!   loop blocks on send().await. The resulting vsock backpressure reaches the
+//!   guest's bounded writer channel, which stops reading the guest application's
+//!   socket (TCP flow control), so the guest is throttled to the destination's
+//!   rate instead of the upload accumulating in host memory. The trade-off is
+//!   that a stalled destination also stalls the other streams of the session
+//!   until the queue drains; memory stays bounded either way.
 
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -38,6 +47,12 @@ const MAX_DATA_PAYLOAD: usize = 32 * 1024;
 /// Provides enough burst capacity while preventing unbounded memory growth.
 const WRITER_CHANNEL_CAPACITY: usize = 1024;
 
+/// Per-stream channel capacity (guest → destination direction).
+/// At 32KB per DATA frame, 256 slots = max 8MB buffered per stream — comparable
+/// to a kernel TCP socket buffer. When full, the mux reader stops reading the
+/// vsock, propagating backpressure to the guest instead of buffering the upload.
+const STREAM_CHANNEL_CAPACITY: usize = 256;
+
 /// Max frame payload we'll accept. Anything larger is a protocol error
 /// (prevents OOM from malformed frames claiming enormous payloads).
 const MAX_FRAME_PAYLOAD: usize = MAX_DATA_PAYLOAD + 1024;
@@ -55,8 +70,11 @@ const AF_INET: u8 = 0x04;
 const AF_INET6: u8 = 0x06;
 
 /// Per-stream channel sender for routing incoming frames.
-/// Unbounded because the vsock reader must never block (would cause HOL blocking).
-type StreamSender = mpsc::UnboundedSender<(u8, Vec<u8>)>;
+/// Bounded so a guest uploading to a slow or stalled destination cannot grow
+/// fcvm's heap without limit: when a stream's queue is full the mux reader
+/// awaits the send, and the resulting vsock backpressure throttles the guest
+/// via its bounded writer channel and TCP flow control.
+type StreamSender = mpsc::Sender<(u8, Vec<u8>)>;
 
 /// Run the host-side egress proxy.
 ///
@@ -190,8 +208,8 @@ async fn handle_mux_session(vsock_stream: UnixStream) -> Result<()> {
                     }
                 };
 
-                // Create per-stream channel
-                let (stream_tx, stream_rx) = mpsc::unbounded_channel();
+                // Create per-stream channel (bounded — see STREAM_CHANNEL_CAPACITY)
+                let (stream_tx, stream_rx) = mpsc::channel(STREAM_CHANNEL_CAPACITY);
                 streams.insert(stream_id, stream_tx);
 
                 // Spawn handler for this stream
@@ -201,12 +219,17 @@ async fn handle_mux_session(vsock_stream: UnixStream) -> Result<()> {
                 });
             }
             FRAME_DATA | FRAME_CLOSE | FRAME_RST => {
-                if let Some(sender) = streams.get(&stream_id) {
-                    if sender.send((frame_type, payload)).is_err() {
-                        streams.remove(&stream_id);
-                    }
-                }
-                if frame_type == FRAME_CLOSE || frame_type == FRAME_RST {
+                // Bounded send: when this stream's queue is full (its destination is
+                // slower than the guest), awaiting here pauses the vsock read loop.
+                // The vsock backpressure propagates to the guest's bounded writer
+                // channel and from there to the guest application via TCP flow
+                // control, so guest → destination data is never buffered beyond
+                // STREAM_CHANNEL_CAPACITY frames per stream.
+                let send_failed = match streams.get(&stream_id) {
+                    Some(sender) => sender.send((frame_type, payload)).await.is_err(),
+                    None => false,
+                };
+                if send_failed || frame_type == FRAME_CLOSE || frame_type == FRAME_RST {
                     streams.remove(&stream_id);
                 }
             }
@@ -226,7 +249,7 @@ async fn handle_stream(
     stream_id: u32,
     dest_ip: IpAddr,
     dest_port: u16,
-    mut stream_rx: mpsc::UnboundedReceiver<(u8, Vec<u8>)>,
+    mut stream_rx: mpsc::Receiver<(u8, Vec<u8>)>,
     writer_tx: mpsc::Sender<Vec<u8>>,
 ) {
     // Connect to real destination (works for both IPv4 and IPv6)

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -13,8 +13,55 @@ pub use pasta::PastaNetwork;
 pub use routed::RoutedNetwork;
 pub use types::*;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::net::IpAddr;
+
+/// Acquire a cross-process lock serializing host-global bridged network configuration.
+///
+/// Bridged networking mutates state shared by every fcvm process on the host
+/// (veth host IPs, global MASQUERADE rules). The check-then-act sequences on that
+/// state must hold one of these locks so two fcvm processes cannot interleave.
+///
+/// Lock files live in the state directory, following the same flock pattern as
+/// `loopback-ip.lock` (world-writable so root and non-root processes can coordinate,
+/// never deleted to avoid the recreate-while-locked race).
+///
+/// Lock ordering: `bridged-subnet.lock` may be held while `bridged-nat.lock` is
+/// acquired (setup error paths that call cleanup()); the reverse never happens.
+pub(crate) async fn acquire_host_network_lock(
+    name: &str,
+) -> Result<nix::fcntl::Flock<std::fs::File>> {
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+    let dir = crate::paths::state_dir();
+    tokio::fs::create_dir_all(&dir)
+        .await
+        .with_context(|| format!("creating state directory {}", dir.display()))?;
+    let path = dir.join(name);
+
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .mode(0o666)
+        .open(&path)
+        .with_context(|| format!("opening lock file {}", path.display()))?;
+    // Force permissions regardless of umask (only effective if we own the file or are root)
+    let _ = file.set_permissions(std::fs::Permissions::from_mode(0o666));
+
+    // Acquire in spawn_blocking: flock blocks until the lock is free, and these
+    // critical sections span multiple subprocess invocations, so don't pin a
+    // tokio worker thread while waiting.
+    let lock_name = name.to_string();
+    tokio::task::spawn_blocking(move || {
+        use nix::fcntl::{Flock, FlockArg};
+        Flock::lock(file, FlockArg::LockExclusive)
+            .map_err(|(_, err)| anyhow::anyhow!("flock failed: {}", err))
+    })
+    .await
+    .context("joining lock acquisition task")?
+    .with_context(|| format!("acquiring host network lock {}", lock_name))
+}
 
 /// Network manager trait
 #[async_trait::async_trait]

--- a/src/network/portmap.rs
+++ b/src/network/portmap.rs
@@ -229,12 +229,25 @@ pub async fn cleanup_port_mappings(rules: &[String]) -> Result<()> {
     Ok(())
 }
 
+/// Comment used to tag iptables rules that fcvm added.
+///
+/// `cleanup_global_nat_if_unused()` only deletes rules carrying this comment, so
+/// fcvm never removes NAT configuration an admin or another tool put in place.
+const FCVM_RULE_COMMENT: &str = "fcvm-bridged";
+
 /// Ensures global NAT is enabled for VM traffic
 ///
 /// Sets up:
 /// 1. Verifies IP forwarding is enabled (errors if not — admin must configure)
 /// 2. Enables per-interface forwarding on the outbound interface
-/// 3. MASQUERADE rule for outbound traffic from VM subnet
+/// 3. MASQUERADE rule for outbound traffic from VM subnet (tagged with an
+///    fcvm comment so cleanup only ever removes rules fcvm created)
+///
+/// The check-then-add of the MASQUERADE rule runs under the host-level
+/// `bridged-nat.lock`, serializing it against `cleanup_global_nat_if_unused()`
+/// in other fcvm processes. Without the lock, a stopping VM that has already
+/// listed interfaces (and saw no veths) could delete the rule right after this
+/// check sees it, leaving this VM without outbound NAT.
 ///
 /// This should be called once during fcvm initialization, not per-VM.
 pub async fn ensure_global_nat(vm_subnet: &str, outbound_iface: &str) -> Result<()> {
@@ -277,7 +290,13 @@ pub async fn ensure_global_nat(vm_subnet: &str, outbound_iface: &str) -> Result<
         );
     }
 
-    // Check if MASQUERADE rule already exists
+    // Serialize the check-then-add against cleanup_global_nat_if_unused() running
+    // in a concurrently stopping fcvm process.
+    let _nat_lock = super::acquire_host_network_lock("bridged-nat.lock")
+        .await
+        .context("acquiring bridged NAT lock")?;
+
+    // Check if the fcvm-tagged MASQUERADE rule already exists
     let output = Command::new("iptables")
         .args([
             "-t",
@@ -288,6 +307,10 @@ pub async fn ensure_global_nat(vm_subnet: &str, outbound_iface: &str) -> Result<
             vm_subnet,
             "-o",
             outbound_iface,
+            "-m",
+            "comment",
+            "--comment",
+            FCVM_RULE_COMMENT,
             "-j",
             "MASQUERADE",
         ])
@@ -311,6 +334,10 @@ pub async fn ensure_global_nat(vm_subnet: &str, outbound_iface: &str) -> Result<
             vm_subnet,
             "-o",
             outbound_iface,
+            "-m",
+            "comment",
+            "--comment",
+            FCVM_RULE_COMMENT,
             "-j",
             "MASQUERADE",
         ])
@@ -330,10 +357,24 @@ pub async fn ensure_global_nat(vm_subnet: &str, outbound_iface: &str) -> Result<
 /// Removes global NAT rules if no bridged VMs are running
 ///
 /// Checks for veth0-* interfaces (indicates active bridged VMs).
-/// If none exist, removes the MASQUERADE rules for both subnets.
+/// If none exist, removes the fcvm-tagged MASQUERADE rules for both subnets
+/// (rules without the fcvm comment were added by someone else and are left alone).
 /// IP forwarding is intentionally left enabled (other services may depend on it).
 /// Best-effort — logs warnings but doesn't fail.
+///
+/// The list-then-delete sequence runs under the host-level `bridged-nat.lock`,
+/// serializing it against `ensure_global_nat()` in concurrently starting fcvm
+/// processes so this never deletes a MASQUERADE rule another VM just confirmed.
 pub async fn cleanup_global_nat_if_unused() {
+    // Serialize against ensure_global_nat() in other fcvm processes.
+    let _nat_lock = match super::acquire_host_network_lock("bridged-nat.lock").await {
+        Ok(lock) => lock,
+        Err(e) => {
+            warn!(error = %e, "failed to acquire bridged NAT lock, leaving global NAT rules in place");
+            return;
+        }
+    };
+
     // Check if any veth0- interfaces exist (active bridged VMs)
     let output = match Command::new("ip")
         .args(["-o", "link", "show"])
@@ -361,7 +402,7 @@ pub async fn cleanup_global_nat_if_unused() {
         }
     };
 
-    // Remove MASQUERADE rules for both subnets
+    // Remove the fcvm-tagged MASQUERADE rules for both subnets
     for subnet in &["172.30.0.0/16", "10.0.0.0/8"] {
         let output = Command::new("iptables")
             .args([
@@ -373,6 +414,10 @@ pub async fn cleanup_global_nat_if_unused() {
                 subnet,
                 "-o",
                 &outbound_iface,
+                "-m",
+                "comment",
+                "--comment",
+                FCVM_RULE_COMMENT,
                 "-j",
                 "MASQUERADE",
             ])
@@ -385,8 +430,11 @@ pub async fn cleanup_global_nat_if_unused() {
             }
             Ok(o) => {
                 let stderr = String::from_utf8_lossy(&o.stderr);
-                // Rule may already be gone
-                if !stderr.contains("does not exist") && !stderr.contains("No chain") {
+                // Rule may already be gone (or was never added by fcvm)
+                if !stderr.contains("does not exist")
+                    && !stderr.contains("No chain")
+                    && !stderr.contains("Bad rule")
+                {
                     warn!(subnet = %subnet, error = %stderr, "failed to remove MASQUERADE rule");
                 }
             }

--- a/src/network/veth.rs
+++ b/src/network/veth.rs
@@ -71,6 +71,32 @@ pub async fn create_veth_pair(host_veth: &str, guest_veth: &str, ns_name: &str) 
     Ok(())
 }
 
+/// Check whether an `ip -o addr show` output line shows a fcvm-managed veth
+/// (`veth0-*`) carrying exactly `ip`.
+///
+/// The IP is matched as `inet <ip>/` so that 172.30.0.1 never matches a parallel
+/// VM's 172.30.0.13 (or its broadcast address) — a bare substring match here can
+/// select another VM's veth and delete it during that VM's setup window.
+fn line_has_exact_ip_on_managed_veth(line: &str, ip: &str) -> bool {
+    let inet_pattern = format!("inet {}/", ip);
+    line.contains(&inet_pattern) && line.contains("veth0-")
+}
+
+/// Extract the nexthop ("via") address from `ip route show <prefix>` output.
+///
+/// Returns None when the route has no gateway (direct/dev route) or the output
+/// is empty. Token-exact comparison avoids substring false positives
+/// (e.g. 10.0.1.2 vs 10.0.1.20).
+fn route_nexthop(route_output: &str) -> Option<&str> {
+    let mut tokens = route_output.split_whitespace();
+    while let Some(token) = tokens.next() {
+        if token == "via" {
+            return tokens.next();
+        }
+    }
+    None
+}
+
 /// Check if a network namespace has any running processes
 async fn namespace_has_processes(ns_name: &str) -> bool {
     // Use ip netns pids to check for processes in the namespace
@@ -121,7 +147,7 @@ async fn cleanup_stale_veth_with_ip(ip_with_cidr: &str, exclude_veth: &str) -> R
     // Parse output to find veth interfaces with matching IP
     // Format: "4: veth0-vm-abc@if3: <...> inet 10.0.1.1/30 ..."
     for line in stdout.lines() {
-        if line.contains(ip) && line.contains("veth0-") {
+        if line_has_exact_ip_on_managed_veth(line, ip) {
             // Extract interface name
             if let Some(iface) = line.split_whitespace().nth(1) {
                 // Remove trailing @... and colon
@@ -703,7 +729,8 @@ pub async fn add_host_route_to_guest(
         let existing_route = String::from_utf8_lossy(&check_output.stdout);
         if !existing_route.trim().is_empty() {
             // Route exists - check if it points to our veth or a different one
-            if !existing_route.contains(veth_inner_ip) {
+            // (token-exact via match: 10.0.1.2 must not "match" a route via 10.0.1.20)
+            if route_nexthop(&existing_route) != Some(veth_inner_ip) {
                 // Route points to a different gateway - likely stale from crashed VM
                 // Check if the device in the route still exists
                 if let Some(dev_start) = existing_route.find("dev ") {
@@ -772,23 +799,38 @@ pub async fn add_host_route_to_guest(
     Ok(())
 }
 
-/// Deletes the host route to a guest IP
+/// Deletes the host route to a guest IP, but only the route this clone owns
 ///
 /// This removes the route added by `add_host_route_to_guest`. Must be called during
 /// cleanup to prevent stale routes from interfering with future VMs using the same guest IP.
-pub async fn delete_host_route_to_guest(guest_ip: &str) -> Result<()> {
-    debug!(guest_ip = %guest_ip, "deleting host route to guest IP");
+///
+/// Bridged clones restored from the same snapshot share one guest IP, and
+/// `add_host_route_to_guest` deliberately lets the newest clone replace the
+/// {guest_ip}/32 route. Deleting unconditionally on cleanup would remove the route
+/// out from under a surviving clone, breaking host -> guest access (and HTTP health
+/// checks) for it. The delete is therefore qualified with `via {veth_inner_ip}`:
+/// it only matches the route that points at this clone's namespace veth, so a route
+/// owned by another clone is left in place. The kernel evaluates the qualifier
+/// atomically, so this stays correct even if another clone replaces the route
+/// concurrently.
+pub async fn delete_host_route_to_guest(guest_ip: &str, veth_inner_ip: &str) -> Result<()> {
+    debug!(
+        guest_ip = %guest_ip,
+        via = %veth_inner_ip,
+        "deleting host route to guest IP (if owned by this clone)"
+    );
 
     let route = format!("{}/32", guest_ip);
     let output = Command::new("ip")
-        .args(["route", "del", &route])
+        .args(["route", "del", &route, "via", veth_inner_ip])
         .output()
         .await
         .context("deleting host route to guest IP")?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        // Ignore "No such process" - route already deleted or never existed
+        // Ignore "No such process" - route already deleted, never existed,
+        // or is owned by another clone (different nexthop)
         if !stderr.contains("No such process") {
             warn!(guest_ip = %guest_ip, error = %stderr, "failed to delete host route (non-fatal)");
         }
@@ -856,6 +898,63 @@ pub async fn delete_veth_forward_rule(veth_name: &str) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod parse_tests {
+    use super::*;
+
+    #[test]
+    fn exact_ip_on_managed_veth_matches() {
+        let line = "4: veth0-vm-abc12345    inet 172.30.0.1/30 brd 172.30.0.3 scope global veth0-vm-abc12345";
+        assert!(line_has_exact_ip_on_managed_veth(line, "172.30.0.1"));
+    }
+
+    #[test]
+    fn prefix_ip_does_not_match_other_vm() {
+        // 172.30.0.1 must NOT match a parallel VM's veth carrying 172.30.0.13
+        // (substring match here previously deleted the other VM's veth)
+        let line = "7: veth0-vm-def67890    inet 172.30.0.13/30 brd 172.30.0.15 scope global veth0-vm-def67890";
+        assert!(!line_has_exact_ip_on_managed_veth(line, "172.30.0.1"));
+    }
+
+    #[test]
+    fn broadcast_address_does_not_match() {
+        // The brd field must not trigger a match either
+        let line = "7: veth0-vm-def67890    inet 172.30.0.13/30 brd 172.30.0.15 scope global veth0-vm-def67890";
+        assert!(!line_has_exact_ip_on_managed_veth(line, "172.30.0.15"));
+    }
+
+    #[test]
+    fn unmanaged_interface_does_not_match() {
+        let line = "2: eth0    inet 172.30.0.1/30 brd 172.30.0.3 scope global eth0";
+        assert!(!line_has_exact_ip_on_managed_veth(line, "172.30.0.1"));
+    }
+
+    #[test]
+    fn route_nexthop_extracts_via() {
+        let output = "172.30.90.2 via 10.0.1.2 dev veth0-vm-abc12345 \n";
+        assert_eq!(route_nexthop(output), Some("10.0.1.2"));
+    }
+
+    #[test]
+    fn route_nexthop_none_for_dev_route() {
+        let output = "172.30.90.2 dev veth0-vm-abc12345 scope link \n";
+        assert_eq!(route_nexthop(output), None);
+    }
+
+    #[test]
+    fn route_nexthop_none_for_empty_output() {
+        assert_eq!(route_nexthop(""), None);
+    }
+
+    #[test]
+    fn route_nexthop_is_token_exact() {
+        // 10.0.1.2 must not be considered the nexthop of a route via 10.0.1.20
+        let output = "172.30.90.2 via 10.0.1.20 dev veth0-vm-def67890 \n";
+        assert_ne!(route_nexthop(output), Some("10.0.1.2"));
+        assert_eq!(route_nexthop(output), Some("10.0.1.20"));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Host networking fixes from review:

- Stale-veth cleanup and route-ownership checks match the exact IP on
  fcvm-managed interfaces instead of substring matches, so cleaning up
  one VM can no longer delete a parallel VM's veth or host route, and
  bridged clone cleanup only deletes the /32 route it added (qualified
  by its own veth nexthop).
- Global MASQUERADE management is serialized with a host-level lock and
  the rules are tagged, so concurrent VM startup and shutdown can no
  longer delete NAT rules another fcvm just added, and fcvm only ever
  removes rules it created.
- Bridged subnet allocation takes a host-level lock around the
  check-then-assign window (same pattern as loopback IP allocation), so
  two concurrently starting VMs cannot pick the same subnet.
- The host-side egress proxy uses bounded per-stream channels with
  backpressure that propagates to the guest's TCP flow control, instead
  of buffering guest traffic without limit.

Tested: cargo fmt and clippy clean; make test-unit passes (includes new
unit tests for the exact-IP veth matching). The bridged, egress, and
snapshot-clone end-to-end suites in CI exercise these paths.
