### PR TITLE
bench: withdraw the CDP A/B numbers and fix the harness defects that invalidated them

### DIFF
--- a/Containerfile.chromium-bench
+++ b/Containerfile.chromium-bench
@@ -6,7 +6,17 @@
 # each drive one CDP render via bench/chromium/render.py.
 #
 # Build (repo root context; .dockerignore excludes target/):
-#   podman build -t localhost/chromium-bench -f Containerfile.chromium-bench .
+#   podman build --format docker -t localhost/chromium-bench -f Containerfile.chromium-bench .
+#
+# --format docker is LOAD-BEARING. podman's default OCI format DROPS the
+# HEALTHCHECK at the bottom of this file with only a warning
+# ("HEALTHCHECK is not supported for OCI image format and will be ignored")
+# and exits 0. fcvm then sees no healthcheck, and src/health.rs treats a
+# MISSING one as a PASS (`None => HealthStatus::Healthy`), so the golden
+# snapshot fires on "container is running" — a COLD browser — and every
+# restored clone's "warm" latency is really a first-paint number. Verify:
+#   podman inspect localhost/chromium-bench --format '{{json .HealthCheck}}'
+# must print the Test array containing cdp_health.
 #
 # Host smoke test (fast loop, no VM):
 #   podman run -d --name cb localhost/chromium-bench
@@ -19,9 +29,12 @@
 #   fcvm exec --pid <PID> -c -- python3 /opt/bench/render.py \
 #       http://127.0.0.1:8000/medium.html --out-prefix /tmp/medium
 #
-# Golden-snapshot warm point: /ready returns 200 only after warmup, so
-#   --health-check http://127.0.0.1:8000/ready
-# makes the auto startup snapshot capture a WARM browser.
+# Golden-snapshot warm point: SUPERSEDED — do NOT pass a --health-check URL.
+# An earlier recipe here suggested `--health-check http://127.0.0.1:8000/ready`.
+# That sets `has_http_check` in src/health.rs, which SKIPS the podman HEALTHCHECK
+# entirely — i.e. it disables the CDP round-trip gate defined at the bottom of
+# this file, which is the trigger this design actually relies on. Leave
+# --health-check UNSET so fcvm's AND-logic consults the image's HEALTHCHECK.
 #
 # Fixtures live in bench/chromium/pages/ and are COPY'd in; the host-side
 # fixture server (bench harness) serves the SAME directory so in-guest and

--- a/Containerfile.chromium-bench
+++ b/Containerfile.chromium-bench
@@ -40,6 +40,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     chromium \
     python3 \
     fonts-dejavu-core \
+    socat \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/partial
 
 # Belt-and-braces half of the getenv/setenv workaround documented at length in
@@ -56,7 +57,43 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV VK_ICD_FILENAMES=/usr/lib/chromium/./vk_swiftshader_icd.json
 
 COPY bench/chromium/pages/ /opt/bench/pages/
-COPY bench/chromium/pageserver.py bench/chromium/render.py bench/chromium/entry.sh /opt/bench/
-RUN chmod +x /opt/bench/entry.sh /opt/bench/render.py /opt/bench/pageserver.py
+COPY bench/chromium/pageserver.py bench/chromium/render.py bench/chromium/entry.sh \
+     bench/chromium/cdp_health.py /opt/bench/
+RUN chmod +x /opt/bench/entry.sh /opt/bench/render.py /opt/bench/pageserver.py \
+     /opt/bench/cdp_health.py
+
+# The request path IS Chromium's DevTools Protocol endpoint -- no wrapper of
+# ours parses, re-encodes or re-frames a single CDP message. But reaching it
+# from the host needs ONE relay hop, and that is a MEASURED cost, not a detail:
+#
+#   Chromium IGNORES --remote-debugging-address on this build (151.0.7922.71,
+#   Debian bookworm arm64). Verified, not assumed: the flag is present in
+#   /proc/<pid>/cmdline while /proc/net/tcp shows 0100007F:2406 (127.0.0.1:9222)
+#   and nothing else -- in the same container where the page server's
+#   00000000:1F40 proves a wildcard bind works fine. It is Chromium, not us.
+#
+#   fcvm has NO feature that exposes a guest-LOOPBACK port to the host.
+#   --forward-localhost runs the other way (guest -> host: "enables containers
+#   to reach host-only services via localhost", src/cli/args.rs; the guest relay
+#   dials 10.0.2.2 at fc-agent/src/network.rs:479). Pointing it at 9222 does not
+#   just fail to help -- it HIJACKS the guest's own 127.0.0.1:9222 and breaks
+#   Chromium's readiness probe.
+#
+# So: socat bridges guest-wildcard 9223 -> guest-loopback 9222, and fcvm's
+# --publish 9223:9223 carries host -> guest (clones inherit port_mappings from
+# snapshot metadata, src/commands/snapshot.rs:1001/1051/1070). socat is ~1 MB
+# resident and is the ONLY process this design adds to a clone; its cost is
+# reported rather than waved away.
+EXPOSE 9223
+
+# fcvm's health gate is the golden-snapshot trigger. With no `--health-check`
+# URL, `Healthy` = container running AND podman's HEALTHCHECK healthy
+# (src/health.rs, "AND logic"), so THIS is what decides when the snapshot is
+# taken. cdp_health.py requires a warm marker AND a live CDP round trip that
+# finds a page target: healthy means provably able to screenshot.
+# start-period covers Chromium's cold launch + the warm render; interval is the
+# resolution of the snapshot trigger, so it is short.
+HEALTHCHECK --interval=1s --timeout=5s --start-period=90s --retries=3 \
+    CMD ["python3", "/opt/bench/cdp_health.py"]
 
 CMD ["/opt/bench/entry.sh"]

--- a/bench/chromium/AGENTS.md
+++ b/bench/chromium/AGENTS.md
@@ -153,21 +153,40 @@ is load-bearing. Fix the registration first, then prove it with the #617 repro.
 ## fcvm reference numbers (main @ 2026-08-08, quiet box)
 
 Compare against these; a large deviation means contention or a regression.
+"Large" is only decidable against a spread, so every row carries one — a row with
+a bare point estimate cannot tell a reader whether their 45 ms is a regression or
+a draw. Defect 6 applies to this table as much as to a report.
+
+**Basis for the whole-request row: n=10 draws, one clone at a time, quiet box.**
+The decomposed stages below it were recorded in the SAME run but were not
+re-sampled per stage, so they carry the whole's dispersion, not their own. They
+are quoted to the precision that supports — whole ms — and they sum to ~126 ms
+against a whole of 132, a difference well inside the 12 ms spread of the whole.
+Do not read the stage split as ten independent measurements.
 
 | Metric | Value |
 |---|---|
 | clone spawn → exec-ready | **132 ms p50** (min 121, p90 133, n=10) |
-| — `resolve-fc` | 0.5 ms (was 341 ms: per-clone `git ls-remote`) |
-| — `listeners+state` | 2.5 ms |
-| — `netns+pasta` | 38.0 ms (was ~96: inotify replaced a 50 ms poll) |
-| — `snapshot-load` | 5.8 ms — the actual Firecracker restore primitive |
-| — `resume→ready` | 79.3 ms (was 220: a 201 ms sleep that guarded nothing) |
-| routed first-egress after restore | 0.7 ms (was 1002.5 — IPv6 DAD) |
-| reflink, 12.8 GB disk | 9.4 ms (tracks extent count; the published 1.5 ms does not generalize) |
-| host-native warm Chromium floor | ~245 ms |
+| — `resolve-fc` | <1 ms (n=10; was 341 ms: per-clone `git ls-remote`) |
+| — `listeners+state` | ~3 ms (n=10) |
+| — `netns+pasta` | ~38 ms (n=10; was ~96: inotify replaced a 50 ms poll) |
+| — `snapshot-load` | ~6 ms (n=10) — the actual Firecracker restore primitive |
+| — `resume→ready` | ~79 ms (n=10; was 220: a 201 ms sleep that guarded nothing) |
+| routed first-egress after restore | ~1 ms (n=10; was ~1000 — IPv6 DAD) |
+| reflink, 12.8 GB disk | ~9 ms (tracks extent count; the published 1.5 ms does not generalize) |
+| host-native warm Chromium floor | ~245 ms (order of magnitude only; n and spread not recorded) |
 
-`--exec` runs in-container via podman entry (~94–100 ms) vs `crun exec` (~4 ms) —
-known, unfixed, and a real component of any end-to-end number.
+**One number for the restore primitive.** The `snapshot-load` row above and the
+"hypervisor restore" figure in the request-path section below were previously
+quoted as 5.8 ms and 4 ms — a 45% disagreement between two point estimates of the
+same primitive, in one file, neither carrying a band that would make it a
+non-disagreement. They are the same quantity measured in two different runs and
+are now quoted once, as **~6 ms**, from the row above. If you need it tighter,
+re-measure it and quote an interval.
+
+`--exec` runs in-container via podman entry (~94–100 ms, n and basis NOT recorded
+— treat as an order of magnitude, not a measurement) vs `crun exec` (~4 ms, same
+caveat). Known, unfixed, and a real component of any end-to-end number.
 
 ### CDP handshake is now a PER-REQUEST cost — measure it, don't drop it
 
@@ -202,10 +221,13 @@ prints a hardcoded `connect_ms=0.0`.
 ## The request-optimized path (CDP direct + fast teardown)
 
 The measured 573 ms request breaks into ~145 ms of request-INDEPENDENT process
-startup, 226 ms of actual render, and ~154 ms of teardown that runs AFTER the
-screenshot already exists. The hypervisor restore is 4 ms. Two changes attack the
-two non-render parts; they are separate arms in `reqbench.py` so they can be
-attributed separately.
+startup, ~226 ms of actual render, and ~154 ms of teardown that runs AFTER the
+screenshot already exists. The hypervisor restore is **~6 ms** — the single
+`snapshot-load` figure from the reference table above; this line used to say 4 ms
+and the table 5.8 ms, which was two point estimates of one quantity disagreeing
+by 45% with no interval between them. Two changes attack the two non-render
+parts; they are separate arms in `reqbench.py` so they can be attributed
+separately.
 
 **Chromium's CDP endpoint IS the request server.** Do not wrap it. An earlier
 design put a resident Python server in the guest speaking a bespoke JSON protocol
@@ -286,54 +308,101 @@ finds a page target. Healthy therefore means *provably able to screenshot*, not
 *port is open*. Caveat to verify: podman healthchecks need systemd timers in the
 guest; `src/health.rs` notes they can fail to schedule in some rootless setups.
 
-### Fast teardown: one signal, kernel-enforced, cannot leak
+### Fast teardown: one signal, kernel-enforced — scope the guarantee, don't blanket it
 
-`kill(fcvm, SIGKILL)` is the whole teardown. fcvm spawns Firecracker and the
-namespace holder with `PR_SET_PDEATHSIG=SIGKILL`, so the kernel's
-`forget_original_parent()` pass delivers SIGKILL to **both, concurrently, in one
-pass** — no ordering to get wrong, and no cleanup code of ours that must survive a
-SIGKILL. This is the chain PR #730 restored after ~490 VMs leaked.
-Regression proof: `test_sigkill_kills_firecracker_rootless` (podman-run flavour)
-and `test_bench_fast_teardown_leaks_nothing_clone` (the clone flavour the bench
-actually uses, via the snapshot-restore spawn path).
+`kill(fcvm, SIGKILL)` is the whole teardown. fcvm arms `PR_SET_PDEATHSIG=SIGKILL`
+on all three long-lived children — Firecracker
+(`src/utils.rs::install_namespace_pre_exec`), the namespace holder
+(`src/commands/common.rs::spawn_namespace_holder`) and pasta
+(`src/network/pasta.rs`) — so the kernel's `forget_original_parent()` pass
+delivers SIGKILL to all of them, concurrently, in one pass: no ordering to get
+wrong, and no cleanup code of ours that must survive a SIGKILL. This is the chain
+PR #730 restored after ~490 VMs leaked.
 
-Because SIGKILL cannot be caught, `cleanup_vm` never runs and the state file and
-data dir survive. `reqbench.py` reaps them **synchronously** after the clock
-stops — no janitor. The clone-path test asserts the state file is still there
-after the kill, precisely so nobody deletes that reap step.
+**This heading used to read "cannot leak". It does not say that any more, because
+the guarantee is not uniform across the three hops.** pasta's arming carries a
+precondition the other two do not: `commit_creds()` zeroes `pdeath_signal`
+whenever uid/gid change or `cred_cap_issubset(old, new)` fails, and pasta
+`setns()`es into the holder's user namespace after its `pre_exec`. Under sudo
+that is a capability LOSS, the subset test passes, and the signal survives. Run
+fcvm genuinely unprivileged and it becomes a capability GAIN, the kernel clears
+the signal, and pasta falls back to passt's own 1-second PID watch of the holder.
+So: kernel-enforced for the VMM and the holder unconditionally; for pasta while
+fcvm runs as root. A harness must not assume any of it — `reqbench.py`'s
+`teardown_fast` waits on a pidfd per child and REFUSES to reap on-disk state if
+any child is still alive.
+
+Regression proof: `test_sigkill_reaps_rootless_vm_tree` (podman-run flavour) and
+`test_bench_fast_teardown_leaks_nothing_clone` (the clone flavour the bench
+actually uses, via the snapshot-restore spawn path). Both REQUIRE firecracker,
+holder and pasta to be discovered before they assert anything. That is not
+pedantry: until 2026-08-08 the clone test held the holder as a bare `Option` and
+asserted `!holder.is_some_and(running)`, which is `!false` when discovery returns
+`None` — an assertion that cannot fail when its subject is absent, and discovery
+is coupled to production by the literal string `sleep infinity`. Verified by
+fault injection (holder argv → `sleep 2147483647`): the old test still passed
+while a real orphan sat on the box.
+
+Because SIGKILL cannot be caught, `cleanup_vm` never runs and the state file, its
+`.json.lock`, and the data dir all survive. `reqbench.py` reaps them
+**synchronously** after the clock stops — no janitor. Both clone-path tests assert
+the state file AND the data dir are still there after the kill, precisely so
+nobody deletes that reap step. The data dir matters on its own: it holds a reflink
+of the golden rootfs, so a leaked one pins the golden snapshot's extents on btrfs
+and `snapshots delete` frees nothing.
 
 ### Teardown is NOT free — measured, not asserted
 
 Kernel address-space reclaim, measured VM-free on this box (64 cores, 125 GB) with
 the same parent+pdeathsig topology, median of 3 per size, `/proc/<pid>/stat` read
 in the `Z` state so the figure is complete (`exit_mm()` runs before
-`exit_notify()`, so a zombie-state read already includes all reclaim):
+`exit_notify()`, so a zombie-state read already includes all reclaim).
 
-| Address space | reap wall | reclaim CPU |
+**Read the CPU column as quantized, not as measured to 10 ms.** `/proc/<pid>/stat`
+counts in jiffies and `CLK_TCK` is 100 on this box, so its resolution is 10 ms —
+which is why every value in that column is an exact multiple of 10. Each figure is
+`value ± 10 ms` from quantization ALONE, before any sampling variance from n=3.
+
+| Address space | reap wall (n=3) | reclaim CPU (n=3, ±10 ms quantization) |
 |---|---|---|
-| 256 MiB | 15.2 ms | 30 ms |
-| 512 MiB | 32.2 ms | 50 ms |
-| 1024 MiB | 63.5 ms | 110 ms |
-| 2048 MiB | 121.4 ms | 180 ms |
+| 256 MiB | ~15 ms | 30 ± 10 ms |
+| 512 MiB | ~32 ms | 50 ± 10 ms |
+| 1024 MiB | ~64 ms | 110 ± 10 ms |
+| 2048 MiB | ~121 ms | 180 ± 10 ms |
 
-≈ **62 ms wall/GiB, ≈ 90–120 ms CPU/GiB**, linear. CPU EXCEEDS wall, so reclaim
-runs on more than one core: moving it off the response path does not make it free,
-it makes it concurrent. **The claim "early response converts teardown from LATENCY
-into THROUGHPUT cost" is supported — "converts", never "removes".** At saturation
-that ~110 ms CPU/GiB competes with new requests. Do not report the latency win as a
-capacity win.
+A 4-point fit over medians of 3, with the CPU column quantized, supports roughly
+**60 ms wall/GiB and 80–130 ms CPU/GiB** — a fitted RANGE, not a measurement, and
+stated as one. Over most of that range CPU exceeds wall, so reclaim runs on more
+than one core: moving it off the response path does not make it free, it makes it
+concurrent. **The claim "early response converts teardown from LATENCY into
+THROUGHPUT cost" is supported — "converts", never "removes".** At saturation that
+CPU competes with new requests. Do not report the latency win as a capacity win.
+
+**What this table does NOT support:** "CPU exceeds wall" as stated for the 256 MiB
+row. 15 ms wall against 30 ± 10 ms CPU is 15 vs [20, 40] — the direction holds but
+the margin is not resolved by n=3 at this quantization.
 
 Caveat: synthetic dirty-anon pages, not Firecracker's MAP_PRIVATE file-backed
 guest memory; clean file-backed pages may unmap cheaper. Corroboration: the
-observed 78 ms VM teardown for a ~1 GB VM sits right on the 62 ms/GiB line.
+observed ~78 ms VM teardown for a ~1 GB VM sits on the ~60 ms/GiB line.
 
-## Claims currently REFUTED — do not re-publish without new data
+## Claims currently REFUTED — status per `REVIEW.md`
 
-- "fcvm beats a warm container pool on marginal memory (129 vs 151 MiB)"
-- any egress-mode *ordering* (all modes collapsed to ~1.30 ± 0.06 s under review)
-- "16 clones sustain 5.5–6.3 req/s" (n=1 bursts; sustained data said 7.7 rps)
-- "7.9 vs 5.3 req/GB" (slope without intercept)
-- ~70 ms of the 310 ms file-vs-UFFD gap (unattributable at `RUST_LOG=info`)
+This list and `REVIEW.md` disagreed for a while: everything here said "do not
+re-publish" while the ledger had already marked the same claims SUPPORTED /
+SUPERSEDED / REPLACED / RESOLVED on the corrected run. Whichever a reader hit
+first decided whether the number could be published. `REVIEW.md` is the ledger;
+this list now points at it rather than contradicting it.
+
+- "fcvm beats a warm container pool on marginal memory (129 vs 151 MiB)" —
+  **SUPPORTED but much smaller, and backend-dependent** (REVIEW.md row 1). Quote
+  the corrected figures, never the original 129 vs 151.
+- any egress-mode *ordering* — **STILL NOT SUPPORTED** (REVIEW.md row 2). The
+  confound is gone but run-to-run variance dominates; do not publish an ordering.
+- "16 clones sustain 5.5–6.3 req/s" — **SUPERSEDED** (REVIEW.md row 3). And do not
+  quote a burst figure as throughput.
+- "7.9 vs 5.3 req/GB" (slope without intercept) — **REPLACED** (REVIEW.md row 4).
+- ~70 ms of the 310 ms file-vs-UFFD gap — **RESOLVED** (REVIEW.md row 5).
 
 `REVIEW.md` is the ledger of what holds and what doesn't. **Update it every run.**
 

--- a/bench/chromium/AGENTS.md
+++ b/bench/chromium/AGENTS.md
@@ -1,0 +1,368 @@
+# Chromium shared-nothing benchmark — agent guide
+
+Read this BEFORE running or changing anything here. Everything below was paid for
+with a wrong answer that survived until an adversarial review killed it.
+
+## THE ONE RULE
+
+**A number you cannot defend under adversarial review is worse than no number.**
+The 2026-08-07 run produced a full report whose headline claims were then retracted:
+memory density, egress-mode ordering, throughput, and part of the file-vs-UFFD gap
+all failed review. The measurements were real; the *methodology* made them mean
+nothing. Every rule below exists because one of them broke.
+
+## Six methodology defects — do not reintroduce
+
+1. **Matched accounting basis.** Sum memory over the SAME process set for every
+   configuration you compare. The retracted claim ("fcvm 129 MiB/req beats a warm
+   container pool at 151") summed PSS over `firecracker` processes only, while the
+   pool comparator summed an entire cgroup — it excluded the `fcvm` process, the
+   `unshare` holder, `pasta`, and the page cache holding memory.bin. On a matched
+   whole-machine basis the difference vanished and both *lost* to the pool.
+   Report at least two independent bases (per-clone cgroup/PSS **and** whole-machine
+   `MemAvailable` delta from a quiescent baseline) and **reconcile them**. A 2x gap
+   between bases is a finding, not a rounding error.
+
+2. **Interleave, never block.** Modes/configs must be shuffled request-by-request
+   from a recorded seed, all serves running concurrently. The retracted egress
+   comparison ran each mode in its own ~47 s block, so mode effect was perfectly
+   confounded with wall-clock drift — a pure-orchestration probe that never touches
+   egress drifted 631 → 706 ms across those same blocks. Include a **drift control
+   probe** (a request that exercises none of the varied dimension) so drift is
+   measurable and removable.
+
+3. **The burst is the experimental unit.** Clones inside one burst share a 3-second
+   window and one instantaneous machine state — they are pseudoreplicates, not n=16.
+   Repeat bursts (>= 5) and compute CIs over bursts. Also: the retracted report led
+   with a burst figure (3.98 req/s) that its own sustained phase contradicted
+   (7.7 rps, 0 skipped, box not saturated). If two phases disagree, that disagreement
+   is the result — explain it, don't pick the prettier one.
+
+4. **`RUST_LOG=fcvm=debug`, always.** At `info` the exec client's retry ladder is
+   invisible, which made ~70 ms of a 310 ms file-vs-UFFD gap *unresolvable* — fcvm's
+   own 100 ms polling was indistinguishable from real guest latency (the UFFD arms
+   sat in a suspiciously empty 100–139 ms band). The ladder now starts at 5 ms and
+   logs attempts + cumulative wait: USE those lines to attribute every wait.
+
+5. **Slopes need intercepts.** `req/GB = 1024/slope` discarded intercepts that
+   differed by 330 MiB, so the claimed ordering only held asymptotically and
+   *inverted* at realistic concurrency. Report slope AND intercept with uncertainty,
+   state the N range measured, and give req/GB at concrete N.
+
+6. **Quote uncertainty; round to it.** "129.0 MiB" on data carrying ±20–70 MiB is a
+   false claim dressed as precision.
+
+## Environment traps (each cost real time)
+
+- **`/mnt/fcvm-btrfs` is ephemeral instance-store.** A stop/start wipes it: rootfs,
+  kernels, initrd, snapshots, image-cache — all gone. Recovery is one command,
+  `make setup-fcvm` (~5 min; it boots a VM to build the 10 GB Layer-2 rootfs and
+  waits for `FCVM_SETUP_COMPLETE` on the serial console). Golden snapshots must be
+  rebuilt after. Verified 2026-08-08 after a nightly restart.
+- **This box is shared with other agents.** Before measuring: check `uptime` and
+  `pgrep -c firecracker`. Contention silently inflates every number. If load is
+  non-trivial, say so in the report or re-run — do not quietly publish.
+- **After a reboot the page cache is cold.** Discard warmup iterations EXPLICITLY
+  and say you did; otherwise cold-cache runs inflate p50.
+- **`scripts/ci-stray-vm-guard.sh` is DESTRUCTIVE** — it SIGKILLs everything matching,
+  with no interlock against a concurrent job. An agent ran it "to exercise it" and
+  killed another agent's live test. Use `--dry-run`. Never run it on a shared box.
+- **Poisoned CI caches are real.** A runner that dies mid-write with
+  `CACHE_ON_FAILURE: true` persists a truncated cache that later restores and makes
+  `cargo build` segfault in 70 ms. If a build fails impossibly fast, check cache
+  sizes against a known-good ref before blaming the branch.
+
+## Chromium findings worth preserving
+
+- **`VK_ICD_FILENAMES` pre-seed in `entry.sh` is LOAD-BEARING. Do not delete it.**
+  It works around an upstream ANGLE bug ([issues.angleproject.org/issues/543664586](https://issues.angleproject.org/issues/543664586)):
+  `ScopedVkLoaderEnvironment` calls `setenv()` after threads exist, racing fontconfig's
+  `getenv()`; glibc `realloc`s the environ array and frees it under the reader →
+  SIGSEGV during early init. Only exposed under `--single-process`/`--in-process-gpu`.
+  Root-caused from a symbolized core dump; report + patch in `upstream/`.
+- **THE PARITY TRAP.** That race depends on whether glibc's realloc happens to grow
+  in place. Adding *any* env var flips parity, so a clean natural run is **NOT**
+  evidence of a fix — adding one dummy var gave 0/336 failures, statistically
+  identical to the real fix, and 15/15 failures under amplification. Same trap
+  killed a `--no-zygote` "fix". **Verify race fixes with a race amplifier**
+  (a `getenv` that sleeps mid-walk), not with natural rates.
+- **RSS lies about shared memory.** `--single-process` looked like it saved ~460 MB
+  on RSS; on PSS the real saving was ~33 MiB idle, and it was *worse* than
+  site-isolation-off while actively rendering. RSS counts each shared page once per
+  process, and the baseline runs 10–11 processes vs 5. Use PSS.
+- **PNG encoding, not rasterization, dominates screenshot cost** (Chromium devs
+  profiled it; CDP's `optimizeForSpeed` exists for this). JPEG q80 measured −40%
+  screenshot, −21% whole request in-VM.
+- **`--deterministic-mode` is a trap on aarch64** — it bundles
+  `--disable-skia-runtime-opts`, disabling NEON in exactly the raster/encode path
+  you care about. Take its sub-flags selectively.
+- **`--disable-software-rasterizer` silently kills WebGL** while CDP still reports
+  success and the screenshot stays non-uniform (`"WebGL 2.0"` → `"no-webgl"`). A
+  blank-screenshot detector will not catch it. Rejected for that reason.
+- `--headless=old` no longer exists (removed in M132).
+
+## fcvm internals found while building the request path
+
+These came out of a resident-request-server design that was **superseded** by the
+chosen one (expose Chromium's CDP port directly and drive it from the host — see
+`entry.sh`). The design is gone; these two facts about fcvm outlive it.
+
+### fcvm's vsock port map, and where a new port may go
+
+Verified against source, not guessed:
+
+| Port | Purpose | Defined in |
+|---|---|---|
+| 4995 | boot plan | `fc-agent/src/bootplan.rs`, `src/commands/common.rs` |
+| 4996 | TTY exec | `fc-agent/src/tty.rs`, `src/commands/common.rs` |
+| 4997 | output stream | `fc-agent/src/vsock.rs`, `src/commands/podman/listeners.rs` |
+| 4998 | exec | `fc-agent/src/vsock.rs`, `src/commands/exec.rs` |
+| 4999 | container status (`ready`, `exit:{code}`) | `fc-agent/src/vsock.rs`, `src/commands/common.rs` |
+| 5000 + N | volume servers, one per volume | `src/commands/common.rs::VSOCK_VOLUME_PORT_BASE`, `src/volume/mod.rs` |
+| 52000 | egress proxy | `src/network/egress_proxy.rs`, `fc-agent/src/vsock.rs` |
+
+**Rule for a new guest-side vsock port: pick above the volume range and far below
+52000.** The volume block is open-ended (one port per volume, growing upward from
+5000), so anything at 5001–5010 is a future collision; anything near 52000 crowds
+the egress proxy. The host side of any port is a `{uds_path}_{port}` Unix socket
+next to `vsock.sock` — the same `{uds_path}_{port}` convention for both Firecracker
+and Cloud Hypervisor.
+
+### fc-agent's 2 s optimistic-accept fallback is a mio artifact, not a vsock law
+
+`fc-agent/src/vsock.rs::accept()` wakes every 2 s to retry a non-blocking `accept4`,
+because a vsock connection delivered while the VM is PAUSED can sit in the accept
+queue with no readiness edge ever arriving after resume (#617). That is a real bug
+and the fallback really does fix it — **but only because tokio's registration is
+edge-triggered**. `mio`'s `interests_to_epoll()` starts `let mut kind = EPOLLET;`
+(`mio-1.2.2/src/sys/unix/selector/epoll.rs:130`) and there is no way to ask it for
+a level-triggered registration.
+
+Under **level-triggered** epoll the failure mode cannot occur: `epoll_wait` reports
+a non-empty accept queue on *every* call regardless of edges, so a queued-but-edgeless
+connection is delivered on the next wait with no timer involved. Confirmed by
+construction in a prototype that registered the same listener with Python's
+`select.epoll` (level-triggered by default — no `EPOLLET`) and needed no fallback.
+
+**So this is a live sleep-removal candidate the sleep audit did not catch**: register
+that one listener level-triggered (raw `epoll_ctl`, or an `AsyncFd` alternative that
+does not force `EPOLLET`) and the 2 s wakeup — plus its worst-case 2 s tail on the
+lost-edge path — deletes itself. Do NOT just delete the fallback: with mio as-is it
+is load-bearing. Fix the registration first, then prove it with the #617 repro.
+
+## fcvm reference numbers (main @ 2026-08-08, quiet box)
+
+Compare against these; a large deviation means contention or a regression.
+
+| Metric | Value |
+|---|---|
+| clone spawn → exec-ready | **132 ms p50** (min 121, p90 133, n=10) |
+| — `resolve-fc` | 0.5 ms (was 341 ms: per-clone `git ls-remote`) |
+| — `listeners+state` | 2.5 ms |
+| — `netns+pasta` | 38.0 ms (was ~96: inotify replaced a 50 ms poll) |
+| — `snapshot-load` | 5.8 ms — the actual Firecracker restore primitive |
+| — `resume→ready` | 79.3 ms (was 220: a 201 ms sleep that guarded nothing) |
+| routed first-egress after restore | 0.7 ms (was 1002.5 — IPv6 DAD) |
+| reflink, 12.8 GB disk | 9.4 ms (tracks extent count; the published 1.5 ms does not generalize) |
+| host-native warm Chromium floor | ~245 ms |
+
+`--exec` runs in-container via podman entry (~94–100 ms) vs `crun exec` (~4 ms) —
+known, unfixed, and a real component of any end-to-end number.
+
+### CDP handshake is now a PER-REQUEST cost — measure it, don't drop it
+
+Under the chosen design (Chromium's DevTools port exposed and driven from the host)
+the CDP connect happens on every request. Under the superseded resident-server
+design it would have happened once, before the snapshot. It is therefore the one
+cost that design would have removed, and it must be reported rather than quietly
+dropped. `render.py`'s `connect` stage — `/json/list` + TCP + the RFC 6455 upgrade —
+is what to look at.
+
+**These are scavenged from existing logs, NOT a benchmark.** They are here so the
+number is not lost and so a proper measurement has something to disagree with. All
+three are the *in-guest* connect to `127.0.0.1:9222`, so they exclude the host↔guest
+hop that the chosen design adds; a host-driven connect over fcvm port forwarding
+will be **larger** than every figure below.
+
+| Source | n | p50 | p90 | max |
+|---|---|---|---|---|
+| host container, no VM (`scratchpad/cb/*.jsonl`) | 1332 | 3.5 ms | 10.4 ms | 15.4 ms |
+| restored clone, quiet box (`scratchpad/cb/vmlogs/clone-*.log`) | 104 | 10.7 ms | 13.8 ms | 15.4 ms |
+| restored clone, under benchmark load (`results/20260808-corrected/requests/*.log`) | 1138 | 19.1 ms | 30.5 ms | 39.2 ms |
+
+The single `connect_ms=13.3` sample that has been quoted around this work is one
+draw from row 2 (`clone-base-png-medium-1.log`) — roughly its p85, and **not** a
+container-local figure. Do not cite it as a point estimate.
+
+Note the load sensitivity: p50 nearly doubles from quiet box to loaded box. Any
+per-request CDP handshake number is only meaningful with the concurrency stated
+next to it. `results/…` rows exclude the `url=noop` drift-control probe, which
+prints a hardcoded `connect_ms=0.0`.
+
+## The request-optimized path (CDP direct + fast teardown)
+
+The measured 573 ms request breaks into ~145 ms of request-INDEPENDENT process
+startup, 226 ms of actual render, and ~154 ms of teardown that runs AFTER the
+screenshot already exists. The hypervisor restore is 4 ms. Two changes attack the
+two non-render parts; they are separate arms in `reqbench.py` so they can be
+attributed separately.
+
+**Chromium's CDP endpoint IS the request server.** Do not wrap it. An earlier
+design put a resident Python server in the guest speaking a bespoke JSON protocol
+over vsock; it was deleted before it ran. CDP already returns the screenshot as
+base64 in the `Page.captureScreenshot` response, already carries metadata, and is
+already specified. Wrapping it adds a resident interpreter to every clone, a
+custom wire format to debug, and — the expensive part — a
+`VIRTIO_VSOCK_EVENT_TRANSPORT_RESET` problem to solve, since a snapshot restore
+invalidates guest vsock sockets. **Chromium's listener is ordinary in-guest TCP,
+which a restore does not touch, so that entire problem disappears by not being
+created.**
+
+### Reaching CDP from the host — THREE measured traps
+
+All three were found by verifying instead of assuming, on 2026-08-08, with a
+podman-only reproduction (no VM). Each fails SILENTLY.
+
+**1. `HEALTHCHECK` is dropped by podman's default OCI image format.**
+`podman build` prints `HEALTHCHECK is not supported for OCI image format and will
+be ignored` as a *warning* and succeeds. The image then has no healthcheck, fcvm's
+health gate never sees one, and the golden snapshot triggers on the wrong
+condition. **Build with `--format docker`.** Verify:
+`podman inspect <img> --format '{{json .HealthCheck}}'` must print the Test array.
+
+**2. `--remote-debugging-address=0.0.0.0` IS IGNORED by chromium 151.0.7922.71
+(Debian bookworm arm64).** The flag is present in `/proc/<pid>/cmdline` and
+`/proc/net/tcp` still shows `127.0.0.1:9222` and nothing else. Reproduced with a
+minimal `chromium --headless=new --no-sandbox --disable-gpu
+--remote-debugging-address=0.0.0.0 --remote-debugging-port=9222`, so it is the
+build, not our flag set. **The failure mode is a TCP connect that succeeds and is
+then RESET** — which reads exactly like the Host-header rejection everyone warns
+about, and is not it. Do not spend an hour on Host headers: check
+`/proc/net/tcp` inside the container FIRST.
+
+**3. `--publish` cannot work on its own, and `--forward-localhost` DOES NOT DO
+WHAT ITS NAME SUGGESTS.** Since Chromium binds guest loopback and fcvm runs guest
+containers `--network=host` (`fc-agent/src/container.rs`), `--publish 9222:9222`
+forwards to the guest's eth0 address where nothing listens.
+
+**`--forward-localhost` is GUEST -> HOST, not host -> guest.** This was written
+here the wrong way round on 2026-08-08 and cost a full golden-snapshot build to
+discover. The flag's own help says it: *"Enables containers to reach host-only
+services via localhost"* (`src/cli/args.rs:236`). The guest side
+(`fc-agent/src/network.rs:479 setup_localhost_forwarding`) makes the guest's
+`127.0.0.1:<port>` dial **`10.0.2.2:<port>`**, the host gateway; the host side
+(`src/network/routed.rs:715-741`) listens on that alias inside the namespace and
+relays to the HOST's `127.0.0.1:<port>`.
+
+Pointing it at 9222 does not merely fail to help — it **HIJACKS the guest's own
+loopback CDP port**, so Chromium's readiness probe inside `entry.sh` is redirected
+to the host, finds nothing, and the container exits 1. Observed symptom:
+`fcvm::network::tcp_proxy: localhost forward connect failed error=connecting to
+host loopback peer=10.0.2.100:<port>` repeating, then
+`ERROR: chromium-cdp not answering ... after 300 tries`.
+
+**There is NO fcvm feature today that exposes a guest-LOOPBACK port to the host.**
+Not routed, not rootless, not bridged. Adding one is a real fcvm change with its
+own PR and review; it must not be faked in a bench harness.
+
+The way that works today, measured, is a relay inside the container plus ordinary
+`--publish`:
+
+| Hop | Mechanism | Cost |
+|---|---|---|
+| host -> guest eth0:9223 | `--publish 9223:9223`; clones inherit `port_mappings` from snapshot metadata (`src/commands/snapshot.rs:1001/1051/1070`) | measured in `port_wait_ms`, 0.12 ms |
+| guest eth0:9223 -> guest loopback:9222 | `socat TCP-LISTEN:9223,fork` in `entry.sh` | **2.0 MiB PSS**, 0.59% of container PSS |
+
+Verified working on `--network rootless` (no root needed). `reqbench.sh` defaults
+to rootless for this reason.
+
+### The health gate is the snapshot trigger
+
+With no `--health-check` URL, fcvm's `Healthy` = container running AND podman's
+`HEALTHCHECK` healthy (`src/health.rs`, "AND logic"). So the image's HEALTHCHECK
+decides what gets frozen. `cdp_health.py` requires BOTH a warm marker (entry.sh
+touches it only after a full navigate+screenshot) AND a live CDP round trip that
+finds a page target. Healthy therefore means *provably able to screenshot*, not
+*port is open*. Caveat to verify: podman healthchecks need systemd timers in the
+guest; `src/health.rs` notes they can fail to schedule in some rootless setups.
+
+### Fast teardown: one signal, kernel-enforced, cannot leak
+
+`kill(fcvm, SIGKILL)` is the whole teardown. fcvm spawns Firecracker and the
+namespace holder with `PR_SET_PDEATHSIG=SIGKILL`, so the kernel's
+`forget_original_parent()` pass delivers SIGKILL to **both, concurrently, in one
+pass** — no ordering to get wrong, and no cleanup code of ours that must survive a
+SIGKILL. This is the chain PR #730 restored after ~490 VMs leaked.
+Regression proof: `test_sigkill_kills_firecracker_rootless` (podman-run flavour)
+and `test_bench_fast_teardown_leaks_nothing_clone` (the clone flavour the bench
+actually uses, via the snapshot-restore spawn path).
+
+Because SIGKILL cannot be caught, `cleanup_vm` never runs and the state file and
+data dir survive. `reqbench.py` reaps them **synchronously** after the clock
+stops — no janitor. The clone-path test asserts the state file is still there
+after the kill, precisely so nobody deletes that reap step.
+
+### Teardown is NOT free — measured, not asserted
+
+Kernel address-space reclaim, measured VM-free on this box (64 cores, 125 GB) with
+the same parent+pdeathsig topology, median of 3 per size, `/proc/<pid>/stat` read
+in the `Z` state so the figure is complete (`exit_mm()` runs before
+`exit_notify()`, so a zombie-state read already includes all reclaim):
+
+| Address space | reap wall | reclaim CPU |
+|---|---|---|
+| 256 MiB | 15.2 ms | 30 ms |
+| 512 MiB | 32.2 ms | 50 ms |
+| 1024 MiB | 63.5 ms | 110 ms |
+| 2048 MiB | 121.4 ms | 180 ms |
+
+≈ **62 ms wall/GiB, ≈ 90–120 ms CPU/GiB**, linear. CPU EXCEEDS wall, so reclaim
+runs on more than one core: moving it off the response path does not make it free,
+it makes it concurrent. **The claim "early response converts teardown from LATENCY
+into THROUGHPUT cost" is supported — "converts", never "removes".** At saturation
+that ~110 ms CPU/GiB competes with new requests. Do not report the latency win as a
+capacity win.
+
+Caveat: synthetic dirty-anon pages, not Firecracker's MAP_PRIVATE file-backed
+guest memory; clean file-backed pages may unmap cheaper. Corroboration: the
+observed 78 ms VM teardown for a ~1 GB VM sits right on the 62 ms/GiB line.
+
+## Claims currently REFUTED — do not re-publish without new data
+
+- "fcvm beats a warm container pool on marginal memory (129 vs 151 MiB)"
+- any egress-mode *ordering* (all modes collapsed to ~1.30 ± 0.06 s under review)
+- "16 clones sustain 5.5–6.3 req/s" (n=1 bursts; sustained data said 7.7 rps)
+- "7.9 vs 5.3 req/GB" (slope without intercept)
+- ~70 ms of the 310 ms file-vs-UFFD gap (unattributable at `RUST_LOG=info`)
+
+`REVIEW.md` is the ledger of what holds and what doesn't. **Update it every run.**
+
+## Deliverables
+
+The end product is a **readable markdown benchmark with inline visualizations**, in
+the spirit of `~/src/editor-loop-bench/SUMMARY.md` (read it before writing). Match the
+*idea*, not the literal format:
+
+1. **Lead with the one idea.** That report opens with a conceptual split (O(repo) vs
+   O(closure)) that makes every later number obvious. Find ours and state it first —
+   a table of numbers with no thesis is a data dump, not a benchmark.
+2. **Machine + versions in the first screenful**, with a pointer to the raw file that
+   records them (`hostinfo.json`). Reader must be able to tell what hardware this was.
+3. **Every figure traceable to a raw record** — cite the json file (and the cell) next
+   to the table it came from. Extrapolations **labeled as extrapolations**.
+4. **Tables organized by the question a reader has** (per-request cost, density,
+   throughput, mode comparison), not by the order you ran the phases.
+5. **Charts inline.** `charts/*.svg`, referenced from the markdown. **Load the
+   `dataviz` skill BEFORE writing any chart code** — it is not optional, and it covers
+   palette, light/dark, and stat tiles so the set reads as one system.
+   Best candidates here: the per-request stage-breakdown stack, the memory-vs-concurrency
+   regression (show intercept AND slope, with a CI band), the utilization→throughput
+   curve from the scalability run, and a mode-comparison interval plot that shows
+   overlapping CIs honestly rather than implying an ordering.
+6. **Publish an artifact** (HTML via the Artifact tool) for the visual version, and
+   keep the markdown as the in-repo source of record. Self-contained, theme-aware.
+7. **`REVIEW.md` is a first-class deliverable**, not an appendix: what holds, what was
+   refuted, what remains unmeasured.
+
+`results/` is gitignored — commit the harness, the charts, and the findings, not the
+raw output. Uncertainty goes in the tables, not just the prose.

--- a/bench/chromium/AGENTS.md
+++ b/bench/chromium/AGENTS.md
@@ -91,8 +91,13 @@ nothing. Every rule below exists because one of them broke.
   site-isolation-off while actively rendering. RSS counts each shared page once per
   process, and the baseline runs 10–11 processes vs 5. Use PSS.
 - **PNG encoding, not rasterization, dominates screenshot cost** (Chromium devs
-  profiled it; CDP's `optimizeForSpeed` exists for this). JPEG q80 measured −40%
-  screenshot, −21% whole request in-VM.
+  profiled it; CDP's `optimizeForSpeed` exists for this). JPEG q80 measured
+  −28.8% on the screenshot STAGE (−52.9 ms, CI −63.8…−44.8) and −8.3% on the
+  whole request (−65.8 ms, CI −83.1…−42.6), n=12, `corrected.json` ->
+  `screenshot_format`. This line used to read "−40% screenshot, −21% whole
+  request"; both figures are contradicted by the record run and REVIEW.md marks
+  the −21% claim **REFUTED AS STATED**. The screenshot is only ~18% of the
+  request, which is why a −29% stage win is an −8% request win.
 - **`--deterministic-mode` is a trap on aarch64** — it bundles
   `--disable-skia-runtime-opts`, disabling NEON in exactly the raster/encode path
   you care about. Take its sub-flags selectively.
@@ -197,37 +202,66 @@ cost that design would have removed, and it must be reported rather than quietly
 dropped. `render.py`'s `connect` stage — `/json/list` + TCP + the RFC 6455 upgrade —
 is what to look at.
 
-**These are scavenged from existing logs, NOT a benchmark.** They are here so the
-number is not lost and so a proper measurement has something to disagree with. All
-three are the *in-guest* connect to `127.0.0.1:9222`, so they exclude the host↔guest
-hop that the chosen design adds; a host-driven connect over fcvm port forwarding
-will be **larger** than every figure below.
+**The only auditable figure is the primary cell of the record run.** It is
+`corrected.json` -> `primary_cell.stages.r_connect_ms`:
 
-| Source | n | p50 | p90 | max |
-|---|---|---|---|---|
-| host container, no VM (`scratchpad/cb/*.jsonl`) | 1332 | 3.5 ms | 10.4 ms | 15.4 ms |
-| restored clone, quiet box (`scratchpad/cb/vmlogs/clone-*.log`) | 104 | 10.7 ms | 13.8 ms | 15.4 ms |
-| restored clone, under benchmark load (`results/20260808-corrected/requests/*.log`) | 1138 | 19.1 ms | 30.5 ms | 39.2 ms |
+| Source | n | median | 95% CI |
+|---|---|---|---|
+| restored clone, primary cell, one request at a time (`corrected.json`) | 12 | 16.7 ms | 16.4–16.9 ms |
 
-The single `connect_ms=13.3` sample that has been quoted around this work is one
-draw from row 2 (`clone-base-png-medium-1.log`) — roughly its p85, and **not** a
-container-local figure. Do not cite it as a point estimate.
+That is the *in-guest* connect to `127.0.0.1:9222`, so it excludes the host↔guest
+hop the chosen design adds; a host-driven connect over fcvm port forwarding will
+be **larger**.
 
-Note the load sensitivity: p50 nearly doubles from quiet box to loaded box. Any
-per-request CDP handshake number is only meaningful with the concurrency stated
-next to it. `results/…` rows exclude the `url=noop` drift-control probe, which
-prints a hardcoded `connect_ms=0.0`.
+**Three scavenged rows were deleted from this table on 2026-08-08.** They quoted
+a host-container p50 of 3.5 ms (n=1332), a quiet-box clone p50 of 10.7 ms
+(n=104), and a loaded-box p50 of 19.1 ms (n=1138), and concluded "p50 nearly
+doubles from quiet box to loaded box". None of the three is auditable from this
+repo: the first two cite `scratchpad/`, which `git ls-tree` shows is not in the
+tree at all, and the third cites a `requests/*.log` directory under a `results/`
+path that `.gitignore` excludes — so all three violate this file's own
+Deliverables rule 3 ("every figure traceable to a raw record"), and the only
+comparative claim in the block rested entirely on the two uncommitted ones. The
+19.1 ms figure ALSO sat unreconciled next to REVIEW.md's 16.7 ms (16.4–16.9) for
+the same stage in the same PR — two point estimates of one quantity, the exact
+defect the `snapshot-load` entry below was written about. They are different
+populations (all cells and concurrencies under load, vs the primary cell one at a
+time), which is a fine explanation that neither document was making. If the
+load-sensitivity claim matters, re-measure it and commit the record.
+
+`results/…` figures exclude the `url=noop` drift-control probe, which prints a
+hardcoded `connect_ms=0.0`. Any per-request CDP handshake number is only
+meaningful with the concurrency stated next to it.
 
 ## The request-optimized path (CDP direct + fast teardown)
 
-The measured 573 ms request breaks into ~145 ms of request-INDEPENDENT process
-startup, ~226 ms of actual render, and ~154 ms of teardown that runs AFTER the
-screenshot already exists. The hypervisor restore is **~6 ms** — the single
-`snapshot-load` figure from the reference table above; this line used to say 4 ms
-and the table 5.8 ms, which was two point estimates of one quantity disagreeing
-by 45% with no interval between them. Two changes attack the two non-render
-parts; they are separate arms in `reqbench.py` so they can be attributed
-separately.
+Every figure below is `corrected.json` -> `primary_cell.stages`, n=12, cell
+`rootless-proxy`/`uffd-4k`/`medium`/JPEG q80, with its 95% CI:
+
+- **request-independent startup ~305 ms** — restore 52.9 (52.0–54.0) + fcvm exec
+  handshake 28.0 (27.0–29.5) + guest command start 224.5 (217.0–232.0).
+- **render ~356 ms** — CDP handshake 16.7 (16.4–16.9) + page load 204.0
+  (196.6–207.3) + screenshot 133.8 (120.8–144.2) + DOM 1.8 (1.6–2.1).
+- **teardown 175.1 ms (150.4–194.9)**, entirely AFTER the artifact exists.
+- **total 890.6 ms (869.6–928.9)**; artifact 730.1 (708.4–741.1).
+
+So startup is ~34% and teardown ~20% of wall clock — both attackable, which is
+the design argument. Two changes attack the two non-render parts; they are
+separate arms in `reqbench.py` so they can be attributed separately.
+
+*This paragraph used to read "the measured 573 ms request breaks into ~145 ms of
+request-INDEPENDENT process startup, ~226 ms of actual render, and ~154 ms of
+teardown". Three defects: `git grep 573` found exactly two hits — this line and a
+comment in `reqbench.py` citing this line, a circular citation and not evidence;
+145 + 226 + 154 = 525, forty-eight milliseconds short of 573, unattributed and
+unmentioned; and REVIEW.md L3 says "Quote only from `20260808-corrected`", whose
+primary cell is 890.6 ms total, not 573. No committed artifact on this branch
+produces 573 ms.*
+
+The hypervisor restore is **~6 ms** — the single `snapshot-load` figure from the
+reference table above; this line used to say 4 ms and the table 5.8 ms, which was
+two point estimates of one quantity disagreeing by 45% with no interval between
+them.
 
 **Chromium's CDP endpoint IS the request server.** Do not wrap it. An earlier
 design put a resident Python server in the guest speaking a bespoke JSON protocol
@@ -249,8 +283,15 @@ podman-only reproduction (no VM). Each fails SILENTLY.
 `podman build` prints `HEALTHCHECK is not supported for OCI image format and will
 be ignored` as a *warning* and succeeds. The image then has no healthcheck, fcvm's
 health gate never sees one, and the golden snapshot triggers on the wrong
-condition. **Build with `--format docker`.** Verify:
-`podman inspect <img> --format '{{json .HealthCheck}}'` must print the Test array.
+condition. **Build with `--format docker`.** Verify with a command that FAILS —
+"must print the Test array" is an instruction to a human, inside a block designed
+to be pasted, and it exits 0 either way. This is the check `reqbench.sh` already
+gates on, so there is one gate to keep correct rather than two:
+
+```bash
+podman image inspect <img> --format '{{json .HealthCheck}}' \
+  | grep -q cdp_health || { echo 'FATAL: image has no HEALTHCHECK (OCI format drop?)'; exit 1; }
+```
 
 **2. `--remote-debugging-address=0.0.0.0` IS IGNORED by chromium 151.0.7922.71
 (Debian bookworm arm64).** The flag is present in `/proc/<pid>/cmdline` and
@@ -403,6 +444,15 @@ this list now points at it rather than contradicting it.
   quote a burst figure as throughput.
 - "7.9 vs 5.3 req/GB" (slope without intercept) — **REPLACED** (REVIEW.md row 4).
 - ~70 ms of the 310 ms file-vs-UFFD gap — **RESOLVED** (REVIEW.md row 5).
+- "JPEG q80 −21% per request" — **REFUTED AS STATED** (REVIEW.md, SURVIVED table).
+  The screenshot-STAGE win is real (−28.8%); the whole-request win is −8.3%. This
+  list omitted the claim entirely while the Chromium-findings section above kept
+  publishing the refuted number, which is precisely the disagreement the preamble
+  above says this list exists to end.
+- every figure from the `reqbench` CDP A/B — **WITHDRAWN IN FULL** (REVIEW.md,
+  "The CDP-path A/B"). `exec 565 ms`, `cdp 384 ms`, `cdp-fast 372 ms`,
+  `PART 1 −180.5 ms`, `reclaim CPU 0.00 ms`, the `+610.4 ms` machine cost and the
+  `pasta 704 ms` straggler are all withdrawn; do not quote any of them.
 
 `REVIEW.md` is the ledger of what holds and what doesn't. **Update it every run.**
 

--- a/bench/chromium/CLAUDE.md
+++ b/bench/chromium/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/bench/chromium/README.md
+++ b/bench/chromium/README.md
@@ -49,8 +49,15 @@ Fan-out phases add burst latency and marginal memory per concurrent request.
 # pass — so the golden snapshot would fire on a COLD browser.
 podman build --format docker -t localhost/chromium-bench -f Containerfile.chromium-bench .
 
-# ...and verify it survived. This must print the Test array, not `null`:
-podman inspect localhost/chromium-bench --format '{{json .HealthCheck}}'
+# ...and verify it survived — this FAILS (exit 1) if the OCI format dropped it.
+# It must FAIL, not print a warning: fcvm treats a MISSING healthcheck as a PASS
+# (src/health.rs AND-logic), so a dropped HEALTHCHECK means the golden snapshot
+# fires on a COLD browser and silently inflates page load, screenshot, artifact
+# and total for every restore in the run. `bench.sh` — the harness
+# `make bench-chromium` actually runs — has no build step and no healthcheck
+# check, so on that route this line is the ENTIRE verification.
+podman image inspect localhost/chromium-bench --format '{{json .HealthCheck}}' \
+  | grep -q cdp_health || { echo 'FATAL: image has no HEALTHCHECK (OCI format drop?)'; exit 1; }
 
 # host smoke test, no VM:
 podman run -d --name cb localhost/chromium-bench

--- a/bench/chromium/README.md
+++ b/bench/chromium/README.md
@@ -44,7 +44,13 @@ Fan-out phases add burst latency and marginal memory per concurrent request.
 
 ```bash
 # repo root context (.dockerignore excludes target/)
-podman build -t localhost/chromium-bench -f Containerfile.chromium-bench .
+# --format docker is LOAD-BEARING: podman's default OCI format drops the image's
+# HEALTHCHECK with only a warning, and fcvm treats a MISSING healthcheck as a
+# pass — so the golden snapshot would fire on a COLD browser.
+podman build --format docker -t localhost/chromium-bench -f Containerfile.chromium-bench .
+
+# ...and verify it survived. This must print the Test array, not `null`:
+podman inspect localhost/chromium-bench --format '{{json .HealthCheck}}'
 
 # host smoke test, no VM:
 podman run -d --name cb localhost/chromium-bench

--- a/bench/chromium/REVIEW.md
+++ b/bench/chromium/REVIEW.md
@@ -27,11 +27,23 @@ harness defect that caused it is fixed in this PR with a regression test.
 | "Early response converts teardown from latency into throughput cost" — REFUTED | The refutation rested on the two rows above (the machine-cost figure and the pasta straggler). Both are withdrawn, so the refutation is withdrawn with them. The premise returns to **untested**, not to supported. |
 | `n` for every CDP arm | The harness aborted the whole run on any per-rep exception (`run_exec_request` had a bare `proc.wait(timeout=...)`), and a dropped rep produced no record. So the denominators are not auditable from the artifact. |
 
-**Availability gate for the re-run.** Per AGENTS.md's amplification discipline: at
-least **200 CDP requests per backend at 0 failures** before any CDP latency figure
-is quoted. At 0/200 the CP upper bound is 1.5%, which is the first point at which
+**Availability gate for the re-run.** Per the two-sided Clopper-Pearson convention
+used throughout this file: at least **200 CDP requests per backend at 0 failures**
+before any CDP latency figure is quoted. At 0/200 the CP upper bound is 1.8%
+(`reqanalyze.clopper_pearson(0, 200)` -> [0.000%, 1.828%]); n=200 is where the
+zero-failure upper bound first falls below 2%, which is the first point at which
 "we do not drop requests" is a defensible statement rather than a hope. Today the
 observed rates are ~1 in 60 (file) and ~1 in 10 (UFFD), so this gate fails loudly.
+
+*(This said **1.5%** and attributed the gate to "AGENTS.md's amplification
+discipline". 1.5% is the ONE-sided bound, `1 - 0.05**(1/200) = 1.487%`, i.e. 22%
+tighter than the data supports and inconsistent with the convention this file
+declares four paragraphs below; and AGENTS.md's only amplification passage is the
+ANGLE parity trap — it contains no availability gate, so the attribution was
+invented. Six of this file's seven bounds reproduce exactly against
+`reqanalyze.clopper_pearson`; this was the sole outlier, and
+`DocLint.test_every_binomial_bound_matches_reqanalyze_clopper_pearson` now
+recomputes every one of them.)*
 
 **Root cause of the `WsClosed` drops: still undetermined.** `render.py`'s
 `_recv_until` discarded any bytes the peer coalesced past the `\r\n\r\n` of the
@@ -44,7 +56,7 @@ it is the only arm that fails.
 
 **"0 failures" is not a 0% failure rate.** Every success count in this file is
 exact-binomial bounded, not a guarantee: **0/426 is [0, 0.86%]**, **0/462 is
-[0, 0.79%]**, and the single timeout at the `minor`-4K cell is **1/459 = 0.22%
+[0, 0.80%]**, and the single timeout at the `minor`-4K cell is **1/459 = 0.22%
 [0.006%, 1.21%]** (Clopper-Pearson, 95%, two-sided; `reqanalyze.clopper_pearson`
 computes these). Quote the interval whenever the count is used to support a
 claim about reliability.
@@ -63,7 +75,7 @@ change mid-run (sha256 in `hostinfo.json`).
 |---|---|---|
 | 1 | "fcvm marginal memory beats a warm container pool (129 vs 151 MiB)" | **SUPPORTED, but much smaller than claimed, and only for some backends.** On a matched cgroup basis: file-backed **143.5 ± 0.4** vs pool **156.5 ± 5.0** MiB/req — an 8% win, not a comfortable one. UFFD copy-mode **loses** (257.8 ± 1.1). UFFD `minor` wins clearly (132.5 ± 1.0 at 4K; **34.7 ± 0.4** with hugepages). |
 | 2 | any egress-mode *ordering* | **STILL NOT SUPPORTED.** The confound is gone (drift term −68.8 ± 51.9 ms/h, n.s.) and within-run SE is now 8.4 ms, but run-to-run shifts reach 52 ms and the IPv6 modes swap rank. Only "the two IPv4 rootless modes are fastest" reproduces; total spread ~110 ms of ~800 ms. |
-| 3 | "16 clones sustain 5.5–6.3 req/s" | **SUPERSEDED.** Throughput, file-backed N=16, sustained phase: **7.26 rps**, 462/462 completed. That is the throughput figure. *Burst figures are NOT throughput and must not be quoted as such* (see the binding requirement below); for completeness the burst cell, with the burst as the experimental unit (5 bursts/cell), came out at 6.44 requests-per-burst-window (CI 6.37–6.70) file-backed and 7.39 (7.16–7.67) hugepage-minor — i.e. the burst *understates* capacity, which is why leading with it was the original defect. |
+| 3 | "16 clones sustain 5.5–6.3 req/s" | **SUPERSEDED.** Throughput, file-backed N=16, sustained phase: **7.3 rps** — 462 completions in 63.6 s, a **SINGLE** sustained window per cell, so n=1 window and no run-to-run rate interval is derivable from the data as collected (the burst cells are replicated 5x and do carry CIs). all 462 launched requests completed — 0/462 incomplete, CP 95% [0, 0.80%]. *Burst figures are NOT throughput and must not be quoted as such* (see the binding requirement below); for completeness the burst cell, with the burst as the experimental unit (5 bursts/cell), came out at 6.4 req/s measured **within** the burst window (CI 6.4–6.7) file-backed and 7.4 (7.2–7.7) hugepage-minor — i.e. the burst *understates* capacity, which is why leading with it was the original defect. |
 | 4 | "7.9 vs 5.3 req/GB" (slope without intercept) | **REPLACED.** Slopes now carry intercepts and SEs and req/GiB is quoted at concrete N. At N=8: hugepage-minor 27.7, minor-4K 7.5, file-4K 7.0, pool 5.5, copy-4K 3.9. |
 | 5 | ~70 ms of the file-vs-UFFD gap unattributable at `RUST_LOG=info` | **RESOLVED.** At debug the exec retry ladder logged **0.0 ms cumulative retry wait in all 426 requests** (max 0.0) — the quantization is absent, not merely smaller. |
 
@@ -83,8 +95,11 @@ change mid-run (sha256 in `hostinfo.json`).
   concurrent request** (MemAvailable basis 29.1 ± 1.1) — 4.5x better than the warm container pool
   and 7.4x better than UFFD copy-mode. At 4K: 132.5 ± 1.0.
 - **`minor` buys memory, not rate.** At a sustained 8 rps the 4K `minor` cell needed 165 s to
-  drain 459 requests (2.78 rps achieved, p50 1224 ms, 1 request timed out) while file-backed held
-  7.26 rps with 462/462 complete. The serve process is the bottleneck.
+  drain 459 requests (2.8 rps achieved, p50 1224 ms, 1 request timed out — 1/459 = 0.22%
+  [0.006%, 1.21%]) while file-backed held 7.3 rps with 462/462 complete. Both rates come from a
+  SINGLE window per cell, so neither carries a run-to-run interval; the 2.6x gap is far larger
+  than any plausible one-window spread, which is why the *direction* is quoted and the third
+  significant figure is not. The serve process is the bottleneck.
 - **End-to-end request, measured end to end in one run** (not composed): artifact **730.0 ms**
   (708.4–741.0), total **890.6 ms** (869.6–929.0).
 - **The guest-side exec cost is attributed by measurement.** An interleaved shell-only control

--- a/bench/chromium/REVIEW.md
+++ b/bench/chromium/REVIEW.md
@@ -1,11 +1,53 @@
 # Adversarial review ledger — chromium shared-nothing bench
 
-Two runs are on record. **Quote only from the second.**
+Three runs are on record. **Quote only from `20260808-corrected`.**
 
 | run | date | verdict |
 |---|---|---|
 | `20260807-full` | 2026-08-07 | comparative numbers **retracted** on methodology (six defects) |
 | `results/20260808-corrected` | 2026-08-08 | six defects corrected; numbers below are the current record |
+| `reqbench` CDP A/B | 2026-08-08 | **WITHDRAWN IN FULL** — see "The CDP-path A/B" below. Harness defects invalidate every figure it produced. |
+
+---
+
+## The CDP-path A/B (`reqbench.py`) — WITHDRAWN, do not quote
+
+This run measured the host-driven CDP request path against the `exec` path and
+reported `exec 565 ms -> cdp 384 ms`, `PART 1 = -180.5 ms CI [-235.5, -176.7]`,
+a per-child teardown breakdown, and `reclaim CPU 0.00 ms`. **None of it may be
+quoted.** Each figure below is withdrawn for a stated, specific reason, and the
+harness defect that caused it is fixed in this PR with a regression test.
+
+| withdrawn figure | why it cannot stand |
+|---|---|
+| `cdp` 384 ms, `cdp-fast` 372 ms, `PART 1 -180.5 ms` | **Success-conditioned with an arm-correlated censoring rate that was never reported.** `reqanalyze` computed every median over `ok` records only and emitted ONE global `n_failed` — there was no per-arm denominator anywhere in its output. The CDP arms dropped requests with `WsClosed` (file **1/60 = 1.7%**, CP 95% CI [0.04%, 8.9%]; UFFD **6/60 = 10.0%**, CI [3.8%, 20.5%]) while `exec` dropped **0/66** (CI [0%, 5.4%]). A ~5.25 s transport drop truncates the right tail, so the arm with 10% censoring has its median pulled down six times harder than the arm with 1.7% — in the same direction as the reported effect. |
+| `reclaim CPU 0.00 ms [0.00, 0.00]` | **Three independent defects, all in the same number.** (a) `/proc/<pid>/stat` is quantized to one jiffy = 10 ms here, so a sub-tick reclaim reports a hard `0.0` — zero with zero uncertainty, defect 6 exactly. (b) The analyzer POOLED all children into one list and discarded the name, so the median of {firecracker, holder, pasta} is the middle child, not the straggler. (c) The per-child sampler ran SEQUENTIALLY, so a child that exited while an earlier one was still being sampled recorded `null`, not a bound. The honest restatement of what was measured is **"below /proc tick resolution (< 20 ms) for every child sampled"** — which is not the same claim. |
+| machine-cost `+610.4 ms, CI [+575.9, +620.3]` per request | **The ambient baseline was measured while the harness held 100% of one core.** The control window was `while time.monotonic()-t0 < 0.05: pass`. Measured on this box, that reports `control_busy_cores` **1.20–1.40** where a sleeping window over the same ambient load reports **0.00–0.40** — roughly one core of the sampler's own spin, then multiplied by the whole reclaim window and subtracted. The control window was also taken BEFORE the kill, so it additionally contains the still-running VM's own CPU, which the reclaim window does not. Systematic over-subtraction in a value published as "ambient subtracted". |
+| per-child teardown: **pasta 704 ms**, firecracker 19.7 ms, holder 0.2 ms | **Measured on a tree without pasta's pdeathsig.** `46dbb789` (on main, and now under this branch) arms `PR_SET_PDEATHSIG(SIGKILL)` on pasta via `pre_exec`. The measurement — and the conclusion drawn from it, "the pdeathsig guarantee does not cover pasta" — describe a tree that no longer exists. Both are withdrawn. The replacement claim is in AGENTS.md: kernel-enforced for the VMM and the holder unconditionally, and for pasta **while fcvm runs as root** (`cred_cap_issubset` holds only under a capability loss). |
+| "Early response converts teardown from latency into throughput cost" — REFUTED | The refutation rested on the two rows above (the machine-cost figure and the pasta straggler). Both are withdrawn, so the refutation is withdrawn with them. The premise returns to **untested**, not to supported. |
+| `n` for every CDP arm | The harness aborted the whole run on any per-rep exception (`run_exec_request` had a bare `proc.wait(timeout=...)`), and a dropped rep produced no record. So the denominators are not auditable from the artifact. |
+
+**Availability gate for the re-run.** Per AGENTS.md's amplification discipline: at
+least **200 CDP requests per backend at 0 failures** before any CDP latency figure
+is quoted. At 0/200 the CP upper bound is 1.5%, which is the first point at which
+"we do not drop requests" is a defensible statement rather than a hope. Today the
+observed rates are ~1 in 60 (file) and ~1 in 10 (UFFD), so this gate fails loudly.
+
+**Root cause of the `WsClosed` drops: still undetermined.** `render.py`'s
+`_recv_until` discarded any bytes the peer coalesced past the `\r\n\r\n` of the
+101 response, which desyncs the very next frame header and surfaces as exactly
+`WsClosed("connection closed mid-frame")`. That is fixed in this PR — but it is a
+**variable removed, not a diagnosis**: Chromium is not expected to push before the
+first command, and the hypothesis was never confirmed against a failing record.
+The CDP arm is the only arm with a `socat` relay and pasta in the byte path, and
+it is the only arm that fails.
+
+**"0 failures" is not a 0% failure rate.** Every success count in this file is
+exact-binomial bounded, not a guarantee: **0/426 is [0, 0.86%]**, **0/462 is
+[0, 0.79%]**, and the single timeout at the `minor`-4K cell is **1/459 = 0.22%
+[0.006%, 1.21%]** (Clopper-Pearson, 95%, two-sided; `reqanalyze.clopper_pearson`
+computes these). Quote the interval whenever the count is used to support a
+claim about reliability.
 
 The 2026-08-08 run: 426 matrix requests / 0 failures, R=12 per cell, 3 reps per density cell,
 5 bursts per throughput cell, one seeded interleaved schedule (`seed=20260808`),
@@ -21,7 +63,7 @@ change mid-run (sha256 in `hostinfo.json`).
 |---|---|---|
 | 1 | "fcvm marginal memory beats a warm container pool (129 vs 151 MiB)" | **SUPPORTED, but much smaller than claimed, and only for some backends.** On a matched cgroup basis: file-backed **143.5 ± 0.4** vs pool **156.5 ± 5.0** MiB/req — an 8% win, not a comfortable one. UFFD copy-mode **loses** (257.8 ± 1.1). UFFD `minor` wins clearly (132.5 ± 1.0 at 4K; **34.7 ± 0.4** with hugepages). |
 | 2 | any egress-mode *ordering* | **STILL NOT SUPPORTED.** The confound is gone (drift term −68.8 ± 51.9 ms/h, n.s.) and within-run SE is now 8.4 ms, but run-to-run shifts reach 52 ms and the IPv6 modes swap rank. Only "the two IPv4 rootless modes are fastest" reproduces; total spread ~110 ms of ~800 ms. |
-| 3 | "16 clones sustain 5.5–6.3 req/s" | **SUPERSEDED.** With the burst as the experimental unit (5 bursts/cell): file-backed N=16 = **6.44 rps (CI 6.37–6.70)**, hugepage-minor = **7.39 (7.16–7.67)**. But the burst *understates* capacity — sustained file-backed reaches **7.26 rps** with 462/462 completed. **Do not quote burst figures as throughput.** |
+| 3 | "16 clones sustain 5.5–6.3 req/s" | **SUPERSEDED.** Throughput, file-backed N=16, sustained phase: **7.26 rps**, 462/462 completed. That is the throughput figure. *Burst figures are NOT throughput and must not be quoted as such* (see the binding requirement below); for completeness the burst cell, with the burst as the experimental unit (5 bursts/cell), came out at 6.44 requests-per-burst-window (CI 6.37–6.70) file-backed and 7.39 (7.16–7.67) hugepage-minor — i.e. the burst *understates* capacity, which is why leading with it was the original defect. |
 | 4 | "7.9 vs 5.3 req/GB" (slope without intercept) | **REPLACED.** Slopes now carry intercepts and SEs and req/GiB is quoted at concrete N. At N=8: hugepage-minor 27.7, minor-4K 7.5, file-4K 7.0, pool 5.5, copy-4K 3.9. |
 | 5 | ~70 ms of the file-vs-UFFD gap unattributable at `RUST_LOG=info` | **RESOLVED.** At debug the exec retry ladder logged **0.0 ms cumulative retry wait in all 426 requests** (max 0.0) — the quantization is absent, not merely smaller. |
 
@@ -69,7 +111,41 @@ change mid-run (sha256 in `hostinfo.json`).
 - **Teardown** (175 ms, post-artifact) was not moved off the response path; the AGENTS.md
   reclaim measurements suggest it converts to throughput cost rather than disappearing.
 
-## Harness bugs found and fixed while producing this run
+## Harness bugs found in `reqbench.py` / `reqanalyze.py` / `reqbench.sh` (2026-08-08)
+
+Found by adversarial review of the CDP A/B, all fixed in this PR, each with a test
+that was watched fail first (`bench/chromium/test_reqbench.py`, and the clone
+flavour in `tests/test_signal_cleanup.rs`):
+
+1. **A vacuous leak assertion.** `test_bench_fast_teardown_leaks_nothing_clone`
+   held the namespace holder as an `Option` and asserted
+   `!holder.is_some_and(running)` — `!false` when discovery returns `None`.
+   Discovery pgreps for the literal `sleep infinity`, so an argv drift silently
+   turned the assertion into nothing while still reading as coverage. It also
+   never looked for pasta at all. Both are now hard-fail-on-absent.
+2. **The teardown reaped the state file and data dir of a VM it had just failed
+   to kill** — `all_gone` was computed, recorded, and then ignored.
+3. **The CPU-accounting control window was a busy-spin** (see the withdrawal
+   table above), and the pre-kill CPU baseline was sampled BEFORE that window, so
+   the delta also absorbed ~50 ms of the live VM's ordinary CPU.
+4. **Per-child CPU sampling was sequential**, so a child that exited while an
+   earlier one was still being sampled recorded `null`.
+5. **`find_state` was an unthrottled `os.listdir` + `json.load` loop** — 400 ms of
+   harness CPU for a 400 ms wait, 100% of a core, at the instant a 2-vCPU clone
+   was restoring on the same box. Now inotify, matching what fcvm itself does.
+6. **The exec arm's `proc.wait(timeout=…)` was unguarded**, so one slow rep raised
+   out of `main()` and orphaned a live clone into the next run.
+7. **`cmd_verify` always exited 0** — all three hops were `|| echo`, so the gate
+   documented as "do this first" could not fail, and `all` proceeded to measure.
+8. **`reqbench.sh` had no `trap`**, and two of three phases never captured `$!`,
+   so every error path leaked a VM or a serve under `set -e`.
+9. **`--ws-url` was passed verbatim to every clone**, naming one fixed host-side
+   address for a whole run in which every clone has its own.
+10. **The target-id stability probe inspected one clone** under a heading that
+    asked a cross-clone question, and `cdpdrive.py --print-target` — the flag its
+    own docstring offers for checking that claim — did not exist.
+
+## Harness bugs found and fixed while producing the 20260808-corrected run
 
 These were live defects in the harness, not in fcvm:
 

--- a/bench/chromium/analyze.py
+++ b/bench/chromium/analyze.py
@@ -32,8 +32,15 @@ import statistics
 import sys
 import time
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from reqanalyze import clopper_pearson  # noqa: E402 - sibling module, one exact-binomial impl
+
 BOOT_N = 10000
 BOOT_SEED = 20260808
+# The sustained phase runs ONE window per cell, so no rate interval is derivable
+# from it as collected. Splitting that window is the best available and is
+# labelled as not-a-replicate; the durable fix is to replicate the window.
+SUSTAINED_SUBWINDOWS = 5
 
 
 # ---------------------------------------------------------------------------
@@ -434,12 +441,43 @@ def analyse_throughput(results, recs, out):
         cell, rate = mrec["cell"], mrec["rate"]
         done = [r for r in recs if r.get("phase") == f"sust-r{rate}" and
                 r.get("arm") == cell and r.get("ok")]
-        dur = mrec.get("t1", 0) - mrec.get("t0", 0)
+        t_lo, t_hi = mrec.get("t0", 0), mrec.get("t1", 0)
+        dur = t_hi - t_lo
         v, lo, hi, k = boot_ci([r["total_ms"] for r in done if r.get("total_ms")])
+        # THE RATE GETS AN INTERVAL TOO. `achieved_rps` was a bare quotient over
+        # ONE 63.6 s window, printed to two decimals into a table whose only CI
+        # column is latency — while the burst path immediately above it bootstraps
+        # its rate because bursts are replicated 5x. Splitting the single window
+        # into equal sub-windows and bootstrapping the per-sub-window rate is not
+        # a substitute for replicating the window (the sub-windows are not
+        # independent draws of a fresh machine state), so it is labelled as what
+        # it is. When the per-request timestamps needed for the split are absent,
+        # emit NO interval rather than a fabricated one.
+        rate_ci = None
+        rate_basis = "single unreplicated window; no interval derivable"
+        comp_ts = [r["t0_ts"] + r["total_ms"] / 1000.0
+                   for r in done if r.get("t0_ts") and r.get("total_ms")]
+        if dur > 0 and len(comp_ts) == len(done) and len(done) >= SUSTAINED_SUBWINDOWS:
+            w = dur / SUSTAINED_SUBWINDOWS
+            counts = [0] * SUSTAINED_SUBWINDOWS
+            for t in comp_ts:
+                i = int((t - t_lo) / w)
+                counts[min(max(i, 0), SUSTAINED_SUBWINDOWS - 1)] += 1
+            rv, rlo, rhi, _ = boot_ci([c / w for c in counts])
+            rate_ci = [rlo, rhi]
+            rate_basis = (f"{SUSTAINED_SUBWINDOWS} equal sub-windows of one "
+                          f"{dur:.1f}s window (sub-windows are NOT independent "
+                          f"replicates; median {rv:.2f} rps)")
+        # "462/462 completed" is not a 0% failure rate, same rule as everywhere
+        # else in this bench. analyze.py had no binomial function at all.
+        launched = mrec.get("launched", 0)
+        f_lo, f_hi = clopper_pearson(max(0, launched - len(done)), launched)
         out["sustained"][f"{cell}/target={rate}rps"] = {
-            "launched": mrec["launched"], "skipped": mrec["skipped"],
+            "launched": launched, "skipped": mrec["skipped"],
             "completed_ok": len(done),
             "achieved_rps": (len(done) / dur) if dur > 0 else None,
+            "rate_ci": rate_ci, "rate_ci_basis": rate_basis,
+            "incomplete_rate_ci": [f_lo, f_hi],
             "duration_s": dur,
             "latency_median_ms": v, "latency_ci": [lo, hi], "n": k,
         }
@@ -641,13 +679,27 @@ def write_md(out, path):
         a(f"| {k} | {v['n_bursts']} | {ci_cell(v.get('burst_wall_median_ms'), v.get('burst_wall_ci'))} "
           f"| {ci_cell(v.get('rps_median'), v.get('rps_ci'))} |")
     a("")
-    a("| sustained cell | launched | completed | achieved req/s | latency ms, median (95% CI) |")
+    # `achieved req/s` is one decimal, not two: a single unreplicated window
+    # cannot support 0.01 rps of resolution, and quoting 7.26 claimed it did.
+    a("| sustained cell | launched | completed (CP 95% incomplete) "
+      "| achieved req/s (sub-window CI) | latency ms, median (95% CI) |")
     a("|---|---|---|---|---|")
     for k, v in sorted(out.get("sustained", {}).items()):
-        ar = f"{v['achieved_rps']:.2f}" if v.get("achieved_rps") else "n/a"
-        a(f"| {k} | {v['launched']} | {v['completed_ok']} | {ar} "
+        ar = f"{v['achieved_rps']:.1f}" if v.get("achieved_rps") else "n/a"
+        if v.get("rate_ci"):
+            ar += f" ({v['rate_ci'][0]:.1f}-{v['rate_ci'][1]:.1f})"
+        else:
+            ar += " (single window, no interval)"
+        fci = v.get("incomplete_rate_ci")
+        comp = f"{v['completed_ok']}"
+        if fci:
+            comp += f" [{100 * fci[0]:.2f}%, {100 * fci[1]:.2f}%]"
+        a(f"| {k} | {v['launched']} | {comp} | {ar} "
           f"| {ci_cell(v.get('latency_median_ms'), v.get('latency_ci'))} |")
     a("")
+    a("*Sub-window CIs split ONE window; the sub-windows are not independent "
+      "replicates of a fresh machine state, unlike the burst cells above (5 "
+      "bursts each). Do not read them as run-to-run uncertainty.*\n")
 
     a("### E. Host-native baseline (same pages, same screenshot format)\n")
     a("| baseline | total ms, median (95% CI) | artifact ms, median (95% CI) | n |")

--- a/bench/chromium/cdp_health.py
+++ b/bench/chromium/cdp_health.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Container HEALTHCHECK: prove Chromium can serve a screenshot request.
+
+OFF THE REQUEST PATH. This runs from the image's `HEALTHCHECK` directive, inside
+the container, on podman's schedule. The per-request path is host -> CDP
+WebSocket -> Chromium, with nothing of ours in it.
+
+fcvm's health gate is what triggers the golden snapshot (`src/health.rs`: with no
+`--health-check` URL, `Healthy` = container running AND podman's HEALTHCHECK
+reports healthy). So whatever this script accepts is exactly what gets frozen
+into the snapshot. Two conditions, both required:
+
+  1. The warm marker exists. entry.sh touches it only after it has driven a full
+     navigate + screenshot through CDP, so the renderer, JIT, raster and encode
+     paths are hot. Without this the gate would fire on a cold browser and every
+     "warm clone" number would be a first-paint number.
+  2. A REAL CDP round trip succeeds and finds a page target. Not "the port is
+     open" and not "entry.sh said so" — an actual HTTP request to Chromium's
+     DevTools endpoint whose parsed response contains a target we could attach
+     to. Proven, not inferred.
+
+Exit 0 = healthy. Any other exit = not healthy (podman's contract).
+
+Deliberately does NOT open the WebSocket. Attaching would leave a session that
+the snapshot then captures mid-handshake, and /json/list already proves the
+DevTools endpoint is live, is answering, and has a page. The host's first
+WebSocket upgrade after restore is the thing we want to MEASURE, not something to
+have half-done in the snapshot.
+"""
+
+import json
+import os
+import sys
+import urllib.request
+
+# Deliberately the RELAY port, not Chromium's 9222. The health gate is the
+# golden-snapshot trigger, so whatever it accepts is what gets frozen. Probing
+# through the relay makes "healthy" mean "reachable the way the host will
+# actually reach it" — a snapshot taken while the relay was down would fan out
+# clones that are warm and completely undrivable.
+CDP_HOST = os.environ.get("BENCH_CDP_HEALTH_HOST", "127.0.0.1:9223")
+READY_FILE = os.environ.get("BENCH_READY_FILE", "/run/bench-ready")
+TIMEOUT = float(os.environ.get("BENCH_CDP_HEALTH_TIMEOUT", "3"))
+
+
+def main() -> int:
+    if not os.path.exists(READY_FILE):
+        print(f"unhealthy: warm marker {READY_FILE} absent", file=sys.stderr)
+        return 1
+    try:
+        with urllib.request.urlopen(f"http://{CDP_HOST}/json/list", timeout=TIMEOUT) as r:
+            targets = json.load(r)
+    except Exception as e:  # urllib raises a wide family; any of them = not healthy
+        print(f"unhealthy: CDP /json/list failed: {type(e).__name__}: {e}", file=sys.stderr)
+        return 1
+
+    pages = [
+        t
+        for t in targets
+        if t.get("type") == "page" and not str(t.get("url", "")).startswith("devtools://")
+    ]
+    if not pages:
+        print(f"unhealthy: no page target among {len(targets)} target(s)", file=sys.stderr)
+        return 1
+
+    # Print the target so `podman inspect` health logs record WHICH target was
+    # resolved. If this id is identical across clones, the host can skip its own
+    # /json/list lookup per request (one fewer HTTP round trip) — the benchmark
+    # checks that claim rather than assuming it.
+    print(f"healthy pages={len(pages)} id={pages[0].get('id')} ws={pages[0].get('webSocketDebuggerUrl')}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/chromium/cdpdrive.py
+++ b/bench/chromium/cdpdrive.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Host-side CDP driver: drive a clone's Chromium over fcvm's port forwarding.
+
+This is the request path. There is no server of ours in it — Chromium's DevTools
+Protocol endpoint is already a fully specified request server that returns the
+screenshot as base64 inside the CDP response, so the only thing that needs
+writing is a client.
+
+    cdpdrive.py 127.0.0.19:9222 http://10.0.1.49:18578/medium.html --format jpeg
+
+Prints one machine-parsable JSON line. Every hop of the connection is timed
+separately, because with the resident-render design the connection IS the
+per-request setup cost and a lumped number would hide which hop to attack:
+
+    resolve_ms   HTTP GET /json/list  -> which page target to attach to
+    tcp_ms       TCP connect to the WebSocket endpoint
+    upgrade_ms   RFC 6455 handshake (the 101 exchange)
+    enable_ms    Page.enable + Page.setLifecycleEventsEnabled
+    navigate_ms  Page.navigate -> Page.loadEventFired
+    screenshot_ms Page.captureScreenshot (base64 image arrives here)
+    decode_ms    base64 decode + magic/dimension check on the host
+
+`--ws-url` skips `resolve_ms` entirely. The page target id is baked into the
+golden snapshot, so every clone restored from it should present the SAME target
+id — if that holds, the /json/list lookup can be done ONCE before snapshotting
+instead of once per request. `--print-target` dumps the id so the claim can be
+checked across clones rather than assumed.
+
+WebSocket framing comes from render.py so the host-driven arm and the in-guest
+per-request arm speak CDP through identical code; a divergence there would
+silently invalidate the A/B. Only the connect path is reimplemented here, to time
+its two halves separately.
+"""
+
+import argparse
+import base64
+import hashlib
+import importlib.util
+import json
+import os
+import socket
+import struct
+import sys
+import time
+import urllib.request
+from urllib.parse import urlparse
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def load_render(path: str):
+    spec = importlib.util.spec_from_file_location("bench_render", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load render module at {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def image_dimensions(data: bytes) -> tuple[int, int]:
+    """Width/height from the encoded bytes — no extra CDP round trip.
+
+    `Page.getLayoutMetrics` would cost a full request/response purely to report a
+    number the image already carries, and this driver exists to remove round
+    trips. Returns (0, 0) on anything unparsable: a dimension probe must never
+    fail a render that succeeded.
+    """
+    try:
+        if data.startswith(b"\x89PNG\r\n\x1a\n"):
+            w, h = struct.unpack(">II", data[16:24])  # IHDR is always the first chunk
+            return int(w), int(h)
+        if data.startswith(b"\xff\xd8"):
+            i, n = 2, len(data)
+            while i + 9 < n:
+                if data[i] != 0xFF:
+                    i += 1
+                    continue
+                marker = data[i + 1]
+                if marker in (0xD8, 0x01) or 0xD0 <= marker <= 0xD7:
+                    i += 2
+                    continue
+                (seglen,) = struct.unpack(">H", data[i + 2 : i + 4])
+                if 0xC0 <= marker <= 0xCF and marker not in (0xC4, 0xC8, 0xCC):
+                    h, w = struct.unpack(">HH", data[i + 5 : i + 9])
+                    return int(w), int(h)
+                i += 2 + seglen
+    except (struct.error, IndexError):
+        pass
+    return 0, 0
+
+
+def resolve_target(cdp_host: str, deadline: float, retries: int) -> dict:
+    """GET /json/list and pick the page target.
+
+    Chromium's DevTools HTTP handler validates the Host header and rejects values
+    that are neither `localhost` nor an IP literal (a 403 that reads like a
+    network fault, not an auth fault). We connect by IP, so urllib's default
+    `Host: <ip>:<port>` satisfies the IP-literal branch. `--host-header` exists to
+    prove that specific failure mode rather than argue about it.
+    """
+    last = None
+    for _ in range(max(1, retries)):
+        try:
+            timeout = max(0.05, deadline - time.monotonic())
+            with urllib.request.urlopen(f"http://{cdp_host}/json/list", timeout=timeout) as r:
+                targets = json.load(r)
+            pages = [
+                t
+                for t in targets
+                if t.get("type") == "page" and not str(t.get("url", "")).startswith("devtools://")
+            ]
+            if pages:
+                return pages[0]
+            last = RuntimeError(f"no page target among {len(targets)}")
+        except OSError as e:
+            last = e
+        if time.monotonic() >= deadline:
+            break
+    raise ConnectionError(f"CDP target resolution failed: {last}")
+
+
+class TimedWs:
+    """RFC 6455 client whose TCP connect and HTTP upgrade are timed separately.
+
+    Frame codec (`send_text`/`recv_text`/`_recv_exact`/`_send_frame`) is render.py's
+    — this class only owns the connect path, because that is the part we need
+    split into two numbers.
+    """
+
+    def __init__(self, render_mod, ws_url: str, deadline: float):
+        u = urlparse(ws_url)
+        host, port = u.hostname, u.port or 80
+
+        t = time.monotonic()
+        self.sock = socket.create_connection(
+            (host, port), timeout=max(0.05, deadline - time.monotonic())
+        )
+        self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        self.tcp_ms = (time.monotonic() - t) * 1000
+
+        t = time.monotonic()
+        key = base64.b64encode(os.urandom(16)).decode()
+        path = u.path + ("?" + u.query if u.query else "")
+        self.sock.sendall(
+            (
+                f"GET {path} HTTP/1.1\r\n"
+                f"Host: {host}:{port}\r\n"
+                "Upgrade: websocket\r\n"
+                "Connection: Upgrade\r\n"
+                f"Sec-WebSocket-Key: {key}\r\n"
+                "Sec-WebSocket-Version: 13\r\n\r\n"
+            ).encode()
+        )
+        self._buf = b""
+        response = render_mod.WsClient._recv_until(self, b"\r\n\r\n", deadline)
+        status = response.split(b"\r\n", 1)[0]
+        if b" 101" not in status:
+            raise ConnectionError(f"ws handshake rejected: {status.decode(errors='replace')}")
+        expect = base64.b64encode(
+            hashlib.sha1((key + render_mod.WS_GUID).encode()).digest()
+        )
+        if expect not in response:
+            raise ConnectionError("ws handshake: bad Sec-WebSocket-Accept")
+        self.upgrade_ms = (time.monotonic() - t) * 1000
+
+        # Borrow render.py's frame codec verbatim.
+        for m in ("_recv_until", "_recv_exact", "_send_frame", "send_text", "recv_text", "close"):
+            setattr(self, m, getattr(render_mod.WsClient, m).__get__(self, TimedWs))
+
+
+def nav_timing(cdp, deadline: float) -> dict:
+    expr = 'JSON.stringify(performance.getEntriesByType("navigation")[0]||{})'
+    res = cdp.cmd("Runtime.evaluate", {"expression": expr, "returnByValue": True}, deadline=deadline)
+    nav = json.loads(res["result"]["value"])
+
+    def d(a, b):
+        return max(0.0, nav.get(a, 0) - nav.get(b, 0))
+
+    tls = d("connectEnd", "secureConnectionStart") if nav.get("secureConnectionStart", 0) else 0.0
+    return {
+        "dns_ms": d("domainLookupEnd", "domainLookupStart"),
+        "connect_ms": d("connectEnd", "connectStart"),
+        "tls_ms": tls,
+        "ttfb_ms": d("responseStart", "requestStart"),
+        "resp_ms": d("responseEnd", "responseStart"),
+        "load_ms": nav.get("loadEventEnd", 0.0),
+    }
+
+
+def drive(args) -> dict:
+    render = load_render(args.render_module)
+    t0 = time.monotonic()
+    deadline = t0 + args.timeout
+    out: dict = {"ok": False, "cdp_host": args.cdp_host, "url": args.url, "format": args.format}
+    stages: dict[str, float] = {}
+    stage = "resolve"
+    ws = None
+    try:
+        if args.ws_url:
+            ws_url = args.ws_url
+            target_id = ""
+            stages["resolve_ms"] = 0.0
+            out["target_prewired"] = True
+        else:
+            t = time.monotonic()
+            target = resolve_target(args.cdp_host, deadline, args.connect_retries)
+            ws_url = target["webSocketDebuggerUrl"]
+            target_id = target.get("id", "")
+            stages["resolve_ms"] = (time.monotonic() - t) * 1000
+            out["target_prewired"] = False
+        out["target_id"] = target_id
+        out["ws_url"] = ws_url
+
+        stage = "connect"
+        ws = TimedWs(render, ws_url, deadline)
+        stages["tcp_ms"] = ws.tcp_ms
+        stages["upgrade_ms"] = ws.upgrade_ms
+        cdp = render.Cdp(ws)
+
+        stage = "enable"
+        t = time.monotonic()
+        cdp.cmd("Page.enable", deadline=deadline)
+        if args.idle_wait_ms > 0:
+            cdp.cmd("Page.setLifecycleEventsEnabled", {"enabled": True}, deadline=deadline)
+        stages["enable_ms"] = (time.monotonic() - t) * 1000
+        stages["connect_total_ms"] = (time.monotonic() - t0) * 1000
+
+        stage = "navigate"
+        t = time.monotonic()
+        nav = cdp.cmd("Page.navigate", {"url": args.url}, deadline=deadline)
+        if "errorText" in nav:
+            raise RuntimeError(f"navigation failed: {nav['errorText']}")
+        loader = nav.get("loaderId")
+        cdp.wait_event(lambda ev: ev["method"] == "Page.loadEventFired", deadline)
+        stages["navigate_ms"] = (time.monotonic() - t) * 1000
+
+        stage = "network-idle"
+        t = time.monotonic()
+        out["idle_timeout"] = 0
+        if args.idle_wait_ms > 0:
+            try:
+                cdp.wait_event(
+                    lambda ev: ev["method"] == "Page.lifecycleEvent"
+                    and ev["params"].get("name") == "networkIdle"
+                    and ev["params"].get("loaderId") == loader,
+                    min(deadline, t + args.idle_wait_ms / 1000),
+                )
+            except TimeoutError:
+                out["idle_timeout"] = 1
+        stages["idle_ms"] = (time.monotonic() - t) * 1000
+
+        stage = "screenshot"
+        t = time.monotonic()
+        params = {"format": args.format}
+        if args.format == "jpeg":
+            params["quality"] = args.quality
+        shot = cdp.cmd("Page.captureScreenshot", params, deadline=deadline)
+        stages["screenshot_ms"] = (time.monotonic() - t) * 1000
+
+        stage = "decode"
+        t = time.monotonic()
+        raw = base64.b64decode(shot["data"])
+        magic = b"\x89PNG" if args.format == "png" else b"\xff\xd8\xff"
+        if not raw.startswith(magic):
+            raise RuntimeError(f"captureScreenshot returned non-{args.format.upper()} data")
+        w, h = image_dimensions(raw)
+        out.update(
+            image_bytes=len(raw),
+            image_sha256=hashlib.sha256(raw).hexdigest(),
+            width=w,
+            height=h,
+            quality=args.quality if args.format == "jpeg" else 0,
+        )
+        stages["decode_ms"] = (time.monotonic() - t) * 1000
+        if args.out_prefix:
+            with open(f"{args.out_prefix}.{args.format}", "wb") as f:
+                f.write(raw)
+
+        if args.nav_timing:
+            stage = "nav-timing"
+            t = time.monotonic()
+            out["nav"] = nav_timing(cdp, deadline)
+            stages["nav_timing_ms"] = (time.monotonic() - t) * 1000
+
+        out["ok"] = True
+    except (OSError, RuntimeError, TimeoutError, KeyError, ValueError, render.WsClosed) as e:
+        out["error"] = f"{type(e).__name__}: {e}"
+        out["stage"] = stage
+    finally:
+        if ws is not None:
+            try:
+                ws.close()
+            except OSError:
+                pass
+    stages["total_ms"] = (time.monotonic() - t0) * 1000
+    out["stages"] = stages
+    return out
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("cdp_host", help="clone's forwarded CDP endpoint, e.g. 127.0.0.19:9222")
+    p.add_argument("url", help="fixture URL for the guest to render")
+    p.add_argument("--format", choices=("png", "jpeg"), default="png")
+    p.add_argument("--quality", type=int, default=80)
+    p.add_argument("--timeout", type=float, default=30.0)
+    p.add_argument("--idle-wait-ms", type=float, default=0.0)
+    p.add_argument("--out-prefix", default="", help="also write the image to <prefix>.<fmt>")
+    p.add_argument("--ws-url", default="", help="pre-resolved target; skips /json/list")
+    p.add_argument("--connect-retries", type=int, default=200)
+    p.add_argument("--nav-timing", action="store_true")
+    p.add_argument("--render-module", default=os.path.join(HERE, "render.py"))
+    args = p.parse_args()
+    out = drive(args)
+    print(json.dumps(out, separators=(",", ":")), flush=True)
+    return 0 if out["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/chromium/cdpdrive.py
+++ b/bench/chromium/cdpdrive.py
@@ -286,6 +286,14 @@ def drive(args) -> dict:
     except (OSError, RuntimeError, TimeoutError, KeyError, ValueError, render.WsClosed) as e:
         out["error"] = f"{type(e).__name__}: {e}"
         out["stage"] = stage
+        # Classify, so downstream can gate on it instead of substring-matching the
+        # message. A `WsClosed` is the PEER closing the TCP connection — it is NOT
+        # this driver's own timeout (render.py raises TimeoutError for that), so a
+        # failure at ~5 s against a 120 s deadline is a real transport drop in the
+        # socat+pasta relay this arm adds and the exec arm does not have.
+        out["failure_class"] = (
+            "transport" if isinstance(e, (render.WsClosed, ConnectionError)) else "render"
+        )
     finally:
         if ws is not None:
             try:
@@ -309,8 +317,19 @@ def main() -> int:
     p.add_argument("--ws-url", default="", help="pre-resolved target; skips /json/list")
     p.add_argument("--connect-retries", type=int, default=200)
     p.add_argument("--nav-timing", action="store_true")
+    p.add_argument("--print-target", action="store_true",
+                   help="print the page target id and exit; nothing else is done")
     p.add_argument("--render-module", default=os.path.join(HERE, "render.py"))
     args = p.parse_args()
+    if args.print_target:
+        # The docstring above has promised this flag since the file was written,
+        # and argparse did not have it — so `--print-target` exited 2 with
+        # "unrecognized arguments", and NEITHER of the two places that claim the
+        # target id can be checked across clones could actually check it.
+        target = resolve_target(args.cdp_host, time.monotonic() + args.timeout,
+                                args.connect_retries)
+        print(target.get("id", ""), flush=True)
+        return 0
     out = drive(args)
     print(json.dumps(out, separators=(",", ":")), flush=True)
     return 0 if out["ok"] else 1

--- a/bench/chromium/cdpdrive.py
+++ b/bench/chromium/cdpdrive.py
@@ -42,6 +42,7 @@ import socket
 import struct
 import sys
 import time
+import urllib.error
 import urllib.request
 from urllib.parse import urlparse
 
@@ -89,20 +90,62 @@ def image_dimensions(data: bytes) -> tuple[int, int]:
     return 0, 0
 
 
-def resolve_target(cdp_host: str, deadline: float, retries: int) -> dict:
-    """GET /json/list and pick the page target.
+RESOLVE_RETRY_S = 0.05
+
+
+class TargetNotReady(ConnectionError):
+    """`/json/list` answered, but presented no usable page target in time.
+
+    Distinct from a transport failure ON PURPOSE. `resolve_target` used to raise a
+    bare `ConnectionError` whatever the cause, and `drive()` classifies
+    `ConnectionError` as `transport` — so "no page target among 3", which is pure
+    RESTORE READINESS, inflated the transport-failure count that REVIEW.md's whole
+    `WsClosed` diagnosis rests on. Two different defects must not share a bucket.
+    """
+
+
+def resolve_target(cdp_host: str, deadline: float, retries: int,
+                   host_header: str = "", stats: dict | None = None) -> dict:
+    """GET /json/list and pick the page target. Bounded by the DEADLINE, not by burst.
 
     Chromium's DevTools HTTP handler validates the Host header and rejects values
     that are neither `localhost` nor an IP literal (a 403 that reads like a
     network fault, not an auth fault). We connect by IP, so urllib's default
-    `Host: <ip>:<port>` satisfies the IP-literal branch. `--host-header` exists to
-    prove that specific failure mode rather than argue about it.
+    `Host: <ip>:<port>` satisfies the IP-literal branch. `--host-header` overrides
+    it, to prove that specific failure mode rather than argue about it.
+
+    IT SLEEPS BETWEEN ATTEMPTS. The loop had none: the `timeout` below is
+    urlopen's SOCKET timeout, not an inter-attempt delay, so the retry budget was
+    consumed at line rate and the DEADLINE — the variable that actually expresses
+    the readiness budget — went unused. Measured on this box against a closed port
+    with retries=200 and a 30 s deadline:
+
+        attempts=200  elapsed=40.7 ms  rate=4919 req/s
+        retry budget consumed in 0.041s of a 30.0s deadline -> 0.14% of the window
+
+    Three consequences. `resolve_ms` is a PUBLISHED stage, and the burst happens
+    inside the measured window. A clone 100 ms from ready is recorded as a hard
+    CDP failure, and `reqanalyze` sets `pub = n_bad == 0`, so a single spurious
+    exhaustion censors the arm's median. And 4900 req/s of HTTP is aimed straight
+    at the socat+pasta relay whose drops are under investigation — an uncontrolled
+    variable inside the arm being diagnosed.
+
+    A deterministic 4xx is NOT retried: `urllib.error.HTTPError` subclasses
+    `OSError`, so a 403 from the Host-validation branch used to be retried 200
+    times as though it were a transient socket error.
     """
     last = None
-    for _ in range(max(1, retries)):
+    attempts = 0
+    while True:
+        attempts += 1
+        if stats is not None:
+            stats["resolve_attempts"] = attempts
         try:
             timeout = max(0.05, deadline - time.monotonic())
-            with urllib.request.urlopen(f"http://{cdp_host}/json/list", timeout=timeout) as r:
+            req = urllib.request.Request(f"http://{cdp_host}/json/list")
+            if host_header:
+                req.add_header("Host", host_header)
+            with urllib.request.urlopen(req, timeout=timeout) as r:
                 targets = json.load(r)
             pages = [
                 t
@@ -112,11 +155,24 @@ def resolve_target(cdp_host: str, deadline: float, retries: int) -> dict:
             if pages:
                 return pages[0]
             last = RuntimeError(f"no page target among {len(targets)}")
+        except urllib.error.HTTPError as e:
+            last = e
+            if 400 <= e.code < 500:
+                raise ConnectionError(
+                    f"CDP target resolution rejected after {attempts} attempt(s): {e} "
+                    f"(deterministic {e.code}; not retryable)"
+                ) from e
         except OSError as e:
             last = e
-        if time.monotonic() >= deadline:
+        now = time.monotonic()
+        if now >= deadline or attempts >= max(1, retries):
             break
-    raise ConnectionError(f"CDP target resolution failed: {last}")
+        time.sleep(min(RESOLVE_RETRY_S, deadline - now))
+    msg = f"CDP target resolution failed after {attempts} attempts: {last}"
+    if isinstance(last, RuntimeError):
+        # The endpoint ANSWERED; it just had no page yet. Readiness, not transport.
+        raise TargetNotReady(msg)
+    raise ConnectionError(msg)
 
 
 class TimedWs:
@@ -203,7 +259,13 @@ def drive(args) -> dict:
             out["target_prewired"] = True
         else:
             t = time.monotonic()
-            target = resolve_target(args.cdp_host, deadline, args.connect_retries)
+            # getattr, not args.host_header: reqbench.run_cdp_request hand-builds
+            # an explicit, CLOSED Namespace, and AttributeError is not in this
+            # function's except tuple — it would escape drive(), be swallowed by
+            # run_cdp_request's `except Exception`, and fail EVERY cdp rep. The
+            # Namespace also carries the field now; both halves, deliberately.
+            target = resolve_target(args.cdp_host, deadline, args.connect_retries,
+                                    getattr(args, "host_header", ""), out)
             ws_url = target["webSocketDebuggerUrl"]
             target_id = target.get("id", "")
             stages["resolve_ms"] = (time.monotonic() - t) * 1000
@@ -291,8 +353,15 @@ def drive(args) -> dict:
         # this driver's own timeout (render.py raises TimeoutError for that), so a
         # failure at ~5 s against a 120 s deadline is a real transport drop in the
         # socat+pasta relay this arm adds and the exec arm does not have.
+        #
+        # `readiness` is checked FIRST and is its own bucket: TargetNotReady
+        # subclasses ConnectionError, so folding it into `transport` would keep
+        # inflating the count REVIEW.md's WsClosed investigation depends on with
+        # clones that were merely still restoring.
         out["failure_class"] = (
-            "transport" if isinstance(e, (render.WsClosed, ConnectionError)) else "render"
+            "readiness" if isinstance(e, TargetNotReady)
+            else "transport" if isinstance(e, (render.WsClosed, ConnectionError))
+            else "render"
         )
     finally:
         if ws is not None:
@@ -319,6 +388,9 @@ def main() -> int:
     p.add_argument("--nav-timing", action="store_true")
     p.add_argument("--print-target", action="store_true",
                    help="print the page target id and exit; nothing else is done")
+    p.add_argument("--host-header", default="",
+                   help="override the Host header on /json/list; proves Chromium's "
+                        "DevTools host validation rejects non-IP, non-localhost names")
     p.add_argument("--render-module", default=os.path.join(HERE, "render.py"))
     args = p.parse_args()
     if args.print_target:
@@ -326,8 +398,11 @@ def main() -> int:
         # and argparse did not have it — so `--print-target` exited 2 with
         # "unrecognized arguments", and NEITHER of the two places that claim the
         # target id can be checked across clones could actually check it.
+        # `--host-header` was the SECOND claim in the same docstring and survived
+        # that round untouched, because the fix did not audit the paragraph it was
+        # editing for the same class of promise.
         target = resolve_target(args.cdp_host, time.monotonic() + args.timeout,
-                                args.connect_retries)
+                                args.connect_retries, args.host_header)
         print(target.get("id", ""), flush=True)
         return 0
     out = drive(args)

--- a/bench/chromium/entry.sh
+++ b/bench/chromium/entry.sh
@@ -144,8 +144,14 @@ fi
 #                          --disable-gpu --remote-debugging-address=0.0.0.0
 #                          --remote-debugging-port=9222` too, so it is the build, not our
 #                          flag set. Host ingress therefore CANNOT come from a wildcard
-#                          bind on this image; it comes from fcvm's --forward-localhost
-#                          (routed mode), which forwards the GUEST's loopback port out.
+#                          bind on this image — and it CANNOT come from --forward-localhost
+#                          either. That flag runs GUEST -> HOST ("Enables containers to
+#                          reach host-only services via localhost", src/cli/args.rs:236;
+#                          fc-agent/src/network.rs::setup_localhost_forwarding binds the
+#                          GUEST's 127.0.0.1:<port> and dials the host gateway 10.0.2.2),
+#                          so pointing it at 9222 HIJACKS Chromium's own loopback CDP port
+#                          and breaks the readiness probe below. Ingress comes from the
+#                          socat relay + ordinary --publish; see the CDP RELAY block.
 #                          The flag stays because it is free and correct-in-intent: if a
 #                          future Chromium honours it, the wildcard bind becomes available
 #                          without another archaeology session. Re-verify /proc/net/tcp

--- a/bench/chromium/entry.sh
+++ b/bench/chromium/entry.sh
@@ -3,12 +3,26 @@
 #
 # Sequence: start pageserver -> launch Chromium with CDP -> warm it (navigate a
 # fixture, screenshot once to heat the raster/encode path, park on about:blank)
-# -> touch the ready file (flips /ready to 200 for --health-check based golden
-# snapshots) -> print the READY marker -> hold the browser open.
+# -> touch the ready file (which the container HEALTHCHECK gates on) -> print the
+# READY marker -> hold the browser open.
+#
+# REQUEST PATH: there is NOTHING of ours on it. Chromium's own DevTools Protocol
+# endpoint IS the request server -- it is a fully specified, already-implemented
+# protocol that returns the screenshot as base64 in the CDP response. The host
+# opens a WebSocket straight to the page target and sends Page.navigate +
+# Page.captureScreenshot. No resident interpreter, no bespoke wire format, and
+# nothing of ours that a snapshot restore could invalidate: Chromium's listener
+# is an ordinary in-guest TCP socket, not a virtio-vsock socket, so the
+# VIRTIO_VSOCK_EVENT_TRANSPORT_RESET that a restore raises does not touch it.
+#
+# The pageserver and render.py remain in the image but are OFF the request path:
+# the pageserver serves fixtures (the in-guest fixture arm), and render.py is
+# used once here to warm the renderer and by the legacy per-request exec arm the
+# benchmark A/Bs against.
 #
 # The pageserver binds 0.0.0.0 by default (not 127.0.0.1): fcvm health checks
 # arrive on the guest's eth0 IP via nsenter, not on guest loopback, so a
-# loopback-only bind would break the `--health-check http://127.0.0.1:<port>/ready`
+# loopback-only bind would break a `--health-check http://127.0.0.1:<port>/ready`
 # warm-point trigger. Fixture URLs used by the driver stay on 127.0.0.1. Set
 # BENCH_HTTP_ADDR=127.0.0.1 for a strictly loopback-only server.
 set -eu
@@ -17,6 +31,9 @@ PAGES_DIR="${BENCH_PAGES_DIR:-/opt/bench/pages}"
 HTTP_ADDR="${BENCH_HTTP_ADDR:-0.0.0.0}"
 HTTP_PORT="${BENCH_HTTP_PORT:-8000}"
 CDP_PORT="${BENCH_CDP_PORT:-9222}"
+# Wildcard by default so the host can ingress. See the flag comment below for the
+# security rationale and the one condition that makes it acceptable.
+CDP_ADDR="${BENCH_CDP_ADDR:-0.0.0.0}"
 READY_FILE="${BENCH_READY_FILE:-/run/bench-ready}"
 
 rm -f "$READY_FILE"
@@ -115,7 +132,35 @@ if [ "${CB_SITE_ISOLATION:-on}" = "off" ]; then
 fi
 
 # --no-sandbox           : no user namespaces inside the guest container
-# --remote-allow-origins : primary bench arm connects CDP from outside the page origin
+# --remote-debugging-address=0.0.0.0 : IGNORED BY THIS CHROMIUM. Kept deliberately.
+#                          MEASURED 2026-08-08 on chromium 151.0.7922.71 (Debian bookworm
+#                          arm64): with BOTH --remote-debugging-port=9222 and
+#                          --remote-debugging-address=0.0.0.0 on the command line
+#                          (confirmed present in /proc/<pid>/cmdline), /proc/net/tcp shows
+#                          the listener bound to 127.0.0.1:9222 and nothing else. A host
+#                          connect to the published port TCP-connects and is then RESET —
+#                          which looks exactly like a Host-header rejection and is not one.
+#                          Reproduced with a minimal `chromium --headless=new --no-sandbox
+#                          --disable-gpu --remote-debugging-address=0.0.0.0
+#                          --remote-debugging-port=9222` too, so it is the build, not our
+#                          flag set. Host ingress therefore CANNOT come from a wildcard
+#                          bind on this image; it comes from fcvm's --forward-localhost
+#                          (routed mode), which forwards the GUEST's loopback port out.
+#                          The flag stays because it is free and correct-in-intent: if a
+#                          future Chromium honours it, the wildcard bind becomes available
+#                          without another archaeology session. Re-verify /proc/net/tcp
+#                          before believing it works.
+#                          SECURITY: were it honoured, it would hand full browser control (arbitrary
+#                          navigation, JS execution, local file reads via CDP) to
+#                          anything that can reach the port. Acceptable HERE for exactly
+#                          the reason --no-sandbox is: the microVM is the isolation
+#                          boundary, each clone is single-tenant, serves one request and
+#                          is destroyed, and the port is reachable only through fcvm's
+#                          per-clone forwarding. NOT acceptable in a shared or
+#                          long-lived VM -- do not copy this into a context where the VM
+#                          boundary is not doing that work.
+# --remote-allow-origins : primary bench arm connects CDP from outside the page origin;
+#                          without it the WebSocket upgrade is rejected on Origin check
 # --ignore-certificate-errors : bench arm renders self-signed https from the host
 #                          fixture server; must be baked in BEFORE the snapshot
 # --disable-gpu          : no GPU on this platform; forces deterministic software raster
@@ -128,6 +173,7 @@ HOME=/tmp chromium \
     --headless=new \
     --no-sandbox \
     --remote-debugging-port="$CDP_PORT" \
+    --remote-debugging-address="$CDP_ADDR" \
     --remote-allow-origins='*' \
     --ignore-certificate-errors \
     --disable-gpu \
@@ -146,16 +192,47 @@ HOME=/tmp chromium \
 CHROME_PID=$!
 wait_http "http://127.0.0.1:$CDP_PORT/json/version" 300 chromium-cdp
 
+# ---------------------------------------------------------------------------
+# CDP RELAY. The one process this design adds to a clone, and the reason it is
+# needed is measured, not assumed:
+#
+#   Chromium 151.0.7922.71 (Debian bookworm arm64) IGNORES
+#   --remote-debugging-address. The flag is in /proc/<pid>/cmdline; /proc/net/tcp
+#   shows 0100007F:2406 (127.0.0.1:9222) and nothing else, in the same container
+#   where the page server's 00000000:1F40 proves a wildcard bind works. It is
+#   the browser, not our flags, and not a Host-header rejection.
+#
+#   fcvm cannot bridge that gap either: --forward-localhost runs GUEST -> HOST
+#   (fc-agent/src/network.rs:479 dials 10.0.2.2), so aiming it at 9222 hijacks
+#   the guest's own loopback CDP port and breaks the readiness probe above.
+#
+# socat is deliberately the smallest thing that closes the gap: it copies bytes,
+# it does not parse, re-encode or re-frame CDP, so the wire protocol the host
+# speaks is byte-identical to the in-guest arm's. `fork` gives one short-lived
+# child per connection; the listener is what is resident in the snapshot.
+RELAY_PORT="${BENCH_CDP_RELAY_PORT:-9223}"
+echo "chromium-bench: starting CDP relay 0.0.0.0:$RELAY_PORT -> 127.0.0.1:$CDP_PORT"
+socat TCP-LISTEN:"$RELAY_PORT",fork,reuseaddr,bind=0.0.0.0 \
+      TCP:127.0.0.1:"$CDP_PORT" &
+RELAY_PID=$!
+# Prove the relay end to end BEFORE the warm marker, so the health gate (and
+# therefore the golden snapshot) cannot fire on a browser the host cannot reach.
+wait_http "http://127.0.0.1:$RELAY_PORT/json/version" 100 cdp-relay
+
 echo "chromium-bench: warming renderer"
 python3 /opt/bench/render.py "http://127.0.0.1:$HTTP_PORT/warmup.html" \
     --out-prefix /tmp/warmup --then-blank
 
+# Warm marker. The container HEALTHCHECK (cdp_health.py) requires BOTH this file
+# AND a live CDP round trip that finds a page target, so fcvm's health gate — the
+# trigger for the golden snapshot — cannot fire on a browser that is merely
+# listening. "Healthy" therefore means "warm and provably able to screenshot".
 touch "$READY_FILE"
-echo "CHROMIUM_BENCH_READY cdp=127.0.0.1:$CDP_PORT pages=http://127.0.0.1:$HTTP_PORT"
+echo "CHROMIUM_BENCH_READY cdp=$CDP_ADDR:$CDP_PORT relay=0.0.0.0:$RELAY_PORT pages=http://127.0.0.1:$HTTP_PORT"
 
 # Hold the warm browser. wait exits with chromium's status if it dies, so the
 # container stops instead of hiding a dead browser behind sleep infinity. As
 # PID 1 this shell gets no default signal handlers — without the trap a
 # `podman stop` SIGTERM is dropped and teardown eats the 10s SIGKILL fallback.
-trap 'kill "$CHROME_PID" 2>/dev/null; exit 0' TERM INT
+trap 'kill "$CHROME_PID" "$RELAY_PID" 2>/dev/null; exit 0' TERM INT
 wait "$CHROME_PID"

--- a/bench/chromium/render.py
+++ b/bench/chromium/render.py
@@ -49,6 +49,7 @@ class WsClient:
         self.sock = socket.create_connection(
             (u.hostname, u.port or 80), timeout=max(0.05, deadline - time.monotonic())
         )
+        self._buf = b""  # BEFORE the handshake: _recv_until parks leftovers here
         key = base64.b64encode(os.urandom(16)).decode()
         path = u.path + ("?" + u.query if u.query else "")
         self.sock.sendall(
@@ -68,17 +69,31 @@ class WsClient:
         expect = base64.b64encode(hashlib.sha1((key + WS_GUID).encode()).digest())
         if expect not in response:
             raise ConnectionError("ws handshake: bad Sec-WebSocket-Accept")
-        self._buf = b""
 
     def _recv_until(self, marker: bytes, deadline: float) -> bytes:
-        data = b""
+        """Read through `marker`, KEEPING whatever followed it in `self._buf`.
+
+        It used to accumulate into a local and return it, so any bytes the peer
+        coalesced into the same segment as the 101 response were DROPPED — and
+        `__init__` then reset `self._buf = b""`, discarding them a second time.
+        The next `_recv_exact(2)` would start reading in the middle of a frame,
+        the header parse would desync, and the symptom is precisely
+        `WsClosed("connection closed mid-frame")`. This is a free correctness fix
+        for a failure mode the CDP arm reports at 1.7%/10.0% and the exec arm
+        (which speaks guest loopback with no socat relay in the path) never hits;
+        it is a variable removed, NOT a diagnosis of that drop.
+        """
+        data = self._buf
+        self._buf = b""
         while marker not in data:
             self.sock.settimeout(max(0.05, deadline - time.monotonic()))
             chunk = self.sock.recv(4096)
             if not chunk:
                 raise WsClosed("connection closed during handshake")
             data += chunk
-        return data
+        head, _, rest = data.partition(marker)
+        self._buf = rest
+        return head + marker
 
     def _recv_exact(self, n: int, deadline: float) -> bytes:
         while len(self._buf) < n:

--- a/bench/chromium/reqanalyze.py
+++ b/bench/chromium/reqanalyze.py
@@ -14,12 +14,25 @@ Every rule here exists because of a defect listed in bench/chromium/AGENTS.md:
   * Teardown is never one number. blocking / reap_wall / reclaim_cpu are
     reported separately, and CPU figures flagged `complete=False` are counted as
     LOWER BOUNDS and excluded from the headline rather than averaged in.
+  * AVAILABILITY IS PER ARM, and it gates publication. Every median here is
+    computed over successes only, so two arms with different drop rates are
+    differently censored and their difference is not a like-for-like comparison.
+    Each arm therefore reports attempted/failed with an exact (Clopper-Pearson)
+    binomial interval, and any arm that dropped a request is marked
+    `publishable: false`. "0 failures" is not a 0% rate: 0/426 is [0, 0.70%].
+  * THE LEAK CHECK RUNS OVER EVERY ATTEMPT, NOT OVER THE SUCCESSES. A request
+    that failed is exactly the one whose teardown is most likely to have leaked,
+    and filtering it out reported `all_gone: 27/27 confirmed` on a set containing
+    three teardowns that had explicitly recorded `all_gone: false`.
+  * Per-child reclaim CPU is reported PER CHILD. Pooling the children into one
+    median and taking the median of {firecracker 110 ms, holder 0, pasta 0}
+    publishes 0 — it medians the straggler away, which is the opposite of the
+    thing being measured.
 """
 
 import argparse
 import json
 import math
-import os
 import random
 import statistics
 import sys
@@ -54,6 +67,53 @@ def fmt(med, lo, hi, n=None, unit="ms"):
     return s + (f" n={n}" if n else "")
 
 
+def _log_binom_pmf(i: int, n: int, p: float) -> float:
+    if p <= 0.0:
+        return 0.0 if i == 0 else -math.inf
+    if p >= 1.0:
+        return 0.0 if i == n else -math.inf
+    return (
+        math.lgamma(n + 1) - math.lgamma(i + 1) - math.lgamma(n - i + 1)
+        + i * math.log(p) + (n - i) * math.log1p(-p)
+    )
+
+
+def _binom_cdf(k: int, n: int, p: float) -> float:
+    """P(X <= k) for X ~ Binomial(n, p). Log-space terms, so no overflow at large n."""
+    if k < 0:
+        return 0.0
+    if k >= n:
+        return 1.0
+    return sum(math.exp(_log_binom_pmf(i, n, p)) for i in range(k + 1))
+
+
+def _bisect(f, lo: float, hi: float, iters: int = 80) -> float:
+    for _ in range(iters):
+        mid = (lo + hi) / 2
+        if f(mid) > 0:
+            hi = mid
+        else:
+            lo = mid
+    return (lo + hi) / 2
+
+
+def clopper_pearson(k: int, n: int, conf: float = 0.95):
+    """EXACT binomial CI for k events in n trials, as fractions.
+
+    Used for failure rates. "0 failures in 426" is not a 0% failure rate — its
+    two-sided 95% upper bound is 0.86%, and quoting the bare 0 reads as a
+    guarantee the data does not carry (AGENTS.md defect 6, applied to counts).
+    No scipy in this repo, so the tails are summed in log space and inverted by
+    bisection rather than pulled from a beta quantile.
+    """
+    if n <= 0:
+        return 0.0, 1.0
+    a = (1 - conf) / 2
+    lo = 0.0 if k == 0 else _bisect(lambda p: 1 - _binom_cdf(k - 1, n, p) - a, 0.0, k / n)
+    hi = 1.0 if k == n else _bisect(lambda p: a - _binom_cdf(k, n, p), k / n, 1.0)
+    return lo, hi
+
+
 def load(paths):
     recs, metas = [], []
     for p in paths:
@@ -84,11 +144,11 @@ def hodges_lehmann_shift(a, b, iters=20000, seed=999):
     return d, boots[int(0.025 * iters)], boots[int(0.975 * iters) - 1]
 
 
-def main():
+def main_with(argv=None):
     ap = argparse.ArgumentParser()
     ap.add_argument("jsonl", nargs="+")
     ap.add_argument("--json-out", default="")
-    args = ap.parse_args()
+    args = ap.parse_args(argv)
 
     recs, metas = load(args.jsonl)
     live = [r for r in recs if not r.get("warmup")]
@@ -119,13 +179,42 @@ def main():
               f"max={max(la):.1f}   <-- contention check (AGENTS.md)")
 
     arms = []
-    for r in ok:
-        if r["arm"] not in arms:
+    for r in live:
+        if r.get("arm") and r["arm"] not in arms:
             arms.append(r["arm"])
     arms.sort(key=lambda a: {"exec": 0, "cdp": 1, "cdp-fast": 2, "noop": 9}.get(a, 5))
-    by = {a: [r for r in ok if r["arm"] == a] for a in arms}
+    by = {a: [r for r in ok if r.get("arm") == a] for a in arms}
+    # EVERY attempt, not just the successes. The teardown/leak section reads this
+    # one: a request that failed is precisely the one whose teardown is most
+    # likely to have leaked, and the ok-filter made `all_gone: false` invisible.
+    attempted = {a: [r for r in live if r.get("arm") == a] for a in arms}
 
     out = {"arms": {}, "n_failed": len(bad), "n_warmup_discarded": len(warm)}
+
+    # ---- 0. availability per arm. This gates everything printed below it.
+    print("\n" + "-" * 78)
+    print("AVAILABILITY PER ARM (medians below are computed over SUCCESSES ONLY)")
+    print("-" * 78)
+    any_unpublishable = False
+    for a in arms:
+        n_att = len(attempted[a])
+        n_bad = sum(1 for r in attempted[a] if not r.get("ok"))
+        lo, hi = clopper_pearson(n_bad, n_att)
+        pub = n_bad == 0
+        any_unpublishable |= not pub
+        note = "" if pub else "   ** DO NOT PUBLISH THIS ARM'S LATENCY **"
+        print(f"  {a:9s} {n_att - n_bad}/{n_att} completed   "
+              f"failure {100 * n_bad / n_att if n_att else 0:.1f}% "
+              f"[{100 * lo:.2f}%, {100 * hi:.2f}%] 95% CP{note}")
+        out["arms"].setdefault(a, {}).update(
+            attempted=n_att, failed=n_bad,
+            failure_rate=(n_bad / n_att) if n_att else None,
+            failure_rate_ci=[lo, hi], publishable=pub,
+        )
+    if any_unpublishable:
+        print("  Arms are DIFFERENTLY CENSORED, so a cross-arm delta below is not a")
+        print("  like-for-like comparison. Quote the per-arm failure rate next to any")
+        print("  number taken from an arm marked DO NOT PUBLISH, or do not quote it.")
 
     # ---- 1. drift control FIRST. If this moved, nothing below is trustworthy.
     print("\n" + "-" * 78)
@@ -154,13 +243,13 @@ def main():
     print("END-TO-END, CALLER-BLOCKING (spawn -> answer in hand). Measured, not composed.")
     print("-" * 78)
     for a in arms:
-        v = [r["blocking_ms"] for r in by[a]]
+        v = [r["blocking_ms"] for r in by[a] if r.get("blocking_ms") is not None]
         print(f"  {a:9s} blocking  {fmt(*median_ci(v))}")
         out["arms"].setdefault(a, {})["blocking_ms"] = dict(
             zip(("median", "lo", "hi", "n"), median_ci(v)))
     print("\n  WALL (spawn -> VM fully gone; what the MACHINE pays, not the caller)")
     for a in arms:
-        v = [r["wall_ms"] for r in by[a]]
+        v = [r["wall_ms"] for r in by[a] if r.get("wall_ms") is not None]
         print(f"  {a:9s} wall      {fmt(*median_ci(v))}")
         out["arms"][a]["wall_ms"] = dict(zip(("median", "lo", "hi", "n"), median_ci(v)))
 
@@ -174,15 +263,28 @@ def main():
     out["deltas"] = {}
     for a, b, label in pairs:
         if a in by and b in by:
+            # A delta between differently-censored arms is not a like-for-like
+            # comparison: each median is conditioned on that arm's successes.
+            censor = ""
+            if not (out["arms"][a]["publishable"] and out["arms"][b]["publishable"]):
+                censor = (f"  [CENSORED: {a} dropped {out['arms'][a]['failed']}/"
+                          f"{out['arms'][a]['attempted']}, {b} dropped "
+                          f"{out['arms'][b]['failed']}/{out['arms'][b]['attempted']} "
+                          f"-- DO NOT PUBLISH without both rates]")
             for metric in ("blocking_ms", "wall_ms"):
-                va = [r[metric] for r in by[a]]
-                vb = [r[metric] for r in by[b]]
+                va = [r[metric] for r in by[a] if r.get(metric) is not None]
+                vb = [r[metric] for r in by[b] if r.get(metric) is not None]
                 d, lo, hi = hodges_lehmann_shift(va, vb)
+                if d is None:
+                    continue
                 sig = "" if (lo <= 0 <= hi) else "  *"
-                print(f"  {label}")
+                print(f"  {label}{censor}")
                 print(f"    {metric:12s} {a} -> {b}: {d:+.1f} ms  CI [{lo:+.1f}, {hi:+.1f}]{sig}")
-                out["deltas"][f"{a}->{b}:{metric}"] = {"delta": d, "ci": [lo, hi],
-                                                       "significant": not (lo <= 0 <= hi)}
+                out["deltas"][f"{a}->{b}:{metric}"] = {
+                    "delta": d, "ci": [lo, hi],
+                    "significant": not (lo <= 0 <= hi),
+                    "publishable": censor == "",
+                }
 
     # ---- 4. CDP stage decomposition (the per-request connect cost this design ADDS)
     print("\n" + "-" * 78)
@@ -197,7 +299,18 @@ def main():
             print(f"    {'port_wait_ms':16s} {fmt(*median_ci(pw))}   "
                   f"(restore -> first TCP accept; the ONLY readiness wait)")
             out["arms"][a]["port_wait_ms"] = dict(zip(("median", "lo", "hi", "n"), median_ci(pw)))
+        # `--ws-url` prewiring SKIPS /json/list and writes a synthetic
+        # `resolve_ms = 0.0`. Pooling that with measured values publishes a stage
+        # that was never timed, so the two populations are never mixed.
+        prewired = {bool((r.get("render") or {}).get("target_prewired")) for r in by[a]}
+        out["arms"][a]["target_prewired"] = sorted(prewired)
+        if prewired == {True}:
+            print("    resolve_ms       SKIPPED (--ws-url prewired; NOT measured)")
+        elif len(prewired) > 1:
+            print("    resolve_ms       MIXED prewired/measured records -- refusing to pool")
         for k in stage_keys:
+            if k == "resolve_ms" and (prewired == {True} or len(prewired) > 1):
+                continue
             # cdpdrive nests its timings under render.stages; reading render[k]
             # directly silently yields nothing, which looks like "no data" rather
             # than a bug. Read both, prefer stages.
@@ -221,54 +334,103 @@ def main():
     print("TEARDOWN -- three numbers, deliberately not summed into one")
     print("-" * 78)
     for a in arms:
-        td = [r.get("teardown") for r in by[a] if r.get("teardown")]
+        # `attempted`, NOT `by`: see the module docstring. A failed request's
+        # teardown is the one most likely to have leaked.
+        td = [r.get("teardown") for r in attempted[a] if r.get("teardown")]
         if not td:
             print(f"  {a:9s} (teardown is inside fcvm and not separable in this arm)")
             continue
-        rw = [t.get("reap_wall_ms") for t in td if t.get("reap_wall_ms") is not None]
-        tt = [t.get("teardown_total_ms") for t in td if t.get("teardown_total_ms") is not None]
+        ok_td = [r.get("teardown") for r in by[a] if r.get("teardown")]
+        rw = [t.get("reap_wall_ms") for t in ok_td if t.get("reap_wall_ms") is not None]
+        tt = [t.get("teardown_total_ms") for t in ok_td if t.get("teardown_total_ms") is not None]
         print(f"  [{a}] mode={td[0].get('mode')}")
-        print(f"    reap_wall_ms      {fmt(*median_ci(rw))}   (kill -> processes truly gone)")
-        print(f"    teardown_total_ms {fmt(*median_ci(tt))}   (incl. synchronous on-disk reap)")
-        out["arms"][a]["reap_wall_ms"] = dict(zip(("median", "lo", "hi", "n"), median_ci(rw)))
-        dr = [t.get("disk_reap_ms") for t in td if t.get("disk_reap_ms") is not None]
+        if rw:
+            print(f"    reap_wall_ms      {fmt(*median_ci(rw))}   (kill -> processes truly gone)")
+            print(f"    teardown_total_ms {fmt(*median_ci(tt))}   (incl. synchronous on-disk reap)")
+            out["arms"][a]["reap_wall_ms"] = dict(zip(("median", "lo", "hi", "n"), median_ci(rw)))
+        dr = [t.get("disk_reap_ms") for t in ok_td if t.get("disk_reap_ms") is not None]
         if dr:
             print(f"    disk_reap_ms      {fmt(*median_ci(dr))}   (state file + data dir)")
             out["arms"][a]["disk_reap_ms"] = dict(zip(("median", "lo", "hi", "n"), median_ci(dr)))
-        mc = [t.get("machine_cpu_ms_excess") for t in td
-              if t.get("machine_cpu_ms_excess") is not None]
+
+        # machine_cpu_ms_excess is a whole-machine subtraction whose control window
+        # and reclaim window carry different amounts of the HARNESS's own load. It
+        # is only reported when the record proves the harness subtracted itself out
+        # of both (`harness_cpu_ms` present) — older records cannot support it.
+        mc = [t.get("machine_cpu_ms_excess") for t in ok_td
+              if t.get("machine_cpu_ms_excess") is not None
+              and t.get("harness_cpu_ms") is not None]
+        stale = [t for t in ok_td if t.get("machine_cpu_ms_excess") is not None
+                 and t.get("harness_cpu_ms") is None]
+        if stale:
+            print(f"    machine_cpu_excess WITHHELD on {len(stale)} record(s): they predate "
+                  f"harness self-CPU subtraction, so the ambient baseline includes the "
+                  f"sampler's own spin and the value is not an attribution")
         if mc:
-            print(f"    machine_cpu_excess{fmt(*median_ci(mc))}   "
-                  f"(whole-machine busy jiffies over reclaim, ambient subtracted)")
+            print(f"    machine_cpu_excess {fmt(*median_ci(mc))}   "
+                  f"(whole-machine busy jiffies over reclaim, ambient AND harness subtracted)")
             out["arms"][a]["machine_cpu_ms_excess"] = dict(
                 zip(("median", "lo", "hi", "n"), median_ci(mc)))
-        comp, incomp = [], []
-        for t in td:
-            for _cname, c in (t.get("per_child_cpu") or {}).items():
+
+        # PER CHILD, keyed by comm. Pooling loses the straggler: the median of
+        # {firecracker 110 ms, holder 0, pasta 0} is 0.
+        tick = next((t.get("tick_ms") for t in td if t.get("tick_ms")), None)
+        by_child: dict = {}
+        for t in ok_td:
+            for cname, c in (t.get("per_child_cpu") or {}).items():
                 if c.get("reclaim_cpu_ms") is None:
                     continue
-                (comp if c.get("complete") else incomp).append(c["reclaim_cpu_ms"])
-        if comp:
-            print(f"    reclaim_cpu_ms    {fmt(*median_ci(comp))}   "
-                  f"COMPLETE (zombie state observed, exit_mm already ran)")
-            out["arms"][a]["reclaim_cpu_ms_complete"] = dict(
-                zip(("median", "lo", "hi", "n"), median_ci(comp)))
-        if incomp:
-            print(f"    reclaim_cpu_ms    {fmt(*median_ci(incomp))}   "
-                  f"LOWER BOUND ONLY (reaper won the race) -- not merged with the above")
-            out["arms"][a]["reclaim_cpu_ms_lower_bound"] = dict(
-                zip(("median", "lo", "hi", "n"), median_ci(incomp)))
+                b = by_child.setdefault(cname, {"complete": [], "lower": [], "sub_tick": 0})
+                (b["complete"] if c.get("complete") else b["lower"]).append(c["reclaim_cpu_ms"])
+                if c.get("below_resolution") or c["reclaim_cpu_ms"] == 0.0:
+                    b["sub_tick"] += 1
+        if by_child:
+            res = f" (/proc tick = {tick:.0f} ms)" if tick else ""
+            print(f"    reclaim_cpu_ms per child{res}")
+            out["arms"][a]["reclaim_cpu_ms_by_child"] = {}
+            for cname in sorted(by_child):
+                b = by_child[cname]
+                n_tot = len(b["complete"]) + len(b["lower"])
+                if b["sub_tick"] == n_tot and tick:
+                    print(f"      {cname:20s} < {2 * tick:.0f} ms "
+                          f"(below /proc tick resolution, n={n_tot})")
+                    out["arms"][a]["reclaim_cpu_ms_by_child"][cname] = {
+                        "median": 0.0, "below_resolution": True,
+                        "upper_bound_ms": 2 * tick, "n": n_tot,
+                    }
+                    continue
+                if b["complete"]:
+                    m = median_ci(b["complete"])
+                    print(f"      {cname:20s} {fmt(*m)}   COMPLETE (zombie observed)")
+                    out["arms"][a]["reclaim_cpu_ms_by_child"][cname] = dict(
+                        zip(("median", "lo", "hi", "n"), m))
+                if b["lower"]:
+                    m = median_ci(b["lower"])
+                    print(f"      {cname:20s} {fmt(*m)}   LOWER BOUND (reaper won the race)")
+                    out["arms"][a]["reclaim_cpu_ms_by_child"].setdefault(cname, {})[
+                        "lower_bound"] = dict(zip(("median", "lo", "hi", "n"), m))
+
         ag = [t.get("all_gone") for t in td]
         leaked = ag.count(False)
         print(f"    all_gone: {ag.count(True)}/{len(ag)} confirmed"
               + (f"  ** {leaked} NOT CONFIRMED GONE **" if leaked else ""))
         out["arms"][a]["all_gone_confirmed"] = [ag.count(True), len(ag)]
+        if leaked:
+            for r in attempted[a]:
+                t = r.get("teardown") or {}
+                if t.get("all_gone") is False:
+                    print(f"      rep {r.get('rep')} ok={r.get('ok')} "
+                          f"survivors={t.get('survivors') or t.get('children')}")
 
     if args.json_out:
         with open(args.json_out, "w") as f:
             json.dump(out, f, indent=2, default=str)
         print(f"\nwrote {args.json_out}")
     return 0
+
+
+def main():
+    return main_with()
 
 
 if __name__ == "__main__":

--- a/bench/chromium/reqanalyze.py
+++ b/bench/chromium/reqanalyze.py
@@ -19,7 +19,11 @@ Every rule here exists because of a defect listed in bench/chromium/AGENTS.md:
     differently censored and their difference is not a like-for-like comparison.
     Each arm therefore reports attempted/failed with an exact (Clopper-Pearson)
     binomial interval, and any arm that dropped a request is marked
-    `publishable: false`. "0 failures" is not a 0% rate: 0/426 is [0, 0.70%].
+    `publishable: false`. "0 failures" is not a 0% rate: 0/426 is [0, 0.86%].
+    (This line said 0.70% while `clopper_pearson`'s own docstring 80 lines below
+    said 0.86% for the same k/n — two point estimates of one quantity disagreeing
+    inside one file, which is defect 6's cousin and exactly what the AGENTS.md
+    `snapshot-load` entry was written about. The function computes 0.862%.)
   * THE LEAK CHECK RUNS OVER EVERY ATTEMPT, NOT OVER THE SUCCESSES. A request
     that failed is exactly the one whose teardown is most likely to have leaked,
     and filtering it out reported `all_gone: 27/27 confirmed` on a set containing
@@ -144,10 +148,38 @@ def hodges_lehmann_shift(a, b, iters=20000, seed=999):
     return d, boots[int(0.025 * iters)], boots[int(0.975 * iters) - 1]
 
 
+def failure_label(r: dict) -> str:
+    """The failure string an operator needs, wherever the producer put it.
+
+    `r.get("error", f"rc={r.get('rc')}")` alone reported every CDP drop as
+    `rc=None`: `run_cdp_request` nests the whole cdpdrive result under `render`,
+    and on a clean `ok: false` (cdpdrive returning rather than raising) the top
+    level carried no `error` at all. The producer now lifts the label, but the
+    analyzer is the PUBLICATION GATE reading a JSONL artifact that outlives the
+    producer, so it reads both and prefers the top level.
+    """
+    return (
+        r.get("error")
+        or (r.get("render") or {}).get("error")
+        or f"rc={r.get('rc')}"
+    )
+
+
+def failure_class(r: dict) -> str:
+    """Transport / readiness / render, wherever the producer put it."""
+    return (
+        r.get("failure_class")
+        or (r.get("render") or {}).get("failure_class")
+        or "unknown"
+    )
+
+
 def main_with(argv=None):
     ap = argparse.ArgumentParser()
     ap.add_argument("jsonl", nargs="+")
     ap.add_argument("--json-out", default="")
+    ap.add_argument("--no-gate", action="store_true",
+                    help="exit 0 even when this run is unpublishable (exploratory only)")
     args = ap.parse_args(argv)
 
     recs, metas = load(args.jsonl)
@@ -166,10 +198,9 @@ def main_with(argv=None):
     print(f"\n  records: {len(recs)}  warmup DISCARDED: {len(warm)}  "
           f"measured: {len(live)}  ok: {len(ok)}  failed: {len(bad)}")
     if bad:
-        seen = {}
+        seen: dict = {}
         for r in bad:
-            seen.setdefault(r.get("error", f"rc={r.get('rc')}"), 0)
-            seen[r.get("error", f"rc={r.get('rc')}")] += 1
+            seen[failure_label(r)] = seen.get(failure_label(r), 0) + 1
         for k, v in sorted(seen.items(), key=lambda kv: -kv[1]):
             print(f"    FAILURE x{v}: {k}")
 
@@ -206,10 +237,25 @@ def main_with(argv=None):
         print(f"  {a:9s} {n_att - n_bad}/{n_att} completed   "
               f"failure {100 * n_bad / n_att if n_att else 0:.1f}% "
               f"[{100 * lo:.2f}%, {100 * hi:.2f}%] 95% CP{note}")
+        # A transport drop, a readiness exhaustion and a render error are three
+        # different defects and must not share one bucket in the artifact. This is
+        # what makes REVIEW.md's "200 CDP requests per backend at 0 failures" gate
+        # checkable from the analyzer's own output instead of by hand-reading
+        # jsonl — and `failure_class` was, until now, written by cdpdrive and read
+        # by nothing at all.
+        classes: dict = {}
+        for r in attempted[a]:
+            if not r.get("ok"):
+                c = failure_class(r)
+                classes[c] = classes.get(c, 0) + 1
+        if classes:
+            print("            failure classes: "
+                  + ", ".join(f"{k}={v}" for k, v in sorted(classes.items())))
         out["arms"].setdefault(a, {}).update(
             attempted=n_att, failed=n_bad,
             failure_rate=(n_bad / n_att) if n_att else None,
             failure_rate_ci=[lo, hi], publishable=pub,
+            failure_classes=classes,
         )
     if any_unpublishable:
         print("  Arms are DIFFERENTLY CENSORED, so a cross-arm delta below is not a")
@@ -288,7 +334,13 @@ def main_with(argv=None):
 
     # ---- 4. CDP stage decomposition (the per-request connect cost this design ADDS)
     print("\n" + "-" * 78)
-    print("CDP ARMS: per-request stage decomposition (host -> clone over forward-localhost)")
+    # NOT "forward-localhost". That flag is GUEST -> HOST (bench/chromium/AGENTS.md,
+    # src/cli/args.rs: "Enables containers to reach host-only services via
+    # localhost"), so it cannot carry this path in this direction — and pointing it
+    # at the CDP port HIJACKS the guest's own loopback listener. What is actually
+    # measured is `--publish <relay>:<relay>` to guest eth0, then entry.sh's socat
+    # to guest loopback 9222. reqbench.sh never passes --forward-localhost.
+    print("CDP ARMS: per-request stage decomposition (host -> --publish -> guest relay)")
     print("-" * 78)
     stage_keys = ["resolve_ms", "tcp_ms", "upgrade_ms", "enable_ms", "connect_total_ms",
                   "navigate_ms", "screenshot_ms", "total_ms"]
@@ -333,6 +385,7 @@ def main_with(argv=None):
     print("\n" + "-" * 78)
     print("TEARDOWN -- three numbers, deliberately not summed into one")
     print("-" * 78)
+    any_unconfirmed_teardown = False
     for a in arms:
         # `attempted`, NOT `by`: see the module docstring. A failed request's
         # teardown is the one most likely to have leaked.
@@ -410,22 +463,57 @@ def main_with(argv=None):
                     out["arms"][a]["reclaim_cpu_ms_by_child"].setdefault(cname, {})[
                         "lower_bound"] = dict(zip(("median", "lo", "hi", "n"), m))
 
+        # CLASSIFY ON True, NOT ON False. `ag.count(False)` drove the warning
+        # gate while `len(ag)` drove the denominator, so a null or an absent
+        # `all_gone` landed in the denominator and OUT of the gate: 27 confirmed
+        # + 2 null + 1 missing printed `all_gone: 27/30 confirmed` with no
+        # warning and no per-rep dump — the numerator and denominator disagreeing
+        # by three while the report reads clean. Exactly the failure mode this
+        # section exists to prevent (see the module docstring). Today's producer
+        # cannot emit a non-bool here, but the analyzer is the publication gate
+        # for an artifact that outlives the producer.
         ag = [t.get("all_gone") for t in td]
-        leaked = ag.count(False)
-        print(f"    all_gone: {ag.count(True)}/{len(ag)} confirmed"
-              + (f"  ** {leaked} NOT CONFIRMED GONE **" if leaked else ""))
-        out["arms"][a]["all_gone_confirmed"] = [ag.count(True), len(ag)]
-        if leaked:
+        confirmed = ag.count(True)
+        unconfirmed = len(ag) - confirmed
+        print(f"    all_gone: {confirmed}/{len(ag)} confirmed"
+              + (f"  ** {unconfirmed} NOT CONFIRMED GONE **" if unconfirmed else ""))
+        out["arms"][a]["all_gone_confirmed"] = [confirmed, len(ag)]
+        # Kept separate so "we watched it survive" is distinguishable from "we
+        # have no evidence either way".
+        out["arms"][a]["all_gone_no_evidence"] = sum(
+            1 for x in ag if x is not True and x is not False)
+        if unconfirmed:
+            any_unconfirmed_teardown = True
             for r in attempted[a]:
                 t = r.get("teardown") or {}
-                if t.get("all_gone") is False:
+                if t.get("all_gone") is not True:
                     print(f"      rep {r.get('rep')} ok={r.get('ok')} "
+                          f"all_gone={t.get('all_gone')!r} "
                           f"survivors={t.get('survivors') or t.get('children')}")
 
+    out["publishable"] = not (any_unpublishable or any_unconfirmed_teardown)
     if args.json_out:
         with open(args.json_out, "w") as f:
             json.dump(out, f, indent=2, default=str)
         print(f"\nwrote {args.json_out}")
+
+    # GATE, do not merely narrate. This returned 0 on every path: an unpublishable
+    # arm, an unconfirmed teardown and a detected drift all exited 0 while stdout
+    # said ** DO NOT PUBLISH THIS ARM'S LATENCY **. Measured end to end: a run with
+    # 10% cdp transport censoring printed the banner and exited 0. A benchmark
+    # harness that exits 0 on a run it has itself marked DO NOT PUBLISH will
+    # eventually have those numbers quoted by someone who only checked the exit
+    # code.
+    if not out["publishable"]:
+        why = []
+        if any_unpublishable:
+            why.append("an arm dropped requests")
+        if any_unconfirmed_teardown:
+            why.append("a teardown was not confirmed gone")
+        print(f"\nUNPUBLISHABLE RUN ({'; '.join(why)}). Exiting 5.")
+        print("Pass --no-gate to keep an exploratory run at exit 0.")
+        if not args.no_gate:
+            return 5
     return 0
 
 

--- a/bench/chromium/reqanalyze.py
+++ b/bench/chromium/reqanalyze.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Analysis for the request-optimized A/B. Medians with bootstrap CIs, drift, teardown.
+
+Every rule here exists because of a defect listed in bench/chromium/AGENTS.md:
+
+  * Warmups are dropped EXPLICITLY and the count is printed (defect: cold-cache
+    runs inflate p50 silently).
+  * Uncertainty is a bootstrap CI on the MEDIAN, and every figure is rounded to
+    its own CI (defect 6: "129.0 MiB" on +/-20 MiB data is a false claim).
+  * The `noop` drift-control series is split first-half/second-half and the
+    difference is reported. If the control moved, the arm deltas are suspect and
+    this script says so rather than letting the reader assume a quiet box
+    (defect 2: a control probe drifted 631 -> 706 ms in the retracted run).
+  * Teardown is never one number. blocking / reap_wall / reclaim_cpu are
+    reported separately, and CPU figures flagged `complete=False` are counted as
+    LOWER BOUNDS and excluded from the headline rather than averaged in.
+"""
+
+import argparse
+import json
+import math
+import os
+import random
+import statistics
+import sys
+
+
+def median_ci(xs, iters=20000, conf=0.95, seed=12345):
+    """Median with a percentile-bootstrap CI. Returns (median, lo, hi, n)."""
+    xs = [float(x) for x in xs if x is not None and not math.isnan(float(x))]
+    n = len(xs)
+    if n == 0:
+        return None, None, None, 0
+    med = statistics.median(xs)
+    if n < 3:
+        return med, min(xs), max(xs), n
+    rng = random.Random(seed)
+    boots = []
+    for _ in range(iters):
+        boots.append(statistics.median([xs[rng.randrange(n)] for _ in range(n)]))
+    boots.sort()
+    lo = boots[int((1 - conf) / 2 * iters)]
+    hi = boots[int((1 + conf) / 2 * iters) - 1]
+    return med, lo, hi, n
+
+
+def fmt(med, lo, hi, n=None, unit="ms"):
+    """Round the estimate to the precision its own CI can support (defect 6)."""
+    if med is None:
+        return "n/a"
+    half = max(abs(hi - med), abs(med - lo)) if lo is not None else 0.0
+    digits = 0 if half >= 5 else (1 if half >= 0.5 else 2)
+    s = f"{med:.{digits}f} [{lo:.{digits}f}, {hi:.{digits}f}] {unit}"
+    return s + (f" n={n}" if n else "")
+
+
+def load(paths):
+    recs, metas = [], []
+    for p in paths:
+        with open(p) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                r = json.loads(line)
+                (metas if r.get("kind") == "meta" else recs).append(r)
+    return recs, metas
+
+
+def hodges_lehmann_shift(a, b, iters=20000, seed=999):
+    """Bootstrap CI on the difference of medians (b - a). Sign matters, so report it."""
+    a = [float(x) for x in a]
+    b = [float(x) for x in b]
+    if not a or not b:
+        return None, None, None
+    rng = random.Random(seed)
+    d = statistics.median(b) - statistics.median(a)
+    boots = []
+    for _ in range(iters):
+        sa = [a[rng.randrange(len(a))] for _ in range(len(a))]
+        sb = [b[rng.randrange(len(b))] for _ in range(len(b))]
+        boots.append(statistics.median(sb) - statistics.median(sa))
+    boots.sort()
+    return d, boots[int(0.025 * iters)], boots[int(0.975 * iters) - 1]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("jsonl", nargs="+")
+    ap.add_argument("--json-out", default="")
+    args = ap.parse_args()
+
+    recs, metas = load(args.jsonl)
+    live = [r for r in recs if not r.get("warmup")]
+    warm = [r for r in recs if r.get("warmup")]
+    ok = [r for r in live if r.get("ok")]
+    bad = [r for r in live if not r.get("ok")]
+
+    print("=" * 78)
+    print("REQUEST-OPTIMIZED A/B  --  medians with 95% bootstrap CIs")
+    print("=" * 78)
+    for m in metas:
+        print(f"  seed={m.get('seed')} arms={m.get('arms')} reps={m.get('reps')} "
+              f"warmup={m.get('warmup')} url={m.get('url')}")
+        print(f"  loadavg at start: {m.get('loadavg')}")
+    print(f"\n  records: {len(recs)}  warmup DISCARDED: {len(warm)}  "
+          f"measured: {len(live)}  ok: {len(ok)}  failed: {len(bad)}")
+    if bad:
+        seen = {}
+        for r in bad:
+            seen.setdefault(r.get("error", f"rc={r.get('rc')}"), 0)
+            seen[r.get("error", f"rc={r.get('rc')}")] += 1
+        for k, v in sorted(seen.items(), key=lambda kv: -kv[1]):
+            print(f"    FAILURE x{v}: {k}")
+
+    la = [r.get("loadavg1") for r in live if r.get("loadavg1") is not None]
+    if la:
+        print(f"  loadavg1 during run: min={min(la):.1f} median={statistics.median(la):.1f} "
+              f"max={max(la):.1f}   <-- contention check (AGENTS.md)")
+
+    arms = []
+    for r in ok:
+        if r["arm"] not in arms:
+            arms.append(r["arm"])
+    arms.sort(key=lambda a: {"exec": 0, "cdp": 1, "cdp-fast": 2, "noop": 9}.get(a, 5))
+    by = {a: [r for r in ok if r["arm"] == a] for a in arms}
+
+    out = {"arms": {}, "n_failed": len(bad), "n_warmup_discarded": len(warm)}
+
+    # ---- 1. drift control FIRST. If this moved, nothing below is trustworthy.
+    print("\n" + "-" * 78)
+    print("DRIFT CONTROL (arm=noop: clone spawn + restore + teardown, NO page, NO CDP)")
+    print("-" * 78)
+    noop = by.get("noop", [])
+    if len(noop) >= 6:
+        noop_sorted = sorted(noop, key=lambda r: r["rep"])
+        half = len(noop_sorted) // 2
+        f = [r["blocking_ms"] for r in noop_sorted[:half]]
+        s = [r["blocking_ms"] for r in noop_sorted[half:]]
+        d, dlo, dhi = hodges_lehmann_shift(f, s)
+        print(f"  first half : {fmt(*median_ci(f))}")
+        print(f"  second half: {fmt(*median_ci(s))}")
+        print(f"  drift (2nd - 1st): {d:.1f} ms, 95% CI [{dlo:.1f}, {dhi:.1f}]")
+        drifted = not (dlo <= 0 <= dhi)
+        print("  VERDICT: " + ("DRIFT DETECTED -- arm deltas are confounded, do not publish"
+                               if drifted else
+                               "no significant drift; interleaved arm deltas are usable"))
+        out["drift"] = {"delta_ms": d, "ci": [dlo, dhi], "significant": drifted}
+    else:
+        print("  (insufficient noop samples)")
+
+    # ---- 2. end-to-end, measured end to end, never composed from stages
+    print("\n" + "-" * 78)
+    print("END-TO-END, CALLER-BLOCKING (spawn -> answer in hand). Measured, not composed.")
+    print("-" * 78)
+    for a in arms:
+        v = [r["blocking_ms"] for r in by[a]]
+        print(f"  {a:9s} blocking  {fmt(*median_ci(v))}")
+        out["arms"].setdefault(a, {})["blocking_ms"] = dict(
+            zip(("median", "lo", "hi", "n"), median_ci(v)))
+    print("\n  WALL (spawn -> VM fully gone; what the MACHINE pays, not the caller)")
+    for a in arms:
+        v = [r["wall_ms"] for r in by[a]]
+        print(f"  {a:9s} wall      {fmt(*median_ci(v))}")
+        out["arms"][a]["wall_ms"] = dict(zip(("median", "lo", "hi", "n"), median_ci(v)))
+
+    # ---- 3. paired deltas with CIs
+    print("\n" + "-" * 78)
+    print("DELTAS (negative = faster). CI crossing zero = NOT a result.")
+    print("-" * 78)
+    pairs = [("exec", "cdp", "PART 1: request transport (exec'd python -> host CDP)"),
+             ("cdp", "cdp-fast", "PART 2: teardown discipline (awaited -> early response)"),
+             ("exec", "cdp-fast", "BOTH parts combined")]
+    out["deltas"] = {}
+    for a, b, label in pairs:
+        if a in by and b in by:
+            for metric in ("blocking_ms", "wall_ms"):
+                va = [r[metric] for r in by[a]]
+                vb = [r[metric] for r in by[b]]
+                d, lo, hi = hodges_lehmann_shift(va, vb)
+                sig = "" if (lo <= 0 <= hi) else "  *"
+                print(f"  {label}")
+                print(f"    {metric:12s} {a} -> {b}: {d:+.1f} ms  CI [{lo:+.1f}, {hi:+.1f}]{sig}")
+                out["deltas"][f"{a}->{b}:{metric}"] = {"delta": d, "ci": [lo, hi],
+                                                       "significant": not (lo <= 0 <= hi)}
+
+    # ---- 4. CDP stage decomposition (the per-request connect cost this design ADDS)
+    print("\n" + "-" * 78)
+    print("CDP ARMS: per-request stage decomposition (host -> clone over forward-localhost)")
+    print("-" * 78)
+    stage_keys = ["resolve_ms", "tcp_ms", "upgrade_ms", "enable_ms", "connect_total_ms",
+                  "navigate_ms", "screenshot_ms", "total_ms"]
+    for a in [x for x in arms if x.startswith("cdp")]:
+        print(f"  [{a}]")
+        pw = [r.get("port_wait_ms") for r in by[a] if r.get("port_wait_ms") is not None]
+        if pw:
+            print(f"    {'port_wait_ms':16s} {fmt(*median_ci(pw))}   "
+                  f"(restore -> first TCP accept; the ONLY readiness wait)")
+            out["arms"][a]["port_wait_ms"] = dict(zip(("median", "lo", "hi", "n"), median_ci(pw)))
+        for k in stage_keys:
+            # cdpdrive nests its timings under render.stages; reading render[k]
+            # directly silently yields nothing, which looks like "no data" rather
+            # than a bug. Read both, prefer stages.
+            v = [(r.get("render", {}).get("stages") or {}).get(k)
+                 if (r.get("render", {}).get("stages") or {}).get(k) is not None
+                 else r.get("render", {}).get(k)
+                 for r in by[a]]
+            v = [x for x in v if x is not None]
+            if v:
+                print(f"    {k:16s} {fmt(*median_ci(v))}")
+                out["arms"][a][k] = dict(zip(("median", "lo", "hi", "n"), median_ci(v)))
+    if "exec" in by:
+        v = [r.get("render_total_ms") for r in by["exec"] if r.get("render_total_ms")]
+        if v:
+            print(f"  [exec] in-guest render.py total_ms {fmt(*median_ci(v))}")
+            out["arms"]["exec"]["render_total_ms"] = dict(
+                zip(("median", "lo", "hi", "n"), median_ci(v)))
+
+    # ---- 5. teardown, three separate numbers, never one
+    print("\n" + "-" * 78)
+    print("TEARDOWN -- three numbers, deliberately not summed into one")
+    print("-" * 78)
+    for a in arms:
+        td = [r.get("teardown") for r in by[a] if r.get("teardown")]
+        if not td:
+            print(f"  {a:9s} (teardown is inside fcvm and not separable in this arm)")
+            continue
+        rw = [t.get("reap_wall_ms") for t in td if t.get("reap_wall_ms") is not None]
+        tt = [t.get("teardown_total_ms") for t in td if t.get("teardown_total_ms") is not None]
+        print(f"  [{a}] mode={td[0].get('mode')}")
+        print(f"    reap_wall_ms      {fmt(*median_ci(rw))}   (kill -> processes truly gone)")
+        print(f"    teardown_total_ms {fmt(*median_ci(tt))}   (incl. synchronous on-disk reap)")
+        out["arms"][a]["reap_wall_ms"] = dict(zip(("median", "lo", "hi", "n"), median_ci(rw)))
+        dr = [t.get("disk_reap_ms") for t in td if t.get("disk_reap_ms") is not None]
+        if dr:
+            print(f"    disk_reap_ms      {fmt(*median_ci(dr))}   (state file + data dir)")
+            out["arms"][a]["disk_reap_ms"] = dict(zip(("median", "lo", "hi", "n"), median_ci(dr)))
+        mc = [t.get("machine_cpu_ms_excess") for t in td
+              if t.get("machine_cpu_ms_excess") is not None]
+        if mc:
+            print(f"    machine_cpu_excess{fmt(*median_ci(mc))}   "
+                  f"(whole-machine busy jiffies over reclaim, ambient subtracted)")
+            out["arms"][a]["machine_cpu_ms_excess"] = dict(
+                zip(("median", "lo", "hi", "n"), median_ci(mc)))
+        comp, incomp = [], []
+        for t in td:
+            for _cname, c in (t.get("per_child_cpu") or {}).items():
+                if c.get("reclaim_cpu_ms") is None:
+                    continue
+                (comp if c.get("complete") else incomp).append(c["reclaim_cpu_ms"])
+        if comp:
+            print(f"    reclaim_cpu_ms    {fmt(*median_ci(comp))}   "
+                  f"COMPLETE (zombie state observed, exit_mm already ran)")
+            out["arms"][a]["reclaim_cpu_ms_complete"] = dict(
+                zip(("median", "lo", "hi", "n"), median_ci(comp)))
+        if incomp:
+            print(f"    reclaim_cpu_ms    {fmt(*median_ci(incomp))}   "
+                  f"LOWER BOUND ONLY (reaper won the race) -- not merged with the above")
+            out["arms"][a]["reclaim_cpu_ms_lower_bound"] = dict(
+                zip(("median", "lo", "hi", "n"), median_ci(incomp)))
+        ag = [t.get("all_gone") for t in td]
+        leaked = ag.count(False)
+        print(f"    all_gone: {ag.count(True)}/{len(ag)} confirmed"
+              + (f"  ** {leaked} NOT CONFIRMED GONE **" if leaked else ""))
+        out["arms"][a]["all_gone_confirmed"] = [ag.count(True), len(ag)]
+
+    if args.json_out:
+        with open(args.json_out, "w") as f:
+            json.dump(out, f, indent=2, default=str)
+        print(f"\nwrote {args.json_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -17,29 +17,45 @@ of being reported as one lump:
 
 WHY ONE SIGNAL IS THE CONCURRENT KILL
 -------------------------------------
-`kill(fcvm, SIGKILL)` is not "kill the parent and hope". fcvm spawns Firecracker
-and the namespace holder with `PR_SET_PDEATHSIG=SIGKILL`
-(`src/utils.rs::install_namespace_pre_exec`, `src/commands/common.rs::spawn_namespace_holder`).
-When fcvm dies the kernel's `exit_notify`/`forget_original_parent` walks its child
-list and delivers SIGKILL to EVERY child with a pdeathsig in one pass, before
-anything else can run. So the two kills are issued concurrently by construction —
-there is no ordering to get wrong, no `.await` between them, and no code of ours
-that has to survive to do it.
+`kill(fcvm, SIGKILL)` is not "kill the parent and hope". fcvm arms
+`PR_SET_PDEATHSIG=SIGKILL` on each of its three long-lived children:
+Firecracker (`src/utils.rs::install_namespace_pre_exec`), the namespace holder
+(`src/commands/common.rs::spawn_namespace_holder`) and pasta
+(`src/network/pasta.rs`). When fcvm dies the kernel's
+`exit_notify`/`forget_original_parent` walks its child list and delivers SIGKILL
+to EVERY child with a pdeathsig in one pass, before anything else can run. So the
+kills are issued concurrently by construction — there is no ordering to get
+wrong, no `.await` between them, and no code of ours that has to survive to do it.
 
-That is also why this is the fast path that CANNOT leak. AGENTS.md is explicit:
-"Prefer kernel-enforced reaping over cleanup code. A Drop impl, a signal handler,
-or an always() cleanup step does not run when the process is SIGKILLed — which is
-exactly the case that leaked." PR #730 restored precisely this chain after a
-privilege boundary broke it and ~490 microVMs leaked. This arm depends on the
-same guarantee the leak fix established, and
-`test_sigkill_kills_firecracker_rootless` plus `test_bench_fast_teardown_leaks_nothing_clone`
-(tests/test_signal_cleanup.rs) are its regression proof.
+WHAT THAT GUARANTEE DOES AND DOES NOT COVER. It is kernel-enforced for all three
+hops, but pasta's arming carries a precondition the other two do not:
+`commit_creds()` zeroes `pdeath_signal` whenever uid/gid change or
+`cred_cap_issubset(old, new)` fails, and pasta `setns()`es into the holder's user
+namespace after the `pre_exec`. Under sudo that is a capability LOSS, so the
+subset test passes and the signal survives; run fcvm genuinely unprivileged and it
+becomes a capability GAIN, the kernel clears the signal, and pasta falls back to
+passt's own 1-second PID watch of the holder. So: kernel-enforced for the VMM and
+the holder unconditionally, and for pasta while fcvm runs as root. This harness
+does not assume any of it — `teardown_fast` waits on a pidfd per child and
+REFUSES to reap on-disk state if any of them is still alive (see there).
 
-NO JANITOR. On-disk reaping (state file, data dir) is done synchronously, right
-here, after the clock stops. It is off the caller's critical path but it is not
-deferred to some sweeper that might not run — and it is MEASURED, not hidden.
-SIGKILL cannot be caught, so fcvm's `cleanup_vm` never runs and the state file
-survives the kill; reaping it here is REQUIRED, not an optimization.
+AGENTS.md is explicit: "Prefer kernel-enforced reaping over cleanup code. A Drop
+impl, a signal handler, or an always() cleanup step does not run when the process
+is SIGKILLed — which is exactly the case that leaked." PR #730 restored precisely
+this chain after a privilege boundary broke it and ~490 microVMs leaked. This arm
+depends on the same guarantee the leak fix established;
+`test_sigkill_reaps_rootless_vm_tree` plus
+`test_bench_fast_teardown_leaks_nothing_clone` (tests/test_signal_cleanup.rs) are
+its regression proof, and both require firecracker, holder AND pasta to be found
+before asserting, so a discovery drift fails loudly instead of silently checking
+nothing.
+
+NO JANITOR. On-disk reaping (state file, its lock, data dir) is done
+synchronously, right here, after the clock stops. It is off the caller's critical
+path but it is not deferred to some sweeper that might not run — and it is
+MEASURED, not hidden. SIGKILL cannot be caught, so fcvm's `cleanup_vm` never runs
+and both artifacts survive the kill; reaping them here is REQUIRED, not an
+optimization.
 
 WHAT IS ACTUALLY BEING CLAIMED (part 3)
 ---------------------------------------
@@ -82,6 +98,7 @@ import signal
 import subprocess
 import sys
 import time
+from urllib.parse import urlparse, urlunparse
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, HERE)
@@ -118,6 +135,19 @@ def machine_busy_jiffies():
     vals = [int(x) for x in parts[1:11]]
     idle = vals[3] + vals[4]  # idle + iowait
     return sum(vals) - idle, sum(vals)
+
+
+def self_cpu_ms() -> float:
+    """This harness's OWN cpu (utime+stime), in ms.
+
+    Subtracted from BOTH accounting windows so the sampler's own load cancels by
+    construction instead of being attributed to kernel reclaim. Without this the
+    control window and the reclaim window carry different amounts of harness CPU
+    and the subtraction removes work that was never done in the window it is
+    subtracted from.
+    """
+    s = proc_stat_fields(os.getpid())
+    return (s[1] + s[2]) * 1000.0 / CLK_TCK if s else 0.0
 
 
 def children_of(pid: int) -> list[int]:
@@ -177,60 +207,164 @@ def wait_pidfds(fds: list[int], timeout_s: float) -> bool:
     return True
 
 
-def sample_until_gone(pid: int, deadline: float) -> dict:
-    """Busy-read /proc/<pid>/stat until the task vanishes; keep the LAST sample.
+def sample_all_until_gone(pids: dict, deadline: float) -> dict:
+    """Sample EVERY child's /proc/<pid>/stat concurrently until each one vanishes.
 
-    Deliberately a tight loop with no sleep: the zombie window between
+    Concurrently, not one at a time. The previous version was a per-child call
+    inside a dict comprehension, so child 2 was not sampled at all until child 1
+    had already gone. Children exit on wildly different timescales after a single
+    SIGKILL (the namespace holder in a fraction of a millisecond, Firecracker in
+    tens), so a fast child that was not first in `children_of()` order was ALWAYS
+    already reaped by the time its turn came: `proc_stat_fields` returned None on
+    the first read, `last` stayed None, and its `reclaim_cpu_ms` was recorded as
+    `null`. That is not a lower bound, it is a missing measurement whose presence
+    depended on procfs ordering.
+
+    Still a tight loop with no sleep, deliberately: the zombie window between
     `exit_notify()` and the reaper is short, and catching state `Z` is what
-    upgrades the CPU figure from a lower bound to a complete one (see module
-    docstring). The loop is bounded by `deadline`.
+    upgrades a CPU figure from a lower bound to a complete one (see the module
+    docstring). The cost of that spin is now measured (`self_cpu_ms`) and
+    subtracted from the machine accounting rather than left in it.
     """
-    last = None
-    zombie_seen = False
-    while time.monotonic() < deadline:
-        s = proc_stat_fields(pid)
-        if s is None:
-            break
-        last = s
-        if s[0] in ("Z", "X", "x"):
-            zombie_seen = True
-            break
-    if last is None:
-        return {"cpu_ms": None, "zombie_seen": False}
-    return {
-        "cpu_ms": (last[1] + last[2]) * 1000.0 / CLK_TCK,
-        "zombie_seen": zombie_seen,
-    }
+    live = dict(pids)
+    last: dict = {}
+    zombie: dict = {name: False for name in pids}
+    while live and time.monotonic() < deadline:
+        for name, pid in list(live.items()):
+            s = proc_stat_fields(pid)
+            if s is None:
+                del live[name]
+                continue
+            last[name] = s
+            if s[0] in ("Z", "X", "x"):
+                zombie[name] = True
+                del live[name]
+    out = {}
+    for name in pids:
+        s = last.get(name)
+        out[name] = {
+            "cpu_ms": (s[1] + s[2]) * 1000.0 / CLK_TCK if s else None,
+            "zombie_seen": zombie[name],
+        }
+    return out
 
 
 # ------------------------------------------------------------------ fcvm glue
 
 
-def find_state(state_dir: str, fcvm_pid: int, deadline: float):
-    """Locate the clone's state file by fcvm PID.
+IN_CLOSE_WRITE = 0x00000008
+IN_MOVED_TO = 0x00000080
+IN_CREATE = 0x00000100
 
-    A filesystem scan, not an inotify watch, and deliberately OFF the measured
-    critical path where possible: it runs while the clone is still restoring.
-    Recorded as `discover_ms` so its cost is visible rather than smuggled into
-    the request time.
+
+class DirWatch:
+    """inotify watch on a directory. REGISTER BEFORE THE SPAWN THAT CAN TRIGGER IT.
+
+    fcvm itself uses exactly this discipline (`crate::utils::DirWatch`, e.g.
+    `src/network/pasta.rs`: "Register the inotify watch BEFORE ... the spawn"), and
+    for the same reason: a watch registered after the spawn can miss the event and
+    then wait for one that has already happened.
     """
-    while time.monotonic() < deadline:
-        try:
-            names = os.listdir(state_dir)
-        except OSError:
-            names = []
-        for name in names:
-            if not name.endswith(".json"):
-                continue
-            path = os.path.join(state_dir, name)
+
+    def __init__(self, path: str):
+        self.fd = _libc.inotify_init1(os.O_NONBLOCK)
+        if self.fd < 0:
+            raise OSError(ctypes.get_errno(), f"inotify_init1 on {path}")
+        wd = _libc.inotify_add_watch(
+            self.fd, path.encode(), IN_CREATE | IN_MOVED_TO | IN_CLOSE_WRITE
+        )
+        if wd < 0:
+            err = ctypes.get_errno()
+            os.close(self.fd)
+            self.fd = -1
+            raise OSError(err, f"inotify_add_watch on {path}")
+
+    def drain(self) -> None:
+        """Consume queued events. Call BEFORE scanning, never after: an event that
+        lands between a scan and a drain would be thrown away, and the next wait
+        would block for a change that already happened."""
+        while True:
             try:
-                with open(path) as f:
-                    st = json.load(f)
-            except (OSError, ValueError):
-                continue
-            if st.get("pid") == fcvm_pid:
-                return path, st
+                if not os.read(self.fd, 65536):
+                    return
+            except BlockingIOError:
+                return
+            except OSError:
+                return
+
+    def wait(self, timeout_s: float) -> bool:
+        """Block until the directory changes. Returns False on timeout."""
+        if timeout_s <= 0:
+            return False
+        poller = select.poll()
+        poller.register(self.fd, select.POLLIN)
+        return bool(poller.poll(timeout_s * 1000))
+
+    def close(self) -> None:
+        if self.fd >= 0:
+            os.close(self.fd)
+            self.fd = -1
+
+
+def scan_state(state_dir: str, fcvm_pid: int = 0, name: str = ""):
+    """One pass over the state dir. Matches on fcvm pid OR on VM name.
+
+    The name-keyed match is not a convenience: `allocate_loopback_ip` saves the
+    state file while `vm_state.pid` is still null (the pid is only set POST-RESUME,
+    `src/commands/common.rs`), so there is a whole window — network setup, mount
+    namespace, volume servers, the restore itself — in which the file exists,
+    Firecracker may already be running, and a pid-keyed scan returns nothing. The
+    name IS set before the first save, so it is the only key that covers that
+    window. A state file left behind with `pid: null` is never removed by fcvm's
+    own sweeper either (`cleanup_stale_state` bails on a null pid), so recovering
+    it here is the difference between a reaped clone and a permanent leak.
+    """
+    try:
+        names = os.listdir(state_dir)
+    except OSError:
+        return None, None
+    for fname in names:
+        if not fname.endswith(".json"):
+            continue
+        path = os.path.join(state_dir, fname)
+        try:
+            with open(path) as f:
+                st = json.load(f)
+        except (OSError, ValueError):
+            continue
+        if (fcvm_pid and st.get("pid") == fcvm_pid) or (name and st.get("name") == name):
+            return path, st
     return None, None
+
+
+def find_state(state_dir: str, fcvm_pid: int, deadline: float, watch=None, name: str = ""):
+    """Locate the clone's state file by fcvm PID (or name), EVENT-DRIVEN.
+
+    Was a `while time.monotonic() < deadline:` loop with an `os.listdir` plus a
+    full `json.load` of every file in it and NO sleep, no yield and no backoff. It
+    therefore burned 100% of one core for its entire duration — measured at 400 ms
+    of harness CPU for a 400 ms wall wait — while the 2-vCPU clone it is waiting on
+    was restoring on the same box. `wait_port` a few lines below already had a
+    backoff ladder, so the omission was local, not a policy.
+
+    Now it blocks in `poll()` on an inotify fd and rescans only when the directory
+    actually changes: zero CPU while waiting, and it notices the file sooner than a
+    poll loop would. `discover_ms` still records the wall cost.
+    """
+    own = watch is None
+    if own:
+        watch = DirWatch(state_dir)
+    try:
+        while True:
+            watch.drain()
+            path, st = scan_state(state_dir, fcvm_pid, name)
+            if st is not None:
+                return path, st
+            if not watch.wait(deadline - time.monotonic()):
+                return None, None
+    finally:
+        if own:
+            watch.close()
 
 
 def clone_cdp_endpoint(state: dict, port: int) -> str:
@@ -280,30 +414,113 @@ def wait_port(endpoint: str, deadline: float) -> float:
 # ------------------------------------------------------------------- teardown
 
 
+class SurvivedTeardown(RuntimeError):
+    """A tracked child outlived the fast teardown. The box is now contaminated.
+
+    Carries the partial teardown dict so the failure still lands in the artifact
+    with its survivor list. A leak that aborts the run but leaves no record is
+    only marginally better than one that does not abort it.
+    """
+
+    def __init__(self, message, teardown=None):
+        super().__init__(message)
+        self.teardown = teardown or {}
+        self.record: dict = {}
+
+
+def reap_disk(out: dict, state_path: str, data_dir: str) -> list:
+    """Remove the clone's state file (+ its lock) and data dir. Errors are RECORDED.
+
+    Never `ignore_errors=True`: a silently-failed rmtree reinstates the leak this
+    function exists to prevent, and clone dirs can be root-owned when the bench
+    runs under SUDO, so EPERM has to surface.
+    """
+    reaped = []
+    if state_path and os.path.exists(state_path):
+        try:
+            os.remove(state_path)
+            reaped.append(state_path)
+        except OSError as e:
+            out.setdefault("disk_errors", []).append(f"{state_path}: {e}")
+        # cleanup_stale_state removes `<vm_id>.json.lock` alongside the state file
+        # (src/state/manager.rs); it never runs under SIGKILL, so we remove it too.
+        lock = f"{state_path}.lock" if state_path else ""
+        if lock and os.path.exists(lock):
+            try:
+                os.remove(lock)
+                reaped.append(lock)
+            except OSError as e:
+                out.setdefault("disk_errors", []).append(f"{lock}: {e}")
+    if data_dir and os.path.isdir(data_dir):
+        try:
+            shutil.rmtree(data_dir)
+            reaped.append(data_dir)
+        except OSError as e:
+            out.setdefault("disk_errors", []).append(f"{data_dir}: {e}")
+    return reaped
+
+
 def teardown_fast(fcvm_pid: int, state_path: str, data_dir: str, timeout_s: float) -> dict:
-    """Concurrent SIGKILL via the pdeathsig chain, then synchronous on-disk reap."""
+    """Concurrent SIGKILL via the pdeathsig chain, then synchronous on-disk reap.
+
+    Raises `SurvivedTeardown` if any tracked child outlived the kill. That is not
+    politeness: reaping the state file and rmtree'ing the data dir of a VM whose
+    Firecracker is still RUNNING deletes the only record of a live microVM and
+    pulls its rootfs out from under it, and every later measurement then runs on a
+    box carrying an invisible ~1 GB tenant. Continuing the schedule after that is
+    measuring contention, not the request path.
+    """
     out: dict = {"mode": "fast"}
 
     kids = children_of(fcvm_pid)
-    tracked = {proc_comm(p) or f"pid{p}": p for p in kids}
+    # Keyed by comm, but a COLLISION MUST NOT DROP A CHILD. `{proc_comm(p): p for p
+    # in kids}` silently keeps only the last of any two children sharing a comm,
+    # and a child that is not in `tracked` is neither waited on nor CPU-accounted —
+    # it just does not exist as far as the leak check is concerned. fcvm's clone
+    # happens to have three distinct comms today (firecracker / sleep / pasta), so
+    # this never bit; that is luck, not a guarantee.
+    tracked: dict = {}
+    for p in kids:
+        base = proc_comm(p) or f"pid{p}"
+        key = base if base not in tracked else f"{base}#{p}"
+        tracked[key] = p
     out["children"] = tracked
     fds = {name: pidfd_open(pid) for name, pid in tracked.items()}
-    pre = {name: proc_stat_fields(pid) for name, pid in tracked.items()}
 
     # Control window: same machine, same instant, no reclaim running. Gives the
     # background busy rate to subtract, so ambient load is not attributed to us.
-    ctl_busy0, ctl_tot0 = machine_busy_jiffies()
+    #
+    # It SLEEPS. It used to be `while time.monotonic() - ctl_t0 < 0.05: pass`,
+    # i.e. the "ambient" rate was measured while this thread held 100% of one
+    # core. Measured back to back on this box, same ambient load: the spinning
+    # version reported control_busy_cores 1.40 / 1.40 / 1.20 with 50.0 ms of the
+    # harness's OWN cpu inside a 50 ms window; the sleeping version reports
+    # 0.20 / 0.40 / 0.00 with 0.0 ms. That ~1.2-core inflation was then multiplied
+    # by the ENTIRE reclaim window — in which the harness spins only while a child
+    # is still alive — so the subtraction removed work that was never done there.
+    # Belt and braces: the harness's own CPU is measured over both windows and
+    # subtracted from each, so any residual self-load cancels by construction.
+    ctl_self0 = self_cpu_ms()
+    ctl_busy0, _ = machine_busy_jiffies()
     ctl_t0 = time.monotonic()
-    while time.monotonic() - ctl_t0 < 0.05:
-        pass
-    ctl_busy1, ctl_tot1 = machine_busy_jiffies()
+    time.sleep(0.05)
+    ctl_busy1, _ = machine_busy_jiffies()
     ctl_dt = time.monotonic() - ctl_t0
-    ctl_rate = (ctl_busy1 - ctl_busy0) / CLK_TCK / ctl_dt if ctl_dt > 0 else 0.0
+    ctl_self_ms = self_cpu_ms() - ctl_self0
+    ctl_busy_ms = (ctl_busy1 - ctl_busy0) * 1000.0 / CLK_TCK
+    ctl_rate = (ctl_busy_ms - ctl_self_ms) / 1000.0 / ctl_dt if ctl_dt > 0 else 0.0
 
+    # Sampled HERE, immediately before the kill — not before the control window.
+    # Spanning the control window made the delta absorb ~50 ms of the still-running
+    # VM's ordinary CPU and report it as reclaim.
+    pre = {name: proc_stat_fields(pid) for name, pid in tracked.items()}
+
+    self0 = self_cpu_ms()
     busy0, _ = machine_busy_jiffies()
     t_kill = time.monotonic()
-    # ONE signal. The kernel fans SIGKILL out to firecracker AND the holder in a
-    # single forget_original_parent() pass — concurrent by construction.
+    # ONE signal. The kernel fans SIGKILL out to firecracker, the namespace holder
+    # AND pasta in a single forget_original_parent() pass — concurrent by
+    # construction (all three carry PR_SET_PDEATHSIG; see the module docstring).
     try:
         os.kill(fcvm_pid, signal.SIGKILL)
     except ProcessLookupError:
@@ -311,10 +528,11 @@ def teardown_fast(fcvm_pid: int, state_path: str, data_dir: str, timeout_s: floa
     out["signal_ms"] = (time.monotonic() - t_kill) * 1000
 
     deadline = t_kill + timeout_s
-    cpu = {name: sample_until_gone(pid, deadline) for name, pid in tracked.items()}
+    cpu = sample_all_until_gone(tracked, deadline)
     all_gone = wait_pidfds(list(fds.values()), max(0.0, deadline - time.monotonic()))
     t_gone = time.monotonic()
     busy1, _ = machine_busy_jiffies()
+    self_ms = self_cpu_ms() - self0
 
     for fd in fds.values():
         if fd is not None:
@@ -325,37 +543,63 @@ def teardown_fast(fcvm_pid: int, state_path: str, data_dir: str, timeout_s: floa
     out["reap_wall_ms"] = window_s * 1000
     out["all_gone"] = all_gone
     out["machine_cpu_ms"] = machine_cpu_ms
-    out["machine_cpu_ms_excess"] = machine_cpu_ms - ctl_rate * window_s * 1000
+    out["harness_cpu_ms"] = self_ms
+    out["machine_cpu_ms_excess"] = (machine_cpu_ms - self_ms) - ctl_rate * window_s * 1000
     out["control_busy_cores"] = ctl_rate
+    out["control_harness_cpu_ms"] = ctl_self_ms
+
+    # /proc/<pid>/stat counts in jiffies, so every CPU figure here is quantized to
+    # one tick. At CLK_TCK=100 that is 10 ms, and a sub-tick reclaim reports a hard
+    # 0.0 — a claim of zero CPU with zero uncertainty, which is exactly AGENTS.md
+    # defect 6. Emit the bound instead of the point.
+    tick_ms = 1000.0 / CLK_TCK
+    out["tick_ms"] = tick_ms
     out["per_child_cpu"] = {}
     for name, pid in tracked.items():
         before = pre[name]
         base = (before[1] + before[2]) * 1000.0 / CLK_TCK if before else 0.0
         s = cpu[name]
+        delta = (s["cpu_ms"] - base) if s["cpu_ms"] is not None else None
         out["per_child_cpu"][name] = {
+            "pid": pid,
             "cpu_before_ms": base,
             "cpu_final_ms": s["cpu_ms"],
-            "reclaim_cpu_ms": (s["cpu_ms"] - base) if s["cpu_ms"] is not None else None,
+            "reclaim_cpu_ms": delta,
+            # The interval the two quantized reads can actually support: each
+            # endpoint is truncated to a tick, so the true delta lies in
+            # [delta, delta + 2*tick].
+            "reclaim_cpu_ms_lo": delta,
+            "reclaim_cpu_ms_hi": (delta + 2 * tick_ms) if delta is not None else None,
+            "below_resolution": (delta == 0.0) if delta is not None else None,
             # True  -> exit_mm() had already run, figure is COMPLETE.
             # False -> reaper won the race, figure is a LOWER BOUND.
             "complete": s["zombie_seen"],
         }
 
-    t_disk = time.monotonic()
-    reaped = []
-    for path in (state_path,):
-        if path and os.path.exists(path):
+    if not all_gone:
+        survivors = {
+            name: pid for name, pid in tracked.items() if proc_stat_fields(pid) is not None
+        }
+        out["survivors"] = survivors
+        out["disk_reap_skipped"] = True
+        # Do NOT reap: the state file is the only record that these are ours.
+        # SIGKILL each survivor directly so the box is not left carrying them, then
+        # abort the schedule — a later rep measured next to a leaked microVM is not
+        # a measurement of this request path.
+        for pid in survivors.values():
             try:
-                os.remove(path)
-                reaped.append(path)
-            except OSError as e:
-                out.setdefault("disk_errors", []).append(f"{path}: {e}")
-    if data_dir and os.path.isdir(data_dir):
-        try:
-            shutil.rmtree(data_dir)
-            reaped.append(data_dir)
-        except OSError as e:
-            out.setdefault("disk_errors", []).append(f"{data_dir}: {e}")
+                os.kill(pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass
+        out["teardown_total_ms"] = (time.monotonic() - t_kill) * 1000
+        raise SurvivedTeardown(
+            f"fast teardown of fcvm {fcvm_pid} left {survivors} alive after "
+            f"{timeout_s:.1f}s; state {state_path} and data {data_dir} NOT reaped",
+            out,
+        )
+
+    t_disk = time.monotonic()
+    reaped = reap_disk(out, state_path, data_dir)
     out["disk_reap_ms"] = (time.monotonic() - t_disk) * 1000
     out["disk_reaped"] = reaped
     out["teardown_total_ms"] = (time.monotonic() - t_kill) * 1000
@@ -399,6 +643,21 @@ def teardown_normal(proc: subprocess.Popen, fcvm_pid: int, timeout_s: float) -> 
 # ----------------------------------------------------------------- one request
 
 
+def clone_ws_url(supplied: str, endpoint: str) -> str:
+    """Re-host a prewired `--ws-url` onto THIS clone's endpoint.
+
+    `--ws-url` exists to skip the per-request `/json/list`, and the reusable part
+    of the URL is the PATH — the page target id, which the golden snapshot bakes
+    in so every clone presents the same one. The NETLOC is not reusable: every
+    clone gets its own host-side address (`clone_cdp_endpoint`), so a single
+    prewired URL passed verbatim names one fixed 127.x.y.z:port for the whole run.
+    If that address happens to answer, the rep measures a DIFFERENT clone than the
+    one it just spawned and tore down.
+    """
+    u = urlparse(supplied)
+    return urlunparse(u._replace(netloc=endpoint))
+
+
 def run_cdp_request(args, rep: int, fast: bool) -> dict:
     import cdpdrive
 
@@ -410,56 +669,86 @@ def run_cdp_request(args, rep: int, fast: bool) -> dict:
         "--name", name, "--no-dirty-tracking", "--no-swap",
     ]
     env = dict(os.environ, RUST_LOG=args.rust_log)
+    # Watch registered BEFORE the spawn: a watch created afterwards can miss the
+    # state file's creation and then block waiting for an event already past.
+    watch = DirWatch(args.state_dir)
     t_spawn = time.monotonic()
-    with open(log, "wb") as lf:
-        # stdout/stderr to a FILE, never a pipe we do not drain: an undrained
-        # 64 KB pipe blocks fcvm's writer and stalls everything behind it
-        # (AGENTS.md "Pipe Buffer Deadlock in Tests").
-        proc = subprocess.Popen(cmd, stdout=lf, stderr=lf, stdin=subprocess.DEVNULL, env=env)
-    fcvm_pid = proc.pid
-
-    state_path = data_dir = None
     try:
-        deadline = t_spawn + args.timeout
-        t = time.monotonic()
-        state_path, state = find_state(args.state_dir, fcvm_pid, deadline)
-        if state is None:
-            raise TimeoutError("clone state file never appeared")
-        rec["discover_ms"] = (time.monotonic() - t) * 1000
-        vm_id = state.get("vm_id", "")
-        data_dir = os.path.join(args.data_root, "vm-disks", vm_id)
-        rec["vm_id"] = vm_id
+        with open(log, "wb") as lf:
+            # stdout/stderr to a FILE, never a pipe we do not drain: an undrained
+            # 64 KB pipe blocks fcvm's writer and stalls everything behind it
+            # (AGENTS.md "Pipe Buffer Deadlock in Tests").
+            proc = subprocess.Popen(cmd, stdout=lf, stderr=lf, stdin=subprocess.DEVNULL, env=env)
+        fcvm_pid = proc.pid
 
-        endpoint = clone_cdp_endpoint(state, args.cdp_port)
-        rec["endpoint"] = endpoint
-        rec["port_wait_ms"] = wait_port(endpoint, deadline)
+        state_path = data_dir = None
+        try:
+            deadline = t_spawn + args.timeout
+            t = time.monotonic()
+            state_path, state = find_state(args.state_dir, fcvm_pid, deadline, watch, name)
+            if state is None:
+                raise TimeoutError("clone state file never appeared")
+            rec["discover_ms"] = (time.monotonic() - t) * 1000
+            vm_id = state.get("vm_id", "")
+            data_dir = os.path.join(args.data_root, "vm-disks", vm_id)
+            rec["vm_id"] = vm_id
 
-        drive_args = argparse.Namespace(
-            cdp_host=endpoint,
-            url=args.url,
-            format=args.format,
-            quality=args.quality,
-            timeout=max(1.0, deadline - time.monotonic()),
-            idle_wait_ms=0.0,
-            out_prefix="",
-            ws_url=args.ws_url,
-            connect_retries=200,
-            nav_timing=True,
-            render_module=os.path.join(HERE, "render.py"),
-        )
-        result = cdpdrive.drive(drive_args)
-        rec["render"] = result
-        rec["ok"] = bool(result.get("ok"))
-        # THE CALLER'S ANSWER IS IN HAND HERE. Everything after this line is
-        # teardown, and none of it is latency the caller pays.
-        rec["blocking_ms"] = (time.monotonic() - t_spawn) * 1000
-    except Exception as e:
-        rec["ok"] = False
-        rec["error"] = f"{type(e).__name__}: {e}"
-        rec["blocking_ms"] = (time.monotonic() - t_spawn) * 1000
+            endpoint = clone_cdp_endpoint(state, args.cdp_port)
+            rec["endpoint"] = endpoint
+            rec["port_wait_ms"] = wait_port(endpoint, deadline)
+
+            ws_url = clone_ws_url(args.ws_url, endpoint) if args.ws_url else ""
+            rec["ws_url_prewired"] = bool(ws_url)
+            drive_args = argparse.Namespace(
+                cdp_host=endpoint,
+                url=args.url,
+                format=args.format,
+                quality=args.quality,
+                timeout=max(1.0, deadline - time.monotonic()),
+                idle_wait_ms=0.0,
+                out_prefix="",
+                ws_url=ws_url,
+                connect_retries=200,
+                nav_timing=True,
+                print_target=False,
+                render_module=os.path.join(HERE, "render.py"),
+            )
+            result = cdpdrive.drive(drive_args)
+            rec["render"] = result
+            rec["ok"] = bool(result.get("ok"))
+            # THE CALLER'S ANSWER IS IN HAND HERE. Everything after this line is
+            # teardown, and none of it is latency the caller pays.
+            rec["blocking_ms"] = (time.monotonic() - t_spawn) * 1000
+        except Exception as e:
+            rec["ok"] = False
+            rec["error"] = f"{type(e).__name__}: {e}"
+            rec["blocking_ms"] = (time.monotonic() - t_spawn) * 1000
+            if state_path is None:
+                # find_state may have timed out while fcvm had ALREADY written the
+                # file (it is saved with `pid: null` until post-resume). Leaving
+                # state_path/data_dir as None here means teardown reaps nothing and
+                # the clone's disk artifacts leak permanently — nothing else ever
+                # removes a state file whose pid is null. Rescan by NAME once.
+                state_path, state = scan_state(args.state_dir, fcvm_pid, name)
+                if state is not None:
+                    rec["recovered_state_by_name"] = True
+                    rec["vm_id"] = state.get("vm_id", "")
+                    data_dir = os.path.join(args.data_root, "vm-disks", rec["vm_id"])
+    finally:
+        watch.close()
 
     if fast:
-        rec["teardown"] = teardown_fast(fcvm_pid, state_path, data_dir, args.teardown_timeout)
+        try:
+            rec["teardown"] = teardown_fast(fcvm_pid, state_path, data_dir,
+                                            args.teardown_timeout)
+        except SurvivedTeardown as e:
+            # The rep still gets a record, with the survivor list in it.
+            rec["teardown"] = e.teardown
+            rec["ok"] = False
+            rec["wall_ms"] = (time.monotonic() - t_spawn) * 1000
+            rec["log"] = log
+            e.record = rec
+            raise
         try:
             proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
@@ -508,22 +797,26 @@ def run_noop_request(args, rep: int) -> dict:
         "--name", name, "--no-dirty-tracking", "--no-swap",
     ]
     env = dict(os.environ, RUST_LOG=args.rust_log)
+    watch = DirWatch(args.state_dir)
     t_spawn = time.monotonic()
-    with open(log, "wb") as lf:
-        proc = subprocess.Popen(cmd, stdout=lf, stderr=lf, stdin=subprocess.DEVNULL, env=env)
-    fcvm_pid = proc.pid
     try:
-        deadline = t_spawn + args.timeout
-        state_path, state = find_state(args.state_dir, fcvm_pid, deadline)
-        if state is None:
-            raise TimeoutError("clone state file never appeared")
-        rec["vm_id"] = state.get("vm_id", "")
-        endpoint = clone_cdp_endpoint(state, args.cdp_port)
-        rec["port_wait_ms"] = wait_port(endpoint, deadline)
-        rec["ok"] = True
-    except Exception as e:
-        rec["ok"] = False
-        rec["error"] = f"{type(e).__name__}: {e}"
+        with open(log, "wb") as lf:
+            proc = subprocess.Popen(cmd, stdout=lf, stderr=lf, stdin=subprocess.DEVNULL, env=env)
+        fcvm_pid = proc.pid
+        try:
+            deadline = t_spawn + args.timeout
+            state_path, state = find_state(args.state_dir, fcvm_pid, deadline, watch, name)
+            if state is None:
+                raise TimeoutError("clone state file never appeared")
+            rec["vm_id"] = state.get("vm_id", "")
+            endpoint = clone_cdp_endpoint(state, args.cdp_port)
+            rec["port_wait_ms"] = wait_port(endpoint, deadline)
+            rec["ok"] = True
+        except Exception as e:
+            rec["ok"] = False
+            rec["error"] = f"{type(e).__name__}: {e}"
+    finally:
+        watch.close()
     rec["blocking_ms"] = (time.monotonic() - t_spawn) * 1000
     rec["teardown"] = teardown_normal(proc, fcvm_pid, args.teardown_timeout)
     rec["wall_ms"] = (time.monotonic() - t_spawn) * 1000
@@ -543,10 +836,35 @@ def run_exec_request(args, rep: int) -> dict:
         "--name", name, "--no-dirty-tracking", "--no-swap", "--exec", driver,
     ]
     env = dict(os.environ, RUST_LOG=args.rust_log)
+    rec: dict = {"arm": "exec", "rep": rep, "name": name, "timed_out": False}
     t0 = time.monotonic()
     with open(log, "wb") as lf:
         proc = subprocess.Popen(cmd, stdout=lf, stderr=lf, stdin=subprocess.DEVNULL, env=env)
-    rc = proc.wait(timeout=args.timeout + args.teardown_timeout)
+    try:
+        rc = proc.wait(timeout=args.timeout + args.teardown_timeout)
+    except subprocess.TimeoutExpired:
+        # This was a bare `proc.wait(timeout=...)` with no handler, so a single
+        # slow rep raised `TimeoutExpired` straight out of main() and killed the
+        # harness — leaving the spawned fcvm ORPHANED (Python installs no
+        # pdeathsig and reqbench is not a subreaper) with its Firecracker, holder,
+        # pasta, state file and vm-disks dir still live, into the next run's
+        # measurements. The exec arm was the only arm with this hole; the other two
+        # always reach a teardown call.
+        rec["timed_out"] = True
+        try:
+            os.kill(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            pass
+        rc = -9
+        # The exec arm never resolves the clone's state file in the happy path, so
+        # find it now — by name, since the pid may never have been written.
+        sp, state = scan_state(args.state_dir, proc.pid, name)
+        dd = os.path.join(args.data_root, "vm-disks", state.get("vm_id", "")) if state else ""
+        rec["reaped"] = reap_disk(rec, sp, dd)
     wall = (time.monotonic() - t0) * 1000
     render_ms = None
     try:
@@ -558,14 +876,15 @@ def run_exec_request(args, rep: int) -> dict:
                             render_ms = float(tok.split("=", 1)[1])
     except OSError:
         pass
-    return {
-        "arm": "exec", "rep": rep, "name": name, "ok": rc == 0,
+    rec.update(
+        ok=(rc == 0),
         # The exec arm has no separable "response in hand" instant that the host
         # can observe: fcvm returns only after its own teardown. blocking == wall
         # is not an approximation, it is the arm's defining property.
-        "blocking_ms": wall, "wall_ms": wall,
-        "render_total_ms": render_ms, "rc": rc, "log": log,
-    }
+        blocking_ms=wall, wall_ms=wall,
+        render_total_ms=render_ms, rc=rc, log=log,
+    )
+    return rec
 
 
 def main() -> int:
@@ -621,12 +940,25 @@ def main() -> int:
         out.write(json.dumps(meta) + "\n")
         out.flush()
         for rep, arm, is_warmup in schedule:
-            if arm == "exec":
-                rec = run_exec_request(args, rep)
-            elif arm == "noop":
-                rec = run_noop_request(args, rep)
-            else:
-                rec = run_cdp_request(args, rep, fast=(arm == "cdp-fast"))
+            # Every rep records something, including the ones that blow up. A rep
+            # that raises out of the loop used to take the whole run with it and
+            # leave no trace in the artifact, so `n=` was the only evidence that
+            # anything had been dropped.
+            try:
+                if arm == "exec":
+                    rec = run_exec_request(args, rep)
+                elif arm == "noop":
+                    rec = run_noop_request(args, rep)
+                else:
+                    rec = run_cdp_request(args, rep, fast=(arm == "cdp-fast"))
+                fatal = None
+            except SurvivedTeardown as e:
+                rec = dict(e.record) or {"arm": arm, "rep": rep}
+                rec.update(ok=False, error=f"{type(e).__name__}: {e}")
+                fatal = e
+            except Exception as e:  # noqa: BLE001 - record, then re-raise
+                rec = {"arm": arm, "rep": rep, "ok": False, "error": f"{type(e).__name__}: {e}"}
+                fatal = e
             rec["warmup"] = is_warmup  # discarded explicitly at analysis, never silently
             rec["loadavg1"] = float(open("/proc/loadavg").read().split()[0])
             out.write(json.dumps(rec) + "\n")
@@ -638,6 +970,12 @@ def main() -> int:
                 f"teardown={rec.get('teardown', {}).get('teardown_total_ms', 0):.1f}ms",
                 flush=True,
             )
+            if fatal is not None:
+                # STOP. A survivor means the box now carries a microVM this harness
+                # cannot see; every later rep would be measuring contention.
+                print(f"\nABORTING SCHEDULE: {fatal}", file=sys.stderr, flush=True)
+                print(f"wrote {out_path}")
+                return 4
     print(f"\nwrote {out_path}")
     return 0
 

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -1,0 +1,646 @@
+#!/usr/bin/env python3
+"""Request-optimized A/B: resident CDP + fast teardown, with honest kernel accounting.
+
+THREE ARMS, so the two independent changes can be attributed separately instead
+of being reported as one lump:
+
+  exec      today's path. `fcvm snapshot run --exec <python driver>`: exec
+            handshake, guest python interpreter boot, in-guest CDP connect,
+            render, then fcvm's own SEQUENTIAL teardown, all awaited.
+  cdp       resident render. The clone is restored with no --exec; the host
+            drives Chromium's DevTools endpoint over fcvm's port forwarding.
+            Teardown is still fcvm's: SIGTERM, then await the full sequence.
+            (exec -> cdp isolates PART 1.)
+  cdp-fast  same request path, fast teardown: the response is delivered the
+            instant the image is in hand, THEN one SIGKILL to fcvm.
+            (cdp -> cdp-fast isolates PART 2.)
+
+WHY ONE SIGNAL IS THE CONCURRENT KILL
+-------------------------------------
+`kill(fcvm, SIGKILL)` is not "kill the parent and hope". fcvm spawns Firecracker
+and the namespace holder with `PR_SET_PDEATHSIG=SIGKILL`
+(`src/utils.rs::install_namespace_pre_exec`, `src/commands/common.rs::spawn_namespace_holder`).
+When fcvm dies the kernel's `exit_notify`/`forget_original_parent` walks its child
+list and delivers SIGKILL to EVERY child with a pdeathsig in one pass, before
+anything else can run. So the two kills are issued concurrently by construction —
+there is no ordering to get wrong, no `.await` between them, and no code of ours
+that has to survive to do it.
+
+That is also why this is the fast path that CANNOT leak. AGENTS.md is explicit:
+"Prefer kernel-enforced reaping over cleanup code. A Drop impl, a signal handler,
+or an always() cleanup step does not run when the process is SIGKILLed — which is
+exactly the case that leaked." PR #730 restored precisely this chain after a
+privilege boundary broke it and ~490 microVMs leaked. This arm depends on the
+same guarantee the leak fix established, and
+`test_sigkill_kills_firecracker_rootless` plus `test_bench_fast_teardown_leaks_nothing_clone`
+(tests/test_signal_cleanup.rs) are its regression proof.
+
+NO JANITOR. On-disk reaping (state file, data dir) is done synchronously, right
+here, after the clock stops. It is off the caller's critical path but it is not
+deferred to some sweeper that might not run — and it is MEASURED, not hidden.
+SIGKILL cannot be caught, so fcvm's `cleanup_vm` never runs and the state file
+survives the kill; reaping it here is REQUIRED, not an optimization.
+
+WHAT IS ACTUALLY BEING CLAIMED (part 3)
+---------------------------------------
+The claim under test is: "early response converts teardown from LATENCY into
+THROUGHPUT cost." Converts. Not removes. So this harness refuses to report one
+number and reports three:
+
+  blocking_ms       what the caller waits. Spawn -> image in hand.
+  reap_wall_ms      SIGKILL -> both processes actually gone (pidfd readable).
+                    The caller does not wait for this. The MACHINE does.
+  reclaim_cpu_ms    CPU burned tearing the address space down, from
+                    /proc/<pid>/stat utime+stime.
+
+`reclaim_cpu_ms` is a real number, not an estimate, and here is why it is
+trustworthy: `do_exit()` runs `exit_mm()` — which unmaps and frees the whole
+address space, the expensive part for a ~1 GB VM — BEFORE `exit_notify()` turns
+the task into a zombie. A `/proc/<pid>/stat` read taken while the task is in
+state `Z` therefore already includes all of the reclaim. The sampler records
+whether it caught the `Z` state (`zombie_seen`); when it did, the CPU figure is
+COMPLETE, and when it did not (the parent's reaper won the race) the figure is a
+LOWER BOUND and is labelled as one. Never averaged together.
+
+Whole-machine `/proc/stat` busy-jiffy deltas are recorded over the reclaim window
+AND over an equal-length control window taken immediately before the kill, so
+background load can be subtracted instead of silently inflating the attribution.
+
+At saturation that CPU competes with new requests. A latency win is not a
+capacity win, and this harness deliberately makes it impossible to report one as
+the other.
+"""
+
+import argparse
+import ctypes
+import json
+import os
+import random
+import select
+import shutil
+import signal
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+CLK_TCK = os.sysconf("SC_CLK_TCK")
+
+
+# ---------------------------------------------------------------- procfs utils
+
+
+def proc_stat_fields(pid: int):
+    """(state, utime_ticks, stime_ticks, starttime) or None if the pid is gone.
+
+    `comm` (field 2) can contain spaces and parentheses, so split after the LAST
+    `") "` — the standard trap in /proc/<pid>/stat parsing.
+    """
+    try:
+        with open(f"/proc/{pid}/stat") as f:
+            raw = f.read()
+    except OSError:
+        return None
+    try:
+        after = raw.rsplit(") ", 1)[1]
+        f = after.split()
+        return f[0], int(f[11]), int(f[12]), int(f[19])
+    except (IndexError, ValueError):
+        return None
+
+
+def machine_busy_jiffies():
+    """Non-idle jiffies from /proc/stat's aggregate line."""
+    with open("/proc/stat") as f:
+        parts = f.readline().split()
+    vals = [int(x) for x in parts[1:11]]
+    idle = vals[3] + vals[4]  # idle + iowait
+    return sum(vals) - idle, sum(vals)
+
+
+def children_of(pid: int) -> list[int]:
+    """Direct children via /proc/<pid>/task/<tid>/children."""
+    out = []
+    try:
+        for tid in os.listdir(f"/proc/{pid}/task"):
+            try:
+                with open(f"/proc/{pid}/task/{tid}/children") as f:
+                    out += [int(x) for x in f.read().split()]
+            except OSError:
+                pass
+    except OSError:
+        pass
+    return out
+
+
+def proc_comm(pid: int) -> str:
+    try:
+        with open(f"/proc/{pid}/comm") as f:
+            return f.read().strip()
+    except OSError:
+        return ""
+
+
+_libc = ctypes.CDLL("libc.so.6", use_errno=True)
+
+
+def pidfd_open(pid: int):
+    """A handle that refers to THIS exact process for its whole lifetime.
+
+    Used instead of polling /proc/<pid>: a pidfd can never alias a reused PID, and
+    poll() on it becomes readable exactly when the process exits — so the
+    "is it gone yet" wait is an event, not a timer. AGENTS.md: no sleeps,
+    event-driven only.
+    """
+    fd = _libc.syscall(434, ctypes.c_int(pid), ctypes.c_uint(0))  # SYS_pidfd_open
+    if fd < 0:
+        return None
+    return fd
+
+
+def wait_pidfds(fds: list[int], timeout_s: float) -> bool:
+    """Block until every pidfd is readable (process exited) or the deadline passes."""
+    remaining = [fd for fd in fds if fd is not None]
+    deadline = time.monotonic() + timeout_s
+    poller = select.poll()
+    for fd in remaining:
+        poller.register(fd, select.POLLIN)
+    while remaining:
+        left = deadline - time.monotonic()
+        if left <= 0:
+            return False
+        for fd, _ev in poller.poll(left * 1000):
+            poller.unregister(fd)
+            remaining.remove(fd)
+    return True
+
+
+def sample_until_gone(pid: int, deadline: float) -> dict:
+    """Busy-read /proc/<pid>/stat until the task vanishes; keep the LAST sample.
+
+    Deliberately a tight loop with no sleep: the zombie window between
+    `exit_notify()` and the reaper is short, and catching state `Z` is what
+    upgrades the CPU figure from a lower bound to a complete one (see module
+    docstring). The loop is bounded by `deadline`.
+    """
+    last = None
+    zombie_seen = False
+    while time.monotonic() < deadline:
+        s = proc_stat_fields(pid)
+        if s is None:
+            break
+        last = s
+        if s[0] in ("Z", "X", "x"):
+            zombie_seen = True
+            break
+    if last is None:
+        return {"cpu_ms": None, "zombie_seen": False}
+    return {
+        "cpu_ms": (last[1] + last[2]) * 1000.0 / CLK_TCK,
+        "zombie_seen": zombie_seen,
+    }
+
+
+# ------------------------------------------------------------------ fcvm glue
+
+
+def find_state(state_dir: str, fcvm_pid: int, deadline: float):
+    """Locate the clone's state file by fcvm PID.
+
+    A filesystem scan, not an inotify watch, and deliberately OFF the measured
+    critical path where possible: it runs while the clone is still restoring.
+    Recorded as `discover_ms` so its cost is visible rather than smuggled into
+    the request time.
+    """
+    while time.monotonic() < deadline:
+        try:
+            names = os.listdir(state_dir)
+        except OSError:
+            names = []
+        for name in names:
+            if not name.endswith(".json"):
+                continue
+            path = os.path.join(state_dir, name)
+            try:
+                with open(path) as f:
+                    st = json.load(f)
+            except (OSError, ValueError):
+                continue
+            if st.get("pid") == fcvm_pid:
+                return path, st
+    return None, None
+
+
+def clone_cdp_endpoint(state: dict, port: int) -> str:
+    """Host-side address of the clone's published CDP port.
+
+    fcvm gives every VM a unique address so the SAME guest port can be published
+    by many clones at once: rootless/pasta -> a unique 127.x.y.z loopback IP,
+    bridged -> the veth's host IP with DNAT scoped to it, routed -> a unique
+    loopback IP fronted by the built-in TCP proxy. Port mappings are inherited by
+    a restored clone from the snapshot metadata
+    (`src/commands/snapshot.rs`: `snapshot_config.metadata.port_mappings`), so
+    `--publish 9222:9222` on the golden VM applies to every clone with no
+    per-clone plumbing of ours.
+    """
+    net = state.get("config", {}).get("network", {}) or {}
+    for key in ("loopback_ip", "host_ip", "guest_ip"):
+        ip = net.get(key)
+        if ip:
+            return f"{ip}:{port}"
+    raise RuntimeError(f"no usable host-side IP in network config: {sorted(net)}")
+
+
+def wait_port(endpoint: str, deadline: float) -> float:
+    """Retry-connect until the forwarded CDP port answers. Returns wait in ms.
+
+    This is the readiness signal, and it is the minimum possible one: the first
+    successful TCP connect to Chromium's own listener. There is no health poll,
+    no exec handshake and no marker file in the request path.
+    """
+    import socket
+
+    host, port = endpoint.rsplit(":", 1)
+    t0 = time.monotonic()
+    delay = 0.001
+    while True:
+        try:
+            s = socket.create_connection((host, int(port)), 0.25)
+            s.close()
+            return (time.monotonic() - t0) * 1000
+        except OSError:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"CDP port {endpoint} never answered")
+            time.sleep(delay)
+            delay = min(delay * 1.5, 0.02)
+
+
+# ------------------------------------------------------------------- teardown
+
+
+def teardown_fast(fcvm_pid: int, state_path: str, data_dir: str, timeout_s: float) -> dict:
+    """Concurrent SIGKILL via the pdeathsig chain, then synchronous on-disk reap."""
+    out: dict = {"mode": "fast"}
+
+    kids = children_of(fcvm_pid)
+    tracked = {proc_comm(p) or f"pid{p}": p for p in kids}
+    out["children"] = tracked
+    fds = {name: pidfd_open(pid) for name, pid in tracked.items()}
+    pre = {name: proc_stat_fields(pid) for name, pid in tracked.items()}
+
+    # Control window: same machine, same instant, no reclaim running. Gives the
+    # background busy rate to subtract, so ambient load is not attributed to us.
+    ctl_busy0, ctl_tot0 = machine_busy_jiffies()
+    ctl_t0 = time.monotonic()
+    while time.monotonic() - ctl_t0 < 0.05:
+        pass
+    ctl_busy1, ctl_tot1 = machine_busy_jiffies()
+    ctl_dt = time.monotonic() - ctl_t0
+    ctl_rate = (ctl_busy1 - ctl_busy0) / CLK_TCK / ctl_dt if ctl_dt > 0 else 0.0
+
+    busy0, _ = machine_busy_jiffies()
+    t_kill = time.monotonic()
+    # ONE signal. The kernel fans SIGKILL out to firecracker AND the holder in a
+    # single forget_original_parent() pass — concurrent by construction.
+    try:
+        os.kill(fcvm_pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    out["signal_ms"] = (time.monotonic() - t_kill) * 1000
+
+    deadline = t_kill + timeout_s
+    cpu = {name: sample_until_gone(pid, deadline) for name, pid in tracked.items()}
+    all_gone = wait_pidfds(list(fds.values()), max(0.0, deadline - time.monotonic()))
+    t_gone = time.monotonic()
+    busy1, _ = machine_busy_jiffies()
+
+    for fd in fds.values():
+        if fd is not None:
+            os.close(fd)
+
+    window_s = t_gone - t_kill
+    machine_cpu_ms = (busy1 - busy0) * 1000.0 / CLK_TCK
+    out["reap_wall_ms"] = window_s * 1000
+    out["all_gone"] = all_gone
+    out["machine_cpu_ms"] = machine_cpu_ms
+    out["machine_cpu_ms_excess"] = machine_cpu_ms - ctl_rate * window_s * 1000
+    out["control_busy_cores"] = ctl_rate
+    out["per_child_cpu"] = {}
+    for name, pid in tracked.items():
+        before = pre[name]
+        base = (before[1] + before[2]) * 1000.0 / CLK_TCK if before else 0.0
+        s = cpu[name]
+        out["per_child_cpu"][name] = {
+            "cpu_before_ms": base,
+            "cpu_final_ms": s["cpu_ms"],
+            "reclaim_cpu_ms": (s["cpu_ms"] - base) if s["cpu_ms"] is not None else None,
+            # True  -> exit_mm() had already run, figure is COMPLETE.
+            # False -> reaper won the race, figure is a LOWER BOUND.
+            "complete": s["zombie_seen"],
+        }
+
+    t_disk = time.monotonic()
+    reaped = []
+    for path in (state_path,):
+        if path and os.path.exists(path):
+            try:
+                os.remove(path)
+                reaped.append(path)
+            except OSError as e:
+                out.setdefault("disk_errors", []).append(f"{path}: {e}")
+    if data_dir and os.path.isdir(data_dir):
+        try:
+            shutil.rmtree(data_dir)
+            reaped.append(data_dir)
+        except OSError as e:
+            out.setdefault("disk_errors", []).append(f"{data_dir}: {e}")
+    out["disk_reap_ms"] = (time.monotonic() - t_disk) * 1000
+    out["disk_reaped"] = reaped
+    out["teardown_total_ms"] = (time.monotonic() - t_kill) * 1000
+    return out
+
+
+def teardown_normal(proc: subprocess.Popen, fcvm_pid: int, timeout_s: float) -> dict:
+    """fcvm's own cleanup: SIGTERM, then await the full sequential unwind.
+
+    kill -> holder kill -> network cleanup -> state delete -> FC log save ->
+    data-dir removal, each awaited. This is the control the fast arm is measured
+    against.
+    """
+    out: dict = {"mode": "normal"}
+    kids = children_of(fcvm_pid)
+    fds = [pidfd_open(p) for p in kids]
+    t0 = time.monotonic()
+    try:
+        os.kill(fcvm_pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        proc.wait(timeout=timeout_s)
+    except subprocess.TimeoutExpired:
+        out["timed_out"] = True
+        try:
+            os.kill(fcvm_pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.wait(timeout=10)
+    out["fcvm_exit_ms"] = (time.monotonic() - t0) * 1000
+    out["all_gone"] = wait_pidfds(fds, max(0.0, t0 + timeout_s - time.monotonic()))
+    for fd in fds:
+        if fd is not None:
+            os.close(fd)
+    out["reap_wall_ms"] = (time.monotonic() - t0) * 1000
+    out["teardown_total_ms"] = out["reap_wall_ms"]
+    return out
+
+
+# ----------------------------------------------------------------- one request
+
+
+def run_cdp_request(args, rep: int, fast: bool) -> dict:
+    import cdpdrive
+
+    name = f"rb-{os.getpid()}-{rep}-{'fast' if fast else 'norm'}"
+    log = os.path.join(args.out_dir, f"{name}.log")
+    rec: dict = {"arm": "cdp-fast" if fast else "cdp", "rep": rep, "name": name}
+
+    cmd = [args.fcvm, "snapshot", "run"] + clone_backend_args(args) + [
+        "--name", name, "--no-dirty-tracking", "--no-swap",
+    ]
+    env = dict(os.environ, RUST_LOG=args.rust_log)
+    t_spawn = time.monotonic()
+    with open(log, "wb") as lf:
+        # stdout/stderr to a FILE, never a pipe we do not drain: an undrained
+        # 64 KB pipe blocks fcvm's writer and stalls everything behind it
+        # (AGENTS.md "Pipe Buffer Deadlock in Tests").
+        proc = subprocess.Popen(cmd, stdout=lf, stderr=lf, stdin=subprocess.DEVNULL, env=env)
+    fcvm_pid = proc.pid
+
+    state_path = data_dir = None
+    try:
+        deadline = t_spawn + args.timeout
+        t = time.monotonic()
+        state_path, state = find_state(args.state_dir, fcvm_pid, deadline)
+        if state is None:
+            raise TimeoutError("clone state file never appeared")
+        rec["discover_ms"] = (time.monotonic() - t) * 1000
+        vm_id = state.get("vm_id", "")
+        data_dir = os.path.join(args.data_root, "vm-disks", vm_id)
+        rec["vm_id"] = vm_id
+
+        endpoint = clone_cdp_endpoint(state, args.cdp_port)
+        rec["endpoint"] = endpoint
+        rec["port_wait_ms"] = wait_port(endpoint, deadline)
+
+        drive_args = argparse.Namespace(
+            cdp_host=endpoint,
+            url=args.url,
+            format=args.format,
+            quality=args.quality,
+            timeout=max(1.0, deadline - time.monotonic()),
+            idle_wait_ms=0.0,
+            out_prefix="",
+            ws_url=args.ws_url,
+            connect_retries=200,
+            nav_timing=True,
+            render_module=os.path.join(HERE, "render.py"),
+        )
+        result = cdpdrive.drive(drive_args)
+        rec["render"] = result
+        rec["ok"] = bool(result.get("ok"))
+        # THE CALLER'S ANSWER IS IN HAND HERE. Everything after this line is
+        # teardown, and none of it is latency the caller pays.
+        rec["blocking_ms"] = (time.monotonic() - t_spawn) * 1000
+    except Exception as e:
+        rec["ok"] = False
+        rec["error"] = f"{type(e).__name__}: {e}"
+        rec["blocking_ms"] = (time.monotonic() - t_spawn) * 1000
+
+    if fast:
+        rec["teardown"] = teardown_fast(fcvm_pid, state_path, data_dir, args.teardown_timeout)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
+    else:
+        rec["teardown"] = teardown_normal(proc, fcvm_pid, args.teardown_timeout)
+    rec["wall_ms"] = (time.monotonic() - t_spawn) * 1000
+    rec["log"] = log
+    return rec
+
+
+
+def clone_backend_args(args) -> list:
+    """UFFD serve-backed vs FILE-backed restore, as CLI args.
+
+    These are different memory backends with different per-request costs -- the
+    published 573 ms stage baseline is FILE-backed, and every guest page touched
+    during startup costs a UFFD round trip on the other path. Mixing them and
+    comparing against that baseline would be exactly the matched-accounting
+    failure AGENTS.md defect 1 describes, so the backend is explicit and recorded
+    in the run metadata rather than implied by which flag happened to be passed.
+    """
+    if args.snapshot_tag:
+        return ["--snapshot", args.snapshot_tag]
+    return ["--pid", str(args.serve_pid)]
+
+
+def run_noop_request(args, rep: int) -> dict:
+    """DRIFT CONTROL. Clone spawn -> CDP port answers -> normal teardown. No page.
+
+    AGENTS.md defect 2 requires a probe that exercises NONE of the varied
+    dimension, so wall-clock drift is measurable and removable rather than being
+    silently absorbed into an arm's effect. The varied dimension here is the
+    REQUEST transport (in-guest exec'd python vs host-driven CDP) and the
+    teardown discipline. This probe does neither: it never loads a page, never
+    speaks CDP, never touches the page server.
+
+    What it DOES include is exactly the substrate every arm shares — fcvm clone
+    spawn, snapshot restore, and fcvm's own teardown — so a machine that slows
+    down over the run shows up here, in a series with no arm effect in it.
+    """
+    name = f"rb-{os.getpid()}-{rep}-noop"
+    log = os.path.join(args.out_dir, f"{name}.log")
+    rec: dict = {"arm": "noop", "rep": rep, "name": name}
+    cmd = [args.fcvm, "snapshot", "run"] + clone_backend_args(args) + [
+        "--name", name, "--no-dirty-tracking", "--no-swap",
+    ]
+    env = dict(os.environ, RUST_LOG=args.rust_log)
+    t_spawn = time.monotonic()
+    with open(log, "wb") as lf:
+        proc = subprocess.Popen(cmd, stdout=lf, stderr=lf, stdin=subprocess.DEVNULL, env=env)
+    fcvm_pid = proc.pid
+    try:
+        deadline = t_spawn + args.timeout
+        state_path, state = find_state(args.state_dir, fcvm_pid, deadline)
+        if state is None:
+            raise TimeoutError("clone state file never appeared")
+        rec["vm_id"] = state.get("vm_id", "")
+        endpoint = clone_cdp_endpoint(state, args.cdp_port)
+        rec["port_wait_ms"] = wait_port(endpoint, deadline)
+        rec["ok"] = True
+    except Exception as e:
+        rec["ok"] = False
+        rec["error"] = f"{type(e).__name__}: {e}"
+    rec["blocking_ms"] = (time.monotonic() - t_spawn) * 1000
+    rec["teardown"] = teardown_normal(proc, fcvm_pid, args.teardown_timeout)
+    rec["wall_ms"] = (time.monotonic() - t_spawn) * 1000
+    rec["log"] = log
+    return rec
+
+
+def run_exec_request(args, rep: int) -> dict:
+    """Baseline arm: the existing per-request exec path, teardown fully awaited."""
+    name = f"rb-{os.getpid()}-{rep}-exec"
+    log = os.path.join(args.out_dir, f"{name}.log")
+    driver = (
+        f"python3 /opt/bench/render.py {args.url} --out-prefix /tmp/rb "
+        f"--format {args.format} --quality {args.quality}"
+    )
+    cmd = [args.fcvm, "snapshot", "run"] + clone_backend_args(args) + [
+        "--name", name, "--no-dirty-tracking", "--no-swap", "--exec", driver,
+    ]
+    env = dict(os.environ, RUST_LOG=args.rust_log)
+    t0 = time.monotonic()
+    with open(log, "wb") as lf:
+        proc = subprocess.Popen(cmd, stdout=lf, stderr=lf, stdin=subprocess.DEVNULL, env=env)
+    rc = proc.wait(timeout=args.timeout + args.teardown_timeout)
+    wall = (time.monotonic() - t0) * 1000
+    render_ms = None
+    try:
+        with open(log, "rb") as f:
+            for line in f:
+                if b"RENDER_OK" in line:
+                    for tok in line.decode("utf8", "replace").split():
+                        if tok.startswith("total_ms="):
+                            render_ms = float(tok.split("=", 1)[1])
+    except OSError:
+        pass
+    return {
+        "arm": "exec", "rep": rep, "name": name, "ok": rc == 0,
+        # The exec arm has no separable "response in hand" instant that the host
+        # can observe: fcvm returns only after its own teardown. blocking == wall
+        # is not an approximation, it is the arm's defining property.
+        "blocking_ms": wall, "wall_ms": wall,
+        "render_total_ms": render_ms, "rc": rc, "log": log,
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--serve-pid", type=int, default=0,
+                   help="UFFD serve pid (omit when using --snapshot-tag)")
+    p.add_argument("--snapshot-tag", default="",
+                   help="FILE-backed restore from this tag instead of a UFFD serve")
+    p.add_argument("--url", required=True)
+    p.add_argument("--arms", default="exec,cdp,cdp-fast,noop")
+    p.add_argument("--reps", type=int, default=10)
+    p.add_argument("--warmup", type=int, default=2, help="discarded EXPLICITLY, and reported")
+    p.add_argument("--seed", type=int, default=20260808)
+    p.add_argument("--format", choices=("png", "jpeg"), default="jpeg")
+    p.add_argument("--quality", type=int, default=80)
+    p.add_argument("--cdp-port", type=int, default=9222)
+    p.add_argument("--ws-url", default="")
+    p.add_argument("--fcvm", default=os.path.join(HERE, "..", "..", "target", "release", "fcvm"))
+    p.add_argument("--data-root", default="/mnt/fcvm-btrfs")
+    p.add_argument("--state-dir", default="")
+    p.add_argument("--out-dir", required=True)
+    p.add_argument("--timeout", type=float, default=120.0)
+    p.add_argument("--teardown-timeout", type=float, default=60.0)
+    p.add_argument("--rust-log", default="fcvm=debug")
+    args = p.parse_args()
+
+    args.fcvm = os.path.abspath(args.fcvm)
+    args.state_dir = args.state_dir or os.path.join(args.data_root, "state")
+    os.makedirs(args.out_dir, exist_ok=True)
+    arms = [a.strip() for a in args.arms.split(",") if a.strip()]
+
+    # Defect 2 of bench/chromium/AGENTS.md: interleave, never block. Arms are
+    # shuffled request-by-request from a RECORDED seed so an arm's effect cannot
+    # be confounded with wall-clock drift, exactly the failure that killed the
+    # retracted egress ordering.
+    rng = random.Random(args.seed)
+    schedule = []
+    for rep in range(args.warmup + args.reps):
+        order = list(arms)
+        rng.shuffle(order)
+        for arm in order:
+            schedule.append((rep, arm, rep < args.warmup))
+
+    out_path = os.path.join(args.out_dir, "reqbench.jsonl")
+    with open(out_path, "a") as out:
+        meta = {
+            "kind": "meta", "seed": args.seed,
+            "backend": "file" if args.snapshot_tag else "uffd", "arms": arms, "reps": args.reps,
+            "warmup": args.warmup, "url": args.url, "format": args.format,
+            "loadavg": open("/proc/loadavg").read().split()[:3],
+            "started": time.time(),
+        }
+        out.write(json.dumps(meta) + "\n")
+        out.flush()
+        for rep, arm, is_warmup in schedule:
+            if arm == "exec":
+                rec = run_exec_request(args, rep)
+            elif arm == "noop":
+                rec = run_noop_request(args, rep)
+            else:
+                rec = run_cdp_request(args, rep, fast=(arm == "cdp-fast"))
+            rec["warmup"] = is_warmup  # discarded explicitly at analysis, never silently
+            rec["loadavg1"] = float(open("/proc/loadavg").read().split()[0])
+            out.write(json.dumps(rec) + "\n")
+            out.flush()
+            print(
+                f"{arm:9s} rep={rep}{' [warmup]' if is_warmup else ''} "
+                f"ok={rec.get('ok')} blocking={rec.get('blocking_ms', 0):.1f}ms "
+                f"wall={rec.get('wall_ms', 0):.1f}ms "
+                f"teardown={rec.get('teardown', {}).get('teardown_total_ms', 0):.1f}ms",
+                flush=True,
+            )
+    print(f"\nwrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -207,7 +207,10 @@ def wait_pidfds(fds: list[int], timeout_s: float) -> bool:
     return True
 
 
-def sample_all_until_gone(pids: dict, deadline: float) -> dict:
+SAMPLE_PERIOD_S = 0.0002
+
+
+def sample_all_until_gone(pids: dict, deadline: float) -> tuple[dict, float]:
     """Sample EVERY child's /proc/<pid>/stat concurrently until each one vanishes.
 
     Concurrently, not one at a time. The previous version was a per-child call
@@ -220,11 +223,34 @@ def sample_all_until_gone(pids: dict, deadline: float) -> dict:
     `null`. That is not a lower bound, it is a missing measurement whose presence
     depended on procfs ordering.
 
-    Still a tight loop with no sleep, deliberately: the zombie window between
-    `exit_notify()` and the reaper is short, and catching state `Z` is what
-    upgrades a CPU figure from a lower bound to a complete one (see the module
-    docstring). The cost of that spin is now measured (`self_cpu_ms`) and
-    subtracted from the machine accounting rather than left in it.
+    IT SLEEPS BETWEEN PASSES, and the period is returned so the residual bias is
+    quantifiable. It used to be a tight loop with no sleep, defended on the
+    grounds that catching state `Z` upgrades a CPU figure from a lower bound to a
+    complete one and that the cost of the spin was "measured and subtracted".
+    Accounting is not throttling, and the subtraction could not survive its own
+    arithmetic. Measured on this box against a child that outlives its parent by
+    ~0.5 s:
+
+        reap_wall_ms=541.3  harness_cpu_ms=540.0   (100% of one core)
+        machine_cpu_ms=630.0  machine_cpu_ms_excess=-17.9
+
+    Three consequences, all INSIDE the window being measured. (a) `machine_cpu_ms
+    - self_ms` subtracts a ~540 ms quantity that is itself quantized to one jiffy
+    in order to expose a signal REVIEW.md states is below /proc tick resolution
+    (< 20 ms); the noise on the subtrahend is the size of the signal, and the run
+    above produced a NEGATIVE excess — impossible for a reclaim, and direct
+    evidence the attribution was broken. (b) The control window SLEEPS while this
+    one SPUN, so the two windows carried opposite harness load profiles — exactly
+    the defect the `+610.4 ms` machine-cost figure was withdrawn for, inverted
+    onto the other side of the same subtraction. (c) `reap_wall_ms` itself is
+    corrupted, because the spin competes for CPU with the exiting Firecracker it
+    is timing.
+
+    At 200 us the zombie argument still holds: `exit_mm()` completes before
+    `exit_notify()`, so the reclaim is already in the counters by the time state
+    `Z` is reachable, and MISSING the `Z` only downgrades that child's figure to a
+    labelled LOWER BOUND — a state the record already models (`complete`, and
+    reqanalyze prints the two populations separately, never averaged).
     """
     live = dict(pids)
     last: dict = {}
@@ -239,6 +265,8 @@ def sample_all_until_gone(pids: dict, deadline: float) -> dict:
             if s[0] in ("Z", "X", "x"):
                 zombie[name] = True
                 del live[name]
+        if live:
+            time.sleep(SAMPLE_PERIOD_S)
     out = {}
     for name in pids:
         s = last.get(name)
@@ -246,7 +274,7 @@ def sample_all_until_gone(pids: dict, deadline: float) -> dict:
             "cpu_ms": (s[1] + s[2]) * 1000.0 / CLK_TCK if s else None,
             "zombie_seen": zombie[name],
         }
-    return out
+    return out, SAMPLE_PERIOD_S
 
 
 # ------------------------------------------------------------------ fcvm glue
@@ -428,6 +456,31 @@ class SurvivedTeardown(RuntimeError):
         self.record: dict = {}
 
 
+def safe_vm_data_dir(data_dir: str) -> str:
+    """Return `data_dir` only if it is STRICTLY below a `vm-disks` root. Else "".
+
+    Every call site computes `os.path.join(data_root, "vm-disks", vm_id)` from a
+    state file, and `state.get("vm_id", "")` is empty on a partially-written
+    file. `os.path.join("/mnt/fcvm-btrfs", "vm-disks", "")` is
+    `/mnt/fcvm-btrfs/vm-disks/`, `os.path.isdir` says True, and the rmtree below
+    then deletes EVERY VM's disks on the box — under sudo. Commit e1286e3f called
+    exactly this arithmetic catastrophic and guarded `tests/test_signal_cleanup.rs`
+    (`an_empty_vm_id_resolves_to_the_shared_disk_root_and_must_be_rejected`); the
+    Python harness that does the identical computation was left unguarded, so the
+    guarantee held only for the Rust fixture.
+
+    Symlinks are resolved on both sides before comparing, so a `vm-disks/<id>`
+    that points somewhere else cannot smuggle the deletion out of the tree.
+    """
+    if not data_dir:
+        return ""
+    real = os.path.realpath(data_dir)
+    head, tail = os.path.split(real)
+    if not tail or os.path.basename(head) != "vm-disks":
+        return ""
+    return real
+
+
 def reap_disk(out: dict, state_path: str, data_dir: str) -> list:
     """Remove the clone's state file (+ its lock) and data dir. Errors are RECORDED.
 
@@ -436,6 +489,16 @@ def reap_disk(out: dict, state_path: str, data_dir: str) -> list:
     runs under SUDO, so EPERM has to surface.
     """
     reaped = []
+    if data_dir:
+        safe = safe_vm_data_dir(data_dir)
+        if not safe:
+            out.setdefault("disk_errors", []).append(
+                f"{data_dir}: refusing to remove — not strictly below a vm-disks root "
+                f"(an empty vm_id collapses to the SHARED disk root)"
+            )
+            data_dir = ""
+        else:
+            data_dir = safe
     if state_path and os.path.exists(state_path):
         try:
             os.remove(state_path)
@@ -528,7 +591,7 @@ def teardown_fast(fcvm_pid: int, state_path: str, data_dir: str, timeout_s: floa
     out["signal_ms"] = (time.monotonic() - t_kill) * 1000
 
     deadline = t_kill + timeout_s
-    cpu = sample_all_until_gone(tracked, deadline)
+    cpu, sample_period_s = sample_all_until_gone(tracked, deadline)
     all_gone = wait_pidfds(list(fds.values()), max(0.0, deadline - time.monotonic()))
     t_gone = time.monotonic()
     busy1, _ = machine_busy_jiffies()
@@ -547,6 +610,10 @@ def teardown_fast(fcvm_pid: int, state_path: str, data_dir: str, timeout_s: floa
     out["machine_cpu_ms_excess"] = (machine_cpu_ms - self_ms) - ctl_rate * window_s * 1000
     out["control_busy_cores"] = ctl_rate
     out["control_harness_cpu_ms"] = ctl_self_ms
+    # Both accounting windows now sleep, so the subtraction is between like and
+    # like. The sampler's residual duty cycle is bounded by this period and is
+    # recorded rather than argued about.
+    out["sample_period_s"] = sample_period_s
 
     # /proc/<pid>/stat counts in jiffies, so every CPU figure here is quantized to
     # one tick. At CLK_TCK=100 that is 10 ms, and a sub-tick reclaim reports a hard
@@ -602,7 +669,25 @@ def teardown_fast(fcvm_pid: int, state_path: str, data_dir: str, timeout_s: floa
     reaped = reap_disk(out, state_path, data_dir)
     out["disk_reap_ms"] = (time.monotonic() - t_disk) * 1000
     out["disk_reaped"] = reaped
+    # VERIFY ABSENCE, then gate. `reap_disk` recorded EPERM in `out["disk_errors"]`
+    # and nothing on the branch ever read that key: a rep whose rmtree failed was
+    # written with `ok: true` and the schedule continued. The asymmetry was the
+    # tell — the PROCESS half of this function already aborts, the DISK half did
+    # not. `vm-disks/<vm_id>` holds a reflink of the golden rootfs, so a failed
+    # rmtree pins the golden snapshot's extents on btrfs, and the state file it
+    # leaves behind can never be swept (`cleanup_stale_state` bails on a null
+    # pid). `disk_reap_ms` is also a published per-arm median, computed over
+    # records that included failed reaps.
+    left = [p for p in (state_path, f"{state_path}.lock" if state_path else "", data_dir)
+            if p and os.path.exists(p)]
     out["teardown_total_ms"] = (time.monotonic() - t_kill) * 1000
+    if left or out.get("disk_errors"):
+        out["disk_reap_failed"] = left
+        raise SurvivedTeardown(
+            f"fast teardown of fcvm {fcvm_pid} could not reap on-disk state: "
+            f"left={left} errors={out.get('disk_errors', [])}",
+            out,
+        )
     return out
 
 
@@ -612,6 +697,24 @@ def teardown_normal(proc: subprocess.Popen, fcvm_pid: int, timeout_s: float) -> 
     kill -> holder kill -> network cleanup -> state delete -> FC log save ->
     data-dir removal, each awaited. This is the control the fast arm is measured
     against.
+
+    Raises `SurvivedTeardown` on a real survivor, for the same reason
+    `teardown_fast` does: the `cdp` and `noop` arms used to compute `all_gone`,
+    record it, and continue the schedule with a live Firecracker/holder/pasta on
+    the box. `reqanalyze` printed `** N NOT CONFIRMED GONE **` and still exited 0,
+    so nothing failed.
+
+    TWO defects, in opposite directions, and both had to be fixed together. On the
+    timed_out path the verdict was decided with a ZERO observation budget:
+    `proc.wait(timeout=timeout_s)` spends the whole budget, `proc.wait(timeout=10)`
+    spends more, so `max(0.0, t0 + timeout_s - now)` is always 0.0 by the time it
+    is used — and `wait_pidfds` with a 0 budget returns False WITHOUT EVER
+    POLLING. Measured: a pdeathsig child that died sub-millisecond with its parent
+    was reported `all_gone: False`. Gating on that boolean as it stood would have
+    aborted every healthy rep that merely hit the SIGTERM timeout. So the wait
+    gets a real budget, and the verdict is then re-decided by a fresh liveness
+    check on the PIDFDS — not on the raw pids, which can alias a reused pid, which
+    is why this file opened pidfds in the first place.
     """
     out: dict = {"mode": "normal"}
     kids = children_of(fcvm_pid)
@@ -631,12 +734,34 @@ def teardown_normal(proc: subprocess.Popen, fcvm_pid: int, timeout_s: float) -> 
             pass
         proc.wait(timeout=10)
     out["fcvm_exit_ms"] = (time.monotonic() - t0) * 1000
-    out["all_gone"] = wait_pidfds(fds, max(0.0, t0 + timeout_s - time.monotonic()))
+    left = max(0.0, t0 + timeout_s - time.monotonic())
+    out["all_gone"] = wait_pidfds(fds, left if left > 0 else 0.5)
+    live = []
+    if not out["all_gone"]:
+        poller = select.poll()
+        for fd in fds:
+            if fd is not None:
+                poller.register(fd, select.POLLIN)
+        ready = {fd for fd, _ev in poller.poll(0)}
+        live = [p for p, fd in zip(kids, fds) if fd is not None and fd not in ready]
+        out["all_gone"] = not live
     for fd in fds:
         if fd is not None:
             os.close(fd)
     out["reap_wall_ms"] = (time.monotonic() - t0) * 1000
     out["teardown_total_ms"] = out["reap_wall_ms"]
+    if live:
+        out["survivors"] = {p: proc_comm(p) for p in live}
+        for p in live:
+            try:
+                os.kill(p, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass
+        raise SurvivedTeardown(
+            f"normal teardown of fcvm {fcvm_pid} left {out['survivors']} alive after "
+            f"{timeout_s:.1f}s",
+            out,
+        )
     return out
 
 
@@ -711,11 +836,29 @@ def run_cdp_request(args, rep: int, fast: bool) -> dict:
                 connect_retries=200,
                 nav_timing=True,
                 print_target=False,
+                # This Namespace is an explicit, CLOSED field list, so every flag
+                # cdpdrive grows has to be added here too or `drive()` raises
+                # AttributeError — which is not in its except tuple, escapes it,
+                # and is swallowed by the `except Exception` below, failing every
+                # cdp rep. cdpdrive also reads it with getattr; both halves.
+                host_header="",
                 render_module=os.path.join(HERE, "render.py"),
             )
             result = cdpdrive.drive(drive_args)
             rec["render"] = result
             rec["ok"] = bool(result.get("ok"))
+            if not rec["ok"]:
+                # LIFT THE DIAGNOSTIC TO THE TOP LEVEL. cdpdrive can return
+                # ok=false WITHOUT raising, in which case the `except` below never
+                # runs and `rec["error"]` was never set — the label stayed buried
+                # under `rec["render"]`. reqanalyze's only failure breakdown reads
+                # the top level (`r.get("error", f"rc={r.get('rc')}")`), so a
+                # WsClosed transport drop printed as `FAILURE x1: rc=None`.
+                # Separating transport drops from render failures is the entire
+                # point of REVIEW.md's 200-request availability gate.
+                rec["error"] = result.get("error", "cdpdrive reported ok=false")
+                rec["failure_class"] = result.get("failure_class", "render")
+                rec["failure_stage"] = result.get("stage", "")
             # THE CALLER'S ANSWER IS IN HAND HERE. Everything after this line is
             # teardown, and none of it is latency the caller pays.
             rec["blocking_ms"] = (time.monotonic() - t_spawn) * 1000
@@ -754,7 +897,15 @@ def run_cdp_request(args, rep: int, fast: bool) -> dict:
         except subprocess.TimeoutExpired:
             pass
     else:
-        rec["teardown"] = teardown_normal(proc, fcvm_pid, args.teardown_timeout)
+        try:
+            rec["teardown"] = teardown_normal(proc, fcvm_pid, args.teardown_timeout)
+        except SurvivedTeardown as e:
+            rec["teardown"] = e.teardown
+            rec["ok"] = False
+            rec["wall_ms"] = (time.monotonic() - t_spawn) * 1000
+            rec["log"] = log
+            e.record = rec
+            raise
     rec["wall_ms"] = (time.monotonic() - t_spawn) * 1000
     rec["log"] = log
     return rec
@@ -765,8 +916,12 @@ def clone_backend_args(args) -> list:
     """UFFD serve-backed vs FILE-backed restore, as CLI args.
 
     These are different memory backends with different per-request costs -- the
-    published 573 ms stage baseline is FILE-backed, and every guest page touched
-    during startup costs a UFFD round trip on the other path. Mixing them and
+    published stage baseline (`corrected.json` primary cell: total 890.6 ms
+    [869.6, 928.9], n=12) is UFFD-4K, and every guest page touched during startup
+    costs a UFFD round trip on that path but not on the file path. This comment
+    used to cite "the published 573 ms stage baseline", a figure that appears in
+    no committed artifact and whose only other occurrence was the AGENTS.md line
+    citing this file. Mixing the backends and
     comparing against that baseline would be exactly the matched-accounting
     failure AGENTS.md defect 1 describes, so the backend is explicit and recorded
     in the run metadata rather than implied by which flag happened to be passed.
@@ -818,7 +973,15 @@ def run_noop_request(args, rep: int) -> dict:
     finally:
         watch.close()
     rec["blocking_ms"] = (time.monotonic() - t_spawn) * 1000
-    rec["teardown"] = teardown_normal(proc, fcvm_pid, args.teardown_timeout)
+    try:
+        rec["teardown"] = teardown_normal(proc, fcvm_pid, args.teardown_timeout)
+    except SurvivedTeardown as e:
+        rec["teardown"] = e.teardown
+        rec["ok"] = False
+        rec["wall_ms"] = (time.monotonic() - t_spawn) * 1000
+        rec["log"] = log
+        e.record = rec
+        raise
     rec["wall_ms"] = (time.monotonic() - t_spawn) * 1000
     rec["log"] = log
     return rec
@@ -851,6 +1014,18 @@ def run_exec_request(args, rep: int) -> dict:
         # measurements. The exec arm was the only arm with this hole; the other two
         # always reach a teardown call.
         rec["timed_out"] = True
+        # CHILDREN FIRST, BEFORE THE KILL. This path used to SIGKILL fcvm, wait on
+        # fcvm ITSELF, and then unconditionally reap the state file and rmtree
+        # `vm-disks/<vm_id>` — deleting a live microVM's rootfs out from under it
+        # and destroying the only record that it is ours. Measured with a fake
+        # fcvm that forks an unarmed child:
+        #     reaped=['.../state/vm-red.json', '.../vm-disks/vm-red']
+        #     orphan child still alive=True   rootfs still on disk=False
+        # `children_of` MUST be captured before the signal: once fcvm dies,
+        # `/proc/<fcvm>/task/*/children` no longer exists and the survivors are
+        # unrecoverable. This is the same rule teardown_fast enforces.
+        kids = children_of(proc.pid)
+        fds = [pidfd_open(p) for p in kids]
         try:
             os.kill(proc.pid, signal.SIGKILL)
         except ProcessLookupError:
@@ -860,10 +1035,35 @@ def run_exec_request(args, rep: int) -> dict:
         except subprocess.TimeoutExpired:
             pass
         rc = -9
+        all_gone = wait_pidfds(fds, args.teardown_timeout)
+        for fd in fds:
+            if fd is not None:
+                os.close(fd)
         # The exec arm never resolves the clone's state file in the happy path, so
         # find it now — by name, since the pid may never have been written.
         sp, state = scan_state(args.state_dir, proc.pid, name)
         dd = os.path.join(args.data_root, "vm-disks", state.get("vm_id", "")) if state else ""
+        rec["all_gone"] = all_gone
+        if not all_gone:
+            survivors = {p: proc_comm(p) for p in kids if proc_stat_fields(p) is not None}
+            rec["survivors"] = survivors
+            rec["disk_reap_skipped"] = True
+            rec["ok"] = False
+            rec["blocking_ms"] = rec["wall_ms"] = (time.monotonic() - t0) * 1000
+            rec["rc"] = rc
+            rec["log"] = log
+            for pid in survivors:
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except (ProcessLookupError, PermissionError):
+                    pass
+            e = SurvivedTeardown(
+                f"exec-arm timeout left {survivors} alive; state {sp} and data {dd} "
+                f"NOT reaped",
+                rec,
+            )
+            e.record = rec
+            raise e
         rec["reaped"] = reap_disk(rec, sp, dd)
     wall = (time.monotonic() - t0) * 1000
     render_ms = None
@@ -910,6 +1110,15 @@ def main() -> int:
     p.add_argument("--teardown-timeout", type=float, default=60.0)
     p.add_argument("--rust-log", default="fcvm=debug")
     args = p.parse_args()
+
+    # EXACTLY ONE backend. With neither flag `clone_backend_args` returned
+    # `["--pid", "0"]` — a silently wrong invocation that would be recorded as
+    # `"backend": "uffd"` in the run metadata. With both, the tag silently wins
+    # and the serve is measured as if it were file-backed. These are different
+    # memory backends with different per-request costs; mixing them is AGENTS.md
+    # defect 1.
+    if bool(args.serve_pid) == bool(args.snapshot_tag):
+        p.error("give exactly one of --serve-pid (UFFD) or --snapshot-tag (FILE)")
 
     args.fcvm = os.path.abspath(args.fcvm)
     args.state_dir = args.state_dir or os.path.join(args.data_root, "state")

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -134,7 +134,16 @@ cmd_golden() {
     # NO --health-check URL: leaving it unset is what makes fcvm consult the
     # image's podman HEALTHCHECK (src/health.rs "AND logic"), which is the real
     # CDP round trip we want as the snapshot trigger.
-    FCVM_NO_SNAPSHOT=1 $SUDO env RUST_LOG=$FCVM_LOG "$FCVM" podman run --name "$name" \
+    # The assignment goes AFTER $SUDO, inside the `env` that follows it. Written
+    # as `FCVM_NO_SNAPSHOT=1 $SUDO env RUST_LOG=... fcvm ...` it binds to `sudo`,
+    # whose default env_reset drops it — RUST_LOG survived only because it already
+    # rode the `env`. bench.sh in this same directory has always done it right.
+    # With the variable dropped, src/commands/podman/mod.rs gates `no_snapshot`
+    # false and this phase — documented as "golden: cold boot" — would RESTORE
+    # from a stale cached snapshot and then snapshot THAT as $TAG, contaminating
+    # every arm derived from it. Latent while SUDO defaults to "", live the moment
+    # anyone uses the documented root-mode hook.
+    $SUDO env FCVM_NO_SNAPSHOT=1 RUST_LOG="$FCVM_LOG" "$FCVM" podman run --name "$name" \
         --cpu "$CPU" --mem "$MEM" --network "$NETMODE" --publish "$CDP_PORT:$CDP_PORT" \
         "$IMAGE" >"$lf" 2>&1 &
     # Capture the handle IMMEDIATELY. The BOOT TIMEOUT path below fires before any
@@ -205,15 +214,24 @@ print(n.get("loopback_ip") or n.get("host_ip") or n.get("guest_ip") or "")')
 }
 
 # Print the page target id for a clone, or nothing.
+#
+# Delegates to cdpdrive.py --print-target rather than hand-rolling the lookup,
+# which fixes TWO defects at once. (1) READINESS: this was a single-shot urlopen
+# with `2>/dev/null || true`, and `start_clone` returns as soon as the state file
+# carries a pid — it never waits for the CDP port (contrast reqbench.py's
+# `wait_port`). Clone 1 is warm because HOPs A/B/C ran against it; clone 2 was
+# queried the instant it registered, so a connection refused produced an empty id
+# and the documented stability gate failed on a RACE. It fails closed, which is
+# the right direction, but a flaky gate is the thing people learn to bypass.
+# (2) FILTER MISMATCH: this took the first `type == "page"`, while the driver that
+# actually consumes the id skips `devtools://` pages — so the two could compare
+# different targets. `resolve_target` now retries against a real deadline and
+# applies the devtools:// filter, and both halves are covered by
+# CdpDriveResolveThrottling in test_reqbench.py.
+TARGET_ID_TIMEOUT="${TARGET_ID_TIMEOUT:-60}"
 target_id() {
-    python3 - "$1" <<'PY' 2>/dev/null || true
-import json, sys, urllib.request
-with urllib.request.urlopen(f"http://{sys.argv[1]}/json/list", timeout=10) as r:
-    for t in json.load(r):
-        if t.get("type") == "page":
-            print(t.get("id") or "")
-            break
-PY
+    python3 "$HERE/cdpdrive.py" "$1" http://unused/ --print-target \
+        --timeout "$TARGET_ID_TIMEOUT" 2>/dev/null || true
 }
 
 cmd_verify() {
@@ -304,43 +322,71 @@ PY
     log "verify: done (clone state/data left for inspection; reqbench.py reaps its own)"
 }
 
+# BOTH memory backends are runnable from here. reqbench.py has had the FILE path
+# fully built (`--snapshot-tag` -> fcvm's `--snapshot <name>`, recorded as
+# `"backend": "file"` in the run metadata) while this driver hardcoded the UFFD
+# serve and never passed `--snapshot-tag` at all — so the recorded metadata was
+# honest but could only ever carry one value, and REVIEW.md's re-run gate
+# (">=200 CDP requests PER BACKEND at 0 failures") was not runnable.
+BACKEND="${BACKEND:-uffd}"
+
 cmd_run() {
     guard_quiet
-    log "run: starting serve for $TAG"
-    local sf="$RESULTS/logs/serve.log"
-    $SUDO "$FCVM" snapshot serve "$TAG" >"$sf" 2>&1 &
-    local serve_bg=$!
-    track "$serve_bg"
-    local t0=$SECONDS
-    until grep -q "Waiting for VMs" "$sf" 2>/dev/null; do
-        [ $((SECONDS-t0)) -lt 60 ] || { log "run: serve never came up"; cat "$sf" >&2; return 1; }
-        sleep 0.5
-    done
-    local spid; spid=$(grep -oP 'Serve PID: \K[0-9]+' "$sf" | head -1)
-    [ -n "$spid" ] || { log "run: could not read Serve PID from $sf"; return 1; }
-    track "$spid"
-    log "run: serve pid $spid -> reqbench.py"
-    # Guarded: unguarded, ANY non-zero exit from reqbench.py (including its new
+    local rc=0 spid="" serve_bg=""
+    local backend_args=()
+    case "$BACKEND" in
+        uffd)
+            log "run: BACKEND=uffd — starting serve for $TAG"
+            local sf="$RESULTS/logs/serve.log"
+            $SUDO "$FCVM" snapshot serve "$TAG" >"$sf" 2>&1 &
+            serve_bg=$!
+            track "$serve_bg"
+            local t0=$SECONDS
+            until grep -q "Waiting for VMs" "$sf" 2>/dev/null; do
+                [ $((SECONDS-t0)) -lt 60 ] || { log "run: serve never came up"; cat "$sf" >&2; return 1; }
+                sleep 0.5
+            done
+            spid=$(grep -oP 'Serve PID: \K[0-9]+' "$sf" | head -1)
+            [ -n "$spid" ] || { log "run: could not read Serve PID from $sf"; return 1; }
+            track "$spid"
+            log "run: serve pid $spid -> reqbench.py"
+            backend_args=(--serve-pid "$spid")
+            ;;
+        file)
+            # No serve at all: clones restore MAP_PRIVATE from the snapshot files.
+            log "run: BACKEND=file — no UFFD serve, restoring from $TAG directly"
+            backend_args=(--snapshot-tag "$TAG")
+            ;;
+        *)
+            log "run: unknown BACKEND=$BACKEND (want uffd|file)"; return 2 ;;
+    esac
+    # Guarded: unguarded, ANY non-zero exit from reqbench.py (including its
     # exit 4 when a teardown leaves a survivor) exits the shell under `set -e`
     # before the kill below, leaking the serve into the next phase.
-    local rc=0
-    $SUDO env RUST_LOG=$FCVM_LOG python3 "$HERE/reqbench.py" --serve-pid "$spid" --url "$URL" \
+    $SUDO env RUST_LOG=$FCVM_LOG python3 "$HERE/reqbench.py" "${backend_args[@]}" --url "$URL" \
         --out-dir "$RESULTS" --reps "${REPS:-10}" --warmup "${WARMUP:-2}" \
         --cdp-port "$CDP_PORT" --fcvm "$FCVM" --rust-log "$FCVM_LOG" \
         --arms "${ARMS:-exec,cdp,cdp-fast,noop}" || rc=$?
-    $SUDO kill "$spid" 2>/dev/null || true
-    # WAIT for teardown to finish, so a following phase's guard_quiet does not
-    # race a serve that is still shutting down.
-    wait "$serve_bg" 2>/dev/null || true
-    log "run: results in $RESULTS (reqbench.py exit $rc)"
+    if [ -n "$spid" ]; then
+        $SUDO kill "$spid" 2>/dev/null || true
+        # WAIT for teardown to finish, so a following phase's guard_quiet does not
+        # race a serve that is still shutting down.
+        wait "$serve_bg" 2>/dev/null || true
+    fi
+    log "run: results in $RESULTS (backend=$BACKEND, reqbench.py exit $rc)"
     return $rc
 }
 
-case "${1:-}" in
-    build)  cmd_build ;;
-    golden) cmd_golden ;;
-    verify) cmd_verify ;;
-    run)    cmd_run ;;
-    all)    cmd_build; cmd_golden; cmd_verify; cmd_run ;;
-    *) echo "usage: $0 {build|golden|verify|run|all}" >&2; exit 2 ;;
-esac
+# Only dispatch when EXECUTED. Sourcing the file makes its helpers unit-testable
+# (see ReqbenchShell in test_reqbench.py) instead of reachable only through a
+# whole phase.
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    case "${1:-}" in
+        build)  cmd_build ;;
+        golden) cmd_golden ;;
+        verify) cmd_verify ;;
+        run)    cmd_run ;;
+        all)    cmd_build; cmd_golden; cmd_verify; cmd_run ;;
+        *) echo "usage: $0 {build|golden|verify|run|all}" >&2; exit 2 ;;
+    esac
+fi

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -41,18 +41,65 @@ TAG="${TAG:-cb-req-golden}"
 FCVM_LOG="${FCVM_LOG:-fcvm=debug}"   # AGENTS.md defect 4: never measure at info
 URL="${URL:-http://127.0.0.1:8000/medium.html}"
 
+STATE_DIR="${STATE_DIR:-/mnt/fcvm-btrfs/state}"
+
 mkdir -p "$RESULTS/logs"
 log() { printf '%s %s\n' "$(date +%H:%M:%S)" "$*" >&2; }
+
+# ---------------------------------------------------------------------------
+# TEARDOWN. Every background fcvm this script starts is registered here the
+# instant it exists, and the trap fires on EXIT/INT/TERM.
+#
+# Without it, `set -euo pipefail` turns every error path into a leak: an
+# unguarded failure exits the shell BEFORE the matching kill, and the VM or
+# serve it started keeps running. Two of the three phases did not even capture
+# `$!`, so on those paths there was no handle to kill at all. bench.sh in this
+# same directory has had this shape all along; this file did not have a single
+# `trap`. AGENTS.md: contention silently inflates every number, and a leaked
+# serve holds the snapshot mapping into the NEXT run.
+CLEANUP_PIDS=()
+track() { [ -n "${1:-}" ] && CLEANUP_PIDS+=("$1"); return 0; }
+
+cleanup() {
+    local rc=$?
+    set +e
+    for p in "${CLEANUP_PIDS[@]:-}"; do
+        [ -n "$p" ] && $SUDO kill -9 "$p" 2>/dev/null
+    done
+    # Belt and braces: sweep state files this script's naming owns, in case a
+    # pid was never captured (e.g. the process died between spawn and track).
+    for f in "$STATE_DIR"/*.json; do
+        [ -e "$f" ] || continue
+        local nm pid
+        nm=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("name") or "")' \
+             "$f" 2>/dev/null) || continue
+        case "$nm" in
+            cb-req-*)
+                pid=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("pid") or "")' \
+                      "$f" 2>/dev/null)
+                [ -n "$pid" ] && $SUDO kill -9 "$pid" 2>/dev/null
+                ;;
+        esac
+    done
+    wait 2>/dev/null
+    return $rc
+}
+trap cleanup EXIT INT TERM
 
 # Refuse to measure on a box that is already busy. AGENTS.md: contention silently
 # inflates every number; a run published without saying so is the failure mode.
 guard_quiet() {
-    local fc; fc=$(pgrep -c firecracker || true)
+    # `pgrep -c firecracker` alone never matches a leaked `fcvm snapshot serve`
+    # (its comm is `fcvm`), which is exactly the residue this script's own error
+    # paths used to leave — it would accumulate invisibly while holding the
+    # snapshot mapping. scripts/ci-stray-vm-guard.sh uses this wider pattern for
+    # the same reason.
+    local fc; fc=$(pgrep -c -f '^(.*/)?(firecracker|cloud-hypervisor|fcvm)( |$)' || true)
     local la; la=$(cut -d' ' -f1 /proc/loadavg)
-    log "load=$la firecracker=$fc"
+    log "load=$la vm-processes=$fc"
     if [ "${ALLOW_BUSY:-0}" != 1 ] && { [ "${fc:-0}" -gt 0 ] || \
        [ "$(printf '%.0f' "$la")" -gt 2 ]; }; then
-        log "REFUSING: box is busy (load=$la, $fc firecracker). Set ALLOW_BUSY=1 to override"
+        log "REFUSING: box is busy (load=$la, $fc firecracker/fcvm). Set ALLOW_BUSY=1 to override"
         log "and SAY SO in the report — a number measured under contention is not a number."
         exit 3
     fi
@@ -90,6 +137,10 @@ cmd_golden() {
     FCVM_NO_SNAPSHOT=1 $SUDO env RUST_LOG=$FCVM_LOG "$FCVM" podman run --name "$name" \
         --cpu "$CPU" --mem "$MEM" --network "$NETMODE" --publish "$CDP_PORT:$CDP_PORT" \
         "$IMAGE" >"$lf" 2>&1 &
+    # Capture the handle IMMEDIATELY. The BOOT TIMEOUT path below fires before any
+    # state file exists, so `$!` is the ONLY way to reach this VM at that point.
+    local vm_bg=$!
+    track "$vm_bg"
     local t0=$SECONDS pid=""
     until grep -q CHROMIUM_BENCH_READY "$lf" 2>/dev/null; do
         [ $((SECONDS-t0)) -lt 300 ] || { log "golden: BOOT TIMEOUT"; tail -20 "$lf" >&2; return 1; }
@@ -97,6 +148,7 @@ cmd_golden() {
     done
     pid=$(state_pid_by_name "$name")
     [ -n "$pid" ] || { log "golden: no state pid"; return 1; }
+    track "$pid"
 
     # Wait for fcvm to publish Healthy — i.e. for the container HEALTHCHECK's real
     # CDP round trip to pass. THIS is the warm point the snapshot must capture.
@@ -108,8 +160,12 @@ cmd_golden() {
         sleep 1
     done
     log "golden: healthy after $((SECONDS-t0))s — snapshotting"
-    $SUDO "$FCVM" snapshot create --pid "$pid" --tag "$TAG" >>"$lf" 2>&1
-    $SUDO kill "$pid"
+    # Guarded: unguarded, a failed `snapshot create` exits the shell under `set -e`
+    # before the kill below, leaking a live VM. Now it reaches the trap.
+    $SUDO "$FCVM" snapshot create --pid "$pid" --tag "$TAG" >>"$lf" 2>&1 \
+        || { log "golden: SNAPSHOT CREATE FAILED"; tail -20 "$lf" >&2; return 1; }
+    $SUDO kill "$pid" 2>/dev/null || true
+    wait "$vm_bg" 2>/dev/null || true
     log "golden: done ($TAG)"
 }
 
@@ -117,44 +173,86 @@ cmd_golden() {
 # The end-to-end chain proof. Run this BEFORE trusting any number: it checks the
 # three hops separately so a failure names the hop instead of looking like
 # "networking is broken".
+
+# Start one clone against the running serve. Sets CLONE_PID and CLONE_IP.
+# Factored out so verify can start TWO of them: a single clone's target id
+# cannot answer a question about stability ACROSS clones.
+#
+# Results come back in GLOBALS, not on stdout, on purpose: `x=$(start_clone …)`
+# runs the function in a subshell, so its `track` calls would update a copy of
+# CLEANUP_PIDS that is discarded on return — i.e. the trap would never see the
+# clone it just started, which is the exact leak this trap exists to close.
+CLONE_PID=""
+CLONE_IP=""
+start_clone() {
+    local spid="$1" cname="$2" cl="$3"
+    CLONE_PID=""; CLONE_IP=""
+    $SUDO env RUST_LOG=$FCVM_LOG "$FCVM" snapshot run --pid "$spid" --name "$cname" \
+        --no-dirty-tracking --no-swap >"$cl" 2>&1 &
+    track "$!"
+    local t0=$SECONDS cpid=""
+    until [ -n "$cpid" ]; do
+        cpid=$(state_pid_by_name "$cname")
+        [ $((SECONDS-t0)) -lt 120 ] || { log "clone $cname never registered"; tail -20 "$cl" >&2; return 1; }
+        sleep 0.2
+    done
+    track "$cpid"
+    CLONE_PID="$cpid"
+    CLONE_IP=$($SUDO "$FCVM" ls --json --pid "$cpid" | python3 -c '
+import json,sys
+n=json.load(sys.stdin)[0]["config"]["network"]
+print(n.get("loopback_ip") or n.get("host_ip") or n.get("guest_ip") or "")')
+}
+
+# Print the page target id for a clone, or nothing.
+target_id() {
+    python3 - "$1" <<'PY' 2>/dev/null || true
+import json, sys, urllib.request
+with urllib.request.urlopen(f"http://{sys.argv[1]}/json/list", timeout=10) as r:
+    for t in json.load(r):
+        if t.get("type") == "page":
+            print(t.get("id") or "")
+            break
+PY
+}
+
 cmd_verify() {
+    # Every hop feeds this counter and the function RETURNS it. Each hop used to
+    # be `... || echo "HOP X FAILED"`, which makes the compound command SUCCEED —
+    # so cmd_verify exited 0 no matter how many hops failed, and `all` (which
+    # relies on `set -e` to stop the chain) went straight on to the measured run
+    # after printing three FAILED lines. verify is documented as the gate; a gate
+    # that cannot fail is not a gate.
+    local fail=0
     log "verify: starting serve for $TAG"
     local sf="$RESULTS/logs/verify-serve.log"
     $SUDO "$FCVM" snapshot serve "$TAG" >"$sf" 2>&1 &
-    local serve_pid=$!
+    local serve_bg=$!
+    track "$serve_bg"
     local t0=$SECONDS
     until grep -q "Waiting for VMs" "$sf" 2>/dev/null; do
         [ $((SECONDS-t0)) -lt 60 ] || { log "verify: serve never came up"; cat "$sf" >&2; return 1; }
         sleep 0.5
     done
     local spid; spid=$(grep -oP 'Serve PID: \K[0-9]+' "$sf" | head -1)
+    track "$spid"
     log "verify: serve pid $spid"
 
     local cname="cb-req-verify-$RUNID" cl="$RESULTS/logs/verify-clone.log"
-    $SUDO env RUST_LOG=$FCVM_LOG "$FCVM" snapshot run --pid "$spid" --name "$cname" \
-        --no-dirty-tracking --no-swap >"$cl" 2>&1 &
-    local clone_bg=$!
-    t0=$SECONDS
-    local cpid=""
-    until [ -n "$cpid" ]; do
-        cpid=$(state_pid_by_name "$cname")
-        [ $((SECONDS-t0)) -lt 120 ] || { log "verify: clone never registered"; tail -20 "$cl" >&2; return 1; }
-        sleep 0.2
-    done
-
-    local ip
-    ip=$($SUDO "$FCVM" ls --json --pid "$cpid" | python3 -c '
-import json,sys
-n=json.load(sys.stdin)[0]["config"]["network"]
-print(n.get("loopback_ip") or n.get("host_ip") or n.get("guest_ip") or "")')
+    start_clone "$spid" "$cname" "$cl" || return 1
+    local cpid="$CLONE_PID" ip="$CLONE_IP"
+    # An empty IP is the most likely real misconfiguration, and it used to be
+    # fully swallowed: hops B and C then ran against ":9223", failed, printed
+    # FAILED, and verify still exited 0.
+    [ -n "$ip" ] || { log "verify: NO host-side IP in the clone's network config"; fail=1; }
     log "verify: clone pid=$cpid host-side ip=$ip"
 
     echo "--- HOP A: healthcheck path, 127.0.0.1:$CDP_PORT INSIDE the container ---"
-    $SUDO "$FCVM" exec --pid "$cpid" -c -- python3 /opt/bench/cdp_health.py || \
-        echo "HOP A FAILED (in-container CDP round trip)"
+    $SUDO "$FCVM" exec --pid "$cpid" -c -- python3 /opt/bench/cdp_health.py \
+        || { echo "HOP A FAILED (in-container CDP round trip)"; fail=1; }
 
     echo "--- HOP B: GET /json/version from the HOST against $ip:$CDP_PORT ---"
-    python3 - "$ip:$CDP_PORT" <<'PY' || echo "HOP B FAILED (host -> clone CDP HTTP)"
+    python3 - "$ip:$CDP_PORT" <<'PY' || { echo "HOP B FAILED (host -> clone CDP HTTP)"; fail=1; }
 import json, sys, urllib.request
 host = sys.argv[1]
 # Host-header check: Chromium's DevTools endpoint rejects Host values that are
@@ -173,21 +271,36 @@ PY
 
     echo "--- HOP C: WebSocket upgrade + one CDP command from the HOST ---"
     python3 "$HERE/cdpdrive.py" "$ip:$CDP_PORT" "$URL" --format jpeg --nav-timing \
-        --out-prefix "$RESULTS/verify" || echo "HOP C FAILED (host WS + CDP)"
+        --out-prefix "$RESULTS/verify" || { echo "HOP C FAILED (host WS + CDP)"; fail=1; }
 
-    echo "--- target id (is it stable across clones? -> can skip /json/list per request) ---"
-    python3 - "$ip:$CDP_PORT" <<'PY' || true
-import json, sys, urllib.request
-with urllib.request.urlopen(f"http://{sys.argv[1]}/json/list", timeout=10) as r:
-    for t in json.load(r):
-        if t.get("type") == "page":
-            print(f"  target id={t.get('id')}")
-PY
+    # --- target id stability, ACROSS CLONES, asserted.
+    # This block used to print one clone's id and compare it with nothing, under
+    # a heading that asked a cross-clone question. One id cannot answer it. The
+    # serve is already up, so a second clone is cheap.
+    echo "--- target id stability ACROSS CLONES (-> can /json/list be skipped?) ---"
+    local id1 id2 cname2="cb-req-verify2-$RUNID" cpid2 ip2
+    id1=$(target_id "$ip:$CDP_PORT")
+    start_clone "$spid" "$cname2" "$RESULTS/logs/verify-clone2.log" || return 1
+    cpid2="$CLONE_PID"; ip2="$CLONE_IP"
+    id2=$(target_id "$ip2:$CDP_PORT")
+    echo "  clone1 ($ip) id=${id1:-<none>}"
+    echo "  clone2 ($ip2) id=${id2:-<none>}"
+    if [ -z "$id1" ] || [ -z "$id2" ]; then
+        echo "  TARGET ID UNREADABLE on at least one clone — cannot judge stability"
+        fail=1
+    elif [ "$id1" = "$id2" ]; then
+        echo "  STABLE across 2 clones — --ws-url prewiring is sound for this snapshot"
+    else
+        echo "  TARGET ID NOT STABLE ACROSS CLONES ($id1 != $id2) — /json/list cannot be skipped"
+        fail=1
+    fi
 
+    $SUDO kill -9 "$cpid2" 2>/dev/null || true
     $SUDO kill -9 "$cpid" 2>/dev/null || true
-    wait "$clone_bg" 2>/dev/null || true
     $SUDO kill "$spid" 2>/dev/null || true
-    wait "$serve_pid" 2>/dev/null || true
+    wait 2>/dev/null || true
+    # Return AFTER the cleanup above, never before it.
+    [ "$fail" -eq 0 ] || { log "verify: FAILED ($fail check(s)) — do NOT run the A/B"; return 1; }
     log "verify: done (clone state/data left for inspection; reqbench.py reaps its own)"
 }
 
@@ -196,19 +309,31 @@ cmd_run() {
     log "run: starting serve for $TAG"
     local sf="$RESULTS/logs/serve.log"
     $SUDO "$FCVM" snapshot serve "$TAG" >"$sf" 2>&1 &
+    local serve_bg=$!
+    track "$serve_bg"
     local t0=$SECONDS
     until grep -q "Waiting for VMs" "$sf" 2>/dev/null; do
         [ $((SECONDS-t0)) -lt 60 ] || { log "run: serve never came up"; cat "$sf" >&2; return 1; }
         sleep 0.5
     done
     local spid; spid=$(grep -oP 'Serve PID: \K[0-9]+' "$sf" | head -1)
+    [ -n "$spid" ] || { log "run: could not read Serve PID from $sf"; return 1; }
+    track "$spid"
     log "run: serve pid $spid -> reqbench.py"
+    # Guarded: unguarded, ANY non-zero exit from reqbench.py (including its new
+    # exit 4 when a teardown leaves a survivor) exits the shell under `set -e`
+    # before the kill below, leaking the serve into the next phase.
+    local rc=0
     $SUDO env RUST_LOG=$FCVM_LOG python3 "$HERE/reqbench.py" --serve-pid "$spid" --url "$URL" \
         --out-dir "$RESULTS" --reps "${REPS:-10}" --warmup "${WARMUP:-2}" \
         --cdp-port "$CDP_PORT" --fcvm "$FCVM" --rust-log "$FCVM_LOG" \
-        --arms "${ARMS:-exec,cdp,cdp-fast,noop}"
+        --arms "${ARMS:-exec,cdp,cdp-fast,noop}" || rc=$?
     $SUDO kill "$spid" 2>/dev/null || true
-    log "run: results in $RESULTS"
+    # WAIT for teardown to finish, so a following phase's guard_quiet does not
+    # race a serve that is still shutting down.
+    wait "$serve_bg" 2>/dev/null || true
+    log "run: results in $RESULTS (reqbench.py exit $rc)"
+    return $rc
 }
 
 case "${1:-}" in

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+# Standalone driver for the request-optimized path (CDP direct + fast teardown).
+#
+# Separate from bench.sh ON PURPOSE, and not merged into it: bash reads a script
+# incrementally as it executes, so editing bench.sh while a run is in flight
+# corrupts that run. This file is self-contained; bench.sh is untouched.
+#
+#   ./reqbench.sh golden      # cold boot with CDP published, snapshot at the health gate
+#   ./reqbench.sh verify      # prove all three hops on a RESTORED CLONE (do this first)
+#   ./reqbench.sh run         # the three-arm A/B
+#
+# The two changes under test:
+#   PART 1  the request path is Chromium's own CDP endpoint, driven from the host
+#           over fcvm's port forwarding. Nothing of ours is resident in the guest.
+#   PART 2  the response is delivered the instant the image is in hand; teardown
+#           is ONE SIGKILL to fcvm, which the kernel fans out to Firecracker and
+#           the namespace holder concurrently via PR_SET_PDEATHSIG.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+FCVM="${FCVM:-$REPO/target/release/fcvm}"
+# rootless needs no sudo. SUDO is kept as a hook only so the same script can be
+# pointed at a root-only mode later without rewriting every call site.
+SUDO="${SUDO:-}"
+IMAGE="${IMAGE:-localhost/chromium-bench-req}"
+# 9223 is the RELAY port (socat, in entry.sh). Chromium ignores
+# --remote-debugging-address and binds guest loopback 9222 only; fcvm has no
+# feature that exposes a guest LOOPBACK port, so the relay + --publish is the
+# path. See Containerfile.chromium-bench for the measured evidence.
+CDP_PORT="${CDP_PORT:-9223}"
+# rootless: --publish is supported (pasta -t) and clones inherit port_mappings
+# from snapshot metadata (src/commands/snapshot.rs:1070). No root needed, and it
+# matches the network mode the exec-path baseline was measured on.
+NETMODE="${NETMODE:-rootless}"
+CPU="${CPU:-2}"
+MEM="${MEM:-1024}"
+RUNID="${RUNID:-$(date +%H%M%S)-$$}"
+RESULTS="${RESULTS:-$HERE/results/reqbench-$RUNID}"
+TAG="${TAG:-cb-req-golden}"
+FCVM_LOG="${FCVM_LOG:-fcvm=debug}"   # AGENTS.md defect 4: never measure at info
+URL="${URL:-http://127.0.0.1:8000/medium.html}"
+
+mkdir -p "$RESULTS/logs"
+log() { printf '%s %s\n' "$(date +%H:%M:%S)" "$*" >&2; }
+
+# Refuse to measure on a box that is already busy. AGENTS.md: contention silently
+# inflates every number; a run published without saying so is the failure mode.
+guard_quiet() {
+    local fc; fc=$(pgrep -c firecracker || true)
+    local la; la=$(cut -d' ' -f1 /proc/loadavg)
+    log "load=$la firecracker=$fc"
+    if [ "${ALLOW_BUSY:-0}" != 1 ] && { [ "${fc:-0}" -gt 0 ] || \
+       [ "$(printf '%.0f' "$la")" -gt 2 ]; }; then
+        log "REFUSING: box is busy (load=$la, $fc firecracker). Set ALLOW_BUSY=1 to override"
+        log "and SAY SO in the report — a number measured under contention is not a number."
+        exit 3
+    fi
+}
+
+state_pid_by_name() {
+    $SUDO "$FCVM" ls --json 2>/dev/null | python3 -c '
+import json,sys
+for v in json.load(sys.stdin):
+    if v.get("name")==sys.argv[1]: print(v.get("pid") or ""); break' "$1"
+}
+
+cmd_build() {
+    log "building $IMAGE"
+    # --format docker is LOAD-BEARING: podman's default OCI format DROPS
+    # HEALTHCHECK with only a warning, and fcvm's health gate is what
+    # triggers the golden snapshot (src/health.rs AND-logic).
+    podman build --format docker -t "$IMAGE" -f "$REPO/Containerfile.chromium-bench" "$REPO"
+    podman inspect "$IMAGE" --format '{{json .HealthCheck}}' | grep -q cdp_health \
+        || { log "FATAL: image has no HEALTHCHECK (OCI format drop?)"; return 1; }
+}
+
+cmd_golden() {
+    log "golden: cold boot with CDP published on $CDP_PORT -> snapshot $TAG"
+    $SUDO "$FCVM" snapshots delete -f "$TAG" >/dev/null 2>&1 || true
+    local name="cb-req-g-$RUNID" lf="$RESULTS/logs/golden.log"
+    # --publish carries host -> guest; socat inside the container carries
+    # guest-wildcard 9223 -> guest-loopback 9222, which is the hop Chromium
+    # refuses to make itself. Clones inherit port_mappings from the snapshot
+    # metadata (src/commands/snapshot.rs:1070), which is what makes a restored
+    # clone drivable at all.
+    # NO --health-check URL: leaving it unset is what makes fcvm consult the
+    # image's podman HEALTHCHECK (src/health.rs "AND logic"), which is the real
+    # CDP round trip we want as the snapshot trigger.
+    FCVM_NO_SNAPSHOT=1 $SUDO env RUST_LOG=$FCVM_LOG "$FCVM" podman run --name "$name" \
+        --cpu "$CPU" --mem "$MEM" --network "$NETMODE" --publish "$CDP_PORT:$CDP_PORT" \
+        "$IMAGE" >"$lf" 2>&1 &
+    local t0=$SECONDS pid=""
+    until grep -q CHROMIUM_BENCH_READY "$lf" 2>/dev/null; do
+        [ $((SECONDS-t0)) -lt 300 ] || { log "golden: BOOT TIMEOUT"; tail -20 "$lf" >&2; return 1; }
+        sleep 1
+    done
+    pid=$(state_pid_by_name "$name")
+    [ -n "$pid" ] || { log "golden: no state pid"; return 1; }
+
+    # Wait for fcvm to publish Healthy — i.e. for the container HEALTHCHECK's real
+    # CDP round trip to pass. THIS is the warm point the snapshot must capture.
+    log "golden: waiting for fcvm health gate (pid $pid)"
+    t0=$SECONDS
+    until [ "$($SUDO "$FCVM" ls --json --pid "$pid" | python3 -c \
+              'import json,sys; print(json.load(sys.stdin)[0].get("health_status",""))')" = healthy ]; do
+        [ $((SECONDS-t0)) -lt 300 ] || { log "golden: HEALTH TIMEOUT"; tail -20 "$lf" >&2; return 1; }
+        sleep 1
+    done
+    log "golden: healthy after $((SECONDS-t0))s — snapshotting"
+    $SUDO "$FCVM" snapshot create --pid "$pid" --tag "$TAG" >>"$lf" 2>&1
+    $SUDO kill "$pid"
+    log "golden: done ($TAG)"
+}
+
+# ---------------------------------------------------------------------------
+# The end-to-end chain proof. Run this BEFORE trusting any number: it checks the
+# three hops separately so a failure names the hop instead of looking like
+# "networking is broken".
+cmd_verify() {
+    log "verify: starting serve for $TAG"
+    local sf="$RESULTS/logs/verify-serve.log"
+    $SUDO "$FCVM" snapshot serve "$TAG" >"$sf" 2>&1 &
+    local serve_pid=$!
+    local t0=$SECONDS
+    until grep -q "Waiting for VMs" "$sf" 2>/dev/null; do
+        [ $((SECONDS-t0)) -lt 60 ] || { log "verify: serve never came up"; cat "$sf" >&2; return 1; }
+        sleep 0.5
+    done
+    local spid; spid=$(grep -oP 'Serve PID: \K[0-9]+' "$sf" | head -1)
+    log "verify: serve pid $spid"
+
+    local cname="cb-req-verify-$RUNID" cl="$RESULTS/logs/verify-clone.log"
+    $SUDO env RUST_LOG=$FCVM_LOG "$FCVM" snapshot run --pid "$spid" --name "$cname" \
+        --no-dirty-tracking --no-swap >"$cl" 2>&1 &
+    local clone_bg=$!
+    t0=$SECONDS
+    local cpid=""
+    until [ -n "$cpid" ]; do
+        cpid=$(state_pid_by_name "$cname")
+        [ $((SECONDS-t0)) -lt 120 ] || { log "verify: clone never registered"; tail -20 "$cl" >&2; return 1; }
+        sleep 0.2
+    done
+
+    local ip
+    ip=$($SUDO "$FCVM" ls --json --pid "$cpid" | python3 -c '
+import json,sys
+n=json.load(sys.stdin)[0]["config"]["network"]
+print(n.get("loopback_ip") or n.get("host_ip") or n.get("guest_ip") or "")')
+    log "verify: clone pid=$cpid host-side ip=$ip"
+
+    echo "--- HOP A: healthcheck path, 127.0.0.1:$CDP_PORT INSIDE the container ---"
+    $SUDO "$FCVM" exec --pid "$cpid" -c -- python3 /opt/bench/cdp_health.py || \
+        echo "HOP A FAILED (in-container CDP round trip)"
+
+    echo "--- HOP B: GET /json/version from the HOST against $ip:$CDP_PORT ---"
+    python3 - "$ip:$CDP_PORT" <<'PY' || echo "HOP B FAILED (host -> clone CDP HTTP)"
+import json, sys, urllib.request
+host = sys.argv[1]
+# Host-header check: Chromium's DevTools endpoint rejects Host values that are
+# neither localhost nor an IP literal, with a 403 that reads like a network fault.
+req = urllib.request.Request(f"http://{host}/json/version", headers={"Host": host})
+with urllib.request.urlopen(req, timeout=10) as r:
+    v = json.load(r)
+print("  OK", v.get("Browser"), "| protocol", v.get("Protocol-Version"))
+req2 = urllib.request.Request(f"http://{host}/json/version", headers={"Host": "evil.example.com"})
+try:
+    urllib.request.urlopen(req2, timeout=10)
+    print("  note: non-IP Host header ACCEPTED (no Host validation on this build)")
+except Exception as e:
+    print(f"  note: non-IP Host header REJECTED ({e}) — expected; connect by IP")
+PY
+
+    echo "--- HOP C: WebSocket upgrade + one CDP command from the HOST ---"
+    python3 "$HERE/cdpdrive.py" "$ip:$CDP_PORT" "$URL" --format jpeg --nav-timing \
+        --out-prefix "$RESULTS/verify" || echo "HOP C FAILED (host WS + CDP)"
+
+    echo "--- target id (is it stable across clones? -> can skip /json/list per request) ---"
+    python3 - "$ip:$CDP_PORT" <<'PY' || true
+import json, sys, urllib.request
+with urllib.request.urlopen(f"http://{sys.argv[1]}/json/list", timeout=10) as r:
+    for t in json.load(r):
+        if t.get("type") == "page":
+            print(f"  target id={t.get('id')}")
+PY
+
+    $SUDO kill -9 "$cpid" 2>/dev/null || true
+    wait "$clone_bg" 2>/dev/null || true
+    $SUDO kill "$spid" 2>/dev/null || true
+    wait "$serve_pid" 2>/dev/null || true
+    log "verify: done (clone state/data left for inspection; reqbench.py reaps its own)"
+}
+
+cmd_run() {
+    guard_quiet
+    log "run: starting serve for $TAG"
+    local sf="$RESULTS/logs/serve.log"
+    $SUDO "$FCVM" snapshot serve "$TAG" >"$sf" 2>&1 &
+    local t0=$SECONDS
+    until grep -q "Waiting for VMs" "$sf" 2>/dev/null; do
+        [ $((SECONDS-t0)) -lt 60 ] || { log "run: serve never came up"; cat "$sf" >&2; return 1; }
+        sleep 0.5
+    done
+    local spid; spid=$(grep -oP 'Serve PID: \K[0-9]+' "$sf" | head -1)
+    log "run: serve pid $spid -> reqbench.py"
+    $SUDO env RUST_LOG=$FCVM_LOG python3 "$HERE/reqbench.py" --serve-pid "$spid" --url "$URL" \
+        --out-dir "$RESULTS" --reps "${REPS:-10}" --warmup "${WARMUP:-2}" \
+        --cdp-port "$CDP_PORT" --fcvm "$FCVM" --rust-log "$FCVM_LOG" \
+        --arms "${ARMS:-exec,cdp,cdp-fast,noop}"
+    $SUDO kill "$spid" 2>/dev/null || true
+    log "run: results in $RESULTS"
+}
+
+case "${1:-}" in
+    build)  cmd_build ;;
+    golden) cmd_golden ;;
+    verify) cmd_verify ;;
+    run)    cmd_run ;;
+    all)    cmd_build; cmd_golden; cmd_verify; cmd_run ;;
+    *) echo "usage: $0 {build|golden|verify|run|all}" >&2; exit 2 ;;
+esac

--- a/bench/chromium/reqstages.py
+++ b/bench/chromium/reqstages.py
@@ -108,11 +108,11 @@ def main():
         # render.py's total_ms covers connect+navigate+screenshot ONLY, so this
         # residual IS the guest python interpreter boot + imports. It is a
         # residual and is labelled as one -- no fcvm log can see inside the guest.
-        gо = d("handshake_done", "exec_finished")
-        if gо is not None:
-            add("GO->exec_finished (guest python up + render + exit)", []).append(gо)
+        go_ms = d("handshake_done", "exec_finished")
+        if go_ms is not None:
+            add("GO->exec_finished (guest python up + render + exit)", []).append(go_ms)
             add("  = render.py measured work", []).append(r["total_ms"])
-            add("  = RESIDUAL guest python up + exit", []).append(gо - r["total_ms"])
+            add("  = RESIDUAL guest python up + exit", []).append(go_ms - r["total_ms"])
         for k in ("connect_ms", "navigate_ms", "screenshot_ms", "total_ms"):
             if k in r:
                 add(f"render.py {k}", []).append(r[k])

--- a/bench/chromium/reqstages.py
+++ b/bench/chromium/reqstages.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Attribute every wait in the exec arm from RUST_LOG=fcvm=debug timestamps.
+
+AGENTS.md defect 4: at `info` the exec client's retry ladder is invisible, which
+made ~70 ms of a 310 ms gap unattributable. At `debug` every step is stamped, so
+the exec arm decomposes without guessing -- and the guest-python startup, which
+no fcvm log can see, falls out as the residual between the exec GO and
+render.py's own first timestamp.
+
+Emits medians with a bootstrap CI so each stage is quotable at its own precision.
+"""
+
+import argparse
+import glob
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+from reqanalyze import fmt, median_ci  # noqa: E402
+
+TS = re.compile(r"^(\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d+Z)")
+
+
+def ts(line):
+    m = TS.match(line)
+    if not m:
+        return None
+    h = m.group(1)
+    hh, mm, rest = h.split("T")[1].split(":")[0], h.split("T")[1].split(":")[1], \
+        h.split("T")[1].split(":")[2].rstrip("Z")
+    return int(hh) * 3600 + int(mm) * 60 + float(rest)
+
+
+MARKS = [
+    ("holder_ready", "namespace ready (nsenter probe succeeded)"),
+    ("pasta_ready", "pasta ready (PID file created)"),
+    ("resume_done", "VM resume completed"),
+    ("exec_start", "executing command in VM"),
+    ("handshake_ack", "exec handshake: ACK received"),
+    ("handshake_done", "exec handshake complete"),
+    ("exec_finished", "exec finished, cleaning up"),
+]
+
+
+def parse(path):
+    out = {}
+    first = None
+    render = {}
+    retries = 0
+    for line in open(path, errors="replace"):
+        t = ts(line)
+        if t is not None and first is None:
+            first = t
+        for key, needle in MARKS:
+            if needle in line and key not in out and t is not None:
+                out[key] = t
+        if "RENDER_OK" in line:
+            for tok in line.split():
+                if "=" in tok:
+                    k, v = tok.split("=", 1)
+                    try:
+                        render[k] = float(v)
+                    except ValueError:
+                        pass
+            # render.py's stdout has no fcvm timestamp; use the NEXT fcvm line
+            # ("exec finished") as its upper bound instead of inventing one.
+        if "retrying" in line or "retry attempt" in line:
+            retries += 1
+    out["_first"] = first
+    out["_render"] = render
+    out["_retries"] = retries
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("globs", nargs="+")
+    a = ap.parse_args()
+    files = []
+    for g in a.globs:
+        files += sorted(glob.glob(g))
+    stages = {}
+    retries_total = 0
+    n_ok = 0
+    for f in files:
+        p = parse(f)
+        r = p.get("_render") or {}
+        if not r or "total_ms" not in r:
+            continue
+        n_ok += 1
+        retries_total += p["_retries"]
+
+        def d(a_, b_):
+            if p.get(a_) is None or p.get(b_) is None:
+                return None
+            return (p[b_] - p[a_]) * 1000
+
+        add = stages.setdefault
+        add("spawn->holder_ready", []).append(d("_first", "holder_ready"))
+        add("holder_ready->pasta_ready", []).append(d("holder_ready", "pasta_ready"))
+        add("pasta_ready->resume_done", []).append(d("pasta_ready", "resume_done"))
+        add("resume_done->exec_start", []).append(d("resume_done", "exec_start"))
+        add("exec handshake (start->GO)", []).append(d("exec_start", "handshake_done"))
+        add("handshake ACK wait", []).append(d("exec_start", "handshake_ack"))
+        # Residual: from exec GO until render.py's own measured work ends.
+        # render.py's total_ms covers connect+navigate+screenshot ONLY, so this
+        # residual IS the guest python interpreter boot + imports. It is a
+        # residual and is labelled as one -- no fcvm log can see inside the guest.
+        gо = d("handshake_done", "exec_finished")
+        if gо is not None:
+            add("GO->exec_finished (guest python up + render + exit)", []).append(gо)
+            add("  = render.py measured work", []).append(r["total_ms"])
+            add("  = RESIDUAL guest python up + exit", []).append(gо - r["total_ms"])
+        for k in ("connect_ms", "navigate_ms", "screenshot_ms", "total_ms"):
+            if k in r:
+                add(f"render.py {k}", []).append(r[k])
+
+    print(f"parsed {n_ok} exec logs;  exec-client retry lines seen: {retries_total}")
+    print(f"{'stage':52s} {'median [95% CI]'}")
+    for k, vs in stages.items():
+        vs = [v for v in vs if v is not None]
+        if vs:
+            print(f"{k:52s} {fmt(*median_ci(vs))}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/chromium/teardown_probe.py
+++ b/bench/chromium/teardown_probe.py
@@ -61,6 +61,78 @@ def poll_gone(pid_fds, deadline):
     return out
 
 
+def reap_rep(row: dict, named: dict, sp, data_dir) -> bool:
+    """Reap this rep's on-disk state — but ONLY if every child is confirmed gone.
+
+    Returns True if the rep LEAKED (a child outlived the kill), in which case
+    nothing is reaped and the survivors are SIGKILLed.
+
+    This is `reqbench.py`'s rule, which the probe imported `reap_disk` without:
+    "reaping the state file and rmtree'ing the data dir of a VM whose Firecracker
+    is still RUNNING deletes the only record of a live microVM and pulls its
+    rootfs out from under it." `poll_gone` already returns None for a child still
+    alive at the deadline; the probe printed that as TIMEOUT and then reaped
+    anyway, never signalled the survivor, and still exited 0.
+    """
+    stuck = [n for n, v in (row.get("gone_ms") or {}).items() if v is None]
+    if stuck:
+        row["disk_reap_skipped"] = True
+        row["survivors"] = stuck
+        print(f"rep {row.get('rep')}: NOT reaping — still alive: {stuck}", file=sys.stderr)
+        for n in stuck:
+            pid = named.get(n)
+            if pid:
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except (ProcessLookupError, PermissionError):
+                    pass
+        return True
+    reaped = reap_disk(row, sp, data_dir)
+    if reaped:
+        row["disk_reaped"] = reaped
+    for err in row.get("disk_errors", []):
+        print(f"rep {row.get('rep')}: disk reap failed: {err}", file=sys.stderr)
+    return False
+
+
+def summarize(rows: list) -> int:
+    """Per-child medians WITH their denominator. Returns the censored count.
+
+    `n=` used to be `len(vs2)` — the observed exits only — so the denominator and
+    the timeout count were never printed, and there was no `else` branch at all:
+    a child that TIMED OUT in every rep printed NOTHING, i.e. the straggler this
+    probe exists to find is precisely the one that disappeared from its own
+    summary. Reps that took the no-state branch contribute an empty `gone_ms` and
+    were likewise absent from the denominator.
+    """
+    import statistics
+
+    agg: dict = {}
+    for r in rows:
+        for n, v in (r.get("gone_ms") or {}).items():
+            agg.setdefault(n.split(":")[0], []).append(v)
+    print("\n=== medians per child ===")
+    censored_total = 0
+    for n, vs in sorted(agg.items()):
+        vs2 = [v for v in vs if v is not None]
+        censored = len(vs) - len(vs2)
+        censored_total += censored
+        if vs2:
+            print(f"  {n:22s} median {statistics.median(vs2):8.1f} ms   "
+                  f"min {min(vs2):.1f}  max {max(vs2):.1f}  "
+                  f"n={len(vs2)}/{len(vs)} censored={censored}")
+        else:
+            print(f"  {n:22s} NO EXIT OBSERVED  n=0/{len(vs)} censored={censored}")
+    errored = sum(1 for r in rows if r.get("error"))
+    leaked = sum(1 for r in rows if r.get("disk_reap_skipped"))
+    print(f"  reps attempted={len(rows)} recorded={len(rows)} errored={errored} "
+          f"reaps_skipped={leaked} censored_children={censored_total}")
+    if censored_total:
+        print("  ** CENSORED EXITS ARE LEAKS, NOT MISSING SAMPLES — do not quote "
+              "these medians **")
+    return censored_total
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--serve-pid", type=int, required=True)
@@ -75,101 +147,115 @@ def main():
     a.fcvm = os.path.abspath(a.fcvm)
     state_dir = os.path.join(a.data_root, "state")
 
-    rows = []
-    for i in range(a.n):
-        name = f"tdp-{os.getpid()}-{i}"
-        log = f"/tmp/{name}.log"
-        cmd = [a.fcvm, "snapshot", "run", "--pid", str(a.serve_pid), "--name", name,
-               "--no-dirty-tracking", "--no-swap"]
-        watch = DirWatch(state_dir)  # registered BEFORE the spawn
-        with open(log, "wb") as lf:
-            proc = subprocess.Popen(cmd, stdout=lf, stderr=lf, stdin=subprocess.DEVNULL,
-                                    env=dict(os.environ, RUST_LOG="fcvm=debug"))
-        sp = None
-        data_dir = None
-        row = {"rep": i, "gone_ms": {}}
-        # ONE reap path for every rep, including the failures. The `no state`
-        # branch used to `continue` — never signalling `proc`, never waiting on
-        # it, and dropping the reference on the next iteration. CPython's
-        # Popen.__del__ only queues a later *reap*; it never kills. So a scan that
-        # gave up while fcvm was mid-restore (the state file is written with
-        # `pid: null` well before the post-resume pid write, so this is a real
-        # window, not a hypothetical) left the fcvm, its firecracker, pasta, the
-        # holder, the netns, the 127.x loopback IP, the vm-disks dir AND a state
-        # file that fcvm's own sweeper will never remove — `cleanup_stale_state`
-        # bails on a null pid. Nothing was recorded either: no row, no error field.
-        try:
-            deadline = time.monotonic() + a.state_timeout
-            sp, state = find_state(state_dir, proc.pid, deadline, watch, name)
-            if state is None:
-                row["error"] = f"no state file within {a.state_timeout}s"
+    rows: list = []
+    leaked = False
+    # EVERY rep records something, and the summary + artifact are written whatever
+    # happens. `wait_port` raises TimeoutError when the port never answers and
+    # `clone_cdp_endpoint` raises RuntimeError ("no usable host-side IP"); neither
+    # was caught, so one bad rep left main() through a bare try/finally, the
+    # summary never printed, `json.dump(rows, f)` never ran, and reps 0..i-1 were
+    # lost with no trace. reqbench.py's main() deliberately does the opposite.
+    try:
+        for i in range(a.n):
+            name = f"tdp-{os.getpid()}-{i}"
+            log = f"/tmp/{name}.log"
+            cmd = [a.fcvm, "snapshot", "run", "--pid", str(a.serve_pid), "--name", name,
+                   "--no-dirty-tracking", "--no-swap"]
+            watch = DirWatch(state_dir)  # registered BEFORE the spawn
+            with open(log, "wb") as lf:
+                proc = subprocess.Popen(cmd, stdout=lf, stderr=lf, stdin=subprocess.DEVNULL,
+                                        env=dict(os.environ, RUST_LOG="fcvm=debug"))
+            sp = None
+            data_dir = None
+            named: dict = {}
+            row = {"rep": i, "gone_ms": {}}
+            # ONE reap path for every rep, including the failures. The `no state`
+            # branch used to `continue` — never signalling `proc`, never waiting on
+            # it, and dropping the reference on the next iteration. CPython's
+            # Popen.__del__ only queues a later *reap*; it never kills. So a scan
+            # that gave up while fcvm was mid-restore (the state file is written
+            # with `pid: null` well before the post-resume pid write, so this is a
+            # real window, not a hypothetical) left the fcvm, its firecracker,
+            # pasta, the holder, the netns, the 127.x loopback IP, the vm-disks dir
+            # AND a state file that fcvm's own sweeper will never remove —
+            # `cleanup_stale_state` bails on a null pid.
+            try:
+                deadline = time.monotonic() + a.state_timeout
+                sp, state = find_state(state_dir, proc.pid, deadline, watch, name)
+                if state is None:
+                    row["error"] = f"no state file within {a.state_timeout}s"
+                    print(f"rep {i}: no state -> killing the clone and skipping",
+                          file=sys.stderr)
+                    continue
+                data_dir = os.path.join(a.data_root, "vm-disks", state.get("vm_id", ""))
+                wait_port(clone_cdp_endpoint(state, a.cdp_port), deadline)
+                time.sleep(0.3)  # settle: measure steady-state teardown, not mid-restore
+
+                for p in children_of(proc.pid):
+                    named[f"{proc_comm(p)}:{p}"] = p
+                fds = {n: pidfd_open(p) for n, p in named.items()}
+                fds = {n: f for n, f in fds.items() if f is not None}
+                t_kill = time.monotonic()
+                os.kill(proc.pid, signal.SIGKILL)
+                gone = poll_gone(fds, t_kill + 30)
+                for f in fds.values():
+                    os.close(f)
+                row["gone_ms"] = gone
+                print(f"rep {i}: " + "  ".join(
+                    f"{n.split(':')[0]}={('%.1f' % v) if v is not None else 'TIMEOUT'}ms"
+                    for n, v in sorted(gone.items(), key=lambda kv: (kv[1] is None, kv[1]))))
+            except Exception as e:  # noqa: BLE001 - record, never lose the run
+                row["error"] = f"{type(e).__name__}: {e}"
+                print(f"rep {i}: {row['error']}", file=sys.stderr)
+            finally:
+                watch.close()
+                # SIGKILL cannot be caught, so `cleanup_vm` never runs: WE own the
+                # reap of BOTH artifacts. The state file alone is not enough —
+                # nothing in fcvm ever removes `vm-disks/<vm_id>`, which holds a
+                # reflink of the golden rootfs and therefore pins the golden
+                # snapshot's extents on btrfs even after `snapshots delete`.
+                if proc.poll() is None:
+                    # We never reached the MEASURED kill (no state file, or an
+                    # exception), so capture the children BEFORE signalling — after
+                    # fcvm dies, /proc/<fcvm>/task/*/children is gone and any
+                    # survivor is unrecoverable. Without this the failure paths
+                    # reaped with no evidence at all.
+                    if not named:
+                        for p in children_of(proc.pid):
+                            named[f"{proc_comm(p)}:{p}"] = p
+                    late = {n: pidfd_open(p) for n, p in named.items()}
+                    late = {n: f for n, f in late.items() if f is not None}
+                    try:
+                        os.kill(proc.pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                    try:
+                        proc.wait(timeout=10)
+                    except subprocess.TimeoutExpired:
+                        print(f"rep {i}: fcvm {proc.pid} survived SIGKILL", file=sys.stderr)
+                    if late:
+                        row["gone_ms"] = {**row["gone_ms"],
+                                          **poll_gone(late, time.monotonic() + 30)}
+                        for f in late.values():
+                            os.close(f)
+                if sp is None:
+                    # The pid-keyed scan is exactly what failed; the NAME is written
+                    # before the first save, so it is the only key that can recover
+                    # vm_id (and thus the data dir) on this path.
+                    sp, state = scan_state(state_dir, proc.pid, name)
+                    if state is not None:
+                        data_dir = os.path.join(a.data_root, "vm-disks",
+                                                state.get("vm_id", ""))
+                leaked |= reap_rep(row, named, sp, data_dir)
                 rows.append(row)
-                print(f"rep {i}: no state -> killing the clone and skipping", file=sys.stderr)
-                continue
-            data_dir = os.path.join(a.data_root, "vm-disks", state.get("vm_id", ""))
-            wait_port(clone_cdp_endpoint(state, a.cdp_port), deadline)
-            time.sleep(0.3)  # settle: measure steady-state teardown, not mid-restore
-
-            kids = children_of(proc.pid)
-            named = {}
-            for p in kids:
-                named[f"{proc_comm(p)}:{p}"] = p
-            fds = {n: pidfd_open(p) for n, p in named.items()}
-            fds = {n: f for n, f in fds.items() if f is not None}
-            t_kill = time.monotonic()
-            os.kill(proc.pid, signal.SIGKILL)
-            gone = poll_gone(fds, t_kill + 30)
-            for f in fds.values():
-                os.close(f)
-            row["gone_ms"] = gone
-            rows.append(row)
-            print(f"rep {i}: " + "  ".join(
-                f"{n.split(':')[0]}={('%.1f' % v) if v is not None else 'TIMEOUT'}ms"
-                for n, v in sorted(gone.items(), key=lambda kv: (kv[1] is None, kv[1]))))
-        finally:
-            watch.close()
-            # SIGKILL cannot be caught, so `cleanup_vm` never runs: WE own the reap
-            # of BOTH artifacts. The state file alone is not enough — nothing in
-            # fcvm ever removes `vm-disks/<vm_id>`, which holds a reflink of the
-            # golden rootfs and therefore pins the golden snapshot's extents on
-            # btrfs even after `snapshots delete`.
-            if proc.poll() is None:
-                try:
-                    os.kill(proc.pid, signal.SIGKILL)
-                except ProcessLookupError:
-                    pass
-                try:
-                    proc.wait(timeout=10)
-                except subprocess.TimeoutExpired:
-                    print(f"rep {i}: fcvm {proc.pid} survived SIGKILL", file=sys.stderr)
-            if sp is None:
-                # The pid-keyed scan is exactly what failed; the NAME is written
-                # before the first save, so it is the only key that can recover
-                # vm_id (and thus the data dir) on this path.
-                sp, state = scan_state(state_dir, proc.pid, name)
-                if state is not None:
-                    data_dir = os.path.join(a.data_root, "vm-disks", state.get("vm_id", ""))
-            reaped = reap_disk(row, sp, data_dir)
-            if reaped:
-                row["disk_reaped"] = reaped
-            for err in row.get("disk_errors", []):
-                print(f"rep {i}: disk reap failed: {err}", file=sys.stderr)
-
-    print("\n=== medians per child ===")
-    agg = {}
-    for r in rows:
-        for n, v in r["gone_ms"].items():
-            agg.setdefault(n.split(":")[0], []).append(v)
-    import statistics
-    for n, vs in sorted(agg.items()):
-        vs2 = [v for v in vs if v is not None]
-        if vs2:
-            print(f"  {n:22s} median {statistics.median(vs2):8.1f} ms   "
-                  f"min {min(vs2):.1f}  max {max(vs2):.1f}  n={len(vs2)}")
-    if a.out:
-        with open(a.out, "w") as f:
-            json.dump(rows, f, indent=2)
-    return 0
+    finally:
+        censored = summarize(rows)
+        if a.out:
+            with open(a.out, "w") as f:
+                json.dump(rows, f, indent=2)
+    # 4 matches reqbench.py's exit code for the same condition: the box now
+    # carries a microVM this harness cannot see.
+    return 4 if (leaked or censored) else 0
 
 
 if __name__ == "__main__":

--- a/bench/chromium/teardown_probe.py
+++ b/bench/chromium/teardown_probe.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Per-child teardown timing: WHICH process is the straggler after one SIGKILL?
+
+The A/B measured `reap_wall` for the fast arm at ~410 ms while the summed
+reclaim CPU across all children was ~30 ms. A 380 ms gap that burns no CPU is
+not memory reclaim -- something is WAITING. Aggregate numbers cannot say what,
+so this probe times each child's disappearance INDEPENDENTLY, with its own
+pidfd, from the single kill instant.
+
+Run: python3 teardown_probe.py --serve-pid N [--n 5]
+"""
+
+import argparse
+import ctypes
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+from reqbench import (  # noqa: E402
+    children_of, clone_cdp_endpoint, find_state, pidfd_open, proc_comm, wait_port,
+)
+
+libc = ctypes.CDLL("libc.so.6", use_errno=True)
+
+
+def poll_gone(pid_fds, deadline):
+    """Return {name: ms_until_gone}. Polls each pidfd separately so one slow
+    child cannot hide behind another -- the exact failure of an all_gone flag."""
+    import select
+
+    t0 = time.monotonic()
+    out = {}
+    pending = dict(pid_fds)
+    poller = select.poll()
+    for name, fd in pending.items():
+        poller.register(fd, select.POLLIN)
+    while pending and time.monotonic() < deadline:
+        for fd, _ev in poller.poll(20):
+            for name, f in list(pending.items()):
+                if f == fd:
+                    out[name] = (time.monotonic() - t0) * 1000
+                    poller.unregister(fd)
+                    del pending[name]
+    for name in pending:
+        out[name] = None
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--serve-pid", type=int, required=True)
+    ap.add_argument("--n", type=int, default=5)
+    ap.add_argument("--cdp-port", type=int, default=9223)
+    ap.add_argument("--fcvm", default=os.path.join(HERE, "..", "..", "target", "release", "fcvm"))
+    ap.add_argument("--data-root", default="/mnt/fcvm-btrfs")
+    ap.add_argument("--out", default="")
+    a = ap.parse_args()
+    a.fcvm = os.path.abspath(a.fcvm)
+    state_dir = os.path.join(a.data_root, "state")
+
+    rows = []
+    for i in range(a.n):
+        name = f"tdp-{os.getpid()}-{i}"
+        log = f"/tmp/{name}.log"
+        cmd = [a.fcvm, "snapshot", "run", "--pid", str(a.serve_pid), "--name", name,
+               "--no-dirty-tracking", "--no-swap"]
+        with open(log, "wb") as lf:
+            proc = subprocess.Popen(cmd, stdout=lf, stderr=lf, stdin=subprocess.DEVNULL,
+                                    env=dict(os.environ, RUST_LOG="fcvm=debug"))
+        deadline = time.monotonic() + 120
+        sp, state = find_state(state_dir, proc.pid, deadline)
+        if state is None:
+            print("no state", file=sys.stderr)
+            continue
+        wait_port(clone_cdp_endpoint(state, a.cdp_port), deadline)
+        time.sleep(0.3)  # settle: measure steady-state teardown, not mid-restore
+
+        kids = children_of(proc.pid)
+        named = {}
+        for p in kids:
+            named[f"{proc_comm(p)}:{p}"] = p
+        fds = {n: pidfd_open(p) for n, p in named.items()}
+        fds = {n: f for n, f in fds.items() if f is not None}
+        t_kill = time.monotonic()
+        os.kill(proc.pid, signal.SIGKILL)
+        gone = poll_gone(fds, t_kill + 30)
+        for f in fds.values():
+            os.close(f)
+        row = {"rep": i, "gone_ms": gone}
+        rows.append(row)
+        print(f"rep {i}: " + "  ".join(
+            f"{n.split(':')[0]}={('%.1f' % v) if v is not None else 'TIMEOUT'}ms"
+            for n, v in sorted(gone.items(), key=lambda kv: (kv[1] is None, kv[1]))))
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
+        if sp and os.path.exists(sp):
+            os.remove(sp)
+
+    print("\n=== medians per child ===")
+    agg = {}
+    for r in rows:
+        for n, v in r["gone_ms"].items():
+            agg.setdefault(n.split(":")[0], []).append(v)
+    import statistics
+    for n, vs in sorted(agg.items()):
+        vs2 = [v for v in vs if v is not None]
+        if vs2:
+            print(f"  {n:22s} median {statistics.median(vs2):8.1f} ms   "
+                  f"min {min(vs2):.1f}  max {max(vs2):.1f}  n={len(vs2)}")
+    if a.out:
+        with open(a.out, "w") as f:
+            json.dump(rows, f, indent=2)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/chromium/teardown_probe.py
+++ b/bench/chromium/teardown_probe.py
@@ -1,13 +1,22 @@
 #!/usr/bin/env python3
 """Per-child teardown timing: WHICH process is the straggler after one SIGKILL?
 
-The A/B measured `reap_wall` for the fast arm at ~410 ms while the summed
-reclaim CPU across all children was ~30 ms. A 380 ms gap that burns no CPU is
-not memory reclaim -- something is WAITING. Aggregate numbers cannot say what,
-so this probe times each child's disappearance INDEPENDENTLY, with its own
-pidfd, from the single kill instant.
+Aggregate numbers cannot say which child is slow, so this probe times each
+child's disappearance INDEPENDENTLY, with its own pidfd, from the single kill
+instant.
 
-Run: python3 teardown_probe.py --serve-pid N [--n 5]
+WHAT THIS PROBE HAS AND HAS NOT ESTABLISHED. The run that motivated it reported
+`reap_wall ~410 ms` against a summed reclaim CPU of ~30 ms and concluded "a gap
+that burns no CPU is not memory reclaim -- something is WAITING", then attributed
+the wait to pasta at 704 ms. Both figures are WITHDRAWN (see REVIEW.md): the CPU
+side came from a sampler whose control window was a busy-spin and whose per-child
+values were quantized to a 10 ms jiffy, and the pasta side was measured on a tree
+that did not yet arm `PR_SET_PDEATHSIG` on pasta (`46dbb789`). The per-child WALL
+times this file produces are unaffected by the CPU defects -- they come from
+`poll_gone`, which is pure pidfd timing -- but they must be RE-MEASURED on the
+current tree before any of them is quoted.
+
+Run: python3 teardown_probe.py --serve-pid N [--n 5] [--state-timeout 120]
 """
 
 import argparse
@@ -22,7 +31,8 @@ import time
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, HERE)
 from reqbench import (  # noqa: E402
-    children_of, clone_cdp_endpoint, find_state, pidfd_open, proc_comm, wait_port,
+    DirWatch, children_of, clone_cdp_endpoint, find_state, pidfd_open, proc_comm,
+    reap_disk, scan_state, wait_port,
 )
 
 libc = ctypes.CDLL("libc.so.6", use_errno=True)
@@ -59,6 +69,8 @@ def main():
     ap.add_argument("--fcvm", default=os.path.join(HERE, "..", "..", "target", "release", "fcvm"))
     ap.add_argument("--data-root", default="/mnt/fcvm-btrfs")
     ap.add_argument("--out", default="")
+    ap.add_argument("--state-timeout", type=float, default=120.0,
+                    help="how long to wait for the clone's state file to appear")
     a = ap.parse_args()
     a.fcvm = os.path.abspath(a.fcvm)
     state_dir = os.path.join(a.data_root, "state")
@@ -69,39 +81,79 @@ def main():
         log = f"/tmp/{name}.log"
         cmd = [a.fcvm, "snapshot", "run", "--pid", str(a.serve_pid), "--name", name,
                "--no-dirty-tracking", "--no-swap"]
+        watch = DirWatch(state_dir)  # registered BEFORE the spawn
         with open(log, "wb") as lf:
             proc = subprocess.Popen(cmd, stdout=lf, stderr=lf, stdin=subprocess.DEVNULL,
                                     env=dict(os.environ, RUST_LOG="fcvm=debug"))
-        deadline = time.monotonic() + 120
-        sp, state = find_state(state_dir, proc.pid, deadline)
-        if state is None:
-            print("no state", file=sys.stderr)
-            continue
-        wait_port(clone_cdp_endpoint(state, a.cdp_port), deadline)
-        time.sleep(0.3)  # settle: measure steady-state teardown, not mid-restore
-
-        kids = children_of(proc.pid)
-        named = {}
-        for p in kids:
-            named[f"{proc_comm(p)}:{p}"] = p
-        fds = {n: pidfd_open(p) for n, p in named.items()}
-        fds = {n: f for n, f in fds.items() if f is not None}
-        t_kill = time.monotonic()
-        os.kill(proc.pid, signal.SIGKILL)
-        gone = poll_gone(fds, t_kill + 30)
-        for f in fds.values():
-            os.close(f)
-        row = {"rep": i, "gone_ms": gone}
-        rows.append(row)
-        print(f"rep {i}: " + "  ".join(
-            f"{n.split(':')[0]}={('%.1f' % v) if v is not None else 'TIMEOUT'}ms"
-            for n, v in sorted(gone.items(), key=lambda kv: (kv[1] is None, kv[1]))))
+        sp = None
+        data_dir = None
+        row = {"rep": i, "gone_ms": {}}
+        # ONE reap path for every rep, including the failures. The `no state`
+        # branch used to `continue` — never signalling `proc`, never waiting on
+        # it, and dropping the reference on the next iteration. CPython's
+        # Popen.__del__ only queues a later *reap*; it never kills. So a scan that
+        # gave up while fcvm was mid-restore (the state file is written with
+        # `pid: null` well before the post-resume pid write, so this is a real
+        # window, not a hypothetical) left the fcvm, its firecracker, pasta, the
+        # holder, the netns, the 127.x loopback IP, the vm-disks dir AND a state
+        # file that fcvm's own sweeper will never remove — `cleanup_stale_state`
+        # bails on a null pid. Nothing was recorded either: no row, no error field.
         try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            pass
-        if sp and os.path.exists(sp):
-            os.remove(sp)
+            deadline = time.monotonic() + a.state_timeout
+            sp, state = find_state(state_dir, proc.pid, deadline, watch, name)
+            if state is None:
+                row["error"] = f"no state file within {a.state_timeout}s"
+                rows.append(row)
+                print(f"rep {i}: no state -> killing the clone and skipping", file=sys.stderr)
+                continue
+            data_dir = os.path.join(a.data_root, "vm-disks", state.get("vm_id", ""))
+            wait_port(clone_cdp_endpoint(state, a.cdp_port), deadline)
+            time.sleep(0.3)  # settle: measure steady-state teardown, not mid-restore
+
+            kids = children_of(proc.pid)
+            named = {}
+            for p in kids:
+                named[f"{proc_comm(p)}:{p}"] = p
+            fds = {n: pidfd_open(p) for n, p in named.items()}
+            fds = {n: f for n, f in fds.items() if f is not None}
+            t_kill = time.monotonic()
+            os.kill(proc.pid, signal.SIGKILL)
+            gone = poll_gone(fds, t_kill + 30)
+            for f in fds.values():
+                os.close(f)
+            row["gone_ms"] = gone
+            rows.append(row)
+            print(f"rep {i}: " + "  ".join(
+                f"{n.split(':')[0]}={('%.1f' % v) if v is not None else 'TIMEOUT'}ms"
+                for n, v in sorted(gone.items(), key=lambda kv: (kv[1] is None, kv[1]))))
+        finally:
+            watch.close()
+            # SIGKILL cannot be caught, so `cleanup_vm` never runs: WE own the reap
+            # of BOTH artifacts. The state file alone is not enough — nothing in
+            # fcvm ever removes `vm-disks/<vm_id>`, which holds a reflink of the
+            # golden rootfs and therefore pins the golden snapshot's extents on
+            # btrfs even after `snapshots delete`.
+            if proc.poll() is None:
+                try:
+                    os.kill(proc.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    print(f"rep {i}: fcvm {proc.pid} survived SIGKILL", file=sys.stderr)
+            if sp is None:
+                # The pid-keyed scan is exactly what failed; the NAME is written
+                # before the first save, so it is the only key that can recover
+                # vm_id (and thus the data dir) on this path.
+                sp, state = scan_state(state_dir, proc.pid, name)
+                if state is not None:
+                    data_dir = os.path.join(a.data_root, "vm-disks", state.get("vm_id", ""))
+            reaped = reap_disk(row, sp, data_dir)
+            if reaped:
+                row["disk_reaped"] = reaped
+            for err in row.get("disk_errors", []):
+                print(f"rep {i}: disk reap failed: {err}", file=sys.stderr)
 
     print("\n=== medians per child ===")
     agg = {}

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -22,6 +22,7 @@ import tempfile
 import threading
 import time
 import unittest
+import urllib.request
 from contextlib import redirect_stdout
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -70,6 +71,35 @@ def spawn_mixed_parent(linger_bin, fast_bin):
     return subprocess.Popen([sys.executable, "-c", code, linger_bin, fast_bin])
 
 
+def spawn_pdeathsig_parent_ignoring_sigterm(child_argv):
+    """A parent that IGNORES SIGTERM but whose child dies with it.
+
+    `teardown_normal` sends SIGTERM first, so this shape forces the timed_out
+    path — and the child still dies sub-millisecond once the SIGKILL lands. That
+    combination is what separates "the teardown timed out" from "the teardown
+    leaked": exactly the distinction the all_gone verdict has to get right.
+    """
+    code = (
+        "import ctypes,signal,subprocess,sys,time;"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN);"
+        "libc=ctypes.CDLL('libc.so.6');"
+        "subprocess.Popen(sys.argv[1:],preexec_fn=lambda: libc.prctl(1, signal.SIGKILL));"
+        "time.sleep(3600)"
+    )
+    return subprocess.Popen([sys.executable, "-c", code, *child_argv])
+
+
+def wait_for_child(pid, timeout=5.0):
+    """Block until `pid` has forked at least one child. Returns the child list."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        kids = reqbench.children_of(pid)
+        if kids:
+            return kids
+        time.sleep(0.005)
+    raise AssertionError(f"pid {pid} never forked a child")
+
+
 def kill_tree(p):
     """SIGKILL a parent and anything still under it. Tests must not leak either."""
     for pid in reqbench.children_of(p.pid):
@@ -100,7 +130,10 @@ class TeardownFastReapGuard(unittest.TestCase):
     def test_survivor_blocks_the_reap_and_raises(self):
         with tempfile.TemporaryDirectory() as d:
             state = os.path.join(d, "vm-test.json")
-            data = os.path.join(d, "data")
+            # Shaped exactly as production builds it — `<data_root>/vm-disks/<vm_id>`
+            # — because `reap_disk` now refuses anything that is not strictly below
+            # a `vm-disks` root (see ReapDiskPathGuard).
+            data = os.path.join(d, "vm-disks", "vm-test")
             with open(state, "w") as f:
                 json.dump({"vm_id": "vm-test", "pid": 1}, f)
             os.makedirs(os.path.join(data, "disks"))
@@ -143,7 +176,7 @@ class TeardownFastReapGuard(unittest.TestCase):
         """The guard must not disarm the reap on the normal path."""
         with tempfile.TemporaryDirectory() as d:
             state = os.path.join(d, "vm-test.json")
-            data = os.path.join(d, "data")
+            data = os.path.join(d, "vm-disks", "vm-test")
             with open(state, "w") as f:
                 json.dump({"vm_id": "vm-test"}, f)
             with open(state + ".lock", "w") as f:
@@ -156,6 +189,248 @@ class TeardownFastReapGuard(unittest.TestCase):
             self.assertFalse(os.path.exists(state))
             self.assertFalse(os.path.exists(state + ".lock"), "the .json.lock must go too")
             self.assertFalse(os.path.isdir(data))
+
+
+    def test_failed_rmtree_aborts_the_run(self):
+        """A reap that could not remove the data dir must STOP the schedule.
+
+        RED BEFORE THE FIX: `reap_disk` recorded the EPERM in `out["disk_errors"]`
+        and `teardown_fast` returned normally, so main() wrote `ok: true` and ran
+        the next rep against a box carrying an un-reapable multi-GB reflink of the
+        golden rootfs. Observed:
+            teardown_fast returned NORMALLY:
+              disk_errors=['/tmp/.../data: [Errno 1] EPERM']
+              disk_reaped=['/tmp/.../vm-test.json']  data dir still on disk=True
+        `git grep disk_errors` found no reader anywhere in the harness.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            state = os.path.join(d, "vm-test.json")
+            data = os.path.join(d, "vm-disks", "vm-test")
+            with open(state, "w") as f:
+                json.dump({"vm_id": "vm-test"}, f)
+            os.makedirs(data)
+            real = shutil.rmtree
+
+            def boom(*_a, **_k):
+                raise PermissionError(1, "Operation not permitted")
+
+            p = subprocess.Popen(["sleep", "300"])
+            shutil.rmtree = boom
+            try:
+                with self.assertRaises(reqbench.SurvivedTeardown) as cm:
+                    reqbench.teardown_fast(p.pid, state, data, 5.0)
+            finally:
+                shutil.rmtree = real
+                p.wait(timeout=5)
+            self.assertIn("could not reap", str(cm.exception))
+            self.assertTrue(os.path.isdir(data), "the un-reaped dir is still there")
+            self.assertTrue(cm.exception.teardown.get("disk_errors"))
+            self.assertIn(data, cm.exception.teardown.get("disk_reap_failed", []))
+
+
+class ReapDiskPathGuard(unittest.TestCase):
+    """`reap_disk` must refuse a data_dir that is not strictly below vm-disks.
+
+    RED BEFORE THE FIX: every call site computes
+    `os.path.join(data_root, "vm-disks", state.get("vm_id", ""))`, and an empty
+    vm_id makes that `<data_root>/vm-disks/` — a directory `os.path.isdir` accepts,
+    which `shutil.rmtree` then empties. That is EVERY VM's disks on the box. Commit
+    e1286e3f called this arithmetic catastrophic and guarded only the Rust fixture
+    (`an_empty_vm_id_resolves_to_the_shared_disk_root_and_must_be_rejected`); the
+    Python harness that does the identical computation, runs under sudo, and
+    rmtree's the result was left unguarded.
+    """
+
+    def test_an_empty_vm_id_does_not_wipe_the_shared_disk_root(self):
+        with tempfile.TemporaryDirectory() as root:
+            disks = os.path.join(root, "vm-disks")
+            os.makedirs(os.path.join(disks, "vm-a"))
+            os.makedirs(os.path.join(disks, "vm-b"))
+            out: dict = {}
+            reaped = reqbench.reap_disk(out, "", os.path.join(disks, ""))
+            self.assertTrue(os.path.isdir(os.path.join(disks, "vm-a")),
+                            "another VM's disks were deleted")
+            self.assertTrue(os.path.isdir(os.path.join(disks, "vm-b")),
+                            "another VM's disks were deleted")
+            self.assertEqual(reaped, [])
+            self.assertTrue(any("vm-disks" in e for e in out.get("disk_errors", [])),
+                            f"the refusal must be recorded: {out}")
+
+    def test_a_real_per_vm_dir_is_still_reaped(self):
+        """The guard must not disarm the ordinary reap."""
+        with tempfile.TemporaryDirectory() as root:
+            dd = os.path.join(root, "vm-disks", "vm-a", "disks")
+            os.makedirs(dd)
+            out: dict = {}
+            reaped = reqbench.reap_disk(out, "", os.path.join(root, "vm-disks", "vm-a"))
+            self.assertEqual(reaped, [os.path.join(root, "vm-disks", "vm-a")])
+            self.assertFalse(os.path.isdir(os.path.join(root, "vm-disks", "vm-a")))
+            self.assertNotIn("disk_errors", out)
+
+
+class TeardownNormalLeakVerdict(unittest.TestCase):
+    """`teardown_normal` computes `all_gone` and must ACT on it — correctly.
+
+    Two failures in opposite directions, both live on the branch:
+      * a real survivor is recorded and then ignored, so `cdp`/`noop` keep running
+        the schedule next to a live Firecracker;
+      * on the timed_out path the verdict is decided with a ZERO observation
+        budget (`max(0.0, t0 + timeout_s - now)` is always 0 by then, and
+        `wait_pidfds` returns False without polling at all), so a perfectly clean
+        teardown is reported as a leak.
+    """
+
+    def test_a_survivor_stops_the_schedule(self):
+        """RED BEFORE THE FIX: returned {'timed_out': True, 'all_gone': False} and
+        the caller ran the next rep with the survivor still in /proc."""
+        p = subprocess.Popen(["bash", "-c", "trap '' TERM; sleep 300 & wait"])
+        kids = wait_for_child(p.pid)
+        try:
+            with self.assertRaises(reqbench.SurvivedTeardown) as cm:
+                reqbench.teardown_normal(p, p.pid, 0.4)
+            self.assertTrue(cm.exception.teardown.get("survivors"))
+            # ...and the survivor was SIGKILLed rather than left on the box.
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                if all(reqbench.proc_stat_fields(k) is None
+                       or reqbench.proc_stat_fields(k)[0] in ("Z", "X", "x") for k in kids):
+                    break
+                time.sleep(0.01)
+            alive = [k for k in kids if reqbench.proc_stat_fields(k) is not None
+                     and reqbench.proc_stat_fields(k)[0] not in ("Z", "X", "x")]
+            self.assertEqual(alive, [], "the survivor must be killed before we abort")
+        finally:
+            kill_tree(p)
+
+    def test_a_clean_timed_out_teardown_is_not_reported_as_a_leak(self):
+        """RED BEFORE THE FIX: all_gone=False although the pdeathsig child died
+        sub-millisecond — `wait_pidfds` was handed a 0.0 budget and returns False
+        without ever polling. Gating on that boolean would abort healthy runs."""
+        p = spawn_pdeathsig_parent_ignoring_sigterm(["sleep", "300"])
+        try:
+            wait_for_child(p.pid)
+            out = reqbench.teardown_normal(p, p.pid, 0.4)
+        finally:
+            kill_tree(p)
+        self.assertIs(out.get("timed_out"), True, "SIGTERM was ignored; this must time out")
+        self.assertTrue(out["all_gone"],
+                        f"pdeathsig child died with its parent, but all_gone={out['all_gone']}")
+
+
+class CdpFailureIsLabelledOnTheRecord(unittest.TestCase):
+    """A cdpdrive `ok: false` that does not RAISE must still label the record.
+
+    RED BEFORE THE FIX: `run_cdp_request` set `rec["ok"] = bool(result["ok"])` and
+    nothing else, so the error/stage/failure_class stayed buried under
+    `rec["render"]`. `reqanalyze`'s only failure breakdown reads the TOP level
+    (`r.get("error", f"rc={r.get('rc')}")`), so a WsClosed transport drop printed
+    as `FAILURE x1: rc=None` — the exact separation REVIEW.md's availability gate
+    depends on, erased.
+    """
+
+    def test_a_non_raising_failure_is_stamped_at_the_top_level(self):
+        import cdpdrive
+
+        with tempfile.TemporaryDirectory() as d:
+            state_dir = os.path.join(d, "state")
+            os.makedirs(state_dir)
+            stub = os.path.join(d, "fcvm-stub")
+            with open(stub, "w") as f:
+                f.write(
+                    "#!/bin/bash\n"
+                    f"cat > {state_dir}/vm-red.json <<EOF\n"
+                    '{"vm_id": "vm-red", "pid": $$, '
+                    '"config": {"network": {"loopback_ip": "127.0.0.1"}}}\n'
+                    "EOF\n"
+                    "exec sleep 600\n"
+                )
+            os.chmod(stub, 0o755)
+            # A listener so wait_port succeeds without a VM.
+            import socket
+            srv = socket.socket()
+            srv.bind(("127.0.0.1", 0))
+            srv.listen(8)
+            port = srv.getsockname()[1]
+
+            real_drive = cdpdrive.drive
+            cdpdrive.drive = lambda _a: {
+                "ok": False, "error": "WsClosed: connection closed mid-frame",
+                "failure_class": "transport", "stage": "navigate", "stages": {},
+            }
+            args = argparse.Namespace(
+                fcvm=stub, out_dir=d, url="http://x/", format="jpeg", quality=80,
+                snapshot_tag="", serve_pid=1, rust_log="off",
+                timeout=10.0, teardown_timeout=5.0, cdp_port=port,
+                state_dir=state_dir, data_root=d, ws_url="",
+            )
+            try:
+                rec = reqbench.run_cdp_request(args, 0, fast=True)
+            finally:
+                cdpdrive.drive = real_drive
+                srv.close()
+            self.assertIs(rec["ok"], False)
+            self.assertIn("WsClosed", rec.get("error", ""))
+            self.assertEqual(rec.get("failure_class"), "transport")
+            self.assertEqual(rec.get("failure_stage"), "navigate")
+
+
+class ExecArmTimeoutDoesNotReapALiveClone(unittest.TestCase):
+    """The exec arm's timeout path must not delete a live microVM's only record.
+
+    RED BEFORE THE FIX: `run_exec_request` SIGKILLed fcvm, waited only on fcvm
+    ITSELF, then unconditionally `reap_disk`'d the state file AND rmtree'd
+    `vm-disks/<vm_id>`. `children_of()` was never called — and it cannot be called
+    after the kill, because `/proc/<fcvm>/task/*/children` is gone by then, so the
+    survivors are unrecoverable. Observed:
+        timed_out=True
+        reaped=['.../state/vm-red.json', '.../vm-disks/vm-red']
+        orphan child still alive=True   rootfs still on disk=False
+    i.e. the rootfs was deleted underneath a running child. This is the same rule
+    `teardown_fast` enforces at its `if not all_gone:` guard, bypassed.
+    """
+
+    def test_a_surviving_child_blocks_the_reap_and_raises(self):
+        with tempfile.TemporaryDirectory() as d:
+            state_dir = os.path.join(d, "state")
+            disks = os.path.join(d, "vm-disks", "vm-red")
+            os.makedirs(state_dir)
+            os.makedirs(disks)
+            marker = os.path.join(disks, "rootfs.raw")
+            with open(marker, "w") as f:
+                f.write("golden reflink")
+            stub = os.path.join(d, "fcvm-stub")
+            with open(stub, "w") as f:
+                f.write(
+                    "#!/bin/bash\n"
+                    f"cat > {state_dir}/vm-red.json <<EOF\n"
+                    '{"vm_id": "vm-red", "pid": $$}\n'
+                    "EOF\n"
+                    "sleep 300 &\n"     # UNARMED child: no pdeathsig, survives the kill
+                    "wait\n"
+                )
+            os.chmod(stub, 0o755)
+            args = argparse.Namespace(
+                fcvm=stub, out_dir=d, url="http://x/", format="jpeg", quality=80,
+                snapshot_tag="", serve_pid=1, rust_log="off",
+                timeout=0.6, teardown_timeout=0.4,
+                state_dir=state_dir, data_root=d,
+            )
+            with self.assertRaises(reqbench.SurvivedTeardown) as cm:
+                reqbench.run_exec_request(args, 0)
+            rec = cm.exception.record
+            try:
+                self.assertTrue(rec.get("survivors"), f"no survivor list in {rec}")
+                self.assertIs(rec.get("disk_reap_skipped"), True)
+                self.assertTrue(os.path.exists(marker),
+                                "rootfs of a live child must NOT be reaped")
+                self.assertTrue(os.path.exists(os.path.join(state_dir, "vm-red.json")),
+                                "the state file is the only record that child is ours")
+            finally:
+                for pid in rec.get("survivors", {}):
+                    try:
+                        os.kill(int(pid), 9)
+                    except (ProcessLookupError, PermissionError, ValueError):
+                        pass
 
 
 class TeardownFastCpuAccounting(unittest.TestCase):
@@ -181,6 +456,34 @@ class TeardownFastCpuAccounting(unittest.TestCase):
             f"control window burned {out['control_harness_cpu_ms']:.1f} ms of OUR cpu "
             f"(total call {spent:.1f} ms) — it is spinning, so control_busy_cores "
             f"({out['control_busy_cores']:.2f}) is ambient + the harness",
+        )
+
+    def test_reclaim_sampler_does_not_burn_a_core(self):
+        """The RECLAIM window must not spin either — the control window is only half.
+
+        RED BEFORE THE FIX: `sample_all_until_gone` was a `while live and ...` loop
+        with no sleep, no yield and no backoff, INSIDE the window whose CPU it
+        reports. Measured on this box against a child that outlives its parent by
+        ~0.5 s:
+            reap_wall_ms=541.3  harness_cpu_ms=540.0   (100% of a core)
+            machine_cpu_ms=630.0  machine_cpu_ms_excess=-17.9
+        A NEGATIVE reclaim excess is physically impossible and is direct evidence
+        the subtraction is broken: the subtrahend is a ~540 ms quantity quantized
+        to one jiffy, and the signal it is meant to expose is "< 20 ms".
+        """
+        p = subprocess.Popen(["bash", "-c", "sleep 0.6 & wait"])
+        wait_for_child(p.pid)
+        out = reqbench.teardown_fast(p.pid, "", "", 5.0)
+        p.wait(timeout=5)
+        self.assertGreater(out["reap_wall_ms"], 300, "the child must outlive the kill")
+        self.assertIn("sample_period_s", out, "the residual bias must be quantifiable")
+        self.assertLess(
+            out["harness_cpu_ms"],
+            0.2 * out["reap_wall_ms"],
+            f"the reclaim sampler burned {out['harness_cpu_ms']:.1f} ms cpu over "
+            f"{out['reap_wall_ms']:.1f} ms wall "
+            f"({100 * out['harness_cpu_ms'] / out['reap_wall_ms']:.0f}% of a core) "
+            f"INSIDE the window whose CPU it reports",
         )
 
     def test_reclaim_cpu_is_reported_as_an_interval_not_a_bare_zero(self):
@@ -376,6 +679,176 @@ class ExecArmTimeout(unittest.TestCase):
             self.assertEqual(leaked, [], f"stub survived the timeout: {leaked}")
 
 
+class _JsonListServer:
+    """A stdlib HTTP server that speaks just enough `/json/list` to drive cdpdrive.
+
+    `targets(elapsed_s)` decides what the list contains, so a test can make the
+    page target appear LATE (readiness) or never (exhaustion). Every inbound Host
+    header is recorded, which is how the `--host-header` claim gets checked
+    instead of argued about.
+    """
+
+    def __init__(self, targets):
+        import http.server
+
+        self.hosts = []
+        self.hits = 0
+        outer = self
+
+        class H(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):  # noqa: N802 - stdlib naming
+                outer.hosts.append(self.headers.get("Host"))
+                outer.hits += 1
+                body = json.dumps(targets(time.monotonic() - outer.t0)).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *_a):
+                pass
+
+        self.t0 = time.monotonic()
+        self.srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), H)
+        self.endpoint = "127.0.0.1:%d" % self.srv.server_address[1]
+        self.th = threading.Thread(target=self.srv.serve_forever, daemon=True)
+        self.th.start()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_a):
+        self.srv.shutdown()
+        self.srv.server_close()
+        self.th.join(timeout=5)
+
+
+PAGE_TARGET = {"type": "page", "id": "ABC123", "url": "http://x/",
+               "webSocketDebuggerUrl": "ws://127.0.0.1:1/devtools/page/ABC123"}
+
+
+class CdpDriveHostHeader(unittest.TestCase):
+    """The docstring has promised `--host-header` since the file was written.
+
+    RED BEFORE THE FIX: argparse did not have it, so the invocation the docstring
+    documents exited 2:
+        $ python3 cdpdrive.py 127.0.0.1:9222 http://x/ --host-header example.com
+        cdpdrive.py: error: unrecognized arguments: --host-header example.com
+    This is a REPEAT of the defect the previous round fixed for `--print-target`
+    in this same docstring, and did not audit the rest of the paragraph for.
+    """
+
+    def test_the_flag_is_accepted_and_actually_sets_the_header(self):
+        with _JsonListServer(lambda _t: [PAGE_TARGET]) as s:
+            r = subprocess.run(
+                [sys.executable, os.path.join(HERE, "cdpdrive.py"), s.endpoint,
+                 "http://x/", "--print-target", "--host-header", "evil.example"],
+                capture_output=True, text=True, timeout=30,
+            )
+            self.assertNotEqual(r.returncode, 2, f"argparse rejected the flag: {r.stderr}")
+            self.assertEqual(r.stdout.strip(), "ABC123")
+            self.assertIn("evil.example", s.hosts)
+
+    def test_without_the_flag_urllib_sends_the_ip_literal(self):
+        with _JsonListServer(lambda _t: [PAGE_TARGET]) as s:
+            r = subprocess.run(
+                [sys.executable, os.path.join(HERE, "cdpdrive.py"), s.endpoint,
+                 "http://x/", "--print-target"],
+                capture_output=True, text=True, timeout=30,
+            )
+            self.assertEqual(r.returncode, 0, r.stderr)
+            self.assertEqual(s.hosts, [s.endpoint])
+
+    def test_reqbench_namespace_satisfies_cdpdrive(self):
+        """Pin the producer/consumer coupling a new flag can silently break.
+
+        `run_cdp_request` hand-builds an explicit, CLOSED field list. A `drive()`
+        that reads `args.host_header` directly raises AttributeError — which is
+        NOT in drive()'s except tuple, so it escapes drive(), is swallowed by
+        run_cdp_request's `except Exception`, and every cdp/cdp-fast rep fails.
+        This is the regression test the `--print-target` round should have left.
+        """
+        import cdpdrive
+
+        ns = argparse.Namespace(
+            cdp_host="127.0.0.1:1", url="http://x/", format="jpeg", quality=80,
+            timeout=0.35, idle_wait_ms=0.0, out_prefix="", ws_url="",
+            connect_retries=2, nav_timing=True, print_target=False,
+            render_module=os.path.join(HERE, "render.py"),
+        )
+        out = cdpdrive.drive(ns)  # must NOT raise AttributeError
+        self.assertIs(out["ok"], False)
+        self.assertEqual(out["stage"], "resolve", f"never reached resolve: {out}")
+
+
+class CdpDriveResolveThrottling(unittest.TestCase):
+    """Target resolution must be bounded by the DEADLINE, not by burning retries.
+
+    RED BEFORE THE FIX: the loop had no sleep anywhere in it — the `timeout` on
+    line 104 is urlopen's SOCKET timeout, not an inter-attempt delay. Measured on
+    this box against a closed port with retries=200 and a 30 s deadline:
+        attempts=200  elapsed=40.7 ms  rate=4919 req/s
+        retry budget consumed in 0.041s of a 30.0s deadline -> 0.14% of the window
+    A clone whose DevTools endpoint needs 100 ms more to present a page target is
+    recorded as a hard CDP failure — and `reqanalyze` sets `pub = n_bad == 0`, so
+    one spurious exhaustion censors the whole arm.
+    """
+
+    def test_it_sleeps_between_attempts_and_spends_the_deadline(self):
+        import cdpdrive
+
+        attempts = [0]
+        real = urllib.request.urlopen
+
+        def counting(*_a, **_k):
+            attempts[0] += 1
+            raise ConnectionRefusedError(111, "Connection refused")
+
+        urllib.request.urlopen = counting
+        t0 = time.monotonic()
+        try:
+            with self.assertRaises(ConnectionError):
+                cdpdrive.resolve_target("127.0.0.1:1", time.monotonic() + 1.0, 200)
+        finally:
+            urllib.request.urlopen = real
+        elapsed = time.monotonic() - t0
+        self.assertLessEqual(attempts[0], 25,
+                             f"{attempts[0]} attempts in {elapsed:.3f}s — still a burst")
+        self.assertGreaterEqual(elapsed, 0.9,
+                                f"gave up after {elapsed:.3f}s of a 1.0s deadline")
+
+    def test_a_late_page_target_is_resolved_not_failed(self):
+        import cdpdrive
+
+        with _JsonListServer(lambda t: [PAGE_TARGET] if t > 0.3 else []) as s:
+            got = cdpdrive.resolve_target(s.endpoint, time.monotonic() + 5.0, 200)
+        self.assertEqual(got["id"], "ABC123")
+
+    def test_readiness_exhaustion_is_not_classified_as_transport(self):
+        """`resolve_target` raised bare ConnectionError regardless of cause, and
+        ConnectionError subclasses OSError, so `no page target among 3` — pure
+        readiness — was counted as a TRANSPORT drop. That is the very count
+        REVIEW.md's WsClosed diagnosis rests on."""
+        import cdpdrive
+
+        with _JsonListServer(lambda _t: []) as s:
+            ns = argparse.Namespace(
+                cdp_host=s.endpoint, url="http://x/", format="jpeg", quality=80,
+                timeout=0.6, idle_wait_ms=0.0, out_prefix="", ws_url="",
+                connect_retries=200, nav_timing=False, print_target=False,
+                host_header="", render_module=os.path.join(HERE, "render.py"),
+            )
+            out = cdpdrive.drive(ns)
+        self.assertIs(out["ok"], False)
+        self.assertNotEqual(out["failure_class"], "transport",
+                            "a clone that is merely not ready yet is not a transport drop")
+        self.assertEqual(out["failure_class"], "readiness")
+        self.assertGreater(out.get("resolve_attempts", 0), 1,
+                           "the attempt count must be recorded so a retried "
+                           "resolve_ms is separable from a first-try one")
+
+
 class AnalyzerAvailability(unittest.TestCase):
     """Failed requests must be counted per arm, and must not hide a leak.
 
@@ -403,11 +876,20 @@ class AnalyzerAvailability(unittest.TestCase):
                     "teardown": {"mode": "fast", "all_gone": True,
                                  "reap_wall_ms": 63.0, "teardown_total_ms": 70.0},
                 }) + "\n")
+            # THE PRODUCER'S SHAPE, not a convenient one: run_cdp_request nests
+            # the whole cdpdrive result under `render` and lifts the label to the
+            # top level. The old fixture wrote `error` at the top level ONLY, a
+            # schema nothing emitted, so the analyzer test was green against a
+            # record the harness never produces.
             for i in range(27, 30):
                 f.write(json.dumps({
                     "arm": "cdp", "rep": i, "ok": False,
                     "error": "WsClosed: connection closed mid-frame",
+                    "failure_class": "transport", "failure_stage": "navigate",
                     "blocking_ms": 5250.0, "wall_ms": 5300.0,
+                    "render": {"ok": False,
+                               "error": "WsClosed: connection closed mid-frame",
+                               "failure_class": "transport", "stage": "navigate"},
                     "teardown": {"mode": "fast", "all_gone": False,
                                  "reap_wall_ms": 60000.0, "teardown_total_ms": 60000.0},
                 }) + "\n")
@@ -443,6 +925,152 @@ class AnalyzerAvailability(unittest.TestCase):
                 "the 3 failed reps' teardowns must be examined, not filtered out",
             )
             self.assertIn("NOT CONFIRMED GONE", buf.getvalue())
+
+    def test_the_stage_header_does_not_claim_forward_localhost(self):
+        """AGENTS.md: `--forward-localhost` is GUEST->HOST and cannot carry this path.
+
+        RED BEFORE THE FIX: the CDP stage table printed under
+            CDP ARMS: per-request stage decomposition (host -> clone over forward-localhost)
+        The harness never passes `--forward-localhost` — reqbench.sh publishes the
+        RELAY port (`--publish 9223:9223`) and entry.sh's socat carries guest
+        eth0 -> guest loopback. a55d25d4 claimed to have fixed the direction
+        "in the right direction" everywhere; `git show` proves it never touched
+        this line, which was then the only place in bench/chromium still asserting
+        the wrong one.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(d, "r.jsonl")
+            self._synthetic(src)
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                reqanalyze.main_with([src, "--no-gate"])
+            text = buf.getvalue()
+            self.assertNotIn("forward-localhost", text)
+            self.assertIn("publish", text)
+            self.assertIn("relay", text)
+
+    def test_a_null_all_gone_is_not_counted_as_confirmed(self):
+        """`ag.count(False)` treats null and absent as CONFIRMED GONE.
+
+        RED BEFORE THE FIX, reproduced by running the branch analyzer on 27
+        `all_gone: true` + 2 `all_gone: null` + 1 with the key absent:
+            all_gone: 27/30 confirmed
+        No warning, no per-rep dump, and `--json-out` said `[27, 30]` — the
+        numerator and denominator disagreeing by three while the report reads
+        clean. a55d25d4 EDITED these exact lines and reinforced the False-only
+        test rather than fixing it.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(d, "r.jsonl")
+            dst = os.path.join(d, "r.json")
+            with open(src, "w") as f:
+                f.write(json.dumps({"kind": "meta", "seed": 1}) + "\n")
+                for i in range(27):
+                    f.write(json.dumps({
+                        "arm": "cdp", "rep": i, "ok": True,
+                        "blocking_ms": 384.0, "wall_ms": 455.0,
+                        "teardown": {"mode": "fast", "all_gone": True,
+                                     "reap_wall_ms": 63.0, "teardown_total_ms": 70.0},
+                    }) + "\n")
+                for i in (27, 28):
+                    f.write(json.dumps({
+                        "arm": "cdp", "rep": i, "ok": True,
+                        "blocking_ms": 384.0, "wall_ms": 455.0,
+                        "teardown": {"mode": "fast", "all_gone": None,
+                                     "reap_wall_ms": 63.0, "teardown_total_ms": 70.0},
+                    }) + "\n")
+                f.write(json.dumps({
+                    "arm": "cdp", "rep": 29, "ok": True,
+                    "blocking_ms": 384.0, "wall_ms": 455.0,
+                    "teardown": {"mode": "fast",
+                                 "reap_wall_ms": 63.0, "teardown_total_ms": 70.0},
+                }) + "\n")
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = reqanalyze.main_with(["--json-out", dst, src, "--no-gate"])
+            text = buf.getvalue()
+            self.assertIn("** 3 NOT CONFIRMED GONE **", text)
+            for rep in (27, 28, 29):
+                self.assertIn(f"rep {rep}", text, f"rep {rep} must appear in the dump")
+            with open(dst) as f:
+                out = json.load(f)
+            self.assertEqual(out["arms"]["cdp"]["all_gone_confirmed"], [27, 30])
+            self.assertEqual(out["arms"]["cdp"]["all_gone_no_evidence"], 3)
+            self.assertEqual(rc, 0, "--no-gate was passed")
+
+    def test_a_transport_drop_is_named_in_the_failure_breakdown(self):
+        """A record whose diagnostic is only NESTED must still be named.
+
+        RED BEFORE THE FIX, run against the shipped analyzer on the shape
+        `run_cdp_request` actually emitted (error under `render`):
+            FAILURE x3: rc=None
+        The WsClosed message, the stage and the failure_class never reached the
+        operator, and the existing test passed only because its fixture put
+        `error` at the TOP level — a shape the producer did not write.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(d, "r.jsonl")
+            dst = os.path.join(d, "r.json")
+            with open(src, "w") as f:
+                f.write(json.dumps({"kind": "meta", "seed": 1}) + "\n")
+                for i in range(3):
+                    f.write(json.dumps({
+                        "arm": "cdp", "rep": i, "ok": False,
+                        "blocking_ms": 5250.0, "wall_ms": 5300.0,
+                        "render": {"ok": False,
+                                   "error": "WsClosed: connection closed mid-frame",
+                                   "failure_class": "transport", "stage": "navigate"},
+                    }) + "\n")
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                reqanalyze.main_with(["--json-out", dst, src, "--no-gate"])
+            text = buf.getvalue()
+            self.assertIn("WsClosed", text)
+            self.assertNotIn("rc=None", text)
+            with open(dst) as f:
+                out = json.load(f)
+            self.assertEqual(out["arms"]["cdp"]["failure_classes"], {"transport": 3})
+
+    def test_failure_class_is_consumed_not_just_written(self):
+        """RED BEFORE THE FIX: `git grep failure_class` over the whole branch
+        returned exactly ONE hit — the line in cdpdrive.py that writes it. The
+        comment above it said downstream could gate on it instead of
+        substring-matching the message; nothing downstream read it."""
+        with open(os.path.join(HERE, "reqanalyze.py")) as f:
+            self.assertIn("failure_class", f.read(),
+                          "the analyzer must CONSUME the classification, not just "
+                          "let cdpdrive write it into the void")
+
+    def test_an_unpublishable_arm_makes_the_analyzer_exit_nonzero(self):
+        """RED BEFORE THE FIX: measured EXIT CODE 0 at 10% cdp censoring with
+        ** DO NOT PUBLISH THIS ARM'S LATENCY ** on stdout. A harness that exits 0
+        on a run it has itself marked DO NOT PUBLISH will have those numbers
+        quoted by someone who only checked the exit code."""
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(d, "r.jsonl")
+            self._synthetic(src)
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = reqanalyze.main_with([src])
+            self.assertIn("DO NOT PUBLISH", buf.getvalue())
+            self.assertNotEqual(rc, 0, "the run must gate, not merely narrate")
+
+    def test_a_clean_run_still_exits_zero(self):
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(d, "r.jsonl")
+            with open(src, "w") as f:
+                f.write(json.dumps({"kind": "meta", "seed": 1}) + "\n")
+                for i in range(10):
+                    f.write(json.dumps({
+                        "arm": "cdp", "rep": i, "ok": True,
+                        "blocking_ms": 384.0, "wall_ms": 455.0,
+                        "teardown": {"mode": "fast", "all_gone": True,
+                                     "reap_wall_ms": 63.0, "teardown_total_ms": 70.0},
+                    }) + "\n")
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = reqanalyze.main_with([src])
+            self.assertEqual(rc, 0, buf.getvalue())
 
     def test_per_child_cpu_is_reported_by_name_not_pooled(self):
         """Pooling across children medians a straggler away.
@@ -491,6 +1119,500 @@ class AnalyzerAvailability(unittest.TestCase):
                 "a sub-tick child must print as a bound, never as an exact zero",
             )
             self.assertIn("below /proc tick resolution", text)
+
+
+class TeardownProbeGuards(unittest.TestCase):
+    """The probe imported `reap_disk` but not the RULE that governs it.
+
+    `reqbench.py`'s `teardown_fast` refuses to reap the state file and data dir of
+    a VM whose Firecracker is still running, SIGKILLs the survivors and aborts.
+    The probe computed the identical per-child evidence (`poll_gone` returns None
+    for a child still alive at 30 s), printed it as TIMEOUT, discarded it, and
+    reaped anyway — then returned 0.
+    """
+
+    def test_a_survivor_blocks_the_reap_and_is_killed(self):
+        """RED BEFORE THE FIX: the `finally` inspected only fcvm (`if proc.poll()
+        is None:` — already -9 by then, so the branch never ran) and called
+        `reap_disk` unconditionally at the end. Both artifacts were deleted, the
+        survivor stayed in /proc, and main() returned 0."""
+        import teardown_probe
+
+        with tempfile.TemporaryDirectory() as d:
+            state = os.path.join(d, "vm-test.json")
+            data = os.path.join(d, "vm-disks", "vm-test")
+            with open(state, "w") as f:
+                json.dump({"vm_id": "vm-test"}, f)
+            os.makedirs(data)
+            p = subprocess.Popen(["bash", "-c", "sleep 300 & wait"])
+            kids = wait_for_child(p.pid)
+            try:
+                named = {f"{reqbench.proc_comm(k)}:{k}": k for k in kids}
+                row = {"rep": 0, "gone_ms": {n: None for n in named}}
+                leaked = teardown_probe.reap_rep(row, named, state, data)
+                self.assertTrue(leaked)
+                self.assertTrue(os.path.exists(state),
+                                "the state file is the only record this VM is ours")
+                self.assertTrue(os.path.isdir(data),
+                                "the data dir holds a reflink of the golden rootfs")
+                self.assertTrue(row["disk_reap_skipped"])
+                deadline = time.monotonic() + 5
+                while time.monotonic() < deadline:
+                    if all(reqbench.proc_stat_fields(k) is None
+                           or reqbench.proc_stat_fields(k)[0] in ("Z", "X", "x")
+                           for k in kids):
+                        break
+                    time.sleep(0.01)
+                alive = [k for k in kids
+                         if reqbench.proc_stat_fields(k) is not None
+                         and reqbench.proc_stat_fields(k)[0] not in ("Z", "X", "x")]
+                self.assertEqual(alive, [], "a survivor must be SIGKILLed, not left")
+            finally:
+                kill_tree(p)
+
+    def test_a_clean_rep_is_still_reaped(self):
+        import teardown_probe
+
+        with tempfile.TemporaryDirectory() as d:
+            state = os.path.join(d, "vm-test.json")
+            data = os.path.join(d, "vm-disks", "vm-test")
+            with open(state, "w") as f:
+                json.dump({"vm_id": "vm-test"}, f)
+            os.makedirs(data)
+            row = {"rep": 0, "gone_ms": {"firecracker:1": 12.0}}
+            leaked = teardown_probe.reap_rep(row, {"firecracker:1": 1}, state, data)
+            self.assertFalse(leaked)
+            self.assertFalse(os.path.exists(state))
+            self.assertFalse(os.path.isdir(data))
+
+    def test_summarize_reports_the_censoring_rate_not_only_the_survivors(self):
+        """RED BEFORE THE FIX: `n=` was `len(vs2)` — the observed exits only — and
+        the timeout count and the denominator were never printed. Worse, there was
+        no `else`, so a child that TIMED OUT in EVERY rep printed NOTHING AT ALL:
+        the straggler the probe exists to find is the one that vanished from its
+        own summary."""
+        import teardown_probe
+
+        rows = [
+            {"rep": 0, "gone_ms": {"firecracker:1": 12.0, "pasta:2": None}},
+            {"rep": 1, "gone_ms": {"firecracker:3": 14.0, "pasta:4": None}},
+            {"rep": 2, "gone_ms": {}, "error": "no state file within 120.0s"},
+        ]
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            censored = teardown_probe.summarize(rows)
+        text = buf.getvalue()
+        self.assertIn("n=2/2", text)                 # firecracker: both observed
+        self.assertIn("censored=2", text)            # pasta: both timed out
+        self.assertIn("pasta", text, "an all-timeout child must still get a row")
+        self.assertIn("NO EXIT OBSERVED", text)
+        self.assertIn("reps attempted=3", text)
+        self.assertIn("errored=1", text)
+        self.assertNotEqual(censored, 0, "a TIMEOUT is a leak, not a missing sample")
+
+    def test_an_exception_mid_rep_does_not_lose_every_other_row(self):
+        """RED BEFORE THE FIX: `wait_port` raising TimeoutError (or
+        `clone_cdp_endpoint` raising RuntimeError) left main() through a bare
+        try/finally, so `json.dump(rows, f)` never ran and reps 0..i-1 were lost.
+        reqbench.py's main() deliberately does the opposite."""
+        import teardown_probe
+
+        with tempfile.TemporaryDirectory() as d:
+            state_dir = os.path.join(d, "state")
+            os.makedirs(state_dir)
+            os.makedirs(os.path.join(d, "vm-disks", "vm-red"))
+            stub = os.path.join(d, "fcvm-stub")
+            with open(stub, "w") as f:
+                f.write(
+                    "#!/bin/bash\n"
+                    f"cat > {state_dir}/vm-$$.json <<EOF\n"
+                    '{"vm_id": "vm-red", "pid": $$, '
+                    '"config": {"network": {"loopback_ip": "127.0.0.1"}}}\n'
+                    "EOF\n"
+                    "exec sleep 600\n"
+                )
+            os.chmod(stub, 0o755)
+            out_json = os.path.join(d, "probe.json")
+            real = teardown_probe.wait_port
+
+            def boom(*_a, **_k):
+                raise TimeoutError("CDP port never answered")
+
+            teardown_probe.wait_port = boom
+            argv = sys.argv
+            sys.argv = ["teardown_probe.py", "--serve-pid", "1", "--n", "2",
+                        "--fcvm", stub, "--data-root", d, "--out", out_json,
+                        "--state-timeout", "5"]
+            try:
+                buf = io.StringIO()
+                with redirect_stdout(buf):
+                    teardown_probe.main()
+            finally:
+                teardown_probe.wait_port = real
+                sys.argv = argv
+            self.assertTrue(os.path.exists(out_json), "no artifact was written at all")
+            with open(out_json) as f:
+                rows = json.load(f)
+            self.assertEqual(len(rows), 2, f"reps were lost: {rows}")
+            self.assertTrue(all("error" in r for r in rows), rows)
+
+
+class BackendIsExplicit(unittest.TestCase):
+    """A run must name exactly one memory backend.
+
+    RED BEFORE THE FIX: with neither flag, `clone_backend_args` returned
+    `["--pid", "0"]` and the meta record still said `"backend": "uffd"`; with
+    both, the tag silently won while the metadata was decided by the same
+    expression. Two different backends with different per-request costs, mixed
+    without saying so — AGENTS.md defect 1.
+    """
+
+    def _main(self, extra):
+        argv = sys.argv
+        sys.argv = ["reqbench.py", "--url", "http://x/", "--out-dir", "/tmp"] + extra
+        try:
+            with self.assertRaises(SystemExit) as cm:
+                with redirect_stdout(io.StringIO()):
+                    reqbench.main()
+            return cm.exception.code
+        finally:
+            sys.argv = argv
+
+    def test_neither_backend_is_rejected(self):
+        self.assertEqual(self._main([]), 2)
+
+    def test_both_backends_are_rejected(self):
+        self.assertEqual(self._main(["--serve-pid", "7", "--snapshot-tag", "t"]), 2)
+
+
+class ReqbenchShell(unittest.TestCase):
+    """`reqbench.sh` drives the run; three defects live in it.
+
+    Driven with stubs on PATH so no VM, no sudo and no podman are involved.
+    """
+
+    SH = os.path.join(HERE, "reqbench.sh")
+
+    def _env(self, d, **extra):
+        binx = os.path.join(d, "bin")
+        os.makedirs(binx, exist_ok=True)
+        env = dict(os.environ)
+        env.update(
+            PATH=binx + os.pathsep + env["PATH"],
+            RESULTS=os.path.join(d, "results"),
+            STATE_DIR=os.path.join(d, "state"),
+            ALLOW_BUSY="1",
+            RUNID="test",
+        )
+        env.update(extra)
+        os.makedirs(env["STATE_DIR"], exist_ok=True)
+        return env, binx
+
+    def _write(self, path, body):
+        with open(path, "w") as f:
+            f.write(body)
+        os.chmod(path, 0o755)
+
+    def test_fcvm_no_snapshot_survives_sudo(self):
+        """RED BEFORE THE FIX: `FCVM_NO_SNAPSHOT=1 $SUDO env RUST_LOG=... fcvm ...`
+        binds the assignment to SUDO, whose default env_reset drops it. RUST_LOG
+        survives only because it rides the `env` AFTER sudo. The sibling harness
+        already does it right (bench.sh: `sudo env FCVM_NO_SNAPSHOT=1 RUST_LOG=...`),
+        so this is a local divergence, not house style. With the variable dropped,
+        `src/commands/podman/mod.rs` takes the snapshot-cache path and the phase
+        documented as `golden: cold boot` would RESTORE from a stale cached
+        snapshot and then snapshot THAT as $TAG — contaminating every arm.
+        Observed with an env_reset-emulating sudo stub: FCVM_NO_SNAPSHOT=<unset>.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            env, binx = self._env(d)
+            seen = os.path.join(d, "seen.txt")
+            self._write(os.path.join(binx, "sudo"),
+                        '#!/bin/bash\nexec env -i PATH="$PATH" HOME="$HOME" "$@"\n')
+            fcvm = os.path.join(d, "fcvm")
+            self._write(fcvm, f"""#!/bin/bash
+case "$1 $2" in
+  "podman run")
+      echo "FCVM_NO_SNAPSHOT=${{FCVM_NO_SNAPSHOT:-<unset>}}" >> {seen}
+      echo CHROMIUM_BENCH_READY; sleep 30 ;;
+  "snapshot create") echo created ;;
+  "snapshots delete") ;;
+  "ls --json")
+      if [ "$3" = "--pid" ]; then
+          echo '[{{"pid": 4242, "health_status": "healthy"}}]'
+      else
+          echo '[{{"name": "cb-req-g-test", "pid": 4242}}]'
+      fi ;;
+esac
+""")
+            r = subprocess.run([self.SH, "golden"], env=dict(env, SUDO="sudo", FCVM=fcvm),
+                               capture_output=True, text=True, timeout=120)
+            got = open(seen).read() if os.path.exists(seen) else "<no invocation>"
+            self.assertIn("FCVM_NO_SNAPSHOT=1", got,
+                          f"the assignment did not survive sudo: {got}\n{r.stderr[-800:]}")
+
+    def _run_stub(self, d, backend):
+        env, binx = self._env(d, BACKEND=backend, REPS="1", WARMUP="0")
+        argv = os.path.join(d, "argv.log")
+        pyargv = os.path.join(d, "pyargv.log")
+        fcvm = os.path.join(d, "fcvm")
+        self._write(fcvm, f"""#!/bin/bash
+echo "$@" >> {argv}
+if [ "$1 $2" = "snapshot serve" ]; then
+    echo "Serve PID: $$"; echo "Waiting for VMs"; sleep 30
+fi
+""")
+        self._write(os.path.join(binx, "python3"),
+                    f'#!/bin/bash\necho "$@" >> {pyargv}\nexit 0\n')
+        r = subprocess.run([self.SH, "run"], env=dict(env, FCVM=fcvm),
+                           capture_output=True, text=True, timeout=180)
+        return (r,
+                open(argv).read() if os.path.exists(argv) else "",
+                open(pyargv).read() if os.path.exists(pyargv) else "")
+
+    def test_backend_file_runs_without_a_uffd_serve(self):
+        """RED BEFORE THE FIX: `cmd_run` hardcoded `snapshot serve` + `--serve-pid`
+        and `grep -n snapshot-tag reqbench.sh` had no hit, so the FILE-backed arm
+        that `reqbench.py` fully supports (`--snapshot-tag` -> `--snapshot <name>`)
+        had NO PATH THROUGH THIS DRIVER. REVIEW.md's re-run gate is ">=200 CDP
+        requests PER BACKEND", and that re-run was not runnable."""
+        with tempfile.TemporaryDirectory() as d:
+            r, argv, pyargv = self._run_stub(d, "file")
+            self.assertNotIn("snapshot serve", argv,
+                             f"a UFFD serve was started for a FILE-backed run:\n{argv}")
+            self.assertIn("--snapshot-tag", pyargv, f"{pyargv}\n{r.stderr[-800:]}")
+            self.assertNotIn("--serve-pid", pyargv, pyargv)
+
+    def test_backend_uffd_is_still_the_default_and_serves(self):
+        with tempfile.TemporaryDirectory() as d:
+            r, argv, pyargv = self._run_stub(d, "uffd")
+            self.assertIn("snapshot serve", argv, f"{argv}\n{r.stderr[-800:]}")
+            self.assertIn("--serve-pid", pyargv, pyargv)
+            self.assertNotIn("--snapshot-tag", pyargv, pyargv)
+
+    def test_target_id_waits_for_readiness_and_skips_devtools_pages(self):
+        """RED BEFORE THE FIX: `target_id` was a SINGLE-SHOT urlopen with
+        `2>/dev/null || true`, and `start_clone` returns as soon as the state file
+        carries a pid — it never waits for the CDP port. Clone 1 is warm because
+        HOP A/B/C ran against it; clone 2 is queried the instant it registers, so
+        connection-refused yields an empty id and the documented stability gate
+        fails on a RACE. It also took the first `type == "page"`, while the driver
+        that consumes the id skips `devtools://` pages — so the two could compare
+        different targets."""
+        with tempfile.TemporaryDirectory() as d:
+            with _JsonListServer(lambda t: ([] if t < 0.6 else [
+                {"type": "page", "id": "DEVTOOLS", "url": "devtools://devtools/x.html"},
+                PAGE_TARGET,
+            ])) as s:
+                script = (
+                    f'source {self.SH}\n'
+                    f'target_id "{s.endpoint}"\n'
+                )
+                env, _ = self._env(d)
+                r = subprocess.run(["bash", "-c", script], env=env,
+                                   capture_output=True, text=True, timeout=120)
+            self.assertEqual(r.stdout.strip(), "ABC123",
+                             f"stdout={r.stdout!r} stderr={r.stderr[-800:]}")
+
+
+class SustainedRateUncertainty(unittest.TestCase):
+    """The throughput HEADLINE must carry uncertainty, like everything else here.
+
+    RED BEFORE THE FIX: `analyse_throughput`'s sustained block emitted
+    `achieved_rps` as a bare `len(done)/dur` quotient — no `rate_ci` key existed
+    anywhere in corrected.json — and the only `boot_ci` call in that block was
+    spent on latency, while the BURST path immediately above it does bootstrap its
+    rate (it can: bursts are replicated 5x). `analyze.py` also had no binomial
+    function at all (`grep`: zero hits), so "462/462 completed" was quoted bare
+    sixteen lines after the paragraph that forbids exactly that.
+    """
+
+    def test_sustained_reports_a_rate_interval_and_a_binomial_bound(self):
+        import analyze
+
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, "samples"))
+            t0 = 1000.0
+            dur = 60.0
+            with open(os.path.join(d, "samples", "bursts.jsonl"), "w") as f:
+                f.write(json.dumps({"phase": "sustained-meta", "cell": "file-4k",
+                                    "rate": 8, "launched": 100, "skipped": 0,
+                                    "t0": t0, "t1": t0 + dur}) + "\n")
+            recs = [{"phase": "sust-r8", "arm": "file-4k", "ok": True,
+                     "total_ms": 600.0, "t0_ts": t0 + i * (dur / 99)}
+                    for i in range(98)]
+            out: dict = {}
+            analyze.analyse_throughput(d, recs, out)
+            v = out["sustained"]["file-4k/target=8rps"]
+            self.assertIsNotNone(v["rate_ci"], "the rate must carry an interval")
+            self.assertEqual(len(v["rate_ci"]), 2)
+            self.assertIn("sub-window", v["rate_ci_basis"])
+            lo, hi = v["incomplete_rate_ci"]
+            self.assertGreater(hi, 0.0, "2/100 incomplete is not a 0% failure rate")
+            exp = reqanalyze.clopper_pearson(2, 100)
+            self.assertAlmostEqual(lo, exp[0], places=9)
+            self.assertAlmostEqual(hi, exp[1], places=9)
+
+
+class DocLint(unittest.TestCase):
+    """The docs ARE the deliverable, so their numbers get the same gate as the code.
+
+    AGENTS.md's own Deliverables rule 3: "Every figure traceable to a raw record —
+    cite the json file (and the cell)." Nothing enforced that, which is how two
+    rounds of review walked past a CP bound the repo's own function contradicts
+    and a refuted percentage still published as a finding.
+    """
+
+    def _read(self, name):
+        with open(os.path.join(HERE, name)) as f:
+            return f.read()
+
+    def _corrected(self):
+        with open(os.path.join(HERE, "results", "20260808-corrected", "corrected.json")) as f:
+            return json.load(f)
+
+    def test_every_binomial_bound_matches_reqanalyze_clopper_pearson(self):
+        """RED BEFORE THE FIX: REVIEW.md L32 said "At 0/200 the CP upper bound is
+        1.5%". `reqanalyze.clopper_pearson(0, 200)` gives [0.000%, 1.828%]; 1.5% is
+        the ONE-sided bound (1 - 0.05**(1/200) = 1.487%) while L48 declares the
+        convention as "Clopper-Pearson, 95%, two-sided". Six of the file's seven
+        bounds reproduce exactly — which is itself the proof the convention is
+        two-sided. reqanalyze.py's own docstring carried a second one: "0/426 is
+        [0, 0.70%]" against 0.862% computed by the function 80 lines below it.
+        """
+        import re
+
+        bad = []
+        for name in ("REVIEW.md", "reqanalyze.py"):
+            flat = re.sub(r"\s+", " ", self._read(name))
+            claims = [
+                (int(m.group(1)), int(m.group(2)), m.group(3), m.group(4), m.group(0))
+                for m in re.finditer(
+                    r"(\d+)/(\d+)\b[^\[\]]{0,80}?\[\s*([\d.]+)\s*%?\s*,\s*([\d.]+)\s*%\s*\]",
+                    flat)
+            ]
+            claims += [
+                (int(m.group(1)), int(m.group(2)), None, m.group(3), m.group(0))
+                for m in re.finditer(
+                    r"(\d+)/(\d+)\s+the CP upper bound is\s+([\d.]+)\s*%", flat)
+            ]
+            self.assertTrue(claims, f"{name}: the lint matched nothing — it is vacuous")
+            for k, n, q_lo, q_hi, raw in claims:
+                lo, hi = reqanalyze.clopper_pearson(k, n)
+                for quoted, computed in ((q_lo, 100 * lo), (q_hi, 100 * hi)):
+                    if quoted is None:
+                        continue
+                    dec = len(quoted.split(".")[1]) if "." in quoted else 0
+                    tol = 0.5 * 10 ** -dec + 1e-9
+                    if abs(float(quoted) - computed) > tol:
+                        bad.append(f"{name}: {raw!r} -> {k}/{n} is "
+                                   f"[{100 * lo:.3f}%, {100 * hi:.3f}%], "
+                                   f"quoted {quoted}%")
+        self.assertEqual(bad, [], "\n".join(bad))
+
+    def test_agents_md_jpeg_figures_match_the_record_run(self):
+        """RED BEFORE THE FIX: AGENTS.md L95 published "JPEG q80 measured −40%
+        screenshot, −21% whole request in-VM" while REVIEW.md marks exactly that
+        claim **REFUTED AS STATED** and corrected.json says screenshot_ms pct
+        −28.81 and artifact_ms pct −8.34. Both numbers on that line are
+        contradicted by the record run, and the AGENTS.md REFUTED list — whose own
+        preamble says it "now points at [REVIEW.md] rather than contradicting it"
+        — omitted the claim entirely.
+        """
+        import re
+
+        text = self._read("AGENTS.md")
+        m = re.search(r"JPEG q80 measured\s+(.+?)\n-", text, re.S)
+        self.assertIsNotNone(m, "the JPEG bullet moved; update this lint")
+        # Only the CLAIM, not the marked history. A refuted number quoted behind
+        # "used to read" IS the refutation and must stay; an unmarked one is the
+        # defect. That distinction is the whole point of the AGENTS.md/REVIEW.md
+        # reconciliation.
+        seg = m.group(1).split("used to read")[0]
+        self.assertIn("corrected.json", m.group(1), "the figures must cite their record")
+        pcts = {round(float(x), 1) for x in re.findall(r"[-−]([\d.]+)%", seg)}
+        sf = self._corrected()["screenshot_format"]
+        want = {round(abs(sf["screenshot_ms"]["pct"]), 1),
+                round(abs(sf["artifact_ms"]["pct"]), 1)}
+        self.assertFalse(pcts & {40.0, 21.0},
+                         f"refuted figures still published: {pcts & {40.0, 21.0}}")
+        self.assertTrue(want <= pcts,
+                        f"AGENTS.md says {sorted(pcts)}, corrected.json says {sorted(want)}")
+        self.assertIn("REFUTED AS STATED", text,
+                      "the REFUTED list must carry this claim, per its own preamble")
+
+    def test_every_path_cited_in_a_doc_table_is_committed(self):
+        """RED BEFORE THE FIX: the CDP-handshake table cited
+        `scratchpad/cb/*.jsonl`, `scratchpad/cb/vmlogs/clone-*.log` and
+        `results/20260808-corrected/requests/*.log`. `git ls-tree` shows zero
+        `scratchpad` entries — the directory is not in the tree at all — and
+        `results/` is gitignored except for the nine committed files, which do not
+        include a `requests/` directory. AGENTS.md Deliverables rule 3 requires
+        every figure to be traceable to a raw record.
+        """
+        import fnmatch
+        import re
+
+        root = subprocess.run(["git", "rev-parse", "--show-toplevel"], cwd=HERE,
+                              capture_output=True, text=True, check=True).stdout.strip()
+        tracked = subprocess.run(["git", "ls-files"], cwd=root, capture_output=True,
+                                 text=True, check=True).stdout.split()
+        here_rel = os.path.relpath(HERE, root)
+        bad = []
+        for name in ("AGENTS.md", "REVIEW.md"):
+            for line in self._read(name).splitlines():
+                if not line.lstrip().startswith("|"):
+                    continue
+                for cited in re.findall(r"`([^`]*/[^`]*)`", line):
+                    cited = cited.strip()
+                    if not re.search(r"\.\w+$", cited):
+                        continue
+                    # Cites are written relative to the repo root OR to this
+                    # directory; both are legitimate, neither is "uncommitted".
+                    pats = (cited, f"{here_rel}/{cited}")
+                    if not any(fnmatch.fnmatch(t, p) for t in tracked for p in pats):
+                        bad.append(f"{name}: table cites {cited!r}, not in git ls-files")
+        self.assertEqual(bad, [], "\n".join(bad))
+
+    def test_the_readme_healthcheck_verification_actually_fails(self):
+        """RED BEFORE THE FIX: the README's verification step was
+        `podman inspect ... --format '{{json .HealthCheck}}'` followed by the prose
+        "This must print the Test array, not `null`" — exit 0 whichever it printed.
+        "Must" is an instruction to a human, inside a block designed to be pasted.
+        `reqbench.sh` already has the hard gate for its own path, but bench.sh —
+        the harness `make bench-chromium` runs — has no podman build, no
+        `--format docker` and no healthcheck check at all, so on that route this
+        non-failing line is the ENTIRE verification that the golden snapshot will
+        freeze a WARM browser rather than a cold one.
+        """
+        import re
+
+        for name in ("README.md", "AGENTS.md"):
+            text = self._read(name)
+            cmds = [c for c in re.split(r"\n(?!\s)", text.replace("\\\n", " "))
+                    if "HealthCheck" in c and "podman" in c]
+            self.assertTrue(cmds, f"{name}: no healthcheck verification found")
+            with tempfile.TemporaryDirectory() as d:
+                binx = os.path.join(d, "bin")
+                os.makedirs(binx)
+                with open(os.path.join(binx, "podman"), "w") as f:
+                    f.write("#!/bin/bash\necho null\n")   # the OCI-drop outcome
+                os.chmod(os.path.join(binx, "podman"), 0o755)
+                env = dict(os.environ, PATH=binx + os.pathsep + os.environ["PATH"])
+                for c in cmds:
+                    snippet = "\n".join(
+                        ln for ln in c.splitlines()
+                        if ln.strip() and not ln.lstrip().startswith(("#", "`", ">"))
+                    )
+                    if not snippet.strip():
+                        continue
+                    r = subprocess.run(["bash", "-c", snippet], env=env,
+                                       capture_output=True, text=True, timeout=60)
+                    self.assertNotEqual(
+                        r.returncode, 0,
+                        f"{name}: the verification exits 0 on a MISSING healthcheck "
+                        f"(fcvm treats a missing healthcheck as a PASS, so the golden "
+                        f"snapshot would fire on a cold browser).\n{snippet}")
 
 
 if __name__ == "__main__":

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -1617,3 +1617,42 @@ class DocLint(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+class NoConfusableIdentifiers(unittest.TestCase):
+    """No bench source may contain a Cyrillic homoglyph.
+
+    `reqstages.py` had a variable whose name was Latin `g` followed by CYRILLIC SMALL
+    LETTER O (U+043E) rather than Latin `o`. It runs, and it is indistinguishable on
+    screen from `go`, so anyone who types the name they can plainly see gets a NameError
+    on a variable that is right there. The same trap exists for U+0441/c, U+0435/e,
+    U+0430/a, U+0440/p, U+0445/x.
+
+    This file states those characters by CODEPOINT, never literally: an earlier version
+    spelled them out and the guard flagged its own docstring, which is funny once and
+    useless afterwards.
+
+    A reviewer caught the first one. This catches the next.
+    """
+
+    def test_no_cyrillic_homoglyphs_in_bench_sources(self):
+        import pathlib
+
+        here = pathlib.Path(__file__).parent
+        offenders = []
+        for path in sorted(here.glob("*.py")) + sorted(here.glob("*.sh")):
+            text = path.read_text(encoding="utf-8", errors="replace")
+            for lineno, line in enumerate(text.split("\n"), 1):
+                bad = [ch for ch in line if 0x0400 <= ord(ch) <= 0x04FF]
+                if bad:
+                    offenders.append(
+                        f"{path.name}:{lineno} contains {[hex(ord(c)) for c in bad]} "
+                        f"in: {line.strip()[:70]}"
+                    )
+        self.assertEqual(
+            offenders,
+            [],
+            "Cyrillic characters found in bench sources. If one sits inside an identifier "
+            "it is a homoglyph trap: the name reads as ASCII and is not.\n"
+            + "\n".join(offenders),
+        )

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python3
+"""Regression tests for the request-bench harness. VM-free, deterministic, ~2 s.
+
+    python3 -m unittest discover -s bench/chromium -p 'test_*.py' -v
+
+Every test here was watched FAIL against the code as it stood before the matching
+fix; the failure each one produced is quoted in its docstring. A test never seen
+red is not evidence, so the ones that could not be made to fail (they need a real
+microVM) are not in this file — they are in tests/test_signal_cleanup.rs.
+
+There is no pytest in this repo, so this is stdlib `unittest` only.
+"""
+
+import argparse
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from contextlib import redirect_stdout
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+import reqanalyze  # noqa: E402
+import reqbench  # noqa: E402
+
+
+def self_cpu_ms() -> float:
+    s = reqbench.proc_stat_fields(os.getpid())
+    return (s[1] + s[2]) * 1000.0 / reqbench.CLK_TCK
+
+
+def spawn_pdeathsig_parent(child_argv):
+    """A parent whose child dies with it — fcvm's shape, without a VM.
+
+    `PR_SET_PDEATHSIG` is 1. The child inherits nothing else special, so killing
+    the parent exercises exactly the kernel-enforced reap the fast arm relies on.
+    """
+    code = (
+        "import ctypes,signal,subprocess,sys;"
+        "libc=ctypes.CDLL('libc.so.6');"
+        "p=subprocess.Popen(sys.argv[1:],preexec_fn=lambda: libc.prctl(1, signal.SIGKILL));"
+        "p.wait()"
+    )
+    return subprocess.Popen([sys.executable, "-c", code, *child_argv])
+
+
+def spawn_mixed_parent(linger_bin, fast_bin):
+    """Fork order [linger (no pdeathsig), fast (pdeathsig)].
+
+    The linger child outlives the parent's SIGKILL; the fast one dies with it in
+    under a millisecond. That is the fcvm shape the ordering defect needs — a
+    child that is ALIVE at kill time and gone almost immediately after — which a
+    child that simply exits early does not reproduce.
+    """
+    code = (
+        "import ctypes,signal,subprocess,sys,time;"
+        "libc=ctypes.CDLL('libc.so.6');"
+        "subprocess.Popen([sys.argv[1],'300']);"
+        "subprocess.Popen([sys.argv[2],'300'],"
+        " preexec_fn=lambda: libc.prctl(1, signal.SIGKILL));"
+        "time.sleep(3600)"
+    )
+    return subprocess.Popen([sys.executable, "-c", code, linger_bin, fast_bin])
+
+
+def kill_tree(p):
+    """SIGKILL a parent and anything still under it. Tests must not leak either."""
+    for pid in reqbench.children_of(p.pid):
+        try:
+            os.kill(pid, 9)
+        except (ProcessLookupError, PermissionError):
+            pass
+    try:
+        os.kill(p.pid, 9)
+    except ProcessLookupError:
+        pass
+    try:
+        p.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        pass
+
+
+class TeardownFastReapGuard(unittest.TestCase):
+    """teardown_fast must NOT delete the tracking record of a VM it failed to kill.
+
+    RED BEFORE THE FIX: `all_gone` was computed and stored, then the state file was
+    removed and the data dir rmtree'd unconditionally, so a parent whose child has
+    no pdeathsig produced
+        all_gone: False, disk_reaped: [state.json, data/], state exists: False
+    with the survivor still in /proc afterwards.
+    """
+
+    def test_survivor_blocks_the_reap_and_raises(self):
+        with tempfile.TemporaryDirectory() as d:
+            state = os.path.join(d, "vm-test.json")
+            data = os.path.join(d, "data")
+            with open(state, "w") as f:
+                json.dump({"vm_id": "vm-test", "pid": 1}, f)
+            os.makedirs(os.path.join(data, "disks"))
+
+            # A parent whose child does NOT inherit a pdeathsig: killing the parent
+            # leaves the child running. This is the shape of an unarmed hop.
+            p = subprocess.Popen(["bash", "-c", "sleep 300 & wait"])
+            try:
+                # Give bash a moment to actually fork the child, then confirm.
+                deadline = time.monotonic() + 5
+                while not reqbench.children_of(p.pid) and time.monotonic() < deadline:
+                    time.sleep(0.01)
+                self.assertTrue(reqbench.children_of(p.pid), "bash never forked its child")
+
+                with self.assertRaises(reqbench.SurvivedTeardown) as cm:
+                    reqbench.teardown_fast(p.pid, state, data, 0.3)
+
+                self.assertIn("NOT reaped", str(cm.exception))
+                self.assertTrue(
+                    os.path.exists(state),
+                    "state file of a VM that survived the kill must NOT be reaped",
+                )
+                self.assertTrue(
+                    os.path.isdir(data),
+                    "data dir of a VM that survived the kill must NOT be rmtree'd",
+                )
+            finally:
+                for pid in reqbench.children_of(p.pid):
+                    try:
+                        os.kill(pid, 9)
+                    except ProcessLookupError:
+                        pass
+                try:
+                    os.kill(p.pid, 9)
+                except ProcessLookupError:
+                    pass
+                p.wait(timeout=5)
+
+    def test_clean_teardown_still_reaps_both_artifacts(self):
+        """The guard must not disarm the reap on the normal path."""
+        with tempfile.TemporaryDirectory() as d:
+            state = os.path.join(d, "vm-test.json")
+            data = os.path.join(d, "data")
+            with open(state, "w") as f:
+                json.dump({"vm_id": "vm-test"}, f)
+            with open(state + ".lock", "w") as f:
+                f.write("")
+            os.makedirs(data)
+            p = subprocess.Popen(["sleep", "300"])
+            out = reqbench.teardown_fast(p.pid, state, data, 5.0)
+            p.wait(timeout=5)
+            self.assertTrue(out["all_gone"])
+            self.assertFalse(os.path.exists(state))
+            self.assertFalse(os.path.exists(state + ".lock"), "the .json.lock must go too")
+            self.assertFalse(os.path.isdir(data))
+
+
+class TeardownFastCpuAccounting(unittest.TestCase):
+    """The CPU-accounting windows must not be dominated by the harness's own spin.
+
+    RED BEFORE THE FIX: the control window was `while time.monotonic()-t0 < 0.05:
+    pass`, so `control_busy_cores` came back at 3.0-3.4 on this box against ~2.0
+    for the same ambient load measured over a sleep — one full core of the
+    harness's own `pass` loop, then multiplied by the whole reclaim window.
+    """
+
+    def test_control_window_does_not_measure_our_own_spin(self):
+        p = subprocess.Popen(["sleep", "300"])
+        before = self_cpu_ms()
+        out = reqbench.teardown_fast(p.pid, "", "", 5.0)
+        spent = self_cpu_ms() - before
+        p.wait(timeout=5)
+        # 50 ms of control window: a spin would put >=45 ms of user time in it.
+        # The whole call (control + reclaim sampling) must stay well under that.
+        self.assertLess(
+            out["control_harness_cpu_ms"],
+            5.0,
+            f"control window burned {out['control_harness_cpu_ms']:.1f} ms of OUR cpu "
+            f"(total call {spent:.1f} ms) — it is spinning, so control_busy_cores "
+            f"({out['control_busy_cores']:.2f}) is ambient + the harness",
+        )
+
+    def test_reclaim_cpu_is_reported_as_an_interval_not_a_bare_zero(self):
+        """A sub-tick reclaim is `0.0 +/- one tick`, never a hard 0.0.
+
+        RED BEFORE THE FIX: per_child_cpu carried only
+        {'cpu_before_ms': 0.0, 'cpu_final_ms': 0.0, 'reclaim_cpu_ms': 0.0,
+         'complete': False} — zero CPU quoted with zero uncertainty on data whose
+        resolution is 1000/CLK_TCK ms (10 ms here). AGENTS.md defect 6.
+        """
+        p = spawn_pdeathsig_parent(["sleep", "300"])
+        try:
+            deadline = time.monotonic() + 10
+            while not reqbench.children_of(p.pid) and time.monotonic() < deadline:
+                time.sleep(0.01)
+            self.assertTrue(reqbench.children_of(p.pid), "child never appeared")
+            out = reqbench.teardown_fast(p.pid, "", "", 10.0)
+        finally:
+            kill_tree(p)
+        self.assertTrue(out["all_gone"], "the pdeathsig child should have died with its parent")
+        self.assertEqual(out["tick_ms"], 1000.0 / reqbench.CLK_TCK)
+        self.assertTrue(out["per_child_cpu"], "no children were tracked")
+        for name, c in out["per_child_cpu"].items():
+            self.assertIn("below_resolution", c, f"{name} has no resolution flag")
+            self.assertIn("reclaim_cpu_ms_hi", c, f"{name} has no upper bound")
+            if c["reclaim_cpu_ms"] == 0.0:
+                self.assertTrue(c["below_resolution"])
+                self.assertEqual(c["reclaim_cpu_ms_hi"], 2 * out["tick_ms"])
+
+    def test_every_tracked_child_gets_a_cpu_sample(self):
+        """A fast child must not be skipped because a slow one was sampled first.
+
+        RED BEFORE THE FIX: `{name: sample_until_gone(pid, deadline) for ...}` ran
+        SEQUENTIALLY, so a later child was not looked at until every earlier one
+        had gone. `/proc/<pid>/task/<tid>/children` is in FORK order (verified),
+        so putting the long-lived child first and a short-lived one second makes
+        the defect deterministic: by the time the second child's turn came it had
+        been reaped, `proc_stat_fields` returned None on the very first read, and
+        its `reclaim_cpu_ms` was recorded as null. Observed:
+            AssertionError: ['fastexit'] != []
+            these tracked children were never sampled at all: ['fastexit']
+        """
+        with tempfile.TemporaryDirectory() as d:
+            # Distinct comms, so the two children cannot collide in `tracked`.
+            linger = os.path.join(d, "lingersleep")
+            fast = os.path.join(d, "fastexit")
+            shutil.copy("/bin/sleep", linger)
+            shutil.copy("/bin/sleep", fast)
+            p = spawn_mixed_parent(linger, fast)
+            try:
+                deadline = time.monotonic() + 10
+                while len(reqbench.children_of(p.pid)) < 2 and time.monotonic() < deadline:
+                    time.sleep(0.005)
+                kids = reqbench.children_of(p.pid)
+                self.assertEqual(len(kids), 2, "parent never forked both children")
+                # Precondition: the child that dies FIRST must be SECOND in fork
+                # order, or this test is not exercising the ordering defect at all.
+                self.assertEqual(
+                    [reqbench.proc_comm(k) for k in kids], ["lingersleep", "fastexit"],
+                    "fork order is not [linger, fast]; the ordering defect is not exercised",
+                )
+                # `lingersleep` has no pdeathsig, so it survives and teardown_fast
+                # (correctly) refuses to reap and raises. The partial record it
+                # carries is what this test inspects.
+                with self.assertRaises(reqbench.SurvivedTeardown) as cm:
+                    reqbench.teardown_fast(p.pid, "", "", 1.0)
+                out = cm.exception.teardown
+                missing = [n for n, c in out["per_child_cpu"].items()
+                           if c["cpu_final_ms"] is None]
+                self.assertEqual(
+                    missing,
+                    [],
+                    f"these tracked children were never sampled at all: {missing} "
+                    f"(all: {out['per_child_cpu']})",
+                )
+            finally:
+                kill_tree(p)
+
+
+class FindStateIsEventDriven(unittest.TestCase):
+    """find_state must not burn a core while the measured clone is restoring.
+
+    RED BEFORE THE FIX: `while time.monotonic() < deadline:` with an os.listdir +
+    json.load of every file and no sleep. Measured 400 ms of harness CPU for a
+    400 ms wait with 8 unrelated state files present — 100% of one core, at the
+    exact instant a 2-vCPU clone is restoring on the same box.
+    """
+
+    def test_waiting_for_the_state_file_costs_no_cpu(self):
+        with tempfile.TemporaryDirectory() as d:
+            for i in range(8):  # unrelated files, as on a real box
+                with open(os.path.join(d, f"vm-other{i}.json"), "w") as f:
+                    json.dump({"vm_id": f"o{i}", "pid": 900000 + i}, f)
+
+            target = os.path.join(d, "vm-mine.json")
+
+            def writer():
+                time.sleep(0.4)
+                tmp = target + ".tmp"
+                with open(tmp, "w") as f:
+                    json.dump({"vm_id": "vm-mine", "pid": 123456, "name": "mine"}, f)
+                os.rename(tmp, target)
+
+            watch = reqbench.DirWatch(d)  # registered BEFORE the writer starts
+            th = threading.Thread(target=writer)
+            th.start()
+            t0 = time.monotonic()
+            c0 = self_cpu_ms()
+            path, st = reqbench.find_state(d, 123456, time.monotonic() + 10, watch)
+            wall_ms = (time.monotonic() - t0) * 1000
+            cpu_ms = self_cpu_ms() - c0
+            th.join()
+            watch.close()
+
+            self.assertIsNotNone(st, "did not find the state file")
+            self.assertEqual(path, target)
+            self.assertGreater(wall_ms, 300, "the file landed at +400 ms; sanity check")
+            self.assertLess(
+                cpu_ms,
+                0.1 * wall_ms,
+                f"burned {cpu_ms:.0f} ms cpu over {wall_ms:.0f} ms wall "
+                f"({100 * cpu_ms / wall_ms:.0f}% of a core) — this is a spin, not a wait",
+            )
+
+    def test_state_is_findable_by_name_when_pid_is_null(self):
+        """fcvm writes the state file with `pid: null` until POST-RESUME.
+
+        RED BEFORE THE FIX: `scan_state`/`find_state` matched only on pid, so the
+        entire window between the first save and the post-resume pid write was
+        invisible — and a file left behind with a null pid is never removed by
+        fcvm's own sweeper either (`cleanup_stale_state` bails on a null pid).
+        """
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "vm-x.json")
+            with open(p, "w") as f:
+                json.dump({"vm_id": "vm-x", "pid": None, "name": "rb-1-0-fast"}, f)
+            path, st = reqbench.scan_state(d, 4242, "rb-1-0-fast")
+            self.assertEqual(path, p)
+            self.assertEqual(st["vm_id"], "vm-x")
+            # ...and a pid-only scan still finds nothing, which is the bug's shape.
+            self.assertEqual(reqbench.scan_state(d, 4242)[0], None)
+
+
+class WsUrlPrewiring(unittest.TestCase):
+    """A prewired --ws-url must be re-hosted onto THIS clone's endpoint.
+
+    RED BEFORE THE FIX: reqbench passed `ws_url=args.ws_url` verbatim into the
+    per-clone Namespace, so a single URL named one fixed 127.x.y.z:port for the
+    whole run while every clone had its own address.
+    """
+
+    def test_netloc_is_rebuilt_from_this_clones_endpoint(self):
+        got = reqbench.clone_ws_url(
+            "ws://127.0.0.99:9223/devtools/page/DEADBEEF", "127.0.0.19:9223"
+        )
+        self.assertEqual(got, "ws://127.0.0.19:9223/devtools/page/DEADBEEF")
+
+    def test_path_carrying_the_target_id_is_preserved(self):
+        got = reqbench.clone_ws_url("ws://x:1/devtools/page/ABC123", "127.0.0.5:9223")
+        self.assertTrue(got.endswith("/devtools/page/ABC123"))
+
+
+class ExecArmTimeout(unittest.TestCase):
+    """A slow exec rep must be recorded as a failure, not abort the whole run.
+
+    RED BEFORE THE FIX: `rc = proc.wait(timeout=...)` was bare, so
+    subprocess.TimeoutExpired propagated out of run_exec_request AND out of main,
+    orphaning the spawned fcvm (no pdeathsig from Python, harness is not a
+    subreaper) with its whole VM tree into the next run.
+    """
+
+    def test_timeout_is_recorded_and_the_child_is_killed(self):
+        with tempfile.TemporaryDirectory() as d:
+            stub = os.path.join(d, "fcvm-stub")
+            with open(stub, "w") as f:
+                f.write("#!/bin/bash\nexec sleep 600\n")
+            os.chmod(stub, 0o755)
+            args = argparse.Namespace(
+                fcvm=stub, out_dir=d, url="http://x/", format="jpeg", quality=80,
+                snapshot_tag="", serve_pid=1, rust_log="off",
+                timeout=0.3, teardown_timeout=0.2,
+                state_dir=d, data_root=d,
+            )
+            before = set(reqbench.children_of(os.getpid()))
+            rec = reqbench.run_exec_request(args, 0)  # must NOT raise
+            self.assertIs(rec["ok"], False)
+            self.assertIs(rec["timed_out"], True)
+            leaked = [
+                pid for pid in reqbench.children_of(os.getpid())
+                if pid not in before and reqbench.proc_stat_fields(pid)
+                and reqbench.proc_stat_fields(pid)[0] not in ("Z", "X", "x")
+            ]
+            self.assertEqual(leaked, [], f"stub survived the timeout: {leaked}")
+
+
+class AnalyzerAvailability(unittest.TestCase):
+    """Failed requests must be counted per arm, and must not hide a leak.
+
+    RED BEFORE THE FIX (both observed by running the shipped analyzer on a
+    synthetic jsonl of 30 exec-ok + 27 cdp-ok + 3 cdp-failed-with-all_gone-false):
+      * it printed `all_gone: 27/27 confirmed` with no warning, because the
+        teardown section read the ok-FILTERED list, so `all_gone: False` on a
+        FAILED record was never examined;
+      * `arms.cdp` had no `attempted`/`failed`/`failure_rate` keys at all — only
+        one global scalar `n_failed` over every arm.
+    """
+
+    def _synthetic(self, path):
+        with open(path, "w") as f:
+            f.write(json.dumps({"kind": "meta", "seed": 1, "arms": ["exec", "cdp"]}) + "\n")
+            for i in range(30):
+                f.write(json.dumps({
+                    "arm": "exec", "rep": i, "ok": True,
+                    "blocking_ms": 565.0, "wall_ms": 565.0,
+                }) + "\n")
+            for i in range(27):
+                f.write(json.dumps({
+                    "arm": "cdp", "rep": i, "ok": True,
+                    "blocking_ms": 384.0, "wall_ms": 455.0,
+                    "teardown": {"mode": "fast", "all_gone": True,
+                                 "reap_wall_ms": 63.0, "teardown_total_ms": 70.0},
+                }) + "\n")
+            for i in range(27, 30):
+                f.write(json.dumps({
+                    "arm": "cdp", "rep": i, "ok": False,
+                    "error": "WsClosed: connection closed mid-frame",
+                    "blocking_ms": 5250.0, "wall_ms": 5300.0,
+                    "teardown": {"mode": "fast", "all_gone": False,
+                                 "reap_wall_ms": 60000.0, "teardown_total_ms": 60000.0},
+                }) + "\n")
+
+    def test_failed_records_are_counted_per_arm_and_gate_publication(self):
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(d, "r.jsonl")
+            dst = os.path.join(d, "r.json")
+            self._synthetic(src)
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                reqanalyze.main_with(["--json-out", dst, src])
+            out = json.load(open(dst))
+            self.assertEqual(out["arms"]["cdp"]["attempted"], 30)
+            self.assertEqual(out["arms"]["cdp"]["failed"], 3)
+            self.assertEqual(out["arms"]["exec"]["failed"], 0)
+            self.assertIn("failure_rate_ci", out["arms"]["cdp"])
+            self.assertIs(out["arms"]["cdp"]["publishable"], False)
+            self.assertIs(out["arms"]["exec"]["publishable"], True)
+            self.assertIn("DO NOT PUBLISH", buf.getvalue())
+
+    def test_a_leak_on_a_FAILED_request_is_still_reported(self):
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(d, "r.jsonl")
+            dst = os.path.join(d, "r.json")
+            self._synthetic(src)
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                reqanalyze.main_with(["--json-out", dst, src])
+            out = json.load(open(dst))
+            self.assertEqual(
+                out["arms"]["cdp"]["all_gone_confirmed"], [27, 30],
+                "the 3 failed reps' teardowns must be examined, not filtered out",
+            )
+            self.assertIn("NOT CONFIRMED GONE", buf.getvalue())
+
+    def test_per_child_cpu_is_reported_by_name_not_pooled(self):
+        """Pooling across children medians a straggler away.
+
+        RED BEFORE THE FIX: reqanalyze appended every child's value to one list and
+        discarded the name, so {firecracker 110 ms, holder 0 ms, pasta 0 ms}
+        published a median of 0 — the opposite of the finding.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(d, "r.jsonl")
+            dst = os.path.join(d, "r.json")
+            with open(src, "w") as f:
+                f.write(json.dumps({"kind": "meta", "seed": 1}) + "\n")
+                for i in range(5):
+                    f.write(json.dumps({
+                        "arm": "cdp-fast", "rep": i, "ok": True,
+                        "blocking_ms": 372.0, "wall_ms": 1065.0,
+                        "teardown": {
+                            "mode": "fast", "all_gone": True, "tick_ms": 10.0,
+                            "reap_wall_ms": 634.0, "teardown_total_ms": 640.0,
+                            "per_child_cpu": {
+                                "firecracker": {"reclaim_cpu_ms": 110.0, "complete": True,
+                                                "below_resolution": False,
+                                                "reclaim_cpu_ms_hi": 130.0},
+                                "sleep": {"reclaim_cpu_ms": 0.0, "complete": True,
+                                          "below_resolution": True,
+                                          "reclaim_cpu_ms_hi": 20.0},
+                                "pasta": {"reclaim_cpu_ms": 0.0, "complete": True,
+                                          "below_resolution": True,
+                                          "reclaim_cpu_ms_hi": 20.0},
+                            },
+                        },
+                    }) + "\n")
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                reqanalyze.main_with(["--json-out", dst, src])
+            out = json.load(open(dst))
+            per_child = out["arms"]["cdp-fast"]["reclaim_cpu_ms_by_child"]
+            self.assertIn("firecracker", per_child)
+            self.assertIn("pasta", per_child)
+            self.assertEqual(per_child["firecracker"]["median"], 110.0)
+            text = buf.getvalue()
+            self.assertIn("firecracker", text)
+            self.assertNotIn(
+                "0.00 [0.00, 0.00] ms", text,
+                "a sub-tick child must print as a bound, never as an exact zero",
+            )
+            self.assertIn("below /proc tick resolution", text)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_signal_cleanup.rs
+++ b/tests/test_signal_cleanup.rs
@@ -134,6 +134,27 @@ fn opt_running(t: Option<Tracked>) -> bool {
 }
 
 /// Send a signal to a process
+/// SIGTERM, await the exit, escalate only if it hangs.
+///
+/// `Child::kill()` is SIGKILL, which fcvm's `cleanup_vm` cannot survive — so a
+/// fixture torn down with it leaks the VM's state file AND its multi-GB reflinked
+/// `vm-disks/<vm_id>` directory every run, which is exactly the artifact class the
+/// tests in this file exist to police. No process leaks (pdeathsig reaps the
+/// tree), so the leak is invisible to every stray-VM guard.
+///
+/// Signal first, `wait()` second. `Child::kill()` is `start_kill()` + `wait()`, so
+/// it REAPS — a `kill_process(pid)` issued afterwards targets a freed PID, which
+/// is precisely the bare-PID signalling this file's #628 tests exist to forbid.
+async fn graceful_shutdown(child: &mut tokio::process::Child, pid: u32) {
+    let _ = send_signal(pid, "TERM");
+    if tokio::time::timeout(Duration::from_secs(30), child.wait())
+        .await
+        .is_err()
+    {
+        let _ = child.kill().await;
+    }
+}
+
 fn send_signal(pid: u32, signal: &str) -> Result<()> {
     let output = Command::new("kill")
         .arg(format!("-{}", signal))
@@ -1712,10 +1733,18 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
             Err(e) => {
                 common::kill_process(clone_pid).await;
                 let _ = clone_child.wait().await;
-                let _ = serve_child.kill().await;
-                let _ = base_child.kill().await;
-                common::kill_process(base_pid).await;
-                common::kill_process(serve_pid).await;
+                // GRACEFUL, not `Child::kill()` — see `graceful_shutdown`. A
+                // SIGKILLed baseline leaks its state file and its reflinked
+                // vm-disks dir, which this very test asserts about for the clone.
+                graceful_shutdown(&mut serve_child, serve_pid).await;
+                graceful_shutdown(&mut base_child, base_pid).await;
+                // The snapshot is uniquely tagged per run (`unique_names`), so
+                // nothing ever overwrites it: without an explicit delete it
+                // accumulates one guest-RAM `memory.bin` (default --mem 1024 MiB)
+                // plus vmstate and a reflinked disk per run. Ordering is
+                // load-bearing — `snapshot serve` holds memory.bin open and takes
+                // the snapshot-dir lock, so the delete must come AFTER it is dead.
+                let _ = common::delete_snapshot(&snapshot_name).await;
                 return Err(e);
             }
         };
@@ -1724,55 +1753,62 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
             fc.pid, holder.pid, pasta.pid
         );
 
-        // State files are keyed by vm_id (a UUID), NOT by the VM's name — find this
-        // clone's file by its recorded fcvm pid, the same way reqbench.py does. The data
-        // directory is `<data_root>/vm-disks/<vm_id>`; both must survive the SIGKILL.
-        let (state_file, data_dir) = {
-            let dir = fcvm::paths::state_dir();
-            let mut found = None;
-            for entry in std::fs::read_dir(&dir).context("reading state dir")? {
-                let path = entry?.path();
-                if path.extension().and_then(|e| e.to_str()) != Some("json") {
-                    continue;
-                }
-                let Ok(text) = std::fs::read_to_string(&path) else {
-                    continue;
-                };
-                let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) else {
-                    continue;
-                };
-                if v.get("pid").and_then(|p| p.as_u64()) == Some(clone_pid as u64) {
-                    // NEVER default this. `vm_runtime_dir("")` is `<data_dir>/vm-disks`
-                    // ITSELF, and this test later calls `remove_dir_all` on that path — so
-                    // a state file missing `vm_id` would delete every VM's disks on the
-                    // machine, including those of tests running concurrently in CI. A
-                    // missing id means the state file is not what we think it is; fail
-                    // loudly instead of computing a path that is catastrophic when wrong.
-                    let vm_id = v
-                        .get("vm_id")
-                        .and_then(|s| s.as_str())
-                        .filter(|s| !s.is_empty())
-                        .with_context(|| {
-                            format!(
-                                "state file {} matched the clone PID but carries no vm_id; \
+        // State files are keyed by vm_id (a UUID), NOT by the VM's name — find a VM's
+        // file by its recorded fcvm pid, the same way reqbench.py does. The data
+        // directory is `<data_root>/vm-disks/<vm_id>`.
+        let artifacts_for =
+            |want_pid: u32| -> Result<Option<(std::path::PathBuf, std::path::PathBuf)>> {
+                let dir = fcvm::paths::state_dir();
+                for entry in std::fs::read_dir(&dir).context("reading state dir")? {
+                    let path = entry?.path();
+                    if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                        continue;
+                    }
+                    let Ok(text) = std::fs::read_to_string(&path) else {
+                        continue;
+                    };
+                    let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) else {
+                        continue;
+                    };
+                    if v.get("pid").and_then(|p| p.as_u64()) == Some(want_pid as u64) {
+                        // NEVER default this. `vm_runtime_dir("")` is `<data_dir>/vm-disks`
+                        // ITSELF, and this test later calls `remove_dir_all` on that path — so
+                        // a state file missing `vm_id` would delete every VM's disks on the
+                        // machine, including those of tests running concurrently in CI. A
+                        // missing id means the state file is not what we think it is; fail
+                        // loudly instead of computing a path that is catastrophic when wrong.
+                        let vm_id = v
+                            .get("vm_id")
+                            .and_then(|s| s.as_str())
+                            .filter(|s| !s.is_empty())
+                            .with_context(|| {
+                                format!(
+                                    "state file {} matched PID {} but carries no vm_id; \
                                  refusing to derive a runtime directory from an empty id",
-                                path.display()
-                            )
-                        })?
-                        .to_string();
-                    let dir = fcvm::paths::vm_runtime_dir(&vm_id);
-                    anyhow::ensure!(
-                        dir.starts_with(fcvm::paths::data_dir().join("vm-disks"))
-                            && dir != fcvm::paths::data_dir().join("vm-disks"),
-                        "refusing to treat {} as a per-VM runtime directory",
-                        dir.display()
-                    );
-                    found = Some((path, dir));
-                    break;
+                                    path.display(),
+                                    want_pid
+                                )
+                            })?
+                            .to_string();
+                        let dir = fcvm::paths::vm_runtime_dir(&vm_id);
+                        anyhow::ensure!(
+                            dir.starts_with(fcvm::paths::data_dir().join("vm-disks"))
+                                && dir != fcvm::paths::data_dir().join("vm-disks"),
+                            "refusing to treat {} as a per-VM runtime directory",
+                            dir.display()
+                        );
+                        return Ok(Some((path, dir)));
+                    }
                 }
-            }
-            found.context("no state file recorded for the clone")?
-        };
+                Ok(None)
+            };
+        // The clone's pair must survive the SIGKILL (asserted below).
+        let (state_file, data_dir) =
+            artifacts_for(clone_pid)?.context("no state file recorded for the clone")?;
+        // The BASELINE's pair, captured now so the fixture's own teardown can be
+        // held to the same standard. It is torn down gracefully, so fcvm's
+        // `cleanup_vm` runs and BOTH of these must be GONE afterwards.
+        let base_artifacts = artifacts_for(base_pid)?;
 
         // THE FAST TEARDOWN: one signal to fcvm. Nothing else is signalled by us.
         send_signal(clone_pid, "KILL").context("SIGKILL to clone fcvm")?;
@@ -1801,13 +1837,35 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
         let state_survived = state_file.exists();
         let data_survived = data_dir.is_dir();
 
-        // Clean up the rest of the fixture before asserting, so a failure does not also leak.
-        let _ = serve_child.kill().await;
-        let _ = base_child.kill().await;
-        common::kill_process(base_pid).await;
-        common::kill_process(serve_pid).await;
+        // Clean up the rest of the fixture before asserting, so a failure does not also
+        // leak. GRACEFULLY: this block used to be `serve_child.kill()` +
+        // `base_child.kill()` (both SIGKILL) followed by `kill_process()` calls against
+        // already-reaped PIDs, so fcvm's `cleanup_vm` never ran for the baseline or the
+        // serve and every run left behind the baseline's state file, its multi-GB
+        // reflinked `vm-disks/<vm_id>`, the serve's state file and its uffd socket.
+        // Proven by this test's OWN passing assertions below: SIGKILL => both artifacts
+        // survive. It reaped them for the clone and not for the fixture.
+        graceful_shutdown(&mut serve_child, serve_pid).await;
+        graceful_shutdown(&mut base_child, base_pid).await;
+        // AFTER the serve is dead, never before: `snapshot serve` holds memory.bin
+        // open and takes the snapshot-dir lock, so removing the directory under a
+        // live UFFD server pulls files out from under it. The tag is unique per run
+        // (`unique_names`), so nothing ever overwrote it and each run left a guest-RAM
+        // memory.bin (default --mem 1024 MiB) + vmstate + a reflinked disk behind.
+        // ONLY this tag: the baseline may also have populated the image-keyed SYSTEM
+        // startup-snapshot cache, which is shared and intended to persist.
+        let snapshot_delete = common::delete_snapshot(&snapshot_name).await;
+        let snapshot_leaked = common::snapshot_exists(&snapshot_name);
         std::fs::remove_file(&state_file).ok();
         std::fs::remove_dir_all(&data_dir).ok();
+
+        let base_leak = base_artifacts
+            .as_ref()
+            .map(|(s, d)| (s.exists(), d.is_dir()));
+        if let Some((s, d)) = &base_artifacts {
+            std::fs::remove_file(s).ok();
+            std::fs::remove_dir_all(d).ok();
+        }
 
         assert!(
             survivors.is_empty(),
@@ -1836,6 +1894,40 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
              copy of the golden rootfs, so a harness that does not reap it leaks disk without \
              leaking a process — invisible to every stray-VM guard.",
             data_dir.display()
+        );
+
+        // ...and the FIXTURE is held to the same standard as the thing under test.
+        // The baseline is torn down with SIGTERM, so `cleanup_vm` runs and both of
+        // its artifacts must be gone. With the old `Child::kill()` teardown they
+        // both survived — by this test's own state_survived/data_survived logic —
+        // and every run leaked a state file plus a multi-GB reflinked rootfs.
+        if let (Some((s, d)), Some((s_left, d_left))) = (&base_artifacts, base_leak) {
+            assert!(
+                !s_left && !d_left,
+                "the BASELINE VM's teardown leaked: state_file_left={} ({}) \
+                 data_dir_left={} ({}). It must be shut down with SIGTERM so fcvm's \
+                 cleanup_vm runs; Child::kill() is SIGKILL and cleanup_vm cannot \
+                 survive it.",
+                s_left,
+                s.display(),
+                d_left,
+                d.display()
+            );
+        }
+
+        // Each run creates a uniquely-tagged snapshot (`unique_names`), so without an
+        // explicit delete they accumulate one guest-RAM memory.bin + vmstate +
+        // reflinked disk per run. `let _ = delete_snapshot(...)` alone would swallow a
+        // failed delete and reinstate the leak, which is the reasoning
+        // bench/chromium/reqbench.py applies to rmtree ("never ignore_errors=True").
+        snapshot_delete.with_context(|| format!("deleting snapshot {}", snapshot_name))?;
+        assert!(
+            !snapshot_leaked,
+            "leaked snapshot {} — this test creates a uniquely-tagged memory+disk \
+             snapshot per run, so without an explicit delete they accumulate one per \
+             run. Bounded only by `make clean-test-data`, and the CI counter that \
+             prints snapshot entries does not gate the run.",
+            snapshot_name
         );
 
         println!("test_bench_fast_teardown_leaks_nothing_clone PASSED");

--- a/tests/test_signal_cleanup.rs
+++ b/tests/test_signal_cleanup.rs
@@ -1555,3 +1555,179 @@ fn test_start_time_identity_defeats_pid_reuse_628() {
         assert!(!is_dead_state(s), "{} should count as a live state", s);
     }
 }
+
+/// The bench fast-teardown path must not leak a microVM. Clone flavour.
+///
+/// `bench/chromium/reqbench.py` (arm `cdp-fast`) delivers the rendered image the instant
+/// it is in hand and then SIGKILLs the clone's `fcvm`. It never signals Firecracker or the
+/// namespace holder itself: `PR_SET_PDEATHSIG(SIGKILL)` is set on both
+/// (`src/utils.rs::install_namespace_pre_exec`, `src/commands/common.rs::spawn_namespace_holder`),
+/// so the kernel's `exit_notify`/`forget_original_parent` pass delivers SIGKILL to BOTH in one
+/// go — concurrently by construction, with no ordering for the harness to get wrong and no
+/// cleanup code of ours that has to survive a SIGKILL in order to run.
+///
+/// `test_sigkill_kills_firecracker_rootless` already proves that chain for a `podman run` VM.
+/// This test proves it for the shape the bench actually uses: a CLONE restored from a
+/// `snapshot serve` memory server, which reaches Firecracker through the restore path in
+/// `src/commands/snapshot.rs` rather than the fresh-boot path. Same guarantee, different
+/// spawn site — and a regression in either one is a repeat of #730, where a broken pdeathsig
+/// chain orphaned ~490 microVMs and wedged two CI runners at load 523.
+///
+/// It also pins the OTHER half of the fast-path contract: because SIGKILL cannot be caught,
+/// `cleanup_vm` never runs, so the state file survives the kill. The harness is therefore
+/// REQUIRED to reap on-disk state synchronously (it does; there is no janitor). Asserting
+/// that the file is still there after the kill is what stops someone "simplifying" the
+/// harness by deleting that step and silently leaking state files instead of VMs.
+#[test]
+fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
+    println!("\ntest_bench_fast_teardown_leaks_nothing_clone");
+
+    let rt = tokio::runtime::Runtime::new().context("creating tokio runtime")?;
+    rt.block_on(async {
+        let fcvm_path = common::find_fcvm_binary()?;
+        let (base_name, clone_name, snapshot_name, serve_name) =
+            common::unique_names("fastteardown");
+
+        // Baseline VM -> snapshot -> memory server: the exact topology the bench uses.
+        let (mut base_child, base_pid) = common::spawn_fcvm_with_logs(
+            &["podman", "run", "--name", &base_name, common::TEST_IMAGE],
+            &base_name,
+        )
+        .await
+        .context("spawning baseline VM")?;
+        common::poll_health_by_pid(base_pid, 120).await?;
+
+        let out = tokio::process::Command::new(&fcvm_path)
+            .args([
+                "snapshot",
+                "create",
+                "--pid",
+                &base_pid.to_string(),
+                "--tag",
+                &snapshot_name,
+            ])
+            .output()
+            .await
+            .context("running snapshot create")?;
+        anyhow::ensure!(
+            out.status.success(),
+            "snapshot create failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        let (mut serve_child, serve_pid) =
+            common::spawn_fcvm_with_logs(&["snapshot", "serve", &snapshot_name], &serve_name)
+                .await
+                .context("spawning memory server")?;
+        common::poll_serve_ready(&snapshot_name, serve_pid, 60).await?;
+
+        // The clone: no --exec, exactly as the `cdp-fast` arm restores it.
+        let (mut clone_child, clone_pid) = common::spawn_fcvm_with_logs(
+            &[
+                "snapshot",
+                "run",
+                "--pid",
+                &serve_pid.to_string(),
+                "--name",
+                &clone_name,
+            ],
+            &clone_name,
+        )
+        .await
+        .context("spawning clone")?;
+        common::poll_health_by_pid(clone_pid, 120).await?;
+        println!("clone healthy (fcvm PID {})", clone_pid);
+
+        // Capture the exact children by (pid, start_time) + pidfd, so neither the post-kill
+        // zombie window nor PID reuse can fake a pass (#628).
+        let fc = find_firecracker_for_fcvm(clone_pid).context("clone has no firecracker child")?;
+        let holder = find_holder_for_fcvm(clone_pid);
+        assert!(
+            fc.running(),
+            "firecracker should be running before the fast teardown"
+        );
+        println!(
+            "firecracker PID {}, holder {:?}",
+            fc.pid,
+            holder.as_ref().map(|h| h.pid)
+        );
+
+        // State files are keyed by vm_id (a UUID), NOT by the VM's name — find this
+        // clone's file by its recorded fcvm pid, the same way reqbench.py does.
+        let state_file = {
+            let dir = fcvm::paths::state_dir();
+            let mut found = None;
+            for entry in std::fs::read_dir(&dir).context("reading state dir")? {
+                let path = entry?.path();
+                if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                    continue;
+                }
+                let Ok(text) = std::fs::read_to_string(&path) else {
+                    continue;
+                };
+                let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) else {
+                    continue;
+                };
+                if v.get("pid").and_then(|p| p.as_u64()) == Some(clone_pid as u64) {
+                    found = Some(path);
+                    break;
+                }
+            }
+            found.context("no state file recorded for the clone")?
+        };
+
+        // THE FAST TEARDOWN: one signal to fcvm. Nothing else is signalled by us.
+        send_signal(clone_pid, "KILL").context("SIGKILL to clone fcvm")?;
+        let _ = clone_child.wait().await;
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        while std::time::Instant::now() < deadline {
+            if !fc.running() && !holder.as_ref().is_some_and(|h| h.running()) {
+                break;
+            }
+            tokio::time::sleep(common::POLL_INTERVAL).await;
+        }
+
+        let fc_alive = fc.running();
+        if fc_alive {
+            fc.kill_if_running();
+        }
+        let holder_alive = holder.as_ref().is_some_and(|h| h.running());
+        if let Some(h) = holder.as_ref() {
+            if holder_alive {
+                h.kill_if_running();
+            }
+        }
+
+        // Clean up the rest of the fixture before asserting, so a failure does not also leak.
+        let _ = serve_child.kill().await;
+        let _ = base_child.kill().await;
+        common::kill_process(base_pid).await;
+        common::kill_process(serve_pid).await;
+
+        assert!(
+            !fc_alive,
+            "LEAK: firecracker (PID {}) survived the fast teardown's SIGKILL of fcvm — the \
+             PR_SET_PDEATHSIG chain through the snapshot-restore spawn path is broken (#730)",
+            fc.pid
+        );
+        assert!(
+            !holder_alive,
+            "LEAK: namespace holder survived the fast teardown's SIGKILL of fcvm"
+        );
+
+        // The other half of the contract: SIGKILL cannot be caught, so cleanup_vm did NOT run
+        // and on-disk state is still there. The harness must reap it synchronously.
+        assert!(
+            state_file.exists(),
+            "expected the clone's state file to SURVIVE the SIGKILL (at {}). If it is gone, \
+             fcvm gained a cleanup path that runs under SIGKILL and reqbench.py's synchronous \
+             on-disk reap should be revisited.",
+            state_file.display()
+        );
+        std::fs::remove_file(&state_file).ok();
+
+        println!("test_bench_fast_teardown_leaks_nothing_clone PASSED");
+        Ok::<(), anyhow::Error>(())
+    })
+}

--- a/tests/test_signal_cleanup.rs
+++ b/tests/test_signal_cleanup.rs
@@ -1020,6 +1020,30 @@ fn find_pasta_for_fcvm(fcvm_pid: u32) -> Option<Tracked> {
     None
 }
 
+/// Holder discovery is coupled to production by a literal string. Pin it.
+///
+/// `find_holder_for_fcvm` pgreps for `sleep infinity`, which is what
+/// `PastaNetwork::build_holder_command` emits. Nothing enforces that agreement, and
+/// when it broke (verified by changing the argv to `sleep 2147483647`) discovery
+/// returned `None`, the leak assertions in the two teardown tests silently stopped
+/// checking anything, and both tests still passed while a real orphan sat on the box.
+///
+/// Honest scope: this is GREEN today. It is a drift alarm, not a regression test for
+/// a present defect — it fires the moment someone changes the holder's argv, which is
+/// the one change that would re-disarm those assertions without any other symptom.
+#[test]
+fn holder_discovery_pattern_tracks_production_holder_argv() {
+    let argv = fcvm::network::PastaNetwork::new("t".into(), "tap-t".into(), vec![])
+        .build_holder_command()
+        .join(" ");
+    assert!(
+        argv.contains("sleep infinity"),
+        "find_holder_for_fcvm() pgreps for `sleep infinity`, but the production holder \
+         argv is `{argv}`. Holder discovery would silently return None and every \
+         holder-leak assertion in this file would stop checking anything. Update BOTH."
+    );
+}
+
 fn find_holder_for_fcvm(fcvm_pid: u32) -> Option<Tracked> {
     let output = Command::new("pgrep")
         .args(["-f", "sleep infinity"])
@@ -1559,25 +1583,44 @@ fn test_start_time_identity_defeats_pid_reuse_628() {
 /// The bench fast-teardown path must not leak a microVM. Clone flavour.
 ///
 /// `bench/chromium/reqbench.py` (arm `cdp-fast`) delivers the rendered image the instant
-/// it is in hand and then SIGKILLs the clone's `fcvm`. It never signals Firecracker or the
-/// namespace holder itself: `PR_SET_PDEATHSIG(SIGKILL)` is set on both
-/// (`src/utils.rs::install_namespace_pre_exec`, `src/commands/common.rs::spawn_namespace_holder`),
-/// so the kernel's `exit_notify`/`forget_original_parent` pass delivers SIGKILL to BOTH in one
-/// go — concurrently by construction, with no ordering for the harness to get wrong and no
-/// cleanup code of ours that has to survive a SIGKILL in order to run.
+/// it is in hand and then SIGKILLs the clone's `fcvm`. It never signals Firecracker, the
+/// namespace holder or pasta itself: `PR_SET_PDEATHSIG(SIGKILL)` is armed on all three
+/// (`src/utils.rs::install_namespace_pre_exec`, `src/commands/common.rs::spawn_namespace_holder`,
+/// `src/network/pasta.rs`), so the kernel's `exit_notify`/`forget_original_parent` pass
+/// delivers SIGKILL to every one of them in a single go — concurrently by construction, with
+/// no ordering for the harness to get wrong and no cleanup code of ours that has to survive
+/// a SIGKILL in order to run.
 ///
-/// `test_sigkill_kills_firecracker_rootless` already proves that chain for a `podman run` VM.
+/// `test_sigkill_reaps_rootless_vm_tree` already proves that chain for a `podman run` VM.
 /// This test proves it for the shape the bench actually uses: a CLONE restored from a
 /// `snapshot serve` memory server, which reaches Firecracker through the restore path in
 /// `src/commands/snapshot.rs` rather than the fresh-boot path. Same guarantee, different
 /// spawn site — and a regression in either one is a repeat of #730, where a broken pdeathsig
 /// chain orphaned ~490 microVMs and wedged two CI runners at load 523.
 ///
+/// ALL THREE CHILDREN MUST BE FOUND, and a missing one is a hard failure rather than a
+/// skipped assertion. Until 2026-08-08 the holder was captured as a bare `Option` and the
+/// leak assertion read `assert!(!holder.as_ref().is_some_and(|h| h.running()))` — which is
+/// `assert!(!false)` when discovery returns `None`, i.e. an assertion that CANNOT FAIL when
+/// the thing it checks is absent. Discovery is coupled to production by string
+/// (`find_holder_for_fcvm` pgreps for the literal `sleep infinity` that
+/// `PastaNetwork::build_holder_command` emits), so any drift in that argv silently converted
+/// this test into coverage-shaped nothing. Verified by fault injection: with the holder argv
+/// changed to `sleep 2147483647` the OLD test still passed while a real `sleep` orphan sat on
+/// the box; with this `.context(...)?` it fails at discovery. Same reasoning applies to pasta,
+/// which the old version did not look for at all.
+///
+/// Scope, honestly (same caveat as `test_sigkill_reaps_rootless_vm_tree`): this asserts the
+/// END STATE — nothing from the VM tree outlives fcvm — not the mechanism by which each
+/// process dies. pasta joins the holder by PID and passt exits when that PID exits, so pasta
+/// dies here even with its own `pre_exec` removed.
+///
 /// It also pins the OTHER half of the fast-path contract: because SIGKILL cannot be caught,
-/// `cleanup_vm` never runs, so the state file survives the kill. The harness is therefore
-/// REQUIRED to reap on-disk state synchronously (it does; there is no janitor). Asserting
-/// that the file is still there after the kill is what stops someone "simplifying" the
-/// harness by deleting that step and silently leaking state files instead of VMs.
+/// `cleanup_vm` never runs, so the state file AND the clone's data directory survive the
+/// kill. The harness is therefore REQUIRED to reap both synchronously (it does; there is no
+/// janitor). Asserting that they are still there after the kill is what stops someone
+/// "simplifying" the harness by deleting that step and silently leaking state files and
+/// multi-GB reflinked rootfs images instead of VMs.
 #[test]
 fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
     println!("\ntest_bench_fast_teardown_leaks_nothing_clone");
@@ -1640,21 +1683,51 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
 
         // Capture the exact children by (pid, start_time) + pidfd, so neither the post-kill
         // zombie window nor PID reuse can fake a pass (#628).
-        let fc = find_firecracker_for_fcvm(clone_pid).context("clone has no firecracker child")?;
-        let holder = find_holder_for_fcvm(clone_pid);
-        assert!(
-            fc.running(),
-            "firecracker should be running before the fast teardown"
-        );
+        //
+        // A healthy rootless clone ALWAYS has all three, so a missing one is a failure, not a
+        // reason to skip an assertion — an assertion that cannot fail when its subject is
+        // absent reads as coverage while proving nothing. Bailing out must tear the fixture
+        // down first, or a discovery failure leaks the very microVM this test polices.
+        let discover = || -> Result<(Tracked, Tracked, Tracked)> {
+            let fc =
+                find_firecracker_for_fcvm(clone_pid).context("clone has no firecracker child")?;
+            let holder = find_holder_for_fcvm(clone_pid).context(
+                "clone has no namespace holder child — the rootless restore path spawns \
+                 `unshare --user --net -- sleep infinity`, and find_holder_for_fcvm pgreps for \
+                 that exact argv. If discovery drifts, the holder-leak assertion below checks \
+                 nothing at all",
+            )?;
+            let pasta = find_pasta_for_fcvm(clone_pid)
+                .context("clone has no pasta child — rootless networking always spawns one")?;
+            anyhow::ensure!(
+                fc.running(),
+                "firecracker should be running before teardown"
+            );
+            anyhow::ensure!(holder.running(), "holder should be running before teardown");
+            anyhow::ensure!(pasta.running(), "pasta should be running before teardown");
+            Ok((fc, holder, pasta))
+        };
+        let (fc, holder, pasta) = match discover() {
+            Ok(tree) => tree,
+            Err(e) => {
+                common::kill_process(clone_pid).await;
+                let _ = clone_child.wait().await;
+                let _ = serve_child.kill().await;
+                let _ = base_child.kill().await;
+                common::kill_process(base_pid).await;
+                common::kill_process(serve_pid).await;
+                return Err(e);
+            }
+        };
         println!(
-            "firecracker PID {}, holder {:?}",
-            fc.pid,
-            holder.as_ref().map(|h| h.pid)
+            "clone tree: firecracker={}, holder={}, pasta={}",
+            fc.pid, holder.pid, pasta.pid
         );
 
         // State files are keyed by vm_id (a UUID), NOT by the VM's name — find this
-        // clone's file by its recorded fcvm pid, the same way reqbench.py does.
-        let state_file = {
+        // clone's file by its recorded fcvm pid, the same way reqbench.py does. The data
+        // directory is `<data_root>/vm-disks/<vm_id>`; both must survive the SIGKILL.
+        let (state_file, data_dir) = {
             let dir = fcvm::paths::state_dir();
             let mut found = None;
             for entry in std::fs::read_dir(&dir).context("reading state dir")? {
@@ -1669,7 +1742,12 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
                     continue;
                 };
                 if v.get("pid").and_then(|p| p.as_u64()) == Some(clone_pid as u64) {
-                    found = Some(path);
+                    let vm_id = v
+                        .get("vm_id")
+                        .and_then(|s| s.as_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    found = Some((path, fcvm::paths::vm_runtime_dir(&vm_id)));
                     break;
                 }
             }
@@ -1682,50 +1760,63 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
 
         let deadline = std::time::Instant::now() + Duration::from_secs(15);
         while std::time::Instant::now() < deadline {
-            if !fc.running() && !holder.as_ref().is_some_and(|h| h.running()) {
+            if !fc.running() && !holder.running() && !pasta.running() {
                 break;
             }
             tokio::time::sleep(common::POLL_INTERVAL).await;
         }
 
-        let fc_alive = fc.running();
-        if fc_alive {
-            fc.kill_if_running();
+        // Snapshot all three BEFORE asserting, then clean up whatever survived, so a failure
+        // of this test cannot itself leak a microVM or a stray forwarding listener.
+        let survivors: Vec<(&str, Tracked)> =
+            [("firecracker", fc), ("holder", holder), ("pasta", pasta)]
+                .into_iter()
+                .filter(|(_, t)| t.running())
+                .collect();
+        for (role, t) in &survivors {
+            println!("LEAK: {} (PID {}) survived the fast teardown", role, t.pid);
+            t.kill_if_running();
         }
-        let holder_alive = holder.as_ref().is_some_and(|h| h.running());
-        if let Some(h) = holder.as_ref() {
-            if holder_alive {
-                h.kill_if_running();
-            }
-        }
+
+        let state_survived = state_file.exists();
+        let data_survived = data_dir.is_dir();
 
         // Clean up the rest of the fixture before asserting, so a failure does not also leak.
         let _ = serve_child.kill().await;
         let _ = base_child.kill().await;
         common::kill_process(base_pid).await;
         common::kill_process(serve_pid).await;
+        std::fs::remove_file(&state_file).ok();
+        std::fs::remove_dir_all(&data_dir).ok();
 
         assert!(
-            !fc_alive,
-            "LEAK: firecracker (PID {}) survived the fast teardown's SIGKILL of fcvm — the \
-             PR_SET_PDEATHSIG chain through the snapshot-restore spawn path is broken (#730)",
-            fc.pid
-        );
-        assert!(
-            !holder_alive,
-            "LEAK: namespace holder survived the fast teardown's SIGKILL of fcvm"
+            survivors.is_empty(),
+            "LEAK: the fast teardown's single SIGKILL to fcvm left these orphaned to init: \
+             {:?}. The PR_SET_PDEATHSIG chain through the snapshot-restore spawn path is \
+             broken (#730). A surviving pasta is the dangerous one: it keeps the dead clone's \
+             forwarded loopback port bound, and that IP is recycled to a later clone.",
+            survivors
+                .iter()
+                .map(|(role, t)| format!("{} (PID {})", role, t.pid))
+                .collect::<Vec<_>>()
         );
 
         // The other half of the contract: SIGKILL cannot be caught, so cleanup_vm did NOT run
-        // and on-disk state is still there. The harness must reap it synchronously.
+        // and BOTH on-disk artifacts are still there. The harness must reap both synchronously.
         assert!(
-            state_file.exists(),
+            state_survived,
             "expected the clone's state file to SURVIVE the SIGKILL (at {}). If it is gone, \
              fcvm gained a cleanup path that runs under SIGKILL and reqbench.py's synchronous \
              on-disk reap should be revisited.",
             state_file.display()
         );
-        std::fs::remove_file(&state_file).ok();
+        assert!(
+            data_survived,
+            "expected the clone's data dir to SURVIVE the SIGKILL (at {}). It holds a reflinked \
+             copy of the golden rootfs, so a harness that does not reap it leaks disk without \
+             leaking a process — invisible to every stray-VM guard.",
+            data_dir.display()
+        );
 
         println!("test_bench_fast_teardown_leaks_nothing_clone PASSED");
         Ok::<(), anyhow::Error>(())

--- a/tests/test_signal_cleanup.rs
+++ b/tests/test_signal_cleanup.rs
@@ -1742,12 +1742,32 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
                     continue;
                 };
                 if v.get("pid").and_then(|p| p.as_u64()) == Some(clone_pid as u64) {
+                    // NEVER default this. `vm_runtime_dir("")` is `<data_dir>/vm-disks`
+                    // ITSELF, and this test later calls `remove_dir_all` on that path — so
+                    // a state file missing `vm_id` would delete every VM's disks on the
+                    // machine, including those of tests running concurrently in CI. A
+                    // missing id means the state file is not what we think it is; fail
+                    // loudly instead of computing a path that is catastrophic when wrong.
                     let vm_id = v
                         .get("vm_id")
                         .and_then(|s| s.as_str())
-                        .unwrap_or_default()
+                        .filter(|s| !s.is_empty())
+                        .with_context(|| {
+                            format!(
+                                "state file {} matched the clone PID but carries no vm_id; \
+                                 refusing to derive a runtime directory from an empty id",
+                                path.display()
+                            )
+                        })?
                         .to_string();
-                    found = Some((path, fcvm::paths::vm_runtime_dir(&vm_id)));
+                    let dir = fcvm::paths::vm_runtime_dir(&vm_id);
+                    anyhow::ensure!(
+                        dir.starts_with(fcvm::paths::data_dir().join("vm-disks"))
+                            && dir != fcvm::paths::data_dir().join("vm-disks"),
+                        "refusing to treat {} as a per-VM runtime directory",
+                        dir.display()
+                    );
+                    found = Some((path, dir));
                     break;
                 }
             }
@@ -1821,4 +1841,32 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
         println!("test_bench_fast_teardown_leaks_nothing_clone PASSED");
         Ok::<(), anyhow::Error>(())
     })
+}
+
+/// `vm_runtime_dir("")` is the shared `vm-disks` directory, not a per-VM one.
+///
+/// A test that derives a runtime directory from a state file and then `remove_dir_all`s it
+/// must never accept an empty id: doing so deletes EVERY VM's disks on the machine,
+/// including those of tests running concurrently in CI. This pins the arithmetic so the
+/// guard above cannot be simplified away by someone who has not thought about it.
+#[test]
+fn an_empty_vm_id_resolves_to_the_shared_disk_root_and_must_be_rejected() {
+    let shared = fcvm::paths::data_dir().join("vm-disks");
+
+    assert_eq!(
+        fcvm::paths::vm_runtime_dir(""),
+        shared,
+        "an empty vm_id collapses to the SHARED vm-disks root. Any caller that deletes its \
+         computed runtime directory would wipe every VM on the host — which is why the \
+         lookup rejects an empty id rather than defaulting it."
+    );
+    assert_ne!(
+        fcvm::paths::vm_runtime_dir("vm-abc123"),
+        shared,
+        "a real vm_id must resolve BELOW the shared root, never to it"
+    );
+    assert!(
+        fcvm::paths::vm_runtime_dir("vm-abc123").starts_with(&shared),
+        "a per-VM directory must still live under the shared root"
+    );
 }


### PR DESCRIPTION
> **2026-08-08 update after adversarial review: every latency and CPU figure this
> PR originally published is WITHDRAWN.** They were not wrong measurements of the
> right thing — they were measurements taken through a harness with defects that
> make them undefendable. The withdrawals and their specific reasons are recorded
> in [`bench/chromium/REVIEW.md`](bench/chromium/REVIEW.md); the harness defects
> are fixed here with tests that were watched fail first. **This PR now ships the
> corrected harness and the withdrawal ledger. It publishes no A/B result.**

## What this PR is now

Harness, container, and documentation only — still no `src/` change. Three things:

1. **A regression test that could not fail is repaired** (highest priority).
2. **Every published CDP figure is withdrawn**, with the defect that invalidated it.
3. **16 harness defects fixed**, each with a red-verified test.

## 1. The assertion that could not fail

`test_bench_fast_teardown_leaks_nothing_clone` held the namespace holder as a bare
`Option` and asserted:

```rust
let holder = find_holder_for_fcvm(clone_pid);          // Option<Tracked>
let holder_alive = holder.as_ref().is_some_and(|h| h.running());
assert!(!holder_alive, "LEAK: namespace holder survived ...");   // !false when None
```

When discovery returns `None` this is `assert!(!false)`. Discovery is coupled to
production by a literal string — `find_holder_for_fcvm` pgreps for `sleep
infinity`, which `PastaNetwork::build_holder_command` emits — so any argv drift
disarmed it silently. It never looked for pasta at all, and its cleanup was a
no-op on the same path, so the test guarding against leaks would itself leave an
orphaned holder pinning a user+net namespace.

**Red-verified by fault injection** (`build_holder_command` argv →
`sleep 2147483647`, everything else unchanged):

| step | code | test | result |
|---|---|---|---|
| 1 | unmutated | fixed | **passed** |
| 2 | mutated | **old** | **passed** — `firecracker PID 2959733, holder None` |
| 3 | mutated | fixed | **failed** — `Error: clone has no namespace holder child — … If discovery drifts, the holder-leak assertion below checks nothing at all` |
| 4 | reverted | fixed | **passed** |

Step 2 is the finding: the old test passed while reporting `holder None`.

Now all three children are hard-fail-on-absent, the fixture is torn down before
any early return, survivors are listed and killed before asserting, and the data
dir is asserted to survive the SIGKILL alongside the state file. A permanent drift
alarm (`holder_discovery_pattern_tracks_production_holder_argv`) pins the pgrep
pattern to the production argv.

## 2. Withdrawn figures

| withdrawn | why it cannot stand |
|---|---|
| `cdp` **384 ms**, `cdp-fast` **372 ms**, `PART 1 −180.5 ms` | Success-conditioned with an arm-correlated censoring rate the analyzer physically could not report — one global `n_failed`, no per-arm denominator anywhere. CDP dropped **1/60 file (1.7%)** and **6/60 UFFD (10.0%)** with `WsClosed`; `exec` dropped **0/66**. A ~5.25 s transport drop truncates the right tail, so the 10% arm is pulled down ~6× harder than the 1.7% arm — in the same direction as the reported effect. |
| reclaim CPU **0.00 [0.00, 0.00] ms** | Three defects in one number: `/proc/<pid>/stat` is jiffy-quantized (10 ms here) so a sub-tick reclaim reports an exact zero with zero uncertainty; the analyzer **pooled all children and discarded the name**, so the median of {firecracker, holder, pasta} medians the straggler away; and the sampler ran **sequentially**, recording `null` for any child that exited during an earlier child's sample. Honest restatement: *below /proc tick resolution (< 20 ms) for every child sampled*. |
| machine cost **+610.4 ms [+575.9, +620.3]** | The "ambient" baseline was measured while the harness held 100% of one core (`while time.monotonic()-t0 < 0.05: pass`), then multiplied by the whole reclaim window and subtracted. Measured on this box, same shape back to back: **spinning 1.40 / 1.40 / 1.20 cores** vs **sleeping 0.20 / 0.40 / 0.00**. The control window was also taken *before* the kill, so it additionally contains the live VM's own CPU. |
| per-child **pasta 704 ms**, and "the pdeathsig guarantee does not cover pasta" | Measured on a tree predating `46dbb789`, which arms `PR_SET_PDEATHSIG(SIGKILL)` on pasta. Both withdrawn. Replacement claim: kernel-enforced for the VMM and holder **unconditionally**, and for pasta **while fcvm runs as root** (`cred_cap_issubset` holds only under a capability loss). |
| "Early response converts teardown from latency into throughput cost" — **REFUTED** | The refutation rested on the two rows above. Both withdrawn ⇒ the premise returns to **untested**, not to supported. |

**Availability gate for the re-run:** ≥200 CDP requests per backend at 0 failures
before any CDP latency figure is quoted (0/200 ⇒ CP upper bound **1.8%** — `reqanalyze.clopper_pearson(0, 200)` = [0.000%, 1.828%]; the 1.5% previously quoted here and in REVIEW.md was the ONE-sided bound, inconsistent with this file's declared two-sided convention). Today's
observed rates fail that loudly.

`AGENTS.md` also gains uncertainty and `n` on every reference row, quotes the
restore primitive **once** (~6 ms — it said 5.8 ms in a table and 4 ms in the
prose), marks the teardown table as 10 ms-quantized with its slope requoted as a
fitted range, replaces the "cannot leak" heading with the scoped guarantee, and
reconciles its REFUTED list with `REVIEW.md` instead of contradicting it.

## 3. Harness defects fixed

**`reqbench.py`** — `teardown_fast` refuses to reap the state file and data dir of
a VM it failed to kill (it used to record `all_gone: false` and then `rmtree` the
rootfs out from under a live Firecracker), SIGKILLs survivors, and aborts the
schedule; control window sleeps and harness self-CPU is subtracted from both
windows; per-child CPU sampled concurrently and emitted as an interval with
`below_resolution`; `find_state` is inotify-driven with the watch registered
*before* the spawn and matches on name as well as pid (it was a no-sleep
`listdir`+`json.load` spin burning a full core for its whole duration, next to a
restoring 2-vCPU clone); the exec arm's bare `proc.wait(timeout=…)` no longer
raises out of `main()` and orphans a clone; `--ws-url` is re-hosted onto each
clone's own endpoint; same-comm children can no longer collide and drop one.

**`reqanalyze.py`** — per-arm `attempted`/`failed` with exact Clopper-Pearson
intervals and a `publishable` gate; **the teardown/leak section reads every
attempt, not the ok-filtered list**, so `all_gone: false` on a *failed* request is
no longer invisible; per-child CPU reported by comm; cross-arm deltas labelled
CENSORED.

**`reqbench.sh`** — trap-based cleanup with `$!` captured in every phase (two
captured nothing at all); `cmd_verify` returns a failure count instead of `|| echo`
swallowing all three hops and exiting 0; target-id stability compared across **two**
clones instead of printing one id and asserting nothing.

**`cdpdrive.py` / `render.py` / `teardown_probe.py`** — `failure_class` for
transport drops; `--print-target` implemented (its docstring had promised it since
the file was written); `_recv_until` keeps bytes past the handshake marker, whose
loss desyncs the next frame header and surfaces as exactly the observed
`WsClosed("connection closed mid-frame")` — **a variable removed, not a
diagnosis**; `teardown_probe`'s `no state` path no longer leaks the entire clone
and now reaps the data dir.

## Test evidence

```
$ make lint
fmt, clippy -D warnings, audit, deny: clean

$ make test-root FILTER="-E 'test(/holder_discovery_pattern|test_bench_fast_teardown_leaks_nothing_clone/)'"
clone tree: firecracker=2990188, holder=2990182, pasta=2990191
test_bench_fast_teardown_leaks_nothing_clone PASSED
Summary [1.811s] 2 tests run: 2 passed, 689 skipped

$ python3 -m unittest test_reqbench       # bench/chromium/test_reqbench.py
Ran 13 tests in 8.6s — OK
```

All 13 Python tests were watched fail against the unmodified pre-fix files (12
failed/errored; the 13th — the sampling-order test — was made deterministic and
red-verified separately against the untouched sequential sampler).

**Not red-verified, and why:** the `WsClosed` root cause (needs a live clone, fires
at 1.7–10%, no deterministic reproduction); `cmd_verify`'s non-zero exit and the
two-clone target-id comparison (shell paths needing a golden snapshot + serve —
mechanical and `bash -n` clean, but no full verify cycle was run); the pasta arm of
the clone test's discovery (pasta was found on every run, so that `.context()` has
not been observed firing).

Rebased onto `origin/main` to pick up `46dbb789` (pasta pdeathsig) and `3ee2e4f6`
(its root-only precondition).

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Chromium benchmarking workflows for CDP, execution, teardown, and control-path comparisons.
  - Added screenshot driving with navigation timing, validation, retries, and JSON output.
  - Added health checks for Chromium readiness and CDP connectivity.
  - Added analysis tools for benchmark results, execution stages, teardown, and confidence intervals.
  - Added automated build, verification, contention, and cleanup workflows.

- **Bug Fixes**
  - Improved WebSocket handling to preserve data received during connection setup.

- **Documentation**
  - Added benchmark methodology, networking, health-check, and performance guidance.

- **Tests**
  - Added integration and regression coverage for teardown, cleanup, accounting, and request failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
