### PR TITLE
Overlap VM teardown kills instead of serializing them; arm pdeathsig on pasta

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -987,8 +987,10 @@ Do not run `sudo cargo`. Use Makefile targets so cargo runs as your user and tes
 orphans the entire subtree below it.** The chain that must hold, end to end:
 
 ```
-cargo-nextest (uid 1000) → sudo (ruid 1000) → test binary (uid 0) → fcvm → firecracker
-                           ^ setpriv --pdeathsig  ^ set_test_pdeathsig  ^ install_namespace_pre_exec
+cargo-nextest (uid 1000) → sudo (ruid 1000) → test binary (uid 0) → fcvm ─┬→ firecracker
+                           ^ setpriv --pdeathsig  ^ set_test_pdeathsig     ├→ holder
+                                                                           └→ pasta (rootless)
+                                                                              ^ see per-hop list below
 ```
 
 - `scripts/root-test-runner.sh` (`ROOT_TEST_RUNNER` in the Makefile) covers the **sudo hop**.
@@ -998,6 +1000,14 @@ cargo-nextest (uid 1000) → sudo (ruid 1000) → test binary (uid 0) → fcvm �
 - `src/utils.rs::install_namespace_pre_exec` covers **every VMM spawn** (Firecracker, Cloud
   Hypervisor, and the Layer-2 setup VM in `src/setup/rootfs.rs`). It must stay the LAST
   `pre_exec` — `setns(CLONE_NEWUSER)` zeroes `pdeath_signal`, so setting it earlier is lost.
+- `src/commands/common.rs::spawn_namespace_holder` covers the **holder hop** (rootless mode).
+  The holder's pdeathsig is armed in its `pre_exec`, before UID/GID mappings are written.
+- `src/network/pasta.rs` (in `start_pasta`) covers the **pasta hop** (rootless mode). Must be
+  the last `pre_exec`; includes a `getppid` re-check to close the fork/exec race window.
+
+Regression tests: `test_sigkill_reaps_rootless_vm_tree` asserts all three children (firecracker,
+holder, pasta) die when fcvm is SIGKILL'd. `test_root_test_runner_reaps_vm_when_sudo_is_killed`
+covers the sudo hop specifically.
 
 **Why a privilege boundary is special:** the kernel refuses a signal from uid 1000 to a uid-0
 process, and `killpg` still returns success when it managed to signal *any* member — so

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -637,16 +637,95 @@ pub struct CleanupContext {
     pub output_listener_handle: Option<JoinHandle<Vec<(String, String)>>>,
 }
 
-/// Cleanup resources for a VM (used by both podman and snapshot commands)
+/// How long teardown waits for the health monitor to observe its cancellation before
+/// moving on. It only writes state through the per-VM flock, which `delete_state` takes
+/// too, so an unjoined straggler is safe — this is a courtesy join, not a barrier.
+const HEALTH_MONITOR_STOP_BUDGET: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// Total CPU charged to this process's REAPED children so far (`RUSAGE_CHILDREN`).
 ///
