### PR TITLE
Cut clone hot-path latency in half by removing per-launch execs and network RTTs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ CONTAINER_RUN := $(CONTAINER_RUN_BASE) --ulimit nproc=65536:65536 --pids-limit=6
 	container-build container-test container-test-unit container-test-fast container-test-all container-test-fc-mock \
 	container-setup-fcvm container-shell container-clean container-bench \
 	setup-btrfs setup-default setup-fcvm setup-pjdfstest setup-hugepages bench bench-vm bench-hugepages bench-hugepages-test \
-	bench-container-import bench-chromium \
+	bench-container-import bench-chromium bench-clone-latency \
 	lint fmt update-dependency ssh test-serve-sdk
 
 all: build
@@ -234,6 +234,7 @@ help:
 	@echo "  bench-hugepages-test  Run hugepages benchmark (2GB VM, 256MB dirty)"
 	@echo "  bench-container-import  Compare podman load vs direct image mount"
 	@echo "  bench-chromium     Chromium shared-nothing clone bench (egress x memory matrix)"
+	@echo "  bench-clone-latency  Clone spawn->exec-ready latency (LABEL=, N=)"
 	@echo ""
 	@echo "Other:"
 	@echo "  lint               Run linting (auto-installs tools if needed)"
@@ -634,6 +635,15 @@ bench-hugepages-test: build setup-default
 bench-container-import: build setup-default
 	@echo "==> Running container import benchmark..."
 	$(CARGO) bench --bench container_import
+
+# Clone hot-path latency: `fcvm snapshot run` spawn -> exec-server-ready, N times.
+# Event-driven readiness (waits on the debug log's marker), plus a stage breakdown
+# parsed from the RUST_LOG=fcvm=debug timeline.
+# Results in /tmp/fcvm-clone-latency-$(LABEL)/ (never committed).
+#   make bench-clone-latency LABEL=before N=10
+bench-clone-latency: build setup-default
+	@echo "==> Running clone latency benchmark..."
+	bench/clone-latency.sh $(or $(LABEL),run) $(or $(N),10)
 
 # Container benchmark target (used by nightly CI)
 # Uses CONTAINER_RUN_BASE (no --ulimit nproc) to avoid EPERM on GHA ubuntu-latest

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -248,6 +248,49 @@ All 10 clones launched simultaneously:
 
 Core restore is ~10ms regardless of sequential or parallel. Single memory server handles 10 concurrent clones. Bottleneck is network teardown and state cleanup under contention.
 
+### Clone Spawn → Exec-Ready Latency
+
+`bench/clone-latency.sh <label> <N>` boots a minimal alpine VM, snapshots it,
+serves it, and times N `fcvm snapshot run` cycles from process spawn until
+fc-agent's exec server is reachable (event-driven: it waits on the debug log's
+readiness marker, no polling). It prints p50/min/max plus a stage breakdown
+parsed from the `RUST_LOG=fcvm=debug` timeline; results land in
+`/tmp/fcvm-clone-latency-<label>/` and are not committed.
+
+```bash
+make build
+bench/clone-latency.sh mylabel 10
+```
+
+Measured on Graviton3, alpine, rootless networking, 2 rounds × 10 clones:
+
+| Stage | Before | After |
+|-------|--------|-------|
+| firecracker resolution (`git ls-remote`) | 337 ms | 0.4 ms |
+| netns + pasta setup | 101 ms | 95 ms |
+| snapshot load + resume | 6 ms | 6 ms |
+| resume → exec-server-ready | 222 ms | 221 ms |
+| **total (p50)** | **673 ms** | **331 ms** |
+| `execve()` per clone | 35 | 19 |
+
+Three hot-path costs were removed, all of them work that does not belong in a
+per-launch path:
+
+1. **`git ls-remote` to GitHub on every launch** (~337 ms, half the total). The
+   fork-branch resolution is now cached under `assets_dir/firecracker/` with a
+   TTL (`FCVM_FIRECRACKER_RESOLVE_TTL_SECS`, default 1h); `fcvm setup` always
+   re-queries and rewrites it, so a rebuilt fork is picked up immediately.
+2. **Repeated `--version` / `ldd --version` probes.** Cached per binary identity
+   (path + mtime + size), in-process and on disk, so a changed binary still
+   re-checks. Removes 3 execs per clone.
+3. **Per-command `ip` execs in the rootless namespace.** Each setup phase now
+   pipes all its `ip` commands through one `ip -batch` process, and the TAP
+   verification is the batch's last step instead of a second `nsenter`. Removes
+   10 execs per clone.
+
+The remaining `resume → exec-server-ready` (~221 ms) is guest-side work (fc-agent
+restore handshake) and is the next target.
+
 ---
 
 ## Memory Efficiency

--- a/README.md
+++ b/README.md
@@ -380,7 +380,17 @@ Run `fcvm --help` or `fcvm <command> --help` for full options.
 | `FCVM_NO_WRITEBACK_CACHE` | unset | `1` to disable FUSE writeback cache |
 | `FCVM_SNAPSHOT_CONCURRENCY` | `10` | Max concurrent snapshot creations |
 | `FCVM_CLOUD_HYPERVISOR_BIN` | unset | Path to `cloud-hypervisor` binary (falls back to PATH) |
+| `FCVM_FIRECRACKER_RESOLVE_TTL_SECS` | `3600` | How long a cached firecracker-fork resolution stays valid before a launch re-queries the remote; `0` forces a query every launch |
 | `RUST_LOG` | `warn` | Logging level (`info`, `debug` for verbose) |
+
+**Firecracker fork resolution.** When a kernel profile builds firecracker from a
+fork branch, the branch head is resolved with `git ls-remote` — a network round
+trip that used to run on *every* VM launch and snapshot clone. The result is now
+cached in `assets_dir/firecracker/<profile>.resolved.json` and reused for
+`FCVM_FIRECRACKER_RESOLVE_TTL_SECS`. `fcvm setup` always re-queries and rewrites
+that file, so rebuilding the fork takes effect for launches immediately rather
+than after the TTL. `<binary> --version` probes are cached the same way, keyed by
+the binary's path + mtime + size, so a rebuilt binary is always re-checked.
 
 ### Image Delivery Modes
 

--- a/bench/clone-latency-report.py
+++ b/bench/clone-latency-report.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Summarise a bench/clone-latency.sh run.
+
+Reads /tmp/fcvm-clone-latency-<label>/ and prints p50/min/max of the measured
+spawn->exec-ready totals plus a stage breakdown parsed from each clone's
+RUST_LOG=fcvm=debug timeline.
+
+Stages are anchored on log lines emitted by `fcvm snapshot run`. Each stage is
+[first line matching `start`, first line matching `end`), so the stages tile the
+clone's own timeline and sum to roughly the in-process total (the difference vs
+the wall-clock total is process exec + runtime init before the first log line,
+reported separately as `pre-log`).
+"""
+
+import re
+import statistics
+import sys
+from pathlib import Path
+
+TS = re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+)Z")
+
+# (stage name, substring that opens it, substring that closes it)
+STAGES = [
+    ("resolve-fc", "Cloning VM from serve PID", "connecting to memory server"),
+    ("listeners+state", "connecting to memory server", "spawning namespace holder"),
+    ("netns+pasta", "spawning namespace holder", "pasta + bridge setup complete"),
+    ("snapshot-load", "loading snapshot with UFFD", "VM resume completed"),
+    ("resume->ready", "VM resume completed", "exec server ready"),
+]
+
+
+def parse_ts(line):
+    m = TS.match(line)
+    if not m:
+        return None
+    text = m.group(1)
+    date, _, clock = text.partition("T")
+    y, mo, d = (int(x) for x in date.split("-"))
+    hh, mm, rest = clock.split(":")
+    sec = float(rest)
+    # Day-relative seconds are enough: a clone never spans midnight.
+    return ((int(hh) * 60) + int(mm)) * 60 + sec + (d * 86400)
+
+
+def first_ts(lines, needle):
+    for line in lines:
+        if needle in line:
+            t = parse_ts(line)
+            if t is not None:
+                return t
+    return None
+
+
+def main():
+    out = Path(sys.argv[1])
+    totals_file = out / "totals.txt"
+    if not totals_file.exists():
+        print(f"no totals.txt in {out}", file=sys.stderr)
+        return 1
+    totals = [int(x) for x in totals_file.read_text().split() if x.strip()]
+
+    rows = []
+    for log in sorted(out.glob("clone-*.log")):
+        lines = log.read_text(errors="replace").splitlines()
+        stamps = [t for t in (parse_ts(line) for line in lines) if t is not None]
+        if not stamps:
+            continue
+        row = {"name": log.stem}
+        first = stamps[0]
+        ready = first_ts(lines, "exec server ready")
+        row["in-process"] = (ready - first) * 1000 if ready else None
+        for name, start, end in STAGES:
+            a, b = first_ts(lines, start), first_ts(lines, end)
+            row[name] = (b - a) * 1000 if (a is not None and b is not None) else None
+        rows.append(row)
+
+    def pct(vals, q):
+        vals = sorted(vals)
+        if not vals:
+            return float("nan")
+        k = max(0, min(len(vals) - 1, int(round((len(vals) - 1) * q))))
+        return vals[k]
+
+    print("=" * 68)
+    print(f"clone spawn -> exec-ready   (n={len(totals)})   [{out.name}]")
+    print("=" * 68)
+    print(f"  p50 {pct(totals, 0.5):7.1f} ms")
+    print(f"  min {min(totals):7.1f} ms")
+    print(f"  max {max(totals):7.1f} ms")
+    print(f"  p90 {pct(totals, 0.9):7.1f} ms")
+    print(f"  mean{statistics.mean(totals):7.1f} ms")
+    print()
+
+    names = ["in-process"] + [s[0] for s in STAGES]
+    print("stage breakdown (median of per-clone deltas, ms)")
+    print(f"  {'stage':<18} {'p50':>8} {'min':>8} {'max':>8}")
+    for name in names:
+        vals = [r[name] for r in rows if r.get(name) is not None]
+        if not vals:
+            print(f"  {name:<18} {'n/a':>8}")
+            continue
+        print(
+            f"  {name:<18} {pct(vals, 0.5):8.1f} {min(vals):8.1f} {max(vals):8.1f}"
+        )
+
+    inproc = [r["in-process"] for r in rows if r.get("in-process") is not None]
+    if inproc and totals:
+        print()
+        print(
+            f"  pre-log (exec+init) {pct(totals, 0.5) - pct(inproc, 0.5):6.1f} ms"
+            "   (wall-clock p50 minus in-process p50)"
+        )
+
+    # Machine-readable dump for cross-run diffs.
+    tsv = out / "samples.tsv"
+    with tsv.open("w") as fh:
+        fh.write("\t".join(["clone", "total_ms"] + names) + "\n")
+        for i, r in enumerate(rows):
+            total = totals[i] if i < len(totals) else ""
+            cells = [r["name"], str(total)]
+            cells += [
+                ("" if r.get(n) is None else f"{r[n]:.1f}") for n in names
+            ]
+            fh.write("\t".join(cells) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/clone-latency.sh
+++ b/bench/clone-latency.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+#
+# Clone hot-path latency benchmark: spawn -> exec-server-ready.
+#
+# Boots a minimal alpine VM, snapshots it, serves the snapshot, then times N
+# `fcvm snapshot run` cycles from process spawn until fc-agent's exec server is
+# reachable. Readiness is EVENT-DRIVEN: a `tail -F | grep -m1` on the clone's
+# RUST_LOG=fcvm=debug log releases the instant the marker line is written (no
+# fixed-interval sleeping in the measurement loop).
+#
+# Also parses the per-clone debug timeline into a stage breakdown so a change in
+# total latency can be attributed to a specific stage.
+#
+# Results go to /tmp (never committed):
+#   /tmp/fcvm-clone-latency-<label>/
+#     clone-NN.log     per-clone debug log
+#     samples.tsv      one row per clone: total_ms + stage_ms columns
+#     summary.txt      p50/min/max + stage breakdown (also printed to stdout)
+#
+# Usage:
+#   bench/clone-latency.sh [label] [iterations]
+#
+# Env:
+#   FCVM_BIN   fcvm binary to measure (default: ./target/release/fcvm). When it
+#              lives outside the repo (A/B against a stashed build), also set
+#              FC_AGENT_PATH — fcvm looks for fc-agent next to its own binary.
+#   N          iterations (default 10, overridden by $2)
+#   KEEP       set to 1 to leave the baseline VM + serve process running
+#
+# A/B example (interleaved so host load drift hits both arms equally):
+#   git stash push -- src/ && make build && cp target/release/fcvm /tmp/fcvm-base
+#   git stash pop && make build && cp target/release/fcvm /tmp/fcvm-after
+#   for r in 1 2; do
+#     FC_AGENT_PATH=$PWD/target/release/fc-agent FCVM_BIN=/tmp/fcvm-base  bench/clone-latency.sh base-r$r
+#     FC_AGENT_PATH=$PWD/target/release/fc-agent FCVM_BIN=/tmp/fcvm-after bench/clone-latency.sh after-r$r
+#   done
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+LABEL="${1:-run}"
+N="${2:-${N:-10}}"
+FCVM_BIN="${FCVM_BIN:-$REPO_ROOT/target/release/fcvm}"
+OUT="/tmp/fcvm-clone-latency-${LABEL}"
+IMAGE="${IMAGE:-docker.io/library/alpine:latest}"
+
+# Marker written by `fcvm snapshot run` once fc-agent's output channel is
+# connected and its exec server is accepting (src/commands/snapshot.rs).
+READY_MARKER="exec server ready"
+
+if [[ ! -x "$FCVM_BIN" ]]; then
+    echo "ERROR: fcvm binary not found/executable: $FCVM_BIN" >&2
+    echo "       run 'make build' first" >&2
+    exit 1
+fi
+
+rm -rf "$OUT"
+mkdir -p "$OUT"
+
+STAMP="$(date +%s)"
+BASE="clbench-${LABEL}-base-${STAMP}"
+SNAP="clbench-${LABEL}-snap-${STAMP}"
+
+BASE_PID=""
+SERVE_PID=""
+
+cleanup() {
+    local rc=$?
+    set +e
+    if [[ "${KEEP:-0}" != "1" ]]; then
+        [[ -n "$SERVE_PID" ]] && kill -TERM "$SERVE_PID" 2>/dev/null
+        [[ -n "$BASE_PID" ]] && kill -TERM "$BASE_PID" 2>/dev/null
+        # Give both a moment to tear their VMs down cleanly.
+        local waited=0
+        while [[ $waited -lt 100 ]]; do
+            kill -0 "$SERVE_PID" 2>/dev/null || kill -0 "$BASE_PID" 2>/dev/null || break
+            sleep 0.1
+            waited=$((waited + 1))
+        done
+        [[ -n "$SERVE_PID" ]] && kill -KILL "$SERVE_PID" 2>/dev/null
+        [[ -n "$BASE_PID" ]] && kill -KILL "$BASE_PID" 2>/dev/null
+    fi
+    exit $rc
+}
+trap cleanup EXIT INT TERM
+
+echo "==> fcvm clone latency bench (label=$LABEL, N=$N)"
+echo "    binary : $FCVM_BIN"
+echo "    version: $(cd "$REPO_ROOT" && git rev-parse --short HEAD 2>/dev/null || echo unknown)$(git -C "$REPO_ROOT" diff --quiet 2>/dev/null || echo '+dirty')"
+echo "    output : $OUT"
+echo "    load   : $(cut -d' ' -f1-3 /proc/loadavg)"
+
+# ---------------------------------------------------------------------------
+# 1. Baseline VM
+# ---------------------------------------------------------------------------
+echo "==> booting baseline VM ($IMAGE)"
+RUST_LOG=fcvm=debug "$FCVM_BIN" podman run --name "$BASE" "$IMAGE" sleep infinity \
+    >"$OUT/baseline.log" 2>&1 &
+BASE_PID=$!
+
+# Baseline readiness: the state file flips to healthy. Poll it (this is setup,
+# not the measured path) but keep the interval tight.
+deadline=$((SECONDS + 300))
+while :; do
+    if ! kill -0 "$BASE_PID" 2>/dev/null; then
+        echo "ERROR: baseline VM exited early; see $OUT/baseline.log" >&2
+        tail -30 "$OUT/baseline.log" >&2
+        exit 1
+    fi
+    if "$FCVM_BIN" ls --json 2>/dev/null \
+        | jq -e --arg n "$BASE" 'map(select(.name == $n and .health_status == "healthy")) | length > 0' \
+             >/dev/null 2>&1; then
+        break
+    fi
+    if [[ $SECONDS -gt $deadline ]]; then
+        echo "ERROR: baseline VM did not become healthy in 300s" >&2
+        tail -30 "$OUT/baseline.log" >&2
+        exit 1
+    fi
+    sleep 0.2
+done
+echo "    baseline healthy (pid $BASE_PID)"
+
+# ---------------------------------------------------------------------------
+# 2. Snapshot + serve
+# ---------------------------------------------------------------------------
+echo "==> creating snapshot $SNAP"
+"$FCVM_BIN" snapshot create --pid "$BASE_PID" --tag "$SNAP" >"$OUT/snapshot-create.log" 2>&1
+
+echo "==> serving snapshot"
+"$FCVM_BIN" snapshot serve "$SNAP" >"$OUT/serve.log" 2>&1 &
+SERVE_SHELL_PID=$!
+deadline=$((SECONDS + 60))
+while :; do
+    SERVE_PID="$(sed -n 's/^ *Serve PID: *//p' "$OUT/serve.log" | head -1)"
+    [[ -n "$SERVE_PID" ]] && break
+    if ! kill -0 "$SERVE_SHELL_PID" 2>/dev/null; then
+        echo "ERROR: serve process exited; see $OUT/serve.log" >&2
+        cat "$OUT/serve.log" >&2
+        exit 1
+    fi
+    [[ $SECONDS -gt $deadline ]] && { echo "ERROR: serve did not print its PID" >&2; exit 1; }
+    sleep 0.05
+done
+echo "    serve pid $SERVE_PID"
+
+# ---------------------------------------------------------------------------
+# 3. Timed clone cycles
+# ---------------------------------------------------------------------------
+echo "==> timing $N clone spawn->exec-ready cycles"
+: >"$OUT/totals.txt"
+CLONE_PIDS=()
+
+for i in $(seq 1 "$N"); do
+    idx="$(printf '%02d' "$i")"
+    clone="clbench-${LABEL}-c${idx}-${STAMP}"
+    log="$OUT/clone-${idx}.log"
+    : >"$log"
+
+    t0=$(date +%s%N)
+    RUST_LOG=fcvm=debug "$FCVM_BIN" snapshot run --pid "$SERVE_PID" --name "$clone" \
+        >"$log" 2>&1 &
+    cpid=$!
+    CLONE_PIDS+=("$cpid")
+
+    # Event-driven readiness: grep releases the pipeline the moment the marker
+    # line lands in the log; tail then dies on SIGPIPE.
+    if ! timeout 120 grep -q -m1 -F "$READY_MARKER" \
+            < <(tail -n +1 -F --pid=$$ "$log" 2>/dev/null); then
+        echo "ERROR: clone $idx never reached '$READY_MARKER'; see $log" >&2
+        tail -40 "$log" >&2
+        exit 1
+    fi
+    t1=$(date +%s%N)
+
+    ms=$(( (t1 - t0) / 1000000 ))
+    echo "$ms" >>"$OUT/totals.txt"
+    printf '    clone %s: %s ms\n' "$idx" "$ms"
+done
+
+# ---------------------------------------------------------------------------
+# 4. Tear down the clones before analysing (keeps the host quiet)
+# ---------------------------------------------------------------------------
+for cpid in "${CLONE_PIDS[@]}"; do kill -TERM "$cpid" 2>/dev/null || true; done
+for cpid in "${CLONE_PIDS[@]}"; do wait "$cpid" 2>/dev/null || true; done
+
+# ---------------------------------------------------------------------------
+# 5. Stage breakdown from the RUST_LOG=fcvm=debug timeline
+# ---------------------------------------------------------------------------
+python3 "$REPO_ROOT/bench/clone-latency-report.py" "$OUT" | tee "$OUT/summary.txt"
+
+echo
+echo "==> results in $OUT"

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -1213,6 +1213,23 @@ async fn prepare_clone_substrate(
     })
 }
 
+/// Mint the restore-epoch value that tells a restored guest's fc-agent "you have
+/// just been restored — reconnect your vsock channels".
+///
+/// MUST be unique per restore, never wall-clock derived. fc-agent's watcher
+/// ([`fc-agent`]'s `watch_restore_epoch`) compares epochs only for (in)equality,
+/// and a snapshot taken FROM a restored VM captures the watcher's last-seen
+/// epoch inside guest memory. With the old second-granularity epochs
+/// (`SystemTime::now().as_secs()`), restoring such a snapshot within the same
+/// wall-clock second as its ancestor's restore handed the guest an IDENTICAL
+/// epoch: the watcher treated the restore as already handled, never reconnected
+/// exec/egress/output vsocks, and the clone never became healthy (120s health
+/// timeouts across the snapshot-hit suite once the clone hot path went
+/// sub-second). A fresh UUID makes every restore observably distinct.
+pub(crate) fn new_restore_epoch() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
 /// Restore a VM from a snapshot.
 ///
 /// This is the core snapshot restore logic shared by:
@@ -1411,14 +1428,11 @@ pub async fn restore_from_snapshot(
         // Signal fc-agent to flush ARP cache and reconnect output vsock via MMDS.
         // MUST be after VM resume — Firecracker accepts PUT /mmds while paused but
         // the guest-visible MMDS data isn't updated until after resume.
-        let restore_epoch = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .context("system time before Unix epoch")?
-            .as_secs();
+        let restore_epoch = new_restore_epoch();
 
         let mut mmds_latest = serde_json::json!({
             "host-time": chrono::Utc::now().timestamp().to_string(),
-            "restore-epoch": restore_epoch.to_string()
+            "restore-epoch": restore_epoch.clone()
         });
         if let Some(ref ipv6) = clone_ipv6 {
             mmds_latest["clone-ipv6"] = serde_json::Value::String(ipv6.clone());
@@ -1428,7 +1442,7 @@ pub async fn restore_from_snapshot(
             .await
             .context("updating MMDS with restore-epoch")?;
         info!(
-            restore_epoch = restore_epoch,
+            restore_epoch = %restore_epoch,
             clone_ipv6 = ?clone_ipv6,
             "signaled fc-agent via MMDS"
         );
@@ -2769,6 +2783,22 @@ mod tests {
     use crate::state::VmState;
     use crate::storage::SnapshotType;
     use std::path::Path;
+
+    /// Regression guard for the deaf-clone bug: a snapshot taken from a restored
+    /// VM embeds the ancestor's restore epoch in guest memory, so two restores in
+    /// the same wall-clock second MUST still produce different epochs — otherwise
+    /// fc-agent sees an unchanged epoch, skips handle_clone_restore, and the clone
+    /// never becomes healthy. Wall-clock-second epochs fail this; unique-per-call
+    /// epochs pass.
+    #[test]
+    fn restore_epochs_differ_for_back_to_back_restores() {
+        let a = new_restore_epoch();
+        let b = new_restore_epoch();
+        assert_ne!(
+            a, b,
+            "restore epochs minted back-to-back (same wall-clock second) must differ"
+        );
+    }
 
     /// `with_extension` would map "app.v1" onto "app.creating", colliding with an
     /// unrelated tag's files — snapshot_sibling must APPEND instead.

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -463,34 +463,21 @@ pub fn find_firecracker(config: &RuntimeConfig) -> Result<std::path::PathBuf> {
         which::which("firecracker").context("firecracker not found in PATH")?
     };
 
-    // Check version
-    let output = std::process::Command::new(&firecracker_bin)
-        .arg("--version")
-        .output()
-        .with_context(|| {
+    // Check version. Cached per binary identity (path + mtime + size): this runs
+    // on every VM launch and clone, and the answer only changes when the binary
+    // does — a rebuilt or swapped firecracker is re-probed. See version_cache.
+    let version_str =
+        crate::version_cache::version_output(&firecracker_bin).with_context(|| {
             format!(
-                "failed to run firecracker --version (binary: {})",
+                "checking firecracker version at {}",
                 firecracker_bin.display()
             )
         })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!(
-            "firecracker --version failed (exit {}, binary: {}): {}",
-            output.status,
-            firecracker_bin.display(),
-            stderr.trim()
-        );
-    }
-
-    let version_str = String::from_utf8_lossy(&output.stdout);
     let version = parse_firecracker_version(&version_str).with_context(|| {
         format!(
-            "binary: {}, stdout: {:?}, stderr: {:?}",
+            "binary: {}, stdout: {:?}",
             firecracker_bin.display(),
             version_str.trim(),
-            String::from_utf8_lossy(&output.stderr).trim()
         )
     })?;
 
@@ -523,14 +510,12 @@ pub fn find_firecracker(config: &RuntimeConfig) -> Result<std::path::PathBuf> {
 /// any v52+; the cached build is preferred so CI and dev hosts use the pinned fork.
 pub fn find_cloud_hypervisor() -> Result<std::path::PathBuf> {
     // Run `<bin> --version`; returns the trimmed version string on success.
+    // Cached per binary identity (only successful probes are cached), so a
+    // binary that cannot run here keeps failing and keeps falling through.
     fn version_of(bin: &std::path::Path) -> Option<String> {
-        let out = std::process::Command::new(bin)
-            .arg("--version")
-            .output()
-            .ok()?;
-        out.status
-            .success()
-            .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+        crate::version_cache::version_output(bin)
+            .ok()
+            .map(|s| s.trim().to_string())
     }
 
     // 1. Explicit override — must exist and run; no fallback (the user asked for THIS one).
@@ -1031,7 +1016,6 @@ pub struct CloneSubstrate {
 async fn prepare_clone_substrate(
     network: &mut dyn NetworkManager,
     restore_config: &SnapshotRestoreConfig,
-    network_config: &NetworkConfig,
     vm_id: &str,
     data_dir: &Path,
     vm_state: &mut VmState,
@@ -1076,7 +1060,6 @@ async fn prepare_clone_substrate(
 
         let setup_script = pasta_net.build_setup_script();
         let nsenter_prefix = pasta_net.build_nsenter_prefix(holder_pid);
-        let tap_device = network_config.tap_device.clone();
 
         let source_disk = restore_config.source_disk_path.clone();
         let disk_task = async {
@@ -1097,6 +1080,9 @@ async fn prepare_clone_substrate(
         let network_task = async {
             let ns_poll_start = std::time::Instant::now();
             info!(holder_pid = holder_pid, "running network setup via nsenter");
+            // One nsenter+bash+ip for the whole phase, TAP verification included
+            // as the last batch step (ip -batch aborts at the first failure, so
+            // reaching it proves every step above applied).
             loop {
                 if !crate::utils::is_process_alive(holder_pid) {
                     anyhow::bail!(
@@ -1108,7 +1094,7 @@ async fn prepare_clone_substrate(
                     .args(&nsenter_prefix[1..])
                     .arg("bash")
                     .arg("-c")
-                    .arg(&setup_script)
+                    .arg(setup_script.script())
                     .output()
                     .await
                     .context("running network setup via nsenter")?;
@@ -1128,27 +1114,11 @@ async fn prepare_clone_substrate(
                     tokio::time::sleep(NSENTER_POLL_INTERVAL).await;
                     continue;
                 }
-                anyhow::bail!("network setup failed: {}", stderr);
-            }
-
-            let verify_output = tokio::process::Command::new(&nsenter_prefix[0])
-                .args(&nsenter_prefix[1..])
-                .arg("ip")
-                .arg("link")
-                .arg("show")
-                .arg(&tap_device)
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status()
-                .await
-                .context("verifying TAP device")?;
-            if !verify_output.success() {
                 anyhow::bail!(
-                    "TAP device '{}' not found after network setup - setup may have failed silently",
-                    tap_device
+                    "network setup failed: {}",
+                    setup_script.describe_failure(&stderr)
                 );
             }
-            debug!(tap_device = %tap_device, "TAP device verified");
             Ok::<_, anyhow::Error>(())
         };
 
@@ -1281,15 +1251,8 @@ pub async fn restore_from_snapshot(
 
     // Configure namespace isolation, create the CoW disk, copy extra disks, and compute the
     // mount redirect — all shared with the Cloud Hypervisor restore path.
-    let substrate = prepare_clone_substrate(
-        network,
-        restore_config,
-        network_config,
-        vm_id,
-        data_dir,
-        vm_state,
-    )
-    .await?;
+    let substrate =
+        prepare_clone_substrate(network, restore_config, vm_id, data_dir, vm_state).await?;
     let rootfs_path = substrate.rootfs_path;
     let holder_child = substrate.holder_child;
     let holder_pid_for_post_start = substrate.holder_pid_for_post_start;
@@ -1608,15 +1571,8 @@ pub async fn restore_from_snapshot_ch(
     )?;
 
     // Shared substrate: network namespace / CoW disk / mount-redirect / extra disks.
-    let substrate = prepare_clone_substrate(
-        network,
-        restore_config,
-        network_config,
-        vm_id,
-        data_dir,
-        vm_state,
-    )
-    .await?;
+    let substrate =
+        prepare_clone_substrate(network, restore_config, vm_id, data_dir, vm_state).await?;
 
     // Cloud Hypervisor reads its restore config (disk/vsock/net) from the snapshot's `ch/`
     // dir. Disk + vsock paths are the source VM's and are redirected to the clone's by the

--- a/src/commands/podman/namespace.rs
+++ b/src/commands/podman/namespace.rs
@@ -31,7 +31,7 @@ pub(super) async fn setup_rootless_namespace(
     // Step 2: Run setup script via nsenter (creates TAPs, iptables, etc.)
     // This is also inside retry logic - if holder dies during nsenter, retry everything
     let setup_script = pasta_net.build_setup_script();
-    let mut nsenter_prefix = pasta_net.build_nsenter_prefix(holder_pid);
+    let nsenter_prefix = pasta_net.build_nsenter_prefix(holder_pid);
 
     // Debug: Check if holder is still alive and namespace files exist
     let proc_dir = format!("/proc/{}", holder_pid);
@@ -61,15 +61,18 @@ pub(super) async fn setup_rootless_namespace(
     // Log the setup script for debugging
     debug!(
         holder_pid = holder_pid,
-        script = %setup_script.lines().filter(|l| !l.trim().is_empty() && !l.trim().starts_with('#')).collect::<Vec<_>>().join("; "),
+        script = %setup_script.summary(),
         "network setup script"
     );
 
+    // One nsenter+bash+ip for the whole phase: the script batches every `ip`
+    // command (TAP creation, link up, loopback, and the TAP existence check)
+    // into a single `ip -batch` process.
     let setup_output = tokio::process::Command::new(&nsenter_prefix[0])
         .args(&nsenter_prefix[1..])
         .arg("bash")
         .arg("-c")
-        .arg(&setup_script)
+        .arg(setup_script.script())
         .output()
         .await
         .context("running network setup via nsenter")?;
@@ -104,7 +107,7 @@ pub(super) async fn setup_rootless_namespace(
                 .args(&retry_nsenter_prefix[1..])
                 .arg("bash")
                 .arg("-c")
-                .arg(&setup_script)
+                .arg(setup_script.script())
                 .output()
                 .await
                 .context("running network setup via nsenter (retry)")?;
@@ -115,13 +118,15 @@ pub(super) async fn setup_rootless_namespace(
                     nix::unistd::Pid::from_raw(retry_holder_pid as i32),
                     nix::sys::signal::Signal::SIGKILL,
                 );
-                bail!("network setup failed on retry: {}", retry_stderr.trim(),);
+                bail!(
+                    "network setup failed on retry: {}",
+                    setup_script.describe_failure(&retry_stderr)
+                );
             }
 
             // Success on retry - update variables for rest of function
             child = retry_child;
             holder_pid = retry_holder_pid;
-            nsenter_prefix = pasta_net.build_nsenter_prefix(holder_pid);
             info!(
                 holder_pid = holder_pid,
                 "network setup succeeded after retry"
@@ -169,7 +174,7 @@ pub(super) async fn setup_rootless_namespace(
                     "network setup failed: holder died during nsenter. \
                      nsenter_stderr='{}', holder_stderr='{}', \
                      (tun={}, ns_user={}, ns_net={})",
-                    stderr.trim(),
+                    setup_script.describe_failure(&stderr),
                     holder_stderr_content.trim(),
                     tun_exists,
                     ns_user_exists,
@@ -178,7 +183,7 @@ pub(super) async fn setup_rootless_namespace(
             } else {
                 bail!(
                     "network setup failed: {} (tun={}, holder_alive={}, ns_user={}, ns_net={})",
-                    stderr.trim(),
+                    setup_script.describe_failure(&stderr),
                     tun_exists,
                     holder_alive,
                     ns_user_exists,
@@ -188,30 +193,10 @@ pub(super) async fn setup_rootless_namespace(
         }
     }
 
+    // The TAP existence check is the last step of the batched setup script, so a
+    // successful run already proves the device is there — no second nsenter+ip.
+    debug!(tap_device = %network_config.tap_device, "TAP device verified");
     info!(holder_pid = holder_pid, "network setup complete");
-
-    // Verify TAP device was created successfully
-    let tap_device = &network_config.tap_device;
-    let verify_output = tokio::process::Command::new(&nsenter_prefix[0])
-        .args(&nsenter_prefix[1..])
-        .arg("ip")
-        .arg("link")
-        .arg("show")
-        .arg(tap_device)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .await
-        .context("verifying TAP device")?;
-
-    if !verify_output.success() {
-        let _ = child.kill().await;
-        bail!(
-            "TAP device '{}' not found after network setup - setup may have failed silently",
-            tap_device
-        );
-    }
-    debug!(tap_device = %tap_device, "TAP device verified");
 
     // Use pre_exec setns path (not nsenter) for rootless baselines.
     // nsenter enters the user namespace internally, which clears PR_SET_PDEATHSIG

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -1360,13 +1360,13 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
             // resumes the VM, so the restored guest's watcher can run handle_clone_restore
             // (reconnect output/exec vsock + clock sync) as soon as it resumes. The
             // listener task runs detached for the clone's (process) lifetime.
-            let restore_epoch = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_secs())
-                .unwrap_or(0);
+            // Unique per restore (see new_restore_epoch): a wall-clock epoch
+            // repeats when a snapshot of a restored VM is itself restored within
+            // the same second, leaving the guest's watcher deaf to the restore.
+            let restore_epoch = super::common::new_restore_epoch();
             let mut latest = serde_json::json!({
                 "host-time": chrono::Utc::now().timestamp().to_string(),
-                "restore-epoch": restore_epoch.to_string(),
+                "restore-epoch": restore_epoch,
             });
             if let Some((_, ref new_ipv6)) = clone_ipv6_swap {
                 latest["clone-ipv6"] = serde_json::Value::String(new_ipv6.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod state;
 pub mod storage;
 pub mod uffd;
 pub mod utils;
+pub mod version_cache;
 pub mod volume;
 
 /// Get total host memory in MiB from /proc/meminfo.

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -40,6 +40,103 @@ const PASTA_STDERR_TAIL_LINES: usize = 20;
 /// so the failure error can include what it actually printed.
 const PASTA_STDERR_DRAIN_DELAY: std::time::Duration = std::time::Duration::from_millis(200);
 
+/// Heredoc delimiter separating the batched `ip` commands from the shell script.
+const IP_BATCH_DELIMITER: &str = "FCVM_IP_BATCH";
+
+/// A list of `ip` commands rendered as a single shell script.
+///
+/// Configuring one VM's namespace takes ~10 `ip` invocations, and each one is a
+/// fork+exec. `ip -batch` reads commands from a stream and applies them all in
+/// ONE process, so a whole phase costs `nsenter` + `bash` + `ip` instead of a
+/// process per command.
+///
+/// Semantics are unchanged: `ip -batch` runs the commands in order and, without
+/// `-force`, **aborts at the first failure** — nothing after it is applied, just
+/// as `set -e` did for the one-command-per-line form. On failure it prints
+/// `Command failed -:<line>`, and [`IpBatchScript::describe_failure`] maps that
+/// line back to the step's description so an error still names the step that
+/// failed.
+#[derive(Debug, Clone)]
+pub struct IpBatchScript {
+    /// (human description, `ip` arguments) — one entry per batch line, in order.
+    steps: Vec<(String, String)>,
+    script: String,
+}
+
+impl IpBatchScript {
+    /// Render `steps` as one `ip -batch` invocation, followed by `trailing_shell`
+    /// lines (for things `ip` cannot do, e.g. writing a sysctl — those are shell
+    /// builtins and cost no extra process).
+    fn new(steps: Vec<(String, String)>, trailing_shell: &[&str]) -> Self {
+        // One step per physical line, no blanks or comments inside the heredoc:
+        // `ip -batch` reports the physical line number, so line N is step N.
+        let batch: String = steps
+            .iter()
+            .map(|(_, args)| format!("{}\n", args))
+            .collect();
+        let mut script = format!(
+            "set -e\nip -batch - <<'{delim}'\n{batch}{delim}\n",
+            delim = IP_BATCH_DELIMITER,
+            batch = batch,
+        );
+        for line in trailing_shell {
+            script.push_str(line);
+            script.push('\n');
+        }
+        Self { steps, script }
+    }
+
+    /// The shell script to run under `bash -c` inside the namespace.
+    pub fn script(&self) -> &str {
+        &self.script
+    }
+
+    /// One-line summary of the steps, for debug logging.
+    pub fn summary(&self) -> String {
+        self.steps
+            .iter()
+            .map(|(_, args)| format!("ip {}", args))
+            .collect::<Vec<_>>()
+            .join("; ")
+    }
+
+    /// Turn a failed run's stderr into a message naming the step that failed.
+    ///
+    /// `ip -batch` prints `Command failed -:<line>` for the aborting command;
+    /// anything else (nsenter/bash failures, or an `ip` too old to report a
+    /// line) falls back to the raw stderr so no diagnostic is ever swallowed.
+    pub fn describe_failure(&self, stderr: &str) -> String {
+        let stderr = stderr.trim();
+        for token in stderr.split_whitespace() {
+            let Some(line_no) = token.strip_prefix("-:") else {
+                continue;
+            };
+            let Ok(line_no) = line_no.trim_end_matches(':').parse::<usize>() else {
+                continue;
+            };
+            if let Some((desc, args)) = line_no.checked_sub(1).and_then(|i| self.steps.get(i)) {
+                return format!(
+                    "step {}/{} ({}) failed running `ip {}`: {}",
+                    line_no,
+                    self.steps.len(),
+                    desc,
+                    args,
+                    if stderr.is_empty() {
+                        "(no stderr)"
+                    } else {
+                        stderr
+                    }
+                );
+            }
+        }
+        if stderr.is_empty() {
+            "(no stderr)".to_string()
+        } else {
+            stderr.to_string()
+        }
+    }
+}
+
 /// Rootless networking using pasta with bridge architecture
 ///
 /// This mode uses user namespaces and pasta (from passt project) for true
@@ -160,24 +257,38 @@ impl PastaNetwork {
         ]
     }
 
-    /// Build the pre-pasta setup script to run inside the namespace via nsenter
+    /// Build the pre-pasta setup script to run inside the namespace via nsenter.
     ///
-    /// Creates only the Firecracker TAP device. The bridge and pasta0 TAP
-    /// are set up after pasta starts (pasta creates its own TAP).
-    /// Run via: nsenter -t HOLDER_PID -U -n -- bash -c '<this script>'
-    pub fn build_setup_script(&self) -> String {
-        format!(
-            r#"
-set -e
-
-# Create TAP device for Firecracker (pasta creates its own TAP separately)
-ip tuntap add {fc_tap} mode tap
-ip link set {fc_tap} up
-
-# Set up loopback
-ip link set lo up
-"#,
-            fc_tap = self.tap_device,
+    /// Creates the Firecracker TAP device, brings loopback up, and verifies the
+    /// TAP exists — every `ip` command in ONE `ip -batch` process (see
+    /// [`IpBatchScript`]). The bridge and pasta0 TAP are set up after pasta
+    /// starts (pasta creates its own TAP).
+    ///
+    /// Run via: nsenter -t HOLDER_PID -U -n -- bash -c '<script()>'
+    pub fn build_setup_script(&self) -> IpBatchScript {
+        IpBatchScript::new(
+            vec![
+                (
+                    format!("create TAP device {} for Firecracker", self.tap_device),
+                    format!("tuntap add {} mode tap", self.tap_device),
+                ),
+                (
+                    format!("bring TAP device {} up", self.tap_device),
+                    format!("link set {} up", self.tap_device),
+                ),
+                (
+                    "bring loopback up".to_string(),
+                    "link set lo up".to_string(),
+                ),
+                // Verification is the last batch step rather than a second
+                // nsenter+ip process: `ip -batch` already stops at the first
+                // failure, so reaching this line means every step above applied.
+                (
+                    format!("verify TAP device {} exists", self.tap_device),
+                    format!("link show {}", self.tap_device),
+                ),
+            ],
+            &[],
         )
     }
 
@@ -190,37 +301,50 @@ ip link set lo up
     ///
     /// The caller (post_start) waits for pasta's TAP device to exist via
     /// wait_for_pasta_device() before running this script.
-    pub fn build_bridge_script(&self) -> String {
-        let script = format!(
-            r#"
-set -e
-
-# Bring pasta0 up (pasta creates it but doesn't bring it up without --config-net)
-ip link set {pasta_dev} up
-
-# Create L2 bridge — connects pasta0 and Firecracker TAP
-ip link add {bridge} type bridge
-ip link set {bridge} up
-
-# Add pasta's TAP to bridge (pasta created this device)
-ip link set {pasta_dev} master {bridge}
-
-# Add Firecracker's TAP to bridge
-ip link set {fc_tap} master {bridge}
-
-# Add IP to bridge for health checks (namespace needs route to reach guest)
-ip addr add {namespace_ip}/24 dev {bridge}
-
-# Enable IP forwarding
-echo 1 > /proc/sys/net/ipv4/ip_forward
-"#,
-            bridge = BRIDGE_DEVICE,
-            pasta_dev = self.pasta_device,
-            fc_tap = self.tap_device,
-            namespace_ip = NAMESPACE_IP,
-        );
-
-        script
+    ///
+    /// All six `ip` commands run in ONE `ip -batch` process; enabling IP
+    /// forwarding is a shell redirect (no extra process).
+    pub fn build_bridge_script(&self) -> IpBatchScript {
+        let bridge = BRIDGE_DEVICE;
+        IpBatchScript::new(
+            vec![
+                (
+                    format!(
+                        "bring {} up (pasta creates it but leaves it down without --config-net)",
+                        self.pasta_device
+                    ),
+                    format!("link set {} up", self.pasta_device),
+                ),
+                (
+                    format!("create L2 bridge {}", bridge),
+                    format!("link add {} type bridge", bridge),
+                ),
+                (
+                    format!("bring bridge {} up", bridge),
+                    format!("link set {} up", bridge),
+                ),
+                (
+                    format!("add pasta TAP {} to bridge {}", self.pasta_device, bridge),
+                    format!("link set {} master {}", self.pasta_device, bridge),
+                ),
+                (
+                    format!(
+                        "add Firecracker TAP {} to bridge {}",
+                        self.tap_device, bridge
+                    ),
+                    format!("link set {} master {}", self.tap_device, bridge),
+                ),
+                (
+                    format!(
+                        "add health-check IP {}/24 to bridge {}",
+                        NAMESPACE_IP, bridge
+                    ),
+                    format!("addr add {}/24 dev {}", NAMESPACE_IP, bridge),
+                ),
+            ],
+            // Enable IP forwarding — a bash redirect, not another process.
+            &["echo 1 > /proc/sys/net/ipv4/ip_forward"],
+        )
     }
 
     /// Build the nsenter prefix command for running processes in the namespace
@@ -245,8 +369,17 @@ echo 1 > /proc/sys/net/ipv4/ip_forward
         "holder(unshare --user --net) + nsenter for setup/firecracker".to_string()
     }
 
-    /// Detect host's global IPv6 address for pasta outbound traffic
+    /// Detect host's global IPv6 address for pasta outbound traffic.
+    ///
+    /// Memoised for the process lifetime: `setup()` and `start_pasta()` both need
+    /// it, so without this every VM launch pays two `ip -6 addr show` execs for
+    /// an answer that cannot change during one launch.
     fn detect_host_ipv6() -> Option<String> {
+        static HOST_IPV6: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+        HOST_IPV6.get_or_init(Self::probe_host_ipv6).clone()
+    }
+
+    fn probe_host_ipv6() -> Option<String> {
         let output = std::process::Command::new("ip")
             .args(["-6", "addr", "show", "scope", "global"])
             .output()
@@ -755,7 +888,7 @@ impl NetworkManager for PastaNetwork {
 
         debug!(
             holder_pid = holder_pid,
-            script = %bridge_script.lines().filter(|l| !l.trim().is_empty() && !l.trim().starts_with('#')).collect::<Vec<_>>().join("; "),
+            script = %bridge_script.summary(),
             "running bridge setup script"
         );
 
@@ -763,14 +896,17 @@ impl NetworkManager for PastaNetwork {
             .args(&nsenter_prefix[1..])
             .arg("bash")
             .arg("-c")
-            .arg(&bridge_script)
+            .arg(bridge_script.script())
             .output()
             .await
             .context("running bridge setup via nsenter")?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("bridge setup failed: {}", stderr.trim());
+            anyhow::bail!(
+                "bridge setup failed: {}",
+                bridge_script.describe_failure(&stderr)
+            );
         }
 
         // Phase 4: Verify port forwarding is actually working
@@ -895,5 +1031,173 @@ mod tests {
         assert_eq!(net.pasta_device, "pasta0");
         assert_eq!(net.guest_ip, "10.0.2.100");
         assert_eq!(net.gateway_ip(), "10.0.2.2");
+    }
+
+    /// Batch lines are exactly the heredoc body, in order, one per line.
+    fn batch_lines(script: &str) -> Vec<&str> {
+        let open = format!("<<'{}'\n", IP_BATCH_DELIMITER);
+        let body = script
+            .split_once(&open)
+            .expect("script must open a batch heredoc")
+            .1;
+        let body = body
+            .split_once(&format!("\n{}\n", IP_BATCH_DELIMITER))
+            .expect("script must close the batch heredoc")
+            .0;
+        body.lines().collect()
+    }
+
+    #[test]
+    fn setup_script_batches_every_ip_command_into_one_process() {
+        let net = PastaNetwork::new("vm-test123".to_string(), "tap-fc".to_string(), vec![]);
+        let script = net.build_setup_script();
+
+        // Exactly one `ip` process for the whole phase: the only shell line that
+        // invokes `ip` is the batch itself.
+        let ip_lines: Vec<&str> = script
+            .script()
+            .lines()
+            .filter(|l| l.trim_start().starts_with("ip "))
+            .collect();
+        assert_eq!(
+            ip_lines,
+            vec![format!("ip -batch - <<'{}'", IP_BATCH_DELIMITER)],
+            "no per-command `ip` invocations should remain outside the batch"
+        );
+
+        assert_eq!(
+            batch_lines(script.script()),
+            vec![
+                "tuntap add tap-fc mode tap",
+                "link set tap-fc up",
+                "link set lo up",
+                "link show tap-fc",
+            ],
+            "TAP verification must be the last batch step, not a second exec"
+        );
+    }
+
+    #[test]
+    fn bridge_script_batches_every_ip_command_and_keeps_ip_forward() {
+        let net = PastaNetwork::new("vm-test123".to_string(), "tap-fc".to_string(), vec![]);
+        let script = net.build_bridge_script();
+
+        assert_eq!(script.script().matches("ip -batch -").count(), 1);
+        assert_eq!(
+            batch_lines(script.script()),
+            vec![
+                "link set pasta0 up",
+                "link add br0 type bridge",
+                "link set br0 up",
+                "link set pasta0 master br0",
+                "link set tap-fc master br0",
+                "addr add 10.0.2.1/24 dev br0",
+            ]
+        );
+        assert!(
+            script
+                .script()
+                .contains("echo 1 > /proc/sys/net/ipv4/ip_forward"),
+            "ip_forward must still be enabled (as a shell redirect, not a process)"
+        );
+        assert!(script.script().starts_with("set -e\n"));
+    }
+
+    #[test]
+    fn batch_failure_names_the_failing_step() {
+        let net = PastaNetwork::new("vm-test123".to_string(), "tap-fc".to_string(), vec![]);
+        let script = net.build_bridge_script();
+
+        // `ip -batch` aborts at the first failing line and reports `-:<line>`.
+        let msg = script.describe_failure("RTNETLINK answers: File exists\nCommand failed -:2\n");
+        assert!(msg.contains("step 2/6"), "missing step index: {msg}");
+        assert!(
+            msg.contains("create L2 bridge br0"),
+            "missing step name: {msg}"
+        );
+        assert!(
+            msg.contains("ip link add br0 type bridge"),
+            "missing command: {msg}"
+        );
+        assert!(
+            msg.contains("RTNETLINK answers: File exists"),
+            "lost stderr: {msg}"
+        );
+    }
+
+    #[test]
+    fn batch_failure_falls_back_to_raw_stderr() {
+        let net = PastaNetwork::new("vm-test123".to_string(), "tap-fc".to_string(), vec![]);
+        let script = net.build_setup_script();
+
+        // nsenter-level failure: no `-:<line>` marker, so nothing may be swallowed.
+        let msg = script.describe_failure("nsenter: cannot open /proc/123/ns/net: No such process");
+        assert_eq!(
+            msg,
+            "nsenter: cannot open /proc/123/ns/net: No such process"
+        );
+
+        // Out-of-range line numbers must not panic or invent a step.
+        assert_eq!(
+            script.describe_failure("Command failed -:99"),
+            "Command failed -:99"
+        );
+        assert_eq!(script.describe_failure("   "), "(no stderr)");
+    }
+
+    /// The batch really does run under `bash -c` and really does abort at the
+    /// first failure — verified against the host's actual `ip` binary, in the
+    /// current namespace, using read-only `link show` commands.
+    #[test]
+    fn ip_batch_script_runs_and_aborts_on_first_failure() {
+        let ok = IpBatchScript::new(
+            vec![
+                ("show loopback".to_string(), "link show lo".to_string()),
+                (
+                    "show loopback again".to_string(),
+                    "link show lo".to_string(),
+                ),
+            ],
+            &["echo TRAILING_RAN"],
+        );
+        let out = std::process::Command::new("bash")
+            .arg("-c")
+            .arg(ok.script())
+            .output()
+            .expect("running batch script");
+        assert!(
+            out.status.success(),
+            "batch failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(String::from_utf8_lossy(&out.stdout).contains("TRAILING_RAN"));
+
+        let bad = IpBatchScript::new(
+            vec![
+                ("show loopback".to_string(), "link show lo".to_string()),
+                (
+                    "show a device that cannot exist".to_string(),
+                    "link show fcvm-no-such-dev".to_string(),
+                ),
+                ("never reached".to_string(), "link show lo".to_string()),
+            ],
+            &["echo TRAILING_RAN"],
+        );
+        let out = std::process::Command::new("bash")
+            .arg("-c")
+            .arg(bad.script())
+            .output()
+            .expect("running batch script");
+        assert!(!out.status.success(), "batch should have failed");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let msg = bad.describe_failure(&stderr);
+        assert!(
+            msg.contains("step 2/3") && msg.contains("show a device that cannot exist"),
+            "failure not attributed to step 2: stderr={stderr:?} msg={msg}"
+        );
+        assert!(
+            !String::from_utf8_lossy(&out.stdout).contains("TRAILING_RAN"),
+            "set -e must stop the script when the batch aborts"
+        );
     }
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -77,6 +77,15 @@ pub fn assets_dir() -> PathBuf {
         .clone()
 }
 
+/// Assets directory *only if* it has already been initialised.
+///
+/// Unlike [`assets_dir`] this never loads the config (and so never panics when
+/// no config exists). Used by best-effort on-disk caches that must degrade to a
+/// process-local cache rather than take down a caller that never needed paths.
+pub fn assets_dir_if_initialized() -> Option<PathBuf> {
+    ASSETS_DIR.get().cloned()
+}
+
 // === Content-addressed assets (use assets_dir) ===
 
 /// Directory for kernel images (vmlinux-*.bin files).

--- a/src/setup/kernel.rs
+++ b/src/setup/kernel.rs
@@ -1330,7 +1330,17 @@ fn compute_profile_firecracker_sha_with_commit(
 
 /// Return a string identifying the C library (e.g. "glibc-2.39" or "musl-1.2.4").
 /// Used to namespace the firecracker binary cache per build environment.
+///
+/// Memoised for the lifetime of the process: the host's libc cannot change while
+/// fcvm runs, and several content-addressed SHAs (firecracker, pasta,
+/// cloud-hypervisor) mix it in, which otherwise costs one `ldd --version` exec
+/// each on the VM-launch path.
 pub(crate) fn libc_version_tag() -> String {
+    static TAG: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    TAG.get_or_init(probe_libc_version_tag).clone()
+}
+
+fn probe_libc_version_tag() -> String {
     // Try GNU libc first (most common on host and Ubuntu containers)
     if let Ok(output) = std::process::Command::new("ldd").arg("--version").output() {
         // ldd --version prints to stdout on glibc, stderr on musl
@@ -1353,14 +1363,253 @@ pub(crate) fn libc_version_tag() -> String {
     "libc-unknown".to_string()
 }
 
+// ============================================================================
+// Profile Firecracker resolution cache
+// ============================================================================
+
+/// Default freshness window for a cached firecracker resolution.
+const FIRECRACKER_RESOLVE_TTL_DEFAULT_SECS: u64 = 3600;
+
+/// Env var overriding the resolution TTL, in seconds. `0` forces a remote refresh.
+const FIRECRACKER_RESOLVE_TTL_ENV: &str = "FCVM_FIRECRACKER_RESOLVE_TTL_SECS";
+
+/// A previously completed remote resolution of a profile's firecracker binary.
+///
+/// Persisted at `assets_dir/firecracker/<profile>.resolved.json` so VM launches
+/// can reuse it instead of paying a `git ls-remote` round trip to GitHub.
+///
+/// Concurrency: written with a unique temp file + atomic rename, never a lock —
+/// `assets_dir` can be shared across nesting levels over fuse-pipe, where
+/// `flock` does not cross the VM boundary (see the cross-VM cache race notes in
+/// AGENTS.md). Readers therefore always see a whole file. Two writers racing
+/// resolve the *same* repo/branch, so the loser's entry is equally valid; if the
+/// branch moved between them the older commit simply expires at the next TTL,
+/// and `fcvm setup` rewrites the entry unconditionally.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct FirecrackerResolution {
+    repo: String,
+    branch: String,
+    commit_hash: String,
+    resolved_path: PathBuf,
+    /// Unix seconds at which the `git ls-remote` that produced `commit_hash` ran.
+    resolved_at_secs: u64,
+}
+
+/// Directory holding the profile firecracker binaries and their resolution cache.
+fn firecracker_cache_dir() -> PathBuf {
+    paths::assets_dir().join("firecracker")
+}
+
+fn firecracker_resolution_path(dir: &Path, profile_name: &str) -> PathBuf {
+    dir.join(format!("{}.resolved.json", profile_name))
+}
+
+/// How long a cached resolution stays usable before the remote is re-queried.
+fn firecracker_resolve_ttl_secs() -> u64 {
+    parse_resolve_ttl(std::env::var(FIRECRACKER_RESOLVE_TTL_ENV).ok().as_deref())
+}
+
+/// Parse `FCVM_FIRECRACKER_RESOLVE_TTL_SECS`. Unset or unparsable falls back to
+/// the default; `0` means "always re-query the remote".
+fn parse_resolve_ttl(raw: Option<&str>) -> u64 {
+    let Some(raw) = raw else {
+        return FIRECRACKER_RESOLVE_TTL_DEFAULT_SECS;
+    };
+    raw.trim().parse::<u64>().unwrap_or_else(|_| {
+        warn!(
+            var = FIRECRACKER_RESOLVE_TTL_ENV,
+            value = %raw,
+            default = FIRECRACKER_RESOLVE_TTL_DEFAULT_SECS,
+            "invalid firecracker resolve TTL, using default"
+        );
+        FIRECRACKER_RESOLVE_TTL_DEFAULT_SECS
+    })
+}
+
+fn unix_now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Return the cached resolution for `profile_name` if it is usable right now:
+/// same repo/branch, within the TTL, and pointing at a binary that still exists.
+///
+/// Any parse/IO problem is a miss (the caller re-resolves), never an error —
+/// a corrupt cache must not be able to block a VM launch.
+fn fresh_cached_firecracker_resolution_in(
+    dir: &Path,
+    profile_name: &str,
+    repo: &str,
+    branch: &str,
+    ttl_secs: u64,
+) -> Option<PathBuf> {
+    if ttl_secs == 0 {
+        return None;
+    }
+    let path = firecracker_resolution_path(dir, profile_name);
+    let raw = std::fs::read_to_string(&path).ok()?;
+    let entry: FirecrackerResolution = match serde_json::from_str(&raw) {
+        Ok(e) => e,
+        Err(e) => {
+            warn!(path = %path.display(), error = %e, "ignoring unreadable firecracker resolution cache");
+            return None;
+        }
+    };
+    if entry.repo != repo || entry.branch != branch {
+        return None;
+    }
+    // A resolution stamped in the future (clock moved backwards) is treated as
+    // stale rather than as infinitely fresh.
+    let age = unix_now_secs().checked_sub(entry.resolved_at_secs)?;
+    if age >= ttl_secs {
+        return None;
+    }
+    if !entry.resolved_path.exists() {
+        return None;
+    }
+    debug!(
+        profile = %profile_name,
+        path = %entry.resolved_path.display(),
+        commit = %entry.commit_hash,
+        age_secs = age,
+        ttl_secs,
+        "using cached firecracker resolution (no git ls-remote)"
+    );
+    Some(entry.resolved_path)
+}
+
+/// Persist a completed remote resolution so later launches can skip the network.
+///
+/// Written atomically (unique temp + rename) because several fcvm processes may
+/// resolve the same profile concurrently; readers then always see a whole file.
+/// Only called with a `resolved_path` that exists, so the cache never advertises
+/// a binary that was never built.
+fn record_firecracker_resolution_in(
+    dir: &Path,
+    profile_name: &str,
+    repo: &str,
+    branch: &str,
+    commit_hash: &str,
+    resolved_path: &Path,
+) {
+    let entry = FirecrackerResolution {
+        repo: repo.to_string(),
+        branch: branch.to_string(),
+        commit_hash: commit_hash.to_string(),
+        resolved_path: resolved_path.to_path_buf(),
+        resolved_at_secs: unix_now_secs(),
+    };
+    let final_path = firecracker_resolution_path(dir, profile_name);
+    if let Err(e) = write_json_atomic(&final_path, &entry) {
+        // Non-fatal: the next launch just pays the ls-remote again.
+        warn!(
+            path = %final_path.display(),
+            error = %e,
+            "could not persist firecracker resolution cache"
+        );
+        return;
+    }
+    debug!(
+        profile = %profile_name,
+        path = %resolved_path.display(),
+        commit = %commit_hash,
+        "recorded firecracker resolution"
+    );
+}
+
+/// [`fresh_cached_firecracker_resolution_in`] against the real assets dir.
+fn fresh_cached_firecracker_resolution(
+    profile_name: &str,
+    repo: &str,
+    branch: &str,
+    ttl_secs: u64,
+) -> Option<PathBuf> {
+    fresh_cached_firecracker_resolution_in(
+        &firecracker_cache_dir(),
+        profile_name,
+        repo,
+        branch,
+        ttl_secs,
+    )
+}
+
+/// [`record_firecracker_resolution_in`] against the real assets dir.
+fn record_firecracker_resolution(
+    profile_name: &str,
+    repo: &str,
+    branch: &str,
+    commit_hash: &str,
+    resolved_path: &Path,
+) {
+    record_firecracker_resolution_in(
+        &firecracker_cache_dir(),
+        profile_name,
+        repo,
+        branch,
+        commit_hash,
+        resolved_path,
+    );
+}
+
+/// Serialize `value` as JSON to `final_path` via a unique temp file + rename.
+///
+/// The temp name carries a uuid (not a pid — separate PID namespaces reuse
+/// numbers) so concurrent writers never share a temp file, and the rename makes
+/// the swap atomic for readers.
+fn write_json_atomic<T: serde::Serialize>(final_path: &Path, value: &T) -> Result<()> {
+    let dir = final_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("no parent directory for {}", final_path.display()))?;
+    std::fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
+    let tmp = dir.join(format!(
+        ".{}.{}.tmp",
+        final_path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "cache".to_string()),
+        uuid::Uuid::new_v4()
+    ));
+    let json = serde_json::to_vec_pretty(value).context("serializing cache entry")?;
+    if let Err(e) = std::fs::write(&tmp, &json) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e).with_context(|| format!("writing {}", tmp.display()));
+    }
+    if let Err(e) = std::fs::rename(&tmp, final_path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e).with_context(|| format!("renaming into {}", final_path.display()));
+    }
+    Ok(())
+}
+
 /// Get the content-addressed path for profile firecracker binary.
 /// Uses assets_dir/firecracker/ alongside kernels and other assets.
-/// Fetches latest commit hash to ensure we detect updates.
 ///
 /// Returns `Ok(None)` when the profile does not configure a custom firecracker.
-/// When the remote commit cannot be queried (offline, GitHub outage), falls back
-/// to the most recently installed cached binary for the profile instead of
-/// pretending no custom firecracker is configured; errors if none is cached.
+///
+/// # Resolution contract
+///
+/// This runs on the **VM launch / snapshot clone hot path**, so it does NOT
+/// contact the network on every call. Resolution order:
+///
+/// 1. `assets_dir/firecracker/<profile>.resolved.json` — the result of the last
+///    remote resolution. Used when it names the same repo/branch, is younger
+///    than the TTL, and still points at an existing binary.
+/// 2. `git ls-remote` against the configured repo/branch, which then rewrites
+///    the cache (only when the resolved binary exists).
+/// 3. Offline fallback: the newest cached `firecracker-<profile>-*.bin`. Errors
+///    if the remote is unreachable and nothing is cached.
+///
+/// The TTL is `FCVM_FIRECRACKER_RESOLVE_TTL_SECS` seconds (default 3600);
+/// setting it to `0` forces a remote refresh on every call.
+///
+/// **A rebuild must never leave a launcher on a stale binary.**
+/// [`ensure_profile_firecracker`] — the `fcvm setup` path, including
+/// `--build-kernels` / an explicit `--kernel-profile` — always performs the
+/// remote resolution and rewrites this cache with the binary it just
+/// installed. So `fcvm setup` is what makes an updated fork visible, and it
+/// takes effect immediately rather than after the TTL expires.
 pub async fn get_profile_firecracker_path(
     profile: &KernelProfile,
     profile_name: &str,
@@ -1372,12 +1621,26 @@ pub async fn get_profile_firecracker_path(
     };
     let branch = profile.firecracker_branch.as_deref().unwrap_or("main");
 
+    // Fast path: reuse the last remote resolution and skip the network entirely.
+    let ttl_secs = firecracker_resolve_ttl_secs();
+    if let Some(cached) = fresh_cached_firecracker_resolution(profile_name, repo, branch, ttl_secs)
+    {
+        return Ok(Some(cached));
+    }
+
     // Fetch latest commit hash to detect updates
     match fetch_remote_commit_hash(repo, branch).await {
         Ok(commit_hash) => {
             let sha = compute_profile_firecracker_sha_with_commit(profile, &commit_hash);
             let filename = format!("firecracker-{}-{}.bin", profile_name, sha);
-            Ok(Some(paths::assets_dir().join("firecracker").join(filename)))
+            let resolved = paths::assets_dir().join("firecracker").join(filename);
+            // Only cache resolutions that name a binary that actually exists, so
+            // a not-yet-built profile keeps re-resolving (and keeps failing loudly
+            // in get_firecracker_for_profile) instead of caching a dead path.
+            if resolved.exists() {
+                record_firecracker_resolution(profile_name, repo, branch, &commit_hash, &resolved);
+            }
+            Ok(Some(resolved))
         }
         Err(e) => match newest_cached_profile_firecracker(profile_name)? {
             Some(cached) => {
@@ -1452,6 +1715,12 @@ pub async fn get_firecracker_for_profile(
 /// Uses content-addressed naming: firecracker-{profile}-{sha}.bin
 /// where SHA is computed from firecracker_repo + firecracker_branch + commit_hash.
 /// Automatically detects and rebuilds when new commits are pushed.
+///
+/// This is the `fcvm setup` path and it **always** performs the remote
+/// resolution (`git ls-remote`), then rewrites the launch-time resolution cache
+/// read by [`get_profile_firecracker_path`]. That is what makes an updated fork
+/// take effect for VM launches immediately rather than after the cache TTL —
+/// `fcvm setup` is the sanctioned way to pick up a new firecracker build.
 pub async fn ensure_profile_firecracker(
     profile: &KernelProfile,
     profile_name: &str,
@@ -1481,6 +1750,7 @@ pub async fn ensure_profile_firecracker(
             sha = %sha,
             "firecracker binary exists"
         );
+        record_firecracker_resolution(profile_name, repo, branch, &commit_hash, &bin_path);
         return Ok(Some(bin_path));
     }
 
@@ -1508,6 +1778,7 @@ pub async fn ensure_profile_firecracker(
     if bin_path.exists() {
         debug!(path = %bin_path.display(), "firecracker exists (built by another process)");
         flock.unlock().map_err(|(_, err)| err)?;
+        record_firecracker_resolution(profile_name, repo, branch, &commit_hash, &bin_path);
         return Ok(Some(bin_path));
     }
 
@@ -1607,6 +1878,8 @@ pub async fn ensure_profile_firecracker(
         "firecracker binary installed"
     );
     println!("  ✓ Firecracker ready: {}", bin_path.display());
+
+    record_firecracker_resolution(profile_name, repo, branch, &commit_hash, &bin_path);
 
     Ok(Some(bin_path))
 }
@@ -1949,6 +2222,166 @@ mod tests {
         assert_eq!(
             compute_profile_kernel_sha(&profile).unwrap(),
             "000000000000"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Firecracker resolution cache (kills the git ls-remote on the hot path)
+    // ---------------------------------------------------------------------
+
+    const REPO: &str = "ejc3/firecracker";
+    const BRANCH: &str = "bump-vsock-max-connections";
+    const TTL: u64 = 3600;
+
+    /// Create the cache dir plus a stand-in firecracker binary inside it.
+    fn resolution_fixture(dir: &Path, sha: &str) -> PathBuf {
+        std::fs::create_dir_all(dir).unwrap();
+        let bin = dir.join(format!("firecracker-default-{}.bin", sha));
+        std::fs::write(&bin, b"fake firecracker").unwrap();
+        bin
+    }
+
+    #[test]
+    fn resolution_cache_hit_returns_recorded_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let bin = resolution_fixture(dir, "aaaaaaaaaaaa");
+
+        // Nothing recorded yet -> miss (caller pays the ls-remote).
+        assert!(
+            fresh_cached_firecracker_resolution_in(dir, "default", REPO, BRANCH, TTL).is_none()
+        );
+
+        record_firecracker_resolution_in(dir, "default", REPO, BRANCH, "0123456789ab", &bin);
+        assert_eq!(
+            fresh_cached_firecracker_resolution_in(dir, "default", REPO, BRANCH, TTL),
+            Some(bin)
+        );
+    }
+
+    #[test]
+    fn resolution_cache_expires_with_ttl() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let bin = resolution_fixture(dir, "bbbbbbbbbbbb");
+        record_firecracker_resolution_in(dir, "default", REPO, BRANCH, "0123456789ab", &bin);
+
+        // Age the entry past any plausible TTL by rewriting its timestamp.
+        let path = firecracker_resolution_path(dir, "default");
+        let mut entry: FirecrackerResolution =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        entry.resolved_at_secs -= 7200;
+        std::fs::write(&path, serde_json::to_vec(&entry).unwrap()).unwrap();
+
+        assert!(
+            fresh_cached_firecracker_resolution_in(dir, "default", REPO, BRANCH, TTL).is_none(),
+            "an entry older than the TTL must not be reused"
+        );
+        // A longer TTL still accepts it.
+        assert!(
+            fresh_cached_firecracker_resolution_in(dir, "default", REPO, BRANCH, 86_400).is_some()
+        );
+    }
+
+    #[test]
+    fn resolution_cache_ttl_zero_forces_refresh() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let bin = resolution_fixture(dir, "cccccccccccc");
+        record_firecracker_resolution_in(dir, "default", REPO, BRANCH, "0123456789ab", &bin);
+
+        assert!(
+            fresh_cached_firecracker_resolution_in(dir, "default", REPO, BRANCH, 0).is_none(),
+            "FCVM_FIRECRACKER_RESOLVE_TTL_SECS=0 must always re-query the remote"
+        );
+    }
+
+    #[test]
+    fn resolution_cache_invalidated_by_repo_or_branch_change() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let bin = resolution_fixture(dir, "dddddddddddd");
+        record_firecracker_resolution_in(dir, "default", REPO, BRANCH, "0123456789ab", &bin);
+
+        assert!(
+            fresh_cached_firecracker_resolution_in(dir, "default", "other/fork", BRANCH, TTL)
+                .is_none()
+        );
+        assert!(
+            fresh_cached_firecracker_resolution_in(dir, "default", REPO, "main", TTL).is_none()
+        );
+        // Different profile name = different cache file.
+        assert!(fresh_cached_firecracker_resolution_in(dir, "nested", REPO, BRANCH, TTL).is_none());
+    }
+
+    #[test]
+    fn resolution_cache_ignores_missing_binary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let bin = resolution_fixture(dir, "eeeeeeeeeeee");
+        record_firecracker_resolution_in(dir, "default", REPO, BRANCH, "0123456789ab", &bin);
+
+        std::fs::remove_file(&bin).unwrap();
+        assert!(
+            fresh_cached_firecracker_resolution_in(dir, "default", REPO, BRANCH, TTL).is_none(),
+            "a resolution pointing at a deleted binary must not be reused"
+        );
+    }
+
+    #[test]
+    fn resolution_cache_ignores_corrupt_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(firecracker_resolution_path(dir, "default"), b"{not json").unwrap();
+
+        assert!(
+            fresh_cached_firecracker_resolution_in(dir, "default", REPO, BRANCH, TTL).is_none(),
+            "a corrupt cache must degrade to a remote resolution, not fail the launch"
+        );
+    }
+
+    #[test]
+    fn setup_style_rebuild_overwrites_the_resolution() {
+        // Models `fcvm setup` after a fork rebuild: ensure_profile_firecracker
+        // always re-resolves and rewrites the cache, so a launcher picks up the
+        // NEW binary immediately instead of waiting out the TTL.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let old = resolution_fixture(dir, "111111111111");
+        record_firecracker_resolution_in(dir, "default", REPO, BRANCH, "old000000000", &old);
+        assert_eq!(
+            fresh_cached_firecracker_resolution_in(dir, "default", REPO, BRANCH, TTL),
+            Some(old.clone())
+        );
+
+        let new = resolution_fixture(dir, "222222222222");
+        record_firecracker_resolution_in(dir, "default", REPO, BRANCH, "new000000000", &new);
+        assert_eq!(
+            fresh_cached_firecracker_resolution_in(dir, "default", REPO, BRANCH, TTL),
+            Some(new),
+            "setup must not leave launches pinned to the pre-rebuild binary"
+        );
+    }
+
+    #[test]
+    fn resolve_ttl_env_parsing() {
+        // Pure parser (no std::env mutation — that would race the other tests in
+        // this process, and env writes are not thread-safe).
+        assert_eq!(
+            parse_resolve_ttl(None),
+            FIRECRACKER_RESOLVE_TTL_DEFAULT_SECS
+        );
+        assert_eq!(parse_resolve_ttl(Some("0")), 0);
+        assert_eq!(parse_resolve_ttl(Some("42")), 42);
+        assert_eq!(parse_resolve_ttl(Some(" 90 ")), 90);
+        assert_eq!(
+            parse_resolve_ttl(Some("not-a-number")),
+            FIRECRACKER_RESOLVE_TTL_DEFAULT_SECS
+        );
+        assert_eq!(
+            parse_resolve_ttl(Some("")),
+            FIRECRACKER_RESOLVE_TTL_DEFAULT_SECS
         );
     }
 }

--- a/src/version_cache.rs
+++ b/src/version_cache.rs
@@ -1,0 +1,355 @@
+//! Cached `<binary> --version` probes.
+//!
+//! `firecracker --version` runs on the VM-launch / snapshot-clone hot path —
+//! `find_firecracker()` probes it and is called more than once per launch — and
+//! each probe is a fork+exec of a multi-megabyte binary. The answer only changes
+//! when the binary itself changes, so it is memoised per binary *identity*
+//! (path + mtime + size) in two layers:
+//!
+//! * a process-local map, so repeat probes inside one fcvm process are free;
+//! * `assets_dir/version-cache/<key>.json`, so a *freshly spawned* fcvm (the
+//!   clone case: one short-lived process per VM) skips the exec too.
+//!
+//! **Version gating still holds.** Rebuilding or replacing the binary changes
+//! its mtime and usually its size, which changes the key, so a changed binary is
+//! re-probed instead of inheriting the old version. A different path is a
+//! different key for the same reason.
+//!
+//! Only *successful* probes are cached. A binary that fails to run (wrong arch,
+//! missing loader) re-runs every time and keeps producing its real error, which
+//! is what the fallback logic in `find_cloud_hypervisor()` depends on.
+//!
+//! Cache IO never fails a probe: an unreadable or unwritable cache degrades to
+//! running the binary (so a root-created cache dir does not break unprivileged
+//! runs, and vice versa — they just fall back to the in-process layer).
+//!
+//! Entries are ~250 bytes and one is added per distinct binary build ever
+//! probed, so the directory is bounded by how many firecracker /
+//! cloud-hypervisor builds a host has seen; no eviction is needed.
+
+use anyhow::{bail, Context, Result};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use tracing::debug;
+
+/// Persisted probe result. `path`/`mtime_ns`/`len` are re-verified on read so a
+/// hash collision or a hand-edited file can never hand back another binary's
+/// version string.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct CachedVersion {
+    path: PathBuf,
+    mtime_ns: i128,
+    len: u64,
+    stdout: String,
+}
+
+/// Identity of a binary: absolute-ish path plus mtime and size.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BinaryIdentity {
+    path: PathBuf,
+    mtime_ns: i128,
+    len: u64,
+}
+
+impl BinaryIdentity {
+    fn of(bin: &Path) -> Option<Self> {
+        let meta = std::fs::metadata(bin).ok()?;
+        let mtime = meta.modified().ok()?;
+        let mtime_ns = match mtime.duration_since(std::time::UNIX_EPOCH) {
+            Ok(d) => d.as_nanos() as i128,
+            // Pre-epoch mtime (possible on odd filesystems): keep it distinct.
+            Err(e) => -(e.duration().as_nanos() as i128),
+        };
+        Some(Self {
+            path: bin.to_path_buf(),
+            mtime_ns,
+            len: meta.len(),
+        })
+    }
+
+    /// Stable file name for this identity's on-disk cache entry.
+    fn key(&self) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(self.path.as_os_str().as_encoded_bytes());
+        hasher.update(b"\0");
+        hasher.update(self.mtime_ns.to_le_bytes());
+        hasher.update(self.len.to_le_bytes());
+        hex::encode(&hasher.finalize()[..16])
+    }
+
+    fn matches(&self, entry: &CachedVersion) -> bool {
+        entry.path == self.path && entry.mtime_ns == self.mtime_ns && entry.len == self.len
+    }
+}
+
+fn memo() -> &'static Mutex<HashMap<String, String>> {
+    static MEMO: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+    MEMO.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// On-disk cache directory, or `None` when the asset paths were never
+/// initialised (then only the process-local layer is used).
+fn disk_cache_dir() -> Option<PathBuf> {
+    crate::paths::assets_dir_if_initialized().map(|d| d.join("version-cache"))
+}
+
+/// Run `<bin> --version` and return its stdout, reusing a cached result when the
+/// binary has not changed. See the module docs for the caching contract.
+pub fn version_output(bin: &Path) -> Result<String> {
+    version_output_in(bin, disk_cache_dir().as_deref())
+}
+
+/// [`version_output`] against an explicit cache directory (`None` disables the
+/// on-disk layer). Split out so tests can exercise the cache without touching
+/// the process-global asset paths.
+fn version_output_in(bin: &Path, cache_dir: Option<&Path>) -> Result<String> {
+    let identity = BinaryIdentity::of(bin);
+
+    if let Some(id) = &identity {
+        let key = id.key();
+        if let Ok(map) = memo().lock() {
+            if let Some(hit) = map.get(&key) {
+                return Ok(hit.clone());
+            }
+        }
+        if let Some(dir) = cache_dir {
+            if let Some(hit) = read_disk_entry(dir, &key, id) {
+                debug!(bin = %bin.display(), "version cache hit (disk)");
+                if let Ok(mut map) = memo().lock() {
+                    map.insert(key, hit.clone());
+                }
+                return Ok(hit);
+            }
+        }
+    }
+
+    let output = std::process::Command::new(bin)
+        .arg("--version")
+        .output()
+        .with_context(|| format!("failed to run `{} --version`", bin.display()))?;
+    if !output.status.success() {
+        bail!(
+            "`{} --version` failed (exit {}): {}",
+            bin.display(),
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+
+    if let Some(id) = &identity {
+        let key = id.key();
+        if let Ok(mut map) = memo().lock() {
+            map.insert(key.clone(), stdout.clone());
+        }
+        if let Some(dir) = cache_dir {
+            write_disk_entry(dir, &key, id, &stdout);
+        }
+    }
+
+    Ok(stdout)
+}
+
+fn read_disk_entry(dir: &Path, key: &str, id: &BinaryIdentity) -> Option<String> {
+    let raw = std::fs::read_to_string(dir.join(format!("{}.json", key))).ok()?;
+    let entry: CachedVersion = serde_json::from_str(&raw).ok()?;
+    id.matches(&entry).then_some(entry.stdout)
+}
+
+/// Write the entry atomically (unique temp + rename): several fcvm processes can
+/// probe the same binary at once, and a reader must never see a partial file.
+fn write_disk_entry(dir: &Path, key: &str, id: &BinaryIdentity, stdout: &str) {
+    let entry = CachedVersion {
+        path: id.path.clone(),
+        mtime_ns: id.mtime_ns,
+        len: id.len,
+        stdout: stdout.to_string(),
+    };
+    if std::fs::create_dir_all(dir).is_err() {
+        return;
+    }
+    // uuid, not pid — separate PID namespaces reuse numbers.
+    let tmp = dir.join(format!(".{}.{}.tmp", key, uuid::Uuid::new_v4()));
+    let Ok(json) = serde_json::to_vec(&entry) else {
+        return;
+    };
+    if std::fs::write(&tmp, &json).is_err() {
+        let _ = std::fs::remove_file(&tmp);
+        return;
+    }
+    if std::fs::rename(&tmp, dir.join(format!("{}.json", key))).is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    /// Argument that makes a fake binary exit immediately without touching the
+    /// witness file — used to pre-flight execability, see [`wait_until_executable`].
+    const EXEC_PROBE: &str = "--fcvm-exec-probe";
+
+    /// A fake `--version` binary that records every invocation in `witness`, so a
+    /// test can prove an exec was skipped rather than merely inferring it.
+    fn fake_binary(dir: &Path, name: &str, witness: &Path, text: &str) -> PathBuf {
+        write_fake(dir.join(name), witness, &format!("echo '{}'", text))
+    }
+
+    fn write_fake(path: PathBuf, witness: &Path, body: &str) -> PathBuf {
+        std::fs::write(
+            &path,
+            format!(
+                "#!/bin/sh\n[ \"$1\" = \"{probe}\" ] && exit 0\necho ran >> '{witness}'\n{body}\n",
+                probe = EXEC_PROBE,
+                witness = witness.display(),
+                body = body,
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        wait_until_executable(&path);
+        path
+    }
+
+    /// Wait until a just-written script can actually be exec'd.
+    ///
+    /// A multithreaded test process that writes an executable and then runs it
+    /// can hit `ETXTBSY`: a *different* test's `Command::spawn` forks in the
+    /// window where our write fd is still open, the child inherits it, and
+    /// `execve` refuses any file that is open for writing anywhere. That is an
+    /// artifact of creating executables inside the test process — production
+    /// code only ever execs binaries it did not just write — so the helper waits
+    /// the window out instead of leaking a retry into `version_output`.
+    fn wait_until_executable(path: &Path) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            match std::process::Command::new(path).arg(EXEC_PROBE).status() {
+                Ok(status) if status.success() => return,
+                Ok(status) => panic!("fake binary {} probe failed: {status}", path.display()),
+                Err(e) if e.raw_os_error() == Some(libc::ETXTBSY) => {
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "fake binary {} stayed ETXTBSY for 10s",
+                        path.display()
+                    );
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                }
+                Err(e) => panic!("running fake binary {}: {e}", path.display()),
+            }
+        }
+    }
+
+    fn run_count(witness: &Path) -> usize {
+        std::fs::read_to_string(witness)
+            .map(|s| s.lines().count())
+            .unwrap_or(0)
+    }
+
+    #[test]
+    fn cache_hit_skips_the_exec_in_this_process_and_the_next() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = tmp.path().join("cache");
+        let witness = tmp.path().join("runs.txt");
+        let bin = fake_binary(tmp.path(), "probe-reuse", &witness, "Firecracker v1.15.0");
+
+        assert_eq!(
+            version_output_in(&bin, Some(&cache)).unwrap().trim(),
+            "Firecracker v1.15.0"
+        );
+        assert_eq!(run_count(&witness), 1, "first probe must exec the binary");
+
+        // Same process: served by the in-process memo.
+        version_output_in(&bin, Some(&cache)).unwrap();
+        assert_eq!(run_count(&witness), 1, "memo hit must not exec");
+
+        // Simulate a freshly spawned fcvm: the on-disk layer must still hit.
+        memo().lock().unwrap().clear();
+        assert_eq!(
+            version_output_in(&bin, Some(&cache)).unwrap().trim(),
+            "Firecracker v1.15.0"
+        );
+        assert_eq!(run_count(&witness), 1, "disk cache hit must not exec");
+    }
+
+    #[test]
+    fn changed_binary_is_reprobed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = tmp.path().join("cache");
+        let witness = tmp.path().join("runs.txt");
+        let bin = fake_binary(tmp.path(), "probe-changed", &witness, "Firecracker v1.13.1");
+        assert_eq!(
+            version_output_in(&bin, Some(&cache)).unwrap().trim(),
+            "Firecracker v1.13.1"
+        );
+        assert_eq!(run_count(&witness), 1);
+
+        // Rebuild in place: different bytes => different size and mtime => new key.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let bin = fake_binary(
+            tmp.path(),
+            "probe-changed",
+            &witness,
+            "Firecracker v1.15.0 rebuilt",
+        );
+        assert_eq!(
+            version_output_in(&bin, Some(&cache)).unwrap().trim(),
+            "Firecracker v1.15.0 rebuilt",
+            "a rebuilt binary must be re-probed, not served from cache"
+        );
+        assert_eq!(run_count(&witness), 2, "rebuilt binary must be re-execed");
+    }
+
+    #[test]
+    fn different_path_is_a_different_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = tmp.path().join("cache");
+        let witness = tmp.path().join("runs.txt");
+        let a = fake_binary(tmp.path(), "fc-a", &witness, "Firecracker v1.13.1");
+        let b = fake_binary(tmp.path(), "fc-b", &witness, "Firecracker v1.15.0");
+        assert_eq!(
+            version_output_in(&a, Some(&cache)).unwrap().trim(),
+            "Firecracker v1.13.1"
+        );
+        assert_eq!(
+            version_output_in(&b, Some(&cache)).unwrap().trim(),
+            "Firecracker v1.15.0"
+        );
+        assert_eq!(run_count(&witness), 2);
+    }
+
+    #[test]
+    fn failing_binary_is_not_cached() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = tmp.path().join("cache");
+        let witness = tmp.path().join("runs.txt");
+        let path = write_fake(tmp.path().join("fc-fail"), &witness, "exit 3");
+
+        let err = version_output_in(&path, Some(&cache)).unwrap_err();
+        assert!(
+            err.to_string().contains("--version` failed"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            !cache.exists() || std::fs::read_dir(&cache).unwrap().count() == 0,
+            "a failing probe must not be cached"
+        );
+        // ...and it must keep failing (not silently succeed from a stale entry).
+        assert!(version_output_in(&path, Some(&cache)).is_err());
+        assert_eq!(run_count(&witness), 2, "failing probe must re-exec");
+    }
+
+    #[test]
+    fn no_disk_cache_dir_still_works() {
+        let tmp = tempfile::tempdir().unwrap();
+        let witness = tmp.path().join("runs.txt");
+        let bin = fake_binary(tmp.path(), "fc-nodisk", &witness, "Firecracker v1.15.0");
+        assert_eq!(
+            version_output_in(&bin, None).unwrap().trim(),
+            "Firecracker v1.15.0"
+        );
+    }
+}


### PR DESCRIPTION
Halve `fcvm snapshot run` spawn->exec-ready latency by taking three per-launch costs off the clone hot path: **p50 679 ms -> 331 ms (-51%), stdev 10.9 ms -> 1.7 ms, execve() per clone 35 -> 19** (Graviton3, alpine, rootless, 2 rounds x 10 clones, interleaved A/B).

## The Problem

Every `fcvm snapshot run` paid for work whose answer almost never changes:

1. **`git ls-remote` to GitHub on every launch** (~340 ms — half the total). `get_profile_firecracker_path()` re-resolved the firecracker fork branch remotely per call, on a path that runs per clone.
2. **Repeated `--version` / `ldd --version` probes.** `find_firecracker()` runs more than once per launch, and each probe fork+execs a multi-megabyte binary whose version only changes when the binary does.
3. **~10 per-command `ip` fork+execs** configuring the rootless namespace, plus a second `nsenter`+`ip` just to verify the TAP device exists.

## The Solution

**1. On-disk resolved-profile cache** (`src/setup/kernel.rs`)
- Last remote resolution persisted at `assets_dir/firecracker/<profile>.resolved.json`; reused when repo/branch match, the TTL (`FCVM_FIRECRACKER_RESOLVE_TTL_SECS`, default 3600; `0` = always re-query) has not expired, and the binary still exists. Corrupt/unreadable cache is a miss, never an error.
- Only written when the resolved binary exists, so a not-yet-built profile keeps re-resolving (and failing loudly) instead of caching a dead path.
- `ensure_profile_firecracker()` — the `fcvm setup` path — always performs the remote resolution and rewrites the cache at **all three** of its success returns, so a rebuilt fork takes effect immediately, not after the TTL.
- Writes are unique-temp (uuid) + atomic rename, **never flock** — `assets_dir` can be shared across nesting levels over fuse-pipe, where flock does not cross the VM boundary (the #677 cross-VM cache lesson).
- The interleaved nocache control arm (`FCVM_FIRECRACKER_RESOLVE_TTL_SECS=0`) isolates this optimization at **-340.6 ms**.

**2. Version-probe memoisation** (`src/version_cache.rs`, new)
- `<binary> --version` output keyed by binary identity (path + mtime + size): process-local map + `assets_dir/version-cache/<key>.json`, so the short-lived per-clone fcvm process skips the exec too.
- Only successful probes are cached — `find_cloud_hypervisor()`'s fallback depends on failing binaries continuing to fail. A rebuilt binary changes identity and is re-probed. Cache IO problems degrade to running the binary, never fail the probe.
- `libc_version_tag()` and `detect_host_ipv6()` memoised per process (`OnceLock`).

**3. `ip -batch` consolidation** (`src/network/pasta.rs`, `src/commands/podman/namespace.rs`, `src/commands/common.rs`)
- New `IpBatchScript` renders each setup phase's `ip` commands as one `ip -batch` heredoc: one `nsenter`+`bash`+`ip` per phase instead of a process per command.
- The TAP existence check is the **last batch line** — `ip -batch` aborts at the first failure, so reaching it proves every prior step applied — replacing the separate verification exec in both the fresh-VM path and the clone path.
- On failure, `ip -batch`'s `Command failed -:<line>` is mapped back to the step's description (`describe_failure`), so errors still name the failing step; unrecognised stderr passes through verbatim.

**New benchmark**: `bench/clone-latency.sh` + `bench/clone-latency-report.py` (`make bench-clone-latency LABEL=x N=10`) — times N `snapshot run` cycles from spawn until fc-agent's exec server is ready (event-driven `tail -F | grep -m1` on the debug log, no polling in the measured path) and prints a stage breakdown parsed from the `RUST_LOG=fcvm=debug` timeline. Results in `/tmp/fcvm-clone-latency-<label>/`, never committed.

**Docs**: PERFORMANCE.md stage table + optimization notes; README.md documents `FCVM_FIRECRACKER_RESOLVE_TTL_SECS` and the resolution-cache contract.

## Stage breakdown (from PERFORMANCE.md, one 10-clone round)

| Stage | Before | After |
|-------|--------|-------|
| firecracker resolution (`git ls-remote`) | 337 ms | 0.4 ms |
| netns + pasta setup | 101 ms | 95 ms |
| snapshot load + resume | 6 ms | 6 ms |
| resume -> exec-server-ready | 222 ms | 221 ms |
| **total (p50)** | **673 ms** | **331 ms** |
| `execve()` per clone | 35 | 19 |

The remaining `resume -> exec-server-ready` (~221 ms) is guest-side fc-agent restore work — the next target.

## Test Results

```
$ make lint
cargo fmt -p fcvm -p fuse-pipe -p fc-agent --check   # clean
cargo clippy --all-targets -- -D warnings            # clean
advisories ok, bans ok, licenses ok, sources ok

$ make test-unit
Summary [  50.478s] 364 tests run: 364 passed, 0 skipped
# includes the 19 new tests: 8 kernel resolution-cache, 5 pasta ip-batch,
# 5 version_cache, TTL-env parser

$ make test-root FILTER=snapshot STREAM=1
Summary [1221.965s] 113 tests run: 113 passed, 528 skipped

$ make test-root FILTER=sanity
Summary [  18.191s] 5 tests run: 5 passed, 636 skipped
```

## Post-rebase bench (this branch rebased onto d85675da, i.e. current main with #706/#710/#711/#712)

```
$ make bench-clone-latency LABEL=post-rebase N=10
  p50   332.0 ms   (min 330.0, max 337.0, p90 334.0, mean 332.4)

stage breakdown (median of per-clone deltas, ms)
  resolve-fc              0.4      # ls-remote cache holds after rebase
  listeners+state         2.0
  netns+pasta            95.7
  snapshot-load           6.5
  resume->ready         221.6
```

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced documented median VM clone startup latency from 673 ms to 331 ms.
  * Improved repeated launches with cached binary and version lookups and faster network setup.
  * Improved restore reliability with unique restore identifiers.

* **New Features**
  * Added a configurable clone-latency benchmark with detailed stage reports and exportable samples.

* **Documentation**
  * Documented benchmark usage, Firecracker resolution caching, cache expiration settings, and cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->