### PR TITLE
Two review-comment traps: findings that hide, and findings that reappear

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -890,18 +890,26 @@ gh pr view <pr-number> --json comments \
 
 **GitHub re-anchors still-open review comments onto the current head.** After you push a fix,
 an *old* comment's `commit_id` and `line` both change to match the new HEAD — so a finding you
-already fixed reappears looking brand new, at a shifted line number. Acting on that means
-re-fixing work you already did, or concluding your fix was rejected when nobody said so.
-`commit_id` cannot distinguish the two. `original_commit_id` (the commit the comment was
-actually written against) plus `created_at` can:
+already fixed reappears looking brand new, at a shifted line number. Observed live: four
+comments created at `09:01:36Z` against `23558456` re-anchored onto the fix commit, with
+`prefetch.rs:179 → 196` and `server.rs:1975 → 1991`, while the comment count never changed.
+
+**`isResolved` is the ONLY field that means resolved.** Age does not:
 ```bash
-gh api repos/{owner}/{repo}/pulls/<pr-number>/comments \
-  --jq '.[] | "\(.created_at) orig=\(.original_commit_id[0:8]) now=\(.commit_id[0:8]) \(.path)"'
-# created_at BEFORE your fix commit => already addressed, re-anchored. Not a new finding.
+gh api graphql -f query='{repository(owner:"O",name:"R"){pullRequest(number:N){
+  reviewThreads(first:100){nodes{isResolved comments(first:100){nodes{author{login} path line body}}}}}}}' \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)'
 ```
-Observed live: four comments created at `09:01:36Z` against `23558456` re-anchored onto the
-fix commit, with `prefetch.rs:179 → 196` and `server.rs:1975 → 1991`. Comment count never
-changed. Compare timestamps, not commit ids.
+An earlier version of this file said "`created_at` BEFORE your fix commit ⇒ already addressed",
+and that rule is **unsound** — it was wrong here for months of nothing and then wrong in
+practice within a day. When one commit fixes SOME of several findings, every older comment
+still predates it, **including the ones nobody fixed**, so the rule silently reclassifies
+unfixed blockers as handled. `original_commit_id` + `created_at` can tell you a comment is OLD
+or RE-ANCHORED; neither can tell you its concern was addressed. Only a human reading the
+thread, or `isResolved`, can.
+
+Use age for one thing only: deciding whether a finding needs re-reading after a push, never
+whether it needs fixing.
 
 ### GitHub Actions Workflow Security (claude.yml)
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -63,6 +63,68 @@ Enforcement: `scripts/check-review-threads.sh <pr>` fails while any review threa
 unresolved, AND while any thread that *describes* broken behaviour has been resolved without a
 `RED-VERIFIED: <test>` reply. CI state cannot tell you whether a finding was answered.
 
+### A GATE MUST FAIL CLOSED — check your dependencies before you trust your verdict
+
+A check that cannot run must **block**, never pass. Passing is a claim, and a tool that could
+not evaluate anything has no basis for making it.
+
+This bit immediately, in the gate written to enforce the rule above. `jq` is not in the CI
+container. Every `jq` call failed to stderr, the counts came back empty, and the script printed
+`verdict: CLEAR ... exit 0` — waving every PR through *precisely because it could not evaluate
+them*. Strictly worse than having no gate, because it looks like one:
+
+```
+review threads:  total,  unresolved
+verdict: CLEAR — every thread resolved, ...
+check-review-threads.sh: line 49: jq: command not found
+```
+
+Any script that renders a verdict must begin by proving it can:
+```bash
+for tool in jq gh; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "BLOCKED: '$tool' missing" >&2; exit 2; }
+done
+```
+And its tests must run **where CI runs it**, not only on a dev box that happens to have the
+tooling. A green unit test on your laptop says nothing about the container.
+
+### HOW TO GET CI LOGS — there is always a way; never report "no logs available"
+
+"The logs aren't available yet" is almost always a tooling mistake, not a fact. Two independent
+routes, in order of preference:
+
+**1. Per-job API — works even while the RUN is still in progress.**
+```bash
+JOB=$(gh api repos/{o}/{r}/commits/<sha>/check-runs \
+       --jq '.check_runs[] | select(.conclusion=="failure") | .id' | head -1)
+gh api --allow-escape-sequences repos/{o}/{r}/actions/jobs/$JOB/logs > job.log
+sed -i 's/\x1b\[[0-9;]*m//g' job.log
+```
+`--allow-escape-sequences` is **mandatory**: job logs contain ANSI, and without it `gh api`
+writes nothing to stdout and puts the reason **only on stderr** — so `> job.log` yields an
+empty file from a command that looks like it succeeded. That empty file is what makes people
+announce there are no logs.
+
+Note `gh run view --log` refuses while the RUN is in progress even for jobs that finished long
+ago. Do not wait for the run; use the per-job API above.
+
+**2. SSH to the self-hosted runner — it has the checkout AND the environment.**
+```bash
+gh api repos/{o}/{r}/actions/runners --jq '.runners[] | "\(.name)\t\(.status)\t\(.busy)"'
+# names are runner-i-<instance-id>; get IPs read-only:
+aws ec2 describe-instances --instance-ids i-... \
+  --query 'Reservations[].Instances[].{id:InstanceId,pub:PublicIpAddress,arch:Architecture}' --output text
+ssh -i ~/.ssh/runner_key ubuntu@<public-ip>
+# the CI tree, exactly as the job saw it (merge commit of PR head into base):
+cd /opt/actions-runner/_work/fcvm/fcvm/fcvm && sudo git log --oneline -1
+```
+This is how a `cargo fmt --check` failure was diagnosed in one command after the API route had
+been (wrongly) given up on. `_diag/Worker_*.log` is runner METADATA — step output is not there;
+either use route 1 or re-run the failing command in that checkout.
+
+**Check `busy` first and leave a busy runner alone** — it is executing someone's job, and a
+build you start competes for its cargo cache and disk.
+
 ### "It is too big / slow / expensive to test" is almost always false
 
 That excuse is how the worst bugs stay uncovered, because expensive-to-reach paths are exactly

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -37,6 +37,55 @@ Writing tests without running them is pointless. Compilation does not equal corr
 
 **Anti-pattern:** "All 85 unit tests pass" + never ran the integration tests that actually exercise the new code paths.
 
+## A DEFECT CLAIM IS CLOSED BY A RED TEST, NOT BY A FIX
+
+**Whenever anyone — a reviewer, a bot, a teammate, you — says "this is broken", the thing that
+closes it is a test that FAILS WITHOUT THE FIX.** Not the fix. Not "verified manually". Not a
+green suite after the change, which proves only that the suite never covered it.
+
+Applies to every source of a defect claim, not just review comments: a CI failure, a bug
+report, a hunch you had in the shower, a comment you wrote yourself.
+
+**The procedure, in order:**
+1. Write the test. Run it against the **unfixed** tree. **Watch it fail.**
+2. Apply the fix. Watch it pass.
+3. Revert the fix once more and confirm it goes red again — if you skipped step 1, this is
+   your last chance to learn the test was vacuous.
+4. Only then resolve the thread / close the issue, citing the test by name.
+
+A test written after the fix, never observed failing, is indistinguishable from a test that
+cannot fail. This repo has repeatedly found checks that could never fire — a contention
+detector matching a truncated `comm`, a leak check whose pattern never matched, a `"VM exited"`
+branch logged 0 times across 137 runs, a `grep '^ *FAIL'` blind to nextest's `TRY 1 FAIL`.
+Every one of them was green for its whole life.
+
+Enforcement: `scripts/check-review-threads.sh <pr>` fails while any review thread is
+unresolved, AND while any thread that *describes* broken behaviour has been resolved without a
+`RED-VERIFIED: <test>` reply. CI state cannot tell you whether a finding was answered.
+
+### "It is too big / slow / expensive to test" is almost always false
+
+That excuse is how the worst bugs stay uncovered, because expensive-to-reach paths are exactly
+where nobody looks. Find the cheap equivalent:
+
+- **Large files → sparse files.** The FUSE `remap_file_range` u32 truncation
+  (`kernel/patches/0001-fuse-add-remap_file_range-support.patch`) only bites above 4 GiB,
+  because `fuse_write_out.size` is a `u32` and the client saturates it — the destination inode
+  records ~4 GiB and later guest reads come back short. Sounds like it needs a 4 GiB fixture.
+  It does not: a sparse file costs no real blocks and on btrfs the reflink is O(1).
+  `truncate -s 5G` + FICLONE reproduces it for free.
+- **Slow timeouts → inject the signal.** Use the failpoint harness (`make fuzz`, `FAILPOINT`
+  specs) instead of waiting out a real timeout.
+- **Rare races → make the interleaving deterministic.** A seeded schedule beats hoping.
+- **Huge memory → test the arithmetic.** Feed the boundary value (`u32::MAX`, `pid_max`, a
+  9-digit `pid_start_time`) to the function directly rather than provisioning the machine that
+  would produce it naturally.
+- **Multi-hour soak → assert the invariant, not the duration.** If a leak takes 6 hours to be
+  visible, count the resource instead of watching the clock.
+
+If after genuinely trying you cannot make it cheap, say so **in the test file**, with what it
+would take — never only in a commit message, where the next reader will not find it.
+
 ## STACKED PRs BY DEFAULT
 
 **All work goes in stacked PRs.** Each new PR should be based on the previous one, not main.
@@ -750,9 +799,18 @@ CodeRabbit and Codex put their actual findings, live on a different endpoint and
 to that query:
 ```bash
 gh pr view <pr-number> --json comments --jq '.comments[] | .body'   # top-level only
-gh api repos/{owner}/{repo}/pulls/<pr-number>/comments \
-  --jq '.[] | "\(.user.login) \(.path):\(.line) \(.body[0:200])"'   # inline — the findings
+gh api --paginate repos/{owner}/{repo}/pulls/<pr-number>/comments \
+  --jq '.[] | "=== \(.user.login) \(.path):\(.line // .original_line)\n\(.body)\n"'
 ```
+Two things that look like details and are not:
+
+- **`--paginate` is mandatory.** Without it you get the first page only, so a PR that has
+  accumulated findings over several review rounds silently reports a subset — and the audit
+  that was supposed to catch hidden findings becomes one.
+- **Print `.body` whole.** A `[0:200]` preview drops the scenario, the evidence, and the
+  suggested fix — the parts you need in order to decide. A truncated finding is not a finding
+  you have read.
+
 On 2026-08-08 a PR carried **four unread inline findings, two of them Major**, while the check
 rendered `CodeRabbit  pass`. One was a slice index that would panic inside the fault-handler
 task and hang the guest. Reading only the top-level comments would have merged all four.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -744,10 +744,18 @@ git push
 gh pr close <fix-pr-number>  # Close the auto-generated PR
 ```
 
-**MANDATORY before merging any PR:** Read all review comments first:
+**MANDATORY before merging any PR:** Read all review comments first — and note that
+`--json comments` returns **only issue comments**. Inline review comments, which is where
+CodeRabbit and Codex put their actual findings, live on a different endpoint and are invisible
+to that query:
 ```bash
-gh pr view <pr-number> --json comments --jq '.comments[] | .body'
+gh pr view <pr-number> --json comments --jq '.comments[] | .body'   # top-level only
+gh api repos/{owner}/{repo}/pulls/<pr-number>/comments \
+  --jq '.[] | "\(.user.login) \(.path):\(.line) \(.body[0:200])"'   # inline — the findings
 ```
+On 2026-08-08 a PR carried **four unread inline findings, two of them Major**, while the check
+rendered `CodeRabbit  pass`. One was a slice index that would panic inside the fault-handler
+task and hang the guest. Reading only the top-level comments would have merged all four.
 
 **A green `CodeRabbit` check does NOT mean CodeRabbit reviewed anything.** When it hits its
 rate limit it posts *"Review limit reached ... we couldn't start this review"* and the check
@@ -759,6 +767,21 @@ gh pr view <pr-number> --json comments \
   --jq '.comments[] | select(.author.login=="coderabbitai") | .body' | head -5
 # "Review limit reached" / "next review in NN minutes" => NOT reviewed. Re-run before merging.
 ```
