### PR TITLE
Power off Cloud Hypervisor guests via ACPI instead of triple fault

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,16 +87,11 @@ endif
 # Scoped to package(fcvm) so fuse-pipe's fast test_nested_file unit test is NOT excluded.
 # Mutually exclusive with IPV6_FILTER in practice — CI runners have an IPv4 route, so
 # IPV6_ONLY is never set there (two -E filtersets would be UNIONED, not intersected).
-# The CH cold-boot exclusion (see CI_FAST_FILTER, #687) is ANDed into the SAME filterset
-# here rather than added as a second -E: test-root uses default features (which include
-# integration-fast), so the CH integration tests also run under test-root, and a separate
-# -E would be UNIONED (re-including cold_boot) instead of intersected.
 CI ?=
 ifndef FILTER
 ifeq ($(CI),true)
-# Base test-root CI filter: the nested subset (exclude all nested except the 3 kept) AND
-# always exclude the CH cold-boot test (#687).
-CI_ROOT_BASE := (not (package(fcvm) & (test(/nested/) | test(/podman_load_over_fuse/))) | test(=test_nested_run_fcvm_inside_vm) | test(=test_nested_l2_with_large_files) | test(=test_nested_l2_nfs)) & not test(=test_cloud_hypervisor_cold_boot)
+# Base test-root CI filter: the nested subset (exclude all nested except the 3 kept).
+CI_ROOT_BASE := (not (package(fcvm) & (test(/nested/) | test(/podman_load_over_fuse/))) | test(=test_nested_run_fcvm_inside_vm) | test(=test_nested_l2_with_large_files) | test(=test_nested_l2_nfs))
 ifeq ($(FCVM_NO_SNAPSHOT),)
 # SnapshotEnabled mode (FCVM_NO_SNAPSHOT unset): ALSO drop test_nested_l2_with_large_files.
 # It guards FUSE-over-FUSE DATA INTEGRITY (the #630 DSB cache-coherency fix) — a live-traffic
@@ -111,19 +106,6 @@ else
 # SnapshotDisabled mode: keep test_nested_l2_with_large_files (the FUSE-integrity guard runs here).
 CI_NESTED_FILTER := -E '$(CI_ROOT_BASE)'
 endif
-endif
-endif
-
-# test-fast CI exclusions. test_cloud_hypervisor_cold_boot (a CH cold boot of an
-# instant-exit container, snapshots disabled) storms on x86_64 under full CI parallel
-# load: the host↔guest output-vsock/shutdown handshake loops and the VM never powers
-# off (180s timeout). Passes on arm64 and in isolation locally; same class as the #630
-# cold-boot event-loop storm. The snapshot-roundtrip test still cold-boots a CH VM
-# (nginx baseline) and exercises snapshot/restore, so CH cold boot keeps CI coverage.
-# Tracked in #687. Gated on CI=true; runs locally and with an explicit FILTER=.
-ifndef FILTER
-ifeq ($(CI),true)
-CI_FAST_FILTER := -E 'not test(=test_cloud_hypervisor_cold_boot)'
 endif
 endif
 
@@ -391,7 +373,7 @@ _test-unit:
 
 _test-fast:
 	RUST_LOG="$(TEST_LOG)" \
-	./scripts/no-sudo.sh $(NEXTEST) $(NEXTEST_CAPTURE) --no-default-features --features integration-fast $(CI_FAST_FILTER) $(FILTER)
+	./scripts/no-sudo.sh $(NEXTEST) $(NEXTEST_CAPTURE) --no-default-features --features integration-fast $(FILTER)
 
 _test-all:
 	RUST_LOG="$(TEST_LOG)" \

--- a/fc-agent/src/system.rs
+++ b/fc-agent/src/system.rs
@@ -184,6 +184,20 @@ pub fn raise_resource_limits() {
     }
 }
 
