### PR TITLE
Classify runner loss before invoking the CI fixer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           path: fcvm
+      - name: Test CI infrastructure classifier
+        working-directory: fcvm
+        run: make test-ci-infrastructure
       - uses: ./fcvm/.github/actions/checkout-deps
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.93.0

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -237,6 +237,77 @@ jobs:
             echo "ok=false" >> $GITHUB_OUTPUT
           fi
 
+  # A runner disappearing is not a code failure. Classify the completed CI run
+  # before ci-fix checks out or builds its head, rerun failed jobs once when the
+  # evidence is exclusively infrastructural, and keep Claude out of that path.
+  classify-ci-failure:
+    needs: safety-check
+    if: |
+      needs.safety-check.outputs.eligible == 'true' &&
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.name == 'CI'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
+    concurrency:
+      group: claude-infra-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+      cancel-in-progress: false
+    outputs:
+      classification: ${{ steps.classify.outputs.classification }}
+      rerun: ${{ steps.classify.outputs.rerun }}
+    steps:
+      # workflow_run is privileged. The classifier must come from the trusted
+      # default branch, never from the failed head whose logs it is inspecting.
+      - name: Check out trusted classifier
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          persist-credentials: false
+          path: fcvm
+
+      - name: Classify failed jobs
+        id: classify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          FAILED_RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+        run: |
+          set -euo pipefail
+          RESULT=$(python3 fcvm/scripts/classify_ci_failure.py \
+            --repository "$REPO" \
+            --run-id "$FAILED_RUN_ID" \
+            --run-attempt "$RUN_ATTEMPT")
+          printf '%s\n' "$RESULT" | jq .
+          CLASSIFICATION=$(printf '%s\n' "$RESULT" | jq -er \
+            '.classification | select(. == "infrastructure" or . == "not_infrastructure")')
+          RERUN=$(printf '%s\n' "$RESULT" | jq -er \
+            'if .rerun_failed_jobs == true then "true" elif .rerun_failed_jobs == false then "false" else empty end')
+          echo "classification=$CLASSIFICATION" >> "$GITHUB_OUTPUT"
+          echo "rerun=$RERUN" >> "$GITHUB_OUTPUT"
+
+      - name: Rerun failed infrastructure jobs once
+        if: steps.classify.outputs.rerun == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          FAILED_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          RUN=$(gh api "repos/$REPO/actions/runs/$FAILED_RUN_ID")
+          CURRENT_ATTEMPT=$(printf '%s\n' "$RUN" | jq -er '.run_attempt')
+          CURRENT_STATUS=$(printf '%s\n' "$RUN" | jq -er '.status')
+          if [ "$CURRENT_ATTEMPT" != "1" ] || [ "$CURRENT_STATUS" != "completed" ]; then
+            echo "::notice::Run $FAILED_RUN_ID is already attempt $CURRENT_ATTEMPT/$CURRENT_STATUS; not rerunning"
+            exit 0
+          fi
+          gh run rerun "$FAILED_RUN_ID" --failed --repo "$REPO"
+
   # Review PRs from org members, auto-fix medium/critical issues
   review:
     needs: safety-check
@@ -482,9 +553,10 @@ jobs:
 
   # Auto-fix CI failures
   ci-fix:
-    needs: safety-check
+    needs: [safety-check, classify-ci-failure]
     if: |
       needs.safety-check.outputs.eligible == 'true' &&
+      needs.classify-ci-failure.outputs.classification != 'infrastructure' &&
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.head_repository.full_name == github.repository &&
       github.event.workflow_run.conclusion == 'failure' &&

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -561,7 +561,7 @@ jobs:
       github.event.workflow_run.head_repository.full_name == github.repository &&
       github.event.workflow_run.conclusion == 'failure' &&
       !startsWith(github.event.workflow_run.head_branch, 'claude/fix-') &&
-      github.event.workflow_run.name != 'Claude Assistant'
+      github.event.workflow_run.name == 'CI'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     concurrency:

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ CONTAINER_RUN_BASE := podman run --rm --privileged \
 CONTAINER_RUN := $(CONTAINER_RUN_BASE) --ulimit nproc=65536:65536 --pids-limit=65536
 
 .PHONY: all help build clean clean-test-data check-disk \
-	test test-unit test-fast test-all test-root test-packaging fuzz \
+	test test-unit test-fast test-all test-root test-packaging test-ci-infrastructure fuzz \
 	_test-unit _test-fast _test-all _test-root _setup-fcvm _bench \
 	container-build container-test container-test-unit container-test-fast container-test-all container-test-fc-mock \
 	container-setup-fcvm container-shell container-clean container-bench \
@@ -217,6 +217,7 @@ help:
 	@echo "  test-all           + slow VM tests (rootless, no sudo)"
 	@echo "  test-root, test    + privileged tests (bridged, pjdfstest, sudo)"
 	@echo "  test-fc-mock       Run tests with fc-mock (no KVM required)"
+	@echo "  test-ci-infrastructure  Deterministic runner-failure classifier fixtures"
 	@echo "  fuzz               Seeded lifecycle chaos fuzz (SEEDS=N|list OPS=M, defaults 1/10)"
 	@echo ""
 	@echo "Test (container):"
@@ -646,6 +647,9 @@ analyze-chromium-request:
 test-chromium-request:
 	@python3 -m unittest discover -s bench/chromium -p 'test_reqbench.py' \
 		$(if $(FILTER),-k '$(FILTER)',)
+
+test-ci-infrastructure:
+	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_ci_infrastructure.py'
 
 bench: build
 	@echo "==> Running benchmarks..."

