### PR TITLE
Add disk-capacity preflight + hourly runner guard so a full runner can't poison jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,18 @@ jobs:
       - uses: actions/checkout@v6
         with:
           path: fcvm
+      # Free space before the dependency clones and builds that need it, and
+      # fail loudly (naming the runner) if the disk can't be recovered — a
+      # full runner otherwise produces mystery ENOSPC failures downstream.
+      # Runs as early as the repo's own script is available; it cannot rescue
+      # a runner already too full for "Set up job" itself (2026-08-06:
+      # runner-i-0ea78b39da373fcca died there on _diag/ and killed every job
+      # it picked up, including two on the dependabot merge train). That case
+      # is covered on the runner by scripts/runner-disk-guard.timer, which
+      # runs this same script hourly with --quarantine. Needs no secrets.
+      - name: Disk preflight
+        working-directory: fcvm
+        run: ./scripts/runner-disk-preflight.sh
       - uses: ./fcvm/.github/actions/checkout-deps
       - name: Install Rust
         run: |
@@ -463,6 +475,18 @@ jobs:
       - uses: actions/checkout@v6
         with:
           path: fcvm
+      # Free space before the dependency clones and builds that need it, and
+      # fail loudly (naming the runner) if the disk can't be recovered — a
+      # full runner otherwise produces mystery ENOSPC failures downstream.
+      # Runs as early as the repo's own script is available; it cannot rescue
+      # a runner already too full for "Set up job" itself (2026-08-06:
+      # runner-i-0ea78b39da373fcca died there on _diag/ and killed every job
+      # it picked up, including two on the dependabot merge train). That case
+      # is covered on the runner by scripts/runner-disk-guard.timer, which
+      # runs this same script hourly with --quarantine. Needs no secrets.
+      - name: Disk preflight
+        working-directory: fcvm
+        run: ./scripts/runner-disk-preflight.sh
       - uses: ./fcvm/.github/actions/checkout-deps
       - name: Install Rust
         run: |
@@ -649,6 +673,18 @@ jobs:
       - uses: actions/checkout@v6
         with:
           path: fcvm
+      # Free space before the dependency clones and builds that need it, and
+      # fail loudly (naming the runner) if the disk can't be recovered — a
+      # full runner otherwise produces mystery ENOSPC failures downstream.
+      # Runs as early as the repo's own script is available; it cannot rescue
+      # a runner already too full for "Set up job" itself (2026-08-06:
+      # runner-i-0ea78b39da373fcca died there on _diag/ and killed every job
+      # it picked up, including two on the dependabot merge train). That case
+      # is covered on the runner by scripts/runner-disk-guard.timer, which
+      # runs this same script hourly with --quarantine. Needs no secrets.
+      - name: Disk preflight
+        working-directory: fcvm
+        run: ./scripts/runner-disk-preflight.sh
       - uses: ./fcvm/.github/actions/checkout-deps
       - name: Setup KVM and rootless podman
         run: |

--- a/scripts/build-ami.sh
+++ b/scripts/build-ami.sh
@@ -17,6 +17,15 @@ compute_hash() {
     # Include the passt build inputs so a pin or patch change rebuilds the AMI
     # instead of reusing one whose baked-in pasta no longer matches CI.
     cat "$SCRIPT_DIR/build-passt.sh" "$SCRIPT_DIR"/passt-*.patch 2>/dev/null
+    # Include the disk guard's script and units: they are baked into the AMI,
+    # so a change to them must produce a new AMI rather than silently reusing
+    # one without the fix.
+    cat "$SCRIPT_DIR/runner-disk-preflight.sh" \
+      "$SCRIPT_DIR/runner-disk-guard.service" "$SCRIPT_DIR/runner-disk-guard.timer" 2>/dev/null
+    # Include the provisioning script itself. Without this, editing the AMI's
+    # user-data changes nothing the hash can see, so the cached AMI is reused
+    # and the edit never reaches a runner.
+    create_user_data
   } | sha256sum | cut -c1-12
 }
 
@@ -157,6 +166,16 @@ curl -o /tmp/actions-runner.tar.gz -L \
 tar xzf /tmp/actions-runner.tar.gz -C /opt/actions-runner
 chown -R ubuntu:ubuntu /opt/actions-runner
 /opt/actions-runner/bin/installdependencies.sh