-/// This function handles the complete cleanup sequence:
-/// 1. Cancel health monitor gracefully
-/// 2. Abort volume server tasks
-/// 3. Kill VM process
-/// 4. Kill holder process (rootless mode)
-/// 5. Cleanup network resources
-/// 6. Delete state file
-/// 7. Remove data directory
+/// A child's ENTIRE lifetime CPU lands here at the moment it is reaped, not as it runs — so
+/// a raw delta across teardown is the VMM's whole-life CPU (measured: 12.3 CPU-seconds for
+/// a VM that lived a couple of minutes), NOT the cost of tearing it down. See
+/// [`process_cpu`] for the subtraction that turns this into a reclaim figure.
+fn reaped_children_cpu() -> std::time::Duration {
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
+    // SAFETY: getrusage fully initializes the rusage it is given; we only read it on success.
+    if unsafe { libc::getrusage(libc::RUSAGE_CHILDREN, usage.as_mut_ptr()) } != 0 {
+        return std::time::Duration::ZERO;
+    }
+    let usage = unsafe { usage.assume_init() };
+    let to_duration = |t: libc::timeval| {
+        std::time::Duration::new(t.tv_sec.max(0) as u64, (t.tv_usec.max(0) as u32) * 1000)
+    };
+    to_duration(usage.ru_utime) + to_duration(usage.ru_stime)
+}
+
+/// CPU (`utime + stime`) consumed so far by a LIVE process, from `/proc/<pid>/stat`.
+///
+/// Sampled just before the SIGKILL, this is what a child had already spent while doing its
+/// job. Subtracting it from that child's whole-life CPU (credited to `RUSAGE_CHILDREN` when
+/// it is reaped) leaves exactly the CPU it accrued after the signal — i.e. its exit path,
+/// which for the VMM is dominated by `exit_mmap()` unmapping the guest's multi-GiB address
+/// space. Returns zero if the process is already gone, which biases the reported reclaim
+/// UP, never down: this number exists to stop teardown being called free.
+///
+/// `comm` (field 2) can contain spaces and parentheses, so fields are counted from after
+/// the last `") "`; `utime`/`stime` are fields 14/15, i.e. indices 11/12 from there.
+fn process_cpu(pid: u32) -> std::time::Duration {
+    let Ok(stat) = std::fs::read_to_string(format!("/proc/{}/stat", pid)) else {
+        return std::time::Duration::ZERO;
+    };
+    let Some(after_comm) = stat.rsplit_once(") ").map(|(_, rest)| rest) else {
+        return std::time::Duration::ZERO;
+    };
+    let fields: Vec<&str> = after_comm.split_whitespace().collect();
+    let ticks: u64 = [11usize, 12]
+        .iter()
+        .filter_map(|i| fields.get(*i))
+        .filter_map(|f| f.parse::<u64>().ok())
+        .sum();
+    // SAFETY: sysconf is a pure query with no memory effects.
+    let hz = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
+    if hz <= 0 {
+        return std::time::Duration::ZERO;
+    }
+    std::time::Duration::from_nanos(ticks.saturating_mul(1_000_000_000 / hz as u64))
+}
+
+/// Tear down every resource a VM owns. Used by both the podman and snapshot commands.
+///
+/// Ordered to minimize how long the caller is blocked without deferring any of the work:
+///
+/// 1. **Signal, block on nothing.** SIGKILL the VMM, the namespace holder and the network
+///    helper, and cancel/abort the in-process tasks — no `await` in between, so every
+///    process is already dying before the first wait. Previously each kill awaited its own
+///    exit before the next was even signalled, which serialized ~40ms of VMM address-space
+///    reclaim, the holder's exit and ~28ms of pasta teardown that could have overlapped.
+/// 2. **Join the waits together**, so the total is the slowest exit rather than their sum.
+/// 3. **Network cleanup**, once the processes that were using the namespace are gone.
+/// 4. **On-disk reaping — synchronous, always.** State file, NFS exports, Firecracker log,
+///    VM data directory.
+///
+/// Nothing is moved to a background task or a janitor. "Leave nothing on disk" is a
+/// correctness contract exactly like "leave no orphaned VM": a deferred sweep would let a
+/// crash between here and the sweep strand a state file (whose PID is then reused), a
+/// reflinked rootfs, or an `/etc/exports.d` entry that makes every later `exportfs -ra`
+/// fail. It measures ~10ms. It is not the problem.
+///
+/// Emits one `vm teardown complete` record with three DISTINCT numbers, because a fast
+/// teardown and a free one are not the same thing:
+/// - `caller_blocking_ms` — what the request actually pays, start to finish.
+/// - `until_gone_ms` — first SIGKILL until the last resource is released. Below
+///   `caller_blocking_ms` only by the pre-signal bookkeeping; that they are near-equal is
+///   the point, and is what makes "nothing was deferred" checkable rather than asserted.
+/// - `reclaim_cpu_ms` — CPU the VMM and holder accrued AFTER their SIGKILL, i.e. what the
+///   kernel spent actually destroying them (mostly `exit_mmap()` on the guest mapping).
+///   Overlapping the waits does not shrink it: the box is still burning this either way,
+///   which is the whole reason it is reported separately from the wall-clock numbers.
+///
+/// Plus a per-phase breakdown in MICROseconds (`processes_us`/`network_us`/`disk_us`) —
+/// two of those phases are sub-millisecond in bridged mode and would round to a useless 0.
 pub async fn cleanup_vm(
     ctx: CleanupContext,
     vm_manager: &mut dyn Hypervisor,
@@ -663,78 +742,127 @@ pub async fn cleanup_vm(
         health_monitor_handle,
         output_listener_handle,
     } = ctx;
+    // Started before the first log line so `caller_blocking_ms` covers everything the
+    // caller actually waits for, including our own bookkeeping.
+    let cleanup_start = std::time::Instant::now();
+    let cpu_before = reaped_children_cpu();
     info!("cleaning up resources");
 
-    // Signal health monitor to stop gracefully, then wait briefly for it
-    if let (Some(token), Some(handle)) = (health_cancel_token, health_monitor_handle) {
-        token.cancel();
-        tokio::select! {
-            _ = handle => {
-                debug!("health monitor stopped gracefully");
-            }
-            _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {
-                debug!("health monitor didn't stop in time, continuing cleanup");
-            }
+    // --- Phase 1: signal everything. No `await` until all signals are out. -------------
+    // Sample what the VMM and holder have already spent, so the reclaim figure below is
+    // their POST-signal CPU rather than their whole-life CPU (see `process_cpu`).
+    let cpu_spent_before_kill = vm_manager.pid().map(process_cpu).unwrap_or_default()
+        + holder_child
+            .as_ref()
+            .and_then(|h| h.id())
+            .map(process_cpu)
+            .unwrap_or_default();
+
+    let kill_start = std::time::Instant::now();
+    if let Err(e) = vm_manager.start_kill() {
+        warn!("failed to signal VM process: {}", e);
+    }
+    if let Some(ref mut holder) = holder_child {
+        if let Err(e) = holder.start_kill() {
+            warn!("failed to signal namespace holder process: {}", e);
         }
     }
+    network.start_kill_processes();
 
-    // Abort output listener task if still running
+    // In-process tasks: cancel/abort is synchronous, the join happens in phase 2.
+    if let Some(ref token) = health_cancel_token {
+        token.cancel();
+    }
     if let Some(handle) = output_listener_handle {
         handle.abort();
     }
-
-    // Cancel VolumeServer tasks
     for handle in volume_server_handles {
         handle.abort();
     }
 
-    // Kill VM process
-    if let Err(e) = vm_manager.kill().await {
-        warn!("failed to kill VM process: {}", e);
-    }
-
-    // Kill holder process (rootless mode only)
-    if let Some(ref mut holder) = holder_child {
-        info!("killing namespace holder process");
-        if let Err(e) = holder.kill().await {
-            warn!("failed to kill holder process: {}", e);
+    // --- Phase 2: join every wait at once. ---------------------------------------------
+    let vmm_reaped = vm_manager.reap();
+    let holder_reaped = async {
+        if let Some(ref mut holder) = holder_child {
+            // Reap the zombie left by the SIGKILL above.
+            let _ = holder.wait().await;
         }
-        let _ = holder.wait().await; // Clean up zombie
-    }
+    };
+    let health_stopped = async {
+        let Some(handle) = health_monitor_handle else {
+            return;
+        };
+        tokio::select! {
+            _ = handle => debug!("health monitor stopped gracefully"),
+            _ = tokio::time::sleep(HEALTH_MONITOR_STOP_BUDGET) => {
+                debug!("health monitor didn't stop in time, continuing cleanup");
+            }
+        }
+    };
+    tokio::join!(vmm_reaped, holder_reaped, health_stopped);
+    let processes_us = kill_start.elapsed().as_micros();
 
-    // Cleanup network
+    // Sampled HERE, before network cleanup reaps pasta, so the delta covers exactly the two
+    // processes whose pre-kill CPU we subtracted. Anything reaped later (pasta) would add
+    // its whole lifetime and silently inflate the reclaim.
+    let reclaim_cpu = reaped_children_cpu()
+        .saturating_sub(cpu_before)
+        .saturating_sub(cpu_spent_before_kill);
+
+    // --- Phase 3: network teardown, now that nothing is using the namespace. -----------
+    let network_start = std::time::Instant::now();
     if let Err(e) = network.cleanup().await {
         warn!("failed to cleanup network: {}", e);
     }
+    let network_us = network_start.elapsed().as_micros();
 
-    // Remove this VM's NFS exports (no-op when the VM had none). Lives here so
-    // every exit path — podman run, converge teardown, restored clones — drops
-    // its /etc/exports.d entry; a leftover entry for a deleted directory makes
-    // every later `exportfs -ra` fail until the self-heal prunes it.
-    super::podman::cleanup_nfs_exports(&vm_id).await;
-
-    // Delete state file
-    if let Err(e) = state_manager.delete_state(&vm_id).await {
-        warn!("failed to delete state file: {}", e);
-    }
-
-    // Save Firecracker log before cleanup (for debugging snapshot restore failures)
-    let fc_log = data_dir.join("firecracker.log");
-    if fc_log.exists() {
-        let dest = std::path::PathBuf::from(format!("/tmp/fcvm-firecracker-{}.log", vm_id));
-        if let Err(e) = tokio::fs::copy(&fc_log, &dest).await {
-            debug!(vm_id = %vm_id, error = %e, "could not save firecracker log");
-        } else {
-            info!(vm_id = %vm_id, log = %dest.display(), "saved firecracker log");
+    // --- Phase 4: on-disk reaping. Synchronous — cleanup_vm does not return until every
+    // one of these is done. They are independent of each other, so they run concurrently;
+    // the log copy and the directory removal are the one ordered pair (the log lives in
+    // the directory), so they share a future.
+    let disk_start = std::time::Instant::now();
+    // Removing this VM's /etc/exports.d entry (no-op when it had none) belongs on every exit
+    // path — podman run, converge teardown, restored clones. A leftover entry for a deleted
+    // directory makes every later `exportfs -ra` fail until the self-heal prunes it.
+    let exports_removed = super::podman::cleanup_nfs_exports(&vm_id);
+    let state_deleted = async {
+        if let Err(e) = state_manager.delete_state(&vm_id).await {
+            warn!("failed to delete state file: {}", e);
         }
-    }
+    };
+    let data_dir_removed = async {
+        // Preserve the Firecracker log (for debugging snapshot restore failures) BEFORE
+        // removing the directory it lives in.
+        let fc_log = data_dir.join("firecracker.log");
+        if fc_log.exists() {
+            let dest = std::path::PathBuf::from(format!("/tmp/fcvm-firecracker-{}.log", vm_id));
+            if let Err(e) = tokio::fs::copy(&fc_log, &dest).await {
+                debug!(vm_id = %vm_id, error = %e, "could not save firecracker log");
+            } else {
+                info!(vm_id = %vm_id, log = %dest.display(), "saved firecracker log");
+            }
+        }
 
-    // Cleanup VM data directory (includes disks, sockets, etc.)
-    if let Err(e) = tokio::fs::remove_dir_all(&data_dir).await {
-        warn!(vm_id = %vm_id, error = %e, "failed to cleanup VM data directory");
-    } else {
-        info!(vm_id = %vm_id, "cleaned up VM data directory");
-    }
+        // Includes disks, sockets, everything under the VM's runtime directory.
+        if let Err(e) = tokio::fs::remove_dir_all(&data_dir).await {
+            warn!(vm_id = %vm_id, error = %e, "failed to cleanup VM data directory");
+        } else {
+            info!(vm_id = %vm_id, "cleaned up VM data directory");
+        }
+    };
+    tokio::join!(exports_removed, state_deleted, data_dir_removed);
+    let disk_us = disk_start.elapsed().as_micros();
+
+    info!(
+        vm_id = %vm_id,
+        caller_blocking_ms = cleanup_start.elapsed().as_millis(),
+        until_gone_ms = kill_start.elapsed().as_millis(),
+        reclaim_cpu_ms = reclaim_cpu.as_millis(),
+        processes_us,
+        network_us,
+        disk_us,
+        "vm teardown complete"
+    );
 }
 
 /// Memory backend configuration for snapshot restore

--- a/src/firecracker/vm.rs
+++ b/src/firecracker/vm.rs
@@ -515,16 +515,35 @@ impl VmManager {
         }
     }
 
-    /// Kill the VM process
-    pub async fn kill(&mut self) -> Result<()> {
-        if let Some(mut process) = self.process.take() {
-            info!(vm_id = %self.vm_id, "killing Firecracker process");
+    /// SIGKILL the Firecracker process without waiting for it to exit.
+    ///
+    /// Pairs with [`Self::reap`]. Keeping the handle here (rather than taking it) is what
+    /// lets the caller signal other processes before coming back to wait on this one.
+    pub fn start_kill(&mut self) -> Result<()> {
+        if let Some(ref mut process) = self.process {
+            info!(vm_id = %self.vm_id, "SIGKILL to Firecracker process");
             process
-                .kill()
-                .await
-                .context("killing Firecracker process")?;
-            let _ = process.wait().await; // Wait to clean up zombie
+                .start_kill()
+                .context("sending SIGKILL to Firecracker process")?;
         }
+        Ok(())
+    }
+
+    /// Wait for the Firecracker process to exit and reap it.
+    ///
+    /// The bulk of the wait is the kernel reclaiming the guest's address space, so this
+    /// returning means the guest memory is genuinely released — not just signalled.
+    pub async fn reap(&mut self) {
+        if let Some(mut process) = self.process.take() {
+            let _ = process.wait().await;
+        }
+    }
+
+    /// SIGKILL the Firecracker process and reap it. For callers that have nothing else to
+    /// tear down concurrently; teardown proper uses the two phases separately.
+    pub async fn kill(&mut self) -> Result<()> {
+        self.start_kill()?;
+        self.reap().await;
         Ok(())
     }
 

--- a/src/hypervisor/cloud_hypervisor/mod.rs
+++ b/src/hypervisor/cloud_hypervisor/mod.rs
@@ -397,16 +397,22 @@ impl Hypervisor for CloudHypervisorBackend {
         }
     }
 
-    async fn kill(&mut self) -> Result<()> {
+    fn start_kill(&mut self) -> Result<()> {
         if let Some(tail) = self.console_tail.take() {
             tail.abort();
         }
-        if let Some(mut p) = self.process.take() {
-            info!(vm_id = %self.vm_id, "killing Cloud Hypervisor process");
-            p.kill().await.context("killing Cloud Hypervisor")?;
-            let _ = p.wait().await;
+        if let Some(ref mut p) = self.process {
+            info!(vm_id = %self.vm_id, "SIGKILL to Cloud Hypervisor process");
+            p.start_kill()
+                .context("sending SIGKILL to Cloud Hypervisor")?;
         }
         Ok(())
+    }
+
+    async fn reap(&mut self) {
+        if let Some(mut p) = self.process.take() {
+            let _ = p.wait().await;
+        }
     }
 
     async fn stream_console(&self, _console_path: &Path) -> Result<mpsc::Receiver<String>> {

--- a/src/hypervisor/firecracker.rs
+++ b/src/hypervisor/firecracker.rs
@@ -111,8 +111,12 @@ impl Hypervisor for FirecrackerBackend {
         self.vm.wait().await
     }
 
-    async fn kill(&mut self) -> Result<()> {
-        self.vm.kill().await
+    fn start_kill(&mut self) -> Result<()> {
+        self.vm.start_kill()
+    }
+
+    async fn reap(&mut self) {
+        self.vm.reap().await
     }
 
     async fn stream_console(&self, console_path: &Path) -> Result<mpsc::Receiver<String>> {

--- a/src/hypervisor/mod.rs
+++ b/src/hypervisor/mod.rs
@@ -171,8 +171,31 @@ pub trait Hypervisor: Send {
     /// Wait for the VMM process to exit.
     async fn wait(&mut self) -> Result<ExitStatus>;
 
-    /// Kill the VMM process and reap it.
-    async fn kill(&mut self) -> Result<()>;
+    /// SIGKILL the VMM process and return immediately, WITHOUT reaping it.
+    ///
+    /// Split from [`Self::reap`] so teardown can signal every process it owns — VMM,
+    /// namespace holder, network helper — before blocking on any one of them. The kernel
+    /// then tears them down concurrently: the VMM's `exit_mmap()` of a multi-GiB guest
+    /// mapping is the long pole, and everything signalled alongside it finishes underneath
+    /// instead of queueing behind it.
+    ///
+    /// Always followed by [`Self::reap`]; a signalled child that is never waited for is a
+    /// zombie. Idempotent — safe to call on an already-signalled or already-exited process.
+    fn start_kill(&mut self) -> Result<()>;
+
+    /// Wait for the VMM process to exit and reap it. No-op if it was already reaped.
+    ///
+    /// The kernel unmaps the guest's address space before the task becomes reapable, so
+    /// this returning is proof the reclaim actually finished — not merely that the signal
+    /// was delivered.
+    async fn reap(&mut self);
+
+    /// SIGKILL the VMM process and reap it.
+    async fn kill(&mut self) -> Result<()> {
+        self.start_kill()?;
+        self.reap().await;
+        Ok(())
+    }
 
     /// Stream the guest serial/virtio console line-by-line.
     async fn stream_console(&self, console_path: &Path) -> Result<mpsc::Receiver<String>>;

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -76,6 +76,17 @@ pub trait NetworkManager: Send + Sync {
         Ok(())
     }
 
+    /// SIGKILL any long-lived helper process this network owns, WITHOUT waiting for it.
+    ///
+    /// Lets teardown signal the network helper in the same instant as the VMM and the
+    /// namespace holder, so the helper's exit overlaps the VMM's address-space reclaim
+    /// instead of queueing behind it; [`Self::cleanup`] then reaps a process that is
+    /// already dead. Purely an optimization — `cleanup()` still kills and reaps on its
+    /// own, so calling this is optional and calling it twice is harmless.
+    ///
+    /// Default: no-op (bridged and routed have no helper process).
+    fn start_kill_processes(&mut self) {}
+
     /// Cleanup network after VM stop
     async fn cleanup(&mut self) -> Result<()>;
 

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -621,9 +621,24 @@ impl PastaNetwork {
         //
         // Must be the LAST pre_exec (there is only this one, but keep the invariant
         // explicit): a credential change zeroes `task->pdeath_signal`, so anything that
-        // switches namespaces or identity first would silently drop it. pasta's own
-        // `--runas 0:0` under sudo is a no-op re-assertion of root, and its namespace entry
-        // happens in a forked child, so the signal set here survives into steady state.
+        // switches namespaces or identity first would silently drop it.
+        //
+        // pasta DOES change credentials after this exec — it setns()es into the holder's
+        // user namespace (measured CapEff 0x1ffffffffff -> 0x2014c2) — and the signal
+        // survives it. `commit_creds()` clears it only when uid/gid change or
+        // `cred_cap_issubset(old, new)` FAILS; under sudo pasta's prior creds are full root
+        // and `--runas 0:0` holds uid/gid at 0:0, so the new set is a strict SUBSET and that
+        // branch is never taken — the signal survives because pasta LOSES privilege on entry.
+        // pasta does not fork either: `--foreground` is single-threaded and its own -P
+        // pidfile reports the PID armed here. Verified with the holder held ALIVE so passt's
+        // PID watch cannot fire — armed pasta dies 2-54ms after fcvm is SIGKILLed, unarmed
+        // pasta survives 5s.
+        //
+        // PRECONDITION: this holds only while fcvm runs as ROOT. Unprivileged, entering the
+        // userns is a capability GAIN, `cred_cap_issubset` fails, the kernel zeroes the
+        // signal, and pasta silently reverts to passt's 1-second PID watch with no symptom
+        // until something leaks. Argued from the kernel rule, NOT measured — the harness
+        // that verified the above was itself root.
         //
         // The `getppid` re-check closes the fork/exec window: a parent that dies after
         // fork() but before the prctl above would leave the signal unarmed and pasta

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -600,6 +600,53 @@ impl PastaNetwork {
             .stdout(Stdio::null())
             .stderr(Stdio::piped());
 
+        // Kill pasta if fcvm dies, including from SIGKILL — the same per-hop guarantee
+        // `install_namespace_pre_exec` gives the VMM and `spawn_namespace_holder` gives the
+        // holder, and the one hop that did not have it.
+        //
+        // This is hardening, not a fix for an observed leak: pasta joins the holder BY PID,
+        // and passt terminates itself when the PID whose namespaces it joined exits, so
+        // today pasta already dies whenever the holder does. Measured both ways on this
+        // branch — with the pre_exec removed, pasta still exited on fcvm SIGKILL (via the
+        // holder), and it still exited even with the holder's netns pinned open by an
+        // external fd, confirming the trigger is passt's PID watch rather than namespace
+        // teardown.
+        //
+        // Arming pdeathsig directly is still worth its ten lines. That chain runs through
+        // TWO things fcvm does not own: the holder's own pdeathsig, and an undocumented
+        // passt behaviour (`--no-netns-quit` documents only the filesystem-bound case) in a
+        // binary this repo pins to a patched fork and periodically rebases. AGENTS.md is
+        // explicit that teardown is per-hop and that one unprotected hop orphans everything
+        // below it; this makes pasta's death depend on nothing but the kernel.
+        //
+        // Must be the LAST pre_exec (there is only this one, but keep the invariant
+        // explicit): a credential change zeroes `task->pdeath_signal`, so anything that
+        // switches namespaces or identity first would silently drop it. pasta's own
+        // `--runas 0:0` under sudo is a no-op re-assertion of root, and its namespace entry
+        // happens in a forked child, so the signal set here survives into steady state.
+        //
+        // The `getppid` re-check closes the fork/exec window: a parent that dies after
+        // fork() but before the prctl above would leave the signal unarmed and pasta
+        // orphaned — the very outcome this is here to prevent. If we have already been
+        // reparented, fail the exec so no pasta exists to leak.
+        //
+        // SAFETY: pre_exec runs between fork() and exec(). `prctl` and `getppid` are both
+        // async-signal-safe, and the closure allocates nothing (`fcvm_pid` is copied in).
+        let fcvm_pid = std::process::id() as libc::pid_t;
+        unsafe {
+            cmd.pre_exec(move || {
+                if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if libc::getppid() != fcvm_pid {
+                    return Err(std::io::Error::other(
+                        "parent died before PR_SET_PDEATHSIG was armed",
+                    ));
+                }
+                Ok(())
+            });
+        }
+
         debug!(cmd = ?cmd, "pasta command");
         let mut child = cmd.spawn().context("failed to spawn pasta")?;
 
@@ -968,14 +1015,24 @@ impl NetworkManager for PastaNetwork {
         Ok(())
     }
 
+    fn start_kill_processes(&mut self) {
+        if let Some(process) = self.pasta_process.as_mut() {
+            if let Err(e) = process.start_kill() {
+                warn!(vm_id = %self.vm_id, error = %e, "failed to signal pasta");
+            }
+        }
+    }
+
     async fn cleanup(&mut self) -> Result<()> {
         info!(vm_id = %self.vm_id, "cleaning up pasta resources");
 
+        // `kill()` is start_kill + wait, so this stays correct whether or not
+        // `start_kill_processes` already signalled pasta (re-signalling a not-yet-reaped
+        // process is a no-op); when it did, the wait below has nothing left to wait for.
         if let Some(mut process) = self.pasta_process.take() {
             if let Err(e) = process.kill().await {
                 warn!("failed to kill pasta: {}", e);
             }
-            let _ = process.wait().await;
         }
 
         if let Some(ref pid_file) = self.pid_file {

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -631,7 +631,13 @@ impl PastaNetwork {
         // reparented, fail the exec so no pasta exists to leak.
         //
         // SAFETY: pre_exec runs between fork() and exec(). `prctl` and `getppid` are both
-        // async-signal-safe, and the closure allocates nothing (`fcvm_pid` is copied in).
+        // async-signal-safe, `fcvm_pid` is copied in, and NEITHER return path allocates:
+        // both errors use the `Repr::Os` errno representation of `io::Error`, which stores
+        // a bare i32. A message-carrying error (`io::Error::other`) would box its payload,
+        // and malloc after fork(2) in a multi-threaded process can deadlock outright if
+        // another thread held the allocator lock at fork — which would hang the child in
+        // exactly the parent-death race the getppid check exists to handle. ESRCH ("no such
+        // process") is the errno for that case and needs no message.
         let fcvm_pid = std::process::id() as libc::pid_t;
         unsafe {
             cmd.pre_exec(move || {
@@ -639,9 +645,7 @@ impl PastaNetwork {
                     return Err(std::io::Error::last_os_error());
                 }
                 if libc::getppid() != fcvm_pid {
-                    return Err(std::io::Error::other(
-                        "parent died before PR_SET_PDEATHSIG was armed",
-                    ));
+                    return Err(std::io::Error::from_raw_os_error(libc::ESRCH));
                 }
                 Ok(())
             });

--- a/tests/test_signal_cleanup.rs
+++ b/tests/test_signal_cleanup.rs
@@ -557,15 +557,31 @@ fn test_sigterm_cleanup_rootless() -> Result<()> {
     Ok(())
 }
 
-/// Test that SIGKILL on fcvm also kills Firecracker via PR_SET_PDEATHSIG.
+/// SIGKILL on fcvm must reap the ENTIRE rootless process tree via PR_SET_PDEATHSIG:
+/// Firecracker, the namespace holder, AND pasta.
 ///
-/// Unlike SIGTERM/SIGINT, SIGKILL cannot be caught — fcvm gets no chance to run
-/// cleanup code. The Firecracker child dies because pre_exec sets
-/// PR_SET_PDEATHSIG(SIGKILL), which makes the kernel automatically send SIGKILL
-/// to the child when its parent dies.
+/// Unlike SIGTERM/SIGINT, SIGKILL cannot be caught — fcvm gets no chance to run cleanup
+/// code, so nothing in `cleanup_vm` executes. Each child survives or dies purely on whether
+/// its own `pre_exec` armed `PR_SET_PDEATHSIG(SIGKILL)`; teardown is per-hop, and one
+/// unprotected hop orphans everything under it.
+///
+/// pasta is asserted here because it is the hop that most recently gained its own
+/// pdeathsig, and because an orphaned pasta is worse than wasted memory: it would keep
+/// listening on the loopback IP:port it was forwarding for a VM that no longer exists, and
+/// loopback IPs are allocated sequentially and recycled, so a later clone can be handed the
+/// same address while the old listener is still bound.
+///
+/// Scope, honestly: this asserts the END STATE — nothing from the VM tree outlives fcvm —
+/// not the mechanism by which each process dies. It does NOT isolate pasta's own pdeathsig,
+/// and it cannot. pasta joins the holder by PID and passt exits when that PID exits, so
+/// pasta dies here even with its `pre_exec` removed (measured; it also still dies with the
+/// holder's netns pinned open, ruling out namespace teardown as the trigger). What this
+/// test does catch is any regression that lets the whole chain go slack — a dropped
+/// pdeathsig on the holder, or a passt version that stops watching the PID — which is
+/// exactly the failure that left ~490 orphaned processes on two runners.
 #[test]
-fn test_sigkill_kills_firecracker_rootless() -> Result<()> {
-    println!("\ntest_sigkill_kills_firecracker_rootless");
+fn test_sigkill_reaps_rootless_vm_tree() -> Result<()> {
+    println!("\ntest_sigkill_reaps_rootless_vm_tree");
 
     let fcvm_path = common::find_fcvm_binary()?;
     let (vm_name, _, _, _) = common::unique_names("sigkill-rootless");
@@ -613,22 +629,24 @@ fn test_sigkill_kills_firecracker_rootless() -> Result<()> {
         anyhow::bail!("VM did not become healthy within 120 seconds");
     }
 
-    // Find the specific child processes for THIS VM
-    let our_fc_pid = find_firecracker_for_fcvm(fcvm_pid);
-    let our_holder_pid = find_holder_for_fcvm(fcvm_pid);
+    // Find the specific child processes for THIS VM. A healthy rootless VM ALWAYS has all
+    // three, so a missing one is a failure, not a reason to skip an assertion — silently
+    // not-asserting is how an orphaned pasta stayed invisible in the first place.
+    // Each is tracked by (pid, start_time) + pidfd so the post-kill checks survive both the
+    // SIGKILL'd-but-unreaped zombie window and PID reuse under parallel load (#628).
+    let fc = find_firecracker_for_fcvm(fcvm_pid)
+        .context("no firecracker process found under this fcvm")?;
+    let holder =
+        find_holder_for_fcvm(fcvm_pid).context("no namespace holder found under this fcvm")?;
+    let pasta = find_pasta_for_fcvm(fcvm_pid).context("no pasta process found under this fcvm")?;
     println!(
-        "Our firecracker PID: {:?}, holder PID: {:?}",
-        our_fc_pid, our_holder_pid
+        "Our tree: firecracker={}, holder={}, pasta={}",
+        fc.pid, holder.pid, pasta.pid
     );
 
-    assert!(
-        our_fc_pid.is_some(),
-        "should have started a firecracker process"
-    );
-    // `fc`/`holder` are tracked by (pid, start_time) so the post-kill checks below survive
-    // both the SIGKILL'd-but-unreaped zombie window and PID reuse under parallel load (#628).
-    let fc = our_fc_pid.unwrap();
     assert!(fc.running(), "firecracker should be running before SIGKILL");
+    assert!(holder.running(), "holder should be running before SIGKILL");
+    assert!(pasta.running(), "pasta should be running before SIGKILL");
 
     // Send SIGKILL to fcvm — no cleanup handler runs
     println!("Sending SIGKILL to fcvm (PID {})", fcvm_pid);
@@ -642,47 +660,44 @@ fn test_sigkill_kills_firecracker_rootless() -> Result<()> {
     // Poll briefly in case of scheduling delay.
     let start = std::time::Instant::now();
     while start.elapsed() < Duration::from_secs(5) {
-        if !fc.running() && !opt_running(our_holder_pid) {
+        if !fc.running() && !holder.running() && !pasta.running() {
             break;
         }
         std::thread::sleep(common::POLL_INTERVAL);
     }
 
-    let fc_still_running = fc.running();
-    if fc_still_running {
+    // Snapshot all three BEFORE asserting, then clean up whatever survived, so a failure of
+    // this test cannot itself leak a microVM or a stray listener onto the runner.
+    let survivors: Vec<(&str, Tracked)> =
+        [("firecracker", fc), ("holder", holder), ("pasta", pasta)]
+            .into_iter()
+            .filter(|(_, t)| t.running())
+            .collect();
+    for (role, t) in &survivors {
         println!(
-            "BUG: firecracker (PID {}) still running after fcvm SIGKILL!",
-            fc.pid
+            "BUG: {} (PID {}) still running after fcvm SIGKILL!",
+            role, t.pid
         );
-        fc.kill_if_running();
+        t.kill_if_running();
     }
-    assert!(
-        !fc_still_running,
-        "firecracker (PID {}) should die via PR_SET_PDEATHSIG when fcvm is SIGKILL'd",
-        fc.pid
-    );
 
-    if let Some(holder) = our_holder_pid {
-        let holder_still_running = holder.running();
-        if holder_still_running {
-            println!(
-                "BUG: namespace holder (PID {}) still running after fcvm SIGKILL!",
-                holder.pid
-            );
-            holder.kill_if_running();
-        }
-        assert!(
-            !holder_still_running,
-            "namespace holder (PID {}) should die via PR_SET_PDEATHSIG when fcvm is SIGKILL'd",
-            holder.pid
-        );
-        println!("Holder PID {} correctly cleaned up", holder.pid);
-    }
+    assert!(
+        survivors.is_empty(),
+        "every child must die via PR_SET_PDEATHSIG when fcvm is SIGKILL'd, but these \
+         survived and were orphaned to init: {:?}. A surviving pasta is the dangerous one: \
+         it keeps the dead VM's forwarded loopback port bound, and that IP is recycled to a \
+         later clone.",
+        survivors
+            .iter()
+            .map(|(role, t)| format!("{} (PID {})", role, t.pid))
+            .collect::<Vec<_>>()
+    );
+    println!("firecracker, holder and pasta all reaped by the kernel");
 
     // fcvm.wait() above already reaped the exact child, so no procfs assert needed (a bare
     // /proc check would only add a PID-reuse false failure).
 
-    println!("test_sigkill_kills_firecracker_rootless PASSED");
+    println!("test_sigkill_reaps_rootless_vm_tree PASSED");
     Ok(())
 }
 

--- a/tests/test_signal_cleanup.rs
+++ b/tests/test_signal_cleanup.rs
@@ -634,19 +634,35 @@ fn test_sigkill_reaps_rootless_vm_tree() -> Result<()> {
     // not-asserting is how an orphaned pasta stayed invisible in the first place.
     // Each is tracked by (pid, start_time) + pidfd so the post-kill checks survive both the
     // SIGKILL'd-but-unreaped zombie window and PID reuse under parallel load (#628).
-    let fc = find_firecracker_for_fcvm(fcvm_pid)
-        .context("no firecracker process found under this fcvm")?;
-    let holder =
-        find_holder_for_fcvm(fcvm_pid).context("no namespace holder found under this fcvm")?;
-    let pasta = find_pasta_for_fcvm(fcvm_pid).context("no pasta process found under this fcvm")?;
+    //
+    // Bailing out of here must tear the VM down first. `set_test_pdeathsig_std` only fires
+    // when the whole test BINARY exits, which can be many minutes and many tests away — so
+    // an early return would leave a live microVM holding a loopback port for the rest of
+    // the run, i.e. exactly the leak this test exists to catch.
+    let discover = || -> Result<(Tracked, Tracked, Tracked)> {
+        let fc = find_firecracker_for_fcvm(fcvm_pid)
+            .context("no firecracker process found under this fcvm")?;
+        let holder =
+            find_holder_for_fcvm(fcvm_pid).context("no namespace holder found under this fcvm")?;
+        let pasta =
+            find_pasta_for_fcvm(fcvm_pid).context("no pasta process found under this fcvm")?;
+        anyhow::ensure!(fc.running(), "firecracker should be running before SIGKILL");
+        anyhow::ensure!(holder.running(), "holder should be running before SIGKILL");
+        anyhow::ensure!(pasta.running(), "pasta should be running before SIGKILL");
+        Ok((fc, holder, pasta))
+    };
+    let (fc, holder, pasta) = match discover() {
+        Ok(tree) => tree,
+        Err(e) => {
+            fcvm::utils::graceful_kill(fcvm_pid, 2000);
+            let _ = fcvm.wait();
+            return Err(e);
+        }
+    };
     println!(
         "Our tree: firecracker={}, holder={}, pasta={}",
         fc.pid, holder.pid, pasta.pid
     );
-
-    assert!(fc.running(), "firecracker should be running before SIGKILL");
-    assert!(holder.running(), "holder should be running before SIGKILL");
-    assert!(pasta.running(), "pasta should be running before SIGKILL");
 
     // Send SIGKILL to fcvm — no cleanup handler runs
     println!("Sending SIGKILL to fcvm (PID {})", fcvm_pid);


### PR DESCRIPTION
Teardown ran its kills back to back even though nothing orders them. This overlaps
them, and arms `PR_SET_PDEATHSIG` on pasta — the one hop in the rootless tree that
did not have it.

## Fast teardown

~154ms of every clone request happens after the result exists. `cleanup_vm()` awaited
each kill before sending the next, so the VMM's address-space reclaim (~40ms of
`exit_mmap()` on a ~1GiB guest mapping), the namespace holder's exit and pasta's
teardown (~28ms) serialized. Restructured into four phases:

1. **Signal, block on nothing** — SIGKILL the VMM, the holder and the network helper,
   and cancel/abort the in-process tasks, with no `await` in between.
2. **Join the waits together** — teardown costs the slowest exit, not the sum.
3. **Network cleanup** — once nothing is left using the namespace.
4. **On-disk reaping** — state file, NFS exports, Firecracker log, data directory.

Phase 4 is **fully synchronous**: `cleanup_vm` does not return until all of it is
gone. No janitor, no deferral. "Leave nothing on disk" is a correctness contract just
like "leave no orphaned VM" — a deferred sweep lets a crash strand a state file whose
PID is then reused, a reflinked rootfs, or an `/etc/exports.d` entry that makes every
later `exportfs -ra` fail. The three steps are independent so they run concurrently
(the log copy and directory removal share a future, since the log lives in the
directory), but all inside the blocking window.

Enabling that required splitting the kill in two:

- `Hypervisor` gains `fn start_kill()` and `async fn reap()`. `kill()` becomes a
  provided method composing them, so both backends keep a single implementation.
- `NetworkManager` gains `fn start_kill_processes()`, default no-op, implemented by
  `PastaNetwork`. `cleanup()` still kills *and* reaps unconditionally, so it stays
  correct on the error paths that never call `start_kill_processes`.

### Reporting it honestly

Teardown emits one record with three **distinct** numbers, so overlapping work can
never be presented as eliminating it:

| field | meaning |
|---|---|
| `caller_blocking_ms` | what the request actually pays, start to finish |
| `until_gone_ms` | first SIGKILL until the last resource is released |
| `reclaim_cpu_ms` | CPU the kernel burned destroying the processes |

plus `processes_us` / `network_us` / `disk_us` (microseconds — two phases are
sub-millisecond and would round to a useless 0).

`reclaim_cpu_ms` needed a correction *during* this work. `RUSAGE_CHILDREN` credits a
child's **entire lifetime** CPU at the moment it is reaped, so the first version
reported `reclaim_cpu_ms=12328` for a VM that had simply been alive a while. It is now
the delta minus the CPU the VMM and holder had already spent (sampled from
`/proc/<pid>/stat` just before the signal), sampled after phase 2 so pasta's lifetime
CPU cannot leak in. What remains is genuinely the post-SIGKILL cost.

Observed on real clone teardowns:

```
caller_blocking_ms=41  until_gone_ms=41  processes_us=35832 network_us=143 disk_us=5716
caller_blocking_ms=135 until_gone_ms=135 processes_us=77085 network_us=85  disk_us=58390
```

`caller_blocking` and `until_gone` being equal is the point: nothing was hidden.

## pasta pdeathsig — and a correction to the severity

pasta is now spawned with `PR_SET_PDEATHSIG(SIGKILL)` via `pre_exec`, plus a
`getppid()` re-check that fails the exec if the parent died inside the fork/exec
window. AGENTS.md requires teardown be armed per hop; pasta was the only hop without
it.

**It was graded CRITICAL on the theory that an orphaned pasta keeps a recycled
loopback port bound and misroutes a client into an old clone's namespace. That does
not reproduce, and this PR does not claim it does.** Measured on this branch:

- With the `pre_exec` **removed** and the binary verifiably rebuilt, pasta still died
  on fcvm SIGKILL. The reaping test passed either way.
- Killing only the holder (fcvm alive) left pasta in state `Z` — it had exited. So the
  trigger is the holder's death, not fcvm's.
- Repeating the SIGKILL with the holder's netns **pinned open by an external fd** still
  killed pasta, ruling out namespace teardown. pasta joins the holder *by PID* and
  passt exits when that PID exits.

So pasta cannot currently outlive its holder, and the holder cannot outlive fcvm. The
fix is still worth its ten lines: today's guarantee runs through two things fcvm does
not own — the holder's own pdeathsig, and an **undocumented** passt behaviour
(`--no-netns-quit` documents only the filesystem-bound case) in a binary this repo
pins to a patched fork and periodically rebases. This makes pasta's death depend on
nothing but the kernel.

## Test

`test_sigkill_kills_firecracker_rootless` → `test_sigkill_reaps_rootless_vm_tree`
(extended, not duplicated):

- finds firecracker, the holder **and** pasta, and **requires all three to be found** —
  previously a missing holder or pasta silently skipped its own assertion, exactly the
  hedge that lets an orphan go unnoticed;
- asserts none survive, reporting every survivor in one message and killing them first
  so a failure of this test cannot itself leak a microVM;
- documents its scope honestly: it guards the **end state**, not pasta's pdeathsig
  specifically, which no VM-level test can isolate for the reason above.

## Test Results

```
$ make lint
fmt, clippy --all-targets -D warnings, audit, deny — all clean (exit 0)

$ make build
Finished `release` profile

$ make test-root FILTER=sigkill STREAM=1
Our tree: firecracker=1744507, holder=1744435, pasta=1744511
Sending SIGKILL to fcvm (PID 1744433)
firecracker, holder and pasta all reaped by the kernel
test_sigkill_reaps_rootless_vm_tree PASSED
     Summary [5.343s] 1 test run: 1 passed, 687 skipped
```

`make test-root FILTER=snapshot` is queued to run on a free box — the host had a
concurrent VM suite from another worktree writing the same shared `FCVM_DATA_DIR`,
and results from a contended box are not worth reporting. Will update this PR with
the outcome.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual machine shutdown reliability by signaling processes promptly and completing cleanup more efficiently.
  * Prevented orphaned networking and namespace processes when a virtual machine exits unexpectedly.
  * Ensured Firecracker, networking helpers, logs, disk data, NFS exports, and related resources are fully cleaned up.
  * Added safeguards to verify that all shutdown-related processes terminate correctly.
  * Improved shutdown monitoring with timing and CPU-reclaim measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->