### PR TITLE
fix: analyze_ci_vms.py silently passes on missing artifacts (#639)

### DIFF
--- a/scripts/analyze_ci_vms.py
+++ b/scripts/analyze_ci_vms.py
@@ -3,17 +3,25 @@
 Analyze CI test run artifacts - counts VMs spawned during tests.
 
 Usage:
-    python3 scripts/analyze_ci_vms.py /tmp/ci-artifacts
+    python3 scripts/analyze_ci_vms.py [--allow-missing] /tmp/ci-artifacts
 """
 import sys
 from pathlib import Path
 
 
 def main():
+    flags = [a for a in sys.argv[1:] if a.startswith("--")]
     args = [a for a in sys.argv[1:] if not a.startswith("--")]
-    allow_missing = "--allow-missing" in sys.argv[1:]
-    if len(args) < 1:
-        print("Usage: analyze_ci_vms.py [--allow-missing] <artifacts-dir>")
+    allow_missing = "--allow-missing" in flags
+    # Reject unknown flags rather than silently discarding them — a typo like
+    # `--allow-misssing` must not be quietly ignored back into strict mode.
+    unknown = [f for f in flags if f != "--allow-missing"]
+    if unknown or len(args) != 1:
+        print(
+            f"Usage: analyze_ci_vms.py [--allow-missing] <artifacts-dir>"
+            + (f"\nUnknown argument(s): {' '.join(unknown)}" if unknown else ""),
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     artifacts_dir = Path(args[0])

--- a/scripts/analyze_ci_vms.py
+++ b/scripts/analyze_ci_vms.py
@@ -10,17 +10,30 @@ from pathlib import Path
 
 
 def main():
-    if len(sys.argv) < 2:
-        print("Usage: analyze_ci_vms.py <artifacts-dir>")
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    allow_missing = "--allow-missing" in sys.argv[1:]
+    if len(args) < 1:
+        print("Usage: analyze_ci_vms.py [--allow-missing] <artifacts-dir>")
         sys.exit(1)
 
-    artifacts_dir = Path(sys.argv[1])
+    artifacts_dir = Path(args[0])
     if not artifacts_dir.is_dir():
-        # No artifacts to analyze. The Summary job already gates this step on the
-        # test matrix having run, so reaching here means the matrix produced no
-        # artifacts (e.g. it was skipped). Report it without failing the job.
-        print("No CI artifacts to analyze (test matrix skipped or uploaded nothing)")
-        return
+        # Missing artifacts directory. This is only benign when the caller KNOWS
+        # the matrix was intentionally skipped (pass --allow-missing). Otherwise
+        # the matrix ran but produced no artifacts — e.g. jobs died before
+        # creating their log dir, with uploads set to `if-no-files-found: ignore`
+        # — which is a real loss of diagnostics, NOT success. Fail loudly so the
+        # Summary signal is not silently green (#639).
+        if allow_missing:
+            print("No CI artifacts to analyze (test matrix skipped)")
+            return
+        print(
+            f"ERROR: artifacts directory {artifacts_dir} is missing, but the test "
+            "matrix was expected to run. Test jobs likely failed before uploading "
+            "logs. Pass --allow-missing only on the intentional skip path.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     # Count VMs from log files
     base_vms = 0


### PR DESCRIPTION
## The Problem
`scripts/analyze_ci_vms.py` returned success (exit 0) whenever the artifacts directory was missing — for **every** caller. The Summary job runs the analyzer only when `needs.skip-check.outputs.skip != 'true'` (i.e. the matrix was supposed to run). If selected self-hosted jobs die before `Create test log directory`, uploads (`if-no-files-found: ignore`) produce no `test-logs-*` artifact, the dir is absent, and the analyzer printed "uploaded nothing" then exited 0 — **silently masking lost diagnostics** and weakening the Summary signal.

## The Fix
- **Default = strict:** a missing artifacts dir is a hard error (exit 1) with an explanatory message.
- **`--allow-missing`** flag restores the graceful return, for the *intentional* skipped-matrix path only.
- `ci.yml` already gates the Analyze step on `skip != 'true'`, so it stays strict (no `--allow-missing` passed); the skip case never reaches the script.

## How it was found
Local `codex` CLI adversarial review of merged PR #601, re-verified against `main`. Both GitHub bots missed it.

## Test Results
```
$ python3 scripts/analyze_ci_vms.py /tmp/does-not-exist            # exit 1 (error)
$ python3 scripts/analyze_ci_vms.py --allow-missing /tmp/none      # exit 0 (notice)
$ python3 scripts/analyze_ci_vms.py /tmp/empty-dir                 # exit 0 (0 VMs)
$ python3 scripts/analyze_ci_vms.py /tmp/dir-with-logs            # exit 0 (counts)
```

Addresses #639.