### PR TITLE
fix: export localhost images by immutable image ID (#598)

### DIFF
--- a/src/commands/podman/image.rs
+++ b/src/commands/podman/image.rs
@@ -106,10 +106,17 @@ pub(super) async fn get_image_cache_ref(image: &str) -> Result<ImageCacheRef> {
         )
     })?;
 
-    let cache_key = digest.trim().trim_start_matches("sha256:").to_string();
     let image_id = id.trim().to_string();
     if image_id.is_empty() {
         bail!("podman returned an empty image id for '{}'", image);
+    }
+
+    // A locally-built image can report an empty manifest digest. Fall back to the
+    // (always-present, immutable) image id so distinct images never collide on an empty
+    // cache key — which would conflate their cached archives/snapshots.
+    let mut cache_key = digest.trim().trim_start_matches("sha256:").to_string();
+    if cache_key.is_empty() {
+        cache_key = image_id.trim_start_matches("sha256:").to_string();
     }
 
     Ok(ImageCacheRef {

--- a/src/commands/podman/image.rs
+++ b/src/commands/podman/image.rs
@@ -78,6 +78,79 @@ pub(super) async fn get_image_identifier(image: &str) -> Result<String> {
     }
 }
 
+/// Get the immutable image ID (config digest, e.g. `sha256:abc…`) for a localhost image.
+///
+/// Captured at inspect time so the later export can pin the exact content the digest
+/// cache key names, even if a parallel build repoints the tag in between (#598).
+/// Unlike a manifest digest, an image ID is accepted by `skopeo copy
+/// containers-storage:<id>`, which lets us export immutable content while still
+/// writing the original repo tag into the archive's RepoTags.
+pub(super) async fn get_localhost_image_id(image: &str) -> Result<String> {
+    let output = tokio::process::Command::new("podman")
+        .args(["image", "inspect", image, "--format", "{{.Id}}"])
+        .output()
+        .await
+        .context("running podman inspect for image id")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("Failed to get image id for '{}': {}", image, stderr);
+    }
+
+    let id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if id.is_empty() {
+        bail!("podman returned an empty image id for '{}'", image);
+    }
+    Ok(id)
+}
+
+/// Export a localhost image's content to a docker-archive at `dest`, by immutable
+/// image ID, tagged as `repo_tag`.
+///
+/// `skopeo copy containers-storage:<image_id>` reads the exact image content named by
+/// the ID — immune to a concurrent `podman build` repointing the tag (#598) — while the
+/// `docker-archive:<dest>:<repo_tag>` destination records `repo_tag` in the archive's
+/// RepoTags so the guest can `podman load` and run it by name. This is non-destructive:
+/// unlike `podman tag <id> <repo_tag>`, it never mutates the caller's live image store.
+///
+/// `repo_tag` may contain a `:` (e.g. `localhost/foo:latest`); skopeo treats everything
+/// after the archive path as the reference, so the colon is preserved.
+pub async fn export_image_archive(image_id: &str, repo_tag: &str, dest: &Path) -> Result<()> {
+    let dest_str = dest
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("archive path is not valid UTF-8: {}", dest.display()))?;
+
+    let output = tokio::process::Command::new("skopeo")
+        .args([
+            "copy",
+            &format!("containers-storage:{}", image_id),
+            &format!("docker-archive:{}:{}", dest_str, repo_tag),
+        ])
+        .output()
+        .await
+        .context("running skopeo copy")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "skopeo copy failed for image '{}' (id {}): {}",
+            repo_tag,
+            image_id,
+            stderr
+        );
+    }
+
+    // docker-archive format requires manifest.json; guard against a malformed archive.
+    if !validate_docker_archive(dest)? {
+        bail!(
+            "skopeo copy produced an invalid archive (missing manifest.json) for image '{}'",
+            repo_tag
+        );
+    }
+
+    Ok(())
+}
+
 /// Create an ext4 disk image from a directory's contents.
 ///
 /// When `shrink` is true, runs `resize2fs -M` after creation to minimize the image size.

--- a/src/commands/podman/image.rs
+++ b/src/commands/podman/image.rs
@@ -48,60 +48,74 @@ pub(super) fn validate_docker_archive(archive_path: &Path) -> Result<bool> {
     Ok(false)
 }
 
-/// Get the image identifier for cache key computation.
+/// An image's cache key and (for localhost images) its immutable export source.
 ///
