### PR TITLE
feat(hypervisor): extract Hypervisor trait around Firecracker (P0, #632)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -457,7 +457,7 @@ plumbing — the disk itself carries the signal.
 Every VM is configured "reboot possible" **up front**: each lifecycle path builds a
 launch plan (`RebootSpec`: firecracker binary/args, fully-resolved launch config,
 boot args, vsock path) before the VM runs, and all paths boot through one shared
-primitive, `configure_and_boot_firecracker`:
+primitive, `configure_and_boot_vm`:
 
 - initial `fcvm podman run` boot
 - disk-only clone cold boot (via `prepare_vm` with `rootfs_override`)

--- a/docs/hypervisor-abstraction.md
+++ b/docs/hypervisor-abstraction.md
@@ -1,9 +1,14 @@
 # Design: hypervisor-agnostic abstraction (Firecracker + Cloud Hypervisor)
 
-Status: **proposal / RFC** (epic: #632). Canonical design doc; #632 holds the full proven
+Status: **in implementation** (epic: #632). Canonical design doc; #632 holds the full proven
 capability mapping with source citations, a code-verified seam audit (per-call-site routing
-table + P0 checklist), and **measured experiment results** (2026-06-12: CH v52 boots the full
-fcvm stack; FC File-backend sharing quantified; CH v52 snapshot creation fails on ARM64).
+table + P0 checklist), and **measured experiment results**. P0 (the `Hypervisor` trait around
+Firecracker, no behavior change) is implemented in `src/hypervisor/`. Measured 2026-06-13:
+CH v52 boots the full fcvm stack (console `hvc0`, PCI on, kernel already in ARM64 `Image`
+format); FC File-backend sharing quantified; the CH ARM64 snapshot failure was **root-caused
+to the SVE register-save bug (CH #8057, fixed by #8268)** — NOT nesting — and snapshot create
+is **verified working on this Graviton3** with a post-fix CH build, so CH snapshot/restore
+(P2) is unblocked.
 
 **Scope: the two microVMs — Firecracker and Cloud Hypervisor.** QEMU is explicitly out of
 scope (it was the outlier on every hard axis: no host vsock UDS proxy, QMP vs REST, a much
@@ -42,7 +47,7 @@ Full table + citations in #632.
 | vsock host↔guest (`CONNECT`) | ✅ | ✅ same design (live parity unverified) | single `GuestChannel` (UdsConnect) expected |
 | full snapshot + restore-into-fresh-process | ✅ | ✅ | trait |
 | UFFD lazy restore | ✅ | ✅ (`memory_restore_mode=ondemand`, v52) | trait |
-| **cross-clone memory sharing** | ✅ **measured**: `File` backend mmaps `memory.bin` MAP_PRIVATE; 3× 1GiB clones ≈ 230MiB total PSS, with dirty tracking on OR off. UFFD path is **lazy population, not sharing** (UFFDIO_COPY makes per-VM copies) | ❓ blocked: CH v52 snapshot create fails on ARM64 (`GetAarchCoreRegister` EINVAL), so density unmeasured | split caps: `file_backed_cow_restore` / `external_uffd_lazy_restore` / `internal_uffd_lazy_restore` |
+| **cross-clone memory sharing** | ✅ **measured**: `File` backend mmaps `memory.bin` MAP_PRIVATE; 3× 1GiB clones ≈ 230MiB total PSS, with dirty tracking on OR off. UFFD path is **lazy population, not sharing** (UFFDIO_COPY makes per-VM copies) | ⏳ unblocked, density unmeasured: CH `ondemand` is in-process UFFD (per-VM pages), so density must come from page-cache sharing of a `MAP_PRIVATE` snapshot file — measurable now that snapshot create works (post-#8268) | split caps: `file_backed_cow_restore` / `external_uffd_lazy_restore` / `internal_uffd_lazy_restore` |
 | diff / incremental snapshots | ✅ | ❌ | cap `diff_snapshots` (FC-only; CH takes full) |
 | drive retarget on restore (`patch_drive`) | ✅ | ❌ | use **bind-mount redirect** (already VMM-agnostic) everywhere |
 | metadata service (boot plan) | ✅ MMDS | ❌ no MMDS | **boot-plan over vsock** (portable; keep MMDS as FC fast path) |
@@ -94,15 +99,19 @@ pub trait GuestChannel { fn connect(&self, port: u32) -> Result<UnixStream>; fn 
    (also: vsock CID convention, the restore-reset event — CH also resets vsock on restore).
 2. **Drive retarget.** Make the **bind-mount namespace redirect** primary (VMM-agnostic);
    `patch_drive` becomes an FC optimization.
-3. **Memory-share clones — measured (#632, 2026-06-12).** FC's `File` backend mmaps the
+3. **Memory-share clones — measured (#632, 2026-06-13).** FC's `File` backend mmaps the
    snapshot MAP_PRIVATE: 3× 1GiB clones cost ~230MiB total PSS, and `track_dirty_pages`
    does NOT erode the sharing (ON vs OFF within 1MiB — the flag's costs are KVM logging
    overhead and the 2M→4K hugepage split). FC's UFFD path is **lazy population, not
    sharing**: guest RAM is MAP_ANONYMOUS and UFFDIO_COPY makes a private per-VM copy of
    each faulted page — density there comes from only working sets materializing. CH's
-   density is **unmeasured**: CH v52 snapshot creation fails on ARM64
-   (`GetAarchCoreRegister` EINVAL; FC snapshots work on the same host), blocking both the
-   `ondemand` and CoW-backing experiments.
+   `ondemand` restore is also in-process UFFD (per-VM pages), so CH clone density must
+   come from page-cache sharing of a `MAP_PRIVATE` snapshot file, the same mechanism as
+   FC's `File` backend. CH density is **unmeasured but now measurable**: the earlier ARM64
+   snapshot-create failure (`GetAarchCoreRegister` EINVAL) was misattributed to NV2/nesting
+   — it is the SVE register-save bug (CH #8057), which hits every SVE-capable aarch64 host
+   regardless of nesting, and is fixed by CH #8268. With a post-#8268 CH build, snapshot
+   create is verified working on this Graviton3.
 4. **Diff snapshots / ARM64 nesting / native metadata.** Capability-gated to Firecracker.
 5. **Snapshot format/version is per-VMM** — the cache key must encode
    `(backend, binary, version)` and refuse cross-backend/version restores.
@@ -124,23 +133,35 @@ optional future: evaluate embedding a VMM via rust-vmm/libkrun.
 - **P0.5** Boot-plan-over-vsock in fc-agent (removes the MMDS dependency for CH).
 - **P1** Cloud Hypervisor backend: cold boot + run a container via the vsock boot-plan (no
   snapshots). De-risked by experiment (#632): CH v52 boots fcvm's kernel+initrd+rootfs to
-  fc-agent today — needs `console=ttyAMA0` (custom profile kernels lack PL011: add
-  `CONFIG_SERIAL_AMBA_PL011=y` or use `hvc0`), `--cpus boot=`, `image_type=raw` on disks,
-  no `pci=off`. fc-agent starts ALL vsock channels only after the boot-plan fetch, so P0.5
-  is a hard prerequisite for any guest-channel function on CH.
+  fc-agent today — needs `console=hvc0` (CH's default console is virtio-pci `hvc0`, NOT the
+  PL011 `ttyAMA0`, which is the `--serial` device and off by default), `--cpus boot=N`,
+  `image_type=raw` on disks (auto-detect deprecated in v52, pass it explicitly), `--net`,
+  `--vsock cid=,socket=`, NO `pci=off` (CH puts virtio devices on PCI). fcvm's kernel asset
+  is already in ARM64 `Image` (PE/MZ) format, which CH loads directly — no conversion. The
+  host↔guest `CONNECT <port>` proxy reply is `OK <port>\n`, wire-compatible with Firecracker
+  (`exec.rs` parser needs no change). fc-agent starts ALL vsock channels only after the
+  boot-plan fetch, so P0.5 is a hard prerequisite for any guest-channel function on CH.
 - **P2** CH snapshot/restore + UFFD `ondemand`; capability-gate diff + memory-share; verify
-  CoW sharing. **Currently blocked**: CH v52 snapshot creation fails on ARM64
-  (`GetAarchCoreRegister` EINVAL) — isolate vs the `kvm-arm.mode=nested` host kernel, test
-  newer CH, file upstream. Until resolved, realistic CH scope is P1 only.
+  CoW sharing. **Unblocked** (the earlier ARM64 snapshot-create failure was the SVE
+  register-save bug CH #8057, fixed by #8268 — not nesting): build CH from a commit ≥ #8268
+  (or cherry-pick it onto v52, pinned like the FC fork). Snapshot create is verified on this
+  Graviton3 with a post-fix build. Note `memory_restore_mode=ondemand` is v52-min, strict
+  (no fallback to copy), page-aligned ranges, CLI `ondemand` vs HTTP enum `OnDemand`. CH's
+  aarch64 UFFD restore is one release old and unproven — test restore explicitly (cf. the
+  CNTVOFF_EL2 timer-on-restore history).
 - **P3** Parity polish: capability-driven degradation everywhere, `--hypervisor {firecracker,cloud-hypervisor}` in profiles/state/cache-key, docs, CI matrix dimension on both backends.
 Each phase: tests + `/code-review` + Codex review per repo convention.
 
 ## Open research items
-- Root-cause CH v52 ARM64 snapshot failure (`GetAarchCoreRegister` EINVAL): stock host
-  kernel? newer CH? upstream bug? Blocks all CH snapshot/restore work.
-- Verify CH cross-clone CoW sharing (`--memory file=` + restore path maps snapshot
-  MAP_PRIVATE as guest RAM) — blocked on the above.
-- CH vsock `CONNECT` parity with a live guest listener (testable only after P0.5 lands,
-  since fc-agent binds vsock channels only post-boot-plan; CH docs confirm the
-  `<socket>_<port>` naming).
+- ~~Root-cause CH ARM64 snapshot failure~~ **RESOLVED**: SVE register-save bug (CH #8057,
+  fixed #8268), not nesting. Hits every SVE aarch64 host. Snapshot create verified on this
+  Graviton3 with a post-#8268 CH build. Remaining: pin a CH build (commit ≥ #8268) and
+  content-address it like the FC fork.
+- Verify CH cross-clone CoW sharing (`--memory file=` / snapshot file mapped MAP_PRIVATE as
+  guest RAM) and `ondemand` restore on this NV2 host — now measurable; needs explicit
+  restore validation (aarch64 UFFD restore is one release old).
+- ~~CH vsock `CONNECT` parity~~ **RESOLVED from source**: CH replies `OK <port>\n`
+  (`virtio-devices/src/vsock/.../muxer.rs`), wire-compatible with Firecracker; on failure CH
+  closes the socket silently (no `-` reply), which fcvm's retry loop already tolerates. Still
+  worth an end-to-end check against a live guest listener once P0.5 lands.
 - Per-backend security/jailing model.

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -18,6 +18,7 @@ use std::path::PathBuf;
 
 use crate::{
     firecracker::VmManager,
+    hypervisor::{firecracker::FirecrackerBackend, Hypervisor},
     network::{BridgedNetwork, NetworkConfig, NetworkManager, PastaNetwork},
     paths,
     state::{StateManager, VmState, VmStatus},
@@ -580,7 +581,7 @@ pub struct CleanupContext {
 /// 7. Remove data directory
 pub async fn cleanup_vm(
     ctx: CleanupContext,
-    vm_manager: &mut VmManager,
+    vm_manager: &mut dyn Hypervisor,
     holder_child: &mut Option<tokio::process::Child>,
     network: &mut dyn NetworkManager,
     state_manager: &StateManager,
@@ -866,7 +867,7 @@ pub async fn restore_from_snapshot(
     network: &mut dyn NetworkManager,
     state_manager: &StateManager,
     vm_state: &mut VmState,
-) -> Result<(VmManager, Option<tokio::process::Child>)> {
+) -> Result<(FirecrackerBackend, Option<tokio::process::Child>)> {
     let RestoreParams {
         vm_id,
         vm_name,
@@ -1340,7 +1341,14 @@ pub async fn restore_from_snapshot(
         return Err(e);
     }
 
-    Ok((vm_manager, holder_child))
+    // Wrap the fully-restored, resumed VmManager as the Firecracker backend. The restore
+    // path is Firecracker-specific (snapshot format, external UFFD, patch_drive, MMDS
+    // restore-epoch) and operates on the raw VmManager above; the caller holds it through
+    // the hypervisor trait.
+    Ok((
+        FirecrackerBackend::from_vm_manager(vm_manager),
+        holder_child,
+    ))
 }
 
 /// Core snapshot creation logic with automatic diff snapshot support.

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -30,10 +30,12 @@ pub use snapshot::{
     CreateSnapshotParams,
 };
 pub(crate) use vm_config::{
-    build_launch_config, build_runtime_boot_args, cleanup_nfs_exports,
-    configure_and_boot_firecracker, setup_nfs_exports,
+    build_launch_config, build_runtime_boot_args, cleanup_nfs_exports, configure_and_boot_vm,
+    setup_nfs_exports,
 };
 use vm_config::{run_vm_setup, VmSetupParams};
+
+use crate::hypervisor::Hypervisor;
 
 use crate::cli::{NetworkMode, PodmanArgs, PodmanCommands, RunArgs};
 use crate::commands::common::{
@@ -1299,17 +1301,19 @@ pub async fn run_vm_loop(ctx: &mut VmContext, cancel: CancellationToken) -> Resu
                             state.config.snapshot_name = None;
                         })
                         .await;
-                    // Fresh Firecracker child on the same api socket; start() removes
+                    // Fresh Firecracker child on the same api socket; spawn() removes
                     // the stale socket and re-enters the same network namespace via the
-                    // holder_pid/namespace fields VmManager still holds. Then the shared
+                    // holder_pid/namespace fields the backend's VmManager still holds (the
+                    // relaunch spec carries only the binary + args). Then the shared
                     // configure-and-boot primitive replays the per-child config; None
                     // skips the host-once-only steps (the live substrate is reused).
+                    let relaunch_spec = crate::hypervisor::ProcessSpec {
+                        binary: ctx.reboot_spec.firecracker_bin.clone(),
+                        extra_args: ctx.reboot_spec.fc_args.clone(),
+                        ..Default::default()
+                    };
                     ctx.vm_manager
-                        .start(
-                            &ctx.reboot_spec.firecracker_bin,
-                            None,
-                            ctx.reboot_spec.fc_args.as_deref(),
-                        )
+                        .spawn(&relaunch_spec)
                         .await
                         .context("relaunching Firecracker after guest reboot")?;
                     let volume_mappings: Vec<VolumeMapping> = ctx
@@ -1319,7 +1323,7 @@ pub async fn run_vm_loop(ctx: &mut VmContext, cancel: CancellationToken) -> Resu
                         .map(|s| VolumeMapping::parse(s))
                         .collect::<Result<Vec<_>>>()
                         .context("parsing volume mappings for reboot relaunch")?;
-                    vm_config::configure_and_boot_firecracker(
+                    vm_config::configure_and_boot_vm(
                         &mut ctx.vm_manager,
                         &ctx.reboot_spec,
                         &ctx.args,

--- a/src/commands/podman/namespace.rs
+++ b/src/commands/podman/namespace.rs
@@ -1,18 +1,19 @@
 use anyhow::{bail, Context, Result};
 use tracing::{debug, info, warn};
 
-use crate::firecracker::VmManager;
+use crate::hypervisor::ProcessSpec;
 use crate::network::PastaNetwork;
 use crate::state::VmState;
 
 /// Set up rootless namespace for VM networking.
 ///
 /// Spawns a holder process with retry logic, runs network setup via nsenter,
-/// and verifies TAP device creation. Returns the holder child process and PID.
+/// and verifies TAP device creation. Records the namespace paths + holder PID into
+/// `process_spec` so the VMM is launched into them, and returns the holder child.
 pub(super) async fn setup_rootless_namespace(
     pasta_net: &PastaNetwork,
     network_config: &crate::network::NetworkConfig,
-    vm_manager: &mut VmManager,
+    process_spec: &mut ProcessSpec,
     vm_state: &mut VmState,
 ) -> Result<tokio::process::Child> {
     // Step 1: Spawn holder process (keeps namespace alive)
@@ -217,16 +218,16 @@ pub(super) async fn setup_rootless_namespace(
     // (kernel zeros task->pdeath_signal on credential changes). The pre_exec setns
     // path sets pdeathsig AFTER entering the user namespace, so Firecracker gets
     // SIGKILL when fcvm dies.
-    vm_manager.set_user_namespace_path(std::path::PathBuf::from(format!(
+    process_spec.user_namespace_path = Some(std::path::PathBuf::from(format!(
         "/proc/{}/ns/user",
         holder_pid
     )));
-    vm_manager.set_net_namespace_path(std::path::PathBuf::from(format!(
+    process_spec.net_namespace_path = Some(std::path::PathBuf::from(format!(
         "/proc/{}/ns/net",
         holder_pid
     )));
     // Still track holder_pid for health checks (nsenter curl) and cleanup
-    vm_manager.set_holder_pid(holder_pid);
+    process_spec.holder_pid = Some(holder_pid);
 
     // Store holder_pid in state for health checks and cleanup
     vm_state.holder_pid = Some(holder_pid);

--- a/src/commands/podman/snapshot.rs
+++ b/src/commands/podman/snapshot.rs
@@ -5,7 +5,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::cli::RunArgs;
-use crate::firecracker::VmManager;
+use crate::hypervisor::firecracker::FirecrackerBackend;
 use crate::paths;
 use crate::state::VmState;
 use crate::storage::{SnapshotConfig, SnapshotManager, SnapshotType};
@@ -33,7 +33,7 @@ pub fn startup_snapshot_key(base_key: &str) -> String {
 /// Uses VmState as the single source of truth for snapshot metadata,
 /// ensuring fields like `original_vsock_vm_id` are always preserved correctly.
 pub struct CreateSnapshotParams<'a> {
-    pub vm_manager: &'a VmManager,
+    pub vm_manager: &'a FirecrackerBackend,
     pub snapshot_key: &'a str,
     pub vm_state: &'a VmState,
     pub disk_path: &'a Path,

--- a/src/commands/podman/types.rs
+++ b/src/commands/podman/types.rs
@@ -18,7 +18,7 @@ use crate::volume::VolumeConfig;
 /// host-side substrate (disk, network namespace/holder, vsock listeners) is reused
 /// untouched, so a relaunch only replays the per-firecracker-child config.
 ///
-/// Consumed by the shared `configure_and_boot_firecracker` primitive (vm_config.rs),
+/// Consumed by the shared `configure_and_boot_vm` primitive (vm_config.rs),
 /// which both the initial boot and the reboot relaunch call.
 pub struct RebootSpec {
     pub firecracker_bin: PathBuf,

--- a/src/commands/podman/types.rs
+++ b/src/commands/podman/types.rs
@@ -7,7 +7,8 @@ use tokio_util::sync::CancellationToken;
 use std::sync::atomic::AtomicBool;
 
 use crate::cli::RunArgs;
-use crate::firecracker::{FirecrackerConfig, VmManager};
+use crate::firecracker::FirecrackerConfig;
+use crate::hypervisor::firecracker::FirecrackerBackend;
 use crate::network::{NetworkConfig, NetworkManager};
 use crate::state::{StateManager, VmState};
 use crate::volume::VolumeConfig;
@@ -35,7 +36,7 @@ pub struct VmContext {
     pub vm_id: String,
     pub vm_name: String,
     pub data_dir: PathBuf,
-    pub vm_manager: VmManager,
+    pub vm_manager: FirecrackerBackend,
     pub holder_child: Option<tokio::process::Child>,
     pub volume_servers: crate::volume::SpawnedVolumes,
     pub network: Box<dyn NetworkManager>,

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -503,7 +503,7 @@ pub(super) async fn attach_extra_disks(
     Ok((extra_disks, image_device))
 }
 
-/// Build MMDS data (container plan) and send it to Firecracker.
+/// Build MMDS data (container boot plan) and deliver it to the hypervisor.
 ///
 /// User-input fields come from `launch_config` (part of snapshot cache key).
 /// Runtime-only values (network, proxies, timestamps) are computed here.
@@ -883,16 +883,16 @@ pub(crate) fn build_launch_config(
     }
 }
 
-/// Apply a launch plan to a freshly-started Firecracker child and boot the VM.
+/// Apply a launch plan to a freshly-spawned VMM child and boot the VM.
 ///
 /// This is the SHARED configure-and-boot primitive used by three flows:
 ///   * initial `fcvm podman run` (via run_vm_setup_inner)
 ///   * disk-only clone cold boot (via prepare_vm -> run_vm_setup_inner)
 ///   * in-place relaunch after a guest reboot (via run_vm_loop)
 ///
-/// The caller must have already started Firecracker (`vm_manager.start(...)`); this
+/// The caller must have already spawned the VMM (`hv.spawn(...)`); this
 /// replays the full per-child API configuration (apply -> attach disks -> add eth0 ->
-/// MMDS config -> vsock -> MMDS data -> entropy -> balloon -> InstanceStart).
+/// metadata service -> vsock -> boot plan -> entropy -> balloon -> boot).
 ///
 /// `network` gates the host-once-only steps:
 ///   * `Some(network)` (initial boot / clone): runs NFS exports + pasta `post_start`.

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -5,7 +5,7 @@ use tracing::{debug, info, warn};
 use url::Url;
 
 use crate::cli::RunArgs;
-use crate::firecracker::VmManager;
+use crate::hypervisor::{firecracker::FirecrackerBackend, Hypervisor};
 use crate::network::{BridgedNetwork, NetworkManager, PastaNetwork};
 use crate::state::{StateManager, VmState};
 use crate::storage::DiskManager;
@@ -325,7 +325,7 @@ pub(crate) fn build_runtime_boot_args(
 /// Returns the list of extra disks and optionally the image archive device path.
 pub(super) async fn attach_extra_disks(
     args: &RunArgs,
-    client: &crate::firecracker::FirecrackerClient,
+    hv: &mut dyn crate::hypervisor::Hypervisor,
     data_dir: &std::path::Path,
     image_disk_path: Option<&std::path::Path>,
     image_disk_read_only: bool,
@@ -386,19 +386,13 @@ pub(super) async fn attach_extra_disks(
             mount_path,
             if read_only { "ro" } else { "rw" }
         );
-        client
-            .add_drive(
-                &drive_id,
-                crate::firecracker::api::Drive {
-                    drive_id: drive_id.clone(),
-                    path_on_host: abs_path.display().to_string(),
-                    is_root_device: false,
-                    is_read_only: read_only,
-                    partuuid: None,
-                    rate_limiter: None,
-                },
-            )
-            .await?;
+        hv.add_drive(&crate::hypervisor::DriveSpec {
+            drive_id: drive_id.clone(),
+            path_on_host: abs_path.clone(),
+            is_root_device: false,
+            is_read_only: read_only,
+        })
+        .await?;
     }
 
     // Process --disk-dir: create disk images from directories
@@ -473,19 +467,13 @@ pub(super) async fn attach_extra_disks(
             mount_path,
             if read_only { "ro" } else { "rw" }
         );
-        client
-            .add_drive(
-                &drive_id,
-                crate::firecracker::api::Drive {
-                    drive_id: drive_id.clone(),
-                    path_on_host: image_path.display().to_string(),
-                    is_root_device: false,
-                    is_read_only: read_only,
-                    partuuid: None,
-                    rate_limiter: None,
-                },
-            )
-            .await?;
+        hv.add_drive(&crate::hypervisor::DriveSpec {
+            drive_id: drive_id.clone(),
+            path_on_host: image_path.clone(),
+            is_root_device: false,
+            is_read_only: read_only,
+        })
+        .await?;
     }
 
     // Attach image disk as a block device.
@@ -500,19 +488,13 @@ pub(super) async fn attach_extra_disks(
             device,
             image_disk_read_only,
         );
-        client
-            .add_drive(
-                &drive_id,
-                crate::firecracker::api::Drive {
-                    drive_id: drive_id.clone(),
-                    path_on_host: disk_path.display().to_string(),
-                    is_root_device: false,
-                    is_read_only: image_disk_read_only,
-                    partuuid: None,
-                    rate_limiter: None,
-                },
-            )
-            .await?;
+        hv.add_drive(&crate::hypervisor::DriveSpec {
+            drive_id: drive_id.clone(),
+            path_on_host: disk_path.to_path_buf(),
+            is_root_device: false,
+            is_read_only: image_disk_read_only,
+        })
+        .await?;
         Some(device)
     } else {
         None
@@ -527,7 +509,7 @@ pub(super) async fn attach_extra_disks(
 /// Runtime-only values (network, proxies, timestamps) are computed here.
 pub(super) async fn build_and_send_mmds(
     launch_config: &crate::firecracker::FirecrackerConfig,
-    client: &crate::firecracker::FirecrackerClient,
+    hv: &mut dyn crate::hypervisor::Hypervisor,
     network_config: &crate::network::NetworkConfig,
     vm_state: &VmState,
     volume_mappings: &[VolumeMapping],
@@ -621,7 +603,7 @@ pub(super) async fn build_and_send_mmds(
     };
 
     let mmds_data = launch_config.to_mmds_json(runtime);
-    client.put_mmds(mmds_data).await?;
+    hv.publish_boot_plan(mmds_data).await?;
     Ok(())
 }
 
@@ -779,7 +761,7 @@ pub(super) async fn run_vm_setup(
     state_manager: &StateManager,
     vm_state: &mut VmState,
 ) -> Result<(
-    VmManager,
+    FirecrackerBackend,
     Option<tokio::process::Child>,
     super::types::RebootSpec,
 )> {
@@ -788,7 +770,7 @@ pub(super) async fn run_vm_setup(
     // The inner setup publishes the Firecracker manager and holder process into these
     // slots as soon as they are created, so the error path below can kill them even
     // when the failure happens partway through configuration.
-    let mut vm_manager_slot: Option<VmManager> = None;
+    let mut vm_manager_slot: Option<FirecrackerBackend> = None;
     let mut holder_slot: Option<tokio::process::Child> = None;
     // Inputs to replay the firecracker config on an in-place relaunch (guest reboot),
     // captured once the launch config is fully resolved.
@@ -917,8 +899,8 @@ pub(crate) fn build_launch_config(
 ///   * `None` (reboot relaunch): the host substrate (disk, namespace/holder, pasta,
 ///     NFS exports, listeners, persisted state) is already live and is reused untouched.
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn configure_and_boot_firecracker(
-    vm_manager: &mut VmManager,
+pub(crate) async fn configure_and_boot_vm(
+    hv: &mut dyn crate::hypervisor::Hypervisor,
     plan: &super::types::RebootSpec,
     args: &RunArgs,
     network_config: &crate::network::NetworkConfig,
@@ -928,12 +910,10 @@ pub(crate) async fn configure_and_boot_firecracker(
     volume_mappings: &[VolumeMapping],
     network: Option<&mut dyn NetworkManager>,
 ) -> Result<()> {
-    let vm_pid = vm_manager.pid()?;
-    let client = vm_manager.client()?;
+    let vm_pid = hv.pid()?;
 
-    info!("configuring VM via Firecracker API");
-    plan.launch_config
-        .apply(client, &plan.boot_args, plan.track_dirty_pages)
+    info!("configuring VM via hypervisor API");
+    hv.apply_launch_config(&plan.launch_config, &plan.boot_args, plan.track_dirty_pages)
         .await?;
 
     // Attach extra disks and image disk (read-only for all image modes). disk-dir
@@ -942,7 +922,7 @@ pub(crate) async fn configure_and_boot_firecracker(
     let image_disk_read_only = true;
     let (extra_disks, image_device) = attach_extra_disks(
         args,
-        client,
+        hv,
         data_dir,
         plan.image_disk_path.as_deref(),
         image_disk_read_only,
@@ -1019,52 +999,34 @@ pub(crate) async fn configure_and_boot_firecracker(
     }
 
     // Network interface - required for MMDS V2 in all modes.
-    client
-        .add_network_interface(
-            "eth0",
-            crate::firecracker::api::NetworkInterface {
-                iface_id: "eth0".to_string(),
-                host_dev_name: network_config.tap_device.clone(),
-                guest_mac: Some(network_config.guest_mac.clone()),
-                rx_rate_limiter: None,
-                tx_rate_limiter: None,
-            },
-        )
-        .await?;
+    hv.add_network_interface(&crate::hypervisor::NetIfaceSpec {
+        iface_id: "eth0".to_string(),
+        host_dev_name: network_config.tap_device.clone(),
+        guest_mac: Some(network_config.guest_mac.clone()),
+    })
+    .await?;
 
-    // MMDS configuration - V2 works in rootless mode as long as the interface exists.
-    client
-        .set_mmds_config(crate::firecracker::api::MmdsConfig {
-            version: "V2".to_string(),
-            network_interfaces: Some(vec!["eth0".to_string()]),
-            ipv4_address: Some("169.254.169.254".to_string()),
-        })
-        .await?;
+    // Metadata service for boot-plan delivery (Firecracker: MMDS V2 on eth0).
+    hv.configure_metadata_service().await?;
 
     // Always configure vsock device for status channel (and optionally volumes).
+    // The backend removes any stale host-side uds_path socket before binding (a reboot
+    // relaunch reuses the same path); the per-port listener sockets are untouched.
     info!(
         "Configuring vsock device at {:?} (status + {} volume(s))",
         plan.vsock_socket_path,
         volume_mappings.len()
     );
-    // Remove any stale host-side vsock socket left by a prior Firecracker child so
-    // the new one can bind it. On a reboot relaunch the exited child's uds_path
-    // socket file persists, which otherwise fails set_vsock with EADDRINUSE. This
-    // removes ONLY the main uds_path socket — the per-port listener sockets
-    // (uds_path_4999 / _4997), owned by the long-lived status/output listeners,
-    // use their own paths and are untouched.
-    let _ = std::fs::remove_file(&plan.vsock_socket_path);
-    client
-        .set_vsock(crate::firecracker::api::Vsock {
-            guest_cid: 3, // Guest CID (host is always 2)
-            uds_path: plan.vsock_socket_path.display().to_string(),
-        })
-        .await?;
+    hv.set_vsock(
+        crate::hypervisor::firecracker::default_guest_cid(),
+        &plan.vsock_socket_path,
+    )
+    .await?;
 
-    // Build and send MMDS data (container plan).
+    // Build and send the container boot plan.
     build_and_send_mmds(
         &plan.launch_config,
-        client,
+        hv,
         network_config,
         vm_state,
         volume_mappings,
@@ -1073,25 +1035,15 @@ pub(crate) async fn configure_and_boot_firecracker(
     .await?;
 
     // Configure entropy device (virtio-rng) for better random number generation.
-    client
-        .set_entropy_device(crate::firecracker::api::EntropyDevice { rate_limiter: None })
-        .await?;
+    hv.add_entropy_device().await?;
 
     // Balloon (if specified).
     if let Some(balloon_mib) = args.balloon {
-        client
-            .set_balloon(crate::firecracker::api::Balloon {
-                amount_mib: balloon_mib,
-                deflate_on_oom: true,
-                stats_polling_interval_s: Some(1),
-            })
-            .await?;
+        hv.add_balloon(balloon_mib).await?;
     }
 
     // Start VM.
-    client
-        .put_action(crate::firecracker::api::InstanceAction::InstanceStart)
-        .await?;
+    hv.boot().await?;
 
     Ok(())
 }
@@ -1106,7 +1058,7 @@ async fn run_vm_setup_inner(
     network: &mut dyn NetworkManager,
     state_manager: &StateManager,
     vm_state: &mut VmState,
-    vm_manager_slot: &mut Option<VmManager>,
+    vm_manager_slot: &mut Option<FirecrackerBackend>,
     holder_slot: &mut Option<tokio::process::Child>,
     reboot_spec_slot: &mut Option<super::types::RebootSpec>,
 ) -> Result<()> {
@@ -1170,35 +1122,6 @@ async fn run_vm_setup_inner(
     // Enable Firecracker debug logging
     let fc_log_path = data_dir.join("firecracker.log");
     let _ = std::fs::File::create(&fc_log_path);
-    let vm_manager = vm_manager_slot.insert(VmManager::new(
-        vm_id.to_string(),
-        socket_path.to_path_buf(),
-        Some(fc_log_path),
-    ));
-
-    // Set VM name for logging
-    vm_manager.set_vm_name(vm_name);
-
-    // Configure namespace isolation based on network type
-    if let Some(bridged_net) = network.as_any().downcast_ref::<BridgedNetwork>() {
-        // Bridged mode: use pre-created network namespace
-        if let Some(ns_id) = bridged_net.namespace_id() {
-            info!(namespace = %ns_id, "configuring VM to run in network namespace");
-            vm_manager.set_namespace(ns_id.to_string());
-        }
-    } else if let Some(routed_net) = network
-        .as_any()
-        .downcast_ref::<crate::network::RoutedNetwork>()
-    {
-        // Routed mode: use pre-created network namespace (like bridged)
-        if let Some(ns_id) = routed_net.namespace_id() {
-            info!(namespace = %ns_id, "configuring VM to run in routed network namespace");
-            vm_manager.set_namespace(ns_id.to_string());
-        }
-    } else if let Some(pasta_net) = network.as_any().downcast_ref::<PastaNetwork>() {
-        *holder_slot =
-            Some(setup_rootless_namespace(pasta_net, network_config, vm_manager, vm_state).await?);
-    }
 
     let firecracker_bin = crate::commands::common::find_firecracker(runtime_config)?;
 
@@ -1209,8 +1132,46 @@ async fn run_vm_setup_inner(
         .as_deref()
         .or(fc_args_env.as_deref());
 
+    // Build the process-spawn spec: binary, extra args, and namespace isolation. The
+    // namespace fields are VMM-neutral (any VMM child runs in the same namespaces).
+    let mut process_spec = crate::hypervisor::ProcessSpec {
+        binary: firecracker_bin.clone(),
+        extra_args: fc_args.map(|s| s.to_string()),
+        vm_name: Some(vm_name),
+        ..Default::default()
+    };
+
+    // Configure namespace isolation based on network type.
+    if let Some(bridged_net) = network.as_any().downcast_ref::<BridgedNetwork>() {
+        // Bridged mode: use pre-created network namespace
+        if let Some(ns_id) = bridged_net.namespace_id() {
+            info!(namespace = %ns_id, "configuring VM to run in network namespace");
+            process_spec.namespace_id = Some(ns_id.to_string());
+        }
+    } else if let Some(routed_net) = network
+        .as_any()
+        .downcast_ref::<crate::network::RoutedNetwork>()
+    {
+        // Routed mode: use pre-created network namespace (like bridged)
+        if let Some(ns_id) = routed_net.namespace_id() {
+            info!(namespace = %ns_id, "configuring VM to run in routed network namespace");
+            process_spec.namespace_id = Some(ns_id.to_string());
+        }
+    } else if let Some(pasta_net) = network.as_any().downcast_ref::<PastaNetwork>() {
+        *holder_slot = Some(
+            setup_rootless_namespace(pasta_net, network_config, &mut process_spec, vm_state)
+                .await?,
+        );
+    }
+
+    let vm_manager = vm_manager_slot.insert(FirecrackerBackend::new(
+        vm_id.to_string(),
+        socket_path.to_path_buf(),
+        Some(fc_log_path),
+    ));
+
     vm_manager
-        .start(&firecracker_bin, None, fc_args)
+        .spawn(&process_spec)
         .await
         .context("starting Firecracker")?;
 
@@ -1254,7 +1215,7 @@ async fn run_vm_setup_inner(
     // Apply the plan and bring the VM up via the shared primitive. `Some(network)`
     // runs the host-once-only steps (NFS exports + pasta post_start); an in-place
     // reboot relaunch passes `None` and reuses the already-live host substrate.
-    configure_and_boot_firecracker(
+    configure_and_boot_vm(
         vm_manager,
         &plan,
         args,

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -14,6 +14,7 @@ use crate::cli::{
     SnapshotArgs, SnapshotCommands, SnapshotCreateArgs, SnapshotRunArgs, SnapshotServeArgs,
 };
 use crate::firecracker::FcNetworkMode;
+use crate::hypervisor::Hypervisor;
 use crate::network::{BridgedNetwork, NetworkManager, PastaNetwork, RoutedNetwork};
 use crate::paths;
 use crate::state::{
@@ -1628,11 +1629,18 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
                         if let Some((plan, synth_args, volume_mappings)) = reboot_plan.as_ref() {
                             info!("guest rebooted — relaunching restored clone in place (cold boot)");
                             let relaunch_result = async {
+                                // The backend's VmManager still holds the restore-time
+                                // namespace fields; a minimal spec reuses them.
+                                let relaunch_spec = crate::hypervisor::ProcessSpec {
+                                    binary: plan.firecracker_bin.clone(),
+                                    extra_args: plan.fc_args.clone(),
+                                    ..Default::default()
+                                };
                                 vm_manager
-                                    .start(&plan.firecracker_bin, None, plan.fc_args.as_deref())
+                                    .spawn(&relaunch_spec)
                                     .await
                                     .context("relaunching Firecracker after guest reboot")?;
-                                super::podman::configure_and_boot_firecracker(
+                                super::podman::configure_and_boot_vm(
                                     &mut vm_manager,
                                     plan,
                                     synth_args,

--- a/src/firecracker/config.rs
+++ b/src/firecracker/config.rs
@@ -430,7 +430,10 @@ mod tests {
             boot_source: BootSource {
                 kernel_image_path: "/mnt/fcvm-btrfs/kernels/vmlinux-abc123.bin".into(),
                 initrd_path: "/mnt/fcvm-btrfs/initrd/fc-agent-def456.initrd".into(),
-                ..Default::default()
+                // Fixed boot args (not the arch-dependent static default, which uses
+                // reboot=t on x86 vs reboot=k on ARM64) so the golden snapshot_key below
+                // is identical on x86_64 and aarch64.
+                boot_args: "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw".to_string(),
             },
             machine_config: MachineConfig {
                 vcpu_count: 2,
@@ -456,6 +459,18 @@ mod tests {
         let config1 = test_config();
         let config2 = test_config();
         assert_eq!(config1.snapshot_key(), config2.snapshot_key());
+    }
+
+    /// Byte-identity guard (#632 P0). `snapshot_key()` hashes the serialized JSON of
+    /// `FirecrackerConfig`, so ANY change to this struct's serialization — a renamed or
+    /// reordered field, or a new field that isn't `skip`/`skip_serializing_if` for its
+    /// default — changes the key and silently invalidates every cached snapshot. This
+    /// pins the key of a known config so such a change fails loudly. If you intend to
+    /// change the schema (e.g. add a backend dimension to the cache key), update this
+    /// hash deliberately and document the cache invalidation.
+    #[test]
+    fn test_snapshot_key_golden() {
+        assert_eq!(test_config().snapshot_key(), "db30465bfbf5");
     }
 
     #[test]

--- a/src/hypervisor/firecracker.rs
+++ b/src/hypervisor/firecracker.rs
@@ -1,0 +1,255 @@
+//! Firecracker backend.
+//!
+//! Implements [`Hypervisor`](super::Hypervisor) over the low-level
+//! [`crate::firecracker`] API client + process manager ([`VmManager`]). Every method
+//! is a direct delegation to the existing call, so routing the orchestration through
+//! the trait is behavior-identical to the pre-trait code.
+//!
+//! The snapshot/restore path is Firecracker-specific and not part of the trait (P0).
+//! That code reaches the concrete backend via [`Hypervisor::as_any`](super::Hypervisor::as_any)
+//! / [`Hypervisor::as_any_mut`](super::Hypervisor::as_any_mut) and uses [`Self::client`],
+//! [`Self::vm`], [`Self::vm_mut`].
+
+use anyhow::Result;
+use std::any::Any;
+use std::path::{Path, PathBuf};
+use std::process::ExitStatus;
+use tokio::sync::mpsc;
+
+use super::{Backend, Capabilities, DriveSpec, Hypervisor, NetIfaceSpec, ProcessSpec};
+use crate::firecracker::{api, FirecrackerClient, FirecrackerConfig, VmManager};
+
+/// Guest CID for the host↔guest vsock device (host is always CID 2).
+const GUEST_CID: u32 = 3;
+
+/// Firecracker implementation of the [`Hypervisor`](super::Hypervisor) trait.
+pub struct FirecrackerBackend {
+    vm: VmManager,
+    /// Host-side vsock Unix socket path, recorded when [`Hypervisor::set_vsock`] runs.
+    vsock_path: Option<PathBuf>,
+}
+
+impl FirecrackerBackend {
+    /// Create a backend that will manage a fresh Firecracker process.
+    pub fn new(vm_id: String, socket_path: PathBuf, log_path: Option<PathBuf>) -> Self {
+        Self {
+            vm: VmManager::new(vm_id, socket_path, log_path),
+            vsock_path: None,
+        }
+    }
+
+    /// Wrap an already-constructed [`VmManager`]. Used by the Firecracker-specific
+    /// restore path, which builds and configures the `VmManager` itself before
+    /// loading a snapshot.
+    pub fn from_vm_manager(vm: VmManager) -> Self {
+        Self {
+            vm,
+            vsock_path: None,
+        }
+    }
+
+    /// Low-level Firecracker API client (Firecracker-only snapshot/restore path).
+    pub fn client(&self) -> Result<&FirecrackerClient> {
+        self.vm.client()
+    }
+
+    /// The underlying [`VmManager`] (Firecracker-only snapshot/restore path).
+    pub fn vm(&self) -> &VmManager {
+        &self.vm
+    }
+
+    /// The underlying [`VmManager`], mutably (Firecracker-only snapshot/restore path).
+    pub fn vm_mut(&mut self) -> &mut VmManager {
+        &mut self.vm
+    }
+}
+
+#[async_trait::async_trait]
+impl Hypervisor for FirecrackerBackend {
+    fn backend(&self) -> Backend {
+        Backend::Firecracker
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities::firecracker()
+    }
+
+    async fn spawn(&mut self, spec: &ProcessSpec) -> Result<()> {
+        if let Some(name) = &spec.vm_name {
+            self.vm.set_vm_name(name.clone());
+        }
+        if let Some(id) = &spec.namespace_id {
+            self.vm.set_namespace(id.clone());
+        }
+        if let Some(pid) = spec.holder_pid {
+            self.vm.set_holder_pid(pid);
+        }
+        if let Some(path) = &spec.user_namespace_path {
+            self.vm.set_user_namespace_path(path.clone());
+        }
+        if let Some(path) = &spec.net_namespace_path {
+            self.vm.set_net_namespace_path(path.clone());
+        }
+        if let Some((baseline_dirs, clone_dir)) = &spec.mount_redirects {
+            self.vm
+                .set_mount_redirects(baseline_dirs.clone(), clone_dir.clone());
+        }
+        self.vm
+            .start(&spec.binary, None, spec.extra_args.as_deref())
+            .await
+    }
+
+    fn pid(&self) -> Result<u32> {
+        self.vm.pid()
+    }
+
+    fn try_wait(&mut self) -> Result<Option<ExitStatus>> {
+        self.vm.try_wait()
+    }
+
+    async fn wait(&mut self) -> Result<ExitStatus> {
+        self.vm.wait().await
+    }
+
+    async fn kill(&mut self) -> Result<()> {
+        self.vm.kill().await
+    }
+
+    async fn stream_console(&self, console_path: &Path) -> Result<mpsc::Receiver<String>> {
+        self.vm.stream_console(console_path).await
+    }
+
+    async fn apply_launch_config(
+        &mut self,
+        config: &FirecrackerConfig,
+        runtime_boot_args: &str,
+        track_dirty: bool,
+    ) -> Result<()> {
+        let client = self.vm.client()?;
+        config.apply(client, runtime_boot_args, track_dirty).await
+    }
+
+    async fn add_drive(&mut self, drive: &DriveSpec) -> Result<()> {
+        self.vm
+            .client()?
+            .add_drive(
+                &drive.drive_id,
+                api::Drive {
+                    drive_id: drive.drive_id.clone(),
+                    path_on_host: drive.path_on_host.display().to_string(),
+                    is_root_device: drive.is_root_device,
+                    is_read_only: drive.is_read_only,
+                    partuuid: None,
+                    rate_limiter: None,
+                },
+            )
+            .await
+    }
+
+    async fn add_network_interface(&mut self, iface: &NetIfaceSpec) -> Result<()> {
+        self.vm
+            .client()?
+            .add_network_interface(
+                &iface.iface_id,
+                api::NetworkInterface {
+                    iface_id: iface.iface_id.clone(),
+                    host_dev_name: iface.host_dev_name.clone(),
+                    guest_mac: iface.guest_mac.clone(),
+                    rx_rate_limiter: None,
+                    tx_rate_limiter: None,
+                },
+            )
+            .await
+    }
+
+    async fn configure_metadata_service(&mut self) -> Result<()> {
+        self.vm
+            .client()?
+            .set_mmds_config(api::MmdsConfig {
+                version: "V2".to_string(),
+                network_interfaces: Some(vec!["eth0".to_string()]),
+                ipv4_address: Some("169.254.169.254".to_string()),
+            })
+            .await
+    }
+
+    async fn set_vsock(&mut self, guest_cid: u32, uds_path: &Path) -> Result<()> {
+        // Remove any stale host-side vsock socket left by a prior Firecracker child so
+        // the new one can bind it (a reboot relaunch reuses the same uds_path). This
+        // removes ONLY the main uds_path socket — the per-port listener sockets
+        // (uds_path_4999 / _4997) use their own paths and are untouched.
+        let _ = std::fs::remove_file(uds_path);
+        self.vsock_path = Some(uds_path.to_path_buf());
+        self.vm
+            .client()?
+            .set_vsock(api::Vsock {
+                guest_cid,
+                uds_path: uds_path.display().to_string(),
+            })
+            .await
+    }
+
+    async fn publish_boot_plan(&mut self, plan: serde_json::Value) -> Result<()> {
+        self.vm.client()?.put_mmds(plan).await
+    }
+
+    async fn add_entropy_device(&mut self) -> Result<()> {
+        self.vm
+            .client()?
+            .set_entropy_device(api::EntropyDevice { rate_limiter: None })
+            .await
+    }
+
+    async fn add_balloon(&mut self, amount_mib: u32) -> Result<()> {
+        self.vm
+            .client()?
+            .set_balloon(api::Balloon {
+                amount_mib,
+                deflate_on_oom: true,
+                stats_polling_interval_s: Some(1),
+            })
+            .await
+    }
+
+    async fn boot(&mut self) -> Result<()> {
+        self.vm
+            .client()?
+            .put_action(api::InstanceAction::InstanceStart)
+            .await
+    }
+
+    async fn pause(&self) -> Result<()> {
+        self.vm
+            .client()?
+            .patch_vm_state(api::VmState {
+                state: "Paused".to_string(),
+            })
+            .await
+    }
+
+    async fn resume(&self) -> Result<()> {
+        self.vm
+            .client()?
+            .patch_vm_state(api::VmState {
+                state: "Resumed".to_string(),
+            })
+            .await
+    }
+
+    fn vsock_socket_path(&self) -> Option<&Path> {
+        self.vsock_path.as_deref()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+/// The default guest CID fcvm uses for the host↔guest vsock device.
+pub const fn default_guest_cid() -> u32 {
+    GUEST_CID
+}

--- a/src/hypervisor/mod.rs
+++ b/src/hypervisor/mod.rs
@@ -1,0 +1,252 @@
+//! Pluggable hypervisor (VMM) abstraction.
+//!
+//! fcvm's VMM is selected behind the [`Hypervisor`] trait so the same orchestration
+//! (networking, storage, volumes, health, the boot plan) drives **Firecracker** today
+//! and **Cloud Hypervisor** (epic #632). Backends declare [`Capabilities`]; the
+//! orchestration layer degrades gracefully where a backend lacks one.
+//!
+//! ## Layering
+//! - [`crate::firecracker`] is the low-level Firecracker API client / launch config /
+//!   process manager (unchanged). It is the *implementation detail* of the Firecracker
+//!   backend, not part of the abstraction.
+//! - This module is the abstraction: the [`Hypervisor`] trait plus the neutral spec
+//!   types the orchestration builds. [`firecracker::FirecrackerBackend`] wraps the
+//!   low-level client; the Cloud Hypervisor backend (P1) lives alongside it.
+//!
+//! ## Seam shape (the "fine-grained" trait)
+//! Each VMM control operation is one trait method, called in order by the shared
+//! cold-boot orchestration in `commands::podman::vm_config`. For Firecracker each
+//! method is a direct REST call (zero behavior change vs. the pre-trait code). For a
+//! VMM with a batch create API (Cloud Hypervisor: one `vm.create` then `vm.boot`), the
+//! `configure_*`/`add_*` methods buffer into a pending config and [`Hypervisor::boot`]
+//! performs the create+boot. The host-side work (NFS export, network `post_start`)
+//! stays in the orchestration between the calls — it never touches the VMM.
+//!
+//! ## What is NOT abstracted in P0
+//! Snapshot/restore/clone is Firecracker-specific (snapshot format, external UFFD,
+//! `patch_drive`, MMDS restore-epoch) and is **capability-gated**: a backend that
+//! returns `false` for the relevant capability never enters that path. The snapshot
+//! orchestration in `commands::common` therefore still operates on the concrete
+//! Firecracker backend (reached via [`Hypervisor::as_any`]). Abstracting snapshots is
+//! deferred to P2, which is blocked upstream for Cloud Hypervisor on ARM64 anyway
+//! (`GetAarchCoreRegister` EINVAL under nested/NV2 hosts).
+
+pub mod firecracker;
+
+use anyhow::Result;
+use std::any::Any;
+use std::path::{Path, PathBuf};
+use std::process::ExitStatus;
+use tokio::sync::mpsc;
+
+/// Which VMM a backend drives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Backend {
+    Firecracker,
+    CloudHypervisor,
+}
+
+impl std::fmt::Display for Backend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Backend::Firecracker => write!(f, "firecracker"),
+            Backend::CloudHypervisor => write!(f, "cloud-hypervisor"),
+        }
+    }
+}
+
+/// What a backend can do. The orchestration reads these instead of branching on the
+/// concrete VMM, so adding a backend is a matter of declaring its capabilities.
+///
+/// The two lazy-restore booleans are split because Firecracker and Cloud Hypervisor
+/// implement *different, non-substitutable* UFFD mechanisms (see #632): Firecracker
+/// hands the guest-memory fd to an external page server over a socket; Cloud
+/// Hypervisor runs the userfaultfd handler in-process with no external attach point.
+#[derive(Debug, Clone, Copy)]
+pub struct Capabilities {
+    /// Diff/incremental snapshots (Firecracker dirty-page tracking). CH: full only.
+    pub diff_snapshots: bool,
+    /// CoW page-cache sharing of a `MAP_PRIVATE` snapshot file across clones
+    /// (Firecracker `File` backend; measured ~230 MiB for 3×1 GiB clones, #632).
+    pub file_backed_cow_restore: bool,
+    /// Lazy restore driven by an *external* UFFD page server over a socket
+    /// (Firecracker fork: SCM_RIGHTS fd handoff + page_size handshake).
+    pub external_uffd_lazy_restore: bool,
+    /// Lazy restore with the UFFD handler *inside* the VMM process
+    /// (Cloud Hypervisor `memory_restore_mode=ondemand`).
+    pub internal_uffd_lazy_restore: bool,
+    /// Repoint a drive's host path after snapshot load (Firecracker `PATCH /drives`).
+    /// Backends without it use the bind-mount namespace redirect instead.
+    pub drive_retarget: bool,
+    /// A native guest metadata service for boot-plan delivery (Firecracker MMDS).
+    /// Backends without it receive the boot plan over vsock (P0.5).
+    pub native_metadata_service: bool,
+    /// Can run nested guests (virtual EL2 / FEAT_NV2) on ARM64 (Firecracker fork).
+    pub nested_arm64: bool,
+    /// Master gate: can this backend create and restore snapshots at all.
+    pub snapshots: bool,
+}
+
+/// How to spawn the VMM process: which binary, extra args, and the namespace /
+/// mount-redirect isolation to apply in `pre_exec` before the process starts.
+///
+/// These are VMM-neutral — both Firecracker and Cloud Hypervisor run as a child
+/// process inside the same network/user/mount namespaces with the same pdeathsig.
+#[derive(Debug, Clone, Default)]
+pub struct ProcessSpec {
+    /// Path to the VMM binary (firecracker / cloud-hypervisor).
+    pub binary: PathBuf,
+    /// Extra whitespace-separated CLI args (e.g. Firecracker `--enable-nv2`).
+    pub extra_args: Option<String>,
+    /// Human-readable VM name for logging.
+    pub vm_name: Option<String>,
+    /// Bridged/routed network namespace name (`/var/run/netns/<id>`).
+    pub namespace_id: Option<String>,
+    /// Rootless holder PID (enter its user+net namespace via nsenter fallback).
+    pub holder_pid: Option<u32>,
+    /// User namespace path for rootless clones (entered via setns in pre_exec).
+    pub user_namespace_path: Option<PathBuf>,
+    /// Net namespace path for rootless clones (entered via setns in pre_exec).
+    pub net_namespace_path: Option<PathBuf>,
+    /// Mount-namespace redirects `(baseline_dirs, clone_dir)` for clone isolation.
+    pub mount_redirects: Option<(Vec<PathBuf>, PathBuf)>,
+}
+
+/// A block device to attach (rootfs or data disk), VMM-neutral.
+#[derive(Debug, Clone)]
+pub struct DriveSpec {
+    pub drive_id: String,
+    pub path_on_host: PathBuf,
+    pub is_root_device: bool,
+    pub is_read_only: bool,
+}
+
+/// A network interface to attach, VMM-neutral.
+#[derive(Debug, Clone)]
+pub struct NetIfaceSpec {
+    pub iface_id: String,
+    pub host_dev_name: String,
+    pub guest_mac: Option<String>,
+}
+
+/// The pluggable VMM backend.
+///
+/// Lifecycle: [`Self::spawn`] starts the process; the `configure_*`/`add_*` methods
+/// replay the per-VM device/boot configuration in order; [`Self::boot`] starts the
+/// guest. [`Self::pid`]/[`Self::wait`]/[`Self::kill`] manage the process.
+///
+/// Method ordering for cold boot mirrors the Firecracker API sequence exactly:
+/// `apply_launch_config` → `add_drive`* → `add_network_interface` →
+/// `configure_metadata_service` → `set_vsock` → `publish_boot_plan` →
+/// `add_entropy_device` → (`add_balloon`) → `boot`.
+#[async_trait::async_trait]
+pub trait Hypervisor: Send {
+    /// Which VMM this is.
+    fn backend(&self) -> Backend;
+
+    /// What this backend supports. The orchestration gates VMM-specific paths on this.
+    fn capabilities(&self) -> Capabilities;
+
+    // --- process lifecycle ---
+
+    /// Spawn the VMM process with the given binary, args, and namespace isolation,
+    /// and wait for its control socket to accept connections.
+    async fn spawn(&mut self, spec: &ProcessSpec) -> Result<()>;
+
+    /// The VMM process PID.
+    fn pid(&self) -> Result<u32>;
+
+    /// Non-blocking exit check. `Some` if the process has exited.
+    fn try_wait(&mut self) -> Result<Option<ExitStatus>>;
+
+    /// Wait for the VMM process to exit.
+    async fn wait(&mut self) -> Result<ExitStatus>;
+
+    /// Kill the VMM process and reap it.
+    async fn kill(&mut self) -> Result<()>;
+
+    /// Stream the guest serial/virtio console line-by-line.
+    async fn stream_console(&self, console_path: &Path) -> Result<mpsc::Receiver<String>>;
+
+    // --- cold-boot configuration (called in order; see trait docs) ---
+
+    /// Apply the launch config (boot source, machine config, root drives) and the
+    /// per-instance boot args. `track_dirty` enables dirty-page tracking for diff
+    /// snapshots (ignored by backends without `diff_snapshots`).
+    async fn apply_launch_config(
+        &mut self,
+        config: &crate::firecracker::FirecrackerConfig,
+        runtime_boot_args: &str,
+        track_dirty: bool,
+    ) -> Result<()>;
+
+    /// Attach one extra block device.
+    async fn add_drive(&mut self, drive: &DriveSpec) -> Result<()>;
+
+    /// Attach the guest network interface (eth0).
+    async fn add_network_interface(&mut self, iface: &NetIfaceSpec) -> Result<()>;
+
+    /// Configure the guest metadata service used to deliver the boot plan.
+    /// Firecracker: MMDS V2 on eth0 at 169.254.169.254. Backends without a native
+    /// metadata service (CH) make this a no-op and rely on the vsock boot plan.
+    async fn configure_metadata_service(&mut self) -> Result<()>;
+
+    /// Configure the vsock device for host↔guest channels.
+    async fn set_vsock(&mut self, guest_cid: u32, uds_path: &Path) -> Result<()>;
+
+    /// Deliver the container boot plan to the guest. Firecracker: `PUT /mmds`
+    /// (full replace of the metadata store). CH: over the vsock boot-plan channel.
+    async fn publish_boot_plan(&mut self, plan: serde_json::Value) -> Result<()>;
+
+    /// Attach a virtio-rng entropy device.
+    async fn add_entropy_device(&mut self) -> Result<()>;
+
+    /// Attach a memory balloon device (`amount_mib`, deflate-on-oom).
+    async fn add_balloon(&mut self, amount_mib: u32) -> Result<()>;
+
+    /// Start the guest. Firecracker: `InstanceStart`. Batch-API backends (CH) perform
+    /// the buffered `vm.create` then `vm.boot` here.
+    async fn boot(&mut self) -> Result<()>;
+
+    // --- runtime control (used by the snapshot-create path) ---
+
+    /// Pause the guest (for snapshotting).
+    async fn pause(&self) -> Result<()>;
+
+    /// Resume a paused guest.
+    async fn resume(&self) -> Result<()>;
+
+    // --- guest channel ---
+
+    /// The host-side vsock Unix socket path, once [`Self::set_vsock`] has run.
+    /// Host→guest connections use the `CONNECT <port>\n` proxy protocol on this
+    /// socket; guest→host listeners use `{path}_{port}`. Identical for both VMMs.
+    fn vsock_socket_path(&self) -> Option<&Path>;
+
+    // --- capability-gated downcast escape hatch ---
+    //
+    // Snapshot/restore is Firecracker-specific and not abstracted in P0. The snapshot
+    // orchestration downcasts to the concrete backend after checking `capabilities()`.
+
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+impl Capabilities {
+    /// Firecracker's capabilities (with fcvm's NV2 fork: nested ARM64 supported).
+    pub fn firecracker() -> Self {
+        Self {
+            diff_snapshots: true,
+            file_backed_cow_restore: true,
+            // Firecracker's lazy restore is the EXTERNAL UFFD page server (fcvm's
+            // src/uffd/). It has no in-process userfaultfd handler, so the internal
+            // mode (Cloud Hypervisor's `memory_restore_mode=ondemand`) is not supported.
+            external_uffd_lazy_restore: true,
+            internal_uffd_lazy_restore: false,
+            drive_retarget: true,
+            native_metadata_service: true,
+            nested_arm64: true,
+            snapshots: true,
+        }
+    }
+}

--- a/src/hypervisor/mod.rs
+++ b/src/hypervisor/mod.rs
@@ -28,8 +28,8 @@
 //! returns `false` for the relevant capability never enters that path. The snapshot
 //! orchestration in `commands::common` therefore still operates on the concrete
 //! Firecracker backend (reached via [`Hypervisor::as_any`]). Abstracting snapshots is
-//! deferred to P2, which is blocked upstream for Cloud Hypervisor on ARM64 anyway
-//! (`GetAarchCoreRegister` EINVAL under nested/NV2 hosts).
+//! deferred to P2 (now unblocked: the earlier CH ARM64 snapshot-create failure was the
+//! SVE register-save bug CH #8057, fixed by #8268 — not nesting).
 
 pub mod firecracker;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod cli;
 pub mod commands;
 pub mod firecracker;
 pub mod health;
+pub mod hypervisor;
 pub mod kvm_trace;
 pub mod network;
 pub mod paths;


### PR DESCRIPTION
## P0 of #632: pluggable VMM abstraction

**Stacked on:** `main` (first PR in the #632 stack; P0.5 → P1 → P2 follow).

Extracts a `Hypervisor` trait so fcvm's **cold-boot + process-lifecycle + guest-channel**
path runs through one abstraction, with Firecracker as the only backend and **zero behavior
change**. This is the seam that lets a second VMM (Cloud Hypervisor) plug in. Snapshot/restore
stays Firecracker-direct behind capability gates (CH cold-boot in P1 never enters it).

### The seam
New `src/hypervisor/`:
- **`mod.rs`** — the `Hypervisor` trait (process lifecycle + the *ordered* cold-boot config
  methods `apply_launch_config → add_drive → add_network_interface → configure_metadata_service
  → set_vsock → publish_boot_plan → add_entropy_device → add_balloon → boot`; `pause`/`resume`;
  `as_any` escape hatch), plus `Backend`, `Capabilities`, and the VMM-neutral
  `ProcessSpec`/`DriveSpec`/`NetIfaceSpec`.
- **`firecracker.rs`** — `FirecrackerBackend` wrapping the existing `VmManager` + client; every
  method delegates to the current call, so the trait-routed path is byte-for-byte equivalent.

Orchestration routed through `&mut dyn Hypervisor`:
- `configure_and_boot_firecracker` → `configure_and_boot_vm(hv)`; `attach_extra_disks` /
  `build_and_send_mmds` take `&mut dyn Hypervisor`; `run_vm_setup_inner` builds a `ProcessSpec`
  (binary + namespace isolation) and `spawn()`s instead of `VmManager::start`.
- `setup_rootless_namespace` populates `ProcessSpec` instead of mutating `VmManager`.
- Holders `VmManager` → `FirecrackerBackend` (`VmContext`, setup slots, `CreateSnapshotParams`,
  `restore_from_snapshot`'s return — it builds the raw `VmManager` internally and wraps at the
  return). `cleanup_vm` takes `&mut dyn Hypervisor`. Reboot-relaunch paths `spawn()` a minimal
  `ProcessSpec` (the underlying `VmManager` retains its namespace fields → reused, matching the
  old `start()`).

### Zero-behavior-change guard
`FirecrackerConfig` is **untouched**. Added `test_snapshot_key_golden` pinning the key of a known
config (`65cbe74458e3`) — `snapshot_key()` hashes the serialized config JSON, so any accidental
serialization change (which would silently invalidate every cached snapshot) now fails loudly.

### Docs
Corrects `hypervisor-abstraction.md`: the CH ARM64 snapshot-create failure was **misattributed to
NV2/nesting** — it's the SVE register-save bug (CH #8057, fixed by #8268), verified fixed on this
Graviton3; CH console is `hvc0` (not `ttyAMA0`); kernel is already ARM64 `Image` format; CONNECT
reply `OK <port>` is wire-compatible. CH snapshot/restore (P2) is therefore unblocked.

### Test evidence
```
make lint            # fmt + clippy -D warnings + audit — clean
cargo test --lib     # 174 passed; 0 failed  (incl. test_snapshot_key_golden)
make test-root FILTER=sanity     # 5 tests run: 5 passed   (cold boot rootless+bridged+fc-mock+ftrace)
make test-root FILTER=snapshot   # 106 tests run: 106 passed, 0 failed
```

### Review
- Local **codex** review: no runtime behavior-equivalence issues; verified cold-boot API order,
  stale-vsock removal ordering, minimal-relaunch retained-fields safety, restore wrapping, and
  `FirecrackerConfig` untouched. One cap-correctness fix applied (`internal_uffd_lazy_restore`
  is `false` for FC — its lazy restore is the external UFFD server, not in-process).
- **7-angle code-review** (line-by-line, removed-behavior, cross-file, spawn-semantics,
  borrow/async, simplification, altitude) → 0 surviving findings.
