### PR TITLE
perf(ci): drop nested large-file test from SnapshotEnabled job (−18 min long pole)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,23 @@ endif
 CI ?=
 ifndef FILTER
 ifeq ($(CI),true)
-CI_NESTED_FILTER := -E '(not (package(fcvm) & (test(/nested/) | test(/podman_load_over_fuse/))) | test(=test_nested_run_fcvm_inside_vm) | test(=test_nested_l2_with_large_files) | test(=test_nested_l2_nfs)) & not test(=test_cloud_hypervisor_cold_boot)'
+# Base test-root CI filter: the nested subset (exclude all nested except the 3 kept) AND
+# always exclude the CH cold-boot test (#687).
+CI_ROOT_BASE := (not (package(fcvm) & (test(/nested/) | test(/podman_load_over_fuse/))) | test(=test_nested_run_fcvm_inside_vm) | test(=test_nested_l2_with_large_files) | test(=test_nested_l2_nfs)) & not test(=test_cloud_hypervisor_cold_boot)
+ifeq ($(FCVM_NO_SNAPSHOT),)
+# SnapshotEnabled mode (FCVM_NO_SNAPSHOT unset): ALSO drop test_nested_l2_with_large_files.
+# It guards FUSE-over-FUSE DATA INTEGRITY (the #630 DSB cache-coherency fix) — a live-traffic
+# property of the always-on kernel patch, independent of the snapshot feature — and it already
+# runs in the SnapshotDisabled job (~225s). Under SnapshotEnabled it runs TWICE (cold + restore)
+# and the warm run is a 4GB *nested* VM UFFD restore whose page faults go through double Stage-2
+# translation (~842s), ~18 min total for zero extra integrity coverage. Snapshot/restore
+# correctness is covered by test_startup_snapshot_* and the CH/clone roundtrips. This is the
+# single biggest lever on the arm64 SnapshotEnabled long pole (the file copy itself is only ~20s).
+CI_NESTED_FILTER := -E '$(CI_ROOT_BASE) & not test(=test_nested_l2_with_large_files)'
+else
+# SnapshotDisabled mode: keep test_nested_l2_with_large_files (the FUSE-integrity guard runs here).
+CI_NESTED_FILTER := -E '$(CI_ROOT_BASE)'
+endif
 endif
 endif
 


### PR DESCRIPTION
**Stacked on:** `ci-cloud-hypervisor-build` (PR #686) — both edit the same CI test-root filter; will retarget to `main` after #686 merges.

## Problem

`test_nested_l2_with_large_files` is the **single longest test in CI by ~17×**. In the arm64 `Host-Root-SnapshotEnabled` job (the long pole) it runs **twice** — cold-boot populate (~225s) + warm restore (~842s) = **~18 min**, serialized at the tail of each run.

Profiling the green main run (27507721193) showed the 32MB FUSE-over-FUSE copy itself is only **~20s**:

| | Run 1 (cold) | Run 2 (warm restore) |
|---|---|---|
| L2 copy TO | 19.5s | 1.7s |
| **whole test** | **225s** | **842s** |

So ~800s is **4GB nested-VM snapshot create→restore** (UFFD page faults through double Stage-2 translation), not the copy. Shrinking the file would save ~18s — the wrong lever.

## Fix

Run this test only in the **SnapshotDisabled** job (where it already runs, ~225s, `FCVM_NO_SNAPSHOT=1`) and **exclude it from SnapshotEnabled**. It guards FUSE-over-FUSE **data integrity** (the #630 DSB cache-coherency fix) — a live-traffic property of the always-on kernel patch, independent of the snapshot feature. Snapshot/restore correctness stays covered by `test_startup_snapshot_*` and the CH/clone roundtrips.

**Projected: arm64 SnapshotEnabled long pole ~49 min → ~31 min** (~37% off the gating job; combined with the earlier nested-subset work, 77 → ~31 min overall).

## Mechanism

The CI test-root filter is built from a shared `CI_ROOT_BASE` (nested subset + CH cold-boot exclusion #687); in SnapshotEnabled mode (`FCVM_NO_SNAPSHOT` empty) it additionally ANDs `not test(=test_nested_l2_with_large_files)`. ANDed into the single `-E` filterset because nextest **unions** separate `-E`.

## Verification

\`\`\`
# make -n _test-root injects the large-file exclusion ONLY when FCVM_NO_SNAPSHOT is empty:
CI=true               → ... & not test(=test_cloud_hypervisor_cold_boot) & not test(=test_nested_l2_with_large_files)
CI=true FCVM_NO_SNAPSHOT=1 → ... & not test(=test_cloud_hypervisor_cold_boot)   (large_files kept)

# cargo nextest list, SnapshotEnabled filter — kept:
fcvm::test_kvm test_nested_l2_nfs
fcvm::test_kvm test_nested_run_fcvm_inside_vm
fcvm::test_sanity test_cloud_hypervisor_snapshot_roundtrip
# dropped: test_nested_l2_with_large_files, test_cloud_hypervisor_cold_boot
\`\`\`