-/// For localhost/ images: returns SHA256 digest from podman (requires podman)
-/// For remote images: returns the image URL/name as-is (no podman needed)
-pub(super) async fn get_image_identifier(image: &str) -> Result<String> {
-    if image.starts_with("localhost/") {
-        // Use podman to get the digest for localhost images
-        let output = tokio::process::Command::new("podman")
-            .args(["image", "inspect", image, "--format", "{{.Digest}}"])
-            .output()
-            .await
-            .context("running podman inspect")?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            bail!("Failed to get digest for image '{}': {}", image, stderr);
-        }
-
-        let digest = String::from_utf8_lossy(&output.stdout)
-            .trim()
-            .trim_start_matches("sha256:")
-            .to_string();
-
-        Ok(digest)
-    } else {
-        // For remote images, use the image name/URL as identifier
-        Ok(image.to_string())
-    }
+/// `cache_key` is the snapshot/image-cache key: the SHA256 manifest digest for
+/// `localhost/` images, or the image reference itself for remote images. `image_id`
+/// is the immutable image ID (`sha256:…`) used to export by content; it is `None` for
+/// remote images (which are pulled in the guest, not exported).
+pub(super) struct ImageCacheRef {
+    pub cache_key: String,
+    pub image_id: Option<String>,
 }
 
-/// Get the immutable image ID (config digest, e.g. `sha256:abc…`) for a localhost image.
+/// Resolve an image's cache key and immutable export id in a SINGLE `podman image
+/// inspect`.
 ///
