### PR TITLE
fix(fuse): rootless --map readable by non-root container processes (#683)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,6 @@ sudo ./fcvm podman run --name web --network routed nginx:alpine
 ./fcvm ls --json
 ```
 
-> **`--map` in rootless mode:** mapped volumes are read/written by the container's
-> *root* user. A container process running as a **non-root** user (e.g. nginx's
-> worker) currently gets I/O errors reading a rootless-mapped volume — use
-> `--network bridged` for those, or run the container as root. (The nginx example
-> above therefore needs `--network bridged` in rootless environments.)
-
 ---
 
 ## Snapshot & Clone Workflow

--- a/tests/test_sanity.rs
+++ b/tests/test_sanity.rs
@@ -719,3 +719,70 @@ async fn test_container_startup_failure_triggers_shutdown() -> Result<()> {
         }
     }
 }
+
+/// #683: a NON-root container process must be able to read a rootless `--map`'d volume.
+///
+/// The rootless volume server runs unprivileged (no CAP_SETUID), so the per-request
+/// fs-credential switch in fuse-backend-rs used to hard-fail with EIO for non-root readers
+/// (e.g. nginx's worker → HTTP 500), while root readers and bridged mode worked. The
+/// fuse-backend-rs cap-gate skips the switch when unprivileged (the guest mount's
+/// DefaultPermissions still enforces DAC). This test runs the VM ROOTLESS *as the
+/// unprivileged user* (no sudo) so it actually reproduces the failure — a privileged run
+/// would hold CAP_SETUID and mask the bug.
+#[tokio::test]
+async fn test_rootless_map_nonroot_reader() -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    println!("\nTest rootless --map readable by a non-root container process (#683)");
+
+    let (vm_name, _, _, _) = common::unique_names("map-nonroot");
+    let host_dir = format!("/tmp/{}", vm_name);
+    tokio::fs::create_dir_all(&host_dir).await?;
+    let marker = "rootless-map-nonroot-ok";
+    let file = format!("{}/data.txt", host_dir);
+    tokio::fs::write(&file, marker).await?;
+    // 0644 so a non-root reader is allowed by DAC — the check exercises the credential
+    // mechanism, not a real permission denial.
+    std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644))?;
+
+    let map_arg = format!("{}:/data:ro", host_dir);
+    let (mut child, fcvm_pid) = common::spawn_fcvm(&[
+        "podman", "run", "--name", &vm_name, "--network", "rootless", "--map", &map_arg,
+        common::TEST_IMAGE,
+    ])
+    .await
+    .context("spawning rootless fcvm with --map")?;
+    let _ = &mut child;
+
+    if let Err(e) = common::poll_health_by_pid(fcvm_pid, 180).await {
+        common::kill_process(fcvm_pid).await;
+        let _ = tokio::fs::remove_dir_all(&host_dir).await;
+        return Err(e.context("VM failed to become healthy"));
+    }
+
+    // Control: root reads the mapped file (this always worked).
+    let root_read = common::exec_in_container(fcvm_pid, &["cat", "/data/data.txt"]).await;
+    // Regression: a NON-root user reads it (returned EIO before the cap-gate fix).
+    let nonroot_read = common::exec_in_container(
+        fcvm_pid,
+        &["su", "-s", "/bin/sh", "nobody", "-c", "cat /data/data.txt"],
+    )
+    .await;
+
+    common::kill_process(fcvm_pid).await;
+    let _ = tokio::fs::remove_dir_all(&host_dir).await;
+
+    let root_out = root_read.context("root read of mapped file failed")?;
+    assert!(
+        root_out.contains(marker),
+        "root should read the mapped file; got: {root_out:?}"
+    );
+    let nonroot_out =
+        nonroot_read.context("non-root read of mapped file failed (#683 EIO regression)")?;
+    assert!(
+        nonroot_out.contains(marker),
+        "non-root container process must read the rootless --map'd file (#683); got: {nonroot_out:?}"
+    );
+    println!("✅ #683: non-root read of rootless --map'd volume works");
+    Ok(())
+}

--- a/tests/test_sanity.rs
+++ b/tests/test_sanity.rs
@@ -747,7 +747,14 @@ async fn test_rootless_map_nonroot_reader() -> Result<()> {
 
     let map_arg = format!("{}:/data:ro", host_dir);
     let (mut child, fcvm_pid) = common::spawn_fcvm(&[
-        "podman", "run", "--name", &vm_name, "--network", "rootless", "--map", &map_arg,
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--network",
+        "rootless",
+        "--map",
+        &map_arg,
         common::TEST_IMAGE,
     ])
     .await
@@ -763,11 +770,12 @@ async fn test_rootless_map_nonroot_reader() -> Result<()> {
     // Control: root reads the mapped file (this always worked).
     let root_read = common::exec_in_container(fcvm_pid, &["cat", "/data/data.txt"]).await;
     // Regression: a NON-root user reads it (returned EIO before the cap-gate fix).
-    let nonroot_read = common::exec_in_container(
-        fcvm_pid,
-        &["su", "-s", "/bin/sh", "nobody", "-c", "cat /data/data.txt"],
-    )
-    .await;
+    // exec_in_container joins argv with spaces and runs it under `sh -c`, so the inner
+    // `su -c <CMD>` must be a single pre-quoted element — otherwise `su -c cat /data/...`
+    // parses only `cat` as the command and `cat` reads empty stdin (exit 0, no output).
+    let nonroot_read =
+        common::exec_in_container(fcvm_pid, &["su -s /bin/sh nobody -c 'cat /data/data.txt'"])
+            .await;
 
     common::kill_process(fcvm_pid).await;
     let _ = tokio::fs::remove_dir_all(&host_dir).await;


### PR DESCRIPTION
Fixes #683.

**Bug:** In rootless mode, a non-root container process (e.g. nginx's worker) got **EIO** reading a `--map`'d volume → HTTP 500. Root readers and bridged mode worked.

**Root cause:** the fuse-pipe volume server runs in-process as the unprivileged rootless user (CapEff=0). The fork's `ScopedCreds::new()` does `setfsuid/setfsgid` then *verifies and hard-fails* — but `setfsuid` is a silent no-op without `CAP_SETUID`, so it returns errno-less `PermissionDenied`, which the server maps to EIO.

**Fix** (in the `fuse-backend-rs` fork, `ejc3/fuse-backend-rs@f42317d`, which CI's checkout-deps tracks on `master`): cap-gate the per-request fs-credential switch — skip it when `CAP_SETUID`/`CAP_SETGID` are absent. The op then runs as the server's own uid (which owns the mapped files), and the guest FUSE mount's `DefaultPermissions` already enforces real DAC against the forwarded uid/gid. Privileged servers (root/bridged) keep the caps, so POSIX semantics + pjdfstest are unchanged.

**This PR** adds the fcvm regression test (`test_rootless_map_nonroot_reader`) — runs ROOTLESS as the unprivileged user so it actually reproduces the failure. Live-verified: rootless nginx+`--map` now returns HTTP 200 (was 500).

Depends on the fork commit (already on `ejc3/fuse-backend-rs@master`).