### PR TITLE
review followups

### DIFF
--- a/.github/workflows/kernels.yml
+++ b/.github/workflows/kernels.yml
@@ -4,6 +4,9 @@ on:
   push:
     paths:
       - 'kernel/**'
+      # The release tag/filename are derived from rootfs-config.toml (kernel_version,
+      # build_inputs), so config-only changes must also trigger a rebuild.
+      - 'rootfs-config.toml'
     branches: [main]
   workflow_dispatch:
     inputs:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -302,6 +302,7 @@ struct RoutedNetwork {
     vm_id: String,
     tap_device: String,
     port_mappings: Vec<PortMapping>,
+    forward_localhost: Vec<u16>,       // guest 127.0.0.1:<port> -> host 127.0.0.1:<port> relays
     loopback_ip: Option<String>,
     namespace_id: Option<String>,
     host_veth: Option<String>,
@@ -312,7 +313,7 @@ struct RoutedNetwork {
 }
 
 async fn setup() -> Result<NetworkConfig> {
-    self.preflight_check()             // root, IPv6, ip6tables (ip6tables skipped if --ipv6-prefix)
+    self.preflight_check()             // root, IPv6, ip6tables (skipped if --ipv6-prefix); rejects /udp publishes
     detect_host_ipv6()                 // find /64 subnet (or /128 with on-link /64); skipped if --ipv6-prefix
     generate_vm_ipv6(prefix, vm_id)    // deterministic IPv6 from hash
     create_namespace(ns_name)
@@ -326,6 +327,7 @@ async fn setup() -> Result<NetworkConfig> {
     // Proxy NDP on default interface
     // ip6tables MASQUERADE for outbound (skipped if --ipv6-prefix is set)
     // TCP proxy port forwarding on loopback IP (setns + tokio relay)
+    // --forward-localhost: 10.0.2.2/32 alias on bridge + TCP relays to host loopback ports
 }
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ clean-test-data: build
 	@echo "==> Killing stale VM processes from previous runs..."
 	@sudo pkill -9 firecracker 2>/dev/null; sudo pkill -9 pasta 2>/dev/null; sudo kill -9 $$(pgrep -x sleep -P 1) 2>/dev/null; sleep 1; true
 	@echo "==> Cleaning stale network namespaces..."
-	@for ns in $$(sudo ip netns list 2>/dev/null | grep '^fcvm-' | awk '{print $$1}'); do sudo ip netns del "$$ns" 2>/dev/null && echo "  deleted $$ns"; done; true
+	@for ns in $$(sudo ip netns list 2>/dev/null | grep -E '^(fcvm-|test-lf-|test-pf-|test-proxy-)' | awk '{print $$1}'); do sudo ip netns del "$$ns" 2>/dev/null && echo "  deleted $$ns"; done; true
 	@echo "==> Cleaning stale iptables rules from fcvm VMs..."
 	@sudo iptables-save -t nat 2>/dev/null | grep -E 'MASQUERADE.*(172\.30\.|10\.0\.)' | sed 's/^-A//' | while read rule; do sudo iptables -t nat -D $$rule 2>/dev/null; done; true
 	@sudo ip6tables-save -t nat 2>/dev/null | grep 'MASQUERADE' | grep -v NETAVARK | sed 's/^-A//' | while read rule; do sudo ip6tables -t nat -D $$rule 2>/dev/null; done; true

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -540,6 +540,23 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
                 );
             }
 
+            // podman save operates on the mutable tag, so re-check that the tag still
+            // resolves to the digest used as the cache key. If the image was rebuilt
+            // mid-export, the archive contents would no longer match the digest-keyed
+            // cache entry (and the snapshot key derived from it).
+            let digest_after = get_image_identifier(&args.image).await?;
+            if digest_after != digest {
+                let _ = tokio::fs::remove_file(&tmp_path).await;
+                drop(lock_file);
+                bail!(
+                    "image '{}' changed while it was being exported (digest {} -> {}); \
+                     re-run the command",
+                    args.image,
+                    digest,
+                    digest_after
+                );
+            }
+
             // Atomic rename within the same filesystem
             tokio::fs::rename(&tmp_path, &archive_path)
                 .await
@@ -1269,12 +1286,12 @@ async fn cmd_podman_run(args: RunArgs) -> Result<()> {
         return Ok(()); // Snapshot cache hit, already handled
     };
 
