### PR TITLE
test+agent: host-side exec timeout and guest accept trace for #617

### DIFF
--- a/fc-agent/src/exec.rs
+++ b/fc-agent/src/exec.rs
@@ -75,6 +75,15 @@ pub async fn run_server(
             result = listener.accept() => {
                 match result {
                     Ok(client_fd) => {
+                        // Diagnostic for #617: confirms accept() actually fired after a
+                        // restore. If a restored-VM exec hangs and this line is absent
+                        // from the serial log while "re-registered" is present, the
+                        // re-registered listener is not delivering readiness for new
+                        // connections (vs. the hang being downstream in handle_connection).
+                        eprintln!(
+                            "[fc-agent] exec server: accepted connection on vsock port {}",
+                            vsock::EXEC_PORT
+                        );
                         tokio::spawn(handle_connection(client_fd));
                     }
                     Err(e) => {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -908,24 +908,41 @@ pub async fn poll_serve_state_by_pid(pid: u32, timeout_secs: u64) -> anyhow::Res
     }
 }
 
-/// Execute a command in the guest VM via exec (--vm flag for VM-level, default is container)
-pub async fn exec_in_vm(pid: u32, cmd: &[&str]) -> anyhow::Result<String> {
+/// Host-side timeout for an exec helper. A hung guest exec server (e.g. #617: exec
+/// into a restored VM that never accepts the connection) must fail fast with a clear
+/// message instead of blocking to the 600s nextest ceiling, which hides the cause.
+/// 120s is well under that ceiling but generous for any legitimately slow command.
+const EXEC_HELPER_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Run `fcvm exec` with a host-side timeout, returning stdout on success.
+/// `vm == true` execs at VM level (`--vm`); otherwise inside the container.
+async fn exec_with_timeout(pid: u32, cmd: &[&str], vm: bool) -> anyhow::Result<String> {
     let fcvm_path = find_fcvm_binary()?;
     let script = cmd.join(" ");
 
-    let output = tokio::process::Command::new(&fcvm_path)
-        .args([
-            "exec",
-            "--pid",
-            &pid.to_string(),
-            "--vm",
-            "--",
-            "sh",
-            "-c",
-            &script,
-        ])
-        .output()
-        .await?;
+    let mut command = tokio::process::Command::new(&fcvm_path);
+    command.arg("exec").arg("--pid").arg(pid.to_string());
+    if vm {
+        command.arg("--vm");
+    }
+    command
+        .args(["--", "sh", "-c", &script])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        // Kill the child if we drop it on timeout so it doesn't linger.
+        .kill_on_drop(true);
+
+    let child = command.spawn().context("spawning fcvm exec")?;
+    let output = match tokio::time::timeout(EXEC_HELPER_TIMEOUT, child.wait_with_output()).await {
+        Ok(result) => result.context("waiting for fcvm exec")?,
+        Err(_) => anyhow::bail!(
+            "fcvm exec timed out after {:?} (pid {}, cmd {:?}) — the guest exec server never \
+             responded. On a restored VM this is #617 (restored-VM exec hang).",
+            EXEC_HELPER_TIMEOUT,
+            pid,
+            cmd
+        ),
+    };
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -935,22 +952,14 @@ pub async fn exec_in_vm(pid: u32, cmd: &[&str]) -> anyhow::Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
+/// Execute a command in the guest VM via exec (--vm flag for VM-level, default is container)
+pub async fn exec_in_vm(pid: u32, cmd: &[&str]) -> anyhow::Result<String> {
+    exec_with_timeout(pid, cmd, true).await
+}
+
 /// Execute a command in the container via exec (default behavior)
 pub async fn exec_in_container(pid: u32, cmd: &[&str]) -> anyhow::Result<String> {
-    let fcvm_path = find_fcvm_binary()?;
-    let script = cmd.join(" ");
-
-    let output = tokio::process::Command::new(&fcvm_path)
-        .args(["exec", "--pid", &pid.to_string(), "sh", "-c", &script])
-        .output()
-        .await?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("exec failed: {}", stderr);
-    }
-
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    exec_with_timeout(pid, cmd, false).await
 }
 
 /// Create a snapshot from a running VM by PID


### PR DESCRIPTION
Addresses #617 (step 1 of its plan). Does **not** close it.

## Background
`test_readme_examples::test_custom_command_bridged` hangs to the 600s nextest ceiling on the **second** SnapshotEnabled pass (the restore pass). Tracing the code: the host `fcvm exec` CONNECT handshake succeeds at Firecracker's vsock proxy (`OK <port>`), then the host blocks reading command output under a **3600s** internal read timeout while the guest exec server never services the connection. The test helper has no timeout, so the hang surfaces only as the 600s ceiling — which hides the cause.

The guest re-registers its vsock listener on restore (`exec_rebind_needed`, set only by the MMDS restore-epoch watcher → `VsockListener::re_register()`). Whether `accept()` then fires for a connection arriving *after* re-register (and after the startup snapshot that immediately follows the restore) is exactly what's unknown. The issue's plan: **make the failure legible first, then capture the guest `accept()` trace** to root-cause the real bug.

## This PR (no behavior change to production paths)
- **`tests/common/mod.rs`** — `exec_in_vm` / `exec_in_container` now run `fcvm exec` under a 120s host-side timeout (`kill_on_drop`), failing fast with a `#617`-referencing message instead of hanging to the ceiling (also satisfies #619 step 6: helper timeouts everywhere). Both delegate to a shared `exec_with_timeout`.
- **`fc-agent/src/exec.rs`** — log `accepted connection on vsock port N` when `accept()` fires. With the existing `re-registered` log, the serial console will now show whether `accept()` ever fires for a post-restore exec, distinguishing "listener never delivers readiness" from "hang downstream in `handle_connection`".

## Not done here (deliberately)
`test_custom_command_bridged` stays `#[ignore]`'d. Re-enabling a still-hanging test would only re-red the SnapshotEnabled matrix. It re-enables once the captured trace confirms the actual vsock fix.

## Test results
```
cargo fmt -p fcvm -p fc-agent --check    # clean
cargo clippy --all-targets --all-features -- -D warnings   # clean
```

cc @codex review — please sanity-check the timeout/kill_on_drop helper and the guest log placement.