### PR TITLE
feat(snapshot): SnapshotKind { Full, DiskOnly } foundation (disk-only-clone P1)

### DIFF
--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -1392,6 +1392,9 @@ pub fn build_snapshot_config(
         disk_path: snapshot_dir.join("disk.raw"),
         created_at: chrono::Utc::now(),
         snapshot_type,
+        // Prod builder always produces Full snapshots; the disk-only path (P2)
+        // sets DiskOnly in create_disk_only_snapshot_core.
+        kind: crate::storage::SnapshotKind::Full,
         metadata: crate::storage::SnapshotMetadata {
             image: vm_state.config.image.clone(),
             vcpu: vm_state.config.vcpu,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4,7 +4,7 @@ pub mod volume;
 
 pub use disk::{DiskConfig, DiskManager};
 pub use snapshot::{
-    SnapshotConfig, SnapshotExtraDisk, SnapshotManager, SnapshotMetadata, SnapshotType,
-    SnapshotVolumeConfig,
+    SnapshotConfig, SnapshotExtraDisk, SnapshotKind, SnapshotManager, SnapshotMetadata,
+    SnapshotType, SnapshotVolumeConfig,
 };
 pub use volume::{VolumeManager, VolumeMount};

--- a/src/storage/snapshot.rs
+++ b/src/storage/snapshot.rs
@@ -29,6 +29,27 @@ impl std::fmt::Display for SnapshotType {
     }
 }
 
+/// Kind of snapshot — distinguishes a full memory+disk snapshot from a
+/// disk-only snapshot (no memory image; clones cold-boot from the captured disk).
+/// Defaults to Full for backward compatibility with existing snapshots.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub enum SnapshotKind {
+    /// Memory + disk snapshot; clones resume mid-execution via UFFD.
+    #[default]
+    Full,
+    /// Disk-only snapshot; clones cold-boot fresh from the captured disk.
+    DiskOnly,
+}
+
+impl std::fmt::Display for SnapshotKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SnapshotKind::Full => write!(f, "full"),
+            SnapshotKind::DiskOnly => write!(f, "disk-only"),
+        }
+    }
+}
+
 /// Snapshot configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SnapshotConfig {
@@ -60,6 +81,10 @@ pub struct SnapshotConfig {
     /// Defaults to System for backward compatibility with existing snapshots
     #[serde(default)]
     pub snapshot_type: SnapshotType,
+    /// Full (memory+disk) vs DiskOnly (no memory image — clones cold-boot).
+    /// Defaults to Full so existing snapshots deserialize unchanged.
+    #[serde(default)]
+    pub kind: SnapshotKind,
     pub metadata: SnapshotMetadata,
 }
 
@@ -263,6 +288,7 @@ mod tests {
             disk_path: PathBuf::from("/path/to/disk.raw"),
             created_at: chrono::Utc::now(),
             snapshot_type: SnapshotType::User,
+            kind: SnapshotKind::Full,
             metadata: SnapshotMetadata {
                 image: "nginx:alpine".to_string(),
                 vcpu: 2,
@@ -389,6 +415,7 @@ mod tests {
             disk_path: PathBuf::from("/disk.raw"),
             created_at: chrono::Utc::now(),
             snapshot_type: SnapshotType::User,
+            kind: SnapshotKind::Full,
             metadata: SnapshotMetadata {
                 image: "alpine:latest".to_string(),
                 vcpu: 2,
@@ -459,6 +486,7 @@ mod tests {
                 disk_path: PathBuf::from("/disk.raw"),
                 created_at: chrono::Utc::now(),
                 snapshot_type: SnapshotType::System,
+                kind: SnapshotKind::Full,
                 metadata: SnapshotMetadata {
                     image: "alpine".to_string(),
                     vcpu: 1,
@@ -516,6 +544,7 @@ mod tests {
             disk_path: PathBuf::from("/disk.raw"),
             created_at: chrono::Utc::now(),
             snapshot_type: SnapshotType::System,
+            kind: SnapshotKind::Full,
             metadata: SnapshotMetadata {
                 image: "alpine".to_string(),
                 vcpu: 1,
@@ -609,6 +638,8 @@ mod tests {
         assert_eq!(config.name, "old-snapshot");
         // Missing snapshot_type should default to System
         assert_eq!(config.snapshot_type, SnapshotType::System);
+        // Missing kind should default to Full (existing snapshots are memory+disk)
+        assert_eq!(config.kind, SnapshotKind::Full);
     }
 
     #[test]
@@ -624,6 +655,7 @@ mod tests {
             disk_path: PathBuf::from("/disk.raw"),
             created_at: chrono::Utc::now(),
             snapshot_type: SnapshotType::User,
+            kind: SnapshotKind::Full,
             metadata: SnapshotMetadata {
                 image: "alpine".to_string(),
                 vcpu: 1,
@@ -671,6 +703,28 @@ mod tests {
         let json = serde_json::to_string(&system_config).unwrap();
         let parsed: SnapshotConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.snapshot_type, SnapshotType::System);
+    }
+
+    #[test]
+    fn test_snapshot_kind_default_is_full() {
+        // Verify SnapshotKind::default() is Full (existing snapshots are memory+disk)
+        assert_eq!(SnapshotKind::default(), SnapshotKind::Full);
+    }
+
+    #[test]
+    fn test_snapshot_kind_display() {
+        assert_eq!(format!("{}", SnapshotKind::Full), "full");
+        assert_eq!(format!("{}", SnapshotKind::DiskOnly), "disk-only");
+    }
+
+    #[test]
+    fn test_snapshot_kind_json_roundtrip() {
+        // Both kinds round-trip through JSON unchanged.
+        for kind in [SnapshotKind::Full, SnapshotKind::DiskOnly] {
+            let json = serde_json::to_string(&kind).unwrap();
+            let parsed: SnapshotKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, kind);
+        }
     }
 
     #[test]


### PR DESCRIPTION
**Stacked on:** main · part of the disk-only-clone feature (RFC #625), stack P1→P4.

P1 = the metadata foundation. Purely additive — defaults to `Full` so every existing snapshot/state file deserializes unchanged.

## Changes
- `SnapshotKind { Full (#[default]), DiskOnly }` enum (mirrors `SnapshotType`), with `Display`.
- `#[serde(default)] kind` field on `SnapshotConfig`; re-exported from `crate::storage`.
- Prod builder (`build_snapshot_config`) sets `kind: Full`; `DiskOnly` is set later by the disk-only capture path (P2).
- Updated all `SnapshotConfig` literals (prod builder + fixtures; the `..user_config` one inherits).

## Tests
\`\`\`
cargo test -p fcvm --lib snapshot  →  52 passed; 0 failed
\`\`\`
- back-compat: a pre-`kind` snapshot JSON deserializes as `Full`
- `kind` default-is-Full, Display, JSON round-trip
- clippy: 0 warnings; cargo fmt clean

Design: docs/disk-only-clone.html (RFC #625).