### PR TITLE
fix: make snapshot cache keys and snapshot creation safe under concurrency

### DIFF
--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -1374,6 +1374,50 @@ pub async fn acquire_vm_snapshot_lock(disk_path: &Path) -> Result<std::fs::File>
     Ok(lock_file)
 }
 
+/// Acquire the per-snapshot directory lock (`<snapshot_dir>.lock`).
+///
+/// Creators take it exclusively while writing or atomically replacing a snapshot
+/// directory; restore paths take it shared so an in-flight restore never observes
+/// the directory mid-swap (mixing one generation's disk.raw with another
+/// generation's memory.bin/vmstate.bin) or mid-removal.
+pub async fn acquire_snapshot_dir_lock(
+    snapshot_dir: &Path,
+    exclusive: bool,
+) -> Result<std::fs::File> {
+    let lock_path = snapshot_dir.with_extension("lock");
+    let lock_file = std::fs::File::create(&lock_path)
+        .with_context(|| format!("creating snapshot lock: {}", lock_path.display()))?;
+    loop {
+        // Fully-qualified fs2 calls: std::fs::File now has inherent try_lock_*
+        // methods with a different error type, and inherent methods win over
+        // trait methods.
+        let result = if exclusive {
+            fs2::FileExt::try_lock_exclusive(&lock_file)
+        } else {
+            fs2::FileExt::try_lock_shared(&lock_file)
+        };
+        match result {
+            Ok(()) => break,
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                debug!(lock = %lock_path.display(), "waiting for per-snapshot lock");
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+            Err(e) => {
+                return Err(anyhow::anyhow!("acquiring per-snapshot lock: {}", e));
+            }
+        }
+    }
+    debug!(lock = %lock_path.display(), exclusive, "acquired per-snapshot lock");
+    Ok(lock_file)
+}
+
+/// Extra files to write into the snapshot directory before it is atomically finalized.
+///
+/// Returns (filename, contents) pairs. Invoked after the Firecracker snapshot is taken
+/// (and the VM resumed) so contents reflect host-side state at snapshot time — e.g.
+/// portable-volume inode tables.
+pub type SnapshotExtraFiles<'a> = Option<&'a (dyn Fn() -> Vec<(String, Vec<u8>)> + Send + Sync)>;
+
 /// Create a snapshot of the running VM.
 ///
 /// # Locking
@@ -1387,6 +1431,7 @@ pub async fn create_snapshot_core(
     mut snapshot_config: crate::storage::snapshot::SnapshotConfig,
     disk_path: &Path,
     parent_snapshot_dir: Option<&Path>,
+    extra_files: SnapshotExtraFiles<'_>,
 ) -> Result<()> {
     use crate::firecracker::api::{SnapshotCreate, VmState as ApiVmState};
 
@@ -1710,6 +1755,20 @@ pub async fn create_snapshot_core(
             bytes_merged = bytes_merged,
             "diff merge complete, building atomic update"
         );
+    }
+
+    // Write caller-provided extra files (e.g. portable-volume inode tables) into the
+    // temp directory BEFORE the atomic rename. A finalized snapshot (config.json present)
+    // must never be missing these files — clones would silently restore without them —
+    // so a write failure here fails the snapshot instead of being logged and ignored.
+    if let Some(extra_files) = extra_files {
+        for (filename, contents) in extra_files() {
+            let path = temp_snapshot_dir.join(&filename);
+            if let Err(e) = tokio::fs::write(&path, &contents).await {
+                let _ = tokio::fs::remove_dir_all(&temp_snapshot_dir).await;
+                return Err(e).with_context(|| format!("writing snapshot extra file {}", filename));
+            }
+        }
     }
 
     // Record parent snapshot for the diff chain.

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -289,6 +289,12 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
         None
     };
 
