### PR TITLE
fix: don't re-read the snapshot-spanning status connection (5-min startup stall)

### DIFF
--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -869,44 +869,71 @@ pub fn notify_cache_ready_and_wait(
             Ok(_) => {}
         }
 
-        if let Some(revents) = poll_fds[0].revents() {
-            if revents.contains(PollFlags::POLLHUP) || revents.contains(PollFlags::POLLERR) {
-                // vsock reset from snapshot RESTORE. This happens on warm start:
-                // the host restored this VM from a cached pre-start snapshot, and
-                // VIRTIO_VSOCK_EVENT_TRANSPORT_RESET killed all connections.
-                eprintln!("[fc-agent] cache-ack connection reset (snapshot restore detected)");
-                return CacheResult::WarmStart;
-            }
-        }
+        // Drain readable data BEFORE acting on POLLHUP/POLLERR. Linux can report
+        // POLLIN|POLLHUP together when the host writes "cache-ack" and then
+        // immediately closes the connection — which the host status listener does
+        // after a cold-start cache handshake. Treating POLLHUP as EOF before
+        // reading would discard a buffered cache-ack and misclassify the cold
+        // start as a warm restore, sending it through the restore-wait path.
+        let hung_up = poll_fds[0]
+            .revents()
+            .is_some_and(|r| r.contains(PollFlags::POLLHUP) || r.contains(PollFlags::POLLERR));
 
         match read(sock.as_raw_fd(), &mut buf[total_read..]) as Result<usize, nix::errno::Errno> {
+            Ok(n) if n > 0 => {
+                total_read += n;
+                let received = std::str::from_utf8(&buf[..total_read]).unwrap_or("");
+                if received.contains("cache-ack") {
+                    eprintln!("[fc-agent] received cache-ack from host");
+                    return CacheResult::ColdStart;
+                }
+                if total_read >= buf.len() {
+                    eprintln!("[fc-agent] cache-ack buffer overflow, giving up");
+                    return CacheResult::Failed;
+                }
+                // Partial data and the peer has hung up: no cache-ack is coming.
+                if hung_up {
+                    eprintln!(
+                        "[fc-agent] cache-ack connection reset after partial read (warm start)"
+                    );
+                    return CacheResult::WarmStart;
+                }
+                // Otherwise keep reading for the rest of the message.
+            }
+            Ok(_) => {
+                // Orderly EOF with no buffered cache-ack — vsock reset from a
+                // snapshot RESTORE (warm start).
+                eprintln!("[fc-agent] cache-ack connection closed (snapshot taken)");
+                return CacheResult::WarmStart;
+            }
             Err(nix::errno::Errno::EAGAIN) => {
-                // Spurious wakeup, continue polling
+                // No data pending. If the peer hung up, it's a genuine reset.
+                if hung_up {
+                    eprintln!("[fc-agent] cache-ack connection reset (snapshot restore detected)");
+                    return CacheResult::WarmStart;
+                }
+                // Spurious wakeup, continue polling.
                 continue;
+            }
+            // A reset/torn-down connection (no buffered cache-ack recovered above)
+            // means the vsock transport went away — either a genuine snapshot
+            // RESTORE, or a cold-start handshake where the host closed the
+            // connection with our write-probe bytes still unread, turning its
+            // close into a RST that flushes our receive buffer. Either way the
+            // correct fallback is a warm start, matching the write-probe
+            // classification above; returning Failed here would abort container
+            // launch on every reset. Only genuinely unexpected errors are fatal.
+            Err(nix::errno::Errno::ECONNRESET)
+            | Err(nix::errno::Errno::EPIPE)
+            | Err(nix::errno::Errno::ENOTCONN)
+            | Err(nix::errno::Errno::ECONNREFUSED) => {
+                eprintln!("[fc-agent] cache-ack connection reset on read (warm start)");
+                return CacheResult::WarmStart;
             }
             Err(e) => {
                 eprintln!("[fc-agent] cache-ack read error: {}", e);
                 return CacheResult::Failed;
             }
-            Ok(0) => {
-                // Connection closed — snapshot vsock reset
-                eprintln!("[fc-agent] cache-ack connection closed (snapshot taken)");
-                return CacheResult::WarmStart;
-            }
-            Ok(n) => {
-                total_read += n;
-            }
-        }
-
-        let received = std::str::from_utf8(&buf[..total_read]).unwrap_or("");
-        if received.contains("cache-ack") {
-            eprintln!("[fc-agent] received cache-ack from host");
-            return CacheResult::ColdStart;
-        }
-
-        if total_read >= buf.len() {
-            eprintln!("[fc-agent] cache-ack buffer overflow, giving up");
-            return CacheResult::Failed;
         }
     }
 }

--- a/src/commands/podman/listeners.rs
+++ b/src/commands/podman/listeners.rs
@@ -142,6 +142,20 @@ pub(super) async fn run_status_listener(
                 if let Err(e) = write_half.write_all(b"cache-ack\n").await {
                     warn!(vm_id = %vm_id, error = %e, "Failed to send cache-ack to fc-agent");
                 }
+                let _ = write_half.flush().await;
+
+                // Stop reading this connection and go back to accept(). fc-agent
+                // sends each status message ("cache-ready", then "ready", then
+                // "exit") on a SEPARATE vsock connection, so nothing more arrives
+                // here. Critically, this connection is the one held open across
+                // the pre-start snapshot's pause/resume: after resume the vsock
+                // transport can fail to propagate its close, so a second read_line
+                // here would block for the full 300s timeout before the accept
+                // loop could take the new connection carrying "ready" — stalling
+                // container startup by ~5 minutes (intermittently, worse on the
+                // NV2 nested kernel). Breaking to re-accept delivers "ready"
+                // immediately regardless of when this connection's EOF arrives.
+                break;
             } else {
                 warn!(vm_id = %vm_id, msg = %msg, "Unexpected status message");
             }


### PR DESCRIPTION
Fixes the intermittent SnapshotEnabled-only stall where a VM took ~5 minutes to report its container ready, blowing test budgets (e.g. test_ficlone, CI run 26862321867).

## Root cause (proven from the host code + the exact 300s boundary)
fc-agent sends each status message on a SEPARATE vsock connection (`send_status` opens a fresh one for `cache-ready`, then `ready`, then `exit`). The host status listener, after handling `cache-ready` on connection A and writing `cache-ack`, stayed in an inner loop doing a second `read_line` on A (300s timeout) waiting for `ready`. But `ready` arrives on a NEW connection B, which the single accept loop can't take while it's blocked reading A.

Connection A is held open across the pre-start snapshot's pause/resume. Normally A closes cleanly and the second read returns EOF at once, so the listener re-accepts and gets B fast (~43s healthy). Intermittently — worse on the NV2 nested kernel — the post-resume vsock fails to propagate A's close, so the second read blocks the full 300s. That is exactly the boundary observed: `cache-ack` at T, `ready` at T+300s.

## Fix
After sending `cache-ack`, flush and `break` to re-accept instead of re-reading A. fc-agent never sends more than one message per connection, so the listener should return to `accept()` for the next one. `ready` is then delivered immediately regardless of when A's EOF arrives. No timeout or parallelism changes.

## Test results
- cargo build --release and clippy clean.
- The SnapshotEnabled matrix jobs are the behavioural check (no more 300s status stalls); validating on this PR's CI run.