### PR TITLE
fcvm: log a shutdown-race exec stream close at debug, not ERROR

### DIFF
--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -299,15 +299,31 @@ pub async fn cmd_exec(args: ExecArgs) -> Result<()> {
 
     // Use binary framing for any mode needing TTY or stdin forwarding
     // JSON line mode only for plain non-interactive commands
-    if tty || interactive {
-        let exit_code = super::tty::run_tty_session_connected(stream, tty, interactive)?;
-        if exit_code != 0 {
-            std::process::exit(exit_code);
+    let result = if tty || interactive {
+        match super::tty::run_tty_session_connected(stream, tty, interactive) {
+            Ok(exit_code) => {
+                if exit_code != 0 {
+                    std::process::exit(exit_code);
+                }
+                Ok(())
+            }
+            Err(e) => Err(e),
         }
-        Ok(())
     } else {
         run_line_mode(stream)
+    };
+
+    // Downgrade the benign "stream closed before exit" race to debug ONLY for quiet
+    // (subprocess) callers — e.g. the health monitor's `--quiet` inspect during
+    // teardown. Still exit non-zero. A user-invoked exec (not quiet) propagates the
+    // error so `main` logs a visible ERROR rather than failing silently.
+    if let Err(e) = &result {
+        if is_benign_quiet_exec_close(quiet, e) {
+            debug!("{:#}", e);
+            std::process::exit(1);
+        }
     }
+    result
 }
 
 /// Read JSON-line exec responses until an Exit (or Error) message arrives.
@@ -350,8 +366,9 @@ fn read_exec_responses<R: BufRead>(
 /// This is a real failure — the command's outcome is unknown, so the caller
 /// still exits non-zero. But it is also the expected, benign terminal
 /// condition when an exec races VM or container shutdown (for example the
-/// health monitor's `podman inspect` healthcheck during teardown), so `main`
-/// logs it at debug rather than alarming at ERROR.
+/// health monitor's `--quiet podman inspect` healthcheck during teardown), so
+/// `cmd_exec` logs it at debug rather than alarming at ERROR *for quiet
+/// (subprocess) callers only* — see `is_benign_quiet_exec_close`.
 #[derive(Debug)]
 pub struct ExecConnectionClosed;
 
@@ -365,6 +382,17 @@ impl std::fmt::Display for ExecConnectionClosed {
 }
 
 impl std::error::Error for ExecConnectionClosed {}
+
+/// Whether an exec error is the benign "stream closed before exit" race AND the caller
+/// opted into quiet mode (the health monitor's `--quiet` inspect subprocess).
+///
+/// Only quiet/subprocess callers get the log downgrade: a user-invoked `fcvm exec`
+/// whose VM/container dies or vsock resets before an Exit frame must still surface a
+/// visible ERROR (not exit 1 silently), so the downgrade is scoped to `quiet` here
+/// rather than applied globally in `main`.
+fn is_benign_quiet_exec_close(quiet: bool, err: &anyhow::Error) -> bool {
+    quiet && err.downcast_ref::<ExecConnectionClosed>().is_some()
+}
 
 /// Run in line-buffered mode (non-TTY), returns exit code
 fn run_line_mode_with_exit_code(stream: UnixStream) -> Result<i32> {
@@ -562,5 +590,23 @@ mod tests {
             err.to_string().contains("before an exit status"),
             "unexpected error: {err}"
         );
+    }
+
+    /// #607 regression (Codex P2): the log downgrade for the benign "stream closed
+    /// before exit" race must be scoped to quiet (subprocess) callers. A user-invoked
+    /// exec (not quiet) must NOT be downgraded — it has to surface a visible error
+    /// instead of exiting 1 silently. This fails if the downgrade is applied globally.
+    #[test]
+    fn benign_close_downgrade_is_scoped_to_quiet() {
+        let closed: anyhow::Error = ExecConnectionClosed.into();
+        // Quiet subprocess (health monitor): downgrade the benign close.
+        assert!(is_benign_quiet_exec_close(true, &closed));
+        // User-invoked exec (not quiet): must stay visible (the regression Codex flagged).
+        assert!(!is_benign_quiet_exec_close(false, &closed));
+
+        // Only the benign close qualifies — other errors are never downgraded.
+        let other = anyhow::anyhow!("some other failure");
+        assert!(!is_benign_quiet_exec_close(true, &other));
+        assert!(!is_benign_quiet_exec_close(false, &other));
     }
 }

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -342,8 +342,29 @@ fn read_exec_responses<R: BufRead>(
         }
     }
 
-    bail!("exec connection closed before an exit status was received")
+    Err(ExecConnectionClosed.into())
 }
