### PR TITLE
feat(hypervisor): boot plan over vsock for non-MMDS VMMs (P0.5, #632)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -456,8 +456,8 @@ plumbing — the disk itself carries the signal.
 
 Every VM is configured "reboot possible" **up front**: each lifecycle path builds a
 launch plan (`RebootSpec`: firecracker binary/args, fully-resolved launch config,
-boot args, vsock path) before the VM runs, and all paths boot through one shared
-primitive, `configure_and_boot_vm`:
+boot args, vsock path, boot-plan transport) before the VM runs, and all paths boot
+through one shared primitive, `configure_and_boot_vm`:
 
 - initial `fcvm podman run` boot
 - disk-only clone cold boot (via `prepare_vm` with `rootfs_override`)

--- a/fc-agent/src/agent.rs
+++ b/fc-agent/src/agent.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use tokio::time::{sleep, Duration};
 
-use crate::{container, exec, lock_test, mmds, mounts, network, output, proxy, system};
+use crate::{bootplan, container, exec, lock_test, mmds, mounts, network, output, proxy, system};
 
 /// Main agent logic — fetches plan, runs container, triggers shutdown.
 pub async fn run() -> Result<()> {
@@ -19,15 +19,19 @@ pub async fn run() -> Result<()> {
     network::configure_dns_from_cmdline();
     network::configure_ipv6_from_cmdline();
 
-    // Fetch plan from MMDS with retry
+    // Select the boot-plan transport (MMDS for Firecracker, vsock for VMMs without a
+    // metadata service like Cloud Hypervisor) from the kernel command line.
+    let transport = bootplan::detect_transport();
+
+    // Fetch the container plan with retry.
     let plan = loop {
-        match mmds::fetch_plan().await {
+        match bootplan::fetch_plan(transport).await {
             Ok(p) => {
                 eprintln!("[fc-agent] received container plan successfully");
                 break p;
             }
             Err(e) => {
-                eprintln!("[fc-agent] MMDS not ready: {:?}", e);
+                eprintln!("[fc-agent] boot plan not ready: {:?}", e);
                 eprintln!("[fc-agent] retrying in 500ms...");
                 sleep(Duration::from_millis(500)).await;
             }
@@ -63,7 +67,7 @@ pub async fn run() -> Result<()> {
         None
     };
 
-    if let Err(e) = mmds::sync_clock_from_host().await {
+    if let Err(e) = bootplan::sync_clock_from_host(transport).await {
         eprintln!("[fc-agent] WARNING: clock sync failed: {:?}", e);
         eprintln!("[fc-agent] continuing anyway (will rely on chronyd)");
     }
@@ -90,21 +94,25 @@ pub async fn run() -> Result<()> {
     let exec_rebind_done = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let exec_rebind_done_notify = std::sync::Arc::new(tokio::sync::Notify::new());
 
-    // Start restore-epoch watcher
-    let restore_signals = crate::restore::RestoreSignals {
-        output: output.clone(),
-        restore_flag: restore_flag.clone(),
-        exec_rebind: exec_rebind.clone(),
-        exec_rebind_needed: exec_rebind_needed.clone(),
-        exec_rebind_done: exec_rebind_done.clone(),
-        exec_rebind_done_notify: exec_rebind_done_notify.clone(),
-        egress_gen_rx: egress_gen_rx.clone(),
-        nfs_mounts: plan.nfs_mounts.clone(),
-    };
-    tokio::spawn(async move {
-        eprintln!("[fc-agent] starting restore-epoch watcher");
-        mmds::watch_restore_epoch(restore_signals).await;
-    });
+    // Start restore-epoch watcher (Firecracker/MMDS only). Vsock restore-epoch delivery
+    // for Cloud Hypervisor clone/restore is P2; under the vsock transport the MMDS
+    // watcher would only spam failed 169.254.169.254 polls, so skip it.
+    if transport == bootplan::Transport::Mmds {
+        let restore_signals = crate::restore::RestoreSignals {
+            output: output.clone(),
+            restore_flag: restore_flag.clone(),
+            exec_rebind: exec_rebind.clone(),
+            exec_rebind_needed: exec_rebind_needed.clone(),
+            exec_rebind_done: exec_rebind_done.clone(),
+            exec_rebind_done_notify: exec_rebind_done_notify.clone(),
+            egress_gen_rx: egress_gen_rx.clone(),
+            nfs_mounts: plan.nfs_mounts.clone(),
+        };
+        tokio::spawn(async move {
+            eprintln!("[fc-agent] starting restore-epoch watcher");
+            mmds::watch_restore_epoch(restore_signals).await;
+        });
+    }
 
     // Write storage.conf with driver = "overlay" before starting the exec server.
     // The health monitor runs `podman inspect` as soon as exec accepts connections.

--- a/fc-agent/src/bootplan.rs
+++ b/fc-agent/src/bootplan.rs
@@ -1,0 +1,131 @@
+//! Boot-plan transport.
+//!
+//! fc-agent fetches its container plan + host metadata either from **MMDS**
+//! (Firecracker's metadata service) or over **vsock** (for VMMs without MMDS, e.g.
+//! Cloud Hypervisor — #632 P0.5). The transport is chosen from the kernel command
+//! line: `fcvm_bootplan=vsock` selects vsock, otherwise MMDS (the Firecracker default).
+//!
+//! Wire format (vsock): the host serves the same `latest` object MMDS would expose —
+//! `{ "container-plan": { ...Plan... }, "host-time": "<epoch>" }` — on
+//! [`BOOTPLAN_VSOCK_PORT`]. The guest connects to the host (CID 2), reads the JSON to
+//! EOF, and extracts the plan and metadata. Restore-epoch delivery over vsock (for CH
+//! clone/restore) is deferred to P2; the MMDS restore watcher stays Firecracker-only.
+
+use anyhow::{Context, Result};
+use tokio::io::AsyncReadExt;
+use tokio::process::Command;
+
+use crate::types::{LatestMetadata, Plan};
+use crate::vsock::{VsockStream, HOST_CID};
+
+/// Vsock port the host serves the boot plan on (guest connects to host CID 2).
+/// Distinct from 4996 (tty) / 4997 (output) / 4998 (exec) / 4999 (status) / 5000+ (volumes).
+pub const BOOTPLAN_VSOCK_PORT: u32 = 4995;
+
+/// Where fc-agent gets its boot plan and host metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Transport {
+    /// Firecracker MMDS V2 at 169.254.169.254.
+    Mmds,
+    /// Host-served boot plan over vsock (VMMs without a metadata service).
+    Vsock,
+}
+
+/// Decide the boot-plan transport from `/proc/cmdline`.
+/// `fcvm_bootplan=vsock` selects vsock; anything else defaults to MMDS.
+pub fn detect_transport() -> Transport {
+    match std::fs::read_to_string("/proc/cmdline") {
+        Ok(cmdline)
+            if cmdline
+                .split_whitespace()
+                .any(|tok| tok == "fcvm_bootplan=vsock") =>
+        {
+            eprintln!("[fc-agent] boot-plan transport: vsock (port {BOOTPLAN_VSOCK_PORT})");
+            Transport::Vsock
+        }
+        _ => {
+            eprintln!("[fc-agent] boot-plan transport: MMDS");
+            Transport::Mmds
+        }
+    }
+}
+
+/// Read the full boot-plan document (the `latest` object) from the host over vsock.
+async fn read_vsock_doc() -> Result<serde_json::Value> {
+    let mut stream = VsockStream::connect(HOST_CID, BOOTPLAN_VSOCK_PORT)
+        .context("connecting to host boot-plan vsock port")?;
+    let mut buf = Vec::new();
+    // Bounded read: if the host accepts but never closes (a regressed listener/proxy),
+    // don't hang the boot fetch forever — time out so the caller's retry loop recovers.
+    tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        stream.read_to_end(&mut buf),
+    )
+    .await
+    .context("timed out reading boot plan over vsock")?
+    .context("reading boot plan over vsock")?;
+    serde_json::from_slice(&buf)
+        .with_context(|| format!("parsing boot-plan JSON ({} bytes)", buf.len()))
+}
+
+/// Fetch the container plan via the selected transport.
+pub async fn fetch_plan(transport: Transport) -> Result<Plan> {
+    match transport {
+        Transport::Mmds => crate::mmds::fetch_plan().await,
+        Transport::Vsock => {
+            let doc = read_vsock_doc().await?;
+            let plan = doc
+                .get("container-plan")
+                .context("boot-plan document missing 'container-plan'")?
+                .clone();
+            serde_json::from_value(plan).context("parsing container-plan from vsock boot plan")
+        }
+    }
+}
+
+/// Fetch host metadata (host-time, restore-epoch, clone-ipv6) via the selected transport.
+#[allow(dead_code)] // used by the vsock restore watcher in P2
+pub async fn fetch_metadata(transport: Transport) -> Result<LatestMetadata> {
+    match transport {
+        Transport::Mmds => crate::mmds::fetch_latest_metadata_default().await,
+        Transport::Vsock => {
+            let doc = read_vsock_doc().await?;
+            serde_json::from_value(doc).context("parsing metadata from vsock boot plan")
+        }
+    }
+}
+
+/// Sync the VM clock from host time via the selected transport.
+pub async fn sync_clock_from_host(transport: Transport) -> Result<()> {
+    match transport {
+        Transport::Mmds => crate::mmds::sync_clock_from_host().await,
+        Transport::Vsock => {
+            let doc = read_vsock_doc().await?;
+            let meta: LatestMetadata =
+                serde_json::from_value(doc).context("parsing host-time from vsock boot plan")?;
+            set_system_clock(&meta.host_time).await
+        }
+    }
+}
+
+/// Set the system clock to `host_time` (UTC epoch seconds). Shared by both transports.
+pub(crate) async fn set_system_clock(host_time: &str) -> Result<()> {
+    eprintln!("[fc-agent] received host time: {host_time}");
+    let output = Command::new("date")
+        .arg("-u")
+        .arg("-s")
+        .arg(format!("@{host_time}"))
+        .output()
+        .await
+        .context("setting system clock")?;
+    if !output.status.success() {
+        eprintln!(
+            "[fc-agent] WARNING: failed to set clock: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        eprintln!("[fc-agent] continuing anyway (will rely on chronyd)");
+    } else {
+        eprintln!("[fc-agent] system clock synchronized from host");
+    }
+    Ok(())
+}

--- a/fc-agent/src/main.rs
+++ b/fc-agent/src/main.rs
@@ -1,4 +1,5 @@
 mod agent;
+mod bootplan;
 mod container;
 mod exec;
 mod fuse;

--- a/fc-agent/src/mmds.rs
+++ b/fc-agent/src/mmds.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Result};
-use tokio::process::Command;
 use tokio::time::{sleep, Duration};
 
 use crate::types::{LatestMetadata, Plan};
@@ -108,6 +107,16 @@ pub async fn fetch_plan() -> Result<Plan> {
     };
 
     Ok(plan)
+}
+
+/// Fetch `/latest` metadata with a default client (used by the boot-plan transport).
+pub async fn fetch_latest_metadata_default() -> Result<LatestMetadata> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_millis(500))
+        .no_proxy()
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
+    fetch_latest_metadata(&client).await
 }
 
 async fn fetch_latest_metadata(client: &reqwest::Client) -> Result<LatestMetadata> {
@@ -242,25 +251,5 @@ pub async fn sync_clock_from_host() -> Result<()> {
     let metadata: LatestMetadata =
         serde_json::from_str(&body).context("parsing host-time from MMDS")?;
 
-    eprintln!("[fc-agent] received host time: {}", metadata.host_time);
-
-    let output = Command::new("date")
-        .arg("-u")
-        .arg("-s")
-        .arg(format!("@{}", metadata.host_time))
-        .output()
-        .await
-        .context("setting system clock")?;
-
-    if !output.status.success() {
-        eprintln!(
-            "[fc-agent] WARNING: failed to set clock: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        eprintln!("[fc-agent] continuing anyway (will rely on chronyd)");
-    } else {
-        eprintln!("[fc-agent] system clock synchronized from host");
-    }
-
-    Ok(())
+    crate::bootplan::set_system_clock(&metadata.host_time).await
 }

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -53,6 +53,12 @@ pub const VSOCK_OUTPUT_PORT: u32 = 4997;
 /// Vsock port for TTY container I/O (binary exec_proto)
 pub const VSOCK_TTY_PORT: u32 = 4996;
 
+/// Vsock port the host serves the boot plan on, for VMMs without a metadata service
+/// (Cloud Hypervisor — #632 P0.5). fc-agent fetches its plan here when the kernel
+/// boot args contain `fcvm_bootplan=vsock`; Firecracker uses MMDS instead. Must match
+/// `fc-agent::bootplan::BOOTPLAN_VSOCK_PORT`.
+pub const VSOCK_BOOTPLAN_PORT: u32 = 4995;
+
 /// Minimum required Firecracker version for network_overrides support
 const MIN_FIRECRACKER_VERSION: (u32, u32, u32) = (1, 13, 1);
 

--- a/src/commands/podman/listeners.rs
+++ b/src/commands/podman/listeners.rs
@@ -277,6 +277,54 @@ pub(crate) async fn run_status_listener(
     }
 }
 
+/// Bind the boot-plan vsock listener and spawn its serve loop (#632 P0.5).
+///
+/// For VMMs without a metadata service (Cloud Hypervisor), fc-agent fetches its plan
+/// from this listener instead of MMDS. Firecracker forwards a guest connection to vsock
+/// port N to the Unix socket `{uds_path}_{N}`, so we bind that path and write the plan
+/// JSON (the MMDS `latest` object: `{ "container-plan": {...}, "host-time": "..." }`) to
+/// each connecting guest, then close so the guest's `read_to_end` sees EOF.
+///
+/// Serialization and bind happen SYNCHRONOUSLY so a failure is surfaced to the caller
+/// (returns `Err`) instead of being swallowed in a detached task — otherwise the guest
+/// would loop forever waiting for a plan that is never served. The returned task runs for
+/// the VM's lifetime (the guest may reconnect for clock sync); the caller aborts it on
+/// cleanup or on any later boot-config failure.
+pub(crate) fn spawn_bootplan_listener(
+    socket_path: &str,
+    plan: &serde_json::Value,
+) -> Result<tokio::task::JoinHandle<()>> {
+    use tokio::net::UnixListener;
+
+    let payload = serde_json::to_vec(plan).context("serializing boot plan")?;
+    let _ = std::fs::remove_file(socket_path);
+    let listener = UnixListener::bind(socket_path)
+        .with_context(|| format!("binding boot-plan listener to {socket_path}"))?;
+    info!(socket = %socket_path, bytes = payload.len(), "Boot-plan listener started (vsock)");
+
+    Ok(tokio::spawn(serve_bootplan(listener, payload)))
+}
+
+/// Accept loop for the boot-plan listener: write the plan to each connecting guest and
+/// close the write side so the guest's `read_to_end` observes EOF.
+async fn serve_bootplan(listener: tokio::net::UnixListener, payload: Vec<u8>) {
+    use tokio::io::AsyncWriteExt;
+    loop {
+        match listener.accept().await {
+            Ok((mut stream, _)) => {
+                if let Err(e) = stream.write_all(&payload).await {
+                    debug!(error = %e, "boot-plan listener: write failed");
+                    continue;
+                }
+                let _ = stream.shutdown().await;
+            }
+            Err(e) => {
+                warn!(error = %e, "boot-plan listener: accept error");
+            }
+        }
+    }
+}
+
 /// Bidirectional I/O listener for container stdin/stdout/stderr.
 ///
 /// Listens on port 4997 for raw output from fc-agent.

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -1075,7 +1075,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
         return Err(e);
     }
 
-    let (vm_manager, holder_child, reboot_spec) = setup_result.unwrap();
+    let (vm_manager, holder_child, reboot_spec, bootplan_handle) = setup_result.unwrap();
 
     info!(vm_id = %vm_id, "VM started successfully");
 
@@ -1100,6 +1100,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
         data_dir,
         vm_manager,
         holder_child,
+        bootplan_handle,
         volume_servers,
         network,
         network_config,
@@ -1323,7 +1324,13 @@ pub async fn run_vm_loop(ctx: &mut VmContext, cancel: CancellationToken) -> Resu
                         .map(|s| VolumeMapping::parse(s))
                         .collect::<Result<Vec<_>>>()
                         .context("parsing volume mappings for reboot relaunch")?;
-                    vm_config::configure_and_boot_vm(
+                    // Reuse the original boot-plan transport; the relaunched guest's
+                    // boot args still carry fcvm_bootplan=vsock when applicable.
+                    let bootplan_over_vsock = ctx.reboot_spec.bootplan_over_vsock;
+                    if let Some(old) = ctx.bootplan_handle.take() {
+                        old.abort();
+                    }
+                    ctx.bootplan_handle = vm_config::configure_and_boot_vm(
                         &mut ctx.vm_manager,
                         &ctx.reboot_spec,
                         &ctx.args,
@@ -1333,6 +1340,7 @@ pub async fn run_vm_loop(ctx: &mut VmContext, cancel: CancellationToken) -> Resu
                         &ctx.vm_id,
                         &volume_mappings,
                         None,
+                        bootplan_over_vsock,
                     )
                     .await
                     .context("relaunching VM after guest reboot")?;
@@ -1505,6 +1513,11 @@ pub async fn cleanup_vm_context(mut ctx: VmContext) {
 
     // Stop the egress proxy task (rootless mode only)
     if let Some(handle) = ctx.egress_proxy_handle.take() {
+        handle.abort();
+    }
+
+    // Stop the boot-plan vsock listener (vsock transport only)
+    if let Some(handle) = ctx.bootplan_handle.take() {
         handle.abort();
     }
 

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -407,7 +407,16 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
         || args.rootfs_override.is_some()
         || std::env::var("FCVM_NO_SNAPSHOT")
             .map(|v| !v.is_empty())
-            .unwrap_or(false);
+            .unwrap_or(false)
+        // A FORCED boot-plan transport override (FCVM_BOOTPLAN=vsock on Firecracker, which
+        // natively uses MMDS) produces a guest whose fc-agent took the vsock path and never
+        // spawned the MMDS restore-epoch watcher. The snapshot cache key is a hash of
+        // FirecrackerConfig, which does NOT encode the boot-plan transport, so a cached
+        // vsock-built snapshot would be restored by a later NORMAL (MMDS) run under the same
+        // key — the host then signals restore over MMDS that nobody polls, wedging the
+        // restored VM (no exec rebind / output reconnect). Forcing the transport is a
+        // test/debug path with no need to populate the shared cache, so skip caching for it.
+        || std::env::var("FCVM_BOOTPLAN").as_deref() == Ok("vsock");
     let (fc_config, snapshot_key): (
         Option<crate::firecracker::FirecrackerConfig>,
         Option<String>,

--- a/src/commands/podman/types.rs
+++ b/src/commands/podman/types.rs
@@ -29,6 +29,10 @@ pub struct RebootSpec {
     pub track_dirty_pages: bool,
     pub image_disk_path: Option<PathBuf>,
     pub vsock_socket_path: PathBuf,
+    /// Whether the boot plan is delivered over vsock (VMMs without a metadata service)
+    /// rather than MMDS. Baked into `boot_args` too (`fcvm_bootplan=vsock`), so an
+    /// in-place reboot relaunch must re-serve over the same transport.
+    pub bootplan_over_vsock: bool,
 }
 
 /// All state accumulated during VM setup, bundled for the event loop and cleanup.
@@ -38,6 +42,9 @@ pub struct VmContext {
     pub data_dir: PathBuf,
     pub vm_manager: FirecrackerBackend,
     pub holder_child: Option<tokio::process::Child>,
+    /// Boot-plan vsock listener task (Some only when the plan is served over vsock for
+    /// VMMs without a metadata service). Aborted during cleanup.
+    pub bootplan_handle: Option<tokio::task::JoinHandle<()>>,
     pub volume_servers: crate::volume::SpawnedVolumes,
     pub network: Box<dyn NetworkManager>,
     pub network_config: NetworkConfig,

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -507,14 +507,13 @@ pub(super) async fn attach_extra_disks(
 ///
 /// User-input fields come from `launch_config` (part of snapshot cache key).
 /// Runtime-only values (network, proxies, timestamps) are computed here.
-pub(super) async fn build_and_send_mmds(
+pub(super) fn build_boot_plan_json(
     launch_config: &crate::firecracker::FirecrackerConfig,
-    hv: &mut dyn crate::hypervisor::Hypervisor,
     network_config: &crate::network::NetworkConfig,
     vm_state: &VmState,
     volume_mappings: &[VolumeMapping],
     image_device: Option<String>,
-) -> Result<()> {
+) -> serde_json::Value {
     // Build volume mount info for MMDS
     // Format: { guest_path, vsock_port, read_only }
     let volumes: Vec<serde_json::Value> = volume_mappings
@@ -602,9 +601,7 @@ pub(super) async fn build_and_send_mmds(
         host_time: chrono::Utc::now().timestamp().to_string(),
     };
 
-    let mmds_data = launch_config.to_mmds_json(runtime);
-    hv.publish_boot_plan(mmds_data).await?;
-    Ok(())
+    launch_config.to_mmds_json(runtime)
 }
 
 /// Set up NFS exports for VM.
@@ -764,6 +761,7 @@ pub(super) async fn run_vm_setup(
     FirecrackerBackend,
     Option<tokio::process::Child>,
     super::types::RebootSpec,
+    Option<tokio::task::JoinHandle<()>>,
 )> {
     let vm_id = params.vm_id.to_string();
 
@@ -775,6 +773,8 @@ pub(super) async fn run_vm_setup(
     // Inputs to replay the firecracker config on an in-place relaunch (guest reboot),
     // captured once the launch config is fully resolved.
     let mut reboot_spec_slot: Option<super::types::RebootSpec> = None;
+    // Boot-plan vsock listener handle (Some only when serving the plan over vsock).
+    let mut bootplan_handle_slot: Option<tokio::task::JoinHandle<()>> = None;
 
     let result = run_vm_setup_inner(
         params,
@@ -784,6 +784,7 @@ pub(super) async fn run_vm_setup(
         &mut vm_manager_slot,
         &mut holder_slot,
         &mut reboot_spec_slot,
+        &mut bootplan_handle_slot,
     )
     .await;
 
@@ -802,6 +803,10 @@ pub(super) async fn run_vm_setup(
             }
             let _ = holder.wait().await; // Clean up zombie
         }
+        // Abort the boot-plan listener task if it was started.
+        if let Some(handle) = bootplan_handle_slot.take() {
+            handle.abort();
+        }
         // NFS exports may have been written before the failing step; remove them
         // (no-op when the exports file was never created).
         cleanup_nfs_exports(&vm_id).await;
@@ -810,7 +815,7 @@ pub(super) async fn run_vm_setup(
 
     let vm_manager = vm_manager_slot.expect("run_vm_setup_inner sets vm_manager on success");
     let reboot_spec = reboot_spec_slot.expect("run_vm_setup_inner sets reboot_spec on success");
-    Ok((vm_manager, holder_slot, reboot_spec))
+    Ok((vm_manager, holder_slot, reboot_spec, bootplan_handle_slot))
 }
 
 /// Build the FirecrackerConfig used to cold-boot a VM from a disk.
@@ -898,6 +903,9 @@ pub(crate) fn build_launch_config(
 ///   * `Some(network)` (initial boot / clone): runs NFS exports + pasta `post_start`.
 ///   * `None` (reboot relaunch): the host substrate (disk, namespace/holder, pasta,
 ///     NFS exports, listeners, persisted state) is already live and is reused untouched.
+///
+/// Returns the boot-plan vsock listener's task handle when `bootplan_over_vsock` is set
+/// (the caller owns its lifetime and aborts it on cleanup); `None` for the MMDS path.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn configure_and_boot_vm(
     hv: &mut dyn crate::hypervisor::Hypervisor,
@@ -909,7 +917,8 @@ pub(crate) async fn configure_and_boot_vm(
     vm_id: &str,
     volume_mappings: &[VolumeMapping],
     network: Option<&mut dyn NetworkManager>,
-) -> Result<()> {
+    bootplan_over_vsock: bool,
+) -> Result<Option<tokio::task::JoinHandle<()>>> {
     let vm_pid = hv.pid()?;
 
     info!("configuring VM via hypervisor API");
@@ -1023,16 +1032,41 @@ pub(crate) async fn configure_and_boot_vm(
     )
     .await?;
 
-    // Build and send the container boot plan.
-    build_and_send_mmds(
+    // Build the container boot plan and deliver it. For VMMs without a metadata service
+    // (Cloud Hypervisor), serve it over vsock and return the listener handle; otherwise
+    // publish it via MMDS (Firecracker).
+    let plan_json = build_boot_plan_json(
         &plan.launch_config,
-        hv,
         network_config,
         vm_state,
         volume_mappings,
         image_device,
-    )
-    .await?;
+    );
+    // Wrapped in an abort-on-drop guard: if a later boot-config step (entropy/balloon/
+    // boot) returns Err, the guard drops and aborts the listener task instead of leaking
+    // it. On success we disarm and hand the handle to the caller.
+    let bootplan_guard = AbortOnDrop(if bootplan_over_vsock {
+        // fc-agent reads the inner `latest` object; the host listens on
+        // `{vsock_socket}_{VSOCK_BOOTPLAN_PORT}` (Firecracker/CH vsock proxy naming).
+        // Bind happens synchronously here so a bind failure fails setup fast rather than
+        // leaving the guest looping forever waiting for a plan that is never served.
+        let inner = plan_json
+            .get("latest")
+            .cloned()
+            .unwrap_or_else(|| plan_json.clone());
+        let socket = format!(
+            "{}_{}",
+            plan.vsock_socket_path.display(),
+            crate::commands::common::VSOCK_BOOTPLAN_PORT
+        );
+        Some(
+            super::listeners::spawn_bootplan_listener(&socket, &inner)
+                .context("starting boot-plan vsock listener")?,
+        )
+    } else {
+        hv.publish_boot_plan(plan_json).await?;
+        None
+    });
 
     // Configure entropy device (virtio-rng) for better random number generation.
     hv.add_entropy_device().await?;
@@ -1045,7 +1079,26 @@ pub(crate) async fn configure_and_boot_vm(
     // Start VM.
     hv.boot().await?;
 
-    Ok(())
+    Ok(bootplan_guard.disarm())
+}
+
+/// Aborts the wrapped task on drop unless [`Self::disarm`]ed. Ensures the boot-plan vsock
+/// listener spawned mid-`configure_and_boot_vm` is not leaked if a later step fails.
+struct AbortOnDrop(Option<tokio::task::JoinHandle<()>>);
+
+impl AbortOnDrop {
+    /// Take the handle out, defusing the abort-on-drop (the caller now owns it).
+    fn disarm(mut self) -> Option<tokio::task::JoinHandle<()>> {
+        self.0.take()
+    }
+}
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        if let Some(handle) = self.0.take() {
+            handle.abort();
+        }
+    }
 }
 
 /// Inner VM setup: creates the CoW disk, starts Firecracker, and configures the VM.
@@ -1053,6 +1106,7 @@ pub(crate) async fn configure_and_boot_vm(
 /// The Firecracker manager and (for rootless mode) the namespace-holder child are
 /// stored into the provided slots as soon as they exist so that `run_vm_setup` can
 /// kill them if a later step fails.
+#[allow(clippy::too_many_arguments)]
 async fn run_vm_setup_inner(
     params: VmSetupParams<'_>,
     network: &mut dyn NetworkManager,
@@ -1061,6 +1115,7 @@ async fn run_vm_setup_inner(
     vm_manager_slot: &mut Option<FirecrackerBackend>,
     holder_slot: &mut Option<tokio::process::Child>,
     reboot_spec_slot: &mut Option<super::types::RebootSpec>,
+    bootplan_handle_slot: &mut Option<tokio::task::JoinHandle<()>>,
 ) -> Result<()> {
     let VmSetupParams {
         args,
@@ -1175,6 +1230,12 @@ async fn run_vm_setup_inner(
         .await
         .context("starting Firecracker")?;
 
+    // Boot-plan transport: VMMs without a native metadata service (Cloud Hypervisor)
+    // must receive the plan over vsock; Firecracker uses MMDS. FCVM_BOOTPLAN=vsock forces
+    // the vsock path on Firecracker too (exercised by the P0.5 regression test).
+    let bootplan_over_vsock = !vm_manager.capabilities().native_metadata_service
+        || std::env::var("FCVM_BOOTPLAN").as_deref() == Ok("vsock");
+
     // Build FirecrackerConfig for launch (single source of truth for VM config)
     // Use fc_config from cache check if available, otherwise build fresh.
     // IMPORTANT: fc_config uses content-addressed base_rootfs path for cache key,
@@ -1197,7 +1258,11 @@ async fn run_vm_setup_inner(
             )
         });
 
-    let runtime_boot_args = build_runtime_boot_args(args, network_config, runtime_config);
+    let mut runtime_boot_args = build_runtime_boot_args(args, network_config, runtime_config);
+    if bootplan_over_vsock {
+        // fc-agent reads this kernel arg to select the vsock boot-plan transport.
+        runtime_boot_args.push_str(" fcvm_bootplan=vsock");
+    }
 
     // The launch plan: everything needed to (re)boot this VM. Built UP FRONT so the
     // exact same descriptor boots the VM now and relaunches it on a guest reboot, and
@@ -1210,12 +1275,13 @@ async fn run_vm_setup_inner(
         track_dirty_pages,
         image_disk_path: image_disk_path.map(|p| p.to_path_buf()),
         vsock_socket_path: vsock_socket_path.to_path_buf(),
+        bootplan_over_vsock,
     };
 
     // Apply the plan and bring the VM up via the shared primitive. `Some(network)`
     // runs the host-once-only steps (NFS exports + pasta post_start); an in-place
     // reboot relaunch passes `None` and reuses the already-live host substrate.
-    configure_and_boot_vm(
+    *bootplan_handle_slot = configure_and_boot_vm(
         vm_manager,
         &plan,
         args,
@@ -1225,6 +1291,7 @@ async fn run_vm_setup_inner(
         vm_id,
         volume_mappings,
         Some(network),
+        bootplan_over_vsock,
     )
     .await?;
 

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -503,10 +503,12 @@ pub(super) async fn attach_extra_disks(
     Ok((extra_disks, image_device))
 }
 
-/// Build MMDS data (container boot plan) and deliver it to the hypervisor.
+/// Build the boot-plan JSON (the `latest` object served to fc-agent).
 ///
-/// User-input fields come from `launch_config` (part of snapshot cache key).
-/// Runtime-only values (network, proxies, timestamps) are computed here.
+/// Used by both transports: MMDS (`hv.publish_boot_plan`) and vsock
+/// (`spawn_bootplan_listener`). User-input fields come from `launch_config`
+/// (part of snapshot cache key); runtime-only values (network, proxies,
+/// timestamps) are computed here.
 pub(super) fn build_boot_plan_json(
     launch_config: &crate::firecracker::FirecrackerConfig,
     network_config: &crate::network::NetworkConfig,

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -1650,8 +1650,10 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
                                     &vm_id,
                                     volume_mappings,
                                     None,
+                                    plan.bootplan_over_vsock,
                                 )
                                 .await
+                                .map(|_bootplan_handle| ())
                             }
                             .await;
                             match relaunch_result {
@@ -1882,6 +1884,8 @@ async fn build_clone_reboot_plan(
         // overlay/archive-mode container's image layers survive the reboot.
         image_disk_path: meta.image_disk_path.clone(),
         vsock_socket_path: vsock_socket_path.to_path_buf(),
+        // Clones restore from Firecracker snapshots and use MMDS; CH clone/restore is P2.
+        bootplan_over_vsock: false,
     };
     Ok((plan, synth_args, volume_mappings))
 }

--- a/tests/test_sanity.rs
+++ b/tests/test_sanity.rs
@@ -280,6 +280,54 @@ async fn test_trailing_args_command() -> Result<()> {
     Ok(())
 }
 
+/// P0.5 (#632): fc-agent fetches its boot plan over vsock instead of MMDS.
+///
+/// `FCVM_BOOTPLAN=vsock` forces the vsock boot-plan transport on Firecracker (the
+/// transport Cloud Hypervisor requires, since it has no MMDS). This proves the path
+/// end-to-end: the host serves the plan on the boot-plan vsock port, fc-agent reads it
+/// and configures + runs the container. If vsock plan delivery were broken, fc-agent
+/// would never receive its plan and the container would never run, so a clean exit is
+/// definitive proof the vsock boot-plan works.
+#[tokio::test]
+async fn test_bootplan_over_vsock() -> Result<()> {
+    use std::time::Duration;
+
+    println!("\nTest boot plan over vsock (FCVM_BOOTPLAN=vsock)");
+    println!("================================================");
+
+    let (vm_name, _, _, _) = common::unique_names("bootplan-vsock");
+
+    let (mut child, fcvm_pid) = common::spawn_fcvm_with_env(
+        &[
+            "podman",
+            "run",
+            "--name",
+            &vm_name,
+            common::TEST_IMAGE,
+            "echo",
+            "bootplan-vsock-ok",
+        ],
+        &[("FCVM_BOOTPLAN", "vsock")],
+    )
+    .await
+    .context("spawning fcvm with FCVM_BOOTPLAN=vsock")?;
+
+    println!("  fcvm PID: {} (FCVM_BOOTPLAN=vsock)", fcvm_pid);
+
+    let status = tokio::time::timeout(Duration::from_secs(120), child.wait())
+        .await
+        .context("timeout waiting for vsock-boot-plan VM")?
+        .context("waiting for child")?;
+
+    println!("  Exit status: {}", status);
+    assert!(
+        status.success(),
+        "VM should boot via the vsock boot-plan (MMDS disabled) and run the container"
+    );
+    println!("✅ VSOCK BOOT-PLAN TEST PASSED!");
+    Ok(())
+}
+
 /// Test that container stdout streams to host after snapshot.
 ///
 /// Snapshot creation resets all vsock connections (VIRTIO_VSOCK_EVENT_TRANSPORT_RESET).

--- a/tests/test_sanity.rs
+++ b/tests/test_sanity.rs
@@ -288,6 +288,15 @@ async fn test_trailing_args_command() -> Result<()> {
 /// and configures + runs the container. If vsock plan delivery were broken, fc-agent
 /// would never receive its plan and the container would never run, so a clean exit is
 /// definitive proof the vsock boot-plan works.
+///
+/// It ALSO guards against the #670 cache-poisoning regression: the snapshot cache key is
+/// a hash of FirecrackerConfig and does NOT encode the boot-plan transport. If a
+/// forced-vsock run cached a (watcher-less) snapshot under the shared key, a later NORMAL
+/// MMDS run with the same config would restore it and wedge (host signals restore over
+/// MMDS that nobody polls). So we run the SAME command twice — once forced-vsock, then
+/// normal — sharing a unique echo token (hence a unique, collision-free snapshot key).
+/// Without the fix the second run restores the poisoned snapshot and hangs (timeout);
+/// with the fix the forced-vsock run caches nothing, so the second run boots cleanly.
 #[tokio::test]
 async fn test_bootplan_over_vsock() -> Result<()> {
     use std::time::Duration;
@@ -295,17 +304,20 @@ async fn test_bootplan_over_vsock() -> Result<()> {
     println!("\nTest boot plan over vsock (FCVM_BOOTPLAN=vsock)");
     println!("================================================");
 
-    let (vm_name, _, _, _) = common::unique_names("bootplan-vsock");
+    // vm_vsock / vm_mmds: distinct VM names. `token`: a unique marker echoed by BOTH runs
+    // so they share one snapshot cache key that no other test/run can have populated.
+    let (vm_vsock, vm_mmds, token, _) = common::unique_names("bootplan-vsock");
 
+    // Run 1 — forced vsock boot plan.
     let (mut child, fcvm_pid) = common::spawn_fcvm_with_env(
         &[
             "podman",
             "run",
             "--name",
-            &vm_name,
+            &vm_vsock,
             common::TEST_IMAGE,
             "echo",
-            "bootplan-vsock-ok",
+            &token,
         ],
         &[("FCVM_BOOTPLAN", "vsock")],
     )
@@ -319,12 +331,42 @@ async fn test_bootplan_over_vsock() -> Result<()> {
         .context("timeout waiting for vsock-boot-plan VM")?
         .context("waiting for child")?;
 
-    println!("  Exit status: {}", status);
+    println!("  Run 1 (vsock) exit status: {}", status);
     assert!(
         status.success(),
         "VM should boot via the vsock boot-plan (MMDS disabled) and run the container"
     );
-    println!("✅ VSOCK BOOT-PLAN TEST PASSED!");
+
+    // Run 2 — same command, NORMAL (MMDS) transport, no FCVM_BOOTPLAN. Shares run 1's
+    // snapshot key (same image + `echo <token>` + config). Regression guard for #670: if
+    // run 1 had cached its vsock-built snapshot, this run would restore the watcher-less
+    // guest and wedge; the timeout below would then fire and fail the test.
+    let (mut child2, fcvm_pid2) = common::spawn_fcvm(&[
+        "podman",
+        "run",
+        "--name",
+        &vm_mmds,
+        common::TEST_IMAGE,
+        "echo",
+        &token,
+    ])
+    .await
+    .context("spawning normal-MMDS fcvm for the same command")?;
+
+    println!("  fcvm PID: {} (normal MMDS, same key)", fcvm_pid2);
+
+    let status2 = tokio::time::timeout(Duration::from_secs(120), child2.wait())
+        .await
+        .context("timeout waiting for normal-MMDS VM (would indicate #670 cache poisoning)")?
+        .context("waiting for child2")?;
+
+    println!("  Run 2 (MMDS) exit status: {}", status2);
+    assert!(
+        status2.success(),
+        "Normal MMDS run of the same command must boot cleanly (not restore a vsock-built \
+         snapshot under the shared cache key — #670)"
+    );
+    println!("✅ VSOCK BOOT-PLAN + #670 NON-POISONING TEST PASSED!");
     Ok(())
 }
 


### PR DESCRIPTION
## P0.5 of #632: boot plan over vsock

**Stacked on:** `work-632-p0-hypervisor-trait` (P0, #667). Do not merge before P0.

fc-agent fetches its container plan + host time from **MMDS** (Firecracker) or over **vsock**,
selected by the `fcvm_bootplan=vsock` kernel boot parameter. This removes the hard MMDS
dependency so Cloud Hypervisor (no metadata service) can receive the boot plan in P1. MMDS
stays the Firecracker **default** — that path is byte-for-byte unchanged (verified).

### Guest (fc-agent)
- New `bootplan` module: `Transport {Mmds, Vsock}`, `detect_transport()` from `/proc/cmdline`,
  and `fetch_plan` / `fetch_metadata` / `sync_clock_from_host` that dispatch on the transport.
  The vsock path connects to host CID 2 port 4995, reads the `latest` object (bounded by a 10s
  timeout), and extracts the plan + metadata.
- `agent.rs` selects the transport at boot. The MMDS restore-epoch watcher is gated to `Mmds`
  (vsock restore-epoch for CH clone/restore is P2).
- `mmds.rs`: extract `set_system_clock` (shared by both transports), expose `fetch_latest_metadata_default`.

### Host (fcvm)
- `spawn_bootplan_listener`: binds `{vsock_socket}_4995` **synchronously** (fail-fast) and serves
  the plan JSON to each connecting guest, closing the write side for EOF.
- `build_and_send_mmds` → pure `build_boot_plan_json`; `configure_and_boot_vm` dispatches vsock vs
  MMDS, wrapping the listener handle in an `AbortOnDrop` guard.
- `run_vm_setup_inner` selects the transport (`!capabilities().native_metadata_service`, or
  `FCVM_BOOTPLAN=vsock` to force it on Firecracker for testing), appends the boot arg, and threads
  the listener handle through `VmContext` (aborted on cleanup). `RebootSpec.bootplan_over_vsock`
  re-serves on reboot. New `VSOCK_BOOTPLAN_PORT` (4995).

### Reviews
Local **codex** + a **7-angle code-review** (56 agents) converged on the same 3 robustness
findings, all fixed in this PR: fail-fast synchronous bind, abort-on-drop listener guard, and a
bounded guest read. Both confirmed the Firecracker/MMDS default path is unchanged.

### Test evidence
```
make lint                                    # clean, 0 clippy warnings
make test-root FILTER=bootplan_over_vsock    # 1 passed — FC boots via the vsock plan (MMDS off), container exit 0
make test-root FILTER=sanity                 # 5 passed — bridged/rootless/routed/fc-mock/ftrace (MMDS default unchanged)
```