+
+# Disk-capacity guard (hourly timer). A runner that fills its disk fails every
+# job it picks up at "Set up job", before any job step can run, so the CI
+# preflight step cannot rescue it — this cleans caches out-of-band and, if the
+# hard floor still cannot be met, stops the runner service so the box goes
+# offline and gets replaced instead of poisoning jobs.
+install -m 755 /tmp/fcvm/scripts/runner-disk-preflight.sh /usr/local/bin/runner-disk-preflight.sh
+install -m 644 /tmp/fcvm/scripts/runner-disk-guard.service /etc/systemd/system/runner-disk-guard.service
+install -m 644 /tmp/fcvm/scripts/runner-disk-guard.timer /etc/systemd/system/runner-disk-guard.timer
+systemctl enable runner-disk-guard.timer
 
 # Clean up
 apt-get clean

--- a/scripts/runner-disk-guard.service
+++ b/scripts/runner-disk-guard.service
@@ -1,0 +1,20 @@
+# Disk-capacity guard for fcvm CI runners. Installed to /etc/systemd/system by
+# scripts/build-ami.sh (baked into the runner AMI) and scripts/setup-runner.sh,
+# triggered hourly by runner-disk-guard.timer.
+#
+# A job-level preflight step cannot rescue a runner so full that GitHub's
+# "Set up job" phase fails (no step ever runs), so this guard cleans caches
+# before that point and — if the hard floor cannot be met — stops the
+# actions-runner service so the box goes offline and gets replaced instead of
+# poisoning every job it picks up. Same script as the ci.yml preflight step.
+
+[Unit]
+Description=Disk capacity guard: clean caches, quarantine runner if disk stays full
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/runner-disk-preflight.sh --quarantine
+# Pruning large btrfs trees can take a while; don't let the default 90s
+# start timeout kill the cleanup half-way.
+TimeoutStartSec=30min
+Nice=10

