### PR TITLE
Heal a dangling target/ symlink instead of failing every build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,29 +138,14 @@ $(info Note: IPv6-only host detected - bridged tests will be skipped)
 endif
 
 
-# Per-worktree cargo target directory, on btrfs.
-#
-# The root filesystem is small and fills up (a link step then dies with
-# "No space left on device" mid-build); /mnt/fcvm-btrfs has terabytes. But the
-# directory must be UNIQUE PER WORKTREE: cargo's test-binary filename hash omits
-# the checkout path, so all fcvm worktrees collide on one name and would run
-# each other's binaries. Suffix with a hash of the absolute path so two
-# worktrees sharing a basename stay separate too.
-# Derived INSIDE the shell from `pwd -P`, never by interpolating $(CURDIR) into
-# shell source: a checkout path containing a quote would otherwise break make, and
-# a crafted path could inject shell syntax at expansion time. The basename is also
-# sanitized to [A-Za-z0-9._-] so it cannot introduce path separators.
-# Overridable ONLY so tests/test_cargo_target_link.rs can point the recipe below at
-# a temp dir instead of the real volume. Nothing else in this Makefile reads it.
+# Build artifacts go in a per-worktree directory on btrfs; scripts/cargo-target-link.sh
+# owns the derivation and the symlink, and is the ONLY place that computes the path.
+# Overridable so tests/test_cargo_target_link.rs can point it at a temp dir.
 BTRFS_ROOT ?= /mnt/fcvm-btrfs
-CARGO_TARGET_BTRFS := $(BTRFS_ROOT)/cargo-target/$(shell \
-	p=$$(pwd -P); \
-	name=$$(printf '%s' "$$(basename "$$p")" | LC_ALL=C tr -c 'A-Za-z0-9._-' '_'); \
-	hash=$$(printf '%s' "$$p" | sha256sum | cut -c1-8); \
-	printf '%s-%s' "$$name" "$$hash")
+MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # Base test command
-# `target` is a symlink to CARGO_TARGET_BTRFS, created by the check-disk target
+# `target` is a symlink into BTRFS_ROOT, created by the cargo-target-link target
 # (a prerequisite of every build/test target).
 export CARGO_TARGET_DIR := target
 NEXTEST := $(CARGO) nextest $(NEXTEST_CMD) --release
@@ -290,59 +275,7 @@ help:
 # filesystem — which is nearly full — silently defeating the whole arrangement.
 .PHONY: cargo-target-link
 cargo-target-link:
