### PR TITLE
docs: correct memory-sharing model from #632 measurements

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1211,7 +1211,8 @@ fuse-pipe/benches/
    - UFFD memory server serves pages on-demand via Unix socket
    - Clone disk uses btrfs reflink (~3ms instant CoW copy)
    - Clone memory load time: ~2.3ms
-   - Multiple VMs share same memory via kernel page cache
+   - UFFD clones populate lazily (faulted pages are per-VM copies); File-backend
+     clones share clean pages via the page cache (measured in #632)
    - **Performance**: Original VM + 2 clones = ~512MB RAM total (not 1.5GB!)
 
 3. **True Rootless Networking** (2025-11-25)
@@ -1424,8 +1425,9 @@ fcvm snapshot run --pid <serve_pid> --name clone1
 ```
 
 **How it works:**
-- Memory server mmaps snapshot file (MAP_SHARED)
-- Kernel shares physical pages via page cache
+- Memory server mmaps the snapshot file once; the page cache holds one copy
+- Guest RAM is MAP_ANONYMOUS; faults are filled with UFFDIO_COPY (a private
+  per-VM copy of each faulted page — lazy population, not cross-VM sharing)
 - Server uses tokio AsyncFd to handle UFFD events non-blocking
 - tokio::select! multiplexes: accept new VMs + monitor VM exits
 - Each VM gets dedicated async task (JoinSet) for page faults
@@ -1433,8 +1435,11 @@ fcvm snapshot run --pid <serve_pid> --name clone1
 - Server exits gracefully when last VM disconnects
 
 **Memory efficiency:**
-- 50 VMs with 512MB snapshot = ~512MB physical RAM (not 25.6GB)
-- Pages only copied on write (true CoW at page level)
+- UFFD path: density comes from laziness — only each clone's faulted working
+  set materializes (faulted pages are per-VM copies, #632)
+- File-backend restores (`snapshot run --snapshot`): clones genuinely share
+  clean pages via the page cache (MAP_PRIVATE) — measured 3x 1GiB clones
+  ≈ 230MiB total PSS, with or without dirty tracking (#632)
 
 ### FUSE Parallelism (fuse-pipe)
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1213,7 +1213,8 @@ fuse-pipe/benches/
    - Clone memory load time: ~2.3ms
    - UFFD clones populate lazily (faulted pages are per-VM copies); File-backend
      clones share clean pages via the page cache (measured in #632)
-   - **Performance**: Original VM + 2 clones = ~512MB RAM total (not 1.5GB!)
+   - **Performance**: Original VM + 2 idle clones ≈ ~512MB RAM total (not 1.5GB) —
+     only each clone's faulted working set materializes
 
 3. **True Rootless Networking** (2025-11-25)
    - `--network rootless` (default): pasta, no root required

--- a/.claude/plans/disk-only-clone.md
+++ b/.claude/plans/disk-only-clone.md
@@ -1,0 +1,109 @@
+# Plan: Disk-only clone (cold-boot from a captured disk) + free hugepage choice
+
+## Goal (user-agreed)
+Capture a running VM's **disk only** (no memory state), then **cold-boot** fresh,
+independent VMs from that disk. Each clone boots its kernel from scratch and fc-agent
+runs the container against the disk's already-populated podman storage. No UFFD, no
+`vmstate.bin`, no shared memory. A clone may pick **any `--memory`/`--cpu`/`--hugepages`**
+regardless of how the source booted (cold boot ⇒ fresh memory ⇒ no UFFD/backing-match
+constraint — that constraint only exists on the memory-restore path).
+
+## Interface (user choice: extend snapshot commands)
+```
+fcvm snapshot create --pid <vm_pid> --tag base --disk-only      # capture disk only
+fcvm snapshot run --tag base --name c1 --hugepages --memory 8192 --cpu 4   # cold boot
+fcvm snapshot run --tag base --name c2                          # another fresh copy
+```
+- `--disk-only` snapshot stores only `disk.raw` (+ `:ro` extra disks) + `config.json`
+  (`kind=DiskOnly`); no `memory.bin`/`vmstate.bin`; no `serve` step.
+- `snapshot run` on a DiskOnly tag (no `--pid` serve) = cold boot, not memory restore.
+
+## SUCCESS CRITERIA (user-specified)
+1. Implemented end to end (capture + cold-boot run), compiles, tests run locally.
+2. **Run `/code-review`** on the feature PR and address findings.
+3. **Run a Codex adversarial review** (`@codex review`) on the PR and address findings.
+4. **Documentation kept coherent**: update `README.md` (snapshot/clone section), the
+   snapshot workflow docs, and `.claude/CLAUDE.md` (snapshot/UFFD + the "Memory Sharing
+   (UFFD)" / snapshot-workflow sections) to describe disk-only capture + cold-boot clone
+   and the hugepage-on-clone capability; `DESIGN.md` if it covers snapshots.
+
+## Reuse seam (code-grounded — from Plan agent)
+- Cold boot is driven by `DiskManager::create_cow_disk()` (`src/storage/disk.rs:41-102`),
+  which reflinks `self.base_rootfs` → `<vm_dir>/rootfs.raw`. `base_rootfs` is supplied via
+  `DiskManager::new(vm_id, base_rootfs, vm_dir)` (`disk.rs:26`), set in
+  `run_vm_setup_inner` (`src/commands/podman/vm_config.rs:805-806`) from
+  `VmSetupParams.base_rootfs` ← `prepare_vm`'s `ensure_rootfs(...)` (`mod.rs:293`, the
+  `layer2-{sha}.raw`).
+- **Seam:** point `base_rootfs` at the snapshot's `disk.raw` and the identical cold-boot
+  sequence (create_cow_disk → ensure_free_space → Firecracker start → MMDS plan →
+  InstanceStart) clones the captured disk as rootfs. Thread via a new
+  `RunArgs.rootfs_override: Option<PathBuf>` + `RunArgs.disk_only: bool`.
+
+## CRITICAL constraints / gotchas (must handle)
+1. **fc-agent wipes podman storage on cold boot.** `agent.rs:246-248` calls
+   `reset_podman_state()` (`podman system reset --force`, `container.rs:451-468`) for root.
+   A disk-only clone MUST skip this (and `write_early_storage_conf` override) or it
+   destroys the baked-in image. **Requires a new fc-agent disk-only boot mode.**
+2. **Overlay image mode (the DEFAULT) does not bake the image into the rootfs.** Overlay
+   keeps the image on a separate `.storage-v2.img` device mounted as
+   `additionalimagestores` (`mod.rs:571-591`, `container.rs:50-51`). So a disk-only
+   capture of an overlay VM yields a rootfs with no image. **v1: reject `--disk-only`
+   capture of an overlay-mode VM** (require btrfs/archive mode, where fc-agent
+   `podman load`s the image into the rootfs at boot). (Future: also capture+reattach the
+   store device for overlay.) Capture reads the source VM's persisted `image_mode`.
+3. **Disk consistency at capture:** reflink the rootfs while the VM is **paused** (mirror
+   `create_snapshot_core` pause→reflink→resume, `common.rs:1559/1653/1683`). A live reflink
+   risks an inconsistent FS (the corruption class the existing code warns about at
+   `common.rs:1645-1648`).
+4. **Env vars are intentionally NOT persisted to host state** (`mod.rs:643-644`, secrets).
+   For disk-only run, re-supply env at run time (`--env` on `snapshot run`) rather than
+   baking secrets into the world-readable snapshot dir.
+
+## Ordered implementation sequence (from Plan agent)
+1. `SnapshotKind { Full, DiskOnly }` + `#[serde(default)] kind` on `SnapshotConfig`
+   (`storage/snapshot.rs`). Update all 7 `SnapshotConfig { … }` literals (1 prod in
+   `common.rs:1261` build_snapshot_config → `kind: Full`; 6 test fixtures).
+2. Persist `image_mode`, `container_cmd`, `privileged`, `rootfs_type`,
+   `non_blocking_output` into `VmState.config` in `prepare_vm` (`mod.rs:645-673`); check
+   `src/state/types.rs` for existing fields first.
+3. Extend `SnapshotMetadata` (`snapshot.rs:67`) + `build_snapshot_config`
+   (`common.rs:1271`) with: `container_cmd`, `privileged`, `image_mode`, `rootfs_type`,
+   `non_blocking_output` (all `#[serde(default)]`).
+4. `create_disk_only_snapshot_core` in `common.rs` (factor pause→reflink→resume→finalize
+   from `create_snapshot_core`; skip Firecracker `create_snapshot` + the memory-size disk
+   check). Add `--disk-only` to `SnapshotCreateArgs` + branch in `cmd_snapshot_create`
+   (`snapshot.rs:88`) incl. overlay-mode rejection.
+5. fc-agent: `#[serde(default)] Plan.disk_only` (`types.rs`); in `agent.rs` when set, skip
+   `reset_podman_state`/`write_early_storage_conf` override, add a disk-only arm in the
+   image-prep match (`agent.rs:251-274`) that sets `image_ref=plan.image` and verifies it
+   exists locally (`podman image inspect`), skip overlay unmount at cleanup. **Rebuild
+   initrd** (fc-agent changed) for local testing.
+6. `RunArgs.rootfs_override` + `RunArgs.disk_only`; branches in `prepare_vm` (skip the
+   localhost export block `mod.rs:445-611`, `image_disk_path=None`, use override as
+   `base_rootfs`, mark MMDS disk-only) and `to_mmds_json`/`FirecrackerConfig.disk_only`
+   (`config.rs:357-395`).
+7. `cmd_snapshot_run_disk_only` in `snapshot.rs`: dispatch from `cmd_snapshot_run` on
+   `kind==DiskOnly` (reject `--pid`/UFFD); synthesize `RunArgs` from
+   `snapshot_config.metadata` + CLI overrides (`--memory`/`--cpu`/`--hugepages`/`--env`),
+   set `rootfs_override=Some(disk.raw)`, `disk_only=true`, `no_snapshot=true`; call
+   `prepare_vm`→`run_vm_loop`→`cleanup_vm_context`; patch `process_type=Clone` +
+   `snapshot_name` into state.
+8. **Docs** (success criterion #4): README snapshot section, CLAUDE.md, DESIGN.md.
+9. **Tests**: cold-boot-from-disk-clone (write marker in source → capture → cold-boot →
+   marker present + container runs); hugepage upgrade (source no-hugepages → clone
+   `--hugepages` healthy); independence (two clones don't share memory writes); reject
+   overlay-mode capture. Run locally (rootless, no sudo; needs initrd rebuild).
+10. **Reviews** (success criteria #2/#3): `/code-review` + `@codex review` on the PR;
+    address findings.
+
+## Top risks
+1. fc-agent `reset_podman_state()` wiping the baked-in image (most important change).
+2. Overlay-mode default not baking the image into rootfs → v1 rejects overlay capture.
+3. Disk consistency: reflink must be while paused.
+
+## Critical files
+`src/storage/snapshot.rs`, `src/commands/common.rs`, `src/commands/snapshot.rs`,
+`src/commands/podman/mod.rs`, `src/commands/podman/vm_config.rs`, `src/cli/args.rs`,
+`src/state/types.rs`, `src/firecracker/config.rs`, `fc-agent/src/agent.rs`,
+`fc-agent/src/types.rs`; reuse seam `src/storage/disk.rs:41`. Docs: `README.md`,
+`.claude/CLAUDE.md`, `DESIGN.md`.

--- a/docs/hypervisor-abstraction.md
+++ b/docs/hypervisor-abstraction.md
@@ -1,7 +1,9 @@
 # Design: hypervisor-agnostic abstraction (Firecracker + Cloud Hypervisor)
 
 Status: **proposal / RFC** (epic: #632). Canonical design doc; #632 holds the full proven
-capability mapping with source citations.
+capability mapping with source citations, a code-verified seam audit (per-call-site routing
+table + P0 checklist), and **measured experiment results** (2026-06-12: CH v52 boots the full
+fcvm stack; FC File-backend sharing quantified; CH v52 snapshot creation fails on ARM64).
 
 **Scope: the two microVMs — Firecracker and Cloud Hypervisor.** QEMU is explicitly out of
 scope (it was the outlier on every hard axis: no host vsock UDS proxy, QMP vs REST, a much
@@ -39,16 +41,16 @@ Full table + citations in #632.
 | vsock host↔guest (`CONNECT`) | ✅ | ✅ identical | single `GuestChannel` (UdsConnect) |
 | full snapshot + restore-into-fresh-process | ✅ | ✅ | trait |
 | UFFD lazy restore | ✅ | ✅ (`memory_restore_mode=ondemand`, v52) | trait |
-| **cross-clone memory sharing** | ✅ (`File` backend mmaps `memory.bin` MAP_PRIVATE ⇒ CoW) | ⚠️ CoW via `--memory file=`,`shared=off` (MAP_PRIVATE); restore-path wiring to verify | cap `shared_memory_clones`; it's **CoW, not UFFD-exclusive** |
+| **cross-clone memory sharing** | ✅ **measured**: `File` backend mmaps `memory.bin` MAP_PRIVATE; 3× 1GiB clones ≈ 230MiB total PSS, with dirty tracking on OR off. UFFD path is **lazy population, not sharing** (UFFDIO_COPY makes per-VM copies) | ❓ blocked: CH v52 snapshot create fails on ARM64 (`GetAarchCoreRegister` EINVAL), so density unmeasured | split caps: `file_backed_cow_restore` / `external_uffd_lazy_restore` / `internal_uffd_lazy_restore` |
 | diff / incremental snapshots | ✅ | ❌ | cap `diff_snapshots` (FC-only; CH takes full) |
 | drive retarget on restore (`patch_drive`) | ✅ | ❌ | use **bind-mount redirect** (already VMM-agnostic) everywhere |
 | metadata service (boot plan) | ✅ MMDS | ❌ no MMDS | **boot-plan over vsock** (portable; keep MMDS as FC fast path) |
 | nested ARM64 (FEAT_NV2) | ✅ (custom fork + DSB kernel patches) | ❌ (CH nested is x86-only) | cap `nested_arm64` (FC-only) |
 
-Net: only **five** capability gates separate the two (memory-share verification, diff
-snapshots, drive retarget, native metadata, ARM64 nesting) — everything else is shared.
-`uffd_lazy_restore` is a capability (both support it) to future-proof the trait if a
-backend without UFFD is ever added.
+Net: the capability gates separating the two are memory-sharing semantics (split into
+`file_backed_cow_restore` / `external_uffd_lazy_restore` / `internal_uffd_lazy_restore` —
+FC and CH implement *different* lazy-restore mechanisms and neither is a superset), diff
+snapshots, drive retarget, native metadata, and ARM64 nesting — everything else is shared.
 
 ## Proposed abstraction
 Move `src/firecracker/` → `src/hypervisor/{firecracker,cloud_hypervisor}/`.
@@ -57,12 +59,13 @@ Move `src/firecracker/` → `src/hypervisor/{firecracker,cloud_hypervisor}/`.
 pub enum Backend { Firecracker, CloudHypervisor }
 
 pub struct Capabilities {
-    pub diff_snapshots: bool,          // FC: true,  CH: false
-    pub shared_memory_clones: bool,    // FC: true,  CH: verify (CoW file backing)
-    pub uffd_lazy_restore: bool,       // both: true
-    pub drive_retarget: bool,          // FC: true,  CH: false (bind-mount redirect)
-    pub native_metadata_service: bool, // FC: MMDS,  CH: false (vsock boot-plan)
-    pub nested_arm64: bool,            // FC: true,  CH: false
+    pub diff_snapshots: bool,             // FC: true,  CH: false
+    pub file_backed_cow_restore: bool,    // FC: true (measured, #632), CH: unverified (snapshot blocked)
+    pub external_uffd_lazy_restore: bool, // FC: true (fork handshake w/ page_size), CH: false
+    pub internal_uffd_lazy_restore: bool, // FC: n/a,   CH: ondemand (v52; unverified on ARM64)
+    pub drive_retarget: bool,             // FC: true,  CH: false (bind-mount redirect)
+    pub native_metadata_service: bool,    // FC: MMDS,  CH: false (vsock boot-plan)
+    pub nested_arm64: bool,               // FC: true,  CH: false
 }
 
 #[async_trait]
@@ -90,10 +93,15 @@ pub trait GuestChannel { fn connect(&self, port: u32) -> Result<UnixStream>; fn 
    (also: vsock CID convention, the restore-reset event — CH also resets vsock on restore).
 2. **Drive retarget.** Make the **bind-mount namespace redirect** primary (VMM-agnostic);
    `patch_drive` becomes an FC optimization.
-3. **Memory-share clones.** It's CoW of MAP_PRIVATE file-backed guest RAM, not UFFD-only.
-   FC's `File` backend gives it directly; **verify CH's restore can back guest RAM with a
-   MAP_PRIVATE mapping of the shared snapshot** (else CH clones fall back to per-clone
-   `ondemand`/copy — correct but less dense).
+3. **Memory-share clones — measured (#632, 2026-06-12).** FC's `File` backend mmaps the
+   snapshot MAP_PRIVATE: 3× 1GiB clones cost ~230MiB total PSS, and `track_dirty_pages`
+   does NOT erode the sharing (ON vs OFF within 1MiB — the flag's costs are KVM logging
+   overhead and the 2M→4K hugepage split). FC's UFFD path is **lazy population, not
+   sharing**: guest RAM is MAP_ANONYMOUS and UFFDIO_COPY makes a private per-VM copy of
+   each faulted page — density there comes from only working sets materializing. CH's
+   density is **unmeasured**: CH v52 snapshot creation fails on ARM64
+   (`GetAarchCoreRegister` EINVAL; FC snapshots work on the same host), blocking both the
+   `ondemand` and CoW-backing experiments.
 4. **Diff snapshots / ARM64 nesting / native metadata.** Capability-gated to Firecracker.
 5. **Snapshot format/version is per-VMM** — the cache key must encode
    `(backend, binary, version)` and refuse cross-backend/version restores.
@@ -113,12 +121,25 @@ optional future: evaluate embedding a VMM via rust-vmm/libkrun.
 ## Phased plan
 - **P0** Extract the trait around existing Firecracker (no behavior change). Green CI = done.
 - **P0.5** Boot-plan-over-vsock in fc-agent (removes the MMDS dependency for CH).
-- **P1** Cloud Hypervisor backend: cold boot + run a container via the vsock boot-plan (no snapshots).
-- **P2** CH snapshot/restore + UFFD `ondemand`; capability-gate diff + memory-share; verify CoW sharing.
+- **P1** Cloud Hypervisor backend: cold boot + run a container via the vsock boot-plan (no
+  snapshots). De-risked by experiment (#632): CH v52 boots fcvm's kernel+initrd+rootfs to
+  fc-agent today — needs `console=ttyAMA0` (custom profile kernels lack PL011: add
+  `CONFIG_SERIAL_AMBA_PL011=y` or use `hvc0`), `--cpus boot=`, `image_type=raw` on disks,
+  no `pci=off`. fc-agent starts ALL vsock channels only after the boot-plan fetch, so P0.5
+  is a hard prerequisite for any guest-channel function on CH.
+- **P2** CH snapshot/restore + UFFD `ondemand`; capability-gate diff + memory-share; verify
+  CoW sharing. **Currently blocked**: CH v52 snapshot creation fails on ARM64
+  (`GetAarchCoreRegister` EINVAL) — isolate vs the `kvm-arm.mode=nested` host kernel, test
+  newer CH, file upstream. Until resolved, realistic CH scope is P1 only.
 - **P3** Parity polish: capability-driven degradation everywhere, `--hypervisor {firecracker,cloud-hypervisor}` in profiles/state/cache-key, docs, CI matrix dimension on both backends.
 Each phase: tests + `/code-review` + Codex review per repo convention.
 
 ## Open research items
+- Root-cause CH v52 ARM64 snapshot failure (`GetAarchCoreRegister` EINVAL): stock host
+  kernel? newer CH? upstream bug? Blocks all CH snapshot/restore work.
 - Verify CH cross-clone CoW sharing (`--memory file=` + restore path maps snapshot
-  MAP_PRIVATE as guest RAM).
+  MAP_PRIVATE as guest RAM) — blocked on the above.
+- CH vsock `CONNECT` parity with a live guest listener (testable only after P0.5 lands,
+  since fc-agent binds vsock channels only post-boot-plan; CH docs confirm the
+  `<socket>_<port>` naming).
 - Per-backend security/jailing model.

--- a/docs/hypervisor-abstraction.md
+++ b/docs/hypervisor-abstraction.md
@@ -18,10 +18,11 @@ the Firecracker path.
 
 ## Why this pair is a clean fit
 The research proved FC and CH are closely aligned:
-- **vsock is byte-for-byte identical** — both use the hybrid `CONNECT <port>` proxy over a
-  host Unix socket, guest→host via CID 2 with the host listening on `<socket>_<port>` (CH:
-  "based on the Firecracker implementation"). fcvm's exec/volume/status/tty layer ports
-  **unchanged** — and there's effectively **one `GuestChannel` impl**, not two.
+- **vsock uses the same hybrid design** — both use the `CONNECT <port>` proxy over a host
+  Unix socket, guest→host via CID 2 with the host listening on `<socket>_<port>` (CH:
+  "based on the Firecracker implementation"; naming doc-confirmed). fcvm's
+  exec/volume/status/tty layer should port with **one `GuestChannel` impl** — live
+  `CONNECT` parity is still unverified pending P0.5 (see open research items).
 - Both are **REST-over-UDS** control planes (FC `/actions`,`PATCH /vm`; CH `vm.boot`,
   `vm.pause`…), so the API client shape is shared.
 - Both support **direct kernel boot**, **UFFD lazy restore**, **static single binaries**,
@@ -38,7 +39,7 @@ Full table + citations in #632.
 | capability | Firecracker | Cloud Hypervisor | abstraction handling |
 |---|---|---|---|
 | lifecycle / boot / machine / block+net add / console / process model | ✅ | ✅ | trait covers directly |
-| vsock host↔guest (`CONNECT`) | ✅ | ✅ identical | single `GuestChannel` (UdsConnect) |
+| vsock host↔guest (`CONNECT`) | ✅ | ✅ same design (live parity unverified) | single `GuestChannel` (UdsConnect) expected |
 | full snapshot + restore-into-fresh-process | ✅ | ✅ | trait |
 | UFFD lazy restore | ✅ | ✅ (`memory_restore_mode=ondemand`, v52) | trait |
 | **cross-clone memory sharing** | ✅ **measured**: `File` backend mmaps `memory.bin` MAP_PRIVATE; 3× 1GiB clones ≈ 230MiB total PSS, with dirty tracking on OR off. UFFD path is **lazy population, not sharing** (UFFDIO_COPY makes per-VM copies) | ❓ blocked: CH v52 snapshot create fails on ARM64 (`GetAarchCoreRegister` EINVAL), so density unmeasured | split caps: `file_backed_cow_restore` / `external_uffd_lazy_restore` / `internal_uffd_lazy_restore` |

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -377,9 +377,10 @@ pub struct SnapshotRunArgs {
     #[arg(long)]
     pub exec: Option<String>,
 
-    /// Disable KVM dirty page tracking. File-backed pages stay shared through
-    /// the host page cache — multiple clones from the same snapshot share
-    /// physical memory pages. Tradeoff: diff snapshots from this VM won't work.
+    /// Disable KVM dirty page tracking, avoiding its logging overhead.
+    /// Tradeoff: diff snapshots from this VM won't work. Note: file-backed
+    /// clone memory is shared through the host page cache with tracking on
+    /// OR off (measured in #632) — this flag does not change sharing.
     #[arg(long)]
     pub no_dirty_tracking: bool,
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -361,7 +361,7 @@ pub struct SnapshotServeArgs {
 
 #[derive(Args, Debug)]
 pub struct SnapshotRunArgs {
-    /// Serve process PID to clone from (UFFD mode - memory sharing)
+    /// Serve process PID to clone from (UFFD mode - lazy on-demand paging)
     #[arg(long, conflicts_with = "snapshot")]
     pub pid: Option<u32>,
 

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -710,10 +710,12 @@ pub struct RestoreParams<'a> {
     /// For routed mode clones: the unique per-clone IPv6 that fc-agent should
     /// configure on eth0, replacing the snapshot's shared guest IPv6.
     pub clone_ipv6: Option<String>,
-    /// Enable KVM dirty page tracking. When true, KVM CoW-copies file-backed
-    /// pages for dirty tracking (needed for subsequent diff snapshots from this VM).
-    /// When false, pages stay shared through page cache — multiple clones from
-    /// the same snapshot share physical memory pages. Disabled for hugepage VMs
+    /// Enable KVM dirty page tracking (needed for subsequent diff snapshots
+    /// from this VM). File-backed restore memory is mmap'd MAP_PRIVATE either
+    /// way, so clones share clean pages through the host page cache in BOTH
+    /// modes — sharing is bounded by the guest's write footprint, and tracking
+    /// showed no material PSS erosion when measured (#632: 3x 1GiB clones
+    /// ≈ 230MiB total PSS, ON vs OFF within 1MiB). Disabled for hugepage VMs
     /// (KVM would split 2MB TLB entries to 4K).
     pub track_dirty_pages: bool,
 }

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -661,7 +661,8 @@ fn volume_state_from_snapshot(
 /// Run clone from snapshot
 ///
 /// Two modes:
-/// - `--pid <serve_pid>`: Clone via UFFD memory sharing (for multiple concurrent clones)
+/// - `--pid <serve_pid>`: Clone via the UFFD serve process (lazy on-demand paging,
+///   for multiple concurrent clones)
 /// - `--snapshot <name>`: Clone directly from snapshot files (simpler, no serve process needed)
 ///
 /// This is public so podman.rs can call it directly for cache hits.
@@ -1409,7 +1410,7 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
             vm_name, snapshot_name
         );
         if use_uffd {
-            println!("  Memory pages shared via UFFD serve process");
+            println!("  Memory pages served on-demand by UFFD serve process");
         } else {
             println!("  Memory pages served on-demand from snapshot file");
         }


### PR DESCRIPTION
Doc/comment-only corrections driven by the measured experiments in #632 (no code behavior change).

## Summary
- **`track_dirty_pages` does NOT erode page-cache sharing** — measured in #632: 3× 1GiB File-backend clones ≈ 230MiB total PSS with tracking ON or OFF (<1MiB apart). Corrected the `RestoreParams` comment (`src/commands/common.rs`) and the `--no-dirty-tracking` help text (`src/cli/args.rs`), both of which claimed tracking defeats sharing. The flag's real costs: KVM logging overhead + 2MB→4K hugepage split.
- **The UFFD serve/clone path is lazy population, not cross-VM sharing** — guest RAM is MAP_ANONYMOUS and UFFDIO_COPY makes a private per-VM copy of each faulted page (verified against the firecracker fork's `persist.rs`/`vstate/memory.rs`). Fixed `.claude/CLAUDE.md` UFFD sections, the `--pid` help text, and `cmd_snapshot_run` doc/output wording that said "memory sharing".
- **`docs/hypervisor-abstraction.md` refreshed with measured results**: split `shared_memory_clones` into `file_backed_cow_restore` / `external_uffd_lazy_restore` / `internal_uffd_lazy_restore`; recorded the CH v52 ARM64 snapshot blocker (`GetAarchCoreRegister` EINVAL) and CH boot requirements (`console=ttyAMA0`, `image_type=raw`, `--cpus boot=`, P0.5 as guest-channel prerequisite); softened the "byte-for-byte identical vsock / one GuestChannel impl" claim to "same design, live CONNECT parity unverified pending P0.5".

Second commit addresses local codex review findings (stale wording that contradicted the corrected model).

## Test Results
```
$ cargo fmt --check          # clean
$ cargo clippy --all-targets -- -D warnings   # clean
```
Comment/doc-only; measurements backing the claims: https://github.com/ejc3/fcvm/issues/632#issuecomment-4688006285