### PR TITLE
Describe the mountinfo A/B experiment in mountinfo.conf's header

### DIFF
--- a/kernel/mountinfo.conf
+++ b/kernel/mountinfo.conf
@@ -1,9 +1,11 @@
-# fcvm nested kernel config fragment (x86_64)
+# fcvm mountinfo A/B kernel config fragment (x86_64)
 #
-# This fragment is applied on top of Firecracker's microvm kernel config
-# to enable FUSE (for fuse-pipe volumes) and KVM (for nested virtualization).
+# Shared config for the 6.16.1 mountinfo-base / mountinfo-fix comparison
+# profiles (rootfs-config.toml): the two kernels differ ONLY in patches_dir,
+# so the dominating-id cache patch is the sole variable under test.
 #
-# x86-specific: includes CONFIG_KVM_INTEL and CONFIG_KVM_AMD for both CPU types.
+# Copied from nested-x86.conf so the A/B kernels boot the same feature set
+# (FUSE for fuse-pipe volumes, KVM, PCI/MSI for virtio IRQ handling).
 
 # PCI support (required for GENERIC_MSI_IRQ which virtio needs for IRQ handling)
 # Even though Firecracker uses virtio-mmio, the IRQ infrastructure needs PCI_MSI


### PR DESCRIPTION
Comment-only fix for the remaining LOW from PR #699's review: `kernel/mountinfo.conf` was copied byte-for-byte from `nested-x86.conf`, so its header described nested virtualization instead of the mountinfo A/B experiment the file actually serves. New header states what the fragment is for, that the A/B profiles differ only in `patches_dir`, and where it was copied from.

No functional change — the kernel build strips comments, and the config content (which feeds the content-addressed kernel SHA via `build_inputs`) changes only in comment lines, so the two A/B kernel SHAs shift together and stay distinct.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the mountinfo A/B configuration and shared comparison setup.
  * Documented that the dominating-ID cache patch is the only variable being tested.
  * Added notes on supported features, including FUSE, KVM, and PCI/MSI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->