### PR TITLE
fix: redirect every vmstate-embedded disk dir on restore (#608)

### DIFF
--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -712,25 +712,34 @@ pub struct RestoreParams<'a> {
     pub track_dirty_pages: bool,
 }
 
-/// Recover the `vm-disks/<vm_id>` directory IDs that are embedded as block-device
-/// `path_on_host` strings inside a Firecracker `vmstate.bin`.
+/// Recover the `vm-disks/<vm_id>` directory IDs that own the rootfs `path_on_host`
+/// strings embedded inside a Firecracker `vmstate.bin`.
 ///
 /// Firecracker serializes each drive's host path as a plain UTF-8 string, so we can
-/// read the exact paths `LoadSnapshot` will open instead of trusting (possibly stale)
-/// snapshot metadata. This is the ground truth for the bind-mount redirects (#608):
-/// a multi-level snapshot chain (cache → snapshot → cache → snapshot) can embed an
-/// intermediate VM's disk path that the metadata — which only tracks the immediate
+/// read the exact rootfs path `LoadSnapshot` will open instead of trusting (possibly
+/// stale) snapshot metadata. This is the ground truth for the bind-mount redirects
+/// (#608): a multi-level snapshot chain (cache → snapshot → cache → snapshot) can embed
+/// an intermediate VM's disk path that the metadata — which only tracks the immediate
 /// creator (`vm_id`) and the original vsock VM (`original_vsock_vm_id`) — no longer
-/// names. Without a redirect for that directory, `LoadSnapshot` opens the embedded
-/// path directly: it fails (ENOENT) once that sibling has been cleaned up, or, worse,
+/// names. Without a redirect for that directory, `LoadSnapshot` opens the embedded path
+/// directly: it fails (ENOENT) once that sibling has been cleaned up, or, worse,
 /// silently opens a different live VM's rootfs.
 ///
