### PR TITLE
Skip claude.yml safety-check on dependabot-triggered runs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -23,6 +23,13 @@ env:
 jobs:
   # Gatekeeper: Check for non-member commits, comments, and author association
   safety-check:
+    # Dependabot-triggered runs get only Dependabot secrets (no repo Actions
+    # secrets), so create-github-app-token cannot mint a token and this job
+    # fails on every dependabot PR. Skip it instead: a skipped safety-check
+    # skips every Claude job (they all `needs:` it without always(), and
+    # `eligible` stays unset) — strictly more restrictive than running the
+    # eligibility gate, so this only ever reduces what runs. Fail-closed.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     outputs:
       safe: ${{ steps.check.outputs.safe }}


### PR DESCRIPTION
Makes dependabot PRs stop failing the Claude Assistant `safety-check` job.

## The Problem

Every dependabot PR (#689–#693 currently) shows a red `safety-check`. Dependabot-triggered `pull_request` runs execute with the **Dependabot secrets context only** ("Secret source: Dependabot" in the run header), so `secrets.CLAUDE_APP_PRIVATE_KEY` is empty and the job's first step fails:

```
Error: The 'private-key' input must be set to a non-empty string.
```

Example: [run 31066349138](https://github.com/ejc3/fcvm/actions/runs/31066349138/job/92504763032) on #692.

## The Solution

Job-level `if: github.actor != 'dependabot[bot]'` on `safety-check`, with a comment explaining why. Why this is safe:

- All four Claude-executing jobs use `needs: safety-check` with plain `if:` conditions (no `always()`), so a skipped safety-check skips every one of them — strictly more restrictive than running the gate.
- Dependabot could never be eligible anyway: the gate requires PR-author association OWNER/MEMBER/COLLABORATOR.
- `safety-check` is not a required status check (branch protection on main has no `required_status_checks`), so a skip is sufficient for a green PR.
- Per AGENTS.md, the change went through the local codex security review of the full workflow: **VERDICT: SAFE** — no gate weakened for non-dependabot actors, fail-closed for privileged execution, no injection surface added, actor persists across maintainer re-runs.

## Test Results

```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude.yml')); print('YAML OK')"
YAML OK
```

After merge, dependabot PRs need a rebase (`@dependabot rebase`) so their merge commits pick up the updated workflow.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated safety checks to skip runs initiated by Dependabot.
  * Prevented dependent automation jobs from running when safety-check eligibility is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->