### PR TITLE
fix: fc-agent kills guest child when host vsock peer disconnects (#636)

### DIFF
--- a/fc-agent/src/exec.rs
+++ b/fc-agent/src/exec.rs
@@ -305,6 +305,47 @@ async fn handle_connection(client_fd: OwnedFd) {
     }
 }
 
+/// Resolve when the vsock peer (host `fcvm exec`) closes the connection.
+///
+/// Polls a dup'd, independent `AsyncFd` for readability and peeks one byte: 0 (EOF), or a
+/// reset/disconnect error (ECONNRESET/ENOTCONN/EPIPE), means the host is gone. In the
+/// non-TTY pipe path the host sends nothing after the request (it only reads responses), so
+/// any readable EOF is equivalent to "host gone" — used to kill the guest child (#636).
+async fn wait_for_peer_close(watch: &AsyncFd<OwnedFd>) {
+    loop {
+        let mut guard = match watch.readable().await {
+            Ok(g) => g,
+            Err(_) => return, // fd error -> treat as closed
+        };
+        let fd = watch.get_ref().as_raw_fd();
+        let mut byte = [0u8; 1];
+        let n = unsafe {
+            libc::recv(
+                fd,
+                byte.as_mut_ptr().cast(),
+                1,
+                libc::MSG_PEEK | libc::MSG_DONTWAIT,
+            )
+        };
+        if n == 0 {
+            return; // EOF: peer closed its write half
+        }
+        if n < 0 {
+            // EAGAIN/EWOULDBLOCK (same value on Linux): spurious readiness, keep watching.
+            // Any other error (ECONNRESET/ENOTCONN/EPIPE/…) means the peer is gone.
+            if std::io::Error::last_os_error().raw_os_error() == Some(libc::EAGAIN) {
+                guard.clear_ready();
+                continue;
+            }
+            return;
+        }
+        // n > 0: the host should send nothing after the request. Drain one byte so we don't
+        // busy-spin on persistent readiness, then keep watching for the eventual close.
+        let _ = unsafe { libc::recv(fd, byte.as_mut_ptr().cast(), 1, libc::MSG_DONTWAIT) };
+        guard.clear_ready();
+    }
+}
+
 async fn handle_pipe_async(raw_fd: i32, request: &ExecRequest) {
     let proxy_settings = crate::system::read_proxy_settings();
 
@@ -344,6 +385,9 @@ async fn handle_pipe_async(raw_fd: i32, request: &ExecRequest) {
     if request.interactive {
         cmd.stdin(std::process::Stdio::piped());
     }
+    // Own process group so a host disconnect can kill the whole subtree (the command and
+    // anything it spawns), not just the immediate child (#636).
+    cmd.process_group(0);
 
     let mut child = match cmd.spawn() {
         Ok(c) => c,
@@ -355,12 +399,24 @@ async fn handle_pipe_async(raw_fd: i32, request: &ExecRequest) {
         }
     };
 
+    // Capture the child's PID now (used as the PGID for killpg on host disconnect, #636).
+    let child_pid = child.id();
+
     // Spawn succeeded — set non-blocking, take ownership, wrap in AsyncFd
     nix::fcntl::fcntl(
         raw_fd,
         nix::fcntl::FcntlArg::F_SETFL(nix::fcntl::OFlag::O_NONBLOCK),
     )
     .ok();
+    // Independent CLOEXEC dup of the connection for read-side peer-close detection. Polling
+    // readability on a separate fd avoids holding the write Mutex across readable().await
+    // (which would deadlock the stdout/stderr writer tasks). The two OwnedFds own distinct
+    // fd numbers, so there is no double-close.
+    let peer_watch: Option<AsyncFd<OwnedFd>> =
+        match nix::fcntl::fcntl(raw_fd, nix::fcntl::FcntlArg::F_DUPFD_CLOEXEC(0)) {
+            Ok(dup) => AsyncFd::new(unsafe { OwnedFd::from_raw_fd(dup) }).ok(),
+            Err(_) => None,
+        };
     let owned_fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
     let async_fd = match AsyncFd::new(owned_fd) {
         Ok(fd) => Arc::new(Mutex::new(fd)),
@@ -398,7 +454,40 @@ async fn handle_pipe_async(raw_fd: i32, request: &ExecRequest) {
         })
     });
 