+
+**GitHub re-anchors still-open review comments onto the current head.** After you push a fix,
+an *old* comment's `commit_id` and `line` both change to match the new HEAD — so a finding you
+already fixed reappears looking brand new, at a shifted line number. Acting on that means
+re-fixing work you already did, or concluding your fix was rejected when nobody said so.
+`commit_id` cannot distinguish the two. `original_commit_id` (the commit the comment was
+actually written against) plus `created_at` can:
+```bash
+gh api repos/{owner}/{repo}/pulls/<pr-number>/comments \
+  --jq '.[] | "\(.created_at) orig=\(.original_commit_id[0:8]) now=\(.commit_id[0:8]) \(.path)"'
+# created_at BEFORE your fix commit => already addressed, re-anchored. Not a new finding.
+```
+Observed live: four comments created at `09:01:36Z` against `23558456` re-anchored onto the
+fix commit, with `prefetch.rs:179 → 196` and `server.rs:1975 → 1991`. Comment count never
+changed. Compare timestamps, not commit ids.
 
 ### GitHub Actions Workflow Security (claude.yml)
 

--- a/Containerfile
+++ b/Containerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y \
     musl-tools iproute2 iptables passt dnsmasq qemu-utils e2fsprogs btrfs-progs \
     parted fdisk podman skopeo git curl sudo procps zstd busybox-static cpio uidmap iputils-ping patch \
     flex bison bc libelf-dev libssl-dev libseccomp-dev \
+    jq \
     && rm -rf /var/lib/apt/lists/*
 
 # Build passt from source for consistent version across environments

--- a/scripts/capture-review-threads-fixture.sh
+++ b/scripts/capture-review-threads-fixture.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Capture a REAL review-thread response as a test fixture.
+#
+# Hand-written fixtures drift from the query that is supposed to produce them. Ours did:
+# the fixture carried two comments per thread while the query asked for `comments(first: 1)`,
+# so `a_resolved_defect_claim_with_a_red_test_is_accepted` passed against data the code could
+# never return — a green test proving nothing. Capturing from a live PR makes that
+# impossible by construction.
+#
+# Usage: capture-review-threads-fixture.sh <pr> <output.json>
+set -euo pipefail
+command -v gh >/dev/null || { echo "need gh" >&2; exit 2; }
+command -v jq >/dev/null || { echo "need jq" >&2; exit 2; }
+pr=${1:?pr number}; out=${2:?output path}
+gh api graphql -f query="
+  { repository(owner: \"${REPO_OWNER:-ejc3}\", name: \"${REPO_NAME:-fcvm}\") {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            isResolved isOutdated
+            comments(first: 100) { nodes { author { login } path line originalLine body } }
+          } } } } }" | jq '.' > "$out"
+echo "captured PR #$pr -> $out ($(jq '.data.repository.pullRequest.reviewThreads.nodes|length' "$out") threads)"

--- a/scripts/check-review-threads.sh
+++ b/scripts/check-review-threads.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Fail while a PR has UNRESOLVED inline review threads.
+#
+# This is the enforcement half of the review-comment rules in .claude/CLAUDE.md.
+# A doc that says "read the inline findings before merging" cannot fire. This can.
+#
+# It exists because on 2026-08-08 a PR sat at 15 green checks / 0 failures /
+# MERGEABLE with 19 unresolved inline findings, and another merged carrying four
+# unread Major findings behind a green `CodeRabbit pass`. CI state says nothing
+# about whether a human or bot review was answered.
+#
+# Why GraphQL and not `created_at` heuristics: an earlier version of the docs
+# said "comment older than your fix commit => already addressed". That is wrong
+# whenever a fix addresses SOME of several findings — every older comment still
+# predates it, including the unfixed ones, so unfixed blockers get classified as
+# handled. `isResolved` is the only field that means resolved.
+#
+# Usage:
+#   check-review-threads.sh <pr-number>          # query GitHub
+#   check-review-threads.sh --from-file <json>   # parse a saved response (tests)
+set -uo pipefail
+
+REPO_OWNER=${REPO_OWNER:-ejc3}
+REPO_NAME=${REPO_NAME:-fcvm}
+
+fetch_threads() {
+  local pr=$1 cursor=null all='[]'
+  while :; do
+    local after="" resp
+    [ "$cursor" != "null" ] && after=", after: \\\"$cursor\\\""
+    resp=$(gh api graphql -f query="
+      { repository(owner: \"$REPO_OWNER\", name: \"$REPO_NAME\") {
+          pullRequest(number: $pr) {
+            reviewThreads(first: 100$after) {
+              pageInfo { hasNextPage endCursor }
+              nodes {
+                isResolved isOutdated
+                comments(first: 1) { nodes { author { login } path line originalLine body } }
+              } } } } }" 2>/dev/null) || return 1
+    all=$(jq -s '.[0] + (.[1].data.repository.pullRequest.reviewThreads.nodes // [])' \
+          <(echo "$all") <(echo "$resp"))
+    [ "$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<<"$resp")" = "true" ] || break
+    cursor=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor' <<<"$resp")
+  done
+  echo "$all"
+}
+
+if [ "${1:-}" = "--from-file" ]; then
+  threads=$(jq '.data.repository.pullRequest.reviewThreads.nodes' "${2:?need a json file}")
+else
+  pr=${1:?usage: check-review-threads.sh <pr-number> | --from-file <json>}
+  threads=$(fetch_threads "$pr") || { echo "could not query review threads for #$pr" >&2; exit 2; }
+fi
+
+total=$(jq 'length' <<<"$threads")
+unresolved=$(jq '[.[] | select(.isResolved == false)] | length' <<<"$threads")
+
+echo "review threads: $total total, $unresolved unresolved"
+rc=0
+
+if [ "$unresolved" -gt 0 ]; then
+  echo
+  jq -r '.[] | select(.isResolved == false) | .comments.nodes[0] |
+    "  UNRESOLVED  \(.author.login)  \(.path):\(.line // .originalLine // "?")\n    \(.body | split("\n")[0][0:150])"' \
+    <<<"$threads"
+  echo
+  echo "verdict: BLOCKED — resolve or explicitly answer each thread before merging."
+  echo "An unresolved thread is a finding nobody has answered, not a finding that is wrong."
+  rc=1
+fi
+
+# A finding that claims BROKEN BEHAVIOUR cannot be closed by asserting it is
+# fixed. Closing it requires a test that fails without the fix — otherwise the
+# only evidence the bug is gone is the same judgement that shipped it.
+#
+# Mark such a resolution by replying in the thread with:
+#     RED-VERIFIED: <test name or path>
+# and having actually watched it fail with the fix reverted.
+#
+# `defect_re` deliberately errs toward over-matching. A false positive costs one
+# reply naming the test; a false negative closes a real bug on an assertion.
+defect_re='panic|crash|hang|deadlock|leak|corrupt|race|overflow|truncat|silently|wrong|incorrect|breaks|broken|fails|unsound|use-after|out of bounds|off-by-one'
+
+needs_proof=$(jq -r --arg re "$defect_re" '
+  [ .[] | select(.isResolved == true)
+        | select([.comments.nodes[].body] | join(" ") | test($re; "i"))
+        | select(([.comments.nodes[].body] | join(" ") | test("RED-VERIFIED:"; "i")) | not) ]
+  | length' <<<"$threads" 2>/dev/null || echo 0)
+
+if [ "${needs_proof:-0}" -gt 0 ]; then
+  echo
+  jq -r --arg re "$defect_re" '.[] | select(.isResolved == true)
+    | select([.comments.nodes[].body] | join(" ") | test($re; "i"))
+    | select(([.comments.nodes[].body] | join(" ") | test("RED-VERIFIED:"; "i")) | not)
+    | .comments.nodes[0]
+    | "  UNPROVEN   \(.author.login)  \(.path):\(.line // .originalLine // "?")\n    \(.body | split("\n")[0][0:150])"' \
+    <<<"$threads"
+  echo
+  echo "verdict: BLOCKED — $needs_proof resolved thread(s) describe broken behaviour with no test cited."
+  echo "Reply in the thread with 'RED-VERIFIED: <test>' after watching that test fail"
+  echo "with the fix reverted. A test that has never been red proves nothing."
+  rc=1
+fi
+
+if [ "$rc" -eq 0 ]; then
+  echo "verdict: CLEAR — every thread resolved, every defect claim backed by a red-verified test."
+fi
+exit $rc

--- a/scripts/check-review-threads.sh
+++ b/scripts/check-review-threads.sh
@@ -70,6 +70,22 @@ else
   threads=$(fetch_threads "$pr") || { echo "could not query review threads for #$pr" >&2; exit 2; }
 fi
 
+# Prove the payload is what we think before counting it. `jq` emits `null` for a missing
+# path and an empty string on a parse error, and `[ "" -gt 0 ]` is a shell error, not a
+# block — so malformed input previously slid through to a CLEAR verdict. Same failure
+# shape as the missing-jq case: a gate that cannot read its input must not bless it.
+if ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$threads"; then
+  echo "verdict: BLOCKED — review-thread data is not an array; refusing to judge input" >&2
+  echo "this gate could not parse. Re-run, or re-capture the fixture." >&2
+  exit 2
+fi
+if ! jq -e 'all(has("isResolved") and (.comments.nodes | type == "array"))' \
+     >/dev/null 2>&1 <<<"$threads"; then
+  echo "verdict: BLOCKED — a thread is missing isResolved or its comments array. The" >&2
+  echo "only field that means 'resolved' is isResolved; without it nothing can be judged." >&2
+  exit 2
+fi
+
 total=$(jq 'length' <<<"$threads")
 unresolved=$(jq '[.[] | select(.isResolved == false)] | length' <<<"$threads")
 

--- a/scripts/check-review-threads.sh
+++ b/scripts/check-review-threads.sh
@@ -20,6 +20,21 @@
 #   check-review-threads.sh --from-file <json>   # parse a saved response (tests)
 set -uo pipefail
 
+# A GATE MUST FAIL CLOSED. Without this check the script degraded silently when `jq`
+# was absent (it is not in the CI container): every `jq` call errored to stderr, the
+# counts came back empty, and it printed "verdict: CLEAR ... exit 0" — a merge gate
+# waving everything through precisely because it could not run. That is strictly worse
+# than no gate, because it looks like one.
+for tool in jq gh; do
+  # gh is only needed for the live query; --from-file parsing needs jq alone.
+  if [ "$tool" = "gh" ] && [ "${1:-}" = "--from-file" ]; then continue; fi
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "verdict: BLOCKED — '$tool' is not installed, so this gate cannot evaluate" >&2
+    echo "review threads. Refusing to report CLEAR for a check that did not run." >&2
+    exit 2
+  }
+done
+
 REPO_OWNER=${REPO_OWNER:-ejc3}
 REPO_NAME=${REPO_NAME:-fcvm}
 
@@ -27,7 +42,10 @@ fetch_threads() {
   local pr=$1 cursor=null all='[]'
   while :; do
     local after="" resp
-    [ "$cursor" != "null" ] && after=", after: \\\"$cursor\\\""
+    # `\"` here, NOT `\\\"`: the latter puts a literal backslash into the GraphQL
+    # argument and the query fails to parse. Only reachable on page 2+, which is why
+    # single-page fixtures never caught it.
+    [ "$cursor" != "null" ] && after=", after: \"$cursor\""
     resp=$(gh api graphql -f query="
       { repository(owner: \"$REPO_OWNER\", name: \"$REPO_NAME\") {
           pullRequest(number: $pr) {
@@ -35,7 +53,7 @@ fetch_threads() {
               pageInfo { hasNextPage endCursor }
               nodes {
                 isResolved isOutdated
-                comments(first: 1) { nodes { author { login } path line originalLine body } }
+                comments(first: 100) { nodes { author { login } path line originalLine body } }
               } } } } }" 2>/dev/null) || return 1
     all=$(jq -s '.[0] + (.[1].data.repository.pullRequest.reviewThreads.nodes // [])' \
           <(echo "$all") <(echo "$resp"))
@@ -84,14 +102,14 @@ defect_re='panic|crash|hang|deadlock|leak|corrupt|race|overflow|truncat|silently
 needs_proof=$(jq -r --arg re "$defect_re" '
   [ .[] | select(.isResolved == true)
         | select([.comments.nodes[].body] | join(" ") | test($re; "i"))
-        | select(([.comments.nodes[].body] | join(" ") | test("RED-VERIFIED:"; "i")) | not) ]
+        | select(([.comments.nodes[1:][].body] | join(" ") | test("RED-VERIFIED:"; "i")) | not) ]
   | length' <<<"$threads" 2>/dev/null || echo 0)
 
 if [ "${needs_proof:-0}" -gt 0 ]; then
   echo
   jq -r --arg re "$defect_re" '.[] | select(.isResolved == true)
     | select([.comments.nodes[].body] | join(" ") | test($re; "i"))
-    | select(([.comments.nodes[].body] | join(" ") | test("RED-VERIFIED:"; "i")) | not)
+    | select(([.comments.nodes[1:][].body] | join(" ") | test("RED-VERIFIED:"; "i")) | not)
     | .comments.nodes[0]
     | "  UNPROVEN   \(.author.login)  \(.path):\(.line // .originalLine // "?")\n    \(.body | split("\n")[0][0:150])"' \
     <<<"$threads"

--- a/scripts/scan-test-log.sh
+++ b/scripts/scan-test-log.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Canonical nextest log scanner. Use this instead of hand-rolled greps.
+#
+# Every field here exists because a hand-rolled grep got it wrong and turned a
+# real failure into a green report. See tests/test_log_scan.rs for the fixture
+# that pins each one; those tests go RED if these patterns regress.
+#
+#   try_fail   nextest writes retries as "TRY 1 FAIL", so a `grep '^ *FAIL'`
+#              matches NONE of them. A test that failed and passed on retry
+#              then vanishes into a green total.
+#   pass       counting `grep -c 'PASS'` also matches test-internal "PASSED:"
+#              lines the test bodies print themselves. Measured once at 136 vs
+#              nextest's real 119. Anchor on the verdict form "PASS [".
+#   summary    the run's own summary line is the only trustworthy total. A
+#              tally reconstructed from greps is not evidence.
+#   ansi       logs arrive with real ESC bytes (local runs) OR the literal
+#              two-character sequence "^[" (gh run view --log). Strip both.
+#
+# Usage: scan-test-log.sh <logfile>
+set -uo pipefail
+
+log=${1:?usage: scan-test-log.sh <logfile>}
+[ -r "$log" ] || { echo "cannot read $log" >&2; exit 2; }
+
+clean=$(mktemp)
+trap 'rm -f "$clean"' EXIT
+# Real ESC sequences, then the literal caret-bracket form.
+sed -e 's/\x1b\[[0-9;]*m//g' -e 's/\^\[\[[0-9;]*m//g' "$log" > "$clean"
+
+# `grep -c` already prints 0 when it matches nothing AND exits 1, so a
+# `|| echo 0` fallback prints a SECOND zero on its own line. Swallow the exit
+# status instead of appending to the output.
+count() { grep -acE "$1" "$clean" 2>/dev/null; true; }
+
+# Verdicts are anchored on "<KIND> [" — the bracket separates a nextest verdict
+# from prose containing the same word.
+pass=$(count '(^|[^A-Z])PASS \[')
+# A hard FAIL must exclude retry lines: "TRY 1 FAIL [" also ends in " FAIL [",
+# so counting it here would double-report every retry as a hard failure.
+fail=$(grep -aE '(^|[^A-Z])FAIL \[' "$clean" | grep -acvE 'TRY [0-9]+ FAIL'; true)
+try_fail=$(count 'TRY [0-9]+ FAIL')
+timeout=$(count '(^|[^A-Z])TIMEOUT \[')
+leak=$(count '(^|[^A-Z])LEAK \[')
+# The per-test "FLAKY [" verdict and the summary's "(N flaky)" describe the SAME
+# retries; count only the per-test verdict so a flake is not reported twice.
+flaky=$(count '(^|[^A-Z])FLAKY \[')
+
+summary=$(grep -aE 'Summary \[.*tests run:' "$clean" | tail -1 | sed 's/^[[:space:]]*//')
+
+echo "summary: ${summary:-<none found>}"
+echo "pass: $pass"
+echo "fail: $fail"
+echo "try_fail: $try_fail"
+echo "timeout: $timeout"
+echo "leak: $leak"
+echo "flaky: $flaky"
+
+# A run is clean only if the summary says so AND nothing was retried. A retry
+# that passed is a flake, not a pass, and must not be absorbed into a total.
+if [ -z "$summary" ]; then
+  echo "verdict: UNKNOWN (no summary line — did the run finish?)"
+  exit 3
+elif [ "$fail" -gt 0 ] || [ "$timeout" -gt 0 ] || [ "$leak" -gt 0 ]; then
+  echo "verdict: FAILED"
+  exit 1
+elif [ "$try_fail" -gt 0 ] || [ "$flaky" -gt 0 ]; then
+  echo "verdict: FLAKY (passed only on retry — name it, do not absorb it)"
+  exit 1
+else
+  echo "verdict: CLEAN"
+  exit 0
+fi

--- a/scripts/scan-test-log.sh
+++ b/scripts/scan-test-log.sh
@@ -38,7 +38,7 @@ pass=$(count '(^|[^A-Z])PASS \[')
 # A hard FAIL must exclude retry lines: "TRY 1 FAIL [" also ends in " FAIL [",
 # so counting it here would double-report every retry as a hard failure.
 fail=$(grep -aE '(^|[^A-Z])FAIL \[' "$clean" | grep -acvE 'TRY [0-9]+ FAIL'; true)
-try_fail=$(count 'TRY [0-9]+ FAIL')
+try_fail=$(count 'TRY [0-9]+ FAIL \[')
 timeout=$(count '(^|[^A-Z])TIMEOUT \[')
 leak=$(count '(^|[^A-Z])LEAK \[')
 # The per-test "FLAKY [" verdict and the summary's "(N flaky)" describe the SAME
@@ -57,9 +57,30 @@ echo "flaky: $flaky"
 
 # A run is clean only if the summary says so AND nothing was retried. A retry
 # that passed is a flake, not a pass, and must not be absorbed into a total.
+# The summary's own numbers are authoritative. Counting per-test verdict lines is NOT
+# enough: a truncated or filtered log can carry the summary while every `FAIL [` line is
+# gone, and this then reported CLEAN on a run the summary itself called failed —
+#   "Summary [10.0s] 1 tests run: 0 passed, 1 failed"  ->  verdict: CLEAN, exit 0
+# which is the exact defect this scanner exists to catch.
+summary_failed=$(sed -nE 's/.*tests? run:.*[^0-9]([0-9]+) failed.*/\1/p' <<<"$summary" | head -1)
+summary_flaky=$(sed -nE 's/.*\(([0-9]+) flaky\).*/\1/p' <<<"$summary" | head -1)
+summary_passed=$(sed -nE 's/.*tests? run:[^0-9]*([0-9]+) passed.*/\1/p' <<<"$summary" | head -1)
+summary_total=$(sed -nE 's/.*\] ([0-9]+) tests? run:.*/\1/p' <<<"$summary" | head -1)
+
 if [ -z "$summary" ]; then
   echo "verdict: UNKNOWN (no summary line — did the run finish?)"
   exit 3
+elif [ -n "${summary_total:-}" ] && [ -n "${summary_passed:-}" ] \
+     && [ "${summary_failed:-0}" -eq 0 ] && [ "$summary_passed" -ne "$summary_total" ]; then
+  # Neither failed nor accounted for: tests vanished between "run" and "passed".
+  echo "verdict: FAILED (summary says $summary_passed of $summary_total passed and 0 failed — unaccounted tests)"
+  exit 1
+elif [ "${summary_failed:-0}" -gt 0 ]; then
+  echo "verdict: FAILED (the run's own summary reports $summary_failed failed)"
+  exit 1
+elif [ "${summary_flaky:-0}" -gt 0 ]; then
+  echo "verdict: FLAKY (the run's own summary reports $summary_flaky flaky)"
+  exit 1
 elif [ "$fail" -gt 0 ] || [ "$timeout" -gt 0 ] || [ "$leak" -gt 0 ]; then
   echo "verdict: FAILED"
   exit 1