-    // A signal may have arrived while setup was still running — clean up and exit
-    // instead of entering the run loop.
+    // A signal may have arrived while setup was still running — clean up and report
+    // the interruption instead of entering the run loop (or exiting successfully).
     if cancel.is_cancelled() {
         info!("shutdown requested during VM setup, cleaning up");
         cleanup_vm_context(ctx).await;
-        return Ok(());
+        bail!("interrupted by signal during VM setup");
     }
 
     // Run the VM loop, then always clean up — even when the loop reports an error.

--- a/src/network/tcp_proxy.rs
+++ b/src/network/tcp_proxy.rs
@@ -380,6 +380,56 @@ mod tests {
         assert_eq!(addr.port(), 8080);
     }
 
+    /// RAII network namespace for privileged tests.
+    ///
+    /// `ip netns add` is checked (a leftover same-named namespace fails the
+    /// test instead of being silently reused), and Drop deletes the namespace
+    /// even on panics and early returns, so failed tests cannot leak
+    /// namespaces on the host.
+    #[cfg(feature = "privileged-tests")]
+    struct TestNetns {
+        name: String,
+    }
+
+    #[cfg(feature = "privileged-tests")]
+    impl TestNetns {
+        async fn create(name: String) -> Result<Self> {
+            let add = tokio::process::Command::new("ip")
+                .args(["netns", "add", &name])
+                .output()
+                .await
+                .context("creating test namespace")?;
+            anyhow::ensure!(
+                add.status.success(),
+                "ip netns add {} failed: {}",
+                name,
+                String::from_utf8_lossy(&add.stderr).trim()
+            );
+            let lo = tokio::process::Command::new("ip")
+                .args(["netns", "exec", &name, "ip", "link", "set", "lo", "up"])
+                .output()
+                .await
+                .context("bringing up loopback in test namespace")?;
+            anyhow::ensure!(
+                lo.status.success(),
+                "bringing up lo in {} failed: {}",
+                name,
+                String::from_utf8_lossy(&lo.stderr).trim()
+            );
+            Ok(Self { name })
+        }
+    }
+
+    #[cfg(feature = "privileged-tests")]
+    impl Drop for TestNetns {
+        fn drop(&mut self) {
+            // Synchronous on purpose: Drop also runs on panics and `?` returns.
+            let _ = std::process::Command::new("ip")
+                .args(["netns", "del", &self.name])
+                .output();
+        }
+    }
+
     /// Test that connect_in_namespace can reach a listener inside a namespace.
     ///
     /// Creates a temp namespace, binds a listener in it, connects from outside
