### PR TITLE
fix: honor --config and profile patches_dir when resolving kernels

### DIFF
--- a/scripts/kernel-patch.sh
+++ b/scripts/kernel-patch.sh
@@ -43,8 +43,12 @@ get_kernel_version() {
 
     # Extract kernel version for the profile
     # This is a simple grep - for complex configs, use a proper TOML parser
-    grep -A20 "\[kernel_profiles\.$profile\]" "$config_file" | \
-        grep -m1 'kernel_version' | \
+    # Same arch scoping as get_patches_dir: profile tables are arch-suffixed, and
+    # a bare -A20 spans both the .amd64 and .arm64 blocks.
+    local carch="amd64"
+    [[ "$(uname -m)" == "aarch64" ]] && carch="arm64"
+    sed -n "/^\\[kernel_profiles\\.$profile\\.$carch\\]/,/^\\[/p" "$config_file" | \
+        grep -m1 '^kernel_version' | \
         sed 's/.*=.*"\([^"]*\)".*/\1/' || \
         error "Could not find kernel_version for profile '$profile'"
 }

--- a/scripts/kernel-patch.sh
+++ b/scripts/kernel-patch.sh
@@ -220,6 +220,9 @@ cmd_create() {
     local patches_dir=$(get_patches_dir "$profile")
     local workdir="/tmp/kernel-patch-$$"
 
+    # An empty patches_dir means the profile deliberately applies no patches.
+    [[ -z "$patches_dir" ]] && error "Profile '$profile' has patches disabled (patches_dir is empty); cannot create a patch"
+
     info "Creating patch for kernel $version (profile: $profile)"
 
     # Setup kernel source
@@ -263,6 +266,9 @@ cmd_finish() {
     local patches_dir=$(get_patches_dir "$profile")
     local kernel_dir="$workdir/linux-${version}"
 
+    # An empty patches_dir means the profile deliberately applies no patches.
+    [[ -z "$patches_dir" ]] && error "Profile '$profile' has patches disabled (patches_dir is empty); cannot finish a patch"
+
     [[ -d "$kernel_dir" ]] || error "Kernel dir not found: $kernel_dir"
 
     # Ensure patch name has .patch extension
@@ -293,6 +299,9 @@ cmd_edit() {
     local version=$(get_kernel_version "$profile")
     local patches_dir=$(get_patches_dir "$profile")
     local workdir="/tmp/kernel-patch-$$"
+
+    # An empty patches_dir means the profile deliberately applies no patches.
+    [[ -z "$patches_dir" ]] && error "Profile '$profile' has patches disabled (patches_dir is empty); cannot edit a patch"
 
     # Find the patch file
     local patch_file=$(ls "$patches_dir"/${patch_num}*.patch 2>/dev/null | head -1)
@@ -337,6 +346,12 @@ cmd_validate() {
     local version=$(get_kernel_version "$profile")
     local patches_dir=$(get_patches_dir "$profile")
     local workdir="/tmp/kernel-validate-$$"
+
+    # An empty patches_dir means the profile deliberately applies no patches.
+    if [[ -z "$patches_dir" ]]; then
+        info "Profile '$profile' has patches disabled (patches_dir is empty); nothing to validate"
+        return
+    fi
 
     info "Validating patches for kernel $version (profile: $profile)"
 

--- a/scripts/kernel-patch.sh
+++ b/scripts/kernel-patch.sh
@@ -52,6 +52,28 @@ get_kernel_version() {
 # Get patches directory for profile
 get_patches_dir() {
     local profile="$1"
+    local config_file="$REPO_ROOT/rootfs-config.toml"
+
+    # A profile may name its own patches_dir, and the Rust build reads it
+    # (src/setup/kernel.rs). This helper has to agree, or it edits and validates
+    # a different set of patches than the one that actually gets built.
+    #
+    # Profile tables are arch-suffixed ([kernel_profiles.<name>.amd64]), so match
+    # the name followed by either "]" or ".".
+    # Scope to the current arch's table: grep -A20 on a bare profile name spans
+    # both the .amd64 and .arm64 blocks and would read the wrong one.
+    local carch="amd64"
+    [[ "$(uname -m)" == "aarch64" ]] && carch="arm64"
+    local block
+    block=$(sed -n "/^\\[kernel_profiles\\.$profile\\.$carch\\]/,/^\\[/p" "$config_file" 2>/dev/null || true)
+    if grep -q '^patches_dir' <<< "$block"; then
+        local declared
+        declared=$(grep -m1 '^patches_dir' <<< "$block" | sed 's/.*=.*"\([^"]*\)".*/\1/')
+        # An empty string means the profile deliberately applies no patches.
+        [[ -z "$declared" ]] && return
+        echo "$REPO_ROOT/$declared"
+        return
+    fi
 
     # Check for arch-specific patches first
     local arch=$(uname -m)

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -56,6 +56,9 @@ pub async fn cmd_setup(args: SetupArgs) -> Result<()> {
 
     // Ensure btrfs storage is ready (creates loopback if needed)
     // This must be done before accessing any paths under the configured assets_dir
+    if let Some(path) = args.config.as_deref() {
+        crate::setup::rootfs::set_config_path(path);
+    }
     crate::setup::ensure_storage(args.config.as_deref()).context("initializing storage")?;
 
     // Load config and initialize paths (with helpful error if config missing)

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -9,6 +9,13 @@ use crate::setup::rootfs::{generate_config, get_kernel_profile, load_config};
 /// This downloads the Kata kernel (~15MB) and creates the Layer 2 rootfs (~10GB).
 /// The rootfs creation downloads Ubuntu cloud image and installs podman, taking 5-10 minutes.
 pub async fn cmd_setup(args: SetupArgs) -> Result<()> {
+    // Record --config before anything reads config. The --install-host-kernel
+    // branch below returns early, so a later placement leaves that path reading
+    // the discovered config instead of the requested one.
+    if let Some(path) = args.config.as_deref() {
+        crate::setup::rootfs::set_config_path(path);
+    }
+
     // Handle --generate-config: write default config and exit
     if args.generate_config {
         let config_path = generate_config(args.force)?;
@@ -56,9 +63,6 @@ pub async fn cmd_setup(args: SetupArgs) -> Result<()> {
 
     // Ensure btrfs storage is ready (creates loopback if needed)
     // This must be done before accessing any paths under the configured assets_dir
-    if let Some(path) = args.config.as_deref() {
-        crate::setup::rootfs::set_config_path(path);
-    }
     crate::setup::ensure_storage(args.config.as_deref()).context("initializing storage")?;
 
     // Load config and initialize paths (with helpful error if config missing)

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -806,11 +806,14 @@ pub fn find_config_file(explicit_path: Option<&str>) -> Result<PathBuf> {
         return Ok(p);
     }
 
-    // 1b. A --config recorded earlier in this process
+    // 1b. A --config recorded earlier in this process. Missing is an error, not a
+    // reason to fall back: silently reading a different file is the failure this
+    // whole path exists to remove.
     if let Some(p) = EXPLICIT_CONFIG.get() {
-        if p.exists() {
-            return Ok(p.clone());
+        if !p.exists() {
+            bail!("Config file not found: {}", p.display());
         }
+        return Ok(p.clone());
     }
 
     // 2. SUDO_USER's config (when running with sudo)
@@ -2508,5 +2511,18 @@ mod tests {
         );
 
         std::env::remove_var("FCVM_FIRECRACKER_BIN");
+    }
+
+    /// A --config path that does not exist must fail, not quietly fall back to
+    /// the discovered config, which is the bug this whole path removes.
+    #[test]
+    fn find_config_file_rejects_a_missing_explicit_path() {
+        let err = find_config_file(Some("/nonexistent/rootfs-config.toml"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("Config file not found"),
+            "should refuse a missing --config, got: {err}"
+        );
     }
 }

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use tokio::process::Command;
 use tracing::{debug, info, warn};
 
@@ -12,6 +13,19 @@ use crate::paths;
 
 /// Config file name
 const CONFIG_FILE: &str = "rootfs-config.toml";
+
+/// A --config path recorded once, so every later load_config(None) resolves to
+/// the same file. Without this, --config reaches only the call sites that thread
+/// it explicitly, and lookups that go through load_plan() (kernel profiles, for
+/// one) silently read the user config instead. The failure is confusing rather
+/// than loud: fcvm reports a profile "not found in config" while naming a config
+/// that defines it.
+static EXPLICIT_CONFIG: OnceLock<PathBuf> = OnceLock::new();
+
+/// Record the config file chosen on the command line. First call wins.
+pub fn set_config_path(path: &str) {
+    let _ = EXPLICIT_CONFIG.set(PathBuf::from(path));
+}
 
 /// Embedded default config (used by --generate-config)
 const EMBEDDED_CONFIG: &str = include_str!("../../rootfs-config.toml");
@@ -790,6 +804,13 @@ pub fn find_config_file(explicit_path: Option<&str>) -> Result<PathBuf> {
             bail!("Config file not found: {}", path);
         }
         return Ok(p);
+    }
+
+    // 1b. A --config recorded earlier in this process
+    if let Some(p) = EXPLICIT_CONFIG.get() {
+        if p.exists() {
+            return Ok(p.clone());
+        }
     }
 
     // 2. SUDO_USER's config (when running with sudo)

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -925,6 +925,26 @@ pub fn load_config(explicit_path: Option<&str>) -> Result<(Plan, String, String)
     Ok((config, config_sha, config_sha_short))
 }
 
+/// Resolve the Firecracker binary for the rootfs setup VM.
+///
+/// FCVM_FIRECRACKER_BIN first, then PATH. Without this the setup VM shelled out
+/// to a bare "firecracker", so a host that has never installed one system-wide
+/// failed with a plain "No such file or directory" even though fcvm had just
+/// built a Firecracker of its own under the assets directory.
+fn setup_vm_firecracker_bin() -> Result<PathBuf> {
+    if let Ok(path) = std::env::var("FCVM_FIRECRACKER_BIN") {
+        let p = PathBuf::from(&path);
+        if !p.exists() {
+            bail!("FCVM_FIRECRACKER_BIN={} does not exist", path);
+        }
+        return Ok(p);
+    }
+    which::which("firecracker").context(
+        "firecracker not found in PATH; set FCVM_FIRECRACKER_BIN to the binary \
+         fcvm built under <assets_dir>/firecracker/",
+    )
+}
+
 /// Create a synthetic "default" kernel profile from the [kernel] config section.
 ///
 /// This allows all kernel code to work with profiles uniformly. The [kernel]
@@ -2285,7 +2305,8 @@ async fn boot_vm_for_setup(
         "starting Firecracker for Layer 2 setup (serial output: {})",
         serial_path.display()
     );
-    let mut fc_process = Command::new("firecracker")
+    let firecracker_bin = setup_vm_firecracker_bin()?;
+    let mut fc_process = Command::new(&firecracker_bin)
         .args([
             "--api-sock",
             path_to_str(&api_socket)?,
@@ -2462,4 +2483,30 @@ async fn boot_vm_for_setup(
 fn path_to_str(path: &Path) -> Result<&str> {
     path.to_str()
         .ok_or_else(|| anyhow::anyhow!("path contains invalid UTF-8: {:?}", path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// FCVM_FIRECRACKER_BIN is a process-global, so these run in one test.
+    #[test]
+    fn setup_vm_firecracker_bin_honors_env_var() {
+        let real = std::env::current_exe().expect("test binary path");
+
+        // Set and existing: returned as-is, rather than searching PATH.
+        std::env::set_var("FCVM_FIRECRACKER_BIN", &real);
+        assert_eq!(setup_vm_firecracker_bin().unwrap(), real);
+
+        // Set and missing: the error names the variable, so the reader knows
+        // which knob is wrong instead of getting a bare ENOENT.
+        std::env::set_var("FCVM_FIRECRACKER_BIN", "/nonexistent/firecracker");
+        let err = setup_vm_firecracker_bin().unwrap_err().to_string();
+        assert!(
+            err.contains("FCVM_FIRECRACKER_BIN"),
+            "error should name the variable, got: {err}"
+        );
+
+        std::env::remove_var("FCVM_FIRECRACKER_BIN");
+    }
 }


### PR DESCRIPTION
Four lookups ignored what the caller configured, and each failed in the same confusing way: fcvm reported a thing as missing while pointing at a file or a binary that has it.

**`--config` now applies to every config load.** It previously reached only the call sites that threaded it explicitly, so anything going through `load_plan()` (kernel profile lookup among them) silently read the XDG user config. Passing `--config` at a file containing a profile still produced `kernel profile 'x' not found in config`. The path is recorded once in a `OnceLock` that `find_config_file()` consults, matching how `paths.rs` already handles data and assets directories, so all six `load_config(None)` call sites agree.

**The recording happens before the `--install-host-kernel` early return.** Placed after it, that path kept resolving profiles against the discovered config.

**A missing `--config` is an error, not a fallback.** The first version checked `if p.exists()` and fell through when it did not, reintroducing the silent-wrong-file behaviour. It now bails, like the explicit-argument branch above it. Supersedes #703.

**The rootfs setup VM uses the configured Firecracker.** That path called `Command::new("firecracker")`, a bare PATH lookup ignoring both `find_firecracker()` and `FCVM_FIRECRACKER_BIN`, while the same file's doc comment said otherwise. On a host with no system-wide Firecracker it failed with a bare ENOENT two lines after reporting its own Firecracker ready.

**`scripts/kernel-patch.sh` reads the profile's `patches_dir`.** `get_patches_dir()` only ever returned `kernel/patches-arm64` or `kernel/patches`, so for a profile declaring its own directory the helper created, edited and validated a different patch set than the build applies. Its matcher also required the table name to end at the profile, which no arch-suffixed table does, and `grep -A20` spans both arch blocks. Both it and `get_kernel_version()` now scope to the current arch's table, and an empty `patches_dir` means "apply none", as the Rust side already means by it.

**Testing.** `cargo test --release --lib`: 10 + 184 + 68 passed. Two new tests, both watched failing first:

- `setup_vm_firecracker_bin_honors_env_var` fails on the old bare-PATH resolver, naming itself and `firecracker not found in PATH`, and passes with the fix.
- `find_config_file_rejects_a_missing_explicit_path` covers the fallthrough.

Why no test caught the Firecracker one: the resolver is only reached while building a rootfs, and a cached rootfs skips it, so an end-to-end run proves nothing about it on a second invocation.

Found while building the mountinfo A/B kernels for #699.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for explicitly selecting a configuration file during setup, with clear errors when the path is invalid.
  - Added support for selecting the Firecracker binary through an environment variable, with validation and automatic PATH fallback.
  - Setup now consistently uses the selected Firecracker executable.

- **Bug Fixes**
  - Architecture-specific kernel and patch settings are now read from the correct profile.
  - Empty patch directory settings can explicitly disable patch application.
  - Patch creation, editing, and completion now report when patches are disabled.
  - Configuration paths are honored across all setup flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->