### PR TITLE
docs: benchmark fcvm loop disk path

### DIFF
--- a/docs/disk-performance.md
+++ b/docs/disk-performance.md
@@ -99,12 +99,13 @@ the same failure guarantees: the local NVMe device belongs to one host, while EB
 Archil are remote durable storage services. This test did not inject failures or
 independently verify provider durability.
 
-The very high read results on all three fcvm-loop layouts came from the sparse backing
-file's page cache. Each 2 GiB test file had just been written and fit in the host's
-16 GiB of memory. These are warm-cache results, not storage-provider read rates. The
-buffered random results also include that cache. The cache can improve a running
-workload's latency, but it is finite and is lost when a workload moves to another
-host.
+The very high read results on all three fcvm-loop layouts are consistent with the
+sparse backing file's page cache dominating the measurements. Each 2 GiB test file had
+just been written and fit in the host's 16 GiB of memory. Other cache layers may also
+have contributed, particularly on the Archil path. These are warm-cache results, not
+storage-provider read rates. The buffered random results include the same cache
+layers. Those caches can improve a running workload's latency, but host-local caches
+are finite and are lost when a workload moves to another host.
 
 Direct EBS and the EBS direct-I/O-loop image both clustered around baseline gp3's
 provisioned 3,000 IOPS and 125 MiB/s. The fcvm-loop EBS image buffered QD1 writes in
@@ -194,9 +195,10 @@ their own latency and capacity tests.
 
 ## Summary
 
-- fcvm's non-Btrfs-host loop path used the host page cache for the sparse backing file.
-  That made warm reads and some buffered writes much faster, but the results do not
-  represent cold storage-provider performance or durability.
+- fcvm's non-Btrfs-host loop path made the sparse backing file eligible for the host
+  page cache. The high warm-read results are consistent with that cache, although other
+  cache layers may have contributed. They do not represent cold storage-provider
+  performance or durability.
 - Median `fsync` through the fcvm-loop EBS image was 2.04 ms, close to direct EBS at
   1.94 ms, but its p99 was 6.32 ms rather than 2.24 ms and its maximum was 82.3 ms
   rather than 18.0 ms. The direct-I/O-loop EBS image measured a 5.67 ms median.

--- a/docs/disk-performance.md
+++ b/docs/disk-performance.md
@@ -4,9 +4,9 @@ fcvm runs containers inside lightweight virtual machines. Each virtual machine h
 writable raw disk image. fcvm stores those images on Btrfs and uses Btrfs
 copy-on-write features to create snapshots and clones without copying unchanged data.
 
-This note compares four ways to provide that Btrfs storage. It measures the host-side
+This note compares seven ways to provide that Btrfs storage. It measures the host-side
 disk path, not virtual-machine startup or container execution. The tests ran on July
-26, 2026, on one AWS `i8ge.large` host with 2 vCPUs and 16 GiB of memory in
+26 and 27, 2026, on one AWS `i8ge.large` host with 2 vCPUs and 16 GiB of memory in
 `us-west-2`, using fio 3.36.
 
 The tests cover sequential throughput, 4 KiB random I/O, buffered mixed I/O, `fsync`
@@ -21,20 +21,21 @@ volume type. Archil is a remote POSIX filesystem mounted by its Linux FUSE clien
 
 | Name | Layout |
 |---|---|
+| Local NVMe image (fcvm loop) | 8 GiB sparse file on local NVMe/ext4, mounted with fcvm's `mount -o loop` path and formatted as Btrfs |
 | Local NVMe image (direct-I/O loop) | 8 GiB sparse file on local NVMe/ext4, attached through a direct-I/O loop device and formatted as Btrfs |
 | EBS direct | Dedicated 32 GiB baseline gp3 volume formatted directly as Btrfs |
+| EBS image (fcvm loop) | 8 GiB sparse file on the host's gp3/ext4 root volume, mounted with fcvm's `mount -o loop` path and formatted as Btrfs |
 | EBS image (direct-I/O loop) | 8 GiB sparse file on the host's gp3/ext4 root volume, attached through a direct-I/O loop device and formatted as Btrfs |