--- a/scripts/classify_ci_failure.py
+++ b/scripts/classify_ci_failure.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Classify a completed CI failure without executing the failed revision.
+
+The classifier is deliberately narrow. A failed job is infrastructure only
+when GitHub's step metadata contains no genuine failure and either:
+
+* the job log contains GitHub's runner-shutdown sentinel, or
+* the completed job has the silent runner-loss shape (one still-running step,
+  only pending steps after it) and Azure reports that the log blob is missing.
+
+The CI Summary job is derivative when its only failed step is the gate that
+reports a failed dependency. It does not turn an otherwise infrastructure-only
+run into a mixed failure. Every unknown shape is non-infrastructure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+RUNNER_SHUTDOWN_SENTINEL = (
+    "The runner has received a shutdown signal. This can happen when the runner "
+    "service is stopped, or a manually started runner is canceled."
+)
+DERIVATIVE_JOB = "Summary"
+DERIVATIVE_STEP = "Fail if any gating job did not succeed"
+REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+class InputError(RuntimeError):
+    """The GitHub response or fixture did not satisfy the input contract."""
+
+
+def _run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["gh", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _positive_int(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise InputError(f"{field} must be a positive integer")
+    return value
+
+
+def _validate_jobs(jobs: Any) -> list[dict[str, Any]]:
+    if not isinstance(jobs, list):
+        raise InputError("jobs must be an array")
+
+    validated: list[dict[str, Any]] = []
+    ids: set[int] = set()
+    for job in jobs:
+        if not isinstance(job, dict):
+            raise InputError("every job must be an object")
+        job_id = _positive_int(job.get("id"), "job.id")
+        if job_id in ids:
+            raise InputError(f"duplicate job id {job_id}")
+        ids.add(job_id)
+        if not isinstance(job.get("name"), str):
+            raise InputError(f"job {job_id} has no string name")
+        if not isinstance(job.get("status"), str):
+            raise InputError(f"job {job_id} has no string status")
+        conclusion = job.get("conclusion")
+        if conclusion is not None and not isinstance(conclusion, str):
+            raise InputError(f"job {job_id} has an invalid conclusion")
+        steps = job.get("steps")
+        if not isinstance(steps, list):
+            raise InputError(f"job {job_id} has no steps array")
+        for step in steps:
+            if not isinstance(step, dict):
+                raise InputError(f"job {job_id} contains a non-object step")
+            if not isinstance(step.get("name"), str):
+                raise InputError(f"job {job_id} contains a step with no string name")
+            if not isinstance(step.get("status"), str):
+                raise InputError(f"job {job_id} contains a step with no string status")
+            step_conclusion = step.get("conclusion")
+            if step_conclusion is not None and not isinstance(step_conclusion, str):
+                raise InputError(f"job {job_id} contains a step with an invalid conclusion")
+        validated.append(job)
+    return validated
+
+
+def _validate_logs(logs: Any) -> dict[str, dict[str, Any]]:
+    if not isinstance(logs, dict):
+        raise InputError("logs must be an object keyed by job id")
+    validated: dict[str, dict[str, Any]] = {}
+    for job_id, evidence in logs.items():
+        if not isinstance(job_id, str) or not job_id.isdecimal():
+            raise InputError("every logs key must be a decimal job id")
+        if not isinstance(evidence, dict):
+            raise InputError(f"log evidence for job {job_id} must be an object")
+        status = evidence.get("status")
+        if status not in {"available", "missing_blob", "unavailable"}:
+            raise InputError(f"log evidence for job {job_id} has invalid status")
+        if status == "available" and not isinstance(evidence.get("text"), str):
+            raise InputError(f"available log evidence for job {job_id} needs text")
+        if status == "missing_blob" and (
+            evidence.get("http_status") != 404
+            or evidence.get("error_code") != "BlobNotFound"
+        ):
+            raise InputError(
+                f"missing log evidence for job {job_id} must be 404 BlobNotFound"
+            )
+        validated[job_id] = evidence
+    return validated
+
+
+def load_fixture(path: Path) -> tuple[int, list[dict[str, Any]], dict[str, dict[str, Any]]]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise InputError(f"cannot load fixture {path}: {error}") from error
+    if not isinstance(payload, dict):
+        raise InputError("fixture root must be an object")
+    return (
+        _positive_int(payload.get("run_attempt"), "run_attempt"),
+        _validate_jobs(payload.get("jobs")),
+        _validate_logs(payload.get("logs")),
+    )
+
+
+def _fetch_jobs(repository: str, run_id: int, run_attempt: int) -> list[dict[str, Any]]:
+    jobs: list[dict[str, Any]] = []
+    page = 1
+    total_count: int | None = None
+    while total_count is None or len(jobs) < total_count:
+        endpoint = (
+            f"repos/{repository}/actions/runs/{run_id}/attempts/{run_attempt}/jobs"
+            f"?per_page=100&page={page}"
+        )
+        result = _run_gh(["api", endpoint])
+        if result.returncode != 0:
+            raise InputError(
+                f"GitHub jobs API failed for run {run_id} attempt {run_attempt}"
+            )
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError as error:
+            raise InputError("GitHub jobs API returned invalid JSON") from error
+        if not isinstance(payload, dict):
+            raise InputError("GitHub jobs API response is not an object")
+        count = payload.get("total_count")
+        page_jobs = payload.get("jobs")
+        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+            raise InputError("GitHub jobs API returned an invalid total_count")
+        if total_count is None:
+            total_count = count
+        elif total_count != count:
+            raise InputError("GitHub jobs API total_count changed during pagination")
+        if not isinstance(page_jobs, list):
+            raise InputError("GitHub jobs API returned no jobs array")
+        if not page_jobs and len(jobs) < total_count:
+            raise InputError("GitHub jobs API pagination ended before total_count")
+        jobs.extend(page_jobs)
+        page += 1
+    if len(jobs) != total_count:
+        raise InputError("GitHub jobs API returned more jobs than total_count")
+    return _validate_jobs(jobs)
+
+
+def _fetch_log(repository: str, job_id: int) -> dict[str, Any]:
+    result = _run_gh(
+        [
+            "api",
+            "--include",
+            "--allow-escape-sequences",
+            f"repos/{repository}/actions/jobs/{job_id}/logs",
+        ]
+    )
+    if result.returncode == 0:
+        return {"status": "available", "text": result.stdout}
+
+    response = f"{result.stdout}\n{result.stderr}"
+    if "gh: HTTP 404" in response and "BlobNotFound" in response:
+        return {
+            "status": "missing_blob",
+            "http_status": 404,
+            "error_code": "BlobNotFound",
+        }
+    # Authentication, rate limits, 5xx responses, and every other error are not
+    # evidence of runner loss. Preserve the conservative result without copying
+    # possibly sensitive API output into the classifier report.
+    return {"status": "unavailable"}
+
+
+def fetch_live(
+    repository: str, run_id: int, run_attempt: int
+) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]]]:
+    if not REPOSITORY_RE.fullmatch(repository):
+        raise InputError("repository must be OWNER/REPO")
+    jobs = _fetch_jobs(repository, run_id, run_attempt)
+    logs: dict[str, dict[str, Any]] = {}
+    for job in jobs:
+        if job.get("conclusion") != "failure" or _is_derivative(job):
+            continue
+        if _has_genuine_step_failure(job):
+            continue
+        job_id = _positive_int(job.get("id"), "job.id")
+        logs[str(job_id)] = _fetch_log(repository, job_id)
+    return jobs, logs
+
+
+def _failed_steps(job: dict[str, Any]) -> list[dict[str, Any]]:
+    return [step for step in job["steps"] if step.get("conclusion") == "failure"]
+
+
+def _has_genuine_step_failure(job: dict[str, Any]) -> bool:
+    # Only success/skipped/cancelled/null can participate in a runner-loss
+    # shape. Unknown terminal conclusions fail closed as genuine.
+    allowed = {None, "success", "skipped", "cancelled"}
+    return any(step.get("conclusion") not in allowed for step in job["steps"])
+
+
+def _is_derivative(job: dict[str, Any]) -> bool:
+    failed = _failed_steps(job)
+    return (
+        job.get("name") == DERIVATIVE_JOB
+        and len(failed) == 1
+        and failed[0].get("name") == DERIVATIVE_STEP
+        and not any(
+            step.get("conclusion") not in {None, "success", "skipped", "failure"}
+            for step in job["steps"]
+        )
+    )
+
+
+def _has_silent_loss_shape(job: dict[str, Any]) -> bool:
+    if job.get("status") != "completed" or job.get("conclusion") != "failure":
+        return False
+    steps = job["steps"]
+    active = [
+        index
+        for index, step in enumerate(steps)
+        if step.get("status") == "in_progress" and step.get("conclusion") is None
+    ]
+    if len(active) != 1:
+        return False
+    index = active[0]
+    if index == 0 or index == len(steps) - 1:
+        return False
+    before = steps[:index]
+    after = steps[index + 1 :]
+    return all(
+        step.get("status") == "completed"
+        and step.get("conclusion") in {"success", "skipped"}
+        for step in before
+    ) and all(
+        step.get("status") == "pending" and step.get("conclusion") is None
+        for step in after
+    )
+
+
+def _classify_root_job(
+    job: dict[str, Any], evidence: dict[str, Any] | None
+) -> tuple[str, str]:
+    if _has_genuine_step_failure(job):
+        return "genuine", "step metadata records a genuine failure"
+    if job.get("status") != "completed" or job.get("conclusion") != "failure":
+        return "unknown", "job is not a completed failure"
+
+    evidence = evidence or {"status": "unavailable"}
+    if (
+        evidence.get("status") == "available"
+        and RUNNER_SHUTDOWN_SENTINEL in evidence.get("text", "")
+    ):
+        return "infrastructure_explicit", "GitHub runner shutdown sentinel"
+    if evidence.get("status") == "missing_blob" and _has_silent_loss_shape(job):
+        return "infrastructure_silent", "null-step runner loss with missing log blob"
+    return "unknown", "no exclusive runner-loss evidence"
+
+
+def classify(
+    run_attempt: int,
+    jobs: list[dict[str, Any]],
+    logs: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    run_attempt = _positive_int(run_attempt, "run_attempt")
+    jobs = _validate_jobs(jobs)
+    logs = _validate_logs(logs)
+    failed = [job for job in jobs if job.get("conclusion") == "failure"]
+
+    results: list[dict[str, Any]] = []
+    roots: list[str] = []
+    for job in failed:
+        job_id = _positive_int(job.get("id"), "job.id")
+        if _is_derivative(job):
+            kind, reason = "derivative", "Summary reports a failed gating dependency"
+        else:
+            kind, reason = _classify_root_job(job, logs.get(str(job_id)))
+            roots.append(kind)
+        results.append(
+            {
+                "id": job_id,
+                "name": job["name"],
+                "kind": kind,
+                "reason": reason,
+            }
+        )
+
+    infrastructure = bool(roots) and all(kind.startswith("infrastructure_") for kind in roots)
+    return {
+        "run_attempt": run_attempt,
+        "classification": "infrastructure" if infrastructure else "not_infrastructure",
+        "rerun_failed_jobs": infrastructure and run_attempt == 1,
+        "jobs": results,
+    }
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture", type=Path)
+    parser.add_argument("--repository")
+    parser.add_argument("--run-id", type=int)
+    parser.add_argument("--run-attempt", type=int)
+    args = parser.parse_args(argv)
+    if args.fixture is not None:
+        if any(value is not None for value in (args.repository, args.run_id, args.run_attempt)):
+            parser.error("--fixture cannot be combined with live-run arguments")
+    elif any(value is None for value in (args.repository, args.run_id, args.run_attempt)):
+        parser.error("live classification requires --repository, --run-id, and --run-attempt")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        if args.fixture is not None:
+            run_attempt, jobs, logs = load_fixture(args.fixture)
+        else:
+            run_attempt = _positive_int(args.run_attempt, "run_attempt")
+            run_id = _positive_int(args.run_id, "run_id")
+            jobs, logs = fetch_live(args.repository, run_id, run_attempt)
+        result = classify(run_attempt, jobs, logs)
+    except InputError as error:
+        print(f"classification failed: {error}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/classify_ci_failure.py
+++ b/scripts/classify_ci_failure.py
@@ -31,6 +31,9 @@ RUNNER_SHUTDOWN_SENTINEL = (
 DERIVATIVE_JOB = "Summary"
 DERIVATIVE_STEP = "Fail if any gating job did not succeed"
 REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+GH_ESCAPE_REFUSAL = (
+    "the response contains terminal escape sequences; pass --allow-escape-sequences"
+)
 
 
 class InputError(RuntimeError):
@@ -168,14 +171,19 @@ def _fetch_jobs(repository: str, run_id: int, run_attempt: int) -> list[dict[str
 
 
 def _fetch_log(repository: str, job_id: int) -> dict[str, Any]:
-    result = _run_gh(
-        [
-            "api",
-            "--include",
-            "--allow-escape-sequences",
-            f"repos/{repository}/actions/jobs/{job_id}/logs",
-        ]
-    )
+    endpoint = f"repos/{repository}/actions/jobs/{job_id}/logs"
+    # gh <= 2.96 has no --allow-escape-sequences option and emits captured API
+    # output directly. gh >= 2.97 first refuses a response containing terminal
+    # escapes and tells the caller to opt in. Start with the command every version
+    # accepts, then use the newer option only after this exact CLI has advertised
+    # it. The log stays in a subprocess pipe and is never rendered to a terminal.
+    # Any other failure, including a changed refusal shape or a failed retry,
+    # remains unavailable and therefore classifies fail-closed.
+    result = _run_gh(["api", "--include", endpoint])
+    if result.returncode != 0 and GH_ESCAPE_REFUSAL in result.stderr:
+        result = _run_gh(
+            ["api", "--include", "--allow-escape-sequences", endpoint]
+        )
     if result.returncode == 0:
         return {"status": "available", "text": result.stdout}
 

--- a/tests/fixtures/ci-infrastructure/attempt-2.json
+++ b/tests/fixtures/ci-infrastructure/attempt-2.json
@@ -1,0 +1,33 @@
+{
+  "run_attempt": 2,
+  "jobs": [
+    {
+      "id": 5001,
+      "name": "Host-x64",
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [
+        {"name": "Set up job", "status": "completed", "conclusion": "success"},
+        {"name": "test-root", "status": "completed", "conclusion": "cancelled"},
+        {"name": "Complete job", "status": "completed", "conclusion": "success"}
+      ]
+    },
+    {
+      "id": 5002,
+      "name": "Summary",
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [
+        {"name": "Set up job", "status": "completed", "conclusion": "success"},
+        {"name": "Fail if any gating job did not succeed", "status": "completed", "conclusion": "failure"},
+        {"name": "Complete job", "status": "completed", "conclusion": "success"}
+      ]
+    }
+  ],
+  "logs": {
+    "5001": {
+      "status": "available",
+      "text": "##[error]The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.\n"
+    }
+  }
+}

--- a/tests/fixtures/ci-infrastructure/explicit-runner-shutdown.json
+++ b/tests/fixtures/ci-infrastructure/explicit-runner-shutdown.json
@@ -1,0 +1,33 @@
+{
+  "run_attempt": 1,
+  "jobs": [
+    {
+      "id": 1001,
+      "name": "Host-Root-arm64-SnapshotEnabled",
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [
+        {"name": "Set up job", "status": "completed", "conclusion": "success"},
+        {"name": "test-root", "status": "completed", "conclusion": "cancelled"},
+        {"name": "Upload test logs", "status": "completed", "conclusion": "skipped"}
+      ]
+    },
+    {
+      "id": 1002,
+      "name": "Summary",
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [
+        {"name": "Set up job", "status": "completed", "conclusion": "success"},
+        {"name": "Fail if any gating job did not succeed", "status": "completed", "conclusion": "failure"},
+        {"name": "Complete job", "status": "completed", "conclusion": "success"}
+      ]
+    }
+  ],
+  "logs": {
+    "1001": {
+      "status": "available",
+      "text": "2026-08-09T01:21:37Z ##[error]The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.\n"
+    }
+  }
+}

--- a/tests/fixtures/ci-infrastructure/genuine-failure.json
+++ b/tests/fixtures/ci-infrastructure/genuine-failure.json
@@ -1,0 +1,28 @@
+{
+  "run_attempt": 1,
+  "jobs": [
+    {
+      "id": 3001,
+      "name": "Lint",
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [
+        {"name": "Set up job", "status": "completed", "conclusion": "success"},
+        {"name": "Clippy", "status": "completed", "conclusion": "failure"},
+        {"name": "Complete job", "status": "completed", "conclusion": "success"}
+      ]
+    },
+    {
+      "id": 3002,
+      "name": "Summary",
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [
+        {"name": "Set up job", "status": "completed", "conclusion": "success"},
+        {"name": "Fail if any gating job did not succeed", "status": "completed", "conclusion": "failure"},
+        {"name": "Complete job", "status": "completed", "conclusion": "success"}
+      ]
+    }
+  ],
+  "logs": {}
+}

--- a/tests/fixtures/ci-infrastructure/mixed-failure.json
+++ b/tests/fixtures/ci-infrastructure/mixed-failure.json
@@ -1,0 +1,48 @@
+{
+  "run_attempt": 1,
+  "jobs": [
+    {
+      "id": 4001,
+      "name": "Container-x64",
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [
+        {"name": "Set up job", "status": "completed", "conclusion": "success"},
+        {"name": "container-test", "status": "completed", "conclusion": "cancelled"},
+        {"name": "Upload test logs", "status": "completed", "conclusion": "skipped"}
+      ]
+    },
+    {
+      "id": 4002,
+      "name": "Lint",
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [
+        {"name": "Set up job", "status": "completed", "conclusion": "success"},
+        {"name": "Clippy", "status": "completed", "conclusion": "failure"},
+        {"name": "Complete job", "status": "completed", "conclusion": "success"}
+      ]
+    },
+    {
+      "id": 4003,
+      "name": "Summary",
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [
+        {"name": "Set up job", "status": "completed", "conclusion": "success"},
+        {"name": "Fail if any gating job did not succeed", "status": "completed", "conclusion": "failure"},
+        {"name": "Complete job", "status": "completed", "conclusion": "success"}
+      ]
+    }
+  ],
+  "logs": {
+    "4001": {
+      "status": "available",
+      "text": "##[error]The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.\n"
+    },
+    "4002": {
+      "status": "available",
+      "text": "##[error]The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.\n"
+    }
+  }
+}

--- a/tests/fixtures/ci-infrastructure/silent-runner-loss.json
+++ b/tests/fixtures/ci-infrastructure/silent-runner-loss.json
@@ -1,0 +1,36 @@
+{
+  "run_attempt": 1,
+  "jobs": [
+    {
+      "id": 2001,
+      "name": "Container-x64",
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [
+        {"name": "Set up job", "status": "completed", "conclusion": "success"},
+        {"name": "Run actions/checkout@v7", "status": "completed", "conclusion": "success"},
+        {"name": "Clean test data", "status": "in_progress", "conclusion": null},
+        {"name": "container-test-unit", "status": "pending", "conclusion": null},
+        {"name": "Post Run actions/checkout@v7", "status": "pending", "conclusion": null}
+      ]
+    },
+    {
+      "id": 2002,
+      "name": "Summary",
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [
+        {"name": "Set up job", "status": "completed", "conclusion": "success"},
+        {"name": "Fail if any gating job did not succeed", "status": "completed", "conclusion": "failure"},
+        {"name": "Complete job", "status": "completed", "conclusion": "success"}
+      ]
+    }
+  ],
+  "logs": {
+    "2001": {
+      "status": "missing_blob",
+      "http_status": 404,
+      "error_code": "BlobNotFound"
+    }
+  }
+}

--- a/tests/test_ci_infrastructure.py
+++ b/tests/test_ci_infrastructure.py
@@ -1,13 +1,22 @@
+import importlib.util
 import json
 import subprocess
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "classify_ci_failure.py"
 FIXTURES = ROOT / "tests" / "fixtures" / "ci-infrastructure"
+
+CLASSIFIER_SPEC = importlib.util.spec_from_file_location(
+    "classify_ci_failure", SCRIPT
+)
+assert CLASSIFIER_SPEC is not None and CLASSIFIER_SPEC.loader is not None
+CLASSIFIER = importlib.util.module_from_spec(CLASSIFIER_SPEC)
+CLASSIFIER_SPEC.loader.exec_module(CLASSIFIER)
 
 
 def classify_fixture(name: str) -> dict:
@@ -30,6 +39,79 @@ def classify_fixture(name: str) -> dict:
 
 
 class CiInfrastructureClassificationTests(unittest.TestCase):
+    def test_log_fetch_uses_the_command_supported_by_old_gh(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="HTTP/2 200\n\nrunner log", stderr=""
+        )
+        endpoint = "repos/owner/repo/actions/jobs/17/logs"
+
+        with mock.patch.object(CLASSIFIER, "_run_gh", return_value=completed) as run_gh:
+            evidence = CLASSIFIER._fetch_log("owner/repo", 17)
+
+        self.assertEqual(evidence, {"status": "available", "text": completed.stdout})
+        run_gh.assert_called_once_with(["api", "--include", endpoint])
+
+    def test_log_fetch_retries_only_after_new_gh_refuses_escapes(self) -> None:
+        refused = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr=CLASSIFIER.GH_ESCAPE_REFUSAL
+        )
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="HTTP/2 200\n\n\x1b[31mlog\x1b[0m", stderr=""
+        )
+        endpoint = "repos/owner/repo/actions/jobs/18/logs"
+
+        with mock.patch.object(
+            CLASSIFIER, "_run_gh", side_effect=[refused, completed]
+        ) as run_gh:
+            evidence = CLASSIFIER._fetch_log("owner/repo", 18)
+
+        self.assertEqual(evidence, {"status": "available", "text": completed.stdout})
+        self.assertEqual(
+            [call.args[0] for call in run_gh.call_args_list],
+            [
+                ["api", "--include", endpoint],
+                ["api", "--include", "--allow-escape-sequences", endpoint],
+            ],
+        )
+
+    def test_log_fetch_fails_closed_when_escape_retry_fails(self) -> None:
+        refused = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr=CLASSIFIER.GH_ESCAPE_REFUSAL
+        )
+        retry_failed = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="unknown flag"
+        )
+
+        with mock.patch.object(
+            CLASSIFIER, "_run_gh", side_effect=[refused, retry_failed]
+        ):
+            evidence = CLASSIFIER._fetch_log("owner/repo", 19)
+
+        self.assertEqual(evidence, {"status": "unavailable"})
+
+    def test_log_fetch_preserves_missing_blob_evidence_without_new_flag(self) -> None:
+        missing = subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout='HTTP/2 404\n\n{"code":"BlobNotFound"}',
+            stderr="gh: HTTP 404: Not Found",
+        )
+
+        with mock.patch.object(CLASSIFIER, "_run_gh", return_value=missing) as run_gh:
+            evidence = CLASSIFIER._fetch_log("owner/repo", 20)
+
+        self.assertEqual(
+            evidence,
+            {
+                "status": "missing_blob",
+                "http_status": 404,
+                "error_code": "BlobNotFound",
+            },
+        )
+        run_gh.assert_called_once_with(
+            ["api", "--include", "repos/owner/repo/actions/jobs/20/logs"]
+        )
+
     def test_explicit_runner_shutdown_is_rerun_once(self) -> None:
         result = classify_fixture("explicit-runner-shutdown.json")
 

