### PR TITLE
fix(podman): cross-VM image-cache race; run a CI subset of nested NV2 tests

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -869,6 +869,35 @@ When a POSIX test fails:
 
 4. **The mantra:** What do timestamps show? What's different between failing and passing? The logs ALWAYS have the answer.
 
+5. **Real example (cross-VM cache race, #632):** De-serialized nested tests (max-threads>1)
+   failed. The lazy conclusion was "nested KVM can't take concurrency (#660)." It was not —
+   the smoking gun was in the per-VM logs (`/tmp/nested-l2-*.log`), and the technique that
+   caught it is reusable:
+
+   - **Read the per-VM debug logs, not the nextest summary.** Two concurrent chains showed,
+     at the same second: chain A `resize2fs: Inode checksum does not match inode` and chain B
+     `renaming storage image to final path: No such file or directory (os error 2)` — both on
+     the SAME content-addressed path `image-cache/<digest>.storage-v2.img.tmp`. Same file, two
+     writers = race, full stop.
+   - **`e2fsck -fn` the *cached artifact* to prove the race POISONED the cache.** The
+     already-cached `.storage-v2.img` failed checksum ("Filesystem still has errors"). A race
+     that persists a corrupt content-addressed file silently breaks every *later* run too
+     (including serialized ones) — so the symptom and the cause can be in different test runs.
+   - **Know when a single host CAN'T reproduce it.** The per-digest `flock` works fine within
+     one kernel, so host-only concurrent processes serialize and never collide. The race only
+     appears across VM boundaries: nested tests `--map` the host `/mnt/fcvm-btrfs` into every
+     L1, and `flock()` over a fuse-pipe mount that negotiates no `FUSE_FLOCK_LOCKS` is granted
+     LOCALLY per guest kernel — it never reaches the shared host backing store. Faithful repro =
+     clear the digest's cache entry (cold cache) + run two nested tests concurrently.
+   - **Fix at the right altitude:** don't try to make `flock` work over FUSE — make the writes
+     not need a lock. Unique-per-builder temp names (`uuid`, NOT pid — separate PID namespaces
+     reuse numbers) + atomic rename to the content-addressed final (identical bytes → the
+     rename race is idempotent). See `src/commands/podman/{image.rs,mod.rs}`.
+
+   **Generalizable rule:** any file under a `--map`'d / FUSE-shared directory written by more
+   than one VM must be made safe WITHOUT relying on `flock`/`fcntl` locks — those don't cross
+   the fuse-pipe boundary. Use content-addressing + unique temp + atomic rename.
+
 ### NO TEST HEDGES
 
 **Test assertions must be DEFINITIVE.** A test either PASSES or FAILS - no middle ground.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -869,7 +869,7 @@ When a POSIX test fails:
 
 4. **The mantra:** What do timestamps show? What's different between failing and passing? The logs ALWAYS have the answer.
 
-5. **Real example (cross-VM cache race, #632):** De-serialized nested tests (max-threads>1)
+5. **Real example (cross-VM cache race, #677):** De-serialized nested tests (max-threads>1)
    failed. The lazy conclusion was "nested KVM can't take concurrency (#660)." It was not —
    the smoking gun was in the per-VM logs (`/tmp/nested-l2-*.log`), and the technique that
    caught it is reusable:

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -56,11 +56,34 @@ max-threads = 1
 [test-groups.snapshot-tests]
 max-threads = 3
 
-# Nested (NV2) tests run one at a time: each chain is an L1 (4GB) plus an L2
-# VM — the heaviest tests in the suite, and the L2 boots a 10GB disk copy
-# INSIDE the L1 where there is no reflink. A 3-concurrent experiment under
-# full-suite load produced an L2 in-guest failure; serialized is the proven
-# configuration. Revisit with #660.
+# Nested (NV2) tests are the heaviest in the suite: each chain is an L1 (4GB) plus an L2 VM,
+# and the L2 boots a 10GB disk copy INSIDE the L1 where there is no reflink. They run only on
+# arm64 (FEAT_NV2). Run as a whole and serialized they were the CI long pole (~21 min/run,
+# ~54% of the arm64 SnapshotEnabled job's wall time and the reason arm64 CI ≈ 2x x64) — which
+# is why CI now runs only a representative subset (see the CI_NESTED_FILTER block in the
+# Makefile). This group config still governs whatever nested tests DO run (CI subset or the
+# full set locally): they run one at a time.
+#
+# Serialized (max-threads=1) ON PURPOSE — and it must stay that way. TWO independent reasons,
+# both measured (PR #677), not assumed:
+#
+# 1. Cross-VM image-cache race (now FIXED, kept defensively): nested tests `--map` the host
+#    /mnt/fcvm-btrfs into every L1, so two L1s preparing the same content-addressed image
+#    collided on the shared "<digest>.storage-v2.img.tmp" — concurrent mkfs/resize2fs
+#    CORRUPTED the image (e2fsck on the cached file showed "Filesystem still has errors") and
+#    one builder's rename ENOENT'd the other's temp. The per-digest flock did not help: it is
+#    flock() over a fuse-pipe mount that negotiates no FUSE_FLOCK_LOCKS, so each guest kernel
+#    grants it locally and never forwards to the shared host backing store. Fixed by UUID-keyed
+#    temps + atomic rename in src/commands/podman/{image.rs,mod.rs}.
+#
+# 2. Nested VMs do NOT parallelize — concurrency makes them SLOWER, not faster. Measured: two
+#    nested tests cold-cache concurrent = 1085s wall AND a flake (test_nested_l2_network_nfs's
+#    L2 ingress iperf3 starved and blew its internal 840s budget, killed at 852s); the SAME
+#    test alone = 227s. A ~3.7x slowdown from 2-way contention alone (no other suite load).
+#    Mechanism: every nested guest-exit issues a system-wide dsb(sy) (the #630 cache-coherency
+#    patch) + raw NV2 overhead, so concurrent chains stall each other globally. De-serializing
+#    therefore widens the tail and adds retries — the long pole must be cut a different way
+#    (fewer/faster nested tests), not with concurrency.
 [test-groups.nested-tests]
 max-threads = 1
 

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,30 @@ else
 IPV6_FILTER :=
 endif
 
+# CI runs a representative SUBSET of the active nested (NV2) tests, not all of them.
+# Nested tests are the arm64 long pole and do NOT parallelize — they degrade ~3.7x under
+# mutual contention (system-wide dsb(sy) on every nested guest-exit + NV2 overhead; see the
+# [test-groups.nested-tests] comment in .config/nextest.toml), so concurrency can't shrink
+# them. Instead CI runs three that cover the distinct nested risks and skips the rest
+# (which still run locally with a normal `make test-root`):
+#   - test_nested_run_fcvm_inside_vm  : nesting works at all + /dev/kvm usable in the guest
+#   - test_nested_l2_with_large_files : FUSE-over-FUSE cache coherency (the #630 DSB regression guard)
+#   - test_nested_l2_nfs              : the NFS-share data path under nesting
+# Skipped in CI (still run locally): test_nested_l2_fuse (FUSE path is covered by large_files),
+# test_nested_l2_network_fuse / _network_nfs (iperf throughput — the slowest AND flakiest under
+# any contention), and test_utimensat_pjdfstest_nested_kernel. The L3/L4, benchmark, and
+# podman-load nested tests are already #[ignore]'d (run manually, tracked in #630-B).
+# Gated on CI=true (set by GitHub Actions). Override anytime with an explicit FILTER=...
+# Scoped to package(fcvm) so fuse-pipe's fast test_nested_file unit test is NOT excluded.
+# Mutually exclusive with IPV6_FILTER in practice — CI runners have an IPv4 route, so
+# IPV6_ONLY is never set there (two -E filtersets would be UNIONED, not intersected).
+CI ?=
+ifndef FILTER
+ifeq ($(CI),true)
+CI_NESTED_FILTER := -E 'not (package(fcvm) & (test(/nested/) | test(/podman_load_over_fuse/))) | test(=test_nested_run_fcvm_inside_vm) | test(=test_nested_l2_with_large_files) | test(=test_nested_l2_nfs)'
+endif
+endif
+
 # Default log level: fcvm debug, suppress FUSE spam
 # Override with: RUST_LOG=debug make test-root
 TEST_LOG ?= fcvm=debug,health-monitor=info,fuser=warn,fuse_backend_rs=warn,passthrough=warn
@@ -348,7 +372,7 @@ _test-root:
 	FCVM_DATA_DIR=$(ROOT_DATA_DIR) \
 	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
 	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
-	$(NEXTEST) $(NEXTEST_CAPTURE) $(NEXTEST_IGNORED) --features privileged-tests $(IPV6_FILTER) $(FILTER) || \
+	$(NEXTEST) $(NEXTEST_CAPTURE) $(NEXTEST_IGNORED) --features privileged-tests $(IPV6_FILTER) $(CI_NESTED_FILTER) $(FILTER) || \
 	{ echo ""; \
 	  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"; \
 	  echo "TEST FAILED - Check debug logs for root cause:"; \

--- a/src/commands/podman/image.rs
+++ b/src/commands/podman/image.rs
@@ -3,6 +3,27 @@ use std::path::{Path, PathBuf};
 use anyhow::{bail, Context, Result};
 use tracing::{info, warn};
 
+/// Build a unique sibling temp path for atomically publishing a content-addressed cache file.
+///
+/// The image-cache dir is content-addressed and SHARED across VMs: nested tests `--map` the
+/// host `/mnt/fcvm-btrfs` into multiple L1 VMs, so two VMs preparing the same image write to
+/// the same directory on the host backing store. The per-digest `flock` guarding image prep
+/// does NOT coordinate this: it is `flock()` over a fuse-pipe mount that negotiates no
+/// `FUSE_FLOCK_LOCKS`, so each guest kernel grants it locally and never forwards it to the
+/// host. A shared `"<final>.tmp"` therefore lets two builders mkfs/resize the same file
+/// (corruption) and one's rename ENOENT the other's in-flight temp.
+///
+/// Keyed by a fresh UUID — NOT the pid, which is not unique across VMs (separate PID
+/// namespaces reuse the same numbers). The caller atomically renames to `final_path`; because
+/// the bytes are content-addressed, a rename race between builders is idempotent (same result).
+pub(super) fn unique_cache_tmp(final_path: &Path) -> PathBuf {
+    PathBuf::from(format!(
+        "{}.{}.tmp",
+        final_path.display(),
+        uuid::Uuid::new_v4()
+    ))
+}
+
 /// Remove podman state files from a storage root, keeping only image/layer data.
 ///
 /// `podman load` creates state files (db.sql, storage.lock, libpod/, etc.) that
@@ -291,7 +312,11 @@ pub(super) async fn build_storage_image(
     let cache_dir = output_path
         .parent()
         .ok_or_else(|| anyhow::anyhow!("output_path has no parent directory"))?;
-    let tmp_dir = cache_dir.join(format!("tmp-storage-{}", std::process::id()));
+
+    // Temp paths are UUID-keyed because the image-cache dir is shared across VMs and the
+    // per-digest flock does not coordinate cross-VM (see `unique_cache_tmp`). A shared
+    // "tmp-storage-{pid}" would collide too — separate PID namespaces reuse pid numbers.
+    let tmp_dir = cache_dir.join(format!("tmp-storage-{}", uuid::Uuid::new_v4()));
 
     // Clean up any stale temp dir from a previous interrupted run
     if tmp_dir.exists() {
@@ -336,10 +361,10 @@ pub(super) async fn build_storage_image(
     // at a different path, stale state files cause "database graph driver does not match".
     clean_podman_state(&tmp_dir, &["overlay", "overlay-images", "overlay-layers"]).await;
 
-    // Package the storage tree as an ext4 image using the existing helper.
-    // NOTE: Can't use with_extension() here because output_path ends in .storage.img
-    // -- with_extension replaces after the last dot, producing a double "storage".
-    let tmp_img = PathBuf::from(format!("{}.tmp", output_path.display()));
+    // Package the storage tree as an ext4 image, building into a UUID-keyed temp and
+    // atomically renaming (see `unique_cache_tmp` — a shared "<digest>.tmp" lets two VMs
+    // mkfs/resize2fs the same file and one's rename ENOENTs the other's in-flight temp).
+    let tmp_img = unique_cache_tmp(output_path);
     let result = create_disk_from_dir(&tmp_dir, &tmp_img, true).await;
 
     // Clean up temp storage dir regardless of result
@@ -395,5 +420,25 @@ mod tests {
     #[test]
     fn missing_separator_is_an_error() {
         assert!(parse_image_cache_ref("localhost/qux", "no-tab-here\n").is_err());
+    }
+
+    #[test]
+    fn cache_tmp_is_unique_per_call() {
+        // Regression for the cross-VM image-cache race (PR #677): two builders preparing the
+        // same content-addressed file must NOT share a temp name. A fixed "<final>.tmp" let
+        // concurrent VMs (sharing the host image-cache via --map, where flock does not
+        // coordinate) corrupt each other's image and ENOENT each other's rename. The temp
+        // MUST be unique per call.
+        let final_path = Path::new("/mnt/fcvm-btrfs/image-cache/abc123.storage-v2.img");
+        let a = unique_cache_tmp(final_path);
+        let b = unique_cache_tmp(final_path);
+        assert_ne!(a, b, "concurrent builders must get distinct temp paths");
+
+        // It must remain a sibling of the final file (same dir → rename is an atomic
+        // intra-filesystem replace, not a cross-device copy) and carry the final name.
+        assert_eq!(a.parent(), final_path.parent());
+        let a_str = a.to_str().unwrap();
+        assert!(a_str.contains("abc123.storage-v2.img"), "got {a_str}");
+        assert!(a_str.ends_with(".tmp"), "got {a_str}");
     }
 }

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -620,9 +620,12 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
             }
 
             // Atomic rename within the same filesystem
-            tokio::fs::rename(&tmp_path, &archive_path)
-                .await
-                .context("renaming exported archive to final path")?;
+            if let Err(e) = tokio::fs::rename(&tmp_path, &archive_path).await {
+                // Clean up the UUID-keyed temp — unlike the old fixed-name temp, a UUID
+                // orphan is never overwritten by the next run.
+                let _ = tokio::fs::remove_file(&tmp_path).await;
+                return Err(e).context("renaming exported archive to final path");
+            }
 
             info!(path = %archive_path.display(), "Image exported as Docker archive");
         }

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -597,15 +597,12 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
         if needs_export {
             info!(image = %args.image, digest = %digest, "Exporting localhost image as Docker archive");
 
-            // Save to a temp file in the same directory, then rename.
-            // This avoids corrupt archives from interrupted exports (atomic rename).
-            // NOTE: Can't use with_extension("docker.tar.tmp") here because archive_path
-            // ends in .docker.tar — with_extension replaces after the last dot, producing
-            // .docker.docker.tar.tmp (double .docker). Use format! to just append .tmp.
-            let tmp_path = PathBuf::from(format!("{}.tmp", archive_path.display()));
-
-            // Remove stale tmp file if it exists (skopeo won't overwrite)
-            let _ = tokio::fs::remove_file(&tmp_path).await;
+            // Export into a UUID-keyed temp, then atomically rename. This avoids corrupt
+            // archives from interrupted exports AND is safe under cross-VM concurrency: the
+            // image-cache dir is shared across VMs and the per-digest flock above does not
+            // coordinate cross-VM (see image::unique_cache_tmp). A shared "<digest>.tmp"
+            // would let one VM's rename ENOENT the other's in-flight export.
+            let tmp_path = image::unique_cache_tmp(&archive_path);
 
             // Export by the IMMUTABLE image ID captured at inspect time, not the mutable
             // tag (#598). A parallel build can repoint the tag between the cache-key


### PR DESCRIPTION
**Stacked on:** main (independent of the #632 hypervisor stack).

Started as "de-serialize the nested NV2 tests to cut the arm64 long pole." Digging into *why* the de-serialized run failed turned up two distinct things — one a real latent bug, one a measurement that overturns the premise.

## 1. Cross-VM image-cache race (real bug — fixed)
Two VMs preparing the same localhost image into a **shared** image-cache dir raced on a fixed temp name:
```
ERROR fcvm: Error: renaming storage image to final path: No such file or directory (os error 2)
resize2fs: Inode checksum does not match inode ... .storage-v2.img.tmp
```
- Reachable whenever the cache dir is shared across VMs — nested tests `--map` the host `/mnt/fcvm-btrfs` into every L1, and a user running fcvm **inside** a nested VM with a mapped cache hits the same path.
- The per-digest `flock` doesn't help: `fs2::lock_exclusive()` is `flock()` (BSD), and a fuse-pipe mount negotiates no `FUSE_FLOCK_LOCKS`, so each guest kernel grants it **locally** and never forwards to the shared host backing store.
- `e2fsck` on the cached file confirmed the race had been **persisting a corrupt image** (`Filesystem still has errors`) — silently poisoning later runs.

**Fix (right altitude — make the writes not need a lock):** `image::unique_cache_tmp()` keys every temp by a fresh UUID (not pid — separate PID namespaces reuse numbers) + atomic rename to the content-addressed final path (identical bytes → rename race is idempotent). Applied to the storage-image build and the docker-archive export. Regression unit test + the debugging technique documented in `.claude/CLAUDE.md`.

## 2. Nested tests don't parallelize — keep them serialized
Measured: 2 nested tests cold-cache concurrent = **1085s wall + a flake** (an L2 ingress iperf3 starved under contention and blew its internal 840s budget, killed at 852s); the same test alone = **227s**. ~3.7× slowdown from 2-way contention with no other load. Every nested guest-exit issues a system-wide `dsb(sy)` (the #630 cache-coherency patch) on top of NV2 overhead, so concurrent chains stall each other globally. Concurrency widens the tail.

So the long pole is cut by running **fewer** nested tests in CI, not by parallelizing:
- `nextest.toml`: `[test-groups.nested-tests] max-threads = 1` (revert the 1→3 experiment), with both reasons documented.
- `Makefile`: when `CI=true`, run a representative three and skip the rest (still run locally):
  - `test_nested_run_fcvm_inside_vm` — nesting works + `/dev/kvm` in guest
  - `test_nested_l2_with_large_files` — FUSE-over-FUSE coherency (#630 DSB guard)
  - `test_nested_l2_nfs` — NFS data path under nesting
  - Skips the iperf throughput tests (slowest + flakiest) + FUSE/utimensat variants. Scoped to `package(fcvm)` so fuse-pipe's `test_nested_file` is unaffected; override with `FILTER=`.

## Verification
```
# Race fix: cold-cache concurrent nested run rebuilt the image cleanly
#   - no .tmp debris, e2fsck clean, L2 booted (MARKER_L2_OK) where it previously corrupted
# Filter selection (cargo nextest list -E ...): exactly the 3 fcvm nested tests
#   + keeps fuse-pipe test_nested_file; drops l2_fuse, both network, utimensat
cargo test -p fcvm --lib cache_tmp_is_unique_per_call   # ok
cargo fmt --check / cargo clippy                          # clean
```