+| Archil image (fcvm loop) | 8 GiB sparse file on an Archil FUSE mount, mounted with fcvm's `mount -o loop` path and formatted as Btrfs |
 | Archil image (direct-I/O loop) | 8 GiB sparse file on an Archil FUSE mount, attached through a direct-I/O loop device and formatted as Btrfs |
 
-The image layouts are candidate configurations, not fcvm's current loop-device path.
-fcvm currently mounts its storage image with `mount -o loop`, which does not enable
-direct I/O for the loop device. This experiment explicitly enabled loop-device direct
-I/O, which controls how the sparse backing file is opened. That setting is separate
-from fio's own direct-I/O setting. Results for the three image layouts therefore do
-not measure fcvm's shipped loop configuration. This qualification applies to the I/O,
-clone, and reclamation results; EBS direct does not use a loop device. The same tests
-need to be repeated through fcvm's shipped automatic mount path before using these
-numbers to choose or change fcvm's default.
+The fcvm-loop rows reproduced fcvm's first-time formatting and mount commands for a
+non-Btrfs host filesystem: `mkfs.btrfs IMAGE` followed by
+`mount -o loop IMAGE DIRECTORY`. This left loop-device direct I/O off. The
+direct-I/O-loop rows use the same 8 GiB image layout with loop-device direct I/O
+enabled. The image size was held at 8 GiB for comparison. fcvm normally makes the
+logical image size equal to the total capacity of the filesystem containing the
+image's parent directory.
 
 A sparse file does not allocate storage for ranges that have never been written. A
 Linux loop device makes that file look like a block device, allowing Btrfs to be
@@ -43,9 +44,10 @@ created inside it. For the image layouts, a request followed this path:
 These layers are part of the measured path, so the image results are not raw-provider
 or raw-device measurements.
 
-As benchmark parameters, all Btrfs mounts used
-`noatime,space_cache=v2,discard=async`. fcvm's automatic `mount -o loop` path does not
-explicitly request these mount options.
+The direct-I/O-loop and direct-EBS mounts requested
+`noatime,space_cache=v2,discard=async`. The fcvm-loop mounts requested no Btrfs options
+of their own. On this host, `findmnt` reported effective options that included
+`relatime,ssd,space_cache=v2,discard=async`.
 
 ## I/O results
 
@@ -53,51 +55,67 @@ Sequential tests transferred 2 GiB with 1 MiB requests at queue depth 16. Random
 used 4 KiB requests for seven seconds at queue depths 1 and 16. Queue depth is the
 maximum number of I/O requests fio can have outstanding at once. Every pair in the
 table is shown as read first, then write. kIOPS means thousands of I/O operations per
-second.
+second. Each fio value comes from one run for that layout; it is not an average across
+repeated jobs.
 
-Separately from the loop-device setting described above, fio requested direct I/O,
-which bypassed the Linux page cache for the test file. Loop-device direct I/O requested
-direct access to the sparse backing file. Caching could still occur in the FUSE client,
-storage service, or physical device.
+fio requested direct I/O, which bypassed the Linux page cache for the test file inside
+Btrfs. On the fcvm-loop path, the loop device still used buffered I/O for the sparse
+backing file. The backing file could therefore remain in the host page cache. The
+direct-I/O-loop path bypassed that cache as well. Caching could still occur in the FUSE
+client, storage service, or physical device.
 
 | Storage | Sequential R / W (MiB/s) | 4K QD1 R / W (kIOPS) | 4K QD16 R / W (kIOPS) |
 |---|---:|---:|---:|
+| Local NVMe image (fcvm loop) | 9,990 / 213 | 81.6 / 39.9 | 225 / 20.6 |
 | Local NVMe image (direct-I/O loop) | 841 / 292 | 11.6 / 23.5 | 54.6 / 23.1 |
 | EBS direct | 126 / 133 | 1.77 / 1.15 | 3.00 / 1.15 |
+| EBS image (fcvm loop) | 9,352 / 117 | 81.9 / 39.5 | 227 / 3.85 |
 | EBS image (direct-I/O loop) | 126 / 133 | 1.76 / 1.12 | 3.00 / 1.12 |
+| Archil image (fcvm loop) | 9,309 / 490 | 80.5 / 16.8 | 232 / 15.2 |
 | Archil image (direct-I/O loop) | 561 / 528 | 1.43 / 17.3 | 13.2 / 16.2 |
 
 The buffered probe used one synchronous fio worker, 4 KiB random I/O, a 70/30
 read/write mix, and queue depth 1 for ten seconds. Each run started with a new
