### PR TITLE
Make snapshots serial-safe and fc-agent console writes wedge-proof

### DIFF
--- a/fc-agent/src/agent.rs
+++ b/fc-agent/src/agent.rs
@@ -5,11 +5,12 @@ use crate::{bootplan, container, exec, lock_test, mmds, mounts, network, output,
 
 /// Main agent logic — fetches plan, runs container, triggers shutdown.
 pub async fn run() -> Result<()> {
-    // Redirect stderr to /dev/console for direct serial output, bypassing journald.
-    // After snapshot restore, journald crashes (journal corrupted mid-write), which
-    // kills the journal+console output path. Direct /dev/console writes use polled
-    // I/O and work even with stale UART IER register after restore.
-    crate::restore::redirect_stderr_to_console();
+    // Route fd 1/2 through the wedge-proof console pipe (writer thread →
+    // /dev/console). Bypasses journald, which crashes after snapshot restore
+    // (journal corrupted mid-write) and would take the console output path
+    // with it — and guarantees a dead console can only LOSE log lines, never
+    // block a thread on a full tty buffer. See fc-agent/src/console.rs.
+    crate::console::init();
 
     eprintln!("[fc-agent] run_agent starting");
 
@@ -324,10 +325,11 @@ pub async fn run() -> Result<()> {
     // we check, wait_for returns immediately because watch retains the latest value.
     let egress_gen_before = egress_gen_rx.as_ref().map(|rx| *rx.borrow());
 
-    // Notify host for cache snapshot
+    // Notify host for cache snapshot. notify_cache_ready_and_wait logs the
+    // digest itself, then quiesces the console BEFORE the notification so the
+    // host's pre-start snapshot pause can never capture the UART mid-transmit.
     match container::get_image_digest(&image_ref, &cmd_prefix).await {
         Ok(digest) => {
-            eprintln!("[fc-agent] image digest: {}", digest);
             let cache_result = container::notify_cache_ready_and_wait(&digest, &restore_flag);
             match cache_result {
                 container::CacheResult::ColdStart => {

--- a/fc-agent/src/agent.rs
+++ b/fc-agent/src/agent.rs
@@ -328,6 +328,8 @@ pub async fn run() -> Result<()> {
     // Notify host for cache snapshot. notify_cache_ready_and_wait logs the
     // digest itself, then quiesces the console BEFORE the notification so the
     // host's pre-start snapshot pause can never capture the UART mid-transmit.
+    // If the console cannot be proven quiet it returns Failed WITHOUT sending
+    // cache-ready — the host never pauses us and the VM continues cold.
     match container::get_image_digest(&image_ref, &cmd_prefix).await {
         Ok(digest) => {
             let cache_result = container::notify_cache_ready_and_wait(&digest, &restore_flag);

--- a/fc-agent/src/console.rs
+++ b/fc-agent/src/console.rs
@@ -26,7 +26,10 @@
 //!    been written to the console (`pipe empty && enqueued == disposed`);
 //! 2. gate — the writer thread stops writing to the console (bytes accumulate in its
 //!    pending buffer instead; `eprintln!` keeps working and never blocks);
-//! 3. drain — poll `TIOCOUTQ` on the console fd until 0.
+//! 3. drain — poll `TIOCOUTQ` on the console fd until 0. If it never reaches 0
+//!    within the bounded window (or its state is unknowable), quiesce releases the
+//!    gate and FAILS: the caller must abort the handshake — no `cache-ready`, no
+//!    snapshot — rather than let the host pause a VM whose UART may be mid-transmit.
 //!
 //! Why `TIOCOUTQ == 0` proves the UART is idle: the 8250 driver drains its circular
 //! buffer to THR only inside its IRQ handler under the port lock, and the same
@@ -59,10 +62,17 @@ use nix::poll::{poll, PollFd, PollFlags, PollTimeout};
 use nix::unistd::{read, write};
 
 /// Upper bound on bytes buffered while the console is gated or stalled.
-/// Beyond this, new bytes are dropped (and counted). The guest produces no
-/// output while paused for a snapshot, so this only needs to absorb the
-/// pre-pause and post-restore-pre-resolution log traffic.
-const PENDING_CAP: usize = 256 * 1024;
+/// Beyond this, new bytes are dropped (and counted; one summary line is
+/// emitted when the console recovers). Sized for the WORST-CASE gate hold:
+/// the quiesce gate is held for the entire cache-ready→ack handshake, which
+/// host `cache-wait` keepalives can extend to the absolute 600s cap
+/// (`notify_cache_ready_and_wait` in container.rs) — not just a short
+/// pre-pause window. 1 MiB absorbs ~1.7 KiB/s of gated log traffic for that
+/// full window, well above fc-agent's log rate while idling in the handshake
+/// (a few short lines per poll cycle). Dropping on overflow stays deliberate:
+/// bounded memory against a wedged console beats unbounded growth, and drops
+/// are counted and summarized rather than silent.
+const PENDING_CAP: usize = 1024 * 1024;
 
 /// Writer thread poll tick. Bounds how quickly the writer notices a gate
 /// transition; pipe data wakes it immediately via POLLIN.
@@ -111,6 +121,21 @@ impl Drop for QuiesceGuard {
     }
 }
 
+/// The UART could not be proven idle within the drain window. The gate has
+/// already been released — the caller MUST abort the cache-ready handshake
+/// (send nothing, take no snapshot): pausing the VM in this state can capture
+/// the 8250 mid-transmit and poison the snapshot for every restore.
+#[derive(Debug)]
+pub struct QuiesceError;
+
+impl std::fmt::Display for QuiesceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "console UART did not drain within the quiesce window")
+    }
+}
+
+impl std::error::Error for QuiesceError {}
+
 /// Redirect fd 1/2 to the console pipe and start the writer thread.
 ///
 /// Replaces the old direct dup2-to-/dev/console: systemd's `journal+console`
@@ -156,6 +181,12 @@ fn setup(console_fd: OwnedFd) -> nix::Result<Arc<ConsoleShared>> {
     // Write end stays BLOCKING: eprintln! panics on write errors, and a
     // transiently full pipe must block the producer momentarily (the writer
     // thread always drains it), never return EAGAIN into eprintln!.
+    //
+    // nix 0.29 API split: `fcntl` and `read` still take `RawFd`, while `write`
+    // and `poll` already take `AsFd` — the `as_raw_fd()` calls here and at the
+    // writer-loop `read` are required by those signatures, not an opt-out from
+    // the safe wrappers. (Raw `libc::ioctl` below is different: nix has no
+    // TIOCOUTQ/FIONREAD wrapper.)
     let (pipe_rd, pipe_wr) = nix::unistd::pipe2(OFlag::O_CLOEXEC)?;
     let flags = fcntl(pipe_rd.as_raw_fd(), FcntlArg::F_GETFL)?;
     fcntl(
@@ -313,14 +344,22 @@ impl ConsoleShared {
     }
 
     /// Bytes still queued in the tty/UART output buffer.
+    ///
+    /// Returns -1 when the state is UNKNOWN (unexpected `TIOCOUTQ` failure).
+    /// Callers must treat unknown as "not drained": converting "cannot verify
+    /// the UART" into "the UART is idle" would let quiesce vouch for a drain
+    /// it never observed.
     fn uart_backlog(&self) -> i64 {
         let mut n: libc::c_int = 0;
         let rc = unsafe { libc::ioctl(self.console_fd.as_raw_fd(), libc::TIOCOUTQ, &mut n) };
         if rc == 0 {
             n as i64
-        } else {
-            // Not a tty (tests use pipes/files): nothing can be queued in a UART.
+        } else if Errno::last() == Errno::ENOTTY {
+            // Not a tty (tests use pipes/files): there is no 8250 UART, so
+            // nothing can be queued in one.
             0
+        } else {
+            -1
         }
     }
 
@@ -338,11 +377,20 @@ impl ConsoleShared {
     }
 
     /// See [`quiesce_for_snapshot`].
-    fn quiesce(self: &Arc<Self>) -> QuiesceGuard {
+    fn quiesce(self: &Arc<Self>) -> Result<QuiesceGuard, QuiesceError> {
+        self.quiesce_with_timeout(QUIESCE_PHASE_TIMEOUT)
+    }
+
+    /// [`Self::quiesce`] with an explicit per-phase bound. Tests shrink it so
+    /// the no-drain abort path doesn't cost real seconds.
+    fn quiesce_with_timeout(
+        self: &Arc<Self>,
+        phase_timeout: Duration,
+    ) -> Result<QuiesceGuard, QuiesceError> {
         // Phase 1 (politeness): let already-logged lines reach the console so
         // the quiesce announcement lands before the host pauses the VM. Purely
         // cosmetic for safety — phases 2+3 provide the guarantee.
-        let deadline = Instant::now() + QUIESCE_PHASE_TIMEOUT;
+        let deadline = Instant::now() + phase_timeout;
         while !self.flushed() {
             if Instant::now() >= deadline {
                 break;
@@ -357,12 +405,15 @@ impl ConsoleShared {
         // logs concurrently — logs accumulate in the writer's pending buffer.
         self.gate.store(true, Ordering::SeqCst);
         drop(self.write_lock.lock().unwrap_or_else(|e| e.into_inner()));
+        let guard = QuiesceGuard {
+            state: Some(self.clone()),
+        };
 
         // Phase 3 (drain): wait for the UART to go fully idle (TIOCOUTQ == 0
         // also proves THRI is disarmed — see module docs). Monotone: the gate
         // stops all refills. Terminates because the console works pre-snapshot;
         // the cap only prevents an unexpected wedge from stalling startup.
-        let deadline = Instant::now() + QUIESCE_PHASE_TIMEOUT;
+        let deadline = Instant::now() + phase_timeout;
         let mut drained = false;
         while Instant::now() < deadline {
             if self.uart_backlog() == 0 {
@@ -372,33 +423,43 @@ impl ConsoleShared {
             std::thread::sleep(Duration::from_millis(1));
         }
         if !drained {
-            // Held in the pending buffer until the guard drops (console-safe).
+            // The UART cannot be proven idle: a snapshot taken now could
+            // capture the 8250 mid-transmit and every restore of it would have
+            // a dead serial console. Release the gate (dropping the guard —
+            // the VM is staying live and cold, so logging must keep flowing)
+            // and surface the failure so the caller aborts the handshake
+            // instead of inviting the host to pause us.
+            drop(guard);
             eprintln!(
                 "[fc-agent] WARNING: console did not drain before snapshot quiesce; \
-                 a snapshot taken now may capture the UART mid-transmit"
+                 aborting the cache-ready handshake so no snapshot can capture the \
+                 UART mid-transmit"
             );
+            return Err(QuiesceError);
         }
 
-        QuiesceGuard {
-            state: Some(self.clone()),
-        }
+        Ok(guard)
     }
 }
 
 /// Make the serial console provably quiet for a host-side VM pause.
 ///
 /// Called before sending `cache-ready` (which triggers the host's pre-start
-/// snapshot pause). Until the returned guard drops, no byte reaches the UART:
-/// the snapshot cannot capture the 8250 mid-transmit, so its restores keep a
-/// working serial console. `eprintln!` stays usable throughout — lines are
-/// held in the writer's pending buffer and flushed when the guard drops
-/// (ack received, restore detected, or failure).
+/// snapshot pause). On success, until the returned guard drops, no byte
+/// reaches the UART: the snapshot cannot capture the 8250 mid-transmit, so
+/// its restores keep a working serial console. `eprintln!` stays usable
+/// throughout — lines are held in the writer's pending buffer and flushed
+/// when the guard drops (ack received, restore detected, or failure).
 ///
-/// No-op guard if [`init`] didn't run (no /dev/console).
-pub fn quiesce_for_snapshot() -> QuiesceGuard {
+/// `Err` means the UART could not be proven idle: the gate is NOT held, and
+/// the caller must NOT send `cache-ready` — the only safe outcome is to
+/// continue cold with no snapshot artifact.
+///
+/// No-op `Ok` guard if [`init`] didn't run (no /dev/console).
+pub fn quiesce_for_snapshot() -> Result<QuiesceGuard, QuiesceError> {
     match CONSOLE.get() {
         Some(state) => state.quiesce(),
-        None => QuiesceGuard { state: None },
+        None => Ok(QuiesceGuard { state: None }),
     }
 }
 
@@ -437,31 +498,79 @@ mod tests {
         cond()
     }
 
+    /// Append whatever the fake console currently holds to `sink` WITHOUT
+    /// blocking (FIONREAD probe, read only what is there). Blocking reads are
+    /// forbidden in these tests: `flushed()` can be transiently true before
+    /// bytes reach the console, and once the gate closes a blocking read can
+    /// only return after the guard drops — which the test does after the read.
+    /// A lost race must fail an assert, never hang the suite.
+    fn drain_console(console_rd: &mut std::fs::File, sink: &mut Vec<u8>) {
+        let mut out = [0u8; 65536];
+        loop {
+            let mut avail: libc::c_int = 0;
+            let rc = unsafe { libc::ioctl(console_rd.as_raw_fd(), libc::FIONREAD, &mut avail) };
+            if rc != 0 || avail == 0 {
+                return;
+            }
+            match console_rd.read(&mut out) {
+                Ok(0) => return,
+                Ok(n) => sink.extend_from_slice(&out[..n]),
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(e) => panic!("fake console read failed: {}", e),
+            }
+        }
+    }
+
     #[test]
     fn test_console_relay_and_flush() {
         let (console_wr, mut console_rd) = fake_console();
         let state = setup(console_wr).unwrap();
+        let mut seen: Vec<u8> = Vec::new();
 
         write_pipe(&state, b"hello console\n");
         assert!(
-            wait_until(|| state.flushed(), Duration::from_secs(5)),
-            "writer must relay and dispose all bytes"
+            wait_until(
+                || {
+                    drain_console(&mut console_rd, &mut seen);
+                    seen.as_slice() == b"hello console\n"
+                },
+                Duration::from_secs(5)
+            ),
+            "writer must relay all bytes to the console, got {:?}",
+            String::from_utf8_lossy(&seen)
         );
-
-        let mut out = [0u8; 64];
-        let n = console_rd.read(&mut out).unwrap();
-        assert_eq!(&out[..n], b"hello console\n");
+        assert!(
+            wait_until(|| state.flushed(), Duration::from_secs(5)),
+            "writer must account every relayed byte as disposed"
+        );
     }
 
     #[test]
     fn test_console_gate_holds_bytes_then_releases() {
         let (console_wr, mut console_rd) = fake_console();
         let state = setup(console_wr).unwrap();
+        let mut seen: Vec<u8> = Vec::new();
 
+        // Wait for the bytes to actually REACH the console, not merely for
+        // `flushed()`: that check can be transiently true while the bytes sit
+        // in the writer thread's local buffer, and gating in that window would
+        // hold "before-gate" back until the guard drops.
         write_pipe(&state, b"before-gate\n");
-        assert!(wait_until(|| state.flushed(), Duration::from_secs(5)));
+        assert!(
+            wait_until(
+                || {
+                    drain_console(&mut console_rd, &mut seen);
+                    seen.as_slice() == b"before-gate\n"
+                },
+                Duration::from_secs(5)
+            ),
+            "pre-gate bytes must reach the console, got {:?}",
+            String::from_utf8_lossy(&seen)
+        );
 
-        let guard = state.quiesce();
+        let guard = state
+            .quiesce()
+            .expect("quiesce on a pipe-backed console must report drained");
 
         // Logged while gated: consumed from the pipe but NOT written to the console.
         write_pipe(&state, b"held-line\n");
@@ -475,19 +584,67 @@ mod tests {
             "gated bytes must move to the pending buffer, not the console"
         );
 
-        // Nothing new on the fake console while gated.
-        let mut out = [0u8; 64];
-        let n = console_rd.read(&mut out).unwrap();
-        assert_eq!(&out[..n], b"before-gate\n");
+        // Nothing new may arrive on the fake console while gated: the held
+        // bytes are accounted in the pending buffer and the gate was closed
+        // (write lock cycled) before they were written.
+        drain_console(&mut console_rd, &mut seen);
+        assert_eq!(
+            seen.as_slice(),
+            b"before-gate\n",
+            "console must not receive bytes while gated"
+        );
 
         drop(guard);
 
         assert!(
-            wait_until(|| state.flushed(), Duration::from_secs(5)),
-            "dropping the guard must flush held bytes"
+            wait_until(
+                || {
+                    drain_console(&mut console_rd, &mut seen);
+                    seen.as_slice() == b"before-gate\nheld-line\n"
+                },
+                Duration::from_secs(5)
+            ),
+            "dropping the guard must flush held bytes, got {:?}",
+            String::from_utf8_lossy(&seen)
         );
-        let n = console_rd.read(&mut out).unwrap();
-        assert_eq!(&out[..n], b"held-line\n");
+    }
+
+    #[test]
+    fn test_console_quiesce_aborts_when_uart_never_drains() {
+        use nix::sys::socket::{socketpair, AddressFamily, SockFlag, SockType};
+
+        // A socketpair "console": on sockets, `TIOCOUTQ` (== `SIOCOUTQ`)
+        // genuinely reports bytes the peer has not consumed — a never-read
+        // peer models a UART whose TX queue never drains.
+        let (console_fd, peer) = socketpair(
+            AddressFamily::Unix,
+            SockType::Stream,
+            None,
+            SockFlag::SOCK_CLOEXEC,
+        )
+        .unwrap();
+        let state = setup(console_fd).unwrap();
+
+        write_pipe(&state, b"stuck-in-uart\n");
+        assert!(
+            wait_until(|| state.uart_backlog() > 0, Duration::from_secs(5)),
+            "socket console must report an undrained TX backlog"
+        );
+
+        let result = state.quiesce_with_timeout(Duration::from_millis(200));
+        assert!(
+            result.is_err(),
+            "quiesce must ABORT when the UART cannot be proven idle — returning a \
+             guard here would let the host snapshot the VM mid-transmit"
+        );
+        // The failed quiesce must not leave the console gated: the handshake
+        // is aborted, the VM continues cold, and logging must keep flowing.
+        assert!(
+            !state.gate.load(Ordering::SeqCst),
+            "failed quiesce must release the gate before returning"
+        );
+
+        drop(peer);
     }
 
     #[test]
@@ -500,8 +657,8 @@ mod tests {
         let state = setup(console_wr).unwrap();
 
         // Stall the console (nobody reads it) and overwhelm pending: the fake
-        // console absorbs ~4KB, PENDING_CAP holds 256KB, the rest must be
-        // DROPPED — and no producer may ever block.
+        // console absorbs ~4KB, the pending buffer holds PENDING_CAP bytes,
+        // the rest must be DROPPED — and no producer may ever block.
         let chunk = vec![b'x'; 8192];
         let total = 4096 + PENDING_CAP + 64 * 1024;
         let mut written = 0;
@@ -520,21 +677,10 @@ mod tests {
         // Recover the console: drain everything. The writer must flush its
         // pending bytes and append ONE summary line about the dropped bytes.
         let mut sunk: Vec<u8> = Vec::new();
-        let mut out = [0u8; 65536];
         assert!(wait_until(
             || {
                 // Keep draining until the writer reports fully flushed.
-                loop {
-                    // Non-blocking read via FIONREAD probe.
-                    let mut avail: libc::c_int = 0;
-                    let rc =
-                        unsafe { libc::ioctl(console_rd.as_raw_fd(), libc::FIONREAD, &mut avail) };
-                    if rc != 0 || avail == 0 {
-                        break;
-                    }
-                    let n = console_rd.read(&mut out).unwrap();
-                    sunk.extend_from_slice(&out[..n]);
-                }
+                drain_console(&mut console_rd, &mut sunk);
                 state.flushed() && state.dropped.load(Ordering::SeqCst) == 0
             },
             Duration::from_secs(10)

--- a/fc-agent/src/console.rs
+++ b/fc-agent/src/console.rs
@@ -1,0 +1,561 @@
+//! Wedge-proof serial console plumbing + snapshot quiesce support.
+//!
+//! fc-agent's fd 1/2 used to be dup2'd straight onto `/dev/console`. That made every
+//! `eprintln!` a BLOCKING write into the guest UART: after a snapshot captured the
+//! 8250 mid-transmit, the restored device never delivers the TX interrupt the driver
+//! waits for, the tty's 4096-byte output buffer fills, and the next `eprintln!`
+//! blocks its thread forever — including inside async tasks (the exec-server accept
+//! loop logged before spawning, so health checks wedged after ~4KB of output).
+//!
+//! New model: fd 1/2 are dup2'd onto the write end of a pipe. A dedicated writer
+//! thread is the ONLY writer to `/dev/console`:
+//!
+//! ```text
+//! eprintln!/children ──> pipe ──> writer thread ──> /dev/console (O_NONBLOCK)
+//!                                   │ bounded pending buffer (drop + count on overflow)
+//!                                   └ gate: console writes suspended during snapshot quiesce
+//! ```
+//!
+//! A dead console degrades to LOST LOG LINES (counted, summarized on recovery),
+//! never a blocked thread: the writer always drains the pipe, so producers block at
+//! most momentarily on a transiently full pipe, and console writes are non-blocking.
+//!
+//! Snapshot quiesce (`quiesce_for_snapshot`) gives the pre-start snapshot handshake
+//! a STRUCTURAL guarantee that no byte is in UART TX when the host pauses the VM:
+//! 1. politeness flush — wait until everything already logged has left the pipe and
+//!    been written to the console (`pipe empty && enqueued == disposed`);
+//! 2. gate — the writer thread stops writing to the console (bytes accumulate in its
+//!    pending buffer instead; `eprintln!` keeps working and never blocks);
+//! 3. drain — poll `TIOCOUTQ` on the console fd until 0.
+//!
+//! Why `TIOCOUTQ == 0` proves the UART is idle: the 8250 driver drains its circular
+//! buffer to THR only inside its IRQ handler under the port lock, and the same
+//! critical section disables THRI (`__stop_tx`) when the buffer empties. Firecracker
+//! consumes each THR write synchronously on the vCPU MMIO exit. `TIOCOUTQ` takes the
+//! same port lock, so reading 0 happens-after the final THR write AND the THRI
+//! disable — no bytes in flight, no armed TX interrupt to capture in the snapshot.
+//! The gate guarantees the UART STAYS idle until the guard is dropped, no matter
+//! which other task logs concurrently.
+//!
+//! Scope: this covers fc-agent's OWN console writes — the only userspace console
+//! writer at the cache-ready point in this rootfs (no getty on ttyS0; journald
+//! console forwarding is not enabled; systemd is idle between boot and the
+//! container start that follows the ack). Kernel printk is pause-safe by
+//! construction (polled THRE path, no THRI). A future rootfs change that adds
+//! another userspace console writer would reopen the mid-TX window for ITS
+//! writes; the host-side dead-serial watchdog (src/commands/snapshot.rs) exists
+//! to catch exactly that regression loudly.
+
+use std::collections::VecDeque;
+use std::os::fd::{AsFd, AsRawFd, OwnedFd};
+use std::os::unix::fs::OpenOptionsExt;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use nix::errno::Errno;
+use nix::fcntl::{fcntl, FcntlArg, OFlag};
+use nix::poll::{poll, PollFd, PollFlags, PollTimeout};
+use nix::unistd::{read, write};
+
+/// Upper bound on bytes buffered while the console is gated or stalled.
+/// Beyond this, new bytes are dropped (and counted). The guest produces no
+/// output while paused for a snapshot, so this only needs to absorb the
+/// pre-pause and post-restore-pre-resolution log traffic.
+const PENDING_CAP: usize = 256 * 1024;
+
+/// Writer thread poll tick. Bounds how quickly the writer notices a gate
+/// transition; pipe data wakes it immediately via POLLIN.
+const POLL_TICK_MS: u16 = 100;
+
+/// Bound on each quiesce phase (politeness flush / UART drain). The console
+/// works pre-snapshot, so these normally complete in microseconds; the cap
+/// only prevents an unexpected wedge from stalling container startup.
+const QUIESCE_PHASE_TIMEOUT: Duration = Duration::from_secs(5);
+
+static CONSOLE: OnceLock<Arc<ConsoleShared>> = OnceLock::new();
+
+/// Shared state between the writer thread and quiesce callers.
+pub struct ConsoleShared {
+    console_fd: OwnedFd,
+    pipe_rd: OwnedFd,
+    /// Kept so the pipe outlives any exotic fd 1/2 juggling; fd 1/2 are dups.
+    pipe_wr: OwnedFd,
+    /// Bytes the writer thread has taken out of the pipe (responsibility taken).
+    enqueued: AtomicU64,
+    /// Bytes written to the console or deliberately dropped.
+    /// Invariant: `enqueued - disposed == pending buffer length`.
+    disposed: AtomicU64,
+    /// Bytes dropped since the last recovery summary.
+    dropped: AtomicU64,
+    /// While true, the writer thread must not write to the console.
+    gate: AtomicBool,
+    /// Held around every console `write()`; `quiesce` locks it once after
+    /// setting `gate` so no console write is in flight or can start afterwards.
+    write_lock: Mutex<()>,
+}
+
+/// RAII guard for the console gate. Dropping it re-enables console writes
+/// (on every return path of the cache-ready handshake, including the restored
+/// VM resuming inside it).
+pub struct QuiesceGuard {
+    state: Option<Arc<ConsoleShared>>,
+}
+
+impl Drop for QuiesceGuard {
+    fn drop(&mut self) {
+        if let Some(state) = self.state.take() {
+            state.gate.store(false, Ordering::SeqCst);
+            // Writer notices within POLL_TICK_MS and flushes its pending buffer.
+        }
+    }
+}
+
+/// Redirect fd 1/2 to the console pipe and start the writer thread.
+///
+/// Replaces the old direct dup2-to-/dev/console: systemd's `journal+console`
+/// path dies when journald crashes after a snapshot restore (journal corrupted
+/// mid-write), so fc-agent owns its console output directly — but through the
+/// pipe + writer thread so a dead console can never block a logging thread.
+///
+/// If `/dev/console` cannot be opened, fd 1/2 are left untouched.
+pub fn init() {
+    let console = match std::fs::OpenOptions::new()
+        .write(true)
+        .custom_flags(libc::O_NOCTTY | libc::O_NONBLOCK)
+        .open("/dev/console")
+    {
+        Ok(f) => OwnedFd::from(f),
+        Err(_) => return,
+    };
+
+    let state = match setup(console) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    // All existing eprintln!/println! calls (and child processes inheriting
+    // fd 1/2) now feed the pipe. dup2 clears CLOEXEC on fds 1/2. On dup2
+    // failure the fds keep their previous target (direct console) — degraded
+    // but functional, and there is nowhere useful left to report it.
+    unsafe {
+        let r1 = libc::dup2(state.pipe_wr.as_raw_fd(), 1);
+        let r2 = libc::dup2(state.pipe_wr.as_raw_fd(), 2);
+        if r1 < 0 || r2 < 0 {
+            return;
+        }
+    }
+
+    let _ = CONSOLE.set(state);
+}
+
+/// Build the pipe + writer thread around an already-open console fd.
+/// Separated from [`init`] so tests can use a fake console without
+/// re-plumbing the test harness's own fd 1/2.
+fn setup(console_fd: OwnedFd) -> nix::Result<Arc<ConsoleShared>> {
+    // Write end stays BLOCKING: eprintln! panics on write errors, and a
+    // transiently full pipe must block the producer momentarily (the writer
+    // thread always drains it), never return EAGAIN into eprintln!.
+    let (pipe_rd, pipe_wr) = nix::unistd::pipe2(OFlag::O_CLOEXEC)?;
+    let flags = fcntl(pipe_rd.as_raw_fd(), FcntlArg::F_GETFL)?;
+    fcntl(
+        pipe_rd.as_raw_fd(),
+        FcntlArg::F_SETFL(OFlag::from_bits_truncate(flags) | OFlag::O_NONBLOCK),
+    )?;
+    // Belt-and-braces: the console fd must be non-blocking even if the caller
+    // forgot O_NONBLOCK at open time.
+    let cflags = fcntl(console_fd.as_raw_fd(), FcntlArg::F_GETFL)?;
+    fcntl(
+        console_fd.as_raw_fd(),
+        FcntlArg::F_SETFL(OFlag::from_bits_truncate(cflags) | OFlag::O_NONBLOCK),
+    )?;
+
+    let state = Arc::new(ConsoleShared {
+        console_fd,
+        pipe_rd,
+        pipe_wr,
+        enqueued: AtomicU64::new(0),
+        disposed: AtomicU64::new(0),
+        dropped: AtomicU64::new(0),
+        gate: AtomicBool::new(false),
+        write_lock: Mutex::new(()),
+    });
+
+    let thread_state = state.clone();
+    std::thread::Builder::new()
+        .name("console-writer".into())
+        .spawn(move || writer_loop(thread_state))
+        .map_err(|_| Errno::EAGAIN)?;
+
+    Ok(state)
+}
+
+/// The dedicated console writer thread. Sole writer to the console fd.
+/// Panic-free by construction: every syscall result is handled.
+fn writer_loop(state: Arc<ConsoleShared>) {
+    let mut pending: VecDeque<u8> = VecDeque::new();
+    let mut buf = [0u8; 8192];
+
+    loop {
+        // Poll: always watch the pipe; watch the console for writability only
+        // when there is something to flush and the gate is open.
+        let want_write = !pending.is_empty() && !state.gate.load(Ordering::SeqCst);
+        {
+            let mut fds = [
+                PollFd::new(state.pipe_rd.as_fd(), PollFlags::POLLIN),
+                PollFd::new(state.console_fd.as_fd(), PollFlags::POLLOUT),
+            ];
+            let nfds = if want_write { 2 } else { 1 };
+            match poll(&mut fds[..nfds], PollTimeout::from(POLL_TICK_MS)) {
+                Ok(_) => {}
+                Err(Errno::EINTR) => continue,
+                Err(_) => {
+                    // Poll on our own fds failing is unrecoverable; back off so a
+                    // persistent error can't spin the CPU. Producers still block on
+                    // the pipe at worst — same as a full pipe.
+                    std::thread::sleep(Duration::from_millis(100));
+                    continue;
+                }
+            }
+        }
+
+        // 1) Drain the pipe (non-blocking) so producers can never wedge on it.
+        loop {
+            match read(state.pipe_rd.as_raw_fd(), &mut buf) {
+                Ok(0) => break, // all write ends closed (cannot happen: we hold one)
+                Ok(n) => {
+                    state.enqueued.fetch_add(n as u64, Ordering::SeqCst);
+                    let room = PENDING_CAP.saturating_sub(pending.len());
+                    let keep = n.min(room);
+                    pending.extend(&buf[..keep]);
+                    if keep < n {
+                        let over = (n - keep) as u64;
+                        // Dropped bytes are disposed: the enqueued/disposed
+                        // invariant tracks the pending buffer, not the console.
+                        state.dropped.fetch_add(over, Ordering::SeqCst);
+                        state.disposed.fetch_add(over, Ordering::SeqCst);
+                    }
+                    if n < buf.len() {
+                        break;
+                    }
+                }
+                Err(Errno::EAGAIN) => break,
+                Err(Errno::EINTR) => continue,
+                Err(_) => break,
+            }
+        }
+
+        // 2) Flush pending to the console — never while gated, never blocking.
+        let mut wrote_any = false;
+        if !pending.is_empty() {
+            let _guard = state.write_lock.lock().unwrap_or_else(|e| e.into_inner());
+            // Checked under the lock: after quiesce() sets the gate and cycles
+            // this lock, no write can start here.
+            if !state.gate.load(Ordering::SeqCst) {
+                while !pending.is_empty() {
+                    let (head, _) = pending.as_slices();
+                    match write(state.console_fd.as_fd(), head) {
+                        Ok(0) => break,
+                        Ok(n) => {
+                            pending.drain(..n);
+                            state.disposed.fetch_add(n as u64, Ordering::SeqCst);
+                            wrote_any = true;
+                        }
+                        Err(Errno::EAGAIN) => break, // console TX full — try next tick
+                        Err(Errno::EINTR) => continue,
+                        Err(_) => {
+                            // Hard console error (EIO, ENODEV, ...): drop what we
+                            // hold, count it, and keep running — the console may
+                            // come back, and producers must never feel this.
+                            let len = pending.len() as u64;
+                            pending.clear();
+                            state.dropped.fetch_add(len, Ordering::SeqCst);
+                            state.disposed.fetch_add(len, Ordering::SeqCst);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        // 3) Console proven alive again after drops: emit ONE summary line.
+        // Only after a fully successful flush (wrote_any && empty) so a dead
+        // console can't loop summary → drop → summary.
+        if wrote_any && pending.is_empty() {
+            let dropped = state.dropped.swap(0, Ordering::SeqCst);
+            if dropped > 0 {
+                let line = format!(
+                    "[fc-agent] console: dropped {} bytes of log output while the console was stalled\n",
+                    dropped
+                );
+                // Goes through the normal pending path (counted as enqueued so
+                // the enqueued/disposed invariant holds).
+                state
+                    .enqueued
+                    .fetch_add(line.len() as u64, Ordering::SeqCst);
+                pending.extend(line.as_bytes());
+            }
+        }
+    }
+}
+
+impl ConsoleShared {
+    /// Bytes currently readable from the pipe (written by producers, not yet
+    /// picked up by the writer thread).
+    fn pipe_backlog(&self) -> i64 {
+        let mut n: libc::c_int = 0;
+        let rc = unsafe { libc::ioctl(self.pipe_rd.as_raw_fd(), libc::FIONREAD, &mut n) };
+        if rc == 0 {
+            n as i64
+        } else {
+            -1
+        }
+    }
+
+    /// Bytes still queued in the tty/UART output buffer.
+    fn uart_backlog(&self) -> i64 {
+        let mut n: libc::c_int = 0;
+        let rc = unsafe { libc::ioctl(self.console_fd.as_raw_fd(), libc::TIOCOUTQ, &mut n) };
+        if rc == 0 {
+            n as i64
+        } else {
+            // Not a tty (tests use pipes/files): nothing can be queued in a UART.
+            0
+        }
+    }
+
+    /// Everything logged before this call has been handed to the console (or
+    /// dropped): the pipe is empty and the writer holds no pending bytes.
+    fn flushed(&self) -> bool {
+        // Order matters: pipe first. Best-effort: bytes the writer thread has
+        // read from the pipe but not yet counted into `enqueued` are invisible
+        // to both checks, so this can be momentarily true while data sits in
+        // the writer's local buffer. That is fine for its only caller — the
+        // politeness phase of quiesce (cosmetic); the safety guarantee comes
+        // from the gate + TIOCOUTQ drain, not from this check.
+        self.pipe_backlog() == 0
+            && self.enqueued.load(Ordering::SeqCst) == self.disposed.load(Ordering::SeqCst)
+    }
+
+    /// See [`quiesce_for_snapshot`].
+    fn quiesce(self: &Arc<Self>) -> QuiesceGuard {
+        // Phase 1 (politeness): let already-logged lines reach the console so
+        // the quiesce announcement lands before the host pauses the VM. Purely
+        // cosmetic for safety — phases 2+3 provide the guarantee.
+        let deadline = Instant::now() + QUIESCE_PHASE_TIMEOUT;
+        while !self.flushed() {
+            if Instant::now() >= deadline {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(1));
+        }
+
+        // Phase 2 (gate): stop console writes. Setting the flag and then
+        // cycling the write lock waits out any in-flight console write; every
+        // later write attempt re-checks the flag under the same lock. From
+        // here, ZERO new bytes can enter the UART regardless of which task
+        // logs concurrently — logs accumulate in the writer's pending buffer.
+        self.gate.store(true, Ordering::SeqCst);
+        drop(self.write_lock.lock().unwrap_or_else(|e| e.into_inner()));
+
+        // Phase 3 (drain): wait for the UART to go fully idle (TIOCOUTQ == 0
+        // also proves THRI is disarmed — see module docs). Monotone: the gate
+        // stops all refills. Terminates because the console works pre-snapshot;
+        // the cap only prevents an unexpected wedge from stalling startup.
+        let deadline = Instant::now() + QUIESCE_PHASE_TIMEOUT;
+        let mut drained = false;
+        while Instant::now() < deadline {
+            if self.uart_backlog() == 0 {
+                drained = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        if !drained {
+            // Held in the pending buffer until the guard drops (console-safe).
+            eprintln!(
+                "[fc-agent] WARNING: console did not drain before snapshot quiesce; \
+                 a snapshot taken now may capture the UART mid-transmit"
+            );
+        }
+
+        QuiesceGuard {
+            state: Some(self.clone()),
+        }
+    }
+}
+
+/// Make the serial console provably quiet for a host-side VM pause.
+///
+/// Called before sending `cache-ready` (which triggers the host's pre-start
+/// snapshot pause). Until the returned guard drops, no byte reaches the UART:
+/// the snapshot cannot capture the 8250 mid-transmit, so its restores keep a
+/// working serial console. `eprintln!` stays usable throughout — lines are
+/// held in the writer's pending buffer and flushed when the guard drops
+/// (ack received, restore detected, or failure).
+///
+/// No-op guard if [`init`] didn't run (no /dev/console).
+pub fn quiesce_for_snapshot() -> QuiesceGuard {
+    match CONSOLE.get() {
+        Some(state) => state.quiesce(),
+        None => QuiesceGuard { state: None },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+    use std::os::fd::AsRawFd;
+
+    /// Fake console: a pipe whose read end the test controls. Not reading it
+    /// (after filling the buffer) simulates a stalled/dead console.
+    fn fake_console() -> (OwnedFd, std::fs::File) {
+        let (rd, wr) = nix::unistd::pipe2(OFlag::O_CLOEXEC).unwrap();
+        (wr, std::fs::File::from(rd))
+    }
+
+    fn write_pipe(state: &Arc<ConsoleShared>, data: &[u8]) {
+        let mut left = data;
+        while !left.is_empty() {
+            match write(state.pipe_wr.as_fd(), left) {
+                Ok(n) => left = &left[n..],
+                Err(Errno::EINTR) => continue,
+                Err(e) => panic!("pipe write failed: {}", e),
+            }
+        }
+    }
+
+    fn wait_until(mut cond: impl FnMut() -> bool, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if cond() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        cond()
+    }
+
+    #[test]
+    fn test_console_relay_and_flush() {
+        let (console_wr, mut console_rd) = fake_console();
+        let state = setup(console_wr).unwrap();
+
+        write_pipe(&state, b"hello console\n");
+        assert!(
+            wait_until(|| state.flushed(), Duration::from_secs(5)),
+            "writer must relay and dispose all bytes"
+        );
+
+        let mut out = [0u8; 64];
+        let n = console_rd.read(&mut out).unwrap();
+        assert_eq!(&out[..n], b"hello console\n");
+    }
+
+    #[test]
+    fn test_console_gate_holds_bytes_then_releases() {
+        let (console_wr, mut console_rd) = fake_console();
+        let state = setup(console_wr).unwrap();
+
+        write_pipe(&state, b"before-gate\n");
+        assert!(wait_until(|| state.flushed(), Duration::from_secs(5)));
+
+        let guard = state.quiesce();
+
+        // Logged while gated: consumed from the pipe but NOT written to the console.
+        write_pipe(&state, b"held-line\n");
+        assert!(
+            wait_until(
+                || state.pipe_backlog() == 0
+                    && state.enqueued.load(Ordering::SeqCst)
+                        > state.disposed.load(Ordering::SeqCst),
+                Duration::from_secs(5)
+            ),
+            "gated bytes must move to the pending buffer, not the console"
+        );
+
+        // Nothing new on the fake console while gated.
+        let mut out = [0u8; 64];
+        let n = console_rd.read(&mut out).unwrap();
+        assert_eq!(&out[..n], b"before-gate\n");
+
+        drop(guard);
+
+        assert!(
+            wait_until(|| state.flushed(), Duration::from_secs(5)),
+            "dropping the guard must flush held bytes"
+        );
+        let n = console_rd.read(&mut out).unwrap();
+        assert_eq!(&out[..n], b"held-line\n");
+    }
+
+    #[test]
+    fn test_console_stall_drops_and_summarizes_on_recovery() {
+        let (console_wr, mut console_rd) = fake_console();
+        // Shrink the fake console's buffer so a stall is cheap to produce.
+        unsafe {
+            libc::fcntl(console_wr.as_raw_fd(), libc::F_SETPIPE_SZ, 4096);
+        }
+        let state = setup(console_wr).unwrap();
+
+        // Stall the console (nobody reads it) and overwhelm pending: the fake
+        // console absorbs ~4KB, PENDING_CAP holds 256KB, the rest must be
+        // DROPPED — and no producer may ever block.
+        let chunk = vec![b'x'; 8192];
+        let total = 4096 + PENDING_CAP + 64 * 1024;
+        let mut written = 0;
+        while written < total {
+            write_pipe(&state, &chunk);
+            written += chunk.len();
+        }
+        assert!(
+            wait_until(
+                || state.dropped.load(Ordering::SeqCst) > 0,
+                Duration::from_secs(10)
+            ),
+            "overflow beyond the pending cap must be dropped, not block"
+        );
+
+        // Recover the console: drain everything. The writer must flush its
+        // pending bytes and append ONE summary line about the dropped bytes.
+        let mut sunk: Vec<u8> = Vec::new();
+        let mut out = [0u8; 65536];
+        assert!(wait_until(
+            || {
+                // Keep draining until the writer reports fully flushed.
+                loop {
+                    // Non-blocking read via FIONREAD probe.
+                    let mut avail: libc::c_int = 0;
+                    let rc =
+                        unsafe { libc::ioctl(console_rd.as_raw_fd(), libc::FIONREAD, &mut avail) };
+                    if rc != 0 || avail == 0 {
+                        break;
+                    }
+                    let n = console_rd.read(&mut out).unwrap();
+                    sunk.extend_from_slice(&out[..n]);
+                }
+                state.flushed() && state.dropped.load(Ordering::SeqCst) == 0
+            },
+            Duration::from_secs(10)
+        ));
+
+        let text = String::from_utf8_lossy(&sunk);
+        let summaries = text.matches("dropped").count();
+        assert_eq!(
+            summaries,
+            1,
+            "exactly one recovery summary line, got {}: {}",
+            summaries,
+            text.chars().rev().take(200).collect::<String>()
+        );
+        assert!(text.contains("bytes of log output while the console was stalled"));
+    }
+
+    #[test]
+    fn test_console_quiesce_noop_without_init() {
+        // Must not panic or block when /dev/console was never opened.
+        let guard = QuiesceGuard { state: None };
+        drop(guard);
+    }
+}

--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -871,7 +871,9 @@ pub enum CacheResult {
     /// POLLHUP, write-probe, or restore-epoch detected — warm start,
     /// vsock connections are dead (VIRTIO_VSOCK_EVENT_TRANSPORT_RESET).
     WarmStart,
-    /// Handshake failed (connect error, send error, timeout, etc.).
+    /// Handshake failed (console quiesce failure — cache-ready deliberately
+    /// not sent so the host cannot snapshot a mid-transmit UART — or connect
+    /// error, send error, timeout, etc.). The VM continues cold.
     Failed,
 }
 
@@ -920,15 +922,28 @@ pub fn notify_cache_ready_and_wait(
     // waits forever for a TX interrupt the re-created serial device never
     // delivers). So: announce FIRST, then make the console provably quiet
     // (flush + gate + TIOCOUTQ drain — structural, not probabilistic), and
-    // only THEN let the host know we are ready to be paused. The gate holds
-    // until this function returns (every path: ack, restore, failure), so no
-    // concurrent task can put a byte in UART TX while the pause can happen —
-    // lines logged meanwhile are buffered and flushed when the guard drops.
+    // only THEN let the host know we are ready to be paused. On success the
+    // gate holds until this function returns (every path: ack, restore,
+    // failure), so no concurrent task can put a byte in UART TX while the
+    // pause can happen — lines logged meanwhile are buffered and flushed when
+    // the guard drops. If the console CANNOT be proven quiet, the handshake
+    // is aborted BEFORE cache-ready is sent: the host never pauses us, no
+    // poisoned snapshot artifact can be created, and the VM continues cold.
     eprintln!(
         "[fc-agent] image digest {} loaded; quiescing console before cache-ready notification",
         digest
     );
-    let _console_quiesce = crate::console::quiesce_for_snapshot();
+    let _console_quiesce = match crate::console::quiesce_for_snapshot() {
+        Ok(guard) => guard,
+        Err(e) => {
+            eprintln!(
+                "[fc-agent] WARNING: {}; not sending cache-ready — continuing cold \
+                 without a pre-start snapshot",
+                e
+            );
+            return CacheResult::Failed;
+        }
+    };
 
     let sock = match socket(
         AddressFamily::Vsock,

--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -914,6 +914,22 @@ pub fn notify_cache_ready_and_wait(
     use nix::unistd::{read, write};
     use std::os::fd::{AsFd, AsRawFd};
 
+    // Receiving "cache-ready" makes the host PAUSE this VM for the pre-start
+    // snapshot. A snapshot that captures the UART mid-transmit is poisoned:
+    // EVERY restore of it has a dead serial console (the guest 8250 driver
+    // waits forever for a TX interrupt the re-created serial device never
+    // delivers). So: announce FIRST, then make the console provably quiet
+    // (flush + gate + TIOCOUTQ drain — structural, not probabilistic), and
+    // only THEN let the host know we are ready to be paused. The gate holds
+    // until this function returns (every path: ack, restore, failure), so no
+    // concurrent task can put a byte in UART TX while the pause can happen —
+    // lines logged meanwhile are buffered and flushed when the guard drops.
+    eprintln!(
+        "[fc-agent] image digest {} loaded; quiescing console before cache-ready notification",
+        digest
+    );
+    let _console_quiesce = crate::console::quiesce_for_snapshot();
+
     let sock = match socket(
         AddressFamily::Vsock,
         SockType::Stream,

--- a/fc-agent/src/main.rs
+++ b/fc-agent/src/main.rs
@@ -1,5 +1,6 @@
 mod agent;
 mod bootplan;
+mod console;
 mod container;
 mod exec;
 mod fuse;

--- a/fc-agent/src/restore.rs
+++ b/fc-agent/src/restore.rs
@@ -26,32 +26,6 @@ pub struct RestoreSignals {
     pub nfs_mounts: Vec<crate::types::NfsMount>,
 }
 
-/// Redirect stderr (fd 2) to /dev/console for direct serial console output.
-///
-/// systemd's `journal+console` routes output through journald, which writes to
-/// /dev/console. After snapshot restore, journald crashes because its journal file
-/// was mid-write during the snapshot ("corrupted or uncleanly shut down"). With
-/// journald dead, stderr goes nowhere and serial output stops.
-///
-/// Fix: open /dev/console directly and dup2 it to stderr. This bypasses journald
-/// entirely — eprintln!() writes go straight to /dev/console → ttyS0 → Firecracker
-/// serial → host stdout. The console write path uses polled I/O (busy-wait on THRE),
-/// so it works even after snapshot restore when the UART IER register is stale.
-pub fn redirect_stderr_to_console() {
-    use std::os::unix::io::AsRawFd;
-
-    let console = match std::fs::OpenOptions::new().write(true).open("/dev/console") {
-        Ok(f) => f,
-        Err(_) => return,
-    };
-
-    unsafe {
-        libc::dup2(console.as_raw_fd(), 2);
-        libc::dup2(console.as_raw_fd(), 1);
-    }
-    // console fd is closed when dropped, but fd 1 and 2 remain open (dup'd)
-}
-
 /// Handle clone restore: kill stale sockets, flush ARP, re-register exec, reconnect output.
 ///
 /// CRITICAL ordering: exec re-register and egress reconnect MUST complete before output reconnect.

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -1658,9 +1658,12 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
         // always prints restore-progress lines BEFORE reconnecting output, so
         // zero console lines shortly after this point is proof of a poisoned
         // snapshot. One loud error naming the snapshot instead of a trail of
-        // mystery test failures.
+        // mystery test failures. The mid-TX-UART diagnosis is Firecracker-only
+        // (8250 on ttyS0); Cloud Hypervisor restores use the hvc0 virtio
+        // console, so they get a backend-neutral missing-console error.
         if output_connected {
             let console_lines = vm_manager.console_line_counter();
+            let backend = vm_manager.backend();
             let snapshot_name = snapshot_name.clone();
             let vm_id = vm_id.clone();
             // 30s, not a few seconds: a freshly restored VM can be CPU-starved for a
@@ -1683,15 +1686,25 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
                         _ = watchdog_cancel.cancelled() => return,
                     }
                 }
-                tracing::error!(
-                    vm_id = %vm_id,
-                    snapshot = %snapshot_name,
-                    "fc-agent's output vsock reconnected after restore but NO serial \
-                     console line arrived within 30s — snapshot '{}' almost certainly \
-                     captured the guest UART mid-transmit and every restore of it will \
-                     have a dead serial console. Recreate the snapshot.",
-                    snapshot_name
-                );
+                match backend {
+                    crate::hypervisor::Backend::Firecracker => tracing::error!(
+                        vm_id = %vm_id,
+                        snapshot = %snapshot_name,
+                        "fc-agent's output vsock reconnected after restore but NO serial \
+                         console line arrived within 30s — snapshot '{}' almost certainly \
+                         captured the guest UART mid-transmit and every restore of it will \
+                         have a dead serial console. Recreate the snapshot.",
+                        snapshot_name
+                    ),
+                    crate::hypervisor::Backend::CloudHypervisor => tracing::error!(
+                        vm_id = %vm_id,
+                        snapshot = %snapshot_name,
+                        "fc-agent's output vsock reconnected after restore but NO console \
+                         output arrived within 30s — restores of snapshot '{}' come up with \
+                         a dead guest console. Recreate the snapshot.",
+                        snapshot_name
+                    ),
+                }
             });
         }
     }

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -1621,11 +1621,15 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
     if !tty_mode {
         let mut liveness_interval = tokio::time::interval(std::time::Duration::from_secs(5));
         liveness_interval.tick().await; // consume immediate first tick
+        let mut output_connected = false;
         loop {
             tokio::select! {
                 result = &mut output_connected_rx => {
                     match result {
-                        Ok(()) => info!(vm_id = %vm_id, "fc-agent output connected, exec server ready"),
+                        Ok(()) => {
+                            info!(vm_id = %vm_id, "fc-agent output connected, exec server ready");
+                            output_connected = true;
+                        }
                         Err(_) => warn!(vm_id = %vm_id, "output connected_tx dropped"),
                     }
                     break;
@@ -1644,6 +1648,51 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
                     }
                 }
             }
+        }
+        // Dead-serial detection: the output vsock reconnecting proves the guest
+        // and its virtio transport are alive, but the serial console can still
+        // be dead if the snapshot was captured with UART TX bytes in flight —
+        // the restored guest's 8250 driver then waits forever for a TX
+        // interrupt the re-created serial device never delivers, and every log
+        // line from the VM silently disappears. A healthy restored fc-agent
+        // always prints restore-progress lines BEFORE reconnecting output, so
+        // zero console lines shortly after this point is proof of a poisoned
+        // snapshot. One loud error naming the snapshot instead of a trail of
+        // mystery test failures.
+        if output_connected {
+            let console_lines = vm_manager.console_line_counter();
+            let snapshot_name = snapshot_name.clone();
+            let vm_id = vm_id.clone();
+            // 30s, not a few seconds: a freshly restored VM can be CPU-starved for a
+            // while (see the untimed output-connect wait above), and fc-agent's
+            // console gate releases up to ~500ms after WarmStart. A poisoned
+            // snapshot's serial is dead FOREVER, so a generous window costs nothing.
+            // Cancel-aware so it can't fire after the VM is torn down.
+            let watchdog_cancel = health_cancel_token.clone();
+            tokio::spawn(async move {
+                let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+                loop {
+                    if console_lines.load(std::sync::atomic::Ordering::Relaxed) > 0 {
+                        return;
+                    }
+                    if tokio::time::Instant::now() >= deadline {
+                        break;
+                    }
+                    tokio::select! {
+                        _ = tokio::time::sleep(std::time::Duration::from_millis(250)) => {}
+                        _ = watchdog_cancel.cancelled() => return,
+                    }
+                }
+                tracing::error!(
+                    vm_id = %vm_id,
+                    snapshot = %snapshot_name,
+                    "fc-agent's output vsock reconnected after restore but NO serial \
+                     console line arrived within 30s — snapshot '{}' almost certainly \
+                     captured the guest UART mid-transmit and every restore of it will \
+                     have a dead serial console. Recreate the snapshot.",
+                    snapshot_name
+                );
+            });
         }
     }
 

--- a/src/firecracker/vm.rs
+++ b/src/firecracker/vm.rs
@@ -50,6 +50,10 @@ pub struct VmManager {
     mount_redirects: Option<(Vec<PathBuf>, PathBuf)>, // (baseline_dirs, clone_dir) for mount namespace isolation
     process: Option<Child>,
     stderr_tail: Arc<Mutex<VecDeque<String>>>, // last few Firecracker stderr lines, for launch failure errors
+    /// Guest serial console lines observed on the Firecracker child's stdout
+    /// since spawn. Watched by the restore path to detect a dead serial
+    /// console (snapshot captured the UART mid-transmit).
+    console_lines: Arc<std::sync::atomic::AtomicU64>,
     client: Option<FirecrackerClient>,
 }
 
@@ -67,8 +71,15 @@ impl VmManager {
             mount_redirects: None,
             process: None,
             stderr_tail: Arc::new(Mutex::new(VecDeque::new())),
+            console_lines: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             client: None,
         }
+    }
+
+    /// Counter of guest serial console lines seen since the Firecracker child
+    /// spawned (see [`crate::hypervisor::Hypervisor::console_line_counter`]).
+    pub fn console_line_counter(&self) -> Arc<std::sync::atomic::AtomicU64> {
+        Arc::clone(&self.console_lines)
     }
 
     /// Set the VM name for logging purposes
@@ -274,10 +285,17 @@ impl VmManager {
 
         // Spawn process with streaming output
         let stderr_tail = Arc::clone(&self.stderr_tail);
+        let console_lines = Arc::clone(&self.console_lines);
         let child = spawn_streaming(cmd, move |line, is_stderr| {
             let clean = strip_firecracker_prefix(line);
             // fc-agent and container output at INFO/WARN, everything else at DEBUG
             let is_important = clean.contains("fc-agent") || clean.contains("[ctr:");
+            if !is_stderr {
+                // Firecracker writes the guest serial console to its stdout
+                // (its own logs go to --log-path), so every stdout line is
+                // guest console output.
+                console_lines.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
             if is_stderr {
                 // Keep the last few stderr lines so launch failures can report
                 // what Firecracker actually printed (its errors only appear at

--- a/src/hypervisor/cloud_hypervisor/mod.rs
+++ b/src/hypervisor/cloud_hypervisor/mod.rs
@@ -79,6 +79,9 @@ pub struct CloudHypervisorBackend {
     /// The relaunch reuses the VM dir and keeps `ch-console.log`, so an orphaned tail
     /// would not self-exit — it must be aborted explicitly.
     console_tail: Option<JoinHandle<()>>,
+    /// Guest console (hvc0) lines observed by the console tail since spawn
+    /// (see [`Hypervisor::console_line_counter`]).
+    console_lines: Arc<std::sync::atomic::AtomicU64>,
 }
 
 impl CloudHypervisorBackend {
@@ -100,6 +103,7 @@ impl CloudHypervisorBackend {
             pending: PendingConfig::default(),
             vsock_path: None,
             console_tail: None,
+            console_lines: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         }
     }
 
@@ -354,7 +358,10 @@ impl Hypervisor for CloudHypervisorBackend {
             old.abort();
         }
         if let Some(cpath) = self.console_path() {
-            self.console_tail = Some(tokio::spawn(tail_console_to_tracing(cpath)));
+            self.console_tail = Some(tokio::spawn(tail_console_to_tracing(
+                cpath,
+                Arc::clone(&self.console_lines),
+            )));
         }
         Ok(())
     }
@@ -407,6 +414,10 @@ impl Hypervisor for CloudHypervisorBackend {
         // spawn_streaming, not via a separate console device file. Return an empty stream.
         let (_tx, rx) = mpsc::channel(1);
         Ok(rx)
+    }
+
+    fn console_line_counter(&self) -> Arc<std::sync::atomic::AtomicU64> {
+        Arc::clone(&self.console_lines)
     }
 
     async fn apply_launch_config(
@@ -518,8 +529,9 @@ pub const fn default_guest_cid() -> u32 {
 /// tracing logs (the portable equivalent of Firecracker streaming its serial to stdout).
 /// fc-agent / container lines go at INFO, kernel/boot noise at DEBUG. The loop exits once
 /// the file has been gone for a few seconds (the VM dir was cleaned up), so it never
-/// outlives its VM.
-async fn tail_console_to_tracing(path: PathBuf) {
+/// outlives its VM. Each line also bumps `console_lines` (dead-console detection
+/// after restore — see [`Hypervisor::console_line_counter`]).
+async fn tail_console_to_tracing(path: PathBuf, console_lines: Arc<std::sync::atomic::AtomicU64>) {
     use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader};
 
     // Wait for Cloud Hypervisor to create the console file at boot.
@@ -545,6 +557,7 @@ async fn tail_console_to_tracing(path: PathBuf) {
                             Ok(0) => break, // caught up; poll again after a short sleep
                             Ok(n) => {
                                 pos += n as u64;
+                                console_lines.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                                 let clean = line.trim_end();
                                 if clean.contains("fc-agent") || clean.contains("[ctr:") {
                                     info!(target: "cloud-hypervisor", "{}", clean);

--- a/src/hypervisor/firecracker.rs
+++ b/src/hypervisor/firecracker.rs
@@ -119,6 +119,10 @@ impl Hypervisor for FirecrackerBackend {
         self.vm.stream_console(console_path).await
     }
 
+    fn console_line_counter(&self) -> std::sync::Arc<std::sync::atomic::AtomicU64> {
+        self.vm.console_line_counter()
+    }
+
     async fn apply_launch_config(
         &mut self,
         config: &FirecrackerConfig,

--- a/src/hypervisor/mod.rs
+++ b/src/hypervisor/mod.rs
@@ -177,6 +177,14 @@ pub trait Hypervisor: Send {
     /// Stream the guest serial/virtio console line-by-line.
     async fn stream_console(&self, console_path: &Path) -> Result<mpsc::Receiver<String>>;
 
+    /// Counter of guest console lines observed on this VMM process's console
+    /// stream since it spawned (serial → stdout for Firecracker, hvc0 file
+    /// tail for Cloud Hypervisor). The restore path watches it to detect a
+    /// restored VM whose serial console is dead — a snapshot that captured
+    /// the UART mid-transmit restores with the guest driver waiting on a TX
+    /// interrupt that never arrives, so no console line ever surfaces.
+    fn console_line_counter(&self) -> std::sync::Arc<std::sync::atomic::AtomicU64>;
+
     // --- cold-boot configuration (called in order; see trait docs) ---
 
     /// Apply the launch config (boot source, machine config, root drives) and the

--- a/tests/test_exec.rs
+++ b/tests/test_exec.rs
@@ -963,8 +963,12 @@ async fn run_exec_with_pty(
             // Wrap master fd in File for I/O (File takes ownership, will close on drop)
             let mut master = unsafe { std::fs::File::from_raw_fd(master_fd) };
 
-            // Delay to let child start - container exec via podman needs more time
-            std::thread::sleep(Duration::from_millis(500));
+            // Delay to let child start - container exec via podman needs more time.
+            // Async, not std::thread::sleep: these helpers run on tokio's
+            // current-thread test runtime, and a blocking sleep freezes every
+            // other task — including the spawn_fcvm log consumers, which is
+            // exactly what truncated the debug logs of wedged VMs.
+            tokio::time::sleep(Duration::from_millis(500)).await;
 
             // Write stdin input only if provided
             if let Some(input) = stdin_input {
@@ -1006,7 +1010,9 @@ async fn run_exec_with_pty(
                             Ok(nix::sys::wait::WaitStatus::Exited(_, _)) => break,
                             Ok(nix::sys::wait::WaitStatus::Signaled(_, _, _)) => break,
                             _ => {
-                                std::thread::sleep(Duration::from_millis(50));
+                                // Async sleep: keeps the current-thread runtime's
+                                // log-consumer tasks draining while we poll.
+                                tokio::time::sleep(Duration::from_millis(50)).await;
                             }
                         }
                     }
@@ -1141,7 +1147,8 @@ async fn run_exec_with_pty_interrupt(
                             let output_str = String::from_utf8_lossy(&output);
                             if output_str.contains(wait_for) {
                                 // Small delay to ensure command is in expected state
-                                std::thread::sleep(Duration::from_millis(100));
+                                // (async so log-consumer tasks keep draining).
+                                tokio::time::sleep(Duration::from_millis(100)).await;
 
                                 // Send the control character through PTY
                                 use std::io::Write;
@@ -1159,7 +1166,9 @@ async fn run_exec_with_pty_interrupt(
                         ) {
                             Ok(nix::sys::wait::WaitStatus::Exited(_, _)) => break,
                             Ok(nix::sys::wait::WaitStatus::Signaled(_, _, _)) => break,
-                            _ => std::thread::sleep(Duration::from_millis(50)),
+                            // Async sleep: keeps the current-thread runtime's
+                            // log-consumer tasks draining while we poll.
+                            _ => tokio::time::sleep(Duration::from_millis(50)).await,
                         }
                     }
                     Err(_) => break,

--- a/tests/test_serial_console.rs
+++ b/tests/test_serial_console.rs
@@ -1,18 +1,20 @@
 //! Test that the guest serial console works after snapshot restore.
 //!
-//! After snapshot restore, systemd-journald crashes because its journal file was
-//! mid-write during the snapshot. Since fc-agent.service uses journal+console,
-//! stderr goes to a journal socket — with journald dead, that socket goes nowhere
-//! and serial output stops flowing.
-//!
-//! Fix: fc-agent calls redirect_stderr_to_console() at startup, which opens
-//! /dev/console directly and dup2's it to fd 1 and fd 2. This bypasses journald
-//! entirely — eprintln!() writes go straight to /dev/console → ttyS0 → Firecracker
-//! serial → host stdout. The console write path uses polled I/O (busy-wait on THRE),
-//! so it works even with stale UART IER register after restore.
+//! Two ways the restored console used to die:
+//! - systemd-journald crashes after restore (journal mid-write during the
+//!   snapshot); fc-agent.service's journal+console stderr then went nowhere.
+//!   Fix: fc-agent owns its console output directly (console::init() at startup
+//!   routes fd 1/2 through a pipe drained by a dedicated writer thread that
+//!   writes /dev/console non-blocking — see fc-agent/src/console.rs).
+//! - The pre-start snapshot was captured with UART TX bytes in flight; the
+//!   restored 8250 driver waits forever for a TX interrupt the re-created
+//!   serial device never delivers, killing ALL restored serial output.
+//!   Fix: fc-agent quiesces the console (flush + gate + TIOCOUTQ drain) BEFORE
+//!   sending cache-ready, so the host's snapshot pause always captures an idle
+//!   UART (container::notify_cache_ready_and_wait).
 //!
 //! Architecture:
-//!   Guest eprintln!() → fd 2 (dup2'd to /dev/console) → kernel console driver
+//!   Guest eprintln!() → fd 2 (pipe) → console-writer thread → /dev/console
 //!   → /dev/ttyS0 → Firecracker UART emulation → host stdout → tracing → log file
 
 #![cfg(feature = "integration-fast")]


### PR DESCRIPTION
Fixes the arm64 trio from CI run 31066211429 attempt 1 — `test_serial_console_after_restore`, `test_exec_rootless`, `test_exec_parallel_tty_stress` — which was ONE bug, not three, and was previously written off as "transient infrastructure".

## The Problem

The rootless pre-start snapshot was created at the exact instant fc-agent's `sent cache-ready… waiting for ack` line was in flight in the guest UART (host log: pause at 04:12:23.192; the guest line surfaced only at resume, 04:12:24.773 — the bytes were captured undelivered in the memory image). Every restore of that snapshot (26/26, plus every chained clone) had permanently dead serial output; 199/199 restores of clean snapshots were fine — a perfect A/B at the same second between the bridged and rootless estress tests.

Dead serial then escalated: fc-agent's fd1/2 were dup2'd directly onto `/dev/console`, the tty's 4096-byte buffer filled, and the next `eprintln!` **blocked its thread forever** — including inside the exec-server accept loop (it logs before spawning), so execs and the exec-based health checks wedged after ~4KB of output. That is exactly why the failures looked like three unrelated timeouts (`consecutive_failures=30 status=Unknown`, 600s nextest kill).

## The Solution

Four fixes, one per layer (adversarially reviewed; findings folded in):

1. **Wedge-proof console** (`fc-agent/src/console.rs`, new): fd1/2 feed a pipe; a dedicated writer thread is the only `/dev/console` writer, using non-blocking writes with a bounded pending buffer that drops on a dead console (counted, one summary line on recovery). A dead console now costs log lines, never a blocked thread. 4 unit tests.
2. **Deterministic creation safety**: `notify_cache_ready_and_wait` announces first, then quiesces — politeness flush, structural gate (writer stops touching the console; `eprintln!` keeps working into the pending buffer), then a `TIOCOUTQ==0` drain that happens-after the final THR write *and* the THRI disable — and only then sends cache-ready. An RAII guard holds the gate until ack/restore/failure, so the pause can never capture the UART mid-transmit, regardless of concurrent logging. (Scope — fc-agent is the only userspace console writer at this point — is documented, with the watchdog below as the tripwire for future regressions.)
3. **Host-side detection**: after a restore, if fc-agent's output vsock reconnects but no console line arrives within 30s (generous: restored VMs can be CPU-starved), one tracing ERROR names the poisoned snapshot. Cancel-aware and bounded — one loud message instead of three mystery test failures.
4. **Test-harness diagnosability**: the PTY helpers in `tests/test_exec.rs` busy-looped with `std::thread::sleep` on the current-thread runtime, freezing log consumers (both failing exec tests' debug logs truncated at exactly the moment PTY tests began). Now tokio sleeps; same delays, no assertion changes.

The general Firecracker-fork fix (persist/replay UART TX state across restore, covering user-initiated `snapshot create --pid` at arbitrary instants) is tracked in **#708**.

## Test Results

```
$ make lint                                      # clean
$ make test-root FILTER=test_console
Summary [ 0.322s] 4 tests run: 4 passed          # new console unit tests
$ make test-root FILTER=serial_console
Summary [31.368s] 1 test run: 1 passed           # warm start from restored snapshot, serial alive
$ make test-root FILTER=test_exec_rootless
Summary: 1 passed [81.0s]                        # all 26 subtests incl. the CI wedge point
$ make test-root FILTER=test_exec_parallel_tty_stress
Summary: 1 passed [6.4s]                         # vs 600s CI timeout; 100/100 execs, 250 execs/sec
$ make test-root FILTER=sanity
Summary [22.267s] 5 tests run: 5 passed
```

Creation-side proof from the debug log: the quiesce announcement lands **before** `Cache-ready notification received` → `pausing VM for snapshot`, zero fc-agent console lines inside the pause window, and the held line flushes right after `VM resumed`. Restore-side: 35 live serial lines incl. `handling restore`/`restore complete`, watchdog silent.

Related: #710 (exec handshake) and #711 (Healthy gate) — the three PRs together close every mechanism found in this week's flake investigation.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved serial-console output handling during VM operation and snapshot creation.
  * Snapshot restore now detects missing console output and reports an error after a 30-second timeout.

* **Bug Fixes**
  * Console output is flushed and temporarily paused before snapshots, reducing lost or inconsistent output.
  * Console recovery now reports previously dropped output.

* **Tests**
  * Expanded coverage for console relaying, flushing, stalled consoles, recovery, and restore failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->