### PR TITLE
fix: post-merge green follow-ups (export warning, pasta netlink race)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -20,8 +20,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Build passt from source for consistent version across environments
-COPY scripts/build-passt.sh scripts/passt-addr-seen.patch /tmp/
-RUN /tmp/build-passt.sh && rm -rf /tmp/passt-build* /tmp/build-passt.sh /tmp/passt-addr-seen.patch
+COPY scripts/build-passt.sh scripts/passt-*.patch /tmp/
+RUN /tmp/build-passt.sh && rm -rf /tmp/passt-build* /tmp/build-passt.sh /tmp/passt-*.patch
 
 # Install Firecracker
 ARG ARCH=aarch64

--- a/scripts/build-passt.sh
+++ b/scripts/build-passt.sh
@@ -5,18 +5,24 @@
 # from its pool (which 404'd the previous pin), while snapshot.debian.org
 # archives every version permanently. The checksum guards the pin.
 #
-# A local patch (passt-addr-seen.patch, kept next to this script) is applied
-# on top: it stops overheard bridge traffic from retargeting pasta's inbound
-# port forwarding away from the guest. See the patch header for details.
+# Local patches (passt-*.patch, kept next to this script) are applied on top:
+#   - passt-addr-seen.patch: stops overheard bridge traffic from retargeting
+#     pasta's inbound port forwarding away from the guest.
+#   - passt-netlink-neigh-sync.patch: upstream fix (post-pin) for a netlink
+#     sequence-number race during the initial neighbour sync that makes pasta
+#     exit right after startup.
 set -euo pipefail
 
 PASST_TARBALL_URL="https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/p/passt/passt_0.0~git20260120.386b5f5.orig.tar.xz"
 PASST_TARBALL_SHA256="cc0a86b0ac28e1e5b2a4243bcf7fa84b14dd91c7dc883a78896060111e12d105"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PASST_PATCH="$SCRIPT_DIR/passt-addr-seen.patch"
+PASST_PATCHES=(
+    "$SCRIPT_DIR/passt-addr-seen.patch"
+    "$SCRIPT_DIR/passt-netlink-neigh-sync.patch"
+)
 # Key the build dir on the patch contents so a cached build tree from an older
-# patch (or no patch) is rebuilt instead of silently reused.
-PATCH_FINGERPRINT="$(sha256sum "$PASST_PATCH" | cut -c1-12)"
+# patch set (or no patches) is rebuilt instead of silently reused.
+PATCH_FINGERPRINT="$(cat "${PASST_PATCHES[@]}" | sha256sum | cut -c1-12)"
 BUILD_DIR="${BUILD_DIR:-/tmp/passt-build-${PATCH_FINGERPRINT}}"
 
 echo "==> Building passt from Debian source tarball (commit 386b5f5)..."
@@ -27,7 +33,9 @@ if [ ! -f "$BUILD_DIR/Makefile" ]; then
     curl -fsSL -o "$BUILD_DIR/passt.orig.tar.xz" "$PASST_TARBALL_URL"
     echo "$PASST_TARBALL_SHA256  $BUILD_DIR/passt.orig.tar.xz" | sha256sum -c -
     tar -xJf "$BUILD_DIR/passt.orig.tar.xz" -C "$BUILD_DIR" --strip-components=1
-    patch -p1 -d "$BUILD_DIR" < "$PASST_PATCH"
+    for p in "${PASST_PATCHES[@]}"; do
+        patch -p1 -d "$BUILD_DIR" < "$p"
+    done
 fi
 
 cd "$BUILD_DIR"

--- a/scripts/passt-netlink-neigh-sync.patch
+++ b/scripts/passt-netlink-neigh-sync.patch
@@ -1,0 +1,128 @@
+From d00255bd3ccc3b19099fb34ab278b06d6be2ca59 Mon Sep 17 00:00:00 2001
+From: Stefano Brivio <sbrivio@redhat.com>
+Date: Thu, 21 May 2026 19:00:51 +0200
+Subject: [PATCH] netlink: Use regular request/response netlink socket for
+ initial neighbour sync
+
+...instead of the one dedicated to the neighbour monitor, because, if
+neighbour notifications start coming in before or while we send the
+initial request to read out the neighbour tables, messages and
+sequence numbers will collide.
+
+For example, if nl_neigh_sync() sends a RTM_GETNEIGH request with
+sequence 20, we expect a corresponding reply with sequence 20. But
+given that we already used the same socket to subscribe to
+notifications, and notifications don't correspond to any specific
+request we sent, we might now get a message with sequence 0.
+
+The collision between messages wouldn't actually matter, as we'll
+handle anyway any RTM_NEWNEIGH message in the same fashion, but we
+need to validate sequence numbers for robustness, and that will fail.
+
+At the same time, we have to subscribe to neighbour notifications
+before calling nl_neigh_sync(), because we'll have a race condition
+otherwise, as we might miss neighbours that were added before the
+notifier is registered.
+
+Use the regular nl_sock for nl_neigh_sync().
+
+Drop the interface index from the request: we won't get any entry
+otherwise, because the Linux kernel (as of version 7.0) is unable to
+filter on it. Results are now filtered by interface index as we read
+them.
+
+Passing along an interface index used to work when nl_neigh_sync()
+used the notifier socket, because NETLINK_GET_STRICT_CHK is not set
+on it, meaning that results weren't filtered at all (interface and
+IP version passed in the request were ignored altogether).
+
+To reproduce the issue fixed here:
+
+* detach a network and user namespace:
+
+  [terminal 0]
+  $ unshare -rUn
+  # echo $$
+  1543307
+
+* attach pasta to it:
+
+  [terminal 1]
+  $ ./pasta -f --config-net 1543307 -I enp9s0
+
+* enter that namespace from yet another terminal:
+
+  [terminal 2]
+  $ nsenter --preserve-credentials -U -n -t 1543307
+
+* start flooding the MAC address table of this namespace:
+
+  [terminal 1]
+  # for i in $(seq 10 99); do for j in $(seq 10 99); do for k in $(seq 10 99); do ip ne add dev enp9s0 10.$i.$j.$k lladdr 00:11:22:$i:$j:$k; done; done; done
+
+* and now start another instance of pasta in this namespace:
+
+  [terminal 2]
+  # ./pasta -d --config-net
+
+which will eventually result in pasta exiting with a message like:
+
+  0.0253: netlink: Unexpected sequence number (0 != 34)
+
+Reported-by: Paul Holzinger <pholzing@redhat.com>
+Link: https://bugs.passt.top/show_bug.cgi?id=203
+Fixes: 3c469013cfaa ("netlink: add subscription on changes in NDP/ARP table")
+Signed-off-by: Stefano Brivio <sbrivio@redhat.com>
+Reviewed-by: David Gibson <david@gibson.dropbear.id.au>
+---
+ netlink.c | 15 +++++++--------
+ 1 file changed, 7 insertions(+), 8 deletions(-)
+
+diff --git a/netlink.c b/netlink.c
+index c3c830e..0863734 100644
+--- a/netlink.c
++++ b/netlink.c
+@@ -1206,24 +1206,23 @@ static void nl_neigh_msg_read(const struct ctx *c, struct nlmsghdr *nh)
+  * @proto:	Protocol, AF_INET or AF_INET6
+  * @ifi:	Interface index
+  */
+-static void nl_neigh_sync(const struct ctx *c, int proto, int ifi)
++static void nl_neigh_sync(const struct ctx *c, int proto)
+ {
+ 	struct {
+ 		struct nlmsghdr nlh;
+ 		struct ndmsg    ndm;
+ 	} req = {
+-		.ndm.ndm_family  = proto,
+-		.ndm.ndm_ifindex = ifi,
++		.ndm.ndm_family = proto,
+ 	};
+ 	struct nlmsghdr *nh;
+ 	char buf[NLBUFSIZ];
+ 	ssize_t status;
+ 	uint32_t seq;
+ 
+-	seq = nl_send(nl_sock_neigh, &req, RTM_GETNEIGH,
+-		      NLM_F_DUMP, sizeof(req));
+-	nl_foreach_oftype(nh, status, nl_sock_neigh, buf, seq, RTM_NEWNEIGH)
++	seq = nl_send(nl_sock, &req, RTM_GETNEIGH, NLM_F_DUMP, sizeof(req));
++	nl_foreach_oftype(nh, status, nl_sock, buf, seq, RTM_NEWNEIGH)
+ 		nl_neigh_msg_read(c, nh);
++
+ 	if (status < 0)
+ 		warn("netlink: RTM_GETNEIGH failed: %s", strerror_(-status));
+ }
+@@ -1298,8 +1297,8 @@ int nl_neigh_notify_init(const struct ctx *c)
+ 		return -1;
+ 	}
+ 
+-	nl_neigh_sync(c, AF_INET, c->ifi4);
+-	nl_neigh_sync(c, AF_INET6, c->ifi6);
++	nl_neigh_sync(c, AF_INET);
++	nl_neigh_sync(c, AF_INET6);
+ 
+ 	return 0;
+ }
+-- 
+2.53.0-Meta
+

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -540,20 +540,20 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
                 );
             }
 
-            // podman save operates on the mutable tag, so re-check that the tag still
-            // resolves to the digest used as the cache key. If the image was rebuilt
-            // mid-export, the archive contents would no longer match the digest-keyed
-            // cache entry (and the snapshot key derived from it).
+            // podman save operates on the mutable tag, so re-check whether the tag still
+            // resolves to the digest used as the cache key. A concurrent rebuild of the
+            // same tag (parallel tests routinely rebuild shared localhost images) is
+            // legitimate, so this is a warning rather than an error: the archive may
+            // contain the newer build under the older digest's cache entry, which is the
+            // pre-existing race for mutable tags. Exporting by an immutable reference
+            // (while preserving the repo tag for the guest-side load) is the real fix.
             let digest_after = get_image_identifier(&args.image).await?;
             if digest_after != digest {
-                let _ = tokio::fs::remove_file(&tmp_path).await;
-                drop(lock_file);
-                bail!(
-                    "image '{}' changed while it was being exported (digest {} -> {}); \
-                     re-run the command",
-                    args.image,
-                    digest,
-                    digest_after
+                warn!(
+                    image = %args.image,
+                    digest_at_key = %digest,
+                    digest_at_export = %digest_after,
+                    "image was rebuilt while it was being exported; cached archive may be newer than its cache key"
                 );
             }
 


### PR DESCRIPTION
Two fixes for the failures in the post-merge CI run on main (run 26827965718):

- The export digest re-verification added in the review follow-ups turned legitimate concurrent rebuilds of shared localhost tags into hard failures (test_localhost_archive_mode, test_localhost_default_mode, test_localhost_rootless_btrfs_keepid_ext4). It is now a warning naming both digests; exporting by an immutable reference remains the proper follow-up.
- The new pasta supervision attributed the recurring "Cannot find device pasta0" clone failures to pasta dying at startup with "netlink: Unexpected sequence number". Upstream fixed this after our pinned commit (d00255bd, netlink: use a regular request/response socket for the initial neighbour sync); that patch is now carried alongside the addr_seen patch, with the build directory keyed on the combined patch contents.

Verified: cargo fmt/clippy clean; both passt patches apply to the pinned tarball and the patched source builds; bash -n passes on the build script. The localhost-image and clone connection/stress suites in this PR's CI run are the end-to-end check.