### PR TITLE
fix(#661): pinned pasta build with the addr_seen patch; bench scheduling exclusivity

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -70,7 +70,7 @@ max-threads = "num-cpus"
 
 # The 8000-connection egress bench saturates the host (conntrack, ephemeral
 # ports, CPU for every pasta process); heavy clone tests sharing its window
-# flake on try 1 (rounds 5-6 of #630: extra_disk_ro_clone and a rotating
+# flake on try 1 (the #663 gate rounds: extra_disk_ro_clone and a rotating
 # stress_100 variant, each burning 100-150s before a clean retry). Give the
 # bench the entire runner: ~160s of exclusivity is cheaper in wall time than
 # the try-1 burns plus retries it causes.

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -68,8 +68,20 @@ max-threads = 1
 [test-groups.vm-tests]
 max-threads = "num-cpus"
 
+# The 8000-connection egress bench saturates the host (conntrack, ephemeral
+# ports, CPU for every pasta process); heavy clone tests sharing its window
+# flake on try 1 (rounds 5-6 of #630: extra_disk_ro_clone and a rotating
+# stress_100 variant, each burning 100-150s before a clean retry). Give the
+# bench the entire runner: ~160s of exclusivity is cheaper in wall time than
+# the try-1 burns plus retries it causes.
 [[profile.default.overrides]]
-filter = "package(fcvm) & (test(/stress_100/) | test(/8000_concurrent/))"
+filter = "package(fcvm) & test(/8000_concurrent/)"
+test-group = "stress-tests"
+threads-required = "num-test-threads"
+slow-timeout = { period = "600s", terminate-after = 1 }
+
+[[profile.default.overrides]]
+filter = "package(fcvm) & test(/stress_100/)"
 test-group = "stress-tests"
 slow-timeout = { period = "600s", terminate-after = 1 }
 

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -85,7 +85,7 @@ filter = "package(fcvm) & test(/stress_100/)"
 test-group = "stress-tests"
 slow-timeout = { period = "600s", terminate-after = 1 }
 
-# Nested (NV2) tests: 3-concurrent + 20-minute budget. An L1+L2 chain takes
+# Nested (NV2) tests: serialized (see group comment) + 20-minute budget. An L1+L2 chain takes
 # ~3-6 minutes end to end; the budget leaves room for the in-test
 # 'timeout -k 10 840' around the L1 pipeline (which starts AFTER the
 # image build/export prep) to always fire-and-clean-up BEFORE nextest's

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1536,10 +1536,10 @@ fcvm/
 │   │
 │   └── setup/              # Setup utilities
 │       ├── mod.rs
-│       ├── preflight.rs    # Pre-flight checks
-│       ├── kernel.rs       # Kernel setup
-│       ├── kernel_build.rs # Kernel build
-│       └── rootfs.rs       # Rootfs setup
+│       ├── kernel.rs       # Kernel + firecracker setup/build
+│       ├── pasta.rs        # Pinned pasta build (upstream commit + patches)
+│       ├── rootfs.rs       # Rootfs setup
+│       └── storage.rs      # btrfs storage setup
 │
 ├── fc-agent/               # Guest agent crate
 │   ├── Cargo.toml

--- a/pasta/patches/0001-tap-dont-let-overheard-traffic-move-addr_seen.patch
+++ b/pasta/patches/0001-tap-dont-let-overheard-traffic-move-addr_seen.patch
@@ -1,0 +1,132 @@
+From 6d0caa9684504b538ed856e269644f888e868d95 Mon Sep 17 00:00:00 2001
+From: EJ Campbell <ej.campbell@gmail.com>
+Date: Thu, 11 Jun 2026 04:06:09 +0000
+Subject: [PATCH] tap: don't let overheard traffic move addr_seen when address
+ is explicit
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When pasta's tap interface shares an L2 segment with other endpoints
+(e.g. bridged in a namespace with a VM behind a second tap), frames
+from those endpoints flood to pasta and their source addresses
+overwrite addr_seen — inbound flows are then spliced or forwarded to
+whichever address spoke last instead of the configured guest.
+
+In such a setup the namespace kernel's own broadcasts (ARP probes,
+IGMP joins, sourced from the bridge address) race the guest's traffic
+for addr_seen, and inbound port-forwarded connections intermittently
+get RST after pasta dials the bridge address, where nothing listens:
+
+  Flow 0 (TCP connection (spliced)):
+    HOST [127.0.0.1]:57280 -> [127.0.0.2]:22844
+      => SPLICE [0.0.0.0]:0 -> [10.0.2.1]:80    <- bridge addr, not -a
+  Flow 0 (TCP connection (spliced)): Error event on socket: Connection refused
+
+When -a / --address is given, the user has explicitly said where the
+guest is: track that decision with a new addr_fixed flag (per address
+family) and skip the addr_seen updates in the tap handlers. Behaviour
+without -a is unchanged, and IPv6 link-local tracking (addr_ll_seen)
+is unaffected — a global -a says nothing about which link-local
+address the guest chose.
+
+With this change, a reproducer that previously failed one run in three
+(99 spliced connections per run) passed six consecutive runs.
+
+Signed-off-by: EJ Campbell <ej.campbell@gmail.com>
+---
+ conf.c  | 2 ++
+ passt.h | 6 ++++++
+ tap.c   | 9 ++++++---
+ 3 files changed, 14 insertions(+), 3 deletions(-)
+
+diff --git a/conf.c b/conf.c
+index cd05adf..4755a9f 100644
+--- a/conf.c
++++ b/conf.c
+@@ -1583,10 +1583,12 @@ void conf(struct ctx *c, int argc, char **argv)
+ 			if (inany_v4(&addr)) {
+ 				c->ip4.addr = *inany_v4(&addr);
+ 				c->ip4.prefix_len = prefix_len - 96;
++				c->ip4.addr_fixed = true;
+ 				if (c->mode == MODE_PASTA)
+ 					c->ip4.no_copy_addrs = true;
+ 			} else {
+ 				c->ip6.addr = addr.a6;
++				c->ip6.addr_fixed = true;
+ 				if (c->mode == MODE_PASTA)
+ 					c->ip6.no_copy_addrs = true;
+ 			}
+diff --git a/passt.h b/passt.h
+index c5f51d1..19d8c59 100644
+--- a/passt.h
++++ b/passt.h
+@@ -82,6 +82,8 @@ enum passt_modes {
+  * @ifname_out:		Optional interface name to bind outbound sockets to
+  * @no_copy_routes:	Don't copy all routes when configuring target namespace
+  * @no_copy_addrs:	Don't copy all addresses when configuring namespace
++ * @addr_fixed:		Address was given explicitly (-a): don't update
++ *			addr_seen from traffic observed on tap
+  */
+ struct ip4_ctx {
+ 	/* PIF_TAP addresses */
+@@ -103,6 +105,7 @@ struct ip4_ctx {
+ 
+ 	bool no_copy_routes;
+ 	bool no_copy_addrs;
++	bool addr_fixed;
+ };
+ 
+ /**
+@@ -123,6 +126,8 @@ struct ip4_ctx {
+  * @ifname_out:		Optional interface name to bind outbound sockets to
+  * @no_copy_routes:	Don't copy all routes when configuring target namespace
+  * @no_copy_addrs:	Don't copy all addresses when configuring namespace
++ * @addr_fixed:		Address was given explicitly (-a): don't update
++ *			addr_seen from traffic observed on tap
+  */
+ struct ip6_ctx {
+ 	/* PIF_TAP addresses */
+@@ -144,6 +149,7 @@ struct ip6_ctx {
+ 
+ 	bool no_copy_routes;
+ 	bool no_copy_addrs;
++	bool addr_fixed;
+ };
+ 
+ #include <netinet/if_ether.h>
+diff --git a/tap.c b/tap.c
+index 4cba4c7..2b1699a 100644
+--- a/tap.c
++++ b/tap.c
+@@ -770,7 +770,8 @@ resume:
+ 			continue;
+ 		}
+ 
+-		if (iph->saddr && c->ip4.addr_seen.s_addr != iph->saddr)
++		if (!c->ip4.addr_fixed &&
++		    iph->saddr && c->ip4.addr_seen.s_addr != iph->saddr)
+ 			c->ip4.addr_seen.s_addr = iph->saddr;
+ 
+ 		if (!iov_drop_header(&data, hlen))
+@@ -1003,13 +1004,15 @@ resume:
+ 		if (IN6_IS_ADDR_LINKLOCAL(saddr)) {
+ 			c->ip6.addr_ll_seen = *saddr;
+ 
+-			if (IN6_IS_ADDR_UNSPECIFIED(&c->ip6.addr_seen)) {
++			if (!c->ip6.addr_fixed &&
++			    IN6_IS_ADDR_UNSPECIFIED(&c->ip6.addr_seen)) {
+ 				c->ip6.addr_seen = *saddr;
+ 			}
+ 
+ 			if (IN6_IS_ADDR_UNSPECIFIED(&c->ip6.addr))
+ 				c->ip6.addr = *saddr;
+-		} else if (!IN6_IS_ADDR_UNSPECIFIED(saddr)){
++		} else if (!c->ip6.addr_fixed &&
++			   !IN6_IS_ADDR_UNSPECIFIED(saddr)) {
+ 			c->ip6.addr_seen = *saddr;
+ 		}
+ 
+-- 
+2.43.0
+

--- a/rootfs-config.toml
+++ b/rootfs-config.toml
@@ -18,6 +18,20 @@ assets_dir = "/mnt/fcvm-btrfs"
 # Ignored if the host filesystem is already btrfs.
 btrfs_size = "60G"
 
+# Pinned pasta (passt) build
+# Rootless networking requires pasta behavior that upstream hasn't released:
+# the addr_seen fix (without it, pasta adopts the last source address it
+# overhears on its tap as "the guest", and the namespace bridge's broadcasts
+# intermittently poison inbound port forwarding — issue #661; patch submitted
+# upstream to passt-dev). `fcvm setup` builds this commit plus the patches
+# embedded in fcvm (pasta/patches/) into a content-addressed binary; rootless
+# VMs refuse to fall back to a distro pasta while this section is present.
+# When upstream ships the fix: bump the commit, drop the patch, then remove
+# this section once distros carry the release.
+[pasta]
+repo = "https://passt.top/passt"
+commit = "e1a6d9ef626aa6dbcfeef97dbbab3bd69c35b4b1"
+
 # Default Firecracker binary
 # Build from fork with diff snapshot fix for multi-slot VMs (>3GB RAM).
 # `fcvm setup` builds this automatically; `find_firecracker()` uses it.

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -723,7 +723,7 @@ pub(crate) async fn setup_nfs_exports(
         // hard NFS mount would hang until the test budget kills it. Fail
         // loudly instead.
         anyhow::bail!(
-            "exportfs -ra failed; NFS export for {} is not active (check              /etc/exports.d for stale entries)",
+            "exportfs -ra failed; NFS export for {} is not active (check /etc/exports.d for stale entries)",
             exports_path
         );
     }

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -70,6 +70,15 @@ pub async fn cmd_setup(args: SetupArgs) -> Result<()> {
         .context("setting up kernel")?;
     println!("  ✓ Kernel ready: {}", kernel_path.display());
 
+    // Build the pinned pasta if configured in [pasta] section (rootless
+    // networking requires it when configured — see src/setup/pasta.rs)
+    if let Some(path) = crate::setup::ensure_pasta(config.pasta.as_ref())
+        .await
+        .context("setting up pasta")?
+    {
+        println!("  ✓ Pasta ready: {}", path.display());
+    }
+
     // Build default Firecracker if configured in [firecracker] section
     // The [firecracker] config is injected into the "default" profile by synthesize_default_profile()
     if config.firecracker.is_some() {

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -328,7 +328,16 @@ echo 1 > /proc/sys/net/ipv4/ip_forward
             "starting pasta for rootless networking"
         );
 
-        let mut cmd = Command::new("pasta");
+        // Resolve the pasta binary through the pinned-build machinery: with a
+        // [pasta] config section the content-addressed patched build is
+        // required (a distro pasta would reintroduce the addr_seen inbound
+        // poisoning, #661); without one, PATH is used as before.
+        let (config, _, _) =
+            crate::setup::rootfs::load_config(None).context("loading config for pasta")?;
+        let pasta_bin = crate::setup::get_pasta_for_config(config.pasta.as_ref())?;
+        info!(pasta_bin = %pasta_bin.display(), "resolved pasta binary");
+
+        let mut cmd = Command::new(&pasta_bin);
         cmd.arg("--foreground")
             .arg("--quiet")
             .arg("-P")

--- a/src/setup/kernel.rs
+++ b/src/setup/kernel.rs
@@ -1330,7 +1330,7 @@ fn compute_profile_firecracker_sha_with_commit(
 
 /// Return a string identifying the C library (e.g. "glibc-2.39" or "musl-1.2.4").
 /// Used to namespace the firecracker binary cache per build environment.
-fn libc_version_tag() -> String {
+pub(crate) fn libc_version_tag() -> String {
     // Try GNU libc first (most common on host and Ubuntu containers)
     if let Ok(output) = std::process::Command::new("ldd").arg("--version").output() {
         // ldd --version prints to stdout on glibc, stderr on musl

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -1,4 +1,5 @@
 pub mod kernel;
+pub mod pasta;
 pub mod rootfs;
 pub mod storage;
 
@@ -6,6 +7,7 @@ pub use kernel::{
     ensure_kernel, ensure_profile_firecracker, get_firecracker_for_profile, get_kernel_path,
     get_kernel_url_hash, get_profile_firecracker_path, install_host_kernel,
 };
+pub use pasta::{ensure_pasta, get_pasta_for_config};
 pub use rootfs::{
     ensure_fc_agent_initrd, ensure_rootfs, get_kernel_profile, resolve_rootfs_type, KernelProfile,
 };

--- a/src/setup/pasta.rs
+++ b/src/setup/pasta.rs
@@ -1,0 +1,239 @@
+//! Build pasta (passt) from a pinned upstream commit plus fcvm-carried patches.
+//!
+//! fcvm's rootless networking depends on pasta behavior that upstream hasn't
+//! released yet — currently the addr_seen fix (pasta otherwise adopts the last
+//! source address it overhears on its tap as "the guest", and the namespace
+//! bridge's own broadcasts poison inbound port forwarding; see issue #661 and
+//! the patch submitted to passt-dev). Until a fixed release ships in distros,
+//! fcvm builds its own pasta the same way it builds its firecracker fork:
+//! content-addressed in the shared assets dir, built on demand by `fcvm setup`.
+//!
+//! Robustness choices (deliberately stricter than the firecracker builder):
+//! - The upstream ref is a PINNED COMMIT, not a branch: the binary path is
+//!   computable offline (no ls-remote, no network-failure fallback paths).
+//! - Patches are EMBEDDED in the fcvm binary (include_str!), not read from
+//!   the repo checkout: builds work from any working directory, and editing
+//!   a patch automatically produces a new content hash (and thus a rebuild).
+//! - Installs are atomic (temp file + rename) and serialized by an exclusive
+//!   flock, double-checked after acquisition.
+
+use anyhow::{bail, Context, Result};
+use nix::fcntl::{Flock, FlockArg};
+use sha2::{Digest, Sha256};
+use std::path::PathBuf;
+use tokio::process::Command;
+use tracing::{debug, info};
+
+use crate::paths;
+use crate::setup::rootfs::PastaConfig;
+
+/// Patches applied on top of the pinned upstream commit, in order.
+/// Embedded so the build is independent of the working directory and the
+/// content hash tracks patch edits automatically.
+const PATCHES: &[(&str, &str)] = &[(
+    "0001-tap-dont-let-overheard-traffic-move-addr_seen.patch",
+    include_str!("../../pasta/patches/0001-tap-dont-let-overheard-traffic-move-addr_seen.patch"),
+)];
+
+/// Content hash for the pasta binary: upstream repo + pinned commit + every
+/// embedded patch + the host libc (dynamically linked binaries must not be
+/// shared across incompatible C libraries — same rule as firecracker).
+fn compute_pasta_sha(config: &PastaConfig) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(config.repo.as_bytes());
+    hasher.update(config.commit.as_bytes());
+    for (name, content) in PATCHES {
+        hasher.update(name.as_bytes());
+        hasher.update(content.as_bytes());
+    }
+    hasher.update(super::kernel::libc_version_tag().as_bytes());
+    let result = hasher.finalize();
+    hex::encode(&result[..6])
+}
+
+/// Content-addressed path for the pasta binary. Pure computation — works
+/// offline because the upstream ref is a pinned commit.
+pub fn pasta_bin_path(config: &PastaConfig) -> PathBuf {
+    let sha = compute_pasta_sha(config);
+    paths::assets_dir()
+        .join("pasta")
+        .join(format!("pasta-{}.bin", sha))
+}
+
+/// Resolve the pasta binary to run.
+///
+/// With a `[pasta]` config section, the content-addressed build is REQUIRED:
+/// a missing binary is an error pointing at `fcvm setup`, not a silent
+/// fallback to a distro pasta with the bug fcvm is patching around.
+/// Without the section, the system pasta from PATH is used unchanged.
+pub fn get_pasta_for_config(config: Option<&PastaConfig>) -> Result<PathBuf> {
+    match config {
+        Some(cfg) => {
+            let path = pasta_bin_path(cfg);
+            if !path.exists() {
+                bail!(
+                    "patched pasta not found at {}. Run 'fcvm setup' (or 'make setup-fcvm') \
+                     to build it from {} @ {}",
+                    path.display(),
+                    cfg.repo,
+                    &cfg.commit[..cfg.commit.len().min(12)]
+                );
+            }
+            Ok(path)
+        }
+        None => which::which("pasta").context("pasta not found in PATH"),
+    }
+}
+
+/// Ensure the patched pasta binary exists, building it if needed.
+/// Returns `Ok(None)` when no `[pasta]` section is configured.
+pub async fn ensure_pasta(config: Option<&PastaConfig>) -> Result<Option<PathBuf>> {
+    let config = match config {
+        Some(c) => c,
+        None => return Ok(None),
+    };
+
+    let bin_path = pasta_bin_path(config);
+    if bin_path.exists() {
+        info!(path = %bin_path.display(), "pasta binary exists");
+        return Ok(Some(bin_path));
+    }
+
+    let pasta_dir = bin_path.parent().expect("pasta path has parent");
+    tokio::fs::create_dir_all(&pasta_dir)
+        .await
+        .context("creating pasta assets directory")?;
+
+    // Serialize concurrent builds of the same binary (parallel `fcvm setup`).
+    let lock_file = bin_path.with_extension("lock");
+    use std::os::unix::fs::OpenOptionsExt;
+    let lock_fd = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(&lock_file)
+        .context("opening pasta build lock file")?;
+    let flock = Flock::lock(lock_fd, FlockArg::LockExclusive)
+        .map_err(|(_, err)| err)
+        .context("acquiring exclusive lock for pasta build")?;
+
+    // Another process may have finished the build while we waited.
+    if bin_path.exists() {
+        debug!(path = %bin_path.display(), "pasta exists (built by another process)");
+        flock.unlock().map_err(|(_, err)| err)?;
+        return Ok(Some(bin_path));
+    }
+
+    let sha = compute_pasta_sha(config);
+    println!(
+        "  → Building pasta from {} @ {} ({} patch(es), sha: {})...",
+        config.repo,
+        &config.commit[..config.commit.len().min(12)],
+        PATCHES.len(),
+        sha
+    );
+
+    let build_dir = PathBuf::from(format!("/tmp/pasta-build-{}", sha));
+    if build_dir.exists() {
+        tokio::fs::remove_dir_all(&build_dir)
+            .await
+            .context("removing old pasta build directory")?;
+    }
+
+    if let Err(e) = build_pasta(config, &build_dir, &bin_path).await {
+        // Failures keep the build tree for debugging; never leave a partial
+        // binary behind (build_pasta installs atomically).
+        let _ = flock.unlock();
+        return Err(e);
+    }
+
+    let _ = tokio::fs::remove_dir_all(&build_dir).await;
+    flock.unlock().map_err(|(_, err)| err)?;
+    println!("  ✓ pasta ready: {}", bin_path.display());
+    Ok(Some(bin_path))
+}
+
+async fn build_pasta(
+    config: &PastaConfig,
+    build_dir: &std::path::Path,
+    bin_path: &std::path::Path,
+) -> Result<()> {
+    // Full clone then checkout of the pinned commit: shallow fetches of an
+    // arbitrary SHA need uploadpack.allowReachableSHA1InWant on the server,
+    // which passt.top does not advertise. The repo is ~15MB; correctness
+    // over cleverness.
+    let status = Command::new("git")
+        .args(["clone", &config.repo, build_dir.to_str().unwrap()])
+        .status()
+        .await
+        .context("cloning pasta repo")?;
+    if !status.success() {
+        bail!("failed to clone pasta repo from {}", config.repo);
+    }
+
+    let status = Command::new("git")
+        .args(["checkout", "--detach", &config.commit])
+        .current_dir(build_dir)
+        .status()
+        .await
+        .context("checking out pinned pasta commit")?;
+    if !status.success() {
+        bail!(
+            "pinned pasta commit {} not found in {} — the pin and repo must agree",
+            config.commit,
+            config.repo
+        );
+    }
+
+    for (name, content) in PATCHES {
+        let patch_path = build_dir.join(name);
+        tokio::fs::write(&patch_path, content)
+            .await
+            .with_context(|| format!("writing embedded patch {}", name))?;
+        let status = Command::new("git")
+            .args(["apply", "--verbose", name])
+            .current_dir(build_dir)
+            .status()
+            .await
+            .with_context(|| format!("applying pasta patch {}", name))?;
+        if !status.success() {
+            bail!(
+                "pasta patch {} does not apply to {} @ {} — rebase the patch or move the pin",
+                name,
+                config.repo,
+                &config.commit[..config.commit.len().min(12)]
+            );
+        }
+    }
+
+    let status = Command::new("make")
+        .arg("pasta")
+        .current_dir(build_dir)
+        .status()
+        .await
+        .context("building pasta (is a C toolchain installed? apt install gcc make)")?;
+    if !status.success() {
+        bail!(
+            "pasta build failed (build tree kept at {})",
+            build_dir.display()
+        );
+    }
+
+    let built = build_dir.join("pasta");
+    if !built.exists() {
+        bail!("pasta binary not found at {} after build", built.display());
+    }
+
+    // Atomic install: a killed copy must never leave a partial binary that
+    // later runs treat as valid.
+    let temp_path = bin_path.with_extension("tmp");
+    let _ = tokio::fs::remove_file(&temp_path).await;
+    tokio::fs::copy(&built, &temp_path)
+        .await
+        .context("staging pasta binary")?;
+    tokio::fs::rename(&temp_path, bin_path)
+        .await
+        .context("installing pasta binary")?;
+    Ok(())
+}

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -39,10 +39,25 @@ pub struct Plan {
     /// Used when no kernel profile overrides it.
     #[serde(default)]
     pub firecracker: Option<FirecrackerConfig>,
+    /// Pinned pasta build (upstream commit + fcvm-carried patches).
+    /// When set, rootless networking REQUIRES the built binary — see
+    /// src/setup/pasta.rs for the why and the robustness rules.
+    #[serde(default)]
+    pub pasta: Option<PastaConfig>,
     /// Kernel profiles: kernel_profiles.{name}.{arch} = KernelProfile
     /// E.g., kernel_profiles.nested.arm64 = { kernel_version = "6.18", ... }
     #[serde(default)]
     pub kernel_profiles: HashMap<String, HashMap<String, KernelProfile>>,
+}
+
+/// Pinned pasta build configuration.
+#[derive(Debug, Deserialize, Clone)]
+pub struct PastaConfig {
+    /// Git URL of the passt repository (canonical: https://passt.top/passt)
+    pub repo: String,
+    /// Pinned upstream commit (full SHA). A commit — not a branch — so the
+    /// content-addressed binary path is computable offline.
+    pub commit: String,
 }
 
 /// Default Firecracker build configuration.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1735,12 +1735,15 @@ pub async fn dump_clone_network_diagnostics(pid: u32) {
         run_nsenter_diagnostic(&hp_str, &["bridge", "link"], "bridge links").await;
     }
 
-    // Check what the VM sees (listening sockets)
+    // Check what the VM sees (listening sockets). `--vm` matters: the default
+    // execs into the container, where alpine images have no `ss` — the section
+    // then prints empty and reads as "nothing is listening" (it misled the
+    // #661 investigation exactly that way).
     let pid_str = pid.to_string();
     run_cmd_diagnostic(
         "VM listening sockets",
         &fcvm_path.to_string_lossy(),
-        &["exec", "--pid", &pid_str, "--", "ss", "-tnl"],
+        &["exec", "--pid", &pid_str, "--vm", "--", "ss", "-tnl"],
     )
     .await;
 }


### PR DESCRIPTION
Delivers the #661 fix through fcvm's own machinery, plus the test-scheduling change that removes the load-window try-1 flakes seen in the #663 gate rounds.

## The #661 root cause (full forensics in the issue)

pasta splices inbound port-forwarded connections to the **last source address it overheard** on its tap. fcvm's rootless topology puts a bridge inside the namespace, so the namespace kernel's own broadcasts (ARP probes, IGMP joins, sourced from the bridge address `10.0.2.1`) race the guest's traffic for that slot. When they win, pasta dials `10.0.2.1:PORT` — nothing listens — and the client gets `Connection reset by peer`. Captured in pasta's own `--trace` output, both variants side by side:

```
SPLICE [0.0.0.0]:0 -> [10.0.2.100]:80   <- guest (works)
SPLICE [0.0.0.0]:0 -> [10.0.2.1]:80    <- bridge addr: Connection refused -> RST
```

Approaches that were tried and proven insufficient (preserved in the issue for the record): static FDB/neighbor entries (multicast still floods past them) and a connect-side readiness probe (pasta dials the guest lazily on first client data, so a data-less probe can't exercise the backend). The only correct layer is pasta itself; the fix is **submitted upstream** (passt-dev: "tap: don't let overheard traffic move addr_seen when address is explicit" — key `addr_seen` updates off an explicitly given `-a`).

## What this PR does

- `bc86db3c` — **`[pasta]` pinned build**: `rootfs-config.toml` pins an upstream commit; `fcvm setup` clones it, applies the patch carried in `pasta/patches/` (the same patch submitted upstream), and installs a content-addressed binary in the shared assets dir. Rootless networking then *requires* that binary — a missing build errors with a `fcvm setup` pointer instead of silently using a distro pasta with the bug. Deliberately stricter than the firecracker builder: pinned commit (binary path computable offline — no ls-remote fallback chains), patch embedded via `include_str!` (cwd-independent; patch edits change the hash and force a rebuild), atomic installs under an exclusive flock. When upstream ships the fix: bump the pin, drop the patch, eventually delete the section.
- Also in `bc86db3c`: the clone-network diagnostics exec'd into the container (no `ss` in alpine) instead of the VM — the empty output misdirected this very investigation; now `--vm`. Plus the two cosmetic nits from the #663 review (stale nextest comment, exportfs message whitespace).
- `47a10f1a` — **bench exclusivity**: the 8000-connection egress bench saturates the host (conntrack, ephemeral ports, every pasta process); heavy clone tests sharing its window burned 100–150s try-1 failures in both #663 gate rounds (`extra_disk_ro_clone` twice, a rotating `stress_100` variant). `threads-required = "num-test-threads"` gives it the runner alone — its ~160s of exclusivity costs less wall time than the retries it caused.

## Test results

```
$ make setup-fcvm           # builds pasta-39927af1b41b.bin from the pin
$ make test-root FILTER=test_clone_port_forward_stress_rootless   # x6
PASS 43.5s / 43.9s / 43.5s / 43.4s / 43.5s / 42.3s   (6/6)
```

With **stock pasta**: ~1-in-3 failure (`curl: (56) Recv failure: Connection reset by peer` on the first clone's pre-storm check). The 6/6 above runs with the distro pasta still on PATH — fcvm resolves its own pinned build, proving the delivery path. `sanity_rootless` green.

Related: #661 (root cause + upstream patch thread), #664 (other nested follow-ups), #619 (flake-tracking policy).