### PR TITLE
fix: stop overheard bridge traffic from retargeting pasta port forwarding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y fuse3 libfuse3-dev libclang-dev clang musl-tools \
-            iproute2 iptables passt dnsmasq qemu-utils e2fsprogs parted \
+            iproute2 iptables passt dnsmasq qemu-utils e2fsprogs parted patch \
             podman skopeo busybox-static cpio zstd autoconf automake libtool cmake \
             libseccomp-dev nfs-kernel-server \
             flex bison bc libelf-dev libssl-dev
@@ -466,7 +466,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y fuse3 libfuse3-dev libclang-dev clang musl-tools \
-            iproute2 iptables passt dnsmasq qemu-utils e2fsprogs parted \
+            iproute2 iptables passt dnsmasq qemu-utils e2fsprogs parted patch \
             podman skopeo busybox-static cpio zstd autoconf automake libtool cmake \
             libseccomp-dev nfs-kernel-server \
             flex bison bc libelf-dev libssl-dev

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y fuse3 libfuse3-dev libclang-dev clang musl-tools \
-            iproute2 iptables passt dnsmasq qemu-utils e2fsprogs parted \
+            iproute2 iptables passt dnsmasq qemu-utils e2fsprogs parted patch \
             podman skopeo busybox-static cpio zstd autoconf automake libtool cmake \
             libseccomp-dev
       - name: Build passt from source

--- a/Containerfile
+++ b/Containerfile
@@ -15,13 +15,13 @@ RUN cargo install cargo-nextest cargo-audit cargo-deny --locked
 RUN apt-get update && apt-get install -y \
     fuse3 libfuse3-dev autoconf automake libtool perl libclang-dev clang cmake \
     musl-tools iproute2 iptables passt dnsmasq qemu-utils e2fsprogs btrfs-progs \
-    parted fdisk podman skopeo git curl sudo procps zstd busybox-static cpio uidmap iputils-ping \
+    parted fdisk podman skopeo git curl sudo procps zstd busybox-static cpio uidmap iputils-ping patch \
     flex bison bc libelf-dev libssl-dev libseccomp-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Build passt from source for consistent version across environments
-COPY scripts/build-passt.sh /tmp/build-passt.sh
-RUN /tmp/build-passt.sh && rm -rf /tmp/passt-build /tmp/build-passt.sh
+COPY scripts/build-passt.sh scripts/passt-addr-seen.patch /tmp/
+RUN /tmp/build-passt.sh && rm -rf /tmp/passt-build* /tmp/build-passt.sh /tmp/passt-addr-seen.patch
 
 # Install Firecracker
 ARG ARCH=aarch64

--- a/scripts/build-passt.sh
+++ b/scripts/build-passt.sh
@@ -4,11 +4,20 @@
 # Served from snapshot.debian.org: deb.debian.org drops superseded versions
 # from its pool (which 404'd the previous pin), while snapshot.debian.org
 # archives every version permanently. The checksum guards the pin.
+#
+# A local patch (passt-addr-seen.patch, kept next to this script) is applied
+# on top: it stops overheard bridge traffic from retargeting pasta's inbound
+# port forwarding away from the guest. See the patch header for details.
 set -euo pipefail
 
 PASST_TARBALL_URL="https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/p/passt/passt_0.0~git20260120.386b5f5.orig.tar.xz"
 PASST_TARBALL_SHA256="cc0a86b0ac28e1e5b2a4243bcf7fa84b14dd91c7dc883a78896060111e12d105"
-BUILD_DIR="${BUILD_DIR:-/tmp/passt-build}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PASST_PATCH="$SCRIPT_DIR/passt-addr-seen.patch"
+# Key the build dir on the patch contents so a cached build tree from an older
+# patch (or no patch) is rebuilt instead of silently reused.
+PATCH_FINGERPRINT="$(sha256sum "$PASST_PATCH" | cut -c1-12)"
+BUILD_DIR="${BUILD_DIR:-/tmp/passt-build-${PATCH_FINGERPRINT}}"
 
 echo "==> Building passt from Debian source tarball (commit 386b5f5)..."
 
@@ -18,6 +27,7 @@ if [ ! -f "$BUILD_DIR/Makefile" ]; then
     curl -fsSL -o "$BUILD_DIR/passt.orig.tar.xz" "$PASST_TARBALL_URL"
     echo "$PASST_TARBALL_SHA256  $BUILD_DIR/passt.orig.tar.xz" | sha256sum -c -
     tar -xJf "$BUILD_DIR/passt.orig.tar.xz" -C "$BUILD_DIR" --strip-components=1
