### PR TITLE
Replace three sleep-based race covers with real signals

### DIFF
--- a/fc-agent/src/agent.rs
+++ b/fc-agent/src/agent.rs
@@ -161,10 +161,12 @@ pub async fn run() -> Result<()> {
     };
     let has_shared_volume = mounted_fuse_paths.iter().any(|p| p == "/mnt/shared");
 
-    // Start chronyd for ongoing NTP time sync.
-    // Must be after FUSE mounts so /etc-host/chrony.conf is readable.
-    // makestep 1 -1 allows stepping the clock at any time (critical after snapshot restore).
-    start_chronyd().await;
+    // Start chronyd for ongoing NTP time sync, OFF the boot critical path.
+    // Nothing below depends on the daemon being up, and the setup costs a
+    // process spawn plus a command-socket round trip — awaiting it inline made
+    // every cold boot wait for chrony before it could mount disks and launch
+    // the container. The task logs its own outcome, including the loud failure.
+    tokio::spawn(start_chronyd());
 
     let mounted_disk_paths = if !plan.extra_disks.is_empty() {
         eprintln!(
@@ -509,73 +511,300 @@ pub async fn run() -> Result<()> {
     system::shutdown_vm(exit_code).await
 }
 
-/// Start chronyd for NTP time sync.
+/// Config file fc-agent writes and hands to chronyd with an explicit `-f`.
 ///
-/// Writes a chrony config using the host's NTP servers (from /etc-host/chrony.conf),
-/// then starts chronyd as a daemon. `makestep 1 -1` allows stepping the clock at
-/// any time, which is critical after snapshot restore when the drift can be hours.
+/// The `-f` is not cosmetic: chronyd's compiled-in default on this rootfs is
+/// `/etc/chrony/chrony.conf` (the file `rootfs-config.toml` ships), so a config
+/// written anywhere else is read by nobody — and takes `makestep 1 -1` with it,
+/// the one directive that lets the clock be stepped at ANY time and therefore
+/// the one that matters after a snapshot restore.
+const CHRONY_CONF: &str = "/etc/chrony.conf";
+
+/// The distro config shipped in the rootfs (see `rootfs-config.toml`), and the
+/// single source of truth for WHICH NTP servers a guest uses. fc-agent copies
+/// its `server`/`pool` directives rather than restating them, so changing the
+/// servers stays a rootfs-config change.
+const ROOTFS_CHRONY_CONF: &str = "/etc/chrony/chrony.conf";
+
+/// Used only if the rootfs config carries no `server`/`pool` directive at all.
+const FALLBACK_NTP_SOURCE: &str = "pool pool.ntp.org iburst";
+
+/// Bound on waiting for chronyd to answer chronyc AND report an NTP source.
+///
+/// The wait ends when a real `chronyc` round trip reports a source, so this only
+/// bounds a daemon that never comes up — or one whose pool never resolves, which
+/// is equally worth an error. Generous because this runs off the critical path:
+/// nothing waits on it, so the only cost of patience is a later log line, while
+/// impatience would mean crying wolf about a guest whose pool was just slow.
+const CHRONYD_READY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Bound on waiting for a pre-existing chronyd to exit after SIGTERM, before
+/// escalating to SIGKILL.
+const CHRONYD_TERM_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Start chronyd for ongoing NTP time sync.
+///
+/// Spawned as its own task by [`run`], never awaited: nothing in the boot
+/// sequence depends on the daemon, so this work belongs off the critical path.
+///
+/// Both waits inside are real signals, not delays. Replacing the daemon systemd
+/// may have started waits on a pidfd for that process to actually exit; the
+/// daemon's readiness waits on chronyc actually getting an answer. The previous
+/// fixed 500ms + 1s pair cost every cold boot 1.5s AND failed silently: when the
+/// command socket took longer than the guess, every configuration step was
+/// discarded with no error, leaving a VM with ZERO NTP sources and a clock free
+/// to drift — worst exactly after a snapshot restore, where chrony is the
+/// correction.
 async fn start_chronyd() {
-    // Read NTP server addresses from host's chrony.conf
-    let host_conf = std::path::Path::new("/etc-host/chrony.conf");
-    let mut server_addrs = Vec::new();
-    if let Ok(content) = tokio::fs::read_to_string(host_conf).await {
-        for line in content.lines() {
-            // Parse both "server" and "pool" directives (some distros only use pool)
-            if line.starts_with("server ") || line.starts_with("pool ") {
-                if let Some(addr) = line.split_whitespace().nth(1) {
-                    server_addrs.push(addr.to_string());
-                }
-            }
-        }
+    let mut sources = rootfs_ntp_sources().await;
+    if sources.is_empty() {
+        eprintln!(
+            "[fc-agent] WARNING: no server/pool directive in {ROOTFS_CHRONY_CONF}; \
+             falling back to '{FALLBACK_NTP_SOURCE}'"
+        );
+        sources.push(FALLBACK_NTP_SOURCE.to_string());
     }
 
-    // Write minimal config — servers are added dynamically via chronyc because
-    // chronyd's config parser doesn't handle bare IPv6 addresses correctly.
-    let config = "makestep 1 -1\ndriftfile /var/lib/chrony/drift\ncmdallow 127.0.0.1\n";
+    // `makestep 1 -1`: step the clock at ANY update, not just the first few. A
+    // restored VM can resume hours off; slewing that back would take days.
+    let config = format!(
+        "# Written by fc-agent at boot; chronyd is started with -f on this path.\n\
+         # NTP sources copied from {ROOTFS_CHRONY_CONF} (set in rootfs-config.toml).\n\
+         {}\n\
+         makestep 1 -1\n\
+         driftfile /var/lib/chrony/drift\n\
+         cmdallow 127.0.0.1\n",
+        sources.join("\n")
+    );
 
     let _ = tokio::fs::create_dir_all("/var/lib/chrony").await;
     let _ = tokio::fs::create_dir_all("/var/run/chrony").await;
-    let _ = tokio::fs::write("/etc/chrony.conf", config).await;
+    if let Err(e) = tokio::fs::write(CHRONY_CONF, config).await {
+        eprintln!("[fc-agent] ERROR: cannot write {CHRONY_CONF}: {e}; no NTP time sync");
+        return;
+    }
 
-    // Kill any existing chronyd (systemd may have started one as _chrony user,
-    // which can't send UDP in this VM). Then restart as root.
-    let _ = tokio::process::Command::new("pkill")
-        .args(["-x", "chronyd"])
-        .output()
-        .await;
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    // The rootfs enables chrony.service, so systemd starts its own chronyd as the
+    // _chrony user — which cannot send UDP in this VM. Replace it, and wait for it
+    // to be GONE, because the replacement binds the same command socket.
+    stop_running_chronyd().await;
 
+    // chronyd daemonizes: this command returns as soon as the daemon is spawned,
+    // which is BEFORE the daemon has bound its command socket.
     match tokio::process::Command::new("/usr/sbin/chronyd")
-        .args(["-u", "root"])
+        .args(["-f", CHRONY_CONF, "-u", "root"])
         .output()
         .await
     {
-        Ok(out) if out.status.success() => {
-            eprintln!("[fc-agent] chronyd started (NTP time sync)");
-        }
+        Ok(out) if out.status.success() => {}
         Ok(out) => {
             eprintln!(
-                "[fc-agent] WARNING: chronyd failed: {}",
+                "[fc-agent] ERROR: chronyd failed to start ({}): {}",
+                out.status,
                 String::from_utf8_lossy(&out.stderr).trim()
             );
             return;
         }
         Err(e) => {
-            eprintln!("[fc-agent] WARNING: failed to start chronyd: {}", e);
+            eprintln!("[fc-agent] ERROR: failed to exec chronyd: {e}");
             return;
         }
     }
 
-    // Add servers dynamically via chronyc (works reliably with IPv6)
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-    for addr in &server_addrs {
-        let _ = tokio::process::Command::new("/usr/bin/chronyc")
-            .args(["add", "server", addr, "iburst"])
-            .output()
-            .await;
+    // Positive verification. Waiting for chronyc to answer proves the daemon is
+    // up; counting its sources proves the config we wrote was actually loaded.
+    // Zero sources is a REAL failure — the clock will drift with nothing to
+    // correct it — so it is reported as an error rather than passed over.
+    match wait_for_chrony_sources().await {
+        Ok(count) => eprintln!("[fc-agent] chronyd started with {count} NTP source(s)"),
+        Err(e) => eprintln!("[fc-agent] ERROR: chronyd is not usable: {e}"),
     }
-    eprintln!(
-        "[fc-agent] added {} NTP servers via chronyc",
-        server_addrs.len()
-    );
+}
+
+/// The `server`/`pool` directives from the rootfs's chrony config.
+///
+/// Copied verbatim so their options (`iburst`, …) and address syntax survive
+/// unchanged — which also sidesteps having to re-render addresses that chronyd's
+/// parser is picky about.
+async fn rootfs_ntp_sources() -> Vec<String> {
+    let Ok(content) = tokio::fs::read_to_string(ROOTFS_CHRONY_CONF).await else {
+        return Vec::new();
+    };
+    content
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with("server ") || line.starts_with("pool "))
+        .map(str::to_string)
+        .collect()
+}
+
+/// Stop systemd's chrony unit, then terminate any chronyd still running and wait
+/// until each one has actually exited.
+///
+/// Stopping the UNIT first is what makes this race-free. `chrony.service` is
+/// enabled in the rootfs, so systemd starts its own chronyd concurrently with
+/// fc-agent; killing by PID alone would lose to the ordering where systemd has
+/// not spawned it yet, and the unit would come up moments later and fight ours
+/// for the command socket. `systemctl stop` is authoritative over both a running
+/// service and a queued start job. Failure is fine and expected in a guest whose
+/// systemd is not up yet — the PID sweep below is the backstop either way.
+///
+/// The per-process wait is a pidfd — readable exactly when that process dies —
+/// rather than a fixed delay, which was simultaneously too long for the common
+/// case (the daemon exits in ~1ms) and unreliable under load. Signals go through
+/// `pidfd_send_signal` so a PID recycled between the /proc scan and the signal
+/// can never be hit: the pidfd pins the process it was opened for.
+async fn stop_running_chronyd() {
+    let _ = tokio::process::Command::new("systemctl")
+        .args(["stop", "chrony"])
+        .output()
+        .await;
+
+    for pid in running_chronyd_pids() {
+        let pidfd = match PidFd::open(pid) {
+            Some(fd) => fd,
+            // Already gone between the scan and the open — nothing to wait for.
+            None => continue,
+        };
+        if !pidfd.send_signal(libc::SIGTERM) {
+            continue;
+        }
+        if pidfd.wait_for_exit(CHRONYD_TERM_TIMEOUT).await {
+            continue;
+        }
+        eprintln!("[fc-agent] chronyd pid {pid} ignored SIGTERM; sending SIGKILL");
+        if pidfd.send_signal(libc::SIGKILL) {
+            // SIGKILL cannot be caught; a process that still has not exited is
+            // wedged in the kernel (uninterruptible), and the new daemon will
+            // report the socket conflict itself.
+            pidfd.wait_for_exit(CHRONYD_TERM_TIMEOUT).await;
+        }
+    }
+}
+
+/// PIDs of all running `chronyd` processes, from `/proc/<pid>/comm`.
+fn running_chronyd_pids() -> Vec<libc::pid_t> {
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return Vec::new();
+    };
+    let mut pids = Vec::new();
+    for entry in entries.flatten() {
+        let Ok(pid) = entry.file_name().to_string_lossy().parse::<libc::pid_t>() else {
+            continue;
+        };
+        if let Ok(comm) = std::fs::read_to_string(format!("/proc/{pid}/comm")) {
+            if comm.trim() == "chronyd" {
+                pids.push(pid);
+            }
+        }
+    }
+    pids
+}
+
+/// A pidfd: a handle to a specific process that is immune to PID reuse and
+/// becomes readable when that process exits.
+struct PidFd(std::os::fd::OwnedFd);
+
+impl PidFd {
+    /// Open a pidfd for `pid`, or `None` if the process is already gone.
+    fn open(pid: libc::pid_t) -> Option<Self> {
+        // SAFETY: pidfd_open takes a pid and flags and returns a new fd or -1.
+        let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) };
+        if fd < 0 {
+            return None;
+        }
+        // SAFETY: pidfd_open returned a fresh, owned fd.
+        Some(Self(unsafe {
+            <std::os::fd::OwnedFd as std::os::fd::FromRawFd>::from_raw_fd(fd as std::os::fd::RawFd)
+        }))
+    }
+
+    /// Signal the pinned process. Returns false if it is already gone.
+    fn send_signal(&self, signal: libc::c_int) -> bool {
+        use std::os::fd::AsRawFd;
+        // SAFETY: the fd is a live pidfd owned by self; a null siginfo means
+        // "behave like kill()".
+        let rc = unsafe {
+            libc::syscall(
+                libc::SYS_pidfd_send_signal,
+                self.0.as_raw_fd(),
+                signal,
+                std::ptr::null::<libc::siginfo_t>(),
+                0,
+            )
+        };
+        rc == 0
+    }
+
+    /// Wait until the pinned process exits, bounded by `timeout`.
+    ///
+    /// Returns true if it exited. A pidfd becomes readable on exit, so this is
+    /// an epoll wakeup rather than a poll loop.
+    async fn wait_for_exit(&self, timeout: Duration) -> bool {
+        use std::os::fd::AsRawFd;
+        let Ok(async_fd) = tokio::io::unix::AsyncFd::new(self.0.as_raw_fd()) else {
+            return false;
+        };
+        tokio::time::timeout(timeout, async_fd.readable())
+            .await
+            .is_ok_and(|guard| guard.is_ok())
+    }
+}
+
+/// Wait for chronyd's command socket to answer, then report how many NTP
+/// sources it has configured.
+///
+/// Each attempt is a real `chronyc` round trip, so the loop ends on the daemon
+/// being reachable — not on elapsed time. Sources are counted afterwards and
+/// re-checked until at least one appears, because a `pool` directive only
+/// materializes its sources once the pool name resolves.
+async fn wait_for_chrony_sources() -> Result<usize> {
+    let deadline = tokio::time::Instant::now() + CHRONYD_READY_TIMEOUT;
+
+    loop {
+        // Whatever went wrong on THIS attempt — reported if the deadline lands
+        // next, so the error describes the state we actually gave up in.
+        let failure = match chronyc_sources().await {
+            Ok(count) if count > 0 => return Ok(count),
+            Ok(_) => "chronyd is running but has 0 NTP sources — its config was not \
+                      loaded, or its pool did not resolve"
+                .to_string(),
+            Err(e) => e,
+        };
+
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!("{failure} (after {CHRONYD_READY_TIMEOUT:?})");
+        }
+        // chronyc is a fork+exec per attempt (~2ms); this keeps the retries from
+        // becoming a spin without materially delaying the answer.
+        sleep(Duration::from_millis(20)).await;
+    }
+}
+
+/// Number of NTP sources chronyd reports, or the reason chronyc could not ask.
+///
+/// `chronyc -n sources` prints a column header, a `=====` rule, then one line
+/// per source; it exits non-zero when the daemon cannot be reached. Counting
+/// from the rule rather than a fixed offset keeps this correct if the header
+/// ever gains a line.
+async fn chronyc_sources() -> std::result::Result<usize, String> {
+    let out = tokio::process::Command::new("/usr/bin/chronyc")
+        .args(["-n", "sources"])
+        .output()
+        .await
+        .map_err(|e| format!("cannot exec chronyc: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "chronyc -n sources failed ({}): {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    Ok(stdout
+        .lines()
+        .skip_while(|line| !line.contains("====="))
+        .skip(1)
+        .filter(|line| !line.trim().is_empty())
+        .count())
 }

--- a/fc-agent/src/container.rs
+++ b/fc-agent/src/container.rs
@@ -1105,7 +1105,20 @@ pub fn notify_cache_ready_and_wait(
                 total_read += n;
                 let received = std::str::from_utf8(&buf[..total_read]).unwrap_or("");
                 if received.contains("cache-ack") {
-                    eprintln!("[fc-agent] received cache-ack from host");
+                    // Positive close handshake: close our end FIRST, before any
+                    // logging, so the host's drain sees EOF as early as possible.
+                    // The host holds this connection open until then precisely so
+                    // it never closes with one of our 500ms liveness probes still
+                    // unread — an unread byte at close becomes a vsock RST that
+                    // flushes this receive buffer, and the ack we just read would
+                    // have been lost to a spurious WarmStart (#627). Our close is
+                    // what tells the host the ack landed.
+                    //
+                    // `poll_fds` borrowed `sock`, but its last use was the
+                    // `hung_up` read above, so the borrow has already ended and
+                    // the socket can be dropped — which closes the fd.
+                    drop(sock);
+                    eprintln!("[fc-agent] received cache-ack from host (handshake closed)");
                     return CacheResult::ColdStart;
                 }
                 // Host keepalive: it is alive but still queued on the snapshot

--- a/src/commands/podman/listeners.rs
+++ b/src/commands/podman/listeners.rs
@@ -7,6 +7,15 @@ use tracing::{debug, info, warn};
 
 use super::types::{CacheRequest, LogLine};
 
+/// Upper bound on waiting for fc-agent to close the cache handshake connection.
+///
+/// The close is the guest's acknowledgement of the ack (see the drain in
+/// [`run_status_listener`]); it follows the guest's read within microseconds.
+/// This only bounds the case where no close is coming at all — the ack was
+/// suppressed because the VM is being replaced, or the VM died — so the drain
+/// releases the connection instead of holding it for the process's lifetime.
+const CACHE_ACK_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Listen for fc-agent status messages on the status vsock port.
 ///
 /// Firecracker forwards guest vsock connections to Unix sockets with format:
@@ -247,28 +256,75 @@ pub(crate) async fn run_status_listener(
                     let _ = write_half.flush().await;
                 }
 
-                // Grace-drain before the connection drops at the `break` below:
-                // consume any last in-flight guest probe bytes so the close is
-                // clean — an unread byte at close becomes a vsock RST that can
-                // flush the guest's receive buffer before it reads the ack.
-                let mut tail = String::new();
-                let _ = tokio::time::timeout(
-                    std::time::Duration::from_millis(250),
-                    reader.read_line(&mut tail),
-                )
-                .await;
+                // Positive close handshake. fc-agent closes this connection the
+                // instant it has read the ack (see `notify_cache_ready_and_wait`
+                // in fc-agent/src/container.rs), so EOF here is PROOF the ack
+                // landed and that no liveness probe is still in flight. Only then
+                // is it safe to drop the connection: closing with an unread byte
+                // queued turns the close into a vsock RST that can flush the
+                // guest's receive buffer BEFORE it reads cache-ack, so the guest
+                // classifies a cold start as a warm restore (#627). A fixed grace
+                // window cannot give that guarantee — a probe landing one
+                // millisecond after it expires reopens exactly the same race.
+                //
+                // Detached so the accept loop is never held up. The next
+                // connection carries "ready", and it must not queue behind a
+                // guest that is slow to close — or never closes, which is the
+                // normal outcome when the ack was suppressed above and this VM is
+                // being torn down and replaced by a restore.
+                let drain_vm_id = vm_id.to_string();
+                tokio::spawn(async move {
+                    let deadline = tokio::time::Instant::now() + CACHE_ACK_CLOSE_TIMEOUT;
+                    let mut probe = String::new();
+                    loop {
+                        probe.clear();
+                        match tokio::time::timeout_at(deadline, reader.read_line(&mut probe)).await
+                        {
+                            // EOF: fc-agent closed after reading the ack.
+                            Ok(Ok(0)) => {
+                                debug!(vm_id = %drain_vm_id, "cache handshake connection closed by guest");
+                                break;
+                            }
+                            // A liveness probe still in flight — discard it and
+                            // keep reading. Leaving it unread is the RST above.
+                            Ok(Ok(_)) => {}
+                            // Reset or read error: the guest is gone either way.
+                            Ok(Err(e)) => {
+                                debug!(vm_id = %drain_vm_id, error = %e, "cache handshake connection ended");
+                                break;
+                            }
+                            Err(_) => {
+                                debug!(
+                                    vm_id = %drain_vm_id,
+                                    "guest did not close the cache handshake connection within \
+                                     the bound; releasing it"
+                                );
+                                break;
+                            }
+                        }
+                    }
+                    // Load-bearing, not tidying: an `async move` block captures
+                    // only what its body mentions. Without this the write half
+                    // would stay behind and drop at the `break` below, shutting
+                    // down the connection's write side while the drain is still
+                    // reading — reintroducing the close-with-unread-bytes RST
+                    // this whole handshake exists to prevent. Both halves must
+                    // outlive the drain, so both are dropped here.
+                    drop(write_half);
+                });
 
-                // Stop reading this connection and go back to accept(). fc-agent
-                // sends each status message ("cache-ready", then "ready", then
-                // "exit") on a SEPARATE vsock connection, so nothing more arrives
-                // here. Critically, this connection is the one held open across
-                // the pre-start snapshot's pause/resume: after resume the vsock
-                // transport can fail to propagate its close, so a second read_line
-                // here would block for the full 300s timeout before the accept
-                // loop could take the new connection carrying "ready" — stalling
+                // Go back to accept(). fc-agent sends each status message
+                // ("cache-ready", then "ready", then "exit") on a SEPARATE vsock
+                // connection, so nothing more arrives on this one. Critically,
+                // this connection is the one held open across the pre-start
+                // snapshot's pause/resume: after resume the vsock transport can
+                // fail to propagate its close, so reading it again on THIS task
+                // would block for the full 300s timeout before the accept loop
+                // could take the new connection carrying "ready" — stalling
                 // container startup by ~5 minutes (intermittently, worse on the
-                // NV2 nested kernel). Breaking to re-accept delivers "ready"
-                // immediately regardless of when this connection's EOF arrives.
+                // NV2 nested kernel). That is why the close handshake above runs
+                // detached: re-accepting here delivers "ready" immediately,
+                // whenever this connection's EOF arrives.
                 break;
             } else {
                 warn!(vm_id = %vm_id, msg = %msg, "Unexpected status message");

--- a/src/firecracker/vm.rs
+++ b/src/firecracker/vm.rs
@@ -21,9 +21,11 @@ const SOCKET_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Number of recent Firecracker stderr lines kept for error reporting.
 const STDERR_TAIL_LINES: usize = 10;
-/// How long to let the async stderr reader drain the pipe after Firecracker
-/// exits, so the failure error can include what it actually printed.
-const STDERR_DRAIN_DELAY: Duration = Duration::from_millis(200);
+/// Upper bound on waiting for the stderr reader to reach EOF after Firecracker
+/// exits, so the failure error can include what it actually printed. The wait
+/// ends on EOF (normally microseconds — the exit closed the write end); this
+/// only bounds the pathological case of an inherited, still-open pipe.
+const STDERR_EOF_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Manages a Firecracker VM process
 ///
@@ -53,6 +55,10 @@ pub struct VmManager {
     mount_redirects: Option<(Vec<PathBuf>, PathBuf)>, // (baseline_dirs, clone_dir) for mount namespace isolation
     process: Option<Child>,
     stderr_tail: Arc<Mutex<VecDeque<String>>>, // last few Firecracker stderr lines, for launch failure errors
+    // Reader task for the child's stderr pipe. Awaited (bounded) before rendering
+    // `stderr_tail` on a launch failure, so the tail is complete rather than
+    // whatever happened to have been logged by then.
+    stderr_reader: Option<tokio::task::JoinHandle<()>>,
     /// Guest serial console lines observed on the Firecracker child's stdout
     /// since spawn. Watched by the restore path to detect a dead serial
     /// console (snapshot captured the UART mid-transmit).
@@ -74,6 +80,7 @@ impl VmManager {
             mount_redirects: None,
             process: None,
             stderr_tail: Arc::new(Mutex::new(VecDeque::new())),
+            stderr_reader: None,
             console_lines: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             client: None,
         }
@@ -289,7 +296,7 @@ impl VmManager {
         // Spawn process with streaming output
         let stderr_tail = Arc::clone(&self.stderr_tail);
         let console_lines = Arc::clone(&self.console_lines);
-        let child = spawn_streaming(cmd, move |line, is_stderr| {
+        let spawned = spawn_streaming(cmd, move |line, is_stderr| {
             let clean = strip_firecracker_prefix(line);
             // fc-agent and container output at INFO/WARN, everything else at DEBUG
             let is_important = clean.contains("fc-agent") || clean.contains("[ctr:");
@@ -322,7 +329,8 @@ impl VmManager {
         })
         .context("spawning Firecracker process")?;
 
-        self.process = Some(child);
+        self.process = Some(spawned.child);
+        self.stderr_reader = Some(spawned.stderr_reader);
 
         // Wait for socket to be ready
         self.wait_for_socket().await?;
@@ -400,9 +408,11 @@ impl VmManager {
             }
 
             if let Some(status) = self.try_wait()? {
-                // Give the async stderr reader a moment to drain the pipe so
-                // the error includes what Firecracker actually printed.
-                sleep(STDERR_DRAIN_DELAY).await;
+                // Wait for the stderr reader to hit EOF so the error includes
+                // everything Firecracker printed. The exit closed the write end,
+                // so this returns as soon as the reader drains the pipe.
+                crate::utils::wait_for_stderr_eof(&mut self.stderr_reader, STDERR_EOF_TIMEOUT)
+                    .await;
                 bail!(
                     "Firecracker exited with {} before its API socket became ready{}",
                     status,

--- a/src/hypervisor/cloud_hypervisor/mod.rs
+++ b/src/hypervisor/cloud_hypervisor/mod.rs
@@ -39,7 +39,9 @@ const GUEST_CID: u32 = 3;
 const SOCKET_WAIT_RETRY_COUNT: u32 = 500;
 const SOCKET_WAIT_RETRY_DELAY: Duration = Duration::from_millis(10);
 const STDERR_TAIL_LINES: usize = 10;
-const STDERR_DRAIN_DELAY: Duration = Duration::from_millis(200);
+/// Upper bound on waiting for the stderr reader to reach EOF after the VMM
+/// exits. The wait ends on EOF; this only bounds an inherited, still-open pipe.
+const STDERR_EOF_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Buffered VM configuration accumulated by the `configure_*` methods, applied at boot.
 #[derive(Default)]
@@ -64,6 +66,9 @@ pub struct CloudHypervisorBackend {
     log_path: Option<PathBuf>,
     process: Option<Child>,
     stderr_tail: Arc<Mutex<VecDeque<String>>>,
+    /// Reader task for the child's stderr pipe, awaited (bounded) before rendering
+    /// `stderr_tail` on a launch failure so the tail is complete.
+    stderr_reader: Option<JoinHandle<()>>,
     client: Option<ChClient>,
     pending: PendingConfig,
     vsock_path: Option<PathBuf>,
@@ -99,6 +104,7 @@ impl CloudHypervisorBackend {
             log_path,
             process: None,
             stderr_tail: Arc::new(Mutex::new(VecDeque::new())),
+            stderr_reader: None,
             client: None,
             pending: PendingConfig::default(),
             vsock_path: None,
@@ -183,7 +189,10 @@ impl CloudHypervisorBackend {
                 return Ok(());
             }
             if let Some(status) = self.try_wait()? {
-                sleep(STDERR_DRAIN_DELAY).await;
+                // Wait for the stderr reader to hit EOF (the exit closed the write
+                // end) so the error carries everything the VMM printed.
+                crate::utils::wait_for_stderr_eof(&mut self.stderr_reader, STDERR_EOF_TIMEOUT)
+                    .await;
                 bail!(
                     "Cloud Hypervisor exited with {} before its API socket became ready{}",
                     status,
@@ -324,7 +333,7 @@ impl Hypervisor for CloudHypervisorBackend {
         install_namespace_pre_exec(&mut cmd, &self.namespace)?;
 
         let stderr_tail = Arc::clone(&self.stderr_tail);
-        let child = spawn_streaming(cmd, move |line, is_stderr| {
+        let spawned = spawn_streaming(cmd, move |line, is_stderr| {
             let clean = line.trim_end();
             if is_stderr {
                 if let Ok(mut tail) = stderr_tail.lock() {
@@ -345,7 +354,8 @@ impl Hypervisor for CloudHypervisorBackend {
         })
         .context("spawning Cloud Hypervisor process")?;
 
-        self.process = Some(child);
+        self.process = Some(spawned.child);
+        self.stderr_reader = Some(spawned.stderr_reader);
         self.wait_for_api().await?;
         self.client = Some(ChClient::new(self.api_socket.clone()));
 

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -36,9 +36,11 @@ const PASTA_DEVICE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs
 /// Number of recent pasta stderr lines kept for error reporting
 const PASTA_STDERR_TAIL_LINES: usize = 20;
 
-/// How long to let the async stderr reader drain the pipe after pasta exits,
-/// so the failure error can include what it actually printed.
-const PASTA_STDERR_DRAIN_DELAY: std::time::Duration = std::time::Duration::from_millis(200);
+/// Upper bound on waiting for the stderr reader to reach EOF after pasta exits,
+/// so the failure error can include what it actually printed. The wait ends on
+/// EOF (pasta's exit closed the write end); this only bounds the pathological
+/// case of an inherited, still-open pipe.
+const PASTA_STDERR_EOF_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// Heredoc delimiter separating the batched `ip` commands from the shell script.
 const IP_BATCH_DELIMITER: &str = "FCVM_IP_BATCH";
@@ -183,6 +185,10 @@ pub struct PastaNetwork {
     // State (populated during setup)
     pasta_process: Option<Child>,
     stderr_tail: Arc<Mutex<VecDeque<String>>>, // last few pasta stderr lines, for failure attribution
+    // Reader task for pasta's stderr pipe. Awaited (bounded) before rendering
+    // `stderr_tail` on the paths that report a dead pasta, so the attribution
+    // carries what pasta printed instead of racing the reader task.
+    stderr_reader: Option<tokio::task::JoinHandle<()>>,
     pid_file: Option<PathBuf>,
     loopback_ip: Option<String>, // Unique loopback IP for port forwarding (127.x.y.z)
     holder_pid: Option<u32>,     // Namespace PID (set in post_start)
@@ -200,6 +206,7 @@ impl PastaNetwork {
             guest_ipv6: GUEST_IPV6.to_string(),
             pasta_process: None,
             stderr_tail: Arc::new(Mutex::new(VecDeque::new())),
+            stderr_reader: None,
             pid_file: None,
             loopback_ip: None,
             holder_pid: None,
@@ -609,7 +616,7 @@ impl PastaNetwork {
         // unrelated bridge setup failure.
         if let Some(stderr) = child.stderr.take() {
             let stderr_tail = Arc::clone(&self.stderr_tail);
-            tokio::spawn(async move {
+            self.stderr_reader = Some(tokio::spawn(async move {
                 let mut lines = BufReader::new(stderr).lines();
                 while let Ok(Some(line)) = lines.next_line().await {
                     warn!(target: "pasta", "{}", line);
@@ -620,7 +627,7 @@ impl PastaNetwork {
                         tail.push_back(line);
                     }
                 }
-            });
+            }));
         }
 
         // Wait for the PID file to appear (pasta writes it once ready).
@@ -639,9 +646,14 @@ impl PastaNetwork {
 
             tokio::select! {
                 status = child.wait() => {
-                    // pasta died during startup. Give the stderr reader a moment
-                    // to drain the pipe so the error includes what pasta printed.
-                    tokio::time::sleep(PASTA_STDERR_DRAIN_DELAY).await;
+                    // pasta died during startup. Wait for the stderr reader to hit
+                    // EOF — pasta's exit closed the write end, so this returns as
+                    // soon as the pipe is drained — and the error names the cause.
+                    crate::utils::wait_for_stderr_eof(
+                        &mut self.stderr_reader,
+                        PASTA_STDERR_EOF_TIMEOUT,
+                    )
+                    .await;
                     match status {
                         Ok(status) => anyhow::bail!(
                             "pasta exited before becoming ready (status: {}){}",
@@ -738,9 +750,13 @@ impl PastaNetwork {
             };
             if let Some(status) = pasta_exit {
                 self.pasta_process = None;
-                // Give the stderr reader a moment to drain the pipe so the
-                // error includes what pasta actually printed.
-                tokio::time::sleep(PASTA_STDERR_DRAIN_DELAY).await;
+                // Wait for the stderr reader to hit EOF so the error includes what
+                // pasta actually printed before dying.
+                crate::utils::wait_for_stderr_eof(
+                    &mut self.stderr_reader,
+                    PASTA_STDERR_EOF_TIMEOUT,
+                )
+                .await;
                 anyhow::bail!(
                     "pasta exited (status: {}) before its TAP device {} appeared in the namespace{}",
                     status,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -206,14 +206,59 @@ pub fn strip_firecracker_prefix(line: &str) -> &str {
     result
 }
 
+/// A process spawned by [`spawn_streaming`], plus the background tasks draining
+/// its stdout and stderr pipes.
+///
+/// The reader handles are returned, not detached, so that a caller which sees
+/// the child exit early can WAIT for the stderr reader to reach EOF before
+/// formatting an error out of the tail it captured. Without a handle there is
+/// nothing to await: every such caller resorted to a fixed sleep, which is both
+/// a tax on the happy path and too short under load — reporting "no stderr
+/// captured" exactly when the process printed the reason it died.
+pub struct StreamingChild {
+    /// The spawned process. The caller owns its lifecycle.
+    pub child: tokio::process::Child,
+    /// Completes when stdout hits EOF and every line has reached the callback.
+    pub stdout_reader: tokio::task::JoinHandle<()>,
+    /// Completes when stderr hits EOF and every line has reached the callback.
+    pub stderr_reader: tokio::task::JoinHandle<()>,
+}
+
+/// Wait for a [`StreamingChild`] stderr reader to finish, bounded by `timeout`.
+///
+/// Call this on an error path that has already observed the child exit and is
+/// about to render its stderr tail. Completion is the real signal that the tail
+/// is whole: the reader task ends only at EOF, and the write end of the pipe is
+/// closed by the exit that got us here, so EOF normally arrives in microseconds.
+///
+/// The bound covers the one case where EOF can be delayed indefinitely — a
+/// grandchild inherited the pipe and holds it open. There the error is reported
+/// with whatever was captured rather than hanging.
+///
+/// The handle is taken, so a second call is a no-op.
+pub async fn wait_for_stderr_eof(
+    reader: &mut Option<tokio::task::JoinHandle<()>>,
+    timeout: Duration,
+) {
+    let Some(handle) = reader.take() else {
+        return;
+    };
+    if tokio::time::timeout(timeout, handle).await.is_err() {
+        warn!(
+            timeout_ms = timeout.as_millis() as u64,
+            "stderr pipe did not reach EOF within the bound; error output may be truncated"
+        );
+    }
+}
+
 /// Spawn a command and stream its output via tracing logs.
 ///
 /// Takes a closure that receives each line and logs it appropriately.
-/// Returns the child process handle (caller must manage lifecycle).
+/// Returns the child and its reader tasks (caller must manage lifecycle).
 pub fn spawn_streaming<F>(
     mut cmd: tokio::process::Command,
     log_line: F,
-) -> anyhow::Result<tokio::process::Child>
+) -> anyhow::Result<StreamingChild>
 where
     F: Fn(&str, bool) + Send + Sync + Clone + 'static,
 {
@@ -224,31 +269,38 @@ where
 
     let mut child = cmd.spawn()?;
 
+    // Both pipes were just configured above, so `take()` yields them here.
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("spawned child has no stdout pipe"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("spawned child has no stderr pipe"))?;
+
     // Stream stdout (is_stderr=false)
-    if let Some(stdout) = child.stdout.take() {
-        let reader = BufReader::new(stdout);
-        let mut lines = reader.lines();
-        let log = log_line.clone();
-        tokio::spawn(async move {
-            while let Ok(Some(line)) = lines.next_line().await {
-                log(&line, false);
-            }
-        });
-    }
+    let log = log_line.clone();
+    let stdout_reader = tokio::spawn(async move {
+        let mut lines = BufReader::new(stdout).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            log(&line, false);
+        }
+    });
 
     // Stream stderr (is_stderr=true)
-    if let Some(stderr) = child.stderr.take() {
-        let reader = BufReader::new(stderr);
-        let mut lines = reader.lines();
-        let log = log_line;
-        tokio::spawn(async move {
-            while let Ok(Some(line)) = lines.next_line().await {
-                log(&line, true);
-            }
-        });
-    }
+    let stderr_reader = tokio::spawn(async move {
+        let mut lines = BufReader::new(stderr).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            log_line(&line, true);
+        }
+    });
 
-    Ok(child)
+    Ok(StreamingChild {
+        child,
+        stdout_reader,
+        stderr_reader,
+    })
 }
 
 /// Run a command and stream its output via tracing at INFO/WARN level.
@@ -259,14 +311,17 @@ pub async fn run_streaming(
     prefix: &str,
 ) -> anyhow::Result<std::process::ExitStatus> {
     let prefix = prefix.to_string();
-    let mut child = spawn_streaming(cmd, move |line, is_stderr| {
+    // The reader handles are deliberately dropped: this helper logs each line as
+    // it arrives and renders no tail afterwards, so it has nothing to wait for.
+    // Dropping detaches the tasks, which run on to EOF on their own.
+    let mut spawned = spawn_streaming(cmd, move |line, is_stderr| {
         if is_stderr {
             warn!("[{}] {}", prefix, line);
         } else {
             info!("[{}] {}", prefix, line);
         }
     })?;
-    Ok(child.wait().await?)
+    Ok(spawned.child.wait().await?)
 }
 
 /// Result of waiting for namespace readiness.

--- a/tests/test_sanity.rs
+++ b/tests/test_sanity.rs
@@ -787,3 +787,116 @@ async fn test_rootless_map_nonroot_reader() -> Result<()> {
     println!("✅ #683: non-root read of rootless --map'd volume works");
     Ok(())
 }
+
+/// The guest actually has NTP sources, from the config fc-agent wrote.
+///
+/// fc-agent's chrony setup used to fail SILENTLY in both halves. It read the NTP
+/// servers from `/etc-host/chrony.conf`, a path nothing ever mounts, so the list
+/// was always empty and the `chronyc add server` loop it slept a second for ran
+/// zero times. And it started `chronyd -u root` with no `-f`, so the config it
+/// wrote — carrying `makestep 1 -1`, which is what lets a restored VM step a
+/// multi-hour clock jump — was read by nobody; chronyd loaded the rootfs's
+/// `/etc/chrony/chrony.conf` (`makestep 1.0 3`) instead. Nothing logged an error
+/// in either case, and a VM with no correctable clock looks perfectly healthy.
+///
+/// So this asserts the POSITIVE, all three links of the chain:
+/// 1. chronyd is running against the config fc-agent wrote (`-f`),
+/// 2. that config carries `makestep 1 -1`,
+/// 3. the daemon really has NTP sources configured.
+#[tokio::test]
+async fn test_sanity_chrony_ntp_configured() -> Result<()> {
+    println!("\nTest guest chrony has NTP sources from fc-agent's config");
+    println!("========================================================");
+
+    let (vm_name, _, _, _) = common::unique_names("chrony-ntp");
+    let (mut child, fcvm_pid) = common::spawn_fcvm(&[
+        "podman",
+        "run",
+        "--name",
+        &vm_name,
+        "--network",
+        "rootless",
+        common::TEST_IMAGE,
+    ])
+    .await
+    .context("spawning fcvm for chrony check")?;
+    let _ = &mut child;
+
+    if let Err(e) = common::poll_health_by_pid(fcvm_pid, 180).await {
+        common::kill_process(fcvm_pid).await;
+        return Err(e.context("VM failed to become healthy"));
+    }
+
+    // chronyd runs off the boot critical path, so it can still be coming up when
+    // the VM first reports healthy, and a `pool` directive only materializes its
+    // sources once the pool name resolves. Retry until sources actually appear —
+    // the loop ends on the real condition, and the bound is what fails the test.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    let source_lines = loop {
+        let attempt = match common::exec_in_vm(fcvm_pid, &["chronyc", "-n", "sources"]).await {
+            Ok(out) => {
+                // `chronyc -n sources` prints a header, a `=====` rule, then one
+                // line per source.
+                let count = out
+                    .lines()
+                    .skip_while(|line| !line.contains("====="))
+                    .skip(1)
+                    .filter(|line| !line.trim().is_empty())
+                    .count();
+                if count > 0 {
+                    break count;
+                }
+                format!("chronyd answered but reported 0 sources; it said:\n{out}")
+            }
+            Err(e) => format!("chronyc did not answer: {e:#}"),
+        };
+        if std::time::Instant::now() >= deadline {
+            common::kill_process(fcvm_pid).await;
+            return Err(anyhow::anyhow!(
+                "guest never reported an NTP source within 60s — its clock would silently \
+                 drift with nothing to correct it. Last attempt: {attempt}"
+            ));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    };
+
+    let chronyd_argv = common::exec_in_vm(fcvm_pid, &["ps", "-o", "args=", "-C", "chronyd"]).await;
+    let written_conf = common::exec_in_vm(fcvm_pid, &["cat", "/etc/chrony.conf"]).await;
+
+    common::kill_process(fcvm_pid).await;
+
+    // 1. EVERY running chronyd is fc-agent's, reading the config fc-agent wrote.
+    // Without the `-f` the config is inert; a daemon without it is either the
+    // systemd-started one fc-agent is supposed to have replaced, or fc-agent's
+    // own falling back to the distro default.
+    let chronyd_argv = chronyd_argv.context("reading chronyd argv in the guest")?;
+    let daemons: Vec<&str> = chronyd_argv
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect();
+    assert!(
+        !daemons.is_empty(),
+        "no chronyd running in the guest, yet chronyc answered: {chronyd_argv:?}"
+    );
+    assert!(
+        daemons
+            .iter()
+            .all(|argv| argv.contains("-f /etc/chrony.conf")),
+        "every chronyd must run against fc-agent's config (-f /etc/chrony.conf), \
+         else the config it writes is inert; got: {daemons:?}"
+    );
+
+    // 2. That config carries the restore-critical makestep.
+    let written_conf = written_conf.context("reading /etc/chrony.conf in the guest")?;
+    assert!(
+        written_conf.contains("makestep 1 -1"),
+        "fc-agent's chrony config must allow stepping the clock at any time \
+         (makestep 1 -1) for snapshot restore; got: {written_conf:?}"
+    );
+
+    // 3. The daemon really has sources — established by the loop above, which
+    // only exits on source_lines > 0 or by failing the test.
+    println!("✅ chrony: {source_lines} NTP source(s) from fc-agent's config");
+    Ok(())
+}


### PR DESCRIPTION
Three sites from the codebase-wide sleep audit where a fixed delay was standing in for a signal that already existed. Each is a separate commit; they are grouped here because they are one concern — a sleep used as a race cover — and they touch disjoint code.

None of these is "the same sleep, but shorter": every one now waits on a real event, with a bound that only covers the case where the event can never arrive.

## 1. chronyd blocked every cold boot for ~1.5s — and failed silently

`fc-agent/src/agent.rs`, awaited inline from `run()`.

The audit flagged two sleeps (a 500ms "pkill worked" and a 1s "the command socket must be up by now"). Probing a live guest showed both were guarding code that could not work:

- The NTP servers were read from `/etc-host/chrony.conf`. **Nothing in the tree ever mounts `/etc-host`** — the string occurs only in that one function — so the list was always empty and the `chronyc add server` loop the 1s sleep existed for ran **zero times**.
- chronyd was started as `chronyd -u root` with **no `-f`**, so the config fc-agent wrote was read by nobody. chronyd loaded its compiled-in default, the rootfs's `/etc/chrony/chrony.conf`. The `makestep 1 -1` that lets a restored VM step a multi-hour clock jump was silently replaced by `makestep 1.0 3` — step only during the first three updates. Post-restore is exactly where chrony is supposed to be the correction.

Measured in a guest, before → after:

| | before | after |
|---|---|---|
| chronyd argv | `/usr/sbin/chronyd -u root` | `/usr/sbin/chronyd -f /etc/chrony.conf -u root` |
| makestep in force | `1.0 3` (rootfs config) | **`1 -1`** (fc-agent's, as intended) |
| `/etc-host` | does not exist | not used |
| `chronyc -n sources` | 4 (from the rootfs pool) | 4 (same pool, copied into fc-agent's config) |

Fixes: spawn the setup instead of awaiting it (the initial clock is already set synchronously by `sync_clock_from_host()` further up, so nothing in boot depends on chronyd); pass `-f` explicitly; build that config from the rootfs config's own `server`/`pool` directives so `rootfs-config.toml` stays the single source of truth for *which* servers a guest uses; replace the 500ms sleep with `systemctl stop chrony` plus a **pidfd** per leftover process (readable exactly when it exits, and `pidfd_send_signal` so a recycled PID can never be hit); replace the 1s sleep with a checked `chronyc` retry that ends on a real answer.

And it is no longer silent: the source count is logged on success, and an ERROR is logged when chronyd cannot be reached or reports zero sources.

Boot log after the change:

```
07:28:03.633 [fc-agent] output vsock connected (port 4997)
07:28:03.677 [fc-agent] chronyd started with 4 NTP source(s)
07:28:03.713 [fc-agent] root filesystem is btrfs, resized to fill disk
```

~44ms, concurrent with the rest of boot, where it previously blocked for at least the 1.5s of sleeps.

## 2. The cache-ack handshake closed on a 250ms grace window (#627's failure mode)

`src/commands/podman/listeners.rs` + `fc-agent/src/container.rs`.

The host wrote `cache-ack`, drained guest probe bytes for a fixed 250ms, then dropped the connection. A liveness probe arriving after that window was left unread — and an unread byte at close turns the close into a vsock RST that can flush the guest's receive buffer **before** it reads `cache-ack`, so the guest classifies a cold start as a warm restore. A window is a guess: a probe landing one millisecond late reopens the whole race.

Now: fc-agent closes the connection the moment it has read the ack, before it even logs, and the host drains **to EOF**. EOF is proof the ack landed and no probe is in flight, so the close cannot race the read.

The drain is **detached**, which matters: the next connection carries `ready`, and the documented post-resume vsock close-propagation failure (which made a second `read_line` on this task cost 300s) must not delay it.

## 3. Four copies of "sleep 200ms and hope the stderr reader drained"

`src/utils.rs`, `src/firecracker/vm.rs`, `src/hypervisor/cloud_hypervisor/mod.rs`, `src/network/pasta.rs` (2 sites).

`spawn_streaming` discarded both reader `JoinHandle`s, so a caller that saw its child exit early had nothing to await — and under load reported `no stderr captured` exactly when the cause mattered. It now returns them, and the exited-early paths await stderr EOF (2s bound, only for a grandchild holding the pipe open).

## Test Results

```
$ make lint
advisories ok, bans ok, licenses ok, sources ok

$ make test-root FILTER=sanity
    PASS [   7.937s] (1/6) fcvm::test_sanity test_sanity_rootless
    PASS [   8.192s] (2/6) fcvm::test_sanity test_sanity_bridged
    PASS [  17.849s] (3/6) fcvm::test_sanity test_sanity_routed
    PASS [  22.297s] (4/6) fcvm::test_fc_mock test_fc_mock_sanity
    PASS [  22.416s] (5/6) fcvm::test_sanity test_sanity_chrony_ntp_configured
    PASS [  28.071s] (6/6) fcvm::test_sanity test_ftrace_sanity
 Summary [  28.074s] 6 tests run: 6 passed, 683 skipped

$ make test-root FILTER=snapshot STREAM=1
 Summary [1251.705s] 116 tests run: 116 passed, 573 skipped

$ make test-root FILTER=chrony     # re-run against the final binary
    PASS [   6.744s] (1/1) fcvm::test_sanity test_sanity_chrony_ntp_configured
    ✅ chrony: 4 NTP source(s) from fc-agent's config
```

The new `test_sanity_chrony_ntp_configured` asserts all three links of the chain, because the failure mode is silence: every running chronyd uses `-f` on fc-agent's config, that config carries `makestep 1 -1`, and the daemon really reports at least one NTP source. The pre-fix guest runs `/usr/sbin/chronyd -u root`, which does not satisfy the first assertion — the test discriminates the bug rather than merely passing.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NTP synchronization now starts without delaying system boot and verifies that a time source is available.
  * NTP settings from the system configuration are preserved, with a default time source used when none is configured.

* **Bug Fixes**
  * Improved cache-handshake completion and connection cleanup.
  * Improved startup error reporting for virtualization and networking components by capturing complete process output.

* **Tests**
  * Added integration coverage verifying NTP configuration and readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->