### PR TITLE
Defer Healthy publication until the startup-snapshot pause is over

### DIFF
--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -924,8 +924,8 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
     // - Have a snapshot key
     // - Have a health_check URL configured (HTTP health check, not just container-ready)
     let (startup_tx, startup_rx): (
-        Option<tokio::sync::oneshot::Sender<()>>,
-        Option<tokio::sync::oneshot::Receiver<()>>,
+        Option<tokio::sync::oneshot::Sender<crate::health::StartupSnapshotAck>>,
+        Option<tokio::sync::oneshot::Receiver<crate::health::StartupSnapshotAck>>,
     ) = if !skip_snapshot_creation && snapshot_key.is_some() && args.health_check.is_some() {
         let (tx, rx) = tokio::sync::oneshot::channel();
         (Some(tx), Some(rx))
@@ -1454,8 +1454,11 @@ pub async fn run_vm_loop(ctx: &mut VmContext, cancel: CancellationToken) -> Resu
                 }
                 // Continue waiting for VM exit or cancellation
             }
-            // Handle startup snapshot creation when health becomes healthy
-            Ok(()) = async {
+            // Handle startup snapshot creation when health becomes healthy. The health
+            // monitor defers publishing Healthy until `startup_ack` is sent (or dropped
+            // by the abort paths below), so no client can observe Healthy while the
+            // snapshot pause has the vCPUs stopped.
+            Ok(startup_ack) = async {
                 match ctx.startup_rx.as_mut() {
                     Some(rx) => rx.await,
                     None => std::future::pending().await,
@@ -1524,6 +1527,10 @@ pub async fn run_vm_loop(ctx: &mut VmContext, cancel: CancellationToken) -> Resu
                         }
                     }
                 }
+                // Snapshot attempt over (created, skipped, or failed) and the VM is
+                // resumed — let the health monitor publish Healthy. The early-return
+                // abort paths above drop `startup_ack`, which unblocks it the same way.
+                let _ = startup_ack.send(());
                 // Continue waiting for VM exit or cancellation
             }
         }

--- a/src/commands/podman/types.rs
+++ b/src/commands/podman/types.rs
@@ -60,7 +60,9 @@ pub struct VmContext {
     /// Egress proxy task (rootless mode only); aborted during cleanup.
     pub egress_proxy_handle: Option<tokio::task::JoinHandle<()>>,
     pub cache_rx: Option<mpsc::Receiver<CacheRequest>>,
-    pub startup_rx: Option<oneshot::Receiver<()>>,
+    /// Startup-snapshot trigger from the health monitor. Carries the ack the
+    /// snapshot path must send (or drop) before the monitor publishes Healthy.
+    pub startup_rx: Option<oneshot::Receiver<crate::health::StartupSnapshotAck>>,
     pub snapshot_key: Option<String>,
     pub volume_configs: Vec<VolumeConfig>,
     pub args: RunArgs,

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -1598,8 +1598,8 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
     // - startup_snapshot_base_key is set (passed from podman run on cache hit)
     // - snapshot has a health check URL (needed to know when VM is fully initialized)
     let (startup_tx, mut startup_rx): (
-        Option<tokio::sync::oneshot::Sender<()>>,
-        Option<tokio::sync::oneshot::Receiver<()>>,
+        Option<tokio::sync::oneshot::Sender<crate::health::StartupSnapshotAck>>,
+        Option<tokio::sync::oneshot::Receiver<crate::health::StartupSnapshotAck>>,
     ) = if args.startup_snapshot_base_key.is_some()
         && snapshot_config.metadata.health_check_url.is_some()
     {
@@ -1784,8 +1784,11 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
                     }
                     break;
                 }
-                // Handle startup snapshot creation when health becomes healthy
-                Ok(()) = async {
+                // Handle startup snapshot creation when health becomes healthy. The
+                // health monitor defers publishing Healthy until `startup_ack` is sent
+                // (or dropped by the abort paths below), so no client can observe
+                // Healthy while the snapshot pause has the vCPUs stopped.
+                Ok(startup_ack) = async {
                     match startup_rx.as_mut() {
                         Some(rx) => rx.await,
                         None => std::future::pending().await,
@@ -1855,6 +1858,10 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
                             }
                         }
                     }
+                    // Snapshot attempt over (created, skipped, or failed) and the VM is
+                    // resumed — let the health monitor publish Healthy. The break/abort
+                    // paths above drop `startup_ack`, which unblocks it the same way.
+                    let _ = startup_ack.send(());
                     // Continue waiting for VM exit or signals
                 }
             }

--- a/src/health.rs
+++ b/src/health.rs
@@ -45,6 +45,11 @@ pub fn spawn_health_monitor_with_cancel(
     spawn_health_monitor_full(vm_id, pid, state_dir, cancel_token, None)
 }
 
+/// Ack sent by the startup-snapshot path once its pause/resume cycle is over
+/// (snapshot created, skipped, or failed). Dropping it unblocks the monitor
+/// too, so an aborted snapshot path can never wedge health reporting.
+pub type StartupSnapshotAck = oneshot::Sender<()>;
+
 /// Spawn a health monitor with full configuration options.
 ///
 /// Parameters:
@@ -52,15 +57,18 @@ pub fn spawn_health_monitor_with_cancel(
 /// - `pid`: Optional process ID for the VM
 /// - `state_dir`: Directory for state files
 /// - `cancel_token`: Optional token for graceful shutdown
-/// - `startup_healthy_tx`: Optional oneshot channel to signal when health first becomes Healthy.
-///   This is used to trigger startup snapshot creation. Only fires once, when transitioning
-///   from non-healthy to healthy state.
+/// - `startup_healthy_tx`: Optional channel to signal when health first becomes Healthy.
+///   This triggers startup snapshot creation, which PAUSES the VM (the memory dump can
+///   take tens of seconds under I/O load). A paused VM cannot answer forwarded ports or
+///   execs, so the monitor sends an ack channel along with the signal and defers
+///   publishing Healthy to the state file until the snapshot path acks (or drops the
+///   ack): once Healthy is externally visible, the data plane is actually live.
 pub fn spawn_health_monitor_full(
     vm_id: String,
     pid: Option<u32>,
     state_dir: PathBuf,
     cancel_token: Option<CancellationToken>,
-    startup_healthy_tx: Option<oneshot::Sender<()>>,
+    startup_healthy_tx: Option<oneshot::Sender<StartupSnapshotAck>>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         let state_manager = StateManager::new(state_dir);
@@ -124,22 +132,59 @@ pub fn spawn_health_monitor_full(
             }
 
             let check_start = Instant::now();
-            let health_status = match update_health_status_once(
+            let checked = check_health_once(
                 &state_manager,
                 &vm_id,
                 pid,
                 &mut last_failure_log,
                 &mut skip_podman_healthcheck,
             )
-            .await
-            {
-                Ok((status, _exit_code)) => status,
+            .await;
+            let check_duration = check_start.elapsed();
+            let (health_status, exit_code, check_ok) = match checked {
+                Ok((status, exit_code)) => (status, exit_code, true),
                 Err(e) => {
                     warn!(target: "health-monitor", error = %e, "health check iteration failed");
-                    HealthStatus::Unknown
+                    (HealthStatus::Unknown, None, false)
                 }
             };
-            let check_duration = check_start.elapsed();
+
+            // First healthy transition: the healthy signal triggers startup-snapshot
+            // creation, which pauses the VM. Run that pause/resume cycle to completion
+            // BEFORE persisting Healthy, so no client (port-forward curl, exec, `fcvm
+            // ls` poller) can observe Healthy while the vCPUs are paused. The snapshot
+            // path acks when done; a dropped ack (abort/shutdown) unblocks us too.
+            if health_status == HealthStatus::Healthy && !is_healthy {
+                if let Some(tx) = startup_tx.take() {
+                    let (ack_tx, ack_rx) = oneshot::channel::<()>();
+                    if tx.send(ack_tx).is_ok() {
+                        info!(target: "health-monitor",
+                            "signaling startup snapshot trigger; deferring Healthy until its pause is over");
+                        if let Some(ref token) = cancel_token {
+                            tokio::select! {
+                                _ = ack_rx => {}
+                                _ = token.cancelled() => {
+                                    info!(target: "health-monitor", "cancellation requested during startup snapshot, stopping");
+                                    break;
+                                }
+                            }
+                        } else {
+                            let _ = ack_rx.await;
+                        }
+                    }
+                }
+            }
+
+            // Persist after the gate above. A failed check persists nothing (same as
+            // before the check/persist split): the next iteration retries.
+            if check_ok {
+                if let Err(e) = state_manager
+                    .update_health_status(&vm_id, health_status, exit_code)
+                    .await
+                {
+                    warn!(target: "health-monitor", error = %e, "persisting health status failed");
+                }
+            }
 
             // Track consecutive failures for escalated logging
             if health_status == HealthStatus::Healthy {
@@ -172,12 +217,6 @@ pub fn spawn_health_monitor_full(
                     is_healthy = true;
                     poll_interval = HEALTH_POLL_HEALTHY_INTERVAL;
                     info!(target: "health-monitor", "VM healthy, switching to {:?} polling", HEALTH_POLL_HEALTHY_INTERVAL);
-
-                    // Signal startup snapshot trigger (fires only once)
-                    if let Some(tx) = startup_tx.take() {
-                        info!(target: "health-monitor", "signaling startup snapshot trigger");
-                        let _ = tx.send(()); // Ignore error if receiver dropped
-                    }
                 }
             } else if is_healthy {
                 // VM was healthy but is no longer — revert to adaptive polling
@@ -506,8 +545,11 @@ async fn run_podman_healthcheck(pid: u32, username: Option<&str>, user_spec: Opt
     }
 }
 
-/// Perform a single health check iteration and persist the result.
-async fn update_health_status_once(
+/// Perform a single health check iteration WITHOUT persisting the result.
+///
+/// The monitor loop persists separately so the first Healthy can be gated on
+/// the startup-snapshot pause finishing (see `spawn_health_monitor_full`).
+async fn check_health_once(
     state_manager: &StateManager,
     vm_id: &str,
     pid: Option<u32>,
@@ -790,16 +832,10 @@ async fn update_health_status_once(
         (HealthStatus::Unknown, None)
     };
 
-    // Update state file atomically (lock held across read-modify-write)
-    state_manager
-        .update_health_status(vm_id, health_status, exit_code)
-        .await
-        .context("updating health state atomically")?;
-
     Ok((health_status, exit_code))
 }
 
-/// Run a single health check iteration (exposed for tests).
+/// Run a single health check iteration and persist the result (exposed for tests).
 pub async fn run_health_check_once(
     vm_id: &str,
     pid: Option<u32>,
@@ -808,7 +844,7 @@ pub async fn run_health_check_once(
     let state_manager = StateManager::new(state_dir);
     let mut last_failure_log = None;
     let mut skip_podman_healthcheck = false;
-    let (status, _exit_code) = update_health_status_once(
+    let (status, exit_code) = check_health_once(
         &state_manager,
         vm_id,
         pid,
@@ -816,6 +852,11 @@ pub async fn run_health_check_once(
         &mut skip_podman_healthcheck,
     )
     .await?;
+    // Update state file atomically (lock held across read-modify-write)
+    state_manager
+        .update_health_status(vm_id, status, exit_code)
+        .await
+        .context("updating health state atomically")?;
     Ok(status)
 }
 

--- a/src/health.rs
+++ b/src/health.rs
@@ -160,16 +160,31 @@ pub fn spawn_health_monitor_full(
                     if tx.send(ack_tx).is_ok() {
                         info!(target: "health-monitor",
                             "signaling startup snapshot trigger; deferring Healthy until its pause is over");
-                        if let Some(ref token) = cancel_token {
+                        let acked = if let Some(ref token) = cancel_token {
                             tokio::select! {
-                                _ = ack_rx => {}
+                                res = ack_rx => res.is_ok(),
                                 _ = token.cancelled() => {
                                     info!(target: "health-monitor", "cancellation requested during startup snapshot, stopping");
                                     break;
                                 }
                             }
                         } else {
-                            let _ = ack_rx.await;
+                            ack_rx.await.is_ok()
+                        };
+                        if !acked {
+                            // The ack sender was dropped without completing: the
+                            // startup-snapshot path was abandoned (guest-reboot
+                            // relaunch clears startup_rx; shutdown paths return
+                            // early). This Healthy observation predates that pause
+                            // or reboot — persisting it would publish Healthy for
+                            // a VM that is mid-reboot. Discard the observation and
+                            // re-check real state next tick. The spent trigger is
+                            // intentionally not re-armed: the relaunched VM takes
+                            // no startup snapshot, so from now on Healthy
+                            // observations persist ungated.
+                            warn!(target: "health-monitor",
+                                "startup snapshot ack dropped; discarding pre-pause Healthy observation and re-checking");
+                            continue;
                         }
                     }
                 }
@@ -177,12 +192,16 @@ pub fn spawn_health_monitor_full(
 
             // Persist after the gate above. A failed check persists nothing (same as
             // before the check/persist split): the next iteration retries.
+            let mut persisted = false;
             if check_ok {
-                if let Err(e) = state_manager
+                match state_manager
                     .update_health_status(&vm_id, health_status, exit_code)
                     .await
                 {
-                    warn!(target: "health-monitor", error = %e, "persisting health status failed");
+                    Ok(_) => persisted = true,
+                    Err(e) => {
+                        warn!(target: "health-monitor", error = %e, "persisting health status failed");
+                    }
                 }
             }
 
@@ -230,10 +249,19 @@ pub fn spawn_health_monitor_full(
                     check_duration.clamp(HEALTH_POLL_MIN_INTERVAL, HEALTH_POLL_MAX_INTERVAL);
             }
 
-            // Stop monitoring if container has stopped
+            // Stop monitoring if container has stopped — but only once the Stopped
+            // status actually reached the state file. If the persist failed, exiting
+            // here would leave the state file stale (possibly Healthy) forever; keep
+            // looping so the next tick retries the check and the write (mirrors the
+            // pre-split behavior where a persist error yielded Unknown and the
+            // monitor stayed alive).
             if health_status == HealthStatus::Stopped {
-                info!(target: "health-monitor", "container stopped, ending health monitor");
-                break;
+                if persisted {
+                    info!(target: "health-monitor", "container stopped, ending health monitor");
+                    break;
+                }
+                warn!(target: "health-monitor",
+                    "container stopped but persisting Stopped failed; retrying next tick");
             }
         }
     })


### PR DESCRIPTION
Fixes the hidden `test_port_forward_rootless` flake and closes the "Healthy but paused" window for every client.

## The Problem

In CI run 31053451833 (green job, flake hidden by nextest retry), fcvm persisted Healthy to the state file at 23:04:18.179 and paused the VM for startup-snapshot creation at 23:04:18.180 — 1ms later. The test saw Healthy, fired its single-shot `curl --max-time 5` at the pasta-forwarded loopback IP, and the entire 5s elapsed inside a pause that lasted >5s under parallel-suite I/O load (the same memory dump took 1.7s on the passing retry vs 24.3s on the failing try). Paused vCPUs can't answer a forwarded SYN. Any client that treats Healthy as "the data plane is live" — port-forward traffic, execs, `fcvm ls` pollers — could hit this window.

## The Solution

Healthy becomes externally visible only after the startup-snapshot pause is over:

- `health.rs`: `check_health_once` (pure check) is split from persistence; the monitor persists explicitly. On the first healthy transition it signals the startup-snapshot trigger **carrying an ack channel** and awaits the ack — or its drop, or cancellation — before persisting Healthy. No timeouts, no retries: the gate is structural.
- The startup-snapshot select arms (`podman/mod.rs`, `snapshot.rs`) send the ack once the snapshot attempt is over (created, skipped, or failed) and the VM is resumed. Abort/shutdown paths drop the sender, which unblocks the monitor identically — no path can wedge health reporting.

The single-shot curl in `test_port_forward_rootless` now legitimately asserts that Healthy implies a live data plane (no retry loop added, per AGENTS.md).

Complements the exec-handshake PR: this removes the biggest pause-vs-client race at its source; the handshake makes any remaining overlap (e.g. user-initiated `snapshot create --pid`) harmless for execs.

## Test Results

```
$ make lint                            # clean
$ make test-root FILTER=health
Summary [ 34.304s] 12 tests run: 12 passed   # incl. startup-snapshot tests
$ make test-root FILTER=port_forward
Summary [ 64.322s] 8 tests run: 8 passed
$ make test-root FILTER=sanity
Summary [ 23.732s] 5 tests run: 5 passed
```

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup health reporting so the system is marked healthy only after startup snapshot processing and VM resumption complete.
  * Prevented interrupted or failed startup snapshot operations from leaving health monitoring blocked.
  * Improved health state persistence by avoiding misleading `Unknown` states after failed checks.
  * Ensured stopped monitoring is recorded reliably, with retries when state updates fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->