### PR TITLE
test: drop pasta-era retry workarounds and build runner passt from the pinned script

### DIFF
--- a/benches/clone.rs
+++ b/benches/clone.rs
@@ -263,34 +263,22 @@ impl CloneFixture {
             std::thread::sleep(Duration::from_millis(50));
         };
 
-        // Make HTTP request to nginx via loopback port forward (pasta).
-        // verify_port_forwarding() already confirmed the port works, but under
-        // heavy CI load the first request can get an empty response if pasta's
-        // internal forwarding state is briefly inconsistent. Retry up to 3 times.
+        // Make one HTTP request to nginx via the loopback port forward (pasta).
+        // verify_port_forwarding() already confirmed the L2 path, and pasta no
+        // longer retargets forwarding from overheard bridge traffic
+        // (scripts/passt-addr-seen.patch), so the first request must succeed.
         let addr = format!("{}:{}", loopback_ip, health_port);
         let request = "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
 
         let mut last_response = String::new();
-        for attempt in 0..3 {
-            if attempt > 0 {
-                std::thread::sleep(Duration::from_millis(500));
-            }
-            let Ok(mut stream) = TcpStream::connect(&addr) else {
-                continue;
-            };
+        if let Ok(mut stream) = TcpStream::connect(&addr) {
             let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
             let _ = stream.set_write_timeout(Some(Duration::from_secs(5)));
 
-            if stream.write_all(request.as_bytes()).is_err() {
-                continue;
-            }
-
-            let mut response = Vec::new();
-            let _ = stream.read_to_end(&mut response);
-            last_response = String::from_utf8_lossy(&response).to_string();
-
-            if last_response.contains("200 OK") {
-                break;
+            if stream.write_all(request.as_bytes()).is_ok() {
+                let mut response = Vec::new();
+                let _ = stream.read_to_end(&mut response);
+                last_response = String::from_utf8_lossy(&response).to_string();
             }
         }
 
@@ -322,7 +310,7 @@ impl CloneFixture {
                 .join("\n");
 
             panic!(
-                "clone HTTP failed after 3 attempts\n\
+                "clone HTTP request failed\n\
                  addr: {}:{}\n\
                  last_response: {} bytes\n\
                  clone_pid: {}\n\

--- a/scripts/build-ami.sh
+++ b/scripts/build-ami.sh
@@ -7,13 +7,16 @@ REGION="${AWS_REGION:-us-west-1}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 KERNEL_DIR="$(dirname "$SCRIPT_DIR")/kernel"
 
-# Compute build hash (from kernel config + patches + boot_args)
+# Compute build hash (from kernel config + patches + boot_args + passt build inputs)
 compute_hash() {
   local repo_root="$(dirname "$KERNEL_DIR")"
   {
     cat "$KERNEL_DIR/nested.conf" "$KERNEL_DIR/patches/"*.patch 2>/dev/null
     # Include boot_args from config to invalidate cache when they change
     grep -E '^boot_args\s*=' "$repo_root/rootfs-config.toml" 2>/dev/null || true
+    # Include the passt build inputs so a pin or patch change rebuilds the AMI
+    # instead of reusing one whose baked-in pasta no longer matches CI.
+    cat "$SCRIPT_DIR/build-passt.sh" "$SCRIPT_DIR"/passt-*.patch 2>/dev/null
   } | sha256sum | cut -c1-12
 }
 

--- a/scripts/build-ami.sh
+++ b/scripts/build-ami.sh
@@ -107,22 +107,16 @@ export HOME=/root
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 source /root/.cargo/env
 
-# Build passt from source for consistent version across environments
-PASST_TAG="2025_01_20.386b5f5"
-git clone https://passt.top/passt /tmp/passt-build
-cd /tmp/passt-build
-git checkout "$PASST_TAG"
-make -j"$(nproc)"
-for bin in pasta passt; do cp "$bin" "/usr/local/bin/${bin}.tmp.$$" && mv -f "/usr/local/bin/${bin}.tmp.$$" "/usr/local/bin/${bin}"; done
-rm -rf /tmp/passt-build
-cd /
-
 # Clone fcvm and its dependencies
 git clone --depth 1 https://github.com/ejc3/fcvm.git /tmp/fcvm
 git clone --depth 1 https://github.com/ejc3/fuse-backend-rs.git /tmp/fuse-backend-rs
 git clone --depth 1 https://github.com/ejc3/fuser.git /tmp/fuser
 cd /tmp/fcvm
 cargo build --release
+
+# Build pasta/passt from the repo's pinned source so the AMI matches CI
+# (scripts/build-passt.sh owns the pin and the local patches).
+./scripts/build-passt.sh
 
 # Use repo's config which has nested profile defined
 mkdir -p /root/.config/fcvm

--- a/scripts/setup-runner.sh
+++ b/scripts/setup-runner.sh
@@ -83,15 +83,11 @@ ln -sf /home/ubuntu/.cargo/bin/cargo /usr/local/bin/cargo
 ln -sf /home/ubuntu/.cargo/bin/rustc /usr/local/bin/rustc
 ln -sf /home/ubuntu/.cargo/bin/rustup /usr/local/bin/rustup
 
-# Build passt from source for consistent version across environments
-PASST_TAG="2025_01_20.386b5f5"
-cd /tmp
-git clone https://passt.top/passt /tmp/passt-build
-cd /tmp/passt-build
-git checkout "$PASST_TAG"
-make -j"$(nproc)"
-for bin in pasta passt; do cp "$bin" "/usr/local/bin/${bin}.tmp.$$" && mv -f "/usr/local/bin/${bin}.tmp.$$" "/usr/local/bin/${bin}"; done
-rm -rf /tmp/passt-build
+# Build pasta/passt from the repo's pinned source so runners match CI
+# (scripts/build-passt.sh owns the pin and the local patches).
+git clone --depth 1 https://github.com/ejc3/fcvm.git /tmp/fcvm-passt
+/tmp/fcvm-passt/scripts/build-passt.sh
+rm -rf /tmp/fcvm-passt /tmp/passt-build-*
 cd /
 
 # Firecracker (upstream baseline - CI overrides with custom fork from rootfs-config.toml)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1625,50 +1625,28 @@ pub async fn curl_check(ip: &str, port: u16, timeout_secs: u32) -> CurlResult {
     }
 }
 
-/// Make HTTP requests via curl with retries until success or deadline.
+/// Make a single HTTP request via curl and dump network diagnostics on failure.
 ///
-/// After snapshot restore, the network channel (L2 + pasta) is ready but the
-/// guest application may need a moment. This retries with 500ms backoff
-/// and prints extensive diagnostics on failure.
-pub async fn curl_check_retry(
+/// Used for the first request through a clone's port forward after restore.
+/// The request must succeed on the first attempt (pasta's forwarding target is
+/// no longer retargeted by overheard bridge traffic, see
+/// scripts/passt-addr-seen.patch); a failure dumps the pasta and namespace
+/// state needed to debug it.
+pub async fn curl_check_with_diag(
     ip: &str,
     port: u16,
     timeout_secs: u32,
     clone_pid: Option<u32>,
 ) -> CurlResult {
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs as u64);
-    let mut attempt = 0u32;
-    let mut last_result = CurlResult {
-        success: false,
-        body_len: 0,
-        error: "no attempt made".to_string(),
-    };
-
-    while std::time::Instant::now() < deadline {
-        attempt += 1;
-        last_result = curl_check(ip, port, 1).await;
-        if last_result.success && last_result.body_len > 0 {
-            if attempt > 1 {
-                println!(
-                    "    curl_check_retry: succeeded on attempt {} after retries",
-                    attempt
-                );
-            }
-            return last_result;
-        }
-        println!(
-            "    curl_check_retry attempt {}: {}:{} -> success={} body={} err={}",
-            attempt, ip, port, last_result.success, last_result.body_len, last_result.error
-        );
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    let result = curl_check(ip, port, timeout_secs).await;
+    if result.success && result.body_len > 0 {
+        return result;
     }
 
-    // All retries exhausted — dump diagnostics
     println!(
-        "\n    curl_check_retry FAILED after {} attempts to {}:{}",
-        attempt, ip, port
+        "\n    curl_check_with_diag FAILED for {}:{} (success={} body={} err={})",
+        ip, port, result.success, result.body_len, result.error
     );
-    println!("    last error: {}", last_result.error);
 
     // Verbose curl to see exactly what happens at TCP level
     let url = format!("http://{}:{}", ip, port);
@@ -1688,7 +1666,7 @@ pub async fn curl_check_retry(
         dump_clone_network_diagnostics(pid).await;
     }
 
-    last_result
+    result
 }
 
 /// Dump network diagnostics for a clone VM: pasta processes, ARP cache,

--- a/tests/test_clone_port_forward_stress.rs
+++ b/tests/test_clone_port_forward_stress.rs
@@ -179,13 +179,14 @@ async fn test_clone_port_forward_stress_rootless() -> Result<()> {
         });
     }
 
-    // Step 5: Verify each clone's port forwarding before the stress storm
-    // Use curl_check_retry: the L2 channel is ready (verify_port_forwarding passed)
-    // but the guest application may need a moment after snapshot restore.
-    println!("\nStep 5: Pre-storm verification of each clone (with retries)...");
+    // Step 5: Verify each clone's port forwarding before the stress storm.
+    // One request per clone: verify_port_forwarding() already confirmed the L2
+    // path, and pasta no longer retargets forwarding from overheard bridge
+    // traffic, so the first request must succeed.
+    println!("\nStep 5: Pre-storm verification of each clone...");
     for clone in &clones {
         let check =
-            common::curl_check_retry(&clone.loopback_ip, host_port, 10, Some(clone.pid)).await;
+            common::curl_check_with_diag(&clone.loopback_ip, host_port, 10, Some(clone.pid)).await;
         println!(
             "  Clone {} ({}:{}): {} ({} bytes)",
             clone.name,
@@ -196,7 +197,7 @@ async fn test_clone_port_forward_stress_rootless() -> Result<()> {
         );
         assert!(
             check.success && check.body_len > 0,
-            "Pre-storm curl to clone {} failed after retries: {}",
+            "Pre-storm curl to clone {} failed: {}",
             clone.name,
             check.error
         );

--- a/tests/test_snapshot_clone.rs
+++ b/tests/test_snapshot_clone.rs
@@ -1508,14 +1508,14 @@ async fn test_clone_port_forward_rootless() -> Result<()> {
     println!("  Clone loopback IP: {}", loopback_ip);
 
     // Test: Access via loopback IP and forwarded port
-    // verify_port_forwarding() confirmed the L2 channel is ready (ping + TCP connect).
-    // Use retry because the guest application may need a moment after restore.
+    // verify_port_forwarding() confirmed the L2 channel is ready, so the first
+    // request through the forward must succeed.
     println!(
-        "  Testing access via loopback {}:{} (with retries)...",
+        "  Testing access via loopback {}:{}...",
         loopback_ip, host_port
     );
     let loopback_check =
-        common::curl_check_retry(&loopback_ip, host_port, 10, Some(clone_pid)).await;
+        common::curl_check_with_diag(&loopback_ip, host_port, 10, Some(clone_pid)).await;
     let loopback_works = loopback_check.success && loopback_check.body_len > 0;
     if loopback_works {
         println!(
@@ -1668,13 +1668,13 @@ async fn test_clone_port_forward_routed() -> Result<()> {
     println!("  Clone loopback IP: {}", loopback_ip);
 
     // Test: Access via loopback IP and forwarded port
-    // Use retry because the guest application may need a moment after restore.
+    // The first request through the forward must succeed.
     println!(
-        "  Testing access via loopback {}:{} (with retries)...",
+        "  Testing access via loopback {}:{}...",
         loopback_ip, host_port
     );
     let loopback_check =
-        common::curl_check_retry(&loopback_ip, host_port, 10, Some(clone_pid)).await;
+        common::curl_check_with_diag(&loopback_ip, host_port, 10, Some(clone_pid)).await;
     let loopback_works = loopback_check.success && loopback_check.body_len > 0;
     if loopback_works {
         println!(


### PR DESCRIPTION
**Stacked on:** passt-pin-bump (PR #597)

Now that pasta no longer retargets inbound forwarding from overheard bridge traffic (passt-addr-seen.patch, on main) and no longer dies at startup on the netlink neighbour-sync race (#594, and the pin bump in #597), the retry workarounds that tolerated those failures come out:

- benches/clone.rs: the clone HTTP benchmark makes one request instead of three attempts with 500ms sleeps; a failure panics with the existing diagnostics.
- tests/common: curl_check_retry() is replaced by curl_check_with_diag(), a single request that dumps the pasta and namespace diagnostics on failure. The clone port-forward stress test and both snapshot-clone port-forward tests now assert the first request succeeds.
- scripts/setup-runner.sh and scripts/build-ami.sh stop building passt themselves. They cloned the upstream repo at tag 2025_01_20.386b5f5, which does not exist (the real tag is 2026_01_20.386b5f5), and applied none of our patches. Both now run scripts/build-passt.sh, so the pin and patches live in one place.

Deliberately untouched: restore_mode and the skipped post-restore TCP port probe. Those guard against probe connections leaving half-open flows toward a guest that is not up yet, which is a separate mechanism still being investigated.

## Test results
- cargo fmt and cargo clippy --all-targets pass; bash -n passes on both scripts. cargo audit could not fetch the advisory database from this host and runs in CI.
- The clone port-forward stress and snapshot-clone suites in this PR's CI run are the behavioral check; the CI run will be dispatched once #597 lands and this retargets to main.