### PR TITLE
Replay restore working sets without blocking UFFD service

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1765,6 +1765,67 @@ fcvm snapshot run --pid <serve_pid> --name clone1
   clean pages via the page cache (MAP_PRIVATE) — measured 3x 1GiB clones
   ≈ 230MiB total PSS, with or without dirty tracking (#632)
 
+### Working-Set Replay (`--uffd-prefetch`, default on)
+
+Demand paging is the UFFD path's latency tax: a Chromium clone takes ~56,300 faults at
+~5.6 us marginal each (+316 ms versus a file-backed restore on the same page). Clones of one
+snapshot fault almost the same PAGES — pairwise Jaccard median 0.927 across 8 clones, 82.2% of
+the union faulted by all 8 — but NOT in the same ORDER (only 8.6% of faults are the next
+sequential page, which is why readahead and fault-around do nothing here). So the server
+records the SET and replays it.
+
+- **Record**: every demand fault marks its snapshot file offset in a 4 KiB-granular bitmap
+  (32 KiB per GiB of guest RAM). On handler exit the bitmap is unioned into the serve
+  process's in-memory set and scheduled onto one bounded, coalescing background writer. The
+  writer publishes `<memory.bin>.working-set` beside the snapshot under an `flock` + atomic
+  rename, and only writes when the union actually grew — so the steady state writes nothing,
+  and a clone that was killed mid-restore gets completed by the next one instead of baking in
+  a truncated set. Persistence is a performance hint: sidecar lock contention skips that
+  publication attempt without delaying clone teardown, admission slots, or server shutdown;
+  the in-memory union remains available for the next request. Publication also takes the
+  snapshot generation lock shared from the final image-identity check through the atomic
+  rename. Snapshot replacement takes that lock exclusively, so it either finishes before the
+  check (the old clone declines to publish) or waits until an active publication completes; it
+  cannot land in between.
+- **Replay**: at handshake the recorded set is coalesced into runs, mapped into that clone's
+  regions, aligned to its page size, and populated in 2 MiB `UFFDIO_COPY`/`UFFDIO_CONTINUE`
+  chunks. This runs before the guest's first instruction (fcvm loads with `resume_vm: false`),
+  but it is NOT a barrier — the resume comes from the clone process — so a drain of real
+  faults precedes every chunk and demand always beats speculation.
+- **Invalidation**: keyed by the exact `config.json` digest plus the memory image's
+  (`len, mtime, ino, dev`) identity, not a memory-image content hash — SHA-256 of a 2 GiB
+  image measures 1.4 s at 1.5 GB/s here, which costs more than the mis-prefetch it would
+  prevent. The config digest makes atomically installed generations distinct even under inode
+  reuse. Safe because a working set only says WHICH offsets to copy; the BYTES always come
+  from the file being served, so a stale set wastes a copy and can never corrupt a guest.
+- **Isolation**: replay touches pages the guest never asked for, so it must stay private.
+  `UFFDIO_COPY` writes into the clone's own anonymous memory, and `UFFDIO_CONTINUE` installs a
+  read-only PTE that copies on write. Proven by `prefetched_pages_are_private_to_each_clone`
+  (mechanism level, milliseconds) and `test_snapshot_clone_working_set_replay` (two clones,
+  cross-write invisibility, `memory.bin` byte-identical).
+- **Measuring it**: the memory server logs `replayed recorded working set` with
+  `prefetched_pages`, and `VM exited` with `fault_count`. Compare a recording clone against a
+  replaying one; `--uffd-prefetch off` (or `FCVM_UFFD_PREFETCH=off`) gives an inert baseline
+  arm — no recording, no replay, no files.
+- **The trade is latency for eagerness, not for total memory.** A replaying clone materialises
+  its working set at restore instead of over the first ~750 ms, so a clone that lives a full
+  life ends up at the same footprint, just sooner; a clone that is created and destroyed
+  immediately pays for pages it would not have reached. Density claims above (idle clones cost
+  only what they faulted) still hold per page — replay changes WHEN, not WHAT. Turn it off for
+  workloads that spawn many clones which never run.
+
+**End of clone (`PeerVmm`)**: a userfaultfd reports nothing when the process that created it
+dies — measured on this kernel, `poll` returns 0/revents=0 forever and `read` returns EAGAIN —
+because the server still holds its own reference. The server therefore obtains the connecting
+Firecracker's pidfd atomically from the accepted socket with `SO_PEERPIDFD`, before handshake
+or admission, and selects that exact handle alongside UFFD readiness. PIDs are never
+re-resolved, so process reuse cannot redirect observation or the fail-closed SIGKILL. The pidfd
+edge ends a normal handler and schedules the working-set union for best-effort background
+publication. Handshake and page-fault service failures follow the existing fail-closed path and
+terminate the pinned VMM rather than leaving its guest wedged on an unserved fault; hint load,
+speculative-population, and persistence failures degrade to ordinary demand paging because they
+do not stop fault service.
+
 ### FUSE Parallelism (fuse-pipe)
 
 **Kernel clone fd model (`FUSE_DEV_IOC_CLONE`):**

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1495,7 +1495,7 @@ fcvm snapshot create my-vm --tag warm-nginx
 
 **Usage**:
 ```bash
-fcvm snapshot serve <SNAPSHOT_NAME>
+fcvm snapshot serve <SNAPSHOT_NAME> [--uffd-mode copy|minor] [--uffd-prefetch on|off]
 ```
 
 The memory server:
@@ -1503,12 +1503,26 @@ The memory server:
 - Listens for clone connections via Unix socket
 - Serves memory pages on-demand via UFFD (userfaultfd)
 - Enables sharing physical pages across multiple clones
+- Records each clone's restore working set and replays it into the next clone
+
+**Flags**:
+
+| Flag | Env var | Default | Effect |
+|------|---------|---------|--------|
+| `--uffd-mode copy\|minor` | `FCVM_UFFD_MODE` | `copy` | `copy` fills faults with `UFFDIO_COPY` (private per-clone pages); `minor` serves a sealed memfd with `UFFDIO_CONTINUE` (true page sharing) |
+| `--uffd-prefetch on\|off` | `FCVM_UFFD_PREFETCH` | `on` | Working-set replay. `on` records faulted offsets to `<memory.bin>.working-set` and replays them into later clones; `off` is fully inert — no recording, no replay, no files |
 
 **Example**:
 ```bash
 # Start memory server (blocks, keeps running)
 fcvm snapshot serve my-snapshot
+
+# Baseline arm for measurement: pure demand paging, nothing recorded
+fcvm snapshot serve my-snapshot --uffd-prefetch off
 ```
+
+See "Working-Set Replay" in `AGENTS.md` for the fault-locality data behind the default and for
+the invalidation/isolation rules.
 
 #### `fcvm snapshot run`
 
@@ -1675,7 +1689,9 @@ fcvm/
 │   ├── uffd/               # UFFD memory server
 │   │   ├── mod.rs
 │   │   ├── server.rs       # Userfaultfd page handler
-│   │   └── handler.rs      # UFFD event handler
+│   │   ├── handler.rs      # UFFD event handler
+│   │   ├── working_set.rs  # Record/persist the restore working set
+│   │   └── prefetch.rs     # Replay it into a restoring clone
 │   │
 │   ├── volume/             # FUSE volume handling
 │   │   └── mod.rs          # Host → guest filesystem mapping

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -381,6 +381,15 @@ pub struct SnapshotServeArgs {
     ///   instead of a running guest dying with SIGBUS when the pool runs dry.
     #[arg(long, value_name = "copy|minor", env = "FCVM_UFFD_MODE")]
     pub uffd_mode: Option<String>,
+
+    /// Whether to record each clone's restore working set and replay it into the next one.
+    ///
+    /// - `on` (default): the pages a clone faults are recorded beside the snapshot and
+    ///   bulk-populated into every later clone, so it does not trap for pages we already know
+    ///   it will touch. A missing, stale or wrong record just means demand paging.
+    /// - `off`: no recording, no replay — every clone faults every page in.
+    #[arg(long, value_name = "on|off", env = "FCVM_UFFD_PREFETCH")]
+    pub uffd_prefetch: Option<String>,
 }
 
 #[derive(Args, Debug)]

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -20,7 +20,7 @@ use crate::state::{
     generate_vm_id, truncate_id, validate_vm_name, StateManager, VmState, VmStatus,
 };
 use crate::storage::{validate_snapshot_name, SnapshotGeneration, SnapshotManager};
-use crate::uffd::{UffdBacking, UffdServer};
+use crate::uffd::{Prefetch, UffdBacking, UffdServer};
 use crate::volume::{SpawnedVolumes, VolumeConfig};
 
 use super::common::{
@@ -671,14 +671,26 @@ async fn cmd_snapshot_serve(args: SnapshotServeArgs) -> Result<()> {
         None => UffdBacking::Copy,
     };
 
+    // Whether clones replay the snapshot's recorded working set instead of faulting it in
+    // one page at a time (--uffd-prefetch / FCVM_UFFD_PREFETCH).
+    let prefetch = match args.uffd_prefetch.as_deref() {
+        Some(value) => Prefetch::parse(value)?,
+        None => Prefetch::On,
+    };
+
     // The server names its own socket after this process's (pid, start_time), so no two
     // live servers can collide on it. Clones rebuild the same name from the serve state
     // file (see `cmd_snapshot_run`).
     let server = UffdServer::new(
         args.snapshot_name.clone(),
         &snapshot_config.memory_path,
+        &paths::snapshot_dir()
+            .join(&args.snapshot_name)
+            .join("config.json"),
+        &super::common::snapshot_sibling(&paths::snapshot_dir().join(&args.snapshot_name), "lock"),
         &paths::data_dir(),
         backing,
+        prefetch,
     )
     .await
     .context("creating UFFD server")?;
@@ -1599,9 +1611,11 @@ async fn cmd_snapshot_run_inner(
                 "FCVM_FORCE_UFFD"
             };
             let backing = setup_try!(UffdBacking::from_env(hugepages));
+            let prefetch = setup_try!(Prefetch::from_env());
             info!(
                 reason = %reason,
                 mode = backing.name(),
+                prefetch = ?prefetch,
                 "starting implicit UFFD server for snapshot restore"
             );
 
@@ -1619,8 +1633,16 @@ async fn cmd_snapshot_run_inner(
             let server = setup_try!(UffdServer::new(
                 "implicit".to_string(),
                 &snapshot_config.memory_path,
+                &paths::snapshot_dir()
+                    .join(&snapshot_name)
+                    .join("config.json"),
+                &super::common::snapshot_sibling(
+                    &paths::snapshot_dir().join(&snapshot_name),
+                    "lock",
+                ),
                 &data_dir,
                 backing,
+                prefetch,
             )
             .await
             .context("creating implicit UFFD server"));

--- a/src/uffd/mod.rs
+++ b/src/uffd/mod.rs
@@ -1,5 +1,9 @@
 mod handler;
+mod prefetch;
 mod server;
+mod working_set;
 
 pub use handler::UffdHandler;
-pub use server::{preflight_clone_hugepages, UffdBacking, UffdServer};
+pub use server::{preflight_clone_hugepages, Prefetch, UffdBacking, UffdServer};
+/// Exported so integration tests can read back what a real restore recorded.
+pub use working_set::WorkingSetStore;

--- a/src/uffd/prefetch.rs
+++ b/src/uffd/prefetch.rs
@@ -1,0 +1,994 @@
+//! Replaying a recorded working set into a restoring clone.
+//!
+//! [`plan`] turns a [`PageSet`](super::working_set::PageSet) of snapshot file offsets into the
+//! host-address ranges of one particular clone, coalesced into as few pieces as possible;
+//! [`populate_chunk`] materialises one piece with a single `UFFDIO_COPY`/`UFFDIO_CONTINUE`.
+//!
+//! Two properties matter and are enforced here rather than by the caller:
+//!
+//! * **Speculation never blocks demand.** A piece is populated in bounded chunks so the fault
+//!   handler can interleave real faults between them; a guest that resumes mid-prefetch waits
+//!   for at most one chunk, not for the whole set.
+//! * **Speculation never breaks the guest.** Nothing in here can fail a restore. A page that
+//!   is already present, a clone that exits mid-prefetch, or a kernel error all stop the
+//!   prefetch and leave the VM to fault on demand, which is exactly the behaviour of a
+//!   snapshot with no recording at all.
+
+use tracing::debug;
+use userfaultfd::Uffd;
+
+use super::working_set::PageSet;
+
+/// Bytes populated per ioctl.
+///
+/// This is the latency a demand fault can spend queued behind speculation, so it is small
+/// enough to be invisible (~100 us of `memcpy` on this host) while still amortising the ioctl
+/// over 512 4 KiB pages. It is also exactly one 2 MiB granule, so a hugepage clone never gets
+/// a chunk that splits a page.
+pub const CHUNK_BYTES: usize = 2 * 1024 * 1024;
+
+/// Maximum fragmentation accepted from an on-disk performance hint.
+///
+/// The hint is untrusted cache state. Planning must have a fixed CPU/allocation ceiling and
+/// degrade to ordinary demand paging instead of allocating proportional to a corrupt bitmap.
+pub const MAX_PREFETCH_RUNS: usize = 65_536;
+pub const MAX_PREFETCH_SEGMENTS: usize = 65_536;
+
+/// One guest memory region of a clone, as needed to place snapshot offsets in its address
+/// space. A view of the handshake's `GuestRegionUffdMapping`, not the wire type.
+#[derive(Debug, Clone, Copy)]
+pub struct Region {
+    /// Where this region starts in the clone's address space.
+    pub base_host_virt_addr: u64,
+    /// Where this region starts in the snapshot memory file.
+    pub file_offset: u64,
+    /// Length of the region, in bytes.
+    pub size: usize,
+}
+
+/// A contiguous piece of prefetch work: `len` bytes of the snapshot at `file_offset`, to be
+/// materialised at `host_addr` in the clone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Segment {
+    pub host_addr: usize,
+    pub file_offset: u64,
+    pub len: usize,
+}
+
+/// Where prefetched bytes come from — the mode-specific half of [`populate`].
+pub enum Source<'a> {
+    /// A read-only mapping of the snapshot memory file. Pages are copied out of it into the
+    /// clone's private anonymous memory (`UFFDIO_COPY`).
+    Copy(&'a [u8]),
+    /// The clone already maps the shared snapshot memfd `MAP_PRIVATE`; the page only needs a
+    /// (read-only) PTE (`UFFDIO_CONTINUE`). No bytes move.
+    Minor,
+}
+
+/// Why a prefetch stopped short. Neither variant is an error the caller propagates: both mean
+/// "these pages stay unpopulated and will fault on demand", which is the no-recording
+/// behaviour.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Stop {
+    /// The clone's address space is gone (it exited). Stop prefetching, quietly.
+    VmGone,
+    /// The kernel refused; the reason is logged.
+    Refused,
+}
+
+/// Place a recorded working set in one clone's address space.
+///
+/// Runs are clipped to the regions the clone actually mapped, aligned out to its page size
+/// (prefetching a few neighbouring pages is free; a partial page is not addressable), clipped
+/// to the memory file, and finally merged so alignment cannot produce overlapping copies.
+pub fn plan(set: &PageSet, regions: &[Region], page_size: usize, mem_len: u64) -> Vec<Segment> {
+    let mut segments: Vec<Segment> = Vec::new();
+    if !page_size.is_power_of_two() || !(4096..=CHUNK_BYTES).contains(&page_size) {
+        return segments;
+    }
+
+    for (run_index, run) in set.runs().enumerate() {
+        if run_index >= MAX_PREFETCH_RUNS {
+            return Vec::new();
+        }
+        let run_end = run.offset.saturating_add(run.len).min(mem_len);
+        if run_end <= run.offset {
+            continue;
+        }
+        for region in regions {
+            let Ok(region_size) = u64::try_from(region.size) else {
+                continue;
+            };
+            let Some(region_end) = region.file_offset.checked_add(region_size) else {
+                continue;
+            };
+            let start = run.offset.max(region.file_offset);
+            let end = run_end.min(region_end).min(mem_len);
+            if end <= start {
+                continue;
+            }
+
+            // Align within the region: the region base is page-aligned, so aligning the
+            // offset *relative to it* keeps host addresses aligned too.
+            let Ok(rel_start) = usize::try_from(start - region.file_offset) else {
+                continue;
+            };
+            let Ok(rel_end) = usize::try_from(end - region.file_offset) else {
+                continue;
+            };
+            let rel_start = rel_start & !(page_size - 1);
+            let Some(rel_end) = rel_end.checked_next_multiple_of(page_size) else {
+                continue;
+            };
+            let rel_end = rel_end.min(region.size);
+            if rel_end <= rel_start {
+                continue;
+            }
+            // A page that runs past the end of the memory file cannot be copied whole; leave
+            // it to the fault path, which zero-fills the missing tail.
+            let Ok(rel_start_u64) = u64::try_from(rel_start) else {
+                continue;
+            };
+            let Some(file_offset) = region.file_offset.checked_add(rel_start_u64) else {
+                continue;
+            };
+            let len = rel_end - rel_start;
+            let Ok(len_u64) = u64::try_from(len) else {
+                continue;
+            };
+            let Some(file_end) = file_offset.checked_add(len_u64) else {
+                continue;
+            };
+            if file_end > mem_len {
+                continue;
+            }
+            let Some(host_addr) = region.base_host_virt_addr.checked_add(rel_start_u64) else {
+                continue;
+            };
+            let Ok(host_addr) = usize::try_from(host_addr) else {
+                continue;
+            };
+
+            let segment = Segment {
+                host_addr,
+                file_offset,
+                len,
+            };
+
+            // Alignment can make this segment overlap or abut the previous one (two runs in
+            // the same page, or two adjacent pages). Merge instead of copying twice.
+            //
+            // The gap is computed with `checked_sub` rather than compared: guest memory
+            // regions are separate mmaps, so a region holding LATER file offsets can sit at a
+            // LOWER host address, and a plain subtraction would underflow on such a snapshot
+            // (panicking in debug, silently wrapping in release).
+            let merged = segments.last_mut().is_some_and(|prev| {
+                let Some(gap) = segment.host_addr.checked_sub(prev.host_addr) else {
+                    return false;
+                };
+                let Ok(gap_u64) = u64::try_from(gap) else {
+                    return false;
+                };
+                let Some(expected_offset) = prev.file_offset.checked_add(gap_u64) else {
+                    return false;
+                };
+                if gap > prev.len || segment.file_offset != expected_offset {
+                    return false;
+                }
+                let Some(merged_len) = gap.checked_add(segment.len) else {
+                    return false;
+                };
+                prev.len = prev.len.max(merged_len);
+                true
+            });
+            if !merged {
+                if segments.len() >= MAX_PREFETCH_SEGMENTS {
+                    return Vec::new();
+                }
+                segments.push(segment);
+            }
+        }
+    }
+
+    segments
+}
+
+/// Materialise up to [`CHUNK_BYTES`] of `segment`, starting `done` bytes into it, in ONE
+/// ioctl.
+///
+/// Returns how many bytes are now resident from that point, or the outcome that stopped it.
+/// The caller drives this one chunk at a time so it can serve demand faults in between.
+/// Partial progress is normal and is reported so the caller can continue from there:
+///
+/// * `EAGAIN` after progress — the kernel stopped early (`mmap_changing`, or it hit a page
+///   that is already present); the copied prefix still counts.
+/// * `EEXIST` with no progress — the page is already resident (a demand fault beat us to it,
+///   or a previous chunk covered it). Skip exactly one page and carry on.
+/// * `ESRCH` — the clone's mm is gone.
+pub fn populate_chunk(
+    uffd: &Uffd,
+    source: &Source<'_>,
+    segment: &Segment,
+    done: usize,
+    page_size: usize,
+    vm_id: &str,
+) -> Result<usize, Stop> {
+    let Some(remaining) = segment
+        .len
+        .checked_sub(done)
+        .filter(|remaining| *remaining > 0)
+    else {
+        return Err(Stop::Refused);
+    };
+    let Some(host_addr) = segment.host_addr.checked_add(done) else {
+        return Err(Stop::Refused);
+    };
+    let Ok(done_u64) = u64::try_from(done) else {
+        return Err(Stop::Refused);
+    };
+    let Some(file_offset) = segment.file_offset.checked_add(done_u64) else {
+        return Err(Stop::Refused);
+    };
+    let len = CHUNK_BYTES.min(remaining);
+    let dst = host_addr as *mut std::ffi::c_void;
+    let result = match source {
+        Source::Copy(mmap) => {
+            // Checked, not indexed. `plan` bounds segments by the `mem_len` it was given,
+            // which is a DIFFERENT value from this mapping's length (the caller passes
+            // `ctx.mem_size` and `&mmap[..]` separately). They are equal today - both come
+            // from the same `metadata().len()` - but nothing enforces it here, and this
+            // module promises at the top of the file that it can never fail a restore. A
+            // slice index would make a broken invariant a panic inside the fault-handler
+            // task, which hangs the guest; refusing degrades to demand paging instead.
+            let Ok(file_start) = usize::try_from(file_offset) else {
+                return Err(Stop::Refused);
+            };
+            let Some(file_end) = file_start.checked_add(len) else {
+                return Err(Stop::Refused);
+            };
+            let Some(chunk) = mmap.get(file_start..file_end) else {
+                debug!(
+                    target: "uffd",
+                    vm_id = %vm_id,
+                    file_offset,
+                    len,
+                    mapped = mmap.len(),
+                    "prefetch chunk runs past the snapshot mapping"
+                );
+                return Err(Stop::Refused);
+            };
+            // SAFETY: `chunk` is a `len`-byte slice of the snapshot mapping, and `dst` is a
+            // page-aligned range inside a region the clone registered with this uffd.
+            unsafe { uffd.copy(chunk.as_ptr() as *const std::ffi::c_void, dst, len, true) }
+        }
+        Source::Minor => uffd
+            .r#continue(dst, len, true)
+            .map(|mapped| mapped as usize),
+    };
+
+    match result {
+        Ok(copied) if copied > 0 => Ok(copied),
+        // The kernel never reports zero-byte success; treat it as no progress rather than
+        // spinning on the same address forever.
+        Ok(_) => Ok(page_size.min(len)),
+        Err(userfaultfd::Error::PartiallyCopied(copied)) if copied > 0 => Ok(copied),
+        Err(e) => match errno_of(&e) {
+            Some(libc::EEXIST) => Ok(page_size.min(len)),
+            Some(libc::ESRCH) => Err(Stop::VmGone),
+            // Zero-progress EAGAIN: an event-generating operation is in flight
+            // (`mmap_changing`). Nothing is waiting on a speculative page, so give up on
+            // this segment rather than spinning; the pages fault on demand.
+            Some(libc::EAGAIN) => {
+                debug!(
+                    target: "uffd",
+                    vm_id = %vm_id,
+                    addr = format!("0x{host_addr:x}"),
+                    "prefetch chunk deferred (mmap_changing)"
+                );
+                Err(Stop::Refused)
+            }
+            _ => {
+                debug!(
+                    target: "uffd",
+                    vm_id = %vm_id,
+                    addr = format!("0x{host_addr:x}"),
+                    error = ?e,
+                    "prefetch chunk refused by kernel"
+                );
+                Err(Stop::Refused)
+            }
+        },
+    }
+}
+
+/// The raw errno behind a `userfaultfd` error, whichever variant it arrived in.
+///
+/// The crate pins its own `nix`, so the `Errno` values cannot be matched directly against
+/// fcvm's — compare the raw integer instead.
+fn errno_of(e: &userfaultfd::Error) -> Option<i32> {
+    match e {
+        userfaultfd::Error::CopyFailed(errno) | userfaultfd::Error::ZeropageFailed(errno) => {
+            Some(*errno as i32)
+        }
+        userfaultfd::Error::SystemError(errno) => Some(*errno as i32),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::uffd::working_set::GRANULE;
+
+    const G: u64 = GRANULE;
+    const PAGE: usize = 4096;
+
+    fn set_of(mem_len: u64, granules: &[u64]) -> PageSet {
+        let mut set = PageSet::empty(mem_len);
+        for g in granules {
+            set.insert_range(g * G, G);
+        }
+        set
+    }
+
+    /// One region at a non-zero host address: file offsets must land at the right host
+    /// addresses, and contiguous granules must become ONE segment.
+    #[test]
+    fn plan_maps_file_offsets_into_the_clone_and_coalesces() {
+        let mem_len = 64 * G;
+        let regions = [Region {
+            base_host_virt_addr: 0x7f00_0000_0000,
+            file_offset: 0,
+            size: (64 * G) as usize,
+        }];
+        let set = set_of(mem_len, &[0, 1, 2, 9]);
+
+        assert_eq!(
+            plan(&set, &regions, PAGE, mem_len),
+            vec![
+                Segment {
+                    host_addr: 0x7f00_0000_0000,
+                    file_offset: 0,
+                    len: 3 * PAGE
+                },
+                Segment {
+                    host_addr: 0x7f00_0000_0000 + 9 * PAGE,
+                    file_offset: 9 * G,
+                    len: PAGE
+                },
+            ]
+        );
+    }
+
+    /// Firecracker splits guest memory into several regions with their own host bases; a run
+    /// that spans the boundary must be split at it, not copied across it.
+    #[test]
+    fn plan_splits_runs_at_region_boundaries() {
+        let mem_len = 32 * G;
+        let regions = [
+            Region {
+                base_host_virt_addr: 0x1000_0000,
+                file_offset: 0,
+                size: (16 * G) as usize,
+            },
+            Region {
+                base_host_virt_addr: 0x9000_0000, // deliberately NOT contiguous with region 0
+                file_offset: 16 * G,
+                size: (16 * G) as usize,
+            },
+        ];
+        // One run straddling the boundary: granules 15,16,17.
+        let set = set_of(mem_len, &[15, 16, 17]);
+
+        assert_eq!(
+            plan(&set, &regions, PAGE, mem_len),
+            vec![
+                Segment {
+                    host_addr: 0x1000_0000 + 15 * PAGE,
+                    file_offset: 15 * G,
+                    len: PAGE
+                },
+                Segment {
+                    host_addr: 0x9000_0000,
+                    file_offset: 16 * G,
+                    len: 2 * PAGE
+                },
+            ]
+        );
+    }
+
+    /// Guest memory regions are independent mmaps: the region holding LATER file offsets can
+    /// sit at a LOWER host address. Planning must handle that without underflowing the
+    /// merge arithmetic, and must place every page at its own region's base.
+    #[test]
+    fn plan_handles_regions_whose_host_addresses_descend() {
+        let mem_len = 32 * G;
+        let regions = [
+            Region {
+                base_host_virt_addr: 0x9000_0000, // low file offset, HIGH host address
+                file_offset: 0,
+                size: (16 * G) as usize,
+            },
+            Region {
+                base_host_virt_addr: 0x1000_0000, // high file offset, LOW host address
+                file_offset: 16 * G,
+                size: (16 * G) as usize,
+            },
+        ];
+        let set = set_of(mem_len, &[15, 16, 17]);
+
+        assert_eq!(
+            plan(&set, &regions, PAGE, mem_len),
+            vec![
+                Segment {
+                    host_addr: 0x9000_0000 + 15 * PAGE,
+                    file_offset: 15 * G,
+                    len: PAGE
+                },
+                Segment {
+                    host_addr: 0x1000_0000,
+                    file_offset: 16 * G,
+                    len: 2 * PAGE
+                },
+            ]
+        );
+    }
+
+    /// A 4 KiB-granular recording replayed into a 2 MiB-backed clone: every segment must be
+    /// hugepage-aligned and hugepage-sized, and two granules in the same huge page must
+    /// produce ONE segment rather than two overlapping ones.
+    #[test]
+    fn plan_aligns_up_to_the_clone_page_size_without_overlapping() {
+        const HUGE: usize = 2 * 1024 * 1024;
+        let mem_len = 8 * HUGE as u64;
+        let regions = [Region {
+            base_host_virt_addr: 0x4000_0000,
+            file_offset: 0,
+            size: 8 * HUGE,
+        }];
+        // Granules 1 and 300 are both inside the FIRST 2 MiB page (512 granules); 700 is in
+        // the second.
+        let set = set_of(mem_len, &[1, 300, 700]);
+
+        let segments = plan(&set, &regions, HUGE, mem_len);
+        assert_eq!(
+            segments,
+            vec![Segment {
+                host_addr: 0x4000_0000,
+                file_offset: 0,
+                len: 2 * HUGE
+            }],
+            "three scattered 4 KiB granules in two adjacent huge pages = one 4 MiB copy"
+        );
+        for s in &segments {
+            assert_eq!(s.host_addr % HUGE, 0, "segment must be hugepage-aligned");
+            assert_eq!(
+                s.len % HUGE,
+                0,
+                "segment must be a whole number of huge pages"
+            );
+        }
+    }
+
+    /// Pages outside what the clone mapped, and pages past the end of the memory file, are
+    /// dropped rather than turned into an out-of-bounds copy.
+    #[test]
+    fn plan_drops_pages_outside_the_regions_and_the_file() {
+        let mem_len = 8 * G;
+        let regions = [Region {
+            base_host_virt_addr: 0x2000_0000,
+            file_offset: 2 * G,
+            size: (4 * G) as usize, // covers file [2G, 6G)
+        }];
+        // 0 and 1 are before the region, 6 and 7 after it.
+        let set = set_of(mem_len, &[0, 1, 3, 6, 7]);
+
+        assert_eq!(
+            plan(&set, &regions, PAGE, mem_len),
+            vec![Segment {
+                host_addr: 0x2000_0000 + PAGE,
+                file_offset: 3 * G,
+                len: PAGE
+            }]
+        );
+
+        // A region that claims more than the file holds: the tail page is not copyable.
+        let short_file = 3 * G + 100;
+        let set = set_of(mem_len, &[3]);
+        assert!(
+            plan(&set, &regions, PAGE, short_file).is_empty(),
+            "a page that runs past the end of the memory file must be left to the fault path"
+        );
+    }
+
+    #[test]
+    fn plan_of_an_empty_set_is_empty() {
+        let regions = [Region {
+            base_host_virt_addr: 0x1000,
+            file_offset: 0,
+            size: (8 * G) as usize,
+        }];
+        assert!(plan(&PageSet::empty(8 * G), &regions, PAGE, 8 * G).is_empty());
+    }
+
+    #[test]
+    fn plan_rejects_host_address_overflow() {
+        let mem_len = 4 * G;
+        let set = set_of(mem_len, &[1]);
+        let regions = [Region {
+            base_host_virt_addr: u64::MAX - 2047,
+            file_offset: 0,
+            size: (4 * G) as usize,
+        }];
+        assert!(
+            plan(&set, &regions, PAGE, mem_len).is_empty(),
+            "mapping a file offset must never wrap the clone's host address"
+        );
+    }
+
+    #[test]
+    fn plan_rejects_more_runs_than_the_prefetch_budget() {
+        let run_count = MAX_PREFETCH_RUNS + 1;
+        let mem_len = u64::try_from(run_count * 2).unwrap() * G;
+        let mut set = PageSet::empty(mem_len);
+        for run in 0..run_count {
+            set.insert_range(u64::try_from(run * 2).unwrap() * G, G);
+        }
+        let regions = [Region {
+            base_host_virt_addr: 0x4000_0000,
+            file_offset: 0,
+            size: usize::try_from(mem_len).unwrap(),
+        }];
+        assert!(
+            plan(&set, &regions, PAGE, mem_len).is_empty(),
+            "a fragmented hint beyond the fixed planning budget must degrade to demand paging"
+        );
+    }
+
+    // =========================================================================
+    // Against a real userfaultfd. These stand in for a clone's guest memory:
+    // anonymous MAP_PRIVATE pages registered MISSING, exactly what Firecracker
+    // hands the server in COPY mode.
+    // =========================================================================
+
+    use std::os::unix::io::AsRawFd;
+
+    /// Anonymous private memory, like a clone's guest RAM before restore.
+    fn guest_memory(len: usize) -> usize {
+        // SAFETY: a fresh anonymous mapping; the address is returned to the caller.
+        let p = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                len,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        };
+        assert_ne!(p, libc::MAP_FAILED, "mmap guest memory");
+        p as usize
+    }
+
+    fn register_missing(base: usize, len: usize) -> Uffd {
+        let uffd = userfaultfd::UffdBuilder::new()
+            .close_on_exec(true)
+            .non_blocking(true)
+            .user_mode_only(true)
+            .create()
+            .expect("creating userfaultfd (via /dev/userfaultfd)");
+        uffd.register(base as *mut std::ffi::c_void, len)
+            .expect("registering guest memory");
+        uffd
+    }
+
+    /// Block until the uffd has an event, or give up. Event-driven, never a sleep:
+    /// `poll` returns the instant the kernel queues the fault.
+    fn wait_for_event(uffd: &Uffd, timeout_ms: i32) -> bool {
+        let mut pfd = libc::pollfd {
+            fd: uffd.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: one initialised pollfd, owned fd.
+        unsafe { libc::poll(&mut pfd, 1, timeout_ms) > 0 }
+    }
+
+    fn read_u8(addr: usize) -> u8 {
+        // SAFETY: `addr` is inside a live mapping.
+        unsafe { std::ptr::read_volatile(addr as *const u8) }
+    }
+
+    /// Populate a whole plan, asserting nothing refuses it.
+    fn run_plan(uffd: &Uffd, source: &Source<'_>, segments: &[Segment], page_size: usize) {
+        for segment in segments {
+            let mut done = 0usize;
+            while done < segment.len {
+                match populate_chunk(uffd, source, segment, done, page_size, "test") {
+                    Ok(progress) => done += progress,
+                    Err(stop) => panic!("prefetch stopped: {stop:?}"),
+                }
+            }
+        }
+    }
+
+    /// The planner's memory length and the COPY mapping length are separate inputs. A broken
+    /// caller invariant must refuse the speculative range, not panic the clone handler while
+    /// its VMM remains blocked on userfaultfd memory.
+    #[test]
+    fn populate_chunk_refuses_a_copy_range_past_the_source() {
+        let base = guest_memory(PAGE);
+        let uffd = register_missing(base, PAGE);
+        let snapshot = vec![0xAB; PAGE];
+        let segment = Segment {
+            host_addr: base,
+            file_offset: PAGE as u64,
+            len: PAGE,
+        };
+
+        assert_eq!(
+            populate_chunk(
+                &uffd,
+                &Source::Copy(&snapshot),
+                &segment,
+                0,
+                PAGE,
+                "copy-range-boundary",
+            ),
+            Err(Stop::Refused),
+            "an unavailable source range must fall back to demand paging"
+        );
+
+        // SAFETY: unmapping our own mapping.
+        unsafe { libc::munmap(base as *mut std::ffi::c_void, PAGE) };
+    }
+
+    /// A page in the recorded set is resident with the right contents and produces NO fault
+    /// when the guest reads it; a page outside the set still faults normally. This is the
+    /// whole feature in one test.
+    #[test]
+    fn prefetched_pages_carry_snapshot_content_and_never_fault() {
+        const PAGES: usize = 8;
+        let len = PAGES * PAGE;
+        // "Snapshot": page i is filled with byte i + 1.
+        let snapshot: Vec<u8> = (0..PAGES)
+            .flat_map(|i| std::iter::repeat_n(i as u8 + 1, PAGE))
+            .collect();
+
+        let base = guest_memory(len);
+        let uffd = register_missing(base, len);
+        let regions = [Region {
+            base_host_virt_addr: base as u64,
+            file_offset: 0,
+            size: len,
+        }];
+
+        let recorded = set_of(len as u64, &[0, 1, 2, 5]);
+        let segments = plan(&recorded, &regions, PAGE, len as u64);
+        assert_eq!(segments.len(), 2, "0-2 coalesce, 5 stands alone");
+        run_plan(&uffd, &Source::Copy(&snapshot), &segments, PAGE);
+
+        for page in [0usize, 1, 2, 5] {
+            assert_eq!(
+                read_u8(base + page * PAGE),
+                page as u8 + 1,
+                "prefetched page {page} must hold snapshot content"
+            );
+        }
+        assert!(
+            !wait_for_event(&uffd, 0),
+            "reading a prefetched page must not generate a fault - that is the point"
+        );
+
+        // A page that was NOT recorded still faults, proving the registration is live and
+        // that prefetch degrades to demand paging for anything it missed.
+        let reader = std::thread::spawn(move || read_u8(base + 3 * PAGE));
+        assert!(
+            wait_for_event(&uffd, 5000),
+            "an unrecorded page must still fault"
+        );
+        let event = uffd.read_event().unwrap().expect("queued fault");
+        let fault_addr = match event {
+            userfaultfd::Event::Pagefault { addr, .. } => addr as usize & !(PAGE - 1),
+            other => panic!("expected a page fault, got {other:?}"),
+        };
+        assert_eq!(fault_addr, base + 3 * PAGE);
+        // SAFETY: resolving the pending fault at a registered address.
+        unsafe {
+            uffd.copy(
+                snapshot[3 * PAGE..].as_ptr() as *const std::ffi::c_void,
+                fault_addr as *mut std::ffi::c_void,
+                PAGE,
+                true,
+            )
+        }
+        .unwrap();
+        assert_eq!(reader.join().unwrap(), 4);
+
+        // SAFETY: unmapping our own mapping.
+        unsafe { libc::munmap(base as *mut std::ffi::c_void, len) };
+    }
+
+    /// A corrupt record must cost nothing but the prefetch: the clone restores on demand,
+    /// with the RIGHT BYTES, and never hangs.
+    ///
+    /// Ported from the closed #742 branch, which had it as an end-to-end serve test. Valid
+    /// magic is the dangerous shape — it is exactly what a length or checksum check can wave
+    /// through — and a bitmap that silently replayed the WRONG pages into a guest would look
+    /// like success from the outside. So every case here pins all three outcomes: nothing
+    /// replayed, every page faulted on demand, and the bytes the guest reads are correct.
+    #[test]
+    fn a_corrupt_working_set_falls_back_to_on_demand_faulting() {
+        use crate::uffd::working_set::WorkingSetStore;
+
+        const PAGES: usize = 6;
+        let len = PAGES * PAGE;
+        // "Snapshot": page i is filled with byte i + 1.
+        let snapshot: Vec<u8> = (0..PAGES)
+            .flat_map(|i| std::iter::repeat_n(i as u8 + 1, PAGE))
+            .collect();
+
+        // Each case writes a working-set file that has a VALID `FCVMWSET` magic and is
+        // unusable after it. Building the bytes by hand (rather than via the encoder) means
+        // the test cannot be fooled by a change to the encoder itself.
+        type Corrupt = Box<dyn Fn(&std::path::Path, u64)>;
+        let cases: Vec<(&str, Corrupt)> = vec![
+            // The #742 payload: valid magic, garbage after it, shorter than a header.
+            (
+                "valid magic, garbage body",
+                Box::new(|ws: &std::path::Path, _len: u64| {
+                    std::fs::write(ws, b"FCVMWSET this is not a working set").unwrap();
+                }),
+            ),
+            // Structurally perfect for ANOTHER image: right magic, version, granule, image
+            // size, granule count and bitmap length, claiming every page. A length or
+            // checksum check waves this through; only the identity key rejects it. If it
+            // were replayed, a foreign bitmap would populate this guest.
+            (
+                "well-formed but foreign",
+                Box::new(|ws: &std::path::Path, len: u64| {
+                    let granules = len.div_ceil(GRANULE);
+                    let mut buf = Vec::new();
+                    buf.extend_from_slice(b"FCVMWSET");
+                    buf.extend_from_slice(&1u64.to_le_bytes()); // version
+                    buf.extend_from_slice(&GRANULE.to_le_bytes());
+                    buf.extend_from_slice(&len.to_le_bytes());
+                    buf.extend_from_slice(&granules.to_le_bytes());
+                    buf.extend_from_slice(&[0xAAu8; 32]); // a key that is not this image's
+                    for _ in 0..granules.div_ceil(64) {
+                        buf.extend_from_slice(&u64::MAX.to_le_bytes()); // every page "recorded"
+                    }
+                    std::fs::write(ws, &buf).unwrap();
+                }),
+            ),
+            // A genuine record for THIS image, one byte short. Produced through the real API
+            // so the header and key are authentic and only the bitmap is truncated.
+            (
+                "authentic header, truncated bitmap",
+                Box::new(|ws: &std::path::Path, len: u64| {
+                    let image = ws.with_file_name("memory.bin");
+                    let store = WorkingSetStore::open(
+                        &image,
+                        len,
+                        &image.with_file_name("config.json"),
+                        &image.with_file_name("snapshot.lock"),
+                    )
+                    .unwrap();
+                    let mut observed = store.recorder();
+                    observed.insert_range(0, len);
+                    assert!(store.merge_and_persist(&observed).unwrap().persisted);
+                    let mut good = std::fs::read(ws).unwrap();
+                    good.truncate(good.len() - 1);
+                    std::fs::write(ws, &good).unwrap();
+                }),
+            ),
+        ];
+
+        for (label, write_corrupt) in cases {
+            let dir = tempfile::tempdir().unwrap();
+            let image = dir.path().join("memory.bin");
+            let generation_config = dir.path().join("config.json");
+            std::fs::write(&generation_config, b"generation-1").unwrap();
+            std::fs::write(&image, &snapshot).unwrap();
+            write_corrupt(&WorkingSetStore::path_for(&image), len as u64);
+
+            // 1. Nothing is replayed: the record is refused, so there is no plan at all.
+            let generation_lock = dir.path().join("snapshot.lock");
+            let store =
+                WorkingSetStore::open(&image, len as u64, &generation_config, &generation_lock)
+                    .unwrap();
+            let recorded = store.to_prefetch();
+            assert!(
+                recorded.is_empty(),
+                "[{label}] a corrupt record must never be replayed"
+            );
+
+            let base = guest_memory(len);
+            let uffd = register_missing(base, len);
+            let regions = [Region {
+                base_host_virt_addr: base as u64,
+                file_offset: 0,
+                size: len,
+            }];
+            let segments = plan(&recorded, &regions, PAGE, len as u64);
+            assert!(
+                segments.is_empty(),
+                "[{label}] nothing to prefetch means no segments"
+            );
+            run_plan(&uffd, &Source::Copy(&snapshot), &segments, PAGE);
+
+            // 2. Every page is served on demand, and 3. carries the right bytes.
+            let mut faults = 0u64;
+            for page in 0..PAGES {
+                let reader = std::thread::spawn(move || read_u8(base + page * PAGE));
+                assert!(
+                    wait_for_event(&uffd, 5000),
+                    "[{label}] page {page} must fault - the fallback is demand paging"
+                );
+                let event = uffd.read_event().unwrap().expect("queued fault");
+                let fault_addr = match event {
+                    userfaultfd::Event::Pagefault { addr, .. } => addr as usize & !(PAGE - 1),
+                    other => panic!("[{label}] expected a page fault, got {other:?}"),
+                };
+                assert_eq!(fault_addr, base + page * PAGE, "[{label}] wrong fault addr");
+                faults += 1;
+                // SAFETY: resolving the pending fault at a registered address.
+                unsafe {
+                    uffd.copy(
+                        snapshot[page * PAGE..].as_ptr() as *const std::ffi::c_void,
+                        fault_addr as *mut std::ffi::c_void,
+                        PAGE,
+                        true,
+                    )
+                }
+                .unwrap();
+                assert_eq!(
+                    reader.join().unwrap(),
+                    page as u8 + 1,
+                    "[{label}] page {page} must hold its snapshot byte"
+                );
+            }
+            assert_eq!(
+                faults, PAGES as u64,
+                "[{label}] every page must have been served on demand"
+            );
+
+            // The corrupt file is REPAIRED rather than left to poison every later restore:
+            // the image is unchanged, so publication passes the identity gate and the next
+            // server replays a correct record.
+            let mut observed = store.recorder();
+            observed.insert_range(0, 2 * GRANULE);
+            let outcome = store.merge_and_persist(&observed).unwrap();
+            assert!(
+                outcome.persisted && !outcome.superseded,
+                "[{label}] recording over a corrupt record must repair it"
+            );
+            let repaired =
+                WorkingSetStore::open(&image, len as u64, &generation_config, &generation_lock)
+                    .unwrap()
+                    .to_prefetch();
+            assert_eq!(repaired.len(), 2, "[{label}] the repaired record must load");
+
+            // SAFETY: unmapping our own mapping.
+            unsafe { libc::munmap(base as *mut std::ffi::c_void, len) };
+        }
+    }
+
+    /// Prefetching a page the guest already faulted (EEXIST) is a no-op, not a failure: the
+    /// two paths race by design.
+    #[test]
+    fn prefetch_tolerates_an_already_resident_page() {
+        let len = 4 * PAGE;
+        let snapshot = vec![0xABu8; len];
+        let base = guest_memory(len);
+        let uffd = register_missing(base, len);
+        let segment = Segment {
+            host_addr: base,
+            file_offset: 0,
+            len,
+        };
+
+        // Populate once...
+        run_plan(&uffd, &Source::Copy(&snapshot), &[segment], PAGE);
+        // ...and again over the same range. Every page is present now, so each chunk reports
+        // EEXIST with no progress and the loop must still terminate having covered it.
+        let mut done = 0usize;
+        let mut iterations = 0;
+        while done < segment.len {
+            done += populate_chunk(
+                &uffd,
+                &Source::Copy(&snapshot),
+                &segment,
+                done,
+                PAGE,
+                "test",
+            )
+            .expect("EEXIST must not abort a prefetch");
+            iterations += 1;
+            assert!(iterations <= len / PAGE, "must not spin on a present page");
+        }
+        assert_eq!(read_u8(base), 0xAB);
+
+        // SAFETY: unmapping our own mapping.
+        unsafe { libc::munmap(base as *mut std::ffi::c_void, len) };
+    }
+
+    /// ISOLATION. Prefetch touches pages the guest never asked for, so it must be proven that
+    /// a prefetched page is private: two clones prefetched from ONE snapshot mapping, one
+    /// writes, and the other clone AND the snapshot file on disk must be untouched.
+    ///
+    /// This is the mechanism-level version of `test_snapshot_clone_isolation_*`; it fails in
+    /// milliseconds if someone maps the snapshot writable or shared.
+    #[test]
+    fn prefetched_pages_are_private_to_each_clone() {
+        use std::io::Write;
+
+        const PAGES: usize = 4;
+        let len = PAGES * PAGE;
+
+        // A real snapshot file, mapped read-only exactly the way the server maps it.
+        let fixture = tempfile::Builder::new()
+            .prefix("fcvm-prefetch-iso-")
+            .tempdir()
+            .unwrap();
+        let path = fixture.path().join("memory.bin");
+        let mut f = std::fs::File::create(&path).unwrap();
+        for page in 0..PAGES {
+            f.write_all(&vec![0x10u8 + page as u8; PAGE]).unwrap();
+        }
+        f.sync_all().unwrap();
+        drop(f);
+        let original = std::fs::read(&path).unwrap();
+        let file = std::fs::File::open(&path).unwrap();
+        // SAFETY: read-only mapping of a file nothing else writes.
+        let snapshot = unsafe { memmap2::MmapOptions::new().len(len).map(&file).unwrap() };
+
+        // Two clones, each prefetching the whole recorded set.
+        let mut recorded = PageSet::empty(len as u64);
+        recorded.insert_range(0, len as u64);
+        let mut clones = Vec::new();
+        for _ in 0..2 {
+            let base = guest_memory(len);
+            let uffd = register_missing(base, len);
+            let regions = [Region {
+                base_host_virt_addr: base as u64,
+                file_offset: 0,
+                size: len,
+            }];
+            let segments = plan(&recorded, &regions, PAGE, len as u64);
+            run_plan(&uffd, &Source::Copy(&snapshot), &segments, PAGE);
+            clones.push((base, uffd));
+        }
+
+        let (a, _uffd_a) = &clones[0];
+        let (b, _uffd_b) = &clones[1];
+        assert_eq!(read_u8(*a), 0x10);
+        assert_eq!(read_u8(*b), 0x10);
+
+        // Clone A writes to a prefetched page.
+        // SAFETY: writing inside clone A's own mapping.
+        unsafe { std::ptr::write_volatile(*a as *mut u8, 0xEE) };
+
+        assert_eq!(read_u8(*a), 0xEE, "clone A must see its own write");
+        assert_eq!(
+            read_u8(*b),
+            0x10,
+            "MEMORY LEAKED BETWEEN CLONES: clone B saw clone A's write to a prefetched page"
+        );
+        assert_eq!(
+            snapshot[0], 0x10,
+            "SNAPSHOT CORRUPTED: clone A's write reached the shared snapshot mapping"
+        );
+        drop(snapshot);
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            original,
+            "SNAPSHOT CORRUPTED: the memory file changed after a clone wrote to a prefetched page"
+        );
+
+        for (base, _) in &clones {
+            // SAFETY: unmapping our own mapping.
+            unsafe { libc::munmap(*base as *mut std::ffi::c_void, len) };
+        }
+    }
+}

--- a/src/uffd/server.rs
+++ b/src/uffd/server.rs
@@ -14,6 +14,9 @@ use memmap2::MmapOptions;
 use userfaultfd::{Event, FaultKind, Uffd};
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;
 
+use crate::uffd::prefetch;
+use crate::uffd::working_set::{PageSet, WorkingSetPersistence, WorkingSetStore};
+
 /// 2MiB — the only huge page size fcvm supports for guest memory.
 const HUGE_PAGE_2M: usize = 2 * 1024 * 1024;
 
@@ -63,6 +66,14 @@ const MAX_EVENTS_PER_BATCH: usize = 128;
 
 /// How long a connecting VMM has to complete the UFFD handshake.
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How long to wait for new events before re-attempting parked CONTINUEs. Retries are also
+/// attempted after every drain and between prefetch chunks, so this only bounds the
+/// idle-queue case.
+const CONTINUE_RETRY_DELAY: Duration = Duration::from_millis(2);
+
+/// How long a parked MINOR fault may stay unresolved before the handler fails closed.
+const MAX_CONTINUE_WAIT: Duration = Duration::from_secs(2);
 
 /// `sockaddr_un.sun_path` is a fixed 108-byte array on Linux; bind(2) fails with a bare
 /// `EINVAL` when a path overflows it. Checked up front so the error names the real problem.
@@ -329,6 +340,58 @@ impl PeerVmm {
     }
 }
 
+/// Keeps an admitted clone fail-closed even if its async task unwinds or is cancelled.
+///
+/// The normal Result path disarms this only after [`serve_clone_fail_closed`] has either
+/// completed cleanly or killed the peer for an error. Any other exit leaves it armed.
+struct PeerTaskGuard {
+    peer: PeerVmm,
+    vm_id: String,
+    armed: bool,
+}
+
+impl PeerTaskGuard {
+    fn new(peer: PeerVmm, vm_id: impl Into<String>) -> Self {
+        Self {
+            peer,
+            vm_id: vm_id.into(),
+            armed: true,
+        }
+    }
+
+    fn peer(&self) -> &PeerVmm {
+        &self.peer
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for PeerTaskGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            error!(
+                target: "uffd",
+                vm_id = %self.vm_id,
+                peer_pid = self.peer.pid,
+                "admitted clone task ended without normal fail-closed completion; killing VMM"
+            );
+            self.peer
+                .kill_now("admitted clone task unwound or was cancelled");
+        }
+    }
+}
+
+/// Releases one admission slot on every task exit, including an unpolled cancellation.
+struct SlotGuard(Arc<AtomicUsize>);
+
+impl Drop for SlotGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
 /// How the server materialises snapshot pages into a clone's guest memory.
 ///
 /// Both modes serve the same snapshot; they differ in whether the physical page a clone
@@ -400,6 +463,43 @@ enum PageSource {
     Minor { backing: File },
 }
 
+/// Whether a server records each clone's restore working set and replays it into later clones.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Prefetch {
+    On,
+    Off,
+}
+
+/// Working-set state carried by one admitted clone.
+///
+/// Recording/replay and persistence are one optional subsystem, but persistence may be
+/// unavailable while an already-loaded hint remains usable. Keep both capabilities together
+/// while preserving that degraded mode.
+#[derive(Default)]
+struct CloneWorkingSet {
+    store: Option<Arc<WorkingSetStore>>,
+    persistence: Option<WorkingSetPersistence>,
+}
+
+impl Prefetch {
+    pub fn parse(value: &str) -> Result<Self> {
+        match value {
+            "on" => Ok(Self::On),
+            "off" => Ok(Self::Off),
+            other => anyhow::bail!(
+                "invalid UFFD prefetch setting {other:?} (expected \"on\" or \"off\")"
+            ),
+        }
+    }
+
+    pub fn from_env() -> Result<Self> {
+        match std::env::var("FCVM_UFFD_PREFETCH") {
+            Ok(value) => Self::parse(&value),
+            Err(_) => Ok(Self::On),
+        }
+    }
+}
+
 /// Async UFFD server that serves memory pages for multiple VMs from a single snapshot
 pub struct UffdServer {
     snapshot_id: String,
@@ -407,6 +507,9 @@ pub struct UffdServer {
     source: Arc<PageSource>,
     backing: UffdBacking,
     max_clones: usize,
+    mem_size: usize,
+    working_set: Option<Arc<WorkingSetStore>>,
+    working_set_persistence: Option<WorkingSetPersistence>,
 }
 
 impl UffdServer {
@@ -432,8 +535,11 @@ impl UffdServer {
     pub async fn new(
         snapshot_id: String,
         mem_file_path: &Path,
+        generation_config_path: &Path,
+        generation_lock_path: &Path,
         dir: &Path,
         backing: UffdBacking,
+        prefetch: Prefetch,
     ) -> Result<Self> {
         // Before anything else: prove we can fail closed on this kernel.
         require_peer_pidfd_support()?;
@@ -510,12 +616,57 @@ impl UffdServer {
         // remove is the normal case.
         let _ = tokio::fs::remove_file(&socket_path).await;
 
+        // The recording is a performance hint. A missing, stale, corrupt, or unwritable
+        // sidecar falls back to ordinary demand paging and must never fail a restore.
+        let working_set = match prefetch {
+            Prefetch::Off => {
+                info!(target: "uffd", snapshot = %snapshot_id, "working-set replay disabled");
+                None
+            }
+            Prefetch::On => match WorkingSetStore::open(
+                mem_file_path,
+                mem_size as u64,
+                generation_config_path,
+                generation_lock_path,
+            ) {
+                Ok(store) => Some(Arc::new(store)),
+                Err(error) => {
+                    warn!(
+                        target: "uffd",
+                        snapshot = %snapshot_id,
+                        error = %error,
+                        "no usable restore working set; clones will fault on demand"
+                    );
+                    None
+                }
+            },
+        };
+
+        let working_set_persistence = match working_set.as_ref() {
+            Some(store) => match WorkingSetPersistence::new(Arc::clone(store)) {
+                Ok(persistence) => Some(persistence),
+                Err(error) => {
+                    warn!(
+                        target: "uffd",
+                        snapshot = %snapshot_id,
+                        error = ?error,
+                        "working-set persistence is unavailable; loaded hints remain usable"
+                    );
+                    None
+                }
+            },
+            None => None,
+        };
+
         Ok(Self {
             snapshot_id,
             socket_path: socket_path.to_path_buf(),
             source: Arc::new(source),
             backing,
             max_clones: max_clones_per_server()?,
+            mem_size,
+            working_set,
+            working_set_persistence,
         })
     }
 
@@ -620,6 +771,11 @@ impl UffdServer {
                             admitted.fetch_add(1, Ordering::AcqRel);
 
                             let source = Arc::clone(&self.source);
+                            let working_set = CloneWorkingSet {
+                                store: self.working_set.clone(),
+                                persistence: self.working_set_persistence.clone(),
+                            };
+                            let mem_size = self.mem_size;
                             let admitted_slot = Arc::clone(&admitted);
 
                             info!(
@@ -633,6 +789,11 @@ impl UffdServer {
 
                             // Spawn per-connection task so the accept loop returns
                             // immediately — no blocking on slow/misbehaving clones.
+                            // Both guards are constructed BEFORE the future. If JoinSet drops
+                            // it before its first poll, the captured guards still kill the
+                            // unserved VMM and release its admission slot.
+                            let slot_guard = SlotGuard(admitted_slot);
+                            let peer_guard = PeerTaskGuard::new(peer, vm_id.clone());
                             vm_tasks.spawn(async move {
                                 // Release the slot from a Drop guard, not a trailing
                                 // statement. A panic inside serve_clone_fail_closed skips
@@ -641,14 +802,19 @@ impl UffdServer {
                                 // `max_clones` panics the server refuses every future clone
                                 // as "at its concurrent-clone cap" while serving nothing.
                                 // Drop runs during unwind; a trailing statement does not.
-                                struct SlotGuard(std::sync::Arc<AtomicUsize>);
-                                impl Drop for SlotGuard {
-                                    fn drop(&mut self) {
-                                        self.0.fetch_sub(1, Ordering::AcqRel);
-                                    }
-                                }
-                                let _slot = SlotGuard(admitted_slot);
-                                serve_clone_fail_closed(&vm_id, stream, source, peer).await;
+                                let _slot = slot_guard;
+                                let mut peer_guard = peer_guard;
+                                serve_clone_fail_closed(
+                                    &vm_id,
+                                    stream,
+                                    source,
+                                    working_set,
+                                    mem_size,
+                                    peer_guard.peer(),
+                                )
+                                .await;
+                                peer_guard.disarm();
+                                drop(peer_guard);
                                 vm_id
                             });
                         }
@@ -724,9 +890,11 @@ async fn serve_clone_fail_closed(
     vm_id: &str,
     stream: UnixStream,
     source: Arc<PageSource>,
-    peer: PeerVmm,
+    working_set: CloneWorkingSet,
+    mem_size: usize,
+    peer: &PeerVmm,
 ) {
-    match serve_clone(vm_id, stream, source, &peer).await {
+    match serve_clone(vm_id, stream, source, working_set, mem_size, peer).await {
         Ok(()) => info!(
             target: "uffd",
             vm_id = %vm_id,
@@ -761,12 +929,15 @@ async fn serve_clone(
     vm_id: &str,
     stream: UnixStream,
     source: Arc<PageSource>,
+    working_set: CloneWorkingSet,
+    mem_size: usize,
     peer: &PeerVmm,
 ) -> Result<()> {
-    let (uffd, mappings) = tokio::time::timeout(HANDSHAKE_TIMEOUT, handshake(stream, &source))
-        .await
-        .map_err(|_| anyhow!("UFFD handshake did not complete within {HANDSHAKE_TIMEOUT:?}"))?
-        .context("UFFD handshake failed")?;
+    let (uffd, mappings) =
+        tokio::time::timeout(HANDSHAKE_TIMEOUT, handshake(stream, &source, mem_size))
+            .await
+            .map_err(|_| anyhow!("UFFD handshake did not complete within {HANDSHAKE_TIMEOUT:?}"))?
+            .context("UFFD handshake failed")?;
 
     info!(
         target: "uffd",
@@ -776,7 +947,16 @@ async fn serve_clone(
         mappings.len()
     );
 
-    handle_vm_page_faults(vm_id.to_string(), uffd, mappings, source, peer).await
+    handle_vm_page_faults(
+        vm_id.to_string(),
+        uffd,
+        mappings,
+        source,
+        working_set,
+        mem_size,
+        peer,
+    )
+    .await
 }
 
 /// Whether a UFFDIO_ZEROPAGE error means the range (or part of it) is already populated.
@@ -935,15 +1115,88 @@ async fn wait_for_peer_vmm_exit(
     Ok(())
 }
 
-/// Handle page faults for a single VM
+struct VmContext<'a> {
+    vm_id: &'a str,
+    mappings: &'a [GuestRegionUffdMapping],
+    source: &'a PageSource,
+    page_size: usize,
+    page_mask: usize,
+    mem_size: usize,
+}
+
+struct VmState {
+    fault_count: u64,
+    pending_continues: std::collections::BTreeMap<usize, std::time::Instant>,
+    recorded: Option<PageSet>,
+    started: std::time::Instant,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReplayStep {
+    VmExited,
+    RetryPending,
+    Populate,
+    DrainAgain,
+}
+
+fn replay_steps_after_drain(outcome: DrainOutcome) -> &'static [ReplayStep] {
+    const EXITED: &[ReplayStep] = &[ReplayStep::VmExited];
+    const DRAINED: &[ReplayStep] = &[ReplayStep::RetryPending, ReplayStep::Populate];
+    // A full batch still gets the same pending-CONTINUE retry as an empty queue before it
+    // yields. Sustained demand must not bypass a parked fault's retry or fail-closed deadline.
+    const FULL: &[ReplayStep] = &[ReplayStep::RetryPending, ReplayStep::DrainAgain];
+    match outcome {
+        DrainOutcome::VmExited => EXITED,
+        DrainOutcome::QueueDrained => DRAINED,
+        DrainOutcome::BatchFull => FULL,
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReplayAfterRetry {
+    Populate,
+    WaitForPending,
+}
+
+fn replay_after_retry(has_pending: bool) -> ReplayAfterRetry {
+    if has_pending {
+        ReplayAfterRetry::WaitForPending
+    } else {
+        ReplayAfterRetry::Populate
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FaultFinalizationStep {
+    Kill,
+    Persist,
+}
+
+fn fault_finalization_steps(failed: bool) -> &'static [FaultFinalizationStep] {
+    const CLEAN: &[FaultFinalizationStep] = &[FaultFinalizationStep::Persist];
+    const FAILED: &[FaultFinalizationStep] =
+        &[FaultFinalizationStep::Kill, FaultFinalizationStep::Persist];
+    if failed {
+        FAILED
+    } else {
+        CLEAN
+    }
+}
+
+/// Handle page faults for a single VM.
 async fn handle_vm_page_faults(
     vm_id: String,
     uffd: Uffd,
     mappings: Vec<GuestRegionUffdMapping>,
     source: Arc<PageSource>,
+    working_set: CloneWorkingSet,
+    mem_size: usize,
     peer: &PeerVmm,
 ) -> Result<()> {
-    // Derive page size from mappings (all regions use the same page size)
+    let CloneWorkingSet {
+        store: working_set,
+        persistence: working_set_persistence,
+    } = working_set;
     let page_size = mappings.first().map(|m| m.page_size).unwrap_or(4096);
     let page_mask = !(page_size - 1);
 
@@ -954,176 +1207,305 @@ async fn handle_vm_page_faults(
         "page fault handler started"
     );
 
-    // Set UFFD to non-blocking mode for async integration
     let uffd_fd = uffd.as_raw_fd();
+    // SAFETY: `uffd_fd` is live for this scope and F_SETFL changes only its status flags.
     unsafe {
         let flags = libc::fcntl(uffd_fd, libc::F_GETFL);
         libc::fcntl(uffd_fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
     }
 
-    // Wrap UFFD in AsyncFd for tokio integration
     let async_uffd = AsyncFd::new(uffd).context("creating AsyncFd for UFFD")?;
     // Firecracker keeps its own UFFD reference for the VMM's lifetime, and this handler
     // owns another one. Consequently, a normal VMM exit does not make OUR UFFD readable
-    // or close it: without a separate lifetime signal this task parks forever, retaining
-    // both fds and the server's admitted-clone slot. The pidfd already pins the exact VMM
-    // process, so wait on that same handle alongside page faults. A pidfd stays readable
-    // after exit, which also closes the race where the VMM dies before this registration.
+    // or close it: the pidfd is the only authoritative lifetime signal.
     let async_peer_pidfd = AsyncFd::new(PidfdRef(&peer.pidfd))
         .context("registering peer VMM pidfd with the reactor")?;
 
-    let mut fault_count = 0u64;
-    let start_time = std::time::Instant::now();
+    let ctx = VmContext {
+        vm_id: &vm_id,
+        mappings: &mappings,
+        source: &source,
+        page_size,
+        page_mask,
+        mem_size,
+    };
+    let mut state = VmState {
+        fault_count: 0,
+        pending_continues: std::collections::BTreeMap::new(),
+        recorded: working_set.as_deref().map(WorkingSetStore::recorder),
+        started: std::time::Instant::now(),
+    };
 
-    // MINOR faults whose UFFDIO_CONTINUE came back `EAGAIN` (`mmap_changing` was set),
-    // keyed by page address, value = retry attempts so far. The faulting vCPU sleeps
-    // until a successful CONTINUE wakes it and will never re-fault on its own, so every
-    // entry here MUST eventually resolve or the handler must die loudly — silently
-    // dropping one is a permanently hung guest.
-    let mut pending_continues: std::collections::BTreeMap<usize, u32> =
-        std::collections::BTreeMap::new();
-    // How long to wait for new events before re-attempting parked CONTINUEs. Retries are
-    // also attempted after every drain, so this only bounds the idle-queue case.
-    const CONTINUE_RETRY_DELAY: Duration = Duration::from_millis(2);
-    // Hard bound on retries per fault (~2s at CONTINUE_RETRY_DELAY): mmap_changing
-    // clears as soon as the queued event is read, so persistent EAGAIN means something
-    // is wedged. Failing the handler is loud; an infinite loop or a drop would not be.
-    const MAX_CONTINUE_ATTEMPTS: u32 = 1000;
+    let result = replay_then_serve(
+        &ctx,
+        &async_uffd,
+        &async_peer_pidfd,
+        peer.pid,
+        &mut state,
+        working_set.as_deref(),
+    )
+    .await;
 
-    loop {
-        // Wait for UFFD to be readable — but never park indefinitely while resolved-later
-        // faults are waiting, because no new event will ever arrive for THEM.
-        let maybe_guard = if pending_continues.is_empty() {
-            tokio::select! {
-                // If both descriptors become ready while the VMM is exiting, its pidfd is
-                // authoritative: this is an ordinary end of life, not a UFFD-service
-                // failure that should enter the fail-closed kill path.
-                biased;
-                peer_exit = wait_for_peer_vmm_exit(&async_peer_pidfd, &vm_id, peer.pid) => {
-                    peer_exit?;
-                    return Ok(());
-                }
-                uffd_ready = async_uffd.readable() => match uffd_ready {
-                    Ok(guard) => Some(guard),
-                    Err(e) => {
-                        error!(target: "uffd", vm_id = %vm_id, error = %e, "error waiting for UFFD readability");
-                        return Err(e.into());
+    let mut persistence = Some((working_set_persistence, state.recorded.take()));
+    for step in fault_finalization_steps(result.is_err()) {
+        match step {
+            FaultFinalizationStep::Kill => {
+                let error = result
+                    .as_ref()
+                    .expect_err("failed finalization has an error");
+                error!(
+                    target: "uffd",
+                    vm_id = %vm_id,
+                    peer_pid = peer.pid,
+                    peer_alive = peer.is_alive(),
+                    error = ?error,
+                    "clone's UFFD service FAILED — killing its VMM before persistence"
+                );
+                peer.kill_now(&format!("{error:#}"));
+            }
+            FaultFinalizationStep::Persist => {
+                let (persistence, observed) = persistence
+                    .take()
+                    .expect("working-set persistence runs exactly once");
+                persist_observed_working_set(&vm_id, persistence, observed);
+            }
+        }
+    }
+
+    result
+}
+
+fn persist_observed_working_set(
+    vm_id: &str,
+    persistence: Option<WorkingSetPersistence>,
+    observed: Option<PageSet>,
+) {
+    let (Some(persistence), Some(observed)) = (persistence, observed) else {
+        return;
+    };
+    persistence.schedule(vm_id, observed);
+}
+
+async fn replay_then_serve(
+    ctx: &VmContext<'_>,
+    async_uffd: &AsyncFd<Uffd>,
+    async_peer_pidfd: &AsyncFd<PidfdRef<'_>>,
+    peer_pid: u32,
+    state: &mut VmState,
+    working_set: Option<&WorkingSetStore>,
+) -> Result<()> {
+    if let Some(store) = working_set {
+        let recorded = store.to_prefetch();
+        if !recorded.is_empty() && replay_working_set(ctx, async_uffd, &recorded, state).await? {
+            log_clone_finished(ctx, state, "clone exited during working-set replay");
+            return Ok(());
+        }
+    }
+
+    serve_faults(ctx, async_uffd, async_peer_pidfd, peer_pid, state).await
+}
+
+async fn replay_working_set(
+    ctx: &VmContext<'_>,
+    async_uffd: &AsyncFd<Uffd>,
+    recorded: &PageSet,
+    state: &mut VmState,
+) -> Result<bool> {
+    let regions: Vec<prefetch::Region> = ctx
+        .mappings
+        .iter()
+        .map(|mapping| prefetch::Region {
+            base_host_virt_addr: mapping.base_host_virt_addr,
+            file_offset: mapping.offset,
+            size: mapping.size,
+        })
+        .collect();
+    let segments = prefetch::plan(recorded, &regions, ctx.page_size, ctx.mem_size as u64);
+    let source = match ctx.source {
+        PageSource::Copy { mmap } => prefetch::Source::Copy(&mmap[..]),
+        PageSource::Minor { .. } => prefetch::Source::Minor,
+    };
+    let started = std::time::Instant::now();
+    let mut bytes = 0u64;
+    let mut refused = 0u64;
+
+    'segments: for segment in &segments {
+        let mut done = 0usize;
+        'chunk: while done < segment.len {
+            for step in replay_steps_after_drain(drain_events(async_uffd.get_ref(), ctx, state)?) {
+                match step {
+                    ReplayStep::VmExited => return Ok(true),
+                    ReplayStep::RetryPending => {
+                        if !retry_pending_continues(ctx, async_uffd.get_ref(), state)? {
+                            return Ok(true);
+                        }
+                    }
+                    ReplayStep::Populate => {}
+                    ReplayStep::DrainAgain => {
+                        tokio::task::yield_now().await;
+                        continue 'chunk;
                     }
                 }
             }
-        } else {
-            tokio::select! {
-                biased;
-                peer_exit = wait_for_peer_vmm_exit(&async_peer_pidfd, &vm_id, peer.pid) => {
-                    peer_exit?;
-                    return Ok(());
+            if replay_after_retry(!state.pending_continues.is_empty())
+                == ReplayAfterRetry::WaitForPending
+            {
+                tokio::time::sleep(CONTINUE_RETRY_DELAY).await;
+                continue 'chunk;
+            }
+
+            match prefetch::populate_chunk(
+                async_uffd.get_ref(),
+                &source,
+                segment,
+                done,
+                ctx.page_size,
+                ctx.vm_id,
+            ) {
+                Ok(progress) => {
+                    done += progress;
+                    bytes += progress as u64;
                 }
-                uffd_ready = tokio::time::timeout(
-                    CONTINUE_RETRY_DELAY,
-                    async_uffd.readable(),
-                ) => match uffd_ready {
-                    Ok(Ok(guard)) => Some(guard),
-                    Ok(Err(e)) => {
-                        error!(target: "uffd", vm_id = %vm_id, error = %e, "error waiting for UFFD readability");
-                        return Err(e.into());
-                    }
-                    // Timeout: no new events. Fall through and retry the parked faults.
-                    Err(_) => None,
+                Err(prefetch::Stop::VmGone) => return Ok(true),
+                Err(prefetch::Stop::Refused) => {
+                    refused += 1;
+                    tokio::task::yield_now().await;
+                    continue 'segments;
                 }
+            }
+            tokio::task::yield_now().await;
+        }
+    }
+
+    info!(
+        target: "uffd",
+        vm_id = %ctx.vm_id,
+        prefetched_pages = bytes / ctx.page_size as u64,
+        prefetched_mib = bytes / (1024 * 1024),
+        segments = segments.len(),
+        refused_segments = refused,
+        prefetch_ms = started.elapsed().as_millis(),
+        demand_faults_during_replay = state.fault_count,
+        "replayed recorded working set"
+    );
+    Ok(false)
+}
+
+async fn serve_faults(
+    ctx: &VmContext<'_>,
+    async_uffd: &AsyncFd<Uffd>,
+    async_peer_pidfd: &AsyncFd<PidfdRef<'_>>,
+    peer_pid: u32,
+    state: &mut VmState,
+) -> Result<()> {
+    loop {
+        let retry_due = async {
+            if state.pending_continues.is_empty() {
+                std::future::pending::<()>().await
+            } else {
+                tokio::time::sleep(CONTINUE_RETRY_DELAY).await
             }
         };
 
-        // Set when the drain stopped on its batch limit rather than on an empty queue, so
-        // this handler gives the runtime a turn before coming back for the rest.
         let mut yield_after_batch = false;
-        if let Some(mut guard) = maybe_guard {
-            match drain_events(
-                &mut guard,
-                &vm_id,
-                &mappings,
-                &source,
-                page_size,
-                page_mask,
-                &mut fault_count,
-                &mut pending_continues,
-                start_time,
-            )? {
-                DrainOutcome::VmExited => return Ok(()),
-                DrainOutcome::QueueDrained => guard.clear_ready(),
-                // Events are still queued. Deliberately do NOT clear readiness: AsyncFd is
-                // edge-triggered, and the kernel raises no new edge for events already
-                // sitting in the queue, so clearing here could park this handler until the
-                // guest happens to fault again — with faulting vCPUs already asleep.
-                DrainOutcome::BatchFull => yield_after_batch = true,
-            }
-        }
+        tokio::select! {
+            biased;
 
-        // Retry parked faults now that the queue is drained — reading the queued event is
-        // exactly what allows the in-flight operation to finish and `mmap_changing` to
-        // clear, so this is the earliest moment a retry can succeed.
-        if !pending_continues.is_empty() {
-            let mut resolved = Vec::new();
-            for (&page, attempts) in pending_continues.iter_mut() {
-                match continue_page(async_uffd.get_ref(), &vm_id, page, page_size)? {
-                    ContinueOutcome::Resolved => resolved.push(page),
-                    ContinueOutcome::VmGone => {
-                        info!(target: "uffd", vm_id = %vm_id, "VM exited during CONTINUE retry");
+            peer_exit = wait_for_peer_vmm_exit(async_peer_pidfd, ctx.vm_id, peer_pid) => {
+                peer_exit?;
+                log_clone_finished(ctx, state, "clone process exited");
+                return Ok(());
+            }
+
+            readable = async_uffd.readable() => {
+                let mut guard = readable.context("waiting for UFFD readability")?;
+                match drain_events(guard.get_inner(), ctx, state)? {
+                    DrainOutcome::VmExited => {
+                        log_clone_finished(ctx, state, "clone exited during fault service");
                         return Ok(());
                     }
-                    ContinueOutcome::Retry => {
-                        *attempts += 1;
-                        if *attempts >= MAX_CONTINUE_ATTEMPTS {
-                            return Err(anyhow!(
-                                "UFFDIO_CONTINUE at 0x{:x} still EAGAIN after {} attempts — \
-                                 mmap_changing never cleared. Refusing to drop the fault \
-                                 (a dropped fault is a permanently hung vCPU); failing the \
-                                 handler for vm {} instead",
-                                page,
-                                MAX_CONTINUE_ATTEMPTS,
-                                vm_id
-                            ));
-                        }
-                    }
+                    DrainOutcome::QueueDrained => guard.clear_ready(),
+                    DrainOutcome::BatchFull => yield_after_batch = true,
                 }
             }
-            for page in resolved {
-                pending_continues.remove(&page);
-            }
+
+            _ = retry_due => {}
         }
 
-        // Fairness: one clone's fault storm must not own a runtime worker forever. The
-        // events left in the queue are picked up on the next pass (readiness was left set).
+        if !retry_pending_continues(ctx, async_uffd.get_ref(), state)? {
+            log_clone_finished(ctx, state, "clone exited during CONTINUE retry");
+            return Ok(());
+        }
         if yield_after_batch {
             tokio::task::yield_now().await;
         }
     }
 }
 
-/// How a [`drain_events`] pass ended.
+fn log_clone_finished(ctx: &VmContext<'_>, state: &VmState, reason: &str) {
+    let elapsed = state.started.elapsed();
+    let rate = if elapsed.as_secs_f64() > 0.0 {
+        state.fault_count as f64 / elapsed.as_secs_f64()
+    } else {
+        0.0
+    };
+    info!(
+        target: "uffd",
+        vm_id = %ctx.vm_id,
+        fault_count = state.fault_count,
+        elapsed_secs = format!("{:.1}", elapsed.as_secs_f64()),
+        pages_per_sec = format!("{:.0}", rate),
+        reason,
+        "VM exited"
+    );
+}
+
+fn retry_pending_continues(ctx: &VmContext<'_>, uffd: &Uffd, state: &mut VmState) -> Result<bool> {
+    let mut resolved = Vec::new();
+    for (&page, parked_at) in &state.pending_continues {
+        match continue_page(uffd, ctx.vm_id, page, ctx.page_size)? {
+            ContinueOutcome::Resolved => resolved.push(page),
+            ContinueOutcome::VmGone => return Ok(false),
+            ContinueOutcome::Retry if parked_at.elapsed() >= MAX_CONTINUE_WAIT => {
+                return Err(anyhow!(
+                    "UFFDIO_CONTINUE at 0x{page:x} still EAGAIN after {:?}; refusing to drop \
+                     a fault that would permanently hang a vCPU for vm {}",
+                    parked_at.elapsed(),
+                    ctx.vm_id
+                ));
+            }
+            ContinueOutcome::Retry => {}
+        }
+    }
+    for page in resolved {
+        state.pending_continues.remove(&page);
+    }
+    Ok(true)
+}
+
+/// How a drain_events pass ended.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DrainOutcome {
-    /// The uffd is closed: the clone's VMM exited and there is nothing left to serve.
+    /// The clone's address space disappeared during an ioctl (ESRCH).
     VmExited,
     /// The event queue is empty; readiness may be cleared and the handler may park.
     QueueDrained,
-    /// [`MAX_EVENTS_PER_BATCH`] events were handled and more remain queued. The caller must
+    /// MAX_EVENTS_PER_BATCH events were handled and more remain queued. The caller must
     /// leave readiness SET (edge-triggered epoll raises no new edge for queued events) and
     /// yield before draining the rest.
     BatchFull,
 }
 
-/// Drain up to [`MAX_EVENTS_PER_BATCH`] ready events from the uffd.
-#[allow(clippy::too_many_arguments)]
-fn drain_events(
-    guard: &mut tokio::io::unix::AsyncFdReadyGuard<'_, Uffd>,
-    vm_id: &str,
-    mappings: &[GuestRegionUffdMapping],
-    source: &PageSource,
-    page_size: usize,
-    page_mask: usize,
-    fault_count: &mut u64,
-    pending_continues: &mut std::collections::BTreeMap<usize, u32>,
-    start_time: std::time::Instant,
-) -> Result<DrainOutcome> {
+/// Drain up to MAX_EVENTS_PER_BATCH ready events from the uffd.
+///
+/// A read error is a service failure, not proof of process exit: the pidfd is the sole
+/// authoritative exit signal. Propagating it enters the fail-closed kill path.
+fn drain_events(uffd: &Uffd, ctx: &VmContext<'_>, state: &mut VmState) -> Result<DrainOutcome> {
+    let vm_id = ctx.vm_id;
+    let mappings = ctx.mappings;
+    let source = ctx.source;
+    let page_size = ctx.page_size;
+    let page_mask = ctx.page_mask;
     {
         let mut handled = 0usize;
         // Read available events (non-blocking), bounded by the batch size
@@ -1131,33 +1513,24 @@ fn drain_events(
             if handled >= MAX_EVENTS_PER_BATCH {
                 return Ok(DrainOutcome::BatchFull);
             }
-            let event = match guard.get_inner().read_event() {
+            let event = match uffd.read_event() {
                 Ok(Some(event)) => event,
                 Ok(None) => break, // No more events ready
-                Err(_) => {
-                    // UFFD closed = VM exited
-                    let elapsed = start_time.elapsed();
-                    let rate = if elapsed.as_secs_f64() > 0.0 {
-                        *fault_count as f64 / elapsed.as_secs_f64()
-                    } else {
-                        0.0
-                    };
-                    info!(
-                        target: "uffd",
-                        vm_id = %vm_id,
-                        fault_count = *fault_count,
-                        elapsed_secs = format!("{:.1}", elapsed.as_secs_f64()),
-                        pages_per_sec = format!("{:.0}", rate),
-                        "VM exited"
-                    );
-                    return Ok(DrainOutcome::VmExited);
+                Err(error) => {
+                    return Err(anyhow!(
+                        "reading userfaultfd events for vm {} failed after {} faults and {:?}: {:?}",
+                        vm_id,
+                        state.fault_count,
+                        state.started.elapsed(),
+                        error
+                    ));
                 }
             };
             handled += 1;
 
             match event {
                 Event::Pagefault { addr, kind, .. } => {
-                    *fault_count += 1;
+                    state.fault_count += 1;
 
                     // Find which memory region this address belongs to
                     let fault_page = (addr as usize) & page_mask;
@@ -1176,6 +1549,19 @@ fn drain_events(
                             fault_page,
                             base_host
                         ));
+                    }
+
+                    let offset_in_region = fault_page - base_host;
+                    let mapping_offset = usize::try_from(mapping.offset)
+                        .map_err(|_| anyhow!("mapping offset exceeds host address space"))?;
+                    let offset_in_file = mapping_offset
+                        .checked_add(offset_in_region)
+                        .ok_or_else(|| anyhow!("mapping offset overflow"))?;
+
+                    // Record demand, never replay: the set converges on what the guest
+                    // actually requested rather than recursively recording its prediction.
+                    if let Some(recorder) = state.recorded.as_mut() {
+                        recorder.insert_range(offset_in_file as u64, page_size as u64);
                     }
 
                     let mmap = match source {
@@ -1200,7 +1586,7 @@ fn drain_events(
                                     fault_page
                                 ));
                             }
-                            match continue_page(guard.get_inner(), vm_id, fault_page, page_size)? {
+                            match continue_page(uffd, vm_id, fault_page, page_size)? {
                                 ContinueOutcome::Resolved => {}
                                 ContinueOutcome::VmGone => return Ok(DrainOutcome::VmExited),
                                 ContinueOutcome::Retry => {
@@ -1213,7 +1599,10 @@ fn drain_events(
                                         fault_addr = format!("0x{:x}", fault_page),
                                         "UFFDIO_CONTINUE EAGAIN (mmap_changing) - parked for retry"
                                     );
-                                    pending_continues.entry(fault_page).or_insert(0);
+                                    state
+                                        .pending_continues
+                                        .entry(fault_page)
+                                        .or_insert_with(std::time::Instant::now);
                                 }
                             }
                             continue;
@@ -1221,12 +1610,6 @@ fn drain_events(
                         PageSource::Copy { mmap } => mmap,
                     };
 
-                    let offset_in_region = fault_page - base_host;
-                    let mapping_offset = usize::try_from(mapping.offset)
-                        .map_err(|_| anyhow!("mapping offset exceeds host address space"))?;
-                    let offset_in_file = mapping_offset
-                        .checked_add(offset_in_region)
-                        .ok_or_else(|| anyhow!("mapping offset overflow"))?;
                     let mmap_len = mmap.len();
 
                     if offset_in_file >= mmap_len {
@@ -1239,7 +1622,7 @@ fn drain_events(
                         // Heap-allocate zero buffer (2MB on stack would overflow for hugepages)
                         let zero_page: Vec<u8> = vec![0u8; page_size];
                         let result = unsafe {
-                            guard.get_inner().copy(
+                            uffd.copy(
                                 zero_page.as_ptr() as *const std::ffi::c_void,
                                 fault_page as *mut std::ffi::c_void,
                                 page_size,
@@ -1268,7 +1651,7 @@ fn drain_events(
                     let copy_result = if bytes_available >= page_size {
                         let page_data = &mmap[offset_in_file..offset_in_file + page_size];
                         unsafe {
-                            guard.get_inner().copy(
+                            uffd.copy(
                                 page_data.as_ptr() as *const std::ffi::c_void,
                                 fault_page as *mut std::ffi::c_void,
                                 page_size,
@@ -1283,7 +1666,7 @@ fn drain_events(
                             &mmap[offset_in_file..offset_in_file + bytes_available],
                         );
                         unsafe {
-                            guard.get_inner().copy(
+                            uffd.copy(
                                 temp.as_ptr() as *const std::ffi::c_void,
                                 fault_page as *mut std::ffi::c_void,
                                 page_size,
@@ -1396,7 +1779,7 @@ fn drain_events(
                     // by falling back to per-page zeroing that skips already-present pages.
                     // Killing the handler here would close the uffd and silently corrupt the
                     // still-running VM.
-                    let bulk_result = unsafe { guard.get_inner().zeropage(start, len, true) };
+                    let bulk_result = unsafe { uffd.zeropage(start, len, true) };
                     if let Err(e) = bulk_result {
                         if !zeropage_hit_present_page(&e) {
                             error!(
@@ -1420,11 +1803,7 @@ fn drain_events(
                         let mut page = start_addr;
                         while page < end_addr {
                             let page_result = unsafe {
-                                guard.get_inner().zeropage(
-                                    page as *mut std::ffi::c_void,
-                                    page_size,
-                                    true,
-                                )
+                                uffd.zeropage(page as *mut std::ffi::c_void, page_size, true)
                             };
                             if let Err(page_err) = page_result {
                                 if !zeropage_hit_present_page(&page_err) {
@@ -1456,7 +1835,6 @@ fn drain_events(
     }
     Ok(DrainOutcome::QueueDrained)
 }
-
 /// Memory region mapping from Firecracker.
 ///
 /// Firecracker sends these in the UFFD handshake JSON. The `page_size` field
@@ -1497,27 +1875,111 @@ impl GuestRegionUffdMapping {
                 self.base_host_virt_addr
             );
         }
-        // Validate page_size is a non-zero power of two
-        if self.page_size == 0 || !self.page_size.is_power_of_two() {
+        // The fault path allocates one zero page and constructs one ioctl range at this
+        // granularity. Accept only the page sizes fcvm can actually materialise.
+        if !self.page_size.is_power_of_two() || !(4096..=HUGE_PAGE_2M).contains(&self.page_size) {
             anyhow::bail!(
-                "invalid page_size {}: must be a non-zero power of two",
-                self.page_size
+                "invalid page_size {}: expected a power of two from 4096 through {}",
+                self.page_size,
+                HUGE_PAGE_2M,
             );
         }
-        // Check for overflow in base + size
-        if self
-            .base_host_virt_addr
-            .checked_add(self.size as u64)
-            .is_none()
-        {
-            anyhow::bail!(
+
+        let size = u64::try_from(self.size).context("mapping size does not fit in u64")?;
+        // Check both address domains before using either as an ioctl or file range.
+        self.base_host_virt_addr.checked_add(size).ok_or_else(|| {
+            anyhow!(
                 "mapping range overflow: base 0x{:x}, size {}",
                 self.base_host_virt_addr,
                 self.size
+            )
+        })?;
+        self.offset.checked_add(size).ok_or_else(|| {
+            anyhow!(
+                "mapping file range overflow: offset {}, size {}",
+                self.offset,
+                self.size
+            )
+        })?;
+
+        let page_size = self.page_size as u64;
+        if self.base_host_virt_addr % page_size != 0
+            || size % page_size != 0
+            || self.offset % page_size != 0
+        {
+            anyhow::bail!(
+                "mapping is not page-aligned: base 0x{:x}, size {}, offset {}, page_size {}",
+                self.base_host_virt_addr,
+                self.size,
+                self.offset,
+                self.page_size
             );
         }
         Ok(())
     }
+}
+
+fn validate_mappings(mappings: &[GuestRegionUffdMapping], mem_size: usize) -> Result<()> {
+    if mappings.is_empty() {
+        anyhow::bail!("received empty memory mappings from Firecracker");
+    }
+    let expected_page_size = mappings[0].page_size;
+    let mem_size = u64::try_from(mem_size).context("memory image size does not fit in u64")?;
+    let mut host_ranges = Vec::with_capacity(mappings.len());
+    let mut file_ranges = Vec::with_capacity(mappings.len());
+    for (index, mapping) in mappings.iter().enumerate() {
+        mapping
+            .validate()
+            .with_context(|| format!("invalid mapping at index {index}"))?;
+        if mapping.page_size != expected_page_size {
+            anyhow::bail!(
+                "mapping at index {index} uses page_size {}, expected {}",
+                mapping.page_size,
+                expected_page_size
+            );
+        }
+        let size = u64::try_from(mapping.size).context("mapping size does not fit in u64")?;
+        let file_end = mapping
+            .offset
+            .checked_add(size)
+            .context("mapping file range overflow")?;
+        if file_end > mem_size {
+            anyhow::bail!(
+                "mapping at index {index} ends at {file_end}, beyond memory image size {mem_size}"
+            );
+        }
+        let host_end = mapping
+            .base_host_virt_addr
+            .checked_add(size)
+            .context("mapping host range overflow")?;
+        host_ranges.push((mapping.base_host_virt_addr, host_end, index));
+        file_ranges.push((mapping.offset, file_end, index));
+    }
+
+    host_ranges.sort_unstable();
+    for adjacent in host_ranges.windows(2) {
+        let (left_start, left_end, left_index) = adjacent[0];
+        let (right_start, right_end, right_index) = adjacent[1];
+        if right_start < left_end {
+            anyhow::bail!(
+                "host ranges overlap: mapping {left_index} [{left_start:#x}, {left_end:#x}) and \
+                 mapping {right_index} [{right_start:#x}, {right_end:#x})"
+            );
+        }
+    }
+
+    file_ranges.sort_unstable();
+    for adjacent in file_ranges.windows(2) {
+        let (left_start, left_end, left_index) = adjacent[0];
+        let (right_start, right_end, right_index) = adjacent[1];
+        if right_start < left_end {
+            anyhow::bail!(
+                "snapshot ranges overlap: mapping {left_index} [{left_start}, {left_end}) and \
+                 mapping {right_index} [{right_start}, {right_end})"
+            );
+        }
+    }
+    Ok(())
 }
 
 /// Complete the handshake with a newly connected Firecracker.
@@ -1532,6 +1994,7 @@ impl GuestRegionUffdMapping {
 async fn handshake(
     stream: tokio::net::UnixStream,
     source: &PageSource,
+    mem_size: usize,
 ) -> Result<(Uffd, Vec<GuestRegionUffdMapping>)> {
     let std_stream = stream.into_std().context("converting to std stream")?;
     // Keep non-blocking — AsyncFd handles readiness
@@ -1566,15 +2029,7 @@ async fn handshake(
     let mappings: Vec<GuestRegionUffdMapping> =
         serde_json::from_str(&message).context("parsing memory mappings JSON")?;
 
-    // Validate all received mappings
-    if mappings.is_empty() {
-        anyhow::bail!("received empty memory mappings from Firecracker");
-    }
-    for (i, mapping) in mappings.iter().enumerate() {
-        mapping
-            .validate()
-            .with_context(|| format!("invalid mapping at index {}", i))?;
-    }
+    validate_mappings(&mappings, mem_size)?;
 
     // Convert File to Uffd
     let uffd = unsafe { Uffd::from_raw_fd(uffd_file.into_raw_fd()) };
@@ -1812,6 +2267,135 @@ pub fn preflight_clone_hugepages(memory_mib: usize) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nix::fcntl::{Flock, FlockArg};
+
+    /// A full demand batch means events remain queued. Speculative replay must not issue an
+    /// ioctl until those faults have had another bounded drain turn.
+    #[test]
+    fn replay_batch_full_drains_demand_before_prefetching() {
+        let steps = replay_steps_after_drain(DrainOutcome::BatchFull);
+        assert!(
+            steps.contains(&ReplayStep::DrainAgain) && !steps.contains(&ReplayStep::Populate),
+            "BatchFull leaves demand faults queued; prefetch must wait for another drain"
+        );
+    }
+
+    /// A parked MINOR fault must be retried after every bounded drain. Otherwise sustained
+    /// BatchFull traffic skips both its retry and the fail-closed deadline indefinitely.
+    #[test]
+    fn replay_batch_full_retries_parked_continues_before_draining_again() {
+        assert_eq!(
+            replay_steps_after_drain(DrainOutcome::BatchFull),
+            &[ReplayStep::RetryPending, ReplayStep::DrainAgain],
+            "BatchFull must retry parked CONTINUEs before yielding for the next drain"
+        );
+    }
+
+    #[test]
+    fn replay_waits_for_parked_demand_before_speculative_population() {
+        assert_eq!(
+            replay_after_retry(true),
+            ReplayAfterRetry::WaitForPending,
+            "an unresolved demand CONTINUE must block speculative population"
+        );
+        assert_eq!(replay_after_retry(false), ReplayAfterRetry::Populate);
+    }
+
+    /// Once serving fails, the clone can be frozen on its next fault. Stopping the VMM is
+    /// therefore the first finalization action; scheduling hint persistence is cleanup.
+    #[test]
+    fn failed_fault_service_kills_before_working_set_persistence() {
+        assert_eq!(
+            fault_finalization_steps(true),
+            &[FaultFinalizationStep::Kill, FaultFinalizationStep::Persist,],
+            "a failed handler must kill the VMM before scheduling persistence"
+        );
+    }
+
+    /// A working-set file is only a performance hint. Even while a snapshot operation holds
+    /// the generation lease, finishing a clone must release its admission slot and let the
+    /// Tokio runtime shut down; persistence may continue on its detached worker.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn working_set_persistence_does_not_gate_clone_finalization() {
+        let fixture = tempfile::tempdir().unwrap();
+        let memory_path = fixture.path().join("memory.bin");
+        let config_path = fixture.path().join("config.json");
+        let generation_lock_path = fixture.path().join("snapshot.lock");
+        std::fs::write(&memory_path, vec![0u8; 64 * 4096]).unwrap();
+        std::fs::write(&config_path, b"generation-1").unwrap();
+        let store = Arc::new(
+            WorkingSetStore::open(&memory_path, 64 * 4096, &config_path, &generation_lock_path)
+                .unwrap(),
+        );
+
+        let generation_file = File::options()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&generation_lock_path)
+            .unwrap();
+        let generation_guard = Flock::lock(generation_file, FlockArg::LockExclusive).unwrap();
+
+        let mut observed = store.recorder();
+        observed.insert_range(0, 4096);
+        let persistence = WorkingSetPersistence::new(Arc::clone(&store)).unwrap();
+        let (started_tx, started_rx) = std::sync::mpsc::sync_channel(1);
+        // Capacity one is deliberate: on the RED path the receive times out while I/O is
+        // parked, then cleanup releases the lease and joins the thread. Its late completion
+        // signal must not itself block that cleanup join.
+        let (finished_tx, finished_rx) = std::sync::mpsc::sync_channel(1);
+        let runtime_thread = std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            started_tx.send(()).unwrap();
+            runtime.block_on(async move {
+                persist_observed_working_set(
+                    "vm-parked-persistence",
+                    Some(persistence),
+                    Some(observed),
+                );
+            });
+            drop(runtime);
+            finished_tx.send(()).unwrap();
+        });
+        started_rx.recv().unwrap();
+
+        // The worker cannot take its shared generation lease while this exclusive lease is
+        // held. Clone finalization and dropping an otherwise idle Tokio runtime must still
+        // finish, because neither owns or joins the detached persistence worker.
+        let clone_finalization_finished = finished_rx.recv_timeout(Duration::from_secs(2)).is_ok();
+        generation_guard.unlock().unwrap();
+        runtime_thread.join().unwrap();
+
+        let persistence_deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while Arc::strong_count(&store) != 1 {
+            assert!(
+                std::time::Instant::now() < persistence_deadline,
+                "detached persistence worker did not drain and exit after the lease was released"
+            );
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            WorkingSetStore::path_for(&memory_path).exists(),
+            "the drained persistence worker must publish the queued union"
+        );
+        assert!(
+            clone_finalization_finished,
+            "working-set I/O gated clone finalization, retaining its admission slot and \
+             blocking server shutdown"
+        );
+    }
+
+    #[test]
+    fn prefetch_setting_accepts_only_explicit_on_or_off() {
+        assert_eq!(Prefetch::parse("on").unwrap(), Prefetch::On);
+        assert_eq!(Prefetch::parse("off").unwrap(), Prefetch::Off);
+        assert!(Prefetch::parse("true").is_err());
+        assert!(Prefetch::parse("").is_err());
+    }
 
     /// The implicit-restore socket must fit in `sun_path` under the LONGEST path fcvm
     /// actually produces, not the one that happened to be measured.
@@ -1987,6 +2571,114 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("invalid page_size"));
+    }
+
+    #[test]
+    fn mappings_reject_page_sizes_larger_than_fcvm_can_serve() {
+        let oversized = GuestRegionUffdMapping {
+            base_host_virt_addr: 0,
+            size: HUGE_PAGE_2M * 2,
+            offset: 0,
+            page_size: HUGE_PAGE_2M * 2,
+        };
+        assert!(
+            validate_mappings(&[oversized], HUGE_PAGE_2M * 2).is_err(),
+            "an accepted page size becomes an allocation and address mask in the fault path"
+        );
+    }
+
+    #[test]
+    fn mappings_reject_unaligned_regions() {
+        let unaligned = GuestRegionUffdMapping {
+            base_host_virt_addr: 1,
+            size: 4096,
+            offset: 0,
+            page_size: 4096,
+        };
+        assert!(
+            validate_mappings(&[unaligned], 4096).is_err(),
+            "an unaligned registration cannot be served with page-aligned UFFD ioctls"
+        );
+    }
+
+    #[test]
+    fn mappings_reject_mixed_page_sizes() {
+        let mixed = [
+            GuestRegionUffdMapping {
+                base_host_virt_addr: 0x20_0000,
+                size: 0x20_0000,
+                offset: 0,
+                page_size: 4096,
+            },
+            GuestRegionUffdMapping {
+                base_host_virt_addr: 0x40_0000,
+                size: 0x20_0000,
+                offset: 0x20_0000,
+                page_size: HUGE_PAGE_2M,
+            },
+        ];
+        assert!(
+            validate_mappings(&mixed, 0x40_0000).is_err(),
+            "the handler uses one global page mask, so every region must use the same size"
+        );
+    }
+
+    #[test]
+    fn mappings_reject_ranges_past_memory_image() {
+        let past_image = GuestRegionUffdMapping {
+            base_host_virt_addr: 0x1000,
+            size: 4096,
+            offset: 4096,
+            page_size: 4096,
+        };
+        assert!(
+            validate_mappings(&[past_image], 4096).is_err(),
+            "a mapping beyond the served memory image must fail the handshake"
+        );
+    }
+
+    #[test]
+    fn mappings_reject_overlapping_host_ranges() {
+        let overlapping = [
+            GuestRegionUffdMapping {
+                base_host_virt_addr: 0x1000,
+                size: 4096,
+                offset: 0,
+                page_size: 4096,
+            },
+            GuestRegionUffdMapping {
+                base_host_virt_addr: 0x1000,
+                size: 4096,
+                offset: 4096,
+                page_size: 4096,
+            },
+        ];
+        assert!(
+            validate_mappings(&overlapping, 8192).is_err(),
+            "one host fault must resolve to exactly one snapshot offset"
+        );
+    }
+
+    #[test]
+    fn mappings_reject_overlapping_file_ranges() {
+        let overlapping = [
+            GuestRegionUffdMapping {
+                base_host_virt_addr: 0x1000,
+                size: 4096,
+                offset: 0,
+                page_size: 4096,
+            },
+            GuestRegionUffdMapping {
+                base_host_virt_addr: 0x2000,
+                size: 4096,
+                offset: 0,
+                page_size: 4096,
+            },
+        ];
+        assert!(
+            validate_mappings(&overlapping, 4096).is_err(),
+            "one snapshot range must not be placed at conflicting host addresses"
+        );
     }
 
     #[test]
@@ -2198,7 +2890,10 @@ mod tests {
         let base = map.as_mut_ptr() as usize;
         let uffd = userfaultfd::UffdBuilder::new()
             .close_on_exec(true)
-            .non_blocking(false)
+            // Production wraps a non-blocking UFFD in AsyncFd. Linux reports POLLERR
+            // unconditionally for a blocking userfaultfd, which makes readiness unable to
+            // distinguish a queued demand fault in this mechanism-level test.
+            .non_blocking(true)
             .user_mode_only(true)
             .create()
             .expect("creating userfaultfd (via /dev/userfaultfd)");
@@ -2209,14 +2904,68 @@ mod tests {
         )
         .expect("MINOR registration on a MAP_PRIVATE mapping of the sealed fd");
 
+        // Exercise the production working-set replay helper in MINOR mode. Page zero is
+        // backed by nonzero snapshot data and has not been touched, so CONTINUE must install
+        // it proactively without first receiving a demand event.
+        let segment = prefetch::Segment {
+            host_addr: base,
+            file_offset: 0,
+            len: 4096,
+        };
+        assert_eq!(
+            prefetch::populate_chunk(
+                &uffd,
+                &prefetch::Source::Minor,
+                &segment,
+                0,
+                4096,
+                "sealed-backing-minor-prefetch",
+            )
+            .expect("MINOR prefetch should continue the page"),
+            4096
+        );
+        let mut readiness = libc::pollfd {
+            fd: uffd.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        assert_eq!(
+            unsafe { libc::poll(&mut readiness, 1, 0) },
+            0,
+            "prefetch must not leave a synthetic demand event queued"
+        );
+        assert_eq!(
+            readiness.revents & (libc::POLLIN | libc::POLLERR | libc::POLLNVAL),
+            0
+        );
+        assert_eq!(unsafe { std::ptr::read_volatile(base as *const u8) }, 0xAB);
+        readiness.revents = 0;
+        assert_eq!(
+            unsafe { libc::poll(&mut readiness, 1, 0) },
+            0,
+            "reading a prefetched page must not fault on demand"
+        );
+
         // Touch page 2 from another thread -> MINOR fault -> resolve with continue_page.
         let reader = std::thread::spawn(move || unsafe {
             std::ptr::read_volatile((base + 8192) as *const u8)
         });
+        let mut demand_ready = libc::pollfd {
+            fd: uffd.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        assert_eq!(
+            unsafe { libc::poll(&mut demand_ready, 1, 5000) },
+            1,
+            "page-2 demand fault did not reach userfaultfd"
+        );
+        assert_ne!(demand_ready.revents & libc::POLLIN, 0);
+        assert_eq!(demand_ready.revents & (libc::POLLERR | libc::POLLNVAL), 0);
         let event = uffd
             .read_event()
             .unwrap()
-            .expect("blocking read yields an event");
+            .expect("ready non-blocking UFFD yields an event");
         let fault_addr = match event {
             Event::Pagefault {
                 kind: FaultKind::Minor,
@@ -2386,6 +3135,35 @@ mod tests {
         );
     }
 
+    /// An admitted task can unwind outside the ordinary `Result` path. Dropping its pidfd is
+    /// not enough: Firecracker retains the UFFD and the guest would remain alive but frozen.
+    #[tokio::test]
+    async fn admitted_task_panic_kills_the_pinned_vmm() {
+        let victim = spawn_victim();
+        let peer = PeerVmm::from_pid(victim.id()).unwrap();
+        let task = tokio::spawn(async move {
+            let _guard = PeerTaskGuard::new(peer, "vm-panicked-task");
+            panic!("deterministic admitted-task panic");
+        });
+        assert!(task.await.unwrap_err().is_panic());
+        assert_vmm_was_killed(victim).await;
+    }
+
+    /// Cancellation can drop a spawned future before Tokio polls its body even once. The
+    /// fail-closed guard must already exist then; constructing it inside the body is too late.
+    #[tokio::test]
+    async fn dropping_unpolled_admitted_task_kills_the_pinned_vmm() {
+        let victim = spawn_victim();
+        let peer = PeerVmm::from_pid(victim.id()).unwrap();
+        let guard = PeerTaskGuard::new(peer, "vm-unpolled-task");
+        let admitted = async move {
+            let _guard = guard;
+            std::future::pending::<()>().await;
+        };
+        drop(admitted);
+        assert_vmm_was_killed(victim).await;
+    }
+
     /// The headline regression: when the page-fault handler fails, the clone's VMM is
     /// KILLED. Before this, the handler merely logged that the VM "should be killed" and
     /// left it alive to wedge on its next unserved page fault.
@@ -2455,7 +3233,15 @@ mod tests {
             std::thread::spawn(move || unsafe { std::ptr::read_volatile(guest_addr as *const u8) });
 
         // The production fail-closed path, verbatim.
-        serve_clone_fail_closed("vm-test", server_side, source, peer).await;
+        serve_clone_fail_closed(
+            "vm-test",
+            server_side,
+            source,
+            CloneWorkingSet::default(),
+            4096,
+            &peer,
+        )
+        .await;
 
         assert_vmm_was_killed(victim).await;
 
@@ -2465,6 +3251,52 @@ mod tests {
         assert_eq!(toucher.join().unwrap(), 0);
         unsafe { libc::munmap(guest, 4096) };
         drop(client);
+    }
+
+    /// A malformed event stream is a service failure, not evidence that the VMM exited.
+    /// The error must reach the existing fail-closed path and kill the exact pidfd-pinned
+    /// peer instead of silently abandoning a guest whose next fault would wedge.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_read_event_error_kills_the_clones_vmm() {
+        use std::io::Write;
+
+        let (snap_path, mem_size) = write_test_snapshot();
+        let mem_file = File::open(&snap_path).unwrap();
+        // SAFETY: the temporary snapshot file is immutable for the mapping's lifetime.
+        let mmap = unsafe { MmapOptions::new().len(mem_size).map(&mem_file).unwrap() };
+        let source = Arc::new(PageSource::Copy { mmap });
+        std::fs::remove_file(&snap_path).ok();
+
+        let victim = spawn_victim();
+        let peer = PeerVmm::from_pid(victim.id()).unwrap();
+        let (server_side, client_side) = UnixStream::pair().unwrap();
+
+        // Pass a socket instead of a userfaultfd through the real SCM_RIGHTS handshake.
+        // One byte is shorter than `uffd_msg`, so `read_event` deterministically returns
+        // `IncompleteMsg` after the handshake succeeds.
+        let (fake_uffd, mut event_writer) = std::os::unix::net::UnixStream::pair().unwrap();
+        event_writer.write_all(&[0x12]).unwrap();
+        let mappings = r#"[{"base_host_virt_addr":4096,"size":4096,"offset":0,"page_size":4096}]"#;
+        let client = client_side.into_std().unwrap();
+        client.set_nonblocking(false).unwrap();
+        client
+            .send_with_fd(mappings.as_bytes(), fake_uffd.as_raw_fd())
+            .expect("send malformed event fd through the real handshake");
+
+        serve_clone_fail_closed(
+            "vm-read-error",
+            server_side,
+            source,
+            CloneWorkingSet::default(),
+            mem_size,
+            &peer,
+        )
+        .await;
+        assert_vmm_was_killed(victim).await;
+
+        drop(client);
+        drop(fake_uffd);
+        drop(event_writer);
     }
 
     #[test]

--- a/src/uffd/working_set.rs
+++ b/src/uffd/working_set.rs
@@ -1,0 +1,1402 @@
+//! The restore working set: which pages of a snapshot a clone actually touches.
+//!
+//! A clone restored over UFFD starts with *nothing* resident and faults its way in one page
+//! at a time. Every fault is a vCPU trap, a read from the uffd queue, and an ioctl — measured
+//! at ~5.6 us marginal on this host, and a Chromium clone takes ~56,300 of them, so the
+//! demand-paging tax is hundreds of milliseconds of pure latency before the guest does any
+//! useful work.
+//!
+//! Clones of the same snapshot fault almost the same pages: across 8 clones of one snapshot
+//! the pairwise page-set Jaccard median is 0.927 and 82.2% of the union is faulted by ALL 8.
+//! What is *not* reproducible is the ORDER — only 8.6% of faults land on the page after the
+//! previous one, which is why readahead and fault-around do nothing here. The set is stable
+//! even though the sequence is not, so the thing worth persisting is the SET.
+//!
+//! This module records that set, keeps it beside the snapshot, and hands it back on the next
+//! restore so the server can populate those pages up front instead of trapping for each one.
+//!
+//! # The set is a hint, never data
+//!
+//! A working set only ever says WHICH offsets to populate. The bytes always come from the
+//! memory file being served right now, through the same code path a demand fault would use.
+//! So a wrong, stale, or truncated set cannot corrupt a guest — the worst case is a wasted
+//! copy of pages nobody asked for, plus the demand faults that still happen for the pages the
+//! set missed. Every validation failure in here therefore degrades to "prefetch nothing and
+//! re-record", never to an error that reaches the VM.
+//!
+//! # Why the image key is an identity tuple and not a content hash
+//!
+//! The key exists to stop a set recorded against one memory image from being replayed against
+//! a different one. Because a mismatch can only waste work (see above), the key is sized to
+//! that harm: SHA-256 over the exact snapshot `config.json` digest plus the memory file's
+//! `(len, mtime, ino, dev)`, which is one small read and one `stat`.
+//! Hashing the image itself was measured at 1.5 GB/s on this host — 1.4 s for a 2 GiB snapshot,
+//! paid on every `snapshot serve` startup — which is a far bigger cost than the mis-prefetch it
+//! would prevent. Rewriting a snapshot (`snapshot create --tag` over an existing tag) always
+//! writes a new file: new inode, new mtime, new key, and the stale set is dropped.
+
+use anyhow::{Context, Result};
+use nix::fcntl::{Flock, FlockArg};
+use sha2::{Digest, Sha256};
+use std::fs::File;
+use std::io::{Read, Write};
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{sync_channel, Receiver, SyncSender, TrySendError};
+use std::sync::{Arc, Mutex};
+use tracing::{debug, info, warn};
+
+/// Bitmap granularity, in bytes.
+///
+/// Fixed at 4 KiB rather than the clone's page size so ONE recorded set serves every clone of
+/// a snapshot regardless of how its guest memory is backed: 4 KiB, ARM64 16 KiB, and 2 MiB
+/// hugepage granules are all whole multiples of this, so a fault on any of them marks a whole
+/// number of bits and a set recorded by a 4 KiB clone is directly usable by a 2 MiB one.
+pub const GRANULE: u64 = 4096;
+
+/// `magic || version || granule || mem_len || granules || image_key`.
+const HEADER_LEN: usize = 8 + 8 + 8 + 8 + 8 + 32;
+const MAGIC: &[u8; 8] = b"FCVMWSET";
+const VERSION: u64 = 1;
+
+/// Refuse to even allocate a bitmap for an implausible memory file (1 TiB of 4 KiB granules
+/// is a 32 MiB bitmap). Guards against a corrupt header turning into a huge allocation.
+const MAX_MEM_LEN: u64 = 1 << 40;
+
+/// Identity of the snapshot memory image a working set was recorded against.
+///
+/// See the module docs for why this combines the exact config digest with a `stat` tuple
+/// instead of hashing the multi-gigabyte memory image.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ImageKey([u8; 32]);
+
+impl ImageKey {
+    /// Derive the key of the memory image at `path`.
+    pub fn of(path: &Path, config_digest: &[u8; 32]) -> Result<Self> {
+        let meta = std::fs::metadata(path)
+            .with_context(|| format!("stat-ing memory image {}", path.display()))?;
+        let mut hasher = Sha256::new();
+        hasher.update(config_digest);
+        hasher.update(meta.len().to_le_bytes());
+        hasher.update(meta.mtime().to_le_bytes());
+        hasher.update(meta.mtime_nsec().to_le_bytes());
+        hasher.update(meta.ino().to_le_bytes());
+        hasher.update(meta.dev().to_le_bytes());
+        Ok(Self(hasher.finalize().into()))
+    }
+}
+
+impl std::fmt::Debug for ImageKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for b in &self.0[..8] {
+            write!(f, "{b:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+/// A contiguous run of snapshot memory, in file offsets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Run {
+    pub offset: u64,
+    pub len: u64,
+}
+
+/// A set of snapshot pages, as a bitmap over [`GRANULE`]-sized granules of the memory file.
+///
+/// A bitmap rather than a list of offsets because it dedupes for free (the same page faults
+/// more than once across a clone's life), costs a fixed 32 KiB per GiB of guest memory, and
+/// makes merging two clones' observations a word-wise OR.
+#[derive(Clone, PartialEq, Eq)]
+pub struct PageSet {
+    granules: u64,
+    words: Vec<u64>,
+}
+
+/// Print the runs, not 32 KiB of hex: a failing assertion should say WHICH pages differ.
+impl std::fmt::Debug for PageSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "PageSet({} of {} granules) ", self.len(), self.granules)?;
+        f.debug_list()
+            .entries(
+                self.runs()
+                    .map(|r| format!("{:#x}..{:#x}", r.offset, r.offset + r.len)),
+            )
+            .finish()
+    }
+}
+
+impl PageSet {
+    /// An empty set covering a memory image of `mem_len` bytes.
+    pub fn empty(mem_len: u64) -> Self {
+        let granules = mem_len.div_ceil(GRANULE);
+        Self {
+            granules,
+            words: vec![0; (granules as usize).div_ceil(64)],
+        }
+    }
+
+    /// Number of granules currently in the set.
+    pub fn len(&self) -> u64 {
+        self.words.iter().map(|w| w.count_ones() as u64).sum()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.words.iter().all(|w| *w == 0)
+    }
+
+    /// Bytes covered by the set.
+    pub fn bytes(&self) -> u64 {
+        self.len() * GRANULE
+    }
+
+    /// Mark the whole `[offset, offset + len)` range as touched.
+    ///
+    /// Ranges outside the image are ignored rather than rejected: this is called from the
+    /// fault path, where a mapping that runs past the end of a truncated memory file is
+    /// already handled (zero-filled) and must not become an error here.
+    pub fn insert_range(&mut self, offset: u64, len: u64) {
+        let first = offset / GRANULE;
+        let last = offset.saturating_add(len.max(1) - 1) / GRANULE;
+        for granule in first..=last.min(self.granules.saturating_sub(1)) {
+            if granule >= self.granules {
+                break;
+            }
+            self.words[(granule / 64) as usize] |= 1u64 << (granule % 64);
+        }
+    }
+
+    /// Membership of a single granule. Serving only ever walks whole [`Run`]s, so this exists
+    /// for the tests that pin down `insert_range`'s granule arithmetic.
+    #[cfg(test)]
+    fn contains(&self, granule: u64) -> bool {
+        granule < self.granules
+            && self.words[(granule / 64) as usize] & (1u64 << (granule % 64)) != 0
+    }
+
+    /// OR `other` into `self`, returning how many granules were newly added.
+    ///
+    /// Sets built for different image sizes merge over their overlap; the caller validates
+    /// sizes, this just refuses to read or write out of bounds.
+    pub fn union_from(&mut self, other: &PageSet) -> u64 {
+        let mut added = 0u64;
+        let common = self.words.len().min(other.words.len());
+        for i in 0..common {
+            let before = self.words[i];
+            let after = before | other.words[i];
+            added += (after & !before).count_ones() as u64;
+            self.words[i] = after;
+        }
+        added
+    }
+
+    /// Coalesce the set into as few contiguous runs as possible.
+    ///
+    /// This is what turns 56k scattered fault offsets into a few hundred bulk copies: the
+    /// arrival ORDER of faults is scattered, but the SET is dense in runs.
+    pub fn runs(&self) -> RunIter<'_> {
+        RunIter {
+            set: self,
+            cursor: 0,
+        }
+    }
+
+    /// First granule at or after `from` that is in the set.
+    fn next_set(&self, from: u64) -> Option<u64> {
+        let mut granule = from;
+        while granule < self.granules {
+            let word_idx = (granule / 64) as usize;
+            let word = self.words[word_idx] >> (granule % 64);
+            if word != 0 {
+                let hit = granule + word.trailing_zeros() as u64;
+                return (hit < self.granules).then_some(hit);
+            }
+            granule = (word_idx as u64 + 1) * 64;
+        }
+        None
+    }
+
+    /// First granule at or after `from` that is NOT in the set (capped at `granules`).
+    fn next_clear(&self, from: u64) -> u64 {
+        let mut granule = from;
+        while granule < self.granules {
+            let word_idx = (granule / 64) as usize;
+            let word = !self.words[word_idx] >> (granule % 64);
+            if word != 0 {
+                return (granule + word.trailing_zeros() as u64).min(self.granules);
+            }
+            granule = (word_idx as u64 + 1) * 64;
+        }
+        self.granules
+    }
+
+    /// Serialise to the on-disk representation.
+    fn encode(&self, key: &ImageKey, mem_len: u64) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(HEADER_LEN + self.words.len() * 8);
+        buf.extend_from_slice(MAGIC);
+        buf.extend_from_slice(&VERSION.to_le_bytes());
+        buf.extend_from_slice(&GRANULE.to_le_bytes());
+        buf.extend_from_slice(&mem_len.to_le_bytes());
+        buf.extend_from_slice(&self.granules.to_le_bytes());
+        buf.extend_from_slice(&key.0);
+        for word in &self.words {
+            buf.extend_from_slice(&word.to_le_bytes());
+        }
+        buf
+    }
+
+    /// Parse the on-disk representation, checking it describes `key`'s image.
+    ///
+    /// Every rejection is a `Ok(None)` with a reason, not an error: a working set that does
+    /// not apply is simply absent.
+    fn decode(buf: &[u8], key: &ImageKey, mem_len: u64) -> Option<Self> {
+        let reject = |why: &str| -> Option<Self> {
+            debug!(target: "uffd", reason = why, "ignoring recorded working set");
+            None
+        };
+        if buf.len() < HEADER_LEN {
+            return reject("file shorter than header");
+        }
+        let u64_at = |off: usize| u64::from_le_bytes(buf[off..off + 8].try_into().unwrap());
+        if &buf[0..8] != MAGIC {
+            return reject("bad magic");
+        }
+        if u64_at(8) != VERSION {
+            return reject("unsupported version");
+        }
+        if u64_at(16) != GRANULE {
+            return reject("different granule");
+        }
+        if u64_at(24) != mem_len {
+            return reject("memory image size changed");
+        }
+        let granules = u64_at(32);
+        if granules != mem_len.div_ceil(GRANULE) {
+            return reject("granule count does not match image size");
+        }
+        if buf[40..72] != key.0 {
+            return reject("memory image changed (key mismatch)");
+        }
+        let words = (granules as usize).div_ceil(64);
+        if buf.len() < HEADER_LEN + words * 8 {
+            return reject("truncated bitmap");
+        }
+        let mut set = Self {
+            granules,
+            words: Vec::with_capacity(words),
+        };
+        for i in 0..words {
+            let off = HEADER_LEN + i * 8;
+            set.words
+                .push(u64::from_le_bytes(buf[off..off + 8].try_into().unwrap()));
+        }
+        // Bits past the end of the image would produce runs outside the file.
+        if granules % 64 != 0 {
+            let tail = &mut set.words[words - 1];
+            *tail &= u64::MAX >> (64 - granules % 64);
+        }
+        Some(set)
+    }
+}
+
+/// Iterator over the maximal contiguous runs of a [`PageSet`].
+pub struct RunIter<'a> {
+    set: &'a PageSet,
+    cursor: u64,
+}
+
+impl Iterator for RunIter<'_> {
+    type Item = Run;
+
+    fn next(&mut self) -> Option<Run> {
+        let start = self.set.next_set(self.cursor)?;
+        let end = self.set.next_clear(start);
+        self.cursor = end;
+        Some(Run {
+            offset: start * GRANULE,
+            len: (end - start) * GRANULE,
+        })
+    }
+}
+
+/// What a merge did, for logging.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MergeOutcome {
+    /// Granules in the union after merging.
+    pub total: u64,
+    /// Granules this clone contributed that nothing had recorded before.
+    pub added: u64,
+    /// Whether the union was written back to disk (only when it grew).
+    pub persisted: bool,
+    /// The image at the memory path is no longer the one we served, so nothing was published.
+    /// Happens when a snapshot tag is recreated while this serve process is still running: the
+    /// server keeps its open (old) inode, but the working-set path now belongs to the NEW
+    /// image, and publishing our bitmap there would clobber the new generation's record.
+    pub superseded: bool,
+}
+
+/// One clone-completion notification for the persistence worker.
+///
+/// The bitmap itself is already merged into [`WorkingSetStore::known`] before this is queued;
+/// the request is only a coalescible prompt to publish the latest in-memory union.
+struct PersistRequest {
+    vm_id: String,
+    faulted_pages: u64,
+    learned_pages: u64,
+}
+
+/// A non-blocking front end to the on-disk working-set hint.
+///
+/// One detached OS thread owns filesystem persistence for a served snapshot. Tokio does not
+/// own or join that thread, so a stuck filesystem cannot retain a clone's admission slot or
+/// prevent the async runtime from shutting down. The one-entry channel is intentionally
+/// bounded: every caller first unions its observations into `known`, so a queued request will
+/// publish all later observations too and additional requests can be safely coalesced.
+#[derive(Clone)]
+pub(crate) struct WorkingSetPersistence {
+    store: Arc<WorkingSetStore>,
+    requests: SyncSender<PersistRequest>,
+}
+
+impl WorkingSetPersistence {
+    pub(crate) fn new(store: Arc<WorkingSetStore>) -> Result<Self> {
+        let (requests, receiver) = sync_channel(1);
+        let worker_store = Arc::clone(&store);
+        let worker = std::thread::Builder::new()
+            .name("fcvm-ws-write".to_string())
+            .spawn(move || persistence_worker(worker_store, receiver))
+            .context("spawning working-set persistence worker")?;
+        // Deliberately detach: unlike Tokio's blocking pool, a stuck hint writer must not be
+        // joined during runtime/process teardown.
+        drop(worker);
+        Ok(Self { store, requests })
+    }
+
+    /// Merge `observed` into memory and non-blockingly prompt the worker to publish it.
+    pub(crate) fn schedule(&self, vm_id: &str, observed: PageSet) {
+        let faulted_pages = observed.len();
+        let learned_pages = self.store.remember(&observed);
+        let request = PersistRequest {
+            vm_id: vm_id.to_string(),
+            faulted_pages,
+            learned_pages,
+        };
+        match self.requests.try_send(request) {
+            Ok(()) => {}
+            Err(TrySendError::Full(request)) => debug!(
+                target: "uffd",
+                vm_id = %request.vm_id,
+                faulted_pages = request.faulted_pages,
+                learned_pages = request.learned_pages,
+                "coalesced working-set persistence behind the queued union"
+            ),
+            Err(TrySendError::Disconnected(request)) => warn!(
+                target: "uffd",
+                vm_id = %request.vm_id,
+                faulted_pages = request.faulted_pages,
+                learned_pages = request.learned_pages,
+                "working-set persistence worker is unavailable; restore remains demand-page safe"
+            ),
+        }
+    }
+}
+
+fn persistence_worker(store: Arc<WorkingSetStore>, receiver: Receiver<PersistRequest>) {
+    while let Ok(request) = receiver.recv() {
+        match store.try_persist_known() {
+            Ok(Some(outcome)) => info!(
+                target: "uffd",
+                vm_id = %request.vm_id,
+                faulted_pages = request.faulted_pages,
+                learned_pages = request.learned_pages,
+                known_pages = outcome.total,
+                persisted = outcome.persisted,
+                superseded = outcome.superseded,
+                "merged this clone's faults into the snapshot's working set"
+            ),
+            Ok(None) => debug!(
+                target: "uffd",
+                vm_id = %request.vm_id,
+                faulted_pages = request.faulted_pages,
+                learned_pages = request.learned_pages,
+                "working-set sidecar is busy; retained the union in memory"
+            ),
+            Err(error) => warn!(
+                target: "uffd",
+                vm_id = %request.vm_id,
+                faulted_pages = request.faulted_pages,
+                learned_pages = request.learned_pages,
+                error = ?error,
+                "could not persist the working set; restore remains demand-page safe"
+            ),
+        }
+    }
+}
+
+/// The working set stored beside a snapshot's memory image.
+///
+/// One store per served snapshot, shared by every clone the server hosts. It holds the union
+/// of everything known about the image — what was on disk at startup, plus what each clone has
+/// contributed since — so a clone that starts later in the same server benefits from what an
+/// earlier clone already discovered without a round trip through the filesystem.
+pub struct WorkingSetStore {
+    path: PathBuf,
+    /// The memory image this set describes. Kept so the identity can be re-checked at publish
+    /// time — the path may name a different image by then (see `MergeOutcome::superseded`).
+    mem_path: PathBuf,
+    /// Exact config bytes bind the hint to one atomically installed snapshot generation,
+    /// independently of filesystem inode reuse or timestamp granularity.
+    generation_config_path: PathBuf,
+    generation_config_digest: [u8; 32],
+    /// Stable sibling generation lock used by snapshot create/delete/restore.
+    ///
+    /// A merge takes this shared before it re-identifies the memory image and keeps it
+    /// through the atomic sidecar publication. Without that single critical section, a
+    /// creator could replace the snapshot after the identity check but before `rename`, and
+    /// the old server would publish its bitmap into the new generation.
+    generation_lock_path: PathBuf,
+    lock_path: PathBuf,
+    key: ImageKey,
+    mem_len: u64,
+    known: Mutex<PageSet>,
+}
+
+impl WorkingSetStore {
+    /// Path of the working set recorded beside the memory image at `mem_file_path`.
+    pub fn path_for(mem_file_path: &Path) -> PathBuf {
+        let mut name = mem_file_path.file_name().unwrap_or_default().to_os_string();
+        name.push(".working-set");
+        mem_file_path.with_file_name(name)
+    }
+
+    /// Open (and load, if present and applicable) the working set for a memory image.
+    ///
+    /// Never fails because of the recorded file: an unreadable, stale or corrupt one leaves an
+    /// empty store, which prefetches nothing and re-records from scratch. The exact config,
+    /// memory identity, and sidecar are read under the snapshot's shared generation lease so
+    /// a creator cannot mix generations during startup.
+    pub fn open(
+        mem_file_path: &Path,
+        mem_len: u64,
+        generation_config_path: &Path,
+        generation_lock_path: &Path,
+    ) -> Result<Self> {
+        anyhow::ensure!(
+            mem_len <= MAX_MEM_LEN,
+            "memory image {} is {mem_len} bytes, past the {MAX_MEM_LEN}-byte working-set limit",
+            mem_file_path.display()
+        );
+        let generation_file = File::options()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(generation_lock_path)
+            .with_context(|| {
+                format!(
+                    "opening snapshot generation lock {}",
+                    generation_lock_path.display()
+                )
+            })?;
+        let generation_lock = Flock::lock(generation_file, FlockArg::LockShared)
+            .map_err(|(_, err)| err)
+            .context("locking snapshot generation while opening its working set")?;
+        let generation_config = std::fs::read(generation_config_path).with_context(|| {
+            format!(
+                "reading snapshot generation config {}",
+                generation_config_path.display()
+            )
+        })?;
+        let generation_config_digest: [u8; 32] = Sha256::digest(&generation_config).into();
+        let key = ImageKey::of(mem_file_path, &generation_config_digest)?;
+        let path = Self::path_for(mem_file_path);
+        let mut lock_name = path.file_name().unwrap_or_default().to_os_string();
+        lock_name.push(".lock");
+        let lock_path = path.with_file_name(lock_name);
+
+        let known = match read_set(&path, &key, mem_len) {
+            Some(set) => {
+                info!(
+                    target: "uffd",
+                    path = %path.display(),
+                    pages = set.len(),
+                    mib = set.bytes() / (1024 * 1024),
+                    key = ?key,
+                    "loaded recorded restore working set"
+                );
+                set
+            }
+            None => PageSet::empty(mem_len),
+        };
+        generation_lock.unlock().map_err(|(_, err)| err).ok();
+
+        Ok(Self {
+            path,
+            mem_path: mem_file_path.to_path_buf(),
+            generation_config_path: generation_config_path.to_path_buf(),
+            generation_config_digest,
+            generation_lock_path: generation_lock_path.to_path_buf(),
+            lock_path,
+            key,
+            mem_len,
+            known: Mutex::new(known),
+        })
+    }
+
+    /// The set to prefetch for a clone starting now.
+    pub fn to_prefetch(&self) -> PageSet {
+        self.known.lock().expect("working set mutex").clone()
+    }
+
+    /// An empty set sized for this image, for a clone to record into.
+    pub fn recorder(&self) -> PageSet {
+        PageSet::empty(self.mem_len)
+    }
+
+    /// Add one clone's observations to the in-process union without touching the filesystem.
+    fn remember(&self, observed: &PageSet) -> u64 {
+        self.known
+            .lock()
+            .expect("working set mutex")
+            .union_from(observed)
+    }
+
+    /// Merge one clone's observations into the union and persist it if it grew.
+    ///
+    /// Two clones of a snapshot fault nearly the same pages, so in the steady state this adds
+    /// nothing and writes nothing. It matters in exactly two cases: the first clone of a new
+    /// snapshot (which records everything), and a clone that was killed before it finished
+    /// faulting in (whose truncated record is completed by the next clone rather than being
+    /// baked in forever).
+    ///
+    /// Race-free against both other servers and snapshot replacement: the whole
+    /// read-modify-write runs under an exclusive `flock` on a sidecar lock file, while a
+    /// shared snapshot-generation lease spans the final image-identity check and atomic
+    /// rename. Creators/deleters take that generation lease exclusively, so they cannot land
+    /// in the check/publish gap. Losing the cache to a crash is harmless — the next clone
+    /// re-records what is missing.
+    ///
+    /// This is the synchronous transaction used by direct callers and store tests. Production
+    /// clone teardown first updates the in-memory union and schedules
+    /// [`WorkingSetPersistence`], whose detached worker uses a non-blocking sidecar lock. The
+    /// in-memory mutex is held only long enough to clone or update the bitmap, never while
+    /// waiting on `flock` or doing filesystem I/O.
+    pub fn merge_and_persist(&self, observed: &PageSet) -> Result<MergeOutcome> {
+        self.merge_and_persist_inner(observed, false)?
+            .ok_or_else(|| anyhow::anyhow!("blocking working-set lock unexpectedly contended"))
+    }
+
+    /// Publish the latest in-memory union without ever waiting for the sidecar lock.
+    ///
+    /// Another persistence worker already owns that lock when this returns `None`. The
+    /// observations remain in `known`; that worker's queued successor or a later clone will
+    /// publish the union. Contention can therefore cost a cache update, never liveness.
+    fn try_persist_known(&self) -> Result<Option<MergeOutcome>> {
+        self.merge_and_persist_inner(&PageSet::empty(self.mem_len), true)
+    }
+
+    fn merge_and_persist_inner(
+        &self,
+        observed: &PageSet,
+        nonblocking_sidecar: bool,
+    ) -> Result<Option<MergeOutcome>> {
+        let mut merged = self.known.lock().expect("working set mutex").clone();
+
+        // Snapshot creators/deleters take this inode exclusively. Keep the shared lease from
+        // the image-identity check through the sidecar rename: checking first and locking
+        // later leaves a check/use race in which a replacement generation receives the old
+        // generation's bitmap.
+        let generation_file = File::options()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&self.generation_lock_path)
+            .with_context(|| {
+                format!(
+                    "opening snapshot generation lock {}",
+                    self.generation_lock_path.display()
+                )
+            })?;
+        let generation_lock = Flock::lock(generation_file, FlockArg::LockShared)
+            .map_err(|(_, err)| err)
+            .context("locking snapshot generation for working-set publication")?;
+
+        let lock_file = File::options()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&self.lock_path)
+            .with_context(|| format!("opening working-set lock {}", self.lock_path.display()))?;
+        let lock_arg = if nonblocking_sidecar {
+            FlockArg::LockExclusiveNonblock
+        } else {
+            FlockArg::LockExclusive
+        };
+        let lock = match Flock::lock(lock_file, lock_arg) {
+            Ok(lock) => lock,
+            Err((_file, error))
+                if nonblocking_sidecar && error == nix::errno::Errno::EWOULDBLOCK =>
+            {
+                generation_lock.unlock().map_err(|(_, err)| err).ok();
+                return Ok(None);
+            }
+            Err((_file, error)) => return Err(error).context("locking working set"),
+        };
+
+        // Re-read under the lock: another serve process may have recorded since we loaded.
+        let on_disk = read_set(&self.path, &self.key, self.mem_len);
+        let disk_len = on_disk.as_ref().map_or(0, PageSet::len);
+        if let Some(disk) = on_disk {
+            merged.union_from(&disk);
+        }
+        let added = merged.union_from(observed);
+        let total = merged.len();
+
+        // Publish ONLY if the path still names the image we served. A snapshot tag may have
+        // been recreated before this merge acquired its shared generation lease: we keep
+        // serving the old inode we already opened, but `self.path` would now sit beside a NEW
+        // image. The lease prevents any further replacement through the rename below; this
+        // identity check rejects a replacement that already completed.
+        let superseded = !self.image_is_still_ours();
+        let persisted = total > disk_len && !superseded;
+        let result = if persisted {
+            write_set(&self.path, &merged, &self.key, self.mem_len)
+        } else {
+            Ok(())
+        };
+
+        // Release explicitly, so both locks demonstrably span the whole identity-check and
+        // publication transaction above rather than ending wherever the compiler last uses
+        // them. Failed unlocks need no special handling: closing each fd releases its lock.
+        lock.unlock().map_err(|(_, err)| err).ok();
+        generation_lock.unlock().map_err(|(_, err)| err).ok();
+
+        // Preserve everything learned even when publication fails: the current serve process
+        // can still prefetch it, and a later successful merge will retry the disk union.
+        self.known
+            .lock()
+            .expect("working set mutex")
+            .union_from(&merged);
+
+        result?;
+        Ok(Some(MergeOutcome {
+            total,
+            added,
+            persisted,
+            superseded,
+        }))
+    }
+
+    /// Whether the snapshot generation and memory image at our paths are still the ones this
+    /// set describes.
+    ///
+    /// A stat failure counts as "not ours": if the image cannot be identified we must not
+    /// publish, because the file we would write next to is not one we can vouch for.
+    fn image_is_still_ours(&self) -> bool {
+        let current_config = match std::fs::read(&self.generation_config_path) {
+            Ok(config) => config,
+            Err(error) => {
+                warn!(
+                    target: "uffd",
+                    path = %self.generation_config_path.display(),
+                    error = %error,
+                    "cannot re-identify the snapshot generation; not publishing its working set"
+                );
+                return false;
+            }
+        };
+        let current_config_digest: [u8; 32] = Sha256::digest(&current_config).into();
+        if current_config_digest != self.generation_config_digest {
+            return false;
+        }
+        match ImageKey::of(&self.mem_path, &current_config_digest) {
+            Ok(now) => now == self.key,
+            Err(e) => {
+                warn!(
+                    target: "uffd",
+                    path = %self.mem_path.display(),
+                    error = ?e,
+                    "cannot re-identify the memory image; not publishing a working set for it"
+                );
+                false
+            }
+        }
+    }
+}
+
+/// Read and validate a recorded set. `None` means "nothing usable here" — always a normal
+/// outcome, never an error.
+fn read_set(path: &Path, key: &ImageKey, mem_len: u64) -> Option<PageSet> {
+    let granules = mem_len.div_ceil(GRANULE);
+    let bitmap_bytes = granules.div_ceil(64).saturating_mul(8);
+    let max_len = (HEADER_LEN as u64).saturating_add(bitmap_bytes);
+    let mut buf = Vec::new();
+    match File::open(path).and_then(|f| f.take(max_len.saturating_add(1)).read_to_end(&mut buf)) {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            warn!(
+                target: "uffd",
+                path = %path.display(),
+                error = %e,
+                "could not read recorded working set - restore will fault on demand"
+            );
+            return None;
+        }
+    }
+    if buf.len() as u64 > max_len {
+        warn!(
+            target: "uffd",
+            path = %path.display(),
+            bytes = buf.len(),
+            max_len,
+            "recorded working set is oversized - restore will fault on demand"
+        );
+        return None;
+    }
+    PageSet::decode(&buf, key, mem_len)
+}
+
+/// Publish a set atomically: unique temp name in the same directory, then rename.
+///
+/// The temp name carries a uuid rather than a pid because nested VMs have separate pid
+/// namespaces and would collide (see AGENTS.md).
+fn write_set(path: &Path, set: &PageSet, key: &ImageKey, mem_len: u64) -> Result<()> {
+    let mut tmp_name = path.file_name().unwrap_or_default().to_os_string();
+    tmp_name.push(format!(".{}.tmp", uuid::Uuid::new_v4()));
+    let tmp = path.with_file_name(tmp_name);
+
+    let encoded = set.encode(key, mem_len);
+    let write = || -> Result<()> {
+        let mut f = File::create(&tmp).with_context(|| format!("creating {}", tmp.display()))?;
+        f.write_all(&encoded)
+            .with_context(|| format!("writing {}", tmp.display()))?;
+        f.sync_all()
+            .with_context(|| format!("syncing {}", tmp.display()))?;
+        std::fs::rename(&tmp, path).with_context(|| format!("publishing {}", path.display()))?;
+        Ok(())
+    };
+    let result = write();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Owns every sidecar a store test creates, so a panic cannot leak state into a later run.
+    struct FakeImage {
+        _dir: TempDir,
+        path: PathBuf,
+    }
+
+    /// A fake memory image of `len` bytes, so `ImageKey::of` has something to stat.
+    fn fake_image(tag: &str, len: u64) -> FakeImage {
+        let dir = tempfile::Builder::new()
+            .prefix(&format!("fcvm-ws-test-{tag}-"))
+            .tempdir()
+            .unwrap();
+        let path = dir.path().join("memory.bin");
+        let f = File::create(&path).unwrap();
+        f.set_len(len).unwrap();
+        FakeImage { _dir: dir, path }
+    }
+
+    impl std::ops::Deref for FakeImage {
+        type Target = Path;
+
+        fn deref(&self) -> &Self::Target {
+            &self.path
+        }
+    }
+
+    impl AsRef<Path> for FakeImage {
+        fn as_ref(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    fn generation_lock_for(image: &Path) -> PathBuf {
+        let mut name = image.file_name().unwrap_or_default().to_os_string();
+        name.push(".generation.lock");
+        image.with_file_name(name)
+    }
+
+    fn generation_config_for(image: &Path) -> PathBuf {
+        let mut name = image.file_name().unwrap_or_default().to_os_string();
+        name.push(".config.json");
+        image.with_file_name(name)
+    }
+
+    fn image_key(image: &Path) -> ImageKey {
+        ImageKey::of(image, &[0x42; 32]).unwrap()
+    }
+
+    fn open_store(image: &Path, mem_len: u64) -> WorkingSetStore {
+        let config = generation_config_for(image);
+        if !config.exists() {
+            std::fs::write(&config, b"generation-1").unwrap();
+        }
+        WorkingSetStore::open(image, mem_len, &config, &generation_lock_for(image)).unwrap()
+    }
+
+    #[test]
+    fn insert_range_marks_every_granule_it_spans() {
+        let mut set = PageSet::empty(16 * GRANULE);
+        // A 2 MiB-granule fault marks all the 4 KiB granules under it.
+        set.insert_range(4 * GRANULE, 3 * GRANULE);
+        assert_eq!(set.len(), 3);
+        assert!(!set.contains(3));
+        assert!(set.contains(4) && set.contains(5) && set.contains(6));
+        assert!(!set.contains(7));
+
+        // A sub-granule fault still marks exactly one granule.
+        set.insert_range(9 * GRANULE + 17, 1);
+        assert!(set.contains(9));
+        assert_eq!(set.len(), 4);
+    }
+
+    #[test]
+    fn insert_range_ignores_offsets_past_the_image() {
+        let mut set = PageSet::empty(4 * GRANULE);
+        set.insert_range(100 * GRANULE, GRANULE);
+        assert!(set.is_empty(), "out-of-range insert must be dropped");
+        // A range that straddles the end keeps the part that is inside.
+        set.insert_range(3 * GRANULE, 8 * GRANULE);
+        assert_eq!(set.len(), 1);
+        assert!(set.contains(3));
+
+        // A malformed mapping must not wrap the inclusive end back into the bitmap.
+        set.insert_range(u64::MAX - GRANULE, 4 * GRANULE);
+        assert_eq!(set.len(), 1, "overflowing ranges must remain out of bounds");
+    }
+
+    #[test]
+    fn runs_coalesce_contiguous_granules() {
+        let mut set = PageSet::empty(300 * GRANULE);
+        for granule in [0u64, 1, 2, 5, 130, 131] {
+            set.insert_range(granule * GRANULE, GRANULE);
+        }
+        let runs: Vec<Run> = set.runs().collect();
+        assert_eq!(
+            runs,
+            vec![
+                Run {
+                    offset: 0,
+                    len: 3 * GRANULE
+                },
+                Run {
+                    offset: 5 * GRANULE,
+                    len: GRANULE
+                },
+                Run {
+                    offset: 130 * GRANULE,
+                    len: 2 * GRANULE
+                },
+            ]
+        );
+        // Runs cover exactly the set, so bulk copies never touch an unrecorded page.
+        assert_eq!(runs.iter().map(|r| r.len).sum::<u64>(), set.bytes());
+    }
+
+    #[test]
+    fn runs_handle_a_full_set_and_an_empty_set() {
+        let empty = PageSet::empty(64 * GRANULE);
+        assert_eq!(empty.runs().count(), 0);
+
+        let mut full = PageSet::empty(200 * GRANULE);
+        full.insert_range(0, 200 * GRANULE);
+        let runs: Vec<Run> = full.runs().collect();
+        assert_eq!(
+            runs,
+            vec![Run {
+                offset: 0,
+                len: 200 * GRANULE
+            }],
+            "a fully-faulted image must be ONE run, not 200"
+        );
+    }
+
+    #[test]
+    fn union_reports_only_newly_added_granules() {
+        let mut a = PageSet::empty(64 * GRANULE);
+        a.insert_range(0, 2 * GRANULE);
+        let mut b = PageSet::empty(64 * GRANULE);
+        b.insert_range(GRANULE, 3 * GRANULE); // granules 1,2,3 - overlaps a on 1
+
+        assert_eq!(a.union_from(&b), 2, "only granules 2 and 3 are new");
+        assert_eq!(a.len(), 4);
+        assert_eq!(a.union_from(&b), 0, "re-merging adds nothing");
+    }
+
+    #[test]
+    fn encode_decode_round_trips() {
+        let image = fake_image("roundtrip", 1024 * GRANULE);
+        let key = image_key(&image);
+        let mem_len = 1024 * GRANULE;
+
+        let mut set = PageSet::empty(mem_len);
+        set.insert_range(0, GRANULE);
+        set.insert_range(1000 * GRANULE, 5 * GRANULE);
+
+        let encoded = set.encode(&key, mem_len);
+        let decoded = PageSet::decode(&encoded, &key, mem_len).expect("must decode");
+        assert_eq!(decoded, set);
+        assert_eq!(decoded.len(), 6);
+    }
+
+    #[test]
+    fn decode_rejects_a_set_recorded_for_a_different_image() {
+        let mem_len = 64 * GRANULE;
+        let image = fake_image("key-a", mem_len);
+        let other = fake_image("key-b", mem_len);
+        let key = image_key(&image);
+        let other_key = image_key(&other);
+        assert_ne!(
+            key.0, other_key.0,
+            "two distinct images must not share a key"
+        );
+
+        let mut set = PageSet::empty(mem_len);
+        set.insert_range(0, GRANULE);
+        let encoded = set.encode(&key, mem_len);
+
+        assert!(
+            PageSet::decode(&encoded, &other_key, mem_len).is_none(),
+            "a set from another image must be rejected"
+        );
+        assert!(
+            PageSet::decode(&encoded, &key, mem_len * 2).is_none(),
+            "a set from another image SIZE must be rejected"
+        );
+    }
+
+    #[test]
+    fn decode_rejects_corrupt_and_truncated_files() {
+        let mem_len = 64 * GRANULE;
+        let image = fake_image("corrupt", mem_len);
+        let key = image_key(&image);
+        let mut set = PageSet::empty(mem_len);
+        set.insert_range(0, GRANULE);
+        let good = set.encode(&key, mem_len);
+
+        assert!(PageSet::decode(&[], &key, mem_len).is_none(), "empty file");
+        assert!(
+            PageSet::decode(&good[..HEADER_LEN - 1], &key, mem_len).is_none(),
+            "short header"
+        );
+        assert!(
+            PageSet::decode(&good[..good.len() - 1], &key, mem_len).is_none(),
+            "truncated bitmap"
+        );
+
+        let mut bad_magic = good.clone();
+        bad_magic[0] = b'X';
+        assert!(
+            PageSet::decode(&bad_magic, &key, mem_len).is_none(),
+            "magic"
+        );
+
+        let mut bad_version = good.clone();
+        bad_version[8] = 99;
+        assert!(
+            PageSet::decode(&bad_version, &key, mem_len).is_none(),
+            "version"
+        );
+    }
+
+    #[test]
+    fn decode_masks_bits_past_the_end_of_the_image() {
+        // 100 granules is not a multiple of 64, so the last word has 36 unused bits. A file
+        // with those bits set (corruption, or a hand-edited file) must not produce runs that
+        // point past the image.
+        let mem_len = 100 * GRANULE;
+        let image = fake_image("tail", mem_len);
+        let key = image_key(&image);
+        let mut encoded = PageSet::empty(mem_len).encode(&key, mem_len);
+        let last_word = encoded.len() - 8;
+        encoded[last_word..].copy_from_slice(&u64::MAX.to_le_bytes());
+
+        let decoded = PageSet::decode(&encoded, &key, mem_len).unwrap();
+        let end = decoded.runs().map(|r| r.offset + r.len).max().unwrap_or(0);
+        assert!(
+            end <= mem_len,
+            "runs must stay inside the image (got end {end} > {mem_len})"
+        );
+    }
+
+    #[test]
+    fn store_persists_the_union_and_reloads_it() {
+        let mem_len = 512 * GRANULE;
+        let image = fake_image("store", mem_len);
+
+        let store = open_store(&image, mem_len);
+        assert!(
+            store.to_prefetch().is_empty(),
+            "a snapshot with no recording prefetches nothing"
+        );
+
+        // Clone 1 faults 3 granules.
+        let mut clone1 = store.recorder();
+        clone1.insert_range(0, 2 * GRANULE);
+        clone1.insert_range(10 * GRANULE, GRANULE);
+        let outcome = store.merge_and_persist(&clone1).unwrap();
+        assert_eq!(
+            outcome,
+            MergeOutcome {
+                total: 3,
+                added: 3,
+                persisted: true,
+                superseded: false
+            }
+        );
+
+        // Clone 2 faults an overlapping set: only the new granule is added, and because the
+        // union grew it is written again.
+        let mut clone2 = store.recorder();
+        clone2.insert_range(0, GRANULE);
+        clone2.insert_range(11 * GRANULE, GRANULE);
+        let outcome = store.merge_and_persist(&clone2).unwrap();
+        assert_eq!(
+            outcome,
+            MergeOutcome {
+                total: 4,
+                added: 1,
+                persisted: true,
+                superseded: false
+            }
+        );
+
+        // Clone 3 adds nothing: the steady state writes nothing at all.
+        let outcome = store.merge_and_persist(&clone2).unwrap();
+        assert_eq!(
+            outcome,
+            MergeOutcome {
+                total: 4,
+                added: 0,
+                persisted: false,
+                superseded: false
+            }
+        );
+
+        // A fresh server for the same image sees the union.
+        let reopened = open_store(&image, mem_len);
+        let loaded = reopened.to_prefetch();
+        assert_eq!(loaded.len(), 4);
+        assert_eq!(
+            loaded.runs().collect::<Vec<_>>(),
+            vec![
+                Run {
+                    offset: 0,
+                    len: 2 * GRANULE
+                },
+                Run {
+                    offset: 10 * GRANULE,
+                    len: 2 * GRANULE
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn store_drops_a_set_recorded_before_the_snapshot_was_rewritten() {
+        let mem_len = 64 * GRANULE;
+        let image = fake_image("rewrite", mem_len);
+
+        let store = open_store(&image, mem_len);
+        let mut observed = store.recorder();
+        observed.insert_range(0, 4 * GRANULE);
+        store.merge_and_persist(&observed).unwrap();
+        assert_eq!(open_store(&image, mem_len).to_prefetch().len(), 4);
+
+        // Rewriting the snapshot replaces the memory image: new inode, new mtime, new key.
+        std::fs::remove_file(&image).unwrap();
+        let f = File::create(&image).unwrap();
+        f.set_len(mem_len).unwrap();
+        drop(f);
+        std::fs::write(generation_config_for(&image), b"generation-2").unwrap();
+
+        let after = open_store(&image, mem_len);
+        assert!(
+            after.to_prefetch().is_empty(),
+            "a working set from the previous snapshot must not be replayed"
+        );
+    }
+
+    #[test]
+    fn store_binds_to_the_exact_snapshot_config_generation() {
+        let mem_len = 64 * GRANULE;
+        let image = fake_image("config-generation", mem_len);
+        let store = open_store(&image, mem_len);
+        let mut observed = store.recorder();
+        observed.insert_range(0, 2 * GRANULE);
+        assert!(store.merge_and_persist(&observed).unwrap().persisted);
+
+        // Leave memory.bin completely untouched. A different config.json alone represents a
+        // different atomically installed generation and must invalidate the old hint.
+        std::fs::write(generation_config_for(&image), b"generation-2").unwrap();
+        assert!(
+            open_store(&image, mem_len).to_prefetch().is_empty(),
+            "a new config generation must not replay the prior generation's bitmap"
+        );
+        let outcome = store.merge_and_persist(&observed).unwrap();
+        assert!(outcome.superseded && !outcome.persisted);
+    }
+
+    /// A server keeps serving the inode it opened, but its working-set PATH resolves through
+    /// the snapshot tag. If the tag was recreated before its merge acquired the generation
+    /// lease, the finishing old clone must NOT publish over the new generation's record.
+    #[test]
+    fn an_old_generation_clone_does_not_clobber_the_new_generations_record() {
+        let mem_len = 64 * GRANULE;
+        let image = fake_image("supersede", mem_len);
+
+        // Generation 1: the serve process that is still running.
+        let old = open_store(&image, mem_len);
+
+        // The tag is recreated in place: same path, new image.
+        std::fs::remove_file(&image).unwrap();
+        let f = File::create(&image).unwrap();
+        f.set_len(mem_len).unwrap();
+        drop(f);
+        std::fs::write(generation_config_for(&image), b"generation-2").unwrap();
+
+        // Generation 2 records its own working set at the same path.
+        let new = open_store(&image, mem_len);
+        assert_ne!(
+            old.key, new.key,
+            "test is vacuous unless rewriting the image changed its identity"
+        );
+        let mut new_observed = new.recorder();
+        new_observed.insert_range(10 * GRANULE, 3 * GRANULE);
+        assert!(new.merge_and_persist(&new_observed).unwrap().persisted);
+
+        // Now generation 1's clone finishes and tries to record a DIFFERENT set.
+        let mut old_observed = old.recorder();
+        old_observed.insert_range(0, 5 * GRANULE);
+        let outcome = old.merge_and_persist(&old_observed).unwrap();
+        assert!(
+            outcome.superseded,
+            "publishing must be recognised as superseded once the image was replaced"
+        );
+        assert!(
+            !outcome.persisted,
+            "an old-generation set must never be published over the new one"
+        );
+
+        // The new generation's record must be intact and still usable.
+        let reloaded = open_store(&image, mem_len).to_prefetch();
+        assert_eq!(reloaded.len(), 3, "the new generation's set must survive");
+        assert!(reloaded.contains(10) && reloaded.contains(12));
+        assert!(
+            !reloaded.contains(0),
+            "the old generation's pages must not have leaked in"
+        );
+    }
+
+    /// A creator must not be able to replace the snapshot after the old image is checked but
+    /// before its working set is atomically published. Hold the sidecar lock to park a real
+    /// merge after it acquires the generation lease, then prove a separate open file
+    /// description cannot acquire the creator's exclusive lease until that merge completes.
+    #[test]
+    fn working_set_publication_holds_the_snapshot_generation_lease() {
+        let mem_len = 64 * GRANULE;
+        let image = fake_image("generation-lease", mem_len);
+        let store = open_store(&image, mem_len);
+        let sidecar_lock_path = store.lock_path.clone();
+        let generation_lock_path = store.generation_lock_path.clone();
+
+        let sidecar_file = File::options()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&sidecar_lock_path)
+            .unwrap();
+        let sidecar_guard = Flock::lock(sidecar_file, FlockArg::LockExclusive).unwrap();
+
+        let mut observed = store.recorder();
+        observed.insert_range(0, GRANULE);
+        let merge = std::thread::spawn(move || store.merge_and_persist(&observed));
+
+        let generation_probe = File::options()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&generation_lock_path)
+            .unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            match fs2::FileExt::try_lock_exclusive(&generation_probe) {
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => break,
+                Ok(()) => {
+                    fs2::FileExt::unlock(&generation_probe).unwrap();
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "merge never acquired its shared snapshot-generation lease"
+                    );
+                    std::thread::yield_now();
+                }
+                Err(error) => panic!("probing snapshot-generation lease: {error}"),
+            }
+        }
+
+        sidecar_guard.unlock().unwrap();
+        let outcome = merge.join().unwrap().unwrap();
+        assert!(
+            outcome.persisted,
+            "the parked merge must publish after release"
+        );
+        fs2::FileExt::try_lock_exclusive(&generation_probe)
+            .expect("creator's exclusive lease must become available after publication");
+        fs2::FileExt::unlock(&generation_probe).unwrap();
+    }
+
+    /// Direct callers can still wait synchronously on another process's `flock`, while clone
+    /// startup calls `to_prefetch()` on an async worker. A blocked transaction therefore must
+    /// not hold the in-memory set mutex that clone startup needs. Production finalization uses
+    /// the detached non-blocking worker tested below.
+    #[test]
+    fn persistence_waiting_on_file_lock_does_not_block_prefetch_snapshot() {
+        let mem_len = 64 * GRANULE;
+        let image = fake_image("nonblocking-prefetch-snapshot", mem_len);
+        let store = std::sync::Arc::new(open_store(&image, mem_len));
+
+        // Park the real persistence path on the sidecar flock.
+        let sidecar_file = File::options()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&store.lock_path)
+            .unwrap();
+        let sidecar_guard = Flock::lock(sidecar_file, FlockArg::LockExclusive).unwrap();
+
+        let mut observed = store.recorder();
+        observed.insert_range(0, GRANULE);
+        let merge_store = std::sync::Arc::clone(&store);
+        let merge = std::thread::spawn(move || merge_store.merge_and_persist(&observed));
+
+        // Seeing the merge's shared generation lease proves it reached the blocking sidecar
+        // lock. This is an exact interleaving, not a sleep or a scheduler guess.
+        let generation_probe = File::options()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&store.generation_lock_path)
+            .unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            match fs2::FileExt::try_lock_exclusive(&generation_probe) {
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => break,
+                Ok(()) => {
+                    fs2::FileExt::unlock(&generation_probe).unwrap();
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "merge never reached the sidecar-lock boundary"
+                    );
+                    std::thread::yield_now();
+                }
+                Err(error) => panic!("probing snapshot-generation lease: {error}"),
+            }
+        }
+
+        let prefetch_snapshot_is_available = store.known.try_lock().is_ok();
+        sidecar_guard.unlock().unwrap();
+        let outcome = merge.join().unwrap().unwrap();
+        assert!(outcome.persisted, "the released merge must publish");
+        assert!(
+            prefetch_snapshot_is_available,
+            "a merger blocked on filesystem I/O held the in-memory set mutex and would block \
+             clone startup on a Tokio worker"
+        );
+    }
+
+    #[test]
+    fn background_persistence_skips_sidecar_contention_without_losing_the_union() {
+        let mem_len = 64 * GRANULE;
+        let image = fake_image("fail-soft-sidecar-contention", mem_len);
+        let store = open_store(&image, mem_len);
+
+        let sidecar_file = File::options()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&store.lock_path)
+            .unwrap();
+        let sidecar_guard = Flock::lock(sidecar_file, FlockArg::LockExclusive).unwrap();
+
+        let mut observed = store.recorder();
+        observed.insert_range(3 * GRANULE, 2 * GRANULE);
+        assert_eq!(store.remember(&observed), 2);
+        assert!(
+            store.try_persist_known().unwrap().is_none(),
+            "the hint path must skip a busy sidecar instead of waiting"
+        );
+        let generation_probe = File::options()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&store.generation_lock_path)
+            .unwrap();
+        fs2::FileExt::try_lock_exclusive(&generation_probe)
+            .expect("skipping a busy sidecar must release the snapshot-generation lease");
+        fs2::FileExt::unlock(&generation_probe).unwrap();
+        assert_eq!(
+            store.to_prefetch().len(),
+            2,
+            "skipping disk persistence must retain the union for this server's next clone"
+        );
+
+        sidecar_guard.unlock().unwrap();
+        let outcome = store
+            .try_persist_known()
+            .unwrap()
+            .expect("the retry must acquire the released sidecar");
+        assert!(outcome.persisted);
+        assert_eq!(open_store(&image, mem_len).to_prefetch().len(), 2);
+    }
+
+    #[test]
+    fn store_survives_a_corrupt_recorded_file() {
+        let mem_len = 64 * GRANULE;
+        let image = fake_image("garbage", mem_len);
+        std::fs::write(WorkingSetStore::path_for(&image), b"not a working set").unwrap();
+
+        let store = open_store(&image, mem_len);
+        assert!(store.to_prefetch().is_empty());
+
+        // ...and recording over it repairs the file.
+        let mut observed = store.recorder();
+        observed.insert_range(0, GRANULE);
+        assert!(store.merge_and_persist(&observed).unwrap().persisted);
+        assert_eq!(open_store(&image, mem_len).to_prefetch().len(), 1);
+    }
+
+    #[test]
+    fn store_rejects_a_record_larger_than_the_exact_bitmap_shape() {
+        let mem_len = 64 * GRANULE;
+        let image = fake_image("oversized", mem_len);
+        let store = open_store(&image, mem_len);
+        let mut recorded = store.recorder();
+        recorded.insert_range(0, GRANULE);
+        let mut encoded = recorded.encode(&store.key, mem_len);
+        encoded.push(0);
+        std::fs::write(WorkingSetStore::path_for(&image), encoded).unwrap();
+
+        assert!(
+            open_store(&image, mem_len).to_prefetch().is_empty(),
+            "trailing bytes past the exact bitmap shape must invalidate the hint"
+        );
+    }
+}

--- a/tests/test_snapshot_clone.rs
+++ b/tests/test_snapshot_clone.rs
@@ -2292,6 +2292,552 @@ async fn iso_stamp(pid: u32, tag: &str) -> Result<()> {
     Ok(())
 }
 
+/// Value of `key=` in a tracing line, e.g. `field(line, "fault_count=")`.
+fn field(line: &str, key: &str) -> Option<String> {
+    let rest = line.split(key).nth(1)?;
+    Some(
+        rest.split_whitespace()
+            .next()?
+            .trim_matches('"')
+            .to_string(),
+    )
+}
+
+/// `(vm_id, fault_count)` for every clone the memory server has finished serving.
+fn faults_by_vm(log: &str) -> Vec<(String, u64)> {
+    log.lines()
+        .filter(|line| line.contains("VM exited") && line.contains("fault_count="))
+        .filter_map(|line| {
+            Some((
+                field(line, "vm_id=")?,
+                field(line, "fault_count=")?.parse().ok()?,
+            ))
+        })
+        .collect()
+}
+
+/// `(vm_id, prefetched_pages)` for every clone that replayed a recorded working set.
+fn prefetched_by_vm(log: &str) -> Vec<(String, u64)> {
+    log.lines()
+        .filter(|line| line.contains("replayed recorded working set"))
+        .filter_map(|line| {
+            Some((
+                field(line, "vm_id=")?,
+                field(line, "prefetched_pages=")?.parse().ok()?,
+            ))
+        })
+        .collect()
+}
+
+/// Prefetched page count for one exact clone. A serve log can contain entries for several
+/// clones, so callers must never infer clone identity from log ordering.
+fn prefetched_pages_for_vm(prefetched: &[(String, u64)], vm_id: &str) -> Option<u64> {
+    prefetched
+        .iter()
+        .find_map(|(candidate, pages)| (candidate == vm_id).then_some(*pages))
+}
+
+/// Wait until the memory server's log satisfies `ready`, then return it.
+async fn serve_log_until(
+    path: &std::path::Path,
+    timeout_secs: u64,
+    what: &str,
+    ready: impl Fn(&str) -> bool,
+) -> Result<String> {
+    let deadline = Instant::now() + Duration::from_secs(timeout_secs);
+    loop {
+        let log = tokio::fs::read_to_string(path).await.unwrap_or_default();
+        if ready(&log) {
+            return Ok(log);
+        }
+        anyhow::ensure!(
+            Instant::now() < deadline,
+            "timed out after {timeout_secs}s waiting for {what} in {}",
+            path.display()
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn sha256_of(path: &std::path::Path) -> Result<String> {
+    use sha2::{Digest, Sha256};
+    use tokio::io::AsyncReadExt;
+
+    let mut file = tokio::fs::File::open(path)
+        .await
+        .with_context(|| format!("opening {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buf = vec![0u8; 4 * 1024 * 1024];
+    loop {
+        let read = file
+            .read(&mut buf)
+            .await
+            .with_context(|| format!("reading {}", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buf[..read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn working_set_serve_args(snapshot_name: &str) -> Vec<&str> {
+    vec![
+        "snapshot",
+        "serve",
+        snapshot_name,
+        "--uffd-mode",
+        "copy",
+        "--uffd-prefetch",
+        "on",
+    ]
+}
+
+fn require_successful_working_set_exit(status: std::process::ExitStatus, role: &str) -> Result<()> {
+    anyhow::ensure!(
+        status.success(),
+        "{role} exited unsuccessfully during teardown: {status}"
+    );
+    Ok(())
+}
+
+fn record_working_set_cleanup_result(
+    cleanup_errors: &mut Vec<String>,
+    role: &str,
+    pid: u32,
+    result: Result<std::process::ExitStatus>,
+) {
+    if let Err(error) = result.and_then(|status| require_successful_working_set_exit(status, role))
+    {
+        cleanup_errors.push(format!("{role} {pid}: {error:#}"));
+    }
+}
+
+/// Finish the fallible isolation phase without letting its verdict bypass clone cleanup.
+async fn finish_working_set_isolation_phase(
+    verdict: Result<()>,
+    iso_clones: Vec<(tokio::process::Child, u32)>,
+) -> (Result<()>, Vec<String>) {
+    let mut cleanup_errors = Vec::new();
+    for (mut child, pid) in iso_clones {
+        let result = terminate_and_reap(&mut child, pid, "isolation clone").await;
+        record_working_set_cleanup_result(&mut cleanup_errors, "isolation clone", pid, result);
+    }
+    (verdict, cleanup_errors)
+}
+
+#[test]
+fn working_set_replay_test_pins_its_server_modes() {
+    assert_eq!(
+        working_set_serve_args("snapshot-under-test"),
+        [
+            "snapshot",
+            "serve",
+            "snapshot-under-test",
+            "--uffd-mode",
+            "copy",
+            "--uffd-prefetch",
+            "on",
+        ],
+        "ambient FCVM_UFFD_MODE/PREFETCH must not change which replay path the E2E covers"
+    );
+}
+
+#[test]
+fn working_set_replay_rejects_an_unsuccessful_clone_exit() {
+    use std::os::unix::process::ExitStatusExt;
+
+    let status = std::process::ExitStatus::from_raw(17 << 8);
+    assert!(
+        require_successful_working_set_exit(status, "working-set clone clone-under-test").is_err(),
+        "a nonzero clone teardown must fail the E2E instead of being treated as cleanup success"
+    );
+}
+
+#[test]
+fn working_set_replay_epilogue_rejects_an_unsuccessful_process_exit() {
+    use std::os::unix::process::ExitStatusExt;
+
+    let mut cleanup_errors = Vec::new();
+    record_working_set_cleanup_result(
+        &mut cleanup_errors,
+        "memory server",
+        1234,
+        Ok(std::process::ExitStatus::from_raw(23 << 8)),
+    );
+    assert_eq!(
+        cleanup_errors.len(),
+        1,
+        "the E2E epilogue must not discard a process that crashed during teardown"
+    );
+}
+
+#[tokio::test]
+async fn working_set_replay_cleans_isolation_clones_after_failed_assertion() {
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+
+    let child = tokio::process::Command::new("sleep")
+        .arg("600")
+        .spawn()
+        .expect("spawning isolation-clone stand-in");
+    let pid = child.id().expect("stand-in child has a PID");
+    // Keep a race-free process handle after the Child is moved into the production cleanup
+    // helper. If the RED path leaks it, this pidfd also lets the test clean it up safely.
+    // SAFETY: `pid` is the live child we just spawned; a successful syscall returns a fresh
+    // descriptor owned by this process.
+    let raw_pidfd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) as libc::c_int };
+    assert!(
+        raw_pidfd >= 0,
+        "pidfd_open failed: {}",
+        std::io::Error::last_os_error()
+    );
+    // SAFETY: `raw_pidfd` was returned successfully above and ownership has not moved.
+    let pidfd = unsafe { OwnedFd::from_raw_fd(raw_pidfd) };
+
+    let failed_verdict = Err(anyhow::anyhow!("synthetic isolation assertion failure"));
+    let (verdict, _cleanup_errors) =
+        finish_working_set_isolation_phase(failed_verdict, vec![(child, pid)]).await;
+
+    let mut pollfd = libc::pollfd {
+        fd: pidfd.as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    // SAFETY: one initialized pollfd lives for the duration of the call.
+    let poll_rc = unsafe { libc::poll(&mut pollfd, 1, 0) };
+    assert!(poll_rc >= 0, "polling stand-in pidfd failed");
+    let was_reaped = poll_rc == 1 && pollfd.revents & libc::POLLIN != 0;
+    if !was_reaped {
+        // RED-path hygiene: kill through the pinned handle, then reap our own child, before
+        // asserting. The regression test itself must never leak the process it detects.
+        // SAFETY: the pidfd still pins our unreaped child, so the signal cannot hit a reused
+        // PID. After SIGKILL, blocking waitpid reaps that same direct child.
+        unsafe {
+            let kill_rc = libc::syscall(
+                libc::SYS_pidfd_send_signal,
+                pidfd.as_raw_fd(),
+                libc::SIGKILL,
+                std::ptr::null::<libc::siginfo_t>(),
+                0,
+            );
+            assert_eq!(kill_rc, 0, "cleaning leaked stand-in through pidfd failed");
+            let mut status = 0;
+            assert_eq!(
+                libc::waitpid(pid as libc::pid_t, &mut status, 0),
+                pid as libc::pid_t,
+                "reaping leaked stand-in failed"
+            );
+        }
+    }
+
+    assert!(
+        verdict.is_err(),
+        "cleanup must preserve the failed assertion"
+    );
+    assert!(
+        was_reaped,
+        "a failed isolation assertion bypassed cleanup and leaked its clone process"
+    );
+}
+
+#[test]
+fn working_set_replay_attributes_prefetch_to_the_measured_clone() {
+    let prefetched = vec![("recorder".to_owned(), 0), ("replay".to_owned(), 4096)];
+
+    assert_eq!(
+        prefetched_pages_for_vm(&prefetched, "replay"),
+        Some(4096),
+        "the replay assertion must select its clone by vm_id, not log order"
+    );
+}
+
+async fn spawn_working_set_clone(
+    serve_pid: u32,
+    name: &str,
+) -> Result<(tokio::process::Child, u32)> {
+    let serve_pid = serve_pid.to_string();
+    let args = ["snapshot", "run", "--pid", &serve_pid, "--name", name];
+    let (mut child, pid) = common::spawn_fcvm_with_logs(&args, name).await?;
+
+    if let Err(error) = common::poll_health_by_pid(pid, 150)
+        .await
+        .with_context(|| format!("clone {name} never became healthy"))
+    {
+        return match terminate_and_reap(&mut child, pid, &format!("working-set clone {name}")).await
+        {
+            Ok(_) => Err(error),
+            Err(cleanup_error) => {
+                Err(error.context(format!("clone cleanup also failed: {cleanup_error:#}")))
+            }
+        };
+    }
+
+    Ok((child, pid))
+}
+
+async fn run_working_set_clone(serve_pid: u32, name: &str) -> Result<String> {
+    let (mut child, pid) = spawn_working_set_clone(serve_pid, name).await?;
+    let verdict = iso_md5(pid).await;
+    let cleanup = terminate_and_reap(&mut child, pid, &format!("working-set clone {name}"))
+        .await
+        .context("terminating measured working-set clone")
+        .and_then(|status| {
+            require_successful_working_set_exit(status, &format!("working-set clone {name}"))
+        });
+
+    match (verdict, cleanup) {
+        (Ok(md5), Ok(_)) => Ok(md5),
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(error)) => Err(error),
+        (Err(error), Err(cleanup_error)) => {
+            Err(error.context(format!("clone cleanup also failed: {cleanup_error:#}")))
+        }
+    }
+}
+
+/// WORKING-SET REPLAY. One clone's faults are recorded beside the snapshot and replayed into
+/// the next clones, which must then barely fault at all — and because replay populates pages
+/// the guest never asked for, it must not leak between clones or touch the golden snapshot.
+///
+/// The fault counts are the evidence: the recording clone pays full demand paging, the
+/// replaying clones pay a small fraction of it for the same workload.
+#[tokio::test]
+async fn test_snapshot_clone_working_set_replay() -> Result<()> {
+    let (baseline_name, _, snapshot_name, _) = common::unique_names("wsreplay");
+    let snapshot_path = fcvm::paths::snapshot_dir().join(&snapshot_name);
+    let mut baseline: Option<(tokio::process::Child, u32)> = None;
+    let mut serve: Option<(tokio::process::Child, u32)> = None;
+    let mut iso_clones: Vec<(tokio::process::Child, u32)> = Vec::new();
+    let mut snapshot_cleanup_needed = false;
+
+    println!("\n=== Working-set replay test ===");
+
+    let verdict = async {
+        // Every owned process is stored immediately after spawn, before the first fallible
+        // operation. The epilogue below therefore owns cleanup on every setup/assertion edge.
+        let (baseline_child, baseline_pid) = common::spawn_fcvm_with_logs(
+            &[
+                "podman",
+                "run",
+                "--name",
+                &baseline_name,
+                "--network",
+                "rootless",
+                common::TEST_IMAGE,
+            ],
+            &baseline_name,
+        )
+        .await
+        .context("spawning baseline VM")?;
+        baseline = Some((baseline_child, baseline_pid));
+        common::poll_health_by_pid(baseline_pid, 120).await?;
+
+        common::exec_in_vm(
+            baseline_pid,
+            &[&format!(
+                "yes ABCDEFGH | head -c {} > {} && sync",
+                ISO_BYTES, ISO_FILE
+            )],
+        )
+        .await
+        .context("writing baseline pattern")?;
+        let base_md5 = iso_md5(baseline_pid).await?;
+
+        // A failed create may still have installed a partial generation, so cleanup owns this
+        // exact unique tag from before the operation begins.
+        snapshot_cleanup_needed = true;
+        common::create_snapshot_by_pid(baseline_pid, &snapshot_name).await?;
+
+        let snapshots = fcvm::storage::SnapshotManager::new(fcvm::paths::snapshot_dir());
+        let mem_path = snapshots.load_snapshot(&snapshot_name).await?.memory_path;
+        let mem_len = tokio::fs::metadata(&mem_path).await?.len();
+        let working_set_path = fcvm::uffd::WorkingSetStore::path_for(&mem_path);
+        anyhow::ensure!(
+            !working_set_path.exists(),
+            "a freshly created snapshot must not already carry a working set: {}",
+            working_set_path.display()
+        );
+
+        let serve_args = working_set_serve_args(&snapshot_name);
+        let (serve_child, serve_pid, serve_log) =
+            common::spawn_fcvm_with_log_path(&serve_args, "uffd-serve-wsreplay")
+                .await
+                .context("spawning memory server")?;
+        serve = Some((serve_child, serve_pid));
+        common::poll_serve_ready(&snapshot_name, serve_pid, 60).await?;
+
+        // Clone 1 records: nothing to replay, so it faults everything in.
+        let rec_name = format!("{}-rec", snapshot_name);
+        let rec_md5 = run_working_set_clone(serve_pid, &rec_name).await?;
+        anyhow::ensure!(
+            rec_md5 == base_md5,
+            "recording clone restored WRONG memory: {rec_md5} != {base_md5}"
+        );
+
+        serve_log_until(&serve_log, 60, "the recording clone to be merged", |log| {
+            log.contains("merged this clone's faults into the snapshot's working set")
+        })
+        .await?;
+        anyhow::ensure!(
+            working_set_path.exists(),
+            "the first clone must leave a working set at {}",
+            working_set_path.display()
+        );
+        let snapshot_dir = mem_path
+            .parent()
+            .context("snapshot memory path has no parent directory")?;
+        let snapshot_dir_name = snapshot_dir
+            .file_name()
+            .context("snapshot directory has no name")?;
+        let mut generation_lock_name = snapshot_dir_name.to_os_string();
+        generation_lock_name.push(".lock");
+        let generation_lock_path = snapshot_dir.with_file_name(generation_lock_name);
+        let recorded_pages = fcvm::uffd::WorkingSetStore::open(
+            &mem_path,
+            mem_len,
+            &snapshot_dir.join("config.json"),
+            &generation_lock_path,
+        )?
+        .to_prefetch()
+        .len();
+        anyhow::ensure!(
+            recorded_pages > 0,
+            "the recorded working set must not be empty"
+        );
+        println!("  recorded working set: {recorded_pages} pages");
+
+        // Hash incrementally: memory.bin is gigabytes, so the test must not allocate a second
+        // guest-sized buffer merely to prove it remains immutable.
+        let mem_before = sha256_of(&mem_path).await?;
+
+        // Clone 2 replays the set under the same workload and lifetime.
+        let replay_name = format!("{}-replay", snapshot_name);
+        let replay_md5 = run_working_set_clone(serve_pid, &replay_name).await?;
+        anyhow::ensure!(
+            replay_md5 == base_md5,
+            "replaying clone restored WRONG memory: {replay_md5} != {base_md5}"
+        );
+
+        let log = serve_log_until(&serve_log, 60, "both measured clones to exit", |log| {
+            faults_by_vm(log).len() >= 2
+        })
+        .await?;
+        let faults = faults_by_vm(&log);
+        let prefetched = prefetched_by_vm(&log);
+        println!("  faults by clone: {faults:?}");
+        println!("  prefetched by clone: {prefetched:?}");
+
+        let (recorder_faults, replay_faults) = (faults[0].1, faults[1].1);
+        let replay_vm_id = &faults[1].0;
+        anyhow::ensure!(
+            recorder_faults > 0,
+            "the recording clone must have faulted its memory in"
+        );
+        anyhow::ensure!(
+            prefetched_pages_for_vm(&prefetched, replay_vm_id).is_some_and(|pages| pages > 0),
+            "the replaying clone must have replayed pages from a {recorded_pages}-page \
+             working set, got {prefetched:?}"
+        );
+        anyhow::ensure!(
+            replay_faults * 2 < recorder_faults,
+            "REPLAY DID NOT WORK: the replaying clone still took {replay_faults} demand \
+             faults against {recorder_faults} for the identical workload with no recording"
+        );
+        println!(
+            "  ✓ demand faults {recorder_faults} -> {replay_faults} for the same workload \
+             ({:.0}% fewer)",
+            100.0 - (replay_faults as f64 / recorder_faults as f64) * 100.0
+        );
+
+        // Isolation, with two live clones that both replayed.
+        let b_name = format!("{}-b", snapshot_name);
+        let (b_child, b) = spawn_working_set_clone(serve_pid, &b_name).await?;
+        iso_clones.push((b_child, b));
+        let c_name = format!("{}-c", snapshot_name);
+        let (c_child, c) = spawn_working_set_clone(serve_pid, &c_name).await?;
+        iso_clones.push((c_child, c));
+
+        let b_md5 = iso_md5(b).await?;
+        let c_md5 = iso_md5(c).await?;
+        anyhow::ensure!(
+            b_md5 == base_md5 && c_md5 == base_md5,
+            "a replaying clone restored WRONG memory: b={b_md5} c={c_md5} snapshot={base_md5}"
+        );
+
+        iso_stamp(b, "CLONEB").await?;
+        let b_head = iso_head(b, 6).await?;
+        let c_head = iso_head(c, 6).await?;
+        anyhow::ensure!(
+            b_head == "CLONEB",
+            "clone B did not observe its own write (got {b_head:?})"
+        );
+        anyhow::ensure!(
+            c_head == "ABCDEF",
+            "MEMORY LEAKED BETWEEN CLONES: clone C sees {c_head:?} after clone B wrote to a \
+             PREFETCHED page"
+        );
+        anyhow::ensure!(
+            iso_md5(c).await? == base_md5,
+            "MEMORY LEAKED BETWEEN CLONES: clone C's memory changed after clone B wrote"
+        );
+
+        let mem_after = sha256_of(&mem_path).await?;
+        anyhow::ensure!(
+            mem_after == mem_before,
+            "SNAPSHOT CORRUPTED: {} changed while clones ran ({mem_before} -> {mem_after})",
+            mem_path.display()
+        );
+        println!("  ✓ replayed clones are isolated and the snapshot is byte-identical");
+
+        anyhow::Ok(())
+    }
+    .await;
+
+    // Clones first, then the server they depend on. This epilogue runs after every fallible
+    // setup and assertion path above.
+    let (verdict, mut cleanup_errors) =
+        finish_working_set_isolation_phase(verdict, iso_clones).await;
+    if let Some((mut child, pid)) = serve.take() {
+        let result = terminate_and_reap(&mut child, pid, "memory server").await;
+        record_working_set_cleanup_result(&mut cleanup_errors, "memory server", pid, result);
+    }
+    if let Some((mut child, pid)) = baseline.take() {
+        let result = terminate_and_reap(&mut child, pid, "baseline VM").await;
+        record_working_set_cleanup_result(&mut cleanup_errors, "baseline VM", pid, result);
+    }
+    if snapshot_cleanup_needed {
+        match std::fs::symlink_metadata(&snapshot_path) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => cleanup_errors.push(format!(
+                "checking working-set snapshot {} before cleanup: {error:#}",
+                snapshot_path.display()
+            )),
+            Ok(_) => {
+                if let Err(error) = common::delete_snapshot(&snapshot_name).await {
+                    cleanup_errors.push(format!("snapshot {snapshot_name}: {error:#}"));
+                } else if let Err(error) = ensure_path_absent(
+                    &snapshot_path,
+                    "working-set snapshot after production-backed deletion",
+                ) {
+                    cleanup_errors.push(format!("{error:#}"));
+                }
+            }
+        }
+    }
+
+    if cleanup_errors.is_empty() {
+        verdict?;
+        println!("✅ WORKING-SET REPLAY TEST PASSED");
+        Ok(())
+    } else {
+        let cleanup = cleanup_errors.join("; ");
+        match verdict {
+            Ok(()) => anyhow::bail!("test cleanup failed: {cleanup}"),
+            Err(error) => Err(error.context(format!("cleanup also failed: {cleanup}"))),
+        }
+    }
+}
+
 async fn clone_isolation_impl(uffd_mode: &str) -> Result<()> {
     let (baseline_name, _, snapshot_name, _) = common::unique_names(&format!("iso-{}", uffd_mode));
     let fcvm_path = common::find_fcvm_binary()?;


### PR DESCRIPTION
**Stacked on:** issue776-event-signals (PR #779)

## Why

UFFD snapshot clones repeatedly demand-fault nearly the same page set. The sequence is not stable enough for readahead, but the set is: prior measurements across eight clones had a pairwise Jaccard median of 0.927. Recording that set once lets later clones populate it in bounded batches before demand faults pay the same per-page trap cost again.

This rebase is a manual semantic transplant onto the current UFFD server. It preserves #779's modern peer pinning, fail-closed lifecycle, admission cap, per-instance sockets, pidfd-only exit authority, bounded event draining, COPY/CONTINUE exit handling, and read-event error semantics.

## Design

- Record only real demand faults in a 4 KiB bitmap; replay never recursively teaches the predictor.
- Keep the in-process union immediately available, then publish it through one bounded, coalescing detached writer. Hint I/O never retains a clone slot or delays runtime shutdown.
- Take a nonblocking sidecar lock and a snapshot-generation lease; recheck both the exact config digest and memory-file identity through atomic rename. A replaced snapshot never receives an old generation's hint.
- Plan COPY or MINOR replay into validated, non-overlapping clone mappings and populate at most 2 MiB per step.
- Drain demand first, retry parked CONTINUE faults after every drain (including a full batch), enforce their fail-closed deadline, and do not speculate while demand remains unresolved.
- Bound hostile bitmap fragmentation and use checked conversions/additions/ranges throughout. A missing, stale, corrupt, busy, or unpublishable hint falls back to ordinary demand paging.
- Pin the connecting VMM with `SO_PEERPIDFD` before admitting its task. An error, panic, cancellation, or even an unpolled admitted future kills that exact VMM before persistence and releases its slot.
- Add `--uffd-prefetch on|off` / `FCVM_UFFD_PREFETCH` (default `on`). Explicit CLI values own E2E mode so ambient test settings cannot silently disable or change the mechanism.

## Proof

Every reported defect was exercised RED on the unfixed/reverted implementation, GREEN after the fix, then reverted to RED once more before the final GREEN restoration. Coverage includes scheduler order, kill-before-persistence, file-lock and runtime-shutdown liveness, generation replacement, corrupt and oversized hints, checked mapping/range arithmetic, host/file overlap, task panic/cancellation, COPY and real MINOR population, demand-vs-speculation ordering, cleanup, and every process exit status.

Local gates on the final tree:

```text
make test-unit
Summary: 567 passed, 0 skipped

make lint
fmt, clippy -D warnings, audit, and deny passed

FCVM_UFFD_PREFETCH=off FCVM_UFFD_MODE=minor \
  make test-root FILTER=test_snapshot_clone_working_set_replay STREAM=1
Summary: 1 passed
recorded: 19,091 pages
same-workload demand faults: 19,091 -> 2,208 (88% fewer)
replay: 19,091 pages / 74 MiB in 52 ms
two concurrent replay clones remained isolated; memory.bin hash was unchanged
all clone, serve, and baseline processes exited successfully
```

The hostile ambient environment is intentional: the test pins `--uffd-mode copy --uffd-prefetch on` and proves normal command-line ownership. The exact reduction varies with guest activity; it is signal for the mechanism, not a universal benchmark.

An independent post-fix semantic audit found no remaining blocking correctness or liveness issue in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable working-set prefetch for snapshot clones, enabled by default and controllable through the CLI or environment.
  * Clones can replay previously observed memory pages to reduce demand paging during restore.
  * Added persistent, validated working-set storage with snapshot identity checks and safe recovery from unavailable or corrupted data.
  * Added fail-closed handling for clone process failures and stronger snapshot mapping validation.
* **Documentation**
  * Documented prefetch modes, configuration options, behavior, performance tradeoffs, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->