### PR TITLE
Run CI on stacked PRs, not just PRs targeting main

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -62,6 +62,33 @@ gh pr view 2 --json baseRefName
 
 **PR description:** Always note `**Stacked on:** <base-branch> (PR #N)` so reviewers understand the dependency.
 
+### A STACKED PR MUST ACTUALLY RUN CI — "no failures" is not "it ran"
+
+**A `pull_request:` trigger's `branches:` filter matches the PR's BASE branch.** So
+`branches: [main]` silently skips the whole workflow for every stacked PR — the exact PRs this
+section tells you to open. GitHub then shows a check set containing whatever *other* workflows
+did fire (here: `safety-check`), with zero failures. It looks green. Nothing ran.
+
+Observed 2026-08-08: #752 (base `kernel-7.0.14`) was merged on a "no failures" reading. Its
+head sha had **zero** runs of `lint`, `packaging`, `host`, `host-root`, `container` — the only
+non-skipped check was `safety-check`. It carried three rustfmt violations that surfaced the
+moment the change reached a PR whose base *was* main.
+
+**Before treating any PR as green, prove the checks EXIST, then that they passed:**
+```bash
+SHA=$(gh api repos/{o}/{r}/pulls/<N> --jq .head.sha)
+gh api repos/{o}/{r}/commits/$SHA/check-runs \
+  --jq '.check_runs[] | select(.conclusion != "skipped") | "\(.name)\t\(.conclusion)"' | sort -u
+# An expected job missing from this list is a FAILURE to verify, not a pass.
+```
+Any monitor, gate, or script that renders a verdict from `statusCheckRollup` must assert the
+required jobs are **present**. Counting failures and finding none is the fail-open form of the
+same bug as `jq: command not found` printing `verdict: CLEAR`, and as a `CodeRabbit  pass` that
+means the reviewer never started.
+
+Enforcement: `tests/test_ci_workflow_coverage.rs` fails if `ci.yml` reintroduces a
+`branches:`/`branches-ignore:` filter on `pull_request`, or if a gating job leaves that file.
+
 ## Sending Email
 
 Use `aws ses send-email --region us-east-1` (recipient must be verified in SES sandbox).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,12 @@ on:
           - both
           - host
           - container
+  # No `branches:` filter. That filter matches the PR's BASE branch, and stacked
+  # PRs (the documented default in AGENTS.md) are based on the previous PR's
+  # branch, not main — so `branches: [main]` skipped every job below for exactly
+  # the PRs the workflow tells people to open, while still rendering a check set
+  # with no failures. See tests/test_ci_workflow_coverage.rs.
   pull_request:
-    branches: [main]
     paths-ignore:
       - 'scripts/claude-assistant/**'
       - '.github/workflows/claude*.yml'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "serde_norway",
  "serial_test",
  "sha2",
  "shell-words",
@@ -2322,6 +2323,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2987,6 +3001,12 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # small_rng: SmallRng for the seeded chaos harness (tests/test_fuzz_chaos.rs)
 rand = { version = "0.8", features = ["small_rng"] }
+serde_norway = "0.9.42"
 
 [build-dependencies]
 sha2 = "0.10"

--- a/tests/test_ci_workflow_coverage.rs
+++ b/tests/test_ci_workflow_coverage.rs
@@ -1,0 +1,99 @@
+//! CI coverage invariants for `.github/workflows/ci.yml`.
+//!
+//! AGENTS.md makes stacked PRs the default: "All work goes in stacked PRs. Each
+//! new PR should be based on the previous one, not main." A `pull_request:`
+//! trigger's `branches:` filter is matched against the PR's **base** branch, so
+//! `branches: [main]` skips every CI job for exactly the PRs the documented
+//! workflow tells people to open.
+//!
+//! This is not hypothetical. On 2026-08-08, PR #752 (base `kernel-7.0.14`)
+//! presented a check set with zero failures and was merged on that basis. Its
+//! head sha had run `safety-check` and nothing else — `lint`, `packaging`,
+//! `host`, `host-root` and `container` had never run at all. It carried three
+//! rustfmt violations, which surfaced only once the change reached a PR whose
+//! base *was* main. "No failing checks" and "the checks ran" are different
+//! claims, and a base-branch filter is what pries them apart.
+
+use serde_norway::Value;
+use std::path::PathBuf;
+
+fn workflow_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(".github/workflows")
+        .join(name)
+}
+
+fn parse_workflow(name: &str) -> Value {
+    let path = workflow_path(name);
+    let text = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+    serde_norway::from_str(&text)
+        .unwrap_or_else(|e| panic!("{} is not valid YAML: {e}", path.display()))
+}
+
+/// Return the `on:` mapping.
+///
+/// YAML 1.1 resolves the bare word `on` to boolean true; YAML 1.2 keeps it a
+/// string. Accept either spelling, but **fail** if neither is present rather
+/// than returning an empty map — a check that cannot locate what it inspects
+/// has no basis for passing.
+fn triggers(workflow: &Value) -> &Value {
+    workflow
+        .get("on")
+        .or_else(|| workflow.get(Value::Bool(true)))
+        .expect("workflow has no `on:` block — cannot evaluate trigger coverage")
+}
+
+/// A base-branch filter on `pull_request` silently excludes stacked PRs.
+#[test]
+fn ci_runs_on_pull_requests_regardless_of_base_branch() {
+    let ci = parse_workflow("ci.yml");
+    let pull_request = triggers(&ci)
+        .get("pull_request")
+        .expect("ci.yml has no `pull_request:` trigger — PRs would get no CI at all");
+
+    // A bare `pull_request:` (null) means "every PR", which is what we want.
+    if pull_request.is_null() {
+        return;
+    }
+
+    let mapping = pull_request
+        .as_mapping()
+        .expect("`pull_request:` is neither null nor a mapping — unexpected shape");
+
+    for key in ["branches", "branches-ignore"] {
+        assert!(
+            !mapping.contains_key(Value::from(key)),
+            "ci.yml restricts `pull_request` with `{key}:`, which is matched against the PR's \
+             BASE branch. AGENTS.md makes stacked PRs the default, so this skips lint/host/\
+             container for every stacked PR while still reporting a check set with no failures. \
+             Remove the filter; use per-job `if:` conditions if some job must be narrowed."
+        );
+    }
+}
+
+/// The jobs a merge depends on must be reachable from the `pull_request` trigger.
+///
+/// Guards the other half of the same failure: keeping the trigger open but
+/// moving the gating jobs into a workflow that stacked PRs never fire.
+#[test]
+fn gating_jobs_live_in_the_pull_request_workflow() {
+    let ci = parse_workflow("ci.yml");
+    triggers(&ci)
+        .get("pull_request")
+        .expect("ci.yml has no `pull_request:` trigger");
+
+    let jobs = ci
+        .get("jobs")
+        .and_then(Value::as_mapping)
+        .expect("ci.yml has no `jobs:` mapping");
+
+    for job in ["lint", "host", "host-root", "container", "packaging"] {
+        assert!(
+            jobs.contains_key(Value::from(job)),
+            "ci.yml no longer defines the `{job}` job. If it moved to another workflow, that \
+             workflow must also trigger on `pull_request` with no base-branch filter, or \
+             stacked PRs lose the check while still reporting no failures."
+        );
+    }
+}

--- a/tests/test_ci_workflow_coverage.rs
+++ b/tests/test_ci_workflow_coverage.rs
@@ -72,10 +72,14 @@ fn ci_runs_on_pull_requests_regardless_of_base_branch() {
     }
 }
 
-/// The jobs a merge depends on must be reachable from the `pull_request` trigger.
+/// Every job a merge depends on must exist here AND still gate `Summary`.
 ///
 /// Guards the other half of the same failure: keeping the trigger open but
