### PR TITLE
ci: skip artifact analysis when the test matrix was skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -708,10 +708,15 @@ jobs:
       - name: Report skipped
         if: needs.skip-check.outputs.skip == 'true'
         run: echo "::notice::Skipped self-hosted tests — tree SHA already passed CI on a PR branch"
+      # When the test matrix was skipped, no artifacts exist and there is
+      # nothing to analyze; downloading would fail on the missing directory.
       - uses: actions/checkout@v6
+        if: needs.skip-check.outputs.skip != 'true'
       - name: Download all artifacts
+        if: needs.skip-check.outputs.skip != 'true'
         uses: actions/download-artifact@v7
         with:
           path: /tmp/ci-artifacts
       - name: Analyze CI run
+        if: needs.skip-check.outputs.skip != 'true'
         run: python3 scripts/analyze_ci_vms.py /tmp/ci-artifacts

--- a/scripts/analyze_ci_vms.py
+++ b/scripts/analyze_ci_vms.py
@@ -16,8 +16,11 @@ def main():
 
     artifacts_dir = Path(sys.argv[1])
     if not artifacts_dir.is_dir():
-        print(f"Error: {artifacts_dir} is not a directory")
-        sys.exit(1)
+        # No artifacts to analyze. The Summary job already gates this step on the
+        # test matrix having run, so reaching here means the matrix produced no
+        # artifacts (e.g. it was skipped). Report it without failing the job.
+        print("No CI artifacts to analyze (test matrix skipped or uploaded nothing)")
+        return
 
     # Count VMs from log files
     base_vms = 0


### PR DESCRIPTION
The push run for the merge of #594 (run 26840910467) skipped the self-hosted test matrix because the same tree had already passed CI on the PR, which is what skip-check is for, but the Summary job still tried to download artifacts and run scripts/analyze_ci_vms.py. With no artifacts to download it failed with '/tmp/ci-artifacts is not a directory' and turned the whole run red.

Two layers:
1. Gate the Summary job's checkout, artifact download, and analyze steps on `needs.skip-check.outputs.skip != 'true'`, so they don't run when the matrix was skipped. The existing 'Report skipped' notice already covers that case.
2. Make scripts/analyze_ci_vms.py print a note and exit 0 instead of erroring if it is ever handed a missing artifacts dir. This folds in the CI bot's #599 so a missing artifacts dir can't turn a run red on its own.

## Test results
- `python3 scripts/analyze_ci_vms.py /tmp/nonexistent` prints the note and exits 0.
- The behavioral check is the next merge push of an already-tested tree: the Summary job ends green with the skipped notice.