### PR TITLE
fix(ci): update audited dependencies and restore IPv6 proxy test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
@@ -478,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -850,28 +850,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -890,12 +874,6 @@ dependencies = [
  "futures-task",
  "futures-util",
 ]
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
@@ -926,13 +904,10 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1512,9 +1487,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -1885,9 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -2294,25 +2269,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "serde"
@@ -2391,23 +2351,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
- "futures",
+ "futures-executor",
+ "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ CONTAINER_RUN := $(CONTAINER_RUN_BASE) --ulimit nproc=65536:65536 --pids-limit=6
 	container-setup-fcvm container-shell container-clean container-bench \
 	setup-btrfs setup-default setup-fcvm setup-pjdfstest setup-hugepages bench bench-vm bench-hugepages bench-hugepages-test \
 	bench-container-import \
-	lint fmt ssh test-serve-sdk
+	lint fmt update-dependency ssh test-serve-sdk
 
 all: build
 
@@ -209,6 +209,7 @@ help:
 	@echo "Build:"
 	@echo "  build              Build fcvm + fc-agent"
 	@echo "  build-fc-mock      Build fc-mock (Firecracker mock for container mode)"
+	@echo "  update-dependency  Update one Cargo.lock package (PACKAGE=..., optional VERSION=...)"
 	@echo "  clean              Remove target directory"
 	@echo ""
 	@echo "Test (host):"
@@ -668,6 +669,10 @@ lint: setup-lint-tools
 	$(CARGO) clippy --all-targets -- -D warnings
 	$(CARGO) audit
 	$(CARGO) deny check
+
+update-dependency:
+	@test -n "$(PACKAGE)" || (echo "ERROR: PACKAGE required"; exit 1)
+	$(CARGO) update -p "$(PACKAGE)" $(if $(VERSION),--precise "$(VERSION)")
 
 fmt:
 	$(CARGO) fmt

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2223,9 +2223,8 @@ impl LocalProxyServer {
             "[proxy] Got {} bytes from target, forwarding to client",
             response.len()
         );
-        writer.write_all(&response).await?;
-
         request_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        writer.write_all(&response).await?;
         eprintln!("[proxy] Request complete");
         Ok(())
     }