--- a/tests/fixtures/nextest-flaky.log
+++ b/tests/fixtures/nextest-flaky.log
@@ -1,0 +1,18 @@
+    Starting 681 tests across 24 binaries (4 skipped)
+        PASS [   0.012s] (1/681) fcvm::test_state_manager test_save_and_load
+    running 1 test
+    Test trailing args command syntax
+    ==================================
+      fcvm PID: 3440176
+^[[35;1m  TRY 1 FAIL^[[0m [   2.914s] (───────) ^[[35;1mfcvm::test_sanity^[[0m ^[[34;1mtest_trailing_args_command^[[0m
+    [trailing-args-base-3440084-0 ERR] ERROR fcvm: Error: clone FAILED: its VMM exited with status 1
+    ✅ STARTUP FAILURE SHUTDOWN PASSED!
+        PASS [   8.502s] (419/681) fcvm::test_state_manager test_load_state_by_pid_cleans_stale_on_retry
+    PASSED: hugepage cache restore served 4096 pages
+    PASSED: egress reached the proxy on the first attempt
+        PASS [  15.828s] (422/681) fcvm::test_signal_cleanup test_sigint_kills_firecracker_bridged
+    PASSED: pasta exited with the holder still alive
+^[[33;1m       FLAKY^[[0m [   9.565s] (421/681) ^[[35;1mfcvm::test_sanity^[[0m ^[[34;1mtest_trailing_args_command^[[0m
+    PASSED: teardown reclaimed every namespace
+------------
+^[[32;1m     Summary^[[0m [ 728.830s] ^[[1m681^[[0m tests run: ^[[1m681^[[0m ^[[32;1mpassed^[[0m ^[[1m(1 flaky)^[[0m, ^[[1m4^[[0m ^[[33;1mskipped^[[0m

--- a/tests/fixtures/review-threads-clear.json
+++ b/tests/fixtures/review-threads-clear.json
@@ -1,0 +1,3 @@
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+ {"isResolved":true,"isOutdated":true,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"path":"src/uffd/server.rs","line":216,"originalLine":210,"body":"Fixed."}]}}
+]}}}}}

--- a/tests/fixtures/review-threads-live-748.json
+++ b/tests/fixtures/review-threads-live-748.json
@@ -1,0 +1,186 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "reviewThreads": {
+          "pageInfo": {
+            "hasNextPage": false,
+            "endCursor": "Y3Vyc29yOnYyOpK0MjAyNi0wOC0wOFQxNDozMjozN1rOl3qnBQ=="
+          },
+          "nodes": [
+            {
+              "isResolved": true,
+              "isOutdated": true,
+              "comments": {
+                "nodes": [
+                  {
+                    "author": {
+                      "login": "coderabbitai"
+                    },
+                    "path": ".claude/CLAUDE.md",
+                    "line": null,
+                    "originalLine": 754,
+                    "body": "_🎯 Functional Correctness_ | _🟠 Major_ | _⚡ Quick win_\n\n<details>\n<summary>🧩 Analysis chain</summary>\n\n🏁 Script executed:\n\n```shell\n#!/bin/bash\nset -eu\nprintf '%s\\n' '--- .claude/CLAUDE.md:730-790 ---'\nsed -n '730,790p' .claude/CLAUDE.md\nprintf '%s\\n' '--- related commands ---'\nrg -n -C 3 -- '--paginate|pulls/<pr-number>/comments|gh api repos/.*/pulls' .claude/CLAUDE.md\n```\n\nRepository: ejc3/fcvm\n\nLength of output: 4164\n\n---\n\n🌐 Web query:\n\n`Official GitHub CLI gh api --paginate behavior and REST API pull request review comments pagination default`\n\n💡 Result:\n\nIn the GitHub CLI, the --paginate flag used with gh api enables the tool to automatically perform multiple HTTP requests to fetch all pages of results until no more pages remain [1][2][3]. When using --paginate, each individual page request counts toward your GitHub API rate limit [4]. By default, this flag works with GET requests and is not supported for other HTTP methods or when combined with specific flags like --input [2]. Users can also use the --slurp flag in conjunction with --paginate to combine all pages of JSON arrays or objects into a single outer JSON array [1][5]. Regarding the GitHub REST API for pull request review comments (e.g., endpoints such as GET /repos/{owner}/{repo}/pulls/{pull_number}/comments), the default pagination settings are as follows: - per_page: 30 results per page (with a maximum of 100) [6][7][8]. - page: 1 (the initial page number) [6][7][8]. These defaults apply generally across the GitHub REST API unless specified otherwise in the documentation for a particular endpoint [9]. When using the GitHub CLI's --paginate feature, it will respect these API defaults unless you explicitly override them by passing a different per_page value in the URL or via query parameters [9].\n\nCitations:\n\n- 1: https://cli.github.com/manual/gh_api\n- 2: https://github.com/cli/cli/blob/trunk/pkg/cmd/api/api.go\n- 3: https://cli.github.com/manual/gh_help_reference\n- 4: https://github.com/cli/cli/pull/1222\n- 5: https://man.archlinux.org/man/gh-api.1.en.txt\n- 6: https://docs.github.com/en/rest/pulls/comments\n- 7: https://docs.github.com/rest/pulls/comments\n- 8: https://docs.github.com/enterprise-server@3.10/rest/pulls/comments\n- 9: https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2026-03-10\n\n---\n\n\n\n</details>\n\n**Paginate inline review comments.**\n\nWithout `--paginate`, this endpoint returns only the first page and can omit findings. Add `--paginate` before the endpoint.\n\n<details>\n<summary>🤖 Prompt for AI Agents</summary>\n\n```\nVerify each finding against current code. Fix only still-valid issues, skip the\nrest with a brief reason, keep changes minimal, and validate.\n\nIn @.claude/CLAUDE.md around lines 751 - 754, Update the gh api command for\ninline pull-request review comments to include --paginate before the endpoint,\nensuring all comment pages are retrieved while preserving the existing jq\nformatting.\n```\n\n</details>\n\n<!-- fingerprinting:phantom:triton:caracal -->\n\n<!-- cr-indicator-types:potential_issue -->\n\n<!-- cr-comment:v1:3ac11c81f36c6c19f0855854 -->\n\n<!-- This is an auto-generated comment by CodeRabbit -->\n\n✅ Addressed in commit ed9ddf3"
+                  }
+                ]
+              }
+            },
+            {
+              "isResolved": false,
+              "isOutdated": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "author": {
+                      "login": "coderabbitai"
+                    },
+                    "path": ".claude/CLAUDE.md",
+                    "line": 839,
+                    "originalLine": 781,
+                    "body": "_🎯 Functional Correctness_ | _🟠 Major_ | _⚡ Quick win_\n\n<details>\n<summary>🧩 Analysis chain</summary>\n\n🏁 Script executed:\n\n```shell\n#!/bin/bash\nset -eu\nfile=.claude/CLAUDE.md\nsed -n '735,805p' \"$file\"\nprintf '\\n--- related terms ---\\n'\nrg -n -C 3 'created_at|original_commit_id|isResolved|isOutdated|re-anch|review comments' .claude README.md .github 2>/dev/null || true\n```\n\nRepository: ejc3/fcvm\n\nLength of output: 7551\n\n---\n\n🌐 Web query:\n\n`GitHub REST API pull request review comments re-anchored current head original_commit_id created_at unresolved comment isOutdated isResolved`\n\n💡 Result:\n\nIn the GitHub API ecosystem, pull request review comments are managed primarily through the REST API, while thread-level states like resolution status are available exclusively through the GraphQL API [1][2][3]. REST API Capabilities The GitHub REST API (specifically the pull request review comments endpoints) provides comprehensive details for individual comments but does not include thread resolution or outdated status [4][5][2]. Key fields available in the REST response for a pull request review comment include: - id: The unique integer ID of the comment [6][5]. - created_at: The timestamp when the comment was created [4][5]. - original_commit_id: The SHA of the commit at the time the comment was created [6][5]. - commit_id: The SHA of the commit the comment is currently attached to [6][5]. The REST API does not provide fields like isResolved or isOutdated [5][2]. GraphQL API Capabilities To determine the status of a pull request review comment thread, you must use the GitHub GraphQL API [1][2][3]. The pullRequest object contains a reviewThreads connection that exposes the following fields for each thread [1][2]: - isResolved: A boolean indicating whether the conversation thread is marked as resolved [1][2][3]. - isOutdated: A boolean indicating whether the thread is considered outdated due to subsequent code changes [2][3]. - id: The unique GraphQL node ID for the thread (e.g., starting with PRRT_), which is required if you wish to perform mutations such as resolving the thread [1][2][3]. Integration Strategy Because the REST API and GraphQL API use different identifiers, developers typically map them by using the REST API comment.id, which corresponds to the databaseId field of the comment within the GraphQL reviewThreads node [1][2]. By querying the GraphQL API for the reviewThreads of a pull request, you can access the necessary state fields (isResolved, isOutdated) and link them to your existing REST-based data [2][3]. Mutations to resolve a thread can only be performed via the GraphQL resolveReviewThread mutation using the thread's node ID [1][2][3].\n\nCitations:\n\n- 1: https://github.com/hideki5123/agent-skill-set/blob/master/self-pr-review/references/gh-comment-api.md\n- 2: https://github.com/WhatIfWeDigDeeper/agent-skills/blob/9a0e8cdf9673bdd212d538adb9fcaeeab473ae74/skills/pr-comments/SKILL.md\n- 3: https://github.com/majiayu000/claude-skill-registry/blob/main/skills/data/using-github-api-with-gh-cli/SKILL.md\n- 4: https://docs.github.com/en/rest/pulls/comments?apiVersion=2022-11-28\n- 5: https://docs.github.com/rest/pulls/comments\n- 6: https://docs.github.com/en/enterprise-server@3.21/rest/pulls/comments\n\n---\n\n🏁 Script executed:\n\n```shell\n#!/bin/bash\nset -eu\n\npython3 - <<'PY'\nimport json\nimport urllib.request\n\nurls = {\n    \"rest\": \"https://docs.github.com/en/rest/pulls/comments?apiVersion=2022-11-28\",\n    \"graphql\": \"https://docs.github.com/en/graphql/reference/objects#reviewthread\",\n}\n\nfor name, url in urls.items():\n    print(f\"--- {name}: {url} ---\")\n    try:\n        with urllib.request.urlopen(url, timeout=15) as response:\n            text = response.read().decode(\"utf-8\", \"replace\")\n        terms = (\"created_at\", \"original_commit_id\", \"commit_id\",\n                 \"isResolved\", \"isOutdated\", \"outdated\")\n        lines = text.splitlines()\n        for i, line in enumerate(lines):\n            if any(term in line for term in terms):\n                start = max(0, i - 2)\n                end = min(len(lines), i + 3)\n                print(\"\\n\".join(lines[start:end]))\n    except Exception as exc:\n        print(f\"request failed: {exc}\")\nPY\n```\n\nRepository: ejc3/fcvm\n\nLength of output: 615\n\n---\n\n🌐 Web query:\n\n`site:docs.github.com/en/graphql/reference/objects ReviewThread isResolved isOutdated outdated resolved independently`\n\n💡 Result:\n\nIn GitHub’s GraphQL API, `ReviewThread.isResolved` and `ReviewThread.isOutdated` are **independent states**:\n\n- `isResolved`: whether someone explicitly resolved the review thread.\n- `isOutdated`: whether newer changes made the thread’s original code location outdated. ([docs.github.com](https://docs.github.com/es/enterprise-server%403.17/graphql/reference/objects?utm_source=openai))\n\nTherefore, all combinations are possible:\n\n| `isResolved` | `isOutdated` | Meaning |\n|---|---|---|\n| `false` | `false` | Active, unresolved comment |\n| `true` | `false` | Resolved comment on current code |\n| `false` | `true` | Outdated but not explicitly resolved |\n| `true` | `true` | Both outdated and resolved |\n\nTo determine whether a thread still requires attention, typically filter for:\n\n```graphql\nisResolved: false\n```\n\nOptionally also inspect `isOutdated`, depending on whether outdated unresolved threads matter to your workflow.\n\nCitations:\n\n- 1: https://docs.github.com/es/enterprise-server%403.17/graphql/reference/objects?utm_source=openai\n\n---\n\n\n\n</details>\n\n**Do not treat `created_at` as proof of resolution.**\n\n`created_at` only shows that the comment predates the fix commit. An unresolved thread can also become outdated or re-anchor after later changes. Track each comment by `id` and body, then inspect `ReviewThread.isResolved` and `ReviewThread.isOutdated` before excluding it. `isOutdated: true` does not imply `isResolved: true`.\n\n<details>\n<summary>🤖 Prompt for AI Agents</summary>\n\n```\nVerify each finding against current code. Fix only still-valid issues, skip the\nrest with a brief reason, keep changes minimal, and validate.\n\nIn @.claude/CLAUDE.md around lines 771 - 781, Update the GitHub review-comment\nguidance around comment identity to avoid treating created_at or\noriginal_commit_id as proof that a finding was resolved. Track each comment by\nid and body, then inspect ReviewThread.isResolved and ReviewThread.isOutdated;\nexclude comments only when resolved, while retaining outdated but unresolved\nthreads for action.\n```\n\n</details>\n\n<!-- fingerprinting:phantom:triton:caracal -->\n\n<!-- cr-indicator-types:potential_issue -->\n\n<!-- cr-comment:v1:dd97fe5846c498b716f9c4d8 -->\n\n<!-- This is an auto-generated comment by CodeRabbit -->"
+                  }
+                ]
+              }
+            },
+            {
+              "isResolved": false,
+              "isOutdated": true,
+              "comments": {
+                "nodes": [
+                  {
+                    "author": {
+                      "login": "chatgpt-codex-connector"
+                    },
+                    "path": ".claude/CLAUDE.md",
+                    "line": null,
+                    "originalLine": 754,
+                    "body": "**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub>  Paginate the inline review-comment request**\n\nOn PRs with more than one page of review comments, this request returns only the first page, so the mandatory pre-merge audit can silently omit findings accumulated during earlier review rounds. The installed [`gh api` documentation](https://cli.github.com/manual/gh_api) states that all pages are requested only in `--paginate` mode; add that flag before treating this output as all inline comments.\n\nAGENTS.md reference: [AGENTS.md:L747-L750](https://github.com/ejc3/fcvm/blob/ec99904cb6c354eceec0bbafeaf04af29ac1597e/AGENTS.md#L747-L750)\n\nUseful? React with 👍 / 👎."
+                  }
+                ]
+              }
+            },
+            {
+              "isResolved": false,
+              "isOutdated": true,
+              "comments": {
+                "nodes": [
+                  {
+                    "author": {
+                      "login": "chatgpt-codex-connector"
+                    },
+                    "path": ".claude/CLAUDE.md",
+                    "line": null,
+                    "originalLine": 754,
+                    "body": "**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Print the complete inline finding bodies**\n\nWhen an inline comment exceeds 200 characters, this slice discards the remainder even though the surrounding instruction requires reading every finding; the omitted portion commonly contains the affected scenario, evidence, or suggested correction needed to decide whether merging is safe. Print `.body` without `[0:200]` rather than presenting a preview as the findings themselves.\n\nAGENTS.md reference: [AGENTS.md:L756-L758](https://github.com/ejc3/fcvm/blob/ec99904cb6c354eceec0bbafeaf04af29ac1597e/AGENTS.md#L756-L758)\n\nUseful? React with 👍 / 👎."
+                  }
+                ]
+              }
+            },
+            {
+              "isResolved": false,
+              "isOutdated": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "author": {
+                      "login": "chatgpt-codex-connector"
+                    },
+                    "path": ".claude/CLAUDE.md",
+                    "line": 838,
+                    "originalLine": 780,
+                    "body": "**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub>  Do not equate an older comment with an addressed finding**\n\nWhen a fix commit addresses only some of several existing findings, every older comment still has a `created_at` before that commit, including the unresolved ones; following this rule would therefore classify unfixed blockers as addressed and permit them to be merged. `original_commit_id` and `created_at` establish that a comment is old or re-anchored, not that its concern was fixed, so the workflow must correlate the comment with the actual fix or its resolved state.\n\nAGENTS.md reference: [AGENTS.md:L771-L776](https://github.com/ejc3/fcvm/blob/ec99904cb6c354eceec0bbafeaf04af29ac1597e/AGENTS.md#L771-L776)\n\nUseful? React with 👍 / 👎."
+                  }
+                ]
+              }
+            },
+            {
+              "isResolved": false,
+              "isOutdated": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "author": {
+                      "login": "coderabbitai"
+                    },
+                    "path": "scripts/check-review-threads.sh",
+                    "line": 30,
+                    "originalLine": 30,
+                    "body": "_🎯 Functional Correctness_ | _🟠 Major_ | _⚡ Quick win_\n\n<details>\n<summary>🧩 Analysis chain</summary>\n\n🏁 Script executed:\n\n```shell\n#!/bin/bash\nset -euo pipefail\n\ncursor='cursor'\nafter=\", after: \\\\\\\"$cursor\\\\\\\"\"\nprintf 'current expansion: <%s>\\n' \"$after\"\ntest \"$after\" = ', after: \"cursor\"'\n```\n\nRepository: ejc3/fcvm\n\nLength of output: 188\n\n---\n\n🏁 Script executed:\n\n```shell\n#!/bin/bash\nset -euo pipefail\n\nprintf '--- file excerpt ---\\n'\nsed -n '1,80p' scripts/check-review-threads.sh | cat -n\n\nprintf '\\n--- occurrences of after/cursor ---\\n'\nrg -n 'after|cursor' scripts/check-review-threads.sh || true\n```\n\nRepository: ejc3/fcvm\n\nLength of output: 238\n\n---\n\n🏁 Script executed:\n\n```shell\n#!/bin/bash\nset -euo pipefail\n\nprintf '%s\\n' '--- file excerpt ---'\nsed -n '1,80p' scripts/check-review-threads.sh | cat -n\n\nprintf '%s\\n' ''\nprintf '%s\\n' '--- occurrences of after/cursor ---'\nrg -n 'after|cursor' scripts/check-review-threads.sh || true\n```\n\nRepository: ejc3/fcvm\n\nLength of output: 4810\n\n---\n\n\n\n</details>\n\n**Fix the cursor quoting before paginating review threads.**\n\nLine 30 expands the cursor as `after: \\\"<cursor>\\\"`, so pagination sends escaped quotes into the GraphQL argument. The request fails when more threads remain and the script exits without detecting unresolved threads.\n\n<details>\n<summary>Proposed fix</summary>\n\n```diff\n-    [ \"$cursor\" != \"null\" ] && after=\", after: \\\\\\\"$cursor\\\\\\\"\"\n+    [ \"$cursor\" != \"null\" ] && after=\", after: \\\"$cursor\\\"\"\n```\n</details>\n\n<!-- suggestion_start -->\n\n<details>\n<summary>📝 Committable suggestion</summary>\n\n> ‼️ **IMPORTANT**\n> Carefully review the code before committing. Ensure that it accurately replaces the highlighted code, contains no missing lines, and has no issues with indentation. Thoroughly test & benchmark the code to ensure it meets the requirements.\n\n```suggestion\n    [ \"$cursor\" != \"null\" ] && after=\", after: \\\"$cursor\\\"\"\n```\n\n</details>\n\n<!-- suggestion_end -->\n\n<details>\n<summary>🤖 Prompt for AI Agents</summary>\n\n```\nVerify each finding against current code. Fix only still-valid issues, skip the\nrest with a brief reason, keep changes minimal, and validate.\n\nIn `@scripts/check-review-threads.sh` at line 30, Correct the cursor construction\nin the review-thread pagination logic so the GraphQL after argument contains\nnormal quoted cursor text rather than backslash-escaped quotes. Update the after\nassignment guarded by the cursor null check, preserving the existing pagination\nbehavior for null and non-null cursors.\n```\n\n</details>\n\n<!-- fingerprinting:phantom:poseidon:tapir -->\n\n<!-- cr-indicator-types:potential_issue -->\n\n<!-- cr-comment:v1:93a5852b79fa634bf25cdbf8 -->\n\n<!-- This is an auto-generated comment by CodeRabbit -->"
+                  }
+                ]
+              }
+            },
+            {
+              "isResolved": false,
+              "isOutdated": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "author": {
+                      "login": "coderabbitai"
+                    },
+                    "path": "scripts/check-review-threads.sh",
+                    "line": 38,
+                    "originalLine": 38,
+                    "body": "_🎯 Functional Correctness_ | _🟠 Major_ | _⚡ Quick win_\n\n<details>\n<summary>🧩 Analysis chain</summary>\n\n🏁 Script executed:\n\n```shell\n#!/bin/bash\nset -euo pipefail\n\nrg -n 'comments\\(first: 1\\)|RED-VERIFIED' scripts/check-review-threads.sh\njq -e '\n  .data.repository.pullRequest.reviewThreads.nodes[0].comments.nodes\n  | length == 2\n' tests/fixtures/review-threads-resolved-proven.json\n```\n\nRepository: ejc3/fcvm\n\nLength of output: 571\n\n---\n\n🏁 Script executed:\n\n```shell\n#!/bin/bash\nset -euo pipefail\n\nprintf '--- script outline/stat ---\\n'\nwc -l scripts/check-review-threads.sh\nprintf '\\n--- relevant script sections ---\\n'\nsed -n '1,130p' scripts/check-review-threads.sh | cat -n\n\nprintf '\\n--- fixture thread snippets ---\\n'\njq -c '.data.repository.pullRequest.reviewThreads.nodes[0]' tests/fixtures/review-threads-resolved-proven.json | python3 -c \"\nimport sys,json\nd=json.load(sys.stdin)\nprint('state:', d.get('state'))\nprint('comment_count:', d.get('comments',{}).get('totalCount'))\ncomments=d.get('comments',{}).get('nodes',[])\nfor i,c in enumerate(comments):\n    print('comment', i, 'author=', c.get('author',{}).get('login'), 'state=', c.get('state'), 'stateReason=', c.get('stateReason'), 'body_first=', repr((c.get('body') or '')[:200].replace('\\\\n',' ')))\n\"\nprintf '\\n--- all fixtures with RED-VERIFIED ---\\n'\nrg -n 'RED-VERIFIED' tests fixtures scripts || true\nprintf '\\n--- query string usage ---\\n'\nrg -n 'comments|reviewThreads|RED-VERIFIED' scripts/check-review-threads.sh tests -g '*.json' -g '*.sh' | sed -n '1,200p'\n```\n\nRepository: ejc3/fcvm\n\nLength of output: 238\n\n---\n\n🏁 Script executed:\n\n```shell\n#!/bin/bash\nset -euo pipefail\n\necho '--- script outline/stat ---'\nwc -l scripts/check-review-threads.sh\n\necho '--- relevant script sections ---'\nsed -n '1,130p' scripts/check-review-threads.sh | cat -n\n\necho '--- fixture thread snippets ---'\njq -c '.data.repository.pullRequest.reviewThreads.nodes[0]' tests/fixtures/review-threads-resolved-proven.json | python3 - <<'PY'\nimport sys, json\nd = json.load(sys.stdin)\nprint('state:', d.get('state'))\ncomments = d.get('comments', {}).get('nodes', [])\nprint('comment_count:', d.get('comments', {}).get('totalCount'))\nfor i, c in enumerate(comments):\n    print('comment', i,\n          'author=', c.get('author', {}).get('login'),\n          'state=', c.get('state'),\n          'stateReason=', c.get('stateReason'),\n          'body_first=', repr((c.get('body') or '')[:200].strip()))\nPY\n\necho '--- query shape around first/firstReply/lastReply ---'\nrg -n 'comments\\\\(|first: 1|firstReply|lastReply|totalCommentCount|reviewThreads' scripts/check-review-threads.sh tests/fixtures -g '*.json' -g '*.sh' | sed -n '1,220p'\n```\n\nRepository: ejc3/fcvm\n\nLength of output: 6543\n\n---\n\n🏁 Script executed:\n\n```shell\n#!/bin/bash\nset -euo pipefail\n\necho '--- read-only behavioral probe ---'\npython3 - <<'PY'\nimport json\nfrom pathlib import Path\nfixture = Path('tests/fixtures/review-threads-resolved-proven.json').read_text()\ndata = json.loads(fixture)\nnode = data['data']['repository']['pullRequest']['reviewThreads']['nodes'][0]\nprint('state:', node.get('state'))\ncomments = node.get('comments', {})\nprint('commentCount:', comments.get('commentCount'))\nprint('nodes requested:', len(comments.get('nodes', [])))\nnode_comments = [c['body'] for c in comments.get('nodes', [])]\nall_comment_bodies = []\nfor thread in data['data']['repository']['pullRequest']['reviewThreads']['nodes']:\n    all_comment_bodies.extend(c['body'] for c in thread.get('comments', {}).get('nodes', []))\nprint('resolved_contains_one_comment:', any(\n    (len(thread.get('comments', {}).get('nodes',[])) >= 1 and thread.get('state')=='RESOLVED')\n    for thread in data['data']['repository']['pullRequest']['reviewThreads']['nodes']\n))\nprint('all_review_thread_comment_bodies_have_red_verified:' , any('RED-VERIFIED:' in body.upper() for body in all_comment_bodies))\nprint('queries_match_node_comment_count:', all(\n    f'comments(first: {len(c.get(\"nodes\", []))})' in fixture\n    for c in [json.loads(fragment) if isinstance(c, str) else c for fragment in [\n        json.dumps(node)\n    ]]\n))\nPY\n\necho '--- all fixtures with RED-VERIFIED or resolved threads ---'\nrg -n '\"state\"|\"RED-VERIFIED\"|RESOLVED|resolved' tests/fixtures -g '*.json' | sed -n '1,240p'\n```\n\nRepository: ejc3/fcvm\n\nLength of output: 476\n\n---\n\n🌐 Web query:\n\n`GitHub GraphQL ReviewThread comments connection first field default firstComment`\n\n💡 Result:\n\nIn the GitHub GraphQL API, the `comments` field on a `PullRequestReviewThread` is a connection that supports pagination via arguments including `first`, `last`, `after`, and `before` [1][2][3]. There is no specific default value for the `first` argument defined by the GraphQL specification itself or the GitHub API schema; rather, it is an optional parameter [1][2][3]. If you do not provide a value for `first` (or `last`), the connection will typically return a default number of items defined by the GitHub API's internal implementation, or you may receive an error if the schema requires pagination arguments to be explicitly defined for that connection. In practice, developers frequently specify a value (e.g., `first: 100`) to ensure predictable pagination behavior [4][5][6]. If you omit the argument, the API does not guarantee a specific number of items, and relying on implicit defaults is generally discouraged in favor of explicit pagination control [4][6].\n\nCitations:\n\n- 1: https://docs.github.com/enterprise/2.10/developer/v4/object/pullrequestreviewthread\n- 2: https://bryanburgers.github.io/docql/github/object.PullRequestReviewThread.html\n- 3: https://2fd.github.io/graphdoc/github/pullrequestreviewthread.doc.html\n- 4: https://github.com/hideki5123/agent-skill-set/blob/master/address-pr-comments/references/gh-comment-api.md\n- 5: https://github.com/Nittarab/gh-pr-reviews/blob/main/api.go\n- 6: https://cdn.jsdelivr.net/npm/github-pr-automation@0.5.2/src/tools/find-unresolved-comments/lib/graphql-fetcher.ts\n\n---\n\n\n\n</details>\n\n**Fetch all thread comments before checking `RED-VERIFIED` evidence.**\n\nLine 38 limits each thread to one comment. A resolved thread can be valid when the first comment describes the defect and a later reply contains `RED-VERIFIED`. Query the full comments connection, then require `RED-VERIFIED:` in any reply comment. Do not treat the initial defect comment as satisfying its own proof requirement. Also update the resolved-thread checks at lines 84-94.\n\n<details>\n<summary>🤖 Prompt for AI Agents</summary>\n\n```\nVerify each finding against current code. Fix only still-valid issues, skip the\nrest with a brief reason, keep changes minimal, and validate.\n\nIn `@scripts/check-review-threads.sh` at line 38, Update the GraphQL query in\nscripts/check-review-threads.sh to fetch all comments for each thread instead of\nlimiting comments to one node. In the resolved-thread validation around the\nexisting checks at lines 84-94, require a later reply comment—not the initial\ndefect comment—to contain `RED-VERIFIED:` before accepting the thread as valid.\n```\n\n</details>\n\n<!-- fingerprinting:phantom:poseidon:tapir -->\n\n<!-- cr-indicator-types:potential_issue -->\n\n<!-- cr-comment:v1:f4a23a207e12164d7a6d2393 -->\n\n<!-- This is an auto-generated comment by CodeRabbit -->"
+                  }
+                ]
+              }
+            },
+            {
+              "isResolved": false,
+              "isOutdated": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "author": {
+                      "login": "coderabbitai"
+                    },
+                    "path": "scripts/check-review-threads.sh",
+                    "line": 56,
+                    "originalLine": 56,
+                    "body": "_🎯 Functional Correctness_ | _🟠 Major_ | _⚡ Quick win_\n\n**Fail closed when thread data is invalid.**\n\nIf `jq` cannot read the fixture, or GitHub returns a GraphQL error payload without `reviewThreads.nodes`, this path can continue with empty data and print `CLEAR`. Exit with an error unless the response contains a valid thread array. Apply the same validation inside `fetch_threads`.\n\n<details>\n<summary>🤖 Prompt for AI Agents</summary>\n\n```\nVerify each finding against current code. Fix only still-valid issues, skip the\nrest with a brief reason, keep changes minimal, and validate.\n\nIn `@scripts/check-review-threads.sh` around lines 48 - 56, Validate that the\n`--from-file` result and `fetch_threads` response each contain a valid\n`.data.repository.pullRequest.reviewThreads.nodes` array before calculating\n`total` or `unresolved`. Make jq parse failures, missing paths, non-array\nvalues, and GraphQL error payloads exit nonzero with an error instead of\ncontinuing to `CLEAR`; apply the validation within `fetch_threads` as well as\nthe main flow.\n```\n\n</details>\n\n<!-- fingerprinting:phantom:poseidon:tapir -->\n\n<!-- cr-indicator-types:potential_issue -->\n\n<!-- cr-comment:v1:ab1f5506002a94d0908cd1cb -->\n\n<!-- This is an auto-generated comment by CodeRabbit -->"
+                  }
+                ]
+              }
+            },
+            {
+              "isResolved": false,
+              "isOutdated": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "author": {
+                      "login": "coderabbitai"
+                    },
+                    "path": "scripts/scan-test-log.sh",
+                    "line": 41,
+                    "originalLine": 41,
+                    "body": "_🎯 Functional Correctness_ | _🟡 Minor_ | _⚡ Quick win_\n\n**Anchor retry matching on the nextest verdict form.**\n\n`TRY [0-9]+ FAIL` also matches test output. A test can print this text and cause a false FLAKY verdict. Require `FAIL [` to identify a nextest retry verdict.\n\n<details>\n<summary>Proposed fix</summary>\n\n```diff\n-try_fail=$(count 'TRY [0-9]+ FAIL')\n+try_fail=$(count '(^|[^A-Z])TRY [0-9]+ FAIL \\[')\n```\n</details>\n\n<!-- suggestion_start -->\n\n<details>\n<summary>📝 Committable suggestion</summary>\n\n> ‼️ **IMPORTANT**\n> Carefully review the code before committing. Ensure that it accurately replaces the highlighted code, contains no missing lines, and has no issues with indentation. Thoroughly test & benchmark the code to ensure it meets the requirements.\n\n```suggestion\ntry_fail=$(count '(^|[^A-Z])TRY [0-9]+ FAIL \\[')\n```\n\n</details>\n\n<!-- suggestion_end -->\n\n<details>\n<summary>🤖 Prompt for AI Agents</summary>\n\n```\nVerify each finding against current code. Fix only still-valid issues, skip the\nrest with a brief reason, keep changes minimal, and validate.\n\nIn `@scripts/scan-test-log.sh` at line 41, Update the try_fail pattern in the\nscan-test-log counting logic to match the nextest verdict form with “FAIL [”\nrather than the ambiguous “TRY … FAIL” text, preventing ordinary test output\nfrom being counted as retry failures.\n```\n\n</details>\n\n<!-- fingerprinting:phantom:poseidon:tapir -->\n\n<!-- cr-indicator-types:potential_issue -->\n\n<!-- cr-comment:v1:301ca400c670c856151976b5 -->\n\n<!-- This is an auto-generated comment by CodeRabbit -->"
+                  }
+                ]
+              }
+            },
+            {
+              "isResolved": false,
+              "isOutdated": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "author": {
+                      "login": "coderabbitai"
+                    },
+                    "path": "scripts/scan-test-log.sh",
+                    "line": 70,
+                    "originalLine": 70,
+                    "body": "_🎯 Functional Correctness_ | _🟠 Major_ | _⚡ Quick win_\n\n**Parse the summary result before emitting CLEAN.**\n\nA log containing only `Summary [...] 1 tests run: 0 passed, 1 failed` reaches line 69 and exits CLEAN. The scanner checks only that a summary exists. Per-test FAIL lines can be absent from a truncated or filtered log.\n\n- `scripts/scan-test-log.sh#L60-L70`: Parse the summary counts or status. Emit FAILED when it reports failures. Emit UNKNOWN when the summary cannot be validated.\n- `tests/test_log_scan.rs#L137-L153`: Add a fixture with a failed summary and no `FAIL [` line. Assert that the scanner does not emit CLEAN.\n\n<details>\n<summary>📍 Affects 2 files</summary>\n\n- `scripts/scan-test-log.sh#L60-L70` (this comment)\n- `tests/test_log_scan.rs#L137-L153`\n\n</details>\n\n<details>\n<summary>🤖 Prompt for AI Agents</summary>\n\n```\nVerify each finding against current code. Fix only still-valid issues, skip the\nrest with a brief reason, keep changes minimal, and validate.\n\nIn `@scripts/scan-test-log.sh` around lines 60 - 70, Update the summary evaluation\nin scripts/scan-test-log.sh lines 60-70 to parse and validate the summary counts\nor status before emitting CLEAN; emit FAILED when the summary reports failures\nand UNKNOWN when it cannot be validated. Add a tests/test_log_scan.rs lines\n137-153 fixture containing a failed summary without any FAIL [ line, and assert\nthe scanner does not emit CLEAN.\n```\n\n</details>\n\n<!-- consolidated_sites_start -->\n<!--\n<consolidated_sites>\n<site>\n<role>anchor</role>\n<file>scripts/scan-test-log.sh</file>\n<line_range>60-70</line_range>\n</site>\n<site>\n<role>sibling</role>\n<file>tests/test_log_scan.rs</file>\n<line_range>137-153</line_range>\n</site>\n</consolidated_sites>\n-->\n<!-- consolidated_sites_end -->\n\n<!-- fingerprinting:phantom:poseidon:tapir -->\n\n<!-- cr-indicator-types:potential_issue -->\n\n<!-- cr-comment:v1:ebe62855ca925ef24003e994 -->\n\n<!-- This is an auto-generated comment by CodeRabbit -->"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/review-threads-resolved-proven.json
+++ b/tests/fixtures/review-threads-resolved-proven.json
@@ -1,0 +1,6 @@
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+ {"isResolved":true,"isOutdated":false,"comments":{"nodes":[
+   {"author":{"login":"chatgpt-codex-connector"},"path":"src/uffd/prefetch.rs","line":196,"originalLine":196,"body":"P1: indexing the snapshot mapping can panic inside the fault-handler task and hang the guest."},
+   {"author":{"login":"ejc3"},"path":"src/uffd/prefetch.rs","line":196,"originalLine":196,"body":"Fixed in 7672df92. RED-VERIFIED: a_corrupt_working_set_falls_back_to_on_demand_faulting — confirmed failing with the checked get() reverted."}
+ ]}}
+]}}}}}

--- a/tests/fixtures/review-threads-resolved-unproven.json
+++ b/tests/fixtures/review-threads-resolved-unproven.json
@@ -1,0 +1,6 @@
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+ {"isResolved":true,"isOutdated":false,"comments":{"nodes":[
+   {"author":{"login":"chatgpt-codex-connector"},"path":"src/uffd/prefetch.rs","line":196,"originalLine":196,"body":"P1: indexing the snapshot mapping can panic inside the fault-handler task and hang the guest."},
+   {"author":{"login":"ejc3"},"path":"src/uffd/prefetch.rs","line":196,"originalLine":196,"body":"Fixed in 7672df92 — now uses a checked get()."}
+ ]}}
+]}}}}}

--- a/tests/fixtures/review-threads-selfproof.json
+++ b/tests/fixtures/review-threads-selfproof.json
@@ -1,0 +1,5 @@
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+ {"isResolved":true,"isOutdated":false,"comments":{"nodes":[
+   {"author":{"login":"chatgpt-codex-connector"},"path":"src/uffd/prefetch.rs","line":196,"originalLine":196,"body":"P1: this can panic inside the fault handler and hang the guest. Policy note: resolutions require a RED-VERIFIED: <test> reply."}
+ ]}}
+]}}}}}

--- a/tests/fixtures/review-threads-unresolved.json
+++ b/tests/fixtures/review-threads-unresolved.json
@@ -1,0 +1,5 @@
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+ {"isResolved":true,"isOutdated":true,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"path":"src/uffd/server.rs","line":216,"originalLine":210,"body":"Already handled in a follow-up commit."}]}},
+ {"isResolved":false,"isOutdated":true,"comments":{"nodes":[{"author":{"login":"chatgpt-codex-connector"},"path":"src/uffd/prefetch.rs","line":196,"originalLine":179,"body":"P1: indexing the mapping can panic inside the fault handler and hang the guest."}]}},
+ {"isResolved":false,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"path":"tests/test_snapshot_clone.rs","line":2413,"originalLine":2413,"body":"Leaks two clone VMs when an assertion trips."}]}}
+]}}}}}

