### PR TITLE
Make the AMI cache key cover what the host kernel is actually built from

### DIFF
--- a/scripts/build-ami.sh
+++ b/scripts/build-ami.sh
@@ -9,9 +9,60 @@ KERNEL_DIR="$(dirname "$SCRIPT_DIR")/kernel"
 
 # Compute build hash (from kernel config + patches + boot_args + passt build inputs)
 compute_hash() {
-  local repo_root="$(dirname "$KERNEL_DIR")"
+  local repo_root
+  repo_root="$(dirname "$KERNEL_DIR")"
+
+  # FAIL CLOSED. Every read below used to be `2>/dev/null` with its failure
+  # discarded, and `hash=$(compute_hash)` does NOT inherit errexit inside the
+  # command substitution — so a missing glob, an unreadable patch or a dangling
+  # symlink produced a valid-looking hash computed over FEWER inputs. That is the
+  # stale-AMI bug this function exists to prevent, wearing a different hat:
+  # check_existing_ami would match an image built from a different kernel.
+  local -a host_patches=()
+  local p
+  shopt -s nullglob
+  for p in "$KERNEL_DIR/patches-arm64/"*.patch; do
+    case "$p" in *.vm.patch) continue ;; esac
+    host_patches+=("$p")
+  done
+  shopt -u nullglob
+  if [ ${#host_patches[@]} -eq 0 ]; then
+    echo "ERROR: no host-kernel patches matched $KERNEL_DIR/patches-arm64/*.patch;" >&2
+    echo "       the AMI cache key would silently omit them." >&2
+    return 1
+  fi
+
+  # Only the host kernel this AMI bakes. rootfs-config.toml carries eight
+  # kernel_version assignments, so a bare grep also invalidated the key whenever
+  # an unrelated profile (btrfs.arm64, nested.amd64, ...) changed, forcing a full
+  # EC2 rebuild. The builder always selects [kernel_profiles.nested.arm64.host_kernel]
+  # on ARM64. Resolved HERE, not inside the `{ ... } | sha256sum` group below,
+  # because `exit` inside that group leaves only the subshell — sha256sum would
+  # still hash the partial input and emit a plausible key.
+  local host_kernel_version
+  if ! host_kernel_version=$(awk '
+      /^\[/ { in_section = ($0 == "[kernel_profiles.nested.arm64.host_kernel]") }
+      in_section && /^kernel_version[[:space:]]*=/ { print; found = 1 }
+      END { exit(found ? 0 : 1) }
+    ' "$repo_root/rootfs-config.toml"); then
+    echo "ERROR: [kernel_profiles.nested.arm64.host_kernel] has no kernel_version;" >&2
+    echo "       the AMI cache key cannot identify the host kernel." >&2
+    return 1
+  fi
+
+  local f
+  for f in "$KERNEL_DIR/nested.conf" "$repo_root/rootfs-config.toml" \
+    "$SCRIPT_DIR/build-passt.sh" "$SCRIPT_DIR/runner-disk-preflight.sh" \
+    "$SCRIPT_DIR/runner-disk-guard.service" "$SCRIPT_DIR/runner-disk-guard.timer" \
+    "${host_patches[@]}"; do
+    if [ ! -r "$f" ]; then
+      echo "ERROR: AMI cache key input is missing or unreadable: $f" >&2
+      return 1
+    fi
+  done
+
   {
-    cat "$KERNEL_DIR/nested.conf" 2>/dev/null
+    cat "$KERNEL_DIR/nested.conf"
     # The HOST kernel baked into this AMI is built from the arm64 patch set —
     # [kernel_profiles.nested.arm64.host_kernel] build_inputs is
     # "kernel/patches-arm64/*.patch" — NOT kernel/patches. Only two of those nine
@@ -21,13 +72,10 @@ compute_hash() {
     # builder reused a stale image carrying the OLD host kernel.
     # `.vm.patch` is excluded to match compute_host_kernel_sha in
     # src/setup/kernel.rs, which applies those only to the guest kernel.
-    for p in "$KERNEL_DIR/patches-arm64/"*.patch; do
-      case "$p" in *.vm.patch) continue ;; esac
-      cat "$p" 2>/dev/null
-    done
+    cat "${host_patches[@]}"
     # kernel_version is part of the host kernel's identity but was never read,
     # so a pure version bump left the AMI hash unchanged.
-    grep -E '^kernel_version\s*=' "$repo_root/rootfs-config.toml" 2>/dev/null || true
+    printf '%s\n' "$host_kernel_version"
     # Include boot_args from config to invalidate cache when they change
     grep -E '^boot_args\s*=' "$repo_root/rootfs-config.toml" 2>/dev/null || true
     # Include the passt build inputs so a pin or patch change rebuilds the AMI
@@ -288,7 +336,10 @@ wait_for_build() {
 # Main
 main() {
   local hash
-  hash=$(compute_hash)
+  if ! hash=$(compute_hash); then
+    echo "ERROR: cannot compute the AMI cache key; refusing to reuse or tag an AMI" >&2
+    exit 1
+  fi
   echo "Build hash: $hash"
 
   # Check cache

--- a/scripts/build-ami.sh
+++ b/scripts/build-ami.sh
@@ -11,7 +11,23 @@ KERNEL_DIR="$(dirname "$SCRIPT_DIR")/kernel"
 compute_hash() {
   local repo_root="$(dirname "$KERNEL_DIR")"
   {
-    cat "$KERNEL_DIR/nested.conf" "$KERNEL_DIR/patches/"*.patch 2>/dev/null
+    cat "$KERNEL_DIR/nested.conf" 2>/dev/null
+    # The HOST kernel baked into this AMI is built from the arm64 patch set —
+    # [kernel_profiles.nested.arm64.host_kernel] build_inputs is
+    # "kernel/patches-arm64/*.patch" — NOT kernel/patches. Only two of those nine
+    # are symlinks into kernel/patches; the other seven (nv2-vsock-cache-sync,
+    # nv2-vsock-rx-barrier, wfx-stopped-exit, the psci-debug set) were invisible
+    # to this hash, so changing one produced an identical AMI hash and the
+    # builder reused a stale image carrying the OLD host kernel.
+    # `.vm.patch` is excluded to match compute_host_kernel_sha in
+    # src/setup/kernel.rs, which applies those only to the guest kernel.
+    for p in "$KERNEL_DIR/patches-arm64/"*.patch; do
+      case "$p" in *.vm.patch) continue ;; esac
+      cat "$p" 2>/dev/null
+    done
+    # kernel_version is part of the host kernel's identity but was never read,
+    # so a pure version bump left the AMI hash unchanged.
+    grep -E '^kernel_version\s*=' "$repo_root/rootfs-config.toml" 2>/dev/null || true
     # Include boot_args from config to invalidate cache when they change
     grep -E '^boot_args\s*=' "$repo_root/rootfs-config.toml" 2>/dev/null || true
     # Include the passt build inputs so a pin or patch change rebuilds the AMI

--- a/tests/test_ami_hash_inputs.rs
+++ b/tests/test_ami_hash_inputs.rs
@@ -1,0 +1,107 @@
+//! The runner AMI's cache key must cover everything baked into the AMI.
+//!
+//! `scripts/build-ami.sh` skips the (expensive) rebuild when an AMI already
+//! exists tagged with the same `compute_hash`. Anything the host kernel is built
+//! from but the hash does not read is therefore a *silent staleness* bug: the
+//! source changes, the hash does not, and the builder hands back an image
+//! carrying the OLD kernel.
+//!
+//! That was real. `compute_hash` read `kernel/patches/*.patch`, while
+//! `[kernel_profiles.nested.arm64.host_kernel].build_inputs` is
+//! `kernel/patches-arm64/*.patch` — a different directory. Only two of the nine
+//! files there are symlinks back into `kernel/patches`; the other seven were
+//! invisible, including `nv2-vsock-cache-sync.patch` and
+//! `nv2-vsock-rx-barrier.patch`, the DSB cache-coherency patches AGENTS.md
+//! documents as required for NV2 correctness. `kernel_version` was not read
+//! either, so a pure version bump changed nothing the cache key could see.
+
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn build_ami_sh() -> String {
+    let p = repo_root().join("scripts/build-ami.sh");
+    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("cannot read {}: {e}", p.display()))
+}
+
+/// Return the `compute_hash()` function body, so assertions cannot be satisfied
+/// by an unrelated mention of a path elsewhere in the script.
+fn compute_hash_body(script: &str) -> String {
+    let start = script
+        .find("compute_hash()")
+        .expect("build-ami.sh has no compute_hash() — cannot evaluate the cache key");
+    let rest = &script[start..];
+    let end = rest
+        .find("\n}\n")
+        .expect("compute_hash() has no closing brace");
+    rest[..end].to_string()
+}
+
+fn host_kernel_table() -> toml::Value {
+    let p = repo_root().join("rootfs-config.toml");
+    let text =
+        std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("cannot read {}: {e}", p.display()));
+    let cfg: toml::Value = text.parse().expect("rootfs-config.toml is not valid TOML");
+    cfg.get("kernel_profiles")
+        .and_then(|v| v.get("nested"))
+        .and_then(|v| v.get("arm64"))
+        .and_then(|v| v.get("host_kernel"))
+        .cloned()
+        .expect("rootfs-config.toml has no [kernel_profiles.nested.arm64.host_kernel]")
+}
+
+/// Every `build_inputs` glob of the host kernel must be read by `compute_hash`.
+#[test]
+fn ami_hash_covers_every_host_kernel_build_input() {
+    let body = compute_hash_body(&build_ami_sh());
+    let host = host_kernel_table();
+
+    let inputs = host
+        .get("build_inputs")
+        .and_then(|v| v.as_array())
+        .expect("host_kernel has no build_inputs array");
+    assert!(
+        !inputs.is_empty(),
+        "host_kernel.build_inputs is empty — nothing to check, which means this test \
+         would pass no matter what compute_hash reads"
+    );
+
+    for input in inputs {
+        let pattern = input
+            .as_str()
+            .expect("a build_inputs entry is not a string");
+        // Compare on the directory: the script iterates a glob, so the literal
+        // pattern string need not appear, but the directory must.
+        let dir = pattern
+            .rsplit_once('/')
+            .map(|(d, _)| d)
+            .unwrap_or(pattern)
+            .trim_start_matches("kernel/");
+        assert!(
+            body.contains(dir),
+            "the host kernel is built from `{pattern}`, but compute_hash() in \
+             scripts/build-ami.sh never reads `{dir}`. A change there would leave the AMI \
+             hash identical, so the builder reuses an image carrying the OLD host kernel. \
+             compute_hash body:\n{body}"
+        );
+    }
+}
+
+/// The kernel version is part of the baked kernel's identity.
+#[test]
+fn ami_hash_covers_host_kernel_version() {
+    let body = compute_hash_body(&build_ami_sh());
+    let host = host_kernel_table();
+    host.get("kernel_version")
+        .and_then(|v| v.as_str())
+        .expect("host_kernel has no kernel_version");
+
+    assert!(
+        body.contains("kernel_version"),
+        "compute_hash() never reads `kernel_version`, so bumping the host kernel version \
+         alone leaves the AMI cache key unchanged and the builder reuses an AMI built from \
+         the previous version. compute_hash body:\n{body}"
+    );
+}

--- a/tests/test_ami_hash_inputs.rs
+++ b/tests/test_ami_hash_inputs.rs
@@ -1,4 +1,4 @@
-//! The runner AMI's cache key must cover everything baked into the AMI.
+//! The runner AMI's cache key must change when the host kernel's inputs change.
 //!
 //! `scripts/build-ami.sh` skips the (expensive) rebuild when an AMI already
 //! exists tagged with the same `compute_hash`. Anything the host kernel is built
@@ -14,94 +14,187 @@
 //! `nv2-vsock-rx-barrier.patch`, the DSB cache-coherency patches AGENTS.md
 //! documents as required for NV2 correctness. `kernel_version` was not read
 //! either, so a pure version bump changed nothing the cache key could see.
+//!
+//! These tests EXECUTE the real `compute_hash` against a fixture tree and assert
+//! that mutating each input moves the hash. An earlier version scanned the
+//! function's source text for the strings `patches-arm64` and `kernel_version` —
+//! which the explanatory COMMENTS also contain, so deleting the code and keeping
+//! the comments left it green. A check satisfiable by a comment about the check
+//! is exactly the failure mode this file exists to prevent.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
-fn build_ami_sh() -> String {
-    let p = repo_root().join("scripts/build-ami.sh");
-    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("cannot read {}: {e}", p.display()))
-}
+/// Extract `compute_hash()` verbatim from the real script and run it against a
+/// fixture tree. `create_user_data` (its only helper call) is stubbed so this
+/// exercises the kernel-input behaviour in isolation.
+fn run_compute_hash(fixture: &Path) -> String {
+    let script = std::fs::read_to_string(repo_root().join("scripts/build-ami.sh"))
+        .expect("read scripts/build-ami.sh");
 
-/// Return the `compute_hash()` function body, so assertions cannot be satisfied
-/// by an unrelated mention of a path elsewhere in the script.
-fn compute_hash_body(script: &str) -> String {
     let start = script
         .find("compute_hash()")
         .expect("build-ami.sh has no compute_hash() — cannot evaluate the cache key");
     let rest = &script[start..];
     let end = rest
         .find("\n}\n")
-        .expect("compute_hash() has no closing brace");
-    rest[..end].to_string()
-}
+        .expect("compute_hash() has no closing brace")
+        + 2;
+    let func = &rest[..end];
 
-fn host_kernel_table() -> toml::Value {
-    let p = repo_root().join("rootfs-config.toml");
-    let text =
-        std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("cannot read {}: {e}", p.display()));
-    let cfg: toml::Value = text.parse().expect("rootfs-config.toml is not valid TOML");
-    cfg.get("kernel_profiles")
-        .and_then(|v| v.get("nested"))
-        .and_then(|v| v.get("arm64"))
-        .and_then(|v| v.get("host_kernel"))
-        .cloned()
-        .expect("rootfs-config.toml has no [kernel_profiles.nested.arm64.host_kernel]")
-}
-
-/// Every `build_inputs` glob of the host kernel must be read by `compute_hash`.
-#[test]
-fn ami_hash_covers_every_host_kernel_build_input() {
-    let body = compute_hash_body(&build_ami_sh());
-    let host = host_kernel_table();
-
-    let inputs = host
-        .get("build_inputs")
-        .and_then(|v| v.as_array())
-        .expect("host_kernel has no build_inputs array");
-    assert!(
-        !inputs.is_empty(),
-        "host_kernel.build_inputs is empty — nothing to check, which means this test \
-         would pass no matter what compute_hash reads"
+    let program = format!(
+        "set -u\n\
+         KERNEL_DIR={fx}/kernel\n\
+         SCRIPT_DIR={fx}/scripts\n\
+         create_user_data() {{ printf 'stub-user-data'; }}\n\
+         {func}\n\
+         compute_hash\n",
+        fx = fixture.display(),
+        func = func
     );
 
-    for input in inputs {
-        let pattern = input
-            .as_str()
-            .expect("a build_inputs entry is not a string");
-        // Compare on the directory: the script iterates a glob, so the literal
-        // pattern string need not appear, but the directory must.
-        let dir = pattern
-            .rsplit_once('/')
-            .map(|(d, _)| d)
-            .unwrap_or(pattern)
-            .trim_start_matches("kernel/");
-        assert!(
-            body.contains(dir),
-            "the host kernel is built from `{pattern}`, but compute_hash() in \
-             scripts/build-ami.sh never reads `{dir}`. A change there would leave the AMI \
-             hash identical, so the builder reuses an image carrying the OLD host kernel. \
-             compute_hash body:\n{body}"
+    let out = Command::new("bash")
+        .arg("-c")
+        .arg(&program)
+        .output()
+        .expect("run bash");
+    assert!(
+        out.status.success(),
+        "compute_hash failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let hash = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    assert!(
+        !hash.is_empty(),
+        "compute_hash produced no output — every comparison below would be vacuously equal"
+    );
+    hash
+}
+
+/// Build a minimal tree with the layout `compute_hash` reads.
+fn make_fixture() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let w = |rel: &str, body: &str| {
+        let p = root.join(rel);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(p, body).unwrap();
+    };
+
+    w("kernel/nested.conf", "CONFIG_KVM=y\n");
+    w("kernel/patches/0001-fuse.patch", "fuse patch v1\n");
+    // The host kernel's real patch set, including the arm64-only files that were
+    // invisible to the old hash.
+    w("kernel/patches-arm64/0001-fuse.patch", "fuse patch v1\n");
+    w(
+        "kernel/patches-arm64/nv2-vsock-cache-sync.patch",
+        "dsb sy\n",
+    );
+    w(
+        "kernel/patches-arm64/nv2-vsock-rx-barrier.patch",
+        "dsb sy rx\n",
+    );
+    w("kernel/patches-arm64/wfx-stopped-exit.patch", "wfx\n");
+    // Guest-only; must NOT affect the host kernel's hash.
+    w(
+        "kernel/patches-arm64/mmfr4-override.vm.patch",
+        "guest only\n",
+    );
+    w(
+        "rootfs-config.toml",
+        "boot_args = \"kvm-arm.mode=nested\"\nkernel_version = \"6.18.3\"\n",
+    );
+    w("scripts/build-passt.sh", "#!/bin/sh\n");
+    w("scripts/passt-0001.patch", "passt\n");
+    w("scripts/runner-disk-preflight.sh", "#!/bin/sh\n");
+    w("scripts/runner-disk-guard.service", "[Unit]\n");
+    w("scripts/runner-disk-guard.timer", "[Timer]\n");
+    dir
+}
+
+/// Same inputs must give the same hash — otherwise "it changed" proves nothing.
+#[test]
+fn ami_hash_is_stable_for_identical_inputs() {
+    let fx = make_fixture();
+    let a = run_compute_hash(fx.path());
+    let b = run_compute_hash(fx.path());
+    assert_eq!(
+        a, b,
+        "compute_hash is not deterministic, so every mutation test below would pass for the \
+         wrong reason (a hash that changes for everything gates nothing)"
+    );
+}
+
+/// Mutating any host-kernel patch must move the hash.
+#[test]
+fn ami_hash_changes_when_a_host_kernel_patch_changes() {
+    let fx = make_fixture();
+    let base = run_compute_hash(fx.path());
+
+    // The seven arm64-only patches were the ones the old hash could not see.
+    for patch in [
+        "nv2-vsock-cache-sync.patch",
+        "nv2-vsock-rx-barrier.patch",
+        "wfx-stopped-exit.patch",
+    ] {
+        let p = fx.path().join("kernel/patches-arm64").join(patch);
+        let original = std::fs::read_to_string(&p).unwrap();
+        std::fs::write(&p, format!("{original}MUTATED\n")).unwrap();
+        let mutated = run_compute_hash(fx.path());
+        std::fs::write(&p, &original).unwrap();
+
+        assert_ne!(
+            base, mutated,
+            "editing kernel/patches-arm64/{patch} left the AMI hash at {base}. That patch is \
+             built into the host kernel, so build-ami.sh would find a 'matching' AMI and reuse \
+             an image carrying the OLD kernel. For the two nv2-vsock-* patches that means \
+             shipping a host kernel without the DSB cache-coherency fix."
         );
     }
 }
 
-/// The kernel version is part of the baked kernel's identity.
+/// Bumping the host kernel version must move the hash.
 #[test]
-fn ami_hash_covers_host_kernel_version() {
-    let body = compute_hash_body(&build_ami_sh());
-    let host = host_kernel_table();
-    host.get("kernel_version")
-        .and_then(|v| v.as_str())
-        .expect("host_kernel has no kernel_version");
+fn ami_hash_changes_when_kernel_version_changes() {
+    let fx = make_fixture();
+    let base = run_compute_hash(fx.path());
 
-    assert!(
-        body.contains("kernel_version"),
-        "compute_hash() never reads `kernel_version`, so bumping the host kernel version \
-         alone leaves the AMI cache key unchanged and the builder reuses an AMI built from \
-         the previous version. compute_hash body:\n{body}"
+    let cfg = fx.path().join("rootfs-config.toml");
+    let original = std::fs::read_to_string(&cfg).unwrap();
+    std::fs::write(&cfg, original.replace("6.18.3", "7.0.14")).unwrap();
+    let mutated = run_compute_hash(fx.path());
+    std::fs::write(&cfg, &original).unwrap();
+
+    assert_ne!(
+        base, mutated,
+        "bumping kernel_version left the AMI hash at {base}, so a version bump alone reuses an \
+         AMI built from the previous kernel version"
+    );
+}
+
+/// A guest-only `.vm.patch` must NOT move the host hash — otherwise the hash
+/// churns on changes that cannot affect the baked host kernel, and "it changed"
+/// stops meaning anything.
+#[test]
+fn ami_hash_ignores_guest_only_vm_patches() {
+    let fx = make_fixture();
+    let base = run_compute_hash(fx.path());
+
+    let p = fx
+        .path()
+        .join("kernel/patches-arm64/mmfr4-override.vm.patch");
+    let original = std::fs::read_to_string(&p).unwrap();
+    std::fs::write(&p, format!("{original}MUTATED\n")).unwrap();
+    let mutated = run_compute_hash(fx.path());
+    std::fs::write(&p, &original).unwrap();
+
+    assert_eq!(
+        base, mutated,
+        "a *.vm.patch is applied only to the GUEST kernel (see compute_host_kernel_sha in \
+         src/setup/kernel.rs, which excludes them), so it must not invalidate the host AMI"
     );
 }

--- a/tests/test_ami_hash_inputs.rs
+++ b/tests/test_ami_hash_inputs.rs
@@ -33,6 +33,17 @@ fn repo_root() -> PathBuf {
 /// fixture tree. `create_user_data` (its only helper call) is stubbed so this
 /// exercises the kernel-input behaviour in isolation.
 fn run_compute_hash(fixture: &Path) -> String {
+    let (ok, out, err) = try_compute_hash(fixture);
+    assert!(ok, "compute_hash failed: {err}");
+    assert!(
+        !out.is_empty(),
+        "compute_hash produced no output — every comparison below would be vacuously equal"
+    );
+    out
+}
+
+/// Same, but hands back the exit status so the fail-closed cases can assert on it.
+fn try_compute_hash(fixture: &Path) -> (bool, String, String) {
     let script = std::fs::read_to_string(repo_root().join("scripts/build-ami.sh"))
         .expect("read scripts/build-ami.sh");
 
@@ -46,33 +57,30 @@ fn run_compute_hash(fixture: &Path) -> String {
         + 2;
     let func = &rest[..end];
 
+    // Paths go through the ENVIRONMENT, never interpolated into shell source: a
+    // TMPDIR containing whitespace or a metacharacter would otherwise split these
+    // assignments, the helper would hash no fixture inputs at all, and every
+    // mutation test below would compare two copies of the empty-stream digest.
     let program = format!(
         "set -u\n\
-         KERNEL_DIR={fx}/kernel\n\
-         SCRIPT_DIR={fx}/scripts\n\
          create_user_data() {{ printf 'stub-user-data'; }}\n\
          {func}\n\
          compute_hash\n",
-        fx = fixture.display(),
         func = func
     );
 
     let out = Command::new("bash")
         .arg("-c")
         .arg(&program)
+        .env("KERNEL_DIR", fixture.join("kernel"))
+        .env("SCRIPT_DIR", fixture.join("scripts"))
         .output()
         .expect("run bash");
-    assert!(
+    (
         out.status.success(),
-        "compute_hash failed: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let hash = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    assert!(
-        !hash.is_empty(),
-        "compute_hash produced no output — every comparison below would be vacuously equal"
-    );
-    hash
+        String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        String::from_utf8_lossy(&out.stderr).trim().to_string(),
+    )
 }
 
 /// Build a minimal tree with the layout `compute_hash` reads.
@@ -104,9 +112,16 @@ fn make_fixture() -> tempfile::TempDir {
         "kernel/patches-arm64/mmfr4-override.vm.patch",
         "guest only\n",
     );
+    // Two kernel_version assignments on purpose: only the host_kernel one may
+    // move the hash. A bare grep would pick up both and churn the key whenever an
+    // unrelated profile changed.
     w(
         "rootfs-config.toml",
-        "boot_args = \"kvm-arm.mode=nested\"\nkernel_version = \"6.18.3\"\n",
+        "boot_args = \"kvm-arm.mode=nested\"\n\
+         [kernel_profiles.btrfs.arm64]\n\
+         kernel_version = \"6.16.1\"\n\
+         [kernel_profiles.nested.arm64.host_kernel]\n\
+         kernel_version = \"6.18.3\"\n",
     );
     w("scripts/build-passt.sh", "#!/bin/sh\n");
     w("scripts/passt-0001.patch", "passt\n");
@@ -196,5 +211,69 @@ fn ami_hash_ignores_guest_only_vm_patches() {
         base, mutated,
         "a *.vm.patch is applied only to the GUEST kernel (see compute_host_kernel_sha in \
          src/setup/kernel.rs, which excludes them), so it must not invalidate the host AMI"
+    );
+}
+
+/// A cache key computed over FEWER inputs than intended is the stale-AMI bug in
+/// disguise: it looks valid, `check_existing_ami` matches it, and the builder
+/// hands back an image carrying a different kernel.
+///
+/// `hash=$(compute_hash)` does not inherit `errexit` inside the command
+/// substitution, so every read has to police itself. These pin that.
+#[test]
+fn ami_hash_refuses_to_compute_when_an_input_is_unreadable() {
+    let fx = make_fixture();
+    let patch = fx
+        .path()
+        .join("kernel/patches-arm64/nv2-vsock-cache-sync.patch");
+
+    // A dangling symlink is the realistic shape: the patch set carries symlinks
+    // into kernel/patches, and a rename on the other side leaves exactly this.
+    std::fs::remove_file(&patch).unwrap();
+    std::os::unix::fs::symlink("/nonexistent/gone.patch", &patch).unwrap();
+
+    let (ok, out, err) = try_compute_hash(fx.path());
+    assert!(
+        !ok,
+        "compute_hash SUCCEEDED with an unreadable host-kernel patch, returning {out:?}. That \
+         key omits a patch the host kernel is built from — for the two nv2-vsock-* patches that \
+         means reusing an AMI whose kernel lacks the DSB cache-coherency fix. stderr: {err}"
+    );
+}
+
+#[test]
+fn ami_hash_refuses_to_compute_when_no_host_patches_match() {
+    let fx = make_fixture();
+    for e in std::fs::read_dir(fx.path().join("kernel/patches-arm64")).unwrap() {
+        std::fs::remove_file(e.unwrap().path()).unwrap();
+    }
+    let (ok, out, err) = try_compute_hash(fx.path());
+    assert!(
+        !ok,
+        "compute_hash SUCCEEDED with no host-kernel patches at all, returning {out:?} — a key \
+         computed over an empty patch set, which matches nothing that was ever built. \
+         stderr: {err}"
+    );
+}
+
+/// The key must identify the HOST kernel, not every kernel in the file.
+/// rootfs-config.toml carries eight `kernel_version` assignments; a bare grep
+/// churned the key — and forced a full EC2 rebuild — whenever an unrelated
+/// profile moved.
+#[test]
+fn ami_hash_ignores_unrelated_kernel_profiles() {
+    let fx = make_fixture();
+    let base = run_compute_hash(fx.path());
+
+    let cfg = fx.path().join("rootfs-config.toml");
+    let original = std::fs::read_to_string(&cfg).unwrap();
+    std::fs::write(&cfg, original.replace("6.16.1", "6.17.9")).unwrap();
+    let mutated = run_compute_hash(fx.path());
+
+    assert_eq!(
+        base, mutated,
+        "bumping [kernel_profiles.btrfs.arm64] moved the AMI hash. That profile cannot affect \
+         the host kernel baked into this AMI, so the change only costs a full EC2 rebuild for \
+         nothing"
     );
 }


### PR DESCRIPTION
## The problem

`compute_hash()` in `scripts/build-ami.sh` reads `kernel/patches/*.patch`. The host kernel baked into that AMI is built from a **different directory** — `[kernel_profiles.nested.arm64.host_kernel].build_inputs` is `kernel/patches-arm64/*.patch`.

Only two of the nine files there are symlinks back into `kernel/patches`. The other seven were invisible to the cache key:

```
nv2-vsock-cache-sync.patch      <- DSB SY, the NV2 cache-coherency fix
nv2-vsock-rx-barrier.patch      <- DSB SY in virtio_transport_rx_work
wfx-stopped-exit.patch
psci-debug-emulate-nested.patch
psci-debug-handle-exit.patch
psci-debug-psci.patch
mmfr4-override.vm.patch         (guest-only — correctly excluded)
```

Change any of them and the hash is unchanged, so `build-ami.sh` finds a "matching" AMI and returns an image carrying the **old** host kernel.

The first two are the patches AGENTS.md documents as **required** for NV2 cache coherency. Silently shipping a host kernel without them is exactly the L2 FUSE-over-FUSE data-corruption class this repo already fought once ("STREAM CORRUPTION: zero-length message ... 128 bytes of zeros").

`kernel_version` was not read either, so a pure version bump left the cache key untouched.

This is the same failure that has been visible all evening for the FUSE patch, one directory over: **source fixed, artifact stale, nothing reports a problem.**

## The fix

- **`scripts/build-ami.sh`** — hash the host kernel's real `build_inputs` (`patches-arm64`, excluding `*.vm.patch` to match `compute_host_kernel_sha` in `src/setup/kernel.rs`), plus `kernel_version`.
- **`tests/test_ami_hash_inputs.rs`** — parse `rootfs-config.toml` and assert `compute_hash` reads every `host_kernel` build-input directory and `kernel_version`. This closes the class: a future `build_inputs` entry the script does not read fails the test rather than silently reusing an AMI. It also refuses to pass on an empty `build_inputs`, so it cannot become vacuous.

## Test evidence

Red against main's script:

```
$ git show origin/main:scripts/build-ami.sh > scripts/build-ami.sh
ami_hash_covers_host_kernel_version ... FAILED
ami_hash_covers_every_host_kernel_build_input ... FAILED
  the host kernel is built from `kernel/patches-arm64/*.patch`, but compute_hash()
  in scripts/build-ami.sh never reads `patches-arm64`. A change there would leave
  the AMI hash identical, so the builder reuses an image carrying the OLD host kernel.

$ # restore the fix
test result: ok. 2 passed; 0 failed
```

And the hash genuinely moves — the point of the change:

```
old inputs (kernel/patches only):      038a53e858ce
new inputs (patches-arm64 + version):  b189938b7acf

mutate nv2-vsock-cache-sync  -> 9f2d43b93b03   (before: no change)
mutate nv2-vsock-rx-barrier  -> 49b8fb1025fc   (before: no change)
mutate wfx-stopped-exit      -> dff9222a4e06   (before: no change)
```

## Consequence

The next AMI build produces a new hash and therefore a genuinely new AMI, rather than reusing `ami-088028d5edb48796d` (built 2026-01-04, `BuildHash 3c715887d603`). That is required anyway — four commits have touched `kernel/patches/` since that AMI was built, including the FICLONE >4 GiB fix.