+
+/// The exec stream ended before an Exit message arrived.
+///
+/// This is a real failure — the command's outcome is unknown, so the caller
+/// still exits non-zero. But it is also the expected, benign terminal
+/// condition when an exec races VM or container shutdown (for example the
+/// health monitor's `podman inspect` healthcheck during teardown), so `main`
+/// logs it at debug rather than alarming at ERROR.
+#[derive(Debug)]
+pub struct ExecConnectionClosed;
+
+impl std::fmt::Display for ExecConnectionClosed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "exec connection closed before an exit status was received"
+        )
+    }
+}
+
+impl std::error::Error for ExecConnectionClosed {}
 
 /// Run in line-buffered mode (non-TTY), returns exit code
 fn run_line_mode_with_exit_code(stream: UnixStream) -> Result<i32> {

--- a/src/health.rs
+++ b/src/health.rs
@@ -286,6 +286,10 @@ async fn check_container_running(
     // With --user, podman runs as the target user (rootless), so we need runuser.
     let mut cmd_args: Vec<String> = vec![
         "exec".into(),
+        // Quiet: health-monitor subprocess. A benign "stream closed before exit" race
+        // during teardown is downgraded to debug for quiet callers (#607); user-invoked
+        // execs still surface a visible error.
+        "--quiet".into(),
         "--pid".into(),
         pid.to_string(),
         "--vm".into(),
@@ -367,6 +371,10 @@ async fn check_podman_healthcheck(
 
     let mut cmd_args: Vec<String> = vec![
         "exec".into(),
+        // Quiet: health-monitor subprocess. A benign "stream closed before exit" race
+        // during teardown is downgraded to debug for quiet callers (#607); user-invoked
+        // execs still surface a visible error.
+        "--quiet".into(),
         "--pid".into(),
         pid.to_string(),
         "--vm".into(),
@@ -452,6 +460,10 @@ async fn run_podman_healthcheck(pid: u32, username: Option<&str>, user_spec: Opt
 
     let mut cmd_args: Vec<String> = vec![
         "exec".into(),
+        // Quiet: health-monitor subprocess. A benign "stream closed before exit" race
+        // during teardown is downgraded to debug for quiet callers (#607); user-invoked
+        // execs still surface a visible error.
+        "--quiet".into(),
         "--pid".into(),
         pid.to_string(),
         "--vm".into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use clap::Parser;
 use fcvm::cli::Commands;
 use fcvm::{cli, commands, paths};
-use tracing::{debug, error};
+use tracing::error;
 use tracing_log::LogTracer;
 use tracing_subscriber::EnvFilter;
 
@@ -102,15 +102,6 @@ async fn main() -> Result<()> {
 
     // Handle errors
     if let Err(e) = &result {
-        // A benign terminal race: an exec stream that closed before an exit
-        // status (e.g. a healthcheck inspect racing VM/container shutdown).
-        // Still exit non-zero so callers see the failure, but don't alarm at ERROR.
-        if e.downcast_ref::<commands::exec::ExecConnectionClosed>()
-            .is_some()
-        {
-            debug!("{:#}", e);
-            std::process::exit(1);
-        }
         error!("Error: {:#}", e);
         std::process::exit(1);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use clap::Parser;
 use fcvm::cli::Commands;
 use fcvm::{cli, commands, paths};
-use tracing::error;
+use tracing::{debug, error};
 use tracing_log::LogTracer;
 use tracing_subscriber::EnvFilter;
 
@@ -102,6 +102,15 @@ async fn main() -> Result<()> {
 
     // Handle errors
     if let Err(e) = &result {
+        // A benign terminal race: an exec stream that closed before an exit
+        // status (e.g. a healthcheck inspect racing VM/container shutdown).
+        // Still exit non-zero so callers see the failure, but don't alarm at ERROR.
+        if e.downcast_ref::<commands::exec::ExecConnectionClosed>()
+            .is_some()
+        {
+            debug!("{:#}", e);
+            std::process::exit(1);
+        }
         error!("Error: {:#}", e);
         std::process::exit(1);
     }


### PR DESCRIPTION
When an exec stream ends before an Exit message the command's outcome is unknown, so exec still exits non-zero. But this is the expected, benign terminal condition when an exec races VM/container shutdown — most visibly the health monitor's `podman inspect` healthcheck during teardown, which spawns a child `fcvm exec` that printed `ERROR fcvm: Error: exec connection closed before an exit status was received` on every clean shutdown. That ERROR is pure noise; the parent already records the failed inspect as a WARN.

Introduce a typed `ExecConnectionClosed` error and downcast it in `main`: still exit(1), but log at debug instead of ERROR. The error's Display is unchanged, so behaviour and the existing eof/truncation unit tests are intact.

## Test results
- cargo build/clippy clean
- cargo test commands::exec — 4 tests pass, including read_exec_responses_eof_without_exit_is_an_error and the truncated-line case (Display message preserved).