### PR TITLE
docs: reflect Firecracker + Cloud Hypervisor dual-backend reality + fix doc drift (P3, #632)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -208,7 +208,7 @@ ps aux | grep -E "fcvm|script|cat"
 **The process list tells you EXACTLY what's happening.** Read it.
 
 ## Overview
-fcvm is a Firecracker VM manager for running Podman containers in lightweight microVMs. This document tracks implementation findings and decisions.
+fcvm is a hypervisor-agnostic VM manager for running Podman containers in lightweight microVMs. It drives two backends behind a pluggable `Hypervisor` trait — Firecracker (default) and Cloud Hypervisor — selected via `--hypervisor firecracker|cloud-hypervisor`. This document tracks implementation findings and decisions.
 
 ## Nested Virtualization
 
@@ -1151,11 +1151,14 @@ src/
 ├── main.rs           # CLI dispatcher
 ├── paths.rs          # Path utilities for btrfs layout
 ├── health.rs         # Health monitoring
+├── kvm_trace.rs      # KVM ftrace helper for debugging snapshot restore
+├── utils.rs          # Process/system utility functions
 ├── cli/              # Command-line parsing
 │   └── args.rs       # Clap structures
 ├── commands/         # Command implementations
 ├── state/            # VM state management
-├── firecracker/      # Firecracker API client
+├── hypervisor/       # Pluggable hypervisor (VMM) abstraction (Firecracker + Cloud Hypervisor)
+├── firecracker/      # Low-level Firecracker API client (Firecracker backend impl)
 ├── network/          # Networking layer (bridged + pasta + routed + egress proxy)
 ├── storage/          # Disk/snapshot management
 ├── uffd/             # UFFD memory sharing
@@ -1200,11 +1203,13 @@ fuse-pipe/benches/
 ### ✅ Completed
 
 1. **Core Implementation** (2025-11-09)
-   - Firecracker API client using hyper + hyperlocal (Unix sockets)
+   - Pluggable `Hypervisor` trait (`src/hypervisor/mod.rs`) selecting the VMM behind the same orchestration, with two backends: **Firecracker (default)** and **Cloud Hypervisor**, chosen via `--hypervisor firecracker|cloud-hypervisor` (#632)
+   - Firecracker backend: API client using hyper + hyperlocal (Unix sockets); boot plan via MMDS
+   - Cloud Hypervisor backend: cold boot + container run, snapshot/restore/clone via `--restore` + in-process UFFD; boot plan via vsock (no MMDS)
    - Dual networking modes: bridged (iptables) + rootless (pasta)
    - Storage layer with btrfs CoW disk management
    - VM state persistence
-   - Guest agent (fc-agent) with MMDS integration
+   - Guest agent (fc-agent) receives its boot plan via MMDS (Firecracker) or over vsock (Cloud Hypervisor)
 
 2. **Snapshot/Clone Workflow** (2025-11-11, verified 2025-11-12)
    - Pause VM → Create Firecracker snapshot → Resume VM
@@ -1248,9 +1253,17 @@ fuse-pipe/benches/
 
 ## Technical Reference
 
-### Firecracker Requirements
+### Backend Requirements
+
+fcvm runs two microVM backends behind a pluggable `Hypervisor` trait (`src/hypervisor/`), selected with `--hypervisor firecracker|cloud-hypervisor` (default: firecracker). Both cold-boot fcvm's kernel + initrd + rootfs and run a Podman container; fc-agent is injected at boot via initrd in both cases. Rootfs is Ubuntu 24.04 with systemd, Podman, and iproute2 for both.
+
+**Firecracker** (default)
 - **Kernel**: vmlinux or bzImage, boot args: `console=ttyS0 reboot=k panic=1 pci=off`
-- **Rootfs**: ext4 or btrfs (via `--rootfs-type`) with Ubuntu 24.04, systemd, Podman, iproute2, fc-agent injected at boot via initrd
+- **Rootfs**: ext4 or btrfs (via `--rootfs-type`)
+
+**Cloud Hypervisor** (ARM64)
+- **Kernel**: ARM64 `Image` (PE) format (not vmlinux/bzImage), boot args: `console=hvc0 reboot=k panic=1` (virtio console, no `pci=off`)
+- **Rootfs**: declared with `image_type=Raw` (CH does not take an ext4/btrfs filesystem-type flag)
 
 ### Network Modes
 
@@ -1299,7 +1312,7 @@ fuse-pipe/benches/
 - Sparse files: only written blocks use real disk space (50G file with 2G content uses ~2G)
 - Included in `FirecrackerConfig.rootfs_size` → affects snapshot cache key (different sizes = different snapshots)
 - Clones inherit parent's disk size naturally (reflink copies the already-resized file)
-- Implementation: `src/storage/disk.rs::ensure_free_space()`, called from `src/commands/podman.rs`
+- Implementation: `src/storage/disk.rs::ensure_free_space()`, called from `src/commands/podman/vm_config.rs`
 
 **Layer System:**
 The rootfs is named after the SHA of a combined script that includes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Welcome! We're excited you're interested in contributing to fcvm. Whether you're
 ## Getting Started
 
 1. **Fork and clone** the repo
-2. **Set up dependencies** - see the [Required Forks](README.md#required-forks) section in the README
+2. **Set up dependencies** - see the [Prerequisites](README.md#prerequisites) section in the README
 3. **Build** with `make build`
 4. **Run tests** with `make test`
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,4 +1,4 @@
-# FCVM - Firecracker VM Manager Design Specification
+# FCVM - MicroVM Manager Design Specification (Pluggable Hypervisor Backends: Firecracker + Cloud Hypervisor)
 
 ## Table of Contents
 1. [Overview](#overview)
@@ -16,7 +16,7 @@
 
 ## Overview
 
-**fcvm** is a Firecracker VM manager designed to run Podman containers inside lightweight microVMs with lightning-fast cloning capabilities. It provides a simple CLI interface for spinning up isolated container environments with:
+**fcvm** is a microVM manager designed to run Podman containers inside lightweight microVMs with lightning-fast cloning capabilities. It runs VMs behind a pluggable `Hypervisor` trait (`src/hypervisor/`) supporting two backends — **Firecracker** (default) and **Cloud Hypervisor** — selected with `--hypervisor firecracker|cloud-hypervisor` on `fcvm podman run`. It provides a simple CLI interface for spinning up isolated container environments with:
 
 - **Full-featured VMs**: Filesystem access, outbound networking, port forwarding
 - **Fast cloning**: Clone running VMs in <1s using snapshots and CoW disks
@@ -34,7 +34,7 @@
 
 1. **`fcvm podman run` Command**
    - Takes a Docker/Podman container image
-   - Spins up a Firecracker VM running the container
+   - Spins up a microVM (Firecracker or Cloud Hypervisor, via `--hypervisor`) running the container
    - Supports volume mounts via FUSE passthrough (host → guest)
    - Supports port forwarding (host → guest)
    - Process blocks until VM exits (hanging/foreground mode)
@@ -80,7 +80,7 @@
 ### Non-Functional Requirements
 
 - **Performance**: Clone startup <1s
-- **Isolation**: Full VM isolation via Firecracker
+- **Isolation**: Full VM isolation via KVM (Firecracker or Cloud Hypervisor backends)
 - **Compatibility**: Works with rootless Podman in guest
 - **Portability**: Runs on bare metal or nested VMs (VM-in-VM)
 - **Reliability**: Clean shutdown, resource cleanup
@@ -95,8 +95,8 @@
 ┌──────────────────────────────────────────────────────┐
 │                  fcvm CLI (Host)                      │
 │  ┌────────────┐  ┌──────────────┐  ┌─────────────┐  │
-│  │ Networking │  │  Firecracker │  │  Storage &  │  │
-│  │  Manager   │  │  API Client  │  │  Snapshots  │  │
+│  │ Networking │  │  Hypervisor  │  │  Storage &  │  │
+│  │  Manager   │  │  Abstraction │  │  Snapshots  │  │
 │  └────────────┘  └──────────────┘  └─────────────┘  │
 │         │                │                 │          │
 │         └────────────────┴─────────────────┘          │
@@ -105,7 +105,8 @@
                            │
                            ▼
               ┌────────────────────────┐
-              │  Firecracker Process   │
+              │   Hypervisor Process   │
+              │ (Firecracker / CH)     │
               │  (microVM)             │
               │  ┌──────────────────┐  │
               │  │   Linux Kernel   │  │
@@ -128,10 +129,11 @@
    - Manages networking, storage, snapshots
    - Streams logs and handles signals
 
-2. **Firecracker** (External binary)
-   - Runs the microVM
-   - Provides REST API over Unix socket
-   - Manages VM resources (vCPU, memory, drives, network)
+2. **Hypervisor backend** (External binary, pluggable via `--hypervisor`)
+   - Runs the microVM and manages VM resources (vCPU, memory, drives, network)
+   - **Firecracker** (default): REST API over a Unix socket; boot metadata via MMDS
+   - **Cloud Hypervisor**: REST API over the `--api-socket` Unix socket (`/api/v1/vm.create` + `vm.boot`); boot metadata served over vsock (boot-plan port 4995, no MMDS)
+   - Selected behind the `Hypervisor` trait (`src/hypervisor/`); see Core Components for backend-specific details
 
 3. **fc-agent** (Rust, runs in guest)
    - Fetches container configuration from MMDS
@@ -385,6 +387,7 @@ Each VM has:
 │       ├── disk.snap          # Disk snapshot
 │       └── config.json        # VM configuration
 ├── state/                     # VM state JSON files
+├── image-cache/               # Container image layers (sha256:{digest}/)
 └── cache/                     # Downloaded cloud images
 ```
 
@@ -1320,13 +1323,13 @@ match fork() {
 | Command | Purpose |
 |---------|---------|
 | `fcvm setup` | Download kernel, create rootfs (first-time setup, ~5-10 min) |
-| `fcvm podman run` | Launch container in Firecracker VM |
+| `fcvm podman run` | Launch container in a microVM (Firecracker by default, or Cloud Hypervisor via `--hypervisor cloud-hypervisor`) |
 | `fcvm exec` | Execute command in running VM/container |
 | `fcvm ls` | List running VMs |
 | `fcvm snapshot create` | Create snapshot from running VM |
 | `fcvm snapshot serve` | Start UFFD memory server for cloning |
 | `fcvm snapshot run` | Spawn clone from memory server |
-| `fcvm snapshots` | List available snapshots |
+| `fcvm snapshots ls` | List stored snapshots (also: `delete <NAME>`, `prune`) |
 
 ### Key CLI Design Decisions
 
@@ -1402,11 +1405,14 @@ fcvm snapshot serve my-snapshot
 **Usage**:
 ```bash
 fcvm snapshot run --pid <SERVE_PID> [OPTIONS]
+fcvm snapshot run --snapshot <NAME> [OPTIONS]
 ```
 
 **Options**:
 ```
---pid <SERVE_PID>         Memory server PID (required)
+--pid <SERVE_PID>         Memory server PID (UFFD lazy-restore mode)
+--snapshot <NAME>         Snapshot name (direct file mode, no server needed)
+                          (Either --pid or --snapshot is required; mutually exclusive)
 --name <NAME>             Clone VM name (auto-generated if not provided)
 --exec <CMD>              Execute command in container after clone is healthy
 ```
@@ -1458,10 +1464,38 @@ clone-1        12350   running   healthy   rootless  (clone)
 
 #### `fcvm snapshots`
 
-**Purpose**: List available snapshots.
+**Purpose**: Manage stored snapshots. A subcommand is required (`ls`, `delete`, or `prune`).
 
+**List snapshots**:
 ```bash
-fcvm snapshots
+fcvm snapshots ls [--json] [--filter <user|system>] [--image <NAME>] [--shared]
+```
+
+**Delete a specific snapshot**:
+```bash
+fcvm snapshots delete <NAME> [--force]
+```
+
+**Prune snapshots** (deletes system/auto-generated snapshots by default):
+```bash
+fcvm snapshots prune [--force] [--all] [--image <NAME>]
+```
+
+**Options**:
+```
+ls:
+  --json                  Output in JSON format
+  --filter <user|system>  Filter by snapshot type
+  --image <NAME>          Filter by container image name
+  --shared                Show accurate disk usage accounting for btrfs shared extents (slower)
+
+delete:
+  --force, -f             Force deletion without confirmation
+
+prune:
+  --force, -f             Force deletion without confirmation
+  --all                   Delete ALL snapshots (including user-created ones)
+  --image <NAME>          Only delete snapshots matching this container image name
 ```
 
 ---
@@ -1626,7 +1660,7 @@ reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
 
 ### Build System (Makefile)
 
-All builds are done via the root Makefile. See [CLAUDE.md](/.claude/CLAUDE.md#makefile-targets) for the complete target list.
+All builds are done via the root Makefile. Run `make help` for the complete target list (see also [CLAUDE.md](.claude/CLAUDE.md#always-use-the-makefile)).
 
 ```bash
 make build      # Build fcvm + fc-agent

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -136,7 +136,7 @@
    - Selected behind the `Hypervisor` trait (`src/hypervisor/`); see Core Components for backend-specific details
 
 3. **fc-agent** (Rust, runs in guest)
-   - Fetches container configuration from MMDS
+   - Fetches container configuration (boot plan) via MMDS (Firecracker) or vsock (Cloud Hypervisor)
    - Launches Podman with correct parameters
    - Streams container logs to host via vsock
    - Signals readiness to host
@@ -1042,10 +1042,10 @@ async fn main() -> Result<()> {
 
 **Location**: `fc-agent/src/main.rs`
 
-Runs inside the Firecracker VM as a systemd service.
+Runs inside the microVM as a systemd service (both Firecracker and Cloud Hypervisor).
 
 **Responsibilities**:
-1. Fetch container plan from MMDS (Metadata Service)
+1. Fetch container plan (boot plan) via MMDS (Firecracker) or vsock port 4995 (Cloud Hypervisor)
 2. Launch Podman with correct configuration
 3. Stream container logs to serial console
 4. Signal readiness to host (via vsock)
@@ -1091,8 +1091,8 @@ Firecracker provides a metadata service accessible at `http://169.254.169.254/`.
 ```rust
 #[tokio::main]
 async fn main() -> Result<()> {
-    // 1. Fetch plan from MMDS
-    let plan = fetch_mmds_plan().await?;
+    // 1. Fetch plan via MMDS (Firecracker) or vsock (Cloud Hypervisor)
+    let plan = fetch_plan().await?;
 
     // 2. Build Podman command
     let mut cmd = Command::new("podman");
@@ -1148,12 +1148,17 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn fetch_mmds_plan() -> Result<Plan> {
-    loop {
-        match reqwest::get("http://169.254.169.254/").await {
-            Ok(resp) => return resp.json().await.context("parsing MMDS"),
-            Err(_) => {
-                tokio::time::sleep(Duration::from_millis(500)).await;
+// Actual implementation auto-detects transport via /proc/cmdline
+// (fcvm_bootplan=vsock → vsock port 4995; otherwise → MMDS at 169.254.169.254)
+async fn fetch_plan() -> Result<Plan> {
+    match detect_transport() {
+        Transport::Vsock => read_vsock_plan().await,
+        Transport::Mmds => {
+            loop {
+                match reqwest::get("http://169.254.169.254/").await {
+                    Ok(resp) => return resp.json().await.context("parsing MMDS"),
+                    Err(_) => tokio::time::sleep(Duration::from_millis(500)).await,
+                }
             }
         }
     }

--- a/NESTED.md
+++ b/NESTED.md
@@ -9,7 +9,7 @@ fcvm supports running VMs inside VMs using ARM64 FEAT_NV2. Host → L1 → L2 ne
 | **Hardware** | ARM64 with FEAT_NV2 (Graviton3+: c7g.metal, c7gn.metal, r7g.metal) |
 | **Host kernel** | 6.18+ with `kvm-arm.mode=nested` boot parameter |
 | **Nested kernel** | Pre-built from releases or `fcvm setup --kernel-profile nested --build-kernels` |
-| **Firecracker** | Fork with NV2 support (configured via kernel profile) |
+| **Hypervisor** | Firecracker fork with NV2 support, configured via kernel profile (Cloud Hypervisor does not support nested ARM64) |
 
 ## Setting Up an EC2 Instance
 
@@ -89,7 +89,8 @@ sudo ./fcvm podman run \
     --kernel-profile nested \
     --privileged \
     --map /mnt/fcvm-btrfs:/mnt/fcvm-btrfs \
-    --map /path/to/fcvm/binary:/opt/fcvm \
+    # Map the directory containing the fcvm binary so the inner VM can run /opt/fcvm/fcvm
+    --map "$(dirname "$(command -v fcvm)")":/opt/fcvm \
     nginx:alpine
 
 # Verify nested KVM works

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -12,7 +12,7 @@ All benchmarks run on AWS c7g.metal (bare-metal ARM64):
 | Architecture | aarch64 |
 | Memory | 128GB |
 | Storage | btrfs on NVMe |
-| Kernel | 6.18+ with nested virtualization |
+| Kernel | 6.18+ (nested virtualization enabled for the nested L2 benchmarks; not required for general fcvm use) |
 | Instance | c7g.metal |
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # fcvm
 
-fcvm runs Podman containers inside Firecracker microVMs. You use the same images and registries as plain Podman, and each container gets its own kernel, so isolation comes from a VM boundary rather than from namespaces sharing the host kernel.
+fcvm runs Podman containers inside microVMs, with a pluggable hypervisor backend — Firecracker (default) or Cloud Hypervisor, selected with `--hypervisor firecracker|cloud-hypervisor`. You use the same images and registries as plain Podman, and each container gets its own kernel, so isolation comes from a VM boundary rather than from namespaces sharing the host kernel.
 
 fcvm avoids paying the VM boot cost on every run: the first run of an image boots cold and saves a snapshot once the image is loaded, later runs restore from that snapshot, and a running VM can be cloned in milliseconds with copy-on-write memory and disk. `fcvm serve` exposes the same workflow over an HTTP API for programs that create sandboxes on demand.
 
-- Cached startup takes ~540ms via snapshot restore, compared to ~3s for a cold boot (see [Container Image Cache](#container-image-cache))
+- Cached startup takes ~540ms via snapshot restore, compared to ~3.1s for a cold boot (see [Container Image Cache](#container-image-cache))
 - Cloning a running VM takes ~10ms using UFFD memory sharing and btrfs reflinks
 - 50 clones of a 512MB VM share physical pages through the kernel page cache, using ~512MB total rather than 25GB
 - Three network modes: rootless (no root required), bridged, and routed (native IPv6 at kernel line rate)
@@ -124,7 +124,7 @@ same guest path (preserve storage, restart container, regenerate identity).
 
 ### In-Place Reboot
 
-A guest `reboot` does not terminate the VM. The host relaunches Firecracker
+A guest `reboot` does not terminate the VM. The host relaunches the configured hypervisor backend
 against the same disk, network, and listeners — the fcvm process and its PID stay
 stable — and the guest comes back exactly like a disk-only clone cold boot:
 storage preserved, container restarted, identity regenerated. A guest `poweroff`
@@ -175,7 +175,8 @@ sudo ./fcvm setup --kernel-profile nested --install-host-kernel && sudo reboot
 # Outer VM with nested kernel
 sudo ./fcvm podman run --name outer --network bridged \
     --kernel-profile nested --privileged \
-    --map /mnt/fcvm-btrfs:/mnt/fcvm-btrfs nginx:alpine
+    --map /mnt/fcvm-btrfs:/mnt/fcvm-btrfs \
+    --map "$(pwd)":/opt/fcvm nginx:alpine
 
 # Inner VM (inside outer)
 ./fcvm exec --pid <outer_pid> --vm -- \
@@ -242,7 +243,7 @@ Supported runtimes: `python`, `node`, `ruby`, `go`, or any custom image name.
 
 ### Rootless Architecture
 
-Uses [pasta](https://passt.top/) (from the passt project) with a Linux bridge for L2 forwarding between pasta and Firecracker. Pasta uses splice(2) zero-copy L4 translation. IPv6 supported with `--enable-ipv6`.
+Uses [pasta](https://passt.top/) (from the passt project) with a Linux bridge for L2 forwarding between pasta and the VM. Pasta uses splice(2) zero-copy L4 translation. IPv6 supported with `--enable-ipv6`.
 
 Host services are reachable from VMs via pasta gateways: `10.0.2.2` (IPv4) and `fd00::2` (IPv6).
 
@@ -258,7 +259,7 @@ veth-host ←──veth pair──→ veth-ns
   (proxy NDP)                 |
                            br0 (10.0.2.1/24, fd00::1/64)
                                |
-                           tap-vm → Firecracker VM (10.0.2.100, unique IPv6)
+                           tap-vm → microVM (10.0.2.100, unique IPv6)
 ```
 
 ### Egress Proxy
@@ -274,7 +275,7 @@ VMs can reach host services via gateway addresses (not `127.0.0.1`, which is the
 | `10.0.2.2` | `127.0.0.1` (IPv4) | Rootless |
 | `fd00::2` | `::1` (IPv6) | Rootless |
 
-fcvm auto-forwards `http_proxy`/`https_proxy` from host to VM via MMDS.
+fcvm auto-forwards `http_proxy`/`https_proxy` from host to VM as part of the boot plan, delivered via the configured backend's metadata transport (Firecracker: MMDS; Cloud Hypervisor: the host-served vsock boot-plan on port 4995).
 
 ### Port Forwarding
 
@@ -292,8 +293,9 @@ fcvm auto-forwards `http_proxy`/`https_proxy` from host to VM via MMDS.
 - AWS: c6g.metal (ARM64) or c5.metal (x86_64)
 
 **Dependencies:**
-- Rust 1.83+ with musl target: `rustup target add $(uname -m)-unknown-linux-musl`
-- Firecracker binary in PATH
+- Rust 1.75+ with musl target: `rustup target add $(uname -m)-unknown-linux-musl`
+- Firecracker binary in PATH (default backend)
+- Cloud Hypervisor binary in PATH (only if using `--hypervisor cloud-hypervisor`; override location with `FCVM_CLOUD_HYPERVISOR_BIN`)
 - For rootless: `passt` package (provides `pasta`)
 - For bridged: sudo, iptables, iproute2
 - For routed: sudo, iproute2, host with global IPv6 /64 (ip6tables also needed unless `--ipv6-prefix` is set)
@@ -337,7 +339,7 @@ See [`Containerfile`](Containerfile) for the complete dependency list used in CI
 | Command | Description |
 |---------|-------------|
 | `fcvm setup` | Download kernel and create rootfs (5-10 min first run, then cached) |
-| `fcvm podman run` | Run container in Firecracker VM |
+| `fcvm podman run` | Run container in a microVM (backend selected with `--hypervisor`, default `firecracker`) |
 | `fcvm exec` | Execute command in running VM/container |
 | `fcvm ls` | List running VMs (`--json` for JSON) |
 | `fcvm snapshot create` | Snapshot a running VM |
@@ -447,7 +449,7 @@ fcvm/
 
 **Tests hang?** Kill test VMs: `ps aux | grep fcvm | grep test | awk '{print $2}' | xargs sudo kill`
 
-**KVM not available?** Firecracker requires bare-metal or nested virt. On AWS, use `.metal` instances.
+**KVM not available?** Both Firecracker and Cloud Hypervisor require bare-metal KVM or nested virtualization. On AWS, use `.metal` instances.
 
 **Network issues?** Test incrementally inside a VM:
 ```bash

--- a/docs/hypervisor-abstraction.md
+++ b/docs/hypervisor-abstraction.md
@@ -66,7 +66,7 @@ pub enum Backend { Firecracker, CloudHypervisor }
 
 pub struct Capabilities {
     pub diff_snapshots: bool,             // FC: true,  CH: false
-    pub file_backed_cow_restore: bool,    // FC: true (measured, #632), CH: unverified (snapshot blocked)
+    pub file_backed_cow_restore: bool,    // FC: true (measured, #632); CH: unblocked post-#8268, density unmeasured (P2)
     pub external_uffd_lazy_restore: bool, // FC: true (fork handshake w/ page_size), CH: false
     pub internal_uffd_lazy_restore: bool, // FC: n/a,   CH: ondemand (v52; unverified on ARM64)
     pub drive_retarget: bool,             // FC: true,  CH: false (bind-mount redirect)

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -5,7 +5,7 @@ use clap_complete::Shell;
 #[command(
     name = "fcvm",
     version,
-    about = "Firecracker VM runner for Podman containers"
+    about = "Podman container runner with microVM isolation (Firecracker or Cloud Hypervisor)"
 )]
 pub struct Cli {
     /// Running as a subprocess (disables timestamp and level in logs)
@@ -108,7 +108,7 @@ pub struct PodmanArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum PodmanCommands {
-    /// Run a container in a Firecracker VM
+    /// Run a container in a microVM (Firecracker or Cloud Hypervisor)
     Run(RunArgs),
 }
 

--- a/src/hypervisor/mod.rs
+++ b/src/hypervisor/mod.rs
@@ -259,15 +259,17 @@ impl Capabilities {
         }
     }
 
-    /// Cloud Hypervisor's capabilities (#632). Cold boot works (P1); snapshot/restore is
-    /// P2 (needs a CH build with the SVE fix #8268) and is gated off here until then.
+    /// Cloud Hypervisor's capabilities (#632). Cold boot (P1) and snapshot/restore/clone (P2)
+    /// both work: the SVE register-save bug is fixed upstream (#8268), so `snapshots` is enabled
+    /// below (explicit `snapshot create` / `snapshot run` via `--restore`, copy-mode).
     pub fn cloud_hypervisor() -> Self {
         Self {
             diff_snapshots: false,
             file_backed_cow_restore: false,
             // CH's UFFD handler is in-process — no external page server can drive it.
             external_uffd_lazy_restore: false,
-            // memory_restore_mode=ondemand exists (v52) but restore is gated to P2.
+            // memory_restore_mode=ondemand exists (v52) but is unused — CH restore uses
+            // memory_restore_mode=copy; the in-process ondemand lazy-restore handler is a follow-on.
             internal_uffd_lazy_restore: false,
             // No PATCH /drives equivalent — uses the bind-mount redirect instead.
             drive_retarget: false,

--- a/src/volume/mod.rs
+++ b/src/volume/mod.rs
@@ -1,6 +1,7 @@
 //! FUSE-over-vsock volume mounting using fuse-pipe.
 //!
-//! This module provides host directory mounting inside Firecracker VMs
+//! This module provides host directory mounting inside VMs via vsock,
+//! which works with both hypervisor backends (Firecracker and Cloud Hypervisor),
 //! using FUSE over vsock, powered by the high-performance fuse-pipe library.
 //!
 //! # Architecture
@@ -80,12 +81,14 @@ impl VolumeServer {
         Ok(Self { config, host_path })
     }
 
-    /// Serve volumes over Firecracker's vsock Unix socket.
+    /// Serve volumes over the VMM's vsock Unix socket.
     ///
-    /// For guest-initiated connections, Firecracker's vsock expects the host to listen on:
+    /// For guest-initiated connections, the VMM's vsock expects the host to listen on:
     ///   `{uds_path}_{port}` (e.g., `/path/to/v.sock_5000`)
     ///
-    /// When guest connects to CID 2, port 5000, Firecracker forwards to host's v.sock_5000.
+    /// When the guest connects to the host (CID 2) on port 5000, the VMM forwards to the
+    /// host's `v.sock_5000`. This `{uds_path}_{port}` scheme is identical for both Firecracker
+    /// and Cloud Hypervisor.
     pub async fn serve_vsock(&self, vsock_socket_path: &Path) -> Result<()> {
         self.serve_vsock_with_ready_signal(vsock_socket_path, None)
             .await


### PR DESCRIPTION
Documentation-consistency sweep on top of the full #632 stack (P0→P2) — makes the docs reflect that fcvm now runs **Firecracker AND Cloud Hypervisor** behind a pluggable `Hypervisor` trait, and fixes assorted doc-vs-code drift.

**Stacked on:** `work-632-p2-ch-snapshot` (#674) → P1 (#672) → P0.5 (#670) → P0 (#667) → main. Review only the top commit.

## How it was produced
Two multi-agent hunts (fan-out scan → adversarial verify) over every doc surface:
1. **CH-capability hunt** — 37 confirmed: Firecracker-only framing that ignored Cloud Hypervisor.
2. **General inconsistency hunt** — 12 confirmed: nonexistent commands/flags, wrong paths, stale numbers, broken links.

49 confirmed findings, applied per-file (overlaps deduped). `make lint` + `make build` clean.

## What changed
**Dual-backend accuracy** (README, DESIGN, AGENTS, .claude/CLAUDE.md, docs/, PERFORMANCE, NESTED):
- Intros/titles/architecture diagrams now describe the pluggable backend — Firecracker (default) or Cloud Hypervisor via `--hypervisor firecracker|cloud-hypervisor` — both doing cold boot + snapshot/restore/clone.
- Boot-plan/metadata wording: MMDS-only → backend-aware (FC = MMDS; CH = host-served vsock boot-plan, port 4995).
- rustdoc/CLI help (`src/cli/args.rs`, `src/hypervisor/mod.rs`, `src/volume/mod.rs`) — **doc comments / clap help only, no code logic**.

**General drift fixed:**
- `fcvm snapshots` documented bare → it requires a subcommand; DESIGN now shows `snapshots ls|delete|prune` and adds the missing `snapshot run --snapshot` (direct file mode) next to `--pid`.
- MSRV 1.83 → 1.75 (matches Cargo.toml); corrected module/data-layout paths, stale numbers, and a dead CLAUDE.md link.

## Test evidence
```
$ make lint    # clippy -D warnings, cargo fmt, cargo-deny — all clean
$ make build   # the .rs doc-comment / clap-help edits compile
```
Doc-only + comment/help-string changes; no behavior change. (The .rs edits are covered by the stack's existing tests/CI; no new tests needed for documentation.)
