### PR TITLE
Restore the PR_SET_PDEATHSIG teardown chain across the sudo privilege hop

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -981,6 +981,38 @@ assert!(localhost_works, "Localhost port forwarding should work (requires route_
 
 Do not run `sudo cargo`. Use Makefile targets so cargo runs as your user and test binaries run via `CARGO_TARGET_*_RUNNER='sudo -E'`; otherwise `target/` becomes root-owned and breaks builds.
 
+### PROCESS TEARDOWN IS PER-HOP. EVERY HOP.
+
+**`PR_SET_PDEATHSIG` only kills a child whose OWN pdeathsig is set. One unprotected hop
+orphans the entire subtree below it.** The chain that must hold, end to end:
+
+```
+cargo-nextest (uid 1000) → sudo (ruid 1000) → test binary (uid 0) → fcvm → firecracker
+                           ^ setpriv --pdeathsig  ^ set_test_pdeathsig  ^ install_namespace_pre_exec
+```
+
+- `scripts/root-test-runner.sh` (`ROOT_TEST_RUNNER` in the Makefile) covers the **sudo hop**.
+  Never reduce the privileged runner back to a bare `sudo -E env PATH=...`.
+- `tests/common/mod.rs::set_test_pdeathsig{,_std}` covers **every long-lived fcvm spawn** in
+  tests. `spawn_fcvm*` applies it; a hand-rolled `Command::new(&fcvm_path)…spawn()` must too.
+- `src/utils.rs::install_namespace_pre_exec` covers **every VMM spawn** (Firecracker, Cloud
+  Hypervisor, and the Layer-2 setup VM in `src/setup/rootfs.rs`). It must stay the LAST
+  `pre_exec` — `setns(CLONE_NEWUSER)` zeroes `pdeath_signal`, so setting it earlier is lost.
+
+**Why a privilege boundary is special:** the kernel refuses a signal from uid 1000 to a uid-0
+process, and `killpg` still returns success when it managed to signal *any* member — so
+nextest's slow-timeout kill fails **silently** against a `sudo`'d test binary. SIGKILL cannot
+be caught, so `sudo` never forwards it either. On 2026-08-06 that left ~498 `firecracker`
+processes alive on two ARM runners (load average 523, 103 tasks in D-state, 420 zombies) for
+21 hours, and the AWS lease logic kept renewing the dead runners because GitHub still reported
+them busy. Regression test: `test_root_test_runner_reaps_vm_when_sudo_is_killed`
+(`tests/test_signal_cleanup.rs`). Defense in depth (NOT a substitute): `timeout-minutes` on
+every self-hosted job plus the `scripts/ci-stray-vm-guard.sh` pre/post steps in `ci.yml`.
+
+**Prefer kernel-enforced reaping over cleanup code.** A `Drop` impl, a signal handler, or an
+`always()` cleanup step does not run when the process is SIGKILLed — which is exactly the case
+that leaked. If teardown matters, it must survive SIGKILL.
+
 ### Container Build Rules
 
 **Container builds work naturally with layer caching.** No workarounds needed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,11 @@ jobs:
     needs: [skip-check]
     if: ${{ github.event.inputs.job != 'container' && needs.skip-check.outputs.skip != 'true' }}
     runs-on: [self-hosted, Linux, '${{ matrix.arch }}']
+    # Longest of the last 6 successful runs: 12 min. GitHub's default is SIX HOURS, which is
+    # how a wedged runner held a job all day on 2026-08-06 (one job stuck >5h) while the
+    # AWS-side lease logic kept renewing its lease because GitHub still reported it busy.
+    # 5x headroom covers a cold runner (kernel/rootfs rebuilds) and is nowhere near 6h.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -259,6 +264,13 @@ jobs:
       - name: Disk preflight
         working-directory: fcvm
         run: ./scripts/runner-disk-preflight.sh
+      # A self-hosted runner is reused forever, so a leaked microVM is inherited by every
+      # later job. Report (and reap) what the PREVIOUS job left behind before doing anything
+      # else — on 2026-08-06 two runners had accumulated ~498 live firecracker processes and
+      # nothing in any job log had ever mentioned them.
+      - name: Stray microVM guard (pre)
+        working-directory: fcvm
+        run: ./scripts/ci-stray-vm-guard.sh pre
       - uses: ./fcvm/.github/actions/checkout-deps
       - name: Install Rust
         run: |
@@ -412,6 +424,12 @@ jobs:
       - name: test-fast
         working-directory: fcvm
         run: make test-fast
+      # And what THIS job left behind. A non-zero count here means the run leaked microVMs:
+      # it is annotated on the run page, not just buried in the step log.
+      - name: Stray microVM guard (post)
+        if: always()
+        working-directory: fcvm
+        run: ./scripts/ci-stray-vm-guard.sh post
       - name: Upload test logs
         if: always()
         uses: actions/upload-artifact@v6
@@ -446,6 +464,10 @@ jobs:
     needs: [skip-check]
     if: ${{ github.event.inputs.job != 'container' && needs.skip-check.outputs.skip != 'true' }}
     runs-on: [self-hosted, Linux, '${{ matrix.arch }}']
+    # Longest of the last 6 successful runs: 43 min (arm64 SnapshotEnabled, which runs the
+    # whole suite twice, plus the nested + btrfs kernel builds). ~3x headroom.
+    # See the Host job comment for why the 6h default is not acceptable here.
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -487,6 +509,13 @@ jobs:
       - name: Disk preflight
         working-directory: fcvm
         run: ./scripts/runner-disk-preflight.sh
+      # A self-hosted runner is reused forever, so a leaked microVM is inherited by every
+      # later job. Report (and reap) what the PREVIOUS job left behind before doing anything
+      # else — on 2026-08-06 two runners had accumulated ~498 live firecracker processes and
+      # nothing in any job log had ever mentioned them.
+      - name: Stray microVM guard (pre)
+        working-directory: fcvm
+        run: ./scripts/ci-stray-vm-guard.sh pre
       - uses: ./fcvm/.github/actions/checkout-deps
       - name: Install Rust
         run: |
@@ -623,6 +652,12 @@ jobs:
         run: |
           make clean-test-data || true
           make bench-vm
+      # And what THIS job left behind. A non-zero count here means the run leaked microVMs:
+      # it is annotated on the run page, not just buried in the step log.
+      - name: Stray microVM guard (post)
+        if: always()
+        working-directory: fcvm
+        run: ./scripts/ci-stray-vm-guard.sh post
       - name: Capture kernel logs
         if: always()
         run: |
@@ -650,6 +685,9 @@ jobs:
     needs: [skip-check]
     if: ${{ github.event.inputs.job != 'host' && needs.skip-check.outputs.skip != 'true' }}
     runs-on: [self-hosted, Linux, '${{ matrix.arch }}']
+    # Longest of the last 6 successful runs: 21 min. ~3x headroom.
+    # See the Host job comment for why the 6h default is not acceptable here.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -685,6 +723,13 @@ jobs:
       - name: Disk preflight
         working-directory: fcvm
         run: ./scripts/runner-disk-preflight.sh
+      # A self-hosted runner is reused forever, so a leaked microVM is inherited by every
+      # later job. Report (and reap) what the PREVIOUS job left behind before doing anything
+      # else — on 2026-08-06 two runners had accumulated ~498 live firecracker processes and
+      # nothing in any job log had ever mentioned them.
+      - name: Stray microVM guard (pre)
+        working-directory: fcvm
+        run: ./scripts/ci-stray-vm-guard.sh pre
       - uses: ./fcvm/.github/actions/checkout-deps
       - name: Setup KVM and rootless podman
         run: |
@@ -742,6 +787,12 @@ jobs:
           CARGO_CACHE_DIR: ${{ github.workspace }}/cargo-cache
         working-directory: fcvm
         run: make container-test
+      # And what THIS job left behind. A non-zero count here means the run leaked microVMs:
+      # it is annotated on the run page, not just buried in the step log.
+      - name: Stray microVM guard (post)
+        if: always()
+        working-directory: fcvm
+        run: ./scripts/ci-stray-vm-guard.sh post
       - name: Capture kernel logs
         if: always()
         run: |

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,15 @@ endif
 export CARGO_TARGET_DIR := target
 NEXTEST := $(CARGO) nextest $(NEXTEST_CMD) --release
 
+# cargo/nextest target runner for the privileged suites. cargo-nextest stays unprivileged
+# and only the test binary is elevated, so the `sudo` hop sits in the middle of the process
+# tree — and a privilege boundary breaks parent->child teardown in BOTH directions: nextest
+# (uid 1000) cannot signal the uid-0 test binary at all, and `sudo` cannot forward the
+# SIGKILL that killed it. The elevated test binary is then orphaned-but-alive and its whole
+# microVM subtree with it. root-test-runner.sh restores the link with a kernel-enforced
+# PR_SET_PDEATHSIG; see that script's header for the measurements.
+ROOT_TEST_RUNNER := sudo -E env PATH=$(PATH) $(CURDIR)/scripts/root-test-runner.sh
+
 # Optional cargo cache directory (for CI caching)
 CARGO_CACHE_DIR ?=
 ifneq ($(CARGO_CACHE_DIR),)
@@ -396,8 +405,8 @@ _test-root:
 	fi
 	@RUST_LOG="$(TEST_LOG)" \
 	FCVM_DATA_DIR=$(ROOT_DATA_DIR) \
-	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
-	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
+	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='$(ROOT_TEST_RUNNER)' \
+	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='$(ROOT_TEST_RUNNER)' \
 	$(NEXTEST) $(NEXTEST_CAPTURE) $(NEXTEST_IGNORED) --features privileged-tests $(IPV6_FILTER) $(CI_NESTED_FILTER) $(FILTER) || \
 	{ echo ""; \
 	  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"; \
@@ -433,8 +442,8 @@ _test-fc-mock:
 	@FCVM_FIRECRACKER_BIN=/usr/local/bin/fc-mock \
 	RUST_LOG="$(TEST_LOG)" \
 	FCVM_DATA_DIR=$${FCVM_DATA_DIR:-$(ROOT_DATA_DIR)} \
-	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
-	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
+	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='$(ROOT_TEST_RUNNER)' \
+	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='$(ROOT_TEST_RUNNER)' \
 	$(NEXTEST) $(NEXTEST_CAPTURE) --profile fc-mock --features privileged-tests -E '$(FC_MOCK_FILTER)' $(FILTER) || \
 	{ echo ""; \
 	  echo "TEST FAILED (fc-mock mode)"; \
@@ -607,22 +616,22 @@ bench-chromium: build
 
 bench: build
 	@echo "==> Running benchmarks..."
-	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
-	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
+	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='$(ROOT_TEST_RUNNER)' \
+	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='$(ROOT_TEST_RUNNER)' \
 	$(CARGO) bench -p fuse-pipe --bench throughput
-	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
-	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
+	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='$(ROOT_TEST_RUNNER)' \
+	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='$(ROOT_TEST_RUNNER)' \
 	$(CARGO) bench -p fuse-pipe --bench operations
 	$(CARGO) bench -p fuse-pipe --bench protocol
 
 # VM benchmarks (exec, clone) - require KVM, Firecracker, setup
 bench-vm: build setup-default
 	@echo "==> Running VM benchmarks..."
-	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
-	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
+	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='$(ROOT_TEST_RUNNER)' \
+	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='$(ROOT_TEST_RUNNER)' \
 	$(CARGO) bench --bench exec -- --test
-	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
-	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E env PATH=$(PATH)' \
+	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='$(ROOT_TEST_RUNNER)' \
+	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='$(ROOT_TEST_RUNNER)' \
 	$(CARGO) bench --bench clone -- --test
 
 # Hugepages benchmark: compare clone speed with 4KB vs 2MB pages

--- a/scripts/ci-stray-vm-guard.sh
+++ b/scripts/ci-stray-vm-guard.sh
@@ -51,7 +51,7 @@ count_zombies() {
 mapfile -t STRAYS < <(list_strays)
 COUNT=${#STRAYS[@]}
 ZOMBIES=$(count_zombies)
-[ "$ZOMBIES" -gt 0 ] && echo "note: ${ZOMBIES} unreaped ${PHASE} zombie(s) ignored (already dead, hold no resources)"
+[ "$ZOMBIES" -gt 0 ] && echo "note (${PHASE}): ignoring ${ZOMBIES} unreaped zombie(s) — already dead, hold no resources, cannot be killed"
 
 echo "=== stray microVM guard (${PHASE}): ${COUNT} stray process(es) ==="
 
@@ -70,14 +70,15 @@ for row in "${STRAYS[@]}"; do
 done
 
 # A GitHub annotation surfaces on the run page, not just buried in the step log.
-echo "::warning title=Stray microVMs (${PHASE})::${COUNT} fcvm/firecracker process(es) were alive on this runner; killing them. A non-zero 'post' count means this job leaked VMs."
-
 if [ "$DRY_RUN" -eq 1 ]; then
+	echo "::warning title=Stray microVMs (${PHASE}, dry-run)::${COUNT} fcvm/firecracker process(es) are alive on this runner; NOT killing them (--dry-run)."
 	echo "--dry-run: reporting only, killing nothing"
 	[ -n "${GITHUB_STEP_SUMMARY:-}" ] &&
 		echo "- stray microVM guard (${PHASE}, dry-run): found ${COUNT}, zombies ${ZOMBIES}" >>"$GITHUB_STEP_SUMMARY"
 	exit 0
 fi
+
+echo "::warning title=Stray microVMs (${PHASE})::${COUNT} fcvm/firecracker process(es) were alive on this runner; killing them. A non-zero 'post' count means this job leaked VMs."
 
 for row in "${STRAYS[@]}"; do
 	# shellcheck disable=SC2086

--- a/scripts/ci-stray-vm-guard.sh
+++ b/scripts/ci-stray-vm-guard.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Report and reap stray microVM processes on a self-hosted runner.
+#
+# Self-hosted runners are reused forever, so anything a job leaves behind is inherited by
+# every later job on that box. In August 2026 two ARM runners wedged for 21 hours with ~498
+# live `firecracker` processes (load average 523, 103 tasks in D-state, 420 zombies) that had
+# accumulated silently across runs — nothing in any job log ever mentioned them.
+#
+# This is defense in depth, NOT the fix: the leak itself is fixed by the kernel-enforced
+# PR_SET_PDEATHSIG chain (scripts/root-test-runner.sh, src/utils.rs::install_namespace_pre_exec).
+# It also acts only at job BOUNDARIES, so it cannot stop a host that wedges mid-job — that
+# remediation belongs on the AWS side (terminate and replace the instance).
+# Run this at the start of a job (what the previous job left) and at the end (what this job
+# left). Either way the count lands in the job log and, when non-zero, in a GitHub annotation.
+#
+# Usage: ci-stray-vm-guard.sh <pre|post> [--dry-run]
+#
+#   --dry-run  report only, kill nothing. The default mode SIGKILLs every match, which is
+#              correct on a dedicated CI runner and destructive anywhere else — use this to
+#              exercise the script on a shared dev box, where the matches are someone's
+#              running VMs, not garbage.
+set -uo pipefail
+
+PHASE="${1:-post}"
+DRY_RUN=0
+[ "${2:-}" = "--dry-run" ] && DRY_RUN=1
+
+# `comm` is the executable basename truncated to 15 chars, so the content-addressed
+# `firecracker-default-<sha>.bin` shows up as `firecracker-def`. Matching on comm (not the
+# full argv) means this can never match a grep/ps/pgrep of its own patterns.
+STRAY_RE='^(firecracker|cloud-hypervisor|fcvm)'
+
+# Zombies are EXCLUDED ($4 is stat; Z may carry modifiers like `Z+`). A zombie is already
+# dead — it holds no memory, no KVM fd and no vCPU thread, only a process-table slot until
+# its parent reaps it. It is therefore not a leaked microVM, and more importantly it can
+# never be killed: SIGKILL to a zombie is a no-op, so counting them would put them in
+# SURVIVORS forever and fire the "survived SIGKILL, this runner needs a reboot" annotation
+# on every run. The 2026-08-06 incident had 420 zombies alongside the real leak, so this is
+# the difference between a signal and a permanent false alarm.
+list_strays() {
+	ps -eo pid=,ppid=,etimes=,stat=,comm=,args= |
+		awk -v re="$STRAY_RE" '$5 ~ re && $4 !~ /^Z/ { print }'
+}
+
+# Counted and reported, never killed: a high zombie count is a symptom worth seeing (it means
+# something is not reaping its children) but it is not actionable by this script.
+count_zombies() {
+	ps -eo stat=,comm= | awk -v re="$STRAY_RE" '$2 ~ re && $1 ~ /^Z/' | wc -l
+}
+
+mapfile -t STRAYS < <(list_strays)
+COUNT=${#STRAYS[@]}
+ZOMBIES=$(count_zombies)
+[ "$ZOMBIES" -gt 0 ] && echo "note: ${ZOMBIES} unreaped ${PHASE} zombie(s) ignored (already dead, hold no resources)"
+
+echo "=== stray microVM guard (${PHASE}): ${COUNT} stray process(es) ==="
+
+if [ "$COUNT" -eq 0 ]; then
+	echo "✓ no stray fcvm/firecracker/cloud-hypervisor processes"
+	[ -n "${GITHUB_STEP_SUMMARY:-}" ] &&
+		echo "- stray microVM guard (${PHASE}): 0" >>"$GITHUB_STEP_SUMMARY"
+	exit 0
+fi
+
+printf '%8s %8s %9s %-5s %s\n' PID PPID ELAPSED STAT COMMAND
+for row in "${STRAYS[@]}"; do
+	# shellcheck disable=SC2086 # deliberate word splitting into positional fields
+	set -- $row
+	printf '%8s %8s %8ss %-5s %s\n' "$1" "$2" "$3" "$4" "${*:5:12}"
+done
+
+# A GitHub annotation surfaces on the run page, not just buried in the step log.
+echo "::warning title=Stray microVMs (${PHASE})::${COUNT} fcvm/firecracker process(es) were alive on this runner; killing them. A non-zero 'post' count means this job leaked VMs."
+
+if [ "$DRY_RUN" -eq 1 ]; then
+	echo "--dry-run: reporting only, killing nothing"
+	[ -n "${GITHUB_STEP_SUMMARY:-}" ] &&
+		echo "- stray microVM guard (${PHASE}, dry-run): found ${COUNT}, zombies ${ZOMBIES}" >>"$GITHUB_STEP_SUMMARY"
+	exit 0
+fi
+
+for row in "${STRAYS[@]}"; do
+	# shellcheck disable=SC2086
+	set -- $row
+	sudo kill -9 "$1" 2>/dev/null || true
+done
+sleep 2
+
+mapfile -t SURVIVORS < <(list_strays)
+echo "killed ${COUNT}, still present after SIGKILL: ${#SURVIVORS[@]}"
+if [ "${#SURVIVORS[@]}" -gt 0 ]; then
+	# SIGKILL is not delivered to a task blocked in uninterruptible (D) state — that is the
+	# shape of the 21-hour wedge, and it needs a reboot, not another kill.
+	printf '%s\n' "${SURVIVORS[@]}"
+	echo "::warning title=Unkillable microVMs (${PHASE})::${#SURVIVORS[@]} process(es) survived SIGKILL (likely D-state); this runner needs a reboot."
+fi
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+	echo "- stray microVM guard (${PHASE}): found ${COUNT}, unkillable ${#SURVIVORS[@]}" >>"$GITHUB_STEP_SUMMARY"
+fi
+
+exit 0

--- a/scripts/root-test-runner.sh
+++ b/scripts/root-test-runner.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# cargo/nextest target runner for the privileged (root) test and bench suites.
+#
+# `make test-root` runs cargo-nextest AS THE INVOKING USER and elevates only the test
+# binary, via CARGO_TARGET_<TRIPLE>_RUNNER='sudo -E env PATH=... <this script>'. That
+# sudo hop is a one-way door for process teardown, and the whole VM tree hangs off it:
+#
+#   cargo-nextest (uid 1000) -> sudo (ruid 1000) -> test binary (uid 0)
+#                                                     -> fcvm -> firecracker
+#
+#   * The kernel refuses a signal from uid 1000 to a uid-0 process, so nextest's
+#     slow-timeout kill cannot touch the elevated test binary. It kills the test's
+#     process group, and kill(2) still returns success — it signalled `sudo`, which is
+#     enough for the call to report 0 — so the failure is completely silent.
+#   * SIGKILL cannot be caught, so `sudo` never gets a chance to forward it.
+#
+#   Result: the test binary is orphaned to init and keeps running. Because it never
+#   dies, the PR_SET_PDEATHSIG chain BELOW it (test binary -> fcvm -> firecracker) never
+#   fires either, so every microVM the test had booted survives until the box reboots.
+#   Measured: `killpg(SIGKILL)` from uid 1000 left 2/2 root processes alive, reparented
+#   to init. That is how a self-hosted runner accumulated ~490 live `firecracker`
+#   processes and wedged for 21 hours.
+#
+# `setpriv --pdeathsig KILL` re-establishes exactly the link the privilege boundary
+# broke: the kernel SIGKILLs this process the moment `sudo` dies. It is kernel-enforced,
+# so it holds in the case that leaked here — a SIGKILL where no userspace cleanup,
+# Drop impl or signal handler gets to run.
+exec setpriv --pdeathsig KILL "$@"

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -2328,7 +2328,8 @@ async fn boot_vm_for_setup(
         serial_path.display()
     );
     let firecracker_bin = setup_vm_firecracker_bin()?;
-    let mut fc_process = Command::new(&firecracker_bin)
+    let mut fc_cmd = Command::new(&firecracker_bin);
+    fc_cmd
         .args([
             "--api-sock",
             path_to_str(&api_socket)?,
@@ -2339,8 +2340,23 @@ async fn boot_vm_for_setup(
         ])
         .stdout(serial_file.try_clone().context("cloning serial file")?)
         .stderr(std::process::Stdio::null())
-        .spawn()
-        .context("starting Firecracker")?;
+        // Several `?` between here and the wait loop below return without killing the VM.
+        // kill_on_drop closes those windows while fcvm is still alive; pdeathsig covers the
+        // case where fcvm itself dies without unwinding.
+        .kill_on_drop(true);
+    // The Layer 2 build boots a VM for MINUTES. Every other VMM spawn in fcvm goes
+    // through this helper for PR_SET_PDEATHSIG; this one did not, so a `fcvm setup`
+    // that died without running its cleanup (SIGKILL, a cancelled CI job) orphaned a
+    // live Firecracker to init. No namespaces here — the setup VM runs on the host
+    // network — so the helper installs only the parent-death hook.
+    crate::utils::install_namespace_pre_exec(
+        &mut fc_cmd,
+        &crate::utils::NamespaceParams {
+            vm_id: "layer2-setup".to_string(),
+            ..Default::default()
+        },
+    )?;
+    let mut fc_process = fc_cmd.spawn().context("starting Firecracker")?;
 
     // Wait for socket to be ready
     for _ in 0..50 {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -271,26 +271,51 @@ fn ensure_config_exists() {
 /// This only governs process teardown: during the test fcvm runs normally, and the usual
 /// `kill_process` cleanup still does the graceful shutdown on the success path. Zero blast
 /// radius — it does not change what any test must hold or do.
-fn set_test_pdeathsig(cmd: &mut tokio::process::Command) {
-    let parent = std::process::id() as i32;
-    // SAFETY: pre_exec runs in the forked child before exec; prctl/getppid are
-    // async-signal-safe and we allocate nothing here.
+///
+/// **Every long-lived fcvm spawn must go through this** (`spawn_fcvm*` does it for you; tests
+/// that build their own command call it directly). The reaping chain is per-hop: the kernel
+/// only kills a child whose OWN pdeathsig is set, so one unprotected hop orphans everything
+/// below it — an fcvm spawned without it survives its dead test process and keeps its
+/// firecracker alive, which is how a CI runner accumulated ~490 live microVMs.
+pub fn set_test_pdeathsig(cmd: &mut tokio::process::Command) {
+    // SAFETY: pre_exec runs in the forked child before exec; see `pdeathsig_hook`.
     unsafe {
-        cmd.pre_exec(move || {
-            // Full varargs form (the kernel ignores args 3-5 for PR_SET_PDEATHSIG, but pass
-            // them explicitly for the C varargs ABI).
-            if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL, 0, 0, 0) != 0 {
-                return Err(std::io::Error::last_os_error());
-            }
-            // Close the fork-vs-prctl race: if the parent (test process) already exited
-            // between fork and here, getppid() no longer matches — abort the spawn rather
-            // than launch an unsupervised fcvm. Use a raw OS error (no allocation in the
-            // forked child); ESRCH ("no such process") fits "parent gone".
-            if libc::getppid() != parent {
-                return Err(std::io::Error::from_raw_os_error(libc::ESRCH));
-            }
-            Ok(())
-        });
+        cmd.pre_exec(pdeathsig_hook());
+    }
+}
+
+/// `std::process::Command` flavour of [`set_test_pdeathsig`], for the tests that build their
+/// fcvm command with the blocking API. Same guarantee, same hook.
+pub fn set_test_pdeathsig_std(cmd: &mut std::process::Command) {
+    use std::os::unix::process::CommandExt;
+    // SAFETY: pre_exec runs in the forked child before exec; see `pdeathsig_hook`.
+    unsafe {
+        cmd.pre_exec(pdeathsig_hook());
+    }
+}
+
+/// The `pre_exec` body shared by both flavours: set `PR_SET_PDEATHSIG(SIGKILL)`, then close
+/// the fork-vs-prctl race.
+///
+/// Async-signal-safe: `prctl`/`getppid` only, and the parent pid is captured BEFORE the fork
+/// so the closure allocates nothing.
+fn pdeathsig_hook() -> impl FnMut() -> std::io::Result<()> + Send + Sync + 'static {
+    let parent = std::process::id() as i32;
+    move || {
+        // Full varargs form (the kernel ignores args 3-5 for PR_SET_PDEATHSIG, but pass
+        // them explicitly for the C varargs ABI).
+        // SAFETY: prctl with a constant option and no memory effects.
+        if unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL, 0, 0, 0) } != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        // If the parent (test process) already exited between fork and here, getppid() no
+        // longer matches — abort the spawn rather than launch an unsupervised fcvm. Use a raw
+        // OS error (no allocation in the forked child); ESRCH ("no such process") fits.
+        // SAFETY: getppid has no arguments and no memory effects.
+        if unsafe { libc::getppid() } != parent {
+            return Err(std::io::Error::from_raw_os_error(libc::ESRCH));
+        }
+        Ok(())
     }
 }
 

--- a/tests/test_fuse_copy_file_range_vm.rs
+++ b/tests/test_fuse_copy_file_range_vm.rs
@@ -132,6 +132,7 @@ echo "SUCCESS: copy_file_range works through FUSE!"
         cmd.env("SUDO_USER", sudo_user);
     }
 
+    common::set_test_pdeathsig(&mut cmd);
     let mut child = cmd.spawn().context("spawning VM")?;
     let vm_pid = child.id().ok_or_else(|| anyhow::anyhow!("no VM PID"))?;
     println!("  VM started (PID: {})", vm_pid);

--- a/tests/test_fuse_in_vm_matrix.rs
+++ b/tests/test_fuse_in_vm_matrix.rs
@@ -125,6 +125,7 @@ async fn run_category_in_vm(category: &str) -> Result<()> {
         cmd.env("FCVM_NO_WRITEBACK_CACHE", "1");
     }
 
+    common::set_test_pdeathsig(&mut cmd);
     let mut child = cmd.spawn().context("spawning VM")?;
     let vm_pid = child.id().ok_or_else(|| anyhow::anyhow!("no VM PID"))?;
 

--- a/tests/test_localhost_image.rs
+++ b/tests/test_localhost_image.rs
@@ -87,12 +87,12 @@ async fn run_localhost_test_with_kernel(
     }
     args.push(&image_name);
 
-    let mut child = tokio::process::Command::new(&fcvm_path)
-        .args(&args)
+    let mut cmd = tokio::process::Command::new(&fcvm_path);
+    cmd.args(&args)
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .context("spawning fcvm podman run")?;
+        .stderr(Stdio::piped());
+    common::set_test_pdeathsig(&mut cmd);
+    let mut child = cmd.spawn().context("spawning fcvm podman run")?;
 
     let fcvm_pid = child
         .id()

--- a/tests/test_port_forward.rs
+++ b/tests/test_port_forward.rs
@@ -35,22 +35,22 @@ fn test_port_forward_bridged() -> Result<()> {
 
     // Start VM with port forwarding
     // Use --health-check to wait for nginx to be ready (not just container running)
-    let mut fcvm = Command::new(&fcvm_path)
-        .args([
-            "podman",
-            "run",
-            "--name",
-            &vm_name,
-            "--network",
-            "bridged",
-            "--publish",
-            "8080:80",
-            "--health-check",
-            "http://localhost/",
-            common::TEST_IMAGE,
-        ])
-        .spawn()
-        .context("spawning fcvm")?;
+    let mut cmd = Command::new(&fcvm_path);
+    cmd.args([
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--network",
+        "bridged",
+        "--publish",
+        "8080:80",
+        "--health-check",
+        "http://localhost/",
+        common::TEST_IMAGE,
+    ]);
+    common::set_test_pdeathsig_std(&mut cmd);
+    let mut fcvm = cmd.spawn().context("spawning fcvm")?;
 
     let fcvm_pid = fcvm.id();
     println!("Started fcvm with PID: {}", fcvm_pid);
@@ -203,22 +203,22 @@ fn test_port_forward_rootless() -> Result<()> {
     // Start VM with rootless networking and port forwarding
     // Rootless uses unique loopback IPs (127.x.y.z) per VM
     // Use --health-check to wait for nginx to be ready (not just container running)
-    let mut fcvm = Command::new(&fcvm_path)
-        .args([
-            "podman",
-            "run",
-            "--name",
-            &vm_name,
-            "--network",
-            "rootless",
-            "--publish",
-            &publish_arg,
-            "--health-check",
-            "http://localhost/",
-            common::TEST_IMAGE,
-        ])
-        .spawn()
-        .context("spawning fcvm")?;
+    let mut cmd = Command::new(&fcvm_path);
+    cmd.args([
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--network",
+        "rootless",
+        "--publish",
+        &publish_arg,
+        "--health-check",
+        "http://localhost/",
+        common::TEST_IMAGE,
+    ]);
+    common::set_test_pdeathsig_std(&mut cmd);
+    let mut fcvm = cmd.spawn().context("spawning fcvm")?;
 
     let fcvm_pid = fcvm.id();
     println!("Started fcvm with PID: {}", fcvm_pid);
@@ -337,22 +337,22 @@ fn test_port_forward_routed() -> Result<()> {
 
     // Start VM with routed networking and port forwarding
     // Routed uses TCP proxy + unique loopback IPs (like rootless)
-    let mut fcvm = Command::new(&fcvm_path)
-        .args([
-            "podman",
-            "run",
-            "--name",
-            &vm_name,
-            "--network",
-            "routed",
-            "--publish",
-            &publish_arg,
-            "--health-check",
-            "http://localhost/",
-            common::TEST_IMAGE,
-        ])
-        .spawn()
-        .context("spawning fcvm")?;
+    let mut cmd = Command::new(&fcvm_path);
+    cmd.args([
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--network",
+        "routed",
+        "--publish",
+        &publish_arg,
+        "--health-check",
+        "http://localhost/",
+        common::TEST_IMAGE,
+    ]);
+    common::set_test_pdeathsig_std(&mut cmd);
+    let mut fcvm = cmd.spawn().context("spawning fcvm")?;
 
     let fcvm_pid = fcvm.id();
     println!("Started fcvm with PID: {}", fcvm_pid);

--- a/tests/test_proxy.rs
+++ b/tests/test_proxy.rs
@@ -356,22 +356,22 @@ async fn test_no_proxy() -> Result<()> {
     // fcvm passes it to MMDS, fc-agent writes it to /etc/fcvm-proxy.env,
     // and exec reads it back for container commands.
     let fcvm_path = common::find_fcvm_binary()?;
-    let child = tokio::process::Command::new(&fcvm_path)
-        .args([
-            "podman",
-            "run",
-            "--name",
-            &vm_name,
-            "--network",
-            "rootless",
-            "--no-snapshot",
-            common::TEST_IMAGE,
-        ])
-        .env("NO_PROXY", "thefacebook.com,localhost,10.0.2.2")
-        .stdout(std::process::Stdio::inherit())
-        .stderr(std::process::Stdio::inherit())
-        .spawn()
-        .context("spawning fcvm")?;
+    let mut cmd = tokio::process::Command::new(&fcvm_path);
+    cmd.args([
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--network",
+        "rootless",
+        "--no-snapshot",
+        common::TEST_IMAGE,
+    ])
+    .env("NO_PROXY", "thefacebook.com,localhost,10.0.2.2")
+    .stdout(std::process::Stdio::inherit())
+    .stderr(std::process::Stdio::inherit());
+    common::set_test_pdeathsig(&mut cmd);
+    let child = cmd.spawn().context("spawning fcvm")?;
 
     let pid = child.id().expect("no pid");
 

--- a/tests/test_remap_file_range.rs
+++ b/tests/test_remap_file_range.rs
@@ -85,6 +85,7 @@ async fn run_remap_test_in_vm(test_name: &str, test_script: &str) -> Result<()> 
         cmd.env("SUDO_USER", sudo_user);
     }
 
+    common::set_test_pdeathsig(&mut cmd);
     let mut child = cmd.spawn().context("spawning VM")?;
     let vm_pid = child.id().ok_or_else(|| anyhow::anyhow!("no VM PID"))?;
     logger.info(&format!("Spawned VM PID={}", vm_pid));
@@ -235,6 +236,7 @@ async fn test_libfuse_remap_container() {
         cmd.env("SUDO_USER", sudo_user);
     }
 
+    common::set_test_pdeathsig(&mut cmd);
     let mut child = cmd.spawn().expect("spawning VM");
     let vm_pid = child.id().expect("VM PID");
     logger.info(&format!("Spawned VM PID={}", vm_pid));

--- a/tests/test_serve.rs
+++ b/tests/test_serve.rs
@@ -20,13 +20,15 @@ async fn test_serve_create_run_destroy() {
     let port = 18090 + (std::process::id() % 1000) as u16;
     logger.info(&format!("Starting fcvm serve on port {}", port));
 
-    let mut serve_child = tokio::process::Command::new(&fcvm_path)
+    let mut serve_cmd = tokio::process::Command::new(&fcvm_path);
+    serve_cmd
         .args(["serve", "--port", &port.to_string()])
         .env("RUST_LOG", "info")
         .stdout(std::process::Stdio::inherit())
-        .stderr(std::process::Stdio::inherit())
-        .spawn()
-        .expect("spawn fcvm serve");
+        .stderr(std::process::Stdio::inherit());
+    // `fcvm serve` owns every sandbox VM it creates, so orphaning it orphans all of them.
+    common::set_test_pdeathsig(&mut serve_cmd);
+    let mut serve_child = serve_cmd.spawn().expect("spawn fcvm serve");
 
     let serve_pid = serve_child.id().expect("serve process has PID");
     logger.info(&format!("fcvm serve started with PID {}", serve_pid));

--- a/tests/test_signal_cleanup.rs
+++ b/tests/test_signal_cleanup.rs
@@ -160,23 +160,23 @@ fn test_sigint_kills_firecracker_bridged() -> Result<()> {
     // Start fcvm in background
     let fcvm_path = common::find_fcvm_binary()?;
     let (vm_name, _, _, _) = common::unique_names("signal-int");
-    let mut fcvm = Command::new(&fcvm_path)
-        .args([
-            "podman",
-            "run",
-            "--name",
-            &vm_name,
-            "--network",
-            "bridged",
-            // One-shot test: boot, send a signal, verify cleanup. It never restores
-            // a snapshot, so skip the pre-start snapshot create (#618) — under
-            // SnapshotEnabled CI its ~1GB memory dump can exceed the health-wait
-            // budget when this VM is first-to-create under disk contention.
-            "--no-snapshot",
-            common::TEST_IMAGE,
-        ])
-        .spawn()
-        .context("spawning fcvm")?;
+    let mut cmd = Command::new(&fcvm_path);
+    cmd.args([
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--network",
+        "bridged",
+        // One-shot test: boot, send a signal, verify cleanup. It never restores
+        // a snapshot, so skip the pre-start snapshot create (#618) — under
+        // SnapshotEnabled CI its ~1GB memory dump can exceed the health-wait
+        // budget when this VM is first-to-create under disk contention.
+        "--no-snapshot",
+        common::TEST_IMAGE,
+    ]);
+    common::set_test_pdeathsig_std(&mut cmd);
+    let mut fcvm = cmd.spawn().context("spawning fcvm")?;
 
     let fcvm_pid = fcvm.id();
     println!("Started fcvm with PID: {}", fcvm_pid);
@@ -297,23 +297,23 @@ fn test_sigterm_kills_firecracker_bridged() -> Result<()> {
     // Start fcvm in background
     let fcvm_path = common::find_fcvm_binary()?;
     let (vm_name, _, _, _) = common::unique_names("signal-term");
-    let mut fcvm = Command::new(&fcvm_path)
-        .args([
-            "podman",
-            "run",
-            "--name",
-            &vm_name,
-            "--network",
-            "bridged",
-            // One-shot test: boot, send a signal, verify cleanup. It never restores
-            // a snapshot, so skip the pre-start snapshot create (#618) — under
-            // SnapshotEnabled CI its ~1GB memory dump can exceed the health-wait
-            // budget when this VM is first-to-create under disk contention.
-            "--no-snapshot",
-            common::TEST_IMAGE,
-        ])
-        .spawn()
-        .context("spawning fcvm")?;
+    let mut cmd = Command::new(&fcvm_path);
+    cmd.args([
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--network",
+        "bridged",
+        // One-shot test: boot, send a signal, verify cleanup. It never restores
+        // a snapshot, so skip the pre-start snapshot create (#618) — under
+        // SnapshotEnabled CI its ~1GB memory dump can exceed the health-wait
+        // budget when this VM is first-to-create under disk contention.
+        "--no-snapshot",
+        common::TEST_IMAGE,
+    ]);
+    common::set_test_pdeathsig_std(&mut cmd);
+    let mut fcvm = cmd.spawn().context("spawning fcvm")?;
 
     let fcvm_pid = fcvm.id();
     println!("Started fcvm with PID: {}", fcvm_pid);
@@ -428,21 +428,21 @@ fn test_sigterm_cleanup_rootless() -> Result<()> {
     // Start fcvm in rootless mode
     let fcvm_path = common::find_fcvm_binary()?;
     let (vm_name, _, _, _) = common::unique_names("cleanup-rootless");
-    let mut fcvm = Command::new(&fcvm_path)
-        .args([
-            "podman",
-            "run",
-            "--name",
-            &vm_name,
-            "--network",
-            "rootless",
-            // One-shot test (boot, signal, verify cleanup); never restores a
-            // snapshot, so skip the pre-start snapshot create (#618).
-            "--no-snapshot",
-            common::TEST_IMAGE,
-        ])
-        .spawn()
-        .context("spawning fcvm")?;
+    let mut cmd = Command::new(&fcvm_path);
+    cmd.args([
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--network",
+        "rootless",
+        // One-shot test (boot, signal, verify cleanup); never restores a
+        // snapshot, so skip the pre-start snapshot create (#618).
+        "--no-snapshot",
+        common::TEST_IMAGE,
+    ]);
+    common::set_test_pdeathsig_std(&mut cmd);
+    let mut fcvm = cmd.spawn().context("spawning fcvm")?;
 
     let fcvm_pid = fcvm.id();
     println!("Started fcvm with PID: {}", fcvm_pid);
@@ -569,21 +569,21 @@ fn test_sigkill_kills_firecracker_rootless() -> Result<()> {
 
     let fcvm_path = common::find_fcvm_binary()?;
     let (vm_name, _, _, _) = common::unique_names("sigkill-rootless");
-    let mut fcvm = Command::new(&fcvm_path)
-        .args([
-            "podman",
-            "run",
-            "--name",
-            &vm_name,
-            "--network",
-            "rootless",
-            // One-shot test (boot, signal, verify cleanup); never restores a
-            // snapshot, so skip the pre-start snapshot create (#618).
-            "--no-snapshot",
-            common::TEST_IMAGE,
-        ])
-        .spawn()
-        .context("spawning fcvm")?;
+    let mut cmd = Command::new(&fcvm_path);
+    cmd.args([
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--network",
+        "rootless",
+        // One-shot test (boot, signal, verify cleanup); never restores a
+        // snapshot, so skip the pre-start snapshot create (#618).
+        "--no-snapshot",
+        common::TEST_IMAGE,
+    ]);
+    common::set_test_pdeathsig_std(&mut cmd);
+    let mut fcvm = cmd.spawn().context("spawning fcvm")?;
 
     let fcvm_pid = fcvm.id();
     println!("Started fcvm with PID: {}", fcvm_pid);
@@ -684,6 +684,217 @@ fn test_sigkill_kills_firecracker_rootless() -> Result<()> {
 
     println!("test_sigkill_kills_firecracker_rootless PASSED");
     Ok(())
+}
+
+/// The `sudo` hop in the CI process tree must not break VM teardown.
+///
+/// `make test-root` runs cargo-nextest UNPRIVILEGED and elevates only the test binary, via
+/// `CARGO_TARGET_*_RUNNER='sudo -E env PATH=... scripts/root-test-runner.sh'`. The resulting
+/// tree is `nextest (uid 1000) -> sudo (ruid 1000) -> test binary (uid 0) -> fcvm -> firecracker`.
+/// When nextest's `slow-timeout.terminate-after` fires it signals the test's process group —
+/// but the kernel refuses uid 1000 -> uid 0 signals, so the ONLY member it can actually kill is
+/// the `sudo` front-end, and SIGKILL cannot be caught, so `sudo` never forwards it. Everything
+/// below `sudo` is orphaned to init and keeps running; because the test binary never dies, the
+/// PR_SET_PDEATHSIG chain beneath it (test binary -> fcvm -> firecracker) never fires either.
+/// A self-hosted runner accumulated ~490 live `firecracker` processes this way and wedged.
+///
+/// So this test reproduces that topology exactly — the real runner script, a real `sudo` hop, a
+/// real VM — and SIGKILLs ONLY the `sudo` front-end, the single process nextest can reach.
+/// Everything below it must be gone. Drop `setpriv --pdeathsig KILL` from the runner script and
+/// this test fails with fcvm reparented to init and its Firecracker still serving a live VM.
+#[cfg(feature = "privileged-tests")]
+#[test]
+fn test_root_test_runner_reaps_vm_when_sudo_is_killed() -> Result<()> {
+    println!("\ntest_root_test_runner_reaps_vm_when_sudo_is_killed");
+
+    // The SAME runner the Makefile installs as CARGO_TARGET_*_RUNNER — one source of truth.
+    let runner = concat!(env!("CARGO_MANIFEST_DIR"), "/scripts/root-test-runner.sh");
+    assert!(
+        std::path::Path::new(runner).is_file(),
+        "privileged test runner missing at {runner}"
+    );
+
+    let fcvm_path = common::find_fcvm_binary()?;
+    let (vm_name, _, _, _) = common::unique_names("sudo-hop");
+    let path_env = std::env::var("PATH").unwrap_or_default();
+
+    // Never Stdio::piped() without a consumer (pipe-buffer deadlock); a file keeps the VM's
+    // output for post-mortem.
+    std::fs::create_dir_all("/tmp/fcvm-test-logs").ok();
+    let log_path = format!("/tmp/fcvm-test-logs/{}.log", vm_name);
+    let log = std::fs::File::create(&log_path).context("creating VM log file")?;
+
+    // Reproduce the runner invocation verbatim: sudo -E env PATH=... <runner> <program> <args>.
+    let mut sudo = Command::new("sudo")
+        .args([
+            "-E",
+            "env",
+            &format!("PATH={}", path_env),
+            runner,
+            fcvm_path.to_str().context("fcvm path is not UTF-8")?,
+            "podman",
+            "run",
+            "--name",
+            &vm_name,
+            "--network",
+            "rootless",
+            // One-shot test (boot, signal, verify cleanup); never restores a snapshot,
+            // so skip the pre-start snapshot create (#618).
+            "--no-snapshot",
+            common::TEST_IMAGE,
+        ])
+        .stdout(log.try_clone().context("cloning log file")?)
+        .stderr(log)
+        .spawn()
+        .context("spawning sudo runner")?;
+
+    let sudo_pid = sudo.id();
+    println!("sudo front-end PID: {} (log: {})", sudo_pid, log_path);
+
+    // fcvm replaces the runner's own image (env -> sh -> setpriv -> fcvm all exec in place),
+    // so it is a descendant of sudo. Search by ancestry rather than assuming a direct child,
+    // which also covers the pty path where sudo interposes a monitor process.
+    let start = std::time::Instant::now();
+    let fcvm = loop {
+        if let Some(t) = find_descendant_by_comm(sudo_pid, "fcvm") {
+            break t;
+        }
+        if start.elapsed() > Duration::from_secs(60) {
+            let _ = sudo.kill();
+            anyhow::bail!(
+                "fcvm never appeared under the sudo runner (see {})",
+                log_path
+            );
+        }
+        std::thread::sleep(common::POLL_INTERVAL);
+    };
+    println!("fcvm PID under sudo: {}", fcvm.pid);
+
+    // Wait for the VM to be fully up, so the kill lands on a real running microVM.
+    let start = std::time::Instant::now();
+    let mut healthy = false;
+    while start.elapsed() < Duration::from_secs(180) {
+        std::thread::sleep(common::POLL_INTERVAL);
+        let output = Command::new(&fcvm_path)
+            .args(["ls", "--json", "--pid", &fcvm.pid.to_string()])
+            .output()
+            .context("running fcvm ls")?;
+        if is_vm_healthy(&String::from_utf8_lossy(&output.stdout)) {
+            healthy = true;
+            println!("VM is healthy after {:?}", start.elapsed());
+            break;
+        }
+    }
+    if !healthy {
+        fcvm.kill_if_running();
+        let _ = sudo.kill();
+        let _ = sudo.wait();
+        anyhow::bail!("VM did not become healthy within 180s (see {})", log_path);
+    }
+
+    let fc = find_firecracker_for_fcvm(fcvm.pid);
+    assert!(
+        fc.is_some(),
+        "should have started a firecracker process under fcvm (PID {})",
+        fcvm.pid
+    );
+    let fc = fc.unwrap();
+    println!("firecracker PID: {}", fc.pid);
+
+    // Exactly what cargo-nextest can reach: the sudo front-end, and nothing else.
+    println!("SIGKILL to the sudo front-end (PID {}) only", sudo_pid);
+    send_signal(sudo_pid, "KILL").context("sending SIGKILL to sudo")?;
+    let _ = sudo.wait();
+
+    // PR_SET_PDEATHSIG chain: sudo dies -> kernel SIGKILLs fcvm -> kernel SIGKILLs firecracker.
+    // Each hop is one scheduler wakeup; 30s is orders of magnitude of headroom for a loaded runner.
+    let start = std::time::Instant::now();
+    while start.elapsed() < Duration::from_secs(30) {
+        if !fcvm.running() && !fc.running() {
+            break;
+        }
+        std::thread::sleep(common::POLL_INTERVAL);
+    }
+    let fcvm_alive = fcvm.running();
+    let fc_alive = fc.running();
+
+    // Clean up before asserting so a failure of THIS test cannot itself leak a microVM.
+    if fcvm_alive {
+        fcvm.kill_if_running();
+    }
+    if fc_alive {
+        fc.kill_if_running();
+    }
+
+    assert!(
+        !fcvm_alive,
+        "fcvm (PID {}) survived the death of its sudo parent — the privileged test runner is \
+         not setting PR_SET_PDEATHSIG, so a nextest timeout kill orphans the whole VM tree",
+        fcvm.pid
+    );
+    assert!(
+        !fc_alive,
+        "firecracker (PID {}) survived the death of the sudo parent of its fcvm (PID {})",
+        fc.pid, fcvm.pid
+    );
+
+    println!("test_root_test_runner_reaps_vm_when_sudo_is_killed PASSED");
+    Ok(())
+}
+
+/// Find the SHALLOWEST live descendant of `root_pid` whose `comm` starts with `comm_prefix`,
+/// tracked by (pid, start_time) + pidfd so later liveness checks survive PID reuse and the
+/// post-kill zombie window.
+///
+/// Breadth-first on purpose: fcvm spawns its own short-lived `fcvm exec` health-check children,
+/// which have the same `comm`. A flat /proc scan could return one of those (and then "the
+/// process died" would mean nothing); the shallowest match is always the VM's own fcvm.
+#[cfg(feature = "privileged-tests")]
+fn find_descendant_by_comm(root_pid: u32, comm_prefix: &str) -> Option<Tracked> {
+    // One /proc pass -> pid -> ppid, so the walk sees a single consistent snapshot.
+    let mut parents: Vec<(u32, u32)> = Vec::new();
+    for entry in std::fs::read_dir("/proc").ok()?.flatten() {
+        let Ok(pid) = entry.file_name().to_string_lossy().parse::<u32>() else {
+            continue;
+        };
+        if let Some(ppid) = proc_ppid(pid) {
+            parents.push((pid, ppid));
+        }
+    }
+
+    let mut frontier = vec![root_pid];
+    for _ in 0..6 {
+        let children: Vec<u32> = parents
+            .iter()
+            .filter(|(_, ppid)| frontier.contains(ppid))
+            .map(|(pid, _)| *pid)
+            .collect();
+        if children.is_empty() {
+            return None;
+        }
+        for pid in &children {
+            if proc_comm(*pid).is_some_and(|c| c.starts_with(comm_prefix)) {
+                if let Some(t) = capture_descendant(*pid, root_pid, comm_prefix) {
+                    return Some(t);
+                }
+            }
+        }
+        frontier = children;
+    }
+    None
+}
+
+/// Parent pid from `/proc/<pid>/stat` (field 4). `comm` (field 2) can contain spaces and
+/// parens, so parse the remainder after the last `") "`.
+#[cfg(feature = "privileged-tests")]
+fn proc_ppid(pid: u32) -> Option<u32> {
+    let stat = std::fs::read_to_string(format!("/proc/{}/stat", pid)).ok()?;
+    stat.rsplit_once(") ")?
+        .1
+        .split_whitespace()
+        .nth(1)?
+        .parse()
+        .ok()
 }
 
 /// Find the firecracker process spawned by a specific fcvm process
@@ -856,23 +1067,23 @@ fn test_sigterm_cleanup_bridged() -> Result<()> {
     // Start fcvm in bridged mode
     let fcvm_path = common::find_fcvm_binary()?;
     let (vm_name, _, _, _) = common::unique_names("cleanup-bridged");
-    let mut fcvm = Command::new(&fcvm_path)
-        .args([
-            "podman",
-            "run",
-            "--name",
-            &vm_name,
-            "--network",
-            "bridged",
-            // One-shot test: boot, send a signal, verify cleanup. It never restores
-            // a snapshot, so skip the pre-start snapshot create (#618) — under
-            // SnapshotEnabled CI its ~1GB memory dump can exceed the health-wait
-            // budget when this VM is first-to-create under disk contention.
-            "--no-snapshot",
-            common::TEST_IMAGE,
-        ])
-        .spawn()
-        .context("spawning fcvm")?;
+    let mut cmd = Command::new(&fcvm_path);
+    cmd.args([
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--network",
+        "bridged",
+        // One-shot test: boot, send a signal, verify cleanup. It never restores
+        // a snapshot, so skip the pre-start snapshot create (#618) — under
+        // SnapshotEnabled CI its ~1GB memory dump can exceed the health-wait
+        // budget when this VM is first-to-create under disk contention.
+        "--no-snapshot",
+        common::TEST_IMAGE,
+    ]);
+    common::set_test_pdeathsig_std(&mut cmd);
+    let mut fcvm = cmd.spawn().context("spawning fcvm")?;
 
     let fcvm_pid = fcvm.id();
     println!("Started fcvm with PID: {}", fcvm_pid);
@@ -986,23 +1197,23 @@ fn test_sigterm_cleanup_routed() -> Result<()> {
     let host_port = common::find_available_high_port().context("finding available port")?;
     let publish_arg = format!("{}:80", host_port);
 
-    let mut fcvm = Command::new(&fcvm_path)
-        .args([
-            "podman",
-            "run",
-            "--name",
-            &vm_name,
-            "--network",
-            "routed",
-            // One-shot test (boot, signal, verify cleanup); never restores a
-            // snapshot, so skip the pre-start snapshot create (#618).
-            "--no-snapshot",
-            "--publish",
-            &publish_arg,
-            common::TEST_IMAGE,
-        ])
-        .spawn()
-        .context("spawning fcvm")?;
+    let mut cmd = Command::new(&fcvm_path);
+    cmd.args([
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--network",
+        "routed",
+        // One-shot test (boot, signal, verify cleanup); never restores a
+        // snapshot, so skip the pre-start snapshot create (#618).
+        "--no-snapshot",
+        "--publish",
+        &publish_arg,
+        common::TEST_IMAGE,
+    ]);
+    common::set_test_pdeathsig_std(&mut cmd);
+    let mut fcvm = cmd.spawn().context("spawning fcvm")?;
 
     let fcvm_pid = fcvm.id();
     println!("Started fcvm with PID: {}", fcvm_pid);


### PR DESCRIPTION
Restore the PR_SET_PDEATHSIG teardown chain across the sudo privilege hop

`make test-root` keeps cargo-nextest unprivileged and elevates only the test
binary (CARGO_TARGET_*_RUNNER='sudo -E env PATH=...'), so the CI process tree is:

  nextest (uid 1000) -> sudo (ruid 1000) -> test binary (uid 0) -> fcvm -> firecracker

That privilege boundary breaks teardown, silently. When nextest's
slow-timeout.terminate-after fires it signals the test's process group, but the
kernel refuses a uid-1000 -> uid-0 signal, and killpg() still returns success
because it did signal one member -- the `sudo` front-end. SIGKILL cannot be
caught, so `sudo` never forwards it. The elevated test binary is orphaned to
init and keeps running, and because it never dies the pdeathsig chain BELOW it
(test binary -> fcvm -> firecracker) never fires either. Measured directly:
killpg(SIGKILL) from uid 1000 left 2/2 root processes alive, reparented to init.

On 2026-08-06 that left ~498 live firecracker processes on two ARM runners
(load average 523, 103 tasks in D-state, 420 zombies) for 21 hours, and the AWS
lease logic kept renewing the dead runners because GitHub still reported them
busy. Nothing in any job log ever mentioned them.

Teardown is per-hop: the kernel only kills a child whose OWN pdeathsig is set,
so one unprotected hop orphans the whole subtree below it. Every hop is now
covered.

The sudo hop
- scripts/root-test-runner.sh (new, 0755): `exec setpriv --pdeathsig KILL "$@"`.
  Kernel-enforced, so it holds in exactly the case that leaked -- a SIGKILL
  where no Drop impl, signal handler or `always()` cleanup step gets to run.
- Makefile: new ROOT_TEST_RUNNER variable replaces all 12 bare
  `sudo -E env PATH=$(PATH)` runner assignments (both triples x six invocation
  sites) across _test-root, _test-fc-mock, bench and bench-vm.

The test-binary hop
- tests/common/mod.rs: set_test_pdeathsig is now pub, and gains a
  std::process::Command flavour (set_test_pdeathsig_std); both share one
  pre_exec body (pdeathsig_hook) that sets PR_SET_PDEATHSIG(SIGKILL) and then
  closes the fork-vs-prctl race via getppid().
- Applied to all 16 hand-rolled fcvm spawns that bypassed spawn_fcvm*, across
  test_signal_cleanup, test_port_forward, test_proxy, test_localhost_image,
  test_serve, test_remap_file_range, test_fuse_in_vm_matrix and
  test_fuse_copy_file_range_vm. `fcvm serve` matters most: it owns every sandbox
  VM it creates, so orphaning it orphans all of them.

The VMM hop
- src/setup/rootfs.rs: the Layer-2 setup VM was the one VMM spawn in the tree
  that did not go through install_namespace_pre_exec, so a `fcvm setup` killed
  without unwinding (SIGKILL, a cancelled CI job) orphaned a live Firecracker
  that boots for minutes. It now uses the same helper (no namespaces -- the
  setup VM is on the host network -- so only the parent-death hook installs),
  plus kill_on_drop(true) for the several `?` paths that return before the wait
  loop.

Regression test
- tests/test_signal_cleanup.rs: test_root_test_runner_reaps_vm_when_sudo_is_killed
  reproduces the topology exactly -- the real runner script (resolved from
  CARGO_MANIFEST_DIR, so it cannot drift from the Makefile), a real sudo hop, a
  real booted VM -- then SIGKILLs ONLY the sudo front-end, the single process
  nextest can actually reach, and asserts both fcvm and firecracker are gone
  within 30s. It cleans up before asserting so a failure cannot itself leak a VM.

Defense in depth (NOT a substitute for the fix)
- .github/workflows/ci.yml: timeout-minutes on all three self-hosted jobs --
  Host 60, Host-Root 120, Container 60. GitHub's default is SIX HOURS, which is
  how a wedged runner held a job all day (one stuck >5h). Budgets are ~3-5x the
  longest of the last 6 successful runs, read from `gh api`: Host 12 min,
  Host-Root 43 min (arm64 SnapshotEnabled runs the suite twice), Container 21 min.
- scripts/ci-stray-vm-guard.sh (new, 0755) + pre/post steps in all three jobs:
  reports and reaps stray fcvm/firecracker/cloud-hypervisor processes at job
  boundaries, with a GitHub annotation when the count is non-zero so it lands on
  the run page instead of being buried in a step log. It matches on `comm`, not
  argv, so it can never match its own ps/grep. Limitation stated in its header:
  it only acts at job boundaries and cannot help a host that wedges mid-job
  (that remediation is AWS-side: terminate and replace), and D-state survivors
  need a reboot, not another kill.
  Zombies (stat Z) are excluded from BOTH the stray count and the post-SIGKILL
  survivor check, and reported separately. A zombie has already exited -- it
  holds no memory, no KVM fd, no vCPU thread -- so it is not a leaked microVM,
  and it can never be killed, so counting it would land it in SURVIVORS on every
  single run and fire the "survived SIGKILL, replace this runner" annotation for
  one stray <defunct>. A guard that cries wolf every run is a guard everyone
  learns to ignore. The 2026-08-06 incident had 420 zombies next to its 498 live
  firecrackers; only the live ones were the leak.
  A `--dry-run` flag reports without killing, so the script can be exercised
  somewhere other than a dedicated runner -- the default mode SIGKILLs every
  match, which on a shared box destroys someone else's VMs rather than garbage.
- .claude/CLAUDE.md: documents the per-hop rule, the three files that must keep
  covering their hop, and why a privilege boundary is special.

Verification (aarch64, real VMs)
- Both ways on the regression test, which is the whole point of the change:
    WITH the fix    PASS in 4.94s. Tree was sudo 743977 -> fcvm 743978 ->
                    firecracker 744257; SIGKILL to 743977 alone reaped both.
    WITHOUT the fix FAIL, twice (nextest retried): 35.18s and 34.84s, both with
                    "fcvm (PID 754949) survived the death of its sudo parent".
                    Reverted by reducing the runner to a bare `exec "$@"`.
  The test resolves the runner from CARGO_MANIFEST_DIR, so this exercises the
  same file the Makefile installs -- it cannot pass against a stale copy.
- make test-root FILTER=snapshot STREAM=1: 114 tests run, 114 passed [1222s],
  with the stray-process probe at 0 firecracker / 0 fcvm both before and after.
- make test-root FILTER=sanity: 5 tests run, 5 passed.
- make lint (fmt, clippy --all-targets -D warnings, cargo audit, cargo deny): ok
- make build: ok
- shellcheck on both new scripts: clean
- Stray-process probe around the sanity run: firecracker 0 -> 0, fcvm 0 -> 0.
  The failing negative run also left 0 behind, confirming the test cleans up
  before it asserts.
- ci-stray-vm-guard.sh exercised against live VMs in --dry-run: it correctly
  detected both `fcvm` and the 15-char-truncated `firecracker-def` comm, killed
  nothing, and exits 0 either way so it can never fail a job by itself.

Claude-Session: https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd


## Also found, NOT fixed here

These are wedge paths, not leak paths. With the pdeathsig chain intact a wedged
process is now killed when its parent dies, so they are no longer CI-fatal — but
they are real and worth separate PRs:

- `fcvm snapshot run` clones are **not children** of their `snapshot serve`: a
  clone self-registers `serve_pid` in its state file (`src/commands/snapshot.rs:811`),
  so serve's reaper (`src/commands/snapshot.rs:534-627`) is a best-effort state-file
  scan. A SIGKILL'd serve reaps nothing, and a clone still mid-restore is invisible
  to it because state is written only AFTER the firecracker spawn
  (`src/commands/common.rs:1502`).
- `src/commands/snapshot.rs:1604-1641`: the clone output-connect wait has no timeout
  and no cancel arm — it exits only if firecracker dies first.
- `src/commands/podman/mod.rs:1587` + `:470/:507` + `src/commands/snapshot.rs:1731`:
  on the snapshot cache-hit path a SIGTERM arriving before `cmd_snapshot_run`
  installs its own handler is consumed by an already-finished task and dropped,
  while tokio has already changed the process's SIGTERM disposition.
- `src/commands/common.rs:686-694`: cleanup aborts the VolumeServer
  (FUSE-over-vsock) tasks BEFORE `vm_manager.kill()`, whose `process.wait().await`
  is unbounded — the "guest blocked on a FUSE peer that is already gone" shape
  behind the incident's 103 D-state tasks.
- `src/uffd/server.rs:257`: the per-VM handler parks on `readable().await` with no
  timeout or cancellation, so `run()`'s post-cancel drain at `:191` is unbounded.
- `src/network/pasta.rs:604`: pasta is spawned with no pdeathsig.


---

## Commit 2 — `213fd4fa` Make the stray-VM guard's dry-run annotation tell the truth

The `::warning` annotation was emitted *before* the `--dry-run` branch, so a dry-run
announced "killing them" on the run page and then killed nothing. Moved the emit inside the
branch so each mode states what it actually did; reworded the zombie note so the phase reads
as a label. `shellcheck`: clean.

## Independent re-verification (second operator, quiet host, aarch64)

The run above was re-done from scratch on an idle host so the numbers are reproducible rather
than single-shot. Same conclusions, different PIDs:

| Step | Result |
|---|---|
| `make build` | exit 0 |
| `make lint` (fmt, clippy `--all-targets -D warnings`, audit, deny) | `advisories ok, bans ok, licenses ok, sources ok` |
| `make test-root FILTER=sanity` | `5 tests run: 5 passed, 679 skipped` |
| **POSITIVE** — fix in place | `1 test run: 1 passed` in 4.82s |
| **NEGATIVE** — runner reduced to `exec "$@"` | `1 test run: 0 passed, 1 failed`, both tries |
| `shellcheck` both scripts | clean |

The negative half fails for the **right reason** — the child is asserted *alive*, not merely
"the test failed":

```
thread 'test_root_test_runner_reaps_vm_when_sudo_is_killed' panicked at tests/test_signal_cleanup.rs:829:5:
fcvm (PID 857921) survived the death of its sudo parent — the privileged test runner is not
setting PR_SET_PDEATHSIG, so a nextest timeout kill orphans the whole VM tree
```

Positive run, for contrast — tree `sudo 848847 -> fcvm 848848 -> firecracker 849058`, SIGKILL
to `848847` alone, both descendants gone inside the 30s bound.

The same asymmetry reproduces on the bare primitive in ~10s, with no VM involved, which is
useful when triaging this in future:

```
NEGATIVE (bare 'exec "$@"'):        CHILD SURVIVED — state=S, reparented to ppid=1
POSITIVE (setpriv --pdeathsig KILL): CHILD REAPED BY KERNEL
```

**Stray-process probe:** `live firecracker=0 live fcvm=0` before; `0 / 0` after, on a
re-check. The immediate post-probe of the *negative* run caught `firecracker=1` mid-teardown
— the test issues its cleanup kill before asserting, so that is the kill in flight, and it
drains to 0. Worth stating rather than rounding down to a clean "0".

**Guard behaviour, both modes, against synthetic `fcvm`/`firecracker` processes** (the guard
matches on `comm`, so `cp /bin/sleep .../fcvm` is a faithful stray):

```
$ ./scripts/ci-stray-vm-guard.sh pre --dry-run
::warning title=Stray microVMs (pre, dry-run)::1 ... NOT killing them (--dry-run).
  synthetic pid 865440 ALIVE (correct)

$ ./scripts/ci-stray-vm-guard.sh post
::warning title=Stray microVMs (post)::1 ... killing them.
killed 1, still present after SIGKILL: 0
  synthetic pid GONE (correct)
```

Zombie exclusion, checked against a synthetic `ps` table so every state is covered — `Z` and
`Z+` dropped, `D` (the actual wedge signal) still caught, non-VM processes never matched:

```
kept:    111 Sl firecracker-def | 333 Sl fcvm | 444 D firecracker
dropped: 222 Z fcvm | 555 Z+ firecracker-def | 666 sshd (never matched)
```

### Two process-safety notes from doing this verification

* **The guard is destructive by default and has no interlock against a concurrent job.** I ran
  it on a shared dev box to exercise it and it SIGKILLed a live, unrelated test's VM one second
  after that test started. On a dedicated CI runner (one job at a time) that is correct and
  intended; anywhere else `--dry-run` is mandatory. This is exactly why the flag was added.
* **`kill -0` is not a liveness check across a privilege boundary.** A first cut of the
  primitive probe used `kill -0 <root pid>` from uid 1000, which returns `EPERM`, not `ESRCH` —
  so a *surviving* root child read as "reaped" and the negative case looked like it passed.
  Liveness here must come from `/proc/<pid>/stat` (and must exclude state `Z`). That is the same
  uid-1000→uid-0 signal asymmetry this PR is about, which makes it an easy way to fool yourself
  while testing the fix.