--- a/scripts/runner-disk-guard.timer
+++ b/scripts/runner-disk-guard.timer
@@ -1,0 +1,15 @@
+# Hourly trigger for runner-disk-guard.service (see that unit for why).
+# Installed by scripts/build-ami.sh (runner AMI) and scripts/setup-runner.sh.
+
+[Unit]
+Description=Hourly disk capacity guard for the fcvm CI runner
+
+[Timer]
+OnBootSec=10min
+OnUnitActiveSec=1h
+# Spread runners out so a fleet doesn't hammer shared infra in lockstep.
+RandomizedDelaySec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/runner-disk-preflight.sh
+++ b/scripts/runner-disk-preflight.sh
@@ -1,0 +1,444 @@
+#!/usr/bin/env bash
+# Disk-capacity preflight + cleanup for fcvm CI runners.
+#
+# One script, two invocation layers (2026-08-06: runner-i-0ea78b39da373fcca
+# filled its disk and killed every job it picked up at "Set up job" —
+# "No space left on device: /opt/actions-runner/_diag/..." — until it was
+# manually deregistered; neither layer alone can prevent a repeat):
+#
+#   1. ci.yml — first step after checkout in every self-hosted job. Frees
+#      space before the heavy steps and fails LOUDLY (naming the runner) if
+#      the disk cannot be recovered, so a sick runner produces one clear
+#      failure instead of a cascade of mystery ENOSPC errors.
+#
+#   2. runner-disk-guard.timer — hourly systemd timer on the runner itself
+#      (installed by scripts/build-ami.sh and scripts/setup-runner.sh),
+#      running with --quarantine. A job step cannot rescue a runner so full
+#      that "Set up job" itself fails (the job dies before any step runs), so
+#      when the hard floor cannot be met the guard stops the actions-runner
+#      service: the box goes offline and the autoscaler replaces it, instead
+#      of the runner accepting and poisoning every queued job.
+#
+# Thresholds (env-overridable):
+#   MIN_FREE_GB      below this on any monitored fs, run cleanup (default 15)
+#   HARD_FLOOR_GB    below this after cleanup → fail / quarantine (default 5)
+#   LOG_AGE_DAYS     test logs / core dumps older than this (default 1)
+#   TARGET_AGE_DAYS  cargo target dirs idle longer than this (default 3)
+#   CACHE_AGE_DAYS   content-addressed cache entries idle longer (default 4)
+#   DRY_RUN=1        print every candidate, delete nothing; runs all stages
+#                    regardless of thresholds so the candidate list is auditable
+#
+# Cleanup stages run in order of increasing cost-to-recreate, and stop as soon
+# as every monitored filesystem is back above MIN_FREE_GB:
+#   1. podman system prune (rootless + root storage) — images/containers/
+#      volumes are re-pulled or re-built on demand.
+#   2. /tmp/fcvm-test-logs entries older than LOG_AGE_DAYS.
+#   3. cargo/nextest target dirs (runner _work checkouts and
+#      /mnt/fcvm-btrfs/cargo-target*) with no activity for TARGET_AGE_DAYS.
+#   4. content-addressed caches on /mnt/fcvm-btrfs (image-cache entries,
+#      snapshot dirs, kernel/rootfs/initrd/firecracker assets) idle for
+#      CACHE_AGE_DAYS, plus core dumps older than LOG_AGE_DAYS.
+#
+# "Idle" means neither modified NOR read since the cutoff: the btrfs volume is
+# mounted relatime, so content-addressed assets the current checkout's SHAs
+# actually reference are re-read every CI run and keep a fresh atime — they are
+# never candidates. A pruned entry is regenerated on the next cache miss.
+#
+# Never touched: state/ (live VM state), vm-disks/ (possibly-attached VM
+# disks), containers/ (podman's own store — managed via podman prune), and
+# *.lock files (unlinking a lock file a process holds leaves two "owners" of
+# the same critical section — the ABA locking bug class AGENTS.md bans).
+set -euo pipefail
+
+MIN_FREE_GB="${MIN_FREE_GB:-15}"
+HARD_FLOOR_GB="${HARD_FLOOR_GB:-5}"
+LOG_AGE_DAYS="${LOG_AGE_DAYS:-1}"
+TARGET_AGE_DAYS="${TARGET_AGE_DAYS:-3}"
+CACHE_AGE_DAYS="${CACHE_AGE_DAYS:-4}"
+DRY_RUN="${DRY_RUN:-0}"
+
+QUARANTINE=0
+for arg in "$@"; do
+  case "$arg" in
+    --quarantine) QUARANTINE=1 ;;
+    *)
+      echo "usage: $0 [--quarantine]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+GIB=$((1024 * 1024 * 1024))
+BTRFS_ROOT=/mnt/fcvm-btrfs
+
+# All logging goes to stderr: several stages pipe NUL-delimited candidate
+# paths between functions on stdout, and log lines must never enter that data
+# stream.
+log() { printf '[disk-preflight] %s\n' "$*" >&2; }
+human() { numfmt --to=iec-i --suffix=B "$1"; }
+
+# Root is required for most cleanup targets (root-owned test debris, root
+# podman storage). CI runners and dev boxes both have passwordless sudo; the
+# probe's stderr is suppressed only because we replace it with our own loud
+# error right below.
+if [[ $EUID -eq 0 ]]; then
+  SUDO=()
+else
+  SUDO=(sudo -n)
+  if ! sudo -n true 2>/dev/null; then
+    log "ERROR: passwordless sudo unavailable; cannot clean root-owned files"
+    exit 1
+  fi
+fi
+
+# Monitored filesystems: the runner install dir (where _diag lives — the fs
+# that killed jobs at "Set up job"), the fcvm asset volume, and /tmp, deduped
+# down to unique mountpoints. Paths missing on this host (e.g. no runner
+# install, no btrfs volume) are simply not monitored.
+MON=()
+declare -A _seen_mp=()
+for p in / /opt/actions-runner "$BTRFS_ROOT" /tmp; do
+  [[ -e $p ]] || continue
+  mp="$(findmnt -no TARGET -T "$p")"
+  if [[ -z ${_seen_mp[$mp]:-} ]]; then
+    _seen_mp[$mp]=1
+    MON+=("$mp")
+  fi
+done
+
+avail_bytes() { df -B1 --output=avail "$1" | tail -n1 | tr -d ' '; }
+
+# The root/container data dirs are root-owned and not traversable by the CI
+# user, so a plain [[ -d ]] reports "missing" and silently skips the largest
+# cache on the box. Always test through sudo.
+dir_exists() { "${SUDO[@]}" test -d "$1"; }
+
+total_avail() {
+  local sum=0 mp
+  for mp in "${MON[@]}"; do
+    sum=$((sum + $(avail_bytes "$mp")))
+  done
+  printf '%s\n' "$sum"
+}
+
+# any_below <gb>: true if any monitored fs has less than <gb> GiB free
+any_below() {
+  local floor_bytes=$(($1 * GIB)) mp
+  for mp in "${MON[@]}"; do
+    if (($(avail_bytes "$mp") < floor_bytes)); then
+      return 0
+    fi
+  done
+  return 1
+}
+
+df_report() { df -h "${MON[@]}" >&2; }
+
+TARGET_CUTOFF="$(date -d "$TARGET_AGE_DAYS days ago" '+%Y-%m-%d %H:%M:%S')"
+CACHE_CUTOFF="$(date -d "$CACHE_AGE_DAYS days ago" '+%Y-%m-%d %H:%M:%S')"
+
+# recently_used <path> <cutoff>: was any FILE under <path> written (mtime) or
+# read (atime; the volume is mounted relatime) since <cutoff>?
+#
+# -type f is load-bearing, not an optimization: reading a directory's entries
+# updates that directory's atime, so this probe (and any du/ls/find anyone
+# runs) would refresh the very timestamps it reads, and after one preflight
+# run nothing would ever look idle again. File atimes are untouched by
+# directory traversal, so they are the only self-consistent signal here.
+#
+# On probe failure we report the error and claim "in use" — failing toward
+# keeping data, never toward deleting it.
+recently_used() {
+  local found
+  if ! found="$("${SUDO[@]}" find "$1" -type f \( -newermt "$2" -o -newerat "$2" \) -print -quit 2>&1)"; then
+    log "  WARNING: activity probe failed for $1 ($found); treating as in-use"
+    return 0
+  fi
+  [[ -n $found ]]
+}
+
+# delete_candidates <label>: read NUL-delimited paths on stdin, log each with
+# its size, delete unless DRY_RUN. Sizes are apparent allocation (du); btrfs
+# reflinks can make the actually-freed amount smaller — the per-stage df delta
+# logged by main() shows the real effect.
+delete_candidates() {
+  local label="$1" total=0 count=0 path size verb="freed"
+  if ((DRY_RUN)); then
+    verb="would be freed"
+  fi
+  while IFS= read -r -d '' path; do
+    # A candidate can legitimately vanish between listing and deletion
+    # (e.g. a concurrent job's own cleanup); that is not an error.
+    [[ -e $path ]] || continue
+    size="$("${SUDO[@]}" du -sb -- "$path" | awk '{print $1}')" || return 1
+    if ((DRY_RUN)); then
+      log "  would delete: $path ($(human "$size"))"
+    else
+      "${SUDO[@]}" rm -rf -- "$path" || return 1
+      log "  deleted: $path ($(human "$size"))"
+    fi
+    total=$((total + size))
+    count=$((count + 1))
+  done
+  log "[$label] $count entries, $(human "$total") $verb"
+}
+
+# Stage 1: podman images, stopped containers, volumes. Everything podman
+# stores is re-pulled or re-built on demand (localhost/nested-test is
+# auto-rebuilt by ensure_nested_image()).
+stage_podman_prune() {
+  if ! command -v podman >/dev/null 2>&1; then
+    log "podman not installed; nothing to prune"
+    return 0
+  fi
+  local users=() u
+  if [[ $EUID -eq 0 ]]; then
+    # Guard mode (systemd): root storage plus the runner user's rootless
+    # storage (CI configures its graphroot on the btrfs volume).
+    users=(root)
+    if [[ -d /opt/actions-runner ]]; then
+      u="$(stat -c %U /opt/actions-runner)"
+      if [[ $u != root ]]; then
+        users+=("$u")
+      fi
+    fi
+  else
+    users=("$(id -un)" root)
+  fi
+  for u in "${users[@]}"; do
+    if ((DRY_RUN)); then
+      log "would run 'podman system prune -af --volumes' as $u; current usage:"
+      if [[ $u == "$(id -un)" ]]; then
+        podman system df >&2 || return 1
+      else
+        "${SUDO[@]}" podman system df >&2 || return 1
+      fi
+      continue
+    fi
+    log "podman system prune as $u:"
+    if [[ $u == "$(id -un)" ]]; then
+      podman system prune -af --volumes >&2 || return 1
+    elif [[ $u == root ]]; then
+      "${SUDO[@]}" podman system prune -af --volumes >&2 || return 1
+    else
+      # Another user's rootless store, reached from the root guard: runuser
+      # gives a clean login context so podman resolves that user's XDG dirs
+      # and storage config.
+      runuser -u "$u" -- podman system prune -af --volumes >&2 || return 1
+    fi
+  done
+}
+
+# Stage 2: per-test debug logs. CI wipes this dir at job start anyway;
+# entries older than a day are debris from crashed or cancelled runs.
+stage_test_logs() {
+  local dir=/tmp/fcvm-test-logs
+  if [[ ! -d $dir ]]; then
+    log "no $dir; nothing to do"
+    return 0
+  fi
+  "${SUDO[@]}" find "$dir" -mindepth 1 -maxdepth 1 -mmin "+$((LOG_AGE_DAYS * 1440))" -print0 |
+    delete_candidates "stale test logs (>${LOG_AGE_DAYS}d)"
+}
+
+# Stage 3: cargo/nextest build artifacts. Deleting one costs a rebuild, never
+# correctness, so only dirs with no read/write activity for TARGET_AGE_DAYS
+# are pruned (the active checkout's target is touched on every build).
+stage_target_dirs() {
+  local candidates=() d
+  # Runner work-dir checkouts live at _work/<repo>/<repo>/target. -type d
+  # skips the target→btrfs symlink the Makefile creates; that case is the
+  # cargo-target* glob below.
+  if dir_exists /opt/actions-runner/_work; then
+    while IFS= read -r -d '' d; do
+      candidates+=("$d")
+    done < <("${SUDO[@]}" find /opt/actions-runner/_work -mindepth 3 -maxdepth 3 -type d -name target -print0)
+  fi
+  for d in "$BTRFS_ROOT"/cargo-target*; do
+    if [[ -d $d ]]; then
+      candidates+=("$d")
+    fi
+  done
+  if ((${#candidates[@]} == 0)); then
+    log "no cargo target dirs found"
+    return 0
+  fi
+  for d in "${candidates[@]}"; do
+    if recently_used "$d" "$TARGET_CUTOFF"; then
+      log "  keeping (active within ${TARGET_AGE_DAYS}d): $d"
+    else
+      printf '%s\0' "$d"
+    fi
+  done | delete_candidates "idle cargo target dirs (>${TARGET_AGE_DAYS}d)"
+}
+
+# Stage 4a helper: content-addressed image-cache entries
+# (<digest>.docker.tar / <digest>.storage-v2.img). The age gate alone makes
+# racing an in-progress build essentially impossible (a build in progress has
+# a fresh file), but where a <digest>.lock exists we additionally delete under
+# the same per-digest flock the image builders take — a held lock means an
+# active build, so the entry is kept. Builders inside VMs bypass flock (it
+# does not cross the FUSE boundary) but write unique temp names + atomic
+# rename, so the worst case of racing one is a benign cache miss re-build.
+prune_image_cache() {
+  local ic="$BTRFS_ROOT/image-cache" f base lock rc size total=0 count=0 verb="freed"
+  if ! dir_exists "$ic"; then
+    return 0
+  fi
+  if ((DRY_RUN)); then
+    verb="would be freed"
+  fi
+  while IFS= read -r -d '' f; do
+    size="$("${SUDO[@]}" du -sb -- "$f" | awk '{print $1}')" || return 1
+    if ((DRY_RUN)); then
+      log "  would delete: $f ($(human "$size"))"
+      total=$((total + size))
+      count=$((count + 1))
+      continue
+    fi
+    base="$(basename -- "$f")"
+    lock="$ic/${base%%.*}.lock"
+    if [[ -e $lock ]]; then
+      if "${SUDO[@]}" flock -n -E 42 "$lock" rm -f -- "$f"; then
+        log "  deleted: $f ($(human "$size"))"
+      else
+        rc=$?
+        if ((rc == 42)); then
+          log "  keeping (concurrent build holds $lock): $f"
+          continue
+        fi
+        log "ERROR: deleting $f failed (rc=$rc)"
+        return 1
+      fi
+    else
+      "${SUDO[@]}" rm -f -- "$f" || return 1
+      log "  deleted: $f ($(human "$size"))"
+    fi
+    total=$((total + size))
+    count=$((count + 1))
+  done < <("${SUDO[@]}" find "$ic" -maxdepth 1 -type f \
+    \( -name '*.docker.tar' -o -name '*.storage-v2.img' \) \
+    ! -newermt "$CACHE_CUTOFF" ! -newerat "$CACHE_CUTOFF" -print0)
+  log "[image-cache entries (idle >${CACHE_AGE_DAYS}d)] $count entries, $(human "$total") $verb"
+}
+
+# Stage 4: shared content-addressed caches on the btrfs volume. Everything
+# here is keyed by digest/SHA and regenerated on the next cache miss; only
+# entries with no read/write activity for CACHE_AGE_DAYS are pruned, which
+# excludes everything the current checkout's SHAs reference (see header).
+stage_btrfs_caches() {
+  if ! dir_exists "$BTRFS_ROOT"; then
+    log "no $BTRFS_ROOT; nothing to do"
+    return 0
+  fi
+
+  prune_image_cache || return 1
+
+  # Snapshot dirs (default, root and container data dirs). Active snapshots
+  # are being read by serve/restore processes and stay within the age gate.
+  local sd d
+  for sd in "$BTRFS_ROOT/snapshots" "$BTRFS_ROOT/root/snapshots" "$BTRFS_ROOT/container/snapshots"; do
+    dir_exists "$sd" || continue
+    while IFS= read -r -d '' d; do
+      if recently_used "$d" "$CACHE_CUTOFF"; then
+        log "  keeping (active within ${CACHE_AGE_DAYS}d): $d"
+      else
+        printf '%s\0' "$d"
+      fi
+    done < <("${SUDO[@]}" find "$sd" -mindepth 1 -maxdepth 1 -type d -print0) |
+      delete_candidates "idle snapshots in $sd (>${CACHE_AGE_DAYS}d)" || return 1
+  done
+
+  # Content-addressed kernel/rootfs/initrd/firecracker assets. Idle-gated
+  # only (no flock: an in-progress build's file is by definition fresh, so it
+  # can never be a candidate). *.lock siblings are never deleted.
+  for d in kernels rootfs initrd firecracker; do
+    dir_exists "$BTRFS_ROOT/$d" || continue
+    "${SUDO[@]}" find "$BTRFS_ROOT/$d" -maxdepth 1 -type f ! -name '*.lock' \
+      ! -newermt "$CACHE_CUTOFF" ! -newerat "$CACHE_CUTOFF" -print0 |
+      delete_candidates "idle $d assets (>${CACHE_AGE_DAYS}d)" || return 1
+  done
+
+  # Core dumps from crashed VMs/tests: pure debris after LOG_AGE_DAYS.
+  if dir_exists "$BTRFS_ROOT/cores"; then
+    "${SUDO[@]}" find "$BTRFS_ROOT/cores" -mindepth 1 -maxdepth 1 \
+      -mmin "+$((LOG_AGE_DAYS * 1440))" -print0 |
+      delete_candidates "core dumps (>${LOG_AGE_DAYS}d)" || return 1
+  fi
+}
+
+# Stop (and disable, so a reboot cannot resurrect it) the GitHub Actions
+# runner service. The unit name embeds the registered runner name
+# (actions.runner.<org-repo>.<runner-name>.service), so the quarantine log
+# names the runner that needs attention.
+quarantine_runner() {
+  local units=() u
+  mapfile -t units < <(systemctl list-units --all --plain --no-legend 'actions.runner.*.service' | awk '{print $1}')
+  if ((${#units[@]} == 0)); then
+    log "quarantine: no actions.runner service unit on this host"
+    return 0
+  fi
+  for u in "${units[@]}"; do
+    log "QUARANTINE: stopping and disabling $u — this runner is out of disk and now offline; the autoscaler should replace it"
+    "${SUDO[@]}" systemctl stop "$u" || return 1
+    "${SUDO[@]}" systemctl disable "$u" || return 1
+  done
+  "${SUDO[@]}" touch /run/runner-disk-guard-quarantined
+}
+
+main() {
+  local runner_id="${RUNNER_NAME:-$(hostname)}"
+  log "runner: $runner_id"
+  log "monitored filesystems: ${MON[*]}"
+  log "df before:"
+  df_report
+
+  if ((DRY_RUN)); then
+    log "DRY_RUN=1: auditing all cleanup stages regardless of thresholds; nothing will be deleted"
+  elif ! any_below "$MIN_FREE_GB"; then
+    log "OK: every monitored filesystem has >= ${MIN_FREE_GB}GiB free; no cleanup needed"
+    return 0
+  fi
+
+  local stages=(stage_podman_prune stage_test_logs stage_target_dirs stage_btrfs_caches)
+  local failed=() s before after
+  for s in "${stages[@]}"; do
+    if ((!DRY_RUN)) && ! any_below "$MIN_FREE_GB"; then
+      log "recovered above ${MIN_FREE_GB}GiB free; skipping remaining stages"
+      break
+    fi
+    log "=== $s ==="
+    before="$(total_avail)"
+    if ! "$s"; then
+      failed+=("$s")
+      log "ERROR: $s failed; continuing with remaining stages to recover space, will exit nonzero"
+    fi
+    after="$(total_avail)"
+    # btrfs frees extents asynchronously (cleaner thread), so a stage's bytes
+    # can show up in a later stage's delta — trust the per-entry sizes above
+    # and the overall before/after df, not a single stage's number.
+    log "=== $s freed $(human "$((after > before ? after - before : 0))") (df delta across monitored filesystems) ==="
+  done
+
+  log "df after:"
+  df_report
+
+  if ((!DRY_RUN)) && any_below "$HARD_FLOOR_GB"; then
+    log "FATAL: runner '$runner_id' still below ${HARD_FLOOR_GB}GiB free after cleanup"
+    # GitHub error annotation (parsed from stdout) so the failure names the
+    # runner at the top of the job page instead of a mystery ENOSPC later.
+    echo "::error title=Runner disk full::Runner '$runner_id' is below ${HARD_FLOOR_GB}GiB free after cleanup - replace or manually clean this runner"
+    if ((QUARANTINE)); then
+      quarantine_runner || log "ERROR: quarantine failed; runner may still accept jobs"
+    fi
+    return 1
+  fi
+
+  if ((${#failed[@]} > 0)); then
+    log "ERROR: cleanup stage(s) failed: ${failed[*]}"
+    return 1
+  fi
+  log "done"
+}
+
+main "$@"

--- a/scripts/setup-runner.sh
+++ b/scripts/setup-runner.sh
@@ -87,6 +87,19 @@ ln -sf /home/ubuntu/.cargo/bin/rustup /usr/local/bin/rustup
 # (scripts/build-passt.sh owns the pin and the local patches).
 git clone --depth 1 https://github.com/ejc3/fcvm.git /tmp/fcvm-passt
 /tmp/fcvm-passt/scripts/build-passt.sh
+
+# Disk-capacity guard (hourly timer), installed from the same clone. A runner
+# that fills its disk fails every job it picks up at "Set up job", before any
+# job step can run, so the CI preflight step cannot rescue it — this cleans
+# caches out-of-band and, if the hard floor still cannot be met, stops the
+# runner service so the box goes offline and gets replaced instead of
+# poisoning jobs.
+install -m 755 /tmp/fcvm-passt/scripts/runner-disk-preflight.sh /usr/local/bin/runner-disk-preflight.sh
+install -m 644 /tmp/fcvm-passt/scripts/runner-disk-guard.service /etc/systemd/system/runner-disk-guard.service
+install -m 644 /tmp/fcvm-passt/scripts/runner-disk-guard.timer /etc/systemd/system/runner-disk-guard.timer
+systemctl daemon-reload
+systemctl enable --now runner-disk-guard.timer
+
 rm -rf /tmp/fcvm-passt /tmp/passt-build-*
 cd /
 


### PR DESCRIPTION
Makes a disk-full self-hosted runner a loud, self-healing condition instead of a silent job-poisoner.

## The Problem

On 2026-08-06 `runner-i-0ea78b39da373fcca` filled its disk and then failed **every job it picked up** during GitHub's `Set up job` phase:

```
No space left on device: /opt/actions-runner/_diag/...
```

Two of the poisoned jobs were on the dependabot merge train. The runner had to be manually deregistered.

The critical detail for the fix: **the runner died before any job step ran.** A job-level preflight step could not have saved it — there was no step. So a single-layer fix is not a fix.

## The Solution — two layers, one script

### (a) `ci.yml` preflight step

New `Disk preflight` step in the three self-hosted jobs (`host`, `host-root`, `container`), placed right after checkout and before the dependency clones and builds that consume the space. GitHub-hosted jobs (`lint`, `packaging`, `fc-mock`) are untouched — they're ephemeral.

Below `MIN_FREE_GB` (default 15) it cleans in order of increasing cost-to-recreate, stopping as soon as space is recovered:

1. `podman system prune -af --volumes` (rootless + root stores)
2. stale `/tmp/fcvm-test-logs` (> `LOG_AGE_DAYS`, default 1)
3. idle cargo/nextest target dirs — runner `_work` checkouts and `/mnt/fcvm-btrfs/cargo-target*` (> `TARGET_AGE_DAYS`, default 3)
4. content-addressed btrfs caches — `image-cache`, snapshots (incl. the root/container data dirs), kernel/rootfs/initrd/firecracker assets, core dumps (> `CACHE_AGE_DAYS`, default 4)

Still below `HARD_FLOOR_GB` (default 5) afterwards → **fails the job loudly** with a `::error` annotation naming the runner, so it gets attention instead of producing mystery failures downstream. `df` is echoed before and after; every deleted entry is logged with its byte size.

This step needs **no secrets** and adds no `${{ github.event.* }}` interpolation into `run:`.

### (b) Runner-level guard — the layer that actually covers the outage

`scripts/runner-disk-guard.{service,timer}`: an hourly systemd timer running the **same script** with `--quarantine`, installed into the runner AMI (`build-ami.sh`) and by the bootstrap (`setup-runner.sh`). Running out-of-band of any job, it cleans before the box ever reaches setup-fails territory; if the hard floor still can't be met it stops and disables the `actions.runner.*` unit so the runner goes **offline** and the autoscaler replaces it, rather than accepting and killing jobs.

The AMI/bootstrap are defined in this repo, so no `ejc3/aws` change is needed.

**`build-ami.sh` cache-hash fix (required, not incidental):** `compute_hash()` didn't hash the user-data or the installed files, so the cached guard-less AMI would have been reused and layer (b) would never have shipped. It now also hashes the guard script/units and `create_user_data`. Verified: old logic returns an **unchanged** hash on this branch (`005d73a75a65`), new logic returns `ed4dddefe223`.

## Two subtleties the local dry run exposed

Both are fixed and commented in-script, because both would have silently degraded the guard:

- **The idle probe must use `-type f`.** Reading a directory updates that directory's atime — so a probe based on directory atime refreshes the very timestamps it reads, and after one preflight run *nothing would ever look idle again*. File atimes are untouched by directory traversal, making them the only self-consistent signal.
- **`[[ -d ]]` lies here.** The root/container data dirs are root-owned and not traversable by the CI user, so a plain test reported "missing" and **silently skipped the largest cache on the box** (814 snapshot dirs). Existence is now tested through `sudo`.

## Safety of the cache pruning

These are shared content-addressed assets, so the age gate requires **no read AND no write** for a generous margin. Anything the current checkout's SHAs reference is re-read every CI run (relatime keeps atime fresh) and is therefore never a candidate; a pruned entry is regenerated on the next cache miss. `image-cache` deletions additionally take the same per-digest `flock` the image builders use, and skip entries whose lock is held. `state/`, `vm-disks/` and `*.lock` files are never touched. Failures are never silenced — the only tolerated absences are "target legitimately may not exist", each commented.

## Test Results

Run for real on a dev box with podman + `/mnt/fcvm-btrfs`.

**Lint:**
```
$ shellcheck scripts/runner-disk-preflight.sh && bash -n scripts/runner-disk-preflight.sh
SHELLCHECK-CLEAN
# build-ami.sh: 4 findings before and 4 after -- no new findings
$ systemd-analyze verify runner-disk-guard.service runner-disk-guard.timer   # both clean
```

**Dry run (`DRY_RUN=1`, audits all stages regardless of thresholds):**
```
[disk-preflight] monitored filesystems: / /mnt/fcvm-btrfs
... 814 root/snapshots dirs scanned, all "keeping (active within 4d)"
[image-cache entries (idle >4d)]  0 entries, 0B would be freed
[idle cargo target dirs (>3d)]    0 entries, 0B would be freed
[idle kernels assets (>4d)]       0 entries, 0B would be freed
```
Zero candidates — I verified by hand this is correct rather than a broken probe: every entry is genuinely from the previous day (`mtime == atime`), so nothing stale was being masked, and nothing precious (current-SHA kernels/rootfs, live VM state/disks) appeared in the candidate list.

**Real run, thresholds set to force the podman-prune path:**
```
$ MIN_FREE_GB=99999 HARD_FLOOR_GB=1 ./scripts/runner-disk-preflight.sh    # exit 0
=== df -h BEFORE ===
/dev/root       290G  248G   42G  86% /
/dev/nvme1n1    3.5T  671G  2.9T  19% /mnt/fcvm-btrfs

=== stage_podman_prune ===        -> pruned 114 rootless + 37 root images

=== df -h AFTER ===
/dev/root       290G  248G   42G  86% /
/dev/nvme1n1    3.5T  668G  2.9T  19% /mnt/fcvm-btrfs
```
3.1 GiB reclaimed. btrfs frees extents asynchronously, so the bytes land in a later stage's `df` delta — noted in-script so nobody debugs a phantom attribution later.

**Hard-floor failure + quarantine:**
```
$ MIN_FREE_GB=99999 HARD_FLOOR_GB=99999 ./scripts/runner-disk-preflight.sh --quarantine
EXIT=1
[disk-preflight] FATAL: runner 'ip-10-0-1-49' still below 99999GiB free after cleanup
::error title=Runner disk full::Runner 'ip-10-0-1-49' is below 99999GiB free after cleanup - replace or manually clean this runner
[disk-preflight] quarantine: no actions.runner service unit on this host
```

**Default thresholds / arg handling:**
```
$ ./scripts/runner-disk-preflight.sh
[disk-preflight] OK: every monitored filesystem has >= 15GiB free; no cleanup needed
EXIT=0
$ ./scripts/runner-disk-preflight.sh --bogus    ->  EXIT=2
```

**Workflow validation** (no `actionlint`/`yq` on this box, so parsed with PyYAML):
```
host:      step[2] = Disk preflight ; prev=actions/checkout@v6 ; next=checkout-deps
host-root: step[2] = Disk preflight ; prev=actions/checkout@v6 ; next=checkout-deps
container: step[2] = Disk preflight ; prev=actions/checkout@v6 ; next=checkout-deps
GitHub-hosted jobs correctly untouched
```

## Merge note

Ideal merge-train candidate by nature, but it **touches `ci.yml`**, so it needs its own full matrix run anyway.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated disk-capacity monitoring and cleanup for CI runners.
  * Added scheduled protection that runs shortly after startup and hourly thereafter.
  * Runners can be quarantined when disk space remains critically low.
* **Bug Fixes**
  * CI jobs now check available disk space before dependency checkout and builds.
  * AMI provisioning now includes the disk-protection components and reflects related changes in image caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->