--- a/tests/test_ci_infrastructure.py
+++ b/tests/test_ci_infrastructure.py
@@ -1,0 +1,76 @@
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "classify_ci_failure.py"
+FIXTURES = ROOT / "tests" / "fixtures" / "ci-infrastructure"
+
+
+def classify_fixture(name: str) -> dict:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--fixture", str(FIXTURES / name)],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"classifier rejected {name} with {result.returncode}: {result.stderr}"
+        )
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise AssertionError(f"classifier returned invalid JSON: {result.stdout}") from error
+
+
+class CiInfrastructureClassificationTests(unittest.TestCase):
+    def test_explicit_runner_shutdown_is_rerun_once(self) -> None:
+        result = classify_fixture("explicit-runner-shutdown.json")
+
+        self.assertEqual(result["classification"], "infrastructure")
+        self.assertTrue(result["rerun_failed_jobs"])
+        self.assertEqual(
+            [job["kind"] for job in result["jobs"]],
+            ["infrastructure_explicit", "derivative"],
+        )
+
+    def test_silent_null_step_with_missing_blob_is_infrastructure(self) -> None:
+        result = classify_fixture("silent-runner-loss.json")
+
+        self.assertEqual(result["classification"], "infrastructure")
+        self.assertTrue(result["rerun_failed_jobs"])
+        self.assertEqual(result["jobs"][0]["kind"], "infrastructure_silent")
+
+    def test_genuine_failure_is_not_infrastructure(self) -> None:
+        result = classify_fixture("genuine-failure.json")
+
+        self.assertEqual(result["classification"], "not_infrastructure")
+        self.assertFalse(result["rerun_failed_jobs"])
+        self.assertEqual(result["jobs"][0]["kind"], "genuine")
+
+    def test_mixed_failure_is_not_infrastructure(self) -> None:
+        result = classify_fixture("mixed-failure.json")
+
+        self.assertEqual(result["classification"], "not_infrastructure")
+        self.assertFalse(result["rerun_failed_jobs"])
+        self.assertEqual(
+            [job["kind"] for job in result["jobs"]],
+            ["infrastructure_explicit", "genuine", "derivative"],
+        )
+
+    def test_attempt_two_is_classified_but_never_rerun(self) -> None:
+        result = classify_fixture("attempt-2.json")
+
+        self.assertEqual(result["run_attempt"], 2)
+        self.assertEqual(result["classification"], "infrastructure")
+        self.assertFalse(result["rerun_failed_jobs"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ci_workflow_coverage.rs
+++ b/tests/test_ci_workflow_coverage.rs
@@ -357,6 +357,50 @@ fn summary_fails_when_a_gating_job_fails() {
     }
 }
 
+/// The infrastructure classifier decides whether a failed CI run is retried or
+/// handed to a secret-bearing code fixer. Its fixture suite must execute in the
+/// ordinary pull-request gate, not remain a manual-only Make target.
+#[test]
+fn ci_runs_infrastructure_classifier_fixtures_on_ubuntu() {
+    let ci = parse_workflow("ci.yml");
+    let lint = workflow_job(&ci, "lint");
+
+    assert_eq!(
+        lint.get("runs-on").and_then(Value::as_str),
+        Some("ubuntu-latest"),
+        "the classifier fixtures must run on a GitHub-hosted Ubuntu runner"
+    );
+
+    let steps = lint
+        .get("steps")
+        .and_then(Value::as_sequence)
+        .expect("ci.yml `lint` job has no steps");
+    let fixture_step = steps
+        .iter()
+        .find(|step| {
+            step.get("run")
+                .and_then(Value::as_str)
+                .is_some_and(|run| run.trim() == "make test-ci-infrastructure")
+        })
+        .expect(
+            "ci.yml `lint` never runs `make test-ci-infrastructure`; the privileged CI verdict gate has no fixture coverage in CI",
+        );
+    assert_eq!(
+        fixture_step
+            .get("working-directory")
+            .and_then(Value::as_str),
+        Some("fcvm"),
+        "the classifier fixture step must run from the checked-out repository"
+    );
+    assert_ne!(
+        fixture_step
+            .get("continue-on-error")
+            .and_then(Value::as_bool),
+        Some(true),
+        "classifier fixture failures must fail the lint gate"
+    );
+}
+
 /// Infrastructure retries must be bounded, trusted, and mutually exclusive
 /// with the secret-bearing Claude fixer.
 ///

--- a/tests/test_ci_workflow_coverage.rs
+++ b/tests/test_ci_workflow_coverage.rs
@@ -44,6 +44,13 @@ fn triggers(workflow: &Value) -> &Value {
         .expect("workflow has no `on:` block — cannot evaluate trigger coverage")
 }
 
+fn workflow_job<'a>(workflow: &'a Value, name: &str) -> &'a Value {
+    workflow
+        .get("jobs")
+        .and_then(|jobs| jobs.get(name))
+        .unwrap_or_else(|| panic!("workflow has no `{name}` job"))
+}
+
 /// A base-branch filter on `pull_request` silently excludes stacked PRs.
 #[test]
 fn ci_runs_on_pull_requests_regardless_of_base_branch() {
@@ -348,4 +355,187 @@ fn summary_fails_when_a_gating_job_fails() {
              checked on its own, not as one arm of an `||` that a later edit can halve."
         );
     }
+}
+
+/// Infrastructure retries must be bounded, trusted, and mutually exclusive
+/// with the secret-bearing Claude fixer.
+///
+/// `workflow_run` executes with repository secrets even when the failed run
+/// came from a pull request. The classifier therefore checks out only the
+/// default branch and inspects the failed run through the API. Its output must
+/// gate ci-fix so an infrastructure-only failure cannot both rerun and ask
+/// Claude to edit code.
+#[test]
+fn claude_infrastructure_retry_is_trusted_bounded_and_gates_ci_fix() {
+    let claude = parse_workflow("claude.yml");
+    let classifier = workflow_job(&claude, "classify-ci-failure");
+
+    assert_eq!(
+        classifier.get("needs").and_then(Value::as_str),
+        Some("safety-check"),
+        "the infrastructure classifier must inherit the centralized eligibility gate"
+    );
+    let condition = classifier
+        .get("if")
+        .and_then(Value::as_str)
+        .expect("classify-ci-failure has no job condition");
+    for required in [
+        "needs.safety-check.outputs.eligible == 'true'",
+        "github.event_name == 'workflow_run'",
+        "github.event.workflow_run.head_repository.full_name == github.repository",
+        "github.event.workflow_run.conclusion == 'failure'",
+        "github.event.workflow_run.name == 'CI'",
+    ] {
+        assert!(
+            condition.contains(required),
+            "classify-ci-failure is missing its `{required}` trust/failure gate"
+        );
+    }
+
+    let permissions = classifier
+        .get("permissions")
+        .expect("classify-ci-failure has no explicit token permissions");
+    assert_eq!(
+        permissions.get("actions").and_then(Value::as_str),
+        Some("write"),
+        "rerunning failed jobs requires an explicitly scoped actions:write token"
+    );
+    assert_eq!(
+        permissions.get("contents").and_then(Value::as_str),
+        Some("read"),
+        "the trusted classifier checkout needs contents:read and nothing broader"
+    );
+    let concurrency = classifier
+        .get("concurrency")
+        .expect("classify-ci-failure has no duplicate-delivery serialization");
+    let group = concurrency
+        .get("group")
+        .and_then(Value::as_str)
+        .expect("classify-ci-failure concurrency has no group");
+    for identity in [
+        "github.event.workflow_run.id",
+        "github.event.workflow_run.run_attempt",
+    ] {
+        assert!(
+            group.contains(identity),
+            "classifier concurrency does not include `{identity}`"
+        );
+    }
+    assert_eq!(
+        concurrency
+            .get("cancel-in-progress")
+            .and_then(Value::as_bool),
+        Some(false),
+        "duplicate classifier deliveries must serialize instead of cancelling mid-rerun"
+    );
+
+    let steps = classifier
+        .get("steps")
+        .and_then(Value::as_sequence)
+        .expect("classify-ci-failure has no steps");
+    let checkout = steps
+        .iter()
+        .find(|step| {
+            step.get("uses")
+                .and_then(Value::as_str)
+                .is_some_and(|uses| uses.starts_with("actions/checkout@"))
+        })
+        .expect("classify-ci-failure never checks out its classifier");
+    let checkout_with = checkout
+        .get("with")
+        .expect("classifier checkout has no `with:` configuration");
+    assert_eq!(
+        checkout_with.get("ref").and_then(Value::as_str),
+        Some("${{ github.event.repository.default_branch }}"),
+        "a privileged workflow_run job must execute the classifier from the trusted default branch"
+    );
+    assert_eq!(
+        checkout_with
+            .get("persist-credentials")
+            .and_then(Value::as_bool),
+        Some(false),
+        "the classifier checkout must not persist its actions:write credential"
+    );
+    assert!(
+        steps.iter().all(|step| {
+            step.get("uses").and_then(Value::as_str) != Some("actions/create-github-app-token@v3")
+        }),
+        "the classifier should use its narrowly scoped GITHUB_TOKEN, not mint an app token"
+    );
+    for run in steps
+        .iter()
+        .filter_map(|step| step.get("run").and_then(Value::as_str))
+    {
+        assert!(
+            !run.contains("${{ github.event"),
+            "event fields must enter classifier shell through env:, never expression interpolation"
+        );
+    }
+
+    let classify_step = steps
+        .iter()
+        .find(|step| step.get("id").and_then(Value::as_str) == Some("classify"))
+        .expect("classify-ci-failure has no `classify` output step");
+    assert!(
+        classify_step
+            .get("run")
+            .and_then(Value::as_str)
+            .is_some_and(|run| run.contains("scripts/classify_ci_failure.py")),
+        "the workflow must call the deterministic classifier"
+    );
+
+    let rerun_step = steps
+        .iter()
+        .find(|step| {
+            step.get("name")
+                .and_then(Value::as_str)
+                .is_some_and(|name| name.contains("Rerun failed infrastructure"))
+        })
+        .expect("classify-ci-failure has no bounded rerun step");
+    let rerun_condition = rerun_step
+        .get("if")
+        .and_then(Value::as_str)
+        .expect("the rerun step is unconditional");
+    assert!(
+        rerun_condition.contains("steps.classify.outputs.rerun == 'true'"),
+        "the rerun step must be disabled for genuine and second-attempt failures"
+    );
+    let rerun = rerun_step
+        .get("run")
+        .and_then(Value::as_str)
+        .expect("the rerun step has no command");
+    for required in [
+        "CURRENT_ATTEMPT",
+        "CURRENT_STATUS",
+        "gh run rerun",
+        "--failed",
+    ] {
+        assert!(
+            rerun.contains(required),
+            "the rerun step is missing its `{required}` one-shot invariant"
+        );
+    }
+
+    let ci_fix = workflow_job(&claude, "ci-fix");
+    let needs: Vec<&str> = ci_fix
+        .get("needs")
+        .and_then(Value::as_sequence)
+        .expect("ci-fix.needs must include both safety and classification gates")
+        .iter()
+        .map(|need| need.as_str().expect("ci-fix.needs entry is not a string"))
+        .collect();
+    for required in ["safety-check", "classify-ci-failure"] {
+        assert!(
+            needs.contains(&required),
+            "ci-fix no longer waits for `{required}`"
+        );
+    }
+    assert!(
+        ci_fix
+            .get("if")
+            .and_then(Value::as_str)
+            .is_some_and(|condition| condition
+                .contains("needs.classify-ci-failure.outputs.classification != 'infrastructure'")),
+        "ci-fix must be suppressed for infrastructure-only failures"
+    );
 }

--- a/tests/test_ci_workflow_coverage.rs
+++ b/tests/test_ci_workflow_coverage.rs
@@ -574,12 +574,17 @@ fn claude_infrastructure_retry_is_trusted_bounded_and_gates_ci_fix() {
             "ci-fix no longer waits for `{required}`"
         );
     }
-    assert!(
-        ci_fix
-            .get("if")
-            .and_then(Value::as_str)
-            .is_some_and(|condition| condition
-                .contains("needs.classify-ci-failure.outputs.classification != 'infrastructure'")),
-        "ci-fix must be suppressed for infrastructure-only failures"
-    );
+    let ci_fix_condition = ci_fix
+        .get("if")
+        .and_then(Value::as_str)
+        .expect("ci-fix has no job condition");
+    for required in [
+        "needs.classify-ci-failure.outputs.classification != 'infrastructure'",
+        "github.event.workflow_run.name == 'CI'",
+    ] {
+        assert!(
+            ci_fix_condition.contains(required),
+            "ci-fix is missing its `{required}` classification/workflow gate"
+        );
+    }
 }


### PR DESCRIPTION
A self-hosted runner can disappear while a CI step is active. GitHub then reports a failed run even though no repository code failed, and the existing `ci-fix` path treats that result as a code defect. Retrying every ambiguous failure would be equally unsafe because it could hide a real regression.

## What changed

- Add a deterministic classifier for completed CI runs. A run is infrastructure-only only when every root failed job has exclusive runner-loss evidence: either GitHub's exact runner-shutdown sentinel, or the strict null-step/pending-tail shape paired with a `404 BlobNotFound` job log.
- Treat genuine step failures, mixed failures, unavailable evidence, and every unknown shape as code failures. The derivative `Summary` gate does not change the root classification.
- Fetch job logs with the `gh api` form supported by old and new CLI versions. Opt into terminal escape sequences only after the installed CLI explicitly requires and advertises that option; all other failures and failed retries remain unavailable and fail closed.
- Rerun only failed infrastructure jobs, only on attempt 1. Re-read the run attempt and status immediately before requesting the rerun.
- Gate `ci-fix` on the classifier so the infrastructure rerun and secret-bearing code fixer are mutually exclusive.
- Run the classifier fixture suite in the GitHub-hosted Ubuntu lint gate and structurally assert that it remains a mandatory step.
- Add deterministic fixtures, Python tests, and Rust assertions over the workflow's trust, permission, one-shot, compatibility, and gating invariants.

## Security model

`workflow_run` is privileged, so this job inherits the centralized eligibility gate, accepts only failed `CI` runs whose head repository is this repository, and checks out the classifier from the trusted default branch rather than the failed head. The checkout does not persist credentials. Its token is limited to `contents: read` and the `actions: write` needed to rerun failed jobs. Event values enter shell through `env`, and classifier output is parsed into a closed enum before it can gate either path.

## Test results

```text
$ make test-ci-infrastructure
Ran 9 tests in 0.203s
OK

$ make test-unit
Summary [50.498s] 473 tests run: 473 passed, 0 skipped

$ make lint
passed

$ git diff --check origin/main..HEAD
passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated CI failure classification to distinguish infrastructure interruptions from genuine code failures.
  - Infrastructure-related failures can be safely retried once, while repeated failures are not rerun.
  - CI remediation now avoids unnecessary fixes when only the build environment failed.

- **Bug Fixes**
  - Improved handling of runner shutdowns, missing logs, and terminal formatting during failure analysis.

- **Tests**
  - Added comprehensive coverage for failure classification, retry limits, and workflow safety controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