+    // Resolve the image identifier ONCE: digest for localhost/ images (single podman
+    // inspect), name for remote images. The same value feeds both the snapshot cache key
+    // and the image export cache below, so the two can never disagree when a localhost
+    // tag is rebuilt between two separate inspects.
+    let image_identifier = get_image_identifier(&args.image).await?;
+
     // Check for snapshot cache (unless --no-snapshot is set or FCVM_NO_SNAPSHOT env var)
     // Keep fc_config and snapshot_key available for later snapshot creation on miss
     let no_snapshot = args.no_snapshot
@@ -299,8 +305,6 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
         Option<crate::firecracker::FirecrackerConfig>,
         Option<String>,
     ) = if !no_snapshot {
-        // Get image identifier for cache key computation
-        let image_identifier = get_image_identifier(&args.image).await?;
         let resolved_mode = resolve_image_mode(&args);
         let config = build_firecracker_config(
             &args,
@@ -419,27 +423,11 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
     // For localhost/ images, export as OCI archive for direct podman run
     // Uses content-addressable cache to avoid re-exporting the same image
     let image_disk_path = if args.image.starts_with("localhost/") {
-        // Get image digest for content-addressable storage
-        let inspect_output = tokio::process::Command::new("podman")
-            .args(["image", "inspect", &args.image, "--format", "{{.Digest}}"])
-            .output()
-            .await
-            .context("inspecting image digest")?;
-
-        if !inspect_output.status.success() {
-            let stderr = String::from_utf8_lossy(&inspect_output.stderr);
-            bail!(
-                "Failed to get digest for image '{}': {}",
-                args.image,
-                stderr
-            );
-        }
-
-        let digest = String::from_utf8_lossy(&inspect_output.stdout)
-            .trim()
-            // Strip "sha256:" prefix for use in filenames (colons invalid in paths)
-            .trim_start_matches("sha256:")
-            .to_string();
+        // Reuse the digest resolved by get_image_identifier above (already stripped of
+        // the "sha256:" prefix). Using the same inspect result for the snapshot key and
+        // the export cache prevents a tag rebuilt in between from being exported under
+        // a digest that no longer matches the snapshot key.
+        let digest = image_identifier.clone();
 
         // Use content-addressable cache: /mnt/fcvm-btrfs/image-cache/{digest}/
         let image_cache_dir = paths::image_cache_dir();
@@ -462,13 +450,27 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
         let archive_path = cache_dir.with_extension("docker.tar");
         let needs_export = if !archive_path.exists() {
             true
-        } else if !validate_docker_archive(&archive_path)? {
-            warn!(path = %archive_path.display(), "Cached archive is invalid, re-exporting");
-            let _ = tokio::fs::remove_file(&archive_path).await;
-            true
         } else {
-            info!(image = %args.image, digest = %digest, "Using cached Docker archive");
-            false
+            // A cached archive that fails validation — whether it parses cleanly but is
+            // missing manifest.json (Ok(false)) or is structurally corrupt and can't be
+            // parsed at all (Err) — is removed and re-exported. Only the freshly exported
+            // archive below treats a validation error as fatal.
+            match validate_docker_archive(&archive_path) {
+                Ok(true) => {
+                    info!(image = %args.image, digest = %digest, "Using cached Docker archive");
+                    false
+                }
+                Ok(false) => {
+                    warn!(path = %archive_path.display(), "Cached archive is invalid, re-exporting");
+                    let _ = tokio::fs::remove_file(&archive_path).await;
+                    true
+                }
+                Err(e) => {
+                    warn!(path = %archive_path.display(), error = %e, "Cached archive is unreadable, re-exporting");
+                    let _ = tokio::fs::remove_file(&archive_path).await;
+                    true
+                }
+            }
         };
 
         if needs_export {
@@ -1034,7 +1036,6 @@ pub async fn run_vm_loop(ctx: &mut VmContext, cancel: CancellationToken) -> Resu
                         vm_state: &ctx.vm_state,
                         disk_path: &ctx.disk_path,
                         volume_configs: &ctx.volume_configs,
-                        parent_snapshot_key: None, // Pre-start is the first snapshot, no parent
                         remap_refs: &ctx.volume_servers.remap_refs,
                     };
                     match create_snapshot_interruptible(&snap, &cancel).await {
@@ -1088,14 +1089,15 @@ pub async fn run_vm_loop(ctx: &mut VmContext, cancel: CancellationToken) -> Resu
                         // This is safe: startup snapshots are optional (just caching), so
                         // if the VM is paused mid-snapshot when we cancel, cleanup will
                         // kill the VM anyway via vm_manager.kill().
-                        let parent_key = ctx.vm_state.config.snapshot_name.clone();
+                        // The diff parent is resolved inside create_podman_snapshot under
+                        // the per-VM snapshot lock (re-read from the state file), so a
+                        // concurrent `fcvm snapshot create` cannot leave us with a stale base.
                         let snap = CreateSnapshotParams {
                             vm_manager: &ctx.vm_manager,
                             snapshot_key: &startup_key,
                             vm_state: &ctx.vm_state,
                             disk_path: &ctx.disk_path,
                             volume_configs: &ctx.volume_configs,
-                            parent_snapshot_key: parent_key.as_deref(),
                             remap_refs: &ctx.volume_servers.remap_refs,
                         };
                         tokio::select! {

--- a/src/commands/podman/snapshot.rs
+++ b/src/commands/podman/snapshot.rs
@@ -38,7 +38,6 @@ pub struct CreateSnapshotParams<'a> {
     pub vm_state: &'a VmState,
     pub disk_path: &'a Path,
     pub volume_configs: &'a [VolumeConfig],
-    pub parent_snapshot_key: Option<&'a str>,
     /// RemapFs references for portable volumes — used to serialize inode tables at snapshot time.
     pub remap_refs: &'a [Option<std::sync::Arc<fuse_pipe::RemapFs<fuse_pipe::PassthroughFs>>>],
 }
@@ -51,8 +50,10 @@ pub struct CreateSnapshotParams<'a> {
 /// The snapshot is stored in snapshot_dir with snapshot_key as the name,
 /// making it accessible via `fcvm snapshot run --snapshot <snapshot_key>`.
 ///
-/// If `parent_snapshot_key` is provided, the parent's memory.bin will be copied
-/// (via reflink) as a base, enabling diff snapshots for new directories.
+/// The diff parent is resolved from the VM state file while the per-VM snapshot
+/// lock is held, so a concurrent `fcvm snapshot create` (which resets the KVM
+/// dirty bitmap and updates `snapshot_name`) can never leave us merging a diff
+/// onto a stale base.
 pub async fn create_podman_snapshot(snap: &CreateSnapshotParams<'_>) -> Result<()> {
     let CreateSnapshotParams {
         vm_manager,
@@ -60,32 +61,18 @@ pub async fn create_podman_snapshot(snap: &CreateSnapshotParams<'_>) -> Result<(
         vm_state,
         disk_path,
         volume_configs,
-        parent_snapshot_key,
-        remap_refs: _,
+        remap_refs,
     } = snap;
     // Snapshots stored in snapshot_dir with snapshot_key as name
     let snapshot_dir = paths::snapshot_dir().join(snapshot_key);
 
-    // Lock to prevent concurrent snapshot creation
-    let lock_path = snapshot_dir.with_extension("lock");
+    // Per-snapshot lock (exclusive): prevents concurrent creation of the same key
+    // and blocks restores of this snapshot while it is being (re)created.
     tokio::fs::create_dir_all(paths::snapshot_dir())
         .await
         .context("creating snapshot directory")?;
-
-    let lock_file = std::fs::File::create(&lock_path).context("creating snapshot lock file")?;
-
-    // Use try_lock in a loop so we yield to the async runtime and can be interrupted
-    use fs2::FileExt;
-    loop {
-        match lock_file.try_lock_exclusive() {
-            Ok(()) => break,
-            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                // Lock is held by another process, yield and retry
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            }
-            Err(e) => return Err(anyhow::anyhow!("acquiring snapshot lock: {}", e)),
-        }
-    }
+    let _snapshot_lock =
+        crate::commands::common::acquire_snapshot_dir_lock(&snapshot_dir, true).await?;
 
     // Double-check after lock (another process might have created it)
     if snapshot_dir.join("config.json").exists() {
@@ -97,6 +84,25 @@ pub async fn create_podman_snapshot(snap: &CreateSnapshotParams<'_>) -> Result<(
 
     // Per-VM lock: serialize with external `fcvm snapshot create` calls.
     let _vm_lock = crate::commands::common::acquire_vm_snapshot_lock(disk_path).await?;
+
+    // Resolve the diff parent UNDER the per-VM lock by re-reading the state file.
+    // The lock contract requires this: another process may have created a snapshot
+    // (resetting the KVM dirty bitmap) and updated snapshot_name since the caller's
+    // in-memory copy of the state was taken. Using that stale parent would merge a
+    // diff covering only post-reset writes onto an older base, silently dropping
+    // every page dirtied in between.
+    let state_manager = crate::state::StateManager::new(paths::state_dir());
+    let parent_snapshot_key = match state_manager.load_state(&vm_state.vm_id).await {
+        Ok(state) => state.config.snapshot_name,
+        Err(e) => {
+            tracing::warn!(
+                vm_id = %vm_state.vm_id,
+                error = %e,
+                "could not re-read VM state under snapshot lock; creating full snapshot"
+            );
+            None
+        }
+    };
 
     // Get Firecracker client
     let client = vm_manager.client().context("VM not started")?;
@@ -113,36 +119,43 @@ pub async fn create_podman_snapshot(snap: &CreateSnapshotParams<'_>) -> Result<(
         extra_disks,
     );
 
+    // Inode tables for portable volumes are written into the temp (.creating) directory
+    // by create_snapshot_core BEFORE the atomic rename, so a finalized snapshot can never
+    // exist without them. They are loaded by clone VolumeServers via restore_from_table()
+    // to preserve inode numbering across snapshot/restore — eliminating the TTL glitch window.
+    let extra_files = || -> Vec<(String, Vec<u8>)> {
+        let mut files = Vec::new();
+        for (idx, remap_ref) in remap_refs.iter().enumerate() {
+            if let Some(remap) = remap_ref {
+                let port = volume_configs.get(idx).map(|c| c.port).unwrap_or(0);
+                let json = remap.serialize_table();
+                tracing::info!(
+                    port,
+                    bytes = json.len(),
+                    "serialized inode table for snapshot"
+                );
+                files.push((
+                    format!("volume-{}-inode-table.json", port),
+                    json.into_bytes(),
+                ));
+            }
+        }
+        files
+    };
+
     // Use shared core function for snapshot creation
     // If parent key provided, resolve to directory path
-    let parent_dir = parent_snapshot_key.map(|key| paths::snapshot_dir().join(key));
+    let parent_dir = parent_snapshot_key
+        .as_deref()
+        .map(|key| paths::snapshot_dir().join(key));
     crate::commands::common::create_snapshot_core(
         client,
         snapshot_config,
         disk_path,
         parent_dir.as_deref(),
+        Some(&extra_files),
     )
     .await?;
-
-    // Serialize inode tables for portable volumes into the snapshot directory.
-    // These are loaded by clone VolumeServers via restore_from_table() to preserve
-    // inode numbering across snapshot/restore — eliminating the TTL glitch window.
-    for (idx, remap_ref) in snap.remap_refs.iter().enumerate() {
-        if let Some(remap) = remap_ref {
-            let port = snap.volume_configs.get(idx).map(|c| c.port).unwrap_or(0);
-            let json = remap.serialize_table();
-            let table_path = snapshot_dir.join(format!("volume-{}-inode-table.json", port));
-            if let Err(e) = tokio::fs::write(&table_path, &json).await {
-                tracing::warn!(port, error = %e, "failed to serialize inode table");
-            } else {
-                tracing::info!(
-                    port,
-                    bytes = json.len(),
-                    "serialized inode table to snapshot"
-                );
-            }
-        }
-    }
 
     Ok(())
 }
@@ -260,6 +273,8 @@ pub(super) fn build_firecracker_config(
         image_mode,
         non_blocking_output: args.non_blocking_output,
         rootfs_type: super::resolve_rootfs_type(args),
+        ipv6_prefix: args.ipv6_prefix.clone(),
+        portable_volumes: args.portable_volumes,
         firecracker_bin: firecracker_bin.map(|p| p.to_path_buf()),
     }
 }

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -902,6 +902,8 @@ pub(super) async fn run_vm_setup(
                 health_check_url: args.health_check.clone(),
                 user: args.user.clone(),
                 forward_localhost: args.forward_localhost.clone(),
+                ipv6_prefix: args.ipv6_prefix.clone(),
+                portable_volumes: args.portable_volumes,
                 image_mode: super::resolve_image_mode(args),
                 rootfs_type: super::resolve_rootfs_type(args),
                 port_mappings,

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -181,6 +181,16 @@ async fn cmd_snapshot_create(args: SnapshotCreateArgs) -> Result<()> {
         extra_disk_configs,
     );
 
+    // Acquire the per-snapshot lock (exclusive) BEFORE the per-VM lock — same order as
+    // create_podman_snapshot. Re-creating an existing tag atomically swaps the snapshot
+    // directory; restores of this snapshot hold the same lock shared, so a concurrent
+    // `fcvm snapshot run --snapshot <tag>` can never pair one generation's disk.raw with
+    // another generation's memory.bin.
+    tokio::fs::create_dir_all(paths::snapshot_dir())
+        .await
+        .context("creating snapshot directory")?;
+    let _snapshot_lock = super::common::acquire_snapshot_dir_lock(&snapshot_dir, true).await?;
+
     // Acquire per-VM lock BEFORE reading the parent snapshot key.
     // Without this, a concurrent startup snapshot can complete between our state read
     // and the actual Firecracker snapshot — resetting the KVM dirty bitmap while we
@@ -204,6 +214,7 @@ async fn cmd_snapshot_create(args: SnapshotCreateArgs) -> Result<()> {
         snapshot_config.clone(),
         &vm_disk_path,
         parent_dir.as_deref(),
+        None,
     )
     .await?;
 
@@ -610,6 +621,21 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
     };
 
     let state_manager = StateManager::new(paths::state_dir());
+
+    // Hold the per-snapshot lock SHARED from reading config.json until the restore has
+    // opened memory.bin/vmstate.bin and reflinked disk.raw (released after
+    // restore_from_snapshot below). Snapshot creators take the same lock exclusively
+    // while atomically replacing the directory, so a concurrent re-create of this tag
+    // can never swap generations under us mid-restore (mixed disk/memory) or remove
+    // the directory between our reads.
+    tokio::fs::create_dir_all(paths::snapshot_dir())
+        .await
+        .context("creating snapshot directory")?;
+    let snapshot_shared_lock = super::common::acquire_snapshot_dir_lock(
+        &paths::snapshot_dir().join(&snapshot_name),
+        false,
+    )
+    .await?;
 
     // Load snapshot configuration
     let snapshot_manager = SnapshotManager::new(paths::snapshot_dir());
@@ -1100,6 +1126,11 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
     )
     .await;
 
+    // The restore has opened/reflinked everything it needs from the snapshot directory;
+    // release the shared per-snapshot lock so creators are not blocked for the lifetime
+    // of this clone.
+    drop(snapshot_shared_lock);
+
     // If setup failed, cleanup all resources before propagating error
     if let Err(e) = setup_result {
         warn!("Clone setup failed, cleaning up resources");
@@ -1392,14 +1423,15 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
                             // Use select! so SIGTERM can abort startup snapshot immediately.
                             // Startup snapshots are optional (just caching), so if the VM is
                             // paused mid-snapshot, cleanup will kill it via vm_manager.kill().
-                            let parent_key = vm_state.config.snapshot_name.clone();
+                            // The diff parent is resolved inside create_podman_snapshot under
+                            // the per-VM snapshot lock (re-read from the state file), so a
+                            // concurrent `fcvm snapshot create` cannot leave us with a stale base.
                             let snap = CreateSnapshotParams {
                                 vm_manager: &vm_manager,
                                 snapshot_key: &startup_key,
                                 vm_state: &vm_state,
                                 disk_path: &disk_path,
                                 volume_configs: &volume_configs,
-                                parent_snapshot_key: parent_key.as_deref(),
                                 remap_refs: &volume_servers.remap_refs,
                             };
                             tokio::select! {

--- a/src/firecracker/config.rs
+++ b/src/firecracker/config.rs
@@ -98,6 +98,18 @@ pub struct FirecrackerConfig {
     /// Different rootfs types produce different VM states and must not share snapshots.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rootfs_type: Option<String>,
+    /// IPv6 prefix for routed mode (--ipv6-prefix).
+    /// Part of cache key so a run requesting a different prefix never silently
+    /// reuses a snapshot recorded with another prefix (the restore path applies
+    /// the prefix stored in snapshot metadata, not the CLI flag).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ipv6_prefix: Option<String>,
+    /// Portable FUSE volumes (--portable-volumes).
+    /// Part of cache key because per-volume inode tables are baked into the
+    /// snapshot at create time — a portable run must not reuse a non-portable
+    /// snapshot (and vice versa).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub portable_volumes: bool,
     /// Firecracker binary path used to create this snapshot.
     /// Content-addressed (e.g., firecracker-default-76c9e1236dab.bin), so changing
     /// the binary automatically invalidates the cache. Required because snapshots
@@ -131,6 +143,8 @@ impl Default for FirecrackerConfig {
             forward_localhost: Vec::new(),
             image_mode: ImageMode::Overlay,
             rootfs_type: None,
+            ipv6_prefix: None,
+            portable_volumes: false,
             firecracker_bin: None,
         }
     }
@@ -568,6 +582,22 @@ mod tests {
         let config1 = test_config();
         let mut config2 = test_config();
         config2.rootfs_type = Some("btrfs".to_string());
+        assert_ne!(config1.snapshot_key(), config2.snapshot_key());
+    }
+
+    #[test]
+    fn test_snapshot_key_changes_with_ipv6_prefix() {
+        let config1 = test_config();
+        let mut config2 = test_config();
+        config2.ipv6_prefix = Some("2001:db8::/64".to_string());
+        assert_ne!(config1.snapshot_key(), config2.snapshot_key());
+    }
+
+    #[test]
+    fn test_snapshot_key_changes_with_portable_volumes() {
+        let config1 = test_config();
+        let mut config2 = test_config();
+        config2.portable_volumes = true;
         assert_ne!(config1.snapshot_key(), config2.snapshot_key());
     }
 


### PR DESCRIPTION
Snapshot caching fixes from review:

- The diff-snapshot parent key is resolved under the per-VM snapshot lock
  (re-read from the state file) instead of being captured before the lock,
  so a concurrent startup snapshot can no longer reset the dirty bitmap
  while a stale parent reference is used.
- --ipv6-prefix and --portable-volumes are part of the snapshot cache key,
  so a cache hit can no longer silently reuse a snapshot recorded with
  different values for either flag.
- Portable-volume inode tables are written into the snapshot staging
  directory before the atomic rename, so a finalized snapshot can never be
  missing them; a corrupt cached docker archive triggers re-export instead
  of aborting the run; the snapshot key digest and the exported archive
  reuse a single image inspection; and snapshot directory re-creation and
  clone restores coordinate through a per-snapshot lock.

Tested: cargo fmt and clippy clean; make test-unit passes (includes new
snapshot-key divergence tests for the two flags). The snapshot-clone and
diff-snapshot end-to-end suites in CI exercise these paths.
