### PR TITLE
ci: run benchmark workflow weekly instead of nightly

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,8 +1,8 @@
-name: Nightly
+name: Weekly
 
 on:
   schedule:
-    - cron: '0 4 * * *'  # 4 AM UTC daily
+    - cron: '0 4 * * 1'  # 4 AM UTC every Monday (weekly)
   workflow_dispatch:  # Manual trigger
 
 env:


### PR DESCRIPTION
Changes the benchmark workflow from a daily schedule to weekly.

- Renamed `Nightly` -> `Weekly` (`git mv nightly.yml weekly.yml`, history preserved).
- Cron `0 4 * * *` (daily) -> `0 4 * * 1` (Mondays 04:00 UTC).
- `workflow_dispatch` retained for on-demand runs.

The benchmark suite (container benches + self-hosted VM/hugepage/container-import benches) tracks perf trends; weekly is sufficient and frees the self-hosted runners the other 6 days. No code/test changes; nothing else references the workflow by name.