### PR TITLE
ci: retry flaky tests once instead of failing the suite (nextest retries)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,8 +13,14 @@ test-threads = "num-cpus"
 slow-timeout = { period = "60s", terminate-after = 2 }
 # Fail fast on first failure
 fail-fast = false
-# Retry flaky tests once
-retries = 0
+# Retry flaky tests under load before failing the run. The e2e suite runs ~538 tests
+# (twice in the SnapshotEnabled matrix) on contended self-hosted runners, where genuine
+# load/contention flakes (snapshot-create disk contention, clone stress, orphan-zombie
+# reaping) occasionally trip a single test. A short delay lets a contention spike pass.
+# `final-status-level = "flaky"` still REPORTS any test that only passed on retry, so
+# flakes stay visible and tracked (see #619 and the per-test flake tickets) rather than
+# hidden — retries mitigate, they do not excuse leaving a flake un-root-caused.
+retries = { backoff = "fixed", count = 1, delay = "5s" }
 # Status level for output
 status-level = "pass"
 final-status-level = "flaky"
@@ -27,7 +33,7 @@ failure-output = "immediate"
 test-threads = "num-cpus"
 slow-timeout = { period = "120s", terminate-after = 2 }
 fail-fast = false
-retries = 0
+retries = { backoff = "fixed", count = 1, delay = "5s" }
 status-level = "all"
 final-status-level = "all"
 
@@ -96,7 +102,7 @@ slow-timeout = { period = "120s", terminate-after = 1 }
 test-threads = 1  # avoid container name conflicts (fcvm-container)
 slow-timeout = { period = "120s", terminate-after = 2 }
 fail-fast = false
-retries = 0
+retries = { backoff = "fixed", count = 1, delay = "5s" }
 status-level = "pass"
 final-status-level = "flaky"
 success-output = "immediate"


### PR DESCRIPTION
## Problem
`.config/nextest.toml` had `retries = 0` despite a comment "Retry flaky tests once". So a single load-contention flake fails the entire ~538-test e2e suite (run **twice** in the SnapshotEnabled matrix). This repeatedly blocked unrelated PRs today (#607, #620) on tests they don't touch — `test_snapshot_clone_stress_100_bridged` (#626), `test_localhost_archive_mode` (#627), `test_sigkill_kills_firecracker_rootless` (#628).

## Change
Enable `retries = { backoff = "fixed", count = 1, delay = "5s" }` for `default`, `ci`, and `fc-mock` profiles; `quick` (dev) stays `retries = 0` for fast-fail.

- **count=1** matches the original "once" intent and bounds a genuinely-*hung* long-timeout test (600s/900s `slow-timeout`) to 2× rather than 3× (a `/code-review` flagged this wall-clock risk; count=1 is the mitigation while still recovering the common fast-fail flakes).
- **5s delay** lets a contention spike pass before the retry.
- **Visibility preserved:** `final-status-level = "flaky"` (default/fc-mock) / `"all"` (ci) still reports any test that only passed on retry — flakes are NOT hidden, they're surfaced and tracked (#619 + #626/#627/#628). Retries mitigate; they do not excuse leaving a flake un-root-caused.
- Deterministic failures still fail all attempts → still red.

## Validation
TOML parses; retry-table syntax is valid nextest config. CI host tests use the `default` profile (no `--profile` flag); fc-mock tests use `--profile fc-mock`.

cc @codex review