### PR TITLE
fix: surface EOF-before-Exit on interactive exec (#640)

### DIFF
--- a/src/commands/tty.rs
+++ b/src/commands/tty.rs
@@ -266,7 +266,15 @@ fn reader_loop(mut stream: std::os::unix::net::UnixStream, done: Arc<AtomicBool>
             Err(e) => {
                 if e.kind() == std::io::ErrorKind::UnexpectedEof {
                     debug!("reader_loop: EOF");
-                    // EOF without Exit message - return error
+                    // EOF before an Exit message: the exec stream closed before the remote
+                    // command reported its status (e.g. the VM/agent shut down or the vsock
+                    // peer dropped). Surface it instead of exiting 1 with no explanation —
+                    // this is the interactive/TTY path (the quiet non-TTY path is handled at
+                    // the CLI boundary in #607), so an interactive user should see why (#640).
+                    eprintln!(
+                        "\r\nfcvm: exec connection closed before the command's exit status \
+                         was received (the VM or agent may have exited)\r"
+                    );
                     done.store(true, Ordering::Relaxed);
                     return Some(1);
                 }


### PR DESCRIPTION
## Problem (#640, P3 — observability)
The TTY/interactive exec reader (`src/commands/tty.rs::reader_loop`) mapped an `UnexpectedEof` — the exec stream closing before an `Exit` frame — to exit 1 with only a `debug!` log. A user running `fcvm exec -it`/`-i` whose VM or agent dropped saw a bare exit 1 with no explanation. (The non-TTY path already types this as `ExecConnectionClosed` in #607; the protocol-error branch here already prints a message — only the EOF branch was silent.)

## Fix
Print a clear stderr diagnostic on EOF-before-Exit. TTY exec is always interactive (health checks use the non-TTY quiet path), so no quiet-scoping is needed. Exit code (1) is unchanged.

## Notes
Observability-only, single branch. clippy clean. (Reproducing the exact mid-stream EOF needs killing the VM during a live PTY exec; given the change is a stderr diagnostic with unchanged exit semantics, it's verified by inspection + clippy rather than a new PTY integration test.)

Closes #640.