+/// Whether the VMM wants an ACPI/PSCI power-off (`fcvm_shutdown=acpi` on the cmdline).
+///
+/// Firecracker's ACPI-less microVM on x86_64 only exits on a triple fault, so fc-agent
+/// defaults to `reboot -f` under `reboot=t` there. Cloud Hypervisor treats a triple
+/// fault as a guest-initiated RESET and reboots the VM in-process — the guest would
+/// boot-loop forever while fcvm waits for the VMM process to exit. fcvm therefore puts
+/// `fcvm_shutdown=acpi` on the Cloud Hypervisor cmdline: power off instead (CH exits
+/// its process on ACPI S5 on x86_64 exactly as it does for PSCI SYSTEM_OFF on aarch64).
+fn vmm_wants_acpi_shutdown() -> bool {
+    std::fs::read_to_string("/proc/cmdline")
+        .map(|c| c.split_whitespace().any(|tok| tok == "fcvm_shutdown=acpi"))
+        .unwrap_or(false)
+}
+
 /// Shutdown the VM. This function never returns.
 pub async fn shutdown_vm(exit_code: i32) -> ! {
     eprintln!("[fc-agent] shutting down VM (exit_code={})", exit_code);
@@ -223,32 +237,51 @@ pub async fn shutdown_vm(exit_code: i32) -> ! {
         }
     }
 
-    #[cfg(target_arch = "aarch64")]
-    {
-        eprintln!("[fc-agent] calling poweroff -f (PSCI SYSTEM_OFF)...");
+    let acpi = vmm_wants_acpi_shutdown();
+
+    if acpi {
+        eprintln!("[fc-agent] calling poweroff -f (fcvm_shutdown=acpi: ACPI S5 / PSCI SYSTEM_OFF)...");
         let _ = Command::new("poweroff").args(["-f"]).spawn();
-    }
-    #[cfg(target_arch = "x86_64")]
-    {
-        eprintln!("[fc-agent] calling reboot -f (triple-fault via reboot=t)...");
-        let _ = Command::new("reboot").args(["-f"]).spawn();
-    }
-
-    sleep(Duration::from_secs(2)).await;
-
-    #[cfg(target_arch = "aarch64")]
-    {
-        eprintln!("[fc-agent] poweroff didn't complete after 2s, trying reboot -f");
-        let _ = Command::new("reboot").args(["-f"]).spawn();
-    }
-    #[cfg(target_arch = "x86_64")]
-    {
-        eprintln!("[fc-agent] reboot didn't complete after 2s, trying sysrq");
+    } else {
+        #[cfg(target_arch = "aarch64")]
+        {
+            eprintln!("[fc-agent] calling poweroff -f (PSCI SYSTEM_OFF)...");
+            let _ = Command::new("poweroff").args(["-f"]).spawn();
+        }
+        #[cfg(target_arch = "x86_64")]
+        {
+            eprintln!("[fc-agent] calling reboot -f (triple-fault via reboot=t)...");
+            let _ = Command::new("reboot").args(["-f"]).spawn();
+        }
     }
 
     sleep(Duration::from_secs(2)).await;
-    eprintln!("[fc-agent] shutdown didn't complete, trying sysrq reboot");
-    let _ = std::fs::write("/proc/sysrq-trigger", "b");
+
+    if acpi {
+        eprintln!("[fc-agent] poweroff didn't complete after 2s, retrying poweroff -f");
+        let _ = Command::new("poweroff").args(["-f"]).spawn();
+    } else {
+        #[cfg(target_arch = "aarch64")]
+        {
+            eprintln!("[fc-agent] poweroff didn't complete after 2s, trying reboot -f");
+            let _ = Command::new("reboot").args(["-f"]).spawn();
+        }
+        #[cfg(target_arch = "x86_64")]
+        {
+            eprintln!("[fc-agent] reboot didn't complete after 2s, trying sysrq");
+        }
+    }
+
+    sleep(Duration::from_secs(2)).await;
+    if acpi {
+        // sysrq "b" reboots — under a VMM that reboots in-process that would boot-loop,
+        // so the last resort must stay a power-off ("o").
+        eprintln!("[fc-agent] shutdown didn't complete, trying sysrq poweroff");
+        let _ = std::fs::write("/proc/sysrq-trigger", "o");
+    } else {
+        eprintln!("[fc-agent] shutdown didn't complete, trying sysrq reboot");
+        let _ = std::fs::write("/proc/sysrq-trigger", "b");
+    }
 
     sleep(Duration::from_secs(1)).await;
     eprintln!("[fc-agent] VM shutdown completely failed!");

--- a/fc-agent/src/system.rs
+++ b/fc-agent/src/system.rs
@@ -240,7 +240,9 @@ pub async fn shutdown_vm(exit_code: i32) -> ! {
     let acpi = vmm_wants_acpi_shutdown();
 
     if acpi {
-        eprintln!("[fc-agent] calling poweroff -f (fcvm_shutdown=acpi: ACPI S5 / PSCI SYSTEM_OFF)...");
+        eprintln!(
+            "[fc-agent] calling poweroff -f (fcvm_shutdown=acpi: ACPI S5 / PSCI SYSTEM_OFF)..."
+        );
         let _ = Command::new("poweroff").args(["-f"]).spawn();
     } else {
         #[cfg(target_arch = "aarch64")]

--- a/src/hypervisor/cloud_hypervisor/mod.rs
+++ b/src/hypervisor/cloud_hypervisor/mod.rs
@@ -137,6 +137,13 @@ impl CloudHypervisorBackend {
     /// Translate Firecracker-style boot args to a Cloud Hypervisor cmdline: CH's default
     /// console is virtio `hvc0` (not the PL011 `ttyS0`/`ttyAMA0`) and it puts virtio
     /// devices on PCI, so `pci=off` must be dropped.
+    ///
+    /// Also appends `fcvm_shutdown=acpi`: on x86_64 fc-agent's only way to make
+    /// Firecracker exit is a triple fault (`reboot -f` under `reboot=t`), but Cloud
+    /// Hypervisor treats a triple fault as a guest-initiated RESET and reboots the VM
+    /// in-process — the guest boot-loops and fcvm's `vm_manager.wait()` never returns.
+    /// The token tells fc-agent this VMM honors ACPI/PSCI power-off (CH exits its
+    /// process on either), so it must power off instead of triple-faulting.
     fn ch_cmdline(fc_boot_args: &str, runtime_boot_args: &str) -> String {
         let combined = if runtime_boot_args.is_empty() {
             fc_boot_args.to_string()
@@ -146,15 +153,16 @@ impl CloudHypervisorBackend {
         // Token-based (not substring) so we only rewrite/drop whole kernel args, never an
         // embedded value: map the serial console to virtio hvc0 and drop pci=off (CH puts
         // virtio devices on PCI).
-        combined
+        let mut tokens: Vec<&str> = combined
             .split_whitespace()
             .filter_map(|tok| match tok {
                 "pci=off" => None,
                 "console=ttyS0" | "console=ttyAMA0" => Some("console=hvc0"),
                 other => Some(other),
             })
-            .collect::<Vec<_>>()
-            .join(" ")
+            .collect();
+        tokens.push("fcvm_shutdown=acpi");
+        tokens.join(" ")
     }
 
     /// Wait for the api-socket to accept connections and answer a ping, failing fast if
@@ -644,6 +652,10 @@ mod tests {
             toks.contains(&"fcvm_bootplan=vsock"),
             "runtime args appended"
         );
+        assert!(
+            toks.contains(&"fcvm_shutdown=acpi"),
+            "shutdown contract appended: {out}"
+        );
     }
 
     #[test]
@@ -652,12 +664,15 @@ mod tests {
         // left untouched (the substring `.replace()` would have corrupted these).
         let out = CloudHypervisorBackend::ch_cmdline("console=ttyS0extra fcpci=offx", "");
         let toks: Vec<&str> = out.split_whitespace().collect();
-        assert_eq!(toks, vec!["console=ttyS0extra", "fcpci=offx"]);
+        assert_eq!(
+            toks,
+            vec!["console=ttyS0extra", "fcpci=offx", "fcvm_shutdown=acpi"]
+        );
     }
 
     #[test]
     fn ch_cmdline_handles_empty_runtime_args() {
         let out = CloudHypervisorBackend::ch_cmdline("console=ttyAMA0 root=/dev/vda", "");
-        assert_eq!(out, "console=hvc0 root=/dev/vda");
+        assert_eq!(out, "console=hvc0 root=/dev/vda fcvm_shutdown=acpi");
     }
 }


### PR DESCRIPTION
Fixes the 180s `test_cloud_hypervisor_cold_boot` hang on x86_64 and removes its CI exclusions. Fixes #687.

## The Problem

On x86_64, fc-agent shuts the VM down with `reboot -f` under `reboot=t` (triple fault) — the only exit mechanism Firecracker's ACPI-less microVM supports. Cloud Hypervisor treats a triple fault as a guest-initiated **RESET** and reboots the VM in-process (`DEBUG cloud-hypervisor: Rebooting.` in the console log). fcvm's run loop only terminates when the hypervisor *process* exits (`vm_manager.wait()`), so the guest boot-loops — re-fetches its boot plan over vsock, re-runs the container, re-sends `exit:0` — 51 cycles in one CI debug log — until nextest kills the test at 180s.

This was never load-related, and never a flake:
- Three different runners (`runner-i-0f677db3…`, `-0d2a4ebb…`, `-053cc0a3…`) failed **both** nextest tries whenever a CH binary was resolvable on the runner.
- The "passing" sibling run passed in **0.011s** — the skip path (`find_cloud_hypervisor()` failed; no CH binary on that runner). Pass/fail tracked CH-binary presence exactly, i.e. whether a prior Host job's `fcvm setup --cloud-hypervisor` had populated that runner's persistent assets dir.
- The test has never passed on x64 with a real CH — the #686 merge run failed identically on 2026-06-14.
- arm64 was always green because aarch64 fc-agent uses `poweroff -f` → PSCI SYSTEM_OFF, which CH honors by exiting.
- #687's exclusion covered `_test-root`/`_test-fast` only; the Container job runs `_test-all`, which is why Container-x64 kept failing (most recently on dependabot PRs #689/#691/#692).

## The Solution

A boot contract, at the same altitude as the existing `fcvm_bootplan=vsock` token:

- **`ch_cmdline()`** appends `fcvm_shutdown=acpi` — CH exits its process on ACPI S5 on x86_64 exactly as it does for PSCI SYSTEM_OFF on aarch64. Firecracker keeps the implicit triple-fault default.
- **fc-agent `shutdown_vm()`** parses `/proc/cmdline` (same mechanism as `fcvm_bootplan`/`fcvm_dns`): with the token it runs `poweroff -f`, retries, then sysrq `o` (power-off) as last resort — sysrq `b` (reboot) would boot-loop under a VMM that reboots in-process. Without the token, the per-arch defaults are byte-for-byte unchanged.
- **Makefile**: remove the `not test(=test_cloud_hypervisor_cold_boot)` exclusions from `CI_ROOT_BASE` and `CI_FAST_FILTER` — the test runs everywhere again.
- Not a host-side kill on the `exit:` notification: fc-agent sends `exit:` *before* its final `sync`, so killing CH from the host would race the guest's last disk flush.

Known follow-up (separate issue): an *intentional* guest reboot under CH also reboots in-process, while the reboot-in-place path in `run_vm_loop` assumes the hypervisor process exits. Not reachable from the shutdown path after this change.

## Test Results

Local (aarch64 — CH cold boot + snapshot roundtrip + cmdline unit tests):

```
$ make test-root FILTER=cloud_hypervisor
PASS [ 5.654s] fcvm::test_sanity test_cloud_hypervisor_cold_boot
PASS [18.103s] fcvm::test_sanity test_cloud_hypervisor_snapshot_roundtrip
Summary [ 18.107s] 7 tests run: 7 passed, 595 skipped

$ make test-root FILTER=sanity
Summary [ 22.358s] 5 tests run: 5 passed, 597 skipped
```

Guest debug log proves the contract engages end-to-end:

```
[fc-agent] cmdline: console=hvc0 … fcvm_bootplan=vsock fcvm_shutdown=acpi …
[fc-agent] calling poweroff -f (fcvm_shutdown=acpi: ACPI S5 / PSCI SYSTEM_OFF)...
```

x86_64 proof lands in this PR's CI: Host-Root-x64 jobs run `fcvm setup --cloud-hypervisor`, so the un-excluded test now runs there against a real CH deterministically (this dev host is aarch64 and cannot exercise the x86 triple-fault path).

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual machine shutdown handling for ACPI-enabled configurations, providing more consistent poweroff behavior across supported architectures.
  * Preserved expected reboot behavior for standard shutdown configurations.
  * Improved kernel command-line translation for virtual machines, including reliable shutdown configuration and console handling.

* **Tests**
  * Expanded automated coverage for shutdown configuration and cloud hypervisor startup scenarios.
  * Updated continuous integration filtering so cold-boot tests run as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->