-/// moving the gating jobs into a workflow that stacked PRs never fire.
+/// letting a gating job drift out of the gate. Checking only "the job is
+/// defined in this file" is too weak — a refactor can leave `fc-mock` defined
+/// while dropping it from `summary.needs`, at which point it no longer gates
+/// anything and this test would still have passed. So assert membership in
+/// `summary.needs`, which is what actually makes a job a gate.
 #[test]
 fn gating_jobs_live_in_the_pull_request_workflow() {
     let ci = parse_workflow("ci.yml");
@@ -88,12 +92,48 @@ fn gating_jobs_live_in_the_pull_request_workflow() {
         .and_then(Value::as_mapping)
         .expect("ci.yml has no `jobs:` mapping");
 
-    for job in ["lint", "host", "host-root", "container", "packaging"] {
+    let needs: Vec<String> = jobs
+        .get(Value::from("summary"))
+        .and_then(|s| s.get("needs"))
+        .and_then(Value::as_sequence)
+        .expect("ci.yml `summary` job has no `needs:` list — nothing aggregates the gates")
+        .iter()
+        .map(|v| {
+            v.as_str()
+                .expect("a `summary.needs` entry is not a string")
+                .to_string()
+        })
+        .collect();
+
+    // The floor. Shrinking this set is a deliberate act that must be argued for
+    // in review, not something a rename can do silently.
+    for job in [
+        "lint",
+        "packaging",
+        "fc-mock",
+        "host",
+        "host-root",
+        "container",
+    ] {
         assert!(
             jobs.contains_key(Value::from(job)),
             "ci.yml no longer defines the `{job}` job. If it moved to another workflow, that \
              workflow must also trigger on `pull_request` with no base-branch filter, or \
              stacked PRs lose the check while still reporting no failures."
+        );
+        assert!(
+            needs.iter().any(|n| n == job),
+            "`{job}` is defined but is no longer in `summary.needs`, so it no longer gates \
+             anything: Summary can go green while it fails or never runs. Add it back, or \
+             remove the gate deliberately and update this floor list in the same commit."
+        );
+    }
+
+    // Anything Summary waits on must actually exist, or the gate is a no-op.
+    for n in &needs {
+        assert!(
+            jobs.contains_key(Value::from(n.as_str())),
+            "`summary.needs` lists `{n}`, which is not defined in ci.yml"
         );
     }
 }


### PR DESCRIPTION
## The problem

`ci.yml` gated its `pull_request` trigger with `branches: [main]`. That filter matches the PR's **base** branch — and AGENTS.md makes stacked PRs the default:

> All work goes in stacked PRs. Each new PR should be based on the previous one, not main.

So the filter skipped `lint`, `packaging`, `fc-mock`, `host`, `host-root` and `container` for exactly the PRs the documented workflow tells people to open. GitHub still rendered a check set — populated by workflows that fire on any base, e.g. `safety-check` — containing **zero failures**. It reads as green.

"No failing checks" and "the checks ran" are different claims. The filter is what pried them apart.

### It already cost us

PR #752 (base `kernel-7.0.14`) was merged on a no-failures reading. Its head sha:

```
$ gh api repos/ejc3/fcvm/commits/05195dae/check-runs \
    --jq '.check_runs[] | select(.conclusion!="skipped") | .name' | sort -u
safety-check
```

Zero runs of any gating job. It carried three rustfmt violations, which surfaced only once the change reached #751 — a PR whose base *is* main:

```
Diff in fuse-pipe/tests/test_remap_file_range.rs:555
Diff in fuse-pipe/tests/test_remap_file_range.rs:569
Diff in tests/test_remap_patch_invariants.rs:22
```

This is the same fail-open shape as `jq: command not found` printing `verdict: CLEAR`, and as a `CodeRabbit  pass` that means the reviewer never started: absence of a failure signal read as presence of a success signal.

## The fix

- **`.github/workflows/ci.yml`** — drop the `branches:` filter from `pull_request`, with a comment stating why it must not return. `push: branches: [main]` is untouched, so main pushes still build exactly once.
- **`tests/test_ci_workflow_coverage.rs`** — parse `ci.yml` and fail if `pull_request` carries `branches:`/`branches-ignore:`, or if a gating job leaves that workflow (which would reopen the hole from the other side). It accepts `on` as a string or as YAML 1.1's boolean-true, and **panics rather than passing** when the `on:` block can't be found — a check that cannot locate what it inspects has no basis for reporting ok.
- **`Cargo.toml`** — `serde_norway` (maintained `serde_yaml` fork) as a dev-dependency, so the workflow is parsed as YAML rather than pattern-matched as text.
- **`AGENTS.md`** — the footgun, plus the `check-runs` query that proves a job actually ran.

## Test evidence — red/green/red, not just green

```
$ cargo test --test test_ci_workflow_coverage        # before the fix
ci_runs_on_pull_requests_regardless_of_base_branch ... FAILED
  ci.yml restricts `pull_request` with `branches:`, which is matched against
  the PR's BASE branch. [...] this skips lint/host/container for every stacked
  PR while still reporting a check set with no failures.

$ cargo test --test test_ci_workflow_coverage        # after the fix
test result: ok. 2 passed; 0 failed

$ # reinstate `branches: [main]` and re-run — confirms the test is not vacuous
ci_runs_on_pull_requests_regardless_of_base_branch ... FAILED

$ # restore the fix
test result: ok. 2 passed; 0 failed

$ cargo fmt -p fcvm -p fuse-pipe -- --check           # clean
```

## Consequence to expect

Stacked PRs now consume runner capacity they previously skipped. That is the point — they were merging unverified — but it does raise self-hosted load, so it is worth watching queue depth after this lands.