### PR TITLE
Make Summary fail when a gating job fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -818,6 +818,22 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      # `if: always()` is what lets this job report on a run whose tests failed —
+      # and it is also why Summary's own result says nothing about theirs unless
+      # it looks. Without this step Summary reported success over genuinely failed
+      # gating jobs in 8 of the last 40 runs (Lint, Container-*, Host-Root-*), so
+      # "Summary green" was not evidence that anything passed.
+      #
+      # `skipped` is deliberately not a failure: skip-check legitimately skips the
+      # matrix when this tree SHA already passed on a PR branch.
+      - name: Fail if any gating job did not succeed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        env:
+          RESULTS: ${{ join(needs.*.result, ', ') }}
+        run: |
+          echo "::error::A gating job did not succeed — needs results: $RESULTS"
+          exit 1
+
       - name: Report skipped
         if: needs.skip-check.outputs.skip == 'true'
         run: echo "::notice::Skipped self-hosted tests — tree SHA already passed CI on a PR branch"

--- a/tests/test_ci_workflow_coverage.rs
+++ b/tests/test_ci_workflow_coverage.rs
@@ -77,9 +77,13 @@ fn ci_runs_on_pull_requests_regardless_of_base_branch() {
 /// Guards the other half of the same failure: keeping the trigger open but
 /// letting a gating job drift out of the gate. Checking only "the job is
 /// defined in this file" is too weak — a refactor can leave `fc-mock` defined
-/// while dropping it from `summary.needs`, at which point it no longer gates
-/// anything and this test would still have passed. So assert membership in
-/// `summary.needs`, which is what actually makes a job a gate.
+/// while dropping it from `summary.needs`, at which point Summary no longer
+/// even waits for it.
+///
+/// Membership in `summary.needs` is necessary but NOT sufficient: `needs` only
+/// makes Summary *wait*, and with `if: always()` Summary then reports its own
+/// result regardless of theirs. `summary_fails_when_a_gating_job_fails` below
+/// covers the second half.
 #[test]
 fn gating_jobs_live_in_the_pull_request_workflow() {
     let ci = parse_workflow("ci.yml");
@@ -285,4 +289,63 @@ fn gh_existence_probes_do_not_discard_their_error() {
         "found no `gh ... view` probes to inspect — the scan is broken, and a check that \
          inspects nothing must not report success"
     );
+}
+
+/// `Summary` must actually fail when something it gates on failed.
+///
+/// `needs:` makes Summary wait; `if: always()` makes it run even when a
+/// dependency failed. Together those mean Summary reports *its own* success
+/// while a gating job is red — unless it explicitly inspects `needs.*.result`.
+///
+/// It did not. Across the 40 most recent ci.yml runs, 8 finished with
+/// `Summary=success` over genuinely failed jobs:
+///
+/// ```text
+/// run 31271693501: Summary=success but FAILED: Host-Root-arm64-SnapshotEnabled
+/// run 31262066685: Summary=success but FAILED: Lint, Container-x64, Container-arm64
+/// run 31266285914: Summary=success but FAILED: Container-arm64, Container-x64
+/// ```
+///
+/// Anything treating "Summary green" as "CI green" was reading a gate that
+/// could not fail — the same shape as a `CodeRabbit pass` from a review that
+/// never started.
+#[test]
+fn summary_fails_when_a_gating_job_fails() {
+    let ci = parse_workflow("ci.yml");
+    let summary = ci
+        .get("jobs")
+        .and_then(|j| j.get("summary"))
+        .expect("ci.yml has no `summary` job");
+
+    let steps = summary
+        .get("steps")
+        .and_then(Value::as_sequence)
+        .expect("`summary` job has no steps");
+
+    let conds: Vec<&str> = steps
+        .iter()
+        .filter_map(|s| s.get("if").and_then(Value::as_str))
+        .filter(|c| c.contains("needs.*.result"))
+        .collect();
+
+    assert!(
+        !conds.is_empty(),
+        "ci.yml's `summary` job never inspects `needs.*.result`. With `if: always()` it \
+         therefore reports success no matter what its gating jobs did — observed in 8 of the \
+         last 40 runs, including one where Lint failed. Add a step conditioned on \
+         `contains(needs.*.result, 'failure')` that exits non-zero."
+    );
+
+    // Require each non-success terminal state independently. Accepting
+    // `failure OR cancelled` would let a later edit drop the `failure` arm while
+    // keeping `cancelled`, and this test would still pass while Summary went
+    // green over a failed Lint — exactly the regression it exists to prevent.
+    for state in ["failure", "cancelled"] {
+        assert!(
+            conds.iter().any(|c| c.contains(state)),
+            "`summary` inspects `needs.*.result` but never checks for `{state}`, so a {state} \
+             gating job still yields a green Summary. Each non-success terminal state must be \
+             checked on its own, not as one arm of an `||` that a later edit can halve."
+        );
+    }
 }


### PR DESCRIPTION
**Stacked on:** `fix-kernel-build-checkout` (#765), which is stacked on `ci-cover-stacked-prs` (#763).

## The problem

`summary` is the aggregate job. It has:

```yaml
needs: [skip-check, lint, packaging, fc-mock, host, host-root, container]
if: always()
```

`needs` makes it **wait**. `always()` makes it **run** even when a dependency failed. Neither makes it **fail**. Its steps download artifacts and run `analyze_ci_vms.py`; nothing inspects `needs.*.result`. So Summary reported its own success while a gating job was red.

### It happens constantly

Across the 40 most recent `ci.yml` runs, **8** finished `Summary=success` over genuinely failed jobs:

```
run 31271693501: Summary=success but FAILED: Host-Root-arm64-SnapshotEnabled
run 31268989444: Summary=success but FAILED: Host-Root-x64-SnapshotEnabled, Host-Root-arm64-SnapshotEnabled
run 31266285914: Summary=success but FAILED: Container-arm64, Container-x64
run 31265971153: Summary=success but FAILED: Host-Root-x64-SnapshotEnabled, Host-Root-arm64-SnapshotEnabled
run 31265014487: Summary=success but FAILED: Container-arm64, Container-x64
run 31262066685: Summary=success but FAILED: Lint, Container-x64, Container-arm64
run 31253647773: Summary=success but FAILED: Host-Root-x64-SnapshotEnabled, Host-Root-arm64-SnapshotEnabled
run 31248333523: Summary=success but FAILED: Host-Root-x64-SnapshotEnabled, Host-Root-arm64-SnapshotEnabled
```

One of those is a **Lint** failure passing under a green Summary.

"Summary green" was not evidence that anything passed — the same shape as the base-branch filter that let #752 merge with no jobs run (#763), and as a `CodeRabbit pass` from a review that never started.

This also matters for branch protection: `Summary` is the natural single required check, and requiring it today would have enforced nothing.

## The fix

- **`.github/workflows/ci.yml`** — `summary`'s first step exits non-zero when any `needs.*.result` is `failure` or `cancelled`. `skipped` is deliberately excluded: `skip-check` legitimately skips the matrix when this tree SHA already passed on a PR branch. The results string goes through `env:` rather than being interpolated into `run:`, per the workflow-security rules in AGENTS.md.
- **`tests/test_ci_workflow_coverage.rs`** — assert `summary` has a step whose `if` inspects `needs.*.result` for failure/cancelled.
- **Correction to #763.** That PR's test asserts gating jobs appear in `summary.needs`, and I justified it as "what actually makes a job a gate." That was wrong — `needs` only makes Summary wait. Membership is necessary, not sufficient. The rationale is corrected in place and the new test covers the other half.

## Test evidence

```
$ cargo test --test test_ci_workflow_coverage
test result: ok. 4 passed; 0 failed

$ # remove the guard step from ci.yml
$ cargo test --test test_ci_workflow_coverage summary
summary_fails_when_a_gating_job_fails ... FAILED
  ci.yml's `summary` job never inspects `needs.*.result`. With `if: always()` it
  therefore reports success no matter what its gating jobs did — observed in 8 of
  the last 40 runs, including one where Lint failed.

$ # restore
test result: ok. 4 passed
```

## Expect this to turn some runs red

Runs that previously showed a green Summary over a failed job will now show a red Summary. That is the point — those runs were already failing, they just did not say so.