### PR TITLE
Replace every fixed sleep/poll on the clone hot path with event-driven waits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tracing-log = "0.2"  # Bridge log crate to tracing (for fuse-backend-rs)
 libc = "0.2"
-nix = { version = "0.29", features = ["sched", "net", "fs", "user", "mount", "signal", "term"] }
+nix = { version = "0.29", features = ["sched", "net", "fs", "user", "mount", "signal", "term", "inotify"] }
 chrono = { version = "0.4", features = ["serde"] }
 tempfile = "3"
 rand = "0.8"

--- a/fc-agent/src/agent.rs
+++ b/fc-agent/src/agent.rs
@@ -73,8 +73,10 @@ pub async fn run() -> Result<()> {
         eprintln!("[fc-agent] continuing anyway (will rely on chronyd)");
     }
 
-    // Create output channel — the writer task handles all vsock writes
-    let (output, output_writer) = output::create();
+    // Create output channel — the writer task handles all vsock writes. The
+    // reset watch surfaces EPOLLERR on the output connection (vsock transport
+    // reset = snapshot restore) to the restore-epoch watcher.
+    let (output, output_writer, vsock_reset_rx) = output::create();
     tokio::spawn(output_writer);
 
     // Shared flag: set by restore-epoch watcher, checked by notify_cache_ready_and_wait.
