### PR TITLE
ci: don't fail Claude Assistant safety-check on plain-issue comments

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -737,40 +737,18 @@ gh pr close <fix-pr-number>  # Close the auto-generated PR
 gh pr view <pr-number> --json comments --jq '.comments[] | .body'
 ```
 
-### GitHub Actions Workflow Security (claude.yml et al.)
+### GitHub Actions Workflow Security (claude.yml)
 
-`.github/workflows/claude.yml` runs jobs (`review`/`manual-review`/`respond`/`ci-fix`) with
-`CLAUDE_CODE_OAUTH_TOKEN` + a GitHub App token. Editing it is security-critical. Hardening it
-(PR #634) took multiple rounds because each hand-rolled patch introduced a new hole that the
-**local codex CLI caught and our own `/security-review` missed**. The canonical rules
-(Anthropic `claude-code-action/docs/security.md` + GitHub Security Lab "Preventing pwn
-requests") — follow them, don't reinvent:
-
-1. **`pull_request` from forks gets NO secrets** (GitHub sandboxes it). The dangerous
-   triggers run in *our* repo context WITH secrets regardless of trigger:
-   `issue_comment`, `pull_request_target`, `workflow_run`.
-2. **Never check out / build untrusted PR head in a secret-bearing job** (the "pwn request").
-   `ref: refs/pull/<n>/head` or `workflow_run.head_sha` + `pnpm install`/`cargo build`
-   executes fork code (postinstall, build.rs, malicious deps) with secrets → exfiltration.
-3. **Gate on the CODE author, not the commenter.** A member commenting `/claude-review` on an
-   external fork PR must not build that fork's code. Use the **PR author's
-   `author_association`** (un-spoofable; commit-author *email* is spoofable so `commits_ok`
-   alone is insufficient), or the actor's write permission via the collaborators API.
-4. **`workflow_run` trust ≠ branch name** (a fork's default branch is also `main`). Require
-   `github.event.workflow_run.head_repository.full_name == github.repository`; derive the PR
-   number from `github.event.workflow_run.pull_requests`, never a branch-name lookup.
-5. **NEVER interpolate `${{ github.event.* }}` into a `run:` body** — script injection. A fork
-   branch named `x";<cmd>;#` runs `<cmd>` with the token. Pass every event value via `env:`
-   and reference `$VAR`. (`env:` blocks, `concurrency.group:`, `with: ref:` with validated
-   ints/SHAs are fine.)
-6. **Plain issues:** `issue_comment` fires for issues AND PRs; gate on
-   `github.event.issue.pull_request`; a plain-issue comment must be `assoc=NONE` (no OWNER
-   fallback).
-
-Best shape: one centralized `eligible` allowlist output
-(`safe && author_ok && commits_ok && context_allowed`) that every job gates on. **Always
-re-run the local codex CLI on workflow security changes until it returns SAFE TO MERGE
-(see "Claude Review Workflow"); prefer codex's security verdict over our own.**
+Jobs run with secrets, so editing `.github/workflows/claude.yml` is security-critical. Rules
+(Anthropic `claude-code-action/docs/security.md` + GitHub "pwn requests"); re-run local codex
+until SAFE:
+- `pull_request` from forks has no secrets; `issue_comment`/`pull_request_target`/`workflow_run` do.
+- Never check out/build untrusted PR head in a secret job (postinstall/build.rs → exfil).
+- Gate on PR-author `author_association`, not the commenter (commit email is spoofable).
+- `workflow_run`: require `head_repository.full_name == github.repository`, not branch name.
+- Never interpolate `${{ github.event.* }}` into `run:` (injection) — pass via `env:`.
+- `issue_comment` fires for issues too; gate on `github.event.issue.pull_request`.
+- Centralize into one `eligible` allowlist every job gates on.
 
 ### PR Descriptions: Show, Don't Tell
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -737,6 +737,41 @@ gh pr close <fix-pr-number>  # Close the auto-generated PR
 gh pr view <pr-number> --json comments --jq '.comments[] | .body'
 ```
 
+### GitHub Actions Workflow Security (claude.yml et al.)
+
+`.github/workflows/claude.yml` runs jobs (`review`/`manual-review`/`respond`/`ci-fix`) with
+`CLAUDE_CODE_OAUTH_TOKEN` + a GitHub App token. Editing it is security-critical. Hardening it
+(PR #634) took multiple rounds because each hand-rolled patch introduced a new hole that the
+**local codex CLI caught and our own `/security-review` missed**. The canonical rules
+(Anthropic `claude-code-action/docs/security.md` + GitHub Security Lab "Preventing pwn
+requests") — follow them, don't reinvent:
+
+1. **`pull_request` from forks gets NO secrets** (GitHub sandboxes it). The dangerous
+   triggers run in *our* repo context WITH secrets regardless of trigger:
+   `issue_comment`, `pull_request_target`, `workflow_run`.
+2. **Never check out / build untrusted PR head in a secret-bearing job** (the "pwn request").
+   `ref: refs/pull/<n>/head` or `workflow_run.head_sha` + `pnpm install`/`cargo build`
+   executes fork code (postinstall, build.rs, malicious deps) with secrets → exfiltration.
+3. **Gate on the CODE author, not the commenter.** A member commenting `/claude-review` on an
+   external fork PR must not build that fork's code. Use the **PR author's
+   `author_association`** (un-spoofable; commit-author *email* is spoofable so `commits_ok`
+   alone is insufficient), or the actor's write permission via the collaborators API.
+4. **`workflow_run` trust ≠ branch name** (a fork's default branch is also `main`). Require
+   `github.event.workflow_run.head_repository.full_name == github.repository`; derive the PR
+   number from `github.event.workflow_run.pull_requests`, never a branch-name lookup.
+5. **NEVER interpolate `${{ github.event.* }}` into a `run:` body** — script injection. A fork
+   branch named `x";<cmd>;#` runs `<cmd>` with the token. Pass every event value via `env:`
+   and reference `$VAR`. (`env:` blocks, `concurrency.group:`, `with: ref:` with validated
+   ints/SHAs are fine.)
+6. **Plain issues:** `issue_comment` fires for issues AND PRs; gate on
+   `github.event.issue.pull_request`; a plain-issue comment must be `assoc=NONE` (no OWNER
+   fallback).
+
+Best shape: one centralized `eligible` allowlist output
+(`safe && author_ok && commits_ok && context_allowed`) that every job gates on. **Always
+re-run the local codex CLI on workflow security changes until it returns SAFE TO MERGE
+(see "Claude Review Workflow"); prefer codex's security verdict over our own.**
+
 ### PR Descriptions: Show, Don't Tell
 
 **CRITICAL: Review commits in THIS branch before writing PR description.**

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,6 +29,10 @@ jobs:
       pr_number: ${{ steps.get-pr.outputs.number }}
       author_ok: ${{ steps.author.outputs.ok }}
       commits_ok: ${{ steps.commits.outputs.ok }}
+      # Single allowlist gate every Claude-executing job must pass (see the
+      # "Compute eligibility" step). Centralizes the trust model so a future job
+      # cannot accidentally run outside the allowed situations.
+      eligible: ${{ steps.eligible.outputs.ok }}
     steps:
       - name: Generate token
         id: token
@@ -150,13 +154,38 @@ jobs:
             echo "safe=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Compute eligibility (allowlist gate)
+        id: eligible
+        run: |
+          SAFE="${{ steps.check.outputs.safe }}"
+          AUTHOR="${{ steps.author.outputs.ok }}"
+          COMMITS="${{ steps.commits.outputs.ok }}"
+          EVENT="${{ github.event_name }}"
+          # ALLOWLIST of the only trigger CONTEXTS Claude may run in. Anything not
+          # explicitly enumerated here is denied. Note: issue_comment is allowed ONLY
+          # when the issue is actually a pull request (never a plain issue).
+          CONTEXT=false
+          case "$EVENT" in
+            pull_request) CONTEXT=true ;;
+            issue_comment) [ -n "${{ github.event.issue.pull_request.url }}" ] && CONTEXT=true ;;
+            pull_request_review_comment) CONTEXT=true ;;
+            workflow_run) CONTEXT=true ;;
+          esac
+          # Eligible only when the actor is trusted (author_ok, per the commenter for
+          # comment events), there are no non-member commits/comments, AND the trigger
+          # is an allowlisted context.
+          if [ "$SAFE" = "true" ] && [ "$AUTHOR" = "true" ] && [ "$COMMITS" = "true" ] && [ "$CONTEXT" = "true" ]; then
+            echo "ok=true" >> $GITHUB_OUTPUT
+          else
+            echo "::notice::Claude not eligible (safe=$SAFE author=$AUTHOR commits=$COMMITS event=$EVENT context=$CONTEXT)"
+            echo "ok=false" >> $GITHUB_OUTPUT
+          fi
+
   # Review PRs from org members, auto-fix medium/critical issues
   review:
     needs: safety-check
     if: |
-      needs.safety-check.outputs.safe == 'true' &&
-      needs.safety-check.outputs.author_ok == 'true' &&
-      needs.safety-check.outputs.commits_ok == 'true' &&
+      needs.safety-check.outputs.eligible == 'true' &&
       github.event_name == 'pull_request' &&
       !startsWith(github.event.pull_request.head.ref, 'claude/fix-')
     runs-on: ubuntu-latest
@@ -226,9 +255,7 @@ jobs:
   manual-review:
     needs: safety-check
     if: |
-      needs.safety-check.outputs.safe == 'true' &&
-      needs.safety-check.outputs.author_ok == 'true' &&
-      needs.safety-check.outputs.commits_ok == 'true' &&
+      needs.safety-check.outputs.eligible == 'true' &&
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '/claude-review')
@@ -310,9 +337,7 @@ jobs:
   respond:
     needs: safety-check
     if: |
-      needs.safety-check.outputs.safe == 'true' &&
-      needs.safety-check.outputs.author_ok == 'true' &&
-      needs.safety-check.outputs.commits_ok == 'true' &&
+      needs.safety-check.outputs.eligible == 'true' &&
       !contains(github.event.comment.body, '/claude-review') &&
       ((github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||
        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')))
@@ -401,9 +426,7 @@ jobs:
   ci-fix:
     needs: safety-check
     if: |
-      needs.safety-check.outputs.safe == 'true' &&
-      needs.safety-check.outputs.author_ok == 'true' &&
-      needs.safety-check.outputs.commits_ok == 'true' &&
+      needs.safety-check.outputs.eligible == 'true' &&
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'failure' &&
       !startsWith(github.event.workflow_run.head_branch, 'claude/fix-') &&

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -155,13 +155,14 @@ jobs:
             exit 0
           fi
           # Block if any commit author is not a collaborator (permission lookup failure
-          # also fails closed: defaults to "none").
-          NON_MEMBER=$(printf '%s\n' "$LOGINS" | while read -r LOGIN; do
-            if [ -n "$LOGIN" ]; then
-              ASSOC=$(gh api "repos/$REPO/collaborators/$LOGIN/permission" --jq '.permission' 2>/dev/null || echo "none")
-              [ "$ASSOC" = "none" ] && echo "$LOGIN"
-            fi
-          done | head -1)
+          # also fails closed: defaults to "none"). Here-string (not a pipe into `while`)
+          # so a member match doesn't make the pipeline exit non-zero under pipefail+`-e`.
+          NON_MEMBER=""
+          while IFS= read -r LOGIN; do
+            [ -n "$LOGIN" ] || continue
+            ASSOC=$(gh api "repos/$REPO/collaborators/$LOGIN/permission" --jq '.permission' 2>/dev/null || echo "none")
+            if [ "$ASSOC" = "none" ]; then NON_MEMBER="$LOGIN"; break; fi
+          done <<< "$LOGINS"
           if [ -n "$NON_MEMBER" ]; then
             echo "::warning::Blocking Claude - non-member commit author: $NON_MEMBER"
             echo "ok=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,7 +45,14 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" = "issue_comment" ]; then
-            echo "number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+            # issue_comment fires for BOTH issues and PRs; only PRs carry
+            # .issue.pull_request. For a comment on a plain issue there is no PR,
+            # so emit 0 (downstream PR API calls would 404 and fail the job).
+            if [ -n "${{ github.event.issue.pull_request.url }}" ]; then
+              echo "number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+            else
+              echo "number=0" >> $GITHUB_OUTPUT
+            fi
           elif [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
             echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" = "workflow_run" ]; then
@@ -67,10 +74,13 @@ jobs:
         run: |
           PR_NUM="${{ steps.get-pr.outputs.number }}"
           if [ -z "$PR_NUM" ] || [ "$PR_NUM" = "0" ]; then
-            # No PR (e.g., main branch CI) - treat as owner
+            # No PR (e.g., main branch CI, or a comment on a plain issue) - treat as owner.
             echo "assoc=OWNER" >> $GITHUB_OUTPUT
           else
-            ASSOC=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM --jq '.author_association')
+            # Tolerate a 404 (e.g. number is not actually a PR) instead of failing the
+            # whole safety-check job under `bash -e`. An empty/blank assoc is treated as
+            # non-member by the next step, which fails safe (blocks Claude).
+            ASSOC=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM --jq '.author_association' 2>/dev/null || echo "")
             echo "assoc=$ASSOC" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -93,8 +93,13 @@ jobs:
             # A comment with no associated PR (e.g. `@claude` on a plain issue → PR_NUM=0)
             # is never trusted. Do NOT fall through to the OWNER default below.
             echo "assoc=NONE" >> $GITHUB_OUTPUT
+          elif [ "$EVENT" = "workflow_run" ] && [ "${{ github.event.workflow_run.head_repository.full_name }}" != "${{ github.repository }}" ]; then
+            # A workflow_run whose head came from a FORK is never trusted — even if its
+            # head_branch is literally "main" (a fork's default branch is "main" too, which
+            # would otherwise hit the OWNER default and let fork code reach ci-fix).
+            echo "assoc=NONE" >> $GITHUB_OUTPUT
           else
-            # No PR and not a comment (main-branch CI / workflow_run) - treat as owner.
+            # No PR and not a comment: main-branch CI / SAME-REPO workflow_run - owner.
             echo "assoc=OWNER" >> $GITHUB_OUTPUT
           fi
 
@@ -431,6 +436,7 @@ jobs:
     if: |
       needs.safety-check.outputs.eligible == 'true' &&
       github.event_name == 'workflow_run' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
       github.event.workflow_run.conclusion == 'failure' &&
       !startsWith(github.event.workflow_run.head_branch, 'claude/fix-') &&
       github.event.workflow_run.name != 'Claude Assistant'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -144,9 +144,11 @@ jobs:
             echo "ok=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # FAIL CLOSED if the commits API errors (don't let an empty result pass).
