### PR TITLE
docs: fix two README inaccuracies (FCVM_DATA_DIR, rootless IPv6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Supported runtimes: `python`, `node`, `ruby`, `go`, or any custom image name.
 
 ### Rootless Architecture
 
-Uses [pasta](https://passt.top/) (from the passt project) with a Linux bridge for L2 forwarding between pasta and the VM. Pasta uses splice(2) zero-copy L4 translation. IPv6 supported with `--enable-ipv6`.
+Uses [pasta](https://passt.top/) (from the passt project) with a Linux bridge for L2 forwarding between pasta and the VM. Pasta uses splice(2) zero-copy L4 translation. IPv6 is enabled automatically when the host has a global IPv6 address (auto-detected; no flag needed).
 
 Host services are reachable from VMs via pasta gateways: `10.0.2.2` (IPv4) and `fd00::2` (IPv6).
 
@@ -374,7 +374,7 @@ Run `fcvm --help` or `fcvm <command> --help` for full options.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `FCVM_BASE_DIR` | `/mnt/fcvm-btrfs` | Base directory for all data |
+| `FCVM_DATA_DIR` | `/mnt/fcvm-btrfs` | Base directory for all data |
 | `FCVM_NO_SNAPSHOT` | unset | `1` to disable snapshot creation (same as `--no-snapshot`) |
 | `FCVM_NO_WRITEBACK_CACHE` | unset | `1` to disable FUSE writeback cache |
 | `FCVM_SNAPSHOT_CONCURRENCY` | `10` | Max concurrent snapshot creations |

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ sudo ./fcvm podman run --name web --network routed nginx:alpine
 ./fcvm ls --json
 ```
 
+> **`--map` in rootless mode:** mapped volumes are read/written by the container's
+> *root* user. A container process running as a **non-root** user (e.g. nginx's
+> worker) currently gets I/O errors reading a rootless-mapped volume — use
+> `--network bridged` for those, or run the container as root. (The nginx example
+> above therefore needs `--network bridged` in rootless environments.)
+
 ---
 
 ## Snapshot & Clone Workflow


### PR DESCRIPTION
Found while walking through every README example on a live host.

**Fixed:**
1. Env var table said `FCVM_BASE_DIR` — the code reads `FCVM_DATA_DIR` (`src/paths.rs:23`); `FCVM_BASE_DIR` is read nowhere.
2. Rootless section said *'IPv6 supported with `--enable-ipv6`'* — no such flag exists; rootless IPv6 is auto-detected from the host's global IPv6 (`pasta.rs detect_host_ipv6`).

**Verified working as documented:** Quick Start (`podman run … -- echo`, `ls`, `ls --json`, `exec --name`), `--publish` port-forward, `--map` (root reader), comma-separated `--publish`, snapshot `create <name> --tag` / `snapshots ls` / `run --snapshot --name` clone, and `fcvm serve` gateway.

**Separately reported (not in this PR — functional, not doc):** rootless `--map` volumes return EIO for *non-root* container processes (e.g. nginx worker → 500); works in bridged mode. Tracking separately.