### PR TITLE
fix: clean up VM resources on every prepare/run failure path and report missing exit codes

### DIFF
--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -128,6 +128,26 @@ pub async fn cmd_podman(args: PodmanArgs) -> Result<()> {
     }
 }
 
+/// Best-effort removal of host state persisted during a failed `prepare_vm`.
+///
+/// `prepare_vm` creates the per-VM data directory and (for rootless and routed modes
+/// with published ports) persists the VM state file with an allocated loopback IP
+/// before the VM is fully set up. When setup fails partway, remove both so failed
+/// runs don't leave phantom `fcvm ls` entries, allocated loopback IPs, or per-VM
+/// disk directories behind.
+async fn cleanup_failed_prepare(
+    state_manager: &StateManager,
+    vm_id: &str,
+    data_dir: &std::path::Path,
+) {
+    if let Err(e) = state_manager.delete_state(vm_id).await {
+        warn!(vm_id = %vm_id, error = %e, "failed to delete VM state after setup error");
+    }
+    if let Err(e) = tokio::fs::remove_dir_all(data_dir).await {
+        warn!(vm_id = %vm_id, error = %e, "failed to remove VM data directory after setup error");
+    }
+}
+
 pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
     info!("Starting fcvm podman run");
 
@@ -712,6 +732,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
                     cleanup_err
                 );
             }
+            cleanup_failed_prepare(&state_manager, &vm_id, &data_dir).await;
             return Err(e);
         }
     };
@@ -733,6 +754,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
                     cleanup_err
                 );
             }
+            cleanup_failed_prepare(&state_manager, &vm_id, &data_dir).await;
             return Err(e);
         }
         vsock_dir.join("vsock.sock")
@@ -767,6 +789,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
                     cleanup_err
                 );
             }
+            cleanup_failed_prepare(&state_manager, &vm_id, &data_dir).await;
             return Err(e);
         }
     };
@@ -938,6 +961,9 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
                 cleanup_err
             );
         }
+
+        // Remove the persisted state file and per-VM data directory
+        cleanup_failed_prepare(&state_manager, &vm_id, &data_dir).await;
         return Err(e);
     }
 
@@ -973,7 +999,9 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
         health_monitor_handle,
         status_handle,
         tty_handle,
+        tty_socket_path: tty_mode.then_some(tty_socket_path),
         output_handle,
+        egress_proxy_handle,
         cache_rx,
         startup_rx,
         snapshot_key,
@@ -996,6 +1024,50 @@ fn resolve_username(uid: u32) -> String {
     }
 }
 