-    let exit_status = child.wait().await;
+    // Wait for the child, but also watch for the host (vsock peer) disconnecting. If the
+    // host `fcvm exec` dies (e.g. host-side timeout, #622), the connection closes; without
+    // this we would `child.wait()` forever while the guest command keeps running (#636).
+    let mut peer_closed = false;
+    let exit_status = match peer_watch {
+        Some(watch) => {
+            tokio::select! {
+                status = child.wait() => status,
+                _ = wait_for_peer_close(&watch) => {
+                    peer_closed = true;
+                    if let Some(pid) = child_pid {
+                        // Negative pid -> the child's process group (process_group(0) above),
+                        // so the whole subtree is killed, not just the immediate child.
+                        unsafe { libc::kill(-(pid as i32), libc::SIGKILL) };
+                    }
+                    let _ = child.start_kill();
+                    child.wait().await
+                }
+            }
+        }
+        None => child.wait().await,
+    };
+
+    if peer_closed {
+        // Host is gone: stop the writer tasks (nothing to deliver to) and don't bother
+        // writing Exit. fds close on drop.
+        if let Some(task) = stdout_task {
+            task.abort();
+        }
+        if let Some(task) = stderr_task {
+            task.abort();
+        }
+        return;
+    }
 
     if let Some(task) = stdout_task {
         let _ = task.await;

--- a/fc-agent/src/exec.rs
+++ b/fc-agent/src/exec.rs
@@ -339,10 +339,13 @@ async fn wait_for_peer_close(watch: &AsyncFd<OwnedFd>) {
             }
             return;
         }
-        // n > 0: the host should send nothing after the request. Drain one byte so we don't
-        // busy-spin on persistent readiness, then keep watching for the eventual close.
+        // n > 0: the host should send nothing after the request (it only reads responses,
+        // and never half-closes its write side while waiting — see the host exec client).
+        // This branch is therefore defensive: drain one byte and loop WITHOUT clear_ready
+        // (calling clear_ready after a successful read is a tokio anti-pattern). The fd
+        // stays marked ready, so the next readable() drains again until EAGAIN, which then
+        // clears readiness and parks until the eventual close edge.
         let _ = unsafe { libc::recv(fd, byte.as_mut_ptr().cast(), 1, libc::MSG_DONTWAIT) };
-        guard.clear_ready();
     }
 }
 
@@ -414,8 +417,26 @@ async fn handle_pipe_async(raw_fd: i32, request: &ExecRequest) {
     // fd numbers, so there is no double-close.
     let peer_watch: Option<AsyncFd<OwnedFd>> =
         match nix::fcntl::fcntl(raw_fd, nix::fcntl::FcntlArg::F_DUPFD_CLOEXEC(0)) {
-            Ok(dup) => AsyncFd::new(unsafe { OwnedFd::from_raw_fd(dup) }).ok(),
-            Err(_) => None,
+            Ok(dup) => match AsyncFd::new(unsafe { OwnedFd::from_raw_fd(dup) }) {
+                Ok(afd) => Some(afd),
+                // Extremely rare (reactor registration failure). Don't fail the exec, but
+                // don't fail silently either: without the watcher, host-disconnect kill is
+                // disabled for this exec (degrades to the pre-#636 wait-only behavior).
+                Err(e) => {
+                    eprintln!(
+                        "[fc-agent] WARN: peer-close watcher AsyncFd failed ({e}); \
+                         host-disconnect kill disabled for this exec"
+                    );
+                    None
+                }
+            },
+            Err(e) => {
+                eprintln!(
+                    "[fc-agent] WARN: peer-close watcher dup failed ({e}); \
+                     host-disconnect kill disabled for this exec"
+                );
+                None
+            }
         };
     let owned_fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
     let async_fd = match AsyncFd::new(owned_fd) {

--- a/tests/test_exec.rs
+++ b/tests/test_exec.rs
@@ -13,6 +13,7 @@ mod common;
 use anyhow::{Context, Result};
 use std::process::Stdio;
 use std::time::Duration;
+use tokio::io::AsyncBufReadExt;
 
 #[cfg(feature = "privileged-tests")]
 #[tokio::test]
@@ -1850,51 +1851,76 @@ async fn test_exec_host_disconnect_kills_guest_child() -> Result<()> {
         return Err(e.context("VM failed to become healthy"));
     }
 
-    // Unique marker the guest command will `touch` only AFTER an 8s sleep. If the guest
-    // subtree is killed when we drop the host exec, the sleep dies and the marker is never
-    // created.
+    // Unique marker the guest command `touch`es only AFTER an 8s sleep. It first prints
+    // READY so we can wait until the command is actually running before severing the host
+    // exec — otherwise, on a slow runner, we might kill the host exec before the guest
+    // command even started, and the marker would be absent even in the broken impl (a false
+    // pass). Run the work inside an async block so the cleanup below runs on every path.
     let marker = format!("/tmp/fcvm636-{}", fcvm_pid);
-    let guest_cmd = format!("sleep 8 && touch {}", marker);
+    let guest_cmd = format!("echo READY; sleep 8; touch {}", marker);
 
-    // Spawn a host `fcvm exec --vm` directly so we can kill it mid-flight (kill_on_drop).
-    let mut exec = tokio::process::Command::new(&fcvm_path)
-        .args([
-            "exec",
-            "--pid",
-            &fcvm_pid.to_string(),
-            "--vm",
-            "--",
-            "sh",
-            "-c",
-            &guest_cmd,
-        ])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .kill_on_drop(true)
-        .spawn()
-        .context("spawning host fcvm exec")?;
+    let result: Result<()> = async {
+        // Host `fcvm exec --vm` we control directly so we can sever it mid-flight.
+        let mut exec = tokio::process::Command::new(&fcvm_path)
+            .args([
+                "exec",
+                "--pid",
+                &fcvm_pid.to_string(),
+                "--vm",
+                "--",
+                "sh",
+                "-c",
+                &guest_cmd,
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+            .context("spawning host fcvm exec")?;
 
-    // Let the guest command start (it is now mid-`sleep 8`), then sever the host exec.
-    tokio::time::sleep(Duration::from_secs(2)).await;
-    let _ = exec.start_kill();
-    let _ = exec.wait().await;
+        // Wait for READY (proves the guest command is running) before severing.
+        let stdout = exec.stdout.take().context("exec stdout missing")?;
+        let mut lines = tokio::io::BufReader::new(stdout).lines();
+        let ready = tokio::time::timeout(Duration::from_secs(120), async {
+            while let Ok(Some(line)) = lines.next_line().await {
+                if line.contains("READY") {
+                    return true;
+                }
+            }
+            false
+        })
+        .await
+        .unwrap_or(false);
+        anyhow::ensure!(ready, "guest command never signaled READY");
 
-    // Wait past when the marker WOULD appear if the guest sleep had survived.
-    tokio::time::sleep(Duration::from_secs(10)).await;
+        // Sever the host exec now that the guest is mid-`sleep 8`.
+        let _ = exec.start_kill();
+        let _ = exec.wait().await;
 
-    let check = common::exec_in_vm(
-        fcvm_pid,
-        &["sh", "-c", &format!("test -f {} && echo EXISTS || echo GONE", marker)],
-    )
-    .await
-    .context("checking marker in guest")?;
+        // Wait past when the marker WOULD appear if the guest sleep had survived.
+        tokio::time::sleep(Duration::from_secs(10)).await;
 
+        let check = common::exec_in_vm(
+            fcvm_pid,
+            &[
+                "sh",
+                "-c",
+                &format!("test -f {} && echo EXISTS || echo GONE", marker),
+            ],
+        )
+        .await
+        .context("checking marker in guest")?;
+
+        anyhow::ensure!(
+            check.contains("GONE"),
+            "#636 regression: guest command survived host exec disconnect (marker present): {:?}",
+            check
+        );
+        Ok(())
+    }
+    .await;
+
+    // Cleanup on every post-health path (the async block above may return early).
     common::kill_process(fcvm_pid).await;
-
-    assert!(
-        check.contains("GONE"),
-        "#636 regression: guest command survived host exec disconnect (marker present): {:?}",
-        check
-    );
-    Ok(())
+    result
 }

--- a/tests/test_exec.rs
+++ b/tests/test_exec.rs
@@ -1824,3 +1824,77 @@ async fn test_podman_run_no_tty() -> Result<()> {
 
     Ok(())
 }
+
+/// #636: when the host `fcvm exec` process disconnects (e.g. host-side timeout kills it),
+/// fc-agent must kill the guest command instead of leaving it running. Regression test for
+/// the VM-level (non-container) pipe path, which `killpg` fully covers. (The in-container
+/// payload is a documented separate concern — see #636 — so this asserts only the VM path.)
+#[tokio::test]
+async fn test_exec_host_disconnect_kills_guest_child() -> Result<()> {
+    let fcvm_path = common::find_fcvm_binary()?;
+    let (vm_name, _, _, _) = common::unique_names("exec-disconnect");
+
+    let (mut _child, fcvm_pid) = common::spawn_fcvm(&[
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--no-snapshot",
+        common::TEST_IMAGE,
+    ])
+    .await
+    .context("spawning fcvm podman run")?;
+
+    if let Err(e) = common::poll_health_by_pid(fcvm_pid, 180).await {
+        common::kill_process(fcvm_pid).await;
+        return Err(e.context("VM failed to become healthy"));
+    }
+
+    // Unique marker the guest command will `touch` only AFTER an 8s sleep. If the guest
+    // subtree is killed when we drop the host exec, the sleep dies and the marker is never
+    // created.
+    let marker = format!("/tmp/fcvm636-{}", fcvm_pid);
+    let guest_cmd = format!("sleep 8 && touch {}", marker);
+
+    // Spawn a host `fcvm exec --vm` directly so we can kill it mid-flight (kill_on_drop).
+    let mut exec = tokio::process::Command::new(&fcvm_path)
+        .args([
+            "exec",
+            "--pid",
+            &fcvm_pid.to_string(),
+            "--vm",
+            "--",
+            "sh",
+            "-c",
+            &guest_cmd,
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+        .context("spawning host fcvm exec")?;
+
+    // Let the guest command start (it is now mid-`sleep 8`), then sever the host exec.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let _ = exec.start_kill();
+    let _ = exec.wait().await;
+
+    // Wait past when the marker WOULD appear if the guest sleep had survived.
+    tokio::time::sleep(Duration::from_secs(10)).await;
+
+    let check = common::exec_in_vm(
+        fcvm_pid,
+        &["sh", "-c", &format!("test -f {} && echo EXISTS || echo GONE", marker)],
+    )
+    .await
+    .context("checking marker in guest")?;
+
+    common::kill_process(fcvm_pid).await;
+
+    assert!(
+        check.contains("GONE"),
+        "#636 regression: guest command survived host exec disconnect (marker present): {:?}",
+        check
+    );
+    Ok(())
+}


### PR DESCRIPTION
## The Problem (#636)
`fc-agent`'s `handle_pipe_async` (non-tty exec — what `exec_in_vm`/`exec_in_container` use) spawned the child then `child.wait().await` forever. If the host `fcvm exec` died (e.g. host-side timeout, #622), the vsock connection closed but the agent kept waiting, so the guest command (e.g. `apk add`) kept running — racing the next op or holding package locks.

## The Fix
- Run the child in its own process group (`cmd.process_group(0)`) so the whole subtree can be killed.
- Dup the connection fd via `F_DUPFD_CLOEXEC` into an independent `AsyncFd` for read-side peer-close detection (polling readability on the shared write `Mutex` would deadlock the stdout/stderr writer tasks).
- `select! { child.wait() ; wait_for_peer_close() }`: on host disconnect, `kill(-pid, SIGKILL)` the child's process group, reap, abort the writer tasks, skip the `Exit` frame.
- `wait_for_peer_close`: `readable()` + `recv(MSG_PEEK|DONTWAIT)`; `0`/reset/`EPIPE` ⇒ closed, `EAGAIN` ⇒ re-poll. Warns (not silent) if the watcher can't be set up.

**Scope:** killpg fully covers VM-level commands (`exec_in_vm`). For `in_container` the child is the `podman exec` client; the in-container payload may need a separate mechanism (codex), so the test asserts only the VM path.

## Reviews (this flow)
- **Local e2e:** `test_exec_host_disconnect_kills_guest_child` — guest runs `echo READY; sleep 8; touch marker`; test waits for READY (proves it's running), severs the host exec, asserts the marker never appears. Passes on a real VM with the rebuilt initrd (would fail without the fix).
- **Codex:** core fix confirmed correct (fd ownership, select borrow, killpg). Flagged a test P1 (fixed: READY handshake) + P2 (fixed: cleanup guard) + half-close note (documented).
- **`/code-review` (high, fan-out):** 3 PLAUSIBLE, none CONFIRMED — addressed (peer-watch warning instead of silent fallback; dropped `clear_ready()` after a successful `recv`).

Closes #636.