+    patch -p1 -d "$BUILD_DIR" < "$PASST_PATCH"
 fi
 
 cd "$BUILD_DIR"

--- a/scripts/passt-addr-seen.patch
+++ b/scripts/passt-addr-seen.patch
@@ -1,0 +1,47 @@
+Restrict addr_seen updates to the configured guest address.
+
+pasta tracks the latest source address seen on the tap interface
+(addr_seen) and uses it as the target for inbound port forwarding. The
+update accepts any IPv4/IPv6 frame, so when the tap interface sits on a
+shared L2 segment (fcvm enslaves pasta's tap to a bridge that also
+carries the namespace gateway), an overheard frame from another host
+silently retargets all forwarded connections away from the guest. A
+restored clone sends almost no traffic of its own through pasta, so the
+bad target sticks and every forwarded connection is reset.
+
+With this guard, only frames sourced from the configured guest address
+(fcvm always passes -a/--no-dhcp) update addr_seen. Intended for static
+address deployments; to be discussed upstream.
+
+diff -ru a/tap.c b/tap.c
+--- a/tap.c	2026-01-20 10:37:53.000000000 -0800
++++ b/tap.c	2026-06-02 00:11:11.454185065 -0700
+@@ -771,7 +771,13 @@
+ 			continue;
+ 		}
+ 
+-		if (iph->saddr && c->ip4.addr_seen.s_addr != iph->saddr)
++		/* Only frames sourced from the guest's configured address may
++		 * move addr_seen: the tap interface can sit on a shared L2
++		 * segment (e.g. a bridge port), and frames overheard from other
++		 * hosts there must not retarget inbound forwarding.
++		 */
++		if (iph->saddr && iph->saddr == c->ip4.addr.s_addr &&
++		    c->ip4.addr_seen.s_addr != iph->saddr)
+ 			c->ip4.addr_seen.s_addr = iph->saddr;
+ 
+ 		if (!iov_drop_header(&data, hlen))
+@@ -953,7 +959,12 @@
+ 
+ 			if (IN6_IS_ADDR_UNSPECIFIED(&c->ip6.addr))
+ 				c->ip6.addr = *saddr;
+-		} else if (!IN6_IS_ADDR_UNSPECIFIED(saddr)){
++		} else if (!IN6_IS_ADDR_UNSPECIFIED(saddr) &&
++			   (IN6_IS_ADDR_UNSPECIFIED(&c->ip6.addr) ||
++			    IN6_ARE_ADDR_EQUAL(saddr, &c->ip6.addr))) {
++			/* As for IPv4: only the guest's configured address may
++			 * move addr_seen on a shared L2 segment.
++			 */
+ 			c->ip6.addr_seen = *saddr;
+ 		}
+ 


### PR DESCRIPTION
Restored clones intermittently returned 0 bytes (immediate reset) on
their pasta-forwarded loopback ports even though the guest was healthy:
the clone port-forward stress tests and the clone HTTP benchmark fail
this way, and the failures persist for the clone's lifetime.

Root cause: pasta tracks the most recent source address seen on its tap
interface (addr_seen) and targets inbound forwarding at it. The update
accepts any frame, and fcvm's rootless topology enslaves pasta's tap to
a bridge that also carries the namespace gateway (10.0.2.1), so an
overheard frame from the gateway retargets every forwarded connection at
10.0.2.1, where nothing listens. A restored clone pushes almost no
traffic of its own through pasta, so the bad target sticks. The guest's
nginx access logs from the failing CI runs show none of the forwarded
requests arriving while health checks from the gateway keep succeeding,
and the namespace socket tables show pasta's connections going to the
gateway address.

Fix: carry a small patch on the pinned passt source (applied by
scripts/build-passt.sh, which now keys its build directory on the patch
contents so cached build trees refresh) that only lets frames sourced
from the configured guest address update addr_seen. The Containerfile
copies the patch alongside the build script, and the CI dependency lists
gain the patch utility. The newest upstream passt still has the
unguarded update, so a version bump alone would not fix it; the patch is
worth proposing upstream.

Tested: the patch applies to the pinned tarball and the patched source
builds; bash -n passes on the build script. The proof is the clone
port-forward stress tests and the clone_http benchmark passing in the CI
run dispatched on this branch (they failed reproducibly before).