-/// Captured at inspect time so the later export can pin the exact content the digest
-/// cache key names, even if a parallel build repoints the tag in between (#598).
-/// Unlike a manifest digest, an image ID is accepted by `skopeo copy
-/// containers-storage:<id>`, which lets us export immutable content while still
-/// writing the original repo tag into the archive's RepoTags.
-pub(super) async fn get_localhost_image_id(image: &str) -> Result<String> {
+/// Capturing both fields from one observation is required for correctness (#598):
+/// taking the digest and the id from two separate inspects lets a parallel
+/// `podman build` repoint the tag in between, so the cache key would name the old
+/// manifest while the export id names the new image — caching the wrong content under
+/// the old key. One inspect makes them an atomic view of the same image.
+///
+/// For remote images there is no local id and the reference is used as the key.
+pub(super) async fn get_image_cache_ref(image: &str) -> Result<ImageCacheRef> {
+    if !image.starts_with("localhost/") {
+        // Remote images: the reference is the key; no local id (pulled in the guest).
+        return Ok(ImageCacheRef {
+            cache_key: image.to_string(),
+            image_id: None,
+        });
+    }
+
+    // `\t` never appears in a digest or an image id, so it is a safe field separator.
     let output = tokio::process::Command::new("podman")
-        .args(["image", "inspect", image, "--format", "{{.Id}}"])
+        .args([
+            "image",
+            "inspect",
+            image,
+            "--format",
+            "{{.Digest}}\t{{.Id}}",
+        ])
         .output()
         .await
-        .context("running podman inspect for image id")?;
+        .context("running podman inspect")?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        bail!("Failed to get image id for '{}': {}", image, stderr);
+        bail!("Failed to inspect image '{}': {}", image, stderr);
     }
 
-    let id = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if id.is_empty() {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let line = stdout.trim();
+    let (digest, id) = line.split_once('\t').ok_or_else(|| {
+        anyhow::anyhow!(
+            "unexpected `podman image inspect` output for '{}': {:?}",
+            image,
+            line
+        )
+    })?;
+
+    let cache_key = digest.trim().trim_start_matches("sha256:").to_string();
+    let image_id = id.trim().to_string();
+    if image_id.is_empty() {
         bail!("podman returned an empty image id for '{}'", image);
     }
-    Ok(id)
+
+    Ok(ImageCacheRef {
+        cache_key,
+        image_id: Some(image_id),
+    })
 }
 
 /// Export a localhost image's content to a docker-archive at `dest`, by immutable

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -16,6 +16,10 @@ mod vm_config;
 use types::VolumeMapping;
 pub use types::{CacheRequest, LogLine, SnapshotOutcome, VmContext, VmHandle};
 
+// Re-exported for the #598 regression test (export must pin immutable content by image
+// ID even when the tag is rebuilt mid-export).
+pub use image::export_image_archive;
+
 pub(crate) use listeners::run_output_listener;
 use listeners::run_status_listener;
 
@@ -34,7 +38,9 @@ use crate::network::{BridgedNetwork, NetworkManager, PastaNetwork, PortMapping, 
 use crate::paths;
 use crate::state::{generate_vm_id, truncate_id, validate_vm_name, StateManager, VmState};
 use crate::volume::{spawn_volume_servers, VolumeConfig};
-use image::{build_storage_image, get_image_identifier, validate_docker_archive};
+use image::{
+    build_storage_image, get_image_identifier, get_localhost_image_id, validate_docker_archive,
+};
 use tokio_util::sync::CancellationToken;
 
 /// Resolve the rootfs filesystem type from CLI args and kernel profile config.
@@ -315,6 +321,15 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
     // tag is rebuilt between two separate inspects.
     let image_identifier = get_image_identifier(&args.image).await?;
 
+    // For localhost/ images, also capture the immutable image ID now, right next to the
+    // digest cache key, so the export below pins the exact content this key names even if
+    // a parallel build repoints the tag before the export runs (#598).
+    let localhost_image_id = if args.image.starts_with("localhost/") {
+        Some(get_localhost_image_id(&args.image).await?)
+    } else {
+        None
+    };
+
     // Check for snapshot cache (unless --no-snapshot is set or FCVM_NO_SNAPSHOT env var)
     // Keep fc_config and snapshot_key available for later snapshot creation on miss
     let no_snapshot = args.no_snapshot
@@ -503,58 +518,22 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
             // .docker.docker.tar.tmp (double .docker). Use format! to just append .tmp.
             let tmp_path = PathBuf::from(format!("{}.tmp", archive_path.display()));
 
-            // Remove stale tmp file if it exists (podman save won't overwrite)
+            // Remove stale tmp file if it exists (skopeo won't overwrite)
             let _ = tokio::fs::remove_file(&tmp_path).await;
 
-            let output = tokio::process::Command::new("podman")
-                .args([
-                    "save",
-                    "--format",
-                    "docker-archive",
-                    "-o",
-                    tmp_path.to_str().unwrap(),
-                    &args.image,
-                ])
-                .output()
-                .await
-                .context("running podman save")?;
-
-            if !output.status.success() {
-                let stderr = String::from_utf8_lossy(&output.stderr);
+            // Export by the IMMUTABLE image ID captured at inspect time, not the mutable
+            // tag (#598). A parallel build can repoint the tag between the cache-key
+            // inspect and this export; `podman save <tag>` would then archive the newer
+            // build under the older digest's cache entry. export_image_archive pins the
+            // exact content the cache key names and writes the original repo tag into the
+            // archive's RepoTags, so the guest still loads and runs it by name.
+            let image_id = localhost_image_id.as_deref().ok_or_else(|| {
+                anyhow::anyhow!("internal: localhost image id was not captured at inspect time")
+            })?;
+            if let Err(e) = image::export_image_archive(image_id, &args.image, &tmp_path).await {
                 let _ = tokio::fs::remove_file(&tmp_path).await;
                 drop(lock_file);
-                bail!(
-                    "Failed to export image '{}' with podman save: {}",
-                    args.image,
-                    stderr
-                );
-            }
-
-            // Validate the archive contains manifest.json (required for docker-archive format)
-            if !validate_docker_archive(&tmp_path)? {
-                let _ = tokio::fs::remove_file(&tmp_path).await;
-                drop(lock_file);
-                bail!(
-                    "podman save produced invalid archive (missing manifest.json) for image '{}'",
-                    args.image
-                );
-            }
-
-            // podman save operates on the mutable tag, so re-check whether the tag still
-            // resolves to the digest used as the cache key. A concurrent rebuild of the
-            // same tag (parallel tests routinely rebuild shared localhost images) is
-            // legitimate, so this is a warning rather than an error: the archive may
-            // contain the newer build under the older digest's cache entry, which is the
-            // pre-existing race for mutable tags. Exporting by an immutable reference
-            // (while preserving the repo tag for the guest-side load) is the real fix.
-            let digest_after = get_image_identifier(&args.image).await?;
-            if digest_after != digest {
-                warn!(
-                    image = %args.image,
-                    digest_at_key = %digest,
-                    digest_at_export = %digest_after,
-                    "image was rebuilt while it was being exported; cached archive may be newer than its cache key"
-                );
+                return Err(e);
             }
 
             // Atomic rename within the same filesystem

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -38,9 +38,7 @@ use crate::network::{BridgedNetwork, NetworkManager, PastaNetwork, PortMapping, 
 use crate::paths;
 use crate::state::{generate_vm_id, truncate_id, validate_vm_name, StateManager, VmState};
 use crate::volume::{spawn_volume_servers, VolumeConfig};
-use image::{
-    build_storage_image, get_image_identifier, get_localhost_image_id, validate_docker_archive,
-};
+use image::{build_storage_image, get_image_cache_ref, validate_docker_archive};
 use tokio_util::sync::CancellationToken;
 
 /// Resolve the rootfs filesystem type from CLI args and kernel profile config.
@@ -315,20 +313,13 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
         None
     };
 
-    // Resolve the image identifier ONCE: digest for localhost/ images (single podman
-    // inspect), name for remote images. The same value feeds both the snapshot cache key
-    // and the image export cache below, so the two can never disagree when a localhost
-    // tag is rebuilt between two separate inspects.
-    let image_identifier = get_image_identifier(&args.image).await?;
-
-    // For localhost/ images, also capture the immutable image ID now, right next to the
-    // digest cache key, so the export below pins the exact content this key names even if
-    // a parallel build repoints the tag before the export runs (#598).
-    let localhost_image_id = if args.image.starts_with("localhost/") {
-        Some(get_localhost_image_id(&args.image).await?)
-    } else {
-        None
-    };
+    // Resolve the cache key (manifest digest for localhost/, reference for remote) AND
+    // the immutable export id in ONE inspect, so they are an atomic view of the same
+    // image: a parallel build that repoints the tag can't make the cache key name one
+    // image while the export pins another (#598). For remote images image_id is None.
+    let image_ref = get_image_cache_ref(&args.image).await?;
+    let image_identifier = image_ref.cache_key;
+    let localhost_image_id = image_ref.image_id;
 
     // Check for snapshot cache (unless --no-snapshot is set or FCVM_NO_SNAPSHOT env var)
     // Keep fc_config and snapshot_key available for later snapshot creation on miss

--- a/tests/test_localhost_image.rs
+++ b/tests/test_localhost_image.rs
@@ -229,3 +229,130 @@ CMD ["echo", "{marker}"]"#
     println!("  Built {} image", image_name);
     Ok(())
 }
+
+/// Get the immutable image ID (`sha256:…`) of a localhost image via podman.
+async fn podman_image_id(image_name: &str) -> Result<String> {
+    let out = tokio::process::Command::new("podman")
+        .args(["image", "inspect", image_name, "--format", "{{.Id}}"])
+        .output()
+        .await
+        .context("podman image inspect")?;
+    anyhow::ensure!(
+        out.status.success(),
+        "podman inspect failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// The container `Cmd` recorded in a docker-archive, via `skopeo inspect --config`.
+async fn archive_config_cmd(archive: &std::path::Path) -> Result<Vec<String>> {
+    let out = tokio::process::Command::new("skopeo")
+        .args([
+            "inspect",
+            "--config",
+            &format!("docker-archive:{}", archive.display()),
+        ])
+        .output()
+        .await
+        .context("skopeo inspect --config")?;
+    anyhow::ensure!(
+        out.status.success(),
+        "skopeo inspect --config failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let cfg: serde_json::Value = serde_json::from_slice(&out.stdout).context("parsing config")?;
+    Ok(cfg["config"]["Cmd"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default())
+}
+
+/// The RepoTags recorded in a docker-archive's manifest.json (what `podman load` uses
+/// to name the loaded image). Read directly from the tar — `skopeo inspect` does not
+/// surface docker-archive RepoTags reliably.
+async fn archive_repo_tags(archive: &std::path::Path) -> Result<Vec<String>> {
+    let out = tokio::process::Command::new("tar")
+        .args(["-xOf", &archive.to_string_lossy(), "manifest.json"])
+        .output()
+        .await
+        .context("extracting manifest.json")?;
+    anyhow::ensure!(out.status.success(), "tar extract manifest.json failed");
+    let manifest: serde_json::Value =
+        serde_json::from_slice(&out.stdout).context("parsing manifest.json")?;
+    Ok(manifest
+        .as_array()
+        .and_then(|a| a.first())
+        .and_then(|m| m["RepoTags"].as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default())
+}
+
+/// #598: the export must pin the immutable image ID's content even when the tag is
+/// rebuilt between the inspect (cache-key capture) and the export — otherwise the
+/// cached archive holds newer content than the digest used as its cache key. It must
+/// also preserve the repo tag so the guest can `podman load` and run it by name.
+#[tokio::test]
+async fn test_export_pins_immutable_content_across_tag_rebuild() -> Result<()> {
+    println!("\ntest_export_pins_immutable_content_across_tag_rebuild (#598)");
+    let image_name = image_name_for_suffix("export-pin-598");
+    let marker_v1 = "MARKER_V1_export598";
+    let marker_v2 = "MARKER_V2_export598";
+
+    // Build v1 and capture the immutable id fcvm would record at inspect time.
+    build_test_image(&image_name, marker_v1).await?;
+    let v1_id = podman_image_id(&image_name).await?;
+
+    // Rebuild the SAME tag with different content. The tag now resolves to v2, but the
+    // v1 image still exists under v1_id — exactly the race #598 describes.
+    build_test_image(&image_name, marker_v2).await?;
+    let v2_id = podman_image_id(&image_name).await?;
+    anyhow::ensure!(v1_id != v2_id, "rebuild should produce a new image id");
+
+    // Export by the v1 id (what fcvm captured before the rebuild).
+    let tmp = tempfile::TempDir::new()?;
+    let archive = tmp.path().join("out.docker.tar");
+    fcvm::commands::podman::export_image_archive(&v1_id, &image_name, &archive)
+        .await
+        .context("export_image_archive")?;
+
+    // The archive must hold v1's content, NOT the rebuilt v2.
+    let cmd = archive_config_cmd(&archive).await?;
+    assert!(
+        cmd.iter().any(|s| s.contains(marker_v1)),
+        "archive must hold v1 content; got Cmd {:?}",
+        cmd
+    );
+    assert!(
+        !cmd.iter().any(|s| s.contains(marker_v2)),
+        "archive must NOT hold the rebuilt v2 content; got Cmd {:?}",
+        cmd
+    );
+
+    // The original repo tag must be preserved for guest-side `podman load`. skopeo
+    // normalizes an untagged reference to `:latest`, so accept either form.
+    let repo_tags = archive_repo_tags(&archive).await?;
+    let tagged = format!("{}:latest", image_name);
+    assert!(
+        repo_tags.iter().any(|t| t == &image_name || t == &tagged),
+        "archive RepoTags must include {} (or {}); got {:?}",
+        image_name,
+        tagged,
+        repo_tags
+    );
+
+    let _ = tokio::process::Command::new("podman")
+        .args(["rmi", "-f", &image_name, &v1_id, &v2_id])
+        .output()
+        .await;
+    println!("✅ export pinned v1 content across tag rebuild (#598)");
+    Ok(())
+}


### PR DESCRIPTION
Closes #598.

## Problem
fcvm resolves a `localhost/` tag's digest at inspect time (`get_image_identifier`, the snapshot/image cache key) and runs the export later. The export used `podman save <tag>` — the **mutable tag** — so a parallel build that repointed the tag in between (parallel tests routinely rebuild shared localhost images) made the archive hold newer content than the digest its cache entry is keyed by. #594 downgraded that to a non-fatal warning; this is the real fix.

## Fix
Capture the **immutable image ID** alongside the digest at inspect time, and export with:
```
skopeo copy containers-storage:<image_id> docker-archive:<tmp>:<repo_tag>
```
- The image ID names exact content → the archive always matches the digest cache key, even if the tag is rebuilt mid-run.
- skopeo's `docker-archive` destination writes the original repo tag into the archive's `RepoTags`, so the guest still `podman load`s and runs it by name (no guest change needed).
- **Non-destructive**: unlike `podman tag <id> <tag>`, it never mutates the caller's live image store, so it can't clobber a concurrent rebuild.

The post-export digest re-check (the #594 warning) is removed: content is now pinned to the cache-key image, so the mismatch it warned about can no longer occur.

### Changes
- `src/commands/podman/image.rs`: `get_localhost_image_id()`; `export_image_archive()` (skopeo copy by id + manifest.json validation), re-exported from `podman`.
- `src/commands/podman/mod.rs`: capture the image id at inspect time, export via the new function.

## Test results (run locally, pass)
```
✅ export pinned v1 content across tag rebuild (#598)
PASS [0.552s] fcvm::test_localhost_image test_export_pins_immutable_content_across_tag_rebuild
```
Builds v1, captures its id, rebuilds the tag to v2, exports by the v1 id, and asserts the archive holds v1's `Cmd` (not v2) and preserves the repo tag.

cc @codex review — please scrutinize the skopeo `containers-storage:`→`docker-archive:` export, the image-id capture timing vs. the cache key, and the removal of the post-export digest re-check.