-copy-on-write copy of the same 2 GiB source file. The `fsync` probe performed 256
-direct 4 KiB writes and called `fsync` after every write. The p50 value is the median;
-p99 is the 99th percentile. fio invalidated the test file before the buffered run, but
-the experiment did not force provider-level caches into a cold state.
+copy-on-write copy of that layout's 2 GiB source file. The `fsync` probe configured fio
+with `fsync=1` for 256 direct 4 KiB writes; fio reported 255 sync calls. The p50 value
+is the median; p99 is the 99th percentile. fio invalidated the test file before the
+buffered run, but the experiment did not force provider-level caches into a cold
+state.
 
 | Storage | Buffered 70/30 (kIOPS) | `fsync` p50 / p99 / max (ms) |
 |---|---:|---:|
+| Local NVMe image (fcvm loop) | 12.7 | 0.46 / 0.78 / 371.8 |
 | Local NVMe image (direct-I/O loop) | 15.9 | 0.23 / 0.39 / 75.2 |
 | EBS direct | 2.57 | 1.94 / 2.24 / 18.0 |
+| EBS image (fcvm loop) | 6.52 | 2.04 / 6.32 / 82.3 |
 | EBS image (direct-I/O loop) | 2.57 | 5.67 / 5.93 / 13.1 |
+| Archil image (fcvm loop) | 32.5 | 5.08 / 10.3 / 210.9 |
 | Archil image (direct-I/O loop) | 2.26 | 4.82 / 6.85 / 162.0 |
 
-The direct-I/O results measure how quickly each complete stack returned ordinary I/O.
-They do not measure durability. The `fsync` column measures how long the call took to
-return at each stack's persistence boundary. Those boundaries do not have the same
-failure guarantees: the local NVMe device belongs to one host, while EBS and Archil are
-remote durable storage services. This test did not inject failures or independently
-verify provider durability.
+The fio tests without `fsync` measure how quickly each complete stack returned
+ordinary I/O. They do not measure durability. The `fsync` column measures how long the
+call took to return at each stack's persistence boundary. Those boundaries do not have
+the same failure guarantees: the local NVMe device belongs to one host, while EBS and
+Archil are remote durable storage services. This test did not inject failures or
+independently verify provider durability.
 
-The EBS results clustered around baseline gp3's provisioned 3,000 IOPS and 125 MiB/s.
-Because both EBS layouts reached roughly the same provisioned limit, this run cannot
-show how much throughput the candidate image layer would cost above that limit. It did
-show a difference in `fsync`: p50 increased from 1.94 ms on direct EBS to 5.67 ms
-through the candidate direct-I/O-loop image layout.
+The very high read results on all three fcvm-loop layouts came from the sparse backing
+file's page cache. Each 2 GiB test file had just been written and fit in the host's
+16 GiB of memory. These are warm-cache results, not storage-provider read rates. The
+buffered random results also include that cache. The cache can improve a running
+workload's latency, but it is finite and is lost when a workload moves to another
+host.
 
-In the tested candidate configuration, the Archil image had higher sequential
-throughput and QD16 random I/O rates than baseline gp3. Its QD1 random-read and
-buffered results were lower, and its `fsync` distribution had a longer tail. These
-numbers describe the complete FUSE, sparse-file, loop-device, and Btrfs path.
+Direct EBS and the EBS direct-I/O-loop image both clustered around baseline gp3's
+provisioned 3,000 IOPS and 125 MiB/s. The fcvm-loop EBS image buffered QD1 writes in
+memory, while QD16 random writes and sequential writes pushed enough data to approach
+the underlying gp3 limits. Median `fsync` was 1.94 ms on direct EBS, 2.04 ms through
+the fcvm loop, and 5.67 ms through the direct-I/O-loop image.
+
+The Archil fcvm-loop row was also dominated by the backing-file cache for reads and
+buffered mixed I/O. Its median `fsync` was 5.08 ms, close to the 4.82 ms
+direct-I/O-loop result. These numbers describe the complete FUSE, sparse-file,
+loop-device, and Btrfs path.
 
 ## Clone results
 
