### PR TITLE
build: align carried passt addr_seen patch with the upstream submission

### DIFF
--- a/scripts/passt-addr-seen.patch
+++ b/scripts/passt-addr-seen.patch
@@ -1,47 +1,36 @@
-Restrict addr_seen updates to the configured guest address.
+Restrict addr_seen updates to the configured guest address (static deployments).
 
-pasta tracks the latest source address seen on the tap interface
-(addr_seen) and uses it as the target for inbound port forwarding. The
-update accepts any IPv4/IPv6 frame, so when the tap interface sits on a
-shared L2 segment (fcvm enslaves pasta's tap to a bridge that also
-carries the namespace gateway), an overheard frame from another host
-silently retargets all forwarded connections away from the guest. A
-restored clone sends almost no traffic of its own through pasta, so the
-bad target sticks and every forwarded connection is reset.
+pasta tracks the latest source address seen on the tap interface (addr_seen)
+and uses it as the target for inbound port forwarding. The update accepts any
+frame, so when the tap sits on a shared L2 segment (fcvm enslaves pasta's tap
+to a bridge that also carries the namespace gateway), an overheard frame from
+another host silently retargets all forwarded connections away from the guest.
+A restored clone sends almost no traffic of its own through pasta, so the bad
+target sticks and every forwarded connection is reset.
 
-With this guard, only frames sourced from the configured guest address
-(fcvm always passes -a/--no-dhcp) update addr_seen. Intended for static
-address deployments; to be discussed upstream.
+When DHCP is disabled (fcvm always passes -a/--no-dhcp, so c->no_dhcp is set),
+only frames sourced from the configured guest address may update addr_seen.
+With DHCP enabled, behaviour is unchanged. This mirrors the patch submitted
+upstream to passt-dev so CI exercises exactly what we proposed.
 
-diff -ru a/tap.c b/tap.c
---- a/tap.c	2026-01-20 10:37:53.000000000 -0800
-+++ b/tap.c	2026-06-02 00:11:11.454185065 -0700
-@@ -771,7 +771,13 @@
+--- a/tap.c	2026-05-26 09:24:31.000000000 -0700
++++ b/tap.c	2026-06-02 18:19:44.843506022 -0700
+@@ -770,7 +770,17 @@
  			continue;
  		}
  
 -		if (iph->saddr && c->ip4.addr_seen.s_addr != iph->saddr)
-+		/* Only frames sourced from the guest's configured address may
-+		 * move addr_seen: the tap interface can sit on a shared L2
-+		 * segment (e.g. a bridge port), and frames overheard from other
-+		 * hosts there must not retarget inbound forwarding.
++		/* The latest source address seen on the tap is taken to be the
++		 * guest's, and becomes the target for inbound forwarding. On a
++		 * point-to-point tap that's always correct. But if the tap sits
++		 * on a shared L2 segment (e.g. a bridge port carrying other
++		 * hosts) and we serve a fixed address (DHCP disabled), a frame
++		 * overheard from another host must not move addr_seen and
++		 * silently retarget forwarded connections away from the guest.
++		 * fcvm always passes -a/--no-dhcp, so c->no_dhcp is set.
 +		 */
-+		if (iph->saddr && iph->saddr == c->ip4.addr.s_addr &&
-+		    c->ip4.addr_seen.s_addr != iph->saddr)
++		if (iph->saddr && c->ip4.addr_seen.s_addr != iph->saddr &&
++		    (!c->no_dhcp || iph->saddr == c->ip4.addr.s_addr))
  			c->ip4.addr_seen.s_addr = iph->saddr;
  
  		if (!iov_drop_header(&data, hlen))
-@@ -953,7 +959,12 @@
- 
- 			if (IN6_IS_ADDR_UNSPECIFIED(&c->ip6.addr))
- 				c->ip6.addr = *saddr;
--		} else if (!IN6_IS_ADDR_UNSPECIFIED(saddr)){
-+		} else if (!IN6_IS_ADDR_UNSPECIFIED(saddr) &&
-+			   (IN6_IS_ADDR_UNSPECIFIED(&c->ip6.addr) ||
-+			    IN6_ARE_ADDR_EQUAL(saddr, &c->ip6.addr))) {
-+			/* As for IPv4: only the guest's configured address may
-+			 * move addr_seen on a shared L2 segment.
-+			 */
- 			c->ip6.addr_seen = *saddr;
- 		}
- 


### PR DESCRIPTION
Switches the carried scripts/passt-addr-seen.patch to the exact shape proposed upstream on passt-dev, so CI builds and exercises the code we actually submitted rather than a stricter local variant.

Changes vs the patch on main:
- Gate the addr_seen update on `no_dhcp`: the restriction to the configured guest address only applies when DHCP is disabled. fcvm always passes `-a`/`--no-dhcp`, so `c->no_dhcp` is set and behaviour is identical to before; with DHCP enabled (not fcvm) behaviour is unchanged, which is what makes it upstream-acceptable.
- Drop the IPv6 hunk: fcvm runs pasta with `--ipv4-only`, and the upstream patch is IPv4-only. Dead code for fcvm.

For fcvm this is a no-op behaviourally; it just keeps our build in lock-step with the upstream proposal.

## Test results
- Applies to the pinned 038c51e tarball with `patch -p1` and the patched tree builds (verified on a clean extract).
- build-passt.sh keys its build dir on the patch contents, so this forces a passt rebuild in CI.
- The clone port-forward stress and clone_http suites in this PR's CI run are the behavioural check: forwarding to a restored clone must still work without retries.