### PR TITLE
Stop the nested test passing on fcvm's echo of its own command

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -213,6 +213,29 @@ sudo cargo test ...
 
 If the Makefile is missing a target or broken, **fix the Makefile** - don't work around it.
 
+### Raw `cargo` runs a SIBLING WORKTREE's test binary — this is why the rule exists
+
+The environment exports `CARGO_TARGET_DIR=/mnt/fcvm-btrfs/cargo-target`, **shared by every
+worktree**. `Makefile:160` overrides it (`export CARGO_TARGET_DIR := target`), so anything run
+through `make` gets a per-worktree `./target`. A raw `cargo test` does not — it inherits the
+shared directory, and two worktrees building the same package produce the *same* test-binary
+path. Cargo then considers it fresh and runs whatever the other worktree built.
+
+Observed 2026-08-08 while verifying two stacked PRs: `cargo test --test
+test_ci_workflow_coverage` in worktree A printed a test that exists **only in worktree B** and
+silently omitted the one under test:
+
+```
+Running .../cargo-target/debug/deps/test_ci_workflow_coverage-113926a94ccc9fad
+test gh_existence_probes_do_not_discard_their_error ... ok    <- not on this branch
+test result: ok. 4 passed                                     <- summary_fails never ran
+```
+
+Red/green verification is worthless under these conditions: "it went red" and "it went green"
+may both be reports about code you are not editing. Use `make test-unit FILTER=<pattern>`. If
+you must invoke cargo directly, set an explicit per-worktree `CARGO_TARGET_DIR` — and confirm
+the `Running .../deps/<binary>` line points inside it before believing any result.
+
 ## NEVER ROUTE AROUND BUILD PROCESSES
 
 **If a build fails, FIX THE BUILD. Never manually copy files.**

--- a/tests/test_kvm.rs
+++ b/tests/test_kvm.rs
@@ -408,6 +408,10 @@ except OSError as e:
     // The outer VM has --privileged so iptables/namespaces work
     // Use --cmd for the container command (fcvm doesn't support trailing args after IMAGE)
     // Set HOME explicitly to ensure config file is found
+    // Assembled by the guest from two halves (see the assertion below), so this literal
+    // cannot appear in the argv fcvm echoes into the stderr this test captures.
+    const NESTED_MARKER: &str = "NESTED_SUCCESS_INNER_VM_WORKS";
+
     let inner_cmd = r#"
         export PATH=/opt/fcvm:/mnt/fcvm-btrfs/bin:$PATH
         export HOME=/root
@@ -422,7 +426,7 @@ except OSError as e:
         fcvm podman run \
             --name inner-test \
             --network bridged \
-            --cmd "echo NESTED_SUCCESS_INNER_VM_WORKS" \
+            --cmd "printf '%s_%s\n' NESTED_SUCCESS INNER_VM_WORKS" \
             public.ecr.aws/nginx/nginx:alpine
     "#;
 
@@ -469,17 +473,36 @@ except OSError as e:
     common::kill_process(outer_pid).await;
 
     // 6. Verify success
+    //
     // Check both stdout and stderr since fcvm logs container output to its own stderr
-    // with [ctr:stdout] prefix, so when running via exec, the output appears in stderr
+    // with [ctr:stdout] prefix, so when running via exec, the output appears in stderr.
+    //
+    // The marker MUST NOT appear literally in the command we send. fcvm logs the whole
+    // argv at INFO ("exec request acknowledged, command starting command=[...]") and that
+    // log lands in the captured stderr — so a literal `echo NESTED_SUCCESS_INNER_VM_WORKS`
+    // made this assertion match fcvm's echo of the command it was about to run, whether or
+    // not the inner VM ever produced a byte. On 2026-08-08, run 31259262664 "passed" three
+    // times that way in 9.7s/20.1s/6.7s (the three fastest of 94 recorded executions) while
+    // the inner fcvm was dying with "ensuring rootfs free space: e2fsck found uncorrectable
+    // errors". The guest therefore assembles the marker from two halves via printf, so the
+    // joined string can only exist if the guest actually ran the command.
+    assert!(
+        !inner_cmd.contains(NESTED_MARKER),
+        "the success marker `{NESTED_MARKER}` appears literally in the command sent to the \
+         guest. fcvm echoes the argv into its own stderr, which this test captures, so the \
+         assertion below would pass without the inner VM running at all. Build the marker \
+         in the guest (e.g. printf '%s_%s') instead of inlining it."
+    );
+
     let combined = format!("{}\n{}", stdout, stderr);
-    if combined.contains("NESTED_SUCCESS_INNER_VM_WORKS") {
+    if combined.contains(NESTED_MARKER) {
         println!("\n✅ NESTED TEST PASSED!");
         println!("   Successfully ran fcvm inside fcvm (nested virtualization)");
         Ok(())
     } else {
         bail!(
             "Nested virtualization failed - inner VM did not produce expected output\n\
-             Expected: NESTED_SUCCESS_INNER_VM_WORKS\n\
+             Expected: {NESTED_MARKER}\n\
              Got stdout: {}\n\
              Got stderr: {}",
             stdout,


### PR DESCRIPTION
## The problem

`test_nested_run_fcvm_inside_vm` decided success with:

```rust
combined.contains("NESTED_SUCCESS_INNER_VM_WORKS")   // over stdout + stderr
```

while sending the guest:

```
--cmd "echo NESTED_SUCCESS_INNER_VM_WORKS"
```

fcvm logs the entire argv at INFO — `exec request acknowledged, command starting command=[...]` — and that log goes to the stderr this test captures. **The assertion matched fcvm's echo of the command it was about to run**, whether or not the inner VM produced a single byte. The test could not tell "nested virtualization works" from "fcvm logged a string".

## It already hid a real failure

PR #751's run `31259262664` "passed" three times this way, in **9.664s / 20.099s / 6.698s** — the three fastest of 94 recorded executions of this test; every other one is ≥ 30s. All three captured:

```
Inner VM output:
                                    <- nothing
Inner VM stderr (last 10 lines):
... ERROR fcvm: Error: ensuring rootfs free space:
    e2fsck found uncorrectable errors
```

The inner VM died on a corrupt rootfs, and the test printed `✅ NESTED TEST PASSED!`. In a genuine pass (main job `93093599926`) the marker appears on the line *after* `Inner VM output:` — actual guest output.

This is why #751 looked green on that run. It was never green on this test.

## The fix

- The guest assembles the marker from two halves — `printf '%s_%s\n' NESTED_SUCCESS INNER_VM_WORKS` — so the joined literal cannot appear in the argv fcvm echoes.
- An assertion that the marker does **not** occur literally in the command being sent, so a future edit that inlines it fails loudly rather than quietly becoming vacuous again:

```rust
assert!(
    !inner_cmd.contains(NESTED_MARKER),
    "the success marker `{NESTED_MARKER}` appears literally in the command sent to the \
     guest. fcvm echoes the argv into its own stderr, which this test captures, so the \
     assertion below would pass without the inner VM running at all."
);
```

## Also in this PR

`AGENTS.md` gains the shared-`CARGO_TARGET_DIR` footgun — same class of problem, a result that does not mean what it appears to mean. Every worktree's `target/` was symlinked to one directory, so `cargo test` in one worktree could execute a binary another worktree built. (The Makefile fix for that is #767.)

## Verification

`cargo fmt --check` clean, tests compile. The nested test itself needs an arm64 NV2 host and runs in CI as `Host-Root-arm64-*`; this PR's CI exercises it.