-/// Returns the de-duplicated vm_ids found in any `…/vm-disks/<vm_id>/disks…` path.
-/// Best-effort: an unreadable file or no matches yields an empty vec, leaving the
-/// metadata-derived redirects untouched (purely additive, never removes a redirect).
+/// The match is anchored to fcvm's own rootfs filename, `…/vm-disks/<id>/disks/rootfs.raw`,
+/// NOT any `…/vm-disks/<id>/disks…` path. An external `--disk` whose host path happens to
+/// live under such a directory must not be redirected: it is deliberately not copied into
+/// the clone dir (`extra_disks_to_snapshot` filters it out), so shadowing it with a
+/// bind-mount would break `LoadSnapshot`. Bind-mounting the matched `vm-disks/<id>` dir
+/// still redirects any sibling extra disks in the same dir, so this only narrows what we
+/// *match on*, not what a matched redirect covers.
+///
+/// Returns the de-duplicated vm_ids whose rootfs path is embedded. Best-effort: an
+/// unreadable file or no matches yields an empty vec, leaving the metadata-derived
+/// redirects untouched (purely additive, never removes a redirect).
 pub(crate) fn disk_vm_ids_in_vmstate(vmstate_path: &Path) -> Vec<String> {
     const PREFIX: &[u8] = b"/vm-disks/";
-    const SUFFIX: &[u8] = b"/disks";
+    // Anchor on the rootfs filename so an external --disk under a vm-disks dir is ignored.
+    const SUFFIX: &[u8] = b"/disks/rootfs.raw";
 
     let Ok(bytes) = std::fs::read(vmstate_path) else {
         return Vec::new();
@@ -757,7 +766,7 @@ pub(crate) fn disk_vm_ids_in_vmstate(vmstate_path: &Path) -> Vec<String> {
             }
             id_end += 1;
         }
-        // Require the canonical `…/vm-disks/<id>/disks` shape before trusting it.
+        // Require the canonical `…/vm-disks/<id>/disks/rootfs.raw` shape before trusting it.
         if id_end > id_start && bytes[id_end..].starts_with(SUFFIX) {
             if let Ok(id) = std::str::from_utf8(&bytes[id_start..id_end]) {
                 if !ids.iter().any(|e| e == id) {
@@ -2232,29 +2241,34 @@ mod tests {
         assert_eq!(chain, vec!["my-snap", "startup-def", "pre-start-abc"]);
     }
 
-    /// #608: the vmstate disk-path scanner must recover every embedded `vm-disks/<id>`
-    /// directory from a binary blob, including ids the snapshot metadata no longer
-    /// names, while ignoring binary noise and non-canonical occurrences.
+    /// #608: the vmstate scanner must recover every embedded rootfs `vm-disks/<id>`
+    /// directory from a binary blob (including ids the metadata no longer names) while
+    /// ignoring binary noise, non-canonical occurrences, AND — per Codex review — any
+    /// non-rootfs disk path (an external `--disk` that happens to live under a vm-disks
+    /// dir must not be redirected).
     #[test]
     fn test_disk_vm_ids_in_vmstate_extracts_embedded_paths() {
         use std::io::Write;
         use tempfile::NamedTempFile;
 
         let mut f = NamedTempFile::new().unwrap();
-        // Binary noise, then a rootfs path, more noise, an extra-disk path for a
-        // DIFFERENT vm_id (the dropped-intermediate case), a duplicate, and a
-        // non-canonical `/vm-disks/...` without the `/disks` suffix that must be ignored.
+        // Binary noise, then a rootfs path, more noise, a SECOND distinct rootfs path
+        // (the dropped-intermediate case in a multi-level chain), and a duplicate.
         f.write_all(&[0x00, 0xFF, 0x07, 0x42]).unwrap();
         f.write_all(b"/mnt/fcvm-btrfs/container/vm-disks/vm-c09f1234/disks/rootfs.raw")
             .unwrap();
         f.write_all(&[0x00, 0x00, 0x13]).unwrap();
-        f.write_all(b"/mnt/fcvm-btrfs/container/vm-disks/vm-5ba53cAA/disks/disk-dir-0.raw")
+        f.write_all(b"/mnt/fcvm-btrfs/container/vm-disks/vm-5ba53cAA/disks/rootfs.raw")
             .unwrap();
         f.write_all(&[0x99]).unwrap();
         // duplicate of the first id — must be de-duplicated
-        f.write_all(b"/mnt/fcvm-btrfs/container/vm-disks/vm-c09f1234/disks/extra.raw")
+        f.write_all(b"/mnt/fcvm-btrfs/container/vm-disks/vm-c09f1234/disks/rootfs.raw")
             .unwrap();
-        // non-canonical: no `/disks` segment — must be ignored
+        // An external --disk that lives under a vm-disks dir but is NOT a rootfs — must
+        // be ignored so we don't shadow a drive the clone dir doesn't contain.
+        f.write_all(b"/mnt/fcvm-btrfs/container/vm-disks/vm-extern99/disks/my-external.raw")
+            .unwrap();
+        // non-canonical: no `/disks/rootfs.raw` suffix — must be ignored
         f.write_all(b"/vm-disks/not-a-disk-dir/state\x00").unwrap();
         f.flush().unwrap();
 
@@ -2263,7 +2277,8 @@ mod tests {
         assert_eq!(
             ids,
             vec!["vm-5ba53cAA".to_string(), "vm-c09f1234".to_string()],
-            "should recover both embedded disk vm_ids (deduped), ignoring noise and non-disk paths"
+            "should recover only the embedded rootfs vm_ids (deduped), ignoring noise, \
+             non-canonical paths, and non-rootfs (external) disks"
         );
     }
 

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -712,6 +712,64 @@ pub struct RestoreParams<'a> {
     pub track_dirty_pages: bool,
 }
 
+/// Recover the `vm-disks/<vm_id>` directory IDs that are embedded as block-device
+/// `path_on_host` strings inside a Firecracker `vmstate.bin`.
+///
+/// Firecracker serializes each drive's host path as a plain UTF-8 string, so we can
+/// read the exact paths `LoadSnapshot` will open instead of trusting (possibly stale)
+/// snapshot metadata. This is the ground truth for the bind-mount redirects (#608):
+/// a multi-level snapshot chain (cache → snapshot → cache → snapshot) can embed an
+/// intermediate VM's disk path that the metadata — which only tracks the immediate
+/// creator (`vm_id`) and the original vsock VM (`original_vsock_vm_id`) — no longer
+/// names. Without a redirect for that directory, `LoadSnapshot` opens the embedded
+/// path directly: it fails (ENOENT) once that sibling has been cleaned up, or, worse,
+/// silently opens a different live VM's rootfs.
+///
+/// Returns the de-duplicated vm_ids found in any `…/vm-disks/<vm_id>/disks…` path.
+/// Best-effort: an unreadable file or no matches yields an empty vec, leaving the
+/// metadata-derived redirects untouched (purely additive, never removes a redirect).
+pub(crate) fn disk_vm_ids_in_vmstate(vmstate_path: &Path) -> Vec<String> {
+    const PREFIX: &[u8] = b"/vm-disks/";
+    const SUFFIX: &[u8] = b"/disks";
+
+    let Ok(bytes) = std::fs::read(vmstate_path) else {
+        return Vec::new();
+    };
+
+    let mut ids: Vec<String> = Vec::new();
+    let mut search_from = 0usize;
+    while let Some(rel) = bytes[search_from..]
+        .windows(PREFIX.len())
+        .position(|w| w == PREFIX)
+    {
+        let id_start = search_from + rel + PREFIX.len();
+        // The vm_id runs until the next '/'. vm_ids are ASCII [A-Za-z0-9-]; stop early
+        // on anything else so binary noise after a non-path occurrence is ignored.
+        let mut id_end = id_start;
+        while id_end < bytes.len() {
+            let c = bytes[id_end];
+            if c == b'/' {
+                break;
+            }
+            if !(c.is_ascii_alphanumeric() || c == b'-') {
+                id_end = id_start; // not a real path segment
+                break;
+            }
+            id_end += 1;
+        }
+        // Require the canonical `…/vm-disks/<id>/disks` shape before trusting it.
+        if id_end > id_start && bytes[id_end..].starts_with(SUFFIX) {
+            if let Ok(id) = std::str::from_utf8(&bytes[id_start..id_end]) {
+                if !ids.iter().any(|e| e == id) {
+                    ids.push(id.to_string());
+                }
+            }
+        }
+        search_from = id_start.max(search_from + rel + 1);
+    }
+    ids
+}
+
 /// Restore a VM from a snapshot.
 ///
 /// This is the core snapshot restore logic shared by:
@@ -950,6 +1008,22 @@ pub async fn restore_from_snapshot(
     if let Some(ref snapshot_vm_id) = restore_config.snapshot_vm_id {
         if snapshot_vm_id != &restore_config.original_vm_id {
             baseline_dirs.push(paths::vm_runtime_dir(snapshot_vm_id));
+        }
+    }
+    // Ground truth (#608): redirect every vm-disks dir actually embedded in
+    // vmstate.bin, not just the ones the metadata names. A multi-level snapshot
+    // chain can embed an intermediate VM's disk path that original_vm_id /
+    // snapshot_vm_id no longer reference; without a redirect for it, LoadSnapshot
+    // opens that (possibly cleaned-up sibling) path directly. This is additive —
+    // it only ever adds a correct redirect, never drops one.
+    for embedded_id in disk_vm_ids_in_vmstate(&restore_config.vmstate_path) {
+        let dir = paths::vm_runtime_dir(&embedded_id);
+        if !baseline_dirs.contains(&dir) {
+            info!(
+                embedded_disk_vm_id = %embedded_id,
+                "redirecting vmstate-embedded disk dir not named by snapshot metadata (#608)"
+            );
+            baseline_dirs.push(dir);
         }
     }
     info!(
@@ -2156,5 +2230,47 @@ mod tests {
         }
 
         assert_eq!(chain, vec!["my-snap", "startup-def", "pre-start-abc"]);
+    }
+
+    /// #608: the vmstate disk-path scanner must recover every embedded `vm-disks/<id>`
+    /// directory from a binary blob, including ids the snapshot metadata no longer
+    /// names, while ignoring binary noise and non-canonical occurrences.
+    #[test]
+    fn test_disk_vm_ids_in_vmstate_extracts_embedded_paths() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let mut f = NamedTempFile::new().unwrap();
+        // Binary noise, then a rootfs path, more noise, an extra-disk path for a
+        // DIFFERENT vm_id (the dropped-intermediate case), a duplicate, and a
+        // non-canonical `/vm-disks/...` without the `/disks` suffix that must be ignored.
+        f.write_all(&[0x00, 0xFF, 0x07, 0x42]).unwrap();
+        f.write_all(b"/mnt/fcvm-btrfs/container/vm-disks/vm-c09f1234/disks/rootfs.raw")
+            .unwrap();
+        f.write_all(&[0x00, 0x00, 0x13]).unwrap();
+        f.write_all(b"/mnt/fcvm-btrfs/container/vm-disks/vm-5ba53cAA/disks/disk-dir-0.raw")
+            .unwrap();
+        f.write_all(&[0x99]).unwrap();
+        // duplicate of the first id — must be de-duplicated
+        f.write_all(b"/mnt/fcvm-btrfs/container/vm-disks/vm-c09f1234/disks/extra.raw")
+            .unwrap();
+        // non-canonical: no `/disks` segment — must be ignored
+        f.write_all(b"/vm-disks/not-a-disk-dir/state\x00").unwrap();
+        f.flush().unwrap();
+
+        let mut ids = disk_vm_ids_in_vmstate(f.path());
+        ids.sort();
+        assert_eq!(
+            ids,
+            vec!["vm-5ba53cAA".to_string(), "vm-c09f1234".to_string()],
+            "should recover both embedded disk vm_ids (deduped), ignoring noise and non-disk paths"
+        );
+    }
+
+    /// An unreadable vmstate path yields no ids (best-effort, never panics or errors).
+    #[test]
+    fn test_disk_vm_ids_in_vmstate_missing_file_is_empty() {
+        let ids = disk_vm_ids_in_vmstate(Path::new("/nonexistent/vmstate.bin"));
+        assert!(ids.is_empty());
     }
 }

--- a/tests/test_clone_connection.rs
+++ b/tests/test_clone_connection.rs
@@ -1258,3 +1258,125 @@ done
         anyhow::bail!("Clone's resilient client did not reconnect")
     }
 }
+
+/// Read a VM's `vm_id` from `fcvm ls --json --pid <pid>`.
+async fn vm_id_for_pid(fcvm_path: &std::path::Path, pid: u32) -> Result<String> {
+    let output = tokio::process::Command::new(fcvm_path)
+        .args(["ls", "--json", "--pid", &pid.to_string()])
+        .output()
+        .await
+        .context("running fcvm ls")?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let vms: serde_json::Value = serde_json::from_str(&stdout).context("parsing fcvm ls json")?;
+    vms.as_array()
+        .and_then(|a| a.first())
+        .and_then(|v| v.get("vm_id"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| anyhow::anyhow!("no vm_id for pid {} in: {}", pid, stdout))
+}
+
+/// Regression for #608: restoring from a snapshot must succeed even after the
+/// creating VM's `vm-disks/<id>` directory — whose rootfs path is embedded in
+/// vmstate.bin — has been cleaned up.
+///
+/// Before the fix, `LoadSnapshot` opened the embedded path directly and failed with
+/// "No such file or directory" once that sibling directory was gone (or, worse,
+/// silently opened a different live VM's rootfs). The restore now redirects every
+/// vm-disks dir actually embedded in vmstate.bin onto the clone's own disk, so a
+/// cleaned-up creator no longer breaks (or misdirects) the restore.
+#[tokio::test]
+async fn test_clone_restore_after_creator_dir_removed_rootless() -> Result<()> {
+    println!("\ntest_clone_restore_after_creator_dir_removed_rootless (#608)");
+
+    let fcvm_path = common::find_fcvm_binary()?;
+    let (baseline_name, clone_name, snapshot_name, _serve_name) = common::unique_names("sib608");
+
+    // 1. Start the baseline VM and capture its vm_id (its disk dir is the one whose
+    //    path gets embedded in the snapshot's vmstate.bin).
+    let (mut baseline_child, baseline_pid) = common::spawn_fcvm_with_logs(
+        &[
+            "podman",
+            "run",
+            "--name",
+            &baseline_name,
+            common::TEST_IMAGE,
+        ],
+        &baseline_name,
+    )
+    .await
+    .context("spawning baseline VM")?;
+    common::poll_health_by_pid(baseline_pid, 120).await?;
+    let baseline_vm_id = vm_id_for_pid(&fcvm_path, baseline_pid).await?;
+    println!("  baseline vm_id = {}", baseline_vm_id);
+
+    // 2. Snapshot it.
+    let output = tokio::process::Command::new(&fcvm_path)
+        .args([
+            "snapshot",
+            "create",
+            "--pid",
+            &baseline_pid.to_string(),
+            "--tag",
+            &snapshot_name,
+        ])
+        .output()
+        .await
+        .context("creating snapshot")?;
+    anyhow::ensure!(
+        output.status.success(),
+        "snapshot create failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // 3. Stop the baseline and delete its vm-disks directory, simulating the
+    //    sibling-cleanup that triggers #608. The snapshot keeps its own disk.raw,
+    //    so the only thing now missing is the creator path embedded in vmstate.bin.
+    common::kill_process(baseline_pid).await;
+    let _ = baseline_child.wait().await;
+    let creator_dir = fcvm::paths::vm_runtime_dir(&baseline_vm_id);
+    if creator_dir.exists() {
+        std::fs::remove_dir_all(&creator_dir)
+            .with_context(|| format!("removing creator dir {}", creator_dir.display()))?;
+    }
+    anyhow::ensure!(
+        !creator_dir.exists(),
+        "creator dir should be gone: {}",
+        creator_dir.display()
+    );
+    println!("  removed creator dir {}", creator_dir.display());
+
+    // 4. Serve the snapshot and restore a clone — must become healthy despite the
+    //    embedded creator path no longer existing on disk.
+    let (mut serve_child, serve_pid) =
+        common::spawn_fcvm_with_logs(&["snapshot", "serve", &snapshot_name], "uffd-server")
+            .await
+            .context("spawning serve")?;
+    common::poll_serve_ready(&snapshot_name, serve_pid, 30).await?;
+
+    let (mut clone_child, clone_pid) = common::spawn_fcvm_with_logs(
+        &[
+            "snapshot",
+            "run",
+            "--pid",
+            &serve_pid.to_string(),
+            "--name",
+            &clone_name,
+        ],
+        &clone_name,
+    )
+    .await
+    .context("spawning clone")?;
+
+    let restore_ok = common::poll_health_by_pid(clone_pid, 120).await;
+
+    // Cleanup regardless of outcome.
+    common::kill_process(clone_pid).await;
+    let _ = clone_child.wait().await;
+    common::kill_process(serve_pid).await;
+    let _ = serve_child.wait().await;
+
+    restore_ok.context("clone restore must succeed after the creator's disk dir was removed")?;
+    println!("✅ clone restored healthy despite removed creator dir (#608)");
+    Ok(())
+}


### PR DESCRIPTION
Closes #608.

## Root cause (confirmed)
Snapshot restore builds its mount-namespace path redirects (`baseline_dirs`) purely from snapshot **metadata** — `original_vm_id` (vsock paths) and `snapshot_vm_id` (disk paths) — and never checks them against the disk paths actually **embedded in vmstate.bin**.

Firecracker's `LoadSnapshot` (with `resume_vm: false`) opens each drive's `path_on_host` *before* `patch_drive` retargets it, so the path embedded in vmstate.bin must exist and resolve correctly at load time. The bind-mount in `pre_exec` (`src/firecracker/vm.rs`) is what makes the creator's embedded path resolve to the restoring VM's own reflinked disk.

In a multi-level snapshot chain (cache restore → snapshot → cache restore → snapshot), an **intermediate** VM's disk path gets embedded in vmstate.bin, but the metadata only tracks the immediate creator (`vm_id`) and the original vsock VM (`original_vsock_vm_id`) — the intermediate id is dropped. With no redirect for it:
- if that sibling's `vm-disks/<id>` was already cleaned up → `LoadSnapshot` fails with `No such file or directory` (the observed ~0.7% intermittent crash), or
- if it resolves to a *different live* VM's disk → restore silently boots the wrong container's rootfs.

## Fix
Read the ground truth instead of trusting metadata. `disk_vm_ids_in_vmstate()` scans vmstate.bin for the `…/vm-disks/<id>/disks…` path strings Firecracker serializes (plain UTF-8), and restore adds a bind-mount redirect for **every** such dir. This is **purely additive** — it only ever adds a correct redirect on top of the metadata-derived set, never removes one — so the working common path is unchanged and any chain depth is covered. The existing create-dir-if-missing guard in `vm.rs` supplies the mountpoint when the embedded dir was cleaned up.

## Tests
- **Unit (run locally, pass):**
  ```
  test commands::common::tests::test_disk_vm_ids_in_vmstate_extracts_embedded_paths ... ok
  test commands::common::tests::test_disk_vm_ids_in_vmstate_missing_file_is_empty ... ok
  ```
  Extracts and de-dupes embedded ids from a synthetic binary blob (including an intermediate id), ignores non-`/disks` occurrences, and returns empty on a missing file.
- **Integration (#608 deterministic regression, `test_clone_connection.rs`):** snapshot a VM, **delete its `vm-disks/<id>` dir**, then serve + restore a clone and assert it becomes healthy — reproduces the sibling-cleanup failure and verifies the fix. Validated in the rootless clone CI matrix.

cc @codex review — this reads a path out of Firecracker's vmstate.bin by scanning for the serialized `path_on_host` string; please scrutinize that approach and the additive redirect logic.