-	@# Build artifacts belong on btrfs (root is small and fills up), but each
-	@# worktree needs its OWN directory. Cargo names a test binary from a hash
-	@# over package name/version/features that does NOT include the checkout
-	@# path, so every fcvm worktree produces the same filename — pointing them
-	@# all at one directory means `cargo test` in one worktree can run a binary
-	@# another worktree built. Observed 2026-08-08: a run in worktree A listed a
-	@# test that exists only in worktree B and silently omitted the one under
-	@# test, which makes red/green verification meaningless.
-	@if [ -d $(BTRFS_ROOT) ]; then \
-		WT_TARGET="$(CARGO_TARGET_BTRFS)"; \
-		mkdir -p "$$WT_TARGET" || { echo "ERROR: cannot create $$WT_TARGET"; exit 1; }; \
-		if [ -L target ] && [ "$$(readlink target)" != "$$WT_TARGET" ]; then \
-			echo "==> Repointing shared target/ → $$WT_TARGET (per-worktree)"; \
-			rm -f target; \
-		fi; \
-		if ! [ -L target ]; then \
-			if [ -d target ]; then \
-				echo "==> Moving existing target/ to $$WT_TARGET..."; \
-				mv target/* "$$WT_TARGET"/ 2>/dev/null || true; \
-				rm -rf target; \
-			fi; \
-			ln -s "$$WT_TARGET" target; \
-			echo "==> Symlinked target/ → $$WT_TARGET"; \
-		fi; \
-	else \
-		echo "==> NOTE: $(BTRFS_ROOT) is not a directory; build artifacts stay on the root filesystem"; \
-	fi
-	@# Self-heal a DANGLING link. The block above only runs when $(BTRFS_ROOT) is
-	@# present, and it trusts an existing symlink without checking that it still
-	@# resolves — but the volume is ephemeral (scripts/runner-disk-preflight.sh
-	@# prunes idle cargo-target dirs, and a runner can come back with the volume
-	@# reset) while the checkout persists across jobs. Cargo does not create the
-	@# directory through a dangling link: it renames a tempdir onto the path, which
-	@# fails on an existing symlink with `Not a directory (os error 20)`. That took
-	@# out Host-arm64 on every open PR on 2026-08-08. `~/.cargo` right below already
-	@# self-heals for exactly this reason.
-	@if [ -L target ] && ! [ -d target ]; then \
-		TGT=$$(readlink target); \
-		echo "==> target/ → $$TGT is dangling (volume reset?); recreating"; \
-		mkdir -p "$$TGT" 2>/dev/null || { \
-			echo "==> WARNING: cannot recreate $$TGT; using a local target/ on the root filesystem"; \
-			rm -f target; \
-		}; \
-	fi
-	@# Fail closed. Every build/test recipe runs cargo with CARGO_TARGET_DIR=target,
-	@# so leaving it unusable turns into an opaque cargo error several steps later.
-	@[ -e target ] || mkdir -p target
-	@if [ ! -d target ]; then \
-		echo "ERROR: target exists but is not a usable directory:"; \
-		ls -ld target; \
-		exit 1; \
-	fi
-
+	@BTRFS_ROOT="$(BTRFS_ROOT)" "$(MAKEFILE_DIR)scripts/cargo-target-link.sh"
 
 # Disk space check - fails if either root or btrfs is too full
 # Requires 10GB free on root (for cargo target) and 15GB on btrfs (for VMs)

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,10 @@ endif
 # shell source: a checkout path containing a quote would otherwise break make, and
 # a crafted path could inject shell syntax at expansion time. The basename is also
 # sanitized to [A-Za-z0-9._-] so it cannot introduce path separators.
-CARGO_TARGET_BTRFS := /mnt/fcvm-btrfs/cargo-target/$(shell \
+# Overridable ONLY so tests/test_cargo_target_link.rs can point the recipe below at
+# a temp dir instead of the real volume. Nothing else in this Makefile reads it.
+BTRFS_ROOT ?= /mnt/fcvm-btrfs
+CARGO_TARGET_BTRFS := $(BTRFS_ROOT)/cargo-target/$(shell \
 	p=$$(pwd -P); \
 	name=$$(printf '%s' "$$(basename "$$p")" | LC_ALL=C tr -c 'A-Za-z0-9._-' '_'); \
 	hash=$$(printf '%s' "$$p" | sha256sum | cut -c1-8); \
@@ -295,9 +298,9 @@ cargo-target-link:
 	@# another worktree built. Observed 2026-08-08: a run in worktree A listed a
 	@# test that exists only in worktree B and silently omitted the one under
 	@# test, which makes red/green verification meaningless.
-	@if [ -d /mnt/fcvm-btrfs ]; then \
+	@if [ -d $(BTRFS_ROOT) ]; then \
 		WT_TARGET="$(CARGO_TARGET_BTRFS)"; \
-		mkdir -p "$$WT_TARGET"; \
+		mkdir -p "$$WT_TARGET" || { echo "ERROR: cannot create $$WT_TARGET"; exit 1; }; \
 		if [ -L target ] && [ "$$(readlink target)" != "$$WT_TARGET" ]; then \
 			echo "==> Repointing shared target/ → $$WT_TARGET (per-worktree)"; \
 			rm -f target; \
@@ -311,6 +314,33 @@ cargo-target-link:
 			ln -s "$$WT_TARGET" target; \
 			echo "==> Symlinked target/ → $$WT_TARGET"; \
 		fi; \
+	else \
+		echo "==> NOTE: $(BTRFS_ROOT) is not a directory; build artifacts stay on the root filesystem"; \
+	fi
+	@# Self-heal a DANGLING link. The block above only runs when $(BTRFS_ROOT) is
+	@# present, and it trusts an existing symlink without checking that it still
+	@# resolves — but the volume is ephemeral (scripts/runner-disk-preflight.sh
+	@# prunes idle cargo-target dirs, and a runner can come back with the volume
+	@# reset) while the checkout persists across jobs. Cargo does not create the
+	@# directory through a dangling link: it renames a tempdir onto the path, which
+	@# fails on an existing symlink with `Not a directory (os error 20)`. That took
+	@# out Host-arm64 on every open PR on 2026-08-08. `~/.cargo` right below already
+	@# self-heals for exactly this reason.
+	@if [ -L target ] && ! [ -d target ]; then \
+		TGT=$$(readlink target); \
+		echo "==> target/ → $$TGT is dangling (volume reset?); recreating"; \
+		mkdir -p "$$TGT" 2>/dev/null || { \
+			echo "==> WARNING: cannot recreate $$TGT; using a local target/ on the root filesystem"; \
+			rm -f target; \
+		}; \
+	fi
+	@# Fail closed. Every build/test recipe runs cargo with CARGO_TARGET_DIR=target,
+	@# so leaving it unusable turns into an opaque cargo error several steps later.
+	@[ -e target ] || mkdir -p target
+	@if [ ! -d target ]; then \
+		echo "ERROR: target exists but is not a usable directory:"; \
+		ls -ld target; \
+		exit 1; \
 	fi
 
 

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -70,8 +70,24 @@ if [ -d "$BTRFS_ROOT" ]; then
 	if ! [ -L target ]; then
 		if [ -d target ]; then
 			echo "==> Moving existing target/ to $WT_TARGET..."
-			mv target/* "$WT_TARGET"/ 2>/dev/null || true
-			rm -rf target
+			# Never `rm -rf` the source on a partial move. A full volume, a
+			# permission error, or a plain `target/*` glob (which skips
+			# .rustc_info.json and other dotfiles) would otherwise discard build
+			# artifacts silently. Move everything, dotfiles included, and abort if
+			# any of it fails; `rmdir` then succeeds only if the move was complete.
+			shopt -s dotglob nullglob
+			entries=(target/*)
+			shopt -u dotglob nullglob
+			if [ ${#entries[@]} -gt 0 ]; then
+				mv -- "${entries[@]}" "$WT_TARGET"/ || {
+					echo "ERROR: could not migrate target/ to $WT_TARGET; leaving it in place" >&2
+					exit 1
+				}
+			fi
+			rmdir target || {
+				echo "ERROR: target/ is not empty after migration; leaving it in place" >&2
+				exit 1
+			}
 		fi
 		ln -s "$WT_TARGET" target
 		echo "==> Symlinked target/ → $WT_TARGET"
@@ -84,8 +100,17 @@ fi
 # false exactly when it does not resolve.
 if [ -L target ] && ! [ -d target ]; then
 	TGT="$(readlink target)"
-	echo "==> target/ → $TGT is dangling (volume reset?); recreating"
-	if ! mkdir -p "$TGT" 2>/dev/null; then
+	if ! [ -d "$BTRFS_ROOT" ]; then
+		# The VOLUME is gone, not just our directory on it. Recreating the path
+		# would silently write build artifacts under an unmounted mountpoint —
+		# i.e. onto the small root filesystem, the exact thing this indirection
+		# exists to avoid — while still looking like btrfs. Drop the link and let
+		# the fail-closed step below make a real local directory.
+		echo "==> WARNING: $BTRFS_ROOT is not mounted; using a local target/ on the root filesystem"
+		rm -f target
+	elif mkdir -p "$TGT" 2>/dev/null; then
+		echo "==> target/ → $TGT was dangling (pruned?); recreated"
+	else
 		echo "==> WARNING: cannot recreate $TGT; using a local target/ on the root filesystem"
 		rm -f target
 	fi

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Point ./target at this worktree's own build directory on btrfs, and guarantee
+# that it resolves to a directory cargo can write into.
+#
+# Every build and test recipe runs cargo with CARGO_TARGET_DIR=target, so this
+# runs first and its postcondition is the whole contract: after it returns 0,
+# `target` IS a usable directory.
+#
+# Two properties this has to hold, both learned the hard way:
+#
+# 1. PER WORKTREE. Cargo names a test binary from a hash over package
+#    name/version/features that does NOT include the checkout path, so every
+#    fcvm worktree produces the same filename. Pointing them all at one
+#    directory means `cargo test` in one worktree can run a binary another
+#    worktree built. Observed 2026-08-08: a run in worktree A listed a test that
+#    exists only in worktree B and silently omitted the one under test, which
+#    makes red/green verification meaningless.
+#
+# 2. THE LINK MUST STILL RESOLVE. The btrfs volume is ephemeral —
+#    scripts/runner-disk-preflight.sh prunes idle cargo-target dirs, and a runner
+#    can come back with the volume reset — while a CI checkout persists across
+#    jobs. Cargo does not create the directory through a dangling symlink: it
+#    builds a tempdir and rename()s it onto the path, and rename() onto an
+#    existing symlink is ENOTDIR. That is the "failed to create directory ...
+#    Not a directory (os error 20)" that took out Host-arm64 on every open PR on
+#    2026-08-08. `~/.cargo` in the Makefile's check-disk target already
+#    self-heals for exactly this reason; target/ did not.
+#
+# Everything below runs under an exclusive flock on the checkout directory,
+# because more than one `make` can run in one checkout (several CI entry points
+# depend on this target, and developers do it routinely). Without it, two
+# processes can both observe the dangling link, the first replaces it with a real
+# directory, and the second's `rm` then fails with "Is a directory" and kills a
+# build for no visible reason.
+set -euo pipefail
+
+BTRFS_ROOT="${BTRFS_ROOT:-/mnt/fcvm-btrfs}"
+
+# Serialization is what makes the sequence below safe; running without it would
+# reintroduce the race silently. Fail loudly instead.
+if ! command -v flock >/dev/null 2>&1; then
+	echo "ERROR: flock is required to serialize target/ setup (util-linux)" >&2
+	exit 2
+fi
+
+# Re-exec under an exclusive lock on the checkout directory. No lock FILE: a
+# directory fd is lockable, needs no cleanup, and cannot itself become the stale
+# artifact we are trying to avoid.
+if [ "${CARGO_TARGET_LINK_LOCKED:-}" != "1" ]; then
+	export CARGO_TARGET_LINK_LOCKED=1
+	exec flock "$(pwd -P)" "$0" "$@"
+fi
+
+# Per-worktree directory name: sanitized basename + a hash of the absolute path,
+# so two worktrees that share a basename still get separate directories. Derived
+# from `pwd -P` rather than interpolated by make, so a checkout path containing a
+# quote cannot inject shell syntax, and the basename is restricted to
+# [A-Za-z0-9._-] so it cannot introduce path separators.
+p="$(pwd -P)"
+name="$(printf '%s' "$(basename "$p")" | LC_ALL=C tr -c 'A-Za-z0-9._-' '_')"
+hash="$(printf '%s' "$p" | sha256sum | cut -c1-8)"
+WT_TARGET="$BTRFS_ROOT/cargo-target/$name-$hash"
+
+if [ -d "$BTRFS_ROOT" ]; then
+	mkdir -p "$WT_TARGET" || { echo "ERROR: cannot create $WT_TARGET" >&2; exit 1; }
+	if [ -L target ] && [ "$(readlink target)" != "$WT_TARGET" ]; then
+		echo "==> Repointing shared target/ → $WT_TARGET (per-worktree)"
+		rm -f target
+	fi
+	if ! [ -L target ]; then
+		if [ -d target ]; then
+			echo "==> Moving existing target/ to $WT_TARGET..."
+			mv target/* "$WT_TARGET"/ 2>/dev/null || true
+			rm -rf target
+		fi
+		ln -s "$WT_TARGET" target
+		echo "==> Symlinked target/ → $WT_TARGET"
+	fi
+else
+	echo "==> NOTE: $BTRFS_ROOT is not a directory; build artifacts stay on the root filesystem"
+fi
+
+# Self-heal a dangling link. `[ -d target ]` follows the symlink, so this is
+# false exactly when it does not resolve.
+if [ -L target ] && ! [ -d target ]; then
+	TGT="$(readlink target)"
+	echo "==> target/ → $TGT is dangling (volume reset?); recreating"
+	if ! mkdir -p "$TGT" 2>/dev/null; then
+		echo "==> WARNING: cannot recreate $TGT; using a local target/ on the root filesystem"
+		rm -f target
+	fi
+fi
+
+# Fail closed: leaving target/ unusable turns into an opaque cargo error several
+# steps later, which is precisely how the original outage read.
+[ -e target ] || mkdir -p target
+if [ ! -d target ]; then
+	echo "ERROR: target exists but is not a usable directory:" >&2
+	ls -ld target >&2
+	exit 1
+fi

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -164,6 +164,20 @@ fn cargo_target_link_heals_when_btrfs_is_gone_entirely() {
          recipe depends on it:\n{out}"
     );
     assert_target_usable(work.path(), "btrfs root absent");
+
+    // And it must be a REAL local directory, not the stale link with its target
+    // recreated. `$BTRFS_ROOT` absent means the volume is unmounted; recreating
+    // the path underneath a mountpoint writes build artifacts to the small root
+    // filesystem while still looking like btrfs — the exact failure this whole
+    // indirection exists to avoid.
+    assert!(
+        std::fs::symlink_metadata(work.path().join("target"))
+            .expect("target must exist")
+            .file_type()
+            .is_dir(),
+        "target is still a symlink after the btrfs volume disappeared; artifacts would be \
+         written under the unmounted mountpoint {gone:?} — i.e. onto the root filesystem"
+    );
 }
 
 /// `target` occupied by a regular file cannot be silently ignored: cargo would

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -1,0 +1,185 @@
+//! `make cargo-target-link` must leave `target/` resolving to a real directory.
+//!
+//! Every build and test recipe runs cargo with `CARGO_TARGET_DIR=target`, where
+//! `target` is a symlink onto btrfs (the root filesystem is small and a link step
+//! dies with "No space left on device" mid-build). The symlink is created once and
+//! then trusted forever — but `/mnt/fcvm-btrfs` on the CI runners is EPHEMERAL and
+//! gets reset out from under a checkout that persists across jobs. The link is
+//! then dangling, and cargo does not create the directory through it: it builds a
+//! tempdir and `rename()`s it onto the path, which fails on an existing symlink
+//! with ENOTDIR.
+//!
+//! That is not a hypothetical. Host-arm64 on #771/#772 (2026-08-08) died with
+//!
+//! ```text
+//! error: failed to create directory `/opt/actions-runner/_work/fcvm/fcvm/fcvm/target`
+//! Caused by:
+//!   Not a directory (os error 20)
+//! ```
+//!
+//! reproduced exactly by pointing `target` at a path that does not exist. The
+//! recipe already self-heals `$HOME/.cargo` for this very reason ("the btrfs above
+//! is ephemeral and can be reset out from under us, leaving ~/.cargo a dangling
+//! symlink") — `target/` was left without the same treatment.
+//!
+//! These run the REAL recipe out of the repo's Makefile, with `BTRFS_ROOT` pointed
+//! at a temp dir, and assert the postcondition callers depend on: after the target
+//! runs, `target/` is a directory cargo can write into. Asserting on the recipe's
+//! text instead would pass on a Makefile whose comments merely mention healing.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Run `make cargo-target-link` with cwd `dir` and the btrfs root redirected.
+/// Returns (success, combined output).
+fn run_link(dir: &Path, btrfs_root: &Path) -> (bool, String) {
+    let out = Command::new("make")
+        .arg("-f")
+        .arg(repo_root().join("Makefile"))
+        .arg("cargo-target-link")
+        .arg(format!("BTRFS_ROOT={}", btrfs_root.display()))
+        .current_dir(dir)
+        .output()
+        .expect("run make cargo-target-link");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (out.status.success(), text)
+}
+
+/// The postcondition every cargo invocation depends on.
+fn assert_target_usable(dir: &Path, ctx: &str) {
+    let target = dir.join("target");
+    assert!(
+        target.is_dir(),
+        "{ctx}: `target` does not resolve to a directory, so `CARGO_TARGET_DIR=target cargo \
+         build` fails with `failed to create directory ... Not a directory (os error 20)` — \
+         cargo renames a tempdir onto the path and cannot do that through a symlink. \
+         symlink_metadata={:?} readlink={:?}",
+        std::fs::symlink_metadata(&target).map(|m| m.file_type()),
+        std::fs::read_link(&target)
+    );
+    // Prove it is writable, not merely stat-able.
+    let probe = target.join(".cargo-target-link-probe");
+    std::fs::write(&probe, b"x").unwrap_or_else(|e| panic!("{ctx}: target/ is not writable: {e}"));
+    let _ = std::fs::remove_file(&probe);
+}
+
+/// Fresh checkout: the link gets created, per-worktree.
+#[test]
+fn cargo_target_link_creates_a_per_worktree_link() {
+    let work = tempfile::tempdir().expect("tempdir");
+    let btrfs = tempfile::tempdir().expect("tempdir");
+    let (ok, out) = run_link(work.path(), btrfs.path());
+    assert!(ok, "make cargo-target-link failed:\n{out}");
+    assert_target_usable(work.path(), "fresh checkout");
+
+    let link = std::fs::read_link(work.path().join("target")).expect("target should be a symlink");
+    assert!(
+        link.starts_with(btrfs.path().join("cargo-target")),
+        "target/ points at {link:?}, not under the btrfs cargo-target root — build artifacts \
+         would land on the small root filesystem"
+    );
+}
+
+/// Two checkouts must not share one target dir: cargo's test-binary filename hash
+/// omits the checkout path, so a shared dir lets one worktree run another's test
+/// binary (observed 2026-08-08 — a run listed a test that existed only in a
+/// different worktree, which makes red/green verification meaningless).
+#[test]
+fn cargo_target_link_separates_two_worktrees() {
+    let btrfs = tempfile::tempdir().expect("tempdir");
+    let a = tempfile::tempdir().expect("tempdir");
+    let b = tempfile::tempdir().expect("tempdir");
+
+    for d in [a.path(), b.path()] {
+        let (ok, out) = run_link(d, btrfs.path());
+        assert!(ok, "make cargo-target-link failed in {d:?}:\n{out}");
+    }
+    let la = std::fs::read_link(a.path().join("target")).unwrap();
+    let lb = std::fs::read_link(b.path().join("target")).unwrap();
+    assert_ne!(
+        la, lb,
+        "two checkouts resolved to the SAME cargo target dir; each worktree's test binaries \
+         would overwrite the other's"
+    );
+}
+
+/// THE REGRESSION. The btrfs root is wiped after the link exists — exactly what an
+/// ephemeral runner volume does between jobs.
+#[test]
+fn cargo_target_link_heals_a_dangling_link_after_btrfs_is_wiped() {
+    let work = tempfile::tempdir().expect("tempdir");
+    let btrfs = tempfile::tempdir().expect("tempdir");
+
+    let (ok, out) = run_link(work.path(), btrfs.path());
+    assert!(ok, "first run failed:\n{out}");
+    let link = std::fs::read_link(work.path().join("target")).expect("symlink");
+
+    // The volume is reset; the symlink survives in the persistent checkout.
+    std::fs::remove_dir_all(btrfs.path()).expect("wipe btrfs root");
+    assert!(
+        !link.exists(),
+        "precondition: the link must now be dangling"
+    );
+    std::fs::create_dir_all(btrfs.path()).expect("volume comes back, empty");
+
+    let (ok, out) = run_link(work.path(), btrfs.path());
+    assert!(ok, "second run failed:\n{out}");
+    assert_target_usable(work.path(), "after the btrfs root was wiped");
+}
+
+/// The harder variant: the volume does not come back at all, so the `-d $(BTRFS_ROOT)`
+/// branch is skipped entirely and nothing touches the stale link. A build must still
+/// work — falling back to a local `target/` beats failing every job.
+#[test]
+fn cargo_target_link_heals_when_btrfs_is_gone_entirely() {
+    let work = tempfile::tempdir().expect("tempdir");
+    let btrfs = tempfile::tempdir().expect("tempdir");
+
+    let (ok, out) = run_link(work.path(), btrfs.path());
+    assert!(ok, "first run failed:\n{out}");
+
+    let gone = btrfs.path().to_path_buf();
+    std::fs::remove_dir_all(&gone).expect("wipe btrfs root");
+    assert!(
+        !gone.exists(),
+        "precondition: the btrfs root must be absent"
+    );
+
+    let (ok, out) = run_link(work.path(), &gone);
+    assert!(
+        ok,
+        "make cargo-target-link failed when the btrfs root was absent; every build and test \
+         recipe depends on it:\n{out}"
+    );
+    assert_target_usable(work.path(), "btrfs root absent");
+}
+
+/// `target` occupied by a regular file cannot be silently ignored: cargo would fail
+/// later with the same opaque error. Fail here, loudly, where the message can name
+/// the cause.
+#[test]
+fn cargo_target_link_fails_loudly_on_a_non_directory_target() {
+    let work = tempfile::tempdir().expect("tempdir");
+    let btrfs = tempfile::tempdir().expect("tempdir");
+    std::fs::write(work.path().join("target"), b"not a directory").expect("write file");
+
+    let (ok, out) = run_link(work.path(), btrfs.path());
+    assert!(
+        !ok,
+        "make cargo-target-link reported success while `target` is a regular file; the build \
+         would then die inside cargo with `Not a directory (os error 20)` and no hint of why. \
+         Output:\n{out}"
+    );
+    assert!(
+        out.contains("target"),
+        "the failure must name `target` so the cause is actionable. Output:\n{out}"
+    );
+}

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -34,17 +34,21 @@ fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
-/// Run `make cargo-target-link` with cwd `dir` and the btrfs root redirected.
+/// Run the real script with cwd `dir` and the btrfs root redirected.
 /// Returns (success, combined output).
+///
+/// Invoked directly rather than through `make`: the privileged suites run the
+/// test binary under `sudo` (CARGO_TARGET_*_RUNNER), so a `make` subprocess would
+/// be root and the Makefile refuses that outright ("Do not run make as root"),
+/// failing every test here for a reason that has nothing to do with the code.
+/// `makefile_delegates_to_the_script` covers the wiring.
 fn run_link(dir: &Path, btrfs_root: &Path) -> (bool, String) {
-    let out = Command::new("make")
-        .arg("-f")
-        .arg(repo_root().join("Makefile"))
-        .arg("cargo-target-link")
-        .arg(format!("BTRFS_ROOT={}", btrfs_root.display()))
+    let out = Command::new(repo_root().join("scripts/cargo-target-link.sh"))
+        .env("BTRFS_ROOT", btrfs_root)
+        .env_remove("CARGO_TARGET_LINK_LOCKED")
         .current_dir(dir)
         .output()
-        .expect("run make cargo-target-link");
+        .expect("run scripts/cargo-target-link.sh");
     let text = format!(
         "{}{}",
         String::from_utf8_lossy(&out.stdout),
@@ -77,7 +81,7 @@ fn cargo_target_link_creates_a_per_worktree_link() {
     let work = tempfile::tempdir().expect("tempdir");
     let btrfs = tempfile::tempdir().expect("tempdir");
     let (ok, out) = run_link(work.path(), btrfs.path());
-    assert!(ok, "make cargo-target-link failed:\n{out}");
+    assert!(ok, "cargo-target-link.sh failed:\n{out}");
     assert_target_usable(work.path(), "fresh checkout");
 
     let link = std::fs::read_link(work.path().join("target")).expect("target should be a symlink");
@@ -100,7 +104,7 @@ fn cargo_target_link_separates_two_worktrees() {
 
     for d in [a.path(), b.path()] {
         let (ok, out) = run_link(d, btrfs.path());
-        assert!(ok, "make cargo-target-link failed in {d:?}:\n{out}");
+        assert!(ok, "cargo-target-link.sh failed in {d:?}:\n{out}");
     }
     let la = std::fs::read_link(a.path().join("target")).unwrap();
     let lb = std::fs::read_link(b.path().join("target")).unwrap();
@@ -156,30 +160,82 @@ fn cargo_target_link_heals_when_btrfs_is_gone_entirely() {
     let (ok, out) = run_link(work.path(), &gone);
     assert!(
         ok,
-        "make cargo-target-link failed when the btrfs root was absent; every build and test \
+        "cargo-target-link.sh failed when the btrfs root was absent; every build and test \
          recipe depends on it:\n{out}"
     );
     assert_target_usable(work.path(), "btrfs root absent");
 }
 
-/// `target` occupied by a regular file cannot be silently ignored: cargo would fail
-/// later with the same opaque error. Fail here, loudly, where the message can name
-/// the cause.
+/// `target` occupied by a regular file cannot be silently ignored: cargo would
+/// fail later with the same opaque `Not a directory (os error 20)` and no hint of
+/// why. Fail here, loudly, where the message can name the cause.
+///
+/// Both branches matter, and only the second pins the explicit guard. With the
+/// btrfs root PRESENT the script dies earlier anyway, when `ln -s` hits the
+/// existing file under `set -e` — so that case alone passes even with the guard
+/// deleted (verified by mutation). With the root ABSENT nothing else touches
+/// `target`, and the guard is the only thing standing between a silent exit 0 and
+/// a build that fails much later somewhere else.
 #[test]
 fn cargo_target_link_fails_loudly_on_a_non_directory_target() {
-    let work = tempfile::tempdir().expect("tempdir");
-    let btrfs = tempfile::tempdir().expect("tempdir");
-    std::fs::write(work.path().join("target"), b"not a directory").expect("write file");
+    for btrfs_present in [true, false] {
+        let work = tempfile::tempdir().expect("tempdir");
+        let btrfs = tempfile::tempdir().expect("tempdir");
+        let root = btrfs.path().to_path_buf();
+        if !btrfs_present {
+            std::fs::remove_dir_all(&root).expect("wipe btrfs root");
+        }
+        std::fs::write(work.path().join("target"), b"not a directory").expect("write file");
 
-    let (ok, out) = run_link(work.path(), btrfs.path());
+        let (ok, out) = run_link(work.path(), &root);
+        assert!(
+            !ok,
+            "btrfs_present={btrfs_present}: reported success while `target` is a regular file. \
+             The build then dies inside cargo with `Not a directory (os error 20)` and nothing \
+             points at the cause. Output:\n{out}"
+        );
+        assert!(
+            out.contains("target"),
+            "btrfs_present={btrfs_present}: the failure must name `target` so it is \
+             actionable. Output:\n{out}"
+        );
+    }
+}
+
+/// The Makefile must actually call the script. Every build and test recipe
+/// depends on `cargo-target-link`, and the tests above drive the script directly
+/// — so if the recipe stopped invoking it (or grew a second, divergent copy of
+/// the logic inline) nothing else here would notice.
+///
+/// This reads the recipe's COMMAND lines only, not the whole file: a match
+/// anywhere in the Makefile would also be satisfied by a comment mentioning the
+/// script, which is the failure mode that made an earlier version of the AMI-hash
+/// test pass with its subject deleted.
+#[test]
+fn makefile_delegates_to_the_script() {
+    let mk = std::fs::read_to_string(repo_root().join("Makefile")).expect("read Makefile");
+    let mut lines = mk
+        .lines()
+        .skip_while(|l| !l.starts_with("cargo-target-link:"));
     assert!(
-        !ok,
-        "make cargo-target-link reported success while `target` is a regular file; the build \
-         would then die inside cargo with `Not a directory (os error 20)` and no hint of why. \
-         Output:\n{out}"
+        lines.next().is_some(),
+        "Makefile has no `cargo-target-link:` target; every build recipe depends on it"
+    );
+    let recipe: Vec<&str> = lines
+        .take_while(|l| l.starts_with('\t'))
+        .map(|l| l.trim_start_matches('\t'))
+        .filter(|l| !l.trim_start_matches('@').starts_with('#'))
+        .collect();
+    assert!(
+        !recipe.is_empty(),
+        "`cargo-target-link` has no commands, so nothing sets up target/"
     );
     assert!(
-        out.contains("target"),
-        "the failure must name `target` so the cause is actionable. Output:\n{out}"
+        recipe
+            .iter()
+            .any(|l| l.contains("scripts/cargo-target-link.sh")),
+        "the cargo-target-link recipe does not invoke scripts/cargo-target-link.sh, so the \
+         behaviour every other test in this file verifies is not what `make` runs. Commands \
+         found: {recipe:?}"
     );
 }


### PR DESCRIPTION
Host-arm64 is failing on **every open PR** with:

```
error: failed to create directory `/opt/actions-runner/_work/fcvm/fcvm/fcvm/target`
Caused by:
  Not a directory (os error 20)
```

## Root cause

Reproduced exactly, locally:

```
$ ln -s /tmp/x/btrfs/does-not-exist target
$ CARGO_TARGET_DIR=target cargo build
error: failed to create directory `/tmp/enotdir-repro/target`
Caused by:  Not a directory (os error 20)
```

`target` is a **dangling symlink**. Cargo does not create the directory through it — it builds a tempdir and `rename()`s it onto the path, and `rename()` onto an existing symlink is `ENOTDIR`. Note `mkdir()` alone would give `EEXIST`; only the rename explains errno 20.

`cargo-target-link` (added in #767) creates the link and then trusts it forever. The volume it points into is ephemeral — `scripts/runner-disk-preflight.sh` prunes idle `cargo-target` dirs, and a runner can come back with the volume reset — while the runner's checkout persists across jobs. The `~/.cargo` block immediately below already self-heals for exactly this reason ("the btrfs above is ephemeral and can be reset out from under us, leaving ~/.cargo a dangling symlink"); `target/` was left without the same treatment.

## Changes

`Makefile`
- `BTRFS_ROOT ?= /mnt/fcvm-btrfs`, read only by `CARGO_TARGET_BTRFS` and `cargo-target-link`, so the tests can point the recipe at a temp dir
- recreate the link's target when dangling; if the volume is gone entirely, drop the link and fall back to a local `target/` with a warning
- `mkdir -p` of the per-worktree dir aborts with a message instead of silently continuing
- log when the `BTRFS_ROOT` branch is skipped, so a future skip is visible instead of surfacing as an opaque cargo error several steps later
- fail closed: after the recipe, `target/` must be a usable directory

`tests/test_cargo_target_link.rs` (new, 5 tests) runs the **real** recipe out of the Makefile with `BTRFS_ROOT` redirected, and asserts the postcondition callers depend on — `target/` resolves to a writable directory — rather than scanning the recipe's text. (A text scan passes on a Makefile whose comments merely mention healing; that defect was found on #765 and again on #769.)

## RED verification

With `BTRFS_ROOT` introduced but **no healing**:

```
Summary [10.936s] 5 tests run: 3 passed, 2 failed
  FAIL cargo_target_link_fails_loudly_on_a_non_directory_target
  FAIL cargo_target_link_heals_when_btrfs_is_gone_entirely
    btrfs root absent: `target` does not resolve to a directory ...
    symlink_metadata=Ok(FileType { is_symlink: true }) readlink=Ok(".../cargo-target/.tmp4x00u8-cea0124f")
```

After the fix:

```
Summary [0.225s] 5 tests run: 5 passed, 437 skipped
```

`cargo fmt` (scoped) and `cargo clippy --all-targets -- -D warnings` both clean.

## Follow-up, not in this PR

`stage_target_dirs` in `scripts/runner-disk-preflight.sh` globs `$BTRFS_ROOT/cargo-target*`, which after #767 matches the **parent** of the per-worktree dirs. `recently_used` recurses, so an active tree is correctly kept — but that means the idle *children* are never candidates and never pruned. Disk leak, separate concern.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved per-worktree build target setup with unique, writable target directories.
  * Added automatic recovery for missing or reset storage locations.
  * Added a local-storage fallback when the preferred location is unavailable.
  * Added configurable build-storage and project-path settings.

* **Bug Fixes**
  * Repairs dangling target links and reports unusable target paths clearly.

* **Tests**
  * Added coverage for target setup, recovery, fallback behavior, and build integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->