### PR TITLE
make: self-heal cargo toolchain + nextest in check-disk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,35 +222,30 @@ check-disk:
 		ln -sf /mnt/fcvm-btrfs/cargo "$$HOME/.cargo"; \
 		echo "==> Symlinked ~/.cargo → /mnt/fcvm-btrfs/cargo"; \
 	fi
-	@# Fix broken ~/.cargo symlink (target dir was cleaned up)
-	@if [ -L "$$HOME/.cargo" ] && ! [ -e "$$HOME/.cargo" ] && [ -d /mnt/fcvm-btrfs ]; then \
-		echo "==> Fixing broken ~/.cargo symlink..."; \
-		mkdir -p /mnt/fcvm-btrfs/cargo; \
-		echo "==> Restored /mnt/fcvm-btrfs/cargo"; \
-	fi
-	@# Ensure cargo toolchain binaries exist in ~/.cargo/bin (restored from rustup
-	@# if the cargo home was wiped — e.g. ephemeral btrfs reset). Without this,
-	@# `cargo` itself is missing after a wipe and every make target fails.
-	@if ! command -v cargo >/dev/null 2>&1 && ! [ -x "$$HOME/.cargo/bin/cargo" ]; then \
-		TC=$$(rustup show active-toolchain 2>/dev/null | awk '{print $$1}'); \
-		TCBIN="$$HOME/.rustup/toolchains/$$TC/bin"; \
-		if [ -z "$$TC" ]; then TCBIN=$$(ls -d "$$HOME"/.rustup/toolchains/*/bin 2>/dev/null | head -1); fi; \
-		if [ -n "$$TCBIN" ] && [ -d "$$TCBIN" ]; then \
-			echo "==> cargo missing; restoring shims from $$TCBIN"; \
-			mkdir -p "$$HOME/.cargo/bin"; \
+	@# Self-heal a wiped cargo home. The btrfs above is ephemeral and can be reset
+	@# out from under us, leaving ~/.cargo a dangling symlink. cargo can't restore
+	@# itself, so recreate the symlink's TARGET dir (mkdir through a dangling symlink
+	@# fails, so operate on the readlink'd path) and relink the rustup toolchain
+	@# shims; the registry re-downloads on the next build.
+	@if [ -L "$$HOME/.cargo" ] && ! [ -e "$$HOME/.cargo/bin/cargo" ]; then \
+		echo "==> cargo home wiped; restoring toolchain..."; \
+		TGT=$$(readlink "$$HOME/.cargo"); \
+		mkdir -p "$$TGT/bin"; \
+		TCBIN=$$(ls -d "$$HOME"/.rustup/toolchains/*/bin 2>/dev/null | head -1); \
+		if [ -n "$$TCBIN" ]; then \
 			for b in cargo rustc cargo-clippy clippy-driver rustfmt cargo-fmt rustdoc; do \
-				[ -e "$$TCBIN/$$b" ] && ln -sf "$$TCBIN/$$b" "$$HOME/.cargo/bin/$$b"; \
+				[ -e "$$TCBIN/$$b" ] && ln -sf "$$TCBIN/$$b" "$$TGT/bin/$$b"; \
 			done; \
-		fi; \
+			echo "==> Restored cargo shims from $$TCBIN into $$TGT/bin"; \
+		else echo "==> WARNING: no rustup toolchain found to restore cargo from"; fi; \
 	fi
-	@# Ensure cargo-nextest (the test runner) is installed; install prebuilt if missing.
-	@if ! PATH="$$HOME/.cargo/bin:$$PATH" $(CARGO) nextest --version >/dev/null 2>&1; then \
-		echo "==> cargo-nextest missing; installing prebuilt binary..."; \
+	@# Ensure cargo-nextest (the test runner; a separate install from rustup).
+	@if ! PATH="$$HOME/.cargo/bin:$$PATH" cargo nextest --version >/dev/null 2>&1; then \
+		echo "==> Installing cargo-nextest..."; \
 		case "$$(uname -m)" in aarch64|arm64) NURL=https://get.nexte.st/latest/linux-arm ;; *) NURL=https://get.nexte.st/latest/linux ;; esac; \
 		mkdir -p "$$HOME/.cargo/bin"; \
 		curl -LsSf "$$NURL" | tar zxf - -C "$$HOME/.cargo/bin" \
-			|| PATH="$$HOME/.cargo/bin:$$PATH" $(CARGO) install cargo-nextest --locked; \
-		echo "==> cargo-nextest installed"; \
+			|| PATH="$$HOME/.cargo/bin:$$PATH" cargo install cargo-nextest --locked; \
 	fi
 	@if [ -d /mnt/fcvm-btrfs ] && ! [ -L target ]; then \
 		if [ -d target ]; then \

--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,30 @@ check-disk:
 		mkdir -p /mnt/fcvm-btrfs/cargo; \
 		echo "==> Restored /mnt/fcvm-btrfs/cargo"; \
 	fi
+	@# Ensure cargo toolchain binaries exist in ~/.cargo/bin (restored from rustup
+	@# if the cargo home was wiped — e.g. ephemeral btrfs reset). Without this,
+	@# `cargo` itself is missing after a wipe and every make target fails.
+	@if ! command -v cargo >/dev/null 2>&1 && ! [ -x "$$HOME/.cargo/bin/cargo" ]; then \
+		TC=$$(rustup show active-toolchain 2>/dev/null | awk '{print $$1}'); \
+		TCBIN="$$HOME/.rustup/toolchains/$$TC/bin"; \
+		if [ -z "$$TC" ]; then TCBIN=$$(ls -d "$$HOME"/.rustup/toolchains/*/bin 2>/dev/null | head -1); fi; \
+		if [ -n "$$TCBIN" ] && [ -d "$$TCBIN" ]; then \
+			echo "==> cargo missing; restoring shims from $$TCBIN"; \
+			mkdir -p "$$HOME/.cargo/bin"; \
+			for b in cargo rustc cargo-clippy clippy-driver rustfmt cargo-fmt rustdoc; do \
+				[ -e "$$TCBIN/$$b" ] && ln -sf "$$TCBIN/$$b" "$$HOME/.cargo/bin/$$b"; \
+			done; \
+		fi; \
+	fi
+	@# Ensure cargo-nextest (the test runner) is installed; install prebuilt if missing.
+	@if ! PATH="$$HOME/.cargo/bin:$$PATH" $(CARGO) nextest --version >/dev/null 2>&1; then \
+		echo "==> cargo-nextest missing; installing prebuilt binary..."; \
+		case "$$(uname -m)" in aarch64|arm64) NURL=https://get.nexte.st/latest/linux-arm ;; *) NURL=https://get.nexte.st/latest/linux ;; esac; \
+		mkdir -p "$$HOME/.cargo/bin"; \
+		curl -LsSf "$$NURL" | tar zxf - -C "$$HOME/.cargo/bin" \
+			|| PATH="$$HOME/.cargo/bin:$$PATH" $(CARGO) install cargo-nextest --locked; \
+		echo "==> cargo-nextest installed"; \
+	fi
 	@if [ -d /mnt/fcvm-btrfs ] && ! [ -L target ]; then \
 		if [ -d target ]; then \
 			echo "==> Moving existing target/ to /mnt/fcvm-btrfs/cargo-target..."; \


### PR DESCRIPTION
When the ephemeral btrfs that holds `~/.cargo` is wiped, `make` failed with `no such command: nextest` (and a broken package-cache) because check-disk only recreated an empty cargo dir. Now check-disk restores the cargo shims from the rustup toolchain and auto-installs cargo-nextest, so `make test-*` bootstraps its own tooling.

Tested: `make check-disk` passes with no manual env.