### PR TITLE
test: isolate localhost test images by unique name AND content

### DIFF
--- a/tests/test_localhost_image.rs
+++ b/tests/test_localhost_image.rs
@@ -38,6 +38,13 @@ async fn test_localhost_default_mode() -> Result<()> {
     run_localhost_test(None, "localhost-default").await
 }
 
+/// Unique image name for each test to avoid parallel podman build races.
+/// When multiple tests build the same tag concurrently, `podman save` can see
+/// a digest change mid-export, causing "image changed while it was being exported".
+fn image_name_for_suffix(suffix: &str) -> String {
+    format!("localhost/test-hello-{}", suffix)
+}
+
 async fn run_localhost_test(image_mode: Option<&str>, suffix: &str) -> Result<()> {
     run_localhost_test_with_kernel(image_mode, None, suffix).await
 }
@@ -48,6 +55,10 @@ async fn run_localhost_test_with_kernel(
     suffix: &str,
 ) -> Result<()> {
     let mode_label = image_mode.unwrap_or("default (auto-detect)");
+    let image_name = image_name_for_suffix(suffix);
+    // Unique CMD output per test so each image has a distinct content digest
+    // (see build_test_image for why the digest must differ, not just the name).
+    let marker = format!("Hello from localhost container {}!", suffix);
 
     println!("\nLocalhost Image Test ({})", mode_label);
     println!("====================");
@@ -56,14 +67,14 @@ async fn run_localhost_test_with_kernel(
     let fcvm_path = common::find_fcvm_binary()?;
     let (vm_name, _, _, _) = common::unique_names(suffix);
 
-    // Step 1: Build a test container image on the host
-    println!("Step 1: Building test container image localhost/test-hello...");
-    build_test_image().await?;
+    // Step 1: Build a test container image on the host (unique name + content per test)
+    println!("Step 1: Building test container image {}...", image_name);
+    build_test_image(&image_name, &marker).await?;
 
     // Step 2: Start VM with localhost image (rootless mode)
     println!(
-        "Step 2: Starting VM with localhost/test-hello image ({})...",
-        mode_label
+        "Step 2: Starting VM with {} image ({})...",
+        image_name, mode_label
     );
     let mut args = vec!["podman", "run", "--name", &vm_name];
     if let Some(mode) = image_mode {
@@ -74,7 +85,7 @@ async fn run_localhost_test_with_kernel(
         args.push("--kernel-profile");
         args.push(profile);
     }
-    args.push("localhost/test-hello");
+    args.push(&image_name);
 
     let mut child = tokio::process::Command::new(&fcvm_path)
         .args(&args)
@@ -90,6 +101,7 @@ async fn run_localhost_test_with_kernel(
 
     // Monitor stdout for container output (goes directly to stdout without prefix)
     let stdout = child.stdout.take();
+    let expected_marker = marker.clone();
     let stdout_task = tokio::spawn(async move {
         let mut found_hello = false;
         if let Some(stdout) = stdout {
@@ -97,8 +109,8 @@ async fn run_localhost_test_with_kernel(
             let mut lines = reader.lines();
             while let Ok(Some(line)) = lines.next_line().await {
                 eprintln!("[VM stdout] {}", line);
-                // Check for container output (no prefix in clean output mode)
-                if line.contains("Hello from localhost container!") {
+                // Check for this test's unique container output marker
+                if line.contains(&expected_marker) {
                     found_hello = true;
                 }
             }
@@ -154,21 +166,32 @@ async fn run_localhost_test_with_kernel(
     // Check results - verify we got the container output
     if found_hello {
         println!("\n  LOCALHOST IMAGE TEST PASSED! ({})", mode_label);
-        println!("  - Container ran and printed: Hello from localhost container!");
+        println!("  - Container ran and printed: {}", marker);
         if container_exited_zero {
             println!("  - Container exited with code 0");
         }
         Ok(())
     } else {
         println!("\n  LOCALHOST IMAGE TEST FAILED! ({})", mode_label);
-        println!("  - Did not find expected output: 'Hello from localhost container!'");
+        println!("  - Did not find expected output: '{}'", marker);
         println!("  - Check logs above for error details");
         anyhow::bail!("Localhost image test failed ({})", mode_label)
     }
 }
 
-/// Build a simple test container image using podman
-async fn build_test_image() -> Result<()> {
+/// Build a simple test container image using podman with a unique tag and a
+/// unique CMD marker.
+///
+/// Each test uses both its own image NAME and its own CONTENT. Unique names stop
+/// concurrent tests from rebuilding the same tag while another is exporting it.
+/// Unique content is just as important: fcvm caches the delivered image archive
+/// keyed by content digest, and the guest loads it tagged with whichever name
+/// first populated that digest. If two tests built identical content (same
+/// digest) under different names, the second test's `podman run <its-name>`
+/// would miss the cached archive (tagged with the first name) and fall back to
+/// pulling from registry `localhost`, which fails. The `{marker}` makes each
+/// image's content — and therefore its digest — distinct.
+async fn build_test_image(image_name: &str, marker: &str) -> Result<()> {
     use std::io::Write;
     use tempfile::TempDir;
 
@@ -181,7 +204,7 @@ async fn build_test_image() -> Result<()> {
     writeln!(
         file,
         r#"FROM public.ecr.aws/nginx/nginx:alpine
-CMD ["echo", "Hello from localhost container!"]"#
+CMD ["echo", "{marker}"]"#
     )?;
 
     // Build the image with podman
@@ -189,7 +212,7 @@ CMD ["echo", "Hello from localhost container!"]"#
         .args([
             "build",
             "-t",
-            "localhost/test-hello",
+            image_name,
             "-f",
             &containerfile_path.to_string_lossy(),
             temp_dir.path().to_str().unwrap(),
@@ -203,6 +226,6 @@ CMD ["echo", "Hello from localhost container!"]"#
         anyhow::bail!("Failed to build test image: {}", stderr);
     }
 
-    println!("  Built localhost/test-hello image");
+    println!("  Built {} image", image_name);
     Ok(())
 }

--- a/tests/test_localhost_rootless.rs
+++ b/tests/test_localhost_rootless.rs
@@ -15,8 +15,17 @@ mod common;
 
 use anyhow::{Context, Result};
 
-/// Build a simple test container image using podman
-async fn build_test_image() -> Result<()> {
+/// Build a simple test container image using podman with a unique tag.
+/// Each test uses its own image NAME and its own CONTENT to avoid parallel races.
+/// Unique names stop concurrent `podman build` to the same tag from making
+/// `podman save` see a digest change mid-export. Unique content is also required:
+/// fcvm caches the delivered image archive by content digest and the guest loads
+/// it tagged with whichever name first populated that digest, so identical
+/// content under different names would make a later test's `podman run <name>`
+/// miss the cached archive and fall back to pulling from registry `localhost`
+/// (which fails). Embedding `image_name` in the CMD makes each image's content —
+/// and therefore its digest — distinct.
+async fn build_test_image(image_name: &str) -> Result<()> {
     use std::io::Write;
     use tempfile::TempDir;
 
@@ -27,14 +36,14 @@ async fn build_test_image() -> Result<()> {
     writeln!(
         file,
         r#"FROM public.ecr.aws/nginx/nginx:alpine
-CMD ["sh", "-c", "echo 'btrfs-rootless-test-ok' && sleep 600"]"#
+CMD ["sh", "-c", "echo 'btrfs-rootless-test-ok {image_name}' && sleep 600"]"#
     )?;
 
     let output = tokio::process::Command::new("podman")
         .args([
             "build",
             "-t",
-            "localhost/test-btrfs-rootless",
+            image_name,
             "-f",
             &containerfile_path.to_string_lossy(),
             temp_dir.path().to_str().unwrap(),
@@ -48,7 +57,7 @@ CMD ["sh", "-c", "echo 'btrfs-rootless-test-ok' && sleep 600"]"#
         anyhow::bail!("Failed to build test image: {}", stderr);
     }
 
-    println!("  Built localhost/test-btrfs-rootless image");
+    println!("  Built {} image", image_name);
     Ok(())
 }
 
@@ -76,16 +85,19 @@ async fn run_btrfs_storage_test(rootfs_type: Option<&str>) -> Result<()> {
     );
     println!("===================================================");
 
+    // Each test gets a unique image name to avoid parallel podman build races
+    let suffix = format!("btrfs-{}", rootfs_type.unwrap_or("native"));
+    let image_name = format!("localhost/test-btrfs-rootless-{}", suffix);
+
     // Step 1: Build test image
-    println!("\n1. Building test container image...");
-    build_test_image().await?;
+    println!("\n1. Building test container image {}...", image_name);
+    build_test_image(&image_name).await?;
 
     // Step 2: Start VM in rootless mode with btrfs kernel
     println!(
         "\n2. Starting VM (rootless, --kernel-profile btrfs, rootfs: {})...",
         label
     );
-    let suffix = format!("btrfs-{}", rootfs_type.unwrap_or("native"));
     let (vm_name, _, _, _) = common::unique_names(&suffix);
 
     let mut args = vec![
@@ -100,7 +112,7 @@ async fn run_btrfs_storage_test(rootfs_type: Option<&str>) -> Result<()> {
         args.push("--rootfs-type");
         args.push(rt);
     }
-    args.push("localhost/test-btrfs-rootless");
+    args.push(&image_name);
 
     let (mut _child, fcvm_pid) = common::spawn_fcvm(&args).await.context("spawning fcvm")?;
     println!("  fcvm PID: {}", fcvm_pid);
@@ -196,9 +208,11 @@ async fn test_localhost_rootless_btrfs_snapshot_restore() -> Result<()> {
     println!("\nBtrfs Snapshot Restore Test");
     println!("==========================");
 
-    // Step 1: Build test image
-    println!("\n1. Building test container image...");
-    build_test_image().await?;
+    let image_name = "localhost/test-btrfs-rootless-snap";
+
+    // Step 1: Build test image (unique name to avoid parallel build races)
+    println!("\n1. Building test container image {}...", image_name);
+    build_test_image(image_name).await?;
 
     // Step 2: First run (creates snapshot cache)
     println!("\n2. First run (fresh boot, creates snapshot)...");
@@ -214,7 +228,7 @@ async fn test_localhost_rootless_btrfs_snapshot_restore() -> Result<()> {
             "btrfs",
             "--user",
             "1000:1000",
-            "localhost/test-btrfs-rootless",
+            image_name,
         ])
         .await
         .context("spawning fcvm (first run)")?;
@@ -284,7 +298,7 @@ async fn test_localhost_rootless_btrfs_snapshot_restore() -> Result<()> {
             "btrfs",
             "--user",
             "1000:1000",
-            "localhost/test-btrfs-rootless",
+            image_name,
         ])
         .await
         .context("spawning fcvm (second run)")?;
@@ -466,16 +480,19 @@ async fn run_btrfs_keepid_test(rootfs_type: Option<&str>) -> Result<()> {
     );
     println!("=========================================================");
 
-    // Step 1: Build test image (same image, snapshot key includes --user)
-    println!("\n1. Building test container image...");
-    build_test_image().await?;
+    // Each test gets a unique image name to avoid parallel podman build races
+    let suffix = format!("btrfs-kid-{}", rootfs_type.unwrap_or("native"));
+    let image_name = format!("localhost/test-btrfs-rootless-{}", suffix);
+
+    // Step 1: Build test image (unique per test, snapshot key includes --user)
+    println!("\n1. Building test container image {}...", image_name);
+    build_test_image(&image_name).await?;
 
     // Step 2: Start VM with --user 1000:1000 (triggers keep-id in fc-agent)
     println!(
         "\n2. Starting VM (rootless, --kernel-profile btrfs, --user 1000:1000, rootfs: {})...",
         label
     );
-    let suffix = format!("btrfs-kid-{}", rootfs_type.unwrap_or("native"));
     let (vm_name, _, _, _) = common::unique_names(&suffix);
 
     let mut args = vec![
@@ -490,7 +507,7 @@ async fn run_btrfs_keepid_test(rootfs_type: Option<&str>) -> Result<()> {
         args.push("--rootfs-type");
         args.push(rt);
     }
-    args.extend_from_slice(&["--user", "1000:1000", "localhost/test-btrfs-rootless"]);
+    args.extend_from_slice(&["--user", "1000:1000", &image_name]);
 
     let (mut _child, fcvm_pid) = common::spawn_fcvm(&args).await.context("spawning fcvm")?;
     println!("  fcvm PID: {}", fcvm_pid);


### PR DESCRIPTION
Fixes the localhost-image test flake (and supersedes the broken #593).

## Root cause
The localhost tests built shared tags (`localhost/test-hello`, `localhost/test-btrfs-rootless`), so parallel `podman build`s raced `podman save` mid-export. #593 tried unique names but kept identical content, so all images shared one content digest — and fcvm caches the delivered archive by digest, loading it into the guest tagged with whichever name first populated that digest. A test running its own unique name then missed the cached archive and fell back to pulling from registry `localhost`, failing every localhost test deterministically (container exit 125, run 26865703879).

## Fix
Each test now uses a unique image name AND unique content (a per-test marker in the CMD), so every image has a distinct digest and cache entry: no shared mutable tag (no export race) and no digest collision. This is proper per-test resource isolation per the repo's testing rules.

## Test results
- cargo build --release --tests and clippy --tests clean.
- Validated together with #613/#603 on the combined CI run.