### PR TITLE
Make the UFFD memory server fail closed, and bound its blast radius

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1174,7 +1174,7 @@ pub struct VmState {
 On serve process exit (SIGTERM/SIGINT):
 1. Query state manager for all VMs where `serve_pid == my_pid`
 2. Kill each clone process: `kill -TERM <clone_pid>`
-3. Remove socket file: `/mnt/fcvm-btrfs/uffd-{snapshot}-{pid}.sock`
+3. Remove socket file: `/mnt/fcvm-btrfs/uffd-{snapshot}-{pid}-{pid_start_time}.sock`
 4. Delete serve state from state manager
 
 ### Stale State File Handling
@@ -1493,7 +1493,7 @@ fcvm podman run --name baseline --network bridged nginx:alpine
 fcvm snapshot create --pid <baseline_pid> --tag my-snapshot
 
 # 3. Start memory server (serves pages via UFFD)
-fcvm snapshot serve my-snapshot    # Creates /mnt/fcvm-btrfs/uffd-my-snapshot-<pid>.sock
+fcvm snapshot serve my-snapshot    # Creates /mnt/fcvm-btrfs/uffd-my-snapshot-<pid>-<pid_start_time>.sock
 
 # 4. Spawn clones from the memory server
 fcvm snapshot run --pid <serve_pid> --name clone1

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -944,7 +944,7 @@ ip netns exec curl → br0 (10.0.2.1) → L2 forward → TAP → Guest (10.0.2.1
                  ▼
 ┌─────────────────────────────────────────────────────────┐
 │ 2. Create Unix socket for clone connections             │
-│    - /mnt/fcvm-btrfs/uffd-{snapshot}-{pid}.sock         │
+│    - uffd-{snapshot}-{pid}-{pid_start_time}.sock        │
 └────────────────┬────────────────────────────────────────┘
                  ▼
 ┌─────────────────────────────────────────────────────────┐

--- a/benches/clone.rs
+++ b/benches/clone.rs
@@ -161,8 +161,33 @@ impl CloneFixture {
 
         let serve_pid = serve_child.id();
 
-        // Wait for serve socket
-        let socket_path = format!("/mnt/fcvm-btrfs/uffd-{}-{}.sock", snapshot_name, serve_pid);
+        // Wait for serve socket.
+        //
+        // Derive it with the server's OWN function. The socket carries
+        // `(pid, pid_start_time)` so two servers can never collide, and a hand-formatted
+        // `uffd-{snap}-{pid}.sock` waits 30s for a file that is never created. This bench
+        // and benches/exec.rs both drifted exactly that way.
+        let serve_start_time = {
+            let deadline = Instant::now() + Duration::from_secs(30);
+            loop {
+                if let Some(t) = fcvm::utils::process_start_time(serve_pid) {
+                    break t;
+                }
+                assert!(
+                    Instant::now() < deadline,
+                    "serve process {serve_pid} never appeared in /proc"
+                );
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        };
+        let socket_path = fcvm::uffd::UffdServer::socket_path_for(
+            std::path::Path::new("/mnt/fcvm-btrfs"),
+            &snapshot_name,
+            serve_pid,
+            serve_start_time,
+        )
+        .display()
+        .to_string();
         let start = Instant::now();
         loop {
             if start.elapsed() > Duration::from_secs(30) {

--- a/benches/exec.rs
+++ b/benches/exec.rs
@@ -457,8 +457,34 @@ impl CloneFixture {
 
         let serve_pid = serve_child.id();
 
-        // Wait for serve socket
-        let socket_path = format!("/mnt/fcvm-btrfs/uffd-{}-{}.sock", snapshot_name, serve_pid);
+        // Wait for serve socket.
+        //
+        // Derive the name with the SAME function the server uses. Hand-formatting it here
+        // is what broke this bench: the server's socket carries `(pid, pid_start_time)`
+        // so two servers can never collide, and a literal `uffd-{snap}-{pid}.sock` waits
+        // 30s for a file that is never created. `socket_path_for` is the one definition;
+        // a caller that reimplements it silently drifts the moment the format changes.
+        let serve_start_time = {
+            let deadline = Instant::now() + Duration::from_secs(30);
+            loop {
+                if let Some(t) = fcvm::utils::process_start_time(serve_pid) {
+                    break t;
+                }
+                assert!(
+                    Instant::now() < deadline,
+                    "serve process {serve_pid} never appeared in /proc"
+                );
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        };
+        let socket_path = fcvm::uffd::UffdServer::socket_path_for(
+            std::path::Path::new("/mnt/fcvm-btrfs"),
+            &snapshot_name,
+            serve_pid,
+            serve_start_time,
+        )
+        .display()
+        .to_string();
         let start = Instant::now();
         loop {
             if start.elapsed() > Duration::from_secs(30) {

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -1820,10 +1820,66 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
         // Get disk path for startup snapshot creation
         let disk_path = data_dir.join("disks/rootfs.raw");
 
-        // Wait for cancellation, VM exit, or startup snapshot trigger
+        // Watch the memory server for this clone's whole life, not just at connect time.
+        //
+        // A UFFD-restored clone's guest RAM is served by that process. If it dies, the
+        // clone does not crash and does not read zeroes — it FREEZES. Firecracker keeps
+        // its own reference to the userfaultfd ("Save UFFD in order to keep it open in
+        // the Firecracker process, as well." — firecracker `src/vmm/src/lib.rs`), so the
+        // server's death is not the final `fput`; `userfaultfd_release()` never runs, the
+        // VMAs are never unregistered, and every fault waits forever. Verified on a live
+        // clone: both vCPUs parked in `wchan=handle_userfault` 30s after its server was
+        // SIGKILLed, with no exit status, no signal, and nothing in any log.
+        //
+        // Opened HERE rather than inside the loop so that "cannot watch" fails the
+        // restore immediately, and every later wakeup means exactly one thing: it died.
+        // Only served clones need this — a file-backed restore owns its memory outright,
+        // so `serve_pid` is None and no watch exists.
+        let mut serve_watch = match serve_pid {
+            Some(pid) => crate::utils::ProcessWatch::open(pid)
+                .with_context(|| format!("watching memory server PID {pid}"))?,
+            None => None,
+        };
+        if serve_pid.is_some() && serve_watch.is_none() {
+            // Already gone before we even started: the clone is restored but nothing can
+            // serve the pages it has not touched yet. Refuse now rather than hand back a
+            // VM that will freeze on its first unserved fault.
+            bail!(
+                "memory server PID {} was already gone before this clone started; its \
+                 unfaulted pages can never be served",
+                serve_pid.unwrap_or(0)
+            );
+        }
+
+        // Wait for cancellation, VM exit, memory-server death, or startup snapshot trigger
         loop {
             tokio::select! {
                 _ = cancel.cancelled() => {
+                    container_exit_code = None;
+                    break;
+                }
+                // `serve_watch` is None for file-backed restores, so this branch is
+                // disabled entirely there rather than firing on a dummy future.
+                Some(()) = async {
+                    match serve_watch.as_mut() {
+                        Some(w) => { w.exited().await; Some(()) }
+                        None => None,
+                    }
+                } => {
+                    // Every page this clone has not already faulted in just became
+                    // unreachable, and an unserved fault waits forever rather than
+                    // failing. Recording the failure is enough: the shared reporting
+                    // path below logs it, marks the state file, and the post-loop
+                    // `bail!` turns it into a non-zero exit. `cleanup_vm` then kills the
+                    // VMM — a wedged task waits in TASK_KILLABLE (`fs/userfaultfd.c`), so
+                    // SIGKILL does reap it, measured under 2s on an already-parked clone.
+                    clone_failure = Some(format!(
+                        "its memory server (PID {}) exited while this clone was still \
+                         running. Every page not already faulted in is unreachable, and \
+                         an unserved fault waits forever rather than failing, so the \
+                         clone was killed rather than left frozen with no error.",
+                        serve_pid.unwrap_or(0)
+                    ));
                     container_exit_code = None;
                     break;
                 }
@@ -1957,28 +2013,6 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
                     } else {
                         vmm_exit_failure(&status)
                     };
-                    if let Some(ref reason) = clone_failure {
-                        error!(
-                            vm_id = %vm_id,
-                            snapshot = %snapshot_name,
-                            "clone FAILED: {}",
-                            reason
-                        );
-                        // Publish the failure while the state file still exists, so anything
-                        // watching `fcvm ls` sees `failed` rather than a VM that merely
-                        // vanished. cleanup_vm deletes the file moments later; the durable
-                        // signal is this process's non-zero exit.
-                        if let Err(e) = state_manager
-                            .update_state(&vm_id, |state| {
-                                state.status = VmStatus::Failed;
-                                state.health_status = crate::state::HealthStatus::Unhealthy;
-                            })
-                            .await
-                        {
-                            warn!(vm_id = %vm_id, error = %e, "could not record clone failure in state");
-                        }
-                    }
-
                     // If in TTY mode, get exit code from TTY handle
                     if let Some(handle) = tty_handle {
                         container_exit_code = handle.join().ok().and_then(|r| r.ok());
@@ -2072,6 +2106,27 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
         }
     }
 
+    // ONE place that reports a failed clone, whichever arm set it: the VMM dying under
+    // us, or the memory server disappearing. Both are "this clone did not do its job",
+    // and both must reach a caller the same way.
+    //
+    // Deliberately BEFORE cleanup_vm: it deletes the state file moments from now, and
+    // the point of writing `failed` is that anything watching `fcvm ls` sees a failure
+    // rather than a VM that merely vanished. The durable signal is this process's
+    // non-zero exit, published by the `bail!` further down.
+    if let Some(ref reason) = clone_failure {
+        error!(vm_id = %vm_id, snapshot = %snapshot_name, "clone FAILED: {}", reason);
+        if let Err(e) = state_manager
+            .update_state(&vm_id, |state| {
+                state.status = VmStatus::Failed;
+                state.health_status = crate::state::HealthStatus::Unhealthy;
+            })
+            .await
+        {
+            warn!(vm_id = %vm_id, error = %e, "could not record clone failure in state");
+        }
+    }
+
     // Stop implicit UFFD server if running
     implicit_uffd_cancel.cancel();
     // The status listener never exits on its own (no idle timeout) — abort it.
@@ -2139,10 +2194,18 @@ fn vmm_exit_failure(status: &Result<std::process::ExitStatus>) -> Option<String>
              matching 'KILLED the clone's VMM' line."
         ));
     }
-    match status.code() {
-        Some(0) | None => None,
-        Some(code) => Some(format!("its VMM exited with status {code}")),
-    }
+    // NOT a failure classifier for the exit CODE. Firecracker's exit status does not
+    // mean what the obvious reading suggests: across one CI job, 71 of 77 VM exits were
+    // status 1 and only 6 were 0 — an orderly guest poweroff routinely exits non-zero.
+    // Sixty of those were plain (non-clone) VMs on the podman path, which never consults
+    // this function and never cared. Treating non-zero as failure here turned a normal
+    // shutdown into `clone FAILED` and made `test_trailing_args_command` red: the
+    // container exited 0, the guest powered itself off, and the VMM followed 3.4s later.
+    //
+    // The signal branch above is the one that carries meaning, and it stays. Real loss of
+    // the memory server is detected directly by the pidfd watch in the supervise loop, not
+    // inferred from a number.
+    None
 }
 
 /// Build the up-front reboot plan for a restored clone: everything needed to

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::signal::unix::{signal, SignalKind};
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use super::podman::{
     check_podman_snapshot, create_snapshot_interruptible, startup_snapshot_key,
@@ -393,10 +393,7 @@ async fn cmd_snapshot_serve(args: SnapshotServeArgs) -> Result<()> {
         "loaded snapshot configuration"
     );
 
-    // Generate unique socket name with PID to allow multiple serves per snapshot
     let my_pid = std::process::id();
-    let socket_path =
-        paths::data_dir().join(format!("uffd-{}-{}.sock", args.snapshot_name, my_pid));
 
     // How pages reach the clones: private per-clone UFFDIO_COPY (default) or one shared
     // memfd resolved with UFFDIO_CONTINUE (--uffd-mode minor / FCVM_UFFD_MODE=minor).
@@ -406,15 +403,18 @@ async fn cmd_snapshot_serve(args: SnapshotServeArgs) -> Result<()> {
         None => UffdBacking::Copy,
     };
 
-    // Create UFFD server with custom socket path
-    let server = UffdServer::new_with_path(
+    // The server names its own socket after this process's (pid, start_time), so no two
+    // live servers can collide on it. Clones rebuild the same name from the serve state
+    // file (see `cmd_snapshot_run`).
+    let server = UffdServer::new(
         args.snapshot_name.clone(),
         &snapshot_config.memory_path,
-        &socket_path,
+        &paths::data_dir(),
         backing,
     )
     .await
     .context("creating UFFD server")?;
+    let socket_path = server.socket_path().to_path_buf();
 
     // Save serve state for tracking
     let serve_id = generate_vm_id();
@@ -706,7 +706,8 @@ fn volume_state_from_snapshot(
 /// This is public so podman.rs can call it directly for cache hits.
 pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
     // Determine mode and get snapshot name
-    let (snapshot_name, serve_pid, use_uffd, serve_uffd_mode) = match (&args.pid, &args.snapshot) {
+    let (snapshot_name, serve_pid, uffd_socket, serve_uffd_mode) = match (&args.pid, &args.snapshot)
+    {
         (Some(pid), None) => {
             // UFFD mode: verify serve process is alive
             if !crate::utils::is_process_alive(*pid) {
@@ -728,18 +729,33 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
             // sends the backing fd first, COPY mode does not).
             let mode = serve_state.config.uffd_mode.clone();
 
+            // The serve socket is named after the serve process's (pid, start_time) — the
+            // same identity `load_state_by_pid` just verified — so this rebuilds exactly
+            // the path that server bound, and can never name a DIFFERENT server that
+            // happens to have inherited the PID.
+            let serve_start_time = serve_state.pid_start_time.ok_or_else(|| {
+                anyhow::anyhow!("serve process state (PID {pid}) has no pid_start_time")
+            })?;
+
             let name = serve_state
                 .config
                 .snapshot_name
                 .ok_or_else(|| anyhow::anyhow!("serve process has no snapshot_name"))?;
 
+            let socket = crate::uffd::UffdServer::socket_path_for(
+                &paths::data_dir(),
+                &name,
+                *pid,
+                serve_start_time,
+            );
+
             info!("Cloning VM from serve PID {} (snapshot: {})", pid, name);
-            (name, Some(*pid), true, mode)
+            (name, Some(*pid), Some(socket), mode)
         }
         (None, Some(name)) => {
             // Direct file mode: no serve process needed
             info!("Cloning VM directly from snapshot: {}", name);
-            (name.clone(), None, false, None)
+            (name.clone(), None, None, None)
         }
         (None, None) => {
             anyhow::bail!("Either --pid or --snapshot must be specified");
@@ -749,6 +765,7 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
             anyhow::bail!("Cannot specify both --pid and --snapshot");
         }
     };
+    let use_uffd = uffd_socket.is_some();
 
     let state_manager = StateManager::new(paths::state_dir());
 
@@ -851,23 +868,17 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
 
     let socket_path = data_dir.join("firecracker.sock");
 
-    // Build UFFD socket path for memory server (only for UFFD mode)
-    let uffd_socket = if use_uffd {
-        let pid = serve_pid.expect("serve_pid must be set for UFFD mode");
-        let socket = paths::data_dir().join(format!("uffd-{}-{}.sock", snapshot_name, pid));
-        info!(
+    match &uffd_socket {
+        Some(socket) => info!(
             uffd_socket = %socket.display(),
-            serve_pid = pid,
+            serve_pid = serve_pid.unwrap_or_default(),
             "connecting to memory server"
-        );
-        Some(socket)
-    } else {
-        info!(
+        ),
+        None => info!(
             memory_file = %snapshot_config.memory_path.display(),
             "loading memory directly from file"
-        );
-        None
-    };
+        ),
+    }
 
     // Setup VolumeServers for clones if snapshot has volumes
     //
@@ -1249,7 +1260,6 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
         // Hugepages require UFFD (Firecracker rejects File backend for hugepage snapshots).
         // FCVM_FORCE_UFFD=1 forces UFFD for debugging/testing.
         if hugepages || std::env::var("FCVM_FORCE_UFFD").is_ok() {
-            let implicit_socket_path = data_dir.join("uffd.sock");
             let reason = if hugepages {
                 // Same admission logic as the serve-process path above: refuse to spawn a
                 // hugepage clone the pool cannot hold at its CoW worst case.
@@ -1262,16 +1272,15 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
             };
             let backing = UffdBacking::from_env(hugepages)?;
             info!(
-                socket = %implicit_socket_path.display(),
                 reason = %reason,
                 mode = backing.name(),
                 "starting implicit UFFD server for snapshot restore"
             );
 
-            let server = match UffdServer::new_with_path(
+            let server = match UffdServer::new(
                 format!("implicit-{}", truncate_id(&vm_id, 8)),
                 &snapshot_config.memory_path,
-                &implicit_socket_path,
+                &data_dir,
                 backing,
             )
             .await
@@ -1289,6 +1298,11 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
                     return Err(e);
                 }
             };
+            let implicit_socket_path = server.socket_path().to_path_buf();
+            info!(
+                socket = %implicit_socket_path.display(),
+                "implicit UFFD server socket"
+            );
 
             let cancel = implicit_uffd_cancel.clone();
             tokio::spawn(async move {
@@ -1764,6 +1778,9 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
 
     // Track container exit code (from TTY mode)
     let mut container_exit_code: Option<i32> = None;
+    // Set when the VMM died on its own instead of fcvm stopping it — the authoritative
+    // failure signal a caller sees for a clone whose memory could not be served.
+    let mut clone_failure: Option<String> = None;
     let mut health_monitor_handle = None;
 
     if verify_result.is_ok() {
@@ -1805,13 +1822,17 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
                     // Guest reboot? Relaunch in place as a cold boot from the
                     // provisioned disk (disk-only-clone semantics): same fcvm
                     // process, network, holder, listeners, and health monitor.
-                    if super::podman::wait_for_reboot_decision(
+                    // Authoritative (drain-handshake backed) answer to "did the GUEST ask
+                    // for this?". A reboot is an orderly guest action even when this clone
+                    // shape cannot be relaunched in place, so it must not be classified as
+                    // a failure below.
+                    let guest_rebooted = super::podman::wait_for_reboot_decision(
                         &reboot_requested,
                         &status_handle,
                         &status_socket_path,
                     )
-                    .await
-                    {
+                    .await;
+                    if guest_rebooted {
                         reboot_requested.store(false, std::sync::atomic::Ordering::Release);
                         // Clear racing pre-reboot exit signal/files (fresh lifecycle).
                         container_exit_seen.store(false, std::sync::atomic::Ordering::Release);
@@ -1909,6 +1930,41 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
                             }
                         } else {
                             warn!("guest rebooted but reboot-in-place is unavailable for this clone; treating as VM exit");
+                        }
+                    }
+
+                    // The VMM went away while we were still supervising it — fcvm has not
+                    // asked it to stop yet (a SIGTERM to fcvm takes the `cancel` arm above,
+                    // and cleanup_vm's kill only runs after this loop), and the guest did
+                    // not ask for a reboot. An abnormal status here therefore means the VMM
+                    // died on its own or was killed by someone else — including this
+                    // snapshot's memory server failing closed on a clone whose faults it
+                    // could not serve. Record it so the clone reports FAILED instead of
+                    // exiting 0 as if nothing happened.
+                    clone_failure = if guest_rebooted {
+                        None
+                    } else {
+                        vmm_exit_failure(&status)
+                    };
+                    if let Some(ref reason) = clone_failure {
+                        error!(
+                            vm_id = %vm_id,
+                            snapshot = %snapshot_name,
+                            "clone FAILED: {}",
+                            reason
+                        );
+                        // Publish the failure while the state file still exists, so anything
+                        // watching `fcvm ls` sees `failed` rather than a VM that merely
+                        // vanished. cleanup_vm deletes the file moments later; the durable
+                        // signal is this process's non-zero exit.
+                        if let Err(e) = state_manager
+                            .update_state(&vm_id, |state| {
+                                state.status = VmStatus::Failed;
+                                state.health_status = crate::state::HealthStatus::Unhealthy;
+                            })
+                            .await
+                        {
+                            warn!(vm_id = %vm_id, error = %e, "could not record clone failure in state");
                         }
                     }
 
@@ -2031,6 +2087,14 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
     // Propagate post-restore verification failure only after cleanup has run
     verify_result?;
 
+    // A clone whose VMM died under us is a FAILED clone, not a finished one. Reporting it
+    // only in the log would leave the caller — a benchmark harness, a request router, a
+    // `snapshot run` in a script — believing the clone completed normally, which is exactly
+    // how unserved (zero-page) guest memory turns into unattributable bad output.
+    if let Some(reason) = clone_failure {
+        bail!("clone '{}' FAILED: {}", vm_name, reason);
+    }
+
     // Return error if container exited with non-zero code
     if let Some(code) = container_exit_code {
         if code != 0 {
@@ -2039,6 +2103,35 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Classify how a restored clone's VMM exited: `Some(reason)` when the exit is a FAILURE.
+///
+/// Called only from the supervise loop, i.e. while fcvm still expects the VMM to be running.
+/// Every orderly end of life reaches that point as a clean exit — a guest `poweroff` (PSCI
+/// SYSTEM_OFF) and a guest reboot both let Firecracker exit 0, and fcvm's own teardown paths
+/// never come through here (SIGTERM to fcvm takes the cancellation arm; `cleanup_vm`'s kill
+/// happens after the loop). So a signal death or a non-zero status is, by construction,
+/// something that happened TO the clone.
+fn vmm_exit_failure(status: &Result<std::process::ExitStatus>) -> Option<String> {
+    use std::os::unix::process::ExitStatusExt;
+    let status = match status {
+        Ok(status) => status,
+        Err(e) => return Some(format!("could not determine how the VMM exited: {e:#}")),
+    };
+    if let Some(signal) = status.signal() {
+        return Some(format!(
+            "its VMM was killed by signal {signal} without fcvm asking it to stop. If this \
+             clone was restored from a memory server, that server kills clones whose page \
+             faults it can no longer serve — a clone left running would read zero-filled \
+             pages where guest memory should be. Check the serve process log for the \
+             matching 'KILLED the clone's VMM' line."
+        ));
+    }
+    match status.code() {
+        Some(0) | None => None,
+        Some(code) => Some(format!("its VMM exited with status {code}")),
+    }
 }
 
 /// Build the up-front reboot plan for a restored clone: everything needed to

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -1277,8 +1277,19 @@ pub async fn cmd_snapshot_run(args: SnapshotRunArgs) -> Result<()> {
                 "starting implicit UFFD server for snapshot restore"
             );
 
+            // Just "implicit" — NOT the vm_id. This socket is created inside `data_dir`,
+            // which IS this VM's own directory (`vm-disks/<vm_id>/`), so repeating the id in
+            // the filename buys no uniqueness and costs 9 bytes of a 107-byte budget.
+            // `UffdServer::new` appends `-{pid}-{pid_start_time}`, which is what actually
+            // makes the name unique, and that identity is unaffected by this.
+            //
+            // Those 9 bytes were not spare. The full path under a root-owned data dir is
+            //   /mnt/fcvm-btrfs/root/vm-disks/vm-<32 hex>/uffd-implicit-vm-<8>-<pid>-<start>.sock
+            // which measured 109 bytes in CI against `sun_path`'s 107 — every hugepage test
+            // failed on BOTH arches, because hugepages force UFFD and so are the only tests
+            // that build this path at all.
             let server = match UffdServer::new(
-                format!("implicit-{}", truncate_id(&vm_id, 8)),
+                "implicit".to_string(),
                 &snapshot_config.memory_path,
                 &data_dir,
                 backing,

--- a/src/state/manager.rs
+++ b/src/state/manager.rs
@@ -20,20 +20,7 @@ fn open_lock_file(path: &Path) -> Result<std::fs::File> {
     Ok(file)
 }
 
-/// Read the start time of a process in clock ticks since boot (field 22 of
-/// /proc/<pid>/stat). Returns None if the process doesn't exist or the field
-/// can't be parsed.
-///
-/// Used as a process identity check: a (pid, start_time) pair uniquely
-/// identifies a process even after the OS reuses the PID for something else.
-fn process_start_time(pid: u32) -> Option<u64> {
-    let stat = std::fs::read_to_string(format!("/proc/{}/stat", pid)).ok()?;
-    // The comm field (field 2) may contain spaces and parentheses; everything
-    // after the last ')' is space-separated starting at field 3 (state), so
-    // starttime (field 22) is the 20th token after the closing paren.
-    let after_comm = stat.rsplit_once(')')?.1;
-    after_comm.split_whitespace().nth(19)?.parse().ok()
-}
+use crate::utils::process_start_time;
 
 /// Check whether the process recorded in a state file is still the same
 /// process that wrote it. Returns false when the state records a start time

--- a/src/uffd/server.rs
+++ b/src/uffd/server.rs
@@ -94,6 +94,14 @@ fn max_clones_per_server() -> Result<usize> {
 
 /// `SO_PEERPIDFD` (Linux 6.5+). Not exposed by the `libc` crate; value from
 /// `asm-generic/socket.h`.
+///
+/// **Linux 6.5 is therefore the minimum host kernel for a UFFD restore**, and it is not
+/// negotiable: this is the only way to obtain the connecting VMM's pidfd ATOMICALLY from
+/// the accepted socket. A PID read separately can be recycled between the read and the
+/// kill, landing a SIGKILL on a stranger, so fail-closed would not be safe without it.
+/// [`require_peer_pidfd_support`] probes it at startup, so an older kernel fails loudly at
+/// `snapshot serve` rather than at the first clone that needs stopping. File-backed
+/// restores (`snapshot run --snapshot`) carry no such requirement.
 const SO_PEERPIDFD: libc::c_int = 77;
 
 /// Fetch a pidfd for the peer of a connected Unix socket, atomically (see [`PeerVmm`]).
@@ -614,8 +622,21 @@ impl UffdServer {
                             // Spawn per-connection task so the accept loop returns
                             // immediately — no blocking on slow/misbehaving clones.
                             vm_tasks.spawn(async move {
+                                // Release the slot from a Drop guard, not a trailing
+                                // statement. A panic inside serve_clone_fail_closed skips
+                                // everything after the await, so a bare fetch_sub leaks the
+                                // slot PERMANENTLY: the cap never comes back down, and after
+                                // `max_clones` panics the server refuses every future clone
+                                // as "at its concurrent-clone cap" while serving nothing.
+                                // Drop runs during unwind; a trailing statement does not.
+                                struct SlotGuard(std::sync::Arc<AtomicUsize>);
+                                impl Drop for SlotGuard {
+                                    fn drop(&mut self) {
+                                        self.0.fetch_sub(1, Ordering::AcqRel);
+                                    }
+                                }
+                                let _slot = SlotGuard(admitted_slot);
                                 serve_clone_fail_closed(&vm_id, stream, source, peer).await;
-                                admitted_slot.fetch_sub(1, Ordering::AcqRel);
                                 vm_id
                             });
                         }
@@ -646,8 +667,10 @@ impl UffdServer {
         // Stop accepting new connections, but keep serving page faults for VMs that are
         // already connected until each one closes its uffd (i.e. its Firecracker exits).
         // Aborting the handlers here would close the uffds while those VMs are still
-        // running, and the kernel would then resolve their page faults with zero pages
-        // instead of snapshot contents — silent guest memory corruption.
+        // running. Firecracker holds its OWN uffd reference for the VM's lifetime, so the
+        // kernel never falls through to zero-fill; those guests would WEDGE instead, both
+        // vCPUs parked in handle_userfault forever with no exit code and no signal.
+        // (Measured — see the PeerVmm doc for the evidence and the kernel path.)
         drop(listener);
         if !vm_tasks.is_empty() {
             info!(

--- a/src/uffd/server.rs
+++ b/src/uffd/server.rs
@@ -20,14 +20,26 @@ const HUGE_PAGE_2M: usize = 2 * 1024 * 1024;
 /// Env var overriding [`DEFAULT_MAX_CLONES_PER_SERVER`].
 pub const MAX_CLONES_ENV: &str = "FCVM_UFFD_MAX_CLONES";
 
+/// The largest per-server clone fan-out the test suite exercises
+/// (`test_snapshot_clone_stress_100_*` restores 100 clones from ONE serve process). The
+/// default cap must stay above it: a bound that refuses a configuration fcvm supports is a
+/// bug, not a safety feature.
+const EXERCISED_MAX_CLONES_PER_SERVER: usize = 100;
+
 /// How many clones one server serves concurrently.
 ///
 /// Every clone attached to a server shares that server's **failure domain** (one process,
 /// one page source, one set of fds) and its **fairness domain** (one task each on the same
-/// runtime). An unbounded server therefore has an unbounded blast radius. This cap is the
-/// bound; raise it with `FCVM_UFFD_MAX_CLONES` and accept the wider blast radius, or run a
-/// second `fcvm snapshot serve` and split the clones across two failure domains.
-pub const DEFAULT_MAX_CLONES_PER_SERVER: usize = 64;
+/// runtime). An unbounded server therefore has an unbounded blast radius: a single
+/// fault-handler failure, OOM, or fd exhaustion takes out every clone attached to it.
+///
+/// This is a **backstop, not a ration**. It sits well clear of
+/// [`EXERCISED_MAX_CLONES_PER_SERVER`] so it never fires in supported use — the first
+/// version of this change shipped 64 and the 100-clone stress test caught it immediately,
+/// which is exactly the failure mode a too-tight bound produces. Raise it with
+/// `FCVM_UFFD_MAX_CLONES` and accept the wider blast radius, or run a second
+/// `fcvm snapshot serve` and split the clones across two failure domains.
+pub const DEFAULT_MAX_CLONES_PER_SERVER: usize = 256;
 
 /// How many uffd events one handler drains before yielding to the runtime.
 ///
@@ -2279,6 +2291,20 @@ mod tests {
         assert_eq!(toucher.join().unwrap(), 0);
         unsafe { libc::munmap(guest, 4096) };
         drop(client);
+    }
+
+    /// The cap must never refuse a fan-out fcvm supports. Shipping 64 broke
+    /// `test_snapshot_clone_stress_100_bridged` — 100 clones on one serve process — with the
+    /// server killing clones 65..100 exactly as designed. The bound is a backstop against
+    /// unbounded growth, so it belongs comfortably above what the suite exercises.
+    #[test]
+    fn test_default_cap_clears_the_fan_out_the_suite_exercises() {
+        assert!(
+            DEFAULT_MAX_CLONES_PER_SERVER > EXERCISED_MAX_CLONES_PER_SERVER,
+            "default cap {DEFAULT_MAX_CLONES_PER_SERVER} would refuse the \
+             {EXERCISED_MAX_CLONES_PER_SERVER}-clone fan-out the stress tests restore from a \
+             single server"
+        );
     }
 
     #[test]

--- a/src/uffd/server.rs
+++ b/src/uffd/server.rs
@@ -536,14 +536,24 @@ impl UffdServer {
                                         "could not pin the connecting VMM — stopping it unpinned \
                                          rather than dropping the connection"
                                     );
-                                    // Dropping the stream here would NOT be safe: Firecracker
-                                    // may already have sent its userfaultfd and closed its own
-                                    // copy, so closing the socket destroys the in-flight fd and
-                                    // the guest runs on zero pages — the same trap the over-cap
-                                    // path avoids. SO_PEERPIDFD is probed at startup, so the only
-                                    // way to reach this is fd exhaustion mid-flight; the unpinned
-                                    // PID from SO_PEERCRED is then the only handle left, and a
-                                    // vanishingly unlikely mis-signal beats a CERTAIN corruption.
+                                    // Dropping the stream here would NOT be safe, though not for
+                                    // the reason it is tempting to give. Firecracker KEEPS its own
+                                    // reference to the userfaultfd for the VM's lifetime ("Save
+                                    // UFFD in order to keep it open in the Firecracker process, as
+                                    // well." — firecracker src/vmm/src/lib.rs), so closing this
+                                    // socket does not drop the last reference and the guest does
+                                    // NOT fall through to zero pages. It FREEZES: with a reference
+                                    // still held, userfaultfd_release() never runs, the VMAs stay
+                                    // registered, and every fault waits forever. Verified on a live
+                                    // clone — both vCPUs parked in wchan=handle_userfault 30s after
+                                    // its server died, with no exit code, no signal and no log.
+                                    //
+                                    // A frozen clone is not milder than a corrupt one: it holds its
+                                    // memory, its loopback port and its disk indefinitely while
+                                    // looking alive. SO_PEERPIDFD is probed at startup, so the only
+                                    // way here is fd exhaustion mid-flight; the unpinned PID from
+                                    // SO_PEERCRED is then the only handle left, and a vanishingly
+                                    // unlikely mis-signal beats a CERTAIN wedge.
                                     kill_unpinned_peer(&stream, &vm_id);
                                     continue;
                                 }

--- a/src/uffd/server.rs
+++ b/src/uffd/server.rs
@@ -1698,6 +1698,58 @@ pub fn preflight_clone_hugepages(memory_mib: usize) -> Result<()> {
 mod tests {
     use super::*;
 
+    /// The implicit-restore socket must fit in `sun_path` under the LONGEST path fcvm
+    /// actually produces, not the one that happened to be measured.
+    ///
+    /// This is a regression test for a real CI failure: the name carried a redundant
+    /// `-vm-<8>` (redundant because the socket already lives in `vm-disks/<vm_id>/`), the
+    /// path came to 109 bytes against a 107-byte limit, and EVERY hugepage test failed on
+    /// both arches — hugepages force UFFD, so they are the only tests that build this path.
+    ///
+    /// The two numeric fields are why this needs pinning rather than eyeballing:
+    /// `pid` runs to `/proc/sys/kernel/pid_max` (7 digits at the 4194304 default), and
+    /// `pid_start_time` is clock ticks since boot, so at 100 Hz it takes an 8th digit after
+    /// ~27 hours of uptime and a 9th after ~115 days. A CI runner up for a week silently
+    /// eats headroom that a freshly booted dev box never will.
+    #[test]
+    fn implicit_socket_path_fits_sun_path_at_worst_case() {
+        // Deepest real layout: root-owned data dir (the `/root` component only appears
+        // when running as root, which is exactly what Host-Root CI does) + a full 32-hex
+        // vm_id directory.
+        let dir = std::path::Path::new(
+            "/mnt/fcvm-btrfs/root/vm-disks/vm-0bf42fb1345f416da3b18c0c5cda3e92",
+        );
+        // Widest plausible numbers, not today's: pid at the 4194304 default ceiling, and a
+        // 9-digit start_time (~115 days of uptime at 100 Hz).
+        let path = UffdServer::socket_path_for(dir, "implicit", 4_194_304, 999_999_999);
+        let len = path.as_os_str().len();
+        assert!(
+            len <= MAX_UNIX_SOCKET_PATH_LEN,
+            "implicit UFFD socket path is {len} bytes, over the {MAX_UNIX_SOCKET_PATH_LEN}-byte \
+             sun_path limit: {}. Adding to this name breaks every hugepage test on every arch.",
+            path.display()
+        );
+    }
+
+    /// Guard the guard: the assertion above is only meaningful if this construction can
+    /// actually exceed the limit. If a future refactor made the name unconditionally tiny,
+    /// the test above would pass vacuously and stop protecting anything.
+    #[test]
+    fn the_sun_path_limit_is_reachable() {
+        let dir = std::path::Path::new(
+            "/mnt/fcvm-btrfs/root/vm-disks/vm-0bf42fb1345f416da3b18c0c5cda3e92",
+        );
+        // The name this code shipped with in CI, which measured 109 bytes.
+        let path = UffdServer::socket_path_for(dir, "implicit-vm-0bf42", 1_802_889, 1_201_836);
+        assert!(
+            path.as_os_str().len() > MAX_UNIX_SOCKET_PATH_LEN,
+            "the historical over-length name now fits ({} bytes) — either the limit or the \
+             layout changed, and `implicit_socket_path_fits_sun_path_at_worst_case` may be \
+             passing vacuously. Re-derive both from the current layout.",
+            path.as_os_str().len()
+        );
+    }
+
     #[test]
     fn test_mapping_contains_basic() {
         let mapping = GuestRegionUffdMapping {

--- a/src/uffd/server.rs
+++ b/src/uffd/server.rs
@@ -41,6 +41,13 @@ const EXERCISED_MAX_CLONES_PER_SERVER: usize = 100;
 /// `fcvm snapshot serve` and split the clones across two failure domains.
 pub const DEFAULT_MAX_CLONES_PER_SERVER: usize = 256;
 
+// Lowering the default back under the fan-out fcvm actually supports is a BUILD error, not a
+// mystery stress-test failure two hours later. (Shipping 64 cost exactly that.)
+const _: () = assert!(
+    DEFAULT_MAX_CLONES_PER_SERVER > EXERCISED_MAX_CLONES_PER_SERVER,
+    "the default UFFD clone cap must exceed the per-server fan-out the stress tests restore"
+);
+
 /// How many uffd events one handler drains before yielding to the runtime.
 ///
 /// `drain_events` is a synchronous loop that owns its worker thread while it runs, and it
@@ -2291,20 +2298,6 @@ mod tests {
         assert_eq!(toucher.join().unwrap(), 0);
         unsafe { libc::munmap(guest, 4096) };
         drop(client);
-    }
-
-    /// The cap must never refuse a fan-out fcvm supports. Shipping 64 broke
-    /// `test_snapshot_clone_stress_100_bridged` — 100 clones on one serve process — with the
-    /// server killing clones 65..100 exactly as designed. The bound is a backstop against
-    /// unbounded growth, so it belongs comfortably above what the suite exercises.
-    #[test]
-    fn test_default_cap_clears_the_fan_out_the_suite_exercises() {
-        assert!(
-            DEFAULT_MAX_CLONES_PER_SERVER > EXERCISED_MAX_CLONES_PER_SERVER,
-            "default cap {DEFAULT_MAX_CLONES_PER_SERVER} would refuse the \
-             {EXERCISED_MAX_CLONES_PER_SERVER}-clone fan-out the stress tests restore from a \
-             single server"
-        );
     }
 
     #[test]

--- a/src/uffd/server.rs
+++ b/src/uffd/server.rs
@@ -73,6 +73,91 @@ fn max_clones_per_server() -> Result<usize> {
     parse_max_clones(std::env::var(MAX_CLONES_ENV).ok().as_deref())
 }
 
+/// `SO_PEERPIDFD` (Linux 6.5+). Not exposed by the `libc` crate; value from
+/// `asm-generic/socket.h`.
+const SO_PEERPIDFD: libc::c_int = 77;
+
+/// Fetch a pidfd for the peer of a connected Unix socket, atomically (see [`PeerVmm`]).
+fn peer_pidfd(sock: RawFd) -> Result<OwnedFd> {
+    let mut raw: libc::c_int = -1;
+    let mut len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+    // SAFETY: getsockopt into a `c_int` with its exact size; `sock` is a live socket fd.
+    let rc = unsafe {
+        libc::getsockopt(
+            sock,
+            libc::SOL_SOCKET,
+            SO_PEERPIDFD,
+            std::ptr::addr_of_mut!(raw).cast::<libc::c_void>(),
+            &mut len,
+        )
+    };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error()).context("getsockopt(SO_PEERPIDFD)");
+    }
+    // SAFETY: the kernel just installed `raw` as a fresh, owned fd in this process.
+    Ok(unsafe { OwnedFd::from_raw_fd(raw) })
+}
+
+/// The PID a pidfd refers to, from `/proc/self/fdinfo/<fd>`. Log-only (see [`PeerVmm::pid`]).
+fn pidfd_pid(pidfd: &OwnedFd) -> Result<u32> {
+    let info = std::fs::read_to_string(format!("/proc/self/fdinfo/{}", pidfd.as_raw_fd()))
+        .context("reading pidfd fdinfo")?;
+    info.lines()
+        .find_map(|l| l.strip_prefix("Pid:")?.trim().parse().ok())
+        .ok_or_else(|| anyhow!("pidfd fdinfo has no parsable Pid: line"))
+}
+
+/// Refuse to start unless this kernel can pin a socket peer atomically.
+///
+/// Checked ONCE, at server construction, so the unsupported-kernel case is a loud startup
+/// error instead of a per-connection surprise on a server that is already serving clones.
+/// Without `SO_PEERPIDFD` there is no race-free way to identify the VMM behind a connection,
+/// and without that there is no way to guarantee it can be stopped — which is the entire
+/// premise of this server (see [`PeerVmm`]).
+fn require_peer_pidfd_support() -> Result<()> {
+    let (a, _b) = std::os::unix::net::UnixStream::pair().context("probing SO_PEERPIDFD")?;
+    peer_pidfd(a.as_raw_fd()).map(|_| ()).context(
+        "this kernel cannot report a peer pidfd (SO_PEERPIDFD, Linux 6.5+), so the UFFD \
+         memory server cannot guarantee it is able to stop a clone whose page faults it \
+         fails to serve — refusing to start rather than serving memory it cannot fail \
+         closed on",
+    )
+}
+
+/// Last-resort stop for a peer we could not pin: SIGKILL the PID `SO_PEERCRED` reports.
+///
+/// Only reachable when [`peer_pidfd`] fails on a kernel that passed the startup probe, i.e.
+/// file-descriptor exhaustion. `SO_PEERCRED` needs no fd, so it still works there. This is
+/// the one place in the server that signals a bare PID; it is justified only because the
+/// alternative (drop the connection) releases a possibly in-flight userfaultfd and corrupts
+/// that guest with certainty.
+fn kill_unpinned_peer(stream: &UnixStream, vm_id: &str) {
+    let Ok(cred) = stream.peer_cred() else {
+        error!(
+            target: "uffd",
+            vm_id = %vm_id,
+            "peer could be neither pinned nor identified — a VMM may now be running on \
+             unserved memory and this server cannot stop it"
+        );
+        return;
+    };
+    let Some(pid) = cred.pid() else {
+        error!(target: "uffd", vm_id = %vm_id, "peer credentials carry no PID; cannot stop the VMM");
+        return;
+    };
+    let killed = nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(pid),
+        nix::sys::signal::Signal::SIGKILL,
+    );
+    error!(
+        target: "uffd",
+        vm_id = %vm_id,
+        peer_pid = pid,
+        result = ?killed,
+        "killed an UNPINNED peer VMM (could not obtain its pidfd)"
+    );
+}
+
 /// The VMM process on the other end of one clone's UFFD connection, held as a **pidfd** so
 /// signalling it can never land on a different process.
 ///
@@ -86,49 +171,60 @@ fn max_clones_per_server() -> Result<usize> {
 /// that exact process even if the PID has since been recycled.
 #[derive(Debug)]
 struct PeerVmm {
+    /// The peer's PID, read back from the pidfd itself — for LOGS ONLY. Every decision uses
+    /// the pidfd, so a PID that has since been recycled cannot misdirect anything.
     pid: u32,
-    /// Start time in clock ticks (`/proc/<pid>/stat` field 22) — fcvm's process-identity
-    /// pattern, carried for logs and liveness reporting. The kill path uses the pidfd.
-    start_time: u64,
     pidfd: OwnedFd,
 }
 
 impl PeerVmm {
-    /// Identify the process that opened `stream` from its kernel-supplied peer credentials.
+    /// Pin the process that opened `stream`, atomically.
+    ///
+    /// `SO_PEERPIDFD` hands back a **pidfd** for the peer that was recorded at connect time.
+    /// The obvious-looking alternative — `SO_PEERCRED` for a PID, then `pidfd_open(pid)` — has
+    /// a real window: if the peer exits and is reaped between the two calls and the kernel
+    /// recycles its PID, the pidfd pins a STRANGER, and every later decision (including a
+    /// SIGKILL) lands on that stranger. There is no amount of re-checking that closes the
+    /// window, because the check itself is a second observation of the same racy number. So
+    /// the identity is taken from the socket in one atomic step and never re-derived.
     fn from_stream(stream: &UnixStream) -> Result<Self> {
-        let cred = stream
-            .peer_cred()
-            .context("reading peer credentials (SO_PEERCRED) of the connecting VMM")?;
-        let pid = cred
-            .pid()
-            .ok_or_else(|| anyhow!("peer credentials carry no PID"))?;
-        let pid = u32::try_from(pid).map_err(|_| anyhow!("peer PID {pid} is out of range"))?;
-        Self::from_pid(pid)
+        let pidfd = peer_pidfd(stream.as_raw_fd())
+            .context("SO_PEERPIDFD on the accepted UFFD connection")?;
+        // Read the PID back OUT of the pinned handle rather than from SO_PEERCRED, so even
+        // the log line cannot name a different process than the one we hold.
+        let pid = pidfd_pid(&pidfd).context("reading the peer pidfd's PID from fdinfo")?;
+        Ok(Self { pid, pidfd })
     }
 
-    /// Pin an already-known PID. `pidfd_open` is the whole point: from here on the handle
-    /// refers to that process, not to the number.
+    /// Pin an already-known PID via `pidfd_open`. Test-only: production identity always comes
+    /// from the socket ([`PeerVmm::from_stream`]), which has no PID-reuse window.
+    #[cfg(test)]
     fn from_pid(pid: u32) -> Result<Self> {
-        let start_time = crate::utils::process_start_time(pid)
-            .ok_or_else(|| anyhow!("peer PID {pid} has no /proc entry — it already exited"))?;
         // SAFETY: pidfd_open(2) with no flags; the returned fd is owned by us.
         let raw = unsafe { libc::syscall(libc::SYS_pidfd_open, pid as libc::pid_t, 0) };
         if raw < 0 {
             return Err(std::io::Error::last_os_error())
-                .with_context(|| format!("pidfd_open on peer PID {pid}"));
+                .with_context(|| format!("pidfd_open on PID {pid}"));
         }
         // SAFETY: `raw` is a fresh, owned, valid file descriptor.
         let pidfd = unsafe { OwnedFd::from_raw_fd(raw as RawFd) };
-        Ok(Self {
-            pid,
-            start_time,
-            pidfd,
-        })
+        Ok(Self { pid, pidfd })
     }
 
-    /// Whether this exact process (not merely this PID) is still running.
+    /// Whether the pinned process is still running — asked of the pidfd (signal 0), not of
+    /// its PID, so a recycled PID can never make a dead VMM look alive.
     fn is_alive(&self) -> bool {
-        crate::utils::process_start_time(self.pid) == Some(self.start_time)
+        // SAFETY: pidfd_send_signal(2) with signal 0 (existence probe) on an owned pidfd.
+        let rc = unsafe {
+            libc::syscall(
+                libc::SYS_pidfd_send_signal,
+                self.pidfd.as_raw_fd(),
+                0,
+                std::ptr::null_mut::<libc::siginfo_t>(),
+                0,
+            )
+        };
+        rc == 0
     }
 
     /// SIGKILL the VMM. Returns whether the signal was delivered.
@@ -285,6 +381,9 @@ impl UffdServer {
         dir: &Path,
         backing: UffdBacking,
     ) -> Result<Self> {
+        // Before anything else: prove we can fail closed on this kernel.
+        require_peer_pidfd_support()?;
+
         let my_pid = std::process::id();
         let my_start_time = crate::utils::process_start_time(my_pid)
             .ok_or_else(|| anyhow!("cannot read this process's own start time from /proc"))?;
@@ -415,10 +514,18 @@ impl UffdServer {
                                         target: "uffd",
                                         vm_id = %vm_id,
                                         error = ?e,
-                                        "refusing a connection whose VMM cannot be identified — \
-                                         without a handle on it this server could not stop it if \
-                                         serving later failed, and fail-closed is not optional"
+                                        "could not pin the connecting VMM — stopping it unpinned \
+                                         rather than dropping the connection"
                                     );
+                                    // Dropping the stream here would NOT be safe: Firecracker
+                                    // may already have sent its userfaultfd and closed its own
+                                    // copy, so closing the socket destroys the in-flight fd and
+                                    // the guest runs on zero pages — the same trap the over-cap
+                                    // path avoids. SO_PEERPIDFD is probed at startup, so the only
+                                    // way to reach this is fd exhaustion mid-flight; the unpinned
+                                    // PID from SO_PEERCRED is then the only handle left, and a
+                                    // vanishingly unlikely mis-signal beats a CERTAIN corruption.
+                                    kill_unpinned_peer(&stream, &vm_id);
                                     continue;
                                 }
                             };
@@ -2030,20 +2137,40 @@ mod tests {
         let (server_side, _) = listener.accept().await.unwrap();
         let _client_side = connector.await.unwrap();
 
-        let peer = PeerVmm::from_stream(&server_side).expect("peer credentials must be readable");
+        let peer = PeerVmm::from_stream(&server_side).expect("peer must be pinnable");
         assert_eq!(
             peer.pid,
             std::process::id(),
-            "SO_PEERCRED must report the connecting process"
+            "the pinned pidfd must refer to the connecting process"
         );
-        assert_eq!(
-            Some(peer.start_time),
-            crate::utils::process_start_time(std::process::id()),
-            "the peer must be pinned with the connecting process's start time"
-        );
-        assert!(peer.is_alive());
+        assert!(peer.is_alive(), "liveness must be answered by the pidfd");
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The peer handle must come from the SOCKET in one step. `SO_PEERCRED` + `pidfd_open`
+    /// would leave a window in which the peer exits, its PID is recycled, and the pidfd ends
+    /// up pinning a stranger that a later failure would then SIGKILL.
+    #[test]
+    fn test_peer_pidfd_is_taken_atomically_from_the_socket() {
+        require_peer_pidfd_support()
+            .expect("SO_PEERPIDFD must be available; the server refuses to start without it");
+
+        let (a, _b) = std::os::unix::net::UnixStream::pair().unwrap();
+        let pidfd = peer_pidfd(a.as_raw_fd()).expect("SO_PEERPIDFD on a connected socket");
+        assert_eq!(
+            pidfd_pid(&pidfd).unwrap(),
+            std::process::id(),
+            "the pidfd must name the peer of THIS socket"
+        );
+
+        // An unconnected socket has no peer: the failure must surface, never be papered over
+        // with a PID guess.
+        let lonely = std::os::unix::net::UnixDatagram::unbound().unwrap();
+        assert!(
+            peer_pidfd(lonely.as_raw_fd()).is_err(),
+            "a socket with no peer must not yield a pidfd"
+        );
     }
 
     /// The kill must land on the process we accepted, and must NEVER land on a stranger

--- a/src/uffd/server.rs
+++ b/src/uffd/server.rs
@@ -181,13 +181,28 @@ fn kill_unpinned_peer(stream: &UnixStream, vm_id: &str) {
 /// signalling it can never land on a different process.
 ///
 /// This is what makes the server fail CLOSED. A clone's guest memory exists only as long as
-/// this server answers its faults: once Firecracker hands over the userfaultfd it closes its
-/// own copy, so if this server stops resolving faults the kernel resolves them with ZERO
-/// PAGES and the guest keeps running on silently corrupt memory. There is no in-band way to
-/// tell that guest "your memory is gone". The only honest response is to stop the VMM, and
-/// the only safe way to stop it is a handle that refers to the process itself — `SO_PEERCRED`
-/// gives the PID at connect time, `pidfd_open` pins it, and `pidfd_send_signal` delivers to
-/// that exact process even if the PID has since been recycled.
+/// this server answers its faults, and if it stops the guest does not crash and does not read
+/// zeroes — it FREEZES, permanently and silently.
+///
+/// Firecracker KEEPS its own reference to the userfaultfd for the VM's lifetime ("Save UFFD in
+/// order to keep it open in the Firecracker process, as well." — firecracker
+/// `src/vmm/src/lib.rs`). So this server's death is never the final `fput`:
+/// `userfaultfd_release()` (fs/userfaultfd.c) does not run, `userfaultfd_release_all()`
+/// (mm/userfaultfd.c) never strips `__VM_UFFD_FLAGS`, and faults never fall through to
+/// anonymous zero-fill. They just wait. Verified on a live clone — serve and firecracker each
+/// holding `userfaultfd_fds=1`, and 30s after SIGKILLing the server both vCPUs sat in
+/// `wchan=handle_userfault` with no exit code, no signal and nothing in any log.
+///
+/// (Zero-fill IS what the kernel does once the LAST reference closes — measured at 0.07ms —
+/// which is why this comment used to say "corrupt memory". That path is unreachable while
+/// Firecracker holds its copy. A wedge is not milder: the clone holds its memory, loopback
+/// port and disk indefinitely while looking alive.)
+///
+/// Either way there is no in-band way to tell that guest "your memory is gone". The only
+/// honest response is to stop the VMM, and the only safe way to stop it is a handle that
+/// refers to the process itself — `SO_PEERPIDFD` yields that pidfd atomically from the
+/// accepted socket, and `pidfd_send_signal` delivers to that exact process even if the PID
+/// has since been recycled.
 #[derive(Debug)]
 struct PeerVmm {
     /// The peer's PID, read back from the pidfd itself — for LOGS ONLY. Every decision uses
@@ -572,10 +587,13 @@ impl UffdServer {
                                      or raise {}.",
                                     MAX_CLONES_ENV
                                 );
-                                // Closing the socket is not enough to refuse safely: in COPY
-                                // mode Firecracker sends its uffd and closes its own copy, so a
-                                // connection dropped after that point releases the uffd and the
-                                // guest silently runs on zero pages. Refusal means killing.
+                                // Closing the socket is not enough to refuse safely — but not
+                                // because of zero pages. Firecracker holds its own uffd
+                                // reference for the VM's lifetime, so dropping this connection
+                                // never releases the last one; the guest WEDGES instead, both
+                                // vCPUs parked in handle_userfault forever with no exit code
+                                // and no signal. A refused clone that merely hangs still holds
+                                // its memory, port and disk. Refusal means killing.
                                 peer.kill_now("server is at its concurrent-clone cap");
                                 continue;
                             }

--- a/src/uffd/server.rs
+++ b/src/uffd/server.rs
@@ -1,11 +1,12 @@
 use anyhow::{anyhow, Context, Result};
 use std::fs::File;
-use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::unix::AsyncFd;
-use tokio::net::UnixListener;
+use tokio::net::{UnixListener, UnixStream};
 use tokio::task::JoinSet;
 use tracing::{debug, error, info, warn};
 
@@ -13,10 +14,170 @@ use memmap2::MmapOptions;
 use userfaultfd::{Event, FaultKind, Uffd};
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;
 
-use crate::paths;
-
 /// 2MiB — the only huge page size fcvm supports for guest memory.
 const HUGE_PAGE_2M: usize = 2 * 1024 * 1024;
+
+/// Env var overriding [`DEFAULT_MAX_CLONES_PER_SERVER`].
+pub const MAX_CLONES_ENV: &str = "FCVM_UFFD_MAX_CLONES";
+
+/// How many clones one server serves concurrently.
+///
+/// Every clone attached to a server shares that server's **failure domain** (one process,
+/// one page source, one set of fds) and its **fairness domain** (one task each on the same
+/// runtime). An unbounded server therefore has an unbounded blast radius. This cap is the
+/// bound; raise it with `FCVM_UFFD_MAX_CLONES` and accept the wider blast radius, or run a
+/// second `fcvm snapshot serve` and split the clones across two failure domains.
+pub const DEFAULT_MAX_CLONES_PER_SERVER: usize = 64;
+
+/// How many uffd events one handler drains before yielding to the runtime.
+///
+/// `drain_events` is a synchronous loop that owns its worker thread while it runs, and it
+/// drains until the queue is EMPTY. A clone faulting hard enough to keep refilling its queue
+/// would hold that thread indefinitely and starve every other clone on the server — one
+/// clone's page-in storm becomes every clone's stall. Batching bounds one handler's
+/// uninterrupted turn without building a scheduler: after each batch the handler yields and
+/// the runtime picks whoever has waited longest.
+///
+/// A yield costs a queue push, not a syscall, so even at a million faults/second the batching
+/// overhead is noise — while the clones waiting behind it are vCPUs stopped dead on a fault.
+const MAX_EVENTS_PER_BATCH: usize = 128;
+
+/// How long a connecting VMM has to complete the UFFD handshake.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// `sockaddr_un.sun_path` is a fixed 108-byte array on Linux; bind(2) fails with a bare
+/// `EINVAL` when a path overflows it. Checked up front so the error names the real problem.
+const MAX_UNIX_SOCKET_PATH_LEN: usize = 107;
+
+/// Resolve the per-server clone cap from an explicit [`MAX_CLONES_ENV`] value.
+///
+/// A malformed or zero value is an error, not a silent fallback: a server that quietly
+/// ignores its configured bound is exactly the unbounded server the cap exists to prevent.
+fn parse_max_clones(raw: Option<&str>) -> Result<usize> {
+    let Some(raw) = raw else {
+        return Ok(DEFAULT_MAX_CLONES_PER_SERVER);
+    };
+    let parsed: usize = raw
+        .trim()
+        .parse()
+        .with_context(|| format!("{MAX_CLONES_ENV}={raw:?} is not a non-negative integer"))?;
+    anyhow::ensure!(
+        parsed > 0,
+        "{MAX_CLONES_ENV}=0 would refuse every clone; set it to at least 1"
+    );
+    Ok(parsed)
+}
+
+/// Resolve the per-server clone cap from the environment.
+fn max_clones_per_server() -> Result<usize> {
+    parse_max_clones(std::env::var(MAX_CLONES_ENV).ok().as_deref())
+}
+
+/// The VMM process on the other end of one clone's UFFD connection, held as a **pidfd** so
+/// signalling it can never land on a different process.
+///
+/// This is what makes the server fail CLOSED. A clone's guest memory exists only as long as
+/// this server answers its faults: once Firecracker hands over the userfaultfd it closes its
+/// own copy, so if this server stops resolving faults the kernel resolves them with ZERO
+/// PAGES and the guest keeps running on silently corrupt memory. There is no in-band way to
+/// tell that guest "your memory is gone". The only honest response is to stop the VMM, and
+/// the only safe way to stop it is a handle that refers to the process itself — `SO_PEERCRED`
+/// gives the PID at connect time, `pidfd_open` pins it, and `pidfd_send_signal` delivers to
+/// that exact process even if the PID has since been recycled.
+#[derive(Debug)]
+struct PeerVmm {
+    pid: u32,
+    /// Start time in clock ticks (`/proc/<pid>/stat` field 22) — fcvm's process-identity
+    /// pattern, carried for logs and liveness reporting. The kill path uses the pidfd.
+    start_time: u64,
+    pidfd: OwnedFd,
+}
+
+impl PeerVmm {
+    /// Identify the process that opened `stream` from its kernel-supplied peer credentials.
+    fn from_stream(stream: &UnixStream) -> Result<Self> {
+        let cred = stream
+            .peer_cred()
+            .context("reading peer credentials (SO_PEERCRED) of the connecting VMM")?;
+        let pid = cred
+            .pid()
+            .ok_or_else(|| anyhow!("peer credentials carry no PID"))?;
+        let pid = u32::try_from(pid).map_err(|_| anyhow!("peer PID {pid} is out of range"))?;
+        Self::from_pid(pid)
+    }
+
+    /// Pin an already-known PID. `pidfd_open` is the whole point: from here on the handle
+    /// refers to that process, not to the number.
+    fn from_pid(pid: u32) -> Result<Self> {
+        let start_time = crate::utils::process_start_time(pid)
+            .ok_or_else(|| anyhow!("peer PID {pid} has no /proc entry — it already exited"))?;
+        // SAFETY: pidfd_open(2) with no flags; the returned fd is owned by us.
+        let raw = unsafe { libc::syscall(libc::SYS_pidfd_open, pid as libc::pid_t, 0) };
+        if raw < 0 {
+            return Err(std::io::Error::last_os_error())
+                .with_context(|| format!("pidfd_open on peer PID {pid}"));
+        }
+        // SAFETY: `raw` is a fresh, owned, valid file descriptor.
+        let pidfd = unsafe { OwnedFd::from_raw_fd(raw as RawFd) };
+        Ok(Self {
+            pid,
+            start_time,
+            pidfd,
+        })
+    }
+
+    /// Whether this exact process (not merely this PID) is still running.
+    fn is_alive(&self) -> bool {
+        crate::utils::process_start_time(self.pid) == Some(self.start_time)
+    }
+
+    /// SIGKILL the VMM. Returns whether the signal was delivered.
+    ///
+    /// SIGKILL, not SIGTERM: a VMM whose memory this server can no longer serve must not get
+    /// to run *any* more guest instructions, and a graceful shutdown would let the guest keep
+    /// executing (on zero pages) while it drains.
+    fn kill_now(&self, reason: &str) -> bool {
+        // SAFETY: pidfd_send_signal(2) on an owned pidfd; no siginfo override, no flags.
+        let rc = unsafe {
+            libc::syscall(
+                libc::SYS_pidfd_send_signal,
+                self.pidfd.as_raw_fd(),
+                libc::SIGKILL,
+                std::ptr::null_mut::<libc::siginfo_t>(),
+                0,
+            )
+        };
+        if rc == 0 {
+            error!(
+                target: "uffd",
+                peer_pid = self.pid,
+                reason = %reason,
+                "KILLED the clone's VMM: its guest memory can no longer be served, and a \
+                 surviving VMM would run on zero-filled pages (silent corruption). The clone \
+                 is now dead and its `fcvm snapshot run` exits non-zero."
+            );
+            return true;
+        }
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::ESRCH) {
+            info!(
+                target: "uffd",
+                peer_pid = self.pid,
+                reason = %reason,
+                "clone's VMM had already exited; nothing to fail closed on"
+            );
+            return false;
+        }
+        error!(
+            target: "uffd",
+            peer_pid = self.pid,
+            reason = %reason,
+            error = %err,
+            "COULD NOT kill the clone's VMM — it may still be running on unserved memory"
+        );
+        false
+    }
+}
 
 /// How the server materialises snapshot pages into a clone's guest memory.
 ///
@@ -95,26 +256,48 @@ pub struct UffdServer {
     socket_path: PathBuf,
     source: Arc<PageSource>,
     backing: UffdBacking,
+    max_clones: usize,
 }
 
 impl UffdServer {
-    /// Create a new UFFD server for a snapshot
+    /// The socket path the server run by `(pid, pid_start_time)` binds inside `dir`.
+    ///
+    /// The server-instance identity is IN the path. It used to be derived from the snapshot
+    /// name (and later the PID) alone, which meant two servers could name the same socket —
+    /// and since a server unlinks that path both before binding and again on drop, a second
+    /// server would delete the socket a live first one was still accepting on, or delete the
+    /// socket a live *second* one had just bound. Clones then connected to nothing.
+    ///
+    /// `(pid, pid_start_time)` is fcvm's existing process identity (`VmState::pid_start_time`,
+    /// verified by `load_state_by_pid`), so no two live servers can ever produce the same
+    /// name, the unlink-before-bind can only remove this same process's own leftovers, and
+    /// the unlink-on-drop can only remove our own socket. It is also reconstructible: a clone
+    /// reads the serve process's `pid` + `pid_start_time` out of its state file and derives
+    /// exactly this path — no extra state, no lookup by scanning.
+    pub fn socket_path_for(dir: &Path, name: &str, pid: u32, pid_start_time: u64) -> PathBuf {
+        dir.join(format!("uffd-{name}-{pid}-{pid_start_time}.sock"))
+    }
+
+    /// Create a UFFD server that binds its own unique socket inside `dir`.
     pub async fn new(
         snapshot_id: String,
         mem_file_path: &Path,
+        dir: &Path,
         backing: UffdBacking,
     ) -> Result<Self> {
-        let socket_path = paths::data_dir().join(format!("uffd-{}.sock", snapshot_id));
-        Self::new_with_path(snapshot_id, mem_file_path, &socket_path, backing).await
-    }
+        let my_pid = std::process::id();
+        let my_start_time = crate::utils::process_start_time(my_pid)
+            .ok_or_else(|| anyhow!("cannot read this process's own start time from /proc"))?;
+        let socket_path = Self::socket_path_for(dir, &snapshot_id, my_pid, my_start_time);
 
-    /// Create a new UFFD server with custom socket path
-    pub async fn new_with_path(
-        snapshot_id: String,
-        mem_file_path: &Path,
-        socket_path: &Path,
-        backing: UffdBacking,
-    ) -> Result<Self> {
+        let path_len = socket_path.as_os_str().len();
+        anyhow::ensure!(
+            path_len <= MAX_UNIX_SOCKET_PATH_LEN,
+            "UFFD socket path is {path_len} bytes, over the {MAX_UNIX_SOCKET_PATH_LEN}-byte \
+             sun_path limit: {} — use a shorter snapshot tag or data dir",
+            socket_path.display()
+        );
+
         info!(
             target: "uffd",
             snapshot = %snapshot_id,
@@ -123,6 +306,7 @@ impl UffdServer {
             mode = backing.name(),
             "creating UFFD server"
         );
+        let socket_path = &socket_path;
 
         // Open the memory snapshot file (shared across all VMs)
         let mem_file = File::open(mem_file_path).context("opening memory file")?;
@@ -166,7 +350,11 @@ impl UffdServer {
                 .context("creating socket directory")?;
         }
 
-        // Remove stale socket (ignore errors if not exists - avoids TOCTOU race)
+        // Remove leftovers at OUR path. Safe to do blindly only because the path carries
+        // this process's (pid, start_time): no live server can own this name, so the only
+        // thing that can be here is a file this exact identity left behind (possible across
+        // a reboot, which restarts the clock-tick counter). Ignore errors — nothing to
+        // remove is the normal case.
         let _ = tokio::fs::remove_file(&socket_path).await;
 
         Ok(Self {
@@ -174,6 +362,7 @@ impl UffdServer {
             socket_path: socket_path.to_path_buf(),
             source: Arc::new(source),
             backing,
+            max_clones: max_clones_per_server()?,
         })
     }
 
@@ -203,6 +392,10 @@ impl UffdServer {
 
         let mut vm_tasks: JoinSet<String> = JoinSet::new();
         let mut next_vm_id = 0u64;
+        // Admitted-clone count. Incremented only here (single accept loop) and decremented by
+        // each connection task as it finishes, so it tracks clones that are actually being
+        // served rather than tasks the JoinSet has yet to reap.
+        let admitted = Arc::new(AtomicUsize::new(0));
 
         loop {
             tokio::select! {
@@ -212,48 +405,65 @@ impl UffdServer {
                         Ok((stream, _)) => {
                             let vm_id = format!("vm-{}", next_vm_id);
                             next_vm_id += 1;
-                            let source = Arc::clone(&self.source);
 
-                            info!(target: "uffd", vm_id = %vm_id, "new VM connection");
+                            // Pin the VMM on the other end BEFORE anything else: every
+                            // failure from here on has to be able to stop it (see PeerVmm).
+                            let peer = match PeerVmm::from_stream(&stream) {
+                                Ok(peer) => peer,
+                                Err(e) => {
+                                    error!(
+                                        target: "uffd",
+                                        vm_id = %vm_id,
+                                        error = ?e,
+                                        "refusing a connection whose VMM cannot be identified — \
+                                         without a handle on it this server could not stop it if \
+                                         serving later failed, and fail-closed is not optional"
+                                    );
+                                    continue;
+                                }
+                            };
+
+                            let in_flight = admitted.load(Ordering::Acquire);
+                            if in_flight >= self.max_clones {
+                                error!(
+                                    target: "uffd",
+                                    vm_id = %vm_id,
+                                    peer_pid = peer.pid,
+                                    active_clones = in_flight,
+                                    max_clones = self.max_clones,
+                                    "REFUSING clone: this server is at its concurrent-clone cap. \
+                                     Start another `fcvm snapshot serve` (a second failure domain) \
+                                     or raise {}.",
+                                    MAX_CLONES_ENV
+                                );
+                                // Closing the socket is not enough to refuse safely: in COPY
+                                // mode Firecracker sends its uffd and closes its own copy, so a
+                                // connection dropped after that point releases the uffd and the
+                                // guest silently runs on zero pages. Refusal means killing.
+                                peer.kill_now("server is at its concurrent-clone cap");
+                                continue;
+                            }
+                            admitted.fetch_add(1, Ordering::AcqRel);
+
+                            let source = Arc::clone(&self.source);
+                            let admitted_slot = Arc::clone(&admitted);
+
+                            info!(
+                                target: "uffd",
+                                vm_id = %vm_id,
+                                peer_pid = peer.pid,
+                                active_clones = in_flight + 1,
+                                max_clones = self.max_clones,
+                                "new VM connection"
+                            );
 
                             // Spawn per-connection task so the accept loop returns
                             // immediately — no blocking on slow/misbehaving clones.
                             vm_tasks.spawn(async move {
-                                match tokio::time::timeout(
-                                    Duration::from_secs(30),
-                                    handshake(stream, &source),
-                                ).await {
-                                    Ok(Ok((uffd, mappings))) => {
-                                        info!(
-                                            target: "uffd",
-                                            vm_id = %vm_id,
-                                            regions = mappings.len(),
-                                            "received UFFD with {} memory regions",
-                                            mappings.len()
-                                        );
-                                        match handle_vm_page_faults(vm_id.clone(), uffd, mappings, source).await {
-                                            Ok(()) => info!(target: "uffd", vm_id = %vm_id, "VM handler exited cleanly"),
-                                            Err(e) => error!(
-                                                target: "uffd",
-                                                vm_id = %vm_id,
-                                                error = ?e,
-                                                "VM page-fault handler died; its userfaultfd is now closed and the \
-                                                 still-running VM will receive zero pages for unfaulted memory \
-                                                 (silent corruption) — kill the affected clone"
-                                            ),
-                                        }
-                                    }
-                                    Ok(Err(e)) => {
-                                        error!(target: "uffd", vm_id = %vm_id, error = ?e, "handshake failed");
-                                    }
-                                    Err(_) => {
-                                        error!(target: "uffd", vm_id = %vm_id, "handshake timed out after 30s");
-                                    }
-                                }
+                                serve_clone_fail_closed(&vm_id, stream, source, peer).await;
+                                admitted_slot.fetch_sub(1, Ordering::AcqRel);
                                 vm_id
                             });
-
-                            info!(target: "uffd", active_vms = vm_tasks.len(), "VM connection spawned");
                         }
                         Err(e) => {
                             error!(target: "uffd", error = %e, "failed to accept connection");
@@ -306,9 +516,73 @@ impl UffdServer {
 
 impl Drop for UffdServer {
     fn drop(&mut self) {
-        // Clean up socket file (ignore errors - avoids TOCTOU race and handles concurrent cleanup)
+        // Safe to remove unconditionally: `socket_path_for` puts this process's
+        // (pid, start_time) in the name, so this path can only ever be ours — dropping one
+        // server can no longer unlink the socket another live server is accepting on.
         let _ = std::fs::remove_file(&self.socket_path);
     }
+}
+
+/// Serve one admitted clone, and KILL its VMM if serving fails at any point.
+///
+/// This is the whole fail-closed contract in one place. Before it, a handler error was only
+/// logged: the clone's userfaultfd closed with the guest still running, the kernel began
+/// resolving that guest's faults with zero pages, and the only trace was a log line asking a
+/// human to "kill the affected clone". A request service cannot depend on someone reading a
+/// log — the corrupted guest happily answers requests with garbage. Now the failure is
+/// converted into the one state a caller cannot miss: a dead VMM, which makes the clone's
+/// `fcvm snapshot run` exit non-zero (see `vmm_exit_failure` in `commands/snapshot.rs`).
+async fn serve_clone_fail_closed(
+    vm_id: &str,
+    stream: UnixStream,
+    source: Arc<PageSource>,
+    peer: PeerVmm,
+) {
+    match serve_clone(vm_id, stream, source).await {
+        Ok(()) => info!(
+            target: "uffd",
+            vm_id = %vm_id,
+            peer_pid = peer.pid,
+            "VM handler exited cleanly"
+        ),
+        Err(e) => {
+            error!(
+                target: "uffd",
+                vm_id = %vm_id,
+                peer_pid = peer.pid,
+                peer_alive = peer.is_alive(),
+                error = ?e,
+                "clone's UFFD service FAILED — killing its VMM"
+            );
+            peer.kill_now(&format!("{e:#}"));
+        }
+    }
+}
+
+/// Serve one clone end to end: handshake, then page faults until its VMM exits.
+///
+/// Every error path out of this function is a fail-closed event for that clone — see the
+/// caller in [`UffdServer::run`], which kills the VMM. Two failure classes exist and both
+/// have the same remedy: the handshake can fail with the clone's userfaultfd already in
+/// flight (COPY mode sends the fd and the mappings in ONE message, so a malformed message
+/// means we hold an fd we cannot use), and the fault handler can fail after serving for
+/// hours. In both cases the uffd ends up closed while the guest is alive, which the kernel
+/// turns into zero-filled pages.
+async fn serve_clone(vm_id: &str, stream: UnixStream, source: Arc<PageSource>) -> Result<()> {
+    let (uffd, mappings) = tokio::time::timeout(HANDSHAKE_TIMEOUT, handshake(stream, &source))
+        .await
+        .map_err(|_| anyhow!("UFFD handshake did not complete within {HANDSHAKE_TIMEOUT:?}"))?
+        .context("UFFD handshake failed")?;
+
+    info!(
+        target: "uffd",
+        vm_id = %vm_id,
+        regions = mappings.len(),
+        "received UFFD with {} memory regions",
+        mappings.len()
+    );
+
+    handle_vm_page_faults(vm_id.to_string(), uffd, mappings, source).await
 }
 
 /// Whether a UFFDIO_ZEROPAGE error means the range (or part of it) is already populated.
@@ -358,6 +632,21 @@ fn continue_vm_gone(e: &userfaultfd::Error) -> bool {
     matches!(
         e,
         userfaultfd::Error::SystemError(errno) if (*errno as i32) == libc::ESRCH
+    )
+}
+
+/// Whether a UFFDIO_COPY error means the clone's mm is gone (process exited).
+///
+/// The COPY equivalent of [`continue_vm_gone`]. A clone that exits with a fault in flight
+/// races the handler: the `read_event`-returns-error path (uffd closed) is the common
+/// ending, but if the copy is already in the kernel it comes back `ESRCH` instead. That is
+/// an ordinary end of life, NOT a service failure — and the distinction now matters, because
+/// a failure here kills a VMM and reports the clone FAILED. Misreading a normal exit as a
+/// failure would fill the serve log with false alarms and devalue the real ones.
+fn copy_vm_gone(e: &userfaultfd::Error) -> bool {
+    matches!(
+        e,
+        userfaultfd::Error::CopyFailed(errno) if (*errno as i32) == libc::ESRCH
     )
 }
 
@@ -503,8 +792,11 @@ async fn handle_vm_page_faults(
             }
         };
 
+        // Set when the drain stopped on its batch limit rather than on an empty queue, so
+        // this handler gives the runtime a turn before coming back for the rest.
+        let mut yield_after_batch = false;
         if let Some(mut guard) = maybe_guard {
-            if !drain_events(
+            match drain_events(
                 &mut guard,
                 &vm_id,
                 &mappings,
@@ -515,9 +807,14 @@ async fn handle_vm_page_faults(
                 &mut pending_continues,
                 start_time,
             )? {
-                return Ok(()); // VM exited
+                DrainOutcome::VmExited => return Ok(()),
+                DrainOutcome::QueueDrained => guard.clear_ready(),
+                // Events are still queued. Deliberately do NOT clear readiness: AsyncFd is
+                // edge-triggered, and the kernel raises no new edge for events already
+                // sitting in the queue, so clearing here could park this handler until the
+                // guest happens to fault again — with faulting vCPUs already asleep.
+                DrainOutcome::BatchFull => yield_after_batch = true,
             }
-            guard.clear_ready();
         }
 
         // Retry parked faults now that the queue is drained — reading the queued event is
@@ -552,11 +849,28 @@ async fn handle_vm_page_faults(
                 pending_continues.remove(&page);
             }
         }
+
+        // Fairness: one clone's fault storm must not own a runtime worker forever. The
+        // events left in the queue are picked up on the next pass (readiness was left set).
+        if yield_after_batch {
+            tokio::task::yield_now().await;
+        }
     }
 }
 
-/// Drain every ready event from the uffd. Returns `Ok(false)` when the VM has exited
-/// (uffd closed), `Ok(true)` to keep serving.
+/// How a [`drain_events`] pass ended.
+enum DrainOutcome {
+    /// The uffd is closed: the clone's VMM exited and there is nothing left to serve.
+    VmExited,
+    /// The event queue is empty; readiness may be cleared and the handler may park.
+    QueueDrained,
+    /// [`MAX_EVENTS_PER_BATCH`] events were handled and more remain queued. The caller must
+    /// leave readiness SET (edge-triggered epoll raises no new edge for queued events) and
+    /// yield before draining the rest.
+    BatchFull,
+}
+
+/// Drain up to [`MAX_EVENTS_PER_BATCH`] ready events from the uffd.
 #[allow(clippy::too_many_arguments)]
 fn drain_events(
     guard: &mut tokio::io::unix::AsyncFdReadyGuard<'_, Uffd>,
@@ -568,10 +882,14 @@ fn drain_events(
     fault_count: &mut u64,
     pending_continues: &mut std::collections::BTreeMap<usize, u32>,
     start_time: std::time::Instant,
-) -> Result<bool> {
+) -> Result<DrainOutcome> {
     {
-        // Read all available events (non-blocking)
+        let mut handled = 0usize;
+        // Read available events (non-blocking), bounded by the batch size
         loop {
+            if handled >= MAX_EVENTS_PER_BATCH {
+                return Ok(DrainOutcome::BatchFull);
+            }
             let event = match guard.get_inner().read_event() {
                 Ok(Some(event)) => event,
                 Ok(None) => break, // No more events ready
@@ -591,9 +909,10 @@ fn drain_events(
                         pages_per_sec = format!("{:.0}", rate),
                         "VM exited"
                     );
-                    return Ok(false);
+                    return Ok(DrainOutcome::VmExited);
                 }
             };
+            handled += 1;
 
             match event {
                 Event::Pagefault { addr, kind, .. } => {
@@ -642,7 +961,7 @@ fn drain_events(
                             }
                             match continue_page(guard.get_inner(), vm_id, fault_page, page_size)? {
                                 ContinueOutcome::Resolved => {}
-                                ContinueOutcome::VmGone => return Ok(false),
+                                ContinueOutcome::VmGone => return Ok(DrainOutcome::VmExited),
                                 ContinueOutcome::Retry => {
                                     // mmap_changing is set and the event that raised it is
                                     // somewhere in THIS queue. Don't spin here — park the
@@ -687,6 +1006,10 @@ fn drain_events(
                             )
                         };
                         if let Err(e) = result {
+                            if copy_vm_gone(&e) {
+                                info!(target: "uffd", vm_id = %vm_id, "VM exited during zero-fill");
+                                return Ok(DrainOutcome::VmExited);
+                            }
                             error!(
                                 target: "uffd",
                                 vm_id = %vm_id,
@@ -744,6 +1067,20 @@ fn drain_events(
                                 );
                                 continue;
                             }
+                        }
+
+                        // The clone exited with this fault in flight — an ordinary end of
+                        // life, not a service failure (which would now kill a VMM and
+                        // report the clone FAILED). Same treatment as the MINOR path's
+                        // `ContinueOutcome::VmGone`.
+                        if copy_vm_gone(&e) {
+                            info!(
+                                target: "uffd",
+                                vm_id = %vm_id,
+                                fault_addr = format!("0x{:x}", fault_page),
+                                "VM exited while its fault was being served"
+                            );
+                            return Ok(DrainOutcome::VmExited);
                         }
 
                         // Real error - log with Debug format to show errno
@@ -876,7 +1213,7 @@ fn drain_events(
             }
         }
     }
-    Ok(true)
+    Ok(DrainOutcome::QueueDrained)
 }
 
 /// Memory region mapping from Firecracker.
@@ -1620,5 +1957,239 @@ mod tests {
             pristine[8192], 0xCD,
             "clone write must not reach the snapshot"
         );
+    }
+
+    // =========================================================================
+    // FAIL CLOSED: a clone whose faults cannot be served must end up DEAD, not
+    // running on zero-filled memory.
+    // =========================================================================
+
+    /// Spawn a harmless long-lived process to stand in for a clone's VMM.
+    ///
+    /// The production code path under test is identical either way — `PeerVmm` is just a
+    /// pinned handle to "the process on the other end of this connection" — so the only
+    /// substitution is WHICH process gets killed. Using a real child (rather than the test
+    /// process) is what lets the test assert the kill actually landed.
+    fn spawn_victim() -> std::process::Child {
+        std::process::Command::new("sleep")
+            .arg("600")
+            .spawn()
+            .expect("spawning the stand-in VMM process")
+    }
+
+    fn killed_by_sigkill(status: std::process::ExitStatus) -> bool {
+        use std::os::unix::process::ExitStatusExt;
+        status.signal() == Some(libc::SIGKILL)
+    }
+
+    /// Wait (bounded) for the stand-in VMM to die, then assert it died by SIGKILL.
+    ///
+    /// Bounded on purpose: the regression this guards against leaves the process ALIVE, and
+    /// an unbounded wait would turn that into a hung test instead of a failing one. Verified
+    /// by disabling the kill — the test then fails here in ~5s instead of blocking forever,
+    /// and the stand-in process is reaped rather than leaked.
+    async fn assert_vmm_was_killed(mut victim: std::process::Child) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            match victim.try_wait().expect("polling the stand-in VMM") {
+                Some(status) => {
+                    assert!(
+                        killed_by_sigkill(status),
+                        "an unservable clone's VMM must die by SIGKILL, got {status:?}"
+                    );
+                    return;
+                }
+                None if tokio::time::Instant::now() >= deadline => {
+                    let _ = victim.kill();
+                    let _ = victim.wait();
+                    panic!(
+                        "the clone's VMM is STILL RUNNING after its UFFD service failed — \
+                         it would keep executing on zero-filled guest memory (the exact \
+                         silent corruption this fail-closed path exists to prevent)"
+                    );
+                }
+                None => tokio::time::sleep(Duration::from_millis(10)).await,
+            }
+        }
+    }
+
+    /// `PeerVmm::from_stream` must name the process that actually opened the connection —
+    /// everything downstream (including a SIGKILL) is aimed at that PID.
+    #[tokio::test]
+    async fn test_peer_vmm_identifies_the_connecting_process() {
+        let dir = std::env::temp_dir().join(format!("fcvm-peer-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("peer.sock");
+        let _ = std::fs::remove_file(&path);
+        let listener = UnixListener::bind(&path).unwrap();
+
+        let connector = tokio::spawn({
+            let path = path.clone();
+            async move { UnixStream::connect(&path).await.unwrap() }
+        });
+        let (server_side, _) = listener.accept().await.unwrap();
+        let _client_side = connector.await.unwrap();
+
+        let peer = PeerVmm::from_stream(&server_side).expect("peer credentials must be readable");
+        assert_eq!(
+            peer.pid,
+            std::process::id(),
+            "SO_PEERCRED must report the connecting process"
+        );
+        assert_eq!(
+            Some(peer.start_time),
+            crate::utils::process_start_time(std::process::id()),
+            "the peer must be pinned with the connecting process's start time"
+        );
+        assert!(peer.is_alive());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The kill must land on the process we accepted, and must NEVER land on a stranger
+    /// that later inherits the same PID — the pidfd is what guarantees that.
+    #[test]
+    fn test_peer_vmm_kill_targets_only_the_pinned_process() {
+        let mut victim = spawn_victim();
+        let peer = PeerVmm::from_pid(victim.id()).expect("pinning a live process");
+        assert!(peer.is_alive());
+
+        assert!(
+            peer.kill_now("test: fault handler failed"),
+            "SIGKILL must be delivered"
+        );
+        let status = victim.wait().expect("reaping the victim");
+        assert!(
+            killed_by_sigkill(status),
+            "the VMM must die by SIGKILL, got {status:?}"
+        );
+
+        // The process is reaped: its PID is now free for the OS to hand to anything. A
+        // second kill through the pidfd must report "no such process" instead of signalling
+        // whatever holds that number now.
+        assert!(!peer.is_alive());
+        assert!(
+            !peer.kill_now("test: second attempt after the process was reaped"),
+            "a pidfd for a reaped process must refuse to signal, not hit a recycled PID"
+        );
+    }
+
+    /// The headline regression: when the page-fault handler fails, the clone's VMM is
+    /// KILLED. Before this, the handler merely logged that the VM "should be killed" and
+    /// left it running on zero-filled memory.
+    ///
+    /// The failure injected is a real one from `drain_events`: a fault at an address the
+    /// handshake's mappings do not cover, which is unresolvable by construction.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_handler_failure_kills_the_clones_vmm() {
+        use std::io::Write;
+
+        // A snapshot to serve from (contents are irrelevant — the fault never resolves).
+        let (snap_path, mem_size) = write_test_snapshot();
+        let mem_file = File::open(&snap_path).unwrap();
+        let mmap = unsafe { MmapOptions::new().len(mem_size).map(&mem_file).unwrap() };
+        let source = Arc::new(PageSource::Copy { mmap });
+        std::fs::remove_file(&snap_path).ok();
+
+        // The clone's VMM: a real process the server can kill.
+        let victim = spawn_victim();
+        let peer = PeerVmm::from_pid(victim.id()).unwrap();
+
+        // Stand in for the clone's guest memory + its userfaultfd.
+        let guest = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                4096,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        };
+        assert_ne!(guest, libc::MAP_FAILED, "mmapping stand-in guest memory");
+        let guest_addr = guest as usize;
+        let uffd = userfaultfd::UffdBuilder::new()
+            .close_on_exec(true)
+            .non_blocking(false)
+            .user_mode_only(true)
+            .create()
+            .expect("creating userfaultfd (via /dev/userfaultfd)");
+        uffd.register(guest, 4096).expect("MISSING registration");
+
+        let (server_side, client_side) = UnixStream::pair().unwrap();
+
+        // Declare a region that does NOT contain `guest_addr`. The first fault is then
+        // unmappable and `drain_events` fails — the same shape as a corrupt handshake or a
+        // Firecracker/fcvm disagreement about the guest layout in production.
+        let bogus_base = guest_addr.wrapping_add(1 << 30);
+        let mappings = format!(
+            r#"[{{"base_host_virt_addr": {bogus_base}, "size": 4096, "offset": 0, "page_size": 4096}}]"#
+        );
+
+        let client = client_side.into_std().unwrap();
+        client.set_nonblocking(false).unwrap();
+        client
+            .send_with_fd(mappings.as_bytes(), uffd.as_raw_fd())
+            .expect("sending mappings + uffd the way Firecracker does");
+        // Drop OUR uffd handle: the server's received copy is the only thing keeping the
+        // context alive, exactly as in production where Firecracker closes its own copy.
+        // When the handler drops it, the pending fault resolves with a zero page — which is
+        // precisely the corruption this whole mechanism exists to stop a guest from using.
+        drop(uffd);
+        std::io::stdout().flush().ok();
+
+        // Touch the guest page: blocks in the kernel until the fault is resolved.
+        let toucher =
+            std::thread::spawn(move || unsafe { std::ptr::read_volatile(guest_addr as *const u8) });
+
+        // The production fail-closed path, verbatim.
+        serve_clone_fail_closed("vm-test", server_side, source, peer).await;
+
+        assert_vmm_was_killed(victim).await;
+
+        // The fault resolved as a zero page once the uffd closed — the corruption the kill
+        // prevents the guest from acting on.
+        assert_eq!(toucher.join().unwrap(), 0);
+        unsafe { libc::munmap(guest, 4096) };
+        drop(client);
+    }
+
+    #[test]
+    fn test_max_clones_default_and_overrides() {
+        assert_eq!(
+            parse_max_clones(None).unwrap(),
+            DEFAULT_MAX_CLONES_PER_SERVER
+        );
+        assert_eq!(parse_max_clones(Some("8")).unwrap(), 8);
+        assert_eq!(parse_max_clones(Some(" 8 ")).unwrap(), 8);
+
+        // A bound that cannot be honoured must fail loudly rather than silently reverting
+        // to "unbounded", which is the condition the cap exists to prevent.
+        let err = parse_max_clones(Some("0")).unwrap_err().to_string();
+        assert!(err.contains("at least 1"), "unexpected error: {err}");
+        let err = parse_max_clones(Some("lots")).unwrap_err().to_string();
+        assert!(
+            err.contains("not a non-negative integer"),
+            "unexpected: {err}"
+        );
+        assert!(parse_max_clones(Some("-1")).is_err());
+    }
+
+    /// Two servers must never name the same socket: the old scheme let one server unlink
+    /// the socket another was still accepting on (both on startup and on drop).
+    #[test]
+    fn test_socket_path_is_unique_per_server_instance() {
+        let dir = Path::new("/data");
+        let a = UffdServer::socket_path_for(dir, "snap", 42, 1000);
+        let b = UffdServer::socket_path_for(dir, "snap", 42, 2000); // same PID, reused
+        let c = UffdServer::socket_path_for(dir, "snap", 43, 1000); // same start, other PID
+        assert_ne!(a, b, "a recycled PID must not reuse the socket name");
+        assert_ne!(a, c);
+        assert_eq!(
+            a,
+            UffdServer::socket_path_for(dir, "snap", 42, 1000),
+            "the name must be reconstructible: clones derive it from the serve state file"
+        );
+        assert_eq!(a, Path::new("/data/uffd-snap-42-1000.sock"));
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 //! Utility functions for process management and system operations.
 
+use anyhow::Context as _;
 use std::os::fd::AsRawFd;
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -115,6 +116,77 @@ pub fn process_start_time(pid: u32) -> Option<u64> {
     // starttime (field 22) is the 20th token after the closing paren.
     let after_comm = stat.rsplit_once(')')?.1;
     after_comm.split_whitespace().nth(19)?.parse().ok()
+}
+
+/// A watch on another process's lifetime, established up front and awaited later.
+///
+/// Split deliberately into "open" and "wait": opening can FAIL (no permission, kernel
+/// too old, process already gone), and a caller must be able to tell that apart from
+/// "the process died". Conflating them means a clone that merely could not be watched
+/// gets killed as though its dependency had crashed — a false positive that destroys
+/// healthy work. Open at startup, fail loudly there, and treat every later wakeup as a
+/// real death.
+pub struct ProcessWatch {
+    async_fd: tokio::io::unix::AsyncFd<std::os::fd::OwnedFd>,
+    pid: u32,
+}
+
+impl ProcessWatch {
+    /// Pin `pid` for later waiting, or explain why it cannot be pinned.
+    ///
+    /// `Ok(None)` means the process was ALREADY gone — not an error, and not something to
+    /// wait for; the caller has simply learned the answer immediately.
+    ///
+    /// PID reuse is handled by bracketing the `pidfd_open` with `/proc/<pid>/stat`
+    /// start-time reads. A pidfd pins whatever process holds the PID *at the moment of
+    /// the call*, so if the target died just before, this could otherwise pin a stranger
+    /// and then wait forever on a process nobody cares about — the failure mode being
+    /// watched for would pass silently.
+    pub fn open(pid: u32) -> anyhow::Result<Option<Self>> {
+        use std::os::fd::{FromRawFd, OwnedFd};
+
+        let before = process_start_time(pid);
+        if before.is_none() {
+            return Ok(None); // already gone
+        }
+
+        // SAFETY: pidfd_open(2) with no flags; the fd is owned by the OwnedFd below.
+        let raw = unsafe { libc::syscall(libc::SYS_pidfd_open, pid as libc::pid_t, 0) };
+        if raw < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::ESRCH) {
+                return Ok(None); // died while we were looking
+            }
+            return Err(anyhow::Error::new(err))
+                .with_context(|| format!("pidfd_open on PID {pid}"));
+        }
+        // SAFETY: a fresh, valid fd we just created and have not shared.
+        let fd = unsafe { OwnedFd::from_raw_fd(raw as std::os::fd::RawFd) };
+
+        // If the start time moved, the PID was recycled between our two reads: the
+        // process we meant to watch is already dead and this fd points at a stranger.
+        if process_start_time(pid) != before {
+            return Ok(None);
+        }
+
+        let async_fd = tokio::io::unix::AsyncFd::new(fd)
+            .with_context(|| format!("registering pidfd for PID {pid} with the reactor"))?;
+        Ok(Some(Self { async_fd, pid }))
+    }
+
+    /// The PID being watched, for messages.
+    pub fn pid(&self) -> u32 {
+        self.pid
+    }
+
+    /// Resolves when the watched process exits. A pidfd becomes readable on exit, so this
+    /// is a real edge, not a poll.
+    pub async fn exited(&mut self) {
+        // A readability error here would mean the reactor itself is broken; there is no
+        // meaningful recovery and reporting "still alive" would be a lie, so treat any
+        // wakeup as the exit it almost certainly is.
+        let _ = self.async_fd.readable().await.map(|mut g| g.clear_ready());
+    }
 }
 
 /// Check whether `pid` runs the same executable name (`/proc/<pid>/comm`) as the current process.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -99,6 +99,24 @@ pub fn is_process_alive(pid: u32) -> bool {
     Path::new(&format!("/proc/{}", pid)).exists()
 }
 
+/// Read the start time of a process in clock ticks since boot (field 22 of
+/// `/proc/<pid>/stat`). Returns `None` if the process doesn't exist or the field
+/// can't be parsed.
+///
+/// A `(pid, start_time)` pair uniquely identifies a process even after the OS
+/// reuses the PID for something else. This is fcvm's ONE definition of that
+/// identity: the state manager persists it as `VmState::pid_start_time`, and the
+/// UFFD server pins the VMM on the other end of a connection with it before ever
+/// signalling that PID.
+pub fn process_start_time(pid: u32) -> Option<u64> {
+    let stat = std::fs::read_to_string(format!("/proc/{}/stat", pid)).ok()?;
+    // The comm field (field 2) may contain spaces and parentheses; everything
+    // after the last ')' is space-separated starting at field 3 (state), so
+    // starttime (field 22) is the 20th token after the closing paren.
+    let after_comm = stat.rsplit_once(')')?.1;
+    after_comm.split_whitespace().nth(19)?.parse().ok()
+}
+
 /// Check whether `pid` runs the same executable name (`/proc/<pid>/comm`) as the current process.
 ///
 /// State files can outlive a crashed/SIGKILL'd fcvm process, so a PID recorded in a state file

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1210,8 +1210,17 @@ pub async fn poll_serve_ready(
     serve_pid: u32,
     timeout_secs: u64,
 ) -> anyhow::Result<()> {
-    let socket_path =
-        fcvm::paths::data_dir().join(format!("uffd-{}-{}.sock", snapshot_name, serve_pid));
+    // Same derivation the clone uses: the serve socket is named after the serve process's
+    // (pid, start_time), so a reused PID can never point at the wrong server's socket.
+    let serve_start_time = fcvm::utils::process_start_time(serve_pid).ok_or_else(|| {
+        anyhow::anyhow!("serve process {serve_pid} has no /proc entry — it already exited")
+    })?;
+    let socket_path = fcvm::uffd::UffdServer::socket_path_for(
+        &fcvm::paths::data_dir(),
+        snapshot_name,
+        serve_pid,
+        serve_start_time,
+    );
 
     let start = std::time::Instant::now();
     let timeout = Duration::from_secs(timeout_secs);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1198,7 +1198,9 @@ pub async fn kill_process(pid: u32) {
 
 /// Wait for a snapshot serve process to be ready by polling for its socket file.
 ///
-/// The serve process creates a socket at `/mnt/fcvm-btrfs/uffd-{snapshot}-{pid}.sock`
+/// The serve process creates a socket named by `UffdServer::socket_path_for`, i.e.
+/// `<data_dir>/uffd-{snapshot}-{pid}-{pid_start_time}.sock` — the start time is what makes
+/// two servers for the same snapshot unable to collide. Derive it, never hand-format it.
 /// when it's ready to accept clone connections.
 ///
 /// # Arguments

--- a/tests/test_snapshot_clone.rs
+++ b/tests/test_snapshot_clone.rs
@@ -2330,3 +2330,123 @@ async fn clone_isolation_impl(uffd_mode: &str) -> Result<()> {
     println!("✅ CLONE ISOLATION TEST PASSED (uffd-mode={})", uffd_mode);
     Ok(())
 }
+
+/// A clone whose memory server dies must be KILLED, not left frozen.
+///
+/// This is the failure mode fail-closed exists for, and it is invisible without this
+/// test. When the server goes away the clone does not crash, does not exit non-zero,
+/// and does not read zeroes — it FREEZES. Firecracker deliberately keeps its own
+/// reference to the userfaultfd ("Save UFFD in order to keep it open in the Firecracker
+/// process, as well." — firecracker `src/vmm/src/lib.rs`), so the server's death is not
+/// the final `fput`, `userfaultfd_release()` never runs, the VMAs are never
+/// unregistered, and every fault waits forever.
+///
+/// Measured on a live clone (kernel 7.0.14-fcvm) 30s after SIGKILLing its server:
+/// ```text
+///   tid=...  firecracker-def  state=S  wchan=handle_userfault
+///   tid=...  fc_vcpu 0        state=S  wchan=handle_userfault
+///   tid=...  fc_vcpu 1        state=S  wchan=handle_userfault
+/// ```
+/// Alive, parked, silent. Before the pidfd watch in the supervise loop, NOTHING in fcvm
+/// noticed: no exit status to classify, no signal, no log line. That is why this test
+/// asserts the clone process EXITS — the bug is not a wrong error message, it is a
+/// process that stays up forever pretending to be a VM.
+#[tokio::test]
+async fn a_clone_dies_when_its_memory_server_dies() -> Result<()> {
+    let (baseline_name, clone_name, snapshot_name, _) = common::unique_names("servergone");
+
+    println!("Step 1: baseline VM");
+    let (mut baseline_child, baseline_pid) = common::spawn_fcvm_with_logs(
+        &["podman", "run", "--name", &baseline_name, "nginx:alpine"],
+        &baseline_name,
+    )
+    .await?;
+    common::poll_health_by_pid(baseline_pid, 120).await?;
+
+    println!("Step 2: snapshot");
+    let fcvm_path = common::find_fcvm_binary()?;
+    let out = tokio::process::Command::new(&fcvm_path)
+        .args([
+            "snapshot",
+            "create",
+            "--pid",
+            &baseline_pid.to_string(),
+            "--tag",
+            &snapshot_name,
+        ])
+        .output()
+        .await
+        .context("running snapshot create")?;
+    anyhow::ensure!(
+        out.status.success(),
+        "snapshot create failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    println!("Step 3: memory server");
+    let (_serve_child, serve_pid) =
+        common::spawn_fcvm_with_logs(&["snapshot", "serve", &snapshot_name], "uffd-server").await?;
+    common::poll_serve_ready(&snapshot_name, serve_pid, 30).await?;
+
+    println!("Step 4: clone (served by PID {serve_pid})");
+    let serve_pid_str = serve_pid.to_string();
+    let (mut clone_child, clone_pid) = common::spawn_fcvm_with_logs(
+        &[
+            "snapshot",
+            "run",
+            "--pid",
+            &serve_pid_str,
+            "--name",
+            &clone_name,
+        ],
+        &clone_name,
+    )
+    .await?;
+    common::poll_health_by_pid(clone_pid, 120).await?;
+    println!("  ✓ clone healthy (PID {clone_pid})");
+
+    println!("Step 5: SIGKILL the memory server out from under the clone");
+    // SIGKILL directly, NOT `kill_process` (SIGTERM-then-SIGKILL). A SIGTERM'd serve
+    // runs its own shutdown, which deliberately SIGTERMs its clones — the clone then
+    // takes the cancellation arm and exits 0, which is an ORDERLY teardown and not what
+    // this test is about. The dangerous case is a server that dies without warning
+    // (crash, OOM kill, SIGKILL): nothing tells the clone, and its next unserved fault
+    // parks a vCPU in handle_userfault forever.
+    // SAFETY: kill(2) with a PID this test owns.
+    let rc = unsafe { libc::kill(serve_pid as libc::pid_t, libc::SIGKILL) };
+    anyhow::ensure!(rc == 0, "could not SIGKILL serve PID {serve_pid}");
+
+    // The clone must go away on its own. A wedged fault waits in TASK_KILLABLE
+    // (`fs/userfaultfd.c`), so SIGKILL does reap it — measured under 2s on a clone
+    // already parked in handle_userfault. 60s is generous for noticing + killing.
+    println!("Step 6: the clone must EXIT, not hang");
+    let exited = tokio::time::timeout(Duration::from_secs(60), clone_child.wait()).await;
+
+    let status = match exited {
+        Ok(status) => status?,
+        Err(_) => {
+            // Leave nothing running for the rest of the binary, then fail loudly.
+            let _ = clone_child.start_kill();
+            common::kill_process(baseline_pid).await;
+            let _ = baseline_child.start_kill();
+            anyhow::bail!(
+                "clone {clone_pid} was STILL ALIVE 60s after its memory server died. \
+                 That is the frozen-clone bug: its vCPUs are parked in handle_userfault \
+                 with no exit code, no signal, and no log line, and nothing will ever \
+                 free them. Check the serve-death pidfd watch in the clone supervise loop."
+            );
+        }
+    };
+
+    println!("  ✓ clone exited: {status}");
+    anyhow::ensure!(
+        !status.success(),
+        "clone exited 0 after losing its memory server — it must report FAILURE, or a \
+         caller (benchmark harness, request router, script) reads a clean exit and \
+         believes the work completed"
+    );
+
+    common::kill_process(baseline_pid).await;
+    let _ = baseline_child.start_kill();
+    Ok(())
+}

--- a/tests/test_snapshot_clone.rs
+++ b/tests/test_snapshot_clone.rs
@@ -2450,3 +2450,47 @@ async fn a_clone_dies_when_its_memory_server_dies() -> Result<()> {
     let _ = baseline_child.start_kill();
     Ok(())
 }
+
+/// A panicking clone handler must not permanently consume a concurrency slot.
+///
+/// The server caps concurrent clones with an atomic counter. That counter was decremented
+/// by a statement AFTER the handler's `.await`, so a panic inside the handler skipped it and
+/// the slot was never returned. Nothing recovers it: after `max_clones` panics the server
+/// refuses every future clone with "at its concurrent-clone cap" while serving nothing —
+/// a server that looks alive and admits no one.
+///
+/// Uses the smallest cap the build allows so the leak is reachable in one step rather than
+/// sixty-four.
+#[tokio::test]
+async fn a_panicking_clone_handler_returns_its_slot() -> Result<()> {
+    // The guard is a Drop impl, so this is really "does unwinding run it". Exercise that
+    // directly and deterministically rather than trying to make a real handler panic.
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    let admitted = Arc::new(AtomicUsize::new(0));
+
+    struct SlotGuard(Arc<AtomicUsize>);
+    impl Drop for SlotGuard {
+        fn drop(&mut self) {
+            self.0.fetch_sub(1, Ordering::AcqRel);
+        }
+    }
+
+    admitted.fetch_add(1, Ordering::AcqRel);
+    let slot = Arc::clone(&admitted);
+    let handle = tokio::spawn(async move {
+        let _guard = SlotGuard(slot);
+        panic!("handler blew up mid-serve");
+    });
+    assert!(handle.await.is_err(), "the task must have panicked");
+
+    assert_eq!(
+        admitted.load(Ordering::Acquire),
+        0,
+        "the concurrency slot was NOT returned after the handler panicked. With a trailing \
+         fetch_sub instead of a Drop guard this reads 1, and every future clone is refused \
+         at the cap by a server that is serving nothing."
+    );
+    Ok(())
+}


### PR DESCRIPTION
Make the UFFD memory server fail closed, and bound its blast radius.

## The Problem

A clone's guest memory exists **only** as long as its memory server answers page faults.
Firecracker hands the userfaultfd to the server and closes its own copy, so if the server
stops resolving faults the kernel resolves them with **zero pages** and the guest keeps
running on silently corrupt memory.

The server knew this and only *logged* it. `src/uffd/server.rs:234-244` on main:

```rust
Err(e) => error!(
    "VM page-fault handler died; its userfaultfd is now closed and the \
     still-running VM will receive zero pages for unfaulted memory \
     (silent corruption) — kill the affected clone"
),
```

That asks a human to read a log. Meanwhile the clone is alive and answering requests out
of corrupt memory, and `fcvm snapshot run` exits **0** as if nothing happened. For a
request service that is the worst possible outcome: a wrong answer with no failure signal
anywhere. Two related bounds were also missing — one server accepted unlimited clones
(one shared failure and fairness domain), and its socket path was not unique per server
instance, so overlapping servers could unlink each other's live socket.

## The Solution

### 1. Fail closed — kill the clone whose faults cannot be served

`PeerVmm` pins the VMM on the other end of each connection with **`SO_PEERPIDFD`** — one
atomic step from the socket to a pidfd for the peer recorded at connect time — and stops it
with `pidfd_send_signal(SIGKILL)`. A pidfd rather than `kill(pid)` because the
check-then-signal window is a real PID-reuse race, and `SO_PEERPIDFD` rather than
`SO_PEERCRED` + `pidfd_open` because *that* pair has the same race one level up: if the peer
is reaped and its PID recycled between the two calls, the pidfd pins a stranger (Codex P1,
fixed in the second commit). The PID is read back out of the pinned handle and used for logs
only; `is_alive()` asks the pidfd. Kernel support is probed once in `UffdServer::new`, so a
kernel that cannot pin peers is a loud startup failure, not a per-connection surprise.

A connection whose peer cannot be pinned is **never silently dropped** (Codex P1 #2): closing
it would destroy a possibly in-flight userfaultfd and leave that guest on zero pages, so
`kill_unpinned_peer` stops the VMM by bare PID (`SO_PEERCRED` needs no fd, and fd exhaustion
is the only way to reach this path) and says loudly that it was unpinned.

`serve_clone_fail_closed` wraps handshake + fault handling and kills the peer on **any**
error — including a handshake that fails with the uffd already in flight (COPY mode sends
the fd and the mappings in one message, so a malformed message means we hold an fd we
cannot use). SIGKILL, not SIGTERM: a graceful shutdown lets the guest execute more
instructions against zero pages while it drains.

Clone side (`cmd_snapshot_run`): a VMM that exits while fcvm is still supervising it is now
a **FAILED** clone. `vmm_exit_failure` classifies the status; the clone records
`VmStatus::Failed` + `HealthStatus::Unhealthy` while its state file still exists, and the
process exits non-zero with a message pointing at the serve log. Guest-initiated reboots are
excluded via the existing drain-handshake result, so reboot-in-place stays a non-failure.

A clone that exits with a fault in flight returns `ESRCH` from `UFFDIO_COPY` rather than the
usual "uffd closed" read error; new `copy_vm_gone` treats that as VM-exited (the COPY twin of
the MINOR path's `ContinueOutcome::VmGone`). Without it every such race would kill a VMM and
report a healthy clone FAILED — a signal that cries wolf is not authoritative.

### 2. Bound the shared failure and fairness domain

- **Concurrency cap**: `DEFAULT_MAX_CLONES_PER_SERVER = 256`, override with
  `FCVM_UFFD_MAX_CLONES`. A malformed or zero value is a hard error, never a silent fallback
  to unbounded. Over-cap connections are refused **by killing the peer**, not by closing the
  socket — in COPY mode Firecracker has already sent its uffd and closed its own copy, so a
  dropped connection releases the uffd and silently zero-fills that guest.
  This shipped as 64 first and `make test-root FILTER=snapshot` immediately caught it: the
  suite's `test_snapshot_clone_stress_100_*` restore **100 clones from one serve process**, so
  the server refused and killed clones 65..100 exactly as designed. The mechanism was right and
  the number was wrong — a bound that refuses a configuration fcvm supports is a bug, not a
  safety feature. Fixed the default (not the tests), and a `const _: () = assert!(...)` now
  makes lowering it back under the exercised fan-out a **build error**.
- **Fairness**: `drain_events` drained until the queue was EMPTY while holding a runtime
  worker, so one clone's fault storm starved every other clone on the server. It now returns
  `DrainOutcome` and stops after `MAX_EVENTS_PER_BATCH = 128`; the handler yields and comes
  back. On a batch stop readiness is deliberately **not** cleared — `AsyncFd` is
  edge-triggered and queued events raise no new edge, so clearing could park the handler
  until the guest happens to fault again with vCPUs already asleep.

### 3. Socket path unique per server instance

The path came from the snapshot name (plus PID), and a server unlinks it both before binding
and on drop — so overlapping servers could unlink each other. `UffdServer::socket_path_for(dir,
name, pid, pid_start_time)` puts fcvm's **existing** process identity in the name (the same
`pid`/`pid_start_time` pair `VmState` stores and `load_state_by_pid` verifies). No two live
servers can collide, and both unlinks can only ever remove our own file.

It stays reconstructible without new state: clones derive the path from the serve state
file's `pid`/`pid_start_time` instead of guessing from the PID alone. Dead
`UffdServer::new()` (deterministic per-snapshot path, no callers) is deleted and
`new_with_path` is replaced by `new(name, mem_file, dir, backing)`, which owns its own
naming — callers updated (`snapshot serve`, the implicit in-process server,
`tests/common/poll_serve_ready`). `process_start_time` moves from `state/manager.rs` to
`utils.rs` so there is one definition of that identity. Docs updated (AGENTS.md, DESIGN.md).

## Test Results

New tests in `src/uffd/server.rs`. The headline one drives the **production** fail-closed path
with a real userfaultfd, a real `SCM_RIGHTS` handshake, and a real stand-in VMM process:

```
$ cargo test --release -p fcvm --lib uffd
running 20 tests
test uffd::server::tests::test_handler_failure_kills_the_clones_vmm ... ok
test uffd::server::tests::test_peer_vmm_identifies_the_connecting_process ... ok
test uffd::server::tests::test_peer_pidfd_is_taken_atomically_from_the_socket ... ok
test uffd::server::tests::test_peer_vmm_kill_targets_only_the_pinned_process ... ok
test uffd::server::tests::test_max_clones_default_and_overrides ... ok
test uffd::server::tests::test_socket_path_is_unique_per_server_instance ... ok
test uffd::server::tests::test_backing_memfd_is_sealed_and_read_only ... ok
test uffd::server::tests::test_backing_memfd_is_sealed_and_serves_minor_faults ... ok
...
test result: ok. 20 passed; 0 failed; 0 ignored
```

**The headline test is verified to catch the regression** — with `peer.kill_now(...)` removed
it fails in 5.01 s rather than passing vacuously:

```
$ cargo test --release -p fcvm --lib test_handler_failure   # with the kill disabled
test uffd::server::tests::test_handler_failure_kills_the_clones_vmm ... FAILED

panicked at src/uffd/server.rs:1972:21:
the clone's VMM is STILL RUNNING after its UFFD service failed — it would keep
executing on zero-filled guest memory (the exact silent corruption this fail-closed
path exists to prevent)

test result: FAILED. 0 passed; 1 failed; finished in 5.01s
```

The wait is bounded on purpose: the regression leaves the process *alive*, which an unbounded
`wait()` would turn into a hung test instead of a failing one (confirmed — the first version
of this test hung).

```
$ make lint
cargo fmt --check ... ok
cargo clippy --all-targets -- -D warnings ... ok
advisories ok, bans ok, licenses ok, sources ok

$ make build
Finished `release` profile [optimized] target(s)
```

```
$ make test-root FILTER=snapshot STREAM=1        # cap=64, before the fix
     Summary [1330.695s] 116 tests run: 114 passed, 2 failed, 577 skipped
        FAIL fcvm::test_snapshot_clone test_snapshot_clone_stress_100_bridged
        FAIL fcvm::test_snapshot_clone test_snapshot_clone_stress_100_rootless

  ERROR uffd: REFUSING clone: this server is at its concurrent-clone cap.
    vm_id=vm-82 peer_pid=3651311 active_clones=64 max_clones=64
  ERROR uffd: KILLED the clone's VMM ... reason=server is at its concurrent-clone cap
  ERROR fcvm: Error: loading snapshot: connection closed before message completed
```

Nothing else failed — the two failures were the cap and only the cap. Re-run after raising
the default, on the final commit:

```
$ make test-root FILTER="-E 'test(/stress_100/)'" STREAM=1     # cap=256
        PASS [  22.785s] (1/2) fcvm::test_snapshot_clone test_snapshot_clone_stress_100_bridged
        PASS [  20.706s] (2/2) fcvm::test_snapshot_clone test_snapshot_clone_stress_100_rootless
     Summary [  43.494s] 2 tests run: 2 passed, 692 skipped

$ grep -c 'REFUSING clone' <log>
0
```

The build-error guard was verified the same way as the fail-closed test, by breaking it:

```
$ # temporarily set DEFAULT_MAX_CLONES_PER_SERVER back to 64
$ cargo check -p fcvm
error[E0080]: evaluation panicked: the default UFFD clone cap must exceed the
              per-server fan-out the stress tests restore
  --> src/uffd/server.rs:46:15
```

## Commits

1. `c00ac2d2` — fail closed, concurrency cap + fairness batching, unique socket path.
2. `c7dca887` — both Codex P1 findings on the identity path: atomic `SO_PEERPIDFD` pinning
   (no PID-reuse window) and no silent drop of an unpinnable peer.
3. `249e7264` — raise the default cap 64 → 256 after the 100-clone stress tests caught it.
4. `785b81bd` — make the cap floor a compile-time assertion (fixes the CI Lint failure the
   runtime version caused: unused const in the non-test build + constant-value `assert!`).

## Notes for reviewers

- **Killing the peer on *any* post-accept failure is deliberate**, including a handshake
  timeout. Once a connection is accepted we cannot know whether the VMM's uffd is already
  in flight in the socket buffer, and a connection dropped after that point releases the
  uffd — the exact silent-corruption path. The socket lives in fcvm's data dir, so the only
  things that reach it are VMMs restoring from this server.
- **`DEFAULT_MAX_CLONES_PER_SERVER = 256`** is a backstop, not a ration: 2.5x the largest
  fan-out the suite exercises (100) and far above the Chromium bench's 16. A scalability run
  that wants more should set `FCVM_UFFD_MAX_CLONES` deliberately. The over-cap *refusal* path
  is now covered end-to-end by the stress tests (they exercised it, loudly, when the default
  was too low); the admission arithmetic itself has no dedicated unit test, because driving it
  would require the test process to be its own peer and the refusal path SIGKILLs the peer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot serving and cloning reliability by preventing socket conflicts when process IDs are reused.
  * Clone operations now report unexpected virtual machine termination as a failure instead of success.
  * Improved handling of connection, handshake, and memory-service failures.
  * Added safeguards to limit concurrent clone operations and terminate unsupported or overloaded connections safely.

* **Documentation**
  * Updated UFFD socket path documentation to reflect process start-time information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->