### PR TITLE
fix: give whole-lifecycle VM tests the full nextest budget

### DIFF
--- a/tests/test_fuse_copy_file_range_vm.rs
+++ b/tests/test_fuse_copy_file_range_vm.rs
@@ -141,8 +141,12 @@ echo "SUCCESS: copy_file_range works through FUSE!"
     common::spawn_log_consumer_with_logger(child.stdout.take(), "fuse-cfr", logger.clone());
     common::spawn_log_consumer_stderr_with_logger(child.stderr.take(), "fuse-cfr", logger.clone());
 
-    // Wait for completion (5 min timeout)
-    let timeout = std::time::Duration::from_secs(300);
+    // Wait for completion. This single budget covers the whole VM lifecycle (boot,
+    // pre-start snapshot pause, in-guest image/container startup, the test script,
+    // and shutdown), so keep it just under the 600s nextest slow-timeout for VM
+    // tests — under heavy parallel snapshot I/O the container start alone has been
+    // observed to take several minutes.
+    let timeout = std::time::Duration::from_secs(570);
     let result = tokio::time::timeout(timeout, child.wait()).await;
 
     // Cleanup

--- a/tests/test_remap_file_range.rs
+++ b/tests/test_remap_file_range.rs
@@ -94,8 +94,12 @@ async fn run_remap_test_in_vm(test_name: &str, test_script: &str) -> Result<()> 
         logger.clone(),
     );
 
-    // Wait for completion (5 min timeout)
-    let timeout = std::time::Duration::from_secs(300);
+    // Wait for completion. This single budget covers the whole VM lifecycle (cold
+    // bridged boot, pre-start snapshot pause, in-guest image/container startup, the
+    // test script, and shutdown), so keep it just under the 600s nextest
+    // slow-timeout for VM tests — under heavy parallel snapshot I/O the container
+    // start alone has been observed to take several minutes.
+    let timeout = std::time::Duration::from_secs(570);
     let result = tokio::time::timeout(timeout, child.wait()).await;
 
     let exit_status = match result {


### PR DESCRIPTION
test_ficlone_cp_reflink_in_vm timed out at its internal 300 second limit while the VM was healthy and its script was still running: under heavy parallel snapshot I/O the in-guest container start alone took over four minutes, and the helper's single budget also covers the cold bridged boot, the pre-start snapshot pause, the script, and shutdown. The nextest configuration already gives this test class 600 seconds, so the remap_file_range and fuse_copy_file_range helpers now use 570 seconds — just under the nextest limit so their own cleanup and error reporting still run. Evidence and time accounting are from run 26810117612 (job 79037603726): the VM became healthy at T+285s and was killed at T+300s with the test script mid-flight; every other observed pass of this test completed in 7-39s.