@@ -387,37 +437,13 @@ mod tests {
     #[cfg(feature = "privileged-tests")]
     #[tokio::test]
     async fn test_connect_in_namespace() -> Result<()> {
-        let ns_name = format!("test-proxy-{}", std::process::id());
-
-        // Create namespace
-        tokio::process::Command::new("ip")
-            .args(["netns", "add", &ns_name])
-            .output()
-            .await
-            .context("creating test namespace")?;
-
-        // Bring up loopback in namespace (required for 127.0.0.1 to work)
-        tokio::process::Command::new("ip")
-            .args(["netns", "exec", &ns_name, "ip", "link", "set", "lo", "up"])
-            .output()
-            .await?;
-
-        let cleanup = || async {
-            let _ = tokio::process::Command::new("ip")
-                .args(["netns", "del", &ns_name])
-                .output()
-                .await;
-        };
+        // Namespace is deleted by TestNetns::drop, even on failure paths.
+        let ns = TestNetns::create(format!("test-proxy-{}", std::process::id())).await?;
+        let ns_name = ns.name.clone();
 
         // Bind a listener inside the namespace
         let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-        let listener = match bind_in_namespace(&ns_name, addr).await {
-            Ok(l) => l,
-            Err(e) => {
-                cleanup().await;
-                return Err(e);
-            }
-        };
+        let listener = bind_in_namespace(&ns_name, addr).await?;
         let listen_addr = listener.local_addr()?;
         println!("Listener bound at {} in namespace {}", listen_addr, ns_name);
 
@@ -430,14 +456,7 @@ mod tests {
         });
 
         // Connect from "outside" using setns
-        let mut stream = match connect_in_namespace(&ns_name, listen_addr).await {
-            Ok(s) => s,
-            Err(e) => {
-                echo_handle.abort();
-                cleanup().await;
-                return Err(e);
-            }
-        };
+        let mut stream = connect_in_namespace(&ns_name, listen_addr).await?;
 
         // Send data and verify we can write (connection established)
         use tokio::io::AsyncWriteExt;
@@ -445,9 +464,8 @@ mod tests {
         stream.shutdown().await?;
         println!("Successfully connected and sent data via namespace");
 
-        // Cleanup
+        // Cleanup (namespace deleted by TestNetns::drop)
         echo_handle.abort();
-        cleanup().await;
         println!("test_connect_in_namespace PASSED");
         Ok(())
     }
@@ -459,40 +477,20 @@ mod tests {
     #[cfg(feature = "privileged-tests")]
     #[tokio::test]
     async fn test_port_forward_relay() -> Result<()> {
-        let ns_name = format!("test-pf-{}", std::process::id());
-
-        // Create namespace + loopback
-        tokio::process::Command::new("ip")
-            .args(["netns", "add", &ns_name])
-            .output()
-            .await?;
-        tokio::process::Command::new("ip")
-            .args(["netns", "exec", &ns_name, "ip", "link", "set", "lo", "up"])
-            .output()
-            .await?;
-
-        let cleanup = |ns: String| async move {
-            let _ = tokio::process::Command::new("ip")
-                .args(["netns", "del", &ns])
-                .output()
-                .await;
-        };
+        // Namespace is deleted by TestNetns::drop, even on failure paths.
+        let ns = TestNetns::create(format!("test-pf-{}", std::process::id())).await?;
+        let ns_name = ns.name.clone();
 
         // Start echo server inside namespace on a known port
         let server_addr: SocketAddr = "127.0.0.1:9999".parse().unwrap();
         let server_listener = bind_in_namespace(&ns_name, server_addr).await?;
 
         let echo_handle = tokio::spawn(async move {
-            loop {
-                match server_listener.accept().await {
-                    Ok((mut stream, _)) => {
-                        tokio::spawn(async move {
-                            let (mut r, mut w) = stream.split();
-                            let _ = tokio::io::copy(&mut r, &mut w).await;
-                        });
-                    }
-                    Err(_) => break,
-                }
+            while let Ok((mut stream, _)) = server_listener.accept().await {
+                tokio::spawn(async move {
+                    let (mut r, mut w) = stream.split();
+                    let _ = tokio::io::copy(&mut r, &mut w).await;
+                });
             }
         });
 
@@ -523,12 +521,11 @@ mod tests {
         client.read_to_end(&mut buf).await?;
         assert_eq!(buf, b"test data 12345", "echo data should match");
 
-        // Cleanup
+        // Cleanup (namespace deleted by TestNetns::drop)
         for h in handles {
             h.abort();
         }
         echo_handle.abort();
-        cleanup(ns_name).await;
         println!("test_port_forward_relay PASSED");
         Ok(())
     }
@@ -541,24 +538,9 @@ mod tests {
     #[cfg(feature = "privileged-tests")]
     #[tokio::test]
     async fn test_localhost_forward_relay() -> Result<()> {
-        let ns_name = format!("test-lf-{}", std::process::id());
-
-        // Create namespace + loopback
-        tokio::process::Command::new("ip")
-            .args(["netns", "add", &ns_name])
-            .output()
-            .await?;
-        tokio::process::Command::new("ip")
-            .args(["netns", "exec", &ns_name, "ip", "link", "set", "lo", "up"])
-            .output()
-            .await?;
-
-        let cleanup = |ns: String| async move {
-            let _ = tokio::process::Command::new("ip")
-                .args(["netns", "del", &ns])
-                .output()
-                .await;
-        };
+        // Namespace is deleted by TestNetns::drop, even if the assertion panics.
+        let ns = TestNetns::create(format!("test-lf-{}", std::process::id())).await?;
+        let ns_name = ns.name.clone();
 
         // Host service on host-namespace loopback. The relay must reach this
         // even though the listener it accepts from lives inside the namespace.
@@ -598,7 +580,6 @@ mod tests {
         .await;
 
         server_handle.abort();
-        cleanup(ns_name).await;
         result?;
         println!("test_localhost_forward_relay PASSED");
         Ok(())

--- a/src/setup/kernel.rs
+++ b/src/setup/kernel.rs
@@ -498,17 +498,28 @@ pub fn compute_profile_kernel_sha(profile: &KernelProfile) -> Result<String> {
         let paths: Vec<PathBuf> = {
             let entries = glob(&full_pattern)
                 .with_context(|| format!("invalid build_inputs glob pattern: {}", full_pattern))?;
-            let mut paths: Vec<PathBuf> = entries
-                .filter_map(|e| e.ok())
-                // Filter out .disabled files (allows disabling patches without changing SHA)
-                .filter(|p| !p.to_string_lossy().ends_with(".disabled"))
-                .collect();
-            paths.sort(); // Deterministic order
-            paths
+            let mut all_matches: Vec<PathBuf> = entries.filter_map(|e| e.ok()).collect();
+            // Every configured pattern must match at least one file on disk; otherwise a
+            // misspelled or moved pattern would be silently dropped from the cache key
+            // and the kernel name would stop reflecting the configured input set.
+            // (.disabled files count as matches so patches can be disabled without
+            // breaking the pattern check.)
+            if all_matches.is_empty() {
+                bail!(
+                    "kernel build_inputs pattern '{}' matched no files (resolved to '{}'). \
+                     Fix the pattern in rootfs-config.toml or run from the fcvm repository",
+                    pattern,
+                    full_pattern
+                );
+            }
+            // Filter out .disabled files (allows disabling patches without changing SHA)
+            all_matches.retain(|p| !p.to_string_lossy().ends_with(".disabled"));
+            all_matches.sort(); // Deterministic order
+            all_matches
         };
 
         if paths.is_empty() {
-            debug!(pattern = %full_pattern, "no files matched pattern");
+            debug!(pattern = %full_pattern, "all files matched by pattern are .disabled");
         }
 
         for path in paths {
@@ -1697,8 +1708,7 @@ mod tests {
         let profile = profile_with_inputs(vec![missing.display().to_string()]);
         let err = compute_profile_kernel_sha(&profile).unwrap_err();
         assert!(
-            err.to_string()
-                .contains("no kernel build input files matched"),
+            err.to_string().contains("matched no files"),
             "unexpected error: {err:#}"
         );
     }

--- a/tests/test_forward_localhost.rs
+++ b/tests/test_forward_localhost.rs
@@ -22,10 +22,14 @@ fn spawn_host_server() -> Result<(u16, std::thread::JoinHandle<bool>)> {
     // Accept one connection in background (with timeout)
     let accept_handle = std::thread::spawn(move || -> bool {
         listener.set_nonblocking(false).expect("set_nonblocking");
-        // 45s accept timeout (must exceed nc timeout inside VM)
+        // Accept timeout must cover a full cold VM boot plus image export under
+        // parallel CI load (minutes, see the 600s nextest slow-timeout) and nc's
+        // 30s timeout — not just nc. If it expires the listener closes and the
+        // relay's later connect is refused, failing the test even though
+        // forwarding works.
         unsafe {
             let tv = libc::timeval {
-                tv_sec: 45,
+                tv_sec: 570,
                 tv_usec: 0,
             };
             libc::setsockopt(

--- a/tests/test_forward_localhost.rs
+++ b/tests/test_forward_localhost.rs
@@ -86,7 +86,17 @@ async fn run_forward_localhost_case(extra_args: &[&str], name_prefix: &str) -> R
     let stderr = String::from_utf8_lossy(&output.stderr);
     println!("  stdout: {}", stdout.trim());
 
-    let accepted = accept_handle.join().unwrap_or(false);
+    let accepted = if accept_handle.is_finished() {
+        accept_handle.join().unwrap_or(false)
+    } else {
+        // fcvm exited without the container ever connecting (boot failure or a
+        // forwarding regression). Unblock the accept thread with a local
+        // connection so the test reports promptly instead of waiting out the
+        // accept timeout.
+        let _ = std::net::TcpStream::connect(("127.0.0.1", port));
+        let _ = accept_handle.join();
+        false
+    };
     println!("  server accepted: {}", accepted);
 
     assert!(


### PR DESCRIPTION
Follow-ups from review comments and test-robustness findings on the stack:

- The forward-localhost test's host listener now keeps accepting for the full test budget instead of 45 seconds armed before the VM even boots, and unblocks immediately when fcvm exits without the container connecting — no spurious failures under CI load and no long hangs on real failures.
- DESIGN.md's routed-mode pseudocode covers the forward_localhost field, the UDP publish rejection, and the localhost-forwarding setup step; the Build Kernels workflow also triggers on rootfs-config.toml changes since the release tag is derived from it.
- The privileged tcp_proxy namespace tests use an RAII namespace guard (cleanup runs on panics and early returns), check `ip netns add` instead of silently reusing leftovers, and `make clean-test-data` also sweeps the test namespace prefixes.
- Codex inline findings from earlier PRs in the stack are addressed here: kernel build_inputs patterns that match no files now fail the cache-key computation, the localhost image export re-verifies the tag still resolves to the cache-key digest before finalizing, and a signal during VM setup exits non-zero after cleanup.

**Stacked on:** pasta-addr-seen-pin (#590)