--- a/tests/test_log_scan.rs
+++ b/tests/test_log_scan.rs
@@ -1,0 +1,212 @@
+//! Executable guards for the log-scanning and review-gate footguns.
+//!
+//! Each of these pins a mistake that has actually shipped and reported green.
+//! They are written to go RED if the underlying pattern regresses — a doc that
+//! says "don't use `grep '^ *FAIL'`" cannot fire; these can.
+//!
+//! Every assertion here was confirmed to fail with the corresponding fix
+//! reverted (see the PR body for the observed failure output).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn run_scan(log: &Path) -> (String, i32) {
+    let out = Command::new("bash")
+        .arg(repo_root().join("scripts/scan-test-log.sh"))
+        .arg(log)
+        .output()
+        .expect("scan-test-log.sh must be runnable");
+    let mut s = String::from_utf8_lossy(&out.stdout).into_owned();
+    s.push_str(&String::from_utf8_lossy(&out.stderr));
+    (s, out.status.code().unwrap_or(-1))
+}
+
+fn field(out: &str, key: &str) -> i64 {
+    out.lines()
+        .find_map(|l| l.strip_prefix(&format!("{key}: ")))
+        .unwrap_or_else(|| panic!("scan output has no `{key}:` field:\n{out}"))
+        .trim()
+        .parse()
+        .unwrap_or_else(|e| panic!("`{key}` is not a number ({e}):\n{out}"))
+}
+
+/// THE trap: nextest writes a retry as `TRY 1 FAIL`, so `grep '^ *FAIL'` matches
+/// none of them. A test that failed and then passed on retry disappears into a
+/// green total — which is precisely how a flake survives review.
+#[test]
+fn a_retry_is_counted_as_a_retry_and_not_lost() {
+    let log = repo_root().join("tests/fixtures/nextest-flaky.log");
+    let (out, code) = run_scan(&log);
+
+    assert_eq!(
+        field(&out, "try_fail"),
+        1,
+        "the `TRY 1 FAIL` line must be counted. If this is 0, the pattern has \
+         regressed to something that cannot see retries, and every flake will \
+         now report as a clean pass.\n{out}"
+    );
+    // Assert the SPECIFIC verdict, not merely "nonzero". An earlier version used
+    // `assert_ne!(code, 0)` and passed for the wrong reason: dropping the literal
+    // `^[` ANSI strip made the summary line unparseable, so the verdict silently
+    // became UNKNOWN (exit 3) instead of FLAKY (exit 1) — still nonzero, still
+    // "passing", while the scanner had in fact stopped understanding the log.
+    assert_eq!(
+        code, 1,
+        "a run containing a retry must be reported FLAKY (exit 1), not clean and \
+         not UNKNOWN. Exit 3 here means the summary line was not parsed — check \
+         that BOTH ANSI encodings are still being stripped.\n{out}"
+    );
+    assert!(
+        out.contains("verdict: FLAKY"),
+        "the verdict must name the flake explicitly.\n{out}"
+    );
+    // The fixture's summary is wrapped in the literal `^[` ANSI form produced by
+    // `gh run view --log`. If stripping regresses to real-ESC only, this line
+    // stops matching and the whole scan degrades to UNKNOWN.
+    assert!(
+        out.contains("681 tests run"),
+        "the summary must be parsed out of literal `^[`-encoded ANSI.\n{out}"
+    );
+}
+
+/// Test bodies print their own `PASSED:` lines. Counting `grep -c PASS` mixes
+/// those with nextest's verdicts — measured once at 136 against a real 119.
+#[test]
+fn test_internal_passed_lines_do_not_inflate_the_verdict_count() {
+    let log = repo_root().join("tests/fixtures/nextest-flaky.log");
+    let (out, _) = run_scan(&log);
+
+    // The fixture has exactly 3 `PASS [` verdicts and 4 test-internal
+    // "PASSED:"/"PASSED!" lines that must not be counted.
+    assert_eq!(
+        field(&out, "pass"),
+        3,
+        "only `PASS [` verdicts count. A higher number means the pattern is \
+         also matching the `PASSED:` lines test bodies print themselves.\n{out}"
+    );
+}
+
+/// `TRY 1 FAIL [` also ends in ` FAIL [`, so a naive hard-failure pattern
+/// double-reports every retry as a hard failure.
+#[test]
+fn a_retry_is_not_also_counted_as_a_hard_failure() {
+    let log = repo_root().join("tests/fixtures/nextest-flaky.log");
+    let (out, _) = run_scan(&log);
+
+    assert_eq!(
+        field(&out, "fail"),
+        0,
+        "the fixture contains no hard `FAIL [` verdict — only a retry. A nonzero \
+         count means `TRY n FAIL` is being double-counted as a hard failure.\n{out}"
+    );
+}
+
+/// Logs arrive with real ESC bytes locally and the literal two-character `^[`
+/// form from `gh run view --log`. Both must be stripped or every pattern
+/// silently misses.
+#[test]
+fn both_ansi_encodings_are_stripped() {
+    let dir = std::env::temp_dir().join(format!("fcvm-logscan-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let log = dir.join("real-esc.log");
+    // Real ESC (0x1b) rather than the caret form used in the checked-in fixture.
+    let body = format!(
+        "{esc}[35;1m  TRY 1 FAIL{esc}[0m [   2.9s] (--) fcvm::t test_x\n\
+         {esc}[32;1m     Summary{esc}[0m [ 10.0s] 1 tests run: 1 passed, 0 skipped\n",
+        esc = '\u{1b}'
+    );
+    std::fs::write(&log, body).unwrap();
+
+    let (out, _) = run_scan(&log);
+    assert_eq!(
+        field(&out, "try_fail"),
+        1,
+        "a retry wrapped in real ESC sequences must still be seen.\n{out}"
+    );
+    assert!(
+        out.contains("1 tests run"),
+        "the summary line must survive ANSI stripping.\n{out}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A run with no summary line is UNKNOWN, never CLEAN. GitHub will not serve
+/// job logs until the whole run completes, so a truncated log is a normal thing
+/// to be handed — and reporting it clean is how a half-finished run gets merged.
+#[test]
+fn a_log_without_a_summary_is_never_reported_clean() {
+    let dir = std::env::temp_dir().join(format!("fcvm-logscan-nosum-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let log = dir.join("truncated.log");
+    std::fs::write(&log, "        PASS [   0.01s] (1/2) fcvm::t test_a\n").unwrap();
+
+    let (out, code) = run_scan(&log);
+    assert_ne!(code, 0, "a truncated log must not exit 0:\n{out}");
+    assert!(
+        out.contains("UNKNOWN"),
+        "a missing summary must be reported as UNKNOWN, not CLEAN.\n{out}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ---------------------------------------------------------------------------
+// Review-thread gate
+// ---------------------------------------------------------------------------
+
+fn run_threads(fixture: &str) -> (String, i32) {
+    let out = Command::new("bash")
+        .arg(repo_root().join("scripts/check-review-threads.sh"))
+        .arg("--from-file")
+        .arg(repo_root().join("tests/fixtures").join(fixture))
+        .output()
+        .expect("check-review-threads.sh must be runnable");
+    let mut s = String::from_utf8_lossy(&out.stdout).into_owned();
+    s.push_str(&String::from_utf8_lossy(&out.stderr));
+    (s, out.status.code().unwrap_or(-1))
+}
+
+/// A PR can sit at all-green CI, MERGEABLE, and still carry unanswered findings.
+/// Observed: 15 green checks with 19 unresolved threads. CI state says nothing
+/// about whether a review was answered.
+#[test]
+fn unresolved_review_threads_block_the_merge() {
+    let (out, code) = run_threads("review-threads-unresolved.json");
+    assert_ne!(code, 0, "unresolved threads must block:\n{out}");
+    assert!(
+        out.contains("2 unresolved"),
+        "both unresolved threads must be reported, including the outdated one — \
+         `isOutdated` means the diff moved, not that the finding was handled.\n{out}"
+    );
+}
+
+/// The counterpart: the gate must be able to pass, or it is just a wall.
+#[test]
+fn a_fully_resolved_pr_passes_the_gate() {
+    let (out, code) = run_threads("review-threads-clear.json");
+    assert_eq!(code, 0, "an all-resolved PR must pass:\n{out}");
+    assert!(out.contains("CLEAR"), "{out}");
+}
+
+/// Resolving a "this is broken" finding requires citing a test that was watched
+/// failing. Closing it on the same judgement that shipped the bug is not proof.
+#[test]
+fn a_resolved_defect_claim_without_a_red_test_blocks_the_merge() {
+    let (out, code) = run_threads("review-threads-resolved-unproven.json");
+    assert_ne!(
+        code, 0,
+        "a resolved thread describing a panic, with no RED-VERIFIED reply, must \
+         block — otherwise a defect is closed by assertion.\n{out}"
+    );
+    assert!(out.contains("UNPROVEN"), "{out}");
+}
+
+/// ...and citing the test clears it, so the rule is satisfiable.
+#[test]
+fn a_resolved_defect_claim_with_a_red_test_is_accepted() {
+    let (out, code) = run_threads("review-threads-resolved-proven.json");
+    assert_eq!(code, 0, "a RED-VERIFIED reply must satisfy the gate:\n{out}");
+}

--- a/tests/test_log_scan.rs
+++ b/tests/test_log_scan.rs
@@ -338,3 +338,116 @@ fn a_defect_report_cannot_serve_as_its_own_red_verification() {
     );
     assert!(out.contains("UNPROVEN"), "{out}");
 }
+
+/// The run's OWN summary is authoritative — counting per-test lines is not enough.
+///
+/// A truncated or filtered log can carry the summary while every `FAIL [` line is gone.
+/// This scanner then counted zero failures and said CLEAN, exit 0, on a run the summary
+/// itself called failed:
+///   "Summary [10.0s] 1 tests run: 0 passed, 1 failed"  ->  verdict: CLEAN
+/// which is precisely the defect it exists to catch.
+#[test]
+fn a_summary_reporting_failures_is_never_clean() {
+    let dir = std::env::temp_dir().join(format!("fcvm-sumfail-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let log = dir.join("failing-summary.log");
+    std::fs::write(
+        &log,
+        "     Summary [  10.0s] 1 tests run: 0 passed, 1 failed, 0 skipped\n",
+    )
+    .unwrap();
+
+    let (out, code) = run_scan(&log);
+    assert_eq!(
+        code, 1,
+        "a summary reporting failures must exit 1, not 0.\n{out}"
+    );
+    assert!(out.contains("verdict: FAILED"), "{out}");
+    assert!(
+        !out.contains("CLEAN"),
+        "the scanner must not call this run clean.\n{out}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Tests that vanish between "run" and "passed" are not a pass either.
+#[test]
+fn a_summary_with_unaccounted_tests_is_not_clean() {
+    let dir = std::env::temp_dir().join(format!("fcvm-sumgap-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let log = dir.join("unaccounted.log");
+    // 5 run, 3 passed, 0 failed: two tests are simply missing.
+    std::fs::write(
+        &log,
+        "     Summary [ 1.0s] 5 tests run: 3 passed, 0 skipped\n",
+    )
+    .unwrap();
+
+    let (out, code) = run_scan(&log);
+    assert_ne!(
+        code, 0,
+        "3-of-5 passed with 0 failed must not be clean.\n{out}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The retry pattern must anchor on the verdict form, not bare prose.
+#[test]
+fn retry_matching_does_not_fire_on_prose() {
+    let dir = std::env::temp_dir().join(format!("fcvm-prose-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let log = dir.join("prose.log");
+    // A test that PRINTS about retries must not be counted as one.
+    std::fs::write(
+        &log,
+        "    note: the harness will TRY 1 FAIL semantics on the next pass\n\
+             Summary [ 1.0s] 1 tests run: 1 passed, 0 skipped\n",
+    )
+    .unwrap();
+
+    let (out, code) = run_scan(&log);
+    assert_eq!(
+        field(&out, "try_fail"),
+        0,
+        "prose mentioning a retry is not a retry; only `TRY n FAIL [` counts.\n{out}"
+    );
+    assert_eq!(code, 0, "a genuinely clean run must stay clean.\n{out}");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Malformed thread data must BLOCK, exactly like a missing dependency.
+///
+/// `jq` yields `null` for a missing path and an empty string on a parse error, and
+/// `[ "" -gt 0 ]` is a shell error rather than a block — so bad input previously slid
+/// through to CLEAR.
+#[test]
+fn malformed_thread_data_blocks_instead_of_clearing() {
+    let dir = std::env::temp_dir().join(format!("fcvm-malformed-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let f = dir.join("malformed.json");
+    // A thread with no isResolved: the one field that means "resolved".
+    std::fs::write(
+        &f,
+        r#"{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isOutdated":true}]}}}}}"#,
+    )
+    .unwrap();
+
+    let out = Command::new("bash")
+        .arg(repo_root().join("scripts/check-review-threads.sh"))
+        .arg("--from-file")
+        .arg(&f)
+        .output()
+        .expect("script must run");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_ne!(
+        out.status.code().unwrap_or(-1),
+        0,
+        "unparseable thread data must not produce a passing verdict.\n{combined}"
+    );
+    assert!(combined.contains("BLOCKED"), "{combined}");
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/tests/test_log_scan.rs
+++ b/tests/test_log_scan.rs
@@ -157,7 +157,27 @@ fn a_log_without_a_summary_is_never_reported_clean() {
 // Review-thread gate
 // ---------------------------------------------------------------------------
 
+/// Fail with ONE clear message when the gate's own dependency is missing, instead of
+/// six assertion failures whose real cause ("jq: command not found") is buried in the
+/// captured output. This bit for real: `jq` was absent from the CI container, and the
+/// first symptom was six unrelated-looking test failures.
+fn require_jq() {
+    let ok = Command::new("sh")
+        .args(["-c", "command -v jq"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    assert!(
+        ok,
+        "`jq` is not installed, and the review-thread gate cannot run without it. \
+         This is a MISSING DEPENDENCY, not a broken gate — install jq (it is in the \
+         Containerfile for exactly this reason). The gate itself refusing to render a \
+         verdict without jq is covered by `the_gate_blocks_when_it_cannot_run_at_all`."
+    );
+}
+
 fn run_threads(fixture: &str) -> (String, i32) {
+    require_jq();
     let out = Command::new("bash")
         .arg(repo_root().join("scripts/check-review-threads.sh"))
         .arg("--from-file")

--- a/tests/test_log_scan.rs
+++ b/tests/test_log_scan.rs
@@ -213,3 +213,128 @@ fn a_resolved_defect_claim_with_a_red_test_is_accepted() {
         "a RED-VERIFIED reply must satisfy the gate:\n{out}"
     );
 }
+
+/// A gate that cannot run must BLOCK, not pass.
+///
+/// This is a regression test for the gate itself. `jq` is absent from the CI container,
+/// so every `jq` call errored to stderr, the counts came back empty, and the script
+/// printed `verdict: CLEAR` and exited 0 — waving every PR through precisely because it
+/// could not evaluate any of them. Strictly worse than no gate, because it looks like one.
+///
+/// Runs the script with a PATH that genuinely cannot reach `jq`. Note `/bin` is a symlink
+/// to `/usr/bin` on usr-merged systems, so removing one directory from PATH does NOT hide
+/// a tool — the PATH has to be replaced outright.
+#[test]
+fn the_gate_blocks_when_it_cannot_run_at_all() {
+    let empty = std::env::temp_dir().join(format!("fcvm-nodeps-{}", std::process::id()));
+    std::fs::create_dir_all(&empty).unwrap();
+
+    let out = Command::new("/usr/bin/bash")
+        .arg(repo_root().join("scripts/check-review-threads.sh"))
+        .arg("--from-file")
+        .arg(repo_root().join("tests/fixtures/review-threads-unresolved.json"))
+        .env("PATH", &empty) // jq unreachable
+        .output()
+        .expect("script must be runnable");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let code = out.status.code().unwrap_or(-1);
+
+    assert_ne!(
+        code, 0,
+        "with `jq` unreachable the gate MUST NOT exit 0. Exit 0 here means it reported a \
+         verdict it had no ability to compute.\n{combined}"
+    );
+    assert!(
+        !combined.contains("verdict: CLEAR"),
+        "the gate claimed CLEAR while unable to parse anything — fail closed, always.\n{combined}"
+    );
+    assert!(
+        combined.contains("BLOCKED"),
+        "a gate that cannot evaluate must say so explicitly.\n{combined}"
+    );
+    let _ = std::fs::remove_dir_all(&empty);
+}
+
+/// The gate must work on REAL data, not only on fixtures someone hand-wrote.
+///
+/// This exists because a hand-written fixture lied. It carried two comments per thread
+/// while the query asked for `comments(first: 1)`, so the "a RED-VERIFIED reply satisfies
+/// the gate" test passed against a response the code could never produce — green, and
+/// proving nothing. `scripts/capture-review-threads-fixture.sh` regenerates this file
+/// straight from a live PR so the shape cannot drift from the query again.
+///
+/// Captured from PR #748 (the PR that added this gate), which at capture time had 10
+/// threads, 9 unresolved.
+#[test]
+fn the_gate_handles_a_real_captured_pr_response() {
+    let (out, code) = run_threads("review-threads-live-748.json");
+
+    assert_ne!(code, 0, "a PR with unresolved threads must block:\n{out}");
+    assert!(
+        out.contains("10 total, 9 unresolved"),
+        "the captured response has 10 threads with 9 unresolved; if this count moved, \
+         re-capture with scripts/capture-review-threads-fixture.sh and check WHY.\n{out}"
+    );
+    // Real bodies are markdown with badges, HTML comments and embedded shell blocks —
+    // far messier than anything hand-written. Parsing must survive that.
+    assert!(
+        out.contains("UNRESOLVED"),
+        "individual findings must still be listed from real, messy bodies.\n{out}"
+    );
+}
+
+/// Every fixture must carry the fields the live query actually selects. A fixture missing
+/// one would make the gate silently skip a check it believes it performed.
+#[test]
+fn every_fixture_matches_the_shape_the_query_returns() {
+    const REQUIRED: [&str; 5] = ["author", "body", "line", "originalLine", "path"];
+    let dir = repo_root().join("tests/fixtures");
+    let mut checked = 0;
+
+    for entry in std::fs::read_dir(&dir).expect("fixtures dir") {
+        let path = entry.expect("dir entry").path();
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        if !name.starts_with("review-threads-") {
+            continue;
+        }
+        let text = std::fs::read_to_string(&path).expect("read fixture");
+        for field in REQUIRED {
+            assert!(
+                text.contains(&format!("\"{field}\"")),
+                "fixture {name} is missing the `{field}` field that the live query selects. \
+                 A fixture that does not match the query lets a test pass against data the \
+                 code can never receive."
+            );
+        }
+        assert!(
+            text.contains("\"isResolved\""),
+            "fixture {name} lacks isResolved — the only field that means 'resolved'."
+        );
+        checked += 1;
+    }
+    assert!(
+        checked >= 4,
+        "expected several review-thread fixtures, found {checked}"
+    );
+}
+
+/// A defect report cannot prove itself.
+///
+/// The marker must appear in a REPLY. If the check searched every comment including the
+/// opening one, a bot report that merely QUOTES the policy — "resolutions require a
+/// RED-VERIFIED: <test> reply" — would satisfy its own requirement and close a real bug
+/// on nothing. The fixture is exactly that shape: one comment, containing the marker.
+#[test]
+fn a_defect_report_cannot_serve_as_its_own_red_verification() {
+    let (out, code) = run_threads("review-threads-selfproof.json");
+    assert_ne!(
+        code, 0,
+        "a lone defect comment containing the marker must NOT count as proof — the \
+         evidence has to come from a reply.\n{out}"
+    );
+    assert!(out.contains("UNPROVEN"), "{out}");
+}

--- a/tests/test_log_scan.rs
+++ b/tests/test_log_scan.rs
@@ -208,5 +208,8 @@ fn a_resolved_defect_claim_without_a_red_test_blocks_the_merge() {
 #[test]
 fn a_resolved_defect_claim_with_a_red_test_is_accepted() {
     let (out, code) = run_threads("review-threads-resolved-proven.json");
-    assert_eq!(code, 0, "a RED-VERIFIED reply must satisfy the gate:\n{out}");
+    assert_eq!(
+        code, 0,
+        "a RED-VERIFIED reply must satisfy the gate:\n{out}"
+    );
 }


### PR DESCRIPTION
Both traps were hit for real on #744 today, hours apart. Both cost work, and both are the same shape as the defects this repo keeps finding: a check that looks like it fired when it didn't.

## 1. `--json comments` cannot see review findings

`gh pr view <n> --json comments` returns **only issue comments**. Inline review comments — where CodeRabbit and Codex put their actual findings — live on `/pulls/{n}/comments` and are invisible to that query.

The existing doctrine (added this morning in #743) proves the reviewer *ran*. It does not surface what the reviewer *found*. #744 carried **four unread inline findings, two of them Major**, while the check rendered `CodeRabbit  pass`. The worst was a slice index into the snapshot mapping bounded by a different length than `plan` uses (`ctx.mem_size` vs `&mmap[..]`, passed separately) — unreachable today, but it would panic **inside the fault-handler task, which hangs the guest**, which is the exact failure the PR existed to remove.

Measured on #744: **6 inline vs 5 issue comments** — different sets, not a superset.

## 2. GitHub re-anchors old comments onto the current head

After you push a fix, an already-addressed comment's `commit_id` **and** `line` both move to match the new HEAD. It reads as a brand-new finding at a shifted line number. Acting on it means re-fixing work already done — or worse, concluding your fix was rejected when nobody said so.

`commit_id` cannot distinguish a new finding from a re-anchored one. `original_commit_id` + `created_at` can.

Observed live on #744 — the four CodeRabbit comments re-anchored, the two Codex ones did not:

```
2026-08-08T08:34:35Z orig=1268c2fe now=1268c2fe src/uffd/server.rs
2026-08-08T09:01:36Z orig=23558456 now=7672df92 src/uffd/prefetch.rs
2026-08-08T09:01:36Z orig=23558456 now=7672df92 src/uffd/server.rs
```

Line numbers shifted `prefetch.rs:179 → 196` and `server.rs:1975 → 1991`. Comment count never changed.

## Verification

Both documented commands were **run against #744 before committing**, not written from memory. A doctrine that recommends a query returning nothing would be precisely the defect it describes.

Docs only — one file, `.claude/CLAUDE.md`. No code, no CI surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated checks that block merging when unresolved review findings remain.
  * Added validation for defect-related resolutions, requiring regression-test evidence.
  * Added test-log scanning for failures, retries, timeouts, leaks, and flaky results.

* **Documentation**
  * Updated pull request review guidance for inline comments, pagination, review limits, and re-anchored findings.

* **Tests**
  * Added coverage for review validation and test-log verdicts, including incomplete and ANSI-formatted logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->