### PR TITLE
test: scope one-shot signal_cleanup tests out of snapshots (#618)

### DIFF
--- a/tests/test_signal_cleanup.rs
+++ b/tests/test_signal_cleanup.rs
@@ -51,7 +51,6 @@ fn send_signal(pid: u32, signal: &str) -> Result<()> {
 /// correctly when running in parallel with other tests.
 #[cfg(feature = "privileged-tests")]
 #[test]
-#[ignore = "disabled pending #618: one-shot snapshot-create disk contention can exceed the health-wait budget in SnapshotEnabled CI"]
 fn test_sigint_kills_firecracker_bridged() -> Result<()> {
     println!("\ntest_sigint_kills_firecracker_bridged");
 
@@ -66,6 +65,11 @@ fn test_sigint_kills_firecracker_bridged() -> Result<()> {
             &vm_name,
             "--network",
             "bridged",
+            // One-shot test: boot, send a signal, verify cleanup. It never restores
+            // a snapshot, so skip the pre-start snapshot create (#618) — under
+            // SnapshotEnabled CI its ~1GB memory dump can exceed the health-wait
+            // budget when this VM is first-to-create under disk contention.
+            "--no-snapshot",
             common::TEST_IMAGE,
         ])
         .spawn()
@@ -189,7 +193,6 @@ fn test_sigint_kills_firecracker_bridged() -> Result<()> {
 /// correctly when running in parallel with other tests.
 #[cfg(feature = "privileged-tests")]
 #[test]
-#[ignore = "disabled pending #618: one-shot snapshot-create disk contention can exceed the health-wait budget in SnapshotEnabled CI"]
 fn test_sigterm_kills_firecracker_bridged() -> Result<()> {
     println!("\ntest_sigterm_kills_firecracker_bridged");
 
@@ -204,6 +207,11 @@ fn test_sigterm_kills_firecracker_bridged() -> Result<()> {
             &vm_name,
             "--network",
             "bridged",
+            // One-shot test: boot, send a signal, verify cleanup. It never restores
+            // a snapshot, so skip the pre-start snapshot create (#618) — under
+            // SnapshotEnabled CI its ~1GB memory dump can exceed the health-wait
+            // budget when this VM is first-to-create under disk contention.
+            "--no-snapshot",
             common::TEST_IMAGE,
         ])
         .spawn()
@@ -331,6 +339,9 @@ fn test_sigterm_cleanup_rootless() -> Result<()> {
             &vm_name,
             "--network",
             "rootless",
+            // One-shot test (boot, signal, verify cleanup); never restores a
+            // snapshot, so skip the pre-start snapshot create (#618).
+            "--no-snapshot",
             common::TEST_IMAGE,
         ])
         .spawn()
@@ -472,6 +483,9 @@ fn test_sigkill_kills_firecracker_rootless() -> Result<()> {
             &vm_name,
             "--network",
             "rootless",
+            // One-shot test (boot, signal, verify cleanup); never restores a
+            // snapshot, so skip the pre-start snapshot create (#618).
+            "--no-snapshot",
             common::TEST_IMAGE,
         ])
         .spawn()
@@ -718,7 +732,6 @@ fn is_descendant_of(pid: u32, ancestor_pid: u32) -> bool {
 /// correctly when running in parallel with other tests.
 #[cfg(feature = "privileged-tests")]
 #[test]
-#[ignore = "disabled pending #618: one-shot snapshot-create disk contention can exceed the health-wait budget in SnapshotEnabled CI"]
 fn test_sigterm_cleanup_bridged() -> Result<()> {
     println!("\ntest_sigterm_cleanup_bridged");
 
@@ -733,6 +746,11 @@ fn test_sigterm_cleanup_bridged() -> Result<()> {
             &vm_name,
             "--network",
             "bridged",
+            // One-shot test: boot, send a signal, verify cleanup. It never restores
+            // a snapshot, so skip the pre-start snapshot create (#618) — under
+            // SnapshotEnabled CI its ~1GB memory dump can exceed the health-wait
+            // budget when this VM is first-to-create under disk contention.
+            "--no-snapshot",
             common::TEST_IMAGE,
         ])
         .spawn()
@@ -861,6 +879,9 @@ fn test_sigterm_cleanup_routed() -> Result<()> {
             &vm_name,
             "--network",
             "routed",
+            // One-shot test (boot, signal, verify cleanup); never restores a
+            // snapshot, so skip the pre-start snapshot create (#618).
+            "--no-snapshot",
             "--publish",
             &publish_arg,
             common::TEST_IMAGE,


### PR DESCRIPTION
Closes #618.

## Problem
In the SnapshotEnabled CI matrix every `podman run` creates a pre-start snapshot on the boot→healthy path. The `signal_cleanup` tests boot a VM, send a signal, and assert cleanup — they **never restore** a snapshot, so that pre-start snapshot is pure overhead. Under concurrent disk-write contention the ~1GB memory dump can take 45s+, exceeding the test's health-wait budget when the VM is first-to-create a snapshot for its key. That timed out `test_sigint/sigterm_kills_firecracker_bridged` and `test_sigterm_cleanup_bridged` at 122s on arm64 SnapshotEnabled (they passed in 13s on a cache hit), so they were disabled with `#[ignore]` pending this fix.

## Fix
Add `--no-snapshot` to all six one-shot spawns in `test_signal_cleanup.rs` — the established pattern for boot-act-die tests (`test_proxy`, `test_exec`, `test_fuse_copy_file_range_vm`, …). These tests do not assert snapshot behavior, so skipping the pre-start snapshot both fixes the timeout and reduces total dump contention. This is issue #618's preferred option 1 (root-cause fix), not a timing workaround.

Removed the three `#[ignore = "...#618..."]` markers, re-enabling:
- `test_sigint_kills_firecracker_bridged`
- `test_sigterm_kills_firecracker_bridged`
- `test_sigterm_cleanup_bridged`

Applied `--no-snapshot` to the rootless and routed one-shot variants too (they also gain nothing from the pre-start snapshot). This proactively covers the #619 watch-item where `test_sigkill_kills_firecracker_rootless` flaked once under load — same one-shot-under-contention class.

## Test results
```
$ cargo fmt -p fcvm --check        # clean
$ cargo clippy --all-targets -- -D warnings   # clean
```
Behavioral validation is the SnapshotEnabled CI matrix on this PR — the exact environment where the timeouts reproduced.