@@ -107,6 +109,7 @@ pub async fn run() -> Result<()> {
             exec_rebind_done: exec_rebind_done.clone(),
             exec_rebind_done_notify: exec_rebind_done_notify.clone(),
             egress_gen_rx: egress_gen_rx.clone(),
+            vsock_reset_rx,
             nfs_mounts: plan.nfs_mounts.clone(),
         };
         tokio::spawn(async move {

--- a/fc-agent/src/mmds.rs
+++ b/fc-agent/src/mmds.rs
@@ -147,6 +147,16 @@ async fn fetch_latest_metadata(client: &reqwest::Client) -> Result<LatestMetadat
 /// (#632 P2) — both via [`crate::bootplan::fetch_metadata`], so the restore handling is
 /// identical. MMDS polls at 50ms (a cheap local HTTP get); vsock polls slower because each
 /// poll reopens the boot-plan connection and re-reads the whole plan document.
+///
+/// The steady poll is only the fallback. The actual restore EVENT is the vsock
+/// transport reset the device raises at resume (surfaced by the output writer
+/// as `vsock_reset_rx`): a snapshot freezes this loop mid-`sleep`, so with the
+/// poll alone a restored clone waits out the frozen sleep's remainder (avg
+/// ~25ms of the measured clone floor) before even looking for its epoch. On a
+/// reset event the loop fetches immediately and polls at a tight cadence for a
+/// bounded window — the host PUTs the epoch right after resume, so this races
+/// only a few ms ahead of it. If the event never fires (TTY VMs, non-restore
+/// connection errors) behavior degrades to exactly the old poll.
 pub async fn watch_restore_epoch(
     signals: crate::restore::RestoreSignals,
     transport: crate::bootplan::Transport,
@@ -162,9 +172,43 @@ pub async fn watch_restore_epoch(
         crate::bootplan::Transport::Mmds => Duration::from_millis(50),
         crate::bootplan::Transport::Vsock => Duration::from_millis(250),
     };
+    // Post-reset fast cadence: MMDS gets are cheap local HTTP; vsock polls
+    // reopen the boot-plan connection, so keep them a bit gentler.
+    let fast_interval = match transport {
+        crate::bootplan::Transport::Mmds => Duration::from_millis(2),
+        crate::bootplan::Transport::Vsock => Duration::from_millis(10),
+    };
+    const FAST_WINDOW: Duration = Duration::from_secs(1);
+
+    let mut reset_rx = signals.vsock_reset_rx.clone();
+    // Once the watch sender is gone (writer task ended — shutdown), stop
+    // selecting on it so a closed channel can't busy-loop the watcher.
+    let mut reset_armed = true;
+    let mut fast_until: Option<tokio::time::Instant> = None;
 
     loop {
-        sleep(poll_interval).await;
+        let interval = match fast_until {
+            Some(t) if tokio::time::Instant::now() < t => fast_interval,
+            _ => {
+                fast_until = None;
+                poll_interval
+            }
+        };
+        tokio::select! {
+            _ = sleep(interval) => {}
+            changed = reset_rx.changed(), if reset_armed => {
+                match changed {
+                    Ok(()) => {
+                        eprintln!(
+                            "[fc-agent] vsock transport reset observed; fast-polling restore-epoch"
+                        );
+                        fast_until = Some(tokio::time::Instant::now() + FAST_WINDOW);
+                        // Fall through to an immediate fetch.
+                    }
+                    Err(_) => reset_armed = false,
+                }
+            }
+        }
 
         let metadata = match crate::bootplan::fetch_metadata(transport).await {
             Ok(m) => m,
@@ -206,6 +250,8 @@ pub async fn watch_restore_epoch(
                     egress_gen_at_last_stable =
                         signals.egress_gen_rx.as_ref().map(|rx| *rx.borrow());
                     last_epoch = metadata.restore_epoch;
+                    // Epoch found and handled — the fast window did its job.
+                    fast_until = None;
                 }
                 Some(prev) if prev != current => {
                     eprintln!("[fc-agent] restore-epoch changed: {} -> {}", prev, current,);
@@ -224,6 +270,8 @@ pub async fn watch_restore_epoch(
                     egress_gen_at_last_stable =
                         signals.egress_gen_rx.as_ref().map(|rx| *rx.borrow());
                     last_epoch = metadata.restore_epoch;
+                    // Epoch found and handled — the fast window did its job.
+                    fast_until = None;
                 }
                 _ => {}
             }

--- a/fc-agent/src/output.rs
+++ b/fc-agent/src/output.rs
@@ -53,18 +53,33 @@ impl OutputHandle {
     }
 }
 
-/// Create an (OutputHandle, writer future) pair. Spawn the future as a tokio task.
-pub fn create() -> (OutputHandle, impl Future<Output = ()>) {
+/// Create an (OutputHandle, writer future, transport-reset watch) triple. Spawn
+/// the future as a tokio task.
+///
+/// The `watch::Receiver<u64>` increments whenever the writer observes EPOLLERR
+/// on its established vsock connection — the kernel's reaction to
+/// VIRTIO_VSOCK_EVENT_TRANSPORT_RESET, which the device raises at snapshot
+/// restore. It is the guest's earliest "you were just restored" signal: the
+/// restore-epoch watcher uses it to poll for the new epoch immediately instead
+/// of finishing a frozen 50ms sleep first. It is an ACCELERATOR only — every
+/// consumer must keep working (just slower) if it never fires (e.g. TTY-mode
+/// VMs, where no output connection exists).
+pub fn create() -> (
+    OutputHandle,
+    impl Future<Output = ()>,
+    tokio::sync::watch::Receiver<u64>,
+) {
     let (tx, rx) = mpsc::channel(4096);
     let reconnect = Arc::new(Notify::new());
     let reconnect_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let (reset_tx, reset_rx) = tokio::sync::watch::channel(0u64);
     let handle = OutputHandle {
         tx,
         reconnect: reconnect.clone(),
         reconnect_flag: reconnect_flag.clone(),
     };
-    let writer = output_writer(rx, reconnect, reconnect_flag);
-    (handle, writer)
+    let writer = output_writer(rx, reconnect, reconnect_flag, reset_tx);
+    (handle, writer, reset_rx)
 }
 
 /// Try to reconnect the vsock stream, retrying up to 30 times.
@@ -119,6 +134,7 @@ async fn output_writer(
     mut rx: mpsc::Receiver<OutputMessage>,
     reconnect_signal: Arc<Notify>,
     reconnect_flag: Arc<std::sync::atomic::AtomicBool>,
+    reset_tx: tokio::sync::watch::Sender<u64>,
 ) {
     let mut stream: Option<VsockStream> =
         match VsockStream::connect(vsock::HOST_CID, vsock::OUTPUT_PORT) {
@@ -188,7 +204,7 @@ async fn output_writer(
                 }
             }
 
-            // Wait for next message (or reconnect signal).
+            // Wait for next message (or reconnect signal, or transport reset).
             let msg = tokio::select! {
                 msg = rx.recv() => msg,
                 _ = reconnect_signal.notified() => {
@@ -197,6 +213,23 @@ async fn output_writer(
                     // the top of the loop. Re-storing would create a stored-permit
                     // cascade: the next select! would fire immediately, dropping
                     // the freshly-reconnected stream before any data is written.
+                    stream = None;
+                    continue;
+                }
+                _ = s.wait_for_error() => {
+                    // EPOLLERR on the idle connection: the vsock transport was
+                    // reset — for an fc-agent-held connection that means a
+                    // snapshot restore just happened. Publish the earliest
+                    // restore hint (the epoch watcher fast-polls on it), drop
+                    // the dead stream, and wait for the explicit reconnect from
+                    // handle_clone_restore exactly like the write-failure path.
+                    // The snapshot is virtually always taken with output idle,
+                    // so this arm is where a restored writer wakes up; a reset
+                    // mid-write lands in the write-error path instead, which
+                    // doesn't bump the hint — the watcher's normal poll covers
+                    // that case.
+                    eprintln!("[fc-agent] output vsock EPOLLERR (transport reset)");
+                    reset_tx.send_modify(|gen| *gen += 1);
                     stream = None;
                     continue;
                 }

--- a/fc-agent/src/restore.rs
+++ b/fc-agent/src/restore.rs
@@ -18,6 +18,13 @@ pub struct RestoreSignals {
     pub exec_rebind_done: Arc<AtomicBool>,
     pub exec_rebind_done_notify: Arc<Notify>,
     pub egress_gen_rx: Option<watch::Receiver<u64>>,
+    /// Incremented by the output writer when it observes EPOLLERR on its
+    /// established vsock connection — the guest-visible edge of the device's
+    /// VIRTIO_VSOCK_EVENT_TRANSPORT_RESET at snapshot restore. The epoch
+    /// watcher uses it as a wakeup to fast-poll for the new restore-epoch
+    /// instead of finishing a frozen 50ms sleep. Accelerator only: the normal
+    /// poll cadence remains the correctness path.
+    pub vsock_reset_rx: watch::Receiver<u64>,
     /// NFS mounts from the boot-time plan, kept for post-restore remounting.
     /// MMDS can't be re-fetched here: the host's restore-epoch PUT replaces the
     /// whole MMDS store, so `container-plan` is gone by the time restore runs.

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -1478,11 +1478,18 @@ pub async fn restore_from_snapshot(
                 .collect();
         }
 
-        // Post-resume liveness check: verify VM didn't crash immediately.
-        // Under heavy I/O load, snapshot restore can corrupt guest memory (e.g., stack
-        // canary in do_idle), causing an immediate kernel panic + reboot. Detecting this
-        // early surfaces the error instead of silently serving a crashed VM.
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        // Post-resume liveness check (non-blocking): catch a Firecracker process that
+        // already died during load/patch/resume. This used to be `sleep(200ms)` +
+        // try_wait (fe4376b0) to detect restores of corrupt diff snapshots, but the
+        // sleep could never catch what it aimed for: a panicking guest reboots (and
+        // Firecracker exits) only ~1s after resume (`panic=1` boot arg), outside any
+        // 200ms window — and since #630 narrowed cached-snapshot fallback to
+        // Firecracker "Load snapshot error"s, this error is a hard failure anyway
+        // (corrupt diffs are caught at CREATE time by the diff-size validation).
+        // Delayed guest crashes are detected event-driven by every caller's positive
+        // readiness gate: the output-connect wait (with its try_wait liveness poll)
+        // in cmd_snapshot_run, --exec's vsock connect probe, and
+        // verify_port_forwarding. Sleeping here bought nothing but 200ms per clone.
         if let Some(status) = vm_manager.try_wait()? {
             bail!(
                 "VM crashed immediately after snapshot restore (exit status: {:?}). \
@@ -1688,8 +1695,10 @@ pub async fn restore_from_snapshot_ch(
                 .collect();
         }
 
-        // Liveness: ensure the VM didn't crash immediately after restore.
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        // Liveness (non-blocking): catch a CH process that already died during
+        // restore/resume. Same rationale as the Firecracker path above — delayed
+        // guest crashes are detected event-driven by the caller's readiness gates,
+        // so there is nothing a fixed post-resume sleep can catch that they don't.
         if let Some(status) = backend.try_wait()? {
             bail!(
                 "Cloud Hypervisor crashed immediately after snapshot restore (exit status: {:?})",

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -36,11 +36,23 @@ use tracing::{debug, info};
 /// Vsock port for exec commands (fc-agent listens on this)
 pub const EXEC_VSOCK_PORT: u32 = 4998;
 
-/// Maximum number of connection attempts to the exec server
-const MAX_EXEC_CONNECT_ATTEMPTS: u32 = 30;
+/// Maximum number of connection attempts to the exec server. With the 5ms
+/// initial delay, 1.5x growth, and 2s cap this spans ~54s of total waiting —
+/// the same boot-tolerance window as the previous 30 × (100ms, 2x) ladder.
+const MAX_EXEC_CONNECT_ATTEMPTS: u32 = 41;
 
-/// Initial retry delay when connecting to exec server (doubles each attempt)
-const INITIAL_RETRY_DELAY_MS: u64 = 100;
+/// Initial retry delay when connecting to exec server (grows 1.5x per attempt,
+/// capped at 2s). 5ms, not 100ms: a freshly restored clone's exec server
+/// re-registers within single-digit milliseconds, and the adversarial review of
+/// the clone-latency benchmarks showed the old 100ms quantum was
+/// indistinguishable from real guest latency (UFFD arms sat in the empty
+/// 100-139ms band purely from this ladder).
+const INITIAL_RETRY_DELAY_MS: u64 = 5;
+
+/// Multiply the retry delay by 3/2 (integer) each attempt, capped at 2s.
+fn next_retry_delay(delay_ms: u64) -> u64 {
+    std::cmp::min(delay_ms + delay_ms / 2 + 1, 2000)
+}
 
 /// Per-attempt bounded wait for the agent's ACK line. A live agent ACKs in
 /// sub-millisecond time; only an orphaned/paused connection stalls this long.
@@ -71,6 +83,7 @@ const EXEC_WRITE_TIMEOUT: Duration = Duration::from_secs(10);
 fn connect_to_exec_server_with_retry(vsock_socket: &Path) -> Result<UnixStream> {
     let mut attempt = 0;
     let mut delay_ms = INITIAL_RETRY_DELAY_MS;
+    let mut waited_ms: u64 = 0;
 
     loop {
         attempt += 1;
@@ -81,7 +94,8 @@ fn connect_to_exec_server_with_retry(vsock_socket: &Path) -> Result<UnixStream> 
             Err(e) if attempt < MAX_EXEC_CONNECT_ATTEMPTS => {
                 debug!(attempt, delay_ms, "vsock socket not ready, retrying");
                 std::thread::sleep(Duration::from_millis(delay_ms));
-                delay_ms = std::cmp::min(delay_ms * 2, 2000); // Cap at 2 seconds
+                waited_ms += delay_ms;
+                delay_ms = next_retry_delay(delay_ms);
                 continue;
             }
             Err(e) => {
@@ -105,7 +119,8 @@ fn connect_to_exec_server_with_retry(vsock_socket: &Path) -> Result<UnixStream> 
             if attempt < MAX_EXEC_CONNECT_ATTEMPTS {
                 debug!(attempt, delay_ms, error = %e, "failed to send CONNECT, retrying");
                 std::thread::sleep(Duration::from_millis(delay_ms));
-                delay_ms = std::cmp::min(delay_ms * 2, 2000);
+                waited_ms += delay_ms;
+                delay_ms = next_retry_delay(delay_ms);
                 continue;
             }
             bail!(
@@ -123,7 +138,8 @@ fn connect_to_exec_server_with_retry(vsock_socket: &Path) -> Result<UnixStream> 
                 if attempt < MAX_EXEC_CONNECT_ATTEMPTS {
                     debug!(attempt, delay_ms, error = %e, "failed to read CONNECT response, retrying");
                     std::thread::sleep(Duration::from_millis(delay_ms));
-                    delay_ms = std::cmp::min(delay_ms * 2, 2000);
+                    waited_ms += delay_ms;
+                    delay_ms = next_retry_delay(delay_ms);
                     continue;
                 }
                 bail!(
@@ -149,7 +165,8 @@ fn connect_to_exec_server_with_retry(vsock_socket: &Path) -> Result<UnixStream> 
                     );
                 }
                 std::thread::sleep(Duration::from_millis(delay_ms));
-                delay_ms = std::cmp::min(delay_ms * 2, 2000);
+                waited_ms += delay_ms;
+                delay_ms = next_retry_delay(delay_ms);
                 continue;
             }
 
@@ -161,9 +178,15 @@ fn connect_to_exec_server_with_retry(vsock_socket: &Path) -> Result<UnixStream> 
             );
         }
 
-        // Success!
+        // Success! Attempt count + cumulative retry sleep are logged so
+        // benchmark timelines can attribute connect-retry waiting (the ladder's
+        // quantum) separately from real guest latency.
         if attempt > 1 {
-            debug!(attempt, "successfully connected to exec server");
+            debug!(
+                attempts = attempt,
+                retry_wait_ms = waited_ms,
+                "connected to exec server after retries"
+            );
         }
         return Ok(stream);
     }

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -1450,38 +1450,6 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
 
     let (mut vm_manager, mut holder_child) = setup_result.unwrap();
 
-    // Build the cold-boot relaunch plan up front (consumed if the guest reboots).
-    let clone_disk_path = data_dir.join("disks/rootfs.raw");
-    // Reboot-in-place relaunches via the Firecracker cold-boot plan (build_clone_reboot_plan
-    // is FC-specific). Cloud Hypervisor clones don't support it yet — a guest reboot
-    // terminates the clone (same as TTY clones). Tracked for a future increment.
-    let reboot_plan = if is_ch {
-        None
-    } else {
-        match build_clone_reboot_plan(
-            &snapshot_config.metadata,
-            &vm_name,
-            args.cpu.unwrap_or(snapshot_config.metadata.vcpu),
-            args.mem.unwrap_or(snapshot_config.metadata.memory_mib),
-            args.non_blocking_output,
-            &network_config,
-            &runtime_config,
-            &clone_disk_path,
-            &clone_vsock_base,
-        )
-        .await
-        {
-            Ok(plan) => Some(plan),
-            Err(e) => {
-                warn!(
-                    error = %e,
-                    "reboot-in-place unavailable for this clone — a guest reboot will terminate it"
-                );
-                None
-            }
-        }
-    };
-
     // Disable swap for Firecracker if requested via --no-swap
     if args.no_swap {
         if let Ok(pid) = vm_manager.pid() {
@@ -1532,12 +1500,16 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
             let cmd_args: Vec<String> = shell_words::split(exec_cmd)
                 .with_context(|| format!("parsing --exec argument: {}", exec_cmd))?;
 
-            // Wait for vsock socket to be ready (poll instead of blind sleep)
+            // Wait for the vsock socket to be connectable. After a restore the
+            // socket virtually always exists already (Firecracker binds it during
+            // load_snapshot), so probe immediately and back off from 1ms — the old
+            // fixed 10ms interval burned most of an interval per clone --exec.
             let vsock_socket = data_dir.join("vsock.sock");
             let poll_start = std::time::Instant::now();
             const MAX_VSOCK_WAIT: Duration = Duration::from_millis(5000);
-            const VSOCK_POLL_INTERVAL: Duration = Duration::from_millis(10);
+            const VSOCK_POLL_MAX_INTERVAL: Duration = Duration::from_millis(10);
 
+            let mut vsock_poll_interval = Duration::from_millis(1);
             loop {
                 if poll_start.elapsed() > MAX_VSOCK_WAIT {
                     bail!("vsock socket not ready after {:?}", poll_start.elapsed());
@@ -1551,7 +1523,8 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
                     }
                 }
 
-                tokio::time::sleep(VSOCK_POLL_INTERVAL).await;
+                tokio::time::sleep(vsock_poll_interval).await;
+                vsock_poll_interval = (vsock_poll_interval * 2).min(VSOCK_POLL_MAX_INTERVAL);
             }
             crate::commands::exec::run_exec_in_vm(
                 &vsock_socket,
@@ -1624,8 +1597,15 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
     // can take minutes. Proceeding early causes exec failures; waiting is correct.
     // But poll VM liveness to avoid hanging forever if Firecracker crashes.
     if !tty_mode {
-        let mut liveness_interval = tokio::time::interval(std::time::Duration::from_secs(5));
-        liveness_interval.tick().await; // consume immediate first tick
+        // First liveness check at 250ms, then every 5s: restore_from_snapshot no
+        // longer sleeps post-resume (its old 200ms crash-window moved here, off
+        // the hot path), so a VM that dies right after resume is still diagnosed
+        // quickly — while a healthy clone's output connection wins this select
+        // in a few ms and never waits on any tick.
+        let mut liveness_interval = tokio::time::interval_at(
+            tokio::time::Instant::now() + std::time::Duration::from_millis(250),
+            std::time::Duration::from_secs(5),
+        );
         let mut output_connected = false;
         loop {
             tokio::select! {
@@ -1783,6 +1763,42 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
                         container_exit_seen.store(false, std::sync::atomic::Ordering::Release);
                         let _ = std::fs::remove_file(data_dir.join("container-exit"));
                         let _ = std::fs::remove_file(data_dir.join("container-ready"));
+                        // Build the cold-boot relaunch plan ON DEMAND: only a rebooting
+                        // clone needs it, and assembling it (kernel/initrd resolution,
+                        // launch config) cost ~19ms up front on EVERY clone — waste for
+                        // one-shot clones that never reboot. A guest reboot already pays
+                        // a full cold boot, so plan assembly here is noise; a build
+                        // failure has the same outcome as the old eager path (the reboot
+                        // terminates the clone), just diagnosed at reboot time.
+                        // build_clone_reboot_plan is FC-specific; Cloud Hypervisor clones
+                        // don't support reboot-in-place yet — a guest reboot terminates
+                        // them (same as TTY clones). Tracked for a future increment.
+                        let reboot_plan = if is_ch {
+                            None
+                        } else {
+                            match build_clone_reboot_plan(
+                                &snapshot_config.metadata,
+                                &vm_name,
+                                args.cpu.unwrap_or(snapshot_config.metadata.vcpu),
+                                args.mem.unwrap_or(snapshot_config.metadata.memory_mib),
+                                args.non_blocking_output,
+                                &network_config,
+                                &runtime_config,
+                                &data_dir.join("disks/rootfs.raw"),
+                                &clone_vsock_base,
+                            )
+                            .await
+                            {
+                                Ok(plan) => Some(plan),
+                                Err(e) => {
+                                    warn!(
+                                        error = %e,
+                                        "reboot-in-place unavailable for this clone — treating reboot as VM exit"
+                                    );
+                                    None
+                                }
+                            }
+                        };
                         if let Some((plan, synth_args, volume_mappings)) = reboot_plan.as_ref() {
                             info!("guest rebooted — relaunching restored clone in place (cold boot)");
                             let relaunch_result = async {

--- a/src/firecracker/vm.rs
+++ b/src/firecracker/vm.rs
@@ -15,6 +15,9 @@ use super::FirecrackerClient;
 /// Socket/device wait timeout (total wait time = RETRY_COUNT * RETRY_DELAY)
 const SOCKET_WAIT_RETRY_COUNT: u32 = 500;
 const SOCKET_WAIT_RETRY_DELAY: Duration = Duration::from_millis(10);
+/// Total budget for the API socket to accept connections (matches the old
+/// 500 × 10ms retry ladder).
+const SOCKET_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Number of recent Firecracker stderr lines kept for error reporting.
 const STDERR_TAIL_LINES: usize = 10;
@@ -334,27 +337,60 @@ impl VmManager {
     ///
     /// The socket file becoming visible is not enough: there is a window between
     /// Firecracker's bind() (file exists) and listen() where connect() fails with
-    /// ECONNREFUSED. Poll by actually connecting so the first real API request
+    /// ECONNREFUSED. Probe by actually connecting so the first real API request
     /// never races that window.
     ///
-    /// Also polls the Firecracker child process: if it exits before the API
-    /// server accepts connections, fail immediately with its exit status and
-    /// recent stderr output instead of timing out with a generic socket error.
+    /// Event-driven: an inotify watch on the socket's parent directory (registered
+    /// BEFORE the first probe, so a file appearing mid-check always produces an
+    /// event) wakes the probe the instant Firecracker binds — the old fixed 10ms
+    /// poll cost most of that interval on every launch/clone. The bind→listen
+    /// window has no filesystem event, so ECONNREFUSED retries at 1ms. A coarse
+    /// safety tick re-checks even without events, and the deadline bounds all
+    /// paths, so a lost event can only add latency, never hang.
+    ///
+    /// Also watches the Firecracker child process on every iteration (including
+    /// the 1ms ECONNREFUSED path): if it exits before the API server accepts
+    /// connections, fail with its exit status and recent stderr output instead
+    /// of timing out with a generic socket error.
     async fn wait_for_socket(&mut self) -> Result<()> {
         use tokio::time::sleep;
 
-        for _ in 0..SOCKET_WAIT_RETRY_COUNT {
+        let mut watch =
+            self.socket_path
+                .parent()
+                .and_then(|dir| match crate::utils::DirWatch::new(dir) {
+                    Ok(w) => Some(w),
+                    Err(e) => {
+                        warn!(
+                            error = %e,
+                            "inotify unavailable for API-socket wait; degrading to 10ms polling"
+                        );
+                        None
+                    }
+                });
+
+        let deadline = tokio::time::Instant::now() + SOCKET_WAIT_TIMEOUT;
+        loop {
+            // ECONNREFUSED retries on a tight 1ms cadence (set below) instead of
+            // waiting for a directory event — but still falls through to the
+            // child-liveness check first: if Firecracker binds the socket and
+            // then dies, the socket FILE persists and refuses connections
+            // forever, and skipping try_wait would spin out the whole deadline
+            // and report a generic timeout instead of the exit status + stderr.
+            let mut refused = false;
             match tokio::net::UnixStream::connect(&self.socket_path).await {
                 Ok(stream) => {
                     // Only probing readiness — drop the connection immediately.
                     drop(stream);
                     return Ok(());
                 }
-                Err(e)
-                    if e.kind() == std::io::ErrorKind::NotFound
-                        || e.kind() == std::io::ErrorKind::ConnectionRefused =>
-                {
-                    // Socket file not created yet, or created but not listening yet.
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    // Socket file not created yet — wait for a directory event below.
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
+                    // bind() done, listen() imminent (sub-millisecond window
+                    // with no fs event).
+                    refused = true;
                 }
                 Err(e) => bail!(
                     "unexpected error connecting to Firecracker API socket {}: {}",
@@ -373,15 +409,41 @@ impl VmManager {
                     self.stderr_tail_message()
                 );
             }
+            if tokio::time::Instant::now() >= deadline {
+                break;
+            }
 
-            sleep(SOCKET_WAIT_RETRY_DELAY).await;
+            if refused {
+                // Liveness verified above — retry the connect at 1ms.
+                sleep(Duration::from_millis(1)).await;
+                continue;
+            }
+
+            match watch.as_mut() {
+                Some(w) => {
+                    tokio::select! {
+                        event = w.next_event() => {
+                            // Directory activity — loop re-probes the socket.
+                            // A (persistent) watch error degrades to the old
+                            // fixed cadence via this sleep, bounded by deadline.
+                            if event.is_err() {
+                                sleep(SOCKET_WAIT_RETRY_DELAY).await;
+                            }
+                        }
+                        _ = tokio::time::sleep_until(deadline) => {}
+                        _ = sleep(Duration::from_millis(100)) => {
+                            // Safety tick: re-check child liveness + socket
+                            // even if no event arrives.
+                        }
+                    }
+                }
+                None => sleep(SOCKET_WAIT_RETRY_DELAY).await,
+            }
         }
 
-        let timeout_secs =
-            SOCKET_WAIT_RETRY_COUNT as u64 * SOCKET_WAIT_RETRY_DELAY.as_millis() as u64 / 1000;
         bail!(
             "Firecracker socket not ready after {} seconds",
-            timeout_secs
+            SOCKET_WAIT_TIMEOUT.as_secs()
         )
     }
 

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -446,6 +446,24 @@ impl PastaNetwork {
     pub async fn start_pasta(&mut self, namespace_pid: u32) -> Result<()> {
         let pid_file = paths::data_dir().join(format!("pasta-{}.pid", truncate_id(&self.vm_id, 8)));
 
+        // Register the inotify watch BEFORE the stale-file cleanup and spawn:
+        // pasta's PID-file write after this point always produces an event, so
+        // readiness can never be missed (zero-race: watch → check → wait).
+        // Init failure (e.g. fs.inotify.max_user_instances exhausted by many
+        // concurrent clone starts as one user) must not fail start_pasta — the
+        // old poll never had that failure mode. Degrade to the 250ms safety
+        // tick below, same as the vm.rs API-socket watch.
+        let mut pid_file_watch = match crate::utils::DirWatch::new(&paths::data_dir()) {
+            Ok(w) => Some(w),
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "inotify unavailable for pasta PID-file wait; degrading to 250ms polling"
+                );
+                None
+            }
+        };
+
         if pid_file.exists() {
             tokio::fs::remove_file(&pid_file).await?;
         }
@@ -605,40 +623,53 @@ impl PastaNetwork {
             });
         }
 
-        // Wait for PID file to appear (signals pasta is ready)
-        let deadline = std::time::Instant::now() + PASTA_READY_TIMEOUT;
+        // Wait for the PID file to appear (pasta writes it once ready).
+        // Event-driven: the inotify watch registered before spawn wakes us the
+        // instant the file lands (the old 50ms poll noticed a +2.3ms file at
+        // +52.8ms on every rootless clone). pasta death interrupts the wait via
+        // child.wait(); the deadline still bounds everything, and a coarse
+        // safety tick re-checks the file so even a lost/overflowed inotify
+        // event can only add latency, never hang.
+        let deadline = tokio::time::Instant::now() + PASTA_READY_TIMEOUT;
         loop {
             if pid_file.exists() {
                 info!("pasta ready (PID file created)");
                 break;
             }
 
-            // Check if pasta died during startup
-            match child.try_wait() {
-                Ok(Some(status)) => {
-                    // Give the stderr reader a moment to drain the pipe so the
-                    // error includes what pasta actually printed.
+            tokio::select! {
+                status = child.wait() => {
+                    // pasta died during startup. Give the stderr reader a moment
+                    // to drain the pipe so the error includes what pasta printed.
                     tokio::time::sleep(PASTA_STDERR_DRAIN_DELAY).await;
+                    match status {
+                        Ok(status) => anyhow::bail!(
+                            "pasta exited before becoming ready (status: {}){}",
+                            status,
+                            self.stderr_tail_message()
+                        ),
+                        Err(e) => anyhow::bail!("failed to check pasta status: {}", e),
+                    }
+                }
+                event = crate::utils::DirWatch::next_event_opt(&mut pid_file_watch) => {
+                    // Filesystem activity in the data dir — loop re-checks the
+                    // PID file. A watch error degrades to the safety tick.
+                    if event.is_err() {
+                        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                    }
+                }
+                _ = tokio::time::sleep_until(deadline) => {
+                    let _ = child.kill().await;
                     anyhow::bail!(
-                        "pasta exited before becoming ready (status: {}){}",
-                        status,
+                        "pasta did not become ready within {:?}{}",
+                        PASTA_READY_TIMEOUT,
                         self.stderr_tail_message()
                     );
                 }
-                Ok(None) => {} // Still running
-                Err(e) => anyhow::bail!("failed to check pasta status: {}", e),
+                _ = tokio::time::sleep(std::time::Duration::from_millis(250)) => {
+                    // Safety tick: re-check the condition even without events.
+                }
             }
-
-            if std::time::Instant::now() > deadline {
-                let _ = child.kill().await;
-                anyhow::bail!(
-                    "pasta did not become ready within {:?}{}",
-                    PASTA_READY_TIMEOUT,
-                    self.stderr_tail_message()
-                );
-            }
-
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         }
 
         self.pasta_process = Some(child);
@@ -672,6 +703,15 @@ impl PastaNetwork {
     async fn wait_for_pasta_device(&mut self, holder_pid: u32) -> Result<()> {
         let deadline = std::time::Instant::now() + PASTA_DEVICE_TIMEOUT;
         let nsenter_prefix = self.build_nsenter_prefix(holder_pid);
+
+        // Fine-grained backoff, not a fixed 100ms: pasta creates the TAP within
+        // a few ms of writing its PID file, and now that the PID file is
+        // noticed event-driven (+2ms instead of +52ms) this probe regularly
+        // arrives BEFORE the device exists — a fixed 100ms retry put a +100ms
+        // mode on 4/10 benched clones. Each probe is a full nsenter+ip exec
+        // (~1-3ms), so short gaps just keep probing continuously through the
+        // handful of ms until the device appears; the deadline still bounds it.
+        let mut retry_delay = std::time::Duration::from_millis(1);
 
         loop {
             let output = Command::new(&nsenter_prefix[0])
@@ -718,7 +758,8 @@ impl PastaNetwork {
                 );
             }
 
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            tokio::time::sleep(retry_delay).await;
+            retry_delay = (retry_delay * 2).min(std::time::Duration::from_millis(50));
         }
     }
 

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -1502,15 +1502,34 @@ exec switch_root /newroot /sbin/init
 pub async fn ensure_fc_agent_initrd(allow_create: bool) -> Result<PathBuf> {
     // Find fc-agent binary
     let fc_agent_path = find_fc_agent_binary()?;
-    let fc_agent_bytes = std::fs::read(&fc_agent_path)
-        .with_context(|| format!("reading fc-agent binary at {}", fc_agent_path.display()))?;
 
-    // Compute combined hash of all initrd contents
-    let mut combined = fc_agent_bytes.clone();
-    combined.extend_from_slice(INITRD_INIT_SCRIPT.as_bytes());
-    combined.extend_from_slice(FC_AGENT_SERVICE.as_bytes());
-    combined.extend_from_slice(FC_AGENT_SERVICE_STRACE.as_bytes());
-    let initrd_sha = compute_sha256(&combined);
+    // Combined hash of all initrd contents: sha256(fc-agent bytes ++ init script
+    // ++ service files). Reading + hashing the ~4.4MB fc-agent binary costs
+    // ~17ms and sits on every VM-launch / clone hot path, so the result is
+    // memoised per binary identity (path+mtime+size — the version-cache
+    // pattern). The embedded scripts are compile-time constants; their hash
+    // goes into the cache namespace so an fcvm rebuild that changes only the
+    // scripts can never reuse a stale combined SHA.
+    let scripts_sha = {
+        let mut scripts = Vec::new();
+        scripts.extend_from_slice(INITRD_INIT_SCRIPT.as_bytes());
+        scripts.extend_from_slice(FC_AGENT_SERVICE.as_bytes());
+        scripts.extend_from_slice(FC_AGENT_SERVICE_STRACE.as_bytes());
+        compute_sha256(&scripts)
+    };
+    let initrd_sha = crate::version_cache::derived(
+        &fc_agent_path,
+        &format!("initrd-sha:{}", scripts_sha),
+        || {
+            let mut combined = std::fs::read(&fc_agent_path).with_context(|| {
+                format!("reading fc-agent binary at {}", fc_agent_path.display())
+            })?;
+            combined.extend_from_slice(INITRD_INIT_SCRIPT.as_bytes());
+            combined.extend_from_slice(FC_AGENT_SERVICE.as_bytes());
+            combined.extend_from_slice(FC_AGENT_SERVICE_STRACE.as_bytes());
+            Ok(compute_sha256(&combined))
+        },
+    )?;
     let initrd_sha_short = &initrd_sha[..12];
 
     // Check if initrd already exists for this version (fast path, no lock)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,11 +1,89 @@
 //! Utility functions for process management and system operations.
 
+use std::os::fd::AsRawFd;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::thread;
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tracing::{info, warn};
+
+/// Event-driven watch on a directory for "a file appeared / changed" conditions.
+///
+/// Wraps an inotify fd in tokio's `AsyncFd` so readiness waits are epoll-driven
+/// — no fixed-interval polling. The zero-race usage pattern is:
+///
+/// 1. `DirWatch::new(dir)` — register the watch FIRST;
+/// 2. check the real condition (file exists / socket connects);
+/// 3. if not met, `next_event().await`, then re-check — a file that appears
+///    between (2) and (3) produced an event that (3) consumes, so it can never
+///    be missed. Callers keep their own deadline/child-exit select arms.
+///
+/// Events are only wakeups: callers ALWAYS re-check the real condition, so
+/// coalesced events, queue overflow, or unrelated files in the directory are
+/// all safe (just extra re-checks).
+pub struct DirWatch {
+    async_fd: tokio::io::unix::AsyncFd<std::os::fd::RawFd>,
+    // Keeps the inotify fd open; declared after async_fd so the AsyncFd is
+    // dropped (deregistered from the reactor) before the fd is closed.
+    inotify: nix::sys::inotify::Inotify,
+}
+
+impl DirWatch {
+    /// Register an inotify watch on `dir` for file-appearance events
+    /// (create, rename-in, close-after-write, attribute change).
+    pub fn new(dir: &Path) -> anyhow::Result<Self> {
+        use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
+        let inotify = Inotify::init(InitFlags::IN_NONBLOCK | InitFlags::IN_CLOEXEC)
+            .map_err(|e| anyhow::anyhow!("inotify_init1: {e}"))?;
+        inotify
+            .add_watch(
+                dir,
+                AddWatchFlags::IN_CREATE
+                    | AddWatchFlags::IN_MOVED_TO
+                    | AddWatchFlags::IN_CLOSE_WRITE
+                    | AddWatchFlags::IN_ATTRIB,
+            )
+            .map_err(|e| anyhow::anyhow!("inotify_add_watch {}: {e}", dir.display()))?;
+        let raw = std::os::fd::AsFd::as_fd(&inotify).as_raw_fd();
+        let async_fd = tokio::io::unix::AsyncFd::new(raw)
+            .map_err(|e| anyhow::anyhow!("registering inotify fd with tokio: {e}"))?;
+        Ok(Self { async_fd, inotify })
+    }
+
+    /// [`next_event`](Self::next_event) over an optional watch: a `None` watch
+    /// (inotify init failed — e.g. `fs.inotify.max_user_instances` exhausted by
+    /// many concurrent fcvm processes) never completes, so a `select!` caller
+    /// degrades to its safety-tick/deadline arms instead of failing hard.
+    pub async fn next_event_opt(watch: &mut Option<Self>) -> anyhow::Result<()> {
+        match watch {
+            Some(w) => w.next_event().await,
+            None => std::future::pending().await,
+        }
+    }
+
+    /// Wait until at least one filesystem event has been consumed.
+    ///
+    /// Drains everything currently queued (the event batch is only a wakeup —
+    /// the caller re-checks its condition afterwards).
+    pub async fn next_event(&mut self) -> anyhow::Result<()> {
+        loop {
+            let mut guard = self
+                .async_fd
+                .readable()
+                .await
+                .map_err(|e| anyhow::anyhow!("waiting for inotify readability: {e}"))?;
+            match self.inotify.read_events() {
+                Ok(_events) => return Ok(()),
+                Err(nix::errno::Errno::EAGAIN) => {
+                    guard.clear_ready();
+                    continue;
+                }
+                Err(e) => return Err(anyhow::anyhow!("reading inotify events: {e}")),
+            }
+        }
+    }
+}
 
 /// Check if a process is alive by checking /proc/{pid} existence.
 ///

--- a/src/version_cache.rs
+++ b/src/version_cache.rs
@@ -1,31 +1,36 @@
-//! Cached `<binary> --version` probes.
+//! Cached per-binary derivations: `<binary> --version` probes and other strings
+//! that are a pure function of a binary's bytes (e.g. the fc-agent initrd SHA).
 //!
 //! `firecracker --version` runs on the VM-launch / snapshot-clone hot path —
 //! `find_firecracker()` probes it and is called more than once per launch — and
-//! each probe is a fork+exec of a multi-megabyte binary. The answer only changes
-//! when the binary itself changes, so it is memoised per binary *identity*
-//! (path + mtime + size) in two layers:
+//! each probe is a fork+exec of a multi-megabyte binary. Likewise the fc-agent
+//! initrd SHA re-reads and SHA-256s a ~4.4MB binary per launch. The answer only
+//! changes when the binary itself changes, so it is memoised per binary
+//! *identity* (path + mtime + size) in two layers:
 //!
 //! * a process-local map, so repeat probes inside one fcvm process are free;
 //! * `assets_dir/version-cache/<key>.json`, so a *freshly spawned* fcvm (the
-//!   clone case: one short-lived process per VM) skips the exec too.
+//!   clone case: one short-lived process per VM) skips the exec/hash too.
 //!
-//! **Version gating still holds.** Rebuilding or replacing the binary changes
-//! its mtime and usually its size, which changes the key, so a changed binary is
-//! re-probed instead of inheriting the old version. A different path is a
-//! different key for the same reason.
+//! **Gating still holds.** Rebuilding or replacing the binary changes its mtime
+//! and usually its size, which changes the key, so a changed binary is
+//! re-derived instead of inheriting the old value. A different path is a
+//! different key for the same reason. Distinct derivations of the same binary
+//! are separated by a `namespace` string that is hashed into the key AND
+//! re-verified on read (`""` is the `--version` namespace, so pre-existing
+//! cache entries stay valid).
 //!
-//! Only *successful* probes are cached. A binary that fails to run (wrong arch,
-//! missing loader) re-runs every time and keeps producing its real error, which
-//! is what the fallback logic in `find_cloud_hypervisor()` depends on.
+//! Only *successful* derivations are cached. A binary that fails to run (wrong
+//! arch, missing loader) re-runs every time and keeps producing its real error,
+//! which is what the fallback logic in `find_cloud_hypervisor()` depends on.
 //!
-//! Cache IO never fails a probe: an unreadable or unwritable cache degrades to
-//! running the binary (so a root-created cache dir does not break unprivileged
+//! Cache IO never fails a derivation: an unreadable or unwritable cache degrades
+//! to recomputing (so a root-created cache dir does not break unprivileged
 //! runs, and vice versa — they just fall back to the in-process layer).
 //!
 //! Entries are ~250 bytes and one is added per distinct binary build ever
-//! probed, so the directory is bounded by how many firecracker /
-//! cloud-hypervisor builds a host has seen; no eviction is needed.
+//! probed, so the directory is bounded by how many binary builds a host has
+//! seen; no eviction is needed.
 
 use anyhow::{bail, Context, Result};
 use sha2::{Digest, Sha256};
@@ -34,14 +39,18 @@ use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use tracing::debug;
 
-/// Persisted probe result. `path`/`mtime_ns`/`len` are re-verified on read so a
-/// hash collision or a hand-edited file can never hand back another binary's
-/// version string.
+/// Persisted derivation result. `path`/`mtime_ns`/`len`/`namespace` are
+/// re-verified on read so a hash collision or a hand-edited file can never hand
+/// back another binary's (or another derivation's) value.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct CachedVersion {
     path: PathBuf,
     mtime_ns: i128,
     len: u64,
+    /// Which derivation this entry stores (`""` = `--version` stdout). Absent in
+    /// entries written before namespaces existed, which were all `--version`.
+    #[serde(default)]
+    namespace: String,
     stdout: String,
 }
 
@@ -69,18 +78,24 @@ impl BinaryIdentity {
         })
     }
 
-    /// Stable file name for this identity's on-disk cache entry.
-    fn key(&self) -> String {
+    /// Stable file name for this identity's on-disk cache entry. The namespace
+    /// is appended, so `""` (the `--version` namespace) produces byte-identical
+    /// keys to the pre-namespace scheme and existing cache entries stay valid.
+    fn key(&self, namespace: &str) -> String {
         let mut hasher = Sha256::new();
         hasher.update(self.path.as_os_str().as_encoded_bytes());
         hasher.update(b"\0");
         hasher.update(self.mtime_ns.to_le_bytes());
         hasher.update(self.len.to_le_bytes());
+        hasher.update(namespace.as_bytes());
         hex::encode(&hasher.finalize()[..16])
     }
 
-    fn matches(&self, entry: &CachedVersion) -> bool {
-        entry.path == self.path && entry.mtime_ns == self.mtime_ns && entry.len == self.len
+    fn matches(&self, entry: &CachedVersion, namespace: &str) -> bool {
+        entry.path == self.path
+            && entry.mtime_ns == self.mtime_ns
+            && entry.len == self.len
+            && entry.namespace == namespace
     }
 }
 
@@ -105,18 +120,52 @@ pub fn version_output(bin: &Path) -> Result<String> {
 /// on-disk layer). Split out so tests can exercise the cache without touching
 /// the process-global asset paths.
 fn version_output_in(bin: &Path, cache_dir: Option<&Path>) -> Result<String> {
+    derived_in(bin, "", cache_dir, || {
+        let output = std::process::Command::new(bin)
+            .arg("--version")
+            .output()
+            .with_context(|| format!("failed to run `{} --version`", bin.display()))?;
+        if !output.status.success() {
+            bail!(
+                "`{} --version` failed (exit {}): {}",
+                bin.display(),
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    })
+}
+
+/// Memoise an arbitrary string derived purely from a binary's bytes (plus
+/// whatever the caller folds into `namespace`), keyed by binary identity.
+/// `compute` runs on a miss; its value is cached only on success.
+pub fn derived(
+    bin: &Path,
+    namespace: &str,
+    compute: impl FnOnce() -> Result<String>,
+) -> Result<String> {
+    derived_in(bin, namespace, disk_cache_dir().as_deref(), compute)
+}
+
+fn derived_in(
+    bin: &Path,
+    namespace: &str,
+    cache_dir: Option<&Path>,
+    compute: impl FnOnce() -> Result<String>,
+) -> Result<String> {
     let identity = BinaryIdentity::of(bin);
 
     if let Some(id) = &identity {
-        let key = id.key();
+        let key = id.key(namespace);
         if let Ok(map) = memo().lock() {
             if let Some(hit) = map.get(&key) {
                 return Ok(hit.clone());
             }
         }
         if let Some(dir) = cache_dir {
-            if let Some(hit) = read_disk_entry(dir, &key, id) {
-                debug!(bin = %bin.display(), "version cache hit (disk)");
+            if let Some(hit) = read_disk_entry(dir, &key, id, namespace) {
+                debug!(bin = %bin.display(), namespace, "binary derivation cache hit (disk)");
                 if let Ok(mut map) = memo().lock() {
                     map.insert(key, hit.clone());
                 }
@@ -125,46 +174,35 @@ fn version_output_in(bin: &Path, cache_dir: Option<&Path>) -> Result<String> {
         }
     }
 
-    let output = std::process::Command::new(bin)
-        .arg("--version")
-        .output()
-        .with_context(|| format!("failed to run `{} --version`", bin.display()))?;
-    if !output.status.success() {
-        bail!(
-            "`{} --version` failed (exit {}): {}",
-            bin.display(),
-            output.status,
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
-    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let value = compute()?;
 
     if let Some(id) = &identity {
-        let key = id.key();
+        let key = id.key(namespace);
         if let Ok(mut map) = memo().lock() {
-            map.insert(key.clone(), stdout.clone());
+            map.insert(key.clone(), value.clone());
         }
         if let Some(dir) = cache_dir {
-            write_disk_entry(dir, &key, id, &stdout);
+            write_disk_entry(dir, &key, id, namespace, &value);
         }
     }
 
-    Ok(stdout)
+    Ok(value)
 }
 
-fn read_disk_entry(dir: &Path, key: &str, id: &BinaryIdentity) -> Option<String> {
+fn read_disk_entry(dir: &Path, key: &str, id: &BinaryIdentity, namespace: &str) -> Option<String> {
     let raw = std::fs::read_to_string(dir.join(format!("{}.json", key))).ok()?;
     let entry: CachedVersion = serde_json::from_str(&raw).ok()?;
-    id.matches(&entry).then_some(entry.stdout)
+    id.matches(&entry, namespace).then_some(entry.stdout)
 }
 
 /// Write the entry atomically (unique temp + rename): several fcvm processes can
 /// probe the same binary at once, and a reader must never see a partial file.
-fn write_disk_entry(dir: &Path, key: &str, id: &BinaryIdentity, stdout: &str) {
+fn write_disk_entry(dir: &Path, key: &str, id: &BinaryIdentity, namespace: &str, stdout: &str) {
     let entry = CachedVersion {
         path: id.path.clone(),
         mtime_ns: id.mtime_ns,
         len: id.len,
+        namespace: namespace.to_string(),
         stdout: stdout.to_string(),
     };
     if std::fs::create_dir_all(dir).is_err() {
@@ -351,5 +389,57 @@ mod tests {
             version_output_in(&bin, None).unwrap().trim(),
             "Firecracker v1.15.0"
         );
+    }
+
+    /// Different namespaces of the same binary are independent entries, and a
+    /// disk hit for one namespace can never satisfy the other (both the key and
+    /// the stored `namespace` field separate them).
+    #[test]
+    fn namespaces_are_isolated_per_binary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = tmp.path().join("cache");
+        std::fs::write(tmp.path().join("bin"), b"payload").unwrap();
+        let bin = tmp.path().join("bin");
+
+        let mut version_runs = 0;
+        let mut sha_runs = 0;
+        let v = derived_in(&bin, "", Some(&cache), || {
+            version_runs += 1;
+            Ok("v1".into())
+        })
+        .unwrap();
+        let s = derived_in(&bin, "initrd-sha:abc", Some(&cache), || {
+            sha_runs += 1;
+            Ok("sha-value".into())
+        })
+        .unwrap();
+        assert_eq!((v.as_str(), s.as_str()), ("v1", "sha-value"));
+        assert_eq!((version_runs, sha_runs), (1, 1));
+
+        // Fresh process simulation: disk layer must hit per-namespace.
+        memo().lock().unwrap().clear();
+        let v2 = derived_in(&bin, "", Some(&cache), || {
+            version_runs += 1;
+            Ok("WRONG".into())
+        })
+        .unwrap();
+        let s2 = derived_in(&bin, "initrd-sha:abc", Some(&cache), || {
+            sha_runs += 1;
+            Ok("WRONG".into())
+        })
+        .unwrap();
+        assert_eq!((v2.as_str(), s2.as_str()), ("v1", "sha-value"));
+        assert_eq!(
+            (version_runs, sha_runs),
+            (1, 1),
+            "disk hits must not recompute"
+        );
+
+        // A different namespace suffix (changed embedded scripts) recomputes.
+        let s3 = derived_in(&bin, "initrd-sha:def", Some(&cache), || {
+            Ok("new-scripts".into())
+        })
+        .unwrap();
+        assert_eq!(s3, "new-scripts");
     }
 }


### PR DESCRIPTION
Removes every fixed sleep/poll left on the clone hot path and replaces each with the event it was approximating. No wait became unbounded: every event-driven path keeps its deadline plus a coarse safety tick, so a lost/coalesced event can only add latency, never hang.

**Stacked on:** clone-hot-path-latency (PR #719)

## Per-item: sleep purpose -> replacement signal -> measured delta

| # | Removed sleep/poll | What it was for | Replacement signal | Measured delta |
|---|---|---|---|---|
| 1 | `restore_from_snapshot` 200ms post-resume sleep (+ CH twin) | Crash window before `try_wait`, aimed at corrupt-diff restores — but a panicking guest exits ~1s post-resume (`panic=1`), never inside 200ms | Non-blocking `try_wait`; delayed death caught by callers' positive readiness gates (output-connect wait, `--exec` probe, port-forward verify); clone liveness first tick 5s -> 250ms | -200ms/clone |
| 2 | FC API-socket fixed 10ms connect poll | Wait for Firecracker to bind+listen its API UDS | inotify `DirWatch` on socket dir armed before first probe; ECONNREFUSED (no fs event for `listen()`) at 1ms; 100ms safety tick; same 5s deadline | ~-5ms/launch (most of one 10ms interval) |
| 3 | pasta PID-file 50ms existence poll | pasta readiness (writes PID file) | inotify watch armed before stale-file cleanup + spawn; select over {event, child death w/ stderr tail, 10s deadline kill+bail, 250ms safety tick} | file at +2.3ms noticed at +2ms instead of +52.8ms |
| 4 | pasta TAP-device fixed 100ms retry | TAP appears a few ms after PID file; item 3 made the probe arrive first | 1ms -> 50ms exponential backoff (each probe is a real nsenter+ip exec), same deadline | kills the +100ms mode seen on 4/10 benched clones; items 3+4 = -57.5ms p50 on the netns+pasta span |
| 5 | exec connect ladder 30 x (100ms, 2x) | Boot tolerance for `fcvm exec` against a not-yet-listening agent | 41 x (5ms, 1.5x, 2s cap) ≈ same ~54s total window; logs `attempts` + `retry_wait_ms` on success-after-retries | removes the 100ms quantum that masqueraded as guest latency in benchmarks |
| 6 | clone `--exec` vsock-socket fixed 10ms poll | Wait for `vsock.sock` (exists at load_snapshot time) | immediate probe, 1ms -> 10ms backoff | ~-9ms on `--exec` clones |
| 7 | guest restore-epoch 50ms MMDS poll (frozen mid-sleep across snapshot) | Detect the new restore-epoch after resume | vsock TRANSPORT_RESET (EPOLLERR on the idle output connection) via latching watch channel -> immediate fetch + bounded 1s fast window (2ms MMDS / 10ms vsock); 50ms poll stays the correctness path | avg ~-25ms (frozen-sleep remainder) |
| 8 | eager reboot-plan assembly (~19ms) on every clone | Cold-boot relaunch plan for reboot-in-place | built on demand in the reboot path (a rebooting clone already pays a full cold boot) | -19ms/clone |
| 9 | initrd SHA: read+hash 4.4MB fc-agent every launch (~17ms) | Content-addressed initrd naming | memoised via version-cache identity (path+mtime+len) + namespace hashed into key AND re-verified on read; embedded-scripts hash in the namespace; unit-tested | -17ms/launch |

## Interleaved A/B bench

Base = clone-hot-path-latency tip (PR #719 binaries), After = this branch. 2 rounds x 10 rootless clones per arm, arms alternating within the same run so host-load drift hits both equally. `bench/clone-latency.sh` (spawn -> exec-server-ready, event-driven marker).

```
arm    p50      min      max      mean     (n = 20 clones per arm, 2 interleaved rounds)
base   331.0ms  329.0ms  336.0ms  331.6ms
after  129.0ms  116.0ms  202.0ms  134.3ms   ->  -202.0ms p50   (2.57x, -61%)

stage p50 (median of per-clone deltas)   base      after     delta
netns+pasta      (items 3+4)             96.0ms    38.5ms   -57.5ms
resume->ready    (items 1,5,6,7,8)      221.1ms    74.8ms  -146.2ms
snapshot-load    (unchanged control)      6.0ms     5.7ms    -0.3ms
listeners+state  (unchanged control)      2.5ms     2.6ms    +0.1ms
```

Earlier per-stage attribution (4 independent snapshots, p50 over 10-20 clones) matched the arithmetic: the -200ms sleep minus ~50ms of newly-exposed concurrent guest restore work ≈ the resume->ready delta, and items 3+4 ≈ the netns+pasta delta. Known and disclosed: the FIRST clone after an fcvm rebuild pays +80ms once to warm the new binary's version/initrd cache entries (item 9's memoisation is per binary identity).

## Review findings and dispositions

Adversarial review verdict was needs-fixes; dispositions:

1. **SHOULD-FIX (applied)** `src/firecracker/vm.rs` — the ECONNREFUSED arm `continue`d past the child-death `try_wait`. If Firecracker binds the API socket then exits, the socket file persists and refuses connections forever: the loop would spin at 1ms for the full 5s and report the generic "socket not ready" without exit status + stderr tail (a diagnosis regression vs the old 10ms loop exactly on the crash-at-startup case). Fixed: the arm now falls through to the liveness check every iteration and keeps the 1ms cadence.
2. **SHOULD-FIX (applied)** `src/network/pasta.rs` — `DirWatch::new` used `?`, hard-failing `start_pasta` if inotify init fails (EMFILE against `fs.inotify.max_user_instances`, default 128, plausible under many concurrent clone starts as one user; the old poll had no such failure mode). Fixed: degrades to the 250ms safety-tick cadence via `DirWatch::next_event_opt` (a `None` watch never completes, so the select falls back to its tick/deadline arms), matching vm.rs; both degrade sites now log a warn.
3. **NIT (addressed)** — earlier base/new runs were sequential; the interleaved A/B above was run before opening this PR, using the preserved base binaries.
4. **NIT (noted, no change)** — Cloud Hypervisor `wait_for_api` keeps its fixed 10ms poll. It already runs `try_wait` every iteration, so there is no diagnosis gap — just a slower wait, out of this tranche's measured scope (Firecracker is the clone path).

Failpoint coverage for the new event-driven signals (TRANSPORT_RESET fast-poll, DirWatch wakeups) is tracked separately as task #19; the failpoints named in the original brief do not exist in this tree yet.

## Test results

```
$ make lint
cargo fmt -p fcvm -p fuse-pipe -p fc-agent --check   # clean
cargo clippy --all-targets -- -D warnings            # clean
cargo audit && cargo deny check                      # advisories ok, bans ok, licenses ok, sources ok

$ make test-unit
     Summary [  50.479s] 366 tests run: 366 passed, 0 skipped
        PASS [   0.006s] fcvm version_cache::tests::namespaces_are_isolated_per_binary

$ make test-root FILTER=snapshot
     Summary [ 356.799s] 113 tests run: 113 passed, 530 skipped

$ make test-root FILTER=sanity
     Summary [   6.103s] 5 tests run: 5 passed, 638 skipped

$ make test-root FILTER="-E 'test(/custom_command|serial_console_after_restore|exec_parallel_tty_stress|exec_rootless|port_forward_rootless/)'"
        PASS [   6.209s] (1/7) fcvm::test_exec test_exec_parallel_tty_stress
        PASS [  11.762s] (2/7) fcvm::test_snapshot_clone test_snapshot_run_exec_rootless
        PASS [  15.318s] (3/7) fcvm::test_serial_console test_serial_console_after_restore
        PASS [  17.211s] (4/7) fcvm::test_port_forward test_port_forward_rootless
        PASS [  20.885s] (5/7) fcvm::test_readme_examples test_custom_command_bridged
        PASS [  32.954s] (6/7) fcvm::test_snapshot_clone test_clone_port_forward_rootless
        PASS [  81.057s] (7/7) fcvm::test_exec test_exec_rootless
     Summary [  81.061s] 7 tests run: 7 passed, 636 skipped

No nextest retries fired in any suite (nextest reports retried tests as FLAKY; none appeared).
```

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd
