### PR TITLE
test(proxy): isolate IPv6 proxy hop from curl regression

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2223,9 +2223,8 @@ impl LocalProxyServer {
             "[proxy] Got {} bytes from target, forwarding to client",
             response.len()
         );
-        writer.write_all(&response).await?;
-
         request_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        writer.write_all(&response).await?;
         eprintln!("[proxy] Request complete");
         Ok(())
     }

--- a/tests/test_proxy.rs
+++ b/tests/test_proxy.rs
@@ -42,26 +42,25 @@ async fn get_host_ipv6() -> Option<String> {
 
 /// Helper to test proxy functionality for a given address family.
 ///
-/// 1. Target server binds to `host_bind` on host
-/// 2. Proxy server binds to `host_bind` on host
-/// 3. VM uses curl with http_proxy env var pointing to `vm_gateway`
+/// 1. Target server binds to `target_bind` on host
+/// 2. Proxy server binds to `proxy_bind` on host
+/// 3. VM uses curl with `-x` pointing to `vm_gateway`
 /// 4. VM requests target URL via the proxy
 /// 5. Proxy forwards to target and returns response
-async fn test_proxy_to_addr(host_bind: &str, vm_gateway: &str, addr_type: &str) -> Result<()> {
-    let is_ipv6 = host_bind.contains(':');
-
+async fn test_proxy_to_addr(
+    target_bind: &str,
+    proxy_bind: &str,
+    vm_gateway: &str,
+    addr_type: &str,
+) -> Result<()> {
     // Start target server
-    let target_server = common::LocalTestServer::start_on_available_port(host_bind)
+    let target_server = common::LocalTestServer::start_on_available_port(target_bind)
         .await
         .context("start target server")?;
-    let target_url = if is_ipv6 {
-        format!("http://[{}]:{}/", host_bind, target_server.port)
-    } else {
-        format!("http://{}:{}/", host_bind, target_server.port)
-    };
+    let target_url = target_server.url.clone();
 
     // Start proxy server
-    let proxy_server = common::LocalProxyServer::start_on_available_port(host_bind)
+    let proxy_server = common::LocalProxyServer::start_on_available_port(proxy_bind)
         .await
         .context("start proxy server")?;
     let vm_proxy_url = if vm_gateway.contains(':') {
@@ -72,15 +71,15 @@ async fn test_proxy_to_addr(host_bind: &str, vm_gateway: &str, addr_type: &str) 
 
     println!(
         "[{}] Target: {} (host's {})",
-        addr_type, target_url, host_bind
+        addr_type, target_url, target_bind
     );
     println!(
         "[{}] Proxy:  {} (host's {})",
-        addr_type, proxy_server.url, host_bind
+        addr_type, proxy_server.url, proxy_bind
     );
     println!(
         "[{}] VM proxy: {} ({} → {})",
-        addr_type, vm_proxy_url, vm_gateway, host_bind
+        addr_type, vm_proxy_url, vm_gateway, proxy_bind
     );
 
     let (vm_name, _, _, _) = common::unique_names(&format!("proxy-{}", addr_type));
@@ -132,7 +131,7 @@ async fn test_proxy_to_addr(host_bind: &str, vm_gateway: &str, addr_type: &str) 
         pid,
         &[
             "curl",
-            "-s",
+            "-sS",
             "--max-time",
             "10",
             "-x",
@@ -168,7 +167,7 @@ async fn test_proxy_to_addr(host_bind: &str, vm_gateway: &str, addr_type: &str) 
             );
             println!(
                 "[{}] ✓ VM used proxy ({}) to reach target ({})",
-                addr_type, vm_gateway, host_bind
+                addr_type, vm_gateway, target_bind
             );
             Ok(())
         }
@@ -185,15 +184,16 @@ async fn test_proxy_ipv6() -> Result<()> {
         );
         return Ok(());
     }
-    // Note: We use :: (all interfaces) instead of ::1 because pasta IPv6
-    // doesn't have host loopback translation like IPv4's 10.0.2.2 → 127.0.0.1
-    test_proxy_to_addr("::", "fd00::2", "ipv6").await
+    // The proxy listens on :: so the VM must reach it over IPv6 through
+    // pasta's fd00::2 gateway. The proxy-to-target hop is host-local and
+    // independent of the client-to-proxy address family under test.
+    test_proxy_to_addr("127.0.0.1", "::", "fd00::2", "ipv6").await
 }
 
 /// Test IPv4 proxy: VM uses 10.0.2.2 to reach proxy on 127.0.0.1
 #[tokio::test]
 async fn test_proxy_ipv4() -> Result<()> {
-    test_proxy_to_addr("127.0.0.1", "10.0.2.2", "ipv4").await
+    test_proxy_to_addr("127.0.0.1", "127.0.0.1", "10.0.2.2", "ipv4").await
 }
 
 /// Helper to test VM egress to a specific bind address.

--- a/tests/test_proxy.rs
+++ b/tests/test_proxy.rs
@@ -134,6 +134,10 @@ async fn test_proxy_to_addr(
             "-sS",
             "--max-time",
             "10",
+            // Force proxy use even if inherited NO_PROXY contains the target.
+            "--noproxy",
+            // exec_in_container joins command words into a shell script.
+            "\"\"",
             "-x",
             &vm_proxy_url,
             &target_url,


### PR DESCRIPTION
**Stacked on:** agent/fix-audit-dependencies (PR #694)

## Problem

Alpine latest now installs curl 8.21.0. curl issue #22382 causes a non-tunneling HTTP proxy request to an IPv6-literal origin to fail before sending bytes, incorrectly reporting out of memory. This made the host IPv6 proxy test fail even though the VM connected to the proxy over IPv6 successfully.

Upstream diagnosis: https://github.com/curl/curl/issues/22382
Upstream fix: https://github.com/curl/curl/commit/a479459ea39ac0e7de37237f9f0ba9a0c9d7f470

## Fix

Keep the path under test IPv6: curl connects to the proxy at [fd00::2] and the proxy listens on ::. Bind the independent host-local target on IPv4 so the test does not exercise the unrelated curl regression.

Pass an explicitly empty --noproxy value so inherited host exclusions cannot bypass the proxy. Move the proxy request counter increment before writing the response, eliminating a false-zero assertion window after a successful client return.

## Test results

- make lint — passes
- make test-root FILTER=proxy_ipv6 STREAM=1 — 1 passed
- NO_PROXY=127.0.0.1 no_proxy=127.0.0.1 make test-root FILTER=proxy_ipv6 STREAM=1 — 1 passed, proxy handled one request
- make test-root FILTER=proxy STREAM=1 — 16 passed

Independent local and automated reviews found no remaining correctness blocker. The actionable NO_PROXY review thread was fixed, replied to with test evidence, and resolved.