### PR TITLE
Tear down VMs concurrently, and measure what teardown really costs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1013,6 +1013,44 @@ every self-hosted job plus the `scripts/ci-stray-vm-guard.sh` pre/post steps in 
 `always()` cleanup step does not run when the process is SIGKILLed — which is exactly the case
 that leaked. If teardown matters, it must survive SIGKILL.
 
+**pasta is the one hop pdeathsig CANNOT cover — do not "fix" it with a pre_exec.** passt
+changes its own credentials *after* exec: from a bare PID argument, `conf_pasta_ns()` derives
+`/proc/PID/ns/user` and `isolate_user()` does `setns(CLONE_NEWUSER)` into the holder's user
+namespace. That grants capabilities (measured: pasta `CapEff 0x200400` vs fcvm's `0x0`), and
+`commit_creds()` zeroes `task->pdeath_signal` on any credential change that is not a
+capability subset — the same rule that forces `install_namespace_pre_exec`'s hook to run LAST,
+except this transition is inside passt where fcvm cannot re-arm it. Measured with a pre_exec
+pdeathsig installed on pasta: holder gone 2ms after fcvm's SIGKILL, pasta 169-699ms — i.e. the
+hook changed nothing. What actually reaps pasta is passt's own `pasta_netns_quit_*` watchdog:
+`/proc/<holder>/ns/net` disappears when the (pdeathsig'd) holder dies, and passt exits when it
+notices — on procfs it cannot use inotify, so it falls back to a ONE-SECOND interval poll.
+Consequence: pasta is never permanently orphaned, but it can outlive its VM by up to ~1s while
+still holding that VM's forwarded host-side listening sockets, and teardown is now ~40ms, so
+the next VM can be handed the dead VM's loopback IP inside that window. Closing it properly
+means patching passt to re-arm pdeathsig after its isolation completes (`pasta/patches/`, the
+same mechanism as the #661 addr_seen patch). Covered by
+`test_sigkill_kills_firecracker_rootless`, which asserts no PERMANENT orphan.
+
+### TEARDOWN: SIGNAL EVERY CHILD BEFORE WAITING ON ANY
+
+`src/commands/common.rs::cleanup_vm` runs teardown in five phases: stop in-process tasks →
+**SIGKILL the VMM, the holder and the network helper with no await between them** → join their
+exits → network cleanup → synchronous on-disk reaping. The middle rule is load-bearing: the
+kernel reclaims the guest's multi-GiB address space in `exit_mmap()`, charged to the dying
+VMM's system time, and killing-and-waiting each child in turn made every other death queue
+behind it. Never introduce an `.await` between the `start_kill` calls.
+
+**On-disk reaping stays synchronous. Always.** State file, VM data dir, reflink copy, VMM log:
+"leave nothing on disk" is a correctness contract of the same rank as "leave no orphaned VM".
+No janitor, no detached task, no deferral — a process that exits before proving the work is
+done has not done it. It is also not where the time goes: measured `disk_reap_ms` is 54-72ms
+for a full VM's data dir on a loaded host (~10ms for a clone's).
+
+**Report teardown honestly.** `cleanup_vm` logs `caller_blocking_ms`, `processes_gone_ms` and
+`reclaim_cpu_ms` (from `getrusage(RUSAGE_CHILDREN)`) as three separate numbers. Overlapping
+teardown with other work moves the kernel's reclaim cost; it does not delete it. Never quote
+the caller-blocking number alone as if teardown were free.
+
 ### Container Build Rules
 
 **Container builds work naturally with layer caching.** No workarounds needed.

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -172,13 +172,11 @@ pub async fn spawn_namespace_holder(
 
         // Kill holder if parent (fcvm) dies. Without this, holders orphan to init
         // and accumulate when fcvm is SIGKILL'd or crashes.
+        let fcvm_pid = std::process::id();
+        // SAFETY: the pre_exec hook runs post-fork/pre-exec and calls only
+        // async-signal-safe functions (prctl, getppid) — see set_pdeathsig_sigkill.
         unsafe {
-            cmd.pre_exec(|| {
-                if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) != 0 {
-                    return Err(std::io::Error::last_os_error());
-                }
-                Ok(())
-            });
+            cmd.pre_exec(move || crate::utils::set_pdeathsig_sigkill(fcvm_pid));
         }
 
         let child = cmd.spawn().with_context(|| {
@@ -639,14 +637,28 @@ pub struct CleanupContext {
 
 /// Cleanup resources for a VM (used by both podman and snapshot commands)
 ///
-/// This function handles the complete cleanup sequence:
-/// 1. Cancel health monitor gracefully
-/// 2. Abort volume server tasks
-/// 3. Kill VM process
-/// 4. Kill holder process (rootless mode)
-/// 5. Cleanup network resources
-/// 6. Delete state file
-/// 7. Remove data directory
+/// Phases, in order:
+/// 1. Stop in-process tasks (health monitor, output listener, volume servers)
+/// 2. SIGKILL every child process at once — VMM, namespace holder, network helper
+/// 3. Join their exits concurrently
+/// 4. Cleanup network resources (namespace/veth/iptables; reaps the network helper)
+/// 5. Reap on-disk state SYNCHRONOUSLY: NFS exports, state file, VMM log, data directory
+///
+/// **Why phase 2 signals before phase 3 waits.** The old sequence killed-and-waited each
+/// child in turn, so the kernel's address-space reclaim of the guest's multi-GiB mapping
+/// (charged to the dying VMM's system time in `exit_mmap()`) ran with everything else idle,
+/// and the holder and network-helper deaths queued behind it. Signalling all three first
+/// makes those deaths concurrent: teardown costs roughly the slowest child, not their sum.
+///
+/// **Why the on-disk reaping stays synchronous.** "Leave nothing on disk" is a correctness
+/// contract of the same rank as "leave no orphaned VM". Deferring it to a janitor or a
+/// detached task would make it survivable-but-unobserved: the process that knows the paths
+/// would exit before the work is proven done. It is also not where the time goes: measured
+/// `disk_reap_ms` is 54-72ms for a full VM's data dir on a loaded host (~10ms for a clone's),
+/// against the 154ms of post-result teardown this change targets.
+///
+/// Emits one `VM teardown complete` record with the three numbers that describe teardown
+/// honestly — see [`TeardownTiming`]. This function never claims work it did not finish.
 pub async fn cleanup_vm(
     ctx: CleanupContext,
     vm_manager: &mut dyn Hypervisor,
@@ -664,7 +676,9 @@ pub async fn cleanup_vm(
         output_listener_handle,
     } = ctx;
     info!("cleaning up resources");
+    let cleanup_start = std::time::Instant::now();
 
+    // --- Phase 1: stop in-process tasks -------------------------------------------------
     // Signal health monitor to stop gracefully, then wait briefly for it
     if let (Some(token), Some(handle)) = (health_cancel_token, health_monitor_handle) {
         token.cancel();
@@ -688,24 +702,57 @@ pub async fn cleanup_vm(
         handle.abort();
     }
 
-    // Kill VM process
-    if let Err(e) = vm_manager.kill().await {
-        warn!("failed to kill VM process: {}", e);
+    // --- Phase 2: signal every child process, awaiting none of them ---------------------
+    // Nothing between these three calls may await: an await here would let one child's exit
+    // (the VMM's, which is the slow one) delay the others' SIGKILL and re-serialize teardown.
+    let kill_start = std::time::Instant::now();
+    // CPU accounting: RUSAGE_CHILDREN publishes a child's WHOLE-LIFE cpu when it is reaped,
+    // so the reap-window delta must have each child's pre-kill cpu subtracted to leave only
+    // what dying cost (the kernel's exit_mmap reclaim, charged to the dying task's stime).
+    let cpu_before_reap = crate::utils::reaped_children_cpu_time();
+    let mut cpu_alive_at_kill = std::time::Duration::ZERO;
+    if let Ok(pid) = vm_manager.pid() {
+        cpu_alive_at_kill += crate::utils::process_cpu_time(pid);
     }
-
-    // Kill holder process (rootless mode only)
+    if let Some(pid) = holder_child.as_ref().and_then(|h| h.id()) {
+        cpu_alive_at_kill += crate::utils::process_cpu_time(pid);
+    }
+    if let Err(e) = vm_manager.start_kill() {
+        warn!("failed to signal VM process: {}", e);
+    }
     if let Some(ref mut holder) = holder_child {
         info!("killing namespace holder process");
-        if let Err(e) = holder.kill().await {
-            warn!("failed to kill holder process: {}", e);
+        if let Err(e) = holder.start_kill() {
+            warn!("failed to signal holder process: {}", e);
         }
-        let _ = holder.wait().await; // Clean up zombie
     }
+    network.start_kill_processes();
 
-    // Cleanup network
+    // --- Phase 3: join the exits ---------------------------------------------------------
+    // Each child is gone when its wait returns: the kernel unmaps the guest address space in
+    // exit_mmap() before the task becomes reapable, so this join is the real "truly gone".
+    tokio::join!(vm_manager.reap(), async {
+        if let Some(ref mut holder) = holder_child {
+            let _ = holder.wait().await; // Clean up zombie
+        }
+    });
+    let processes_gone = kill_start.elapsed();
+    let reclaim_cpu = crate::utils::reaped_children_cpu_time()
+        .saturating_sub(cpu_before_reap)
+        .saturating_sub(cpu_alive_at_kill);
+
+    // --- Phase 4: network teardown -------------------------------------------------------
+    // Runs after the VMM is gone: deleting a namespace or veth still held open by a live VMM
+    // leaves host state behind. The network helper was signalled in phase 2, so its reap here
+    // is already complete work.
+    let net_start = std::time::Instant::now();
     if let Err(e) = network.cleanup().await {
         warn!("failed to cleanup network: {}", e);
     }
+    let net_cleanup = net_start.elapsed();
+
+    // --- Phase 5: on-disk reaping (SYNCHRONOUS, never deferred) --------------------------
+    let disk_start = std::time::Instant::now();
 
     // Remove this VM's NFS exports (no-op when the VM had none). Lives here so
     // every exit path — podman run, converge teardown, restored clones — drops
@@ -734,6 +781,50 @@ pub async fn cleanup_vm(
         warn!(vm_id = %vm_id, error = %e, "failed to cleanup VM data directory");
     } else {
         info!(vm_id = %vm_id, "cleaned up VM data directory");
+    }
+
+    TeardownTiming {
+        caller_blocking: cleanup_start.elapsed(),
+        processes_gone,
+        reclaim_cpu,
+        net_cleanup,
+        disk_reap: disk_start.elapsed(),
+    }
+    .log(&vm_id);
+}
+
+/// The three numbers that describe a teardown honestly, plus the two phase costs that
+/// explain them. Kept as one struct so no call site can report a subset and imply teardown
+/// is cheaper than it is.
+///
+/// - `caller_blocking` — how long `cleanup_vm` held its caller. This is the latency a
+///   request actually pays.
+/// - `processes_gone` — SIGKILL → last child reaped. The kernel address-space reclaim of a
+///   multi-GiB guest mapping lives here; it does not shrink because the signal returned fast.
+/// - `reclaim_cpu` — CPU (user+system) the children burned DYING: their whole-life total from
+///   `getrusage(RUSAGE_CHILDREN)` at reap, minus the `/proc` cpu they had already used when
+///   the signal was sent. Non-zero here means the machine was genuinely working, not idling.
+///   Overlapping teardown with other work moves this cost; it does not delete it.
+struct TeardownTiming {
+    caller_blocking: std::time::Duration,
+    processes_gone: std::time::Duration,
+    reclaim_cpu: std::time::Duration,
+    net_cleanup: std::time::Duration,
+    disk_reap: std::time::Duration,
+}
+
+impl TeardownTiming {
+    fn log(&self, vm_id: &str) {
+        let ms = |d: std::time::Duration| d.as_secs_f64() * 1000.0;
+        info!(
+            vm_id = %vm_id,
+            caller_blocking_ms = ms(self.caller_blocking),
+            processes_gone_ms = ms(self.processes_gone),
+            reclaim_cpu_ms = ms(self.reclaim_cpu),
+            net_cleanup_ms = ms(self.net_cleanup),
+            disk_reap_ms = ms(self.disk_reap),
+            "VM teardown complete"
+        );
     }
 }
 

--- a/src/firecracker/vm.rs
+++ b/src/firecracker/vm.rs
@@ -515,16 +515,28 @@ impl VmManager {
         }
     }
 
-    /// Kill the VM process
-    pub async fn kill(&mut self) -> Result<()> {
-        if let Some(mut process) = self.process.take() {
-            info!(vm_id = %self.vm_id, "killing Firecracker process");
+    /// SIGKILL the VM process without waiting for it to exit. Pair with [`Self::reap`].
+    pub fn start_kill(&mut self) -> Result<()> {
+        if let Some(ref mut process) = self.process {
+            info!(vm_id = %self.vm_id, "signalling Firecracker process (SIGKILL)");
             process
-                .kill()
-                .await
-                .context("killing Firecracker process")?;
+                .start_kill()
+                .context("signalling Firecracker process")?;
+        }
+        Ok(())
+    }
+
+    /// Wait for the signalled VM process to exit, reaping it.
+    pub async fn reap(&mut self) {
+        if let Some(mut process) = self.process.take() {
             let _ = process.wait().await; // Wait to clean up zombie
         }
+    }
+
+    /// Kill the VM process and reap it.
+    pub async fn kill(&mut self) -> Result<()> {
+        self.start_kill()?;
+        self.reap().await;
         Ok(())
     }
 

--- a/src/hypervisor/cloud_hypervisor/mod.rs
+++ b/src/hypervisor/cloud_hypervisor/mod.rs
@@ -397,15 +397,26 @@ impl Hypervisor for CloudHypervisorBackend {
         }
     }
 
-    async fn kill(&mut self) -> Result<()> {
+    fn start_kill(&mut self) -> Result<()> {
         if let Some(tail) = self.console_tail.take() {
             tail.abort();
         }
+        if let Some(ref mut p) = self.process {
+            info!(vm_id = %self.vm_id, "signalling Cloud Hypervisor process (SIGKILL)");
+            p.start_kill().context("signalling Cloud Hypervisor")?;
+        }
+        Ok(())
+    }
+
+    async fn reap(&mut self) {
         if let Some(mut p) = self.process.take() {
-            info!(vm_id = %self.vm_id, "killing Cloud Hypervisor process");
-            p.kill().await.context("killing Cloud Hypervisor")?;
             let _ = p.wait().await;
         }
+    }
+
+    async fn kill(&mut self) -> Result<()> {
+        self.start_kill()?;
+        self.reap().await;
         Ok(())
     }
 

--- a/src/hypervisor/firecracker.rs
+++ b/src/hypervisor/firecracker.rs
@@ -111,6 +111,14 @@ impl Hypervisor for FirecrackerBackend {
         self.vm.wait().await
     }
 
+    fn start_kill(&mut self) -> Result<()> {
+        self.vm.start_kill()
+    }
+
+    async fn reap(&mut self) {
+        self.vm.reap().await
+    }
+
     async fn kill(&mut self) -> Result<()> {
         self.vm.kill().await
     }

--- a/src/hypervisor/mod.rs
+++ b/src/hypervisor/mod.rs
@@ -171,6 +171,22 @@ pub trait Hypervisor: Send {
     /// Wait for the VMM process to exit.
     async fn wait(&mut self) -> Result<ExitStatus>;
 
+    /// SIGKILL the VMM process WITHOUT waiting for it to exit.
+    ///
+    /// Split from the reap so teardown can signal every child (VMM, namespace holder, pasta)
+    /// before blocking on any one of them: the kernel's address-space reclaim of a
+    /// multi-GiB guest mapping then overlaps with the other deaths instead of serializing
+    /// behind them. Always pair with [`Self::reap`] — a signalled process that is never
+    /// waited for is a zombie.
+    fn start_kill(&mut self) -> Result<()>;
+
+    /// Wait for a [`Self::start_kill`]ed VMM process to exit, reaping it.
+    ///
+    /// Returns when the process is genuinely gone: the kernel unmaps the guest's address
+    /// space in `exit_mmap()` before the task becomes reapable, so this returning is proof
+    /// the reclaim finished — not just that the signal was delivered.
+    async fn reap(&mut self);
+
     /// Kill the VMM process and reap it.
     async fn kill(&mut self) -> Result<()>;
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -76,6 +76,15 @@ pub trait NetworkManager: Send + Sync {
         Ok(())
     }
 
+    /// SIGKILL any long-lived helper process this network owns, WITHOUT waiting for it.
+    ///
+    /// Lets teardown signal the network helper in the same instant as the VMM and the
+    /// namespace holder, so the helper is already dead by the time [`Self::cleanup`] reaps
+    /// it — its exit overlaps the VMM's address-space reclaim instead of queueing behind it.
+    /// Purely an optimization: `cleanup()` still kills and reaps unconditionally, so calling
+    /// this is optional and calling it twice is harmless. Default: no-op (no helper process).
+    fn start_kill_processes(&mut self) {}
+
     /// Cleanup network after VM stop
     async fn cleanup(&mut self) -> Result<()>;
 

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -600,6 +600,32 @@ impl PastaNetwork {
             .stdout(Stdio::null())
             .stderr(Stdio::piped());
 
+        // NO PR_SET_PDEATHSIG HERE — the kernel would discard it. Do not "fix" this by
+        // adding a pre_exec pdeathsig: it is a no-op, and measurement says so.
+        //
+        // Every other long-lived child fcvm spawns (the VMM, the namespace holder) is reaped
+        // by PR_SET_PDEATHSIG. pasta cannot be, because passt changes its own credentials
+        // AFTER exec: given a bare PID, `conf_pasta_ns()` derives `/proc/PID/ns/user` and
+        // `isolate_user()` does `setns(CLONE_NEWUSER)` into the holder's user namespace. That
+        // grants capabilities (observed on this host: pasta CapEff 0x200400 = CAP_SYS_ADMIN |
+        // CAP_NET_BIND_SERVICE, while fcvm's is 0x0), and `commit_creds()` zeroes
+        // `task->pdeath_signal` on any credential change that is not a capability subset. It
+        // is the same rule that forces install_namespace_pre_exec's hook to run LAST — except
+        // here the transition happens inside passt, after exec, where fcvm cannot re-arm it.
+        // Measured with the pre_exec installed: holder died 2ms after fcvm's SIGKILL, pasta
+        // 169-699ms — i.e. unchanged, still on passt's own schedule.
+        //
+        // What DOES reap pasta: passt's `pasta_netns_quit_*` watchdog. Its target
+        // `/proc/<holder>/ns/net` vanishes when the holder dies (kernel-enforced, 2ms), and
+        // passt exits when it notices. Because the path is on procfs, passt cannot use
+        // inotify and falls back to `pasta_netns_quit_timer()` — a ONE-SECOND interval poll.
+        // So pasta is never permanently orphaned, but it can outlive its VM by up to ~1s
+        // while still holding the host-side listening sockets for this VM's forwarded ports.
+        // With teardown now ~40ms, that window is wide enough for the next VM to be handed
+        // this VM's loopback IP. Closing it requires making passt itself re-arm pdeathsig
+        // after its isolation completes (a patch in pasta/patches/, which is how #661 was
+        // fixed) — not another pre_exec here. Tracked by
+        // test_sigkill_kills_firecracker_rootless, which asserts no PERMANENT orphan.
         debug!(cmd = ?cmd, "pasta command");
         let mut child = cmd.spawn().context("failed to spawn pasta")?;
 
@@ -968,11 +994,21 @@ impl NetworkManager for PastaNetwork {
         Ok(())
     }
 
+    fn start_kill_processes(&mut self) {
+        if let Some(ref mut process) = self.pasta_process {
+            if let Err(e) = process.start_kill() {
+                warn!(vm_id = %self.vm_id, error = %e, "failed to signal pasta");
+            }
+        }
+    }
+
     async fn cleanup(&mut self) -> Result<()> {
         info!(vm_id = %self.vm_id, "cleaning up pasta resources");
 
         if let Some(mut process) = self.pasta_process.take() {
-            if let Err(e) = process.kill().await {
+            // Idempotent with start_kill_processes: signalling an already-signalled (or
+            // already-exited) child is a no-op, and the wait below reaps it either way.
+            if let Err(e) = process.start_kill() {
                 warn!("failed to kill pasta: {}", e);
             }
             let _ = process.wait().await;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -412,6 +412,94 @@ pub async fn wait_for_namespace_ready(
     }
 }
 
+/// Arm `PR_SET_PDEATHSIG=SIGKILL` on the calling process, then verify the parent we meant
+/// to bind to is still the parent.
+///
+/// Call ONLY from a `pre_exec` hook (post-fork, pre-exec): every call it makes is
+/// async-signal-safe (`prctl`, `getppid`). `expected_ppid` is the spawner's PID, captured
+/// BEFORE the fork.
+///
+/// The re-check closes the fork/prctl race: if the parent dies in the window between
+/// `fork()` and `prctl()`, the kernel has already sent (and lost) the parent-death
+/// notification, and this process would run forever with nothing to kill it — precisely the
+/// orphan class that wedged two CI runners (#730). Returning an error here aborts the `exec`,
+/// so the child exits instead of orphaning.
+///
+/// Must be the LAST `pre_exec` hook installed on a command that also changes credentials or
+/// namespaces: a credential change (`setns(CLONE_NEWUSER)`, `setuid`) zeroes
+/// `task->pdeath_signal`, so an earlier call would be silently discarded.
+pub fn set_pdeathsig_sigkill(expected_ppid: u32) -> std::io::Result<()> {
+    // SAFETY: prctl(PR_SET_PDEATHSIG) only mutates this task's pdeath_signal; no memory
+    // effects. Return value is checked.
+    if unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: getppid() cannot fail and has no memory effects.
+    let ppid = unsafe { libc::getppid() } as u32;
+    if ppid != expected_ppid {
+        return Err(std::io::Error::other(format!(
+            "parent {expected_ppid} died before PR_SET_PDEATHSIG was armed (now reparented to \
+             {ppid}); refusing to exec an unreapable orphan"
+        )));
+    }
+    Ok(())
+}
+
+/// CPU time (user + system) a LIVE process has consumed so far, from `utime`+`stime`
+/// (fields 14 and 15) of `/proc/<pid>/stat`. `Duration::ZERO` if it is gone or unreadable.
+///
+/// Paired with [`reaped_children_cpu_time`] to isolate what a child spends DYING: sample this
+/// just before the kill and subtract it from the whole-lifetime total that `RUSAGE_CHILDREN`
+/// publishes at reap.
+pub fn process_cpu_time(pid: u32) -> Duration {
+    let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+        return Duration::ZERO;
+    };
+    // `comm` (field 2) can contain spaces and ')', so parse the remainder after the LAST ") ".
+    let Some((_, after_comm)) = stat.rsplit_once(") ") else {
+        return Duration::ZERO;
+    };
+    let fields: Vec<&str> = after_comm.split_whitespace().collect();
+    // In `after_comm`, field 3 (state) is index 0, so utime (14) is index 11, stime (15) is 12.
+    let (Some(u), Some(st)) = (fields.get(11), fields.get(12)) else {
+        return Duration::ZERO;
+    };
+    let (Ok(u), Ok(st)) = (u.parse::<u64>(), st.parse::<u64>()) else {
+        return Duration::ZERO;
+    };
+    // SAFETY: sysconf has no memory effects. A non-positive answer means "unknown"; fall back
+    // to the near-universal 100Hz USER_HZ.
+    let hz = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
+    let hz = if hz > 0 { hz as u64 } else { 100 };
+    Duration::from_nanos((u + st).saturating_mul(1_000_000_000 / hz))
+}
+
+/// Cumulative CPU time (user + system) charged to every child of this process that has
+/// already been reaped, from `getrusage(RUSAGE_CHILDREN)`.
+///
+/// A child's rusage is folded in when it is REAPED and covers its WHOLE life, so a raw delta
+/// across a kill+reap window is that child's lifetime CPU — not what dying cost. Subtract
+/// [`process_cpu_time`] sampled just before the kill to get the death itself: the kernel
+/// unmaps the guest's address space in `exit_mmap()`, in the dying task's own context,
+/// charged to its system time and therefore counted here. That is how teardown reports what
+/// the kernel actually spends releasing a multi-GiB guest, instead of pretending a
+/// fast-returning `kill()` made the work disappear.
+///
+/// Process-wide, so a delta also picks up any OTHER child this process happens to reap in
+/// the same window. Read it as a diagnostic of what teardown cost the machine, not as an
+/// exact per-process attribution.
+pub fn reaped_children_cpu_time() -> Duration {
+    // SAFETY: getrusage writes into a fully-initialized local; the who value is a constant.
+    let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
+    if unsafe { libc::getrusage(libc::RUSAGE_CHILDREN, &mut usage) } != 0 {
+        return Duration::ZERO;
+    }
+    let tv = |t: libc::timeval| {
+        Duration::from_secs(t.tv_sec as u64) + Duration::from_micros(t.tv_usec as u64)
+    };
+    tv(usage.ru_utime) + tv(usage.ru_stime)
+}
+
 /// Network/user/mount-namespace isolation to apply to a spawned VMM process before exec.
 ///
 /// VMM-neutral: both Firecracker and Cloud Hypervisor run as a child process inside the
@@ -603,13 +691,9 @@ pub fn install_namespace_pre_exec(
 
     // Kill the VMM if the parent (fcvm) dies, even from SIGKILL. Unconditional; must be the
     // LAST pre_exec so it runs AFTER setns(CLONE_NEWUSER), which clears pdeath_signal.
+    let fcvm_pid = std::process::id();
     unsafe {
-        cmd.pre_exec(|| {
-            if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) != 0 {
-                return Err(std::io::Error::last_os_error());
-            }
-            Ok(())
-        });
+        cmd.pre_exec(move || set_pdeathsig_sigkill(fcvm_pid));
     }
 
     Ok(())

--- a/tests/test_signal_cleanup.rs
+++ b/tests/test_signal_cleanup.rs
@@ -557,12 +557,30 @@ fn test_sigterm_cleanup_rootless() -> Result<()> {
     Ok(())
 }
 
-/// Test that SIGKILL on fcvm also kills Firecracker via PR_SET_PDEATHSIG.
+/// Test that SIGKILL on fcvm leaves NO surviving child: Firecracker, the namespace holder,
+/// and pasta must all be gone.
 ///
-/// Unlike SIGTERM/SIGINT, SIGKILL cannot be caught — fcvm gets no chance to run
-/// cleanup code. The Firecracker child dies because pre_exec sets
-/// PR_SET_PDEATHSIG(SIGKILL), which makes the kernel automatically send SIGKILL
-/// to the child when its parent dies.
+/// Unlike SIGTERM/SIGINT, SIGKILL cannot be caught — fcvm gets no chance to run cleanup code,
+/// so every guarantee here has to be kernel-enforced.
+///
+/// Firecracker and the holder die from their own `PR_SET_PDEATHSIG(SIGKILL)`, set in
+/// pre_exec: the kernel signals them the instant fcvm dies (measured: 2ms). pdeathsig is
+/// per-hop — a child without it survives no matter what the others have.
+///
+/// **pasta gets there by a different, slower route, and this test pins it.** pasta cannot use
+/// pdeathsig at all: passt does `setns(CLONE_NEWUSER)` into the holder's user namespace after
+/// exec, and that credential change zeroes `task->pdeath_signal` (see the long comment in
+/// `PastaNetwork::start_pasta`). It dies instead because passt watches its target namespace
+/// `/proc/<holder>/ns/net`, which vanishes with the (pdeathsig'd) holder — on a one-second
+/// poll, so pasta lags the holder by up to ~1s (measured 169-699ms).
+///
+/// So the assertion below proves NO PERMANENT ORPHAN, not promptness: it fails if pasta is
+/// ever left running for good — e.g. if `--no-netns-quit` were passed, if the holder stopped
+/// dying, or if pasta were reparented somewhere the watchdog can't see. It deliberately does
+/// NOT assert a tight deadline, because passt's poll makes that a coin flip. The residual
+/// sub-second window (a dead VM's pasta still holding this VM's forwarded host ports while
+/// its loopback IP is recycled) is real and is documented at the call site; closing it needs
+/// a passt-side patch, and if that lands this test should tighten to a deadline.
 #[test]
 fn test_sigkill_kills_firecracker_rootless() -> Result<()> {
     println!("\ntest_sigkill_kills_firecracker_rootless");
@@ -616,19 +634,30 @@ fn test_sigkill_kills_firecracker_rootless() -> Result<()> {
     // Find the specific child processes for THIS VM
     let our_fc_pid = find_firecracker_for_fcvm(fcvm_pid);
     let our_holder_pid = find_holder_for_fcvm(fcvm_pid);
+    let our_pasta_pid = find_pasta_for_fcvm(fcvm_pid);
     println!(
-        "Our firecracker PID: {:?}, holder PID: {:?}",
-        our_fc_pid, our_holder_pid
+        "Our firecracker PID: {:?}, holder PID: {:?}, pasta PID: {:?}",
+        our_fc_pid, our_holder_pid, our_pasta_pid
     );
 
     assert!(
         our_fc_pid.is_some(),
         "should have started a firecracker process"
     );
-    // `fc`/`holder` are tracked by (pid, start_time) so the post-kill checks below survive
-    // both the SIGKILL'd-but-unreaped zombie window and PID reuse under parallel load (#628).
+    // Rootless networking is pasta — if we cannot find it the test would silently stop
+    // covering the pasta hop, so demand it rather than skipping the assertion (NO HEDGES).
+    assert!(
+        our_pasta_pid.is_some(),
+        "rootless mode should have started a pasta process under fcvm (PID {})",
+        fcvm_pid
+    );
+    // `fc`/`holder`/`pasta` are tracked by (pid, start_time) so the post-kill checks below
+    // survive both the SIGKILL'd-but-unreaped zombie window and PID reuse under parallel
+    // load (#628).
     let fc = our_fc_pid.unwrap();
+    let pasta = our_pasta_pid.unwrap();
     assert!(fc.running(), "firecracker should be running before SIGKILL");
+    assert!(pasta.running(), "pasta should be running before SIGKILL");
 
     // Send SIGKILL to fcvm — no cleanup handler runs
     println!("Sending SIGKILL to fcvm (PID {})", fcvm_pid);
@@ -638,15 +667,20 @@ fn test_sigkill_kills_firecracker_rootless() -> Result<()> {
     let _ = fcvm.wait();
     println!("fcvm process reaped");
 
-    // PR_SET_PDEATHSIG delivers SIGKILL to child processes when parent dies.
-    // Poll briefly in case of scheduling delay.
+    // PR_SET_PDEATHSIG delivers SIGKILL to firecracker and the holder when the parent dies.
+    // pasta follows on passt's one-second namespace-gone poll, so the window has to cover
+    // several poll periods, not just a scheduling delay.
     let start = std::time::Instant::now();
-    while start.elapsed() < Duration::from_secs(5) {
-        if !fc.running() && !opt_running(our_holder_pid) {
+    while start.elapsed() < Duration::from_secs(10) {
+        if !fc.running() && !pasta.running() && !opt_running(our_holder_pid) {
             break;
         }
         std::thread::sleep(common::POLL_INTERVAL);
     }
+    println!(
+        "all children gone after {:?} (firecracker+holder: pdeathsig; pasta: passt netns poll)",
+        start.elapsed()
+    );
 
     let fc_still_running = fc.running();
     if fc_still_running {
@@ -661,6 +695,25 @@ fn test_sigkill_kills_firecracker_rootless() -> Result<()> {
         "firecracker (PID {}) should die via PR_SET_PDEATHSIG when fcvm is SIGKILL'd",
         fc.pid
     );
+
+    let pasta_still_running = pasta.running();
+    if pasta_still_running {
+        println!(
+            "BUG: pasta (PID {}) still running after fcvm SIGKILL!",
+            pasta.pid
+        );
+        pasta.kill_if_running();
+    }
+    assert!(
+        !pasta_still_running,
+        "pasta (PID {}) is still running long after fcvm was SIGKILL'd — it is now a permanent \
+         orphan holding this VM's forwarded host ports, so a later VM that is handed this \
+         loopback IP can have its clients accepted by this DEAD VM's pasta. passt's \
+         namespace-gone watchdog should have exited it once the holder died; check that the \
+         holder still dies via pdeathsig and that --no-netns-quit was not introduced",
+        pasta.pid
+    );
+    println!("pasta PID {} correctly cleaned up", pasta.pid);
 
     if let Some(holder) = our_holder_pid {
         let holder_still_running = holder.running();


### PR DESCRIPTION
Makes VM teardown concurrent instead of serial, and reports what it actually costs. Also re-diagnoses the "pasta has no PDEATHSIG" finding: the prescribed fix is a no-op, and the evidence is below.

## The Problem

~154ms of every benchmark request happened *after* the result existed. `src/commands/common.rs::cleanup_vm` killed-and-waited each child in turn:

```
SIGKILL firecracker -> wait  (~40ms: kernel reclaiming a ~1GiB guest mapping)
SIGKILL holder      -> wait
network.cleanup()   -> SIGKILL pasta -> wait  (~28ms)
on-disk reaping                              (~10ms)
```

The kernel unmaps the guest's address space in `exit_mmap()`, in the dying VMM's own context, charged to its system time. Everything else queued behind that reclaim while the machine was otherwise idle.

## The Solution

Five phases, with one load-bearing rule: **signal every child before waiting on any**.

1. Stop in-process tasks (health monitor, output listener, volume servers)
2. `start_kill()` the VMM, the holder and the network helper — **no `.await` between the signals**
3. `tokio::join!` their exits
4. Network cleanup (namespace/veth/iptables; reaps the already-dead helper)
5. On-disk reaping

Two-phase kill split out of the single `kill()`: `Hypervisor` gains `start_kill()`/`reap()` (with `kill()` now their composition, still used by error paths), and `NetworkManager` gains `start_kill_processes()` — default no-op, implemented by `PastaNetwork`. `cleanup()` still kills and reaps unconditionally, so calling it is optional and calling it twice is harmless.

**On-disk reaping stays synchronous.** State file, VM data dir, FC log, NFS exports. "Leave nothing on disk" is a correctness contract of the same rank as "leave no orphaned VM" — a janitor or a detached task would let the process that knows the paths exit before the work is proven done. Measured `disk_reap_ms` is 54-72ms; it is not where the time goes.

## Teardown is measured, not claimed

Every teardown logs three separate numbers, so it can never be reported as free:

```
VM teardown complete vm_id=… caller_blocking_ms=124.3 processes_gone_ms=61.0
                             reclaim_cpu_ms=58.8 net_cleanup_ms=0.15 disk_reap_ms=63.1
```

- `caller_blocking_ms` — what a request actually pays
- `processes_gone_ms` — SIGKILL → last child reaped. `exit_mmap()` runs before a task is reapable, so this returning *is* "truly gone"
- `reclaim_cpu_ms` — CPU the children burned dying

The CPU number needed care. `getrusage(RUSAGE_CHILDREN)` folds in a child's **whole-life** CPU when it is reaped, so a naive window delta read **~4950ms** — the VM's entire runtime, not its death. Subtracting each child's pre-kill `/proc` CPU leaves only the dying cost: **46-60ms**, tracking `processes_gone_ms`. The reclaim is genuine CPU work; overlapping teardown moves that cost, it does not delete it.

## pasta cannot use PDEATHSIG — evidence, not opinion

The review finding ("`src/network/pasta.rs` has no PDEATHSIG") is factually correct, but **adding one does nothing**, so this PR documents the mechanism instead of shipping a placebo.

passt changes its own credentials *after* exec. Given a bare PID, `conf_pasta_ns()` derives `/proc/PID/ns/user`, and `isolate_user()` does `setns(CLONE_NEWUSER)` into the holder's user namespace. That grants capabilities — measured on this host, pasta `CapEff 0x200400` (`CAP_SYS_ADMIN|CAP_NET_BIND_SERVICE`) versus fcvm's `0x0` — and `commit_creds()` zeroes `task->pdeath_signal` on any credential change that is not a capability subset. It is the same kernel rule that already forces `install_namespace_pre_exec`'s hook to run LAST, except here the transition happens inside passt, after exec, where fcvm cannot re-arm it.

Measured with the pre_exec hook installed:

| build | holder death | pasta death |
|---|---|---|
| pdeathsig hook **absent** | 2ms | 188ms |
| pdeathsig hook **present** | 2ms | 169ms / 699ms |

Unchanged — pasta stays on its own schedule. (An experiment routing around it via `--netns` was also tried and reverted: it does not avoid the userns transition either.)

**What does reap pasta:** passt's own `pasta_netns_quit_*` watchdog. Its target `/proc/<holder>/ns/net` vanishes when the holder dies (kernel-enforced, 2ms), and passt exits when it notices — but the path is on procfs, so passt cannot use inotify and falls back to `pasta_netns_quit_timer()`, a **one-second interval poll**.

**Residual risk, stated plainly:** pasta is never permanently orphaned, but it can outlive its VM by up to ~1s while still holding that VM's forwarded host-side listening sockets. With teardown now ~60ms, the next VM can be handed the dead VM's loopback IP inside that window — the routing hazard the review raised, now quantified. Closing it properly means patching passt to re-arm pdeathsig after its isolation completes (`pasta/patches/`, the same mechanism used for the #661 addr_seen fix). That is a vendored-fork + pinned-build change and is deliberately **not** bundled here.

## The leak guarantee is intact

No change to how any child is reaped on SIGKILL. Additionally hardened: one shared `utils::set_pdeathsig_sigkill(expected_ppid)` replaces two copies of the raw `prctl`, and re-checks `getppid()` after arming. That closes the fork/prctl race — a parent that dies in that window has already lost its parent-death notification and the child would have run forever; now the `exec` is aborted instead.

The existing reaping test was **extended, not duplicated**: `test_sigkill_kills_firecracker_rootless` now requires a pasta process to exist and asserts it is gone, proving **no permanent orphan**. It deliberately does *not* assert a tight deadline — passt's one-second poll would make that a coin flip — and the comment states exactly what is and is not proven, plus the instruction to tighten it if the passt patch lands.

## Test Results

```
$ make lint
cargo fmt -p fcvm -p fuse-pipe -p fc-agent -p failpoint --check
cargo clippy --all-targets -- -D warnings      # clean

$ make build                                    # ok

$ make test-root FILTER=snapshot STREAM=1
     Summary [1259.143s] 116 tests run: 116 passed, 572 skipped

$ make _test-root FILTER="-E 'binary(test_signal_cleanup)'" STREAM=1
     Summary [  33.046s] 9 tests run: 9 passed, 0 skipped
```

All nine signal/cleanup tests pass, including the sudo-hop reaping test (`test_root_test_runner_reaps_vm_when_sudo_is_killed`) that guards the #730 regression.

Ran on a box with no measurement workload active (`pgrep -f "twopath|bench.sh|cdp-rebaseline"` empty), though other agents' builds were running concurrently — these are pass/fail results, not benchmarks.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd
