### PR TITLE
Record filed ANGLE issue 543664586 in the setenv-race docs

### DIFF
--- a/bench/chromium/entry.sh
+++ b/bench/chromium/entry.sh
@@ -84,7 +84,7 @@ echo "chromium-bench: launching chromium"
 #   unfixed  25/336 = 7.4% [5.1%, 10.8%] Wilson 95%
 #   this fix  0/336 = 0.0% [0.0%,  1.1%] Wilson 95%
 #
-# Upstream: https://issues.chromium.org/issues/TODO-FILE-ME (ANGLE
+# Upstream: https://issues.angleproject.org/issues/543664586 (ANGLE
 # ScopedVkLoaderEnvironment setenv vs gfx::InitializeGlobalFontConfigAsync).
 # Remove this only once that bug is fixed AND the fixed Chromium is in the image.
 #

--- a/bench/chromium/upstream/ANGLE-setenv-race.md
+++ b/bench/chromium/upstream/ANGLE-setenv-race.md
@@ -1,6 +1,6 @@
 # ANGLE: `ScopedVkLoaderEnvironment` setenv(VK_ICD_FILENAMES) races with concurrent getenv() → SIGSEGV during startup
 
-**STATUS: NOT FILED — filing requires a human-authenticated Google session.**
+**STATUS: FILED 2026-08-07 as https://issues.angleproject.org/issues/543664586.**
 
 **File at: https://issues.angleproject.org/issues/new** — this is ANGLE's tracker, and it is
 where `anglebug.com/new` (the URL ANGLE's own `README.md:113` and `doc/ContributingCode.md`

--- a/bench/chromium/upstream/angle-setenv-race.patch
+++ b/bench/chromium/upstream/angle-setenv-race.patch
@@ -79,7 +79,7 @@ with no environ involvement. That needs Vulkan loader >= 1.3.234 and
 ANGLE loading the ICD itself, so it is not a drop-in given the loader
 versions ANGLE still supports.
 
-Bug: angleproject:TODO-file-me
+Bug: angleproject:543664586
 Test: Chromium 151.0.7922.71, Debian bookworm arm64, --single-process,
     launched under concurrency from a 17-variable parent environment.
     Baseline ~7% SIGSEGV in getenv() under FcConfigGetFilename; 100%


### PR DESCRIPTION
Replaces the TODO-FILE-ME placeholders from #717 with the real upstream issue: https://issues.angleproject.org/issues/543664586 (filed by ej). Comment/doc-only — three lines across entry.sh, the upstream report, and the patch's Bug: trailer.

Ideal candidate for the next CI train (docs-only, zero code risk) rather than its own matrix — see #724.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated references and status information for the documented upstream ANGLE issue.
  * Replaced a placeholder bug reference with the official issue identifier.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->