### PR TITLE
AGENTS.md: a green CodeRabbit check can mean the reviewer never ran

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -749,6 +749,17 @@ gh pr close <fix-pr-number>  # Close the auto-generated PR
 gh pr view <pr-number> --json comments --jq '.comments[] | .body'
 ```
 
+**A green `CodeRabbit` check does NOT mean CodeRabbit reviewed anything.** When it hits its
+rate limit it posts *"Review limit reached ... we couldn't start this review"* and the check
+still renders as `CodeRabbit  pass`. "The reviewer never ran" is indistinguishable from "the
+reviewer approved" — the same class of bug as a contention detector that can never fire, or a
+leak check whose pattern can never match. Prove the review happened before counting it:
+```bash
+gh pr view <pr-number> --json comments \
+  --jq '.comments[] | select(.author.login=="coderabbitai") | .body' | head -5
+# "Review limit reached" / "next review in NN minutes" => NOT reviewed. Re-run before merging.
+```
+
 ### GitHub Actions Workflow Security (claude.yml)
 
 Jobs run with secrets, so editing `.github/workflows/claude.yml` is security-critical. Rules


### PR DESCRIPTION
## What

One warning in the **Claude Review Workflow** section of `AGENTS.md`: a green `CodeRabbit`
check does not mean CodeRabbit reviewed anything.

## Why

CodeRabbit reported `CodeRabbit  pass` on **both** #739 and #740 while reviewing neither.
Its actual comment on each PR:

> ## Review limit reached
> `@ejc3`, you've reached your PR review limit, so we couldn't start this review.

Meanwhile:

```
$ gh pr checks 739
CodeRabbit    pass
$ gh pr checks 740
CodeRabbit    pass
```

The green state means "the reviewer did not run", and it renders identically to "the reviewer
approved". Anyone gating a merge on `gh pr checks` credits a review that never happened.

This is the same failure class the repo has already been bitten by — a contention detector
that could never fire, a leak check whose pattern could never match. The signal is
structurally incapable of reporting the thing it is trusted for, so it always looks fine.

## The fix

A note plus the one-liner that actually distinguishes the two states, because the check
cannot:

```bash
gh pr view <pr-number> --json comments \
  --jq '.comments[] | select(.author.login=="coderabbitai") | .body' | head -5
# "Review limit reached" / "next review in NN minutes" => NOT reviewed. Re-run before merging.
```

Docs only. `AGENTS.md` is a symlink to `.claude/CLAUDE.md`, so the edit lands on the real file.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd