### PR TITLE
Give each worktree its own cargo target dir on btrfs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,15 @@ endif
 # the checkout path, so all fcvm worktrees collide on one name and would run
 # each other's binaries. Suffix with a hash of the absolute path so two
 # worktrees sharing a basename stay separate too.
-CARGO_TARGET_BTRFS := /mnt/fcvm-btrfs/cargo-target/$(notdir $(CURDIR))-$(shell printf '%s' '$(CURDIR)' | sha256sum | cut -c1-8)
+# Derived INSIDE the shell from `pwd -P`, never by interpolating $(CURDIR) into
+# shell source: a checkout path containing a quote would otherwise break make, and
+# a crafted path could inject shell syntax at expansion time. The basename is also
+# sanitized to [A-Za-z0-9._-] so it cannot introduce path separators.
+CARGO_TARGET_BTRFS := /mnt/fcvm-btrfs/cargo-target/$(shell \
+	p=$$(pwd -P); \
+	name=$$(printf '%s' "$$(basename "$$p")" | LC_ALL=C tr -c 'A-Za-z0-9._-' '_'); \
+	hash=$$(printf '%s' "$$p" | sha256sum | cut -c1-8); \
+	printf '%s-%s' "$$name" "$$hash")
 
 # Base test command
 # `target` is a symlink to CARGO_TARGET_BTRFS, created by the check-disk target
@@ -200,7 +208,7 @@ CONTAINER_RUN := $(CONTAINER_RUN_BASE) --ulimit nproc=65536:65536 --pids-limit=6
 	_test-unit _test-fast _test-all _test-root _setup-fcvm _bench \
 	container-build container-test container-test-unit container-test-fast container-test-all container-test-fc-mock \
 	container-setup-fcvm container-shell container-clean container-bench \
-	setup-btrfs setup-default setup-fcvm setup-pjdfstest setup-hugepages bench bench-vm bench-hugepages bench-hugepages-test \
+	cargo-target-link setup-btrfs setup-default setup-fcvm setup-pjdfstest setup-hugepages bench bench-vm bench-hugepages bench-hugepages-test \
 	bench-container-import bench-chromium bench-clone-latency \
 	lint fmt update-dependency ssh test-serve-sdk
 
@@ -272,10 +280,43 @@ help:
 	@echo "  check-disk         Check disk space requirements"
 	@echo ""
 	@echo "Options: FILTER=pattern STREAM=1 LIST=1"
+# Point this worktree's target/ at its own directory on btrfs.
+#
+# Every entry point that invokes cargo must depend on this. `make build` had no
+# such prerequisite, so a fresh worktree created a REAL target/ on the root
+# filesystem — which is nearly full — silently defeating the whole arrangement.
+.PHONY: cargo-target-link
+cargo-target-link:
+	@# Build artifacts belong on btrfs (root is small and fills up), but each
+	@# worktree needs its OWN directory. Cargo names a test binary from a hash
+	@# over package name/version/features that does NOT include the checkout
+	@# path, so every fcvm worktree produces the same filename — pointing them
+	@# all at one directory means `cargo test` in one worktree can run a binary
+	@# another worktree built. Observed 2026-08-08: a run in worktree A listed a
+	@# test that exists only in worktree B and silently omitted the one under
+	@# test, which makes red/green verification meaningless.
+	@if [ -d /mnt/fcvm-btrfs ]; then \
+		WT_TARGET="$(CARGO_TARGET_BTRFS)"; \
+		mkdir -p "$$WT_TARGET"; \
+		if [ -L target ] && [ "$$(readlink target)" != "$$WT_TARGET" ]; then \
+			echo "==> Repointing shared target/ → $$WT_TARGET (per-worktree)"; \
+			rm -f target; \
+		fi; \
+		if ! [ -L target ]; then \
+			if [ -d target ]; then \
+				echo "==> Moving existing target/ to $$WT_TARGET..."; \
+				mv target/* "$$WT_TARGET"/ 2>/dev/null || true; \
+				rm -rf target; \
+			fi; \
+			ln -s "$$WT_TARGET" target; \
+			echo "==> Symlinked target/ → $$WT_TARGET"; \
+		fi; \
+	fi
+
 
 # Disk space check - fails if either root or btrfs is too full
 # Requires 10GB free on root (for cargo target) and 15GB on btrfs (for VMs)
-check-disk:
+check-disk: cargo-target-link
 	@# Ensure test log directory exists for container mounts
 	@mkdir -p $(TEST_LOG_DIR)
 	@# Fix advisory-db ownership (sudo/non-sudo mixing corrupts it)
@@ -317,31 +358,6 @@ check-disk:
 		mkdir -p "$$HOME/.cargo/bin"; \
 		curl -LsSf "$$NURL" | tar zxf - -C "$$HOME/.cargo/bin" \
 			|| PATH="$$HOME/.cargo/bin:$$PATH" cargo install cargo-nextest --locked; \
-	fi
-	@# Build artifacts belong on btrfs (root is small and fills up), but each
-	@# worktree needs its OWN directory. Cargo names a test binary from a hash
-	@# over package name/version/features that does NOT include the checkout
-	@# path, so every fcvm worktree produces the same filename — pointing them
-	@# all at one directory means `cargo test` in one worktree can run a binary
-	@# another worktree built. Observed 2026-08-08: a run in worktree A listed a
-	@# test that exists only in worktree B and silently omitted the one under
-	@# test, which makes red/green verification meaningless.
-	@if [ -d /mnt/fcvm-btrfs ]; then \
-		WT_TARGET="$(CARGO_TARGET_BTRFS)"; \
-		if [ -L target ] && [ "$$(readlink target)" != "$$WT_TARGET" ]; then \
-			echo "==> Repointing shared target/ → $$WT_TARGET (per-worktree)"; \
-			rm -f target; \
-		fi; \
-		if ! [ -L target ]; then \
-			mkdir -p "$$WT_TARGET"; \
-			if [ -d target ]; then \
-				echo "==> Moving existing target/ to $$WT_TARGET..."; \
-				mv target/* "$$WT_TARGET"/ 2>/dev/null || true; \
-				rm -rf target; \
-			fi; \
-			ln -s "$$WT_TARGET" target; \
-			echo "==> Symlinked target/ → $$WT_TARGET"; \
-		fi; \
 	fi
 	@BTRFS_FREE=$$(df -BG /mnt/fcvm-btrfs 2>/dev/null | awk 'NR==2 {gsub("G",""); print $$4}'); \
 	if [ -n "$$BTRFS_FREE" ] && [ "$$BTRFS_FREE" -lt 15 ]; then \
@@ -389,7 +405,7 @@ clean-test-data: build
 	mkdir -p /tmp/fcvm-test-logs
 	@echo "==> Cleaned test data (preserved cached assets)"
 
-build:
+build: cargo-target-link
 	@echo "==> Building..."
 	CARGO_TARGET_DIR=target $(CARGO) build --release -p fcvm
 	CARGO_TARGET_DIR=target $(CARGO) build --release -p fc-agent --target $(MUSL_TARGET)
@@ -397,7 +413,7 @@ build:
 	@# Sync embedded config to user config dir (config is embedded at compile time)
 	@./target/release/fcvm setup --generate-config --force 2>/dev/null || true
 
-build-fc-mock:
+build-fc-mock: cargo-target-link
 	@echo "==> Building fc-mock..."
 	CARGO_TARGET_DIR=target $(CARGO) build --release -p fc-mock
 	@# Install to /usr/local/bin so it's accessible from within user namespaces

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,19 @@ $(info Note: IPv6-only host detected - bridged tests will be skipped)
 endif
 
 
+# Per-worktree cargo target directory, on btrfs.
+#
+# The root filesystem is small and fills up (a link step then dies with
+# "No space left on device" mid-build); /mnt/fcvm-btrfs has terabytes. But the
+# directory must be UNIQUE PER WORKTREE: cargo's test-binary filename hash omits
+# the checkout path, so all fcvm worktrees collide on one name and would run
+# each other's binaries. Suffix with a hash of the absolute path so two
+# worktrees sharing a basename stay separate too.
+CARGO_TARGET_BTRFS := /mnt/fcvm-btrfs/cargo-target/$(notdir $(CURDIR))-$(shell printf '%s' '$(CURDIR)' | sha256sum | cut -c1-8)
+
 # Base test command
+# `target` is a symlink to CARGO_TARGET_BTRFS, created by the check-disk target
+# (a prerequisite of every build/test target).
 export CARGO_TARGET_DIR := target
 NEXTEST := $(CARGO) nextest $(NEXTEST_CMD) --release
 
@@ -306,16 +318,30 @@ check-disk:
 		curl -LsSf "$$NURL" | tar zxf - -C "$$HOME/.cargo/bin" \
 			|| PATH="$$HOME/.cargo/bin:$$PATH" cargo install cargo-nextest --locked; \
 	fi
-	@if [ -d /mnt/fcvm-btrfs ] && ! [ -L target ]; then \
-		if [ -d target ]; then \
-			echo "==> Moving existing target/ to /mnt/fcvm-btrfs/cargo-target..."; \
-			sudo rm -rf /mnt/fcvm-btrfs/cargo-target; \
-			mv target /mnt/fcvm-btrfs/cargo-target; \
-		else \
-			mkdir -p /mnt/fcvm-btrfs/cargo-target; \
+	@# Build artifacts belong on btrfs (root is small and fills up), but each
+	@# worktree needs its OWN directory. Cargo names a test binary from a hash
+	@# over package name/version/features that does NOT include the checkout
+	@# path, so every fcvm worktree produces the same filename — pointing them
+	@# all at one directory means `cargo test` in one worktree can run a binary
+	@# another worktree built. Observed 2026-08-08: a run in worktree A listed a
+	@# test that exists only in worktree B and silently omitted the one under
+	@# test, which makes red/green verification meaningless.
+	@if [ -d /mnt/fcvm-btrfs ]; then \
+		WT_TARGET="$(CARGO_TARGET_BTRFS)"; \
+		if [ -L target ] && [ "$$(readlink target)" != "$$WT_TARGET" ]; then \
+			echo "==> Repointing shared target/ → $$WT_TARGET (per-worktree)"; \
+			rm -f target; \
 		fi; \
-		ln -s /mnt/fcvm-btrfs/cargo-target target; \
-		echo "==> Symlinked target/ → /mnt/fcvm-btrfs/cargo-target"; \
+		if ! [ -L target ]; then \
+			mkdir -p "$$WT_TARGET"; \
+			if [ -d target ]; then \
+				echo "==> Moving existing target/ to $$WT_TARGET..."; \
+				mv target/* "$$WT_TARGET"/ 2>/dev/null || true; \
+				rm -rf target; \
+			fi; \
+			ln -s "$$WT_TARGET" target; \
+			echo "==> Symlinked target/ → $$WT_TARGET"; \
+		fi; \
 	fi
 	@BTRFS_FREE=$$(df -BG /mnt/fcvm-btrfs 2>/dev/null | awk 'NR==2 {gsub("G",""); print $$4}'); \
 	if [ -n "$$BTRFS_FREE" ] && [ "$$BTRFS_FREE" -lt 15 ]; then \


### PR DESCRIPTION
## The problem

`check-disk` symlinked **every** worktree's `target/` to the same path:

```
/home/ubuntu/fcvm/target                  -> /mnt/fcvm-btrfs/cargo-target
/home/ubuntu/src/fcvm-summary-gate/target -> /mnt/fcvm-btrfs/cargo-target
```

`CARGO_TARGET_DIR := target` is relative, so it *looks* per-worktree. Through that symlink it wasn't.

This is worse than a cache collision. Cargo names a test binary from a hash over package name, version, features and profile — which does **not** include the checkout path — so every fcvm worktree emits the identical filename:

```
/mnt/fcvm-btrfs/cargo-target/debug/deps/test_ci_workflow_coverage-113926a94ccc9fad
```

Whoever links last wins, and the fingerprint that decides freshness is keyed by the same hash, so it gets overwritten too.

### What that did

While verifying two stacked PRs, a run in worktree A reported a test that exists **only in worktree B**, and silently skipped the one actually under test:

```
Running .../cargo-target/debug/deps/test_ci_workflow_coverage-113926a94ccc9fad
test gh_existence_probes_do_not_discard_their_error ... ok    <- not on this branch
test result: ok. 4 passed                                     <- summary_fails never ran
```

Red/green verification is meaningless in that state: *"it went red"* and *"it went green"* may both be reports about code you are not editing.

### Why not just move target/ back to the root disk

Root is 290 GB and **97% full**. A link step that runs out of space dies mid-build:

```
error: failed to write /tmp/rustcVz3my2/lib.rmeta: No space left on device (os error 28)
error: could not compile `fcvm` (lib)
make: *** [Makefile:391: _test-unit] Error 101
```

btrfs has 3.3 TB free. Isolation and space are both required; the old setup picked one.

## The fix

`CARGO_TARGET_BTRFS` — a per-worktree directory under `/mnt/fcvm-btrfs/cargo-target`, named `<basename>-<sha256(absolute path)[:8]>` so two worktrees sharing a basename still stay apart. `check-disk` (a prerequisite of every build/test target) creates it, symlinks `target/` to it, and **repoints** an existing symlink that still points at the old shared path — so existing checkouts self-heal on their next `make`.

## Test evidence

```
$ make check-disk
==> Symlinked target/ → /mnt/fcvm-btrfs/cargo-target/fcvm-target-btrfs-e3b8c406

$ readlink target
/mnt/fcvm-btrfs/cargo-target/fcvm-target-btrfs-e3b8c406

$ make build
$ ls /mnt/fcvm-btrfs/cargo-target/fcvm-target-btrfs-e3b8c406/release/fcvm
.../release/fcvm        # real artifact, on btrfs, isolated per worktree
```

## Notes

- First `make` in each existing worktree recompiles once (new directory, cold cache). The old `/mnt/fcvm-btrfs/cargo-target` is left in place; it can be deleted once every worktree has repointed.
- This does not change CI: runners use a single checkout, so they were never affected — which is exactly why the bug survived. It only ever bit local multi-worktree work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented build artifacts from different worktrees from interfering with one another.
  * Automatically creates or updates each worktree’s dedicated Cargo build directory.
  * Existing build artifacts are migrated automatically, helping preserve build results and reduce unnecessary rebuilds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->