### PR TITLE
docs: disk-only clone design (#625) + GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,40 @@
+name: Deploy design docs to GitHub Pages
+
+# Publishes the hand-authored HTML under docs/ to GitHub Pages.
+# Trigger is push-to-main (trusted context) or manual dispatch — never untrusted
+# PR code, so no secrets are exposed to fork content.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+# Least privilege: only what deploy-pages needs.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One in-flight deploy at a time; don't cancel a running publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - name: Upload docs/ artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/disk-only-clone.html
+++ b/docs/disk-only-clone.html
@@ -1,0 +1,445 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Disk-only clone — fcvm design (#625)</title>
+<style>
+  :root{
+    --bg:#0d1117; --panel:#161b22; --panel2:#1c2330; --ink:#e6edf3; --muted:#9aa7b4;
+    --line:#2b3440; --accent:#58a6ff; --accent2:#3fb950; --warn:#d29922; --bad:#f85149;
+    --code:#0b1622; --kbd:#21262d;
+    --mono:"SFMono-Regular", Consolas,"Liberation Mono",Menlo,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  }
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.6;font-size:16px}
+  .wrap{max-width:1080px;margin:0 auto;padding:0 24px}
+  header.hero{border-bottom:1px solid var(--line);background:linear-gradient(180deg,#11161d,#0d1117);padding:48px 0 32px}
+  header.hero h1{font-size:34px;margin:0 0 6px;letter-spacing:-.4px}
+  header.hero .sub{color:var(--muted);font-size:17px;margin:0 0 18px}
+  .tags{display:flex;gap:8px;flex-wrap:wrap}
+  .tag{font-family:var(--mono);font-size:12px;background:var(--kbd);border:1px solid var(--line);color:var(--muted);padding:3px 9px;border-radius:999px}
+  .tag.ok{color:var(--accent2);border-color:#1c3a25}
+  .tag.new{color:var(--accent);border-color:#1f3a5c}
+  nav.toc{position:sticky;top:0;z-index:5;background:rgba(13,17,23,.92);backdrop-filter:blur(6px);border-bottom:1px solid var(--line);padding:10px 0}
+  nav.toc ul{list-style:none;margin:0;padding:0;display:flex;gap:6px 18px;flex-wrap:wrap;font-size:13.5px}
+  nav.toc a{color:var(--muted);text-decoration:none}
+  nav.toc a:hover{color:var(--accent)}
+  main{padding:36px 0 80px}
+  section{margin:0 0 44px;scroll-margin-top:54px}
+  h2{font-size:25px;margin:38px 0 10px;padding-bottom:7px;border-bottom:1px solid var(--line);letter-spacing:-.3px}
+  h3{font-size:19px;margin:26px 0 8px;color:#cdd6e0}
+  h4{font-size:15px;margin:18px 0 6px;color:#cdd6e0;text-transform:uppercase;letter-spacing:.06em;font-weight:600}
+  p{margin:10px 0}
+  a{color:var(--accent)}
+  code{font-family:var(--mono);font-size:13.5px;background:var(--code);border:1px solid var(--line);border-radius:5px;padding:1px 5px;color:#c9d7e6}
+  pre{background:var(--code);border:1px solid var(--line);border-radius:9px;padding:14px 16px;overflow:auto;font-family:var(--mono);font-size:13px;line-height:1.5}
+  pre code{background:none;border:none;padding:0;color:#c9d7e6}
+  .lead{font-size:17.5px;color:#cdd6e0}
+  .panel{background:var(--panel);border:1px solid var(--line);border-radius:11px;padding:18px 20px;margin:16px 0}
+  .grid2{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+  .callout{border-left:3px solid var(--accent);background:var(--panel2);border-radius:0 9px 9px 0;padding:12px 16px;margin:16px 0}
+  .callout.warn{border-color:var(--warn)}
+  .callout.bad{border-color:var(--bad)}
+  .callout.ok{border-color:var(--accent2)}
+  .callout b{color:#fff}
+  table{width:100%;border-collapse:collapse;margin:14px 0;font-size:14px}
+  th,td{border:1px solid var(--line);padding:8px 11px;text-align:left;vertical-align:top}
+  th{background:var(--panel2);color:#cdd6e0;font-weight:600}
+  td code{font-size:12.5px}
+  .src{font-family:var(--mono);font-size:12px;color:var(--muted)}
+  .yes{color:var(--accent2);font-weight:600}
+  .no{color:var(--bad);font-weight:600}
+  .maybe{color:var(--warn);font-weight:600}
+  .matrix{width:100%;border-collapse:separate;border-spacing:8px;margin:18px 0}
+  .matrix td,.matrix th{border-radius:9px;border:1px solid var(--line);padding:14px;text-align:center}
+  .matrix th{background:transparent;border:none;color:var(--muted);font-size:13px}
+  .cell-exist{background:#13251a;border-color:#1c3a25}
+  .cell-new{background:#10243b;border-color:#1f3a5c;box-shadow:0 0 0 1px #1f3a5c}
+  .cell-na{background:#1a1d22;border-color:var(--line);color:var(--muted)}
+  .cell h5{margin:0 0 4px;font-size:14px}
+  .cell .d{font-size:12px;color:var(--muted)}
+  .pill{display:inline-block;font-family:var(--mono);font-size:11px;padding:2px 7px;border-radius:6px;border:1px solid var(--line)}
+  .pill.skip{color:var(--bad);border-color:#5c1f1f;background:#251314}
+  .pill.keep{color:var(--accent2);border-color:#1c3a25;background:#13251a}
+  ol.steps{counter-reset:s;list-style:none;padding-left:0}
+  ol.steps>li{position:relative;padding:14px 16px 14px 56px;margin:12px 0;background:var(--panel);border:1px solid var(--line);border-radius:10px}
+  ol.steps>li::before{counter-increment:s;content:counter(s);position:absolute;left:14px;top:14px;width:28px;height:28px;border-radius:50%;background:var(--accent);color:#06243f;font-weight:700;display:flex;align-items:center;justify-content:center;font-size:14px}
+  .green-gate{display:inline-block;margin-top:8px;font-size:12.5px;color:var(--accent2);font-family:var(--mono)}
+  .green-gate::before{content:"✓ green: "}
+  svg{max-width:100%;height:auto;display:block;margin:18px auto}
+  .legend{display:flex;gap:18px;flex-wrap:wrap;font-size:13px;color:var(--muted);margin:6px 0}
+  .legend span::before{content:"";display:inline-block;width:11px;height:11px;border-radius:3px;margin-right:6px;vertical-align:middle}
+  .lg-exist::before{background:#2ea043}
+  .lg-new::before{background:#388bfd}
+  .lg-agent::before{background:#d29922}
+  footer{border-top:1px solid var(--line);color:var(--muted);font-size:13px;padding:26px 0 60px}
+  @media(max-width:760px){.grid2{grid-template-columns:1fr}.matrix{border-spacing:5px}}
+</style>
+</head>
+<body>
+<header class="hero">
+  <div class="wrap">
+    <h1>Disk-only clone</h1>
+    <p class="sub">Cold-boot fresh, fully independent VMs from a captured disk — with a free choice of memory size, CPU, and hugepages.</p>
+    <div class="tags">
+      <span class="tag">fcvm design</span>
+      <span class="tag">issue #625</span>
+      <span class="tag new">status: design / RFC</span>
+      <span class="tag ok">code-grounded · verified file:line</span>
+    </div>
+  </div>
+</header>
+
+<nav class="toc"><div class="wrap"><ul>
+  <li><a href="#tldr">TL;DR</a></li>
+  <li><a href="#problem">Problem</a></li>
+  <li><a href="#contrast">vs. existing clone</a></li>
+  <li><a href="#abstraction">The abstraction</a></li>
+  <li><a href="#seams">Reuse seams</a></li>
+  <li><a href="#agent">fc-agent storage policy</a></li>
+  <li><a href="#capture">Capture path</a></li>
+  <li><a href="#hugepages">Hugepages</a></li>
+  <li><a href="#risks">Risks</a></li>
+  <li><a href="#prs">Stacked PRs</a></li>
+  <li><a href="#testing">Testing</a></li>
+  <li><a href="#hypervisor">Hypervisor map</a></li>
+</ul></div></nav>
+
+<main class="wrap">
+
+<section id="tldr">
+  <h2>TL;DR</h2>
+  <p class="lead">fcvm's existing <code>snapshot</code> commands clone a <b>running VM's memory + disk</b> and resume it mid-execution via a UFFD page server. <b>Disk-only clone</b> captures <b>only the disk</b> at a consistent point and <b>cold-boots brand-new VMs</b> from it — no memory image, no UFFD, no shared state. Each clone is a fully independent machine that boots its kernel from scratch and re-launches the container against the prepared filesystem.</p>
+  <div class="panel">
+    <pre><code># capture only the disk of a running VM (paused briefly for a consistent reflink)
+fcvm snapshot create --pid &lt;vm_pid&gt; --tag base --disk-only
+
+# cold-boot independent copies — memory/cpu/hugepages chosen freely at run time
+fcvm snapshot run --tag base --name c1 --hugepages --memory 8192 --cpu 4
+fcvm snapshot run --tag base --name c2          # another fresh, independent copy</code></pre>
+  </div>
+  <p class="src">Proposed CLI. This work introduces <code>--disk-only</code> on <code>snapshot create</code> and promotes <code>--tag</code> + <code>--memory/--cpu/--hugepages/--env</code> onto <code>snapshot run</code> (today's run uses <code>--snapshot</code> with cpu/mem internal-only — see <a href="#prs">P4</a>).</p>
+  <p>The headline architectural finding: <b>this feature already exists as the empty cell of a 2×2 matrix.</b> The cold-boot path and the snapshot-restore path <em>already share</em> the same disk-reflink machinery (<code>DiskManager::create_cow_disk</code>). Disk-only clone is <span class="yes">(captured disk) × (cold boot)</span> — a combination the current code never wires up, but every piece of which is already built and tested. The design's job is to make that matrix explicit instead of adding a fourth ad-hoc path.</p>
+  <div class="callout ok"><p><b>Review provenance:</b> this design was hardened by two adversarial passes (local codex + <code>/code-review</code>) before any code was written. They caught four would-be data-loss / broken-build bugs — missing guest <b>quiescing</b>, an unmodeled <b>container-state</b> collision, ungated <b>image resolution</b>, and an over-broad <b>overlay rejection</b> — now folded into the abstraction, risks, and PR plan below. Findings and fixes are flagged inline with <span class="src">(codex-flagged)</span>.</p></div>
+</section>
+
+<section id="problem">
+  <h2>The problem &amp; the two asks</h2>
+  <p>From <a href="https://github.com/ejc3/fcvm/issues/625">#625</a>, verbatim:</p>
+  <div class="callout">
+    <p>“i want functionality that can clone a vm but not its memory state … get a vm booted and then we clone the disk and then can start fresh copies from that cloned disk state.”</p>
+    <p>“i want the ability to start that fresh clone with huge tb's even if the original one wasnt started that way.” <span class="src">(huge tb's = hugepages / huge-TLB memory)</span></p>
+  </div>
+  <h3>Why this is useful</h3>
+  <p>Boot a VM, do expensive one-time work inside it — install packages, warm an image cache, seed a database, run a build — then capture the disk once and <b>fan out N cold copies</b> that each start from that prepared state. Unlike a memory clone, the copies are not frozen mid-execution: they boot fresh, so they can run a <em>different</em> command, get <em>different</em> resources, and have <em>no</em> shared memory pages or in-flight state to corrupt.</p>
+  <h3>The second ask falls out for free</h3>
+  <p>“Start the clone with hugepages even if the original wasn't” is hard for a <em>memory</em> clone: Firecracker rejects the file-backed memory backend for hugepage snapshots, so hugepages force the UFFD restore path and the backing must match the snapshot (<span class="src">src/commands/snapshot.rs:1001, 1016</span>). A <b>disk-only clone has no memory image to restore</b>, so that entire constraint evaporates — the clone allocates fresh guest RAM and can request <code>--hugepages</code>, any <code>--memory</code>, any <code>--cpu</code> with zero coupling to the source. See <a href="#hugepages">Hugepages</a>.</p>
+</section>
+
+<section id="contrast">
+  <h2>How it differs from the existing snapshot/clone</h2>
+  <table>
+    <tr><th></th><th>Existing memory+disk clone (<code>snapshot serve/run --pid</code>)</th><th>Disk-only clone (NEW)</th></tr>
+    <tr><td><b>Captures</b></td><td><code>memory.bin</code> + <code>vmstate.bin</code> + <code>disk.raw</code></td><td><code>disk.raw</code> only (+ <code>:ro</code> extra disks)</td></tr>
+    <tr><td><b>Restore</b></td><td>Resume mid-execution; UFFD serves pages on demand</td><td>Cold boot: fresh kernel, fc-agent re-launches container</td></tr>
+    <tr><td><b>Shared state</b></td><td>Clones share physical pages (CoW) via a serve process</td><td>None — fully independent processes</td></tr>
+    <tr><td><b>Serve step</b></td><td>Required (<code>snapshot serve</code> → UFFD socket)</td><td>None</td></tr>
+    <tr><td><b>Memory/cpu/hugepages</b></td><td>Constrained by the snapshot backing</td><td><span class="yes">Free at run time</span></td></tr>
+    <tr><td><b>Network</b></td><td>IP reconstructed from vmstate; restore-mode quirks</td><td>Fresh allocation; guest reconfigures eth0 from boot args</td></tr>
+    <tr><td><b>Boot time</b></td><td>Milliseconds (resume)</td><td>Seconds (full boot) — the tradeoff for independence</td></tr>
+    <tr><td><b>Use case</b></td><td>Instant warm forks of a live process</td><td>Fan-out of a prepared filesystem template</td></tr>
+  </table>
+</section>
+
+<section id="abstraction">
+  <h2>The proper abstraction</h2>
+  <p>Today there are two boot paths that look unrelated but in fact share their disk plumbing and differ along exactly <b>two orthogonal axes</b>. The design makes those axes first-class instead of bolting on a third special case.</p>
+
+  <h3>Axis A — <code>RootfsSource</code>: where does <code>rootfs.raw</code> come from?</h3>
+  <p><code>DiskManager::new(vm_id, <b>base_rootfs</b>, vm_dir)</code> reflinks whatever <code>base_rootfs</code> points at into the per-VM <code>rootfs.raw</code> (<span class="src">src/storage/disk.rs:26,41</span>). It is already source-agnostic:</p>
+  <ul>
+    <li><b><code>BaseLayer</code></b> — the content-addressed <code>layer2-{sha}.raw</code> from <code>ensure_rootfs(...)</code> (<span class="src">prepare_vm, src/commands/podman/mod.rs:297</span>). Used by <code>podman run</code>.</li>
+    <li><b><code>CapturedDisk(path)</code></b> — a snapshot's <code>disk.raw</code>. <em>Already used today</em> by snapshot-restore, which calls <code>DiskManager::new(vm_id, restore_config.source_disk_path, vm_dir)</code> (<span class="src">src/commands/common.rs:886</span>).</li>
+  </ul>
+
+  <h3>Axis B — <code>BootMode</code>: how does the guest come up?</h3>
+  <ul>
+    <li><b><code>ColdBoot</code></b> — fresh kernel boot; fc-agent reads the MMDS boot-plan and launches the container.</li>
+    <li><b><code>MemoryRestore { uffd, vmstate }</code></b> — resume a paused process from a memory image.</li>
+  </ul>
+
+  <h3>The matrix — disk-only clone is the empty cell</h3>
+  <table class="matrix">
+    <tr><th></th><th>BootMode = ColdBoot</th><th>BootMode = MemoryRestore</th></tr>
+    <tr>
+      <th>RootfsSource<br>= BaseLayer</th>
+      <td class="cell-exist"><div class="cell"><h5 class="yes">✓ <code>podman run</code></h5><div class="d">Today's fresh VM boot</div></div></td>
+      <td class="cell-na"><div class="cell"><h5>— n/a</h5><div class="d">no memory image for a fresh base</div></div></td>
+    </tr>
+    <tr>
+      <th>RootfsSource<br>= CapturedDisk</th>
+      <td class="cell-new"><div class="cell"><h5 class="new">★ disk-only clone</h5><div class="d"><b>NEW</b> — the combination this design fills in</div></div></td>
+      <td class="cell-exist"><div class="cell"><h5 class="yes">✓ <code>snapshot run --pid</code></h5><div class="d">Today's UFFD memory clone</div></div></td>
+    </tr>
+  </table>
+  <p class="lead">Both occupied cells already share <code>create_cow_disk</code>. Disk-only clone = the existing <b>CapturedDisk</b> reflink (from the UFFD cell) composed with the existing <b>ColdBoot</b> machinery (from the <code>podman run</code> cell). Almost no new mechanism — just a new wiring of two proven ones.</p>
+
+  <h3>Axis C — three policies the matrix exposes</h3>
+  <p>Placing the empty cell next to its neighbours reveals that a disk-only clone is not just “cold boot with a different disk” — three smaller policies become explicit. The first review of this design collapsed them into one coarse <code>StoragePolicy</code>; an adversarial pass showed that hides two data-loss bugs, so they are split out.</p>
+
+  <h4>C1 · QuiescePolicy (capture side)</h4>
+  <p>What state must be flushed to the disk <em>before</em> the reflink. A memory snapshot is consistent only because it also captures the dirty page cache; a disk-only capture has no such safety net, so it must <code>sync</code>/<code>fsfreeze</code> (or stop the workload) first. Detailed in <a href="#capture">the capture path</a>.</p>
+
+  <h4>C2 · StoragePolicy (guest side): provision vs. preserve</h4>
+  <p>On a normal cold boot fc-agent <b>provisions</b> storage — it wipes podman state and (re)installs the image. On a disk-only cold boot the storage is <em>already prepared inside the captured disk</em>, so fc-agent must <b>preserve</b> it:</p>
+  <table>
+    <tr><th><code>StoragePolicy</code></th><th>Used by</th><th>fc-agent behavior</th></tr>
+    <tr><td><code>Provision</code> (default)</td><td>BaseLayer cold boot</td><td>wipe storage, set up storage.conf, load/pull the image</td></tr>
+    <tr><td><code>Preserve</code></td><td>CapturedDisk cold boot</td><td>keep captured storage; skip <em>every</em> reset + the destructive btrfs setup; <b>verify</b> image present; re-attach a read-only store only if one existed</td></tr>
+  </table>
+
+  <h4>C3 · ContainerStatePolicy (guest side)</h4>
+  <p>The subtlety an adversarial review surfaced: fc-agent always issues <code>podman run --name fcvm-container</code> with no <code>--replace</code> (<span class="src">fc-agent/src/container.rs:948</span>). A captured VM <em>already has</em> an <code>fcvm-container</code> record and writable layer, so a naïve re-run either collides on the name or, if pre-removed, deletes the prepared layer. The clone must choose explicitly:</p>
+  <table>
+    <tr><th><code>ContainerStatePolicy</code></th><th>Semantics</th><th>Preserves writable layer?</th></tr>
+    <tr><td><code>StartCaptured</code> (default, v1)</td><td><code>podman start</code> the captured container — re-runs its entrypoint against its <b>exact</b> writable layer; no name collision (it's a <code>start</code>, not a <code>run</code>)</td><td><span class="yes">yes</span></td></tr>
+    <tr><td><code>FreshContainer</code></td><td>remove the captured record, <code>podman run</code> a new one — keeps the image + volumes, discards the old container's writable layer</td><td>no (image + volumes survive)</td></tr>
+  </table>
+  <p>v1 defaults to <code>StartCaptured</code>: it is the most faithful reading of “start fresh copies from that cloned disk state” — everything written inside the source (including the container's own filesystem) reappears in each copy — and it sidesteps the name collision because <code>podman start fcvm-container</code> resumes an existing record rather than creating a duplicate. This requires fc-agent to branch from the current unconditional <code>podman run --name fcvm-container</code> (<span class="src">container.rs:948</span>) to <code>podman start</code> for the captured container. <code>FreshContainer</code> is the opt-in for “same image/volumes, clean container.” The P4 “file written inside the container layer survives” test exercises the <code>StartCaptured</code> default.</p>
+
+  <div class="callout warn"><p>These policies surface on the wire as a few <code>#[serde(default)]</code> MMDS fields whose defaults equal today's behavior, so every existing plan deserializes unchanged. <b>This is where the feature can destroy data if done wrong</b> — see <a href="#agent">fc-agent</a> and <a href="#risks">Risks</a>.</p></div>
+
+  <div class="callout ok"><p><b>Why this is the “proper” abstraction, not a fourth path:</b> it names the two axes the code already varies along (<code>RootfsSource</code> × <code>BootMode</code>), places all three real boot scenarios in one matrix, and factors the genuinely new behavior into three small, defaulted policies instead of one ad-hoc branch. No existing path is special-cased; the disk-only clone is a <em>composition</em> plus three explicit choices. It also lines up with the planned <a href="#hypervisor">hypervisor abstraction</a> — <code>RootfsSource</code>/<code>BootMode</code> map onto its neutral <code>RestoreSource</code>/<code>SnapshotKind</code> types, and cold-boot-from-disk is VMM-agnostic (both Firecracker and Cloud Hypervisor do direct kernel boot).</p></div>
+</section>
+
+<section id="seams">
+  <h2>Reuse seams (verified file:line)</h2>
+  <p>Threading <code>rootfs_override: Option&lt;PathBuf&gt;</code> + <code>StoragePolicy</code> through the existing path touches a remarkably small surface, because everything downstream is already parameterized on <code>base_rootfs</code> and <code>args</code>.</p>
+  <table>
+    <tr><th>#</th><th>Seam</th><th>Location</th><th>Change</th></tr>
+    <tr><td>1</td><td><code>RunArgs</code> entry fields</td><td class="src">src/cli/args.rs (end of struct, ~:300)</td><td>add <code>rootfs_override: Option&lt;PathBuf&gt;</code>, <code>storage_policy</code></td></tr>
+    <tr><td>2</td><td><code>base_rootfs</code> resolution</td><td class="src">src/commands/podman/mod.rs:297</td><td><code>match rootfs_override { Some(p)=&gt;p, None=&gt;ensure_rootfs(..) }</code></td></tr>
+    <tr><td>3</td><td>snapshot-cache diversion</td><td class="src">src/commands/podman/mod.rs:326–333,351,381</td><td>gate on <code>rootfs_override.is_none()</code> so a clone does not divert into the UFFD path</td></tr>
+    <tr><td>3b</td><td>image resolution + localhost export</td><td class="src">src/commands/podman/mod.rs:320 (cache ref), :451 (export)</td><td><b>also gate on <code>rootfs_override</code></b> — a baked-in clone must NOT require the original host image tag to still exist or re-export it (codex-flagged gap)</td></tr>
+    <tr><td>4</td><td>disk reflink</td><td class="src">src/commands/podman/vm_config.rs:805–811</td><td><span class="pill keep">unchanged</span> — <code>create_cow_disk</code> reflinks whatever base it's given</td></tr>
+    <tr><td>5</td><td><code>MachineConfig</code> (cpu/mem/hugepages)</td><td class="src">src/commands/podman/vm_config.rs:927–935</td><td><span class="pill keep">unchanged</span> — already <code>huge_pages: if args.hugepages {Some("2M")}</code></td></tr>
+    <tr><td>6</td><td>MMDS boot-plan</td><td class="src">build_and_send_mmds, vm_config.rs:1098; to_mmds_json, config.rs:357</td><td>add one <code>storage_policy</code> field to the plan</td></tr>
+    <tr><td>7</td><td>network setup</td><td class="src">prepare_vm, mod.rs:668–725</td><td><span class="pill keep">unchanged</span> — fresh TAP + <code>allocate_loopback_ip</code> + <code>network.setup()</code></td></tr>
+  </table>
+  <p>The dispatch wrapper (<code>cmd_snapshot_run</code> on a <code>DiskOnly</code> tag) synthesizes a <code>RunArgs</code> from the snapshot's metadata plus CLI overrides, sets <code>rootfs_override = Some(disk.raw)</code> + <code>storage_policy = Preserve</code> + <code>no_snapshot = true</code>, then calls the ordinary <code>prepare_vm → run_vm_loop → cleanup_vm_context</code> trio (<span class="src">mod.rs:155 / :1060 / :1205</span>). All network / vsock / volume / listener / health wiring is reused verbatim.</p>
+</section>
+
+<section id="agent">
+  <h2>fc-agent: the <code>Preserve</code> storage policy</h2>
+  <p>On a normal boot the guest agent <b>destroys</b> podman storage and rebuilds it. A disk-only clone must not — the captured disk already contains the writable container layer and (for some image modes) the image itself. This is the highest-risk part of the feature.</p>
+  <div class="callout bad"><p><b>The wipe risk (citations corrected after review).</b> There are <b>four</b> reachable destroyers: <code>podman system reset --force</code> at <span class="src">container.rs:451</span> (root), <span class="src">:424</span> (btrfs setup), <span class="src">:64</span> (overlay mount), and a reset inside <code>create_vm_user</code> at <span class="src">container.rs:1103</span> (called from <span class="src">agent.rs:225</span>) when a non-root <code>--user</code> is set. <b>And the btrfs setup is destructive even before its reset</b>: it <code>truncate</code>s <code>/var/lib/containers/btrfs.img</code> (<span class="src">container.rs:357</span>) and runs <code>mkfs.btrfs -f</code> (<span class="src">container.rs:377</span>), reached via <span class="src">agent.rs:189</span> for non-overlay modes. A <code>Preserve</code> boot must skip <em>all</em> of these, not just the resets.</p></div>
+
+  <h3>Branch points a <code>Preserve</code> plan must guard</h3>
+  <table>
+    <tr><th>Step</th><th>Location</th><th>Provision</th><th>Preserve</th></tr>
+    <tr><td><code>write_early_storage_conf()</code></td><td class="src">agent.rs:112</td><td><span class="pill keep">do</span></td><td><span class="pill skip">skip</span> — keep captured storage.conf</td></tr>
+    <tr><td>btrfs storage setup branch</td><td class="src">agent.rs:189–198</td><td><span class="pill keep">do</span></td><td>non-destructive variant — <b>mount existing</b> <code>btrfs.img</code>, skip reset/truncate/mkfs (see below)</td></tr>
+    <tr><td><code>reset_podman_state()</code></td><td class="src">agent.rs:246–248</td><td><span class="pill keep">do</span></td><td><span class="pill skip">skip</span> — <b>the wipe</b></td></tr>
+    <tr><td>image-prep match (mount / load / pull)</td><td class="src">agent.rs:251–274</td><td><span class="pill keep">do</span></td><td><span class="pill skip">skip</span> — new <code>Preserve</code> arm</td></tr>
+    <tr><td><code>create_vm_user</code> reset (non-root)</td><td class="src">container.rs:1103 (via agent.rs:225)</td><td><span class="pill keep">do</span></td><td><span class="pill skip">skip</span></td></tr>
+    <tr><td>btrfs setup: <code>truncate</code> + <code>mkfs.btrfs -f</code></td><td class="src">container.rs:357,377 (via agent.rs:189)</td><td><span class="pill keep">do</span></td><td><span class="pill skip">skip the destroy</span> — but still <b>mount the existing</b> <code>btrfs.img</code> (it's a loopback, not persistent across boot — see below)</td></tr>
+    <tr><td><b>container start</b> (<code>--name fcvm-container</code>, no <code>--replace</code>)</td><td class="src">container.rs:948</td><td><span class="pill keep">run new</span></td><td>per <a href="#abstraction"><code>ContainerStatePolicy</code></a>: <code>podman start</code> the captured container (v1) or remove-then-run</td></tr>
+    <tr><td>overlay unmount at cleanup</td><td class="src">agent.rs:436–438</td><td>cond.</td><td>n/a — no <code>/mnt/image-store</code> unless re-attached</td></tr>
+    <tr><td><b>verify image present</b></td><td class="src">get_image_digest, container.rs:697</td><td>—</td><td><span class="pill keep">do</span> — bail clearly if absent (no load/pull fallback)</td></tr>
+    <tr><td>exec server, FUSE/disk/NFS mounts, chronyd, exit-notify</td><td class="src">agent.rs:115–443</td><td><span class="pill keep">do</span></td><td><span class="pill keep">do</span> — identical</td></tr>
+  </table>
+  <p>On the wire this is <code>#[serde(default)]</code> <code>storage_policy</code>/<code>container_state_policy</code> fields on the <code>Plan</code> struct (<span class="src">fc-agent/src/types.rs</span>), defaulting to today's behavior — so existing plans deserialize unchanged (proven by the minimal-plan test). Changing fc-agent requires <b>rebuilding the initrd</b> (content-addressed by the fc-agent binary SHA).</p>
+  <div class="callout warn"><p><b>Subtlety codex's second pass caught — <code>Preserve</code> ≠ "skip the btrfs branch entirely".</b> On a non-native-btrfs rootfs the image store is a <em>loopback</em> at <code>/var/lib/containers/btrfs.img</code> that is created+formatted+mounted at boot (<span class="src">container.rs:328/357/377/396</span>). The file is reflinked (it's inside <code>rootfs.raw</code>), but the loopback <em>mount</em> does not survive a cold boot. So <code>Preserve</code> must skip only the <b>destructive</b> steps (truncate + <code>mkfs</code>) while still <b>mounting the existing</b> <code>btrfs.img</code> — otherwise a btrfs/archive clone boots with the image present on disk but not mounted, i.e. invisible to podman.</p></div>
+
+  <h3>The image-delivery wrinkle (refined after review)</h3>
+  <p>The first draft said “reject overlay mode.” An adversarial pass showed that conflates two different things — what matters is <b>where the image physically lives</b>, which is determined by <em>delivery</em>, not the <code>image_mode</code> label:</p>
+  <table>
+    <tr><th>How the source got its image</th><th>Where the image lives</th><th>Disk-only capture</th></tr>
+    <tr><td><b>Remote pull</b> (<code>image_mode=None</code>, no device) — fc-agent pulls into rootfs at boot (<span class="src">agent.rs:264</span>)</td><td>baked into <code>rootfs.raw</code></td><td><span class="yes">✓ works</span> — reflink carries it</td></tr>
+    <tr><td><b>btrfs / archive</b> — fc-agent <code>podman load</code>s into rootfs storage</td><td>baked into <code>rootfs.raw</code></td><td><span class="yes">✓ works</span></td></tr>
+    <tr><td><b>localhost overlay</b> — RO <code>.storage-v2.img</code> attached as <code>additionalImageStore</code> (<span class="src">mod.rs:541</span>)</td><td><b>separate</b> content-addressed device, NOT in rootfs</td><td><span class="maybe">v1 reject</span> / v2 re-attach</td></tr>
+  </table>
+  <p>So the v1 guard must key on the <b>effective delivery</b> — “was a separate read-only overlay store device attached?” — which is exactly what MMDS records: it emits <code>image_mode</code> only alongside an <code>image_device</code> (<span class="src">config.rs:377</span>). It must <b>not</b> key on the raw <code>resolve_image_mode()</code>, which <em>defaults to Overlay even for remote pulls</em> (<span class="src">mod.rs:77</span>) that have no device and bake into the rootfs; and <b>not</b> on “an <code>image_device</code> exists,” because btrfs/archive also attach a device (<span class="src">vm_config.rs:481</span>) yet <code>podman load</code> it into the rootfs. The reject condition is precisely <em>overlay-mode AND a store device was attached</em>. In every mode the container's <em>writable</em> layer lives in <code>/var/lib/containers</code> on <code>rootfs.raw</code>; that is what <code>Preserve</code> + <code>ContainerStatePolicy</code> protect.</p>
+  <div class="grid2">
+    <div class="panel"><h4>v1 — rootfs-baked images</h4><p>Remote-pull, btrfs, and archive: the image is in the reflinked rootfs; <code>Preserve</code> skips the wipe and runs from local storage. Only the <b>separate-store localhost-overlay</b> capture is rejected (clear error). Smallest, safest first cut.</p></div>
+    <div class="panel"><h4>v2 — overlay re-attach</h4><p>Record <code>image_mode</code> + digest; on cold boot re-attach the same content-addressed <code>.storage</code> device (shared, always present) exactly like a normal overlay boot, then <code>Preserve</code> keeps the writable layer. No baking needed.</p></div>
+  </div>
+</section>
+
+<section id="capture">
+  <h2>The capture path</h2>
+  <p>Disk-only capture is <code>create_snapshot_core</code> (<span class="src">src/commands/common.rs:1553</span>) with the memory half removed and a <a href="#capture">guest quiesce</a> added. The factored <code>create_disk_only_snapshot_core</code> keeps the pause/resume bracket, adds the quiesce, and drops the Firecracker memory dump.</p>
+  <table>
+    <tr><th>Step in <code>create_snapshot_core</code></th><th class="src">lines</th><th>Disk-only</th></tr>
+    <tr><td>acquire snapshot semaphore; derive dirs</td><td class="src">1564–1574</td><td><span class="pill keep">keep</span></td></tr>
+    <tr><td>determine diff base / parent memory</td><td class="src">1585–1604</td><td><span class="pill skip">skip</span> (no memory ⇒ no diff chain)</td></tr>
+    <tr><td>memory disk-space check (<code>memory_mib</code>×1MiB)</td><td class="src">1619–1646</td><td><span class="pill skip">skip</span> (reflink is O(1))</td></tr>
+    <tr><td><b>pause VM</b> (<code>patch_vm_state "Paused"</code>)</td><td class="src">1683–1692</td><td><span class="pill keep">keep</span> — consistency</td></tr>
+    <tr><td>Firecracker <code>create_snapshot</code> (memory dump)</td><td class="src">1696–1702</td><td><span class="pill skip">skip</span> — the call to drop</td></tr>
+    <tr><td><b>reflink disk</b> (+ extra disks)</td><td class="src">1774–1803</td><td><span class="pill keep">keep</span> — the core; do it unconditionally after pause</td></tr>
+    <tr><td><b>resume VM</b> (<code>patch_vm_state "Resumed"</code>)</td><td class="src">1807–1817</td><td><span class="pill keep">keep</span> — “resume no matter what”</td></tr>
+    <tr><td>diff merge</td><td class="src">1843–1882</td><td><span class="pill skip">skip</span></td></tr>
+    <tr><td>write <code>config.json</code>; atomic rename into place</td><td class="src">1903–1927</td><td><span class="pill keep">keep</span> — finalize, <code>kind = DiskOnly</code>, <code>parent = None</code></td></tr>
+  </table>
+  <div class="callout bad"><p><b>Consistency — pause is NOT enough (corrected after review).</b> The memory-snapshot flow is consistent because it captures the dirty <b>guest page cache</b> in <code>memory.bin</code> at <span class="src">common.rs:1696</span>. Disk-only drops that, so <code>vCPU pause</code> alone (<span class="src">common.rs:1683</span>) leaves un-written-back dirty pages and in-flight journal state that never reach <code>rootfs.raw</code> — the reflink would capture a torn filesystem. A disk-only capture <b>must quiesce the guest first</b>.</p></div>
+
+  <h3>QuiescePolicy — flush the guest before the reflink</h3>
+  <p>Before reflinking, fcvm runs a quiesce command <em>inside</em> the guest over the <b>existing exec vsock channel</b> — the same path <code>fcvm exec</code> uses (host <span class="src">src/commands/exec.rs:146</span> → fc-agent exec server <span class="src">agent.rs:120</span> → guest command <span class="src">fc-agent/src/exec.rs:377</span>). No new control channel is needed, and because it's a runtime command (not the boot-time <code>Plan</code>), capture can use it without any fc-agent build change.</p>
+  <table>
+    <tr><th>Level</th><th>Action in guest</th><th>Guarantee</th></tr>
+    <tr><td><code>Sync</code></td><td><code>sync(2)</code></td><td>best-effort only — a <b>write window remains</b> between sync and the vCPU pause, so not race-free on its own</td></tr>
+    <tr><td><code>Freeze</code> (the correctness floor)</td><td><code>fsfreeze --freeze</code> each writable mount → reflink → <code>fsfreeze --unfreeze</code></td><td>filesystem is crash-consistent and <b>no writes can land</b> across the reflink</td></tr>
+    <tr><td><code>StopContainer</code></td><td>stop the workload, then freeze</td><td>strongest: also drains userspace buffers (needed if the app buffers writes itself)</td></tr>
+  </table>
+  <p>Ordering: <b>freeze (exec vsock) → vCPU pause → reflink → vCPU resume → unfreeze (exec vsock)</b>. <code>Freeze</code> is the floor because <code>Sync</code> alone leaves a window before the pause. This is the gap codex's first review flagged ("needs disk quiescing").</p>
+  <div class="callout bad"><p><b>Unfreeze no matter what.</b> A frozen filesystem left frozen wedges the <em>source</em> VM. Today's snapshot code returns immediately on a pause failure (<span class="src">common.rs:1683</span>) — acceptable when nothing is frozen, but disk-only capture must <code>fsfreeze --unfreeze</code> on <b>every</b> exit path (reflink error, pause failure, resume failure), with the same “resume no matter what” discipline extended to the freeze.</p></div>
+
+  <h3>Metadata the <code>DiskOnly</code> config must carry</h3>
+  <p><code>SnapshotMetadata</code> (<span class="src">src/storage/snapshot.rs:66–112</span>) already records image, vcpu, memory, network, volumes, hugepages, extra_disks, user, ports, forward-localhost, network-mode, ipv6-prefix, tty, interactive. To reconstruct a cold-boot plan it additionally needs fields that are currently <b>not persisted</b> anywhere:</p>
+  <table>
+    <tr><th>Field</th><th>Why needed</th><th>Status today</th></tr>
+    <tr><td><code>kind: SnapshotKind</code></td><td>distinguish Full vs DiskOnly at run dispatch</td><td>does not exist (<code>#[serde(default)]</code> ⇒ Full)</td></tr>
+    <tr><td>effective image delivery</td><td>did a <em>separate read-only store</em> get attached? (overlay) vs rootfs-baked (btrfs/archive/remote). v1 rejects only the separate-store case</td><td>not stored; raw <code>resolve_image_mode</code> (<span class="src">mod.rs:58</span>) even defaults to Overlay for remote — so persist the <b>effective</b> delivery, i.e. whether MMDS attached a store device (<span class="src">config.rs:377</span>)</td></tr>
+    <tr><td><code>container_cmd</code></td><td>re-run the original command on cold boot</td><td>no field in <code>VmConfig</code> at all</td></tr>
+    <tr><td><code>kernel_profile</code></td><td>a nested/btrfs-profile source must cold-boot under the SAME kernel, not the default</td><td>chosen each run (<span class="src">mod.rs:220,278</span>), never persisted — <code>rootfs_type</code> alone is insufficient</td></tr>
+    <tr><td><code>privileged</code>, <code>rootfs_type</code>, <code>non_blocking_output</code></td><td>reproduce the boot plan</td><td>not persisted</td></tr>
+  </table>
+  <div class="callout"><p><b>Env vars are intentionally NOT persisted</b> (they may hold secrets; state files are world-readable — <span class="src">mod.rs:613–614, types.rs:109</span>). Disk-only run therefore <b>re-supplies env at run time</b> via a new <code>--env</code> on <code>snapshot run</code>, never baking secrets into the snapshot directory.</p></div>
+</section>
+
+<section id="hugepages">
+  <h2>Hugepages &amp; resources come free</h2>
+  <p>The second ask — “start the clone with hugepages even if the original wasn't” — needs no new mechanism. It is purely a consequence of cold-booting.</p>
+  <div class="grid2">
+    <div class="panel">
+      <h4>Memory clone (constrained)</h4>
+      <p>Hugepages force the UFFD restore path; Firecracker rejects the file backend for hugepage snapshots, and the backing must match what was captured.</p>
+      <pre><code>// src/commands/snapshot.rs:1016
+if hugepages || env("FCVM_FORCE_UFFD") {
+    // implicit in-process UFFD server …
+}</code></pre>
+    </div>
+    <div class="panel">
+      <h4>Disk-only clone (free)</h4>
+      <p>No memory image ⇒ no backing to match. The cold-boot path already feeds <code>args</code> straight into the machine config:</p>
+      <pre><code>// src/commands/podman/vm_config.rs:927
+MachineConfig {
+  vcpu_count: args.cpu,
+  mem_size_mib: args.mem,
+  huge_pages: if args.hugepages { Some("2M") } else { None },
+}</code></pre>
+    </div>
+  </div>
+  <p><code>--hugepages</code>, <code>--memory</code>, and <code>--cpu</code> are <em>already</em> implemented for the fresh-boot path; the disk-only run just exposes them on <code>snapshot run</code> and lets them flow through unchanged. The only existing guard that still applies is the 2 MiB memory-alignment check for hugepages (<span class="src">mod.rs:162</span>).</p>
+</section>
+
+<section id="risks">
+  <h2>Top risks &amp; mitigations</h2>
+  <p>Ranked; the first three are data-loss / silent-corruption class and gate the design.</p>
+  <ol>
+    <li class="panel" style="padding-left:20px"><b>Torn filesystem — pause alone doesn't flush the page cache.</b> <span class="src">(codex-flagged)</span> Without a memory snapshot, dirty guest pages never reach the disk. Mitigation: <a href="#capture"><code>QuiescePolicy</code></a> — <code>sync</code>/<code>fsfreeze</code> (or stop the workload) before the reflink; freeze brackets the copy.</li>
+    <li class="panel" style="padding-left:20px"><b>fc-agent destroys the captured storage.</b> Four resets <em>plus</em> a truncate+mkfs btrfs setup. Mitigation: <code>StoragePolicy::Preserve</code> guards <em>all</em> of them (container.rs:64/424/451/1103 + 357/377); <code>Provision</code> stays the default. Covered by the “file inside the container layer survives the clone” e2e test.</li>
+    <li class="panel" style="padding-left:20px"><b>Container name collision / writable-layer loss.</b> <span class="src">(codex-flagged)</span> <code>podman run --name fcvm-container</code> has no <code>--replace</code>. Mitigation: <a href="#abstraction"><code>ContainerStatePolicy</code></a> — v1 <code>StartCaptured</code> (<code>podman start</code>, preserves the writable layer, no collision); <code>FreshContainer</code> opt-in.</li>
+    <li class="panel" style="padding-left:20px"><b>Clone needs the original host image tag.</b> <span class="src">(codex-flagged)</span> <code>prepare_vm</code> always resolves/exports the image. Mitigation: gate image-resolution + localhost-export (mod.rs:320,451) on <code>rootfs_override</code> — a rootfs-baked clone needs neither.</li>
+    <li class="panel" style="padding-left:20px"><b>Separate-store (localhost-overlay) image not in the rootfs.</b> Mitigation: v1 rejects only when a <b>separate read-only overlay store device was actually attached</b> (the effective delivery, recorded in metadata) — never the raw <code>resolve_image_mode()</code>, which defaults to Overlay even for remote pulls that bake into the rootfs; v2 re-attaches the content-addressed store.</li>
+    <li class="panel" style="padding-left:20px"><b>Wrong kernel for a nested/btrfs-profile source.</b> Mitigation: persist <code>kernel_profile</code> in metadata and cold-boot under it; <code>rootfs_type</code> alone is insufficient.</li>
+    <li class="panel" style="padding-left:20px"><b>Secrets leaking into a world-readable snapshot.</b> Mitigation: env vars are never persisted; re-supplied at run time via <code>--env</code>.</li>
+    <li class="panel" style="padding-left:20px"><b>Footgun: <code>--pid</code> (UFFD) on a DiskOnly tag.</b> Mitigation: dispatch rejects it; a DiskOnly tag has no memory image to serve.</li>
+  </ol>
+</section>
+
+<section id="prs">
+  <h2>Stacked PR sequence — green at every step</h2>
+  <p>The work is decomposed so each PR <b>compiles, passes tests locally, and is independently mergeable</b>. Early PRs are purely additive (new fields default to existing behavior), so nothing changes until the final wiring PR turns the feature on. Each branch is stacked on the previous one (<code>main → P1 → P2 → …</code>).</p>
+
+  <svg viewBox="0 0 980 120" role="img" aria-label="stacked PR chain">
+    <defs><marker id="ar" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#58a6ff"/></marker></defs>
+    <line x1="20" y1="60" x2="960" y2="60" stroke="#2b3440" stroke-width="2"/>
+    <g font-family="Consolas,Menlo,monospace" font-size="12" text-anchor="middle">
+      <circle cx="60"  cy="60" r="8" fill="#2ea043"/><text x="60"  y="92" fill="#9aa7b4">main</text>
+      <circle cx="220" cy="60" r="8" fill="#388bfd"/><text x="220" y="92" fill="#c9d7e6">P1 metadata</text>
+      <circle cx="400" cy="60" r="8" fill="#388bfd"/><text x="400" y="92" fill="#c9d7e6">P2 capture</text>
+      <circle cx="580" cy="60" r="8" fill="#d29922"/><text x="580" y="92" fill="#c9d7e6">P3 fc-agent</text>
+      <circle cx="760" cy="60" r="8" fill="#388bfd"/><text x="760" y="92" fill="#c9d7e6">P4 run + e2e</text>
+      <circle cx="920" cy="60" r="8" fill="#2ea043"/><text x="920" y="92" fill="#c9d7e6">P5 docs/pages</text>
+    </g>
+    <line x1="68" y1="40" x2="212" y2="40" stroke="#58a6ff" stroke-width="1.5" marker-end="url(#ar)"/>
+    <line x1="228" y1="40" x2="392" y2="40" stroke="#58a6ff" stroke-width="1.5" marker-end="url(#ar)"/>
+    <line x1="408" y1="40" x2="572" y2="40" stroke="#58a6ff" stroke-width="1.5" marker-end="url(#ar)"/>
+    <line x1="588" y1="40" x2="752" y2="40" stroke="#58a6ff" stroke-width="1.5" marker-end="url(#ar)"/>
+    <line x1="768" y1="40" x2="912" y2="40" stroke="#58a6ff" stroke-width="1.5" marker-end="url(#ar)"/>
+  </svg>
+  <div class="legend"><span class="lg-exist">no behavior change</span><span class="lg-new">host code</span><span class="lg-agent">fc-agent + initrd rebuild</span></div>
+
+  <ol class="steps">
+    <li>
+      <b>P1 — metadata foundation (no behavior change).</b> Add <code>SnapshotKind { Full, DiskOnly }</code> with <code>#[serde(default)]</code> on <code>SnapshotConfig</code>; persist <b>all</b> fields the later PRs read — effective image delivery (overlay-store-attached vs rootfs-baked), <code>kernel_profile</code>, <code>container_cmd</code>, <code>privileged</code>, <code>rootfs_type</code>, <code>non_blocking_output</code> — into <code>VmConfig</code> (<span class="src">src/state/types.rs:102</span>) and mirror into <code>SnapshotMetadata</code> (built at <span class="src">common.rs:1395</span>). Update all <code>SnapshotConfig{…}</code> literals (prod builder + ~6 test fixtures) to set <code>kind: Full</code>.
+      <span class="green-gate">unit tests for serde round-trip + back-compat (old config deserializes as Full); existing snapshot suite unchanged.</span>
+    </li>
+    <li>
+      <b>P2 — disk-only capture (+ guard the old run/serve paths).</b> <code>--disk-only</code> on <code>snapshot create</code>; factor <code>create_disk_only_snapshot_core</code> (<b>freeze via exec vsock → pause → reflink → resume → unfreeze</b>, with unfreeze on <em>every</em> exit path; skip memory dump + memory disk-check); reject only <em>separate-store</em> capture (overlay mode <b>with</b> an attached store device — the effective delivery, not raw <code>resolve_image_mode</code>). Quiesce uses the existing exec vsock (<span class="src">exec.rs:146</span>), so it needs no fc-agent change and can land here. <b>Reject a <code>DiskOnly</code> tag in the existing <code>cmd_snapshot_run</code> (<span class="src">snapshot.rs:707,1076</span>) AND <code>snapshot serve</code> (<span class="src">snapshot.rs:291</span>)</b> with a clear error, so P2 leaves no crashing path on main.
+      <span class="green-gate">capture from a live VM → disk.raw present, no memory.bin/vmstate.bin, kind=DiskOnly; freeze invoked + unfreeze-on-failure; Overlay rejection; `snapshot run/serve` on a DiskOnly tag fail with a clear message, not a missing-file panic.</span>
+    </li>
+    <li>
+      <b>P3 — fc-agent <code>StoragePolicy</code> + <code>ContainerStatePolicy</code>.</b> Add <code>#[serde(default)]</code> <code>storage_policy</code> + <code>container_state_policy</code> to the boot <code>Plan</code> (defaults = today's behavior). Guard <em>all</em> destroyers behind <code>Preserve</code> — the three resets (container.rs:64/424/451), the <code>create_vm_user</code> reset (container.rs:1103), the destructive btrfs <code>truncate</code>/<code>mkfs</code> (container.rs:357/377) <b>while still mounting the existing</b> <code>btrfs.img</code>, early-storage-conf, image-prep; add the <code>Preserve</code> arm (verify image present, run from local storage). Implement <code>StartCaptured</code> (<code>podman start</code> the captured container — v1 default, no name collision, preserves the writable layer) and <code>FreshContainer</code> (remove-then-run). (Quiesce is NOT here — it's a runtime exec command from P2, not a boot-<code>Plan</code> field.) Rebuild initrd.
+      <span class="green-gate">additive (defaults = today); fc-agent unit tests for Plan deserialization + each guard; full existing host suite still green.</span>
+    </li>
+    <li>
+      <b>P4 — cold-boot run wiring + the end-to-end test.</b> <code>RunArgs.rootfs_override</code> + policies through <code>prepare_vm</code>; gate the snapshot-cache diversion <b>and</b> the image-resolution/localhost-export (<span class="src">mod.rs:320,451</span>) on <code>rootfs_override</code>; promote <code>--memory/--cpu/--hugepages/--env</code> to real args on <code>snapshot run</code>; dispatch <code>cmd_snapshot_run</code> on <code>kind == DiskOnly</code> → synthesize <code>RunArgs</code> from metadata (incl. <code>kernel_profile</code>), reject <code>--pid</code>; set <code>process_type=Clone</code> + <code>snapshot_name</code>.
+      <span class="green-gate">e2e: a file written <b>inside the container layer</b> of the source survives the clone &amp; the container runs; hugepage upgrade (source without → clone with, healthy); two clones independent; clone works after the original host image tag is removed; --pid-on-DiskOnly rejected.</span>
+    </li>
+    <li>
+      <b>P5 — docs &amp; published design.</b> README + <code>.claude/CLAUDE.md</code> + <code>DESIGN.md</code> coherence; this page on GitHub Pages. (The design page itself lands first, ahead of code, as this PR.)
+      <span class="green-gate">Pages workflow deploys; doc links resolve; lint/format clean.</span>
+    </li>
+  </ol>
+  <div class="callout ok"><p><b>Why this ordering keeps CI green:</b> P1–P3 are strictly additive with defaults equal to current behavior, so each merges without changing any existing path. The feature only activates in P4, which lands together with its end-to-end test — there is never a half-wired intermediate state on <code>main</code>. fc-agent (P3) precedes the run wiring (P4) so the initrd that P4's test needs already exists.</p></div>
+</section>
+
+<section id="testing">
+  <h2>Testing plan</h2>
+  <p>Following the repo's rule that a regression test must <b>fail without the fix and pass with it</b>, and that new tests are <b>run locally</b>, not merely compiled:</p>
+  <table>
+    <tr><th>Test</th><th>Asserts</th><th>Lands in</th></tr>
+    <tr><td>serde back-compat</td><td>a pre-<code>kind</code> config deserializes as <code>Full</code>; round-trips</td><td>P1</td></tr>
+    <tr><td>disk-only capture artifact</td><td><code>disk.raw</code> present; no <code>memory.bin</code>/<code>vmstate.bin</code>; <code>kind=DiskOnly</code></td><td>P2</td></tr>
+    <tr><td>Separate-store capture rejected</td><td>clear error only when an overlay store device was attached; remote-pull/btrfs/archive capture <em>succeed</em></td><td>P2</td></tr>
+    <tr><td>DiskOnly rejected by run/serve</td><td><code>snapshot run</code> and <code>serve</code> on a DiskOnly tag error clearly (no missing-memory panic)</td><td>P2</td></tr>
+    <tr><td>Plan deserialization</td><td>missing <code>storage_policy</code> ⇒ <code>Provision</code>; <code>Preserve</code> parses</td><td>P3</td></tr>
+    <tr><td><b>marker survives the clone</b></td><td>write a file inside source → capture → cold-boot clone → file present &amp; container runs</td><td>P4</td></tr>
+    <tr><td><b>hugepage upgrade</b></td><td>source booted <em>without</em> hugepages → clone with <code>--hugepages</code> boots healthy</td><td>P4</td></tr>
+    <tr><td>clone independence</td><td>two clones; a write in one is not visible in the other</td><td>P4</td></tr>
+    <tr><td><code>--pid</code> on DiskOnly rejected</td><td>UFFD restore refused for a disk-only tag</td><td>P4</td></tr>
+  </table>
+  <p>P4's tests require a rebuilt initrd (from P3). All run via <code>make test-root FILTER=…</code> locally before push; CI runs the full host/container × arm64/x64 × snapshot matrix.</p>
+  <h3>Review gates (issue success criteria)</h3>
+  <ul>
+    <li><code>/code-review</code> on each PR; findings addressed before merge.</li>
+    <li>Local <b>codex</b> adversarial review on each diff; findings addressed.</li>
+    <li>Docs kept coherent (README / CLAUDE.md / DESIGN.md) as part of the feature, not after.</li>
+  </ul>
+</section>
+
+<section id="hypervisor">
+  <h2>Fit with the hypervisor abstraction</h2>
+  <p>fcvm has a separate RFC to become hypervisor-agnostic (Firecracker + Cloud Hypervisor — <a href="https://github.com/ejc3/fcvm/blob/main/docs/hypervisor-abstraction.md">docs/hypervisor-abstraction.md</a>, epic #632). Disk-only clone is designed to land <em>now</em> on the Firecracker path while mapping cleanly onto those future neutral types:</p>
+  <table>
+    <tr><th>Disk-only concept</th><th>Hypervisor-abstraction neutral type</th></tr>
+    <tr><td><code>RootfsSource::CapturedDisk</code></td><td><code>RestoreSource</code> (VMM-neutral; reflink/bind-mount redirect is already VMM-agnostic)</td></tr>
+    <tr><td><code>SnapshotKind::DiskOnly</code></td><td><code>SnapshotKind</code> (the doc already plans Full vs diff; DiskOnly is a third, memory-less kind)</td></tr>
+    <tr><td><code>BootMode::ColdBoot</code></td><td>the trait's <code>configure</code>+<code>start</code> (direct kernel boot — supported by both FC and CH)</td></tr>
+    <tr><td><code>StoragePolicy</code> (guest)</td><td>part of the VMM-neutral boot-plan over vsock (guest channel is byte-identical across backends)</td></tr>
+  </table>
+  <p>Because a disk-only clone needs <b>no</b> snapshot format, UFFD, or drive-retarget — the three things that differ most between Firecracker and Cloud Hypervisor — it is the <em>most portable</em> clone variant and a natural early win for the CH backend (which the RFC schedules as “P1: cold boot + run a container, no snapshots”).</p>
+</section>
+
+</main>
+
+<footer><div class="wrap">
+  <p>fcvm · disk-only clone design · issue <a href="https://github.com/ejc3/fcvm/issues/625">#625</a> · all file:line references verified against <code>main</code> at design time. This is a design/RFC document; implementation proceeds via the stacked PR sequence above.</p>
+</div></footer>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>fcvm — design docs</title>
+<style>
+  :root{--bg:#0d1117;--panel:#161b22;--ink:#e6edf3;--muted:#9aa7b4;--line:#2b3440;--accent:#58a6ff;--accent2:#3fb950;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;--mono:"SFMono-Regular",Consolas,Menlo,monospace}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.6}
+  .wrap{max-width:860px;margin:0 auto;padding:64px 24px}
+  h1{font-size:34px;margin:0 0 4px;letter-spacing:-.4px}
+  .sub{color:var(--muted);font-size:17px;margin:0 0 36px}
+  a.card{display:block;text-decoration:none;color:inherit;background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:20px 22px;margin:14px 0;transition:border-color .15s,transform .15s}
+  a.card:hover{border-color:var(--accent);transform:translateY(-1px)}
+  a.card h2{margin:0 0 6px;font-size:20px;color:var(--accent)}
+  a.card p{margin:0;color:var(--muted);font-size:14.5px}
+  .tag{font-family:var(--mono);font-size:11px;background:#21262d;border:1px solid var(--line);color:var(--muted);padding:2px 8px;border-radius:999px;margin-left:8px;vertical-align:middle}
+  .tag.rfc{color:var(--accent)}
+  .tag.merged{color:var(--accent2)}
+  footer{color:var(--muted);font-size:13px;margin-top:40px;border-top:1px solid var(--line);padding-top:18px}
+  footer a{color:var(--accent)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>fcvm design docs</h1>
+  <p class="sub">Architecture &amp; design notes for the Firecracker microVM manager.</p>
+
+  <a class="card" href="disk-only-clone.html">
+    <h2>Disk-only clone <span class="tag rfc">RFC #625</span></h2>
+    <p>Cold-boot fresh, fully independent VMs from a captured disk — free choice of memory, CPU, and hugepages. The abstraction, verified reuse seams, fc-agent storage policy, and a green-at-every-step stacked-PR plan.</p>
+  </a>
+
+  <a class="card" href="https://github.com/ejc3/fcvm/blob/main/docs/hypervisor-abstraction.md">
+    <h2>Hypervisor-agnostic abstraction <span class="tag merged">epic #632</span></h2>
+    <p>Making fcvm pluggable across Firecracker and Cloud Hypervisor via a capability-gated <code>Hypervisor</code> trait. (Rendered on GitHub.)</p>
+  </a>
+
+  <footer>
+    Source: <a href="https://github.com/ejc3/fcvm">github.com/ejc3/fcvm</a> · Published from <code>docs/</code> via GitHub Pages.
+  </footer>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Design/RFC for the **disk-only clone** feature (#625), published as an HTML page on GitHub Pages. No implementation — this lands the design + the Pages infra ahead of the stacked implementation PRs it describes.

## What's here
- **`docs/disk-only-clone.html`** — the deep design.
- **`docs/index.html`** — docs landing page.
- **`docs/.nojekyll`** — serve the hand-authored HTML as-is.
- **`.github/workflows/pages.yml`** — deploy `docs/` to Pages on push to `main` (trusted context only; least-privilege `pages`/`id-token`).

## The design in one breath
Disk-only clone = the empty cell of a **RootfsSource × BootMode** matrix that cold-boot and snapshot-restore **already share** (`DiskManager::create_cow_disk`). It's a *composition* of two proven paths plus three small, defaulted policies:
- **QuiescePolicy** (capture): `fsfreeze` over the exec vsock with guaranteed unfreeze — a pause-only reflink would capture a torn FS (no memory image to carry the page cache).
- **StoragePolicy::Preserve** (guest): skip all four podman resets + the destructive btrfs `truncate`/`mkfs` while still mounting the existing `btrfs.img`; verify the image present.
- **ContainerStatePolicy** (guest): v1 `StartCaptured` (`podman start` — preserves the writable layer, no name collision).

Hugepages "come free" because a cold boot has no memory image to match. Includes ranked risks, a **green-at-every-step stacked-PR sequence** (P1 metadata → P2 capture → P3 fc-agent → P4 run+e2e → P5 docs), a testing plan, and the mapping onto the hypervisor abstraction.

## Review evidence (issue success criterion: codex + /code-review)
Hardened by **four adversarial passes** before any code. Bugs caught and folded in:
1. Pause alone doesn't flush the guest page cache → added **QuiescePolicy** (fsfreeze + unfreeze-always, via exec vsock).
2. `podman run --name fcvm-container` has no `--replace` → added **ContainerStatePolicy** (v1 `StartCaptured`).
3. Image resolution/export not gated by `rootfs_override` → added that seam.
4. Over-broad overlay rejection (raw `resolve_image_mode` defaults Overlay even for remote pulls) → keyed on **effective delivery** (a separate store device was attached).
5. `Preserve` must **re-mount** the `btrfs.img` loopback (not skip wholesale); persist `kernel_profile`; reject `DiskOnly` in run **and** serve.

Codex final verdict: *"no internal contradiction found, sound enough to implement from."*

## Note
After merge, GitHub Pages must be set to **source = GitHub Actions** for the first deploy (enabling in repo settings / via API as part of this change).