-          if ! LOGINS=$(gh api "repos/$REPO/pulls/$PR_NUM/commits" --jq \
-            '[.[] | select(.author.type != "Bot" and .author.login != null) | .author.login] | unique | .[]'); then
+          # FAIL CLOSED if the commits API errors. --paginate so a non-member commit past
+          # page 1 is not missed. A non-bot commit with no linked GitHub login is UNLINKED
+          # (unverifiable) -> treated as non-member below (its permission lookup 404s).
+          if ! LOGINS=$(gh api --paginate "repos/$REPO/pulls/$PR_NUM/commits?per_page=100" --jq \
+            '.[] | select(.author.type != "Bot") | (.author.login // "UNLINKED")' | sort -u); then
             echo "::warning::Blocking Claude - commits API failed (failing closed)"
             echo "ok=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -180,8 +182,10 @@ jobs:
           # FAIL CLOSED: an API error must block Claude, not allow it. (No `|| echo 0`,
           # which would turn a transient 5xx/rate-limit into safe=true and let a
           # non-member comment through.)
-          if ! ISSUE=$(gh api "repos/$REPO/issues/$PR_NUM/comments" --jq "$NONMEMBER_FILTER") \
-             || ! REVIEW=$(gh api "repos/$REPO/pulls/$PR_NUM/comments" --jq "$NONMEMBER_FILTER"); then
+          # --paginate so a non-member comment past page 1 is not missed; sum the
+          # per-page counts. Any API/parse failure fails closed.
+          if ! ISSUE=$(gh api --paginate "repos/$REPO/issues/$PR_NUM/comments?per_page=100" --jq "$NONMEMBER_FILTER" | jq -s 'add // 0') \
+             || ! REVIEW=$(gh api --paginate "repos/$REPO/pulls/$PR_NUM/comments?per_page=100" --jq "$NONMEMBER_FILTER" | jq -s 'add // 0'); then
             echo "::warning::Blocking Claude - comments API failed (failing closed)"
             echo "safe=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -140,6 +140,7 @@ jobs:
           PR_NUM: ${{ steps.get-pr.outputs.number }}
           REPO: ${{ github.repository }}
         run: |
+          set -o pipefail   # so `gh api | jq/sort` propagates a gh failure (not jq/sort's status)
           if [ -z "$PR_NUM" ] || [ "$PR_NUM" = "0" ]; then
             echo "ok=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -175,6 +176,7 @@ jobs:
           PR_NUM: ${{ steps.get-pr.outputs.number }}
           REPO: ${{ github.repository }}
         run: |
+          set -o pipefail   # so `gh api | jq` propagates a gh failure (not jq's status)
           if [ -z "$PR_NUM" ] || [ "$PR_NUM" = "0" ]; then
             echo "safe=true" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -137,48 +137,60 @@ jobs:
         id: commits
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
+          PR_NUM: ${{ steps.get-pr.outputs.number }}
+          REPO: ${{ github.repository }}
         run: |
-          PR_NUM="${{ steps.get-pr.outputs.number }}"
           if [ -z "$PR_NUM" ] || [ "$PR_NUM" = "0" ]; then
-            echo "ok=true" >> $GITHUB_OUTPUT
+            echo "ok=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Check each commit author's association
-          NON_MEMBER=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM/commits --jq \
-            '[.[] | select(.author.type != "Bot" and .author.login != null) | .author.login] | unique | .[]' | while read -r LOGIN; do
+          # FAIL CLOSED if the commits API errors (don't let an empty result pass).
+          if ! LOGINS=$(gh api "repos/$REPO/pulls/$PR_NUM/commits" --jq \
+            '[.[] | select(.author.type != "Bot" and .author.login != null) | .author.login] | unique | .[]'); then
+            echo "::warning::Blocking Claude - commits API failed (failing closed)"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Block if any commit author is not a collaborator (permission lookup failure
+          # also fails closed: defaults to "none").
+          NON_MEMBER=$(printf '%s\n' "$LOGINS" | while read -r LOGIN; do
             if [ -n "$LOGIN" ]; then
-              ASSOC=$(gh api repos/${{ github.repository }}/collaborators/$LOGIN/permission --jq '.permission' 2>/dev/null || echo "none")
-              # Block if not a collaborator (permission = none)
-              if [ "$ASSOC" = "none" ]; then
-                echo "$LOGIN"
-              fi
+              ASSOC=$(gh api "repos/$REPO/collaborators/$LOGIN/permission" --jq '.permission' 2>/dev/null || echo "none")
+              [ "$ASSOC" = "none" ] && echo "$LOGIN"
             fi
           done | head -1)
           if [ -n "$NON_MEMBER" ]; then
             echo "::warning::Blocking Claude - non-member commit author: $NON_MEMBER"
-            echo "ok=false" >> $GITHUB_OUTPUT
+            echo "ok=false" >> "$GITHUB_OUTPUT"
           else
-            echo "ok=true" >> $GITHUB_OUTPUT
+            echo "ok=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check for non-member comments
         id: check
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
+          PR_NUM: ${{ steps.get-pr.outputs.number }}
+          REPO: ${{ github.repository }}
         run: |
-          PR_NUM="${{ steps.get-pr.outputs.number }}"
           if [ -z "$PR_NUM" ] || [ "$PR_NUM" = "0" ]; then
-            echo "safe=true" >> $GITHUB_OUTPUT
+            echo "safe=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          ISSUE=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments --jq "$NONMEMBER_FILTER" 2>/dev/null || echo 0)
-          REVIEW=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM/comments --jq "$NONMEMBER_FILTER" 2>/dev/null || echo 0)
-          TOTAL=$((ISSUE + REVIEW))
-          if [ "$TOTAL" -gt 0 ]; then
-            echo "::warning::Blocking Claude - $TOTAL non-member comment(s) detected"
-            echo "safe=false" >> $GITHUB_OUTPUT
+          # FAIL CLOSED: an API error must block Claude, not allow it. (No `|| echo 0`,
+          # which would turn a transient 5xx/rate-limit into safe=true and let a
+          # non-member comment through.)
+          if ! ISSUE=$(gh api "repos/$REPO/issues/$PR_NUM/comments" --jq "$NONMEMBER_FILTER") \
+             || ! REVIEW=$(gh api "repos/$REPO/pulls/$PR_NUM/comments" --jq "$NONMEMBER_FILTER"); then
+            echo "::warning::Blocking Claude - comments API failed (failing closed)"
+            echo "safe=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$((ISSUE + REVIEW))" -gt 0 ]; then
+            echo "::warning::Blocking Claude - non-member comment(s) detected"
+            echo "safe=false" >> "$GITHUB_OUTPUT"
           else
