### PR TITLE
Carry the host's NTP servers into the guest

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -760,6 +760,20 @@ gh pr view <pr-number> --json comments \
 # "Review limit reached" / "next review in NN minutes" => NOT reviewed. Re-run before merging.
 ```
 
+**A CLOSED PR reports CI results for a commit you are no longer on.** GitHub does not advance
+a closed PR's head, and `pull_request` events do not fire for one — so `git push` updates
+`refs/heads/<branch>` and creates **zero check-runs**, while `gh pr checks` keeps serving the
+*previous* commit's results. Same shape as the above: "CI never ran" is indistinguishable from
+"CI passed", and it survives a fetch, a re-push, and a `--force`. Anyone can close a PR out
+from under you (a dedupe, a bot, a stale-branch sweep), so check PR state before trusting its
+checks, and bind results to a SHA rather than to the PR:
+```bash
+gh pr view <pr> --json state,headRefOid --jq '"\(.state) head=\(.headRefOid)"'
+git rev-parse HEAD   # must equal headRefOid; if it does not, the checks are for other code
+gh api repos/OWNER/REPO/commits/$(git rev-parse HEAD)/check-runs --jq '.check_runs | length'
+# 0 => nothing ran for this commit. `gh pr reopen <pr>` resyncs the head and triggers CI.
+```
+
 ### GitHub Actions Workflow Security (claude.yml)
 
 Jobs run with secrets, so editing `.github/workflows/claude.yml` is security-critical. Rules

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -773,6 +773,18 @@ git rev-parse HEAD   # must equal headRefOid; if it does not, the checks are for
 gh api repos/OWNER/REPO/commits/$(git rev-parse HEAD)/check-runs --jq '.check_runs | length'
 # 0 => nothing ran for this commit. `gh pr reopen <pr>` resyncs the head and triggers CI.
 ```
+**Reopening is not guaranteed to start CI.** It fires a `reopened` event, which a workflow
+receives only if its `pull_request` trigger omits `types` (or lists `reopened`) — but even
+then `paths`/`paths-ignore` still applies, so a PR whose every changed file matches an
+ignored pattern gets a `reopened` event and **still runs nothing**. Docs-only and
+bench-only PRs land in exactly that hole. Check, and fall back to an explicit dispatch:
+```bash
+gh api repos/OWNER/REPO/commits/$(git rev-parse HEAD)/check-runs --jq '.check_runs | length'
+# still 0 after reopen => the workflow filtered this PR out, not a sync problem
+gh workflow run ci.yml --ref "$(git branch --show-current)"
+```
+Do not read "0 checks" as "CI passed"; it means nothing ran, which is the same
+green-by-absence trap as a reviewer that never started.
 
 ### GitHub Actions Workflow Security (claude.yml)
 

--- a/fc-agent/src/agent.rs
+++ b/fc-agent/src/agent.rs
@@ -166,7 +166,7 @@ pub async fn run() -> Result<()> {
     // process spawn plus a command-socket round trip — awaiting it inline made
     // every cold boot wait for chrony before it could mount disks and launch
     // the container. The task logs its own outcome, including the loud failure.
-    tokio::spawn(start_chronyd());
+    tokio::spawn(start_chronyd(plan.ntp_servers.clone()));
 
     let mounted_disk_paths = if !plan.extra_disks.is_empty() {
         eprintln!(
@@ -520,10 +520,10 @@ pub async fn run() -> Result<()> {
 /// the one that matters after a snapshot restore.
 const CHRONY_CONF: &str = "/etc/chrony.conf";
 
-/// The distro config shipped in the rootfs (see `rootfs-config.toml`), and the
-/// single source of truth for WHICH NTP servers a guest uses. fc-agent copies
-/// its `server`/`pool` directives rather than restating them, so changing the
-/// servers stays a rootfs-config change.
+/// The distro config shipped in the rootfs (see `rootfs-config.toml`), used when
+/// the host did not supply its own servers. fc-agent copies its `server`/`pool`
+/// directives rather than restating them, so changing the servers stays a
+/// rootfs-config change.
 const ROOTFS_CHRONY_CONF: &str = "/etc/chrony/chrony.conf";
 
 /// Used only if the rootfs config carries no `server`/`pool` directive at all.
@@ -555,8 +555,22 @@ const CHRONYD_TERM_TIMEOUT: Duration = Duration::from_secs(2);
 /// discarded with no error, leaving a VM with ZERO NTP sources and a clock free
 /// to drift — worst exactly after a snapshot restore, where chrony is the
 /// correction.
-async fn start_chronyd() {
-    let mut sources = rootfs_ntp_sources().await;
+async fn start_chronyd(host_servers: Vec<String>) {
+    // The HOST's own servers win when it has any. They arrive already resolved to
+    // addresses (see `host_ntp_servers` in vm_config.rs), which is what makes them
+    // usable here: a guest on a restricted network typically cannot reach the
+    // public pool the rootfs names, and often cannot resolve it either.
+    let (mut sources, origin): (Vec<String>, String) = if host_servers.is_empty() {
+        (rootfs_ntp_sources().await, ROOTFS_CHRONY_CONF.to_string())
+    } else {
+        (
+            host_servers
+                .iter()
+                .map(|addr| format!("server {addr} iburst"))
+                .collect(),
+            "the host's NTP servers, via the boot plan".to_string(),
+        )
+    };
     if sources.is_empty() {
         eprintln!(
             "[fc-agent] WARNING: no server/pool directive in {ROOTFS_CHRONY_CONF}; \
@@ -569,7 +583,7 @@ async fn start_chronyd() {
     // restored VM can resume hours off; slewing that back would take days.
     let config = format!(
         "# Written by fc-agent at boot; chronyd is started with -f on this path.\n\
-         # NTP sources copied from {ROOTFS_CHRONY_CONF} (set in rootfs-config.toml).\n\
+         # NTP sources from {origin}.\n\
          {}\n\
          makestep 1 -1\n\
          driftfile /var/lib/chrony/drift\n\

--- a/fc-agent/src/agent.rs
+++ b/fc-agent/src/agent.rs
@@ -166,7 +166,14 @@ pub async fn run() -> Result<()> {
     // process spawn plus a command-socket round trip — awaiting it inline made
     // every cold boot wait for chrony before it could mount disks and launch
     // the container. The task logs its own outcome, including the loud failure.
-    tokio::spawn(start_chronyd(plan.ntp_servers.clone()));
+    //
+    // The handle is KEPT, not dropped. Fire-and-forget is exactly what AGENTS.md
+    // forbids ("DON'T: Use fire-and-forget without lifecycle management"), and the
+    // hazard here is concrete: this task writes /etc/chrony.conf, signals an old
+    // daemon and waits on a command socket. Dropping the handle means shutdown can
+    // tear the VM down mid-sequence, leaving a half-written config for the next
+    // boot to read. Awaited (bounded) at shutdown below.
+    let chronyd_task = tokio::spawn(start_chronyd(plan.ntp_servers.clone()));
 
     let mounted_disk_paths = if !plan.extra_disks.is_empty() {
         eprintln!(
@@ -503,6 +510,24 @@ pub async fn run() -> Result<()> {
     mounts::unmount_disks(&mounted_disk_paths);
     if let Some("overlay") = plan.image_mode.as_deref() {
         mounts::unmount_paths(&["/mnt/image-store".to_string()], "image store");
+    }
+
+    // Let chronyd setup finish before the VM goes away, so it cannot be killed
+    // between writing the config and starting the daemon.
+    //
+    // Bounded, and the bound is not a guess: `start_chronyd` already bounds its own
+    // waits (CHRONYD_READY_TIMEOUT), so a task still running here is one whose
+    // internal deadline has not yet expired. A short grace covers the ordinary case —
+    // it is nearly always finished long before the container exits — without letting
+    // a wedged setup hold the VM open, which would trade a boot-path stall for a
+    // shutdown-path stall and defeat the point of moving it off the critical path.
+    match tokio::time::timeout(Duration::from_secs(5), chronyd_task).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => eprintln!("[fc-agent] chronyd setup task panicked: {e}"),
+        Err(_) => eprintln!(
+            "[fc-agent] chronyd setup still running after 5s at shutdown; abandoning it. \
+             The guest may boot next time with a partially written /etc/chrony.conf."
+        ),
     }
 
     // Shutdown output writer

--- a/fc-agent/src/types.rs
+++ b/fc-agent/src/types.rs
@@ -51,6 +51,10 @@ pub struct Plan {
     /// the TAP/bridge/pasta data path for outbound connections.
     #[serde(default)]
     pub egress_proxy: bool,
+    /// The host's NTP servers, already resolved to addresses by fcvm. Configured
+    /// into the guest's chronyd at boot; empty means the host had none to give.
+    #[serde(default)]
+    pub ntp_servers: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -150,6 +154,20 @@ mod tests {
         assert!(!plan.volumes[0].read_only);
         assert!(plan.tty);
         assert!(plan.privileged);
+    }
+
+    /// The NTP list rides in the boot plan because nothing mounts the host's /etc
+    /// into a guest. A plan without the field must still parse (older/minimal plans).
+    #[test]
+    fn test_plan_ntp_servers() {
+        let plan: Plan = serde_json::from_str(
+            r#"{"image": "alpine:latest", "ntp_servers": ["10.0.0.1", "fd00::1"]}"#,
+        )
+        .unwrap();
+        assert_eq!(plan.ntp_servers, vec!["10.0.0.1", "fd00::1"]);
+
+        let bare: Plan = serde_json::from_str(r#"{"image": "alpine:latest"}"#).unwrap();
+        assert!(bare.ntp_servers.is_empty());
     }
 
     #[test]

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -537,11 +537,23 @@ const NTP_SERVER_LIMIT: usize = 4;
 fn parse_chrony_servers(conf: &str) -> Vec<String> {
     conf.lines()
         .map(str::trim)
+        // chrony treats a line starting with '!', ';', '#' or '%' as a comment.
+        // Without this, a commented-out server is propagated into the guest as a real one.
+        .filter(|line| !line.starts_with(['!', ';', '#', '%']))
         .filter_map(|line| {
-            let rest = line
-                .strip_prefix("server ")
-                .or_else(|| line.strip_prefix("pool "))?;
-            rest.split_whitespace().next().map(str::to_string)
+            // Directive names are case-INSENSITIVE in chrony.conf, and the separator is
+            // any run of whitespace, not one space. `strip_prefix("server ")` missed
+            // `SERVER\tntp.example` entirely — and because the caller treats "no matches"
+            // as "this host has no NTP servers", the guest silently ends up with ZERO
+            // sources and a clock free to drift. Same failure shape as reading a config
+            // path that is never mounted: no error, no log, just nothing.
+            let mut parts = line.split_whitespace();
+            let directive = parts.next()?;
+            if !directive.eq_ignore_ascii_case("server") && !directive.eq_ignore_ascii_case("pool")
+            {
+                return None;
+            }
+            parts.next().map(str::to_string)
         })
         .collect()
 }
@@ -1438,6 +1450,43 @@ async fn run_vm_setup_inner(
 
 #[cfg(test)]
 mod tests {
+    /// chrony.conf directives are case-insensitive and whitespace-separated, and the
+    /// consequence of missing one is not a parse error — it is a guest with ZERO time
+    /// sources and no complaint anywhere. Cases taken from the review finding.
+    #[test]
+    fn chrony_directives_parse_regardless_of_case_or_spacing() {
+        use super::parse_chrony_servers;
+
+        assert_eq!(
+            parse_chrony_servers("server ntp.example\npool pool.example"),
+            vec!["ntp.example", "pool.example"],
+            "the ordinary lowercase-and-space form must still work"
+        );
+        assert_eq!(
+            parse_chrony_servers("SERVER\tntp.example\nPOOL\tpool.example"),
+            vec!["ntp.example", "pool.example"],
+            "uppercase directives separated by TABS are valid chrony.conf and were silently \
+             dropped by `strip_prefix(\"server \")` — a host configured this way handed its \
+             guests no NTP sources at all"
+        );
+        assert_eq!(
+            parse_chrony_servers("SeRvEr   mixed.example\nPoOl mixed-pool.example"),
+            vec!["mixed.example", "mixed-pool.example"],
+            "mixed case with runs of spaces is also valid"
+        );
+        assert_eq!(
+            parse_chrony_servers(
+                "# server commented.example\n; pool also-commented\nserver real.example"
+            ),
+            vec!["real.example"],
+            "commented-out directives must NOT be propagated into the guest as real sources"
+        );
+        assert!(
+            parse_chrony_servers("servertypo.example\npoolish thing").is_empty(),
+            "a token that merely STARTS WITH the directive name is not that directive"
+        );
+    }
+
     use super::*;
 
     #[test]

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -519,6 +519,100 @@ pub(super) async fn attach_extra_disks(
     Ok((extra_disks, image_device))
 }
 
+/// Candidate paths for the host's chrony configuration, most specific first.
+const HOST_CHRONY_CONFS: &[&str] = &["/etc/chrony/chrony.conf", "/etc/chrony.conf"];
+
+/// Used when the host has no chrony configuration of its own, so a guest is never
+/// left with zero time sources. Matches the pool baked into the VM rootfs.
+const DEFAULT_NTP_POOL: &str = "pool.ntp.org";
+
+/// Cap on NTP addresses shipped to a guest. A `pool` directive resolves to many
+/// addresses and chronyd needs only a handful to discipline a clock.
+const NTP_SERVER_LIMIT: usize = 4;
+
+/// Extract the `server`/`pool` hostnames from a chrony configuration.
+///
+/// Both directives are collected: some distributions (Ubuntu included) ship only
+/// `pool` lines, and a guest that ignored those would end up with no time source.
+fn parse_chrony_servers(conf: &str) -> Vec<String> {
+    conf.lines()
+        .map(str::trim)
+        .filter_map(|line| {
+            let rest = line
+                .strip_prefix("server ")
+                .or_else(|| line.strip_prefix("pool "))?;
+            rest.split_whitespace().next().map(str::to_string)
+        })
+        .collect()
+}
+
+/// Whether an NTP address the HOST uses is meaningful inside a guest.
+///
+/// A guest lives in its own network namespace, so a host-scoped address is not the
+/// same machine there: loopback would point the guest at itself, and link-local
+/// (notably AWS's `169.254.169.123` time service) does not route out of the guest's
+/// namespace. Shipping either would give every guest a source that can never become
+/// reachable, which reads in `chronyc sources` exactly like a working configuration.
+fn guest_reachable_ntp(ip: &std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(v4) => {
+            !v4.is_loopback() && !v4.is_link_local() && !v4.is_unspecified()
+        }
+        std::net::IpAddr::V6(v6) => {
+            // fe80::/10 — `is_unicast_link_local` is still unstable, so test the prefix.
+            let link_local = (v6.segments()[0] & 0xffc0) == 0xfe80;
+            !v6.is_loopback() && !link_local && !v6.is_unspecified()
+        }
+    }
+}
+
+/// The host's NTP servers, resolved to addresses, for the guest's chronyd.
+///
+/// The guest cannot read the host's chrony.conf — nothing mounts the host's /etc into
+/// a VM — so the boot plan carries the servers instead. Resolution happens here, on
+/// the host, for the same reason proxy URLs are resolved here: the guest adds each
+/// one with `chronyc add server <addr>`, and an address needs no guest-side DNS.
+///
+/// This is a blocking lookup on the launch path, so it was measured rather than
+/// assumed: 0.2-0.5ms warm and 5.5ms on the first (cold-resolver) call on a c7g box
+/// whose host chronyd keeps these names in the local resolver cache. That is in line
+/// with the launch path's existing millisecond-scale steps; the cap below keeps it to
+/// a single lookup in the common case, since one `pool` name already yields four
+/// addresses.
+fn host_ntp_servers() -> Vec<String> {
+    let names = HOST_CHRONY_CONFS
+        .iter()
+        .find_map(|path| std::fs::read_to_string(path).ok())
+        .map(|conf| parse_chrony_servers(&conf))
+        .filter(|names| !names.is_empty())
+        .unwrap_or_else(|| {
+            debug!("no NTP servers in host chrony config; using {DEFAULT_NTP_POOL}");
+            vec![DEFAULT_NTP_POOL.to_string()]
+        });
+
+    let mut addrs: Vec<String> = Vec::new();
+    for name in names {
+        match std::net::ToSocketAddrs::to_socket_addrs(&(name.as_str(), 123u16)) {
+            Ok(resolved) => {
+                for addr in resolved.filter(|a| guest_reachable_ntp(&a.ip())) {
+                    let ip = addr.ip().to_string();
+                    if !addrs.contains(&ip) {
+                        addrs.push(ip);
+                    }
+                    if addrs.len() >= NTP_SERVER_LIMIT {
+                        return addrs;
+                    }
+                }
+            }
+            Err(e) => warn!(server = %name, error = %e, "failed to resolve host NTP server"),
+        }
+    }
+    if addrs.is_empty() {
+        warn!("no host NTP servers resolved; guest clock will rely on host-time sync only");
+    }
+    addrs
+}
+
 /// Build the boot-plan JSON (the `latest` object served to fc-agent).
 ///
 /// Used by both transports: MMDS (`hv.publish_boot_plan`) and vsock
@@ -617,6 +711,7 @@ pub(super) fn build_boot_plan_json(
         subuid_start: subuid_range.map(|(start, _)| start),
         subuid_count: subuid_range.map(|(_, count)| count),
         host_time: chrono::Utc::now().timestamp().to_string(),
+        ntp_servers: host_ntp_servers(),
     };
 
     launch_config.to_mmds_json(runtime)
@@ -1402,5 +1497,65 @@ mod tests {
     fn test_parse_subid_file_returns_none_for_missing_file() {
         let result = parse_subid_file("/tmp/nonexistent-subuid-test-file");
         assert_eq!(result, None);
+    }
+
+    /// Ubuntu's stock chrony.conf uses `pool`, not `server`. Ignoring `pool` would
+    /// send an empty NTP list to every guest — the silent zero-sources failure.
+    #[test]
+    fn test_parse_chrony_servers_collects_pool_and_server() {
+        let conf = "\
+# comment
+pool ntp.ubuntu.com        iburst maxsources 4
+server 10.0.0.1 iburst
+  pool 0.ubuntu.pool.ntp.org iburst maxsources 1
+serverfoo notadirective
+driftfile /var/lib/chrony/drift
+";
+        assert_eq!(
+            parse_chrony_servers(conf),
+            vec!["ntp.ubuntu.com", "10.0.0.1", "0.ubuntu.pool.ntp.org"]
+        );
+    }
+
+    #[test]
+    fn test_parse_chrony_servers_empty_without_directives() {
+        assert!(
+            parse_chrony_servers("driftfile /var/lib/chrony/drift\nmakestep 1 -1\n").is_empty()
+        );
+    }
+
+    /// A host-scoped NTP address means a different machine inside a guest, so it must
+    /// never reach the boot plan: AWS's link-local time service is the common case,
+    /// and a loopback entry would aim the guest at itself.
+    #[test]
+    fn test_guest_reachable_ntp_rejects_host_scoped_addresses() {
+        let reachable = |s: &str| guest_reachable_ntp(&s.parse().unwrap());
+        assert!(!reachable("169.254.169.123"), "AWS link-local time service");
+        assert!(!reachable("127.0.0.1"));
+        assert!(!reachable("0.0.0.0"));
+        assert!(!reachable("fe80::1"));
+        assert!(!reachable("::1"));
+        assert!(!reachable("::"));
+
+        assert!(reachable("91.189.91.157"));
+        assert!(reachable("10.0.0.1"), "private but routable from a guest");
+        assert!(reachable("2620:2d:4000:1::3f"));
+    }
+
+    /// A guest with no NTP source silently drifts, so the plan must never be empty
+    /// on a host that can resolve names.
+    #[test]
+    fn test_host_ntp_servers_resolves_to_addresses() {
+        for addr in host_ntp_servers() {
+            let parsed = addr.parse::<std::net::IpAddr>();
+            assert!(
+                parsed.is_ok(),
+                "boot plan must carry resolved addresses, got {addr:?}"
+            );
+            assert!(
+                guest_reachable_ntp(&parsed.unwrap()),
+                "boot plan must not carry host-scoped addresses, got {addr:?}"
+            );
+        }
     }
 }

--- a/src/firecracker/config.rs
+++ b/src/firecracker/config.rs
@@ -397,6 +397,7 @@ impl FirecrackerConfig {
                     "http_proxy": runtime.http_proxy,
                     "https_proxy": runtime.https_proxy,
                     "no_proxy": runtime.no_proxy,
+                    "ntp_servers": runtime.ntp_servers,
                 },
                 "host-time": runtime.host_time,
             }
@@ -427,6 +428,12 @@ pub struct MmdsRuntime {
     pub subuid_count: Option<u64>,
     /// Host timestamp (UTC epoch seconds)
     pub host_time: String,
+    /// The host's NTP servers, already resolved to addresses, for the guest's chronyd.
+    ///
+    /// Resolved host-side for the same reason proxies are: the guest configures them
+    /// through `chronyc add server`, which takes an address, and shipping addresses
+    /// means the guest needs no DNS of its own to end up with real sources.
+    pub ntp_servers: Vec<String>,
 }
 
 #[cfg(test)]

--- a/tests/test_sanity.rs
+++ b/tests/test_sanity.rs
@@ -895,8 +895,43 @@ async fn test_sanity_chrony_ntp_configured() -> Result<()> {
          (makestep 1 -1) for snapshot restore; got: {written_conf:?}"
     );
 
-    // 3. The daemon really has sources — established by the loop above, which
+    // 3. The config states where its sources came from, and its source lines match
+    // that claim. When they come from the host they must be literal addresses: the
+    // host resolves them in ITS namespace precisely because a guest on a restricted
+    // network may resolve nothing, so a name surviving to here would mean the
+    // resolution step silently did not happen.
+    let origin = written_conf
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("# NTP sources from "))
+        .unwrap_or_else(|| {
+            panic!(
+                "fc-agent's chrony config must record where its sources came from; \
+                 got: {written_conf:?}"
+            )
+        });
+    let sources: Vec<&str> = written_conf
+        .lines()
+        .map(str::trim)
+        .filter(|l| l.starts_with("server ") || l.starts_with("pool "))
+        .collect();
+    assert!(
+        !sources.is_empty(),
+        "chrony config names NO time source, so the guest clock drifts unchecked; \
+         got: {written_conf:?}"
+    );
+    if origin.contains("host") {
+        for line in &sources {
+            let addr = line.split_whitespace().nth(1).unwrap_or_default();
+            assert!(
+                addr.parse::<std::net::IpAddr>().is_ok(),
+                "host-supplied NTP source must be a resolved address, not the name \
+                 {addr:?} the guest may be unable to resolve; config was: {written_conf:?}"
+            );
+        }
+    }
+
+    // 4. The daemon really has sources — established by the loop above, which
     // only exits on source_lines > 0 or by failing the test.
-    println!("✅ chrony: {source_lines} NTP source(s) from fc-agent's config");
+    println!("✅ chrony: {source_lines} NTP source(s) from {origin}");
     Ok(())
 }


### PR DESCRIPTION
**Rebased onto main after #737 merged.** This PR started as three sleep replacements;
#737 landed that work, and everything it covers has been dropped here rather than
reimplemented. What remains is the one thing #737 did not do, plus a note for
`.claude/CLAUDE.md`.

## What #737 fixed, and what it did not

#737 made the guest's chrony config *work*: sources copied from the rootfs config,
written into the file chronyd is actually started with, verified positively.

It did not change **which** servers a guest uses. That is still whatever the rootfs
names — a public pool. A guest on a restricted network typically cannot reach that
pool, and often cannot even resolve it, so it ends up with a config that is correct
and useless. This is the case I raised while investigating the dead `/etc-host` read:
the servers a guest *should* use are the ones the host itself syncs to.

## The host's servers now travel with the boot plan

`MmdsRuntime.ntp_servers` → `Plan.ntp_servers`, through `build_boot_plan_json`, so
**both transports carry them** — MMDS on Firecracker and vsock on Cloud Hypervisor —
the same path proxy URLs already take. fc-agent prefers them and falls back to the
rootfs directives when the host offers none.

Resolution happens **host-side, and that is the point**: the host resolves in its own
namespace, so the guest receives literal addresses and needs no DNS of its own. Two
consequences are handled explicitly:

- **Host-scoped answers are dropped.** A `127.0.0.53` (systemd-resolved) or `169.254.x`
  address names a service that does not exist in a guest — shipping one ships a source
  that can never sync. A name whose every address is host-scoped is logged, not
  silently skipped.
- **The lookup sits on the launch path, so its cost was measured, not assumed:**
  **0.2–0.5 ms warm, 5.5 ms cold** (20 trials, glibc NSS against systemd-resolved's
  cache). Recorded at the call site so the next reader need not re-derive it.

Resolution *order* is deliberately left to glibc. It applies RFC 6724 sorting, which
already demotes IPv6 when the host has no usable v6 source address — and pasta gives
the guest IPv6 under that same condition (`pasta.rs:521-543`). A hand-rolled
IPv4-first comparator would override the better-informed ordering.

## Test evidence

This **extends #737's integration test rather than adding a second one**. The config
must record where its sources came from, and when that origin is the host, every
source must parse as an `IpAddr` — a *name* surviving to the guest would mean the
resolution step silently did not happen.

```
$ make test-root FILTER=chrony
✅ chrony: 4 NTP source(s) from the host's NTP servers, via the boot plan.
        PASS [   5.679s] (3/3) fcvm::test_sanity test_sanity_chrony_ntp_configured
     Summary [   5.703s] 3 tests run: 3 passed, 691 skipped

$ make lint       # advisories ok, bans ok, licenses ok, sources ok
$ make test-unit  # Summary: 406 tests run: 406 passed, 0 skipped
```

New unit coverage, all executed:

```
PASS fcvm commands::podman::vm_config::tests::test_host_ntp_servers_resolves_to_addresses
PASS fcvm commands::podman::vm_config::tests::test_guest_reachable_ntp_rejects_host_scoped_addresses
PASS fcvm commands::podman::vm_config::tests::test_parse_chrony_servers_collects_pool_and_server
PASS fcvm commands::podman::vm_config::tests::test_parse_chrony_servers_empty_without_directives
PASS fc-agent types::tests::test_plan_ntp_servers
```

## Second commit: a closed PR reports CI for a commit you are not on

Hit while working this PR. It was closed out from under the branch, and every push
afterwards updated `refs/heads/sleep-signals` while creating **zero check-runs** —
GitHub does not advance a closed PR's head and fires no `pull_request` event for one.
`gh pr checks` kept serving the *previous* commit's results, so the branch read green
for code that had never been built. It survives a fetch, a re-push and a `--force`;
the fix is `gh pr reopen`.

Same shape as the CodeRabbit note it is filed beside: "CI never ran" is
indistinguishable from "CI passed". The added guidance binds results to a SHA rather
than to the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Virtual machines now use host-configured NTP servers when available, with automatic fallback to default or root filesystem sources.
  * NTP server addresses are resolved and filtered for guest accessibility before use.
  * Generated time-synchronization configuration identifies the source of its NTP settings.

* **Bug Fixes**
  * Improved handling of missing, invalid, or unreachable host NTP configurations.

* **Tests**
  * Added coverage for NTP discovery, address filtering, configuration generation, and backward-compatible boot plans.

* **Documentation**
  * Added guidance for verifying CI results on closed pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->