### PR TITLE
network(pasta): retry transient netlink startup race

### DIFF
--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -689,13 +689,56 @@ impl NetworkManager for PastaNetwork {
             "starting pasta for rootless networking"
         );
 
-        // Phase 1: Start pasta (creates pasta0 TAP in namespace)
-        self.start_pasta(holder_pid).await?;
-
-        // Phase 2: Wait for pasta's TAP device to be visible in the namespace,
-        // failing fast (with pasta's exit status and stderr) if pasta dies right
-        // after startup.
-        self.wait_for_pasta_device(holder_pid).await?;
+        // Phases 1+2: start pasta and wait for its TAP device, with a bounded
+        // retry on a transient startup failure.
+        //
+        // pasta has a netlink startup race: it subscribes to route/neighbour
+        // notifications and then issues request/response netlink calls during
+        // setup; a notification (sequence 0) arriving mid-sequence makes
+        // nl_status() die() with "netlink: Unexpected sequence number". Upstream
+        // d00255bd fixed the neighbour-sync path, but the race still recurs under
+        // heavy parallelism (many pastas starting while veth/tap/bridge churn
+        // generates netlink traffic), so pasta exits before its TAP appears.
+        // It is transient — a fresh start almost always succeeds — so retry a few
+        // times rather than failing the whole VM. (The remaining race is reported
+        // upstream; this keeps us resilient until it lands and the pin is bumped.)
+        const PASTA_START_ATTEMPTS: u32 = 4;
+        let mut last_err = None;
+        for attempt in 1..=PASTA_START_ATTEMPTS {
+            let result = match self.start_pasta(holder_pid).await {
+                Ok(()) => self.wait_for_pasta_device(holder_pid).await,
+                Err(e) => Err(e),
+            };
+            match result {
+                Ok(()) => {
+                    last_err = None;
+                    break;
+                }
+                Err(e) => {
+                    warn!(
+                        attempt,
+                        max = PASTA_START_ATTEMPTS,
+                        error = %e,
+                        "pasta startup failed (likely the transient netlink race), retrying"
+                    );
+                    // Reap the dead pasta (if start_pasta got far enough to store it)
+                    // so the next attempt starts clean; start_pasta also removes a
+                    // stale PID file at its start.
+                    if let Some(mut p) = self.pasta_process.take() {
+                        let _ = p.kill().await;
+                    }
+                    last_err = Some(e);
+                    if attempt < PASTA_START_ATTEMPTS {
+                        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                    }
+                }
+            }
+        }
+        if let Some(e) = last_err {
+            return Err(e.context(format!(
+                "pasta failed to start after {PASTA_START_ATTEMPTS} attempts"
+            )));
+        }
 
         // Phase 3: Create bridge connecting pasta0 and Firecracker's TAP
         let bridge_script = self.build_bridge_script();


### PR DESCRIPTION
## Summary
pasta has a netlink startup race: it subscribes to route/neighbour notifications and then issues request/response netlink calls during setup. A notification (sequence 0) arriving mid-sequence makes pastas `nl_status()` die with `netlink: Unexpected sequence number (0 != N)`, so pasta exits before its TAP device appears and rootless VM startup fails with "pasta exited before its TAP device appeared". Upstream commit d00255bd fixed the neighbour-sync path, but the race still recurs under heavy parallelism, where many pastas start while veth/tap/bridge churn generates netlink traffic (seen as intermittent `test_serve_create_run_destroy` failures).

## Fix
`PastaNetwork::post_start` now retries `start_pasta` + `wait_for_pasta_device` up to 4 times, reaping the dead pasta and waiting 200ms between attempts, instead of failing the whole VM on the first transient miss. If all attempts fail it returns the last error with attempt-count context. The failure is transient — a fresh pasta start almost always succeeds.

The underlying race is reported upstream; this keeps rootless VM startup resilient until the fix lands and the passt pin is bumped.

## Test
- `cargo build --release` clean
- `cargo clippy --release` clean
- `cargo fmt --check` clean