@@ -113,14 +131,17 @@ The median columns measure the time until the clone command returned and the new
 or subvolume was visible. They do not include an explicit persistence operation. To
 show that cost separately, the test created ten clones and then timed one `syncfs` call
 for the containing filesystem. `syncfs` asks the operating system to persist pending
-data and metadata for the whole filesystem. Each median also contains ten clone
+data and metadata for the whole filesystem. Each median was calculated from ten clone
 operations.
 
 | Storage | Source extents | Reflink copy median | `syncfs` after 10 reflinks | Subvolume snapshot median | `syncfs` after 10 snapshots |
 |---|---:|---:|---:|---:|---:|
+| Local NVMe image (fcvm loop) | 443,027 | 56.4 s | 101 ms | 6.08 ms | 1.12 ms |
 | Local NVMe image (direct-I/O loop) | 315,858 | 1.075 s | 1.402 s | 5.97 ms | 1.16 ms |
 | EBS direct | 20,355 | 64.6 ms | 190 ms | 7.84 ms | 1.18 ms |
+| EBS image (fcvm loop) | 440,589 | 107.5 s | 181 ms | 11.3 ms | 1.17 ms |
 | EBS image (direct-I/O loop) | 19,984 | 64.3 ms | 199 ms | 11.7 ms | 1.12 ms |
+| Archil image (fcvm loop) | 246,474 | 828 ms | 1.531 s | 13.1 ms | 1.22 ms |
 | Archil image (direct-I/O loop) | 252,497 | 853 ms | 1.184 s | 13.1 ms | 1.11 ms |
 
 The final `syncfs` value is only the work still outstanding after the ten commands.
@@ -128,15 +149,16 @@ Btrfs may have committed metadata while those commands were running, so this val
 cannot be added to the median or treated as total durable clone latency.
 
 An extent is a contiguous range of file data described by one filesystem metadata
-record. A fragmented file has more extents. The test files had very different extent
-counts, and the reflink results all worked out to roughly 3.2–3.4 microseconds per
-extent. The reflink times therefore show the cost of walking extent metadata, not a
-speed ranking among the storage providers.
+record. A fragmented file has more extents. The direct-I/O-loop reflinks took roughly
+3.2–3.4 microseconds per extent. The fcvm-loop local-NVMe and EBS files had more
+extents and were also much slower per extent. Their median reflinks took 56 and 108
+seconds. The Archil fcvm-loop reflink remained close to its direct-I/O-loop result.
+Extent count alone therefore does not explain the fcvm-loop results.
 
-Subvolume snapshot latency stayed between 6 and 13 ms despite the different extent
-counts. In these candidate configurations, a subvolume per virtual machine made clone
-creation latency less sensitive to source-file fragmentation. Verify this behavior
-through fcvm's shipped mount path before changing its storage layout.
+Subvolume snapshot latency stayed between 6 and 13 ms across all seven layouts despite
+the different extent counts and raw-file reflink times. A subvolume per virtual machine
+made clone creation latency much less sensitive to source-file fragmentation and to
+the loop-device path in this experiment.
 
 ## Reclamation
 
@@ -147,13 +169,16 @@ outer filesystem can remove the corresponding ranges from the sparse file.
 
 | Storage | Observed behavior |
 |---|---|
+| Local NVMe image (fcvm loop) | `fstrim` propagated through the loop device; the sparse file's allocated blocks fell by about 794 MiB |
 | Local NVMe image (direct-I/O loop) | `fstrim` propagated through the loop device; the sparse file's allocated blocks fell by about 655 MiB |
+| EBS image (fcvm loop) | `fstrim` propagated through the loop device; the sparse file's allocated blocks fell by about 1,056 MiB |
 | EBS image (direct-I/O loop) | `fstrim` propagated through the loop device; the sparse file's allocated blocks fell by about 111 MiB |
 | EBS direct | `fstrim` was unsupported on the tested attachment path |
+| Archil image (fcvm loop) | The tested client and mount path did not support removing ranges from the sparse file, so freed Btrfs blocks remained allocated to that file |
 | Archil image (direct-I/O loop) | The tested client and mount path did not support removing ranges from the sparse file, so freed Btrfs blocks remained allocated to that file |
 