+/// Join the TTY session thread after the VM has exited, with a bounded wait.
+///
+/// The TTY thread may still be blocked in `accept()` if the guest never connected
+/// (boot or fc-agent failure before the TTY attach). Connect to the listener from the
+/// host side to unblock it, then join via `spawn_blocking` with a timeout so a wedged
+/// thread can never hang shutdown.
+async fn join_tty_session(
+    handle: std::thread::JoinHandle<Result<i32>>,
+    tty_socket_path: Option<String>,
+) -> Option<i32> {
+    if let Some(socket_path) = tty_socket_path {
+        let _ = std::os::unix::net::UnixStream::connect(&socket_path);
+    }
+    let join = tokio::task::spawn_blocking(move || handle.join().ok().and_then(|r| r.ok()));
+    match tokio::time::timeout(std::time::Duration::from_secs(10), join).await {
+        Ok(Ok(code)) => code,
+        Ok(Err(e)) => {
+            warn!(error = %e, "failed to join TTY session thread");
+            None
+        }
+        Err(_) => {
+            warn!("timed out waiting for TTY session thread");
+            None
+        }
+    }
+}
+
+/// Read the container exit code recorded by the status listener after VM exit.
+///
+/// The exit notification stays buffered in the host-side unix socket even after
+/// Firecracker exits, but the listener task may not have processed it yet when the VM
+/// exit is observed — give it a bounded window to finish before reading the file.
+async fn read_container_exit_code(ctx: &mut VmContext) -> Option<i32> {
+    let drain_window = std::time::Duration::from_secs(5);
+    let drained = tokio::time::timeout(drain_window, &mut ctx.status_handle).await;
+    if drained.is_err() {
+        warn!("status listener still running 5s after VM exit");
+    }
+    let exit_file = ctx.data_dir.join("container-exit");
+    std::fs::read_to_string(&exit_file)
+        .ok()
+        .and_then(|s| s.trim().parse::<i32>().ok())
+}
+
 /// Event loop: waits for VM exit, cancellation, or snapshot requests.
 /// Returns the container exit code (None if cancelled/signalled).
 pub async fn run_vm_loop(ctx: &mut VmContext, cancel: CancellationToken) -> Result<Option<i32>> {
@@ -1007,18 +1079,23 @@ pub async fn run_vm_loop(ctx: &mut VmContext, cancel: CancellationToken) -> Resu
             }
             status = ctx.vm_manager.wait() => {
                 info!(status = ?status, "VM exited");
-                if let Some(handle) = ctx.tty_handle.take() {
-                    let exit_code = handle.join().ok().and_then(|r| r.ok());
+                let exit_code = if let Some(handle) = ctx.tty_handle.take() {
+                    let socket_path = ctx.tty_socket_path.take();
+                    let exit_code = join_tty_session(handle, socket_path).await;
                     info!(container_exit_code = ?exit_code, "TTY container exit code");
-                    return Ok(exit_code);
+                    exit_code
                 } else {
-                    let exit_file = ctx.data_dir.join("container-exit");
-                    let exit_code = std::fs::read_to_string(&exit_file)
-                        .ok()
-                        .and_then(|s| s.trim().parse::<i32>().ok());
+                    let exit_code = read_container_exit_code(ctx).await;
                     info!(container_exit_code = ?exit_code, "container exit code");
-                    return Ok(exit_code);
-                }
+                    exit_code
+                };
+                let Some(code) = exit_code else {
+                    // No exit code means the guest never reported the container's
+                    // result (boot failure, fc-agent crash, or lost vsock
+                    // notification). Fail instead of silently reporting success.
+                    bail!("VM exited without reporting a container exit code");
+                };
+                return Ok(Some(code));
             }
             // Handle cache creation requests from fc-agent
             Some(cache_request) = async {
@@ -1142,6 +1219,11 @@ pub async fn cleanup_vm_context(mut ctx: VmContext) {
     // Cancel status listener (podman-specific)
     ctx.status_handle.abort();
 
+    // Stop the egress proxy task (rootless mode only)
+    if let Some(handle) = ctx.egress_proxy_handle.take() {
+        handle.abort();
+    }
+
     // Cleanup NFS exports
     cleanup_nfs_exports(&ctx.vm_id).await;
 
@@ -1166,11 +1248,11 @@ pub async fn cleanup_vm_context(mut ctx: VmContext) {
 
 /// CLI entrypoint for `fcvm podman run`. Thin wrapper around prepare_vm/run_vm_loop/cleanup.
 async fn cmd_podman_run(args: RunArgs) -> Result<()> {
-    let Some(mut ctx) = prepare_vm(args).await? else {
-        return Ok(()); // Snapshot cache hit, already handled
-    };
-
-    // Setup signal handlers → cancellation token
+    // Setup signal handlers → cancellation token.
+    // Installed before prepare_vm so a SIGTERM/SIGINT during the (potentially long)
+    // setup phase is recorded instead of killing the process and leaving host network
+    // state, the persisted VM state file, and the data directory behind. Shutdown is
+    // deferred until setup finishes, then full cleanup runs below.
     let cancel = CancellationToken::new();
     let cancel_clone = cancel.clone();
     tokio::spawn(async move {
@@ -1183,11 +1265,24 @@ async fn cmd_podman_run(args: RunArgs) -> Result<()> {
         cancel_clone.cancel();
     });
 
-    let exit_code = run_vm_loop(&mut ctx, cancel).await?;
+    let Some(mut ctx) = prepare_vm(args).await? else {
+        return Ok(()); // Snapshot cache hit, already handled
+    };
+
+    // A signal may have arrived while setup was still running — clean up and exit
+    // instead of entering the run loop.
+    if cancel.is_cancelled() {
+        info!("shutdown requested during VM setup, cleaning up");
+        cleanup_vm_context(ctx).await;
+        return Ok(());
+    }
+
+    // Run the VM loop, then always clean up — even when the loop reports an error.
+    let result = run_vm_loop(&mut ctx, cancel).await;
     cleanup_vm_context(ctx).await;
 
-    // Return error if container exited with non-zero exit code
-    if let Some(code) = exit_code {
+    // Propagate a missing exit code as an error and a non-zero exit code as a failure
+    if let Some(code) = result? {
         if code != 0 {
             bail!("container exited with code {}", code);
         }
@@ -1296,5 +1391,42 @@ mod tests {
         args.image_mode = Some(CliImageMode::Btrfs);
 
         assert_eq!(resolve_image_mode(&args), ImageMode::Btrfs);
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_failed_prepare_removes_state_and_data_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        let state_dir = temp.path().join("state");
+        let data_dir = temp.path().join("vm-data");
+        tokio::fs::create_dir_all(&data_dir).await.unwrap();
+        tokio::fs::write(data_dir.join("firecracker.log"), "log")
+            .await
+            .unwrap();
+
+        let state_manager = StateManager::new(state_dir.clone());
+        state_manager.init().await.unwrap();
+        let vm_state = VmState::new(
+            "vm-test-cleanup".to_string(),
+            "alpine:latest".to_string(),
+            1,
+            512,
+        );
+        state_manager.save_state(&vm_state).await.unwrap();
+        assert!(state_dir.join("vm-test-cleanup.json").exists());
+
+        cleanup_failed_prepare(&state_manager, "vm-test-cleanup", &data_dir).await;
+
+        assert!(
+            !state_dir.join("vm-test-cleanup.json").exists(),
+            "state file should be removed after a failed prepare"
+        );
+        assert!(
+            !data_dir.exists(),
+            "data dir should be removed after a failed prepare"
+        );
+
+        // Error paths can run before any state was persisted — calling the helper
+        // again with nothing left to remove must not panic.
+        cleanup_failed_prepare(&state_manager, "vm-test-cleanup", &data_dir).await;
     }
 }

--- a/src/commands/podman/types.rs
+++ b/src/commands/podman/types.rs
@@ -25,7 +25,12 @@ pub struct VmContext {
     pub health_monitor_handle: tokio::task::JoinHandle<()>,
     pub status_handle: tokio::task::JoinHandle<()>,
     pub tty_handle: Option<std::thread::JoinHandle<Result<i32>>>,
+    /// Host-side Unix socket path for the TTY vsock port (set when running with -t).
+    /// Used to unblock the TTY accept thread if the guest never connected.
+    pub tty_socket_path: Option<String>,
     pub output_handle: Option<tokio::task::JoinHandle<Vec<(String, String)>>>,
+    /// Egress proxy task (rootless mode only); aborted during cleanup.
+    pub egress_proxy_handle: Option<tokio::task::JoinHandle<()>>,
     pub cache_rx: Option<mpsc::Receiver<CacheRequest>>,
     pub startup_rx: Option<oneshot::Receiver<()>>,
     pub snapshot_key: Option<String>,

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -718,12 +718,72 @@ pub(super) struct VmSetupParams<'a> {
 /// Helper function that runs VM setup and returns VmManager on success.
 /// This allows the caller to cleanup network resources on error.
 /// For rootless mode, also returns the holder process that keeps the namespace alive.
+///
+/// On error, any Firecracker or namespace-holder process started by the failed setup
+/// is killed and any NFS exports written for the VM are removed, so a partial setup
+/// failure never leaks running processes or host export entries.
 pub(super) async fn run_vm_setup(
     params: VmSetupParams<'_>,
     network: &mut dyn NetworkManager,
     state_manager: &StateManager,
     vm_state: &mut VmState,
 ) -> Result<(VmManager, Option<tokio::process::Child>)> {
+    let vm_id = params.vm_id.to_string();
+
+    // The inner setup publishes the Firecracker manager and holder process into these
+    // slots as soon as they are created, so the error path below can kill them even
+    // when the failure happens partway through configuration.
+    let mut vm_manager_slot: Option<VmManager> = None;
+    let mut holder_slot: Option<tokio::process::Child> = None;
+
+    let result = run_vm_setup_inner(
+        params,
+        network,
+        state_manager,
+        vm_state,
+        &mut vm_manager_slot,
+        &mut holder_slot,
+    )
+    .await;
+
+    if let Err(e) = result {
+        // Firecracker and/or the namespace holder may already be running — kill them
+        // so the failed setup doesn't leak processes (and the guest memory, TAP
+        // device, and CoW disk they hold).
+        if let Some(ref mut vm_manager) = vm_manager_slot {
+            if let Err(kill_err) = vm_manager.kill().await {
+                warn!("failed to kill VM process: {}", kill_err);
+            }
+        }
+        if let Some(ref mut holder) = holder_slot {
+            if let Err(kill_err) = holder.kill().await {
+                warn!("failed to kill holder process: {}", kill_err);
+            }
+            let _ = holder.wait().await; // Clean up zombie
+        }
+        // NFS exports may have been written before the failing step; remove them
+        // (no-op when the exports file was never created).
+        cleanup_nfs_exports(&vm_id).await;
+        return Err(e);
+    }
+
+    let vm_manager = vm_manager_slot.expect("run_vm_setup_inner sets vm_manager on success");
+    Ok((vm_manager, holder_slot))
+}
+
+/// Inner VM setup: creates the CoW disk, starts Firecracker, and configures the VM.
+///
+/// The Firecracker manager and (for rootless mode) the namespace-holder child are
+/// stored into the provided slots as soon as they exist so that `run_vm_setup` can
+/// kill them if a later step fails.
+async fn run_vm_setup_inner(
+    params: VmSetupParams<'_>,
+    network: &mut dyn NetworkManager,
+    state_manager: &StateManager,
+    vm_state: &mut VmState,
+    vm_manager_slot: &mut Option<VmManager>,
+    holder_slot: &mut Option<tokio::process::Child>,
+) -> Result<()> {
     let VmSetupParams {
         args,
         vm_id,
@@ -784,21 +844,18 @@ pub(super) async fn run_vm_setup(
     // Enable Firecracker debug logging
     let fc_log_path = data_dir.join("firecracker.log");
     let _ = std::fs::File::create(&fc_log_path);
-    let mut vm_manager = VmManager::new(
+    let vm_manager = vm_manager_slot.insert(VmManager::new(
         vm_id.to_string(),
         socket_path.to_path_buf(),
         Some(fc_log_path),
-    );
+    ));
 
     // Set VM name for logging
     vm_manager.set_vm_name(vm_name);
 
     // Configure namespace isolation based on network type
-    let holder_child: Option<tokio::process::Child>;
-
     if let Some(bridged_net) = network.as_any().downcast_ref::<BridgedNetwork>() {
         // Bridged mode: use pre-created network namespace
-        holder_child = None;
         if let Some(ns_id) = bridged_net.namespace_id() {
             info!(namespace = %ns_id, "configuring VM to run in network namespace");
             vm_manager.set_namespace(ns_id.to_string());
@@ -808,17 +865,13 @@ pub(super) async fn run_vm_setup(
         .downcast_ref::<crate::network::RoutedNetwork>()
     {
         // Routed mode: use pre-created network namespace (like bridged)
-        holder_child = None;
         if let Some(ns_id) = routed_net.namespace_id() {
             info!(namespace = %ns_id, "configuring VM to run in routed network namespace");
             vm_manager.set_namespace(ns_id.to_string());
         }
     } else if let Some(pasta_net) = network.as_any().downcast_ref::<PastaNetwork>() {
-        holder_child = Some(
-            setup_rootless_namespace(pasta_net, network_config, &mut vm_manager, vm_state).await?,
-        );
-    } else {
-        holder_child = None;
+        *holder_slot =
+            Some(setup_rootless_namespace(pasta_net, network_config, vm_manager, vm_state).await?);
     }
 
     let firecracker_bin = crate::commands::common::find_firecracker(runtime_config)?;
@@ -1077,7 +1130,7 @@ pub(super) async fn run_vm_setup(
     crate::commands::common::save_vm_state_with_network(state_manager, vm_state, network_config)
         .await?;
 
-    Ok((vm_manager, holder_child))
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Host-side VM lifecycle fixes from review:

- A failed VM setup now kills the Firecracker and namespace-holder
  processes it already started, removes the persisted state file (freeing
  the loopback IP and the phantom ls entry), deletes the per-VM data
  directory, and removes any NFS export it wrote, instead of leaking them
  alongside the existing network cleanup.
- SIGINT/SIGTERM during preparation is captured and handled with a full
  cleanup once setup finishes instead of killing the process mid-setup
  and leaking host state.
- TTY sessions can no longer hang VM shutdown forever when the guest
  never connects: the join is unblocked and bounded.
- The egress proxy task is stopped on the normal cleanup path instead of
  leaking one task and listener per VM in long-lived server processes.
- A VM that exits without reporting a container exit code is now an
  error instead of being treated as success; the status listener is
  drained before the exit file is read so a buffered notification cannot
  be missed.

Tested: cargo fmt and clippy clean; make test-unit passes (includes a new
unit test for the failed-prepare cleanup helper). The run, exec, TTY, and
snapshot end-to-end suites in CI exercise these paths.
