### PR TITLE
fix: resolve open issues #617 #626 #627 + #608 diagnostics + #630 ignore hygiene

### DIFF
--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -880,6 +880,30 @@ pub enum CacheResult {
 /// The `restore_flag` is set by the restore-epoch watcher when it detects
 /// a snapshot restore. This breaks the poll loop early when POLLHUP is not
 /// detected (e.g., after pre-start snapshot restore in rootless mode).
+/// Compact the cache-handshake read buffer after checking for "cache-ack":
+/// drop all COMPLETE lines (host "cache-wait" keepalives — the only complete
+/// lines the host sends before the ack) and keep any partial tail, so repeated
+/// keepalives can't overflow the small buffer while a "cache-ack" split across
+/// reads (e.g. "cache-a" + "ck\n") still assembles correctly from the tail.
+///
+/// Returns (new_total_read, saw_cache_wait_keepalive).
+fn consume_cache_wait_lines(buf: &mut [u8; 64], total_read: usize) -> (usize, bool) {
+    let received = std::str::from_utf8(&buf[..total_read]).unwrap_or("");
+    let saw = received.contains("cache-wait");
+    if !saw {
+        return (total_read, false);
+    }
+    match received.rfind('\n') {
+        Some(pos) => {
+            let tail_start = pos + 1;
+            let tail_len = total_read - tail_start;
+            buf.copy_within(tail_start..total_read, 0);
+            (tail_len, true)
+        }
+        None => (total_read, true),
+    }
+}
+
 pub fn notify_cache_ready_and_wait(
     digest: &str,
     restore_flag: &std::sync::atomic::AtomicBool,
@@ -953,8 +977,24 @@ pub fn notify_cache_ready_and_wait(
     // 2. POLLHUP / read returns 0 — vsock reset from snapshot RESTORE
     //    (warm start: VM was restored from cached pre-start snapshot)
     // 3. restore_flag set by restore-epoch watcher (warm start, POLLHUP not delivered)
-    // 4. 30s deadline — failsafe timeout
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    // 4. 30s since the last sign of host liveness — failsafe timeout. The host
+    //    emits a "cache-wait" keepalive every 5s while it is queued on the global
+    //    snapshot semaphore (and while the snapshot runs), and each keepalive
+    //    extends this deadline (#627): under the SnapshotEnabled CI matrix the
+    //    semaphore queue alone can exceed a fixed 30s while the host is perfectly
+    //    alive, and abandoning the wait launches the container out of step with
+    //    the host's pause. The deadline expires only when the host has gone
+    //    genuinely silent — bounded by an absolute 10-minute cap so a wedged host
+    //    that keeps ticking keepalives can't stall container launch forever.
+    //
+    //    Ordering matters: the deadline is checked AFTER each poll/drain cycle,
+    //    never before. Keepalives can queue while the VM is paused for the
+    //    snapshot, and the guest clock can jump forward across the pause (the ARM
+    //    virtual counter keeps running) — checking expiry before draining would
+    //    discard extensions that are already sitting in the socket buffer.
+    let started = std::time::Instant::now();
+    let absolute_deadline = started + std::time::Duration::from_secs(600);
+    let mut deadline = started + std::time::Duration::from_secs(30);
 
     loop {
         // Check if the restore-epoch watcher detected a snapshot restore.
@@ -965,16 +1005,8 @@ pub fn notify_cache_ready_and_wait(
             return CacheResult::WarmStart;
         }
 
-        let remaining_ms = deadline
-            .saturating_duration_since(std::time::Instant::now())
-            .as_millis();
-        if remaining_ms == 0 {
-            eprintln!("[fc-agent] cache-ack deadline expired (30s)");
-            return CacheResult::Failed;
-        }
-
-        // Poll with 500ms intervals (or remaining time, whichever is shorter)
-        let poll_ms = remaining_ms.min(500) as u16;
+        // Fixed 500ms poll; expiry is evaluated after the poll/drain below.
+        let poll_ms = 500u16;
         let mut poll_fds = [PollFd::new(sock.as_fd(), PollFlags::POLLIN)];
 
         match poll(&mut poll_fds, PollTimeout::from(poll_ms)) {
@@ -1003,6 +1035,17 @@ pub fn notify_cache_ready_and_wait(
                         // Write succeeded or other error — connection still alive, continue
                     }
                 }
+                // No data arrived this cycle — judge expiry now (never before a
+                // drain: queued keepalives must be consumed first).
+                let now = std::time::Instant::now();
+                if now >= absolute_deadline {
+                    eprintln!("[fc-agent] cache-ack absolute deadline expired (10 min)");
+                    return CacheResult::Failed;
+                }
+                if now >= deadline {
+                    eprintln!("[fc-agent] cache-ack deadline expired (host silent for 30s)");
+                    return CacheResult::Failed;
+                }
                 continue;
             }
             Ok(_) => {}
@@ -1025,6 +1068,17 @@ pub fn notify_cache_ready_and_wait(
                 if received.contains("cache-ack") {
                     eprintln!("[fc-agent] received cache-ack from host");
                     return CacheResult::ColdStart;
+                }
+                // Host keepalive: it is alive but still queued on the snapshot
+                // semaphore / writing the snapshot. Extend the deadline (bounded
+                // by the absolute cap) and compact the buffer so repeated
+                // keepalives can't overflow it.
+                let (new_total, saw_keepalive) = consume_cache_wait_lines(&mut buf, total_read);
+                total_read = new_total;
+                if saw_keepalive {
+                    deadline = (std::time::Instant::now() + std::time::Duration::from_secs(30))
+                        .min(absolute_deadline);
+                    eprintln!("[fc-agent] cache-wait keepalive from host, extending deadline");
                 }
                 if total_read >= buf.len() {
                     eprintln!("[fc-agent] cache-ack buffer overflow, giving up");
@@ -1497,4 +1551,70 @@ pub async fn run_async(
     }
 
     Ok(exit_code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::consume_cache_wait_lines;
+
+    fn buf_with(data: &[u8]) -> ([u8; 64], usize) {
+        let mut buf = [0u8; 64];
+        buf[..data.len()].copy_from_slice(data);
+        (buf, data.len())
+    }
+
+    #[test]
+    fn keepalive_lines_are_consumed_and_flagged() {
+        let (mut buf, n) = buf_with(b"cache-wait\ncache-wait\n");
+        let (rest, saw) = consume_cache_wait_lines(&mut buf, n);
+        assert!(saw);
+        assert_eq!(rest, 0, "complete keepalive lines must be drained");
+    }
+
+    #[test]
+    fn split_cache_ack_tail_survives_compaction() {
+        // "cache-ack" arriving split across reads must not be destroyed by the
+        // keepalive drain: the partial tail is preserved so the next read
+        // completes it.
+        let (mut buf, n) = buf_with(b"cache-wait\ncache-a");
+        let (rest, saw) = consume_cache_wait_lines(&mut buf, n);
+        assert!(saw);
+        assert_eq!(&buf[..rest], b"cache-a");
+        // Simulate the next read appending the remainder.
+        buf[rest..rest + 3].copy_from_slice(b"ck\n");
+        let total = rest + 3;
+        let received = std::str::from_utf8(&buf[..total]).unwrap();
+        assert!(
+            received.contains("cache-ack"),
+            "split ack must assemble: {received}"
+        );
+    }
+
+    #[test]
+    fn no_keepalive_means_no_compaction() {
+        let (mut buf, n) = buf_with(b"cache-a");
+        let (rest, saw) = consume_cache_wait_lines(&mut buf, n);
+        assert!(!saw);
+        assert_eq!(rest, n, "partial ack untouched when no keepalive present");
+        assert_eq!(&buf[..rest], b"cache-a");
+    }
+
+    #[test]
+    fn repeated_keepalives_never_overflow_buffer() {
+        let mut buf = [0u8; 64];
+        let mut total = 0usize;
+        for _ in 0..50 {
+            let msg = b"cache-wait\n";
+            assert!(
+                total + msg.len() <= buf.len(),
+                "buffer overflow before drain"
+            );
+            buf[total..total + msg.len()].copy_from_slice(msg);
+            total += msg.len();
+            let (rest, saw) = consume_cache_wait_lines(&mut buf, total);
+            assert!(saw);
+            total = rest;
+            assert_eq!(total, 0);
+        }
+    }
 }

--- a/fc-agent/src/exec.rs
+++ b/fc-agent/src/exec.rs
@@ -88,6 +88,9 @@ pub async fn run_server(
                     }
                     Err(e) => {
                         eprintln!("[fc-agent] exec server accept error: {}", e);
+                        // Persistent errors (e.g. a broken listener fd) would
+                        // otherwise spin this select loop with no await point.
+                        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                     }
                 }
             }

--- a/fc-agent/src/vsock.rs
+++ b/fc-agent/src/vsock.rs
@@ -260,9 +260,22 @@ impl VsockListener {
     }
 
     /// Accept a connection. Returns a blocking OwnedFd for spawn_blocking handlers.
+    ///
+    /// Robust against lost readiness edges: a vsock connection that is delivered
+    /// while the VM is PAUSED (snapshot create: pause → dump → resume) can leave the
+    /// accept queue non-empty without ever producing an EPOLLIN edge for the
+    /// listener after resume (#617 — host exec CONNECT is ACKed by Firecracker, but
+    /// the guest's `readable().await` never wakes; the create path, unlike restore,
+    /// never re-registers the listener). Waiting on readiness alone therefore hangs
+    /// forever. The fallback: every 2s of idle waiting, optimistically try a
+    /// non-blocking accept4 — a queued-but-edgeless connection is then served with
+    /// at most 2s latency, while the common path (readiness edge) is unchanged and
+    /// the idle cost is one EAGAIN syscall per tick.
     pub async fn accept(&self) -> Result<OwnedFd> {
         loop {
-            let mut guard = self.inner.readable().await?;
+            // Optimistic non-blocking accept first: serves connections whose edge
+            // was consumed by a previous cycle (readiness persists until EAGAIN
+            // clears it) and connections whose edge was lost across pause/resume.
             let client_fd = unsafe {
                 libc::accept4(
                     self.inner.get_ref().as_raw_fd(),
@@ -271,15 +284,41 @@ impl VsockListener {
                     libc::SOCK_CLOEXEC,
                 )
             };
-            if client_fd < 0 {
-                let err = std::io::Error::last_os_error();
-                if err.kind() == std::io::ErrorKind::WouldBlock {
-                    guard.clear_ready();
+            if client_fd >= 0 {
+                return Ok(unsafe { OwnedFd::from_raw_fd(client_fd) });
+            }
+            let err = std::io::Error::last_os_error();
+            match err.raw_os_error() {
+                Some(libc::EAGAIN) => {} // queue empty — fall through to wait
+                // Transient per-connection / signal conditions: retry without
+                // failing the listener (the caller's accept loop would otherwise
+                // log-and-retry with no await point — a hot loop under sustained
+                // EMFILE pressure).
+                Some(libc::EINTR) | Some(libc::ECONNABORTED) => continue,
+                Some(libc::EMFILE) | Some(libc::ENFILE) => {
+                    eprintln!("[fc-agent] accept: fd exhaustion ({err}); retrying in 100ms");
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                     continue;
                 }
-                bail!("accept failed: {}", err);
+                _ => bail!("accept failed: {}", err),
             }
-            return Ok(unsafe { OwnedFd::from_raw_fd(client_fd) });
+
+            // Queue empty — wait for readiness, with the periodic re-poll fallback.
+            match tokio::time::timeout(std::time::Duration::from_secs(2), self.inner.readable())
+                .await
+            {
+                Ok(guard_result) => {
+                    let mut guard = guard_result?;
+                    // Clear and loop: the accept4 at the top of the loop consumes
+                    // the connection(s); readiness re-arms on the next edge, and
+                    // the EAGAIN path above re-clears if this edge was stale.
+                    guard.clear_ready();
+                }
+                Err(_) => {
+                    // Tick: no edge observed — loop to the optimistic accept4,
+                    // which catches a lost-edge connection (#617).
+                }
+            }
         }
     }
 }

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -812,17 +812,35 @@ fn assert_vmstate_rootfs_covered(
         }
     }
     if vmstate_rootfs_covered(&bytes, &covered_dirs) {
+        // #608 diagnostics: the observed ~0.7% sibling-disk failure has never been
+        // caught with its inputs visible (the metadata-divergence hypothesis was
+        // empirically refuted — the embedded path's vm_id always matched). Log the
+        // exact coverage inputs on every restore so the next occurrence is
+        // self-diagnosing instead of a reconstruction from artifacts: which vm_ids
+        // vmstate embeds, which dirs the bind-mount will cover, and the data_dir
+        // prefix (a prefix change between create and restore is the leading
+        // remaining hypothesis — #638-class).
+        debug!(
+            embedded_vm_ids = ?rootfs_disk_vm_ids_in_bytes(&bytes),
+            covered_dirs = ?covered_dirs
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>(),
+            data_dir = %paths::data_dir().display(),
+            "#608 coverage check passed"
+        );
         return Ok(());
     }
     anyhow::bail!(
         "#608: refusing to restore — vmstate.bin does not reference a rootfs disk under any \
-         baseline bind-mount {:?} (it references vm-disks ids {:?}). LoadSnapshot would open \
-         an uncovered/sibling VM's disk and corrupt it.",
+         baseline bind-mount {:?} (it references vm-disks ids {:?}; data_dir prefix {}). \
+         LoadSnapshot would open an uncovered/sibling VM's disk and corrupt it.",
         covered_dirs
             .iter()
             .map(|p| p.display().to_string())
             .collect::<Vec<_>>(),
         rootfs_disk_vm_ids_in_bytes(&bytes),
+        paths::data_dir().display(),
     )
 }
 

--- a/src/commands/podman/listeners.rs
+++ b/src/commands/podman/listeners.rs
@@ -169,6 +169,16 @@ pub(crate) async fn run_status_listener(
                         // (the failure mode documented in fc-agent's read path).
                         let mut ack_rx = ack_rx;
                         let mut probe_line = String::new();
+                        // Pin the keepalive timer OUTSIDE the loop so it
+                        // survives across select iterations: the guest sends
+                        // probe bytes every ~500ms, and each probe-read
+                        // restarts the select — an inline sleep(5) would
+                        // reset on every probe and never fire while the guest
+                        // is running (the pre-pause semaphore-queue scenario
+                        // that #627 targets).
+                        let keepalive_interval =
+                            tokio::time::sleep(std::time::Duration::from_secs(5));
+                        tokio::pin!(keepalive_interval);
                         loop {
                             probe_line.clear();
                             tokio::select! {
@@ -193,12 +203,17 @@ pub(crate) async fn run_status_listener(
                                         }
                                     }
                                 }
-                                _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {
+                                _ = &mut keepalive_interval => {
                                     if write_half.write_all(b"cache-wait\n").await.is_err() {
                                         let _ = (&mut ack_rx).await;
                                         break;
                                     }
                                     let _ = write_half.flush().await;
+                                    // Reset for the next keepalive interval.
+                                    keepalive_interval.as_mut().reset(
+                                        tokio::time::Instant::now()
+                                            + std::time::Duration::from_secs(5),
+                                    );
                                 }
                             }
                         }
@@ -741,6 +756,107 @@ mod tests {
         assert!(
             wait_pos.is_some() && wait_pos.unwrap() < ack_pos,
             "expected at least one cache-wait keepalive before cache-ack; got: {received:?}"
+        );
+        listener_task.abort();
+    }
+
+    /// Same as above, but the guest continuously sends probe bytes ("\n") every
+    /// 500ms — matching production behaviour. Before the pinned-timer fix, the
+    /// inline `sleep(5)` was reset by each probe-read and would NEVER fire,
+    /// leaving the guest without keepalives during the pre-pause semaphore queue.
+    #[tokio::test]
+    async fn test_status_listener_keepalive_fires_despite_probe_traffic() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt as _};
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let runtime_dir = temp_dir.path().to_path_buf();
+        let socket_path = runtime_dir.join("status.sock");
+        let socket_path_string = socket_path.to_string_lossy().to_string();
+        let runtime_dir_for_task = runtime_dir.clone();
+
+        // cache handler that takes >5s (one keepalive interval) to ack.
+        let (cache_tx, mut cache_rx) = mpsc::channel::<CacheRequest>(1);
+        tokio::spawn(async move {
+            if let Some(req) = cache_rx.recv().await {
+                tokio::time::sleep(std::time::Duration::from_millis(5600)).await;
+                let _ = req.ack_tx.send(());
+            }
+        });
+
+        let reboot_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let exit_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let listener_task = tokio::spawn(async move {
+            run_status_listener(
+                &socket_path_string,
+                &runtime_dir_for_task,
+                "vm-test",
+                Some(cache_tx),
+                reboot_flag,
+                exit_flag,
+            )
+            .await
+        });
+
+        for _ in 0..50 {
+            if socket_path.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        // Split the stream so a background task can write probes while the
+        // main task reads the host's responses.
+        let stream = tokio::net::UnixStream::connect(&socket_path).await.unwrap();
+        let (read_half, mut write_half) = stream.into_split();
+
+        write_half
+            .write_all(b"cache-ready:sha256:abc\n")
+            .await
+            .unwrap();
+
+        // Background task: send probe "\n" every 500ms (mimics fc-agent).
+        // Before the pinned-timer fix, these resets prevented the keepalive
+        // timer from ever firing.
+        let probe_done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let probe_done_clone = probe_done.clone();
+        let probe_task = tokio::spawn(async move {
+            while !probe_done_clone.load(std::sync::atomic::Ordering::Relaxed) {
+                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                if write_half.write_all(b"\n").await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        // Collect everything the host writes until the ack arrives.
+        let mut received = String::new();
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(15);
+        let mut buf = [0u8; 256];
+        let mut read_half = tokio::io::BufReader::new(read_half);
+        while !received.contains("cache-ack") {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "no cache-ack within deadline; got: {received:?}"
+            );
+            let n = tokio::time::timeout(
+                std::time::Duration::from_secs(10),
+                AsyncReadExt::read(&mut read_half, &mut buf),
+            )
+            .await
+            .expect("read timed out")
+            .unwrap();
+            assert!(n > 0, "connection closed before ack; got: {received:?}");
+            received.push_str(std::str::from_utf8(&buf[..n]).unwrap());
+        }
+
+        probe_done.store(true, std::sync::atomic::Ordering::Relaxed);
+        let _ = probe_task.await;
+
+        let wait_pos = received.find("cache-wait");
+        let ack_pos = received.find("cache-ack").unwrap();
+        assert!(
+            wait_pos.is_some() && wait_pos.unwrap() < ack_pos,
+            "expected cache-wait keepalive before cache-ack even with probe traffic; got: {received:?}"
         );
         listener_task.abort();
     }

--- a/src/commands/podman/listeners.rs
+++ b/src/commands/podman/listeners.rs
@@ -148,12 +148,59 @@ pub(crate) async fn run_status_listener(
                     };
 
                     if tx.send(request).await.is_ok() {
-                        // Wait for main task to complete cache creation
-                        // No timeout - host is responsible for completing
-                        if ack_rx.await.is_ok() {
-                            info!(vm_id = %vm_id, "Cache created, sending ack to fc-agent");
-                        } else {
-                            warn!(vm_id = %vm_id, "Cache creation failed or was cancelled");
+                        // Wait for the main task to complete cache creation — no
+                        // overall timeout (the host is responsible for completing),
+                        // but emit a "cache-wait" keepalive every 5s. Under the
+                        // SnapshotEnabled matrix the snapshot path queues on the
+                        // global 10-permit snapshot semaphore BEFORE pausing the
+                        // VM, so the guest keeps running with its fixed 30s
+                        // cache-ack deadline ticking; without a liveness signal
+                        // the guest abandons a perfectly alive handshake
+                        // (CacheResult::Failed) and launches the container out of
+                        // step with the host's pause (#627). The guest extends its
+                        // deadline on each keepalive. While the VM is paused the
+                        // bytes just queue in the socket and are drained on resume.
+                        //
+                        // The select also DRAINS the guest's 500ms liveness probe
+                        // bytes ("\n" writes) as they arrive: leaving them unread
+                        // would turn our eventual close into a vsock RST that can
+                        // flush the guest's receive buffer before it reads the
+                        // cache-ack, misclassifying a cold start as a warm restore
+                        // (the failure mode documented in fc-agent's read path).
+                        let mut ack_rx = ack_rx;
+                        let mut probe_line = String::new();
+                        loop {
+                            probe_line.clear();
+                            tokio::select! {
+                                ack = &mut ack_rx => {
+                                    match ack {
+                                        Ok(()) => info!(vm_id = %vm_id, "Cache created, sending ack to fc-agent"),
+                                        Err(_) => warn!(vm_id = %vm_id, "Cache creation failed or was cancelled"),
+                                    }
+                                    break;
+                                }
+                                read = reader.read_line(&mut probe_line) => {
+                                    match read {
+                                        // Probe bytes drained; nothing to do.
+                                        Ok(n) if n > 0 => {}
+                                        // EOF / read error: guest side gone (e.g.
+                                        // snapshot restore reset). Keep waiting for
+                                        // the ack so the main task's oneshot isn't
+                                        // dropped mid-snapshot.
+                                        _ => {
+                                            let _ = (&mut ack_rx).await;
+                                            break;
+                                        }
+                                    }
+                                }
+                                _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {
+                                    if write_half.write_all(b"cache-wait\n").await.is_err() {
+                                        let _ = (&mut ack_rx).await;
+                                        break;
+                                    }
+                                    let _ = write_half.flush().await;
+                                }
+                            }
                         }
                     } else {
                         warn!(vm_id = %vm_id, "Failed to send cache request to main task");
@@ -165,6 +212,17 @@ pub(crate) async fn run_status_listener(
                     warn!(vm_id = %vm_id, error = %e, "Failed to send cache-ack to fc-agent");
                 }
                 let _ = write_half.flush().await;
+
+                // Grace-drain before the connection drops at the `break` below:
+                // consume any last in-flight guest probe bytes so the close is
+                // clean — an unread byte at close becomes a vsock RST that can
+                // flush the guest's receive buffer before it reads the ack.
+                let mut tail = String::new();
+                let _ = tokio::time::timeout(
+                    std::time::Duration::from_millis(250),
+                    reader.read_line(&mut tail),
+                )
+                .await;
 
                 // Stop reading this connection and go back to accept(). fc-agent
                 // sends each status message ("cache-ready", then "ready", then
@@ -610,6 +668,79 @@ mod tests {
         assert!(
             reboot_flag.load(std::sync::atomic::Ordering::Acquire),
             "drain-ack received but earlier reboot message not yet processed"
+        );
+        listener_task.abort();
+    }
+
+    /// A slow cache-snapshot (host queued on the snapshot semaphore) must emit
+    /// "cache-wait" keepalives on the cache-ready connection BEFORE the final
+    /// "cache-ack", so the guest can extend its fixed deadline instead of
+    /// abandoning a live handshake (#627).
+    #[tokio::test]
+    async fn test_status_listener_emits_cache_wait_keepalive_before_ack() {
+        use tokio::io::AsyncReadExt;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let runtime_dir = temp_dir.path().to_path_buf();
+        let socket_path = runtime_dir.join("status.sock");
+        let socket_path_string = socket_path.to_string_lossy().to_string();
+        let runtime_dir_for_task = runtime_dir.clone();
+
+        // cache handler that takes >5s (one keepalive interval) to ack.
+        let (cache_tx, mut cache_rx) = mpsc::channel::<CacheRequest>(1);
+        tokio::spawn(async move {
+            if let Some(req) = cache_rx.recv().await {
+                tokio::time::sleep(std::time::Duration::from_millis(5600)).await;
+                let _ = req.ack_tx.send(());
+            }
+        });
+
+        let reboot_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let exit_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let listener_task = tokio::spawn(async move {
+            run_status_listener(
+                &socket_path_string,
+                &runtime_dir_for_task,
+                "vm-test",
+                Some(cache_tx),
+                reboot_flag,
+                exit_flag,
+            )
+            .await
+        });
+
+        for _ in 0..50 {
+            if socket_path.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        let mut stream = tokio::net::UnixStream::connect(&socket_path).await.unwrap();
+        stream.write_all(b"cache-ready:sha256:abc\n").await.unwrap();
+
+        // Collect everything the host writes until the ack arrives.
+        let mut received = String::new();
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(15);
+        let mut buf = [0u8; 256];
+        while !received.contains("cache-ack") {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "no cache-ack within deadline; got: {received:?}"
+            );
+            let n = tokio::time::timeout(std::time::Duration::from_secs(10), stream.read(&mut buf))
+                .await
+                .expect("read timed out")
+                .unwrap();
+            assert!(n > 0, "connection closed before ack; got: {received:?}");
+            received.push_str(std::str::from_utf8(&buf[..n]).unwrap());
+        }
+
+        let wait_pos = received.find("cache-wait");
+        let ack_pos = received.find("cache-ack").unwrap();
+        assert!(
+            wait_pos.is_some() && wait_pos.unwrap() < ack_pos,
+            "expected at least one cache-wait keepalive before cache-ack; got: {received:?}"
         );
         listener_task.abort();
     }

--- a/tests/test_diff_snapshot.rs
+++ b/tests/test_diff_snapshot.rs
@@ -617,3 +617,128 @@ async fn test_snapshot_clone_inherits_no_health_check() -> Result<()> {
     println!("  (Previously would get auto-assigned http://127.x.y.z:8080/)");
     Ok(())
 }
+
+/// Resolve a VM's vm_id from its fcvm process pid via `fcvm ls --json --pid`.
+async fn vm_id_for_pid(pid: u32) -> Result<String> {
+    let fcvm_path = common::find_fcvm_binary()?;
+    let output = tokio::process::Command::new(&fcvm_path)
+        .args(["ls", "--json", "--pid", &pid.to_string()])
+        .output()
+        .await
+        .context("running fcvm ls")?;
+    anyhow::ensure!(output.status.success(), "fcvm ls failed");
+    let vms: serde_json::Value =
+        serde_json::from_slice(&output.stdout).context("parsing fcvm ls json")?;
+    vms.get(0)
+        .and_then(|v| v.get("vm_id"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| anyhow::anyhow!("no vm found for pid {pid}"))
+}
+
+/// #608 regression: restoring a snapshot must not depend on its ANCESTORS'
+/// vm-disks directories still existing.
+///
+/// The reported failure: a restore intermittently tried to open a cleaned-up
+/// sibling's `vm-disks/<id>/disks/rootfs.raw` (the path embedded in vmstate.bin),
+/// failing LoadSnapshot — or worse, silently opening a different live VM's disk.
+/// The deterministic shape exercises the divergence-suspect chain end-to-end:
+///
+/// 1. Baseline A → full snapshot T1 (vmstate embeds A's disk path).
+/// 2. Clone B restores T1 (drive patched to B's dir), then snapshot T2 FROM the
+///    restored clone — T2's metadata carries original_vsock_vm_id=A, vm_id=B,
+///    and its vmstate embeds B's patched path (the diff-chain case the #608
+///    analysis suspected).
+/// 3. Kill A and B — their vm-disks dirs are removed by normal cleanup (the
+///    "sibling cleaned up" condition).
+/// 4. Clone C restores T2: the #608 coverage guard must pass (vmstate's embedded
+///    path covered by the bind-mount derived from T2's metadata) and C must boot
+///    healthy with both ancestor dirs gone.
+#[tokio::test]
+async fn test_snapshot_restore_survives_ancestor_dir_cleanup() -> Result<()> {
+    let (name_a, name_b, tag1, _serve) = common::unique_names("sib608");
+    let tag2 = format!("{tag1}-t2");
+    let name_c = format!("{name_b}-c");
+
+    // 1. Baseline A.
+    let (mut child_a, pid_a) = common::spawn_fcvm_with_logs(
+        &["podman", "run", "--name", &name_a, TEST_IMAGE],
+        "sib608-a",
+    )
+    .await?;
+    common::poll_health_by_pid(pid_a, 120).await?;
+    common::create_snapshot_by_pid(pid_a, &tag1)
+        .await
+        .context("creating T1 from baseline")?;
+
+    // 2. Clone B from T1, then snapshot T2 FROM the restored clone.
+    let (mut child_b, pid_b) = common::spawn_fcvm_with_logs(
+        &["snapshot", "run", "--snapshot", &tag1, "--name", &name_b],
+        "sib608-b",
+    )
+    .await?;
+    common::poll_health_by_pid(pid_b, 120).await?;
+    common::create_snapshot_by_pid(pid_b, &tag2)
+        .await
+        .context("creating T2 from restored clone")?;
+
+    // 3. Kill BOTH ancestors; their per-VM data dirs (vm-disks/<id>) are removed
+    //    by normal cleanup, reproducing the sibling-cleanup condition. The test
+    //    then ENFORCES the condition rather than trusting cleanup timing: it
+    //    waits for the dirs to disappear and force-removes any remnant, so clone
+    //    C provably restores with both ancestor dirs gone.
+    let vm_id_a = vm_id_for_pid(pid_a).await.context("vm_id for A")?;
+    let vm_id_b = vm_id_for_pid(pid_b).await.context("vm_id for B")?;
+    common::kill_process(pid_a).await;
+    let _ = child_a.kill().await;
+    common::kill_process(pid_b).await;
+    let _ = child_b.kill().await;
+
+    // Same base resolution as snapshot_dir(): FCVM_DATA_DIR, falling back to
+    // fcvm's config default (/mnt/fcvm-btrfs) — NOT the Makefile's per-suite
+    // override, which only exists when FCVM_DATA_DIR is exported anyway.
+    let vm_disks = std::env::var("FCVM_DATA_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::path::PathBuf::from("/mnt/fcvm-btrfs"))
+        .join("vm-disks");
+    for id in [&vm_id_a, &vm_id_b] {
+        let dir = vm_disks.join(id);
+        // Normal cleanup removes it within a few seconds of SIGTERM.
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        while dir.exists() && std::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+        if dir.exists() {
+            // Cleanup lagged (e.g. SIGKILL path) — force the condition the test
+            // is about: the ancestor's directory must NOT exist at restore time.
+            std::fs::remove_dir_all(&dir)
+                .with_context(|| format!("force-removing ancestor dir {}", dir.display()))?;
+        }
+        assert!(
+            !dir.exists(),
+            "ancestor vm-disks dir must be gone before the restore: {}",
+            dir.display()
+        );
+    }
+
+    // 4. Clone C from T2 must restore and become healthy with the ancestors gone.
+    let (mut child_c, pid_c) = common::spawn_fcvm_with_logs(
+        &["snapshot", "run", "--snapshot", &tag2, "--name", &name_c],
+        "sib608-c",
+    )
+    .await?;
+    common::poll_health_by_pid(pid_c, 120)
+        .await
+        .context("#608: restore failed after ancestor vm-disks cleanup")?;
+
+    // The restored clone must actually work (exec round-trip).
+    let out = common::exec_in_vm(pid_c, &["echo", "sib608-ok"]).await?;
+    assert!(out.contains("sib608-ok"), "exec into C failed: {out}");
+
+    // Cleanup.
+    common::kill_process(pid_c).await;
+    let _ = child_c.kill().await;
+    let _ = std::fs::remove_dir_all(snapshot_dir().join(&tag1));
+    let _ = std::fs::remove_dir_all(snapshot_dir().join(&tag2));
+    Ok(())
+}

--- a/tests/test_kvm.rs
+++ b/tests/test_kvm.rs
@@ -850,7 +850,7 @@ async fn test_nested_l2_network_nfs() -> Result<()> {
 /// container startup to exceed the 10-minute test timeout.
 /// disk-dir and NFS may work better at L3.
 #[tokio::test]
-#[ignore]
+#[ignore = "nested L3 (FUSE-over-FUSE x2): slow + NV2-flaky on shared runners; run manually — tracked in #630-B"]
 async fn test_nested_l3_network_fuse() -> Result<()> {
     run_nested_n_levels(
         3,
@@ -863,7 +863,7 @@ async fn test_nested_l3_network_fuse() -> Result<()> {
 
 /// Test L3 network with NFS (may be faster than FUSE)
 #[tokio::test]
-#[ignore]
+#[ignore = "nested L3 (NFS): slow + NV2-flaky on shared runners; run manually — tracked in #630-B"]
 async fn test_nested_l3_network_nfs() -> Result<()> {
     run_nested_n_levels(
         3,
@@ -881,7 +881,7 @@ async fn test_nested_l3_network_nfs() -> Result<()> {
 /// initialization alone takes 10+ minutes. Need to implement request pipelining
 /// or async PassthroughFs before this test can complete in reasonable time.
 #[tokio::test]
-#[ignore]
+#[ignore = "nested L3: slow + NV2-flaky on shared runners; run manually — tracked in #630-B"]
 async fn test_nested_l3() -> Result<()> {
     run_nested_n_levels(
         3,
@@ -896,7 +896,7 @@ async fn test_nested_l3() -> Result<()> {
 ///
 /// BLOCKED: Same issue as L3, but worse. 4-hop FUSE chain would be even slower.
 #[tokio::test]
-#[ignore]
+#[ignore = "nested L4: very slow + NV2-flaky on shared runners; run manually — tracked in #630-B"]
 async fn test_nested_l4() -> Result<()> {
     run_nested_n_levels(
         4,
@@ -1718,7 +1718,7 @@ FCVM_DATA_DIR=/root/fcvm-data FCVM_FUSE_TRACE_RATE=100 FCVM_FUSE_MAX_WRITE={fuse
 /// slower than L1). FUSE throughput itself is fine (181-224 MB/s on L1).
 /// The bottleneck is podman load's gzip decompression + overlay writes running
 /// under double Stage 2 translation with a single vCPU.
-#[ignore]
+#[ignore = "podman load over FUSE in nested VM: slow + NV2-flaky; run manually — tracked in #630-B"]
 #[tokio::test]
 async fn test_podman_load_over_fuse() -> Result<()> {
     println!("\nPodman Load Over FUSE Performance Test");

--- a/tests/test_readme_examples.rs
+++ b/tests/test_readme_examples.rs
@@ -404,8 +404,11 @@ async fn test_fcvm_ls_bridged() -> Result<()> {
 /// ```
 /// sudo fcvm podman run --name web1 --cmd "nginx -g 'daemon off;'" nginx:alpine
 /// ```
+// Re-enabled after the #617 fix: VsockListener::accept() now has a periodic
+// optimistic-accept fallback, so a connection whose readiness edge is lost across
+// the startup-snapshot create's pause/resume is served within ~2s instead of
+// hanging the exec forever.
 #[tokio::test]
-#[ignore = "disabled pending #617: exec into a restored VM (2nd SnapshotEnabled pass) hangs to the 600s ceiling; cold pass passes"]
 async fn test_custom_command_bridged() -> Result<()> {
     println!("\ntest_custom_command_bridged");
     println!("===========================");

--- a/tests/test_snapshot_clone.rs
+++ b/tests/test_snapshot_clone.rs
@@ -14,7 +14,7 @@ mod common;
 use anyhow::{Context, Result};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Semaphore};
 
 /// Full snapshot/clone workflow test with rootless networking (10 clones)
 #[tokio::test]
@@ -163,6 +163,28 @@ async fn snapshot_clone_test_impl(network: &str, num_clones: usize) -> Result<()
 
     let results: Arc<Mutex<Vec<CloneResult>>> = Arc::new(Mutex::new(Vec::new()));
     let clone_pids: Arc<Mutex<Vec<u32>>> = Arc::new(Mutex::new(Vec::new()));
+    // Child handles are kill_on_drop: a clone dies the moment its spawn task
+    // drops the handle. Retain them here so every clone stays alive until ALL
+    // waves complete — the test then genuinely holds num_clones concurrent live
+    // clones (sharing the serve process's memory) at its peak, which is what the
+    // stress test exists to prove. Dropped (killing the clones) during cleanup.
+    let clone_children: Arc<Mutex<Vec<tokio::process::Child>>> = Arc::new(Mutex::new(Vec::new()));
+
+    // Throttle the spawn+health herd (#626): bound how many clones are in their
+    // boot/health-wait phase at once. Unthrottled, 100 simultaneous boots contend
+    // on UFFD page faults, btrfs reflinks, the host-wide bridged-subnet lock, and
+    // a 100-way `fcvm ls` poll fork-storm — under the SnapshotEnabled matrix the
+    // slowest clone intermittently exceeds its 120s budget. The throttle bounds
+    // that contention while preserving what the test asserts: every clone stays
+    // RUNNING after it turns healthy, so peak live concurrency still reaches
+    // num_clones (all sharing the serve process's memory).
+    //
+    // Explicit trade-off: this intentionally bounds BOOT-phase concurrency to 16,
+    // so the test no longer exercises 100 simultaneous clone *startups* — it
+    // proves N concurrent live clones + bounded-parallel boot, which is the
+    // supported production shape. A dedicated unthrottled-boot stress would be a
+    // separate (manual) test if that load class ever needs coverage.
+    let boot_permits = Arc::new(Semaphore::new(16));
 
     let mut spawn_handles = Vec::new();
 
@@ -170,9 +192,14 @@ async fn snapshot_clone_test_impl(network: &str, num_clones: usize) -> Result<()
         let clone_name = format!("{}-{}", baseline_name.replace("-base-", "-clone-"), i);
         let results = Arc::clone(&results);
         let clone_pids = Arc::clone(&clone_pids);
+        let clone_children = Arc::clone(&clone_children);
         let serve_pid_str = serve_pid.to_string();
+        let boot_permits = Arc::clone(&boot_permits);
 
         let handle = tokio::spawn(async move {
+            // Held across spawn + health wait; released once this clone is healthy
+            // (or failed), letting the next clone start booting.
+            let _permit = boot_permits.acquire().await.expect("boot semaphore closed");
             let spawn_start = Instant::now();
 
             let result = common::spawn_fcvm_with_logs(
@@ -189,16 +216,22 @@ async fn snapshot_clone_test_impl(network: &str, num_clones: usize) -> Result<()
             .await;
 
             match result {
-                Ok((_child, clone_pid)) => {
+                Ok((child, clone_pid)) => {
                     let spawn_ms = spawn_start.elapsed().as_secs_f64() * 1000.0;
 
-                    // Store PID for cleanup
+                    // Store PID for cleanup and retain the kill_on_drop handle so
+                    // this clone outlives the task (see clone_children above).
                     clone_pids.lock().await.push(clone_pid);
+                    clone_children.lock().await.push(child);
 
-                    // Now wait for health check
+                    // Now wait for health check. poll_health_by_pid enforces its
+                    // own 120s deadline (with a rich error); the outer timeout is a
+                    // strictly-larger backstop for the poll loop itself hanging
+                    // (e.g. a wedged `fcvm ls` subprocess), so the inner error wins
+                    // in the normal timeout case.
                     let health_start = Instant::now();
                     let health_result = tokio::time::timeout(
-                        Duration::from_secs(120),
+                        Duration::from_secs(150),
                         common::poll_health_by_pid(clone_pid, 120),
                     )
                     .await;
@@ -232,9 +265,27 @@ async fn snapshot_clone_test_impl(network: &str, num_clones: usize) -> Result<()
         spawn_handles.push(handle);
     }
 
-    // Wait for all spawn+health tasks to complete
-    for handle in spawn_handles {
-        let _ = handle.await;
+    // Wait for all spawn+health tasks, bounded by an explicit step deadline.
+    // The 16-permit throttle serializes a broad-failure run into ~7 waves; at the
+    // 150s worst case per wave that exceeds nextest's 600s terminate-after for
+    // stress tests, which would SIGTERM the test mid-run — losing the per-clone
+    // error table and skipping cleanup. Bounding here keeps the failure
+    // diagnosable: stragglers are aborted, recorded as failures via the missing
+    // results, and the table + cleanup still run.
+    let step4_deadline = Duration::from_secs(450);
+    let all_done = async {
+        for handle in spawn_handles {
+            let _ = handle.await;
+        }
+    };
+    if tokio::time::timeout(step4_deadline, all_done)
+        .await
+        .is_err()
+    {
+        println!(
+            "⚠ step 4 exceeded {}s — proceeding with partial results",
+            step4_deadline.as_secs()
+        );
     }
 
     let clone_total_time = step4_start.elapsed();
@@ -268,11 +319,19 @@ async fn snapshot_clone_test_impl(network: &str, num_clones: usize) -> Result<()
     println!("\nCleaning up...");
     let cleanup_start = Instant::now();
 
-    // Kill clones
-    for pid in clone_pids.iter() {
-        if *pid > 0 {
-            common::kill_process(*pid).await;
-        }
+    // Kill clones — in parallel: with the retained child handles all 100 clones
+    // are still ALIVE here, and a sequential graceful kill (~5s each) would add
+    // ~500s, blowing the stress tests into nextest's 600s terminate-after.
+    let kill_tasks: Vec<_> = clone_pids
+        .iter()
+        .filter(|pid| **pid > 0)
+        .map(|pid| {
+            let pid = *pid;
+            tokio::spawn(async move { common::kill_process(pid).await })
+        })
+        .collect();
+    for task in kill_tasks {
+        let _ = task.await;
     }
     println!("  Killed {} clones", clone_pids.len());
 
@@ -371,6 +430,24 @@ async fn snapshot_clone_test_impl(network: &str, num_clones: usize) -> Result<()
         );
     }
     println!("╚═══════════════════════════════════════════════════════════════╝");
+
+    // The throttle's justifying invariant: every clone that turned healthy is
+    // still RUNNING now that all waves finished — i.e. peak live concurrency
+    // actually reached num_clones (the boot throttle paces startups, it must not
+    // change what the test proves).
+    // (clone_pids was locked above for the stats section.)
+    let alive_now = clone_pids
+        .iter()
+        .filter(|pid| std::path::Path::new(&format!("/proc/{pid}")).exists())
+        .count();
+    if healthy_count == num_clones && alive_now != num_clones {
+        anyhow::bail!(
+            "peak-concurrency invariant violated: {}/{} clones still alive after all waves \
+             completed (a healthy clone died before the end of step 4)",
+            alive_now,
+            num_clones
+        );
+    }
 
     // Fail if any clones failed
     if healthy_count != num_clones {


### PR DESCRIPTION
Investigates and fixes the open-issue backlog (all but the #632 epic). Every diagnosis was produced by a multi-agent investigation with adversarial verification against the code, and the resulting diff passed a second adversarial review (multi-agent /code-review: 9 confirmed findings, all addressed below; local codex: SAFE).

## #617 — exec into a restored VM hangs to the 600s ceiling
**Verified mechanism** (the original re_register hypothesis was refuted): a vsock connection delivered while the VM is PAUSED for the startup-snapshot create leaves the accept queue non-empty with no EPOLLIN edge after resume; the create path never re-registers the listener, so `readable().await` blocks forever.
**Fix:** `VsockListener::accept()` does an optimistic non-blocking `accept4` first, then waits for readiness under a 2s re-poll — a lost-edge connection is served in ≤2s. Transient accept errors (EINTR/ECONNABORTED/EMFILE/ENFILE) retry instead of bailing into a hot loop. **`test_custom_command_bridged` is re-enabled.**

## #627 — archive-mode flake under SnapshotEnabled
**Verified mechanism:** the guest's fixed 30s cache-ack deadline expires while the host is queued on the global 10-permit snapshot semaphore (pre-pause, guest clock ticking) — the host was alive the whole time.
**Fix:** host emits `cache-wait` keepalives every 5s **and drains the guest's probe bytes** (unread bytes turned the close into an RST that could flush the cache-ack); guest extends its deadline per keepalive (10-min absolute cap) and judges expiry only **after** draining queued data (keepalives queue while paused; the guest clock jumps across the pause). Keepalive compaction is a unit-tested helper covering the split-`cache-ack` case; a new host-side unit test asserts `cache-wait` precedes `cache-ack` under a slow handler.

## #626 — 100-clone stress flake
**Fix:** 16-permit boot/health throttle (bounds UFFD/reflink/subnet-lock/poll-fork-storm contention) — and the review-added liveness assertion exposed that the test **never actually held 100 concurrent live clones** (kill_on_drop handles died with their spawn tasks). The child handles are now retained until all waves complete, so the test provably reaches 100 concurrent clones (asserted), cleanup kills them in parallel (sequential graceful kills added ~500s), and an explicit 450s step deadline keeps a broad failure diagnosable instead of an opaque nextest SIGTERM. Stress tests: 24s each.

## #608 — sibling-rootfs restore (diagnostics + regression test)
The metadata-divergence hypothesis was empirically refuted and the #643 hard-fail guard is on main; the real ~0.7% mechanism is still unknown. This adds debug-level coverage diagnostics on every restore (embedded vmstate vm_ids + covered dirs + data_dir prefix — the leading remaining hypothesis is a #638-class prefix change) so the next occurrence is self-diagnosing, plus a deterministic e2e regression test: snapshot a restored clone, **enforce** both ancestors' vm-disks dirs are gone, restore a third VM.

## #630 — ignore hygiene
All 5 bare `#[ignore]`s annotated with reasons + ticket links; zero bare ignores remain in the workspace.

## Test evidence
```
fc-agent units: 20/20 (incl. 4 new compaction tests)
listener units: 5/5 (incl. new keepalive-before-ack + reboot-after-exit race)
e2e: custom_command_bridged 21s ✓ · snapshot_restore_survives_ancestor_dir_cleanup 35s ✓
     localhost_archive_mode 16s ✓ · stress_100_bridged 24s ✓ · stress_100_rootless 24s ✓
make lint clean (fmt, clippy -D warnings, audit, deny)
```