-The two reclaimed amounts are not a speed or efficiency comparison. The backing files
-did not contain the same quantity and layout of deleted data.
+The reclaimed amounts are not a speed or efficiency comparison. The backing files did
+not contain the same quantity and layout of deleted data.
 
 Reclaiming blocks from the EBS-backed sparse file did not reduce the provisioned size
 or billing size of the EBS volume. EBS volumes can grow in place but cannot shrink;
@@ -161,28 +186,24 @@ shrinking requires copying live data to a smaller volume. On the tested Archil c
 and mount path, compaction required copying live data to a new sparse image because
 hole punching was unavailable.
 
-In one additional observation, deleting ten heavily fragmented reflink copies on local
-NVMe was followed by roughly three minutes of Btrfs transaction writeback. This was
-background work after the delete commands, not delete-call latency. It was not a
-controlled comparison, so it should not be used as a provider result. It does show that
-deletion and garbage collection need their own latency and capacity tests.
+Clone cleanup was not a timed benchmark. During the runs, deleting ten heavily
+fragmented reflinks took minutes and sometimes blocked inside the delete call itself.
+The fcvm-loop cleanup was especially slow on local NVMe and EBS. This should not be
+used as a provider ranking, but it does show that deletion and garbage collection need
+their own latency and capacity tests.
 
 ## Summary
 
-- The candidate direct-I/O-loop local NVMe image produced the highest random I/O rate
-  and lowest median `fsync` latency, but the device is tied to one host.
-- Both EBS layouts reached the baseline gp3 limits. In the candidate direct-I/O-loop
-  image layout, the clearest measured cost was median `fsync` latency, which was about
-  2.9 times the direct-EBS result.
-- In the tested candidate configuration, the Archil image had higher sequential
-  throughput and QD16 random I/O rates than baseline gp3, but lower QD1 random-read and
-  buffered results and a longer `fsync` tail.
-- In the candidate configurations, Btrfs subvolume snapshots were less sensitive to
-  source-file fragmentation than reflink-copying the raw disk file.
+- fcvm's non-Btrfs-host loop path used the host page cache for the sparse backing file.
+  That made warm reads and some buffered writes much faster, but the results do not
+  represent cold storage-provider performance or durability.
+- Median `fsync` through the fcvm-loop EBS image was 2.04 ms, close to direct EBS at
+  1.94 ms, but its p99 was 6.32 ms rather than 2.24 ms and its maximum was 82.3 ms
+  rather than 18.0 ms. The direct-I/O-loop EBS image measured a 5.67 ms median.
+- Raw-file reflinks through the fcvm loop were unexpectedly slow on local NVMe and EBS,
+  with medians of 56 and 108 seconds. The Archil fcvm-loop median was 828 ms.
+- Btrfs subvolume snapshots stayed between 6 and 13 ms across all layouts and were much
+  less sensitive to source-file fragmentation than reflink-copying the raw disk file.
 - The tests did not measure attach or mount time, cold-cache behavior, concurrent
   virtual machines, migration, or recovery after a failure. Those measurements are
   still required before selecting a default storage layout.
-- These measurements do not benchmark fcvm's current automatic image-backed setup. Run
-  the same suite against the shipped `mount -o loop` path and the direct-I/O-loop
-  candidate side by side before using the results to predict current performance or
-  select a default.


### PR DESCRIPTION
## Summary

- Repeat the disk suite through fcvm's non-Btrfs-host `mount -o loop` path on local NVMe, EBS, and Archil.
- Add those results beside the existing direct-I/O-loop and direct-EBS measurements.
- Remove the warning that fcvm's shipped loop behavior had not been tested.
- Explain the observed backing-file cache, reflink, subvolume snapshot, and reclamation behavior.

## Test results

- `make lint` — passes
- `make test-unit` — passes
- 24 new fio JSON results validated with zero job errors
- All table values and prose independently checked against the raw results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded disk performance reporting to cover seven Btrfs storage/layout configurations instead of four.
  * Updated test coverage (including date range) and refreshed throughput, IOPS, and `fsync` latency results.
  * Added clarifications on mount options, caching and durability interpretation, reflink timing, `syncfs` semantics, and space-reclamation behavior.
  * Expanded clone and reclamation result tables and updated the document’s summary with revised findings and constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->