### PR TITLE
Add a three-phase exec handshake so snapshot pauses cannot orphan execs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,6 +687,7 @@ name = "fc-mock"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "exec-proto",
  "hyper 0.14.32",
  "hyperlocal",
  "libc",

--- a/exec-proto/src/lib.rs
+++ b/exec-proto/src/lib.rs
@@ -18,6 +18,30 @@ use std::io::{self, Read, Write};
 /// This prevents DoS via large length values.
 const MAX_MESSAGE_SIZE: usize = 1024 * 1024;
 
+/// Three-phase exec handshake tokens, shared by the host client
+/// (`fcvm exec`, src/commands/exec.rs), the guest server (fc-agent/src/exec.rs),
+/// and the mock server (fc-mock/src/vsock_exec.rs).
+///
+/// Every exec connection starts with three newline-terminated lines:
+///
+/// 1. client → server: `ExecRequest` JSON
+/// 2. server → client: `ACK` — the request line was fully consumed; nothing
+///    has executed yet
+/// 3. client → server: `GO` — the server may start executing ONLY after
+///    consuming this line
+///
+/// Why: a VM snapshot pause (pre-start, startup, or a user-initiated
+/// `fcvm snapshot create --pid`) resets the vsock transport and silently
+/// orphans in-flight connections with no error on either side. Before ACK the
+/// client can prove its request never reached execution, so it safely
+/// reconnects and resends; once it has sent GO it must never resend (execution
+/// may have started), and a dead connection is a loud bounded error instead of
+/// a silent hang. The server closes any connection whose handshake stalls, so
+/// orphaned connections can never execute and never leak a thread.
+pub const HANDSHAKE_ACK: &str = "ACK";
+/// See [`HANDSHAKE_ACK`].
+pub const HANDSHAKE_GO: &str = "GO";
+
 /// Message types for the TTY exec protocol
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/fc-agent/src/exec.rs
+++ b/fc-agent/src/exec.rs
@@ -1,6 +1,7 @@
 use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use tokio::io::unix::AsyncFd;
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -8,6 +9,14 @@ use tokio::sync::{Mutex, Notify};
 
 use crate::types::{ExecRequest, ExecResponse};
 use crate::vsock;
+
+/// Overall deadline for the pre-execution handshake (request line, ACK write,
+/// GO line). A connection orphaned by a snapshot pause (the host's bytes were
+/// lost in the vsock transport reset) stalls one of these phases; the deadline
+/// bounds it — the connection is closed and its blocking thread reclaimed,
+/// never leaked, and nothing executes. Generous vs. the sub-millisecond happy
+/// path, tight vs. the previous forever-block.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Run the exec server. Sends ready signal when listening.
 ///
@@ -214,67 +223,234 @@ fn write_line_to_fd(fd: i32, data: &str) {
     }
 }
 
-/// Read the request line synchronously (blocking byte-by-byte read).
-/// Returns (ExecRequest, raw_fd) on success, or None if connection closed or parse error.
+/// Why a line read failed (used for handshake diagnostics).
+#[derive(Debug, PartialEq, Eq)]
+enum LineReadError {
+    /// The overall handshake deadline passed before a full line arrived.
+    TimedOut,
+    /// The peer closed the connection (EOF).
+    Closed,
+    /// The line exceeded the length cap.
+    TooLong,
+    /// read()/poll() failed.
+    Failed,
+}
+
+/// Read one `\n`-terminated line from `fd` (byte-by-byte, so no bytes past the
+/// terminating newline are ever consumed), polling for readability so the read
+/// is bounded by `deadline` instead of blocking forever. Does NOT close the fd.
+fn read_line_bounded(fd: i32, deadline: Instant, max_len: usize) -> Result<Vec<u8>, LineReadError> {
+    let mut line: Vec<u8> = Vec::new();
+    let mut buf = [0u8; 1];
+    loop {
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            return Err(LineReadError::TimedOut);
+        };
+        let mut pfd = libc::pollfd {
+            fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let timeout_ms = remaining.as_millis().clamp(1, i32::MAX as u128) as i32;
+        let rc = unsafe { libc::poll(&mut pfd, 1, timeout_ms) };
+        if rc == 0 {
+            return Err(LineReadError::TimedOut);
+        }
+        if rc < 0 {
+            if std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(LineReadError::Failed);
+        }
+        let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, 1) };
+        if n < 0 {
+            match std::io::Error::last_os_error().kind() {
+                std::io::ErrorKind::Interrupted | std::io::ErrorKind::WouldBlock => continue,
+                _ => return Err(LineReadError::Failed),
+            }
+        }
+        if n == 0 {
+            return Err(LineReadError::Closed);
+        }
+        if buf[0] == b'\n' {
+            return Ok(line);
+        }
+        if line.len() >= max_len {
+            return Err(LineReadError::TooLong);
+        }
+        line.push(buf[0]);
+    }
+}
+
+/// Write `line` + `\n` to `fd`, polling for writability so the write is bounded
+/// by `deadline`. Returns false on error/timeout. Does NOT close the fd.
+fn write_line_bounded(fd: i32, deadline: Instant, line: &str) -> bool {
+    let bytes = format!("{}\n", line);
+    let buf = bytes.as_bytes();
+    let mut written = 0;
+    while written < buf.len() {
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            return false;
+        };
+        let mut pfd = libc::pollfd {
+            fd,
+            events: libc::POLLOUT,
+            revents: 0,
+        };
+        let timeout_ms = remaining.as_millis().clamp(1, i32::MAX as u128) as i32;
+        let rc = unsafe { libc::poll(&mut pfd, 1, timeout_ms) };
+        if rc == 0 {
+            return false;
+        }
+        if rc < 0 {
+            if std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return false;
+        }
+        let n = unsafe {
+            libc::write(
+                fd,
+                buf[written..].as_ptr() as *const libc::c_void,
+                buf.len() - written,
+            )
+        };
+        if n < 0 {
+            match std::io::Error::last_os_error().kind() {
+                std::io::ErrorKind::Interrupted | std::io::ErrorKind::WouldBlock => continue,
+                _ => return false,
+            }
+        }
+        if n == 0 {
+            return false;
+        }
+        written += n as usize;
+    }
+    true
+}
+
+/// Read the request line and complete the three-phase handshake
+/// (request → ACK → GO), all bounded by `timeout`. See exec_proto::HANDSHAKE_ACK.
+///
+/// Phase 1 — read the request line under the deadline. A connection orphaned by
+/// a snapshot pause (host bytes lost in the vsock transport reset) stalls here;
+/// it is closed and its thread reclaimed instead of blocking forever.
+///
+/// Phase 2 — after consuming the FULL request line (parsed, non-empty command),
+/// write an ACK line. Nothing has executed yet: a client that never sees ACK
+/// may safely resend its request on a fresh connection.
+///
+/// Phase 3 — read one GO line under the deadline. ONLY after consuming GO may
+/// execution start. If any phase errors or times out, the connection is closed
+/// WITHOUT executing — this is what makes the client's resend provably unable
+/// to double-execute.
 ///
 /// The request is accumulated as raw bytes and parsed as UTF-8 JSON. The host
 /// serializes ExecRequest with serde_json::to_string, which emits non-ASCII
 /// characters as raw UTF-8 — decoding byte-by-byte (Latin-1) would silently corrupt
 /// multi-byte arguments and paths.
-fn read_request_line(fd: i32) -> Option<(ExecRequest, i32)> {
+///
+/// Returns (ExecRequest, raw_fd) once GO is consumed, or None (fd closed).
+fn read_request_and_handshake(fd: i32, timeout: Duration) -> Option<(ExecRequest, i32)> {
     const MAX_EXEC_LINE_LENGTH: usize = 1_048_576;
-    let mut line: Vec<u8> = Vec::new();
-    let mut buf = [0u8; 1];
-    loop {
-        let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, 1) };
-        if n <= 0 {
+    /// GO is 2 bytes; anything longer is a protocol violation.
+    const MAX_GO_LINE_LENGTH: usize = 16;
+
+    let deadline = Instant::now() + timeout;
+
+    // Phase 1: request line.
+    let line = match read_line_bounded(fd, deadline, MAX_EXEC_LINE_LENGTH) {
+        Ok(line) => line,
+        Err(reason) => {
+            match reason {
+                LineReadError::TimedOut => {
+                    eprintln!(
+                        "[fc-agent] exec handshake: no request line within {:?} \
+                         (connection likely orphaned by a snapshot pause); closing without executing",
+                        timeout
+                    );
+                }
+                LineReadError::TooLong => {
+                    // A pre-ACK Error line makes the client fail deterministically
+                    // (Rejected); a silent close would read as no-ACK and trigger
+                    // futile resends of the same oversized request.
+                    let response = ExecResponse::Error(format!(
+                        "Request line exceeds {} bytes",
+                        MAX_EXEC_LINE_LENGTH
+                    ));
+                    write_line_bounded(fd, deadline, &serde_json::to_string(&response).unwrap());
+                }
+                LineReadError::Closed | LineReadError::Failed => {}
+            }
             unsafe { libc::close(fd) };
             return None;
         }
-        if buf[0] == b'\n' {
-            break;
-        }
-        if line.len() >= MAX_EXEC_LINE_LENGTH {
-            eprintln!(
-                "[fc-agent] exec request line exceeds {} bytes, rejecting",
-                MAX_EXEC_LINE_LENGTH
-            );
-            unsafe { libc::close(fd) };
-            return None;
-        }
-        line.push(buf[0]);
-    }
+    };
 
     let request: ExecRequest = match serde_json::from_slice(&line) {
         Ok(r) => r,
         Err(e) => {
             let response = ExecResponse::Error(format!("Invalid request: {}", e));
-            write_line_to_fd(fd, &serde_json::to_string(&response).unwrap());
+            write_line_bounded(fd, deadline, &serde_json::to_string(&response).unwrap());
             unsafe { libc::close(fd) };
             return None;
         }
     };
 
-    Some((request, fd))
+    if request.command.is_empty() {
+        let response = ExecResponse::Error("Empty command".to_string());
+        write_line_bounded(fd, deadline, &serde_json::to_string(&response).unwrap());
+        unsafe { libc::close(fd) };
+        return None;
+    }
+
+    // Phase 2: ACK — the request is fully consumed and will execute iff GO arrives.
+    if !write_line_bounded(fd, deadline, exec_proto::HANDSHAKE_ACK) {
+        unsafe { libc::close(fd) };
+        return None;
+    }
+
+    // Phase 3: GO — only after consuming this may execution start. A request
+    // that arrived slowly can leave the shared deadline nearly exhausted here;
+    // the client sends GO immediately after ACK, so give this read a small
+    // fresh floor instead of expiring spuriously (which would surface a loud
+    // post-GO error on the client for a command that never ran).
+    let go_deadline = deadline.max(Instant::now() + Duration::from_secs(2));
+    match read_line_bounded(fd, go_deadline, MAX_GO_LINE_LENGTH) {
+        Ok(go) if go == exec_proto::HANDSHAKE_GO.as_bytes() => Some((request, fd)),
+        Ok(other) => {
+            eprintln!(
+                "[fc-agent] exec handshake: expected GO, got {:?}; closing without executing",
+                String::from_utf8_lossy(&other)
+            );
+            unsafe { libc::close(fd) };
+            None
+        }
+        Err(reason) => {
+            eprintln!(
+                "[fc-agent] exec handshake: ACK sent but no GO ({:?}) \
+                 (connection likely orphaned by a snapshot pause); closing without executing",
+                reason
+            );
+            unsafe { libc::close(fd) };
+            None
+        }
+    }
 }
 
 async fn handle_connection(client_fd: OwnedFd) {
-    // Read request line in spawn_blocking (blocking byte-by-byte read, fast)
+    // Read the request line and run the ACK/GO handshake in spawn_blocking
+    // (blocking byte-by-byte I/O, bounded by HANDSHAKE_TIMEOUT).
     let raw_fd = client_fd.into_raw_fd();
-    let parsed = tokio::task::spawn_blocking(move || read_request_line(raw_fd)).await;
+    let parsed =
+        tokio::task::spawn_blocking(move || read_request_and_handshake(raw_fd, HANDSHAKE_TIMEOUT))
+            .await;
 
     let (request, raw_fd) = match parsed {
         Ok(Some((req, fd))) => (req, fd),
-        Ok(None) => return, // connection closed or parse error (already handled)
+        Ok(None) => return, // closed, timed out, or invalid (already handled)
         Err(_) => return,   // spawn_blocking panicked
     };
-
-    if request.command.is_empty() {
-        let response = ExecResponse::Error("Empty command".to_string());
-        write_line_to_fd(raw_fd, &serde_json::to_string(&response).unwrap());
-        unsafe { libc::close(raw_fd) };
-        return;
-    }
 
     // TTY path: must be blocking (fork/PTY)
     if request.tty || request.interactive {
@@ -312,8 +488,9 @@ async fn handle_connection(client_fd: OwnedFd) {
 ///
 /// Polls a dup'd, independent `AsyncFd` for readability and peeks one byte: 0 (EOF), or a
 /// reset/disconnect error (ECONNRESET/ENOTCONN/EPIPE), means the host is gone. In the
-/// non-TTY pipe path the host sends nothing after the request (it only reads responses), so
-/// any readable EOF is equivalent to "host gone" — used to kill the guest child (#636).
+/// non-TTY pipe path the host sends nothing after the handshake's GO line (which was fully
+/// consumed before this watcher exists — it only reads responses from here on), so any
+/// readable EOF is equivalent to "host gone" — used to kill the guest child (#636).
 async fn wait_for_peer_close(watch: &AsyncFd<OwnedFd>) {
     loop {
         let mut guard = match watch.readable().await {
@@ -342,7 +519,7 @@ async fn wait_for_peer_close(watch: &AsyncFd<OwnedFd>) {
             }
             return;
         }
-        // n > 0: the host should send nothing after the request (it only reads responses,
+        // n > 0: the host should send nothing after the handshake (it only reads responses,
         // and never half-closes its write side while waiting — see the host exec client).
         // This branch is therefore defensive: drain one byte and loop WITHOUT clear_ready
         // (calling clear_ready after a successful read is a tokio anti-pattern). The fd
@@ -540,18 +717,44 @@ async fn handle_pipe_async(raw_fd: i32, request: &ExecRequest) {
 mod tests {
     use super::*;
 
-    /// Send `data` over a socketpair and parse it with read_request_line.
-    fn parse_request(data: &[u8]) -> Option<ExecRequest> {
+    fn socketpair() -> (i32, i32) {
         let mut fds = [0i32; 2];
         let rc = unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) };
         assert_eq!(rc, 0, "socketpair failed");
-        let (server_fd, client_fd) = (fds[0], fds[1]);
+        (fds[0], fds[1])
+    }
 
-        let written = unsafe { libc::write(client_fd, data.as_ptr().cast(), data.len()) };
+    fn write_all(fd: i32, data: &[u8]) {
+        let written = unsafe { libc::write(fd, data.as_ptr().cast(), data.len()) };
         assert_eq!(written, data.len() as isize, "short write to socketpair");
+    }
 
-        // read_request_line closes server_fd on error; on success it returns it open.
-        let request = match read_request_line(server_fd) {
+    /// Read everything available from `fd` until EOF (bounded, blocking).
+    fn read_to_eof(fd: i32) -> Vec<u8> {
+        let mut out = Vec::new();
+        let mut buf = [0u8; 256];
+        loop {
+            let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
+            if n <= 0 {
+                return out;
+            }
+            out.extend_from_slice(&buf[..n as usize]);
+        }
+    }
+
+    /// Send `data` over a socketpair (with a pre-buffered GO line so the
+    /// handshake can complete) and parse it with read_request_and_handshake.
+    fn parse_request(data: &[u8]) -> Option<ExecRequest> {
+        let (server_fd, client_fd) = socketpair();
+        write_all(client_fd, data);
+        write_all(
+            client_fd,
+            format!("{}\n", exec_proto::HANDSHAKE_GO).as_bytes(),
+        );
+
+        // read_request_and_handshake closes server_fd on error; on success it
+        // returns it open.
+        let request = match read_request_and_handshake(server_fd, Duration::from_secs(5)) {
             Some((request, fd)) => {
                 unsafe { libc::close(fd) };
                 Some(request)
@@ -563,7 +766,7 @@ mod tests {
     }
 
     #[test]
-    fn test_read_request_line_preserves_utf8_args() {
+    fn test_parse_request_preserves_utf8_args() {
         // The host serializes ExecRequest with serde_json::to_string, which emits
         // non-ASCII characters as raw UTF-8 bytes — they must round-trip intact.
         let json = "{\"command\":[\"touch\",\"/data/héllo wörld.txt\"]}\n";
@@ -574,7 +777,7 @@ mod tests {
     }
 
     #[test]
-    fn test_read_request_line_ascii() {
+    fn test_parse_request_ascii() {
         let json = "{\"command\":[\"echo\",\"hello\"],\"in_container\":true}\n";
         let request = parse_request(json.as_bytes()).expect("request should parse");
         assert_eq!(request.command, vec!["echo", "hello"]);
@@ -582,7 +785,110 @@ mod tests {
     }
 
     #[test]
-    fn test_read_request_line_rejects_invalid_json() {
+    fn test_parse_request_rejects_invalid_json() {
         assert!(parse_request(b"not json\n").is_none());
+    }
+
+    /// Protocol-faithful happy path: the client sends the request, waits for the
+    /// ACK line, then sends GO — the server returns the request only after GO.
+    #[test]
+    fn test_handshake_ack_then_go() {
+        let (server_fd, client_fd) = socketpair();
+
+        let client = std::thread::spawn(move || {
+            write_all(
+                client_fd,
+                b"{\"command\":[\"true\"],\"in_container\":false}\n",
+            );
+            // Wait for the full ACK line before sending GO.
+            let mut ack = Vec::new();
+            let mut byte = [0u8; 1];
+            loop {
+                let n = unsafe { libc::read(client_fd, byte.as_mut_ptr() as *mut libc::c_void, 1) };
+                assert!(n > 0, "server closed before ACK");
+                if byte[0] == b'\n' {
+                    break;
+                }
+                ack.push(byte[0]);
+            }
+            assert_eq!(ack, exec_proto::HANDSHAKE_ACK.as_bytes());
+            write_all(
+                client_fd,
+                format!("{}\n", exec_proto::HANDSHAKE_GO).as_bytes(),
+            );
+            client_fd
+        });
+
+        let (request, fd) = read_request_and_handshake(server_fd, Duration::from_secs(5))
+            .expect("handshake should complete");
+        assert_eq!(request.command, vec!["true"]);
+        unsafe { libc::close(fd) };
+        let client_fd = client.join().unwrap();
+        unsafe { libc::close(client_fd) };
+    }
+
+    /// No GO after ACK (the snapshot-pause orphan shape): the server must time
+    /// out, close the connection, and never hand the request to execution. The
+    /// client must observe exactly ACK then EOF — no Exit/Error response, which
+    /// is the proof nothing executed.
+    #[test]
+    fn test_handshake_no_go_times_out_without_executing() {
+        let (server_fd, client_fd) = socketpair();
+        write_all(
+            client_fd,
+            b"{\"command\":[\"true\"],\"in_container\":false}\n",
+        );
+
+        let start = Instant::now();
+        let result = read_request_and_handshake(server_fd, Duration::from_millis(200));
+        assert!(result.is_none(), "handshake without GO must not execute");
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "timeout must be bounded (thread reclaimed), took {:?}",
+            start.elapsed()
+        );
+
+        // Server closed the fd; the client sees the ACK it sent, then clean EOF.
+        let seen = read_to_eof(client_fd);
+        assert_eq!(
+            seen,
+            format!("{}\n", exec_proto::HANDSHAKE_ACK).into_bytes()
+        );
+        unsafe { libc::close(client_fd) };
+    }
+
+    /// No request line at all (connection accepted, host bytes lost in a vsock
+    /// reset): bounded timeout, no ACK, fd closed, thread reclaimed.
+    #[test]
+    fn test_handshake_request_timeout_is_bounded() {
+        let (server_fd, client_fd) = socketpair();
+
+        let start = Instant::now();
+        let result = read_request_and_handshake(server_fd, Duration::from_millis(200));
+        assert!(result.is_none());
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "orphaned connection must be reclaimed quickly, took {:?}",
+            start.elapsed()
+        );
+
+        // No ACK was ever written — the request was never consumed.
+        let seen = read_to_eof(client_fd);
+        assert!(seen.is_empty(), "no bytes expected, got {:?}", seen);
+        unsafe { libc::close(client_fd) };
+    }
+
+    /// Client vanishes after the request (EOF before GO): close without executing.
+    #[test]
+    fn test_handshake_client_close_before_go() {
+        let (server_fd, client_fd) = socketpair();
+        write_all(
+            client_fd,
+            b"{\"command\":[\"true\"],\"in_container\":false}\n",
+        );
+        unsafe { libc::close(client_fd) };
+
+        let result = read_request_and_handshake(server_fd, Duration::from_secs(5));
+        assert!(result.is_none(), "EOF before GO must not execute");
     }
 }

--- a/fc-mock/Cargo.toml
+++ b/fc-mock/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
+exec-proto = { path = "../exec-proto" }
 hyper = { version = "0.14", features = ["server", "client", "http1"] }
 hyperlocal = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/fc-mock/src/vsock_exec.rs
+++ b/fc-mock/src/vsock_exec.rs
@@ -94,6 +94,41 @@ async fn handle_connection(stream: tokio::net::UnixStream) -> Result<()> {
         "exec request received"
     );
 
+    // Pre-ACK validation, matching fc-agent: an empty command is rejected with
+    // an Error line BEFORE the ACK, so the client sees a deterministic
+    // rejection instead of a mid-handshake close.
+    if request.command.is_empty() {
+        let resp = ExecResponse::Error("Empty command".to_string());
+        let json = serde_json::to_string(&resp)?;
+        write_half.write_all(json.as_bytes()).await?;
+        write_half.write_all(b"\n").await?;
+        return Ok(());
+    }
+
+    // Three-phase handshake (matches fc-agent, see exec_proto::HANDSHAKE_ACK):
+    // ACK that the request was fully consumed, then execute only after the
+    // client's GO line. Bounded so a stalled client can't leak this task.
+    write_half
+        .write_all(format!("{}\n", exec_proto::HANDSHAKE_ACK).as_bytes())
+        .await
+        .context("writing ACK")?;
+    let mut go_line = String::new();
+    tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        reader.read_line(&mut go_line),
+    )
+    .await
+    .context("timed out waiting for GO; closing without executing")?
+    .context("reading GO line")?;
+    // Exact-byte compare (one trailing newline stripped), matching fc-agent.
+    if go_line.strip_suffix('\n').unwrap_or(&go_line) != exec_proto::HANDSHAKE_GO {
+        anyhow::bail!(
+            "expected GO, got {:?}; closing without executing",
+            go_line.trim_end_matches('\n')
+        );
+    }
+    debug!("exec handshake complete (ACK/GO)");
+
     // Execute the command
     if request.tty || request.interactive {
         // TTY mode - not supported yet, send error

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -2088,9 +2088,10 @@ pub async fn create_disk_only_snapshot_core(
         "-f".to_string(),
         "/var/lib/fcvm/provisioned".to_string(),
     ];
-    let marker_out = run_exec_in_vm_captured(vsock_socket, &marker_cmd, false)
-        .await
-        .context("checking provisioned marker in guest")?;
+    let marker_out =
+        run_exec_in_vm_captured(vsock_socket, &marker_cmd, false, &snapshot_config.vm_id)
+            .await
+            .context("checking provisioned marker in guest")?;
     if marker_out.exit_code != 0 {
         let _ = tokio::fs::remove_dir_all(&temp_snapshot_dir).await;
         anyhow::bail!(
@@ -2108,7 +2109,7 @@ pub async fn create_disk_only_snapshot_core(
     // device into the backing file while the rootfs is still writable. (Freezing the
     // rootfs first would deadlock that flush.) Unfreeze happens in reverse order.
     let sync_cmd = vec!["sync".to_string()];
-    let sync_out = run_exec_in_vm_captured(vsock_socket, &sync_cmd, false)
+    let sync_out = run_exec_in_vm_captured(vsock_socket, &sync_cmd, false, &snapshot_config.vm_id)
         .await
         .context("guest sync before freeze")?;
     if sync_out.exit_code != 0 {
@@ -2130,23 +2131,27 @@ pub async fn create_disk_only_snapshot_core(
     // An exec-level error (vsock reset after the request was written) can leave the
     // guest frozen with no response — always attempt a best-effort thaw of BOTH
     // mounts before bailing, never leave the source wedged.
-    let freeze_out = match run_exec_in_vm_captured(vsock_socket, &freeze_cmd, false).await {
-        Ok(out) => out,
-        Err(e) => {
-            let thaw = vec![
-                "sh".to_string(),
-                "-c".to_string(),
-                format!(
-                    "fsfreeze --unfreeze / 2>/dev/null; \
+    let freeze_out =
+        match run_exec_in_vm_captured(vsock_socket, &freeze_cmd, false, &snapshot_config.vm_id)
+            .await
+        {
+            Ok(out) => out,
+            Err(e) => {
+                let thaw = vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    format!(
+                        "fsfreeze --unfreeze / 2>/dev/null; \
                      fsfreeze --unfreeze {m} 2>/dev/null; true",
-                    m = STORAGE_MOUNT
-                ),
-            ];
-            let _ = run_exec_in_vm_captured(vsock_socket, &thaw, false).await;
-            let _ = tokio::fs::remove_dir_all(&temp_snapshot_dir).await;
-            return Err(e).context("freezing guest filesystems");
-        }
-    };
+                        m = STORAGE_MOUNT
+                    ),
+                ];
+                let _ = run_exec_in_vm_captured(vsock_socket, &thaw, false, &snapshot_config.vm_id)
+                    .await;
+                let _ = tokio::fs::remove_dir_all(&temp_snapshot_dir).await;
+                return Err(e).context("freezing guest filesystems");
+            }
+        };
     if freeze_out.exit_code != 0 {
         // Best-effort thaw in case the storage mount froze but the rootfs didn't.
         let thaw = vec![
@@ -2157,7 +2162,7 @@ pub async fn create_disk_only_snapshot_core(
                 m = STORAGE_MOUNT
             ),
         ];
-        let _ = run_exec_in_vm_captured(vsock_socket, &thaw, false).await;
+        let _ = run_exec_in_vm_captured(vsock_socket, &thaw, false, &snapshot_config.vm_id).await;
         let _ = tokio::fs::remove_dir_all(&temp_snapshot_dir).await;
         anyhow::bail!(
             "fsfreeze failed (exit {}): {}",
@@ -2192,7 +2197,8 @@ pub async fn create_disk_only_snapshot_core(
         m = STORAGE_MOUNT
     );
     let unfreeze_cmd = vec!["sh".to_string(), "-c".to_string(), unfreeze_script];
-    let unfreeze_result = run_exec_in_vm_captured(vsock_socket, &unfreeze_cmd, false).await;
+    let unfreeze_result =
+        run_exec_in_vm_captured(vsock_socket, &unfreeze_cmd, false, &snapshot_config.vm_id).await;
 
     if let Err(e) = copy_result {
         let _ = tokio::fs::remove_dir_all(&temp_snapshot_dir).await;
@@ -2242,6 +2248,46 @@ pub async fn create_disk_only_snapshot_core(
 
     info!(snapshot = %snapshot_config.name, "disk-only snapshot created");
     Ok(())
+}
+
+/// Record that this VM's vsock transport was reset by a snapshot pause, by
+/// bumping the persisted `vsock_epoch`.
+///
+/// MUST be called after the pause/save and BEFORE the resume (see
+/// `StateManager::bump_vsock_epoch` for the ordering contract that makes the
+/// exec-side orphan detection race-free). Best-effort: a missing state file
+/// (VM mid-teardown) is expected, and a failed bump must not fail the
+/// snapshot — it only degrades orphan detection for currently-blocked execs
+/// back to the pre-epoch behavior.
+async fn record_vsock_reset_for_snapshot(vm_id: &str, snapshot_name: &str) {
+    let state_manager = crate::state::StateManager::new(paths::state_dir());
+    match state_manager.bump_vsock_epoch(vm_id).await {
+        Ok(Some(epoch)) => {
+            info!(
+                vm_id,
+                snapshot = snapshot_name,
+                vsock_epoch = epoch,
+                "bumped vsock epoch after snapshot pause \
+                 (exec sessions from before the pause are dead and will abort)"
+            );
+        }
+        Ok(None) => {
+            debug!(
+                vm_id,
+                snapshot = snapshot_name,
+                "no state file to bump vsock epoch on (VM being torn down)"
+            );
+        }
+        Err(e) => {
+            warn!(
+                vm_id,
+                snapshot = snapshot_name,
+                error = %e,
+                "failed to bump vsock epoch after snapshot pause; exec sessions \
+                 orphaned by this pause will not detect it"
+            );
+        }
+    }
 }
 
 /// Create a snapshot of the running VM.
@@ -2453,7 +2499,12 @@ pub async fn create_snapshot_core(
                         );
                     }
                     Err(e) => {
-                        // Full retry failed — resume VM and abort
+                        // Full retry failed — record the vsock reset, resume VM, abort.
+                        record_vsock_reset_for_snapshot(
+                            &snapshot_config.vm_id,
+                            &snapshot_config.name,
+                        )
+                        .await;
                         let _ = snapshot_client
                             .patch_vm_state(ApiVmState {
                                 state: "Resumed".to_string(),
@@ -2478,6 +2529,13 @@ pub async fn create_snapshot_core(
     } else {
         Ok(()) // Skip disk copy if snapshot failed
     };
+
+    // The pause/save silently orphans in-flight host↔guest vsock connections
+    // (exec sessions block forever with no error on either side). Record it by
+    // bumping the persisted vsock epoch BEFORE resuming — see
+    // StateManager::bump_vsock_epoch for why this ordering makes the exec-side
+    // orphan detection race-free.
+    record_vsock_reset_for_snapshot(&snapshot_config.vm_id, &snapshot_config.name).await;
 
     // Resume VM (ALWAYS, regardless of snapshot/disk copy result).
     // Memory merge happens after resume since it operates on snapshot files, not live disk.
@@ -2516,6 +2574,11 @@ pub async fn create_snapshot_core(
     // would trigger handle_clone_restore() in fc-agent, which kills TCP connections
     // and reconnects FUSE/output vsock unnecessarily, crashing the running container.
     // restore-epoch is bumped in the restore path (snapshot.rs) where it's needed.
+    //
+    // The HOST-side `vsock_epoch` (VmState) bumped above is a different mechanism:
+    // it never reaches the guest. It only tells host exec clients that byte streams
+    // in flight across the pause were silently lost (the CI-observed orphan mode),
+    // so their blocked reads abort instead of hanging.
 
     if use_diff {
         // Diff snapshot: copy base to temp, merge diff onto it, then atomic rename
@@ -2699,6 +2762,10 @@ pub async fn create_snapshot_ch(
     } else {
         Ok(())
     };
+
+    // Same as the Firecracker path: record the vsock reset caused by the
+    // pause/save BEFORE resuming, so blocked exec sessions abort loudly.
+    record_vsock_reset_for_snapshot(&snapshot_config.vm_id, &snapshot_config.name).await;
 
     // Resume ALWAYS, even if the snapshot or disk copy failed.
     let resume_result = client.resume_vm().await;

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -12,6 +12,13 @@
 //! (bounded retries); once GO is sent, resending is forbidden — execution may
 //! have started — and any connection death is a loud error instead of a hang.
 //!
+//! Post-GO, the same snapshot pause can still orphan the session (ACK received
+//! but GO swallowed, or mid-response): the host bumps the VM's persisted
+//! `vsock_epoch` after every snapshot pause/save, and every blocked response
+//! read polls it via [`SnapshotOrphanGuard`] — an epoch change aborts the
+//! session loudly instead of hanging, while honest silence (a command quiet
+//! for hours) keeps waiting indefinitely.
+//!
 //! TTY mode uses a length-prefixed binary protocol (see exec_proto.rs) to cleanly
 //! separate control messages from raw terminal data. Non-TTY mode continues to use
 //! JSON line protocol.
@@ -22,8 +29,8 @@ use crate::state::StateManager;
 use anyhow::{bail, Context, Result};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::os::unix::net::UnixStream;
-use std::path::Path;
-use std::time::Duration;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 use tracing::{debug, info};
 
 /// Vsock port for exec commands (fc-agent listens on this)
@@ -44,9 +51,13 @@ const ACK_TIMEOUT: Duration = Duration::from_secs(3);
 /// (plus reconnect time) spans realistic snapshot pause durations (~15s).
 const MAX_ACK_ATTEMPTS: u32 = 5;
 
-/// Post-handshake read timeout — commands like phps cookie gen can take
-/// >10 min of silence. A safety net against permanent hangs (not None/infinite).
-const EXEC_READ_TIMEOUT: Duration = Duration::from_secs(3600);
+/// How long a post-GO response read may sit idle before the client checks the
+/// VM's persisted `vsock_epoch` for the snapshot-pause orphan mode (see
+/// `SnapshotOrphanGuard`). Purely a polling interval, NOT a silence limit:
+/// commands like phps cookie gen can be silent for >10 min — with an
+/// unchanged epoch the wait continues indefinitely. Only a session whose
+/// transport was reset by a snapshot pause aborts.
+pub(crate) const EXEC_EPOCH_POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Post-handshake / handshake write timeout.
 const EXEC_WRITE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -171,18 +182,34 @@ enum AckOutcome {
     Rejected(String),
 }
 
-/// Wait for the agent's ACK line, bounded by the stream's read timeout.
+/// Wait for the agent's ACK line, bounded by an absolute deadline of `timeout`
+/// across the WHOLE line — mirroring the agent side's `read_line_bounded`.
 ///
 /// Reads byte-by-byte so no bytes past the ACK newline are ever consumed —
 /// everything after ACK belongs to the post-GO exec protocol (JSON lines or
 /// TTY frames), which the mode loops read from the raw stream.
-fn read_ack_line(stream: &mut UnixStream) -> AckOutcome {
+///
+/// The socket read timeout restarts on every byte, so on its own a
+/// byte-dribbling peer could stretch one ACK wait to ~MAX_ACK_LINE_LENGTH ×
+/// `timeout`. The contract is a bounded per-attempt wait, so the per-read
+/// socket timeout is only the polling mechanism: it is re-armed with the
+/// remaining time each iteration, and the deadline decides.
+fn read_ack_line(stream: &mut UnixStream, timeout: Duration) -> AckOutcome {
     // An ACK line is 4 bytes; a pre-ACK Error line carries a message. Anything
     // bigger is a protocol violation.
     const MAX_ACK_LINE_LENGTH: usize = 65_536;
+    let deadline = Instant::now() + timeout;
     let mut line: Vec<u8> = Vec::new();
     let mut byte = [0u8; 1];
     loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return AckOutcome::NotAcked(format!("timed out after {:?} waiting for ACK", timeout));
+        }
+        // Never zero here (checked above) — a zero read timeout means "block forever".
+        if let Err(e) = stream.set_read_timeout(Some(remaining)) {
+            return AckOutcome::NotAcked(format!("failed to arm ACK read timeout: {}", e));
+        }
         match stream.read(&mut byte) {
             Ok(0) => return AckOutcome::NotAcked("connection closed before ACK".to_string()),
             Ok(_) => {
@@ -204,7 +231,7 @@ fn read_ack_line(stream: &mut UnixStream) -> AckOutcome {
             {
                 return AckOutcome::NotAcked(format!(
                     "timed out after {:?} waiting for ACK",
-                    ACK_TIMEOUT
+                    timeout
                 ));
             }
             Err(e) => return AckOutcome::NotAcked(format!("read error waiting for ACK: {}", e)),
@@ -226,23 +253,178 @@ fn read_ack_line(stream: &mut UnixStream) -> AckOutcome {
     ))
 }
 
+/// A post-GO exec session was orphaned by a VM snapshot pause.
+///
+/// The VM's persisted `vsock_epoch` changed while this session was blocked
+/// waiting for a response: a snapshot create (startup snapshot or
+/// `fcvm snapshot create --pid`) paused the VM and reset its vsock transport,
+/// silently killing connections from before the pause — reads would otherwise
+/// block forever with no error on either side. Never resent: execution may
+/// already have happened.
+#[derive(Debug)]
+pub struct ExecOrphanedBySnapshotPause;
+
+impl std::fmt::Display for ExecOrphanedBySnapshotPause {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "exec session orphaned by a VM snapshot pause: the VM's vsock epoch \
+             changed while this exec was waiting for a response — a snapshot \
+             (startup snapshot or `fcvm snapshot create`) paused the VM and reset \
+             vsock, silently killing this in-flight session. Not resending: the \
+             command may already have executed. Retry the exec."
+        )
+    }
+}
+
+impl std::error::Error for ExecOrphanedBySnapshotPause {}
+
+/// Detects the snapshot-pause orphan mode for post-GO exec sessions.
+///
+/// A snapshot pause resets the VM's vsock transport and silently orphans
+/// in-flight connections: reads block forever and writes can "succeed" into
+/// the dead host socket. Pre-ACK, the bounded handshake handles this (resend);
+/// post-GO, resending is forbidden, so the snapshot paths bump
+/// `VmState::vsock_epoch` after every pause/save (before resuming — see
+/// `StateManager::bump_vsock_epoch`) and blocked exec readers poll it: a
+/// changed epoch means this session's transport was reset.
+///
+/// The baseline is captured after the session's vsock connection is
+/// established and before the request is sent (see `connect_and_start_exec`
+/// for the ordering argument). `check` costs one small file read and runs only
+/// after a read has been idle for `EXEC_EPOCH_POLL_INTERVAL` — never per byte.
+pub struct SnapshotOrphanGuard {
+    state_file: Option<PathBuf>,
+    /// Epoch at capture time. `None` if the state file was missing or
+    /// unreadable at capture (VM without persisted state — e.g. library-API
+    /// tests against fc-mock); the guard then never fires.
+    baseline: Option<u64>,
+}
+
+impl SnapshotOrphanGuard {
+    /// Capture the current epoch of the VM whose state file is `state_file`.
+    fn capture(state_file: PathBuf) -> Self {
+        let baseline = read_vsock_epoch(&state_file);
+        Self {
+            state_file: Some(state_file),
+            baseline,
+        }
+    }
+
+    /// A guard that never fires — for TTY sessions that are not exec sessions
+    /// (the `podman run -it` console socket is host-bound, not an exec vsock).
+    pub fn disabled() -> Self {
+        Self {
+            state_file: None,
+            baseline: None,
+        }
+    }
+
+    /// Check whether the VM's vsock epoch moved past this session's baseline.
+    ///
+    /// A missing/unreadable state file is NOT an orphan signal: VM teardown
+    /// deletes the state file but also kills the hypervisor, which closes the
+    /// vsock socket and surfaces a loud read error on its own.
+    pub fn check(&self) -> std::result::Result<(), ExecOrphanedBySnapshotPause> {
+        let (Some(state_file), Some(baseline)) = (self.state_file.as_deref(), self.baseline) else {
+            return Ok(());
+        };
+        match read_vsock_epoch(state_file) {
+            Some(current) if current != baseline => Err(ExecOrphanedBySnapshotPause),
+            _ => Ok(()),
+        }
+    }
+}
+
+/// Read `vsock_epoch` from a VM state file. A state file written before the
+/// field existed reads as 0; a missing/unparseable file reads as `None`.
+///
+/// Deliberately lock-free: state writers write a temp file and atomically
+/// rename it into place, so a plain read can never observe a torn write.
+/// Taking the per-VM flock here would also recreate lock files that
+/// `delete_state` just removed.
+fn read_vsock_epoch(state_file: &Path) -> Option<u64> {
+    let json = std::fs::read_to_string(state_file).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&json).ok()?;
+    Some(
+        value
+            .get("vsock_epoch")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0),
+    )
+}
+
+/// Read adapter for post-GO exec streams.
+///
+/// The socket carries a short read timeout (`EXEC_EPOCH_POLL_INTERVAL`) purely
+/// as a polling clock: each time a read has sat idle that long, the
+/// snapshot-orphan guard is consulted and the wait continues. A command that
+/// is silent for an hour with an unchanged epoch keeps waiting — this bounds
+/// the ORPHAN case, not honest silence. A session orphaned by a snapshot pause
+/// fails the read with `ExecOrphanedBySnapshotPause` instead of blocking
+/// forever.
+pub(crate) struct EpochGuardedReader {
+    stream: UnixStream,
+    guard: SnapshotOrphanGuard,
+}
+
+impl EpochGuardedReader {
+    pub(crate) fn new(stream: UnixStream, guard: SnapshotOrphanGuard) -> Self {
+        Self { stream, guard }
+    }
+}
+
+impl Read for EpochGuardedReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        loop {
+            match self.stream.read(buf) {
+                Err(e)
+                    if e.kind() == std::io::ErrorKind::WouldBlock
+                        || e.kind() == std::io::ErrorKind::TimedOut =>
+                {
+                    self.guard.check().map_err(std::io::Error::other)?;
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+                other => return other,
+            }
+        }
+    }
+}
+
 /// Connect, send the exec request, and complete the three-phase handshake
 /// (request → ACK → GO). Returns a stream on which execution has just been
-/// authorized: the next bytes from the agent are exec responses.
+/// authorized — the next bytes from the agent are exec responses — plus the
+/// session's `SnapshotOrphanGuard` for the post-GO response wait.
 ///
 /// A request that never gets ACKed (its connection was orphaned by a snapshot
 /// pause's vsock reset — silent, no error on either side) provably never
 /// executed, so it is resent on a fresh connection, bounded by
 /// `MAX_ACK_ATTEMPTS`. After GO is sent, no resend ever happens — fc-agent may
 /// have started executing — so a subsequent connection death surfaces as a
-/// loud error from the mode loops instead (see `ExecConnectionClosed`).
-pub fn connect_and_start_exec(vsock_socket: &Path, request: &ExecRequest) -> Result<UnixStream> {
+/// loud error from the mode loops instead (see `ExecConnectionClosed` and
+/// `ExecOrphanedBySnapshotPause`).
+pub fn connect_and_start_exec(
+    vsock_socket: &Path,
+    request: &ExecRequest,
+    vm_id: &str,
+) -> Result<(UnixStream, SnapshotOrphanGuard)> {
     let request_json = serde_json::to_string(request)?;
+    let state_file = paths::state_dir().join(format!("{}.json", vm_id));
     let mut attempt = 0;
     loop {
         attempt += 1;
         let mut stream = connect_to_exec_server_with_retry(vsock_socket)?;
-        stream.set_read_timeout(Some(ACK_TIMEOUT))?;
+        // Capture the epoch baseline HERE — after this attempt's connection
+        // exists, before the request is sent. Snapshot paths bump the epoch
+        // after the pause but BEFORE the VM resumes, and a vsock CONNECT can
+        // only complete against a running guest, so:
+        //   - a session orphaned after ACK captured its baseline strictly
+        //     before the pause → the bump is observed → loud abort, no hang;
+        //   - a session connected after the resume reads the already-bumped
+        //     value → no false abort.
+        // Re-captured on every retry so a resend starts from the current epoch.
+        let guard = SnapshotOrphanGuard::capture(state_file.clone());
+        // Read timeouts are armed by read_ack_line (handshake) and below (post-GO).
         stream.set_write_timeout(Some(EXEC_WRITE_TIMEOUT))?;
 
         // Phase 1: send the request line.
@@ -258,8 +440,8 @@ pub fn connect_and_start_exec(vsock_socket: &Path, request: &ExecRequest) -> Res
             );
         }
 
-        // Phase 2: wait (bounded) for ACK.
-        match read_ack_line(&mut stream) {
+        // Phase 2: wait (bounded by an absolute deadline) for ACK.
+        match read_ack_line(&mut stream, ACK_TIMEOUT) {
             AckOutcome::Acked => {
                 debug!(attempt, "exec handshake: ACK received, sending GO");
                 // Phase 3: authorize execution. From here on the request must
@@ -278,9 +460,14 @@ pub fn connect_and_start_exec(vsock_socket: &Path, request: &ExecRequest) -> Res
                     );
                 }
                 debug!("exec handshake: GO sent, command starting");
-                stream.set_read_timeout(Some(EXEC_READ_TIMEOUT))?;
+                // Post-GO reads are bounded by the epoch guard, not a wall
+                // clock: this short timeout is the guard's polling interval
+                // (see EpochGuardedReader), so honest long silences keep
+                // waiting while a snapshot-pause orphan aborts within ~one
+                // interval.
+                stream.set_read_timeout(Some(EXEC_EPOCH_POLL_INTERVAL))?;
                 stream.set_write_timeout(Some(EXEC_WRITE_TIMEOUT))?;
-                return Ok(stream);
+                return Ok((stream, guard));
             }
             AckOutcome::NotAcked(reason) => {
                 if attempt < MAX_ACK_ATTEMPTS {
@@ -323,16 +510,19 @@ pub async fn run_exec_in_vm(
     vsock_socket: &Path,
     command: &[String],
     in_container: bool,
+    vm_id: &str,
 ) -> Result<i32> {
     debug!(
         socket = %vsock_socket.display(),
         command = ?command,
         in_container,
+        vm_id,
         "executing command in VM"
     );
 
     let vsock_socket = vsock_socket.to_path_buf();
     let command = command.to_vec();
+    let vm_id = vm_id.to_string();
 
     tokio::task::spawn_blocking(move || {
         // Build the exec request (non-interactive, no TTY)
@@ -344,11 +534,11 @@ pub async fn run_exec_in_vm(
         };
 
         // Connect, send the request, and complete the ACK/GO handshake
-        let stream = connect_and_start_exec(&vsock_socket, &request)?;
+        let (stream, guard) = connect_and_start_exec(&vsock_socket, &request, &vm_id)?;
         debug!("exec handshake complete");
 
         // Run in line mode and capture exit code
-        run_line_mode_with_exit_code(stream)
+        run_line_mode_with_exit_code(stream, guard)
     })
     .await
     .context("exec task panicked")?
@@ -435,7 +625,7 @@ pub async fn cmd_exec(args: ExecArgs) -> Result<()> {
     };
 
     // Connect, send the request, and complete the ACK/GO handshake
-    let stream = connect_and_start_exec(&vsock_socket, &request)?;
+    let (stream, guard) = connect_and_start_exec(&vsock_socket, &request, &vm_state.vm_id)?;
 
     if !quiet {
         info!(
@@ -450,7 +640,7 @@ pub async fn cmd_exec(args: ExecArgs) -> Result<()> {
     // Use binary framing for any mode needing TTY or stdin forwarding
     // JSON line mode only for plain non-interactive commands
     let result = if tty || interactive {
-        match super::tty::run_tty_session_connected(stream, tty, interactive) {
+        match super::tty::run_tty_session_connected(stream, tty, interactive, guard) {
             Ok(exit_code) => {
                 if exit_code != 0 {
                     std::process::exit(exit_code);
@@ -460,7 +650,7 @@ pub async fn cmd_exec(args: ExecArgs) -> Result<()> {
             Err(e) => Err(e),
         }
     } else {
-        run_line_mode(stream)
+        run_line_mode(stream, guard)
     };
 
     // Downgrade the benign "stream closed before exit" race to debug ONLY for quiet
@@ -547,8 +737,8 @@ fn is_benign_quiet_exec_close(quiet: bool, err: &anyhow::Error) -> bool {
 }
 
 /// Run in line-buffered mode (non-TTY), returns exit code
-fn run_line_mode_with_exit_code(stream: UnixStream) -> Result<i32> {
-    let reader = BufReader::new(stream);
+fn run_line_mode_with_exit_code(stream: UnixStream, guard: SnapshotOrphanGuard) -> Result<i32> {
+    let reader = BufReader::new(EpochGuardedReader::new(stream, guard));
     read_exec_responses(
         reader,
         |data| print!("{}", data),
@@ -557,8 +747,8 @@ fn run_line_mode_with_exit_code(stream: UnixStream) -> Result<i32> {
 }
 
 /// Run in line-buffered mode (non-TTY)
-fn run_line_mode(stream: UnixStream) -> Result<()> {
-    let exit_code = run_line_mode_with_exit_code(stream)?;
+fn run_line_mode(stream: UnixStream, guard: SnapshotOrphanGuard) -> Result<()> {
+    let exit_code = run_line_mode_with_exit_code(stream, guard)?;
 
     // Exit with the command's exit code
     if exit_code != 0 {
@@ -613,16 +803,19 @@ pub async fn run_exec_in_vm_captured(
     vsock_socket: &Path,
     command: &[String],
     in_container: bool,
+    vm_id: &str,
 ) -> Result<ExecOutput> {
     debug!(
         socket = %vsock_socket.display(),
         command = ?command,
         in_container,
+        vm_id,
         "executing command in VM (captured)"
     );
 
     let vsock_socket = vsock_socket.to_path_buf();
     let command = command.to_vec();
+    let vm_id = vm_id.to_string();
 
     tokio::task::spawn_blocking(move || {
         let request = ExecRequest {
@@ -633,10 +826,10 @@ pub async fn run_exec_in_vm_captured(
         };
 
         // Connect, send the request, and complete the ACK/GO handshake
-        let stream = connect_and_start_exec(&vsock_socket, &request)?;
+        let (stream, guard) = connect_and_start_exec(&vsock_socket, &request, &vm_id)?;
 
         // Read lines and capture into strings instead of printing
-        let reader = BufReader::new(stream);
+        let reader = BufReader::new(EpochGuardedReader::new(stream, guard));
         let mut stdout = String::new();
         let mut stderr = String::new();
         let exit_code = read_exec_responses(
@@ -657,23 +850,32 @@ pub async fn run_exec_in_vm_captured(
 
 /// Connect, complete the exec handshake for `request`, and return a tokio
 /// async UnixStream on which execution has just been authorized (the next
-/// bytes from the agent are exec responses / TTY frames).
+/// bytes from the agent are exec responses / TTY frames), plus the session's
+/// `SnapshotOrphanGuard`.
 ///
-/// Useful for building WebSocket↔vsock bridges (terminal sessions).
+/// Useful for building WebSocket↔vsock bridges (terminal sessions). The tokio
+/// stream is nonblocking, so the socket read timeout used by the blocking mode
+/// loops does not apply — the async consumer must run the guard on its own
+/// idle poll interval (see `serve.rs`'s websocket terminal).
 ///
 /// The blocking connect/handshake logic is offloaded to a blocking thread pool
 /// so this function is safe to call from async contexts.
 pub async fn start_exec_session_async(
     vsock_socket: &Path,
     request: ExecRequest,
-) -> Result<tokio::net::UnixStream> {
+    vm_id: &str,
+) -> Result<(tokio::net::UnixStream, SnapshotOrphanGuard)> {
     let vsock_socket = vsock_socket.to_path_buf();
-    let std_stream =
-        tokio::task::spawn_blocking(move || connect_and_start_exec(&vsock_socket, &request))
-            .await
-            .context("connect task panicked")??;
+    let vm_id = vm_id.to_string();
+    let (std_stream, guard) = tokio::task::spawn_blocking(move || {
+        connect_and_start_exec(&vsock_socket, &request, &vm_id)
+    })
+    .await
+    .context("connect task panicked")??;
     std_stream.set_nonblocking(true)?;
-    tokio::net::UnixStream::from_std(std_stream).context("converting to tokio UnixStream")
+    let stream =
+        tokio::net::UnixStream::from_std(std_stream).context("converting to tokio UnixStream")?;
+    Ok((stream, guard))
 }
 
 #[cfg(test)]
@@ -757,7 +959,10 @@ mod tests {
             )
             .unwrap();
 
-        assert!(matches!(read_ack_line(&mut client), AckOutcome::Acked));
+        assert!(matches!(
+            read_ack_line(&mut client, ACK_TIMEOUT),
+            AckOutcome::Acked
+        ));
 
         // The exec response following ACK must still be readable in full.
         let mut reader = BufReader::new(client);
@@ -771,7 +976,7 @@ mod tests {
     fn read_ack_line_eof_is_not_acked() {
         let (mut client, server) = UnixStream::pair().unwrap();
         drop(server);
-        match read_ack_line(&mut client) {
+        match read_ack_line(&mut client, Duration::from_secs(1)) {
             AckOutcome::NotAcked(reason) => assert!(reason.contains("closed"), "{reason}"),
             other => panic!("expected NotAcked, got {:?}", other),
         }
@@ -782,15 +987,48 @@ mod tests {
     #[test]
     fn read_ack_line_timeout_is_not_acked() {
         let (mut client, _server) = UnixStream::pair().unwrap();
-        client
-            .set_read_timeout(Some(Duration::from_millis(100)))
-            .unwrap();
         let start = std::time::Instant::now();
-        match read_ack_line(&mut client) {
+        match read_ack_line(&mut client, Duration::from_millis(100)) {
             AckOutcome::NotAcked(reason) => assert!(reason.contains("timed out"), "{reason}"),
             other => panic!("expected NotAcked, got {:?}", other),
         }
         assert!(start.elapsed() < Duration::from_secs(5));
+    }
+
+    /// CodeRabbit finding: the per-read socket timeout restarts on every byte,
+    /// so a peer dribbling one byte just inside each window could stretch a
+    /// single ACK wait to ~MAX_ACK_LINE_LENGTH × timeout. The deadline must be
+    /// absolute across the whole line (contract: bounded per-attempt wait).
+    #[test]
+    fn read_ack_line_dribbled_bytes_hit_absolute_deadline() {
+        let (mut client, mut server) = UnixStream::pair().unwrap();
+        let writer = std::thread::spawn(move || {
+            // Dribble a byte every 25ms, ~1s total — each byte arrives well
+            // inside a freshly-restarted per-read timeout, so only the
+            // absolute deadline can end the wait.
+            for _ in 0..40 {
+                if server.write_all(b"x").is_err() {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(25));
+            }
+        });
+
+        let start = std::time::Instant::now();
+        let outcome = read_ack_line(&mut client, Duration::from_millis(200));
+        let elapsed = start.elapsed();
+        match outcome {
+            AckOutcome::NotAcked(reason) => assert!(reason.contains("timed out"), "{reason}"),
+            other => panic!("expected NotAcked timeout, got {:?}", other),
+        }
+        assert!(
+            elapsed < Duration::from_millis(800),
+            "deadline was not absolute: dribbled bytes kept the read alive for {:?}",
+            elapsed
+        );
+
+        drop(client);
+        writer.join().unwrap();
     }
 
     /// A pre-ACK Error response (invalid/empty request) → Rejected with the
@@ -801,10 +1039,131 @@ mod tests {
         let error_line = response_line(&ExecResponse::Error("Empty command".into()));
         server.write_all(error_line.as_bytes()).unwrap();
 
-        match read_ack_line(&mut client) {
+        match read_ack_line(&mut client, Duration::from_secs(1)) {
             AckOutcome::Rejected(msg) => assert_eq!(msg, "Empty command"),
             other => panic!("expected Rejected, got {:?}", other),
         }
+    }
+
+    /// Write a minimal VM state file with the given epoch; returns its path.
+    fn write_state_with_epoch(dir: &Path, vm_id: &str, epoch: u64) -> PathBuf {
+        let path = dir.join(format!("{}.json", vm_id));
+        std::fs::write(
+            &path,
+            format!(r#"{{"vm_id":"{}","vsock_epoch":{}}}"#, vm_id, epoch),
+        )
+        .unwrap();
+        path
+    }
+
+    /// An unchanged epoch keeps the session waiting — honest silence (a
+    /// command quiet for an hour) is NOT bounded, only the orphan case is.
+    #[test]
+    fn snapshot_orphan_guard_unchanged_epoch_keeps_waiting() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_file = write_state_with_epoch(dir.path(), "vm-guard-same", 3);
+        let guard = SnapshotOrphanGuard::capture(state_file);
+        assert!(guard.check().is_ok());
+        assert!(guard.check().is_ok(), "repeated checks must stay quiet");
+    }
+
+    /// A bumped epoch means a snapshot pause reset the vsock transport while
+    /// this session was in flight — the check must fail loudly, naming the
+    /// snapshot-pause orphan mode.
+    #[test]
+    fn snapshot_orphan_guard_bumped_epoch_aborts_loudly() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_file = write_state_with_epoch(dir.path(), "vm-guard-bump", 3);
+        let guard = SnapshotOrphanGuard::capture(state_file);
+
+        write_state_with_epoch(dir.path(), "vm-guard-bump", 4);
+        let err = guard.check().unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("snapshot"), "must name the cause: {msg}");
+        assert!(msg.contains("pause"), "must name the orphan mode: {msg}");
+        assert!(msg.contains("Not resending"), "must forbid resend: {msg}");
+    }
+
+    /// State files written before vsock_epoch existed read as epoch 0, so a
+    /// bump (0 → 1) is still detected against them.
+    #[test]
+    fn snapshot_orphan_guard_missing_field_reads_as_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vm-guard-old.json");
+        std::fs::write(&path, r#"{"vm_id":"vm-guard-old"}"#).unwrap();
+
+        let guard = SnapshotOrphanGuard::capture(path);
+        assert!(guard.check().is_ok());
+
+        write_state_with_epoch(dir.path(), "vm-guard-old", 1);
+        assert!(guard.check().is_err(), "bump from implicit 0 must fire");
+    }
+
+    /// A state file that disappears is NOT an orphan signal: teardown deletes
+    /// state but also kills the hypervisor, which errors the socket loudly on
+    /// its own. The guard must not abort a session it cannot classify.
+    #[test]
+    fn snapshot_orphan_guard_missing_state_file_is_no_signal() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_file = write_state_with_epoch(dir.path(), "vm-guard-gone", 2);
+        let guard = SnapshotOrphanGuard::capture(state_file.clone());
+
+        std::fs::remove_file(&state_file).unwrap();
+        assert!(guard.check().is_ok());
+    }
+
+    /// No baseline (state file missing at capture — e.g. library API against
+    /// fc-mock) → the guard never fires, even if a state file appears later.
+    #[test]
+    fn snapshot_orphan_guard_without_baseline_never_fires() {
+        let dir = tempfile::tempdir().unwrap();
+        let guard = SnapshotOrphanGuard::capture(dir.path().join("vm-guard-none.json"));
+        assert!(guard.check().is_ok());
+
+        write_state_with_epoch(dir.path(), "vm-guard-none", 7);
+        assert!(guard.check().is_ok());
+
+        let disabled = SnapshotOrphanGuard::disabled();
+        assert!(disabled.check().is_ok());
+    }
+
+    /// The post-GO read loop: an idle read timeout is only a polling tick
+    /// (data flowing and honest silence both keep the session alive), while an
+    /// epoch bump during the idle wait fails the read with
+    /// ExecOrphanedBySnapshotPause instead of hanging.
+    #[test]
+    fn epoch_guarded_reader_aborts_on_bump_and_passes_data_through() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_file = write_state_with_epoch(dir.path(), "vm-guard-read", 1);
+
+        let (client, mut server) = UnixStream::pair().unwrap();
+        // Short poll interval so the test doesn't wait EXEC_EPOCH_POLL_INTERVAL.
+        client
+            .set_read_timeout(Some(Duration::from_millis(30)))
+            .unwrap();
+        let guard = SnapshotOrphanGuard::capture(state_file);
+        let mut reader = EpochGuardedReader::new(client, guard);
+
+        // Data flows through even though several poll ticks elapse first.
+        let writer = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(100));
+            server.write_all(b"hi").unwrap();
+            server
+        });
+        let mut buf = [0u8; 2];
+        reader.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"hi");
+        let _server = writer.join().unwrap();
+
+        // Now bump the epoch while the socket is idle: the blocked read must
+        // abort with the orphan error instead of waiting forever.
+        write_state_with_epoch(dir.path(), "vm-guard-read", 2);
+        let err = reader.read(&mut buf).unwrap_err();
+        let inner = err.get_ref().expect("orphan error must be attached");
+        assert!(
+            inner.is::<ExecOrphanedBySnapshotPause>(),
+            "unexpected error: {err}"
+        );
     }
 
     /// #607 regression (Codex P2): the log downgrade for the benign "stream closed

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -4,6 +4,14 @@
 //! The guest (fc-agent) listens on vsock port 4998.
 //! The host connects via the vsock.sock Unix socket using the CONNECT protocol.
 //!
+//! Every exec session starts with a three-phase handshake (request → ACK → GO,
+//! see `exec_proto::HANDSHAKE_ACK`): a VM snapshot pause (startup snapshot or
+//! `fcvm snapshot create --pid`) resets the vsock transport and silently orphans
+//! in-flight connections with no error on either side. A request that never
+//! receives ACK provably never executed, so it is resent on a fresh connection
+//! (bounded retries); once GO is sent, resending is forbidden — execution may
+//! have started — and any connection death is a loud error instead of a hang.
+//!
 //! TTY mode uses a length-prefixed binary protocol (see exec_proto.rs) to cleanly
 //! separate control messages from raw terminal data. Non-TTY mode continues to use
 //! JSON line protocol.
@@ -27,13 +35,29 @@ const MAX_EXEC_CONNECT_ATTEMPTS: u32 = 30;
 /// Initial retry delay when connecting to exec server (doubles each attempt)
 const INITIAL_RETRY_DELAY_MS: u64 = 100;
 
+/// Per-attempt bounded wait for the agent's ACK line. A live agent ACKs in
+/// sub-millisecond time; only an orphaned/paused connection stalls this long.
+const ACK_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Attempts to send an exec request that was never acknowledged. Resends are
+/// safe (fc-agent never executes before consuming GO). 5 × 3s of ACK waiting
+/// (plus reconnect time) spans realistic snapshot pause durations (~15s).
+const MAX_ACK_ATTEMPTS: u32 = 5;
+
+/// Post-handshake read timeout — commands like phps cookie gen can take
+/// >10 min of silence. A safety net against permanent hangs (not None/infinite).
+const EXEC_READ_TIMEOUT: Duration = Duration::from_secs(3600);
+
+/// Post-handshake / handshake write timeout.
+const EXEC_WRITE_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Connect to the exec server via vsock with retry logic.
 ///
 /// The guest VM takes several seconds to boot and start fc-agent with the exec server.
 /// This function retries the connection with exponential backoff to handle this startup delay.
 ///
 /// Returns a connected UnixStream on success.
-pub fn connect_to_exec_server_with_retry(vsock_socket: &Path) -> Result<UnixStream> {
+fn connect_to_exec_server_with_retry(vsock_socket: &Path) -> Result<UnixStream> {
     let mut attempt = 0;
     let mut delay_ms = INITIAL_RETRY_DELAY_MS;
 
@@ -134,6 +158,158 @@ pub fn connect_to_exec_server_with_retry(vsock_socket: &Path) -> Result<UnixStre
     }
 }
 
+/// Outcome of waiting for the agent's ACK line after sending a request.
+#[derive(Debug)]
+enum AckOutcome {
+    /// ACK consumed — the agent has the full request and awaits GO.
+    Acked,
+    /// No ACK arrived (timeout, EOF, or read error). The request provably
+    /// never reached execution, so resending on a fresh connection is safe.
+    NotAcked(String),
+    /// The agent rejected the request before ACK (invalid JSON, empty
+    /// command). Deterministic — resending cannot help.
+    Rejected(String),
+}
+
+/// Wait for the agent's ACK line, bounded by the stream's read timeout.
+///
+/// Reads byte-by-byte so no bytes past the ACK newline are ever consumed —
+/// everything after ACK belongs to the post-GO exec protocol (JSON lines or
+/// TTY frames), which the mode loops read from the raw stream.
+fn read_ack_line(stream: &mut UnixStream) -> AckOutcome {
+    // An ACK line is 4 bytes; a pre-ACK Error line carries a message. Anything
+    // bigger is a protocol violation.
+    const MAX_ACK_LINE_LENGTH: usize = 65_536;
+    let mut line: Vec<u8> = Vec::new();
+    let mut byte = [0u8; 1];
+    loop {
+        match stream.read(&mut byte) {
+            Ok(0) => return AckOutcome::NotAcked("connection closed before ACK".to_string()),
+            Ok(_) => {
+                if byte[0] == b'\n' {
+                    break;
+                }
+                if line.len() >= MAX_ACK_LINE_LENGTH {
+                    return AckOutcome::Rejected(format!(
+                        "protocol violation: pre-ACK line exceeds {} bytes",
+                        MAX_ACK_LINE_LENGTH
+                    ));
+                }
+                line.push(byte[0]);
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                return AckOutcome::NotAcked(format!(
+                    "timed out after {:?} waiting for ACK",
+                    ACK_TIMEOUT
+                ));
+            }
+            Err(e) => return AckOutcome::NotAcked(format!("read error waiting for ACK: {}", e)),
+        }
+    }
+
+    if line == exec_proto::HANDSHAKE_ACK.as_bytes() {
+        return AckOutcome::Acked;
+    }
+
+    // Not ACK: the agent rejects invalid requests with an Error response line
+    // before ever ACKing. Surface its message rather than a raw protocol dump.
+    if let Ok(ExecResponse::Error(msg)) = serde_json::from_slice::<ExecResponse>(&line) {
+        return AckOutcome::Rejected(msg);
+    }
+    AckOutcome::Rejected(format!(
+        "protocol violation: expected ACK, got {:?}",
+        String::from_utf8_lossy(&line)
+    ))
+}
+
+/// Connect, send the exec request, and complete the three-phase handshake
+/// (request → ACK → GO). Returns a stream on which execution has just been
+/// authorized: the next bytes from the agent are exec responses.
+///
+/// A request that never gets ACKed (its connection was orphaned by a snapshot
+/// pause's vsock reset — silent, no error on either side) provably never
+/// executed, so it is resent on a fresh connection, bounded by
+/// `MAX_ACK_ATTEMPTS`. After GO is sent, no resend ever happens — fc-agent may
+/// have started executing — so a subsequent connection death surfaces as a
+/// loud error from the mode loops instead (see `ExecConnectionClosed`).
+pub fn connect_and_start_exec(vsock_socket: &Path, request: &ExecRequest) -> Result<UnixStream> {
+    let request_json = serde_json::to_string(request)?;
+    let mut attempt = 0;
+    loop {
+        attempt += 1;
+        let mut stream = connect_to_exec_server_with_retry(vsock_socket)?;
+        stream.set_read_timeout(Some(ACK_TIMEOUT))?;
+        stream.set_write_timeout(Some(EXEC_WRITE_TIMEOUT))?;
+
+        // Phase 1: send the request line.
+        if let Err(e) = writeln!(stream, "{}", request_json).and_then(|()| stream.flush()) {
+            if attempt < MAX_ACK_ATTEMPTS {
+                debug!(attempt, error = %e, "exec request send failed; reconnecting to resend");
+                continue;
+            }
+            bail!(
+                "failed to send exec request after {} attempts: {}",
+                attempt,
+                e
+            );
+        }
+
+        // Phase 2: wait (bounded) for ACK.
+        match read_ack_line(&mut stream) {
+            AckOutcome::Acked => {
+                debug!(attempt, "exec handshake: ACK received, sending GO");
+                // Phase 3: authorize execution. From here on the request must
+                // NEVER be resent: fc-agent executes as soon as it consumes GO,
+                // and a local write result cannot prove whether GO was delivered.
+                if let Err(e) =
+                    writeln!(stream, "{}", exec_proto::HANDSHAKE_GO).and_then(|()| stream.flush())
+                {
+                    bail!(
+                        "exec connection died while sending GO (after the request was \
+                         acknowledged): {}. Not resending — the command could run twice. \
+                         If a VM snapshot was being created (startup snapshot or \
+                         `fcvm snapshot create`), the pause resets vsock and kills \
+                         in-flight execs; retry the exec.",
+                        e
+                    );
+                }
+                debug!("exec handshake: GO sent, command starting");
+                stream.set_read_timeout(Some(EXEC_READ_TIMEOUT))?;
+                stream.set_write_timeout(Some(EXEC_WRITE_TIMEOUT))?;
+                return Ok(stream);
+            }
+            AckOutcome::NotAcked(reason) => {
+                if attempt < MAX_ACK_ATTEMPTS {
+                    // Safe by construction: fc-agent never executes before GO,
+                    // and this request never even got ACKed.
+                    debug!(
+                        attempt,
+                        reason,
+                        "exec request never acknowledged (connection likely orphaned by a \
+                         snapshot pause); reconnecting to resend"
+                    );
+                    continue;
+                }
+                bail!(
+                    "exec request was never acknowledged after {} attempts (last: {}). \
+                     A VM snapshot pause (startup snapshot or `fcvm snapshot create`) \
+                     resets vsock and orphans in-flight connections; resends are safe \
+                     but retries are exhausted — is the VM healthy?",
+                    attempt,
+                    reason
+                );
+            }
+            AckOutcome::Rejected(msg) => {
+                bail!("fc-agent rejected the exec request: {}", msg);
+            }
+        }
+    }
+}
+
 /// Execute a command in a VM or its container (programmatic API)
 ///
 /// This is a simpler API for programmatic use (e.g., from snapshot run --exec).
@@ -159,16 +335,6 @@ pub async fn run_exec_in_vm(
     let command = command.to_vec();
 
     tokio::task::spawn_blocking(move || {
-        // Connect to the exec server with retry logic
-        let mut stream = connect_to_exec_server_with_retry(&vsock_socket)?;
-
-        // Long timeout — commands like phps cookie gen can take >10 min.
-        // Use 1 hour as a safety net against permanent hangs (not None/infinite).
-        stream.set_read_timeout(Some(Duration::from_secs(3600)))?;
-        stream.set_write_timeout(Some(Duration::from_secs(10)))?;
-
-        debug!("connected to guest exec server");
-
         // Build the exec request (non-interactive, no TTY)
         let request = ExecRequest {
             command,
@@ -177,10 +343,9 @@ pub async fn run_exec_in_vm(
             tty: false,
         };
 
-        // Send request as JSON followed by newline
-        let request_json = serde_json::to_string(&request)?;
-        writeln!(stream, "{}", request_json)?;
-        stream.flush()?;
+        // Connect, send the request, and complete the ACK/GO handshake
+        let stream = connect_and_start_exec(&vsock_socket, &request)?;
+        debug!("exec handshake complete");
 
         // Run in line mode and capture exit code
         run_line_mode_with_exit_code(stream)
@@ -223,19 +388,6 @@ pub async fn cmd_exec(args: ExecArgs) -> Result<()> {
             port = EXEC_VSOCK_PORT,
             "connecting to VM exec server via vsock"
         );
-    }
-
-    // Connect to the exec server with retry logic
-    let mut stream = connect_to_exec_server_with_retry(&vsock_socket)?;
-
-    // Long timeout — commands like phps cookie gen can take >10 min.
-    // Use 1 hour as a safety net against permanent hangs (not None/infinite).
-    // TTY mode uses select/poll for multiplexing but still benefits from a timeout.
-    stream.set_read_timeout(Some(Duration::from_secs(3600)))?;
-    stream.set_write_timeout(Some(Duration::from_secs(10)))?;
-
-    if !quiet {
-        info!("connected to guest exec server");
     }
 
     // Check if stdin is a TTY
@@ -282,10 +434,8 @@ pub async fn cmd_exec(args: ExecArgs) -> Result<()> {
         tty,
     };
 
-    // Send request as JSON followed by newline
-    let request_json = serde_json::to_string(&request)?;
-    writeln!(stream, "{}", request_json)?;
-    stream.flush()?;
+    // Connect, send the request, and complete the ACK/GO handshake
+    let stream = connect_and_start_exec(&vsock_socket, &request)?;
 
     if !quiet {
         info!(
@@ -293,7 +443,7 @@ pub async fn cmd_exec(args: ExecArgs) -> Result<()> {
             in_container = !args.vm,
             interactive,
             tty,
-            "sent exec request"
+            "exec request acknowledged, command starting"
         );
     }
 
@@ -376,7 +526,9 @@ impl std::fmt::Display for ExecConnectionClosed {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "exec connection closed before an exit status was received"
+            "exec connection closed before an exit status was received \
+             (the VM or agent may have exited, or a VM snapshot pause reset \
+             vsock and killed the exec mid-flight)"
         )
     }
 }
@@ -473,12 +625,6 @@ pub async fn run_exec_in_vm_captured(
     let command = command.to_vec();
 
     tokio::task::spawn_blocking(move || {
-        let mut stream = connect_to_exec_server_with_retry(&vsock_socket)?;
-
-        // Long timeout as safety net (not None/infinite)
-        stream.set_read_timeout(Some(Duration::from_secs(3600)))?;
-        stream.set_write_timeout(Some(Duration::from_secs(10)))?;
-
         let request = ExecRequest {
             command,
             in_container,
@@ -486,9 +632,8 @@ pub async fn run_exec_in_vm_captured(
             tty: false,
         };
 
-        let request_json = serde_json::to_string(&request)?;
-        writeln!(stream, "{}", request_json)?;
-        stream.flush()?;
+        // Connect, send the request, and complete the ACK/GO handshake
+        let stream = connect_and_start_exec(&vsock_socket, &request)?;
 
         // Read lines and capture into strings instead of printing
         let reader = BufReader::new(stream);
@@ -510,16 +655,21 @@ pub async fn run_exec_in_vm_captured(
     .context("exec task panicked")?
 }
 
-/// Connect to the exec server and return a tokio async UnixStream.
+/// Connect, complete the exec handshake for `request`, and return a tokio
+/// async UnixStream on which execution has just been authorized (the next
+/// bytes from the agent are exec responses / TTY frames).
 ///
 /// Useful for building WebSocket↔vsock bridges (terminal sessions).
 ///
-/// The blocking connection/retry logic is offloaded to a blocking thread pool
+/// The blocking connect/handshake logic is offloaded to a blocking thread pool
 /// so this function is safe to call from async contexts.
-pub async fn connect_to_exec_server_async(vsock_socket: &Path) -> Result<tokio::net::UnixStream> {
+pub async fn start_exec_session_async(
+    vsock_socket: &Path,
+    request: ExecRequest,
+) -> Result<tokio::net::UnixStream> {
     let vsock_socket = vsock_socket.to_path_buf();
     let std_stream =
-        tokio::task::spawn_blocking(move || connect_to_exec_server_with_retry(&vsock_socket))
+        tokio::task::spawn_blocking(move || connect_and_start_exec(&vsock_socket, &request))
             .await
             .context("connect task panicked")??;
     std_stream.set_nonblocking(true)?;
@@ -590,6 +740,71 @@ mod tests {
             err.to_string().contains("before an exit status"),
             "unexpected error: {err}"
         );
+    }
+
+    /// ACK arrives → Acked, and NOTHING past the ACK newline is consumed —
+    /// bytes after ACK belong to the post-GO exec protocol.
+    #[test]
+    fn read_ack_line_acked_consumes_nothing_past_newline() {
+        let (mut client, mut server) = UnixStream::pair().unwrap();
+        server
+            .write_all(
+                format!(
+                    "{}\n{{\"type\":\"exit\",\"data\":0}}\n",
+                    exec_proto::HANDSHAKE_ACK
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+
+        assert!(matches!(read_ack_line(&mut client), AckOutcome::Acked));
+
+        // The exec response following ACK must still be readable in full.
+        let mut reader = BufReader::new(client);
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        assert_eq!(line, "{\"type\":\"exit\",\"data\":0}\n");
+    }
+
+    /// Peer closes without ACK → NotAcked (safe to resend).
+    #[test]
+    fn read_ack_line_eof_is_not_acked() {
+        let (mut client, server) = UnixStream::pair().unwrap();
+        drop(server);
+        match read_ack_line(&mut client) {
+            AckOutcome::NotAcked(reason) => assert!(reason.contains("closed"), "{reason}"),
+            other => panic!("expected NotAcked, got {:?}", other),
+        }
+    }
+
+    /// Silence (the snapshot-pause orphan shape) → bounded NotAcked timeout,
+    /// not a hang.
+    #[test]
+    fn read_ack_line_timeout_is_not_acked() {
+        let (mut client, _server) = UnixStream::pair().unwrap();
+        client
+            .set_read_timeout(Some(Duration::from_millis(100)))
+            .unwrap();
+        let start = std::time::Instant::now();
+        match read_ack_line(&mut client) {
+            AckOutcome::NotAcked(reason) => assert!(reason.contains("timed out"), "{reason}"),
+            other => panic!("expected NotAcked, got {:?}", other),
+        }
+        assert!(start.elapsed() < Duration::from_secs(5));
+    }
+
+    /// A pre-ACK Error response (invalid/empty request) → Rejected with the
+    /// agent's message; deterministic, so the client must not resend.
+    #[test]
+    fn read_ack_line_error_response_is_rejected() {
+        let (mut client, mut server) = UnixStream::pair().unwrap();
+        let error_line = response_line(&ExecResponse::Error("Empty command".into()));
+        server.write_all(error_line.as_bytes()).unwrap();
+
+        match read_ack_line(&mut client) {
+            AckOutcome::Rejected(msg) => assert_eq!(msg, "Empty command"),
+            other => panic!("expected Rejected, got {:?}", other),
+        }
     }
 
     /// #607 regression (Codex P2): the log downgrade for the benign "stream closed

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -233,18 +233,21 @@ fn ensure_exec_succeeded(operation: &str, output: &ExecOutput) -> std::result::R
 }
 
 // ============================================================================
-// Helper: get sandbox + vsock path
+// Helper: get sandbox exec target (vsock path + vm_id)
 // ============================================================================
 
-async fn get_vsock_path(
+/// Resolve a sandbox id to its exec target: the vsock socket path plus the
+/// vm_id whose persisted `vsock_epoch` guards exec sessions against the
+/// snapshot-pause orphan mode (see `commands::exec::SnapshotOrphanGuard`).
+async fn get_exec_target(
     state: &SharedState,
     id: &str,
-) -> std::result::Result<std::path::PathBuf, Response> {
+) -> std::result::Result<(std::path::PathBuf, String), Response> {
     let sandboxes = state.sandboxes.read().await;
     let entry = sandboxes
         .get(id)
         .ok_or_else(|| gateway_error(StatusCode::NOT_FOUND, format!("Sandbox {} not found", id)))?;
-    Ok(entry.handle.vsock_socket_path())
+    Ok((entry.handle.vsock_socket_path(), entry.handle.vm_id.clone()))
 }
 
 fn sandbox_url(port: u16, id: &str) -> String {
@@ -501,7 +504,7 @@ async fn run_code(
     Path(id): Path<String>,
     Json(req): Json<RunCodeRequest>,
 ) -> Response {
-    let (vsock_path, language) = {
+    let (vsock_path, vm_id, language) = {
         let sandboxes = state.sandboxes.read().await;
         let entry = match sandboxes.get(&id) {
             Some(e) => e,
@@ -517,12 +520,16 @@ async fn run_code(
                 .unwrap_or("python")
                 .to_string()
         });
-        (entry.handle.vsock_socket_path(), lang)
+        (
+            entry.handle.vsock_socket_path(),
+            entry.handle.vm_id.clone(),
+            lang,
+        )
     };
 
     let cmd = language_to_run_command(&language, &req.code);
 
-    let output = match run_exec_in_vm_captured(&vsock_path, &cmd, true).await {
+    let output = match run_exec_in_vm_captured(&vsock_path, &cmd, true, &vm_id).await {
         Ok(o) => o,
         Err(e) => {
             return gateway_error(
@@ -555,8 +562,8 @@ async fn run_command(
     Path(id): Path<String>,
     Json(req): Json<RunCommandRequest>,
 ) -> Response {
-    let vsock_path = match get_vsock_path(&state, &id).await {
-        Ok(p) => p,
+    let (vsock_path, vm_id) = match get_exec_target(&state, &id).await {
+        Ok(target) => target,
         Err(e) => return e,
     };
 
@@ -566,7 +573,7 @@ async fn run_command(
     };
     let start = std::time::Instant::now();
 
-    let output = match run_exec_in_vm_captured(&vsock_path, &shell_cmd, true).await {
+    let output = match run_exec_in_vm_captured(&vsock_path, &shell_cmd, true, &vm_id).await {
         Ok(o) => o,
         Err(e) => {
             return gateway_error(
@@ -636,8 +643,8 @@ async fn list_files(
     Path(id): Path<String>,
     Query(query): Query<FilesQuery>,
 ) -> Response {
-    let vsock_path = match get_vsock_path(&state, &id).await {
-        Ok(p) => p,
+    let (vsock_path, vm_id) = match get_exec_target(&state, &id).await {
+        Ok(target) => target,
         Err(e) => return e,
     };
 
@@ -654,7 +661,7 @@ async fn list_files(
         ),
     ];
 
-    let output = match run_exec_in_vm_captured(&vsock_path, &cmd, true).await {
+    let output = match run_exec_in_vm_captured(&vsock_path, &cmd, true, &vm_id).await {
         Ok(o) => o,
         Err(e) => {
             return gateway_error(
@@ -710,8 +717,8 @@ async fn create_file(
     Path(id): Path<String>,
     Json(req): Json<CreateFileRequest>,
 ) -> Response {
-    let vsock_path = match get_vsock_path(&state, &id).await {
-        Ok(p) => p,
+    let (vsock_path, vm_id) = match get_exec_target(&state, &id).await {
+        Ok(target) => target,
         Err(e) => return e,
     };
 
@@ -745,7 +752,7 @@ async fn create_file(
 
     let cmd = vec!["sh".into(), "-c".into(), write_cmd];
 
-    let output = match run_exec_in_vm_captured(&vsock_path, &cmd, true).await {
+    let output = match run_exec_in_vm_captured(&vsock_path, &cmd, true, &vm_id).await {
         Ok(o) => o,
         Err(e) => {
             return gateway_error(
@@ -777,8 +784,8 @@ async fn read_file(
     State(state): State<SharedState>,
     Path((id, file_path)): Path<(String, String)>,
 ) -> Response {
-    let vsock_path = match get_vsock_path(&state, &id).await {
-        Ok(p) => p,
+    let (vsock_path, vm_id) = match get_exec_target(&state, &id).await {
+        Ok(target) => target,
         Err(e) => return e,
     };
 
@@ -795,7 +802,7 @@ async fn read_file(
         format!("cat '{}'", abs_path.replace('\'', "'\\''")),
     ];
 
-    let output = match run_exec_in_vm_captured(&vsock_path, &cmd, true).await {
+    let output = match run_exec_in_vm_captured(&vsock_path, &cmd, true, &vm_id).await {
         Ok(o) => o,
         Err(e) => {
             return gateway_error(
@@ -827,8 +834,8 @@ async fn file_exists(
     State(state): State<SharedState>,
     Path((id, file_path)): Path<(String, String)>,
 ) -> Response {
-    let vsock_path = match get_vsock_path(&state, &id).await {
-        Ok(p) => p,
+    let (vsock_path, vm_id) = match get_exec_target(&state, &id).await {
+        Ok(target) => target,
         Err(e) => return e,
     };
 
@@ -845,7 +852,7 @@ async fn file_exists(
         format!("test -e '{}'", abs_path.replace('\'', "'\\''")),
     ];
 
-    let output = match run_exec_in_vm_captured(&vsock_path, &cmd, true).await {
+    let output = match run_exec_in_vm_captured(&vsock_path, &cmd, true, &vm_id).await {
         Ok(o) => o,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
     };
@@ -861,8 +868,8 @@ async fn delete_file(
     State(state): State<SharedState>,
     Path((id, file_path)): Path<(String, String)>,
 ) -> Response {
-    let vsock_path = match get_vsock_path(&state, &id).await {
-        Ok(p) => p,
+    let (vsock_path, vm_id) = match get_exec_target(&state, &id).await {
+        Ok(target) => target,
         Err(e) => return e,
     };
 
@@ -879,7 +886,7 @@ async fn delete_file(
         format!("rm -rf '{}'", abs_path.replace('\'', "'\\''")),
     ];
 
-    if let Err(e) = run_exec_in_vm_captured(&vsock_path, &cmd, true).await {
+    if let Err(e) = run_exec_in_vm_captured(&vsock_path, &cmd, true, &vm_id).await {
         return gateway_error(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Failed to delete file: {}", e),
@@ -921,20 +928,24 @@ async fn ws_terminal(
     Path(id): Path<String>,
     ws: WebSocketUpgrade,
 ) -> Response {
-    let vsock_path = {
+    let (vsock_path, vm_id) = {
         let sandboxes = state.sandboxes.read().await;
         match sandboxes.get(&id) {
-            Some(entry) => entry.handle.vsock_socket_path(),
+            Some(entry) => (entry.handle.vsock_socket_path(), entry.handle.vm_id.clone()),
             None => {
                 return gateway_error(StatusCode::NOT_FOUND, format!("Sandbox {} not found", id));
             }
         }
     };
 
-    ws.on_upgrade(move |socket| ws_terminal_handler(socket, vsock_path))
+    ws.on_upgrade(move |socket| ws_terminal_handler(socket, vsock_path, vm_id))
 }
 
-async fn ws_terminal_handler(mut ws: axum::extract::ws::WebSocket, vsock_path: std::path::PathBuf) {
+async fn ws_terminal_handler(
+    mut ws: axum::extract::ws::WebSocket,
+    vsock_path: std::path::PathBuf,
+    vm_id: String,
+) {
     use axum::extract::ws::{CloseFrame, Message as WsMessage};
     use tokio::io::AsyncWriteExt;
 
@@ -948,9 +959,14 @@ async fn ws_terminal_handler(mut ws: axum::extract::ws::WebSocket, vsock_path: s
 
     // Connect and complete the exec handshake (request → ACK → GO); the
     // returned stream carries only post-GO TTY frames.
-    let stream = match crate::commands::exec::start_exec_session_async(&vsock_path, exec_req).await
+    let (stream, guard) = match crate::commands::exec::start_exec_session_async(
+        &vsock_path,
+        exec_req,
+        &vm_id,
+    )
+    .await
     {
-        Ok(s) => s,
+        Ok(session) => session,
         Err(e) => {
             error!(error = %e, "Failed to start exec session for terminal");
             let _ = ws
@@ -974,10 +990,40 @@ async fn ws_terminal_handler(mut ws: axum::extract::ws::WebSocket, vsock_path: s
     // so frame headers and control messages never reach the terminal stream.
     let (vsock_tx, mut vsock_rx) = tokio::sync::mpsc::channel::<exec_proto::Message>(32);
 
-    // Spawn task to decode exec-proto frames from the vsock and send them to the channel
+    // Spawn task to decode exec-proto frames from the vsock and send them to the
+    // channel. The terminal deliberately has NO overall inactivity timeout — an
+    // idle shell stays open for hours. The only bounded case is the
+    // snapshot-pause orphan: whenever the vsock has been idle for the epoch
+    // poll interval, the session's SnapshotOrphanGuard is consulted, and an
+    // epoch change ends the session loudly (same watcher as the blocking exec
+    // paths, adapted to async).
     let reader_task = tokio::spawn(async move {
         loop {
-            match exec_proto::Message::read_from_async(&mut vsock_read).await {
+            // select! on the PINNED read future: a poll tick does NOT cancel
+            // the in-progress frame read, so partial frame bytes are never
+            // lost (Message::read_from_async is not cancel-safe mid-frame).
+            let result = {
+                let read_fut = exec_proto::Message::read_from_async(&mut vsock_read);
+                tokio::pin!(read_fut);
+                loop {
+                    tokio::select! {
+                        res = &mut read_fut => break res,
+                        // Fresh sleep each iteration: ticks only while the read
+                        // stays pending, i.e. while the vsock is idle.
+                        () = tokio::time::sleep(
+                            crate::commands::exec::EXEC_EPOCH_POLL_INTERVAL
+                        ) => {
+                            // One tiny synchronous state-file read every ~2s of
+                            // idle time (see SnapshotOrphanGuard::check) — not
+                            // worth a spawn_blocking round-trip.
+                            if let Err(orphan) = guard.check() {
+                                break Err(std::io::Error::other(orphan));
+                            }
+                        }
+                    }
+                }
+            };
+            match result {
                 Ok(msg) => {
                     let session_ended = matches!(
                         msg,
@@ -988,7 +1034,19 @@ async fn ws_terminal_handler(mut ws: axum::extract::ws::WebSocket, vsock_path: s
                     }
                 }
                 Err(e) => {
-                    if e.kind() != std::io::ErrorKind::UnexpectedEof {
+                    let is_orphan = e.get_ref().is_some_and(|inner| {
+                        inner.is::<crate::commands::exec::ExecOrphanedBySnapshotPause>()
+                    });
+                    if is_orphan {
+                        // Forward the orphan as a terminal Error frame so the
+                        // main loop closes the WebSocket with the loud,
+                        // snapshot-pause-naming reason instead of a generic
+                        // "closed before exit status".
+                        error!(error = %e, "terminal session orphaned by a VM snapshot pause");
+                        let _ = vsock_tx
+                            .send(exec_proto::Message::Error(e.to_string()))
+                            .await;
+                    } else if e.kind() != std::io::ErrorKind::UnexpectedEof {
                         warn!(error = %e, "terminal vsock protocol error");
                     }
                     break;

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -938,11 +938,21 @@ async fn ws_terminal_handler(mut ws: axum::extract::ws::WebSocket, vsock_path: s
     use axum::extract::ws::{CloseFrame, Message as WsMessage};
     use tokio::io::AsyncWriteExt;
 
-    // Connect to exec server
-    let stream = match crate::commands::exec::connect_to_exec_server_async(&vsock_path).await {
+    // Exec request for interactive bash
+    let exec_req = crate::commands::exec::ExecRequest {
+        command: vec!["/bin/bash".into()],
+        in_container: true,
+        interactive: true,
+        tty: true,
+    };
+
+    // Connect and complete the exec handshake (request → ACK → GO); the
+    // returned stream carries only post-GO TTY frames.
+    let stream = match crate::commands::exec::start_exec_session_async(&vsock_path, exec_req).await
+    {
         Ok(s) => s,
         Err(e) => {
-            error!(error = %e, "Failed to connect to exec server for terminal");
+            error!(error = %e, "Failed to start exec session for terminal");
             let _ = ws
                 .send(WsMessage::Close(Some(CloseFrame {
                     code: 1011,
@@ -953,30 +963,7 @@ async fn ws_terminal_handler(mut ws: axum::extract::ws::WebSocket, vsock_path: s
         }
     };
 
-    // Send exec request for interactive bash
-    let exec_req = crate::commands::exec::ExecRequest {
-        command: vec!["/bin/bash".into()],
-        in_container: true,
-        interactive: true,
-        tty: true,
-    };
     let (mut vsock_read, mut vsock_write) = stream.into_split();
-
-    // Write the exec request as JSON line
-    let req_json = match serde_json::to_string(&exec_req) {
-        Ok(j) => j,
-        Err(e) => {
-            error!(error = %e, "Failed to serialize exec request");
-            return;
-        }
-    };
-    if let Err(e) = vsock_write
-        .write_all(format!("{}\n", req_json).as_bytes())
-        .await
-    {
-        error!(error = %e, "Failed to send exec request");
-        return;
-    }
 
     // Bridge WS ↔ vsock
     // Use a channel for vsock→WS since we can't hold &mut to both ws and vsock in select!

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -778,7 +778,11 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
         "loaded snapshot configuration"
     );
 
-    // Generate VM ID and name
+    // Generate VM ID and name. Restored VMs always get a FRESH vm_id and a
+    // fresh state file (vsock_epoch starts at 0) — including the podman-run
+    // snapshot-miss path, which tears its throwaway VM down (deleting its
+    // state) and relaunches through here. No pre-restore exec session can
+    // reference this state file, so restore needs no vsock-epoch bump.
     let vm_id = generate_vm_id();
     let runtime_config =
         snapshot_restore_runtime_config(&args, snapshot_config.metadata.kernel_profile.as_deref())
@@ -1553,6 +1557,7 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
                 &vsock_socket,
                 &cmd_args,
                 true, // in_container
+                &vm_id,
             )
             .await
         }

--- a/src/commands/tty.rs
+++ b/src/commands/tty.rs
@@ -91,8 +91,16 @@ pub fn run_tty_session(socket_path: &str, tty: bool, interactive: bool) -> Resul
 
     debug!("TTY connection established");
 
-    // Run the session with the connected stream
-    let result = run_tty_session_connected(stream, tty, interactive);
+    // Run the session with the connected stream. This is the `podman run -it`
+    // console (host-bound listener socket, not an exec vsock session), so the
+    // snapshot-orphan guard does not apply — and the socket carries no read
+    // timeout, so the disabled guard is never even consulted.
+    let result = run_tty_session_connected(
+        stream,
+        tty,
+        interactive,
+        crate::commands::exec::SnapshotOrphanGuard::disabled(),
+    );
 
     // Clean up socket
     let _ = std::fs::remove_file(socket_path);
@@ -108,7 +116,18 @@ pub fn run_tty_session(socket_path: &str, tty: bool, interactive: bool) -> Resul
 /// 2. Spawns reader thread (socket -> stdout)
 /// 3. Spawns writer thread if `interactive=true` (stdin -> socket)
 /// 4. Returns exit code from remote command
-pub fn run_tty_session_connected(stream: UnixStream, tty: bool, interactive: bool) -> Result<i32> {
+///
+/// `guard` is the exec session's snapshot-orphan guard: reads that sit idle
+/// past the epoch poll interval check it, so a session silently killed by a
+/// VM snapshot pause aborts loudly instead of hanging (an idle shell with an
+/// unchanged epoch waits forever, which is correct). The `podman run -it`
+/// console path passes `SnapshotOrphanGuard::disabled()`.
+pub fn run_tty_session_connected(
+    stream: UnixStream,
+    tty: bool,
+    interactive: bool,
+    guard: crate::commands::exec::SnapshotOrphanGuard,
+) -> Result<i32> {
     // Set up raw terminal mode if TTY requested
     let stdin_fd = std::io::stdin().as_raw_fd();
 
@@ -132,9 +151,15 @@ pub fn run_tty_session_connected(stream: UnixStream, tty: bool, interactive: boo
     let read_stream = stream.try_clone().context("cloning stream for reader")?;
     let mut write_stream = stream;
 
-    // Spawn reader thread: socket -> stdout
+    // Spawn reader thread: socket -> stdout. The epoch-guarded reader turns
+    // idle-read timeouts into snapshot-orphan checks (see exec.rs).
     let reader_done = done.clone();
-    let reader_thread = std::thread::spawn(move || reader_loop(read_stream, reader_done));
+    let reader_thread = std::thread::spawn(move || {
+        reader_loop(
+            crate::commands::exec::EpochGuardedReader::new(read_stream, guard),
+            reader_done,
+        )
+    });
 
     // Spawn writer thread if interactive: stdin -> socket
     let writer_thread = if interactive {
@@ -227,7 +252,7 @@ fn restore_terminal(stdin_fd: i32, orig_termios: Termios) {
 }
 
 /// Reader loop: read framed messages from socket, write to stdout
-fn reader_loop(mut stream: std::os::unix::net::UnixStream, done: Arc<AtomicBool>) -> Option<i32> {
+fn reader_loop<R: std::io::Read>(mut stream: R, done: Arc<AtomicBool>) -> Option<i32> {
     let mut stdout = std::io::stdout().lock();
     let mut total_read: usize = 0;
 
@@ -275,6 +300,16 @@ fn reader_loop(mut stream: std::os::unix::net::UnixStream, done: Arc<AtomicBool>
                         "\r\nfcvm: exec connection closed before the command's exit status \
                          was received (the VM or agent may have exited)\r"
                     );
+                    done.store(true, Ordering::Relaxed);
+                    return Some(1);
+                }
+                // Snapshot-pause orphan (epoch guard fired): the session's vsock
+                // transport was silently reset — name the failure mode loudly.
+                if let Some(orphan) = e.get_ref().filter(|inner| {
+                    inner.is::<crate::commands::exec::ExecOrphanedBySnapshotPause>()
+                }) {
+                    debug!("reader_loop: snapshot-pause orphan: {}", orphan);
+                    eprintln!("\r\nfcvm: {}\r", orphan);
                     done.store(true, Ordering::Relaxed);
                     return Some(1);
                 }

--- a/src/state/manager.rs
+++ b/src/state/manager.rs
@@ -636,6 +636,29 @@ impl StateManager {
         Ok(previous_status)
     }
 
+    /// Record a host-side vsock transport reset for this VM by bumping the
+    /// persisted `vsock_epoch` (locked read-modify-write via `update_state`).
+    ///
+    /// Ordering contract: call this AFTER a snapshot pause/save and BEFORE the
+    /// VM is resumed. Exec clients capture the epoch right after their vsock
+    /// connection is established — which is only possible against a running
+    /// guest — so bumping while the VM is still paused guarantees that every
+    /// connection from before the pause observes the change (loud orphan abort
+    /// instead of an indefinite hang) and every post-resume connection reads
+    /// the already-bumped value (no false abort).
+    ///
+    /// Returns the new epoch, or `None` if the state file no longer exists
+    /// (VM mid-teardown — its exec sessions get a socket error when the
+    /// hypervisor exits, so no epoch signal is needed).
+    pub async fn bump_vsock_epoch(&self, vm_id: &str) -> Result<Option<u64>> {
+        let updated = self
+            .update_state(vm_id, |state| {
+                state.vsock_epoch += 1;
+            })
+            .await?;
+        Ok(updated.map(|state| state.vsock_epoch))
+    }
+
     /// Allocate a unique loopback IP for rootless networking and persist it atomically
     ///
     /// Uses a global lock file to ensure atomic allocation across concurrent VM starts.

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -34,6 +34,15 @@ pub struct VmState {
     /// Namespace holder PID for rootless networking (used for nsenter health checks)
     #[serde(default)]
     pub holder_pid: Option<u32>,
+    /// Monotonically increasing count of host-side vsock transport resets.
+    /// Bumped (locked read-modify-write via `StateManager::bump_vsock_epoch`)
+    /// after every snapshot pause/save of this VM and BEFORE the VM resumes:
+    /// the pause silently orphans in-flight vsock connections (no error on
+    /// either side), so a changed epoch tells a blocked exec client its
+    /// session is dead (see `commands::exec::SnapshotOrphanGuard`). Defaults
+    /// to 0 so state files written before this field existed still load.
+    #[serde(default)]
+    pub vsock_epoch: u64,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub last_updated: chrono::DateTime<chrono::Utc>,
     pub config: VmConfig,
@@ -208,6 +217,7 @@ impl VmState {
             pid: None,
             pid_start_time: None,
             holder_pid: None,
+            vsock_epoch: 0,
             created_at: now,
             last_updated: now,
             config: VmConfig {
@@ -291,6 +301,24 @@ mod tests {
         assert_eq!(vm_from_str, ProcessType::Vm);
         assert_eq!(serve_from_str, ProcessType::Serve);
         assert_eq!(clone_from_str, ProcessType::Clone);
+    }
+
+    #[test]
+    fn test_vsock_epoch_defaults_to_zero_for_old_state_files() {
+        // State files written before vsock_epoch existed must load as epoch 0,
+        // and a bumped epoch must round-trip.
+        let mut state = VmState::new("vm-old".to_string(), "alpine:latest".to_string(), 1, 128);
+        assert_eq!(state.vsock_epoch, 0);
+
+        let mut json: serde_json::Value = serde_json::to_value(&state).unwrap();
+        json.as_object_mut().unwrap().remove("vsock_epoch");
+        let loaded: VmState = serde_json::from_value(json).unwrap();
+        assert_eq!(loaded.vsock_epoch, 0, "missing field must default to 0");
+
+        state.vsock_epoch = 7;
+        let roundtrip: VmState =
+            serde_json::from_str(&serde_json::to_string(&state).unwrap()).unwrap();
+        assert_eq!(roundtrip.vsock_epoch, 7);
     }
 
     #[test]

--- a/tests/test_fc_mock.rs
+++ b/tests/test_fc_mock.rs
@@ -407,6 +407,25 @@ async fn test_fc_mock_exec_connect_protocol() -> Result<()> {
         .await?;
     println!("  Sent exec request: {}", request_json);
 
+    // Three-phase handshake: the server ACKs the consumed request and executes
+    // only after our GO line (see exec_proto::HANDSHAKE_ACK).
+    let mut ack_line = String::new();
+    tokio::time::timeout(Duration::from_secs(5), reader.read_line(&mut ack_line))
+        .await
+        .context("timeout reading ACK")?
+        .context("reading ACK line")?;
+    assert_eq!(
+        ack_line.trim(),
+        exec_proto::HANDSHAKE_ACK,
+        "should get ACK before any exec response, got: {:?}",
+        ack_line
+    );
+    println!("  Received: ACK");
+    write_half
+        .write_all(format!("{}\n", exec_proto::HANDSHAKE_GO).as_bytes())
+        .await?;
+    println!("  Sent: GO");
+
     // Read responses (stdout, then exit)
     let mut got_stdout = false;
     let mut got_exit = false;

--- a/tests/test_health_monitor.rs
+++ b/tests/test_health_monitor.rs
@@ -51,6 +51,7 @@ async fn test_health_monitor_behaviors() {
         pid: Some(4194305), // Non-existent PID (above /proc/sys/kernel/pid_max)
         pid_start_time: None,
         holder_pid: None,
+        vsock_epoch: 0,
         created_at: now,
         last_updated: now,
         config: VmConfig {

--- a/tests/test_library_api.rs
+++ b/tests/test_library_api.rs
@@ -110,6 +110,7 @@ async fn test_library_api_exec_captured() -> Result<()> {
         &vsock,
         &["echo".into(), "hello-api".into()],
         true, // in_container
+        &handle.vm_id,
     )
     .await?;
 
@@ -125,6 +126,7 @@ async fn test_library_api_exec_captured() -> Result<()> {
         &vsock,
         &["sh".into(), "-c".into(), "echo errmsg >&2; exit 42".into()],
         true,
+        &handle.vm_id,
     )
     .await?;
 
@@ -165,7 +167,8 @@ async fn test_library_api_async_connection() -> Result<()> {
         interactive: false,
         tty: false,
     };
-    let mut stream = exec::start_exec_session_async(&vsock, request).await?;
+    let (mut stream, _guard) =
+        exec::start_exec_session_async(&vsock, request, &handle.vm_id).await?;
 
     // Non-TTY responses are JSON lines; the agent closes after Exit, so read
     // to EOF and check both the output and the exit message arrived.

--- a/tests/test_library_api.rs
+++ b/tests/test_library_api.rs
@@ -139,9 +139,12 @@ async fn test_library_api_exec_captured() -> Result<()> {
     Ok(())
 }
 
-/// Test: connect_to_exec_server_async returns a usable tokio stream
+/// Test: start_exec_session_async completes the ACK/GO handshake and returns a
+/// usable tokio stream carrying post-GO exec responses (the WS bridge use case)
 #[tokio::test(flavor = "multi_thread")]
 async fn test_library_api_async_connection() -> Result<()> {
+    use tokio::io::AsyncReadExt;
+
     let (vm_name, _, _, _) = common::unique_names("api-conn");
     let args = test_run_args(&vm_name);
 
@@ -153,10 +156,29 @@ async fn test_library_api_async_connection() -> Result<()> {
 
     let vsock = handle.vsock_socket_path();
 
-    // Get async stream (for WS bridge use case)
-    let stream = exec::connect_to_exec_server_async(&vsock).await?;
-    // If we got here without error, the async connection works
-    drop(stream);
+    // Start an async exec session (for WS bridge use case). The handshake
+    // (request → ACK → GO) happens inside; the returned stream carries only
+    // the exec responses.
+    let request = exec::ExecRequest {
+        command: vec!["echo".into(), "async-session".into()],
+        in_container: true,
+        interactive: false,
+        tty: false,
+    };
+    let mut stream = exec::start_exec_session_async(&vsock, request).await?;
+
+    // Non-TTY responses are JSON lines; the agent closes after Exit, so read
+    // to EOF and check both the output and the exit message arrived.
+    let mut responses = String::new();
+    stream.read_to_string(&mut responses).await?;
+    assert!(
+        responses.contains("async-session"),
+        "responses should contain the echoed output, got: {responses:?}"
+    );
+    assert!(
+        responses.contains("\"exit\""),
+        "responses should contain an exit message, got: {responses:?}"
+    );
 
     handle.stop().await?;
     Ok(())

--- a/tests/test_readme_examples.rs
+++ b/tests/test_readme_examples.rs
@@ -404,10 +404,16 @@ async fn test_fcvm_ls_bridged() -> Result<()> {
 /// ```
 /// sudo fcvm podman run --name web1 --cmd "nginx -g 'daemon off;'" nginx:alpine
 /// ```
-// Re-enabled after the #617 fix: VsockListener::accept() now has a periodic
-// optimistic-accept fallback, so a connection whose readiness edge is lost across
-// the startup-snapshot create's pause/resume is served within ~2s instead of
-// hanging the exec forever.
+// Two fixes cover execs racing the startup-snapshot create's pause/resume:
+// - #617 (VsockListener::accept() periodic optimistic-accept fallback) covers the
+//   LISTENER-QUEUE phase: a connection whose readiness edge is lost across the
+//   pause is still accepted within ~2s.
+// - The three-phase exec handshake (request → ACK → GO, see
+//   exec_proto::HANDSHAKE_ACK) covers the IN-FLIGHT phase #617 could not: a
+//   connection already accepted by fc-agent but orphaned by the snapshot's vsock
+//   reset before execution started is closed by the agent's handshake deadline,
+//   and the host — whose request was never ACKed and so provably never ran —
+//   resends it on a fresh connection instead of hanging forever.
 #[tokio::test]
 async fn test_custom_command_bridged() -> Result<()> {
     println!("\ntest_custom_command_bridged");

--- a/tests/test_state_manager.rs
+++ b/tests/test_state_manager.rs
@@ -24,6 +24,7 @@ async fn test_state_persistence() {
         pid: Some(12345),
         pid_start_time: None,
         holder_pid: None,
+        vsock_epoch: 0,
         created_at: now,
         last_updated: now,
         config: VmConfig {
@@ -120,6 +121,7 @@ async fn test_list_vms() {
             pid: Some(10000 + i),
             pid_start_time: None,
             holder_pid: None,
+            vsock_epoch: 0,
             created_at: now,
             last_updated: now,
             config: VmConfig {
@@ -187,6 +189,7 @@ async fn test_load_state_by_name_duplicate_detection() {
             pid: Some(pid),
             pid_start_time: None,
             holder_pid: None,
+            vsock_epoch: 0,
             created_at: now,
             last_updated: now,
             config: VmConfig {
@@ -248,6 +251,7 @@ async fn test_load_state_by_name_duplicate_detection() {
         pid: Some(6000),
         pid_start_time: None,
         holder_pid: None,
+        vsock_epoch: 0,
         created_at: now,
         last_updated: now,
         config: VmConfig {
@@ -298,6 +302,7 @@ fn make_vm_state(vm_id: &str, name: &str, pid: u32) -> VmState {
         pid: Some(pid),
         pid_start_time: None,
         holder_pid: None,
+        vsock_epoch: 0,
         created_at: Utc::now(),
         last_updated: Utc::now(),
         config: VmConfig {


### PR DESCRIPTION
Fixes the hidden `test_custom_command_bridged` flake (TRY 1 fails at ~123s, retry masked by the snapshot cache the failure itself populated) and hardens every exec consumer against connections orphaned by snapshot pauses.

## The Problem

Two CI runs (31066358756, 31066357451) show the identical sub-second interleaving: `Creating startup snapshot (VM healthy)` → `[fc-agent] exec server: accepted connection` → `pausing VM for snapshot` **35–38ms later**. Firecracker's snapshot create resets vsock connection state, and the just-accepted in-flight exec is orphaned with no error on either side: the guest blocks in an unbounded byte-by-byte read, the host client waits under a 3600s timeout, and only the test harness's 120s limit surfaces it. TRY 2 "passes" in 6s because TRY 1's failed run already created the `-startup` snapshot, removing the pause window — a retry masked by a cache the failure populated.

The #617 fix (optimistic accept) protects only the pre-accept listener phase; the in-flight phase was uncovered (the comment in `test_readme_examples.rs` claiming otherwise is corrected here).

## The Solution

A three-phase handshake (`exec-proto`: `HANDSHAKE_ACK`/`HANDSHAKE_GO`) with a provable no-double-execution property:

- **fc-agent**: request line read under a deadline (orphaned connections are closed, never leaked threads) → ACK written only after the FULL request is consumed → GO required (fresh 2s floor after ACK) before any execution. Every error/timeout path closes without executing. Invalid/oversized requests get a pre-ACK Error line so the client fails deterministically.
- **fcvm client**: waits ≤3s for ACK. No ACK ⇒ provably nothing executed ⇒ safe reconnect+resend (bounded, 5 attempts, spanning realistic pause durations). After ACK it sends GO and never resends; post-GO connection death errors loudly naming the snapshot-pause failure mode instead of hanging for an hour.
- **Coverage**: every consumer of the exec vsock port routes through the new helper — `fcvm exec` in all modes (and thus health-monitor checks), `snapshot run --exec`, all serve.rs endpoints + the websocket terminal, snapshot freeze/thaw. fc-mock speaks the same protocol. No compat shims: a changed fc-agent changes the initrd SHA and therefore all snapshot cache keys, so old agents are never paired with the new client.

This covers *all* snapshot pause causes: pre-start, startup, and user-initiated `fcvm snapshot create --pid`. An adversarial review confirmed the no-double-execution invariant and caller coverage; its findings (GO deadline floor, deterministic oversized-request rejection, fc-mock parity) are folded in.

## Test Results

```
$ make lint                              # clean
$ make test-unit
Summary [ 50.459s] 333 tests run: 333 passed   # incl. 8 new handshake tests
$ make test-root FILTER=exec
Summary [ 97.252s] 31 tests run: 31 passed     # all exec modes + both stress tests
$ make test-root FILTER=custom_command
PASS [20.623s] fcvm::test_readme_examples test_custom_command_bridged
$ make test-root FILTER=sanity           # 5 passed
$ make test-root FILTER=health           # 12 passed
```

Live-VM debug log shows the handshake flowing: `exec handshake: ACK received, sending GO attempt=1` → `GO sent, command starting`.

Related: #705/#706 (other members of this flake-elimination batch); complements the Healthy-publication gate PR, which shrinks the pause-vs-client race at its source while this PR makes any remaining overlap harmless.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a three-step execution handshake requiring request approval before commands run.
  * Added clear handling for retries, rejections, invalid requests, disconnects, and stalled sessions.
  * Interactive and asynchronous execution paths now use the same handshake flow.

* **Bug Fixes**
  * Added bounded timeouts to prevent execution sessions from hanging.
  * Improved handling of malformed, oversized, empty, and invalid command requests.

* **Documentation**
  * Documented handshake sequencing, retry behavior, and connection-closure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->