-            echo "safe=true" >> $GITHUB_OUTPUT
+            echo "safe=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Compute eligibility (allowlist gate)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -73,8 +73,15 @@ jobs:
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           PR_NUM="${{ steps.get-pr.outputs.number }}"
-          if [ -z "$PR_NUM" ] || [ "$PR_NUM" = "0" ]; then
-            # No PR (e.g., main branch CI, or a comment on a plain issue) - treat as owner.
+          EVENT="${{ github.event_name }}"
+          if [ "$EVENT" = "issue_comment" ] || [ "$EVENT" = "pull_request_review_comment" ]; then
+            # Comment-triggered runs are gated on the COMMENTER's association, never the PR
+            # author's nor a PR_NUM=0 fallback. This blocks an external user who comments
+            # `@claude` on a plain issue (PR_NUM=0), which would otherwise be treated as
+            # OWNER below and bypass every safety output.
+            echo "assoc=${{ github.event.comment.author_association }}" >> $GITHUB_OUTPUT
+          elif [ -z "$PR_NUM" ] || [ "$PR_NUM" = "0" ]; then
+            # No PR and not a comment (e.g., main-branch CI / workflow_run) - treat as owner.
             echo "assoc=OWNER" >> $GITHUB_OUTPUT
           else
             # Tolerate a 404 (e.g. number is not actually a PR) instead of failing the
@@ -307,7 +314,7 @@ jobs:
       needs.safety-check.outputs.author_ok == 'true' &&
       needs.safety-check.outputs.commits_ok == 'true' &&
       !contains(github.event.comment.body, '/claude-review') &&
-      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      ((github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||
        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')))
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -78,21 +78,24 @@ jobs:
         run: |
           PR_NUM="${{ steps.get-pr.outputs.number }}"
           EVENT="${{ github.event_name }}"
-          if [ "$EVENT" = "issue_comment" ] || [ "$EVENT" = "pull_request_review_comment" ]; then
-            # Comment-triggered runs are gated on the COMMENTER's association, never the PR
-            # author's nor a PR_NUM=0 fallback. This blocks an external user who comments
-            # `@claude` on a plain issue (PR_NUM=0), which would otherwise be treated as
-            # OWNER below and bypass every safety output.
-            echo "assoc=${{ github.event.comment.author_association }}" >> $GITHUB_OUTPUT
-          elif [ -z "$PR_NUM" ] || [ "$PR_NUM" = "0" ]; then
-            # No PR and not a comment (e.g., main-branch CI / workflow_run) - treat as owner.
-            echo "assoc=OWNER" >> $GITHUB_OUTPUT
-          else
-            # Tolerate a 404 (e.g. number is not actually a PR) instead of failing the
-            # whole safety-check job under `bash -e`. An empty/blank assoc is treated as
-            # non-member by the next step, which fails safe (blocks Claude).
+          if [ -n "$PR_NUM" ] && [ "$PR_NUM" != "0" ]; then
+            # A real PR: trust is the PR AUTHOR's association — NOT the commenter's. This is
+            # the gate that matters because the privileged jobs check out and BUILD the PR
+            # HEAD (`refs/pull/<n>/head`), i.e. they execute the PR's code with secrets. A
+            # member commenting `@claude`/`/claude-review` on an EXTERNAL fork PR must not
+            # cause that fork's untrusted code to run with secrets, so we gate on the code's
+            # author. The PR-author association cannot be spoofed via commit-author email.
+            # (Non-member *comments* are independently blocked by the `check` step; tolerate
+            # a 404 so a stray non-PR number fails safe rather than erroring under `bash -e`.)
             ASSOC=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM --jq '.author_association' 2>/dev/null || echo "")
             echo "assoc=$ASSOC" >> $GITHUB_OUTPUT
+          elif [ "$EVENT" = "issue_comment" ] || [ "$EVENT" = "pull_request_review_comment" ]; then
+            # A comment with no associated PR (e.g. `@claude` on a plain issue → PR_NUM=0)
+            # is never trusted. Do NOT fall through to the OWNER default below.
+            echo "assoc=NONE" >> $GITHUB_OUTPUT
+          else
+            # No PR and not a comment (main-branch CI / workflow_run) - treat as owner.
+            echo "assoc=OWNER" >> $GITHUB_OUTPUT
           fi
 
       - name: Check author is member
@@ -171,9 +174,9 @@ jobs:
             pull_request_review_comment) CONTEXT=true ;;
             workflow_run) CONTEXT=true ;;
           esac
-          # Eligible only when the actor is trusted (author_ok, per the commenter for
-          # comment events), there are no non-member commits/comments, AND the trigger
-          # is an allowlisted context.
+          # Eligible only when the PR author is trusted (author_ok — the code that runs
+          # with secrets), there are no non-member commits/comments, AND the trigger is an
+          # allowlisted context.
           if [ "$SAFE" = "true" ] && [ "$AUTHOR" = "true" ] && [ "$COMMITS" = "true" ] && [ "$CONTEXT" = "true" ]; then
             echo "ok=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,64 +43,83 @@ jobs:
 
       - name: Get PR number
         id: get-pr
+        # SECURITY: every value below is passed through `env:` and referenced as a shell
+        # variable. NEVER interpolate ${{ github.event.* }} directly into `run:` — a
+        # field like workflow_run.head_branch is attacker-controlled (a fork can name a
+        # branch with shell metacharacters) and direct interpolation is script injection.
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_PR_URL: ${{ github.event.issue.pull_request.url }}
+          WR_EVENT: ${{ github.event.workflow_run.event }}
+          WR_HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          WR_PRS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
+          REPO: ${{ github.repository }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" = "issue_comment" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          elif [ "$EVENT_NAME" = "issue_comment" ]; then
             # issue_comment fires for BOTH issues and PRs; only PRs carry
             # .issue.pull_request. For a comment on a plain issue there is no PR,
             # so emit 0 (downstream PR API calls would 404 and fail the job).
-            if [ -n "${{ github.event.issue.pull_request.url }}" ]; then
-              echo "number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+            if [ -n "$ISSUE_PR_URL" ]; then
+              echo "number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
             else
-              echo "number=0" >> $GITHUB_OUTPUT
+              echo "number=0" >> "$GITHUB_OUTPUT"
             fi
-          elif [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
-            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" = "workflow_run" ]; then
-            BRANCH="${{ github.event.workflow_run.head_branch }}"
-            if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
-              echo "number=0" >> $GITHUB_OUTPUT
+          elif [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
+            echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          elif [ "$EVENT_NAME" = "workflow_run" ]; then
+            # A FORK-originated run is never trusted. Emit 0 (get-author maps a fork
+            # workflow_run to assoc=NONE, and ci-fix independently requires same-repo).
+            # Do NOT look up a PR by branch name — branch names are attacker-controlled
+            # and are not an identity. For a same-repo PR derive the number from the
+            # event payload; a same-repo push is collaborator-only, treat as no-PR (0).
+            if [ "$WR_HEAD_REPO" != "$REPO" ]; then
+              echo "number=0" >> "$GITHUB_OUTPUT"
+            elif [ "$WR_EVENT" = "push" ]; then
+              echo "number=0" >> "$GITHUB_OUTPUT"
             else
-              PR_NUM=$(gh pr list --repo ${{ github.repository }} --head "$BRANCH" --json number --jq '.[0].number // 0')
-              echo "number=$PR_NUM" >> $GITHUB_OUTPUT
+              echo "number=$(printf '%s' "$WR_PRS" | jq -r '.[0].number // 0')" >> "$GITHUB_OUTPUT"
             fi
           else
-            echo "number=0" >> $GITHUB_OUTPUT
+            echo "number=0" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Get PR author association
         id: get-author
+        # SECURITY: values via `env:` only (see get-pr). PR_NUM is our own computed output.
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
+          PR_NUM: ${{ steps.get-pr.outputs.number }}
+          EVENT_NAME: ${{ github.event_name }}
+          WR_HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          REPO: ${{ github.repository }}
         run: |
-          PR_NUM="${{ steps.get-pr.outputs.number }}"
-          EVENT="${{ github.event_name }}"
           if [ -n "$PR_NUM" ] && [ "$PR_NUM" != "0" ]; then
             # A real PR: trust is the PR AUTHOR's association — NOT the commenter's. This is
             # the gate that matters because the privileged jobs check out and BUILD the PR
-            # HEAD (`refs/pull/<n>/head`), i.e. they execute the PR's code with secrets. A
-            # member commenting `@claude`/`/claude-review` on an EXTERNAL fork PR must not
-            # cause that fork's untrusted code to run with secrets, so we gate on the code's
+            # HEAD (refs/pull/<n>/head), i.e. they execute the PR's code with secrets. A
+            # member commenting @claude/claude-review on an EXTERNAL fork PR must not cause
+            # that fork's untrusted code to run with secrets, so we gate on the code's
             # author. The PR-author association cannot be spoofed via commit-author email.
-            # (Non-member *comments* are independently blocked by the `check` step; tolerate
-            # a 404 so a stray non-PR number fails safe rather than erroring under `bash -e`.)
-            ASSOC=$(gh api repos/${{ github.repository }}/pulls/$PR_NUM --jq '.author_association' 2>/dev/null || echo "")
-            echo "assoc=$ASSOC" >> $GITHUB_OUTPUT
-          elif [ "$EVENT" = "issue_comment" ] || [ "$EVENT" = "pull_request_review_comment" ]; then
-            # A comment with no associated PR (e.g. `@claude` on a plain issue → PR_NUM=0)
-            # is never trusted. Do NOT fall through to the OWNER default below.
-            echo "assoc=NONE" >> $GITHUB_OUTPUT
-          elif [ "$EVENT" = "workflow_run" ] && [ "${{ github.event.workflow_run.head_repository.full_name }}" != "${{ github.repository }}" ]; then
+            # (Non-member comments are independently blocked by the `check` step; tolerate a
+            # 404 so a stray non-PR number fails safe rather than erroring under `bash -e`.)
+            ASSOC=$(gh api "repos/$REPO/pulls/$PR_NUM" --jq '.author_association' 2>/dev/null || echo "")
+            echo "assoc=$ASSOC" >> "$GITHUB_OUTPUT"
+          elif [ "$EVENT_NAME" = "issue_comment" ] || [ "$EVENT_NAME" = "pull_request_review_comment" ]; then
+            # A comment with no associated PR (e.g. @claude on a plain issue → PR_NUM=0) is
+            # never trusted. Do NOT fall through to the OWNER default below.
+            echo "assoc=NONE" >> "$GITHUB_OUTPUT"
+          elif [ "$EVENT_NAME" = "workflow_run" ] && [ "$WR_HEAD_REPO" != "$REPO" ]; then
             # A workflow_run whose head came from a FORK is never trusted — even if its
-            # head_branch is literally "main" (a fork's default branch is "main" too, which
-            # would otherwise hit the OWNER default and let fork code reach ci-fix).
-            echo "assoc=NONE" >> $GITHUB_OUTPUT
+            # head_branch is literally "main" (a fork's default branch is "main" too).
+            echo "assoc=NONE" >> "$GITHUB_OUTPUT"
           else
             # No PR and not a comment: main-branch CI / SAME-REPO workflow_run - owner.
-            echo "assoc=OWNER" >> $GITHUB_OUTPUT
+            echo "assoc=OWNER" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check author is member
@@ -164,18 +183,21 @@ jobs:
 
       - name: Compute eligibility (allowlist gate)
         id: eligible
+        # SECURITY: values via `env:` only — no ${{ github.event.* }} in the script body.
+        env:
+          SAFE: ${{ steps.check.outputs.safe }}
+          AUTHOR: ${{ steps.author.outputs.ok }}
+          COMMITS: ${{ steps.commits.outputs.ok }}
+          EVENT: ${{ github.event_name }}
+          ISSUE_PR_URL: ${{ github.event.issue.pull_request.url }}
         run: |
-          SAFE="${{ steps.check.outputs.safe }}"
-          AUTHOR="${{ steps.author.outputs.ok }}"
-          COMMITS="${{ steps.commits.outputs.ok }}"
-          EVENT="${{ github.event_name }}"
           # ALLOWLIST of the only trigger CONTEXTS Claude may run in. Anything not
           # explicitly enumerated here is denied. Note: issue_comment is allowed ONLY
           # when the issue is actually a pull request (never a plain issue).
           CONTEXT=false
           case "$EVENT" in
             pull_request) CONTEXT=true ;;
-            issue_comment) [ -n "${{ github.event.issue.pull_request.url }}" ] && CONTEXT=true ;;
+            issue_comment) [ -n "$ISSUE_PR_URL" ] && CONTEXT=true ;;
             pull_request_review_comment) CONTEXT=true ;;
             workflow_run) CONTEXT=true ;;
           esac
@@ -311,13 +333,15 @@ jobs:
       - name: Get PR info
         id: pr
         working-directory: fcvm
-        run: |
-          PR_DATA=$(gh pr view ${{ github.event.issue.number }} --json headRefName,headRefOid,baseRefName)
-          echo "head_branch=$(echo $PR_DATA | jq -r .headRefName)" >> $GITHUB_OUTPUT
-          echo "head_sha=$(echo $PR_DATA | jq -r .headRefOid)" >> $GITHUB_OUTPUT
-          echo "base_branch=$(echo $PR_DATA | jq -r .baseRefName)" >> $GITHUB_OUTPUT
+        # SECURITY: pass the issue number via env, not interpolated into the shell.
         env:
           GH_TOKEN: ${{ steps.claude-token.outputs.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          PR_DATA=$(gh pr view "$ISSUE_NUMBER" --json headRefName,headRefOid,baseRefName)
+          echo "head_branch=$(echo "$PR_DATA" | jq -r .headRefName)" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(echo "$PR_DATA" | jq -r .headRefOid)" >> "$GITHUB_OUTPUT"
+          echo "base_branch=$(echo "$PR_DATA" | jq -r .baseRefName)" >> "$GITHUB_OUTPUT"
 
       - name: Run Claude review
         working-directory: fcvm


### PR DESCRIPTION
## Problem
The **Claude Assistant** workflow (`.github/workflows/claude.yml`) had two issues triggered by comments on plain (non-PR) issues:

1. **Safety-check crash (commit 1):** `get-pr` set `number = github.event.issue.number` for every `issue_comment`, but `issue_comment` fires for issues *and* PRs. A comment on a plain issue (e.g. #632) made `get-author` call `gh api .../pulls/<issue#>` → 404 → the whole `safety-check` job failed ([run 27084287055](https://github.com/ejc3/fcvm/actions/runs/27084287055)).

2. **Security gap (commit 2):** The commit-1 fix emitted `PR_NUM=0` for plain issues, but `get-author` then granted `assoc=OWNER` unconditionally for `PR_NUM=0` and commits/check short-circuited to true — meaning **all safety outputs passed for any commenter**. An external user could trigger the `respond` job (with full secrets) by commenting `@claude` on a plain issue.

## Fix

### Commit 1 — `93da42f` — Don't fail safety-check on plain-issue comments
- `get-pr`: for `issue_comment`, only use the issue number when it's actually a PR (`github.event.issue.pull_request.url` non-empty); otherwise emit `0`.
- `get-author`: tolerate a 404 (`|| echo ""`) so a stray non-PR number can never hard-fail the gate — a blank assoc fails safe (treated as non-member).

### Commit 2 — `c1e18cd` — Block `@claude` on plain issues from external users (security)
- `get-author`: for `issue_comment` / `pull_request_review_comment`, gate on the **commenter's** `author_association` instead of the PR-author/`PR_NUM=0` fallback. An external commenter gets `NONE`/`CONTRIBUTOR` → `author_ok=false` → blocked.
- `respond` job: require `github.event.issue.pull_request` on the `issue_comment` branch, so it never fires on plain-issue comments (matches `manual-review`'s existing gate).

### Commit 3 — `47d8fbf` — Gate all Claude jobs behind a single allowlist (`eligible`)
- Replace the scattered `safe`/`author_ok`/`commits_ok` checks on each job with one centralized `eligible` output:
  ```
  eligible = safe && author_ok && commits_ok && context_allowed
  ```
- `context_allowed` is a positive allowlist of the **only** trigger contexts Claude may run in: `pull_request`, `issue_comment` (only when the issue is a PR), `pull_request_review_comment`, `workflow_run`.
- All four Claude-executing jobs (`review`, `manual-review`, `respond`, `ci-fix`) now gate on `needs.safety-check.outputs.eligible == 'true'`.
- Anything not enumerated is denied by default, making the trust model auditable in one place and preventing future jobs from accidentally bypassing safety checks.

### Commit 4 — `f51ce18` — Gate comment-triggered Claude jobs on PR-author trust, not commenter
- **Fixes a fork-code-execution regression introduced by commit 2:** commit 2 switched `author_ok` to the *commenter's* association for comment events, but `manual-review`/`respond` check out `refs/pull/<n>/head` and build the PR code with secrets. A trusted member commenting `@claude` on an external fork PR would have caused that fork's untrusted code to execute with `CLAUDE_CODE_OAUTH_TOKEN` + the App token.
- Fix: for a real PR (`PR_NUM != 0`, any event), gate on the **PR author's** association — the author of the code that actually executes with secrets. Comments with no associated PR (plain issue → `PR_NUM=0`) get `assoc=NONE` (blocked, no OWNER fallback). Non-member comments remain blocked by the separate `check` step.
- This restores fork-PR protection while keeping the plain-issue fix and the centralized `eligible` allowlist.

### Commit 5 — `76333f6` — Block fork-originated `workflow_run` from `ci-fix` (pwn-request fix)
- **Fixes a P0 fork-code-execution via `workflow_run`:** `ci-fix` runs on `workflow_run` with full secrets and checks out `github.event.workflow_run.head_sha`, then `pnpm install`s it — executing that commit's code (postinstall scripts) with secrets. `get-pr` classified `head_branch=="main"` as `PR_NUM=0` → OWNER, and a fork's default branch is also `"main"`, so an attacker could fork, add a malicious postinstall, make CI fail, and the resulting `workflow_run` would be treated as trusted.
- Fix 1: `get-author` — a `workflow_run` whose `head_repository.full_name != github.repository` (i.e. a fork) gets `assoc=NONE`, never the OWNER default.
- Fix 2: `ci-fix` job `if` — additionally require `github.event.workflow_run.head_repository.full_name == github.repository`, so the dangerous `head_sha` checkout cannot run on fork code at all.
- Same-repo pushes/PRs (the only legitimate `ci-fix` triggers) are unaffected.

## Validation
- `python3 -c "import yaml; yaml.safe_load(...)"` passes for all commits.
- Defense-in-depth: external users on plain issues are blocked at three layers (commenter association, `issue.pull_request` gate, centralized `context_allowed` allowlist).
- Fork PRs are blocked from executing untrusted code via PR-author association gating (commit 4) and fork `workflow_run` blocking (commit 5).