### PR TITLE
fix(fuse-pipe): raise FUSE max_background to bound release backlog (nightly bench EMFILE)

### DIFF
--- a/fuse-pipe/src/client/fuse.rs
+++ b/fuse-pipe/src/client/fuse.rs
@@ -287,6 +287,23 @@ impl Filesystem for FuseClient {
             }
         }
 
+        // Raise max_background well above the kernel default (fuser default: 16).
+        // RELEASE (and writeback/readahead) are *background* FUSE requests, capped
+        // by the kernel at max_background in flight. Under sustained parallel load
+        // — e.g. the throughput benchmark's 256 workers churning open/read/close —
+        // releases drain at only ~16/RTT while opens proceed at full speed, so the
+        // server's per-open handle fds accumulate within a mount's lifetime until
+        // the process hits its nofile limit (EMFILE — the intermittent Nightly
+        // benchmark failures). Raising the cap lets releases keep pace with opens;
+        // fuser derives congestion_threshold = 3/4·max_background automatically.
+        if let Err(prev) = config.set_max_background(1024) {
+            tracing::warn!(
+                target: "fuse-pipe::client",
+                prev,
+                "Failed to raise max_background, using kernel default"
+            );
+        }
+
         // Spawn additional readers now that INIT is done
         if let Some(callback) = self.init_callback.lock().unwrap().take() {
             callback();

--- a/fuse-pipe/src/client/fuse.rs
+++ b/fuse-pipe/src/client/fuse.rs
@@ -296,11 +296,19 @@ impl Filesystem for FuseClient {
         // the process hits its nofile limit (EMFILE — the intermittent Nightly
         // benchmark failures). Raising the cap lets releases keep pace with opens;
         // fuser derives congestion_threshold = 3/4·max_background automatically.
-        if let Err(prev) = config.set_max_background(1024) {
+        const MAX_BACKGROUND: u16 = 1024;
+        if let Err(clamped) = config.set_max_background(MAX_BACKGROUND) {
             tracing::warn!(
                 target: "fuse-pipe::client",
-                prev,
-                "Failed to raise max_background, using kernel default"
+                requested = MAX_BACKGROUND,
+                clamped,
+                "Failed to set max_background, using clamped value"
+            );
+        } else {
+            tracing::debug!(
+                target: "fuse-pipe::client",
+                max_background = MAX_BACKGROUND,
+                "Set FUSE max_background"
             );
         }
 


### PR DESCRIPTION
Fixes the intermittent **Nightly → Benchmarks** EMFILE failure (3 of the last 6 nights).

## Root cause
`FuseClient::init()` (`fuse-pipe/src/client/fuse.rs`) set writeback-cache and `max_write` but never raised `max_background`, so it stayed at fuser's default of **16**. RELEASE (and writeback/readahead) are *background* FUSE requests, capped by the kernel at `max_background` in flight. Under the throughput benchmark's sustained 256-worker open/read/close load, releases drain at only ~16/RTT while opens proceed full-speed, so the in-process server's per-open handle fds accumulate within a single mount's lifetime until the process hits its 65536 nofile limit — panic at `benches/throughput.rs:65` (`Too many open files`) plus a flood of `flush failed` errors.

**Intermittent** because the crash needs one criterion config to serve ~87k opens within its window, and criterion's iteration count is derived from runner-warmup speed — fast runners cross the limit, slow ones don't. **Not a leak** (fd count collapses on unmount; teardown is correct) and **not a regression** (same failure pre-dates recent merges; observed May 20 / Jun 1).

## Fix
One line: `config.set_max_background(1024)` in `init()`, so releases keep pace with opens. fuser auto-derives `congestion_threshold = 3/4·max_background`, so nothing else changes. Also benefits production fcvm mounts (the same knob throttles writeback flushing against the VolumeServer's fd table).

## Validation (local)
The throughput bench previously peaked at **42,778 fds and crashed mid-run**. With the fix:
```
PEAK_FD=1808   (374 samples)
EMFILE/panic count: 0
benchmark stages completed: 16/16
```
Bounded peak, zero EMFILE, full run. `cargo fmt` + `clippy -D warnings` clean.

Diagnosed via a focused read-only root-cause agent (fd type confirmed via `/proc/fdinfo` flags; CI `fh` counter arithmetic matches the 65536 limit; teardown exonerated empirically; single-knob change eliminates the accumulation 30×).