--- a/tests/test_proxy.rs
+++ b/tests/test_proxy.rs
@@ -42,26 +42,25 @@ async fn get_host_ipv6() -> Option<String> {
 
 /// Helper to test proxy functionality for a given address family.
 ///
-/// 1. Target server binds to `host_bind` on host
-/// 2. Proxy server binds to `host_bind` on host
-/// 3. VM uses curl with http_proxy env var pointing to `vm_gateway`
+/// 1. Target server binds to `target_bind` on host
+/// 2. Proxy server binds to `proxy_bind` on host
+/// 3. VM uses curl with `-x` pointing to `vm_gateway`
 /// 4. VM requests target URL via the proxy
 /// 5. Proxy forwards to target and returns response
-async fn test_proxy_to_addr(host_bind: &str, vm_gateway: &str, addr_type: &str) -> Result<()> {
-    let is_ipv6 = host_bind.contains(':');
-
+async fn test_proxy_to_addr(
+    target_bind: &str,
+    proxy_bind: &str,
+    vm_gateway: &str,
+    addr_type: &str,
+) -> Result<()> {
     // Start target server
-    let target_server = common::LocalTestServer::start_on_available_port(host_bind)
+    let target_server = common::LocalTestServer::start_on_available_port(target_bind)
         .await
         .context("start target server")?;
-    let target_url = if is_ipv6 {
-        format!("http://[{}]:{}/", host_bind, target_server.port)
-    } else {
-        format!("http://{}:{}/", host_bind, target_server.port)
-    };
+    let target_url = target_server.url.clone();
 
     // Start proxy server
-    let proxy_server = common::LocalProxyServer::start_on_available_port(host_bind)
+    let proxy_server = common::LocalProxyServer::start_on_available_port(proxy_bind)
         .await
         .context("start proxy server")?;
     let vm_proxy_url = if vm_gateway.contains(':') {
@@ -72,15 +71,15 @@ async fn test_proxy_to_addr(host_bind: &str, vm_gateway: &str, addr_type: &str) 
 
     println!(
         "[{}] Target: {} (host's {})",
-        addr_type, target_url, host_bind
+        addr_type, target_url, target_bind
     );
     println!(
         "[{}] Proxy:  {} (host's {})",
-        addr_type, proxy_server.url, host_bind
+        addr_type, proxy_server.url, proxy_bind
     );
     println!(
         "[{}] VM proxy: {} ({} → {})",
-        addr_type, vm_proxy_url, vm_gateway, host_bind
+        addr_type, vm_proxy_url, vm_gateway, proxy_bind
     );
 
     let (vm_name, _, _, _) = common::unique_names(&format!("proxy-{}", addr_type));
@@ -132,7 +131,7 @@ async fn test_proxy_to_addr(host_bind: &str, vm_gateway: &str, addr_type: &str) 
         pid,
         &[
             "curl",
-            "-s",
+            "-sS",
             "--max-time",
             "10",
             "-x",
@@ -168,7 +167,7 @@ async fn test_proxy_to_addr(host_bind: &str, vm_gateway: &str, addr_type: &str) 
             );
             println!(
                 "[{}] ✓ VM used proxy ({}) to reach target ({})",
-                addr_type, vm_gateway, host_bind
+                addr_type, vm_gateway, target_bind
             );
             Ok(())
         }
@@ -185,15 +184,16 @@ async fn test_proxy_ipv6() -> Result<()> {
         );
         return Ok(());
     }
-    // Note: We use :: (all interfaces) instead of ::1 because pasta IPv6
-    // doesn't have host loopback translation like IPv4's 10.0.2.2 → 127.0.0.1
-    test_proxy_to_addr("::", "fd00::2", "ipv6").await
+    // The proxy listens on :: so the VM must reach it over IPv6 through
+    // pasta's fd00::2 gateway. The proxy-to-target hop is host-local and
+    // independent of the client-to-proxy address family under test.
+    test_proxy_to_addr("127.0.0.1", "::", "fd00::2", "ipv6").await
 }
 
 /// Test IPv4 proxy: VM uses 10.0.2.2 to reach proxy on 127.0.0.1
 #[tokio::test]
 async fn test_proxy_ipv4() -> Result<()> {
-    test_proxy_to_addr("127.0.0.1", "10.0.2.2", "ipv4").await
+    test_proxy_to_addr("127.0.0.1", "127.0.0.1", "10.0.2.2", "ipv4").await
 }
 
 /// Helper to test VM egress to a specific bind address.

--- a/tests/test_proxy.rs
+++ b/tests/test_proxy.rs
@@ -134,6 +134,10 @@ async fn test_proxy_to_addr(
             "-sS",
             "--max-time",
             "10",
+            // Force proxy use even if inherited NO_PROXY contains the target.
+            "--noproxy",
+            // exec_in_container joins command words into a shell script.
+            "\"\"",
             "-x",
             &vm_proxy_url,
             &target_url,


### PR DESCRIPTION
## Summary

- Update packages flagged by newly published RustSec and cargo-deny advisories.
- Remove the vulnerable transitive scc dependency through serial_test 3.5.
- Add a targeted Makefile dependency-update target.
- Include the separately reviewed proxy fix from PR #696 so the host matrix remains valid with Alpine curl 8.21.

## Why

The advisory database refresh caused make lint to fail. After those updates, the host matrix exposed curl issue #22382: curl 8.21 rejects an IPv6-literal origin through a non-tunneling proxy before sending a request. The test now keeps the VM-to-proxy hop on IPv6 while using an independent IPv4 host-local target, and explicitly overrides inherited NO_PROXY exclusions.

The proxy change was reviewed in PR #696 and merged into this branch so this PR can run the complete protected matrix with both fixes present.

## Test results

- make lint — passes
- make test-unit — passes
- make test-root FILTER=proxy STREAM=1 — 16 passed
- NO_PROXY=127.0.0.1 no_proxy=127.0.0.1 make test-root FILTER=proxy_ipv6 STREAM=1 — 1 passed, proxy handled one request

Upstream curl issue: https://github.com/curl/curl/issues/22382
Upstream curl fix: https://github.com/curl/curl/commit/a479459ea39ac0e7de37237f9f0ba9a0c9d7f470