### PR TITLE
Add deterministic VM lifecycle fuzzing: failpoints + three test tiers

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -97,6 +97,21 @@ max-threads = "num-cpus"
 # stress_100 variant, each burning 100-150s before a clean retry). Give the
 # bench the entire runner: ~160s of exclusivity is cheaper in wall time than
 # the try-1 burns plus retries it causes.
+# Seeded lifecycle chaos fuzz (make fuzz, tests/test_fuzz_chaos.rs): ONE test
+# loops over every requested seed, each booting a VM and running a full op
+# schedule (~2-4 min/seed). The weekly CI run uses 20 seeds x 25 ops, so the
+# single test needs a multi-hour ceiling; the default run (1 seed, 10 ops)
+# finishes in ~2-3 min. Listed before the vm-tests override so it wins.
+[[profile.default.overrides]]
+filter = "package(fcvm) & test(=test_fuzz_lifecycle_chaos)"
+test-group = "vm-tests"
+slow-timeout = { period = "7200s", terminate-after = 1 }
+# NEVER retry the chaos fuzzer: its interleavings are seed-scheduled but not
+# cycle-deterministic, so a wholesale retry would almost always pass and turn a
+# caught race into a green job with only a "flaky" footnote — exactly the hedge
+# this suite exists to eliminate. A chaos failure must fail the run.
+retries = 0
+
 [[profile.default.overrides]]
 filter = "package(fcvm) & test(/8000_concurrent/)"
 test-group = "stress-tests"

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -31,6 +31,101 @@ jobs:
           path: /tmp/fcvm-container-target/criterion/
           if-no-files-found: warn
 
+  # Seeded lifecycle chaos fuzz (tests/test_fuzz_chaos.rs): 20 seeds x 25 ops
+  # against real rootless VMs. Schedule-deterministic per seed — a failure names
+  # the seed and is replayed locally with `make fuzz SEEDS=<seed>, OPS=25`.
+  fuzz:
+    name: Lifecycle-Fuzz-arm64
+    runs-on: [self-hosted, Linux, ARM64]
+    steps:
+      # Fix ownership of root-owned files from previous test runs (sudo test runner)
+      - name: Fix workspace permissions (pre-checkout)
+        run: |
+          sudo chown -R $USER:$USER ${{ github.workspace }}/fcvm 2>/dev/null || true
+          sudo chmod -R u+w ~/.cargo/advisory-db* 2>/dev/null || true
+          sudo chown -R $USER:$USER ~/.cargo/advisory-db* 2>/dev/null || true
+      - uses: actions/checkout@v6
+        with:
+          path: fcvm
+      - uses: ./fcvm/.github/actions/checkout-deps
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          # rust-toolchain.toml handles version + components; just trigger install
+          rustup show active-toolchain || true
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y fuse3 libfuse3-dev libclang-dev clang musl-tools \
+            iproute2 iptables passt dnsmasq qemu-utils e2fsprogs parted patch \
+            podman skopeo busybox-static cpio zstd autoconf automake libtool cmake \
+            libseccomp-dev
+      - name: Build passt from source
+        working-directory: fcvm
+        run: ./scripts/build-passt.sh
+      - name: Install Firecracker
+        run: |
+          ARCH=$(uname -m)
+          FC_VERSION="1.14.0"
+          curl -L -o /tmp/firecracker.tgz \
+            "https://github.com/firecracker-microvm/firecracker/releases/download/v${FC_VERSION}/firecracker-v${FC_VERSION}-${ARCH}.tgz"
+          sudo tar -xzf /tmp/firecracker.tgz -C /usr/local/bin --strip-components=1 \
+            "release-v${FC_VERSION}-${ARCH}/firecracker-v${FC_VERSION}-${ARCH}" \
+            "release-v${FC_VERSION}-${ARCH}/jailer-v${FC_VERSION}-${ARCH}"
+          sudo mv "/usr/local/bin/firecracker-v${FC_VERSION}-${ARCH}" /usr/local/bin/firecracker
+          sudo mv "/usr/local/bin/jailer-v${FC_VERSION}-${ARCH}" /usr/local/bin/jailer
+      - name: Install cargo tools
+        run: |
+          which cargo-nextest || cargo install cargo-nextest@0.9.115 --locked
+          sudo ln -sf $HOME/.cargo/bin/cargo /usr/local/bin/
+          sudo ln -sf $HOME/.cargo/bin/rustc /usr/local/bin/
+          sudo ln -sf $HOME/.cargo/bin/cargo-nextest /usr/local/bin/
+      - name: Setup KVM and networking
+        run: |
+          sudo chmod 666 /dev/kvm
+          sudo mkdir -p /var/run/netns
+          if [ ! -e /dev/userfaultfd ]; then
+            sudo mknod /dev/userfaultfd c 10 126
+          fi
+          sudo chmod 666 /dev/userfaultfd
+          sudo sysctl -w vm.unprivileged_userfaultfd=1
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 2>/dev/null || true
+          sudo sysctl -w net.ipv4.conf.all.forwarding=1
+          sudo sysctl -w net.ipv4.conf.default.forwarding=1
+          sudo sysctl -w net.ipv6.conf.all.forwarding=1
+          sudo sysctl -w net.ipv6.conf.default.forwarding=1
+          # Keep accepting Router Advertisements with forwarding enabled (otherwise default route expires)
+          DEFAULT_IFACE=$(ip route show default | awk '/dev/{print $5; exit}')
+          sudo sysctl -w "net.ipv6.conf.${DEFAULT_IFACE}.accept_ra=2" 2>/dev/null || true
+          echo "user_allow_other" | sudo tee /etc/fuse.conf
+          # Move podman storage to btrfs (more space for container images)
+          mkdir -p ~/.config/containers
+          printf '[storage]\ndriver = "overlay"\ngraphroot = "/mnt/fcvm-btrfs/containers/storage"\n' > ~/.config/containers/storage.conf
+          podman system migrate || true
+      - name: Create test log directory
+        run: sudo rm -rf /tmp/fcvm-test-logs && mkdir -p /tmp/fcvm-test-logs
+      - name: Clean test data
+        working-directory: fcvm
+        run: make clean-test-data || true
+      - name: setup-fcvm
+        working-directory: fcvm
+        run: make setup-fcvm
+      - name: Run lifecycle chaos fuzz
+        working-directory: fcvm
+        env:
+          FUSE_BACKEND_RS: ${{ github.workspace }}/fuse-backend-rs
+          FUSER: ${{ github.workspace }}/fuser
+        run: make fuzz SEEDS=20 OPS=25
+      - name: Upload test logs
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: fuzz-logs-${{ github.run_id }}
+          path: /tmp/fcvm-test-logs/
+          if-no-files-found: ignore
+          retention-days: 14
+
   # VM benchmarks (exec, clone) - require KVM, Firecracker, self-hosted runners
   bench-vm:
     name: VM-Benchmarks-${{ matrix.arch }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,6 +657,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "failpoint"
+version = "0.1.0"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,6 +676,7 @@ dependencies = [
  "anyhow",
  "dashmap 6.1.0",
  "exec-proto",
+ "failpoint",
  "fs2",
  "fuse-pipe",
  "libc",
@@ -712,6 +720,7 @@ dependencies = [
  "criterion",
  "directories",
  "exec-proto",
+ "failpoint",
  "fs2",
  "fuse-pipe",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
-members = [".", "fuse-pipe", "fc-agent", "exec-proto", "fc-mock"]
+members = [".", "fuse-pipe", "fc-agent", "exec-proto", "fc-mock", "failpoint"]
 # Build all members by default (not just the root package)
-default-members = [".", "fuse-pipe", "fc-agent", "exec-proto", "fc-mock"]
+default-members = [".", "fuse-pipe", "fc-agent", "exec-proto", "fc-mock", "failpoint"]
 # Exclude sync-test (used only for Makefile sync verification)
 exclude = ["sync-test"]
 # Resolver v2 makes --no-default-features work across all workspace members
@@ -66,6 +66,7 @@ vmm-sys-util = "0.12"
 shell-words = "1"
 fuse-pipe = { path = "fuse-pipe", default-features = false }
 exec-proto = { path = "exec-proto" }
+failpoint = { path = "failpoint" }
 url = "2"
 axum = { version = "0.8", features = ["ws"] }
 tower-http = { version = "0.6", features = ["cors"] }
@@ -96,6 +97,8 @@ serial_test = "3"
 criterion = "0.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# small_rng: SmallRng for the seeded chaos harness (tests/test_fuzz_chaos.rs)
+rand = { version = "0.8", features = ["small_rng"] }
 
 [build-dependencies]
 sha2 = "0.10"

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ CONTAINER_RUN_BASE := podman run --rm --privileged \
 CONTAINER_RUN := $(CONTAINER_RUN_BASE) --ulimit nproc=65536:65536 --pids-limit=65536
 
 .PHONY: all help build clean clean-test-data check-disk \
-	test test-unit test-fast test-all test-root test-packaging \
+	test test-unit test-fast test-all test-root test-packaging fuzz \
 	_test-unit _test-fast _test-all _test-root _setup-fcvm _bench \
 	container-build container-test container-test-unit container-test-fast container-test-all container-test-fc-mock \
 	container-setup-fcvm container-shell container-clean container-bench \
@@ -200,6 +200,7 @@ help:
 	@echo "  test-all           + slow VM tests (rootless, no sudo)"
 	@echo "  test-root, test    + privileged tests (bridged, pjdfstest, sudo)"
 	@echo "  test-fc-mock       Run tests with fc-mock (no KVM required)"
+	@echo "  fuzz               Seeded lifecycle chaos fuzz (SEEDS=N|list OPS=M, defaults 1/10)"
 	@echo ""
 	@echo "Test (container):"
 	@echo "  container-test-unit    Unit tests in container"
@@ -403,6 +404,17 @@ test-fast: show-notes check-disk setup-fcvm _test-fast
 test-all: show-notes check-disk setup-fcvm _test-all
 test-root: show-notes check-disk setup-fcvm setup-pjdfstest setup-hugepages _test-root
 test: test-root
+
+# Seeded lifecycle chaos fuzz (tests/test_fuzz_chaos.rs): one rootless VM per
+# seed, randomized-but-seeded op schedule, end-state oracles. Runs through the
+# same _test-root machinery as the rest of the suite.
+# Usage: make fuzz SEEDS=25 OPS=30   (defaults: SEEDS=1 OPS=10)
+# SEEDS is a count N (runs seeds 1..=N) or a comma list of literal seeds
+# ("3,17,42"; a trailing comma like "7," replays exactly seed 7).
+SEEDS ?= 1
+OPS ?= 10
+fuzz: show-notes check-disk setup-fcvm
+	FCVM_FUZZ_SEEDS=$(SEEDS) FCVM_FUZZ_OPS=$(OPS) $(MAKE) _test-root FILTER=fuzz_lifecycle_chaos
 
 # fc-mock: container-mode tests (no KVM required)
 # Uses fc-mock binary instead of Firecracker.
@@ -647,7 +659,7 @@ setup-lint-tools:
 	@which cargo-deny > /dev/null || (echo "Installing cargo-deny..." && cargo install cargo-deny@$(CARGO_DENY_VERSION) --locked)
 
 lint: setup-lint-tools
-	$(CARGO) fmt -p fcvm -p fuse-pipe -p fc-agent --check
+	$(CARGO) fmt -p fcvm -p fuse-pipe -p fc-agent -p failpoint --check
 	$(CARGO) clippy --all-targets -- -D warnings
 	$(CARGO) audit
 	$(CARGO) deny check

--- a/failpoint/Cargo.toml
+++ b/failpoint/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "failpoint"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Deterministic failpoints for lifecycle interleaving tests (FCVM_FAILPOINT / FCVM_GUEST_FAILPOINT)"
+
+[dependencies]
+tokio = { version = "1", features = ["time", "fs"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "fs"] }

--- a/failpoint/src/lib.rs
+++ b/failpoint/src/lib.rs
@@ -1,0 +1,459 @@
+//! Deterministic failpoints for lifecycle interleaving tests.
+//!
+//! # Purpose
+//!
+//! Lifecycle transitions (VM pause for snapshot, snapshot restore, the Healthy
+//! state-file persist) race against in-flight client work (exec handshakes,
+//! port-forward curls, serial writes). Those races have windows measured in
+//! microseconds, so stress tests hit them probabilistically. A failpoint turns a
+//! chosen window into a deterministic, individually replayable interleaving: the
+//! harness arms a named point, the code path holds there (sleep or block on a
+//! file), and the harness drives the *other* side of the race into the widened
+//! window.
+//!
+//! This is test-only instrumentation following the existing `FCVM_*` env-gated
+//! pattern (`FCVM_FUSE_TRACE_RATE`, `FCVM_KVM_TRACE`, ...). Unarmed — the only
+//! state production runs ever see — [`hit`] is a single static lookup returning
+//! `None`.
+//!
+//! # Marker-line contract
+//!
+//! Harnesses sequence on stderr marker lines:
+//!
+//! ```text
+//! FAILPOINT <name> reached action=<action>
+//! FAILPOINT <name> released
+//! ```
+//!
+//! "reached" is printed before the action starts, "released" after it completes;
+//! a harness that sees "reached" knows the code path is parked inside the window
+//! and may act. A `block_until_file` point that hits its 60s hard cap prints a
+//! loud `RELEASED BY TIMEOUT` line first — a wedged harness must not wedge the
+//! VM forever. Arming prints `FAILPOINT armed spec=<spec>` once.
+//!
+//! Guest caveat: fc-agent's console output is buffered while the console is
+//! quiesced for a snapshot (see fc-agent's `console` module), so a guest marker
+//! printed inside a quiesce window (e.g. `cache_ready.pre_send`) reaches the
+//! host log only after the guard drops. Sequence on host-side markers, or use
+//! guest sleeps for timing rather than treating guest markers as sync points.
+//!
+//! # Spec grammar
+//!
+//! A spec is comma-separated entries, each `<name>:<action>:<arg>`:
+//!
+//! * `<name>:sleep:<ms>` — hold for `<ms>` milliseconds.
+//! * `<name>:block_until_file:<path>` — poll every 10ms until `<path>` exists,
+//!   hard-capped at 60s. Host-only (see below). `<path>` may contain `:`.
+//!
+//! # Arming
+//!
+//! * Host: `fcvm` calls [`arm_from_env`] once at startup; set `FCVM_FAILPOINT`.
+//! * Guest: fc-agent cannot read host env. `fcvm` forwards `FCVM_GUEST_FAILPOINT`
+//!   onto the kernel cmdline as `fcvm_failpoint=<spec>` (the `fuse_trace_rate`
+//!   pattern); fc-agent parses `/proc/cmdline` at startup and calls
+//!   [`arm_from_str`]. Guest specs are sleep-only and whitespace-free —
+//!   `block_until_file` is host-only (the harness cannot create files inside the
+//!   guest, and a file-blocked guest holds VM-global state for the full cap) —
+//!   enforced host-side by [`validate_guest_spec`] before the VM boots.
+//!
+//! Malformed specs panic: a silently un-armed failpoint would make a
+//! determinism test vacuously pass, which is worse than failing loudly.
+//!
+//! # Guest failpoints and snapshot cache keys
+//!
+//! Guest failpoints ride the kernel cmdline, and the armed spec is baked into
+//! the guest's boot (and therefore into any snapshot taken of it). The runtime
+//! boot-args string itself is deliberately excluded from the snapshot cache key,
+//! so `FirecrackerConfig` carries a dedicated `guest_failpoint` field (populated
+//! from `FCVM_GUEST_FAILPOINT`, skip-serialized when unset) that feeds the key:
+//! a run with guest failpoints armed computes a different snapshot key than a
+//! normal run. Fuzz VMs therefore never pollute normal snapshot caches — they
+//! create and restore their own entries — and normal runs can never restore a
+//! snapshot with failpoints armed.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+/// Poll interval for `block_until_file`.
+const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Hard cap on `block_until_file`: a wedged harness must not wedge the VM forever.
+const BLOCK_CAP: Duration = Duration::from_secs(60);
+
+/// What an armed failpoint does when hit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Action {
+    /// Hold for the given duration.
+    Sleep(Duration),
+    /// Poll every [`BLOCK_POLL_INTERVAL`] until the file exists, capped at
+    /// [`BLOCK_CAP`]. Host-only (see crate docs).
+    BlockUntilFile(PathBuf),
+}
+
+impl fmt::Display for Action {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Action::Sleep(d) => write!(f, "sleep:{}ms", d.as_millis()),
+            Action::BlockUntilFile(p) => write!(f, "block_until_file:{}", p.display()),
+        }
+    }
+}
+
+/// Armed failpoints. Never set = unarmed; `Some(None)` = armed with nothing
+/// (env var unset). Either way [`hit`] is one static lookup on the fast path.
+static ARMED: OnceLock<Option<HashMap<String, Action>>> = OnceLock::new();
+
+fn armed_action(name: &str) -> Option<&'static Action> {
+    match ARMED.get() {
+        Some(Some(map)) => map.get(name),
+        _ => None,
+    }
+}
+
+/// Parse a failpoint spec (see crate docs for the grammar).
+fn parse_spec(spec: &str) -> Result<HashMap<String, Action>, String> {
+    let mut map = HashMap::new();
+    for entry in spec.split(',') {
+        let mut parts = entry.splitn(3, ':');
+        let name = parts.next().unwrap_or("");
+        let kind = parts.next();
+        let arg = parts.next();
+        if name.is_empty() {
+            return Err(format!("entry {entry:?}: empty failpoint name"));
+        }
+        let action = match (kind, arg) {
+            (Some("sleep"), Some(ms)) => {
+                let ms: u64 = ms
+                    .parse()
+                    .map_err(|e| format!("entry {entry:?}: bad sleep milliseconds: {e}"))?;
+                // Same cap as block_until_file: a typo'd hold must not wedge the
+                // VMM or guest beyond the harness's patience. Reject, don't clamp
+                // — a silently shortened hold would make interleavings lie.
+                if Duration::from_millis(ms) > BLOCK_CAP {
+                    return Err(format!(
+                        "entry {entry:?}: sleep exceeds the {}s cap",
+                        BLOCK_CAP.as_secs()
+                    ));
+                }
+                Action::Sleep(Duration::from_millis(ms))
+            }
+            (Some("block_until_file"), Some(path)) if !path.is_empty() => {
+                Action::BlockUntilFile(PathBuf::from(path))
+            }
+            (Some("block_until_file"), _) => {
+                return Err(format!("entry {entry:?}: block_until_file needs a path"));
+            }
+            (Some(other), _) => {
+                return Err(format!(
+                    "entry {entry:?}: unknown action {other:?} (expected sleep or block_until_file)"
+                ));
+            }
+            (None, _) => {
+                return Err(format!("entry {entry:?}: expected <name>:<action>:<arg>"));
+            }
+        };
+        if map.insert(name.to_string(), action).is_some() {
+            return Err(format!("failpoint {name:?} specified twice"));
+        }
+    }
+    Ok(map)
+}
+
+/// Arm failpoints from the `FCVM_FAILPOINT` env var. Unset arms nothing (and
+/// keeps the fast path). Called once at process startup; panics on a malformed
+/// spec (see crate docs) or if failpoints are already armed.
+pub fn arm_from_env() {
+    match std::env::var("FCVM_FAILPOINT") {
+        Ok(spec) => arm_from_str(&spec),
+        Err(_) => {
+            let _ = ARMED.set(None);
+        }
+    }
+}
+
+/// Arm failpoints from a spec string (the guest path: fc-agent passes the
+/// `fcvm_failpoint=` kernel cmdline value). Panics on a malformed spec (see
+/// crate docs) or if failpoints are already armed.
+pub fn arm_from_str(spec: &str) {
+    let map = parse_spec(spec).unwrap_or_else(|e| panic!("invalid failpoint spec {spec:?}: {e}"));
+    if ARMED.set(Some(map)).is_err() {
+        panic!("failpoints already armed (arm_from_env/arm_from_str called twice)");
+    }
+    eprintln!("FAILPOINT armed spec={spec}");
+}
+
+/// Validate a spec for forwarding to the guest kernel cmdline: parseable,
+/// whitespace-free (the cmdline is space-delimited), and sleep-only
+/// (`block_until_file` is host-only — see crate docs).
+pub fn validate_guest_spec(spec: &str) -> Result<(), String> {
+    if spec.chars().any(|c| c.is_whitespace()) {
+        return Err(
+            "guest failpoint spec must not contain whitespace (kernel cmdline is space-delimited)"
+                .to_string(),
+        );
+    }
+    for (name, action) in parse_spec(spec)? {
+        if matches!(action, Action::BlockUntilFile(_)) {
+            return Err(format!(
+                "failpoint {name:?}: block_until_file is host-only; guest failpoints support sleep only"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Hit a failpoint from a sync context (plain threads, `spawn_blocking`).
+/// Zero-cost when unarmed. When armed for `name`: print the "reached" marker,
+/// perform the action (blocking this thread), print "released".
+pub fn hit(name: &str) {
+    if let Some(action) = armed_action(name) {
+        perform_sync(name, action, BLOCK_CAP);
+    }
+}
+
+/// Hit a failpoint from an async context. Same contract as [`hit`], but the
+/// hold suspends the task (tokio sleep) instead of blocking the thread.
+pub async fn hit_async(name: &str) {
+    if let Some(action) = armed_action(name) {
+        perform_async(name, action, BLOCK_CAP).await;
+    }
+}
+
+fn perform_sync(name: &str, action: &Action, cap: Duration) {
+    eprintln!("FAILPOINT {name} reached action={action}");
+    match action {
+        Action::Sleep(d) => std::thread::sleep(*d),
+        Action::BlockUntilFile(path) => {
+            let deadline = Instant::now() + cap;
+            loop {
+                if path.exists() {
+                    break;
+                }
+                if Instant::now() >= deadline {
+                    release_by_timeout(name, path, cap);
+                    break;
+                }
+                std::thread::sleep(BLOCK_POLL_INTERVAL);
+            }
+        }
+    }
+    eprintln!("FAILPOINT {name} released");
+}
+
+async fn perform_async(name: &str, action: &Action, cap: Duration) {
+    eprintln!("FAILPOINT {name} reached action={action}");
+    match action {
+        Action::Sleep(d) => tokio::time::sleep(*d).await,
+        Action::BlockUntilFile(path) => {
+            let deadline = Instant::now() + cap;
+            loop {
+                if path.exists() {
+                    break;
+                }
+                if Instant::now() >= deadline {
+                    release_by_timeout(name, path, cap);
+                    break;
+                }
+                tokio::time::sleep(BLOCK_POLL_INTERVAL).await;
+            }
+        }
+    }
+    eprintln!("FAILPOINT {name} released");
+}
+
+fn release_by_timeout(name: &str, path: &Path, cap: Duration) {
+    eprintln!(
+        "FAILPOINT {name} RELEASED BY TIMEOUT after {}s: {} never appeared \
+         (wedged harness — releasing so the VM is not wedged too)",
+        cap.as_secs(),
+        path.display()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    fn unique_path(tag: &str) -> PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        std::env::temp_dir().join(format!(
+            "failpoint-test-{}-{}-{}",
+            tag,
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    #[test]
+    fn test_parse_sleep_and_block() {
+        let map = parse_spec("a.b:sleep:1500,c.d:block_until_file:/tmp/x").unwrap();
+        assert_eq!(map.len(), 2);
+        assert_eq!(map["a.b"], Action::Sleep(Duration::from_millis(1500)));
+        assert_eq!(map["c.d"], Action::BlockUntilFile(PathBuf::from("/tmp/x")));
+    }
+
+    #[test]
+    fn test_parse_block_path_may_contain_colons() {
+        let map = parse_spec("p:block_until_file:/tmp/a:b:c").unwrap();
+        assert_eq!(
+            map["p"],
+            Action::BlockUntilFile(PathBuf::from("/tmp/a:b:c"))
+        );
+    }
+
+    #[test]
+    fn test_parse_rejects_malformed_entries() {
+        assert!(parse_spec("").is_err()); // empty name
+        assert!(parse_spec("noaction").is_err()); // missing action
+        assert!(parse_spec("x:sleep").is_err()); // missing ms
+        assert!(parse_spec("x:sleep:abc").is_err()); // non-numeric ms
+        assert!(parse_spec("x:explode:1").is_err()); // unknown action
+        assert!(parse_spec("x:block_until_file:").is_err()); // empty path
+        assert!(parse_spec("x:sleep:1,x:sleep:2").is_err()); // duplicate name
+        assert!(parse_spec(":sleep:1").is_err()); // empty name with action
+    }
+
+    #[test]
+    fn test_validate_guest_spec() {
+        assert!(validate_guest_spec("a:sleep:5,b:sleep:10").is_ok());
+        assert!(validate_guest_spec("a:block_until_file:/tmp/x").is_err()); // host-only
+        assert!(validate_guest_spec("a:sleep:5 b:sleep:10").is_err()); // whitespace
+        assert!(validate_guest_spec("garbage").is_err()); // unparseable
+    }
+
+    /// The one test allowed to arm the process-global map (OnceLock arms once
+    /// per process): covers env → parse → arm → hit, and coarse sleep timing.
+    #[test]
+    fn test_arm_from_env_then_hit_sleeps() {
+        std::env::set_var("FCVM_FAILPOINT", "unit.sleep:sleep:80");
+        arm_from_env();
+        let start = Instant::now();
+        hit("unit.sleep");
+        assert!(
+            start.elapsed() >= Duration::from_millis(80),
+            "armed sleep failpoint must hold for its duration"
+        );
+    }
+
+    #[test]
+    fn test_unarmed_fast_path() {
+        // Never armed for this name in any test — with nextest each test is its
+        // own process, and under plain `cargo test` the only arming test uses a
+        // different name, so this exercises both "not set" and "map miss".
+        let start = Instant::now();
+        for _ in 0..1000 {
+            hit("unit.never-armed");
+        }
+        assert!(
+            start.elapsed() < Duration::from_millis(100),
+            "unarmed hit must be effectively free"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_unarmed_fast_path_async() {
+        let start = Instant::now();
+        hit_async("unit.never-armed-async").await;
+        assert!(start.elapsed() < Duration::from_millis(100));
+    }
+
+    #[test]
+    fn test_block_until_file_releases_when_file_appears() {
+        let path = unique_path("release");
+        let creator = {
+            let path = path.clone();
+            std::thread::spawn(move || {
+                std::thread::sleep(Duration::from_millis(60));
+                std::fs::write(&path, b"go").unwrap();
+            })
+        };
+        let start = Instant::now();
+        perform_sync(
+            "unit.block",
+            &Action::BlockUntilFile(path.clone()),
+            Duration::from_secs(10),
+        );
+        let elapsed = start.elapsed();
+        creator.join().unwrap();
+        std::fs::remove_file(&path).unwrap();
+        assert!(
+            elapsed >= Duration::from_millis(50),
+            "must block until the file appears (elapsed {elapsed:?})"
+        );
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "must release promptly once the file exists (elapsed {elapsed:?})"
+        );
+    }
+
+    #[test]
+    fn test_block_until_file_hard_cap() {
+        let path = unique_path("never-created");
+        let start = Instant::now();
+        perform_sync(
+            "unit.cap",
+            &Action::BlockUntilFile(path),
+            Duration::from_millis(150),
+        );
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(150),
+            "must wait out the cap (elapsed {elapsed:?})"
+        );
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "must release at the cap, not hang (elapsed {elapsed:?})"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_block_until_file_async_release_and_cap() {
+        // Release path.
+        let path = unique_path("async-release");
+        let creator = {
+            let path = path.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(60)).await;
+                tokio::fs::write(&path, b"go").await.unwrap();
+            })
+        };
+        let start = Instant::now();
+        perform_async(
+            "unit.block-async",
+            &Action::BlockUntilFile(path.clone()),
+            Duration::from_secs(10),
+        )
+        .await;
+        let elapsed = start.elapsed();
+        creator.await.unwrap();
+        tokio::fs::remove_file(&path).await.unwrap();
+        assert!(elapsed >= Duration::from_millis(50) && elapsed < Duration::from_secs(5));
+
+        // Cap path.
+        let start = Instant::now();
+        perform_async(
+            "unit.cap-async",
+            &Action::BlockUntilFile(unique_path("async-never")),
+            Duration::from_millis(150),
+        )
+        .await;
+        let elapsed = start.elapsed();
+        assert!(elapsed >= Duration::from_millis(150) && elapsed < Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn test_async_sleep_holds() {
+        let start = Instant::now();
+        perform_async(
+            "unit.async-sleep",
+            &Action::Sleep(Duration::from_millis(80)),
+            BLOCK_CAP,
+        )
+        .await;
+        assert!(start.elapsed() >= Duration::from_millis(80));
+    }
+}

--- a/fc-agent/Cargo.toml
+++ b/fc-agent/Cargo.toml
@@ -15,6 +15,7 @@ fs2 = "0.4"
 dashmap = "6"
 fuse-pipe = { path = "../fuse-pipe", default-features = false }
 exec-proto = { path = "../exec-proto" }
+failpoint = { path = "../failpoint" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"

--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -970,6 +970,14 @@ pub fn notify_cache_ready_and_wait(
         return CacheResult::Failed;
     }
 
+    // failpoint: hold AFTER the console quiesce completed and immediately BEFORE
+    // announcing cache-ready (which triggers the host's pre-start snapshot pause) —
+    // proves the quiesce gate keeps the UART idle across an arbitrarily long
+    // pre-pause window. Sync context (this fn is blocking). Note: the marker line
+    // is buffered by the quiesced console and reaches the host log only after the
+    // guard drops — a hold, not a host-visible sync point.
+    failpoint::hit("cache_ready.pre_send");
+
     let msg = format!("cache-ready:{}\n", digest);
     match write(&sock, msg.as_bytes()) {
         Ok(n) if n == msg.len() => {}

--- a/fc-agent/src/exec.rs
+++ b/fc-agent/src/exec.rs
@@ -356,6 +356,11 @@ fn read_request_and_handshake(fd: i32, timeout: Duration) -> Option<(ExecRequest
     /// GO is 2 bytes; anything longer is a protocol violation.
     const MAX_GO_LINE_LENGTH: usize = 16;
 
+    // failpoint: hold after accept, before consuming the request line — forces the
+    // client's 3s ACK timeout and exercises reconnect+resend against a REAL agent
+    // (not a mock). Sync hit(): this fn runs inside spawn_blocking.
+    failpoint::hit("exec.post_accept_pre_read");
+
     let deadline = Instant::now() + timeout;
 
     // Phase 1: request line.
@@ -409,6 +414,11 @@ fn read_request_and_handshake(fd: i32, timeout: Duration) -> Option<(ExecRequest
         unsafe { libc::close(fd) };
         return None;
     }
+
+    // failpoint: hold after the ACK write and BEFORE go_deadline is computed, so a
+    // hold delays the GO read without eating its 2s floor (Instant::now() below is
+    // taken after the hold) — makes "GO races a snapshot pause after ACK" testable.
+    failpoint::hit("exec.post_ack_pre_go");
 
     // Phase 3: GO — only after consuming this may execution start. A request
     // that arrived slowly can leave the shared deadline nearly exhausted here;
@@ -712,6 +722,12 @@ async fn handle_pipe_async(raw_fd: i32, request: &ExecRequest) {
     write_line_async(&conn, &serde_json::to_string(&response).unwrap()).await;
     // fd closed by OwnedFd drop (inside AsyncFd, inside Mutex, inside Arc)
 }
+
+// TIER 0 protocol-interleaving fuzz: systematic peer-death enumeration for the
+// ACK/GO handshake (kept in its own file — see exec_fuzz_tests.rs).
+#[cfg(test)]
+#[path = "exec_fuzz_tests.rs"]
+mod exec_fuzz_tests;
 
 #[cfg(test)]
 mod tests {

--- a/fc-agent/src/exec_fuzz_tests.rs
+++ b/fc-agent/src/exec_fuzz_tests.rs
@@ -1,0 +1,366 @@
+//! TIER 0 protocol-interleaving fuzz: agent side of the exec ACK/GO handshake.
+//!
+//! Systematically enumerates peer death at EVERY protocol stage of
+//! `read_request_and_handshake` over a socketpair:
+//!
+//! * before any bytes
+//! * mid-request (first byte, mid-JSON, just before the newline)
+//! * after the full request, before the ACK could be read (both shapes: peer
+//!   EOF, and peer read-half shutdown so the ACK write itself fails)
+//! * after reading ACK but before GO
+//! * mid-GO
+//! * after GO
+//!
+//! plus garbage-instead-of-GO, an oversized GO line, and an oversized request
+//! (which must produce the pre-ACK Error line).
+//!
+//! For each cut the tests assert the three handshake invariants:
+//! 1. the function returns within its deadline bound (thread reclaimed);
+//! 2. every pre-GO cut returns None — nothing may execute;
+//! 3. Some is returned ONLY when a full GO line was consumed.
+//!
+//! Determinism: every cut is an event (socket shutdown/close observed as EOF or
+//! EPIPE), never a sleep. The generous 5s deadline is never actually waited on
+//! in the EOF paths — the elapsed assertions prove that.
+
+use super::read_request_and_handshake;
+use crate::types::ExecRequest;
+use std::time::{Duration, Instant};
+
+/// A canonical valid request line (raw bytes, newline-terminated).
+const REQUEST: &[u8] = b"{\"command\":[\"true\"],\"in_container\":false}\n";
+
+/// Cuts that consume no deadline (EOF/EPIPE events) must return well before
+/// the 5s handshake deadline; 2s is generous slack for a loaded CI host.
+const EOF_CUT_BOUND: Duration = Duration::from_secs(2);
+
+fn socketpair() -> (i32, i32) {
+    let mut fds = [0i32; 2];
+    let rc = unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) };
+    assert_eq!(rc, 0, "socketpair failed");
+    (fds[0], fds[1])
+}
+
+/// Write all of `data`, looping over partial writes (large payloads exceed the
+/// socketpair buffer and drain only as the server consumes them).
+fn write_all_loop(fd: i32, data: &[u8]) {
+    let mut off = 0;
+    while off < data.len() {
+        let n = unsafe { libc::write(fd, data[off..].as_ptr().cast(), data.len() - off) };
+        assert!(n > 0, "write to socketpair failed at offset {}", off);
+        off += n as usize;
+    }
+}
+
+fn shutdown(fd: i32, how: i32) {
+    let rc = unsafe { libc::shutdown(fd, how) };
+    assert_eq!(rc, 0, "shutdown failed");
+}
+
+/// Read everything from `fd` until EOF (terminates because the handshake
+/// function closes the server fd on every path we drive it down).
+fn read_to_eof(fd: i32) -> Vec<u8> {
+    let mut out = Vec::new();
+    let mut buf = [0u8; 4096];
+    loop {
+        let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
+        if n <= 0 {
+            return out;
+        }
+        out.extend_from_slice(&buf[..n as usize]);
+    }
+}
+
+struct CutOutcome {
+    result: Option<ExecRequest>,
+    /// Every byte the agent wrote to the peer before closing.
+    client_saw: Vec<u8>,
+    elapsed: Duration,
+}
+
+/// Pre-buffer `prefix` as the peer's entire lifetime output, signal peer death
+/// (SHUT_WR → the server sees clean EOF after the prefix), then run the
+/// handshake. Fully deterministic: no threads, no sleeps.
+fn run_prebuffered_cut(prefix: &[u8]) -> CutOutcome {
+    let (server_fd, client_fd) = socketpair();
+    write_all_loop(client_fd, prefix);
+    shutdown(client_fd, libc::SHUT_WR);
+
+    let start = Instant::now();
+    let result =
+        read_request_and_handshake(server_fd, Duration::from_secs(5)).map(|(request, fd)| {
+            unsafe { libc::close(fd) };
+            request
+        });
+    let elapsed = start.elapsed();
+
+    let client_saw = read_to_eof(client_fd);
+    unsafe { libc::close(client_fd) };
+    CutOutcome {
+        result,
+        client_saw,
+        elapsed,
+    }
+}
+
+fn ack_line() -> Vec<u8> {
+    format!("{}\n", exec_proto::HANDSHAKE_ACK).into_bytes()
+}
+
+/// Peer dies before any bytes and at several byte offsets inside the request
+/// line (first byte, mid-JSON, just before the newline): the handshake must
+/// return None promptly and must never write an ACK — the request was never
+/// fully consumed, so the client is allowed to resend it.
+#[test]
+fn fuzz_peer_death_at_every_request_offset() {
+    let offsets = [0, 1, REQUEST.len() / 2, REQUEST.len() - 1];
+    for &off in &offsets {
+        let outcome = run_prebuffered_cut(&REQUEST[..off]);
+        assert!(
+            outcome.result.is_none(),
+            "cut at request offset {} must not execute",
+            off
+        );
+        assert!(
+            outcome.client_saw.is_empty(),
+            "cut at request offset {}: no ACK may be written for a partial request, saw {:?}",
+            off,
+            String::from_utf8_lossy(&outcome.client_saw)
+        );
+        assert!(
+            outcome.elapsed < EOF_CUT_BOUND,
+            "cut at request offset {}: EOF must return promptly, took {:?}",
+            off,
+            outcome.elapsed
+        );
+    }
+}
+
+/// Peer dies right after the full request (EOF before it could read ACK): the
+/// agent ACKs the consumed request, then the GO read hits EOF — no execution,
+/// and the peer-visible bytes are exactly one ACK line.
+#[test]
+fn fuzz_peer_death_after_full_request() {
+    let outcome = run_prebuffered_cut(REQUEST);
+    assert!(outcome.result.is_none(), "no GO consumed → no execution");
+    assert_eq!(
+        outcome.client_saw,
+        ack_line(),
+        "peer must see exactly ACK then EOF"
+    );
+    assert!(
+        outcome.elapsed < EOF_CUT_BOUND,
+        "EOF after request must return promptly, took {:?}",
+        outcome.elapsed
+    );
+}
+
+/// Peer shuts down its READ half after sending the request: the ACK write
+/// itself fails (EPIPE). The agent must return None promptly instead of
+/// proceeding to the GO phase.
+#[test]
+fn fuzz_peer_read_shutdown_fails_ack_write() {
+    let (server_fd, client_fd) = socketpair();
+    write_all_loop(client_fd, REQUEST);
+    // Peer will never read: the ACK write must fail with EPIPE. The write half
+    // stays open, so a buggy path that survived the failed ACK would then park
+    // on the GO read for the full 5s deadline — the elapsed bound catches it.
+    shutdown(client_fd, libc::SHUT_RD);
+
+    let start = Instant::now();
+    let result = read_request_and_handshake(server_fd, Duration::from_secs(5));
+    let elapsed = start.elapsed();
+
+    assert!(result.is_none(), "failed ACK write must not execute");
+    assert!(
+        elapsed < EOF_CUT_BOUND,
+        "EPIPE on ACK must return promptly, took {:?}",
+        elapsed
+    );
+    unsafe { libc::close(client_fd) };
+}
+
+/// Peer reads the ACK (proving the ACK write completed) and then dies before
+/// sending GO: no execution. This is the client-crash-between-ACK-and-GO
+/// interleaving, driven by a real reader thread rather than pre-buffered bytes.
+#[test]
+fn fuzz_peer_death_after_reading_ack_before_go() {
+    let (server_fd, client_fd) = socketpair();
+    write_all_loop(client_fd, REQUEST);
+
+    let reader = std::thread::spawn(move || {
+        // Read exactly one line (the ACK), then die (SHUT_WR → EOF at the GO read).
+        let mut seen = Vec::new();
+        let mut byte = [0u8; 1];
+        loop {
+            let n = unsafe { libc::read(client_fd, byte.as_mut_ptr() as *mut libc::c_void, 1) };
+            assert!(n > 0, "agent closed before writing full ACK");
+            seen.push(byte[0]);
+            if byte[0] == b'\n' {
+                break;
+            }
+        }
+        shutdown(client_fd, libc::SHUT_WR);
+        (client_fd, seen)
+    });
+
+    let start = Instant::now();
+    let result = read_request_and_handshake(server_fd, Duration::from_secs(5));
+    let elapsed = start.elapsed();
+
+    assert!(
+        result.is_none(),
+        "death after ACK, before GO → no execution"
+    );
+    assert!(
+        elapsed < EOF_CUT_BOUND,
+        "EOF at GO must return promptly, took {:?}",
+        elapsed
+    );
+
+    let (client_fd, seen) = reader.join().unwrap();
+    assert_eq!(seen, ack_line(), "peer must have read exactly the ACK line");
+    unsafe { libc::close(client_fd) };
+}
+
+/// Peer dies mid-GO (one byte of "GO" then EOF): a partial GO line must never
+/// authorize execution.
+#[test]
+fn fuzz_peer_death_mid_go() {
+    let mut prefix = REQUEST.to_vec();
+    prefix.push(b'G');
+    let outcome = run_prebuffered_cut(&prefix);
+    assert!(outcome.result.is_none(), "partial GO must not execute");
+    assert_eq!(outcome.client_saw, ack_line());
+    assert!(
+        outcome.elapsed < EOF_CUT_BOUND,
+        "EOF mid-GO must return promptly, took {:?}",
+        outcome.elapsed
+    );
+}
+
+/// Garbage instead of GO: a complete line that is not GO must never authorize
+/// execution, and the agent writes nothing after the ACK.
+#[test]
+fn fuzz_garbage_instead_of_go() {
+    for garbage in [&b"NO\n"[..], &b"GONE\n"[..], &b"go\n"[..], &b"\n"[..]] {
+        let mut prefix = REQUEST.to_vec();
+        prefix.extend_from_slice(garbage);
+        let outcome = run_prebuffered_cut(&prefix);
+        assert!(
+            outcome.result.is_none(),
+            "garbage {:?} instead of GO must not execute",
+            String::from_utf8_lossy(garbage)
+        );
+        assert_eq!(
+            outcome.client_saw,
+            ack_line(),
+            "nothing may be written after ACK for garbage {:?}",
+            String::from_utf8_lossy(garbage)
+        );
+        assert!(
+            outcome.elapsed < EOF_CUT_BOUND,
+            "garbage GO must resolve promptly, took {:?}",
+            outcome.elapsed
+        );
+    }
+}
+
+/// A GO line exceeding MAX_GO_LINE_LENGTH (16 bytes) is a protocol violation:
+/// no execution.
+#[test]
+fn fuzz_oversized_go_line() {
+    let mut prefix = REQUEST.to_vec();
+    prefix.extend_from_slice(b"XXXXXXXXXXXXXXXXXXXX\n"); // 20 X's > 16-byte cap
+    let outcome = run_prebuffered_cut(&prefix);
+    assert!(outcome.result.is_none(), "oversized GO must not execute");
+    assert_eq!(outcome.client_saw, ack_line());
+}
+
+/// Full GO consumed, then peer death: the ONLY cut point where Some is
+/// returned — execution is authorized exactly when a complete GO line was
+/// consumed, regardless of what the peer does afterwards.
+#[test]
+fn fuzz_full_go_then_peer_death_executes_exactly_once() {
+    let mut prefix = REQUEST.to_vec();
+    prefix.extend_from_slice(format!("{}\n", exec_proto::HANDSHAKE_GO).as_bytes());
+    let outcome = run_prebuffered_cut(&prefix);
+    let request = outcome
+        .result
+        .expect("full GO must authorize execution even if the peer dies right after");
+    assert_eq!(request.command, vec!["true"]);
+    assert_eq!(outcome.client_saw, ack_line());
+    assert!(
+        outcome.elapsed < EOF_CUT_BOUND,
+        "happy path must be fast, took {:?}",
+        outcome.elapsed
+    );
+}
+
+/// Oversized request (> 1 MiB without a newline): the agent must reject it
+/// with the pre-ACK Error line — a silent close would read as no-ACK on the
+/// client and trigger futile resends of the same oversized request.
+#[test]
+fn fuzz_oversized_request_gets_pre_ack_error_line() {
+    // MAX_EXEC_LINE_LENGTH is 1 MiB; the cap check fires when byte cap+1 arrives.
+    const OVERSIZED: usize = 1_048_576 + 1;
+    let (server_fd, client_fd) = socketpair();
+
+    // The payload exceeds the socketpair buffer, so a writer thread feeds it
+    // while the server consumes; it then collects the server's response.
+    let writer = std::thread::spawn(move || {
+        let data = vec![b'a'; OVERSIZED];
+        write_all_loop(client_fd, &data);
+        shutdown(client_fd, libc::SHUT_WR);
+        let seen = read_to_eof(client_fd);
+        unsafe { libc::close(client_fd) };
+        seen
+    });
+
+    // Generous deadline: the byte-by-byte 1 MiB consume takes a few seconds of
+    // syscalls; the point of this case is the Error line, not the latency bound
+    // (which the EOF cuts above already pin).
+    let result = read_request_and_handshake(server_fd, Duration::from_secs(60));
+    assert!(result.is_none(), "oversized request must not execute");
+
+    let seen = String::from_utf8_lossy(&writer.join().unwrap()).into_owned();
+    assert!(
+        seen.contains("\"error\"") && seen.contains("exceeds"),
+        "peer must receive the pre-ACK Error line, saw {:?}",
+        seen
+    );
+    assert!(
+        !seen.contains(exec_proto::HANDSHAKE_ACK),
+        "an oversized request must never be ACKed, saw {:?}",
+        seen
+    );
+}
+
+/// Invalid JSON and empty-command requests are rejected with a pre-ACK Error
+/// line (deterministic rejection, not a silent close that would look resend-safe).
+#[test]
+fn fuzz_invalid_requests_get_pre_ack_error_line() {
+    for (bad, why) in [
+        (&b"not json\n"[..], "invalid JSON"),
+        (
+            &b"{\"command\":[],\"in_container\":false}\n"[..],
+            "empty command",
+        ),
+    ] {
+        let outcome = run_prebuffered_cut(bad);
+        assert!(outcome.result.is_none(), "{} must not execute", why);
+        let seen = String::from_utf8_lossy(&outcome.client_saw).into_owned();
+        assert!(
+            seen.contains("\"error\""),
+            "{} must produce a pre-ACK Error line, saw {:?}",
+            why,
+            seen
+        );
+        assert!(
+            !seen.contains(exec_proto::HANDSHAKE_ACK),
+            "{} must never be ACKed, saw {:?}",
+            why,
+            seen
+        );
+    }
+}

--- a/fc-agent/src/main.rs
+++ b/fc-agent/src/main.rs
@@ -78,6 +78,19 @@ async fn main() {
 
     eprintln!("[fc-agent] starting");
 
+    // Arm guest failpoints from the kernel cmdline: fcvm forwards the host env
+    // FCVM_GUEST_FAILPOINT as `fcvm_failpoint=<spec>` (the fuse_trace_rate
+    // pattern) because fc-agent cannot read host env. Sleep actions only in the
+    // guest — block_until_file is host-only, rejected by fcvm before boot.
+    if let Ok(cmdline) = std::fs::read_to_string("/proc/cmdline") {
+        if let Some(spec) = cmdline
+            .split_whitespace()
+            .find_map(|part| part.strip_prefix("fcvm_failpoint="))
+        {
+            failpoint::arm_from_str(spec);
+        }
+    }
+
     if let Err(e) = agent::run().await {
         eprintln!("[fc-agent] ==========================================");
         eprintln!("[fc-agent] FATAL ERROR: Container failed to start");

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -2428,6 +2428,9 @@ pub async fn create_snapshot_core(
 
     // Pause VM before snapshotting (required by Firecracker).
     // If Pause fails/times out, the VM is NOT paused — no resume needed.
+    // failpoint: widen the window just before the pause — makes "in-flight
+    // exec/curl/serial write collides with the VM pause" deterministic.
+    failpoint::hit_async("snapshot.pre_pause").await;
     info!(snapshot = %snapshot_config.name, "pausing VM for snapshot");
     if let Err(e) = pause_client
         .patch_vm_state(ApiVmState {
@@ -2539,6 +2542,10 @@ pub async fn create_snapshot_core(
 
     // Resume VM (ALWAYS, regardless of snapshot/disk copy result).
     // Memory merge happens after resume since it operates on snapshot files, not live disk.
+    // failpoint: hold after the snapshot save (VM still paused) and before resume —
+    // makes "client observes a saved-but-still-paused VM" (stalled exec/curl/vsock
+    // across an arbitrarily long pause) deterministic.
+    failpoint::hit_async("snapshot.post_save_pre_resume").await;
     let resume_result = snapshot_client
         .patch_vm_state(ApiVmState {
             state: "Resumed".to_string(),

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -878,6 +878,13 @@ pub async fn start_exec_session_async(
     Ok((stream, guard))
 }
 
+// TIER 0 protocol-interleaving fuzz: scripted fake agents enumerating connection
+// death at every handshake stage, plus the exactly-once execution property
+// (kept in its own file — see exec_fuzz_tests.rs).
+#[cfg(test)]
+#[path = "exec_fuzz_tests.rs"]
+mod exec_fuzz_tests;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/commands/exec_fuzz_tests.rs
+++ b/src/commands/exec_fuzz_tests.rs
@@ -1,0 +1,461 @@
+//! TIER 0 protocol-interleaving fuzz: client side of the exec ACK/GO handshake,
+//! plus the exactly-once execution property across every cut point.
+//!
+//! A scripted fake "agent" accepts one connection per script entry on a real
+//! Unix socket (speaking Firecracker's `CONNECT <port>` preamble, exactly what
+//! `connect_and_start_exec` expects) and kills the connection at an enumerated
+//! protocol stage. The tests drive the REAL client — `connect_and_start_exec` +
+//! `read_exec_responses` — and assert:
+//!
+//! * pre-ACK deaths are classified resend-safe (the client reconnects and
+//!   resends, bounded by MAX_ACK_ATTEMPTS);
+//! * deterministic rejections (pre-ACK Error line, garbage-instead-of-ACK)
+//!   never retry;
+//! * post-ACK deaths are loud errors, never retries;
+//! * the exactly-once property: counting GO consumptions as "executions",
+//!   every enumerated interleaving yields count ≤ 1, and count == 1 whenever
+//!   the client reports success.
+//!
+//! Determinism: every cut is an event — the server closes or shuts down the
+//! socket — never a sleep. The one timing-coupled case (`SilentAfterRequest`)
+//! deliberately exercises the real 3s ACK bound with the two offsets that
+//! cannot be timing-sensitive: silence forever vs. immediate ACK.
+
+use super::{
+    connect_and_start_exec, read_exec_responses, EpochGuardedReader, ExecRequest, ExecResponse,
+};
+use anyhow::Result;
+use std::io::{BufRead, BufReader, Write};
+use std::net::Shutdown;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// What the fake agent does with one accepted connection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Conn {
+    /// Respond `OK` to CONNECT, then die before reading the request.
+    DieBeforeRequestRead,
+    /// Read the request, then die without writing any ACK bytes.
+    DieAfterRequest,
+    /// Read the request, write a partial ACK ("AC", no newline), die.
+    DiePartialAck,
+    /// Read the request, write a non-ACK garbage line, die.
+    GarbageAck,
+    /// Read the request, write a pre-ACK Error line (deterministic rejection), die.
+    ErrorLine,
+    /// Read the request, shut down the read half, ACK, die: the client's GO
+    /// write deterministically fails (the receive side was down before ACK
+    /// was even sent) — the post-ACK loud-error path.
+    AckThenReadShutdown,
+    /// Read the request, ACK, die before GO. Whether the client's GO write or
+    /// its response read observes the death is scheduling-dependent, but both
+    /// paths must fail loudly without resending — asserted at that level.
+    DieAfterAck,
+    /// Read the request, ACK, consume GO (EXECUTION), die before any response.
+    DieAfterGo,
+    /// Full happy path: ACK, consume GO (EXECUTION), respond Exit(0).
+    Complete,
+    /// Read the request, then stay silent until the client gives up (real 3s
+    /// ACK timeout) and drops the connection.
+    SilentAfterRequest,
+}
+
+/// One connection's log entry: the request line the server read (None if it
+/// died before reading one).
+type ConnLog = Option<String>;
+
+struct FakeAgent {
+    sock: PathBuf,
+    _dir: tempfile::TempDir,
+    log: Arc<Mutex<Vec<ConnLog>>>,
+    /// Number of GO lines consumed — the stand-in for "the command executed".
+    executions: Arc<AtomicUsize>,
+    handle: std::thread::JoinHandle<()>,
+}
+
+impl FakeAgent {
+    fn start(script: &[Conn]) -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock = dir.path().join("x.sock");
+        let listener = UnixListener::bind(&sock).expect("bind fake agent socket");
+        let log: Arc<Mutex<Vec<ConnLog>>> = Arc::new(Mutex::new(Vec::new()));
+        let executions = Arc::new(AtomicUsize::new(0));
+
+        let script: Vec<Conn> = script.to_vec();
+        let log2 = log.clone();
+        let executions2 = executions.clone();
+        let handle = std::thread::spawn(move || {
+            for behavior in script {
+                let (stream, _) = listener.accept().expect("accept");
+                serve_one(stream, behavior, &log2, &executions2);
+            }
+        });
+
+        FakeAgent {
+            sock,
+            _dir: dir,
+            log,
+            executions,
+            handle,
+        }
+    }
+
+    /// Assert the client made exactly `expected` connections, then reap the
+    /// server thread (it has exited its accept loop once the script is spent).
+    fn finish(self, expected_conns: usize) -> (Vec<ConnLog>, usize) {
+        let log = self.log.lock().unwrap().clone();
+        assert_eq!(
+            log.len(),
+            expected_conns,
+            "connection count mismatch: {:?}",
+            log
+        );
+        self.handle.join().expect("fake agent thread panicked");
+        (log, self.executions.load(Ordering::SeqCst))
+    }
+}
+
+fn serve_one(
+    mut stream: UnixStream,
+    behavior: Conn,
+    log: &Mutex<Vec<ConnLog>>,
+    executions: &AtomicUsize,
+) {
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+
+    // Firecracker vsock preamble: CONNECT <port> → OK <port>.
+    let mut connect = String::new();
+    reader.read_line(&mut connect).expect("read CONNECT");
+    assert!(
+        connect.starts_with("CONNECT "),
+        "expected CONNECT preamble, got {:?}",
+        connect
+    );
+    stream.write_all(b"OK 4998\n").expect("write OK");
+
+    if behavior == Conn::DieBeforeRequestRead {
+        log.lock().unwrap().push(None);
+        return; // drop closes the socket
+    }
+
+    let mut request = String::new();
+    reader.read_line(&mut request).expect("read request");
+    log.lock().unwrap().push(Some(request.trim().to_string()));
+
+    match behavior {
+        Conn::DieBeforeRequestRead => unreachable!(),
+        Conn::DieAfterRequest => {}
+        Conn::DiePartialAck => {
+            stream.write_all(b"AC").expect("write partial ACK");
+        }
+        Conn::GarbageAck => {
+            stream.write_all(b"NOT-THE-ACK\n").expect("write garbage");
+        }
+        Conn::ErrorLine => {
+            let line = serde_json::to_string(&ExecResponse::Error("boom".to_string())).unwrap();
+            stream
+                .write_all(format!("{}\n", line).as_bytes())
+                .expect("write Error line");
+        }
+        Conn::AckThenReadShutdown => {
+            // Shut the receive side BEFORE sending ACK: by the time the client
+            // sees ACK, its GO write can only fail (EPIPE) — no race.
+            stream.shutdown(Shutdown::Read).expect("shutdown read");
+            let _ = stream.write_all(format!("{}\n", exec_proto::HANDSHAKE_ACK).as_bytes());
+        }
+        Conn::DieAfterAck => {
+            stream
+                .write_all(format!("{}\n", exec_proto::HANDSHAKE_ACK).as_bytes())
+                .expect("write ACK");
+        }
+        Conn::DieAfterGo | Conn::Complete => {
+            stream
+                .write_all(format!("{}\n", exec_proto::HANDSHAKE_ACK).as_bytes())
+                .expect("write ACK");
+            let mut go = String::new();
+            reader.read_line(&mut go).expect("read GO");
+            assert_eq!(go.trim_end_matches('\n'), exec_proto::HANDSHAKE_GO);
+            // GO consumed — this is the execution point.
+            executions.fetch_add(1, Ordering::SeqCst);
+            if behavior == Conn::Complete {
+                let line = serde_json::to_string(&ExecResponse::Exit(0)).unwrap();
+                stream
+                    .write_all(format!("{}\n", line).as_bytes())
+                    .expect("write Exit");
+            }
+        }
+        Conn::SilentAfterRequest => {
+            // Say nothing; block until the client times out (3s ACK bound) and
+            // drops the connection, which lands here as EOF.
+            let mut rest = String::new();
+            let _ = reader.read_line(&mut rest);
+        }
+    }
+}
+
+fn test_request() -> ExecRequest {
+    ExecRequest {
+        command: vec!["true".to_string()],
+        in_container: false,
+        interactive: false,
+        tty: false,
+    }
+}
+
+/// Run the real client end-to-end: handshake, then read responses to the exit
+/// code. This is exactly what `run_exec_in_vm` does inside spawn_blocking —
+/// including the post-GO `EpochGuardedReader`. The vm_id names no state file,
+/// so the snapshot-orphan guard captures a `None` baseline and never fires
+/// (the documented behavior for VMs without persisted state); these tests cut
+/// connections at the socket level, which the guard is not involved in.
+fn run_client(sock: &Path) -> Result<i32> {
+    let (stream, guard) = connect_and_start_exec(sock, &test_request(), "tier0-fuzz-no-such-vm")?;
+    let reader = BufReader::new(EpochGuardedReader::new(stream, guard));
+    read_exec_responses(reader, |_| {}, |_| {})
+}
+
+/// The request line every connection must carry (resends must be byte-identical).
+fn expected_request_line() -> String {
+    serde_json::to_string(&test_request()).unwrap()
+}
+
+#[test]
+fn fuzz_client_happy_path_immediate_ack() {
+    let agent = FakeAgent::start(&[Conn::Complete]);
+    let code = run_client(&agent.sock).expect("exec should succeed");
+    assert_eq!(code, 0);
+    let (log, execs) = agent.finish(1);
+    assert_eq!(log[0].as_deref(), Some(expected_request_line().as_str()));
+    assert_eq!(execs, 1);
+}
+
+/// Server dies before even reading the request: NotAcked → resend-safe → the
+/// second connection succeeds. Exactly one execution.
+#[test]
+fn fuzz_client_resends_after_death_before_request_read() {
+    let agent = FakeAgent::start(&[Conn::DieBeforeRequestRead, Conn::Complete]);
+    let code = run_client(&agent.sock).expect("resend should succeed");
+    assert_eq!(code, 0);
+    let (log, execs) = agent.finish(2);
+    assert_eq!(log[0], None);
+    assert_eq!(log[1].as_deref(), Some(expected_request_line().as_str()));
+    assert_eq!(execs, 1, "the dead first connection must not execute");
+}
+
+/// Server reads the request then dies with no ACK bytes: NotAcked → the resend
+/// carries the byte-identical request and succeeds. Exactly one execution.
+#[test]
+fn fuzz_client_resends_after_death_after_request() {
+    let agent = FakeAgent::start(&[Conn::DieAfterRequest, Conn::Complete]);
+    let code = run_client(&agent.sock).expect("resend should succeed");
+    assert_eq!(code, 0);
+    let (log, execs) = agent.finish(2);
+    let expected = expected_request_line();
+    assert_eq!(log[0].as_deref(), Some(expected.as_str()));
+    assert_eq!(log[1].as_deref(), Some(expected.as_str()));
+    assert_eq!(execs, 1);
+}
+
+/// A partial ACK ("AC" then EOF) is NOT an ACK: still resend-safe.
+#[test]
+fn fuzz_client_resends_after_partial_ack() {
+    let agent = FakeAgent::start(&[Conn::DiePartialAck, Conn::Complete]);
+    let code = run_client(&agent.sock).expect("resend should succeed");
+    assert_eq!(code, 0);
+    let (_, execs) = agent.finish(2);
+    assert_eq!(execs, 1);
+}
+
+/// Every attempt dies pre-ACK: the client must give up loudly after exactly
+/// MAX_ACK_ATTEMPTS (5) connections — bounded, no hang, zero executions.
+#[test]
+fn fuzz_client_notacked_retries_are_bounded() {
+    let agent = FakeAgent::start(&[Conn::DieAfterRequest; 5]);
+    let err = run_client(&agent.sock).expect_err("must give up after bounded retries");
+    let msg = format!("{:#}", err);
+    assert!(
+        msg.contains("never acknowledged after 5 attempts"),
+        "unexpected error: {msg}"
+    );
+    let (_, execs) = agent.finish(5);
+    assert_eq!(execs, 0);
+}
+
+/// A pre-ACK Error line is a deterministic rejection: exactly one line is
+/// consumed, the agent's message is surfaced, and the client never resends.
+#[test]
+fn fuzz_client_rejected_error_line_never_resends() {
+    let agent = FakeAgent::start(&[Conn::ErrorLine]);
+    let err = run_client(&agent.sock).expect_err("rejection must fail");
+    let msg = format!("{:#}", err);
+    assert!(
+        msg.contains("fc-agent rejected the exec request: boom"),
+        "unexpected error: {msg}"
+    );
+    let (_, execs) = agent.finish(1);
+    assert_eq!(execs, 0);
+}
+
+/// Garbage instead of ACK is a protocol violation → Rejected, never resent.
+#[test]
+fn fuzz_client_garbage_ack_never_resends() {
+    let agent = FakeAgent::start(&[Conn::GarbageAck]);
+    let err = run_client(&agent.sock).expect_err("protocol violation must fail");
+    let msg = format!("{:#}", err);
+    assert!(
+        msg.contains("protocol violation"),
+        "unexpected error: {msg}"
+    );
+    let (_, execs) = agent.finish(1);
+    assert_eq!(execs, 0);
+}
+
+/// The GO write fails after ACK was received: a loud post-GO error naming the
+/// double-execution hazard — and provably no retry (one connection).
+#[test]
+fn fuzz_client_go_write_failure_is_loud_and_never_resends() {
+    let agent = FakeAgent::start(&[Conn::AckThenReadShutdown]);
+    let err = run_client(&agent.sock).expect_err("GO write failure must fail loudly");
+    let msg = format!("{:#}", err);
+    assert!(
+        msg.contains("Not resending") && msg.contains("run twice"),
+        "unexpected error: {msg}"
+    );
+    let (_, execs) = agent.finish(1);
+    assert_eq!(execs, 0, "the agent never consumed GO");
+}
+
+/// Connection dies after GO was consumed (execution started) but before any
+/// response: the outcome is unknown → error, not success, and no retry.
+#[test]
+fn fuzz_client_post_go_death_is_error_not_retry() {
+    let agent = FakeAgent::start(&[Conn::DieAfterGo]);
+    let err = run_client(&agent.sock).expect_err("unknown outcome must not be success");
+    let msg = format!("{:#}", err);
+    assert!(
+        msg.contains("before an exit status"),
+        "unexpected error: {msg}"
+    );
+    let (_, execs) = agent.finish(1);
+    assert_eq!(execs, 1, "execution started exactly once, never re-sent");
+}
+
+/// Silence instead of ACK: the real 3s ACK bound fires (this is the one
+/// deliberately timing-coupled case — silence-forever cannot race the bound),
+/// classified resend-safe, and the follow-up connection succeeds.
+#[test]
+fn fuzz_client_ack_timeout_is_resend_safe() {
+    let agent = FakeAgent::start(&[Conn::SilentAfterRequest, Conn::Complete]);
+    let start = Instant::now();
+    let code = run_client(&agent.sock).expect("resend after ACK timeout should succeed");
+    let elapsed = start.elapsed();
+    assert_eq!(code, 0);
+    assert!(
+        elapsed >= Duration::from_secs(3),
+        "the 3s ACK bound must actually be waited out, took {:?}",
+        elapsed
+    );
+    let (_, execs) = agent.finish(2);
+    assert_eq!(execs, 1);
+}
+
+/// EXACTLY-ONCE PROPERTY, enumerated: for every cut point in the handshake,
+/// executions ≤ 1 per logical request, and == 1 whenever the client reported
+/// success. This pins the no-double-execution invariant as a property over the
+/// whole interleaving space, not as individual examples.
+#[test]
+fn fuzz_exactly_once_across_all_cut_points() {
+    struct Case {
+        name: &'static str,
+        script: &'static [Conn],
+        /// Some(expected executions) when the client outcome is deterministic;
+        /// the property assertions below hold in every case regardless.
+        expect_success: bool,
+        expect_execs: usize,
+    }
+    let cases = [
+        Case {
+            name: "no cut",
+            script: &[Conn::Complete],
+            expect_success: true,
+            expect_execs: 1,
+        },
+        Case {
+            name: "cut before request read",
+            script: &[Conn::DieBeforeRequestRead, Conn::Complete],
+            expect_success: true,
+            expect_execs: 1,
+        },
+        Case {
+            name: "cut after request, before ACK",
+            script: &[Conn::DieAfterRequest, Conn::Complete],
+            expect_success: true,
+            expect_execs: 1,
+        },
+        Case {
+            name: "cut mid-ACK",
+            script: &[Conn::DiePartialAck, Conn::Complete],
+            expect_success: true,
+            expect_execs: 1,
+        },
+        Case {
+            name: "cut after ACK, before GO (GO write fails)",
+            script: &[Conn::AckThenReadShutdown],
+            expect_success: false,
+            expect_execs: 0,
+        },
+        Case {
+            name: "cut after ACK, before GO (close)",
+            script: &[Conn::DieAfterAck],
+            expect_success: false,
+            expect_execs: 0,
+        },
+        Case {
+            name: "cut after GO, before response",
+            script: &[Conn::DieAfterGo],
+            expect_success: false,
+            expect_execs: 1,
+        },
+        Case {
+            name: "cut at every attempt",
+            script: &[Conn::DieAfterRequest; 5],
+            expect_success: false,
+            expect_execs: 0,
+        },
+    ];
+
+    for case in &cases {
+        let agent = FakeAgent::start(case.script);
+        let result = run_client(&agent.sock);
+        let (_, execs) = agent.finish(case.script.len());
+
+        // The invariant proper: never more than one execution, and success
+        // implies exactly one.
+        assert!(
+            execs <= 1,
+            "[{}] executed {} times — double execution!",
+            case.name,
+            execs
+        );
+        if result.is_ok() {
+            assert_eq!(
+                execs, 1,
+                "[{}] client reported success but {} executions",
+                case.name, execs
+            );
+        }
+
+        // Per-cut determinism: outcome and count match the enumeration.
+        assert_eq!(
+            result.is_ok(),
+            case.expect_success,
+            "[{}] outcome mismatch: {:?}",
+            case.name,
+            result.err().map(|e| format!("{:#}", e))
+        );
+        assert_eq!(execs, case.expect_execs, "[{}] execution count", case.name);
+    }
+}

--- a/src/commands/podman/snapshot.rs
+++ b/src/commands/podman/snapshot.rs
@@ -276,6 +276,9 @@ pub(super) fn build_firecracker_config(
         ipv6_prefix: args.ipv6_prefix.clone(),
         portable_volumes: args.portable_volumes,
         firecracker_bin: firecracker_bin.map(|p| p.to_path_buf()),
+        // Cache-key isolation for guest failpoints (see field docs): the spec is
+        // forwarded to the guest by build_runtime_boot_args from the same env var.
+        guest_failpoint: std::env::var("FCVM_GUEST_FAILPOINT").ok(),
     }
 }
 

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -303,6 +303,20 @@ pub(crate) fn build_runtime_boot_args(
         boot_args.push_str(&format!("fuse_trace_rate={}", rate));
     }
 
+    // Pass guest failpoints to fc-agent via kernel command line (test-only
+    // deterministic-interleaving instrumentation — see the failpoint crate).
+    // Validated up front: guest specs are sleep-only and whitespace-free, and a
+    // bad spec must fail the run before a VM boots, not silently un-arm a test.
+    if let Ok(spec) = std::env::var("FCVM_GUEST_FAILPOINT") {
+        if let Err(e) = failpoint::validate_guest_spec(&spec) {
+            panic!("invalid FCVM_GUEST_FAILPOINT: {e}");
+        }
+        if !boot_args.is_empty() {
+            boot_args.push(' ');
+        }
+        boot_args.push_str(&format!("fcvm_failpoint={}", spec));
+    }
+
     // Pass FUSE max_write to fc-agent via kernel command line.
     if let Ok(max_write) = std::env::var("FCVM_FUSE_MAX_WRITE") {
         if !boot_args.is_empty() {
@@ -889,6 +903,9 @@ pub(crate) fn build_launch_config(
         rootfs_type: super::resolve_rootfs_type(args),
         port_mappings,
         firecracker_bin: runtime_config.firecracker_bin.clone(),
+        // Cache-key isolation for guest failpoints (see field docs): the spec is
+        // forwarded to the guest by build_runtime_boot_args from the same env var.
+        guest_failpoint: std::env::var("FCVM_GUEST_FAILPOINT").ok(),
     }
 }
 

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -1351,6 +1351,11 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
     };
     // Restore via the backend that created the snapshot. Both are boxed as `dyn Hypervisor`
     // so the downstream health/exit/cleanup handling is backend-agnostic.
+    // failpoint: hold right before the restore resumes/unblocks the VM (the resume
+    // happens inside restore_from_snapshot{,_ch} below) — clone infra (state file,
+    // status listener, network) is already live, so "client arrives before the
+    // restored guest ever runs" becomes deterministic.
+    failpoint::hit_async("restore.pre_resume").await;
     let setup_result: Result<(
         Box<dyn crate::hypervisor::Hypervisor>,
         Option<tokio::process::Child>,

--- a/src/firecracker/config.rs
+++ b/src/firecracker/config.rs
@@ -116,6 +116,14 @@ pub struct FirecrackerConfig {
     /// created by one FC version cannot be restored by another.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub firecracker_bin: Option<PathBuf>,
+    /// Guest failpoint spec (FCVM_GUEST_FAILPOINT), forwarded to fc-agent on the
+    /// kernel cmdline as `fcvm_failpoint=`. The runtime boot-args string is
+    /// excluded from the cache key, so this dedicated field puts the spec in the
+    /// key: a snapshot whose guest booted with failpoints armed must never be
+    /// restored by a normal run (and vice versa) — fuzz VMs get their own cache
+    /// entries. None (the default) is skip-serialized so existing keys are unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub guest_failpoint: Option<String>,
 }
 
 impl Default for FirecrackerConfig {
@@ -146,6 +154,7 @@ impl Default for FirecrackerConfig {
             ipv6_prefix: None,
             portable_volumes: false,
             firecracker_bin: None,
+            guest_failpoint: None,
         }
     }
 }
@@ -518,6 +527,17 @@ mod tests {
         let config1 = test_config();
         let mut config2 = test_config();
         config2.privileged = true;
+        assert_ne!(config1.snapshot_key(), config2.snapshot_key());
+    }
+
+    /// Guest failpoints ride the kernel cmdline and are baked into the snapshot,
+    /// so a run with FCVM_GUEST_FAILPOINT set must compute a different key —
+    /// fuzz VMs never pollute (or reuse) normal snapshot caches.
+    #[test]
+    fn test_snapshot_key_changes_with_guest_failpoint() {
+        let config1 = test_config();
+        let mut config2 = test_config();
+        config2.guest_failpoint = Some("exec.post_accept_pre_read:sleep:100".to_string());
         assert_ne!(config1.snapshot_key(), config2.snapshot_key());
     }
 

--- a/src/health.rs
+++ b/src/health.rs
@@ -190,6 +190,13 @@ pub fn spawn_health_monitor_full(
                 }
             }
 
+            // failpoint: hold between the first-healthy ack gate above and the
+            // state-file persist — makes "client races the externally-visible
+            // Healthy transition" (exec/curl just before Healthy lands) deterministic.
+            if check_ok && health_status == HealthStatus::Healthy {
+                failpoint::hit_async("health.pre_persist_healthy").await;
+            }
+
             // Persist after the gate above. A failed check persists nothing (same as
             // before the check/persist split): the next iteration retries.
             let mut persisted = false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,10 @@ async fn main() -> Result<()> {
     // Raise resource limits early for fuse-pipe server
     raise_resource_limits();
 
+    // Arm deterministic lifecycle failpoints from FCVM_FAILPOINT (test-only
+    // instrumentation; no-op when unset). Once, before any command runs.
+    failpoint::arm_from_env();
+
     // Parse CLI arguments
     let cli = cli::Cli::parse();
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -35,17 +35,25 @@ pub struct TestLogger {
 }
 
 impl TestLogger {
-    /// Create a new test logger. Logs are written to /tmp/fcvm-test-logs/{test_name}-{timestamp}-{pid}.log
+    /// Create a new test logger. Logs are written to
+    /// /tmp/fcvm-test-logs/{test_name}-{timestamp}-{pid}-{seq}.log. The seq
+    /// counter disambiguates spawns that share a name (e.g. two name-less
+    /// `snapshot create` children) within the same second and process, which
+    /// would otherwise interleave into one file.
     pub fn new(test_name: &str) -> Self {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static LOG_SEQ: AtomicU64 = AtomicU64::new(0);
+
         // Create log directory if needed
         std::fs::create_dir_all(TEST_LOG_DIR).ok();
 
         // Include PID to avoid conflicts between host and container tests
         let timestamp = chrono::Utc::now().format("%Y%m%d-%H%M%S");
         let pid = std::process::id();
+        let seq = LOG_SEQ.fetch_add(1, Ordering::Relaxed);
         let log_path = PathBuf::from(format!(
-            "{}/{}-{}-{}.log",
-            TEST_LOG_DIR, test_name, timestamp, pid
+            "{}/{}-{}-{}-{}.log",
+            TEST_LOG_DIR, test_name, timestamp, pid, seq
         ));
 
         // Create the file — panic immediately if directory isn't writable.
@@ -470,6 +478,19 @@ pub async fn spawn_fcvm_with_env(
     args: &[&str],
     env_vars: &[(&str, &str)],
 ) -> anyhow::Result<(tokio::process::Child, u32)> {
+    let (child, pid, _log_path) = spawn_fcvm_with_env_and_log_path(args, env_vars).await?;
+    Ok((child, pid))
+}
+
+/// Same as `spawn_fcvm_with_env` but also returns the debug log file path.
+///
+/// Use this when a test needs BOTH environment variables (e.g. `FCVM_FAILPOINT` /
+/// `FCVM_GUEST_FAILPOINT`) AND the log path, to sequence on marker lines like
+/// `FAILPOINT <name> reached` (see the failpoint crate's marker contract).
+pub async fn spawn_fcvm_with_env_and_log_path(
+    args: &[&str],
+    env_vars: &[(&str, &str)],
+) -> anyhow::Result<(tokio::process::Child, u32, PathBuf)> {
     // Ensure config exists (runs once per test process)
     ensure_config_exists();
 
@@ -484,6 +505,7 @@ pub async fn spawn_fcvm_with_env(
         .unwrap_or("fcvm");
 
     let logger = TestLogger::new(name);
+    let log_path = logger.path().clone();
 
     let mut cmd = tokio::process::Command::new(&fcvm_path);
     cmd.args(&final_args)
@@ -513,7 +535,7 @@ pub async fn spawn_fcvm_with_env(
     spawn_log_consumer_to_file(child.stdout.take(), name, Some(logger.clone()), false);
     spawn_log_consumer_to_file(child.stderr.take(), name, Some(logger), true);
 
-    Ok((child, pid))
+    Ok((child, pid, log_path))
 }
 
 /// Spawn fcvm with piped IO and automatic log consumers.
@@ -1016,6 +1038,10 @@ pub async fn create_snapshot_by_pid(pid: u32, snapshot_name: &str) -> anyhow::Re
             "--tag",
             snapshot_name,
         ])
+        // Callers race this future against a timeout; without kill_on_drop a
+        // timed-out create would survive as an orphan mid pause/save and could
+        // leave the target VM paused while the caller tears it down.
+        .kill_on_drop(true)
         .output()
         .await?;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -491,6 +491,32 @@ pub async fn spawn_fcvm_with_env_and_log_path(
     args: &[&str],
     env_vars: &[(&str, &str)],
 ) -> anyhow::Result<(tokio::process::Child, u32, PathBuf)> {
+    spawn_fcvm_with_env_and_log_path_inner(args, env_vars, &[]).await
+}
+
+/// Same as `spawn_fcvm_with_env_and_log_path`, but with the snapshot lifecycle
+/// explicitly ENABLED regardless of the ambient test environment.
+///
+/// The CI SnapshotDisabled lane exports `FCVM_NO_SNAPSHOT=1` so that ORDINARY
+/// tests cover fcvm's no-snapshot path. A test whose SUBJECT is the snapshot
+/// lifecycle (startup-snapshot healthy gate, pre-start snapshot quiesce,
+/// teardown racing a snapshot pause) would inherit that lane's env and assert
+/// behavior the lane deliberately turned off. Such a test must opt back into
+/// snapshots explicitly — then it tests what it claims in EVERY lane.
+pub async fn spawn_fcvm_snapshots_enabled_with_env_and_log_path(
+    args: &[&str],
+    env_vars: &[(&str, &str)],
+) -> anyhow::Result<(tokio::process::Child, u32, PathBuf)> {
+    spawn_fcvm_with_env_and_log_path_inner(args, env_vars, &["FCVM_NO_SNAPSHOT"]).await
+}
+
+/// Shared implementation: spawn fcvm with `env_vars` set and `env_remove`
+/// explicitly REMOVED from the child's environment (overriding inheritance).
+async fn spawn_fcvm_with_env_and_log_path_inner(
+    args: &[&str],
+    env_vars: &[(&str, &str)],
+    env_remove: &[&str],
+) -> anyhow::Result<(tokio::process::Child, u32, PathBuf)> {
     // Ensure config exists (runs once per test process)
     ensure_config_exists();
 
@@ -517,6 +543,11 @@ pub async fn spawn_fcvm_with_env_and_log_path(
     for (key, value) in env_vars {
         cmd.env(key, value);
     }
+    // Explicitly drop inherited variables (e.g. the SnapshotDisabled CI lane's
+    // FCVM_NO_SNAPSHOT=1) that the test overrides for its subject.
+    for key in env_remove {
+        cmd.env_remove(key);
+    }
     set_test_pdeathsig(&mut cmd);
 
     let mut child = cmd
@@ -528,8 +559,8 @@ pub async fn spawn_fcvm_with_env_and_log_path(
         .ok_or_else(|| anyhow::anyhow!("failed to get fcvm PID"))?;
 
     logger.info(&format!(
-        "Spawned fcvm PID={} args={:?} env={:?}",
-        pid, args, env_vars
+        "Spawned fcvm PID={} args={:?} env={:?} env_removed={:?}",
+        pid, args, env_vars, env_remove
     ));
 
     spawn_log_consumer_to_file(child.stdout.take(), name, Some(logger.clone()), false);

--- a/tests/test_fc_mock.rs
+++ b/tests/test_fc_mock.rs
@@ -474,11 +474,127 @@ async fn test_fc_mock_exec_connect_protocol() -> Result<()> {
     assert!(got_exit, "should have received exit response");
     assert_eq!(exit_code, Some(0), "exit code should be 0");
 
+    // --- TIER 0 parity: drop-after-ACK against the real fc-mock server ---
+    // Abandon a handshake between ACK and GO (the snapshot-pause orphan shape).
+    // The command would create a marker file if it ever executed; fc-mock must
+    // close the connection without executing and stay fully serviceable.
+    let marker = format!("/tmp/fc-mock-exec-orphan-marker-{}", std::process::id());
+    let _ = std::fs::remove_file(&marker);
+    {
+        let stream = tokio::net::UnixStream::connect(&vsock_path)
+            .await
+            .context("connecting orphan handshake")?;
+        let (read_half, mut write_half) = stream.into_split();
+        let mut reader = BufReader::new(read_half);
+        write_half.write_all(b"CONNECT 4998\n").await?;
+        let mut line = String::new();
+        tokio::time::timeout(Duration::from_secs(5), reader.read_line(&mut line))
+            .await
+            .context("timeout reading orphan OK")?
+            .context("reading orphan OK line")?;
+        assert_eq!(line.trim(), "OK 4998");
+
+        let orphan_request = serde_json::json!({
+            "command": ["touch", marker],
+            "in_container": false,
+            "interactive": false,
+            "tty": false
+        });
+        write_half
+            .write_all(format!("{}\n", serde_json::to_string(&orphan_request)?).as_bytes())
+            .await?;
+        line.clear();
+        tokio::time::timeout(Duration::from_secs(5), reader.read_line(&mut line))
+            .await
+            .context("timeout reading orphan ACK")?
+            .context("reading orphan ACK line")?;
+        assert_eq!(
+            line.trim(),
+            exec_proto::HANDSHAKE_ACK,
+            "orphan connection should be ACKed before being dropped"
+        );
+        // Drop both halves WITHOUT sending GO.
+    }
+    println!("  Orphaned a handshake after ACK (no GO sent)");
+
+    // The server must survive the orphan: a fresh connection completes a full
+    // exec (this also strictly orders the runtime past the orphan's EOF handling).
+    {
+        let stream = tokio::net::UnixStream::connect(&vsock_path)
+            .await
+            .context("connecting post-orphan exec")?;
+        let (read_half, mut write_half) = stream.into_split();
+        let mut reader = BufReader::new(read_half);
+        write_half.write_all(b"CONNECT 4998\n").await?;
+        let mut line = String::new();
+        tokio::time::timeout(Duration::from_secs(5), reader.read_line(&mut line))
+            .await
+            .context("timeout reading post-orphan OK")?
+            .context("reading post-orphan OK line")?;
+        assert_eq!(line.trim(), "OK 4998");
+
+        let request = serde_json::json!({
+            "command": ["echo", "alive-after-orphan"],
+            "in_container": false,
+            "interactive": false,
+            "tty": false
+        });
+        write_half
+            .write_all(format!("{}\n", serde_json::to_string(&request)?).as_bytes())
+            .await?;
+        line.clear();
+        tokio::time::timeout(Duration::from_secs(5), reader.read_line(&mut line))
+            .await
+            .context("timeout reading post-orphan ACK")?
+            .context("reading post-orphan ACK line")?;
+        assert_eq!(line.trim(), exec_proto::HANDSHAKE_ACK);
+        write_half
+            .write_all(format!("{}\n", exec_proto::HANDSHAKE_GO).as_bytes())
+            .await?;
+
+        let mut post_stdout = String::new();
+        let mut post_exit: Option<i32> = None;
+        loop {
+            line.clear();
+            let n = tokio::time::timeout(Duration::from_secs(10), reader.read_line(&mut line))
+                .await
+                .context("timeout reading post-orphan responses")?
+                .context("reading post-orphan response line")?;
+            if n == 0 {
+                break;
+            }
+            let resp: serde_json::Value =
+                serde_json::from_str(line.trim()).context("parsing post-orphan response")?;
+            match resp["type"].as_str() {
+                Some("stdout") => post_stdout.push_str(resp["data"].as_str().unwrap_or("")),
+                Some("exit") => {
+                    post_exit = resp["data"].as_i64().map(|v| v as i32);
+                    break;
+                }
+                _ => {}
+            }
+        }
+        assert!(
+            post_stdout.contains("alive-after-orphan"),
+            "exec after an orphaned handshake should work, got stdout: {:?}",
+            post_stdout
+        );
+        assert_eq!(post_exit, Some(0), "post-orphan exec should exit 0");
+    }
+    println!("  Server fully serviceable after the orphaned handshake");
+
     // Cleanup
     common::kill_process(mock_pid).await;
     let _ = std::fs::remove_file(&socket_path);
     let _ = std::fs::remove_file(&vsock_path);
     let _ = std::fs::remove_file(&status_socket);
+
+    // With fc-mock dead, the marker verdict is final: the ACKed-but-never-GOed
+    // command must not have executed.
+    assert!(
+        !std::path::Path::new(&marker).exists(),
+        "fc-mock executed a command whose handshake never received GO"
+    );
 
     println!("✅ FC-MOCK EXEC CONNECT PROTOCOL TEST PASSED!");
     Ok(())

--- a/tests/test_fuzz_chaos.rs
+++ b/tests/test_fuzz_chaos.rs
@@ -1,0 +1,698 @@
+//! TIER 2: seeded lifecycle chaos harness.
+//!
+//! Boots ONE real rootless VM per seed and fires a randomized (but seeded)
+//! schedule of lifecycle-adjacent operations at it — execs (plain + tty),
+//! port-forward curls, state reads, snapshot creates, console floods, and
+//! jitter sleeps — then shuts down gracefully and checks the end-state
+//! oracles: every exec-appended nonce landed exactly once in the mapped file,
+//! no firecracker/pasta process for the VM survived, and the state file is
+//! gone. A state read that observes `Healthy` immediately chains a curl to
+//! the forwarded port: the Healthy⇒live oracle, sampled at random times.
+//!
+//! # Determinism
+//!
+//! This harness is **schedule-deterministic, not cycle-deterministic**: the
+//! same seed always produces the same op sequence, the same nonces/tags, and
+//! the same jitter delays (`SmallRng::seed_from_u64(seed)`, one `u64` draw
+//! per op), but the wall-clock interleaving against VM-internal events still
+//! varies run to run. The shrinking path for a failure is therefore:
+//! reproduce with the failing seed (see the replay hint in the panic), read
+//! the `FUZZ seed=…` trace to identify the racing pair, then pin that exact
+//! interleaving as a named failpoint case in `test_lifecycle_interleave.rs`
+//! (crate `failpoint/` documents the marker contract).
+//!
+//! # Knobs
+//!
+//! - `FCVM_FUZZ_SEEDS` (default `"1"`): comma list of literal seeds
+//!   (`"3,17,42"` — a trailing comma like `"7,"` forces list form for a
+//!   single literal seed) or a bare count `N` meaning seeds `1..=N`.
+//! - `FCVM_FUZZ_OPS` (default `10`): ops per seed.
+//!
+//! Run via `make fuzz SEEDS=25 OPS=30`.
+
+#![cfg(feature = "integration-fast")]
+
+mod common;
+
+use anyhow::{bail, ensure, Context, Result};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+
+/// Hard per-op timeout: an op that neither completes nor errors within this
+/// FAILS the seed. Generous — every op here normally finishes in seconds.
+const OP_TIMEOUT: Duration = Duration::from_secs(60);
+/// Snapshot create pauses the VM and writes a multi-GB memory image; give it
+/// a larger (still hard) budget than ordinary ops.
+const SNAPSHOT_OP_TIMEOUT: Duration = Duration::from_secs(120);
+/// At most this many SnapshotCreate ops per seed (disk: each is multi-GB).
+const MAX_SNAPSHOTS_PER_SEED: usize = 2;
+/// Bounded wait for first-healthy (covers cold-cache boot incl. the pre-start
+/// startup-snapshot create + converge-on-miss relaunch).
+const HEALTHY_TIMEOUT_SECS: u64 = 300;
+/// Bounded wait for fcvm to exit after SIGTERM. Not exiting in time FAILS the
+/// seed — graceful shutdown hanging is a bug, not something to force-kill over.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
+
+const GUEST_NONCE_FILE: &str = "/mnt/fuzz/nonces.txt";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Op {
+    /// Append a seeded nonce to the mapped file via plain (non-tty) exec.
+    ExecNonce,
+    /// Echo a token through a tty-mode exec.
+    ExecTty,
+    /// Single curl to the forwarded port.
+    CurlPort,
+    /// Read + parse the VM state; if it claims Healthy, chain an immediate
+    /// CurlPort — the Healthy⇒live oracle at a random time.
+    StateRead,
+    /// `fcvm snapshot create --pid <vm> --tag <seeded>` (max 2 per seed).
+    SnapshotCreate,
+    /// Flood the console/exec stream with 5000 lines of output.
+    ConsoleFlood,
+    /// Seeded 0-400ms sleep (also substituted when the snapshot budget is
+    /// spent, keeping rng consumption uniform at one draw per op).
+    JitterSleep,
+}
+
+/// Sampling weights. Order matters only for the cumulative walk; the draw is
+/// a single `gen_range` so the schedule is a pure function of the seed.
+const OP_WEIGHTS: &[(Op, u32)] = &[
+    (Op::ExecNonce, 20),
+    (Op::ExecTty, 10),
+    (Op::CurlPort, 20),
+    (Op::StateRead, 15),
+    (Op::SnapshotCreate, 6),
+    (Op::ConsoleFlood, 9),
+    (Op::JitterSleep, 20),
+];
+
+fn sample_op(rng: &mut SmallRng) -> Op {
+    let total: u32 = OP_WEIGHTS.iter().map(|(_, w)| w).sum();
+    let mut x = rng.gen_range(0..total);
+    for &(op, w) in OP_WEIGHTS {
+        if x < w {
+            return op;
+        }
+        x -= w;
+    }
+    unreachable!("weight walk exhausted");
+}
+
+/// Parse FCVM_FUZZ_SEEDS: comma list of literal seeds, or bare count N = 1..=N.
+fn parse_seeds(spec: &str) -> Vec<u64> {
+    let spec = spec.trim();
+    if spec.contains(',') {
+        let seeds: Vec<u64> = spec
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|s| {
+                s.parse()
+                    .unwrap_or_else(|_| panic!("FCVM_FUZZ_SEEDS: bad seed {:?} in {:?}", s, spec))
+            })
+            .collect();
+        assert!(
+            !seeds.is_empty(),
+            "FCVM_FUZZ_SEEDS: empty seed list {:?}",
+            spec
+        );
+        seeds
+    } else {
+        let n: u64 = spec
+            .parse()
+            .unwrap_or_else(|_| panic!("FCVM_FUZZ_SEEDS: bad count {:?}", spec));
+        assert!(n >= 1, "FCVM_FUZZ_SEEDS: count must be >= 1");
+        (1..=n).collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// /proc helpers for the leaked-process oracle
+// ---------------------------------------------------------------------------
+
+/// Fields of /proc/<pid>/stat AFTER the `(comm)` — comm may contain spaces and
+/// parens, so split on the LAST ')'. Index 1 = ppid (field 4), index 19 =
+/// starttime (field 22, clock ticks since boot).
+fn proc_stat_after_comm(pid: u32) -> Option<Vec<String>> {
+    let stat = std::fs::read_to_string(format!("/proc/{}/stat", pid)).ok()?;
+    let (_, rest) = stat.rsplit_once(')')?;
+    Some(rest.split_whitespace().map(str::to_string).collect())
+}
+
+fn ppid_of(pid: u32) -> Option<u32> {
+    proc_stat_after_comm(pid)?.get(1)?.parse().ok()
+}
+
+fn start_time_of(pid: u32) -> Option<u64> {
+    proc_stat_after_comm(pid)?.get(19)?.parse().ok()
+}
+
+/// Walk the ppid chain (bounded) to see whether `ancestor` is above `pid`.
+fn is_descendant_of(pid: u32, ancestor: u32) -> bool {
+    let mut cur = pid;
+    for _ in 0..64 {
+        match ppid_of(cur) {
+            Some(0) | None => return false,
+            Some(p) if p == ancestor => return true,
+            Some(p) => cur = p,
+        }
+    }
+    false
+}
+
+/// A (pid, starttime) pair uniquely identifies a process even after PID reuse
+/// (same identity check the state manager uses).
+#[derive(Debug)]
+struct TrackedProc {
+    pid: u32,
+    start: u64,
+    label: &'static str,
+}
+
+impl TrackedProc {
+    fn alive(&self) -> bool {
+        start_time_of(self.pid) == Some(self.start)
+    }
+}
+
+/// Find live descendants of `fcvm_pid` whose cmdline matches `pattern`.
+async fn find_descendants(fcvm_pid: u32, pattern: &str, label: &'static str) -> Vec<TrackedProc> {
+    let mut found = Vec::new();
+    let Ok(out) = tokio::process::Command::new("pgrep")
+        .args(["-f", pattern])
+        .output()
+        .await
+    else {
+        return found;
+    };
+    for line in String::from_utf8_lossy(&out.stdout).lines() {
+        let Ok(pid) = line.trim().parse::<u32>() else {
+            continue;
+        };
+        if !is_descendant_of(pid, fcvm_pid) {
+            continue;
+        }
+        // The pid could die between pgrep and this read; a None start just
+        // means it is already gone and there is nothing to track.
+        if let Some(start) = start_time_of(pid) {
+            found.push(TrackedProc { pid, start, label });
+        }
+    }
+    found
+}
+
+// ---------------------------------------------------------------------------
+// State parsing
+// ---------------------------------------------------------------------------
+
+#[derive(serde::Deserialize)]
+struct VmDisplay {
+    #[serde(flatten)]
+    vm: fcvm::state::VmState,
+    #[allow(dead_code)]
+    stale: bool,
+}
+
+/// `fcvm ls --json --pid <pid>` parsed into typed state (never regex on JSON).
+async fn read_vm_state(pid: u32) -> Result<Vec<VmDisplay>> {
+    let fcvm_path = common::find_fcvm_binary()?;
+    let output = tokio::process::Command::new(&fcvm_path)
+        .args(["ls", "--json", "--pid", &pid.to_string()])
+        .output()
+        .await
+        .context("running fcvm ls --json")?;
+    ensure!(
+        output.status.success(),
+        "fcvm ls failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).context("parsing fcvm ls JSON")
+}
+
+/// State files in the state dir claiming this VM name (post-shutdown oracle).
+fn state_files_for_vm(vm_name: &str) -> Vec<PathBuf> {
+    let dir = fcvm::paths::state_dir();
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|e| e == "json"))
+        .filter(|p| {
+            std::fs::read_to_string(p)
+                .ok()
+                .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+                .and_then(|v| v.get("name").and_then(|n| n.as_str()).map(|n| n == vm_name))
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Ops
+// ---------------------------------------------------------------------------
+
+/// Echo a token through a tty-mode exec (`script` provides the PTY, exactly
+/// like test_exec.rs — the harness itself has no controlling terminal).
+async fn exec_tty_echo(pid: u32, token: &str) -> Result<()> {
+    let fcvm_path = common::find_fcvm_binary()?;
+    let fcvm_cmd = format!(
+        "{} exec --pid {} -t -- echo {}",
+        shell_words::quote(&fcvm_path.to_string_lossy()),
+        pid,
+        token
+    );
+    // kill_on_drop: the per-op timeout drops this future on expiry, which must
+    // kill the spawned exec instead of orphaning it.
+    let child = tokio::process::Command::new("script")
+        .args(["-q", "-c", &fcvm_cmd, "/dev/null"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .context("spawning tty exec via script")?;
+    let output = child
+        .wait_with_output()
+        .await
+        .context("waiting for tty exec")?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    ensure!(
+        output.status.success(),
+        "tty exec exited with {:?}: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    ensure!(
+        stdout.contains(token),
+        "tty exec output missing token {:?}: {:?}",
+        token,
+        stdout
+    );
+    Ok(())
+}
+
+async fn curl_once(ip: &str, port: u16) -> Result<String> {
+    let r = common::curl_check(ip, port, 5).await;
+    ensure!(
+        r.success && r.body_len > 0,
+        "curl {}:{} failed (success={} body_len={} err={})",
+        ip,
+        port,
+        r.success,
+        r.body_len,
+        r.error
+    );
+    Ok(format!("body_len={}", r.body_len))
+}
+
+/// Execute one op. `draw` is the op's pre-drawn randomness (one u64 per op).
+/// Returns a short human detail for the trace line.
+#[allow(clippy::too_many_arguments)]
+async fn apply_op(
+    op: Op,
+    draw: u64,
+    seed: u64,
+    op_idx: usize,
+    pid: u32,
+    ip: &str,
+    port: u16,
+    snap_base: &str,
+    nonces: &mut Vec<String>,
+    snapshots: &mut Vec<String>,
+) -> Result<String> {
+    match op {
+        Op::ExecNonce => {
+            let nonce = format!("nonce-{}-{}-{:016x}", seed, op_idx, draw);
+            common::exec_in_container(pid, &[&format!("echo {} >> {}", nonce, GUEST_NONCE_FILE)])
+                .await
+                .with_context(|| format!("appending nonce {}", nonce))?;
+            nonces.push(nonce.clone());
+            Ok(format!("nonce={}", nonce))
+        }
+        Op::ExecTty => {
+            let token = format!("fuzz-tty-{}-{}", seed, op_idx);
+            exec_tty_echo(pid, &token).await?;
+            Ok(format!("token={}", token))
+        }
+        Op::CurlPort => curl_once(ip, port).await,
+        Op::StateRead => {
+            let vms = read_vm_state(pid).await?;
+            ensure!(
+                !vms.is_empty(),
+                "state read mid-run found no state for pid {}",
+                pid
+            );
+            let status = vms[0].vm.health_status;
+            if matches!(status, fcvm::state::HealthStatus::Healthy) {
+                // Healthy⇒live oracle: a state file claiming Healthy must be
+                // backed by a VM that actually serves traffic RIGHT NOW.
+                let detail = curl_once(ip, port)
+                    .await
+                    .context("state says Healthy but the forwarded port is dead")?;
+                Ok(format!("status={:?} chained-curl {}", status, detail))
+            } else {
+                Ok(format!("status={:?} (no chained curl)", status))
+            }
+        }
+        Op::SnapshotCreate => {
+            let tag = format!("{}-{}", snap_base, op_idx);
+            common::create_snapshot_by_pid(pid, &tag).await?;
+            snapshots.push(tag.clone());
+            Ok(format!("tag={}", tag))
+        }
+        Op::ConsoleFlood => {
+            let out = common::exec_in_container(pid, &["seq 1 5000"]).await?;
+            ensure!(
+                out.lines().any(|l| l.trim() == "5000"),
+                "console flood output truncated (no final '5000' line, got {} bytes)",
+                out.len()
+            );
+            Ok(format!("{} bytes", out.len()))
+        }
+        Op::JitterSleep => {
+            let ms = draw % 401; // 0-400ms
+            tokio::time::sleep(Duration::from_millis(ms)).await;
+            Ok(format!("{}ms", ms))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-seed run
+// ---------------------------------------------------------------------------
+
+async fn run_seed(seed: u64, total_ops: usize) -> Result<()> {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let (vm_name, _, snap_base, _) = common::unique_names(&format!("fuzz{}", seed));
+    let scratch = PathBuf::from(format!("/tmp/fcvm-fuzz-{}-{}", std::process::id(), vm_name));
+    let host_dir = scratch.join("host");
+    std::fs::create_dir_all(&host_dir).context("creating scratch dir")?;
+
+    let host_port = common::find_available_high_port()?;
+    let map_arg = format!("{}:/mnt/fuzz", host_dir.display());
+    let publish_arg = format!("{}:80", host_port);
+
+    let (mut child, pid) = common::spawn_fcvm(&[
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--network",
+        "rootless",
+        "--map",
+        &map_arg,
+        "--publish",
+        &publish_arg,
+        "--health-check",
+        "http://localhost/",
+        common::TEST_IMAGE,
+    ])
+    .await?;
+    println!(
+        "FUZZ seed={} vm={} pid={} port={} scratch={}",
+        seed,
+        vm_name,
+        pid,
+        host_port,
+        scratch.display()
+    );
+
+    let mut nonces: Vec<String> = Vec::new();
+    let mut snapshots: Vec<String> = Vec::new();
+    let body = run_seed_body(
+        seed,
+        total_ops,
+        &mut rng,
+        &mut child,
+        pid,
+        &vm_name,
+        &host_dir,
+        host_port,
+        &snap_base,
+        &mut nonces,
+        &mut snapshots,
+    )
+    .await;
+
+    // Cleanup runs on both paths. On failure the VM may still be up — kill it
+    // so a failing seed doesn't leak a VM into the rest of the suite.
+    if body.is_err() {
+        common::kill_process(pid).await;
+        let _ = child.wait().await;
+    }
+    for tag in &snapshots {
+        let _ = common::delete_snapshot(tag).await;
+    }
+    let _ = std::fs::remove_dir_all(&scratch);
+
+    body
+}
+
+/// Boot-wait, op loop, graceful shutdown, oracles. Split out so `run_seed`
+/// can guarantee cleanup around any failure.
+#[allow(clippy::too_many_arguments)]
+async fn run_seed_body(
+    seed: u64,
+    total_ops: usize,
+    rng: &mut SmallRng,
+    child: &mut tokio::process::Child,
+    pid: u32,
+    vm_name: &str,
+    host_dir: &std::path::Path,
+    host_port: u16,
+    snap_base: &str,
+    nonces: &mut Vec<String>,
+    snapshots: &mut Vec<String>,
+) -> Result<()> {
+    // -- Boot: bounded wait for first-healthy -------------------------------
+    let boot_start = Instant::now();
+    common::poll_health(child, HEALTHY_TIMEOUT_SECS)
+        .await
+        .with_context(|| format!("seed {}: VM never became healthy", seed))?;
+    println!(
+        "FUZZ seed={} healthy in {:.1}s",
+        seed,
+        boot_start.elapsed().as_secs_f64()
+    );
+
+    let ip = common::get_loopback_ip(pid).await?;
+    let vm_id = {
+        let vms = read_vm_state(pid).await?;
+        ensure!(
+            !vms.is_empty(),
+            "no state for freshly-healthy VM pid {}",
+            pid
+        );
+        vms[0].vm.vm_id.clone()
+    };
+
+    // Capture the VM's firecracker/pasta processes NOW (pid + starttime), so
+    // the post-shutdown leak oracle checks these exact processes.
+    let mut tracked = find_descendants(pid, "firecracker", "firecracker").await;
+    tracked.extend(find_descendants(pid, "pasta", "pasta").await);
+    ensure!(
+        tracked.iter().any(|t| t.label == "firecracker"),
+        "found no firecracker descendant of fcvm pid {} — leak oracle would be vacuous",
+        pid
+    );
+    println!(
+        "FUZZ seed={} tracking {:?}",
+        seed,
+        tracked
+            .iter()
+            .map(|t| format!("{}={}", t.label, t.pid))
+            .collect::<Vec<_>>()
+    );
+
+    // -- Op loop ------------------------------------------------------------
+    for i in 1..=total_ops {
+        let mut op = sample_op(rng);
+        // One uniform draw per op keeps rng consumption identical whatever
+        // the op does with it (nonce, jitter ms, or nothing).
+        let draw: u64 = rng.gen();
+        if op == Op::SnapshotCreate && snapshots.len() >= MAX_SNAPSHOTS_PER_SEED {
+            // Deterministic downgrade: pure function of the schedule so far.
+            op = Op::JitterSleep;
+        }
+        println!("FUZZ seed={} op={}/{} {:?}", seed, i, total_ops, op);
+        let timeout = if op == Op::SnapshotCreate {
+            SNAPSHOT_OP_TIMEOUT
+        } else {
+            OP_TIMEOUT
+        };
+        let t0 = Instant::now();
+        let outcome = tokio::time::timeout(
+            timeout,
+            apply_op(
+                op, draw, seed, i, pid, &ip, host_port, snap_base, nonces, snapshots,
+            ),
+        )
+        .await;
+        let took = t0.elapsed().as_secs_f64();
+        match outcome {
+            Err(_) => bail!(
+                "op {}/{} {:?} neither completed nor errored within {:?}",
+                i,
+                total_ops,
+                op,
+                timeout
+            ),
+            Ok(Err(e)) => bail!(
+                "op {}/{} {:?} failed after {:.2}s: {:#}",
+                i,
+                total_ops,
+                op,
+                took,
+                e
+            ),
+            Ok(Ok(detail)) => println!(
+                "FUZZ seed={} op={}/{} {:?} -> OK in {:.2}s ({})",
+                seed, i, total_ops, op, took, detail
+            ),
+        }
+    }
+
+    // -- Graceful shutdown --------------------------------------------------
+    println!("FUZZ seed={} shutting down (SIGTERM to {})", seed, pid);
+    let term = tokio::process::Command::new("kill")
+        .args(["-TERM", &pid.to_string()])
+        .output()
+        .await
+        .context("sending SIGTERM")?;
+    ensure!(term.status.success(), "kill -TERM {} failed", pid);
+    match tokio::time::timeout(SHUTDOWN_TIMEOUT, child.wait()).await {
+        Ok(Ok(status)) => println!("FUZZ seed={} fcvm exited: {:?}", seed, status),
+        Ok(Err(e)) => bail!("waiting for fcvm exit: {}", e),
+        Err(_) => bail!(
+            "fcvm (pid {}) did not exit within {:?} of SIGTERM",
+            pid,
+            SHUTDOWN_TIMEOUT
+        ),
+    }
+
+    // -- Oracles ------------------------------------------------------------
+    // 1) Every ExecNonce nonce appears exactly once in the mapped file.
+    let nonce_path = host_dir.join("nonces.txt");
+    let content = std::fs::read_to_string(&nonce_path).unwrap_or_default();
+    for nonce in nonces.iter() {
+        let count = content.lines().filter(|l| l.trim() == nonce).count();
+        ensure!(
+            count == 1,
+            "nonce {} appears {} times in {} (expected exactly once); file:\n{}",
+            nonce,
+            count,
+            nonce_path.display(),
+            content
+        );
+    }
+    println!(
+        "FUZZ seed={} nonce oracle OK ({} nonces, each exactly once)",
+        seed,
+        nonces.len()
+    );
+
+    // 2) No leaked firecracker/pasta for this VM. Cleanup finishes with fcvm's
+    //    exit; poll briefly (bounded) for reaping, then assert hard.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while tracked.iter().any(TrackedProc::alive) && Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    for t in &tracked {
+        ensure!(
+            !t.alive(),
+            "{} (pid {}) leaked: still running after fcvm exit",
+            t.label,
+            t.pid
+        );
+    }
+    // Belt-and-braces: nothing left on the whole host referencing this VM's
+    // name or id (fcvm itself, stray helpers holding the runtime dir, ...).
+    for needle in [vm_name, vm_id.as_str()] {
+        let out = tokio::process::Command::new("pgrep")
+            .args(["-af", needle])
+            .output()
+            .await
+            .context("pgrep leak scan")?;
+        // pgrep: 0 = matches (leak), 1 = no matches (clean), 2/3 = pgrep itself
+        // broke — which must fail the oracle rather than pass as "no leak".
+        ensure!(
+            out.status.code() == Some(1),
+            "leak scan for {:?} did not come back clean (pgrep exit {:?}):\n{}",
+            needle,
+            out.status.code(),
+            String::from_utf8_lossy(&out.stdout)
+        );
+    }
+    println!("FUZZ seed={} process-leak oracle OK", seed);
+
+    // 3) State file removed.
+    let leftover = state_files_for_vm(vm_name);
+    ensure!(
+        leftover.is_empty(),
+        "state file(s) not removed after graceful shutdown: {:?}",
+        leftover
+    );
+    let listed = read_vm_state(pid).await?;
+    ensure!(
+        listed.is_empty(),
+        "fcvm ls still reports pid {} after shutdown",
+        pid
+    );
+    println!("FUZZ seed={} state-file oracle OK", seed);
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Entry point — always runs (defaults keep it ~2-3 min: 1 seed, 10 ops)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_fuzz_lifecycle_chaos() {
+    let seeds_spec = std::env::var("FCVM_FUZZ_SEEDS").unwrap_or_else(|_| "1".to_string());
+    let ops: usize = std::env::var("FCVM_FUZZ_OPS")
+        .map(|v| {
+            v.trim()
+                .parse()
+                .unwrap_or_else(|_| panic!("FCVM_FUZZ_OPS: bad count {:?}", v))
+        })
+        .unwrap_or(10);
+    let seeds = parse_seeds(&seeds_spec);
+    println!(
+        "FUZZ run: {} seed(s) {:?}, {} ops each",
+        seeds.len(),
+        seeds,
+        ops
+    );
+
+    for &seed in &seeds {
+        println!("FUZZ ===== seed {} starting ({} ops) =====", seed, ops);
+        let t0 = Instant::now();
+        if let Err(e) = run_seed(seed, ops).await {
+            panic!(
+                "FUZZ seed {} FAILED after {:.1}s: {:#}\n\
+                 Replay: make fuzz SEEDS={}, OPS={}\n\
+                 (trailing comma = literal seed list; same seed reproduces the same \
+                 op schedule — see the FUZZ trace above for the failing interleaving, \
+                 then pin it as a failpoint case in test_lifecycle_interleave.rs)",
+                seed,
+                t0.elapsed().as_secs_f64(),
+                e,
+                seed,
+                ops
+            );
+        }
+        println!(
+            "FUZZ ===== seed {} PASSED in {:.1}s =====",
+            seed,
+            t0.elapsed().as_secs_f64()
+        );
+    }
+    println!("FUZZ all {} seed(s) passed", seeds.len());
+}

--- a/tests/test_lifecycle_interleave.rs
+++ b/tests/test_lifecycle_interleave.rs
@@ -573,6 +573,12 @@ async fn test_lifecycle_interleave_go_floor_across_ack_stall() -> Result<()> {
 /// ever regresses (Healthy persisted before/during the startup-snapshot
 /// pause), the 50ms poll lands inside the ≥3s frozen window and the one-shot
 /// 2s curl deterministically times out.
+///
+/// This test's SUBJECT is the startup-snapshot lifecycle, so it opts into
+/// snapshots explicitly (`spawn_fcvm_snapshots_enabled_*`) instead of
+/// inheriting the lane's env — the SnapshotDisabled CI lane's
+/// `FCVM_NO_SNAPSHOT=1` covers the no-snapshot path of ORDINARY tests and
+/// must not silently turn off the very pause this test pins.
 #[tokio::test]
 async fn test_lifecycle_interleave_healthy_means_live_dataplane() -> Result<()> {
     let (vm_name, _, _, _) = common::unique_names("ilv-healthy");
@@ -583,7 +589,7 @@ async fn test_lifecycle_interleave_healthy_means_live_dataplane() -> Result<()> 
     let host_port = common::find_available_high_port()?;
     let publish_arg = format!("{}:80", host_port);
 
-    let (mut child, pid, vm_log) = common::spawn_fcvm_with_env_and_log_path(
+    let (mut child, pid, vm_log) = common::spawn_fcvm_snapshots_enabled_with_env_and_log_path(
         &[
             "podman",
             "run",
@@ -719,6 +725,11 @@ async fn test_lifecycle_interleave_healthy_means_live_dataplane() -> Result<()> 
 /// serial lines and the container's console output appear after restore, the
 /// dead-serial watchdog ERROR ("captured the guest UART mid-transmit") never
 /// fires, the run reaches healthy, and SIGTERM produces an orderly exit.
+///
+/// Both runs' SUBJECT is the pre-start snapshot lifecycle, so they opt into
+/// snapshots explicitly (`spawn_fcvm_snapshots_enabled_*`) — the
+/// SnapshotDisabled lane's `FCVM_NO_SNAPSHOT=1` must not leak in and remove
+/// the create/restore path this test pins.
 #[tokio::test]
 async fn test_lifecycle_interleave_quiesce_survives_long_prepause() -> Result<()> {
     let (run1_name, run2_name, _, _) = common::unique_names("ilv-quiesce");
@@ -735,7 +746,7 @@ async fn test_lifecycle_interleave_quiesce_survives_long_prepause() -> Result<()
 
     // --- Run 1: cold boot, creates the pre-start snapshot inside the widened
     // quiesce window, and must itself have a live serial console.
-    let (mut child1, pid1, log1) = common::spawn_fcvm_with_env_and_log_path(
+    let (mut child1, pid1, log1) = common::spawn_fcvm_snapshots_enabled_with_env_and_log_path(
         &[
             "podman",
             "run",
@@ -782,7 +793,7 @@ async fn test_lifecycle_interleave_quiesce_survives_long_prepause() -> Result<()
     );
 
     // --- Run 2: same cmd + env → pre-start snapshot hit → restore.
-    let (mut child2, pid2, log2) = common::spawn_fcvm_with_env_and_log_path(
+    let (mut child2, pid2, log2) = common::spawn_fcvm_snapshots_enabled_with_env_and_log_path(
         &[
             "podman",
             "run",
@@ -860,6 +871,11 @@ async fn test_lifecycle_interleave_quiesce_survives_long_prepause() -> Result<()
 /// teardown work: the process exits within a bounded window WITHOUT SIGKILL,
 /// and afterwards this VM's firecracker and pasta processes are gone and its
 /// state file is deleted.
+///
+/// The interleaving under test IS the pre-start snapshot's pause window, so
+/// the VM opts into snapshots explicitly (`spawn_fcvm_snapshots_enabled_*`) —
+/// under the SnapshotDisabled lane's inherited `FCVM_NO_SNAPSHOT=1` the
+/// snapshot.pre_pause hold would never be reached.
 #[tokio::test]
 async fn test_lifecycle_interleave_no_leaks_after_interleaved_teardown() -> Result<()> {
     let (vm_name, _, _, _) = common::unique_names("ilv-teardown");
@@ -867,7 +883,7 @@ async fn test_lifecycle_interleave_no_leaks_after_interleaved_teardown() -> Resu
     // (and therefore snapshot.pre_pause is hit) on THIS run.
     let script = format!("echo boot-{}; exec sleep 300", vm_name);
 
-    let (mut child, pid, vm_log) = common::spawn_fcvm_with_env_and_log_path(
+    let (mut child, pid, vm_log) = common::spawn_fcvm_snapshots_enabled_with_env_and_log_path(
         &[
             "podman",
             "run",

--- a/tests/test_lifecycle_interleave.rs
+++ b/tests/test_lifecycle_interleave.rs
@@ -1,0 +1,976 @@
+//! TIER 1: deterministic lifecycle interleaving matrix.
+//!
+//! Each test pins ONE named interleaving of a lifecycle transition (snapshot
+//! pause, restore, first-healthy persist) against in-flight client work (exec
+//! handshake, port-forward curl, serial output), made deterministic with the
+//! `failpoint` crate (host: `FCVM_FAILPOINT`, guest: `FCVM_GUEST_FAILPOINT` →
+//! `fcvm_failpoint=` kernel cmdline). Every case is replayable: the failpoint
+//! spec plus the marker-line sequencing in the test IS the interleaving.
+//!
+//! The cases guard the three merged fix branches:
+//! - `exec-ready-ack` — three-phase exec handshake (request → ACK → GO): a
+//!   request that never got ACKed provably never executed, so resending on a
+//!   fresh connection cannot double-execute.
+//! - `healthy-after-startup-snapshot` — the health monitor defers persisting
+//!   the first Healthy until the startup-snapshot pause/resume completed, so
+//!   an observer of Healthy always sees a live dataplane.
+//! - `serial-safe-snapshots` — the guest quiesces its console before the
+//!   cache-ready notification, so the pre-start snapshot can never capture the
+//!   UART mid-transmit (which would poison every restore's serial console).
+//!
+//! All VMs run rootless (no sudo needed beyond what `make test-root` does for
+//! the runner). Test names contain `lifecycle_interleave` so
+//! `make test-root FILTER=lifecycle_interleave STREAM=1` runs exactly this file.
+
+#![cfg(feature = "integration-fast")]
+
+mod common;
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+
+// ---------------------------------------------------------------------------
+// Local helpers (marker sequencing, process tracking, oracles)
+// ---------------------------------------------------------------------------
+
+/// Search a log file for `needle` at/after byte offset `from`.
+/// Returns the byte offset just past the match (a monotone cursor for
+/// "this marker, then that marker" sequencing), or None if absent.
+fn search_log_from(log: &Path, needle: &str, from: u64) -> Option<u64> {
+    use std::io::{Read, Seek, SeekFrom};
+    let mut f = std::fs::File::open(log).ok()?;
+    let len = f.metadata().ok()?.len();
+    let from = from.min(len);
+    f.seek(SeekFrom::Start(from)).ok()?;
+    let mut buf = Vec::new();
+    f.read_to_end(&mut buf).ok()?;
+    let nb = needle.as_bytes();
+    buf.windows(nb.len())
+        .position(|w| w == nb)
+        .map(|i| from + (i + nb.len()) as u64)
+}
+
+/// Whole-file substring check.
+fn log_contains(log: &Path, needle: &str) -> bool {
+    search_log_from(log, needle, 0).is_some()
+}
+
+/// Current length of the log file (a cursor for "only look at what comes next").
+fn log_len(log: &Path) -> u64 {
+    std::fs::metadata(log).map(|m| m.len()).unwrap_or(0)
+}
+
+/// Last `n` lines of a log, for failure messages.
+fn log_tail(log: &Path, n: usize) -> String {
+    let content = std::fs::read_to_string(log).unwrap_or_default();
+    let lines: Vec<&str> = content.lines().collect();
+    let start = lines.len().saturating_sub(n);
+    lines[start..].join("\n")
+}
+
+/// Poll (25ms) until `needle` appears in `log` at/after `from`; returns the
+/// cursor past the match. Fails loudly with the log tail on timeout.
+async fn wait_for_marker(log: &Path, needle: &str, from: u64, timeout: Duration) -> Result<u64> {
+    let start = Instant::now();
+    loop {
+        if let Some(pos) = search_log_from(log, needle, from) {
+            return Ok(pos);
+        }
+        if start.elapsed() > timeout {
+            anyhow::bail!(
+                "marker {:?} not found in {} within {:?}\n--- log tail ---\n{}",
+                needle,
+                log.display(),
+                timeout,
+                log_tail(log, 40)
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+/// Wait for a child to exit within `timeout` (definitive: a hang FAILS, it is
+/// never masked by a SIGKILL fallback).
+async fn wait_exit(
+    child: &mut tokio::process::Child,
+    timeout: Duration,
+) -> Result<std::process::ExitStatus> {
+    match tokio::time::timeout(timeout, child.wait()).await {
+        Ok(res) => res.context("waiting for child"),
+        Err(_) => anyhow::bail!("process did not exit within {:?}", timeout),
+    }
+}
+
+/// Send SIGTERM (graceful shutdown request) to a pid.
+async fn sigterm(pid: u32) {
+    let _ = tokio::process::Command::new("kill")
+        .args(["-TERM", &pid.to_string()])
+        .output()
+        .await;
+}
+
+/// `fcvm ls --json --pid` → our VM's state (None while the state file does not
+/// exist yet).
+async fn ls_vm_by_pid(pid: u32) -> Result<Option<fcvm::state::VmState>> {
+    #[derive(serde::Deserialize)]
+    struct VmDisplay {
+        #[serde(flatten)]
+        vm: fcvm::state::VmState,
+        #[allow(dead_code)]
+        stale: bool,
+    }
+
+    let fcvm_path = common::find_fcvm_binary()?;
+    let output = tokio::process::Command::new(&fcvm_path)
+        .args(["ls", "--json", "--pid", &pid.to_string()])
+        .output()
+        .await
+        .context("running fcvm ls")?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let vms: Vec<VmDisplay> = match serde_json::from_str(&String::from_utf8_lossy(&output.stdout)) {
+        Ok(v) => v,
+        Err(_) => return Ok(None),
+    };
+    Ok(vms.into_iter().next().map(|d| d.vm))
+}
+
+/// Parse `/proc/<pid>/stat` → (comm, state, ppid, start_time). `comm` may
+/// contain spaces/parens, so split on the LAST `)`.
+fn proc_stat(pid: u32) -> Option<(String, char, u32, u64)> {
+    let stat = std::fs::read_to_string(format!("/proc/{}/stat", pid)).ok()?;
+    let open = stat.find('(')?;
+    let close = stat.rfind(')')?;
+    let comm = stat.get(open + 1..close)?.to_string();
+    let rest: Vec<&str> = stat.get(close + 1..)?.split_whitespace().collect();
+    let state = rest.first()?.chars().next()?;
+    let ppid: u32 = rest.get(1)?.parse().ok()?;
+    // start_time is field 22 overall = index 19 after "pid (comm) "
+    let start: u64 = rest.get(19)?.parse().ok()?;
+    Some((comm, state, ppid, start))
+}
+
+/// Walk the parent chain (bounded) to test ancestry.
+fn is_descendant_of(pid: u32, ancestor: u32) -> bool {
+    let mut cur = pid;
+    for _ in 0..15 {
+        if cur == ancestor {
+            return true;
+        }
+        if cur <= 1 {
+            return false;
+        }
+        match proc_stat(cur) {
+            Some((_, _, ppid, _)) => cur = ppid,
+            None => return false,
+        }
+    }
+    false
+}
+
+/// A process pinned by (pid, start_time): immune to PID reuse and to the
+/// post-kill zombie window (Z/X states count as gone).
+struct TrackedProc {
+    pid: u32,
+    start: u64,
+    comm: String,
+}
+
+impl TrackedProc {
+    fn alive(&self) -> bool {
+        matches!(
+            proc_stat(self.pid),
+            Some((_, state, _, start)) if start == self.start && !matches!(state, 'Z' | 'X' | 'x')
+        )
+    }
+}
+
+/// All live descendants of `ancestor` whose comm starts with `prefix`
+/// (comm is truncated to 15 chars, so match by prefix — e.g. the firecracker
+/// binary `firecracker-default-<sha>.bin` shows as `firecracker-def`).
+fn find_descendants_with_comm_prefix(ancestor: u32, prefix: &str) -> Vec<TrackedProc> {
+    let mut found = Vec::new();
+    let Ok(rd) = std::fs::read_dir("/proc") else {
+        return found;
+    };
+    for e in rd.flatten() {
+        let Some(pid) = e.file_name().to_str().and_then(|s| s.parse::<u32>().ok()) else {
+            continue;
+        };
+        let Some((comm, state, _, start)) = proc_stat(pid) else {
+            continue;
+        };
+        if comm.starts_with(prefix)
+            && !matches!(state, 'Z' | 'X' | 'x')
+            && is_descendant_of(pid, ancestor)
+        {
+            found.push(TrackedProc { pid, start, comm });
+        }
+    }
+    found
+}
+
+/// Does any state file in the state dir belong to `vm_name`?
+fn state_file_for_name_exists(vm_name: &str) -> bool {
+    let Ok(rd) = std::fs::read_dir(fcvm::paths::state_dir()) else {
+        return false;
+    };
+    for e in rd.flatten() {
+        let p = e.path();
+        if p.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&p) else {
+            continue;
+        };
+        if let Ok(state) = serde_json::from_str::<fcvm::state::VmState>(&content) {
+            if state.name.as_deref() == Some(vm_name) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Spawn `fcvm exec --pid <pid> --vm -- sh -c <script>` with RUST_LOG=debug and
+/// captured stdio, so the test can assert on the client's handshake debug lines
+/// ("ACK received", "reconnecting to resend").
+fn spawn_exec_capture(vm_pid: u32, script: &str) -> Result<tokio::process::Child> {
+    let fcvm_path = common::find_fcvm_binary()?;
+    let mut cmd = tokio::process::Command::new(fcvm_path);
+    cmd.args([
+        "exec",
+        "--pid",
+        &vm_pid.to_string(),
+        "--vm",
+        "--",
+        "sh",
+        "-c",
+        script,
+    ])
+    .env("RUST_LOG", "debug")
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .kill_on_drop(true);
+    cmd.spawn().context("spawning fcvm exec")
+}
+
+/// Exactly-once oracle for the nonce file written through a `--map`ed volume:
+/// wait (≤10s) for the nonce to appear, then a 2s settle so a phantom second
+/// execution would have landed too, then count matching lines.
+async fn settled_nonce_count(file: &Path, nonce: &str) -> usize {
+    let count = |content: String| content.lines().filter(|l| l.trim() == nonce).count();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let c = tokio::fs::read_to_string(file)
+            .await
+            .map(&count)
+            .unwrap_or(0);
+        if c > 0 || Instant::now() > deadline {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    tokio::fs::read_to_string(file)
+        .await
+        .map(&count)
+        .unwrap_or(0)
+}
+
+/// Best-effort removal of snapshot cache entries this test created (unique keys
+/// per run, so nothing else can be restoring them). Also removes `.creating`
+/// temp dirs left by an interrupted create.
+async fn cleanup_snapshot_keys(keys: &[Option<String>]) {
+    for key in keys.iter().flatten() {
+        let _ = common::delete_snapshot(key).await;
+        let _ = common::delete_snapshot(&format!("{}-startup", key)).await;
+        let _ = tokio::fs::remove_dir_all(
+            fcvm::paths::snapshot_dir().join(format!("{}.creating", key)),
+        )
+        .await;
+    }
+}
+
+/// Count non-overlapping occurrences of `needle` in `hay`.
+fn count_occurrences(hay: &str, needle: &str) -> usize {
+    hay.match_indices(needle).count()
+}
+
+// ---------------------------------------------------------------------------
+// CASE: exec_resend_across_agent_stall
+// ---------------------------------------------------------------------------
+
+/// Pins: the exec handshake RESEND path against a REAL VM — an exec request
+/// orphaned by a snapshot pause is resent on a fresh connection and executes
+/// exactly once (fixed by the `exec-ready-ack` branch: request → ACK → GO;
+/// fc-agent never executes before consuming GO, so an un-ACKed request is
+/// provably safe to resend).
+///
+/// Interleaving (fully marker-sequenced, no timing guesses):
+/// 1. Guest arms `exec.post_accept_pre_read:sleep:2000` — every exec accept
+///    parks 2s before reading the request. 2s is deliberately UNDER the
+///    client's 3s ACK timeout: a stall above 3s would time out every one of
+///    the 5 resend attempts by construction (each accept re-parks), so the
+///    exec could never exit 0 — the pause below, not the stall alone, is what
+///    forces the resend.
+/// 2. Host arms `snapshot.pre_pause:block_until_file` on a `fcvm snapshot
+///    create` process, which parks fully-prepared, right before the Pause API
+///    call ("FAILPOINT snapshot.pre_pause reached" on its stderr).
+/// 3. One exec (nonce append via a --map'd dir) is launched; its accept marker
+///    in the VM log proves connection #1 is parked INSIDE the agent's window.
+/// 4. The go-file is created → the pause lands within the ~1.8s left of the
+///    guest hold → the snapshot's vsock reset orphans connection #1 (its
+///    request was consumed by nobody: the agent was parked pre-read).
+/// 5. The client gets no ACK → reconnects and resends; the post-resume accept
+///    parks 2s again, ACKs at +2s (< 3s timeout), GO authorizes execution.
+///
+/// Oracle: exec exits 0; the client log shows the resend actually happened;
+/// the nonce appears EXACTLY once (the double-execution tripwire: if fc-agent
+/// ever executed connection #1's request without GO, the count would be 2).
+#[tokio::test]
+async fn test_lifecycle_interleave_exec_resend_across_agent_stall() -> Result<()> {
+    let (vm_name, _, snap_tag, _) = common::unique_names("ilv-resend");
+    let host_dir = PathBuf::from(format!("/tmp/{}-map", vm_name));
+    std::fs::create_dir_all(&host_dir)?;
+    let map_arg = format!("{}:/mnt/test", host_dir.display());
+    // Unique env → unique snapshot key → deterministic cold boot every run.
+    let env_unique = format!("ILV_ID={}", vm_name);
+
+    let (mut child, pid, vm_log) = common::spawn_fcvm_with_env_and_log_path(
+        &[
+            "podman",
+            "run",
+            "--name",
+            &vm_name,
+            "--map",
+            &map_arg,
+            "--env",
+            &env_unique,
+            // HTTP health checks: with a health URL the monitor never uses
+            // `fcvm exec` (podman-inspect) probes, so the ONLY exec.* failpoint
+            // hits in the VM log are this test's own exec.
+            "--health-check",
+            "http://localhost/",
+            common::TEST_IMAGE,
+        ],
+        &[(
+            "FCVM_GUEST_FAILPOINT",
+            "exec.post_accept_pre_read:sleep:2000",
+        )],
+    )
+    .await?;
+
+    common::poll_health_by_pid(pid, 300).await?;
+    let base_key = ls_vm_by_pid(pid)
+        .await?
+        .and_then(|s| s.config.snapshot_name);
+
+    // Park a manual snapshot create right before its Pause call.
+    let go_file = PathBuf::from(format!("/tmp/{}-go", vm_name));
+    let _ = std::fs::remove_file(&go_file);
+    let pid_str = pid.to_string();
+    let failpoint_spec = format!("snapshot.pre_pause:block_until_file:{}", go_file.display());
+    let (mut create_child, _create_pid, create_log) = common::spawn_fcvm_with_env_and_log_path(
+        &["snapshot", "create", "--pid", &pid_str, "--tag", &snap_tag],
+        &[("FCVM_FAILPOINT", &failpoint_spec)],
+    )
+    .await?;
+    wait_for_marker(
+        &create_log,
+        "FAILPOINT snapshot.pre_pause reached",
+        0,
+        Duration::from_secs(90),
+    )
+    .await?;
+
+    // Launch the exec and wait until its connection is parked inside the
+    // agent's post-accept window (manual creates do NOT quiesce the guest
+    // console, so the guest marker streams to the VM log immediately).
+    let nonce = format!("nonce-{}", vm_name);
+    let script = format!("echo {} >> /mnt/test/nonce.txt", nonce);
+    let vm_cursor = log_len(&vm_log);
+    let exec_child = spawn_exec_capture(pid, &script)?;
+    wait_for_marker(
+        &vm_log,
+        "FAILPOINT exec.post_accept_pre_read reached",
+        vm_cursor,
+        Duration::from_secs(30),
+    )
+    .await?;
+
+    // Release the pause INTO the parked window.
+    std::fs::write(&go_file, b"go").context("creating go-file")?;
+
+    let create_status = wait_exit(&mut create_child, Duration::from_secs(180)).await?;
+    let exec_output = tokio::time::timeout(Duration::from_secs(120), exec_child.wait_with_output())
+        .await
+        .context("exec did not finish within 120s")?
+        .context("collecting exec output")?;
+    let exec_stderr = String::from_utf8_lossy(&exec_output.stderr).to_string();
+    let nonce_count = settled_nonce_count(&host_dir.join("nonce.txt"), &nonce).await;
+
+    // Teardown before asserting so a failed assert can't leak the VM.
+    let _ = std::fs::remove_file(&go_file);
+    common::kill_process(pid).await;
+    let _ = child.wait().await;
+    cleanup_snapshot_keys(&[base_key, Some(snap_tag.clone())]).await;
+    let _ = std::fs::remove_dir_all(&host_dir);
+
+    assert!(
+        create_status.success(),
+        "snapshot create must succeed (status {:?}); create log tail:\n{}",
+        create_status,
+        log_tail(&create_log, 40)
+    );
+    assert!(
+        exec_output.status.success(),
+        "exec must exit 0 after the resend (status {:?}); exec stderr:\n{}",
+        exec_output.status,
+        exec_stderr
+    );
+    assert!(
+        exec_stderr.contains("reconnecting to resend"),
+        "the pause must orphan connection #1 and force a resend — without it \
+         this test pins nothing; exec stderr:\n{}",
+        exec_stderr
+    );
+    assert!(
+        exec_stderr.contains("ACK received, sending GO"),
+        "the resent request must complete the ACK/GO handshake; exec stderr:\n{}",
+        exec_stderr
+    );
+    assert_eq!(
+        nonce_count, 1,
+        "nonce must appear EXACTLY once (double-execution tripwire); exec stderr:\n{}",
+        exec_stderr
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// CASE: go_floor_across_ack_stall
+// ---------------------------------------------------------------------------
+
+/// Pins: the GO read's 2s fresh floor after a long post-ACK stall (part of the
+/// `exec-ready-ack` branch). fc-agent's whole handshake shares one 10s
+/// deadline; the GO read recomputes `go_deadline = deadline.max(now + 2s)`
+/// with `now` taken AFTER the `exec.post_ack_pre_go` hold. The client sends GO
+/// immediately after ACK, so the GO bytes sit in the socket buffer across the
+/// stall.
+///
+/// The stall is 12s — deliberately LONGER than the agent's 10s handshake
+/// deadline. A shorter stall (e.g. 4s) leaves ~6s of the shared deadline and
+/// passes even WITHOUT the floor, pinning nothing. At 12s the deadline is
+/// exhausted when the hold releases: only the recomputed 2s floor lets the
+/// agent consume the buffered GO. If the floor regresses (deadline computed
+/// before the hold), the agent closes without executing and the client
+/// surfaces a loud post-GO error → exit != 0 → this test fails.
+///
+/// Oracle: exec exits 0, the nonce appears exactly once, and the client log
+/// shows a single handshake attempt (ACK on attempt 1, no resend).
+#[tokio::test]
+async fn test_lifecycle_interleave_go_floor_across_ack_stall() -> Result<()> {
+    let (vm_name, _, _, _) = common::unique_names("ilv-gofloor");
+    let host_dir = PathBuf::from(format!("/tmp/{}-map", vm_name));
+    std::fs::create_dir_all(&host_dir)?;
+    let map_arg = format!("{}:/mnt/test", host_dir.display());
+    let env_unique = format!("ILV_ID={}", vm_name);
+
+    let (mut child, pid, vm_log) = common::spawn_fcvm_with_env_and_log_path(
+        &[
+            "podman",
+            "run",
+            "--name",
+            &vm_name,
+            "--map",
+            &map_arg,
+            "--env",
+            &env_unique,
+            "--health-check",
+            "http://localhost/",
+            common::TEST_IMAGE,
+        ],
+        &[("FCVM_GUEST_FAILPOINT", "exec.post_ack_pre_go:sleep:12000")],
+    )
+    .await?;
+
+    common::poll_health_by_pid(pid, 300).await?;
+    let base_key = ls_vm_by_pid(pid)
+        .await?
+        .and_then(|s| s.config.snapshot_name);
+
+    let nonce = format!("nonce-{}", vm_name);
+    let script = format!("echo {} >> /mnt/test/nonce.txt", nonce);
+    let vm_cursor = log_len(&vm_log);
+    let exec_child = spawn_exec_capture(pid, &script)?;
+
+    // Non-vacuity: the stall must actually be armed and hit.
+    wait_for_marker(
+        &vm_log,
+        "FAILPOINT exec.post_ack_pre_go reached",
+        vm_cursor,
+        Duration::from_secs(30),
+    )
+    .await?;
+
+    let exec_output = tokio::time::timeout(Duration::from_secs(90), exec_child.wait_with_output())
+        .await
+        .context("exec did not finish within 90s (12s stall + command)")?
+        .context("collecting exec output")?;
+    let exec_stderr = String::from_utf8_lossy(&exec_output.stderr).to_string();
+    let nonce_count = settled_nonce_count(&host_dir.join("nonce.txt"), &nonce).await;
+
+    common::kill_process(pid).await;
+    let _ = child.wait().await;
+    cleanup_snapshot_keys(&[base_key]).await;
+    let _ = std::fs::remove_dir_all(&host_dir);
+
+    assert!(
+        exec_output.status.success(),
+        "exec must exit 0 across the 12s post-ACK stall (2s GO floor); \
+         status {:?}; exec stderr:\n{}",
+        exec_output.status,
+        exec_stderr
+    );
+    assert_eq!(
+        count_occurrences(&exec_stderr, "ACK received, sending GO"),
+        1,
+        "exactly one handshake attempt (ACK on the first connection); exec stderr:\n{}",
+        exec_stderr
+    );
+    assert!(
+        !exec_stderr.contains("reconnecting to resend")
+            && !exec_stderr.contains("never acknowledged"),
+        "no resend may happen — ACK arrived before the stall; exec stderr:\n{}",
+        exec_stderr
+    );
+    assert_eq!(
+        nonce_count, 1,
+        "nonce must appear exactly once; exec stderr:\n{}",
+        exec_stderr
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// CASE: healthy_means_live_dataplane
+// ---------------------------------------------------------------------------
+
+/// Pins: the first-healthy gate (`healthy-after-startup-snapshot` branch).
+/// The first healthy check triggers startup-snapshot creation, which PAUSES
+/// the VM; the fix makes the health monitor defer persisting Healthy until
+/// that pause/resume cycle completed and was acked. So the very first
+/// externally observable Healthy implies running vCPUs and a live dataplane.
+///
+/// `snapshot.pre_pause:sleep:3000` in the VM process inflates every snapshot
+/// pause window to ≥3s (pre-start AND startup snapshot). The test polls the
+/// state file every 50ms and, at the FIRST observation of Healthy, fires a
+/// single `curl --max-time 2` at the forwarded loopback ip:port. If the gate
+/// ever regresses (Healthy persisted before/during the startup-snapshot
+/// pause), the 50ms poll lands inside the ≥3s frozen window and the one-shot
+/// 2s curl deterministically times out.
+#[tokio::test]
+async fn test_lifecycle_interleave_healthy_means_live_dataplane() -> Result<()> {
+    let (vm_name, _, _, _) = common::unique_names("ilv-healthy");
+    // Unique env → unique base AND startup snapshot keys → the startup
+    // snapshot is CREATED this run (a warm start would skip the pause and
+    // make this test vacuous).
+    let env_unique = format!("ILV_ID={}", vm_name);
+    let host_port = common::find_available_high_port()?;
+    let publish_arg = format!("{}:80", host_port);
+
+    let (mut child, pid, vm_log) = common::spawn_fcvm_with_env_and_log_path(
+        &[
+            "podman",
+            "run",
+            "--name",
+            &vm_name,
+            "--publish",
+            &publish_arg,
+            "--env",
+            &env_unique,
+            "--health-check",
+            "http://localhost/",
+            common::TEST_IMAGE,
+        ],
+        &[("FCVM_FAILPOINT", "snapshot.pre_pause:sleep:3000")],
+    )
+    .await?;
+
+    // Discover vm_id + loopback IP as soon as the state file exists (long
+    // before healthy), then poll the state FILE directly at 50ms — `fcvm ls`
+    // subprocesses are too slow to pin a 3s window.
+    let discover_deadline = Instant::now() + Duration::from_secs(180);
+    let (vm_id, loopback_ip) = loop {
+        if let Some(state) = ls_vm_by_pid(pid).await? {
+            if let Some(ip) = state.config.network.loopback_ip.clone() {
+                break (state.vm_id, ip);
+            }
+        }
+        if child.try_wait()?.is_some() {
+            anyhow::bail!(
+                "fcvm exited before creating VM state; log tail:\n{}",
+                log_tail(&vm_log, 40)
+            );
+        }
+        if Instant::now() > discover_deadline {
+            anyhow::bail!("VM state with loopback_ip never appeared");
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    };
+    let state_path = fcvm::paths::state_dir().join(format!("{}.json", vm_id));
+
+    // 50ms poll for the FIRST Healthy observation.
+    let poll_deadline = Instant::now() + Duration::from_secs(300);
+    loop {
+        let healthy = std::fs::read_to_string(&state_path)
+            .ok()
+            .and_then(|c| serde_json::from_str::<fcvm::state::VmState>(&c).ok())
+            .map(|s| s.health_status == fcvm::state::HealthStatus::Healthy)
+            .unwrap_or(false);
+        if healthy {
+            break;
+        }
+        if child.try_wait()?.is_some() {
+            anyhow::bail!(
+                "fcvm exited before Healthy; log tail:\n{}",
+                log_tail(&vm_log, 40)
+            );
+        }
+        if Instant::now() > poll_deadline {
+            anyhow::bail!(
+                "VM never became Healthy; log tail:\n{}",
+                log_tail(&vm_log, 40)
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // FIRST observation of Healthy → immediately one single-shot curl.
+    let curl = tokio::process::Command::new("curl")
+        .args([
+            "-sS",
+            "--max-time",
+            "2",
+            &format!("http://{}:{}/", loopback_ip, host_port),
+        ])
+        .output()
+        .await
+        .context("running curl")?;
+    let curl_ok = curl.status.success() && !curl.stdout.is_empty();
+    let curl_err = String::from_utf8_lossy(&curl.stderr).to_string();
+
+    // Non-vacuity: this run must actually have created the startup snapshot
+    // (the pause the gate defers Healthy across) with the inflated window.
+    let created_startup = log_contains(&vm_log, "Creating startup snapshot");
+    let prepause_hit = log_contains(&vm_log, "FAILPOINT snapshot.pre_pause reached");
+    let base_key = ls_vm_by_pid(pid)
+        .await?
+        .and_then(|s| s.config.snapshot_name);
+
+    common::kill_process(pid).await;
+    let _ = child.wait().await;
+    cleanup_snapshot_keys(&[base_key]).await;
+
+    assert!(
+        created_startup,
+        "the startup snapshot must be created THIS run (cold boot) or the gate \
+         is never exercised; log tail:\n{}",
+        log_tail(&vm_log, 40)
+    );
+    assert!(
+        prepause_hit,
+        "the snapshot.pre_pause hold must have fired (failpoint armed); log tail:\n{}",
+        log_tail(&vm_log, 40)
+    );
+    assert!(
+        curl_ok,
+        "single-shot curl at the FIRST observed Healthy must succeed — Healthy \
+         with a paused/frozen dataplane is the exact bug the healthy-after-\
+         startup-snapshot fix removed (curl status {:?}, stderr: {})",
+        curl.status, curl_err
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// CASE: quiesce_survives_long_prepause
+// ---------------------------------------------------------------------------
+
+/// Pins: serial-safe pre-start snapshot creation (`serial-safe-snapshots`
+/// branch). The guest quiesces its console (flush + gate + TIOCOUTQ drain)
+/// BEFORE sending cache-ready; the host's pre-start snapshot pause can
+/// therefore never capture the UART mid-transmit. A mid-transmit capture
+/// poisons the snapshot: every restore has a dead serial console (the guest
+/// 8250 driver waits forever for a TX interrupt that never comes).
+///
+/// Interleaving: the container spams console output; the guest holds 1s
+/// between quiesce and the cache-ready send (`cache_ready.pre_send:sleep:1000`)
+/// and the host holds 2s more before the pause (`snapshot.pre_pause:sleep:2000`)
+/// — a ≥3s window in which un-quiesced output WOULD put bytes in the UART.
+///
+/// Run 1 (unique cmd → cold) CREATES the pre-start snapshot inside that
+/// widened window. Run 2 (same cmd/env → same key) RESTORES it. Oracle on run
+/// 2: the restore path was taken (no silent cold-boot fallback), fc-agent
+/// serial lines and the container's console output appear after restore, the
+/// dead-serial watchdog ERROR ("captured the guest UART mid-transmit") never
+/// fires, the run reaches healthy, and SIGTERM produces an orderly exit.
+#[tokio::test]
+async fn test_lifecycle_interleave_quiesce_survives_long_prepause() -> Result<()> {
+    let (run1_name, run2_name, _, _) = common::unique_names("ilv-quiesce");
+    let canary = format!("serial-canary-{}", run1_name);
+    // Unique canary in the cmd → unique snapshot key → run 1 always cold.
+    let script = format!(
+        "i=0; while true; do echo {} $i; i=$((i+1)); sleep 1; done",
+        canary
+    );
+    let env: [(&str, &str); 2] = [
+        ("FCVM_FAILPOINT", "snapshot.pre_pause:sleep:2000"),
+        ("FCVM_GUEST_FAILPOINT", "cache_ready.pre_send:sleep:1000"),
+    ];
+
+    // --- Run 1: cold boot, creates the pre-start snapshot inside the widened
+    // quiesce window, and must itself have a live serial console.
+    let (mut child1, pid1, log1) = common::spawn_fcvm_with_env_and_log_path(
+        &[
+            "podman",
+            "run",
+            "--name",
+            &run1_name,
+            common::ALPINE_IMAGE,
+            "sh",
+            "-c",
+            &script,
+        ],
+        &env,
+    )
+    .await?;
+    common::poll_health_by_pid(pid1, 300).await?;
+    wait_for_marker(
+        &log1,
+        "Pre-start snapshot created successfully",
+        0,
+        Duration::from_secs(60),
+    )
+    .await?;
+    // The console guard buffers the guest hold's marker during the quiesce and
+    // flushes it afterwards — its presence proves the guest hold really ran.
+    wait_for_marker(
+        &log1,
+        "FAILPOINT cache_ready.pre_send reached",
+        0,
+        Duration::from_secs(60),
+    )
+    .await?;
+    wait_for_marker(&log1, &canary, 0, Duration::from_secs(30)).await?;
+    let run1_cold = log_contains(&log1, "Snapshot miss");
+    let run1_prepause = log_contains(&log1, "FAILPOINT snapshot.pre_pause reached");
+    let base_key = ls_vm_by_pid(pid1)
+        .await?
+        .and_then(|s| s.config.snapshot_name);
+    common::kill_process(pid1).await;
+    let _ = child1.wait().await;
+
+    assert!(run1_cold, "run 1 must be a cold boot (unique cmd)");
+    assert!(
+        run1_prepause,
+        "run 1 must hit the inflated snapshot.pre_pause hold"
+    );
+
+    // --- Run 2: same cmd + env → pre-start snapshot hit → restore.
+    let (mut child2, pid2, log2) = common::spawn_fcvm_with_env_and_log_path(
+        &[
+            "podman",
+            "run",
+            "--name",
+            &run2_name,
+            common::ALPINE_IMAGE,
+            "sh",
+            "-c",
+            &script,
+        ],
+        &env,
+    )
+    .await?;
+    let restore_hit = wait_for_marker(
+        &log2,
+        "Pre-start snapshot hit! Restoring from cached snapshot",
+        0,
+        Duration::from_secs(90),
+    )
+    .await;
+    if let Err(e) = restore_hit {
+        common::kill_process(pid2).await;
+        let _ = child2.wait().await;
+        cleanup_snapshot_keys(std::slice::from_ref(&base_key)).await;
+        return Err(e.context("run 2 must restore the pre-start snapshot"));
+    }
+    common::poll_health_by_pid(pid2, 300).await?;
+    // fc-agent serial lines after restore: the quiesce guard's buffered lines
+    // and restore-progress lines all arrive over the restored UART.
+    wait_for_marker(&log2, "[fc-agent]", 0, Duration::from_secs(30)).await?;
+    // The container's console output flows after restore too.
+    wait_for_marker(&log2, &canary, 0, Duration::from_secs(90)).await?;
+
+    let watchdog_fired = log_contains(&log2, "captured the guest UART mid-transmit");
+    let run2_fell_back_cold = log_contains(&log2, "Snapshot miss");
+
+    // Orderly shutdown is part of the oracle: raw SIGTERM, no SIGKILL fallback.
+    sigterm(pid2).await;
+    let exit2 = wait_exit(&mut child2, Duration::from_secs(60)).await;
+    cleanup_snapshot_keys(&[base_key]).await;
+
+    assert!(
+        !watchdog_fired,
+        "the dead-serial watchdog fired: the pre-start snapshot captured the \
+         UART mid-transmit — the serial-safe-snapshots quiesce regressed; \
+         run 2 log tail:\n{}",
+        log_tail(&log2, 40)
+    );
+    assert!(
+        !run2_fell_back_cold,
+        "run 2 silently fell back to a cold boot instead of restoring; \
+         log tail:\n{}",
+        log_tail(&log2, 40)
+    );
+    let exit2 = exit2.context("run 2 must exit in bounded time after SIGTERM")?;
+    println!("run 2 exited after SIGTERM with {:?}", exit2);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// CASE: no_leaks_after_interleaved_teardown
+// ---------------------------------------------------------------------------
+
+/// Pins: teardown racing a HELD snapshot pause window leaks nothing. SIGTERM
+/// is delivered while the VM process is parked inside the pre-start snapshot's
+/// `snapshot.pre_pause` hold (sequenced on the failpoint marker, and proven by
+/// the "released" marker not yet being in the log at signal time). The hold is
+/// 10s: wide enough that the harness's marker-to-signal latency can never
+/// escape the window.
+///
+/// By design the in-flight snapshot runs to completion after the signal
+/// (dropping the create future between pause and resume would wedge the VM —
+/// see `create_snapshot_interruptible`), then shutdown proceeds. The oracle is
+/// the postcondition of the exec-orphaned/serial-safe/healthy-gate era
+/// teardown work: the process exits within a bounded window WITHOUT SIGKILL,
+/// and afterwards this VM's firecracker and pasta processes are gone and its
+/// state file is deleted.
+#[tokio::test]
+async fn test_lifecycle_interleave_no_leaks_after_interleaved_teardown() -> Result<()> {
+    let (vm_name, _, _, _) = common::unique_names("ilv-teardown");
+    // Unique cmd → unique snapshot key → the pre-start snapshot is created
+    // (and therefore snapshot.pre_pause is hit) on THIS run.
+    let script = format!("echo boot-{}; exec sleep 300", vm_name);
+
+    let (mut child, pid, vm_log) = common::spawn_fcvm_with_env_and_log_path(
+        &[
+            "podman",
+            "run",
+            "--name",
+            &vm_name,
+            common::ALPINE_IMAGE,
+            "sh",
+            "-c",
+            &script,
+        ],
+        &[("FCVM_FAILPOINT", "snapshot.pre_pause:sleep:10000")],
+    )
+    .await?;
+
+    // Wait until the VM process is parked in the pre-pause hold.
+    let reached_at = wait_for_marker(
+        &vm_log,
+        "FAILPOINT snapshot.pre_pause reached",
+        0,
+        Duration::from_secs(300),
+    )
+    .await?;
+
+    // Capture THIS VM's firecracker and pasta (pid + start_time, immune to
+    // PID reuse) while it is parked.
+    let firecrackers = find_descendants_with_comm_prefix(pid, "firecracker");
+    let pastas = find_descendants_with_comm_prefix(pid, "pasta");
+    assert!(
+        !firecrackers.is_empty(),
+        "a running VM must have a firecracker descendant"
+    );
+    assert!(
+        !pastas.is_empty(),
+        "a rootless VM must have a pasta descendant"
+    );
+
+    // Prove we are still INSIDE the held window, then SIGTERM.
+    assert!(
+        search_log_from(&vm_log, "FAILPOINT snapshot.pre_pause released", reached_at).is_none(),
+        "the pre-pause hold ended before SIGTERM could be delivered — the \
+         interleaving did not happen (harness too slow?)"
+    );
+    sigterm(pid).await;
+
+    // Bounded orderly exit. The bound covers the remaining hold (≤10s), the
+    // to-completion snapshot (pause/save/resume of a 1GiB VM), and teardown.
+    // No SIGKILL fallback: a hang here IS the bug this case exists to catch.
+    let status = wait_exit(&mut child, Duration::from_secs(60))
+        .await
+        .with_context(|| {
+            format!(
+                "fcvm did not exit within 60s of SIGTERM during a held pre-pause \
+                 window; log tail:\n{}",
+                log_tail(&vm_log, 40)
+            )
+        })?;
+    println!("fcvm exited after SIGTERM with {:?}", status);
+
+    // No leaked processes for this VM (poll ≤15s: cleanup finishes just before
+    // fcvm exits, but give reaping a moment under load).
+    let leak_deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let leaked: Vec<String> = firecrackers
+            .iter()
+            .chain(pastas.iter())
+            .filter(|p| p.alive())
+            .map(|p| format!("{} (pid {})", p.comm, p.pid))
+            .collect();
+        if leaked.is_empty() {
+            break;
+        }
+        if Instant::now() > leak_deadline {
+            panic!(
+                "leaked processes after teardown during held pause window: {:?}",
+                leaked
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // No state file for this VM remains.
+    assert!(
+        !state_file_for_name_exists(&vm_name),
+        "state file for {} must be deleted on teardown",
+        vm_name
+    );
+
+    // Best-effort cache cleanup: the interrupted-but-completed pre-start
+    // snapshot left a cache entry under this run's unique key; recover the key
+    // from the log line "Creating pre-start snapshot snapshot_key=<key>".
+    if let Some(pos) = search_log_from(&vm_log, "Creating pre-start snapshot", 0) {
+        let content = std::fs::read_to_string(&vm_log).unwrap_or_default();
+        // Find the line containing that byte offset and extract snapshot_key=…
+        let upto = (pos as usize).min(content.len());
+        let line_start = content[..upto].rfind('\n').map(|i| i + 1).unwrap_or(0);
+        let line = content[line_start..].lines().next().unwrap_or("");
+        if let Some(key) = line
+            .split_whitespace()
+            .find_map(|tok| tok.strip_prefix("snapshot_key="))
+        {
+            let key = key.trim_matches('"').to_string();
+            cleanup_snapshot_keys(&[Some(key)]).await;
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
Deterministic VM lifecycle fuzzing: a failpoint crate plus three test tiers that turn lifecycle races (snapshot pause / restore / Healthy publication colliding with in-flight exec, curl, and serial traffic) into replayable, individually named tests instead of probabilistic CI flakes.

This is the suite that found the exec-orphan, healthy-before-pause, and serial-wedge bug trio now fixed on main (#710, #711, #712); it lands after those fixes so every test passes deterministically.

## Why

This week's CI flakes were all one race class: a lifecycle transition (VM pause for snapshot, snapshot restore, first-Healthy persist) landing inside an in-flight guest/host interaction. The windows are microseconds wide, so stress testing hits them probabilistically and `retries=1` hid them inside green runs. This PR makes each window a first-class, widenable, sequenced test target.

## The failpoint crate (`failpoint/`)

- **Named hold points** compiled into fcvm and fc-agent. Unarmed (the only state production ever sees) a hit is one static lookup returning `None` — zero cost, no I/O.
- **Arming**: host via `FCVM_FAILPOINT` (read once at startup); guest via `FCVM_GUEST_FAILPOINT`, which fcvm forwards onto the kernel cmdline as `fcvm_failpoint=<spec>` (the `fuse_trace_rate` pattern) because fc-agent cannot read host env; fc-agent parses `/proc/cmdline` at boot.
- **Actions**: `<name>:sleep:<ms>` and `<name>:block_until_file:<path>` (host-only; the harness can't create files inside the guest, and a file-blocked guest would hold VM-global state). Both are hard-capped at 60s so a wedged harness can never wedge a VM. Guest specs are validated host-side (`validate_guest_spec`) before a VM boots; malformed specs panic loudly — a silently un-armed failpoint would make a determinism test vacuously pass.
- **Marker-line contract**: `FAILPOINT <name> reached action=...` before the hold, `FAILPOINT <name> released` after (plus a loud `RELEASED BY TIMEOUT`). Harnesses sequence on these exact boundaries instead of guessing timing — every Tier 1 test waits for `reached` before driving the other side of the race.
- **Hold points** (each names the race it makes testable): `snapshot.pre_pause`, `snapshot.post_save_pre_resume`, `restore.pre_resume`, `health.pre_persist_healthy` (host); `cache_ready.pre_send`, `exec.post_accept_pre_read`, `exec.post_ack_pre_go` (guest).

### Why guest failpoint specs feed the snapshot cache key

Guest failpoints ride the kernel cmdline, so the armed spec is baked into the guest's boot — and therefore into any snapshot taken of it. The runtime boot-args string is deliberately excluded from the snapshot cache key, so `FirecrackerConfig` gains a dedicated `guest_failpoint` field (populated from `FCVM_GUEST_FAILPOINT`, `skip_serializing_if` when `None`) that feeds the key. A fuzz VM with failpoints armed computes a different key than a normal run: fuzz VMs can never pollute normal snapshot caches, and a normal run can never restore a snapshot whose guest has failpoints armed. The existing golden-key test (`test_snapshot_key_golden`) still passes, proving keys for normal runs are byte-identical to before.

## Three tiers

**Tier 0 — deterministic protocol fuzz** (`fc-agent/src/exec_fuzz_tests.rs`, `src/commands/exec_fuzz_tests.rs`, fc-mock parity in `tests/test_fc_mock.rs`): scripted fake peers enumerate connection death at every ACK/GO handshake stage and byte offset, against the real agent handshake reader and the real client (`connect_and_start_exec` + `EpochGuardedReader` + `read_exec_responses`, exactly the `run_exec_in_vm` path). Includes the exactly-once property enumerated across all cut points: executions ≤ 1 always, == 1 whenever the client reports success. 21 tests, event-driven (server closes/shutdowns as cut events), no sleeps-as-sync.

**Tier 1 — lifecycle interleave matrix** (`tests/test_lifecycle_interleave.rs`, 5 tests): named interleavings with strict oracles, marker-sequenced:
- `exec_resend_across_agent_stall` — snapshot create held at `pre_pause` (block_until_file), exec parked in the agent's post-accept window, pause released into it: pre-ACK orphan must resend and the nonce must appear exactly once (double-execution tripwire).
- `go_floor_across_ack_stall` — 12s guest hold between ACK and GO (longer than the agent's 10s shared handshake deadline): only the recomputed 2s GO floor lets the buffered GO be consumed; one handshake attempt, no resend.
- `healthy_means_live_dataplane` — `snapshot.pre_pause:sleep:3000` inflates the startup-snapshot pause; at the FIRST observed Healthy a one-shot 2s curl must succeed (Healthy may never be visible while vCPUs are paused).
- `quiesce_survives_long_prepause` — guest hold before cache-ready + 2s host pre-pause hold, then a second (restored) run must have a live serial console.
- `no_leaks_after_interleaved_teardown` — SIGTERM into a held pause window; the pause must never complete (`released` marker absent) and process/state leak oracles must come back clean.

**Tier 2 — seeded chaos** (`tests/test_fuzz_chaos.rs`): schedule-reproducible op sequences (exec-nonce / tty-exec / port curl / state-read with Healthy⇒live chained curl / snapshot-create / console-flood / jitter) against a live VM. Hard per-op timeouts make hangs failures; end-of-run oracles check exactly-once nonces, no leaked processes, no leaked state. `make fuzz SEEDS=n OPS=m` replays any seed; one quick seed runs in the normal suite; `weekly.yml` gains a `Lifecycle-Fuzz-arm64` job running 20 seeds x 25 ops. The nextest override pins `retries = 0` for the chaos test: a caught race must fail the run, not vanish on retry (the exact hedge this suite exists to eliminate).

## Bugs this suite caught (all now fixed on main)

The tiers were built against the racy code and reproduced each flake deterministically; the fixes merged first, so this PR lands green:

- **Exec orphaned across a snapshot pause** — hidden `test_custom_command_bridged` flake (exec accepted in the ~40ms accept-to-pause window of startup-snapshot creation was silently orphaned by the vsock reset; the retry passed because the failed run had populated the snapshot cache). Fixed by the three-phase request/ACK/GO handshake + absolute ACK bound + vsock-epoch orphan detection (#710). Pinned by Tier 0 and `exec_resend_across_agent_stall` / `go_floor_across_ack_stall`.
- **Healthy published while vCPUs paused** — clients (port-forward curl, exec, `fcvm ls` pollers) could observe Healthy during the startup-snapshot pause. Fixed by deferring Healthy until the pause/resume cycle acks (#711). Pinned by `healthy_means_live_dataplane` and the chaos harness's Healthy⇒live chained curl.
- **Serial wedge from a mid-UART-TX snapshot** — the arm64 trio (`serial_console_after_restore`, `exec_rootless`, `exec_parallel_tty_stress`): the pre-start snapshot captured mid-UART-TX left a dead serial on every restore, and fc-agent console writes then wedged the exec accept loop after ~4KB. Fixed by the console quiesce-before-cache-ready + wedge-proof console writer (#712; fork-level UART restore fix tracked in #708). Pinned by `quiesce_survives_long_prepause`.
- Related groundwork this suite depends on: the CH ACPI shutdown contract (#706) which unblocked deterministic teardown oracles on x86.

## Rebase notes (hook re-siting onto the merged fixes)

The branch predates the final form of the fix PRs, so the hooks were re-sited into the merged code rather than kept verbatim: `snapshot.post_save_pre_resume` now holds AFTER #710's `record_vsock_reset_for_snapshot` epoch bump (preserving its bump-before-resume invariant), `health.pre_persist_healthy` sits after #711's dropped-ack "discard observation" gate, `cache_ready.pre_send` after #712's quiesce-or-abort gate, and the Tier 0 client harness now drives the post-#710 signature (`connect_and_start_exec(sock, req, vm_id)` → `(stream, SnapshotOrphanGuard)`, responses via `EpochGuardedReader`).

## Test evidence (aarch64, this branch = main + this commit)

```
make lint                                    # clean: cargo fmt --check (incl. failpoint),
                                             # clippy --all-targets -D warnings, cargo deny
make build                                   # clean (fcvm + fc-agent musl)

make test-unit
  Summary [  50.769s] 379 tests run: 379 passed, 0 skipped
  (12 failpoint crate tests, 21 Tier 0 protocol-fuzz tests,
   test_snapshot_key_golden + test_snapshot_key_changes_with_guest_failpoint included)

make test-root FILTER=lifecycle_interleave STREAM=1
  PASS [  29.490s] test_lifecycle_interleave_exec_resend_across_agent_stall
  PASS [  36.840s] test_lifecycle_interleave_go_floor_across_ack_stall
  PASS [  28.343s] test_lifecycle_interleave_healthy_means_live_dataplane
  PASS [  15.606s] test_lifecycle_interleave_no_leaks_after_interleaved_teardown
  PASS [  24.843s] test_lifecycle_interleave_quiesce_survives_long_prepause
  Summary [ 135.125s] 5 tests run: 5 passed, 657 skipped

make fuzz SEEDS=1 OPS=10                     # chaos smoke, retries=0 profile
  FUZZ ===== seed 1 starting (10 ops) =====
  FUZZ seed=1 nonce oracle OK (2 nonces, each exactly once)
  FUZZ seed=1 process-leak oracle OK
  FUZZ seed=1 state-file oracle OK
  FUZZ ===== seed 1 PASSED in 18.1s =====
  Summary [  18.114s] 1 test run: 1 passed, 661 skipped
```

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable lifecycle testing controls for VM startup, execution, snapshots, health checks, and restoration.
  - Added seeded fuzz testing with configurable seeds and operation counts.
  - Added failure logs and replayable test traces for easier investigation.

- **Bug Fixes**
  - Improved handling of interrupted execution handshakes, retries, timeouts, and process cleanup.
  - Prevented stale VM state, orphaned processes, and duplicate command execution during lifecycle interruptions.

- **Tests**
  - Expanded coverage for snapshot, restore, health, shutdown, and execution interleavings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->