### PR TITLE
Lease cargo targets before pruning idle artifacts

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -240,13 +240,14 @@ sudo cargo test ...
 
 If the Makefile is missing a target or broken, **fix the Makefile** - don't work around it.
 
-### Raw `cargo` runs a SIBLING WORKTREE's test binary — this is why the rule exists
+### Never share `CARGO_TARGET_DIR` across worktrees
 
-The environment exports `CARGO_TARGET_DIR=/mnt/fcvm-btrfs/cargo-target`, **shared by every
-worktree**. `Makefile:160` overrides it (`export CARGO_TARGET_DIR := target`), so anything run
-through `make` gets a per-worktree `./target`. A raw `cargo test` does not — it inherits the
-shared directory, and two worktrees building the same package produce the *same* test-binary
-path. Cargo then considers it fresh and runs whatever the other worktree built.
+The Makefile owns Cargo target routing. It sets `CARGO_TARGET_DIR=target`, and
+`cargo-target-link` maps that path to a directory unique to the current worktree. The obsolete
+shell-profile export of `/mnt/fcvm-btrfs/cargo-target` was removed; do not restore it or export
+any other target directory shared by multiple worktrees. Two worktrees building the same
+package can produce the same test-binary path, so a shared target lets Cargo consider a sibling
+worktree's binary fresh and run code from the wrong checkout.
 
 Observed 2026-08-08 while verifying two stacked PRs: `cargo test --test
 test_ci_workflow_coverage` in worktree A printed a test that exists **only in worktree B** and
@@ -259,9 +260,9 @@ test result: ok. 4 passed                                     <- summary_fails n
 ```
 
 Red/green verification is worthless under these conditions: "it went red" and "it went green"
-may both be reports about code you are not editing. Use `make test-unit FILTER=<pattern>`. If
-you must invoke cargo directly, set an explicit per-worktree `CARGO_TARGET_DIR` — and confirm
-the `Running .../deps/<binary>` line points inside it before believing any result.
+may both be reports about code you are not editing. Use the appropriate Make target. Before
+believing a result, confirm `readlink -f target` resolves to this worktree's unique target
+directory and the `Running .../deps/<binary>` line points beneath it.
 
 ## NEVER ROUTE AROUND BUILD PROCESSES
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,10 @@ jobs:
           echo "fuse-backend-rs=$(git -C fuse-backend-rs rev-parse HEAD)" >> $GITHUB_OUTPUT
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: fcvm -> target
+          # Persistent self-hosted targets live in leased btrfs generations.
+          # Restoring a cache here would replace the checkout symlink with an
+          # unleased real directory after disk preflight.
+          cache-targets: "false"
           cache-on-failure: "true"
           shared-key: deps-${{ steps.deps.outputs.fuser }}-${{ steps.deps.outputs.fuse-backend-rs }}
       - name: Install dependencies
@@ -537,7 +540,10 @@ jobs:
           echo "fuse-backend-rs=$(git -C fuse-backend-rs rev-parse HEAD)" >> $GITHUB_OUTPUT
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: fcvm -> target
+          # Persistent self-hosted targets live in leased btrfs generations.
+          # Restoring a cache here would replace the checkout symlink with an
+          # unleased real directory after disk preflight.
+          cache-targets: "false"
           cache-on-failure: "true"
           shared-key: deps-${{ steps.deps.outputs.fuser }}-${{ steps.deps.outputs.fuse-backend-rs }}
       - name: Install dependencies

--- a/.github/workflows/kernels.yml
+++ b/.github/workflows/kernels.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Build fcvm and fc-agent
         working-directory: fcvm
         run: |
-          cargo build --release -p fcvm -p fc-agent
+          make build-host-tools
           # Sync the checkout's embedded config to the runner user's config dir so the
           # kernel build below uses this checkout, not stale per-runner state.
           ./target/release/fcvm setup --generate-config --force
@@ -280,7 +280,7 @@ jobs:
       - name: Build fcvm and fc-agent
         working-directory: fcvm
         run: |
-          cargo build --release -p fcvm -p fc-agent
+          make build-host-tools
           # Sync the checkout's embedded config to the runner user's config dir so the
           # kernel build below uses this checkout, not stale per-runner state.
           ./target/release/fcvm setup --generate-config --force

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -137,11 +137,10 @@ jobs:
     steps:
       - name: Clean workspace (pre-checkout)
         run: |
-          sudo rm -rf ${{ github.workspace }}/fcvm/target ${{ github.workspace }}/fcvm/artifacts || true
-          # Removing target/ and artifacts/ covers the two directories seen so far,
-          # but any other root-owned file a privileged run leaves anywhere in the
-          # workspace still fails checkout with EACCES. Chown the whole tree, as
-          # the Lifecycle-Fuzz job above and every self-hosted job in ci.yml do.
+          sudo rm -rf ${{ github.workspace }}/fcvm/artifacts || true
+          # target/ is a leased generation pointer and must never be recursively
+          # removed outside that protocol. Chown the whole tree so checkout can
+          # update tracked files without an unleased target cleanup.
           sudo chown -R $USER:$USER ${{ github.workspace }}/fcvm 2>/dev/null || true
           sudo chmod -R u+w ~/.cargo/advisory-db* 2>/dev/null || true
           sudo chown -R $USER:$USER ~/.cargo/advisory-db* 2>/dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,12 @@
 SHELL := /bin/bash
 
-# Guard: never run make as root on the host (except clean). Running cargo
+# Guard: never run make as root on the host. Running build plumbing
 # as root leaves root-owned files in target/ that break subsequent user builds
 # with BrokenPipe errors from nextest finding stale binaries.
 # Skip this guard inside containers (where root is normal).
 ifeq ($(shell id -u),0)
-ifeq ($(filter clean,$(MAKECMDGOALS)),)
 ifeq ($(wildcard /.dockerenv /run/.containerenv),)
 $(error Do not run make as root. Use 'make test-root' as your normal user — it uses sudo only for the test runner)
-endif
 endif
 endif
 
@@ -148,6 +146,7 @@ endif
 # owns the derivation and the symlink, and is the ONLY place that computes the path.
 # Overridable so tests/test_cargo_target_link.rs can point it at a temp dir.
 BTRFS_ROOT ?= /mnt/fcvm-btrfs
+export BTRFS_ROOT
 MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # Base test command
@@ -202,7 +201,7 @@ CONTAINER_RUN := $(CONTAINER_RUN_BASE) --ulimit nproc=65536:65536 --pids-limit=6
 	_test-unit _test-fast _test-all _test-root _setup-fcvm _bench \
 	container-build container-test container-test-unit container-test-fast container-test-all container-test-fc-mock \
 	container-setup-fcvm container-shell container-clean container-bench \
-	cargo-target-link setup-btrfs setup-default setup-fcvm setup-pjdfstest setup-hugepages bench bench-vm bench-hugepages bench-hugepages-test \
+	cargo-target-link build-host-tools setup-btrfs setup-default setup-fcvm setup-pjdfstest setup-hugepages bench bench-vm bench-hugepages bench-hugepages-test \
 	bench-container-import bench-chromium bench-chromium-request analyze-chromium-request bench-clone-latency test-chromium-request \
 	lint fmt update-dependency ssh test-serve-sdk
 
@@ -386,6 +385,12 @@ build: cargo-target-link
 	@# Sync embedded config to user config dir (config is embedded at compile time)
 	@./target/release/fcvm setup --generate-config --force 2>/dev/null || true
 
+# Host-native tools used by the kernel-builder AMI/workflow. Unlike `build`,
+# this does not require a musl Rust target for the guest agent.
+build-host-tools: cargo-target-link
+	@echo "==> Building host-native fcvm and fc-agent..."
+	CARGO_TARGET_DIR=target $(CARGO) build --release -p fcvm -p fc-agent
+
 build-fc-mock: cargo-target-link
 	@echo "==> Building fc-mock..."
 	CARGO_TARGET_DIR=target $(CARGO) build --release -p fc-mock
@@ -399,7 +404,9 @@ test-packaging: build
 	./scripts/test-packaging.sh target/release/fcvm
 
 clean:
-	sudo rm -rf target/*
+	@# Publish an empty namespace; the disk guard safely reclaims the retired
+	@# generation without unlinking dentries that may be foreign mountpoints.
+	@BTRFS_ROOT="$(BTRFS_ROOT)" "$(MAKEFILE_DIR)scripts/cargo-target-link.sh" --rotate
 
 # Run-only targets (no setup deps, used by container)
 _test-unit: cargo-target-link

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,13 @@ RUST_BIN := $(shell command -v cargo >/dev/null 2>&1 && dirname $$(command -v ca
 	(ls -d $(HOME)/.rustup/toolchains/stable-*/bin 2>/dev/null | head -1) || \
 	(ls -d $(HOME)/.rustup/toolchains/*/bin 2>/dev/null | head -1))
 export PATH := $(RUST_BIN):$(PATH)
-CARGO := cargo
+CARGO_BIN ?= cargo
+# Every Cargo command issued by this Makefile holds a shared lease on this
+# worktree's target directory.  runner-disk-preflight.sh takes the same lease
+# exclusively before pruning idle artifacts, so age-check -> delete cannot race
+# a build.  `override` prevents `make CARGO=cargo ...` from silently bypassing
+# the safety protocol; CARGO_BIN remains available for toolchain selection.
+override CARGO = "$(MAKEFILE_DIR)scripts/cargo-target-run.sh" $(CARGO_BIN)
 
 # Custom dependencies bin directory
 CUSTOM_DEPS_BIN := /mnt/fcvm-btrfs/deps/bin
@@ -319,12 +325,12 @@ check-disk: cargo-target-link
 		else echo "==> WARNING: no rustup toolchain found to restore cargo from"; fi; \
 	fi
 	@# Ensure cargo-nextest (the test runner; a separate install from rustup).
-	@if ! PATH="$$HOME/.cargo/bin:$$PATH" cargo nextest --version >/dev/null 2>&1; then \
+	@if ! PATH="$$HOME/.cargo/bin:$$PATH" $(CARGO) nextest --version >/dev/null 2>&1; then \
 		echo "==> Installing cargo-nextest..."; \
 		case "$$(uname -m)" in aarch64|arm64) NURL=https://get.nexte.st/latest/linux-arm ;; *) NURL=https://get.nexte.st/latest/linux ;; esac; \
 		mkdir -p "$$HOME/.cargo/bin"; \
 		curl -LsSf "$$NURL" | tar zxf - -C "$$HOME/.cargo/bin" \
-			|| PATH="$$HOME/.cargo/bin:$$PATH" cargo install cargo-nextest --locked; \
+			|| PATH="$$HOME/.cargo/bin:$$PATH" $(CARGO) install cargo-nextest --locked; \
 	fi
 	@BTRFS_FREE=$$(df -BG /mnt/fcvm-btrfs 2>/dev/null | awk 'NR==2 {gsub("G",""); print $$4}'); \
 	if [ -n "$$BTRFS_FREE" ] && [ "$$BTRFS_FREE" -lt 15 ]; then \
@@ -396,18 +402,18 @@ clean:
 	sudo rm -rf target/*
 
 # Run-only targets (no setup deps, used by container)
-_test-unit:
+_test-unit: cargo-target-link
 	$(NEXTEST) --no-default-features
 
-_test-fast:
+_test-fast: cargo-target-link
 	RUST_LOG="$(TEST_LOG)" \
 	./scripts/no-sudo.sh $(NEXTEST) $(NEXTEST_CAPTURE) --no-default-features --features integration-fast $(FILTER)
 
-_test-all:
+_test-all: cargo-target-link
 	RUST_LOG="$(TEST_LOG)" \
 	./scripts/no-sudo.sh $(NEXTEST) $(NEXTEST_CAPTURE) $(FILTER)
 
-_test-root:
+_test-root: cargo-target-link
 	@if find target/ -user root -print -quit 2>/dev/null | grep -q .; then \
 		echo "==> WARNING: root-owned files in target/ (from sudo cargo?). Fixing ownership..."; \
 		sudo chown -R $$(id -u):$$(id -g) target/; \
@@ -447,7 +453,7 @@ fuzz: show-notes check-disk setup-fcvm
 # Uses fc-mock binary instead of Firecracker.
 # Only runs tests known to work with fc-mock (no KVM, no real Firecracker).
 FC_MOCK_FILTER := package(fcvm) & (test(=test_sanity_bridged) | test(=test_sanity_rootless) | test(/fc_mock/) | test(/state_manager/) | test(/health_monitor/) | test(/no_sudo/))
-_test-fc-mock:
+_test-fc-mock: cargo-target-link
 	@FCVM_FIRECRACKER_BIN=/usr/local/bin/fc-mock \
 	RUST_LOG="$(TEST_LOG)" \
 	FCVM_DATA_DIR=$${FCVM_DATA_DIR:-$(ROOT_DATA_DIR)} \
@@ -716,7 +722,7 @@ container-bench: check-disk container-build
 	@echo "==> Running benchmarks in container..."
 	$(CONTAINER_RUN_BASE) $(CONTAINER_TAG) make build _bench
 
-_bench:
+_bench: cargo-target-link
 	@echo "==> Running benchmarks..."
 	$(CARGO) bench -p fuse-pipe --bench throughput
 	$(CARGO) bench -p fuse-pipe --bench operations
@@ -726,9 +732,9 @@ _bench:
 CARGO_AUDIT_VERSION := 0.22.0
 CARGO_DENY_VERSION := 0.18.9
 
-setup-lint-tools:
-	@which cargo-audit > /dev/null || (echo "Installing cargo-audit..." && cargo install cargo-audit@$(CARGO_AUDIT_VERSION) --locked)
-	@which cargo-deny > /dev/null || (echo "Installing cargo-deny..." && cargo install cargo-deny@$(CARGO_DENY_VERSION) --locked)
+setup-lint-tools: cargo-target-link
+	@which cargo-audit > /dev/null || (echo "Installing cargo-audit..." && $(CARGO) install cargo-audit@$(CARGO_AUDIT_VERSION) --locked)
+	@which cargo-deny > /dev/null || (echo "Installing cargo-deny..." && $(CARGO) install cargo-deny@$(CARGO_DENY_VERSION) --locked)
 
 lint: setup-lint-tools
 	$(CARGO) fmt -p fcvm -p fuse-pipe -p fc-agent -p failpoint --check
@@ -736,7 +742,7 @@ lint: setup-lint-tools
 	$(CARGO) audit
 	$(CARGO) deny check
 
-update-dependency:
+update-dependency: cargo-target-link
 	@test -n "$(PACKAGE)" || (echo "ERROR: PACKAGE required"; exit 1)
 	$(CARGO) update -p "$(PACKAGE)" $(if $(VERSION),--precise "$(VERSION)")
 
@@ -770,7 +776,7 @@ train-land:
 train-bisect:
 	./scripts/ci-train.sh --branch $(TRAIN) bisect
 
-fmt:
+fmt: cargo-target-link
 	$(CARGO) fmt
 
 # SSH to jumpbox (IP from terraform: cd ~/src/aws && terraform output jumpbox_ssh_command)

--- a/scripts/build-ami.sh
+++ b/scripts/build-ami.sh
@@ -6,6 +6,36 @@ set -euo pipefail
 REGION="${AWS_REGION:-us-west-1}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 KERNEL_DIR="$(dirname "$SCRIPT_DIR")/kernel"
+FCVM_SOURCE_REMOTE="${FCVM_SOURCE_REMOTE:-https://github.com/ejc3/fcvm.git}"
+
+# Prove the cloud builder can perform the exact fetch rendered below before an
+# EC2 instance is allocated. A local HEAD can identify a perfectly valid but
+# unpushed commit; materializing it locally is not evidence that the separate
+# builder can fetch it. Use a fresh object database so the local checkout's
+# existing object cannot make this probe pass vacuously.
+verify_source_commit_fetchable() {
+  local repo_root="$1"
+  local source_commit="$2"
+  local source_remote="$3"
+  local fetch_probe
+
+  if [[ ! $source_commit =~ ^[0-9a-f]{40}$ ]] || \
+    ! git -C "$repo_root" cat-file -e "$source_commit^{commit}"; then
+    echo "ERROR: invalid local fcvm source commit: $source_commit" >&2
+    return 1
+  fi
+
+  fetch_probe="$(mktemp -d)" || return 1
+  if ! git -C "$fetch_probe" init --quiet || \
+    ! git -C "$fetch_probe" fetch --quiet --depth 1 \
+      "$source_remote" "$source_commit"; then
+    rm -rf -- "$fetch_probe"
+    echo "ERROR: fcvm source commit $source_commit is not fetchable from $source_remote;" >&2
+    echo "       push the commit before launching the AMI builder." >&2
+    return 1
+  fi
+  rm -rf -- "$fetch_probe"
+}
 
 # Materialize exactly the Git tree the AMI builder will fetch. Hashing the
 # caller's working-tree bytes and pinning only HEAD can otherwise label an AMI
@@ -127,13 +157,13 @@ compute_hash() {
   # produced if a read fails.
   local disk_guard_digests
   if ! disk_guard_digests=$(
-    cd "$repo_root" &&
+    cd "$SCRIPT_DIR" &&
       sha256sum \
-        scripts/runner-disk-preflight.sh \
-        scripts/prune-cargo-target.sh \
-        scripts/install-runner-disk-guard.sh \
-        scripts/runner-disk-guard.service \
-        scripts/runner-disk-guard.timer
+        runner-disk-preflight.sh \
+        prune-cargo-target.sh \
+        install-runner-disk-guard.sh \
+        runner-disk-guard.service \
+        runner-disk-guard.timer
   ); then
     echo "ERROR: cannot digest every disk-guard AMI input" >&2
     return 1
@@ -198,7 +228,9 @@ create_user_data() {
     echo "ERROR: invalid fcvm source commit for AMI user data: $source_commit" >&2
     return 1
   fi
-  sed "s/__FCVM_SOURCE_COMMIT__/$source_commit/g" << 'USERDATA'
+  sed \
+    -e "s/__FCVM_SOURCE_COMMIT__/$source_commit/g" \
+    -e "s#__FCVM_SOURCE_REMOTE__#$FCVM_SOURCE_REMOTE#g" << 'USERDATA'
 #!/bin/bash
 exec > >(tee /var/log/ami-build.log) 2>&1
 set -euxo pipefail
@@ -270,8 +302,9 @@ sudo -u ubuntu env HOME=/home/ubuntu bash -c \
 # moving main here allowed a merge during instance boot to install a different
 # disk-guard protocol than the one compute_hash read.
 FCVM_SOURCE_COMMIT="__FCVM_SOURCE_COMMIT__"
+FCVM_SOURCE_REMOTE="__FCVM_SOURCE_REMOTE__"
 git init /tmp/fcvm
-git -C /tmp/fcvm remote add origin https://github.com/ejc3/fcvm.git
+git -C /tmp/fcvm remote add origin "$FCVM_SOURCE_REMOTE"
 git -C /tmp/fcvm fetch --depth 1 origin "$FCVM_SOURCE_COMMIT"
 git -C /tmp/fcvm checkout --detach FETCH_HEAD
 git clone --depth 1 https://github.com/ejc3/fuse-backend-rs.git /tmp/fuse-backend-rs
@@ -442,6 +475,11 @@ main() {
     echo "ami_id=$existing" >> "${GITHUB_OUTPUT:-/dev/null}"
     echo "cached=true" >> "${GITHUB_OUTPUT:-/dev/null}"
     exit 0
+  fi
+
+  if ! verify_source_commit_fetchable \
+    "$repo_root" "$source_commit" "$FCVM_SOURCE_REMOTE"; then
+    exit 1
   fi
 
   echo "No cached AMI, building..."

--- a/scripts/build-ami.sh
+++ b/scripts/build-ami.sh
@@ -7,10 +7,67 @@ REGION="${AWS_REGION:-us-west-1}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 KERNEL_DIR="$(dirname "$SCRIPT_DIR")/kernel"
 
+# Materialize exactly the Git tree the AMI builder will fetch. Hashing the
+# caller's working-tree bytes and pinning only HEAD can otherwise label an AMI
+# with a key for dirty/smudged files that never reach the builder. The running
+# provisioning script is checked too: it defines create_user_data(), so it must
+# be byte-identical to the pinned tree before its output can enter the key.
+materialize_pinned_source_tree() {
+  local repo_root="$1"
+  local source_commit="$2"
+  local destination="$3"
+
+  if ! git -C "$repo_root" archive --format=tar "$source_commit" | \
+    tar -xf - -C "$destination"; then
+    echo "ERROR: cannot materialize fcvm source commit $source_commit" >&2
+    return 1
+  fi
+  if ! cmp -s -- \
+    "$repo_root/scripts/build-ami.sh" \
+    "$destination/scripts/build-ami.sh"; then
+    echo "ERROR: scripts/build-ami.sh differs from pinned commit $source_commit;" >&2
+    echo "       refusing to hash bytes the AMI builder will not provision." >&2
+    return 1
+  fi
+}
+
+# Compute from the immutable tree the remote builder will fetch. Keeping the
+# materialization and KERNEL_DIR/SCRIPT_DIR rebinding in one function makes it
+# behaviorally testable and prevents main from accidentally hashing the caller
+# worktree again during a later refactor.
+compute_pinned_hash() {
+  local repo_root="$1"
+  local source_commit="$2"
+  local source_tree hash
+
+  source_tree="$(mktemp -d)" || return 1
+  if ! materialize_pinned_source_tree "$repo_root" "$source_commit" "$source_tree"; then
+    rm -rf -- "$source_tree"
+    return 1
+  fi
+
+  # Bash functions resolve dynamically scoped locals, so compute_hash and
+  # create_user_data read only the archived commit.
+  local KERNEL_DIR="$source_tree/kernel"
+  local SCRIPT_DIR="$source_tree/scripts"
+  if ! hash=$(compute_hash "$source_commit"); then
+    rm -rf -- "$source_tree"
+    return 1
+  fi
+  rm -rf -- "$source_tree"
+  printf '%s\n' "$hash"
+}
+
 # Compute build hash (from kernel config + patches + boot_args + passt build inputs)
 compute_hash() {
+  local source_commit="$1"
   local repo_root
   repo_root="$(dirname "$KERNEL_DIR")"
+
+  if [[ ! $source_commit =~ ^[0-9a-f]{40}$ ]]; then
+    echo "ERROR: invalid fcvm source commit for AMI cache key: $source_commit" >&2
+    return 1
+  fi
 
   # FAIL CLOSED. Every read below used to be `2>/dev/null` with its failure
   # discarded, and `hash=$(compute_hash)` does NOT inherit errexit inside the
@@ -52,7 +109,9 @@ compute_hash() {
 
   local f
   for f in "$KERNEL_DIR/nested.conf" "$repo_root/rootfs-config.toml" \
-    "$SCRIPT_DIR/build-passt.sh" "$SCRIPT_DIR/runner-disk-preflight.sh" \
+    "$SCRIPT_DIR/build-passt.sh" "$SCRIPT_DIR/install-runner-disk-guard.sh" \
+    "$SCRIPT_DIR/runner-disk-preflight.sh" \
+    "$SCRIPT_DIR/prune-cargo-target.sh" \
     "$SCRIPT_DIR/runner-disk-guard.service" "$SCRIPT_DIR/runner-disk-guard.timer" \
     "${host_patches[@]}"; do
     if [ ! -r "$f" ]; then
@@ -60,6 +119,25 @@ compute_hash() {
       return 1
     fi
   done
+
+  # Frame every baked disk-guard input independently. Raw concatenation makes
+  # `ab` + `cd` indistinguishable from `abc` + `d`, and a failed cat inside the
+  # larger hash pipeline can be masked by a later successful command. sha256sum
+  # emits a name-tagged digest for each file and fails before any cache key is
+  # produced if a read fails.
+  local disk_guard_digests
+  if ! disk_guard_digests=$(
+    cd "$repo_root" &&
+      sha256sum \
+        scripts/runner-disk-preflight.sh \
+        scripts/prune-cargo-target.sh \
+        scripts/install-runner-disk-guard.sh \
+        scripts/runner-disk-guard.service \
+        scripts/runner-disk-guard.timer
+  ); then
+    echo "ERROR: cannot digest every disk-guard AMI input" >&2
+    return 1
+  fi
 
   {
     cat "$KERNEL_DIR/nested.conf"
@@ -84,12 +162,12 @@ compute_hash() {
     # Include the disk guard's script and units: they are baked into the AMI,
     # so a change to them must produce a new AMI rather than silently reusing
     # one without the fix.
-    cat "$SCRIPT_DIR/runner-disk-preflight.sh" \
-      "$SCRIPT_DIR/runner-disk-guard.service" "$SCRIPT_DIR/runner-disk-guard.timer" 2>/dev/null
-    # Include the provisioning script itself. Without this, editing the AMI's
-    # user-data changes nothing the hash can see, so the cached AMI is reused
-    # and the edit never reaches a runner.
-    create_user_data
+    printf '%s\n' "$disk_guard_digests"
+    # Include the exact rendered provisioning script, including the immutable
+    # source commit it fetches and compiles. Hashing a placeholder commit let a
+    # host-tool change outside the selective inputs above reuse an AMI built
+    # from an older checkout even though a cache miss would build the new one.
+    create_user_data "$source_commit"
   } | sha256sum | cut -c1-12
 }
 
@@ -115,7 +193,12 @@ get_base_ami() {
 
 # Create user data script for AMI builder
 create_user_data() {
-  cat << 'USERDATA'
+  local source_commit="$1"
+  if [[ ! $source_commit =~ ^[0-9a-f]{40}$ ]]; then
+    echo "ERROR: invalid fcvm source commit for AMI user data: $source_commit" >&2
+    return 1
+  fi
+  sed "s/__FCVM_SOURCE_COMMIT__/$source_commit/g" << 'USERDATA'
 #!/bin/bash
 exec > >(tee /var/log/ami-build.log) 2>&1
 set -euxo pipefail
@@ -172,23 +255,31 @@ apt-get install -y build-essential bc bison flex libssl-dev \
   fuse3 libfuse3-dev libclang-dev clang musl-tools \
   iproute2 iptables dnsmasq qemu-utils e2fsprogs parted \
   skopeo busybox-static cpio zstd autoconf automake libtool \
-  nfs-kernel-server libseccomp-dev
+  nfs-kernel-server libseccomp-dev python3 util-linux
 
 # Node.js 22.x
 curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
 apt-get install -y nodejs
 
-# Rust (set HOME for cloud-init context)
-export HOME=/root
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-source /root/.cargo/env
+# Rust belongs to the runner user. The Makefile deliberately rejects host
+# builds as root because they leave root-owned target artifacts behind.
+sudo -u ubuntu env HOME=/home/ubuntu bash -c \
+  'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y'
 
-# Clone fcvm and its dependencies
-git clone --depth 1 https://github.com/ejc3/fcvm.git /tmp/fcvm
+# Fetch the exact checkout whose inputs produced this AMI's cache key. Cloning
+# moving main here allowed a merge during instance boot to install a different
+# disk-guard protocol than the one compute_hash read.
+FCVM_SOURCE_COMMIT="__FCVM_SOURCE_COMMIT__"
+git init /tmp/fcvm
+git -C /tmp/fcvm remote add origin https://github.com/ejc3/fcvm.git
+git -C /tmp/fcvm fetch --depth 1 origin "$FCVM_SOURCE_COMMIT"
+git -C /tmp/fcvm checkout --detach FETCH_HEAD
 git clone --depth 1 https://github.com/ejc3/fuse-backend-rs.git /tmp/fuse-backend-rs
 git clone --depth 1 https://github.com/ejc3/fuser.git /tmp/fuser
+chown -R ubuntu:ubuntu /tmp/fcvm /tmp/fuse-backend-rs /tmp/fuser
+sudo -u ubuntu env HOME=/home/ubuntu bash -c \
+  'source "$HOME/.cargo/env"; cd /tmp/fcvm; make build-host-tools'
 cd /tmp/fcvm
-cargo build --release
 
 # Build pasta/passt from the repo's pinned source so the AMI matches CI
 # (scripts/build-passt.sh owns the pin and the local patches).
@@ -201,9 +292,6 @@ cp rootfs-config.toml /root/.config/fcvm/
 # Build and install kernel using fcvm setup
 aws ec2 create-tags --resources $INSTANCE_ID --tags Key=KernelVersion,Value=nested --region us-west-1
 ./target/release/fcvm setup --kernel-profile nested --build-kernels --install-host-kernel
-
-# Rust for ubuntu user (separate from root's rust used for build)
-sudo -u ubuntu bash -c 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y'
 
 # Firecracker
 FIRECRACKER_VERSION="v1.14.0"
@@ -236,9 +324,7 @@ chown -R ubuntu:ubuntu /opt/actions-runner
 # preflight step cannot rescue it — this cleans caches out-of-band and, if the
 # hard floor still cannot be met, stops the runner service so the box goes
 # offline and gets replaced instead of poisoning jobs.
-install -m 755 /tmp/fcvm/scripts/runner-disk-preflight.sh /usr/local/bin/runner-disk-preflight.sh
-install -m 644 /tmp/fcvm/scripts/runner-disk-guard.service /etc/systemd/system/runner-disk-guard.service
-install -m 644 /tmp/fcvm/scripts/runner-disk-guard.timer /etc/systemd/system/runner-disk-guard.timer
+/tmp/fcvm/scripts/install-runner-disk-guard.sh /tmp/fcvm
 systemctl enable runner-disk-guard.timer
 
 # Clean up
@@ -335,8 +421,15 @@ wait_for_build() {
 
 # Main
 main() {
-  local hash
-  if ! hash=$(compute_hash); then
+  local hash repo_root source_commit
+  repo_root="$(dirname "$KERNEL_DIR")"
+  if ! source_commit="$(git -C "$repo_root" rev-parse HEAD)" || \
+    [[ ! $source_commit =~ ^[0-9a-f]{40}$ ]]; then
+    echo "ERROR: cannot identify the exact fcvm source commit for AMI provisioning" >&2
+    exit 1
+  fi
+
+  if ! hash=$(compute_pinned_hash "$repo_root" "$source_commit"); then
     echo "ERROR: cannot compute the AMI cache key; refusing to reuse or tag an AMI" >&2
     exit 1
   fi
@@ -369,7 +462,7 @@ main() {
 
   # Create user data
   user_data_file=$(mktemp)
-  create_user_data > "$user_data_file"
+  create_user_data "$source_commit" > "$user_data_file"
 
   # Launch instance - try spot first, fall back to on-demand
   echo "Trying spot instance..."

--- a/scripts/cargo-target-lib.sh
+++ b/scripts/cargo-target-lib.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Shared Cargo-target generation protocol. This file is sourced by both the
+# publisher and runner so the retirement xattr and its exit-code contract cannot
+# drift between the two sides of the handoff.
+
+# Query the retirement xattr through an already-locked directory fd. Exit 0
+# means retired, 3 means current, and every other status is a fatal protocol
+# error. The pruner persists this xattr before changing a single cache byte.
+target_is_retired() {
+	local fd="$1" rc=0
+	/usr/bin/python3 -c '
+import errno
+import os
+import sys
+
+try:
+    value = os.getxattr(sys.argv[1], b"user.fcvm.retired")
+except OSError as error:
+    if error.errno in (errno.ENODATA, getattr(errno, "ENOATTR", errno.ENODATA)):
+        raise SystemExit(3)
+    raise
+if value != b"v1":
+    print(f"unsupported retired-generation marker: {value!r}", file=sys.stderr)
+    raise SystemExit(4)
+' "/proc/$$/fd/$fd" || rc=$?
+	return "$rc"
+}

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -34,6 +34,10 @@
 # build for no visible reason.
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/cargo-target-lib.sh
+. "$script_dir/cargo-target-lib.sh"
+
 BTRFS_ROOT="${BTRFS_ROOT:-/mnt/fcvm-btrfs}"
 FORCE_ROTATE=0
 case "$#" in
@@ -78,28 +82,6 @@ WT_TARGET="$BTRFS_ROOT/cargo-target/$name-$hash"
 
 if [ -d "$BTRFS_ROOT" ]; then
 	mkdir -p "$WT_TARGET" || { echo "ERROR: cannot create $WT_TARGET" >&2; exit 1; }
-# Query the retirement xattr through an already-locked directory fd. Exit 0
-# means retired, 3 means current, and every other status is a fatal protocol
-# error. The pruner persists this xattr before changing a single cache byte.
-target_is_retired() {
-	local fd="$1" rc=0
-	/usr/bin/python3 -c '
-import errno
-import os
-import sys
-
-try:
-    value = os.getxattr(sys.argv[1], b"user.fcvm.retired")
-except OSError as error:
-    if error.errno in (errno.ENODATA, getattr(errno, "ENOATTR", errno.ENODATA)):
-        raise SystemExit(3)
-    raise
-if value != b"v1":
-    print(f"unsupported retired-generation marker: {value!r}", file=sys.stderr)
-    raise SystemExit(4)
-' "/proc/$$/fd/$fd" || rc=$?
-	return "$rc"
-}
 
 retire_target() {
 	local fd="$1"

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -63,12 +63,22 @@ WT_TARGET="$BTRFS_ROOT/cargo-target/$name-$hash"
 
 if [ -d "$BTRFS_ROOT" ]; then
 	mkdir -p "$WT_TARGET" || { echo "ERROR: cannot create $WT_TARGET" >&2; exit 1; }
+	# The disk pruner locks this directory exclusively.  Hold its shared lease
+	# while wiring or populating it so setup cannot race cleanup before the Cargo
+	# wrapper takes over the same lease.
+	exec {wt_target_lease_fd}<"$WT_TARGET"
+	flock -s "$wt_target_lease_fd"
 	if [ -L target ] && [ "$(readlink target)" != "$WT_TARGET" ]; then
 		echo "==> Repointing shared target/ → $WT_TARGET (per-worktree)"
 		rm -f target
 	fi
 	if ! [ -L target ]; then
 		if [ -d target ]; then
+			# A Cargo process from an earlier invocation can still be using the
+			# local target while btrfs comes online.  Take the directory lease
+			# exclusively before migrating and removing that old lock inode.
+			exec {local_target_lease_fd}<target
+			flock -x "$local_target_lease_fd"
 			echo "==> Moving existing target/ to $WT_TARGET..."
 			# Never `rm -rf` the source on a partial move. A full volume, a
 			# permission error, or a plain `target/*` glob (which skips

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -35,6 +35,21 @@
 set -euo pipefail
 
 BTRFS_ROOT="${BTRFS_ROOT:-/mnt/fcvm-btrfs}"
+FORCE_ROTATE=0
+case "$#" in
+	0) ;;
+	1)
+		if [[ $1 != --rotate ]]; then
+			echo "usage: $0 [--rotate]" >&2
+			exit 2
+		fi
+		FORCE_ROTATE=1
+		;;
+	*)
+		echo "usage: $0 [--rotate]" >&2
+		exit 2
+		;;
+esac
 
 # Serialization is what makes the sequence below safe; running without it would
 # reintroduce the race silently. Fail loudly instead.
@@ -63,46 +78,216 @@ WT_TARGET="$BTRFS_ROOT/cargo-target/$name-$hash"
 
 if [ -d "$BTRFS_ROOT" ]; then
 	mkdir -p "$WT_TARGET" || { echo "ERROR: cannot create $WT_TARGET" >&2; exit 1; }
-	# The disk pruner locks this directory exclusively.  Hold its shared lease
-	# while wiring or populating it so setup cannot race cleanup before the Cargo
-	# wrapper takes over the same lease.
-	exec {wt_target_lease_fd}<"$WT_TARGET"
-	flock -s "$wt_target_lease_fd"
-	if [ -L target ] && [ "$(readlink target)" != "$WT_TARGET" ]; then
-		echo "==> Repointing shared target/ → $WT_TARGET (per-worktree)"
-		rm -f target
-	fi
-	if ! [ -L target ]; then
-		if [ -d target ]; then
-			# A Cargo process from an earlier invocation can still be using the
-			# local target while btrfs comes online.  Take the directory lease
-			# exclusively before migrating and removing that old lock inode.
-			exec {local_target_lease_fd}<target
-			flock -x "$local_target_lease_fd"
-			echo "==> Moving existing target/ to $WT_TARGET..."
-			# Never `rm -rf` the source on a partial move. A full volume, a
-			# permission error, or a plain `target/*` glob (which skips
-			# .rustc_info.json and other dotfiles) would otherwise discard build
-			# artifacts silently. Move everything, dotfiles included, and abort if
-			# any of it fails; `rmdir` then succeeds only if the move was complete.
-			shopt -s dotglob nullglob
-			entries=(target/*)
-			shopt -u dotglob nullglob
-			if [ ${#entries[@]} -gt 0 ]; then
-				mv -- "${entries[@]}" "$WT_TARGET"/ || {
-					echo "ERROR: could not migrate target/ to $WT_TARGET; leaving it in place" >&2
-					exit 1
-				}
-			fi
-			rmdir target || {
-				echo "ERROR: target/ is not empty after migration; leaving it in place" >&2
+# Query the retirement xattr through an already-locked directory fd. Exit 0
+# means retired, 3 means current, and every other status is a fatal protocol
+# error. The pruner persists this xattr before changing a single cache byte.
+target_is_retired() {
+	local fd="$1" rc=0
+	/usr/bin/python3 -c '
+import errno
+import os
+import sys
+
+try:
+    value = os.getxattr(sys.argv[1], b"user.fcvm.retired")
+except OSError as error:
+    if error.errno in (errno.ENODATA, getattr(errno, "ENOATTR", errno.ENODATA)):
+        raise SystemExit(3)
+    raise
+if value != b"v1":
+    print(f"unsupported retired-generation marker: {value!r}", file=sys.stderr)
+    raise SystemExit(4)
+' "/proc/$$/fd/$fd" || rc=$?
+	return "$rc"
+}
+
+retire_target() {
+	local fd="$1"
+	/usr/bin/python3 -c '
+import errno
+import os
+import sys
+
+directory_fd = os.open(sys.argv[1], os.O_RDONLY | os.O_DIRECTORY)
+try:
+    try:
+        value = os.getxattr(directory_fd, b"user.fcvm.retired")
+    except OSError as error:
+        if error.errno not in (errno.ENODATA, getattr(errno, "ENOATTR", errno.ENODATA)):
+            raise
+        os.setxattr(
+            directory_fd,
+            b"user.fcvm.retired",
+            b"v1",
+            flags=os.XATTR_CREATE,
+        )
+    else:
+        if value != b"v1":
+            raise RuntimeError(f"unsupported retired-generation marker: {value!r}")
+    os.fsync(directory_fd)
+finally:
+    os.close(directory_fd)
+' "/proc/$$/fd/$fd"
+}
+
+new_generation() {
+	local retired_rc
+	while :; do
+		FRESH_GENERATION="$(mktemp -d -- "${WT_TARGET}.generation-XXXXXXXX")"
+		exec {fresh_lease_fd}<"$FRESH_GENERATION"
+		flock -x "$fresh_lease_fd"
+		retired_rc=0
+		target_is_retired "$fresh_lease_fd" || retired_rc=$?
+		case "$retired_rc" in
+			0)
+				# The pruner acquired the new name between mkdir and flock. It
+				# retired that physical inode, so leave it untouched and try a
+				# different immutable sibling.
+				exec {fresh_lease_fd}<&-
+				;;
+			3)
+				break
+				;;
+			*)
+				echo "ERROR: cannot initialize target generation $FRESH_GENERATION (rc=$retired_rc)" >&2
 				exit 1
-			}
-		fi
-		ln -s "$WT_TARGET" target
-		echo "==> Symlinked target/ → $WT_TARGET"
+				;;
+		esac
+	done
+
+	# Initialize through the locked fd. A fresh generation must not qualify as
+	# idle in the link-to-wrapper gap; later Cargo writes provide the normal
+	# activity signal. Persist the sentinel before publishing the symlink.
+	/usr/bin/python3 -c '
+import os
+import sys
+
+directory_fd = os.open(sys.argv[1], os.O_RDONLY | os.O_DIRECTORY)
+try:
+    sentinel_fd = os.open(
+        ".fcvm-generation",
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC,
+        0o600,
+        dir_fd=directory_fd,
+    )
+    try:
+        os.write(sentinel_fd, b"v1\n")
+        os.fsync(sentinel_fd)
+    finally:
+        os.close(sentinel_fd)
+    os.fsync(directory_fd)
+finally:
+    os.close(directory_fd)
+' "/proc/$$/fd/$fresh_lease_fd"
+	flock -s "$fresh_lease_fd"
+}
+
+publish_target_link() {
+	local destination="$1" staging
+	staging="$(mktemp -d -- "$p/.fcvm-target-link.XXXXXXXX")"
+	ln -s -- "$destination" "$staging/target"
+	# The checkout lock excludes every cooperating resolver. Replacing only
+	# this symlink is atomic and never renames a physical target dentry (which
+	# could move a mount that exists solely in another namespace).
+	mv -Tf -- "$staging/target" target
+	rmdir -- "$staging"
+}
+
+mkdir -p -- "$(dirname "$WT_TARGET")"
+
+# A pre-protocol real target cannot be replaced safely: another mount
+# namespace may have a mount on that exact dentry. Keep it local and unmanaged;
+# the disk guard will fail its hard floor and quarantine the runner rather than
+# corrupt a hidden mount. Fresh checkouts always take the managed-symlink path.
+if [ -e target ] && ! [ -L target ]; then
+	if [ ! -d target ]; then
+		echo "ERROR: target exists but is not a usable directory:" >&2
+		ls -ld target >&2
+		exit 1
 	fi
+	if ((FORCE_ROTATE)); then
+		echo "ERROR: unmanaged local target/ cannot be atomically rotated; refusing unsafe clean" >&2
+		exit 1
+	fi
+	echo "==> WARNING: retaining unmanaged local target/; it cannot be atomically rotated" >&2
+	exit 0
+fi
+
+candidate="$WT_TARGET"
+old_target_lease_fd=""
+if [ -L target ] && [ -d target ]; then
+	linked="$(readlink target)"
+	# A Cargo wrapper that already crossed the checkout→target lock handoff no
+	# longer holds the checkout lease. Pin and exclusively lease its resolved
+	# generation before publishing any different symlink target.
+	exec {old_target_lease_fd}<target
+	flock -x "$old_target_lease_fd"
+	case "$linked" in
+		"$WT_TARGET"|"$WT_TARGET".generation-*)
+			candidate="$linked"
+			;;
+	esac
+fi
+
+mkdir -p -- "$candidate"
+if [[ -n $old_target_lease_fd && ${linked:-} == "$candidate" ]]; then
+	candidate_state_fd="$old_target_lease_fd"
 else
+	exec {candidate_lease_fd}<"$candidate"
+	if [[ -n $old_target_lease_fd ]] &&
+		[[ "$(stat -Lc '%d:%i' -- "/proc/$$/fd/$old_target_lease_fd")" == \
+		"$(stat -Lc '%d:%i' -- "/proc/$$/fd/$candidate_lease_fd")" ]]; then
+		exec {candidate_lease_fd}<&-
+		candidate_lease_fd=""
+		candidate_state_fd="$old_target_lease_fd"
+	else
+		flock -x "$candidate_lease_fd"
+		candidate_state_fd="$candidate_lease_fd"
+	fi
+fi
+retired_rc=0
+target_is_retired "$candidate_state_fd" || retired_rc=$?
+if ((FORCE_ROTATE)); then
+	retire_target "$candidate_state_fd"
+	retired_rc=0
+fi
+case "$retired_rc" in
+	0)
+		new_generation
+		candidate="$FRESH_GENERATION"
+		final_lease_fd="$fresh_lease_fd"
+		echo "==> Rotating retired target/ → $candidate"
+		;;
+	3)
+		# Downgrade the exclusive inspection lease while publishing the link.
+		flock -s "$candidate_state_fd"
+		final_lease_fd="$candidate_state_fd"
+		;;
+	*)
+		echo "ERROR: cannot read target retirement state for $candidate (rc=$retired_rc)" >&2
+		exit 1
+		;;
+esac
+
+if ! [ -L target ] || [ "$(readlink target)" != "$candidate" ]; then
+	publish_target_link "$candidate"
+	echo "==> Symlinked target/ → $candidate"
+fi
+
+# Keep only the published generation's shared lease until script exit. In
+# particular, the old resolved target stays exclusively pinned through the
+# atomic symlink switch above.
+if [[ -n $old_target_lease_fd && $old_target_lease_fd != "$final_lease_fd" ]]; then
+	exec {old_target_lease_fd}<&-
+fi
+if [[ -n ${candidate_lease_fd:-} && $candidate_lease_fd != "$final_lease_fd" ]]; then
+	exec {candidate_lease_fd}<&-
+fi
+else
+	if ((FORCE_ROTATE)) && [ -d target ]; then
+		echo "ERROR: local target/ cannot be atomically rotated without the managed btrfs namespace; refusing unsafe clean" >&2
+		exit 1
+	fi
 	echo "==> NOTE: $BTRFS_ROOT is not a directory; build artifacts stay on the root filesystem"
 fi
 

--- a/scripts/cargo-target-run.sh
+++ b/scripts/cargo-target-run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Run one Cargo command while holding this worktree target's shared lease.
+#
+# runner-disk-preflight.sh locks the same directory inode exclusively before
+# removing idle artifacts.  The target directory is permanent: deleting it
+# while a process has the inode open would let a replacement directory become
+# a second lock object and reintroduce the unlink/flock ABA race this protocol
+# exists to prevent.
+set -euo pipefail
+
+if (($# == 0)); then
+	echo "usage: $0 <cargo> [args...]" >&2
+	exit 2
+fi
+
+if ! command -v flock >/dev/null 2>&1; then
+	echo "ERROR: flock is required to lease the cargo target (util-linux)" >&2
+	exit 2
+fi
+
+target="${CARGO_TARGET_DIR:-target}"
+if [[ ! -d $target ]]; then
+	echo "ERROR: CARGO_TARGET_DIR '$target' is not a usable directory; the Make target is missing its cargo-target-link prerequisite" >&2
+	exit 1
+fi
+
+# Lock the target directory inode itself.  This works through the checkout's
+# `target` symlink, requires no writable lock file, and gives the pruner a
+# stable inode that also exists for targets created before this protocol.  The
+# pruner must therefore retain the directory rather than rm -rf it.
+exec {lease_fd}<"$target"
+flock -s "$lease_fd"
+
+# The descriptor intentionally survives exec, holding the shared lease for the
+# complete Cargo process lifetime (including every rustc/linker child).
+exec "$@"

--- a/scripts/cargo-target-run.sh
+++ b/scripts/cargo-target-run.sh
@@ -18,27 +18,10 @@ if ! command -v flock >/dev/null 2>&1; then
 fi
 
 target="${CARGO_TARGET_DIR:-target}"
-link_script="$(cd "$(dirname "$0")" && pwd -P)/cargo-target-link.sh"
-
-target_is_retired() {
-	local fd="$1" rc=0
-	/usr/bin/python3 -c '
-import errno
-import os
-import sys
-
-try:
-    value = os.getxattr(sys.argv[1], b"user.fcvm.retired")
-except OSError as error:
-    if error.errno in (errno.ENODATA, getattr(errno, "ENOATTR", errno.ENODATA)):
-        raise SystemExit(3)
-    raise
-if value != b"v1":
-    print(f"unsupported retired-generation marker: {value!r}", file=sys.stderr)
-    raise SystemExit(4)
-' "/proc/$$/fd/$fd" || rc=$?
-	return "$rc"
-}
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/cargo-target-lib.sh
+. "$script_dir/cargo-target-lib.sh"
+link_script="$script_dir/cargo-target-link.sh"
 
 while :; do
 	# cargo-target-link.sh takes this same checkout-directory lock exclusively

--- a/scripts/cargo-target-run.sh
+++ b/scripts/cargo-target-run.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 # Run one Cargo command while holding this worktree target's shared lease.
 #
-# runner-disk-preflight.sh locks the same directory inode exclusively before
-# removing idle artifacts.  The target directory is permanent: deleting it
-# while a process has the inode open would let a replacement directory become
-# a second lock object and reintroduce the unlink/flock ABA race this protocol
-# exists to prevent.
+# runner-disk-preflight.sh locks the same physical generation exclusively
+# before reclaiming idle payload. It retires that inode before changing cache
+# bytes; this wrapper then asks cargo-target-link.sh to publish a fresh sibling
+# generation. Physical target dentries are never deleted or renamed.
 set -euo pipefail
 
 if (($# == 0)); then
@@ -19,18 +18,69 @@ if ! command -v flock >/dev/null 2>&1; then
 fi
 
 target="${CARGO_TARGET_DIR:-target}"
-if [[ ! -d $target ]]; then
-	echo "ERROR: CARGO_TARGET_DIR '$target' is not a usable directory; the Make target is missing its cargo-target-link prerequisite" >&2
-	exit 1
-fi
+link_script="$(cd "$(dirname "$0")" && pwd -P)/cargo-target-link.sh"
 
-# Lock the target directory inode itself.  This works through the checkout's
-# `target` symlink, requires no writable lock file, and gives the pruner a
-# stable inode that also exists for targets created before this protocol.  The
-# pruner must therefore retain the directory rather than rm -rf it.
-exec {lease_fd}<"$target"
-flock -s "$lease_fd"
+target_is_retired() {
+	local fd="$1" rc=0
+	/usr/bin/python3 -c '
+import errno
+import os
+import sys
 
-# The descriptor intentionally survives exec, holding the shared lease for the
-# complete Cargo process lifetime (including every rustc/linker child).
+try:
+    value = os.getxattr(sys.argv[1], b"user.fcvm.retired")
+except OSError as error:
+    if error.errno in (errno.ENODATA, getattr(errno, "ENOATTR", errno.ENODATA)):
+        raise SystemExit(3)
+    raise
+if value != b"v1":
+    print(f"unsupported retired-generation marker: {value!r}", file=sys.stderr)
+    raise SystemExit(4)
+' "/proc/$$/fd/$fd" || rc=$?
+	return "$rc"
+}
+
+while :; do
+	# cargo-target-link.sh takes this same checkout-directory lock exclusively
+	# before publishing target/. Hold it shared until the resolved generation fd
+	# itself is leased, closing the stale-inode window without serializing Cargo
+	# commands for their full lifetimes.
+	checkout="$(pwd -P)"
+	exec {checkout_lease_fd}<"$checkout"
+	flock -s "$checkout_lease_fd"
+
+	if [[ ! -d $target ]]; then
+		echo "ERROR: CARGO_TARGET_DIR '$target' is not a usable directory; the Make target is missing its cargo-target-link prerequisite" >&2
+		exit 1
+	fi
+
+	# Lock the resolved generation inode itself, then inspect its durable
+	# retirement state while both the checkout name and inode are pinned.
+	exec {lease_fd}<"$target"
+	flock -s "$lease_fd"
+	retired_rc=0
+	target_is_retired "$lease_fd" || retired_rc=$?
+	case "$retired_rc" in
+		3)
+			exec {checkout_lease_fd}<&-
+			break
+			;;
+		0)
+			exec {lease_fd}<&-
+			exec {checkout_lease_fd}<&-
+			if [[ $target != target ]]; then
+				echo "ERROR: retired CARGO_TARGET_DIR '$target' is not the managed target/ path" >&2
+				exit 1
+			fi
+			BTRFS_ROOT="${BTRFS_ROOT:-/mnt/fcvm-btrfs}" "$link_script"
+			;;
+		*)
+			echo "ERROR: cannot read target retirement state (rc=$retired_rc)" >&2
+			exit 1
+			;;
+	esac
+done
+
+# The target descriptor intentionally survives exec, holding the shared lease
+# for the complete Cargo process lifetime (including every rustc/linker child).
 exec "$@"

--- a/scripts/fcvm-init.sh
+++ b/scripts/fcvm-init.sh
@@ -29,7 +29,7 @@ echo "[init] firecracker installed to ${BIN}"
 
 # Build guest agent and copy into rootfs later
 echo "[init] building guest agent ..."
-( cd "$(dirname "$0")/.."; cargo build --release -p fc-agent )
+( cd "$(dirname "$0")/.."; make build-host-tools )
 AGENT_BIN="$(dirname "$0")/../target/release/fc-agent"
 
 # Build rootfs (Debian + Podman) and pack into ext4 image

--- a/scripts/install-runner-disk-guard.sh
+++ b/scripts/install-runner-disk-guard.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Install the runner disk guard and its privileged target-pruning helper from
+# one source checkout. DESTDIR is optional and exists so the exact deployment
+# operation can be exercised without writing to the host filesystem.
+set -euo pipefail
+
+if (($# < 1 || $# > 2)); then
+  printf 'usage: %s SOURCE_ROOT [DESTDIR]\n' "$0" >&2
+  exit 2
+fi
+
+source_root="${1%/}"
+destination="${2:-}"
+destination="${destination%/}"
+bin_dir="$destination/usr/local/bin"
+unit_dir="$destination/etc/systemd/system"
+
+install -d -m 755 "$bin_dir" "$unit_dir"
+install -m 755 "$source_root/scripts/runner-disk-preflight.sh" \
+  "$bin_dir/runner-disk-preflight.sh"
+install -m 755 "$source_root/scripts/prune-cargo-target.sh" \
+  "$bin_dir/prune-cargo-target.sh"
+install -m 644 "$source_root/scripts/runner-disk-guard.service" \
+  "$unit_dir/runner-disk-guard.service"
+install -m 644 "$source_root/scripts/runner-disk-guard.timer" \
+  "$unit_dir/runner-disk-guard.timer"

--- a/scripts/prune-cargo-target.sh
+++ b/scripts/prune-cargo-target.sh
@@ -30,6 +30,7 @@ import socket
 import stat
 import subprocess
 import sys
+import time
 
 cutoff, dry_run_text, runner_root, btrfs_target_root = sys.argv[1:]
 if dry_run_text not in ("0", "1"):
@@ -182,7 +183,12 @@ def add_candidate(path, fd, candidates, managed):
     except OSError:
         os.close(fd)
         raise
-    candidates.append({"path": path, "fd": fd, "state": "locked"})
+    candidates.append({
+        "path": path,
+        "fd": fd,
+        "state": "locked",
+        "locked_at_ns": time.monotonic_ns(),
+    })
 
 
 def enumerate_runner_root(path, candidates):
@@ -467,6 +473,20 @@ def synchronize_test_after_enumeration():
             raise RuntimeError("test synchronization peer closed before continuation")
 
 
+def synchronize_test_after_candidate_release(path):
+    # runner-disk-preflight clears this direct-test control at its privilege
+    # boundary. It proves the completed inode is unlocked while later retained
+    # candidates remain exclusively leased.
+    endpoint = os.environ.get("FCVM_PRUNE_TEST_AFTER_RELEASE_SOCKET")
+    if not endpoint:
+        return
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as channel:
+        channel.connect(endpoint)
+        channel.sendall(os.fsencode(path) + b"\0")
+        if channel.recv(1) != b"C":
+            raise RuntimeError("candidate-release test peer closed before continuation")
+
+
 candidates = []
 try:
     # No pruning occurs until every supplied root has been traversed and all
@@ -520,11 +540,12 @@ for candidate in candidates:
     if candidate["state"] == "busy":
         log(f"  keeping (concurrent cargo holds target lease): {path}")
         continue
-    if candidate["active"]:
-        log(f"  keeping (active within cutoff): {path}")
-        continue
 
     try:
+        if candidate["active"]:
+            log(f"  keeping (active within cutoff): {path}")
+            continue
+
         # Rewalk under the retained exclusive lease immediately before reclaim.
         # The second census detects activity, topology, or mount changes before
         # the first fingerprint is invalidated.
@@ -553,6 +574,16 @@ for candidate in candidates:
     except BaseException as error:
         log(f"ERROR: target cleanup failed for {path}: {error}")
         raise SystemExit(49)
+    finally:
+        # Enumeration and the global first census intentionally retain every
+        # candidate lock. Once the current second census/reclaim decision
+        # is complete, later work no longer depends on its lease. Release it on
+        # success, keep, dry-run, and failure paths alike.
+        candidate["fd"] = None
+        os.close(fd)
+        held_ns = time.monotonic_ns() - candidate["locked_at_ns"]
+        log(f"  candidate lease released after {held_ns / 1_000_000_000:.3f}s: {path}")
+        synchronize_test_after_candidate_release(path)
 
 log(
     f"[idle cargo target dirs] considered {considered} per-worktree targets; "

--- a/scripts/prune-cargo-target.sh
+++ b/scripts/prune-cargo-target.sh
@@ -1,0 +1,561 @@
+#!/bin/bash
+# Enumerate and reclaim idle Cargo targets without a pathname handoff. The same
+# privileged process opens and locks candidates as it discovers them, retains
+# every fd until all roots have been enumerated successfully, then validates
+# and truncates reclaimable payloads through those fds. Before changing any
+# payload, it durably retires the target inode. The Cargo wrapper will publish
+# a fresh physical generation before the next build. Directory entries are
+# never removed or renamed: Linux VFS deletion can detach a bind mount that is
+# visible only in another mount namespace, and retained build-script OUT_DIR
+# names are not a valid fresh Cargo cache namespace even after fingerprints are
+# invalidated.
+set -euo pipefail
+
+if (($# != 4)); then
+  printf 'usage: %s CUTOFF DRY_RUN RUNNER_WORK_ROOT BTRFS_TARGET_ROOT\n' "$0" >&2
+  exit 2
+fi
+
+# Stay in the caller's mount namespace so openat2 rejects every mount visible at
+# traversal time. A mount visible only in another namespace cannot be detected
+# here; retaining every dentry is what keeps that foreign mount attached at the
+# same path without traversing its source.
+
+exec /usr/bin/python3 -c '
+import ctypes
+import errno
+import fcntl
+import os
+import socket
+import stat
+import subprocess
+import sys
+
+cutoff, dry_run_text, runner_root, btrfs_target_root = sys.argv[1:]
+if dry_run_text not in ("0", "1"):
+    print(f"invalid DRY_RUN value: {dry_run_text}", file=sys.stderr)
+    raise SystemExit(2)
+dry_run = dry_run_text == "1"
+
+OPEN_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+PATH_FLAGS = os.O_PATH | os.O_NOFOLLOW | os.O_CLOEXEC
+RESOLVE_NO_XDEV = 0x01
+RESOLVE_NO_MAGICLINKS = 0x02
+RESOLVE_NO_SYMLINKS = 0x04
+RESOLVE_BENEATH = 0x08
+SYS_OPENAT2 = 437
+RETIRED_XATTR = b"user.fcvm.retired"
+XATTR_VERSION = b"v1"
+
+
+class OpenHow(ctypes.Structure):
+    _fields_ = [
+        ("flags", ctypes.c_uint64),
+        ("mode", ctypes.c_uint64),
+        ("resolve", ctypes.c_uint64),
+    ]
+
+
+class MountBoundaryError(RuntimeError):
+    pass
+
+
+libc = ctypes.CDLL(None, use_errno=True)
+libc.syscall.restype = ctypes.c_long
+
+
+def log(message):
+    print(f"[disk-preflight] {message}", file=sys.stderr, flush=True)
+
+
+def human(size):
+    value = float(size)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if value < 1024 or unit == "TiB":
+            return f"{value:.1f}{unit}"
+        value /= 1024
+
+
+def parse_cutoff(value):
+    result = subprocess.run(
+        ["/usr/bin/date", "-d", value, "+%s"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or f"invalid cutoff: {value}")
+    return int(result.stdout.strip())
+
+
+try:
+    cutoff_epoch = parse_cutoff(cutoff)
+except BaseException as error:
+    log(f"ERROR: cannot parse target cutoff: {error}")
+    raise SystemExit(2)
+
+
+def open_beneath(parent_fd, name, flags):
+    """Open one child atomically without symlinks, magic links, or mounts."""
+    if not name or name in (".", "..") or "/" in name:
+        raise OSError(errno.EINVAL, "invalid child name", name)
+    how = OpenHow(
+        flags=flags,
+        mode=0,
+        resolve=(
+            RESOLVE_NO_XDEV
+            | RESOLVE_NO_MAGICLINKS
+            | RESOLVE_NO_SYMLINKS
+            | RESOLVE_BENEATH
+        ),
+    )
+    fd = libc.syscall(
+        ctypes.c_long(SYS_OPENAT2),
+        ctypes.c_int(parent_fd),
+        ctypes.c_char_p(os.fsencode(name)),
+        ctypes.byref(how),
+        ctypes.sizeof(how),
+    )
+    if fd >= 0:
+        return fd
+    error = ctypes.get_errno()
+    if error == errno.EXDEV:
+        raise MountBoundaryError(f"mount boundary at child {name!r}")
+    if error == errno.ENOSYS:
+        raise RuntimeError("openat2 is unavailable; refusing unsafe target traversal")
+    raise OSError(error, os.strerror(error), name)
+
+
+def open_absolute_directory(path):
+    """Open every component without following a symlink."""
+    if not path or not os.path.isabs(path):
+        raise OSError(errno.EINVAL, "directory root must be an absolute path", path)
+    current = os.open("/", OPEN_FLAGS)
+    try:
+        for component in [part for part in path.split("/") if part]:
+            next_fd = os.open(component, OPEN_FLAGS, dir_fd=current)
+            os.close(current)
+            current = next_fd
+        return current
+    except BaseException:
+        os.close(current)
+        raise
+
+
+def open_child_directory(parent_fd, name):
+    try:
+        return open_beneath(parent_fd, name, OPEN_FLAGS)
+    except OSError as error:
+        if error.errno in (errno.ELOOP, errno.ENOENT, errno.ENOTDIR):
+            return None
+        raise
+
+
+def open_child_path(parent_fd, name):
+    try:
+        return open_beneath(parent_fd, name, PATH_FLAGS)
+    except OSError as error:
+        if error.errno == errno.ENOENT:
+            return None
+        raise
+
+
+def child_directory_names(parent_fd):
+    # scandir returns names only. The subsequent O_NOFOLLOW open is the act of
+    # discovery: from that point on the fd, not a reusable stat token, owns the
+    # candidate identity.
+    with os.scandir(parent_fd) as entries:
+        return [entry.name for entry in entries]
+
+
+def add_candidate(path, fd, candidates, managed):
+    if not managed:
+        candidates.append({"path": path, "fd": None, "state": "unmanaged"})
+        os.close(fd)
+        return
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        candidates.append({"path": path, "fd": None, "state": "busy"})
+        os.close(fd)
+        return
+    except OSError:
+        os.close(fd)
+        raise
+    candidates.append({"path": path, "fd": fd, "state": "locked"})
+
+
+def enumerate_runner_root(path, candidates):
+    root_fd = open_absolute_directory(path)
+    try:
+        for repo_name in child_directory_names(root_fd):
+            repo_fd = open_child_directory(root_fd, repo_name)
+            if repo_fd is None:
+                continue
+            try:
+                for checkout_name in child_directory_names(repo_fd):
+                    checkout_fd = open_child_directory(repo_fd, checkout_name)
+                    if checkout_fd is None:
+                        continue
+                    try:
+                        target_fd = open_child_directory(checkout_fd, "target")
+                        if target_fd is not None:
+                            add_candidate(
+                                os.path.join(path, repo_name, checkout_name, "target"),
+                                target_fd,
+                                candidates,
+                                False,
+                            )
+                    finally:
+                        os.close(checkout_fd)
+            finally:
+                os.close(repo_fd)
+    finally:
+        os.close(root_fd)
+
+
+def enumerate_btrfs_root(path, candidates):
+    root_fd = open_absolute_directory(path)
+    try:
+        for name in child_directory_names(root_fd):
+            candidate_fd = open_child_directory(root_fd, name)
+            if candidate_fd is not None:
+                add_candidate(os.path.join(path, name), candidate_fd, candidates, True)
+    finally:
+        os.close(root_fd)
+
+
+def regular_key(metadata):
+    return (metadata.st_dev, metadata.st_ino)
+
+
+def record_regular(census, metadata, in_fingerprint):
+    key = regular_key(metadata)
+    record = census.get(key)
+    if record is None:
+        record = {
+            "seen": 0,
+            "fingerprint_seen": 0,
+            "nlink": metadata.st_nlink,
+            "mode": stat.S_IFMT(metadata.st_mode),
+            "size": metadata.st_size,
+            "blocks": metadata.st_blocks * 512,
+            "mtime_ns": metadata.st_mtime_ns,
+            "ctime_ns": metadata.st_ctime_ns,
+        }
+        census[key] = record
+    elif (
+        record["nlink"] != metadata.st_nlink
+        or record["mode"] != stat.S_IFMT(metadata.st_mode)
+        or record["size"] != metadata.st_size
+        or record["mtime_ns"] != metadata.st_mtime_ns
+        or record["ctime_ns"] != metadata.st_ctime_ns
+    ):
+        raise RuntimeError(f"regular inode changed during census: {key}")
+    record["seen"] += 1
+    if in_fingerprint:
+        record["fingerprint_seen"] += 1
+
+
+def inspect_tree(fd, census, in_fingerprint=False):
+    """Return activity, apparent bytes, and retained metadata bytes."""
+    active = False
+    root_metadata = os.fstat(fd)
+    size = root_metadata.st_size
+    retained_metadata = root_metadata.st_blocks * 512
+    for name in child_directory_names(fd):
+        child_fd = open_child_directory(fd, name)
+        if child_fd is not None:
+            try:
+                child_active, child_size, child_retained = inspect_tree(
+                    child_fd,
+                    census,
+                    in_fingerprint or name == ".fingerprint",
+                )
+                active = active or child_active
+                size += child_size
+                retained_metadata += child_retained
+            finally:
+                os.close(child_fd)
+            continue
+
+        path_fd = open_child_path(fd, name)
+        if path_fd is None:
+            continue
+        try:
+            metadata = os.fstat(path_fd)
+            if name == ".fingerprint":
+                raise RuntimeError("Cargo .fingerprint entry is not a real directory")
+            size += metadata.st_size
+            if stat.S_ISREG(metadata.st_mode):
+                record_regular(census, metadata, in_fingerprint)
+                # A prior interrupted reclaim can leave a zero-length file with
+                # a new timestamp between ftruncate and timestamp restoration.
+                # Its zero size is the durable invalidation signal, not activity.
+                if metadata.st_size > 0 and (
+                    metadata.st_mtime > cutoff_epoch
+                    or metadata.st_atime > cutoff_epoch
+                ):
+                    active = True
+            else:
+                if in_fingerprint:
+                    raise RuntimeError(
+                        f"nonregular entry inside Cargo .fingerprint: {name}"
+                    )
+                retained_metadata += metadata.st_blocks * 512
+        finally:
+            os.close(path_fd)
+    return active, size, retained_metadata
+
+
+def metadata_matches(record, metadata):
+    return (
+        record["nlink"] == metadata.st_nlink
+        and record["mode"] == stat.S_IFMT(metadata.st_mode)
+        and record["size"] == metadata.st_size
+        and record["mtime_ns"] == metadata.st_mtime_ns
+        and record["ctime_ns"] == metadata.st_ctime_ns
+    )
+
+
+def open_payload_writer(path_fd, record):
+    writer = os.open(
+        f"/proc/self/fd/{path_fd}",
+        os.O_WRONLY | os.O_CLOEXEC,
+    )
+    metadata = os.fstat(writer)
+    if regular_key(metadata) != regular_key(os.fstat(path_fd)) or not metadata_matches(
+        record, metadata
+    ):
+        os.close(writer)
+        raise RuntimeError("regular inode changed before payload truncation")
+    return writer, metadata
+
+
+def visit_regular_payloads(fd, census, fingerprint_phase, action):
+    processed = set()
+
+    def visit(directory_fd, in_fingerprint=False):
+        for name in child_directory_names(directory_fd):
+            child_fd = open_child_directory(directory_fd, name)
+            if child_fd is not None:
+                try:
+                    visit(child_fd, in_fingerprint or name == ".fingerprint")
+                finally:
+                    os.close(child_fd)
+                continue
+
+            path_fd = open_child_path(directory_fd, name)
+            if path_fd is None:
+                raise RuntimeError(f"target entry disappeared during reclaim: {name}")
+            try:
+                metadata = os.fstat(path_fd)
+                if name == ".fingerprint":
+                    raise RuntimeError("Cargo .fingerprint entry is not a real directory")
+                if not stat.S_ISREG(metadata.st_mode) or in_fingerprint != fingerprint_phase:
+                    continue
+                key = regular_key(metadata)
+                if key in processed:
+                    continue
+                processed.add(key)
+                record = census.get(key)
+                if record is None or not metadata_matches(record, metadata):
+                    raise RuntimeError(f"regular inode changed after census: {key}")
+                action(path_fd, record, in_fingerprint)
+            finally:
+                os.close(path_fd)
+
+    visit(fd)
+
+
+def validate_fingerprint_payloads(fd, census):
+    for key, record in census.items():
+        if record["fingerprint_seen"] and (
+            record["fingerprint_seen"] != record["seen"]
+            or record["seen"] != record["nlink"]
+        ):
+            raise RuntimeError(
+                f"fingerprint inode has an alias outside .fingerprint: {key}"
+            )
+
+    def validate(path_fd, record, _in_fingerprint):
+        writer, _metadata = open_payload_writer(path_fd, record)
+        os.close(writer)
+
+    # Prove every fingerprint is still the censused writable inode before the
+    # first one is invalidated. No payload is touched if this phase fails.
+    visit_regular_payloads(fd, census, True, validate)
+
+
+def truncate_payload_phase(fd, census, fingerprint_phase):
+    reclaimed = 0
+    skipped_external = 0
+
+    def truncate(path_fd, record, in_fingerprint):
+        nonlocal reclaimed, skipped_external
+        if record["seen"] != record["nlink"]:
+            if in_fingerprint:
+                raise RuntimeError("fingerprint alias escaped prevalidation")
+            skipped_external += record["blocks"]
+            return
+
+        writer, metadata = open_payload_writer(path_fd, record)
+        try:
+            os.ftruncate(writer, 0)
+            os.utime(
+                writer,
+                ns=(metadata.st_atime_ns, metadata.st_mtime_ns),
+            )
+            if fingerprint_phase:
+                # Payload truncation cannot become durable before its cache
+                # invalidation. Persist every zero fingerprint before phase 2.
+                os.fsync(writer)
+            reclaimed += record["blocks"]
+        finally:
+            os.close(writer)
+
+    visit_regular_payloads(fd, census, fingerprint_phase, truncate)
+    return reclaimed, skipped_external
+
+
+def reclaim_target(fd, census):
+    # This xattr is the durable namespace retirement record. It is persisted
+    # before any cache byte changes, so a crash can only leave an old generation
+    # that the Cargo wrapper refuses to reuse. Xattrs avoid introducing or
+    # replacing a dentry that could be a mountpoint in another namespace.
+    try:
+        retired = os.getxattr(fd, RETIRED_XATTR)
+    except OSError as error:
+        if error.errno not in (errno.ENODATA, getattr(errno, "ENOATTR", errno.ENODATA)):
+            raise
+        os.setxattr(fd, RETIRED_XATTR, XATTR_VERSION, flags=os.XATTR_CREATE)
+    else:
+        if retired != XATTR_VERSION:
+            raise RuntimeError(f"unsupported retired-generation marker: {retired!r}")
+    os.fsync(fd)
+
+    validate_fingerprint_payloads(fd, census)
+    fingerprint_reclaimed, _ = truncate_payload_phase(fd, census, True)
+    if os.environ.get("FCVM_PRUNE_TEST_FAIL_AFTER_FINGERPRINTS") == "1":
+        raise RuntimeError("injected failure after durable fingerprint invalidation")
+    payload_reclaimed, skipped_external = truncate_payload_phase(fd, census, False)
+    return fingerprint_reclaimed + payload_reclaimed, skipped_external
+
+
+def unique_regular_blocks(census):
+    reclaimable = 0
+    skipped_external = 0
+    for record in census.values():
+        if record["seen"] == record["nlink"]:
+            reclaimable += record["blocks"]
+        else:
+            skipped_external += record["blocks"]
+    return reclaimable, skipped_external
+
+
+def synchronize_test_after_enumeration():
+    # runner-disk-preflight clears test controls at its privilege boundary.
+    # Direct test
+    # invocations use it only to make replacement/mount races deterministic.
+    endpoint = os.environ.get("FCVM_PRUNE_TEST_SYNC_SOCKET")
+    if not endpoint:
+        return
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as channel:
+        channel.connect(endpoint)
+        channel.sendall(b"E")
+        if channel.recv(1) != b"C":
+            raise RuntimeError("test synchronization peer closed before continuation")
+
+
+candidates = []
+try:
+    # No pruning occurs until every supplied root has been traversed and all
+    # candidate fds/locks have been retained. A failure cannot authorize a
+    # partial-view cleanup of the other root.
+    if runner_root:
+        enumerate_runner_root(runner_root, candidates)
+    if btrfs_target_root:
+        enumerate_btrfs_root(btrfs_target_root, candidates)
+except MountBoundaryError as error:
+    log(f"ERROR: refusing cargo target root containing a mount: {error}")
+    raise SystemExit(50)
+except BaseException as error:
+    log(f"ERROR: cannot enumerate every cargo target root: {error}")
+    raise SystemExit(51)
+
+synchronize_test_after_enumeration()
+
+# Inspect every retained candidate before the first mutation. openat2 checks
+# mount identity at each fd-relative component resolution, so path renames
+# cannot create a mountinfo/readlink ABA. The retained locked fd is the cleanup
+# authority: if its pathname is replaced, the replacement is never opened or
+# touched, while the originally authorized target remains safe to reclaim.
+for candidate in candidates:
+    fd = candidate["fd"]
+    if fd is None:
+        continue
+    candidate_path = candidate["path"]
+    try:
+        census = {}
+        active, size, retained_metadata = inspect_tree(fd, census)
+    except MountBoundaryError as error:
+        log(f"ERROR: refusing target containing an exact or descendant mount: {candidate_path} ({error})")
+        raise SystemExit(50)
+    except BaseException as error:
+        log(f"ERROR: cannot inspect target safely: {candidate_path} ({error})")
+        raise SystemExit(49)
+    candidate["active"] = active
+    candidate["size"] = size
+    candidate["census"] = census
+    candidate["retained_metadata"] = retained_metadata
+
+considered = 0
+for candidate in candidates:
+    considered += 1
+    path = candidate["path"]
+    fd = candidate["fd"]
+    if candidate["state"] == "unmanaged":
+        log(f"  keeping (local target has no rotatable generation): {path}")
+        continue
+    if candidate["state"] == "busy":
+        log(f"  keeping (concurrent cargo holds target lease): {path}")
+        continue
+    if candidate["active"]:
+        log(f"  keeping (active within cutoff): {path}")
+        continue
+
+    try:
+        # Rewalk under the retained exclusive lease immediately before reclaim.
+        # The second census detects activity, topology, or mount changes before
+        # the first fingerprint is invalidated.
+        census = {}
+        active, size, retained_metadata = inspect_tree(fd, census)
+        if active:
+            log(f"  keeping (became active before reclaim): {path}")
+            continue
+        reclaimable, skipped_external = unique_regular_blocks(census)
+        if dry_run:
+            log(
+                f"  would reclaim: {path} ({human(reclaimable)} payload; "
+                f"{human(skipped_external)} external-hardlink payload and "
+                f"{human(retained_metadata)} metadata/nonregular retained)"
+            )
+        else:
+            reclaimed, skipped_external = reclaim_target(fd, census)
+            log(
+                f"  reclaimed: {path} ({human(reclaimed)} payload; "
+                f"{human(skipped_external)} external-hardlink payload and "
+                f"{human(retained_metadata)} metadata/nonregular retained)"
+            )
+    except MountBoundaryError as error:
+        log(f"ERROR: refusing target containing a mount at reclaim: {path} ({error})")
+        raise SystemExit(50)
+    except BaseException as error:
+        log(f"ERROR: target cleanup failed for {path}: {error}")
+        raise SystemExit(49)
+
+log(
+    f"[idle cargo target dirs] considered {considered} per-worktree targets; "
+    "directories retained"
+)
+' "$@"

--- a/scripts/run_fuse_pipe_tests.sh
+++ b/scripts/run_fuse_pipe_tests.sh
@@ -54,8 +54,11 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 run_step "stress" sudo env STRESS_WORKERS="${STRESS_WORKERS:-4}" STRESS_OPS="${STRESS_OPS:-1000}" \
+    CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-target}" BTRFS_ROOT="${BTRFS_ROOT:-/mnt/fcvm-btrfs}" \
     "${CARGO_RUNNER}" cargo test -p fuse-pipe --test stress -- --nocapture || die "stress test failed"
 
-run_step "pjdfstest-matrix" sudo "${CARGO_RUNNER}" cargo test -p fuse-pipe --test pjdfstest_matrix -- --nocapture || die "pjdfstest_matrix failed"
+run_step "pjdfstest-matrix" sudo env CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-target}" \
+    BTRFS_ROOT="${BTRFS_ROOT:-/mnt/fcvm-btrfs}" \
+    "${CARGO_RUNNER}" cargo test -p fuse-pipe --test pjdfstest_matrix -- --nocapture || die "pjdfstest_matrix failed"
 
 echo -e "\n==> ALL TESTS PASSED" | tee -a "${LOG_FILE}"

--- a/scripts/run_fuse_pipe_tests.sh
+++ b/scripts/run_fuse_pipe_tests.sh
@@ -15,7 +15,9 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "${ROOT}/fuse-pipe"
+cd "${ROOT}"
+make cargo-target-link
+CARGO_RUNNER="${ROOT}/scripts/cargo-target-run.sh"
 
 LOG_DIR="${LOG_DIR:-/tmp/fuse-pipe-tests}"
 mkdir -p "${LOG_DIR}"
@@ -44,16 +46,16 @@ die() {
     exit 1
 }
 
-run_step "unit+lib" cargo test --lib -- --nocapture || die "unit/lib tests failed"
-run_step "integration" cargo test --test integration -- --nocapture || die "integration tests failed"
+run_step "unit+lib" "${CARGO_RUNNER}" cargo test -p fuse-pipe --lib -- --nocapture || die "unit/lib tests failed"
+run_step "integration" "${CARGO_RUNNER}" cargo test -p fuse-pipe --test integration -- --nocapture || die "integration tests failed"
 
 if [[ $EUID -ne 0 ]]; then
     echo "==> Re-running remaining tests with sudo for full coverage" | tee -a "${LOG_FILE}"
 fi
 
 run_step "stress" sudo env STRESS_WORKERS="${STRESS_WORKERS:-4}" STRESS_OPS="${STRESS_OPS:-1000}" \
-    cargo test --test stress -- --nocapture || die "stress test failed"
+    "${CARGO_RUNNER}" cargo test -p fuse-pipe --test stress -- --nocapture || die "stress test failed"
 
-run_step "pjdfstest-matrix" sudo cargo test --test pjdfstest_matrix -- --nocapture || die "pjdfstest_matrix failed"
+run_step "pjdfstest-matrix" sudo "${CARGO_RUNNER}" cargo test -p fuse-pipe --test pjdfstest_matrix -- --nocapture || die "pjdfstest_matrix failed"
 
 echo -e "\n==> ALL TESTS PASSED" | tee -a "${LOG_FILE}"

--- a/scripts/runner-disk-preflight.sh
+++ b/scripts/runner-disk-preflight.sh
@@ -262,7 +262,7 @@ stage_test_logs() {
 # must never be a candidate. Reclaim retires the old namespace before
 # truncating bytes, so the next Cargo wrapper publishes a fresh generation.
 stage_target_dirs() {
-  local runner_root= btrfs_target_root=
+  local runner_root='' btrfs_target_root=''
 
   # One privileged process enumerates every root, atomically opens and locks
   # candidates as it discovers them, retains those fds until all enumeration
@@ -281,6 +281,7 @@ stage_target_dirs() {
 
   "${SUDO[@]}" env \
     -u FCVM_PRUNE_TEST_SYNC_SOCKET \
+    -u FCVM_PRUNE_TEST_AFTER_RELEASE_SOCKET \
     -u FCVM_PRUNE_TEST_FAIL_AFTER_FINGERPRINTS \
     "$TARGET_PRUNE_HELPER" \
     "$TARGET_CUTOFF" "$DRY_RUN" "$runner_root" "$btrfs_target_root"

--- a/scripts/runner-disk-preflight.sh
+++ b/scripts/runner-disk-preflight.sh
@@ -33,8 +33,10 @@
 #   1. podman system prune (rootless + root storage) — images/containers/
 #      volumes are re-pulled or re-built on demand.
 #   2. /tmp/fcvm-test-logs entries older than LOG_AGE_DAYS.
-#   3. cargo/nextest target dirs (runner _work checkouts and each child of
-#      /mnt/fcvm-btrfs/cargo-target/) with no activity for TARGET_AGE_DAYS.
+#   3. managed cargo/nextest generations under /mnt/fcvm-btrfs/cargo-target/
+#      with no activity for TARGET_AGE_DAYS. Pre-protocol real target dirs in
+#      runner _work are reported but retained because they cannot be atomically
+#      rotated without renaming a possibly-mounted dentry.
 #   4. content-addressed caches on /mnt/fcvm-btrfs (image-cache entries,
 #      snapshot dirs, kernel/rootfs/initrd/firecracker assets) idle for
 #      CACHE_AGE_DAYS, plus core dumps older than LOG_AGE_DAYS.
@@ -49,6 +51,9 @@
 # *.lock files (unlinking a lock file a process holds leaves two "owners" of
 # the same critical section — the ABA locking bug class AGENTS.md bans).
 set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+TARGET_PRUNE_HELPER="$SCRIPT_DIR/prune-cargo-target.sh"
 
 MIN_FREE_GB="${MIN_FREE_GB:-15}"
 HARD_FLOOR_GB="${HARD_FLOOR_GB:-5}"
@@ -252,161 +257,33 @@ stage_test_logs() {
     delete_candidates "stale test logs (>${LOG_AGE_DAYS}d)"
 }
 
-# Was any cargo artifact used since the cutoff?  Directory timestamps cannot be
-# used: merely enumerating a directory updates its atime.  This intentionally
-# examines files recursively, just like recently_used().
-target_recently_used() {
-  recently_used "$1" "$TARGET_CUTOFF"
-}
-
-# Prune one target while holding its directory inode exclusively.  Every Cargo
-# invocation from the Makefile holds a shared flock on that exact inode for its
-# whole process lifetime.  The first activity check is a cheap candidate gate;
-# the second, under the exclusive lease, closes the age-check -> delete race.
-prune_target_dir() {
-  local d="$1" lease_fd rc=0 before_id locked_id size
-
-  if target_recently_used "$d"; then
-    log "  keeping (active within ${TARGET_AGE_DAYS}d): $d"
-    return 0
-  fi
-  if ((DRY_RUN)); then
-    size="$("${SUDO[@]}" du -sb -- "$d" | awk '{print $1}')" || return 1
-    log "  would empty: $d ($(human "$size")); retaining the leased directory"
-    return 0
-  fi
-
-  # Opening the directory itself avoids a separate lock-file creation race and
-  # also covers targets left by older checkouts.  Never unlink this directory:
-  # its inode is the lock object.
-  if ! exec {lease_fd}<"$d"; then
-    log "  WARNING: cannot open target lease $d; keeping it"
-    return 0
-  fi
-  flock -n -x -E 42 "$lease_fd" || rc=$?
-  if ((rc != 0)); then
-    exec {lease_fd}<&-
-    if ((rc == 42)); then
-      log "  keeping (concurrent cargo holds target lease): $d"
-      return 0
-    fi
-    log "ERROR: locking target $d failed (rc=$rc)"
-    return 1
-  fi
-
-  # Fail closed if another cleanup implementation replaced the pathname while
-  # this process opened it.  Current fcvm cleanup never does so; it retains the
-  # directory specifically to keep this identity stable.
-  before_id="$(stat -Lc '%d:%i' -- "$d")" || {
-    exec {lease_fd}<&-
-    log "  keeping (target vanished before identity check): $d"
-    return 0
-  }
-  locked_id="$(stat -Lc '%d:%i' -- "/proc/$$/fd/$lease_fd")" || {
-    exec {lease_fd}<&-
-    log "ERROR: cannot identify locked target $d"
-    return 1
-  }
-  if [[ $before_id != "$locked_id" ]]; then
-    exec {lease_fd}<&-
-    log "  keeping (target path was replaced during lease acquisition): $d"
-    return 0
-  fi
-
-  if target_recently_used "$d"; then
-    exec {lease_fd}<&-
-    log "  keeping (became active before exclusive lease): $d"
-    return 0
-  fi
-
-  size="$("${SUDO[@]}" du -sb -- "$d" | awk '{print $1}')" || {
-    exec {lease_fd}<&-
-    return 1
-  }
-  # `-exec` keeps enumeration and deletion in one status-bearing command; a
-  # process-substitution loop would silently lose find(1)'s exit status and
-  # could report a permission failure as successful cleanup.
-  "${SUDO[@]}" find "$d" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} + || {
-    exec {lease_fd}<&-
-    return 1
-  }
-  exec {lease_fd}<&-
-  log "  emptied: $d ($(human "$size")); retained target directory"
-}
-
-# Stage 3: cargo/nextest build artifacts. Deleting one costs a rebuild, never
-# correctness. Each per-worktree child is considered independently; the
-# cargo-target parent is only a namespace and must never be a candidate.
-collect_target_candidates() {
-  local -n output="$1"
-  local root="$2" candidate find_fd find_pid rc
-  local batch=()
-  shift 2
-
-  # Capture the process-substitution PID immediately, drain its NUL-delimited
-  # output, and wait for its real status before exposing any candidates.  This
-  # uses only a pipe: disk cleanup must not depend on spare /tmp capacity or
-  # leave a manifest behind if the runner is cancelled mid-preflight.
-  if ! exec {find_fd}< <("${SUDO[@]}" find "$root" "$@" -print0); then
-    log "ERROR: cannot start cargo target enumeration under $root"
-    return 1
-  fi
-  find_pid=$!
-  while IFS= read -r -d '' -u "$find_fd" candidate; do
-    batch+=("$candidate")
-  done
-  if ! exec {find_fd}<&-; then
-    wait "$find_pid" || true
-    log "ERROR: cannot close cargo target enumeration pipe for $root"
-    return 1
-  fi
-  if wait "$find_pid"; then
-    output+=("${batch[@]}")
-    return 0
-  else
-    rc=$?
-    log "ERROR: cannot enumerate cargo target dirs under $root (find rc=$rc)"
-    return 1
-  fi
-}
-
+# Stage 3: cargo/nextest build payloads. Each managed physical generation is
+# considered independently; the cargo-target parent is only a namespace and
+# must never be a candidate. Reclaim retires the old namespace before
+# truncating bytes, so the next Cargo wrapper publishes a fresh generation.
 stage_target_dirs() {
-  local candidates=() d count=0
+  local runner_root= btrfs_target_root=
 
-  # Enumerate every root successfully before touching any target.  A find in a
-  # process substitution has no status the parent while-loop can inspect, so a
-  # permission or I/O failure there used to look like an empty/successful root.
-  # collect_target_candidates explicitly waits for each producer and only then
-  # appends its batch; reject either failure rather than pruning a partial view
-  # of the runner.
-  # Runner work-dir checkouts live at _work/<repo>/<repo>/target. -type d
-  # skips the target→btrfs symlink the Makefile creates; that case is the
-  # per-worktree child enumeration below.
+  # One privileged process enumerates every root, atomically opens and locks
+  # candidates as it discovers them, retains those fds until all enumeration
+  # has succeeded, and only then validates/reclaims. A pathname or dev:ino passed
+  # between two processes has an unavoidable replacement/ABA gap.
   if dir_exists "$RUNNER_WORK_ROOT"; then
-    if ! collect_target_candidates candidates "$RUNNER_WORK_ROOT" \
-      -mindepth 3 -maxdepth 3 -type d -name target; then
-      return 1
-    fi
+    runner_root="$RUNNER_WORK_ROOT"
   fi
   if dir_exists "$BTRFS_ROOT/cargo-target"; then
-    if ! collect_target_candidates candidates "$BTRFS_ROOT/cargo-target" \
-      -mindepth 1 -maxdepth 1 -type d; then
-      return 1
-    fi
+    btrfs_target_root="$BTRFS_ROOT/cargo-target"
   fi
-  if ((${#candidates[@]} == 0)); then
+  if [[ -z $runner_root && -z $btrfs_target_root ]]; then
     log "no cargo target dirs found"
     return 0
   fi
-  for d in "${candidates[@]}"; do
-    if ! prune_target_dir "$d"; then
-      return 1
-    fi
-    count=$((count + 1))
-  done
-  # Per-target logs report exact apparent sizes.  This summary deliberately
-  # reports candidates rather than pretending btrfs reflinked bytes equal df.
-  log "[idle cargo target dirs (>${TARGET_AGE_DAYS}d)] considered $count per-worktree targets; directories retained"
+
+  "${SUDO[@]}" env \
+    -u FCVM_PRUNE_TEST_SYNC_SOCKET \
+    -u FCVM_PRUNE_TEST_FAIL_AFTER_FINGERPRINTS \
+    "$TARGET_PRUNE_HELPER" \
+    "$TARGET_CUTOFF" "$DRY_RUN" "$runner_root" "$btrfs_target_root"
 }
 
 # Stage 4a helper: content-addressed image-cache entries

--- a/scripts/runner-disk-preflight.sh
+++ b/scripts/runner-disk-preflight.sh
@@ -337,20 +337,62 @@ prune_target_dir() {
 # Stage 3: cargo/nextest build artifacts. Deleting one costs a rebuild, never
 # correctness. Each per-worktree child is considered independently; the
 # cargo-target parent is only a namespace and must never be a candidate.
+collect_target_candidates() {
+  local -n output="$1"
+  local root="$2" candidate find_fd find_pid rc
+  local batch=()
+  shift 2
+
+  # Capture the process-substitution PID immediately, drain its NUL-delimited
+  # output, and wait for its real status before exposing any candidates.  This
+  # uses only a pipe: disk cleanup must not depend on spare /tmp capacity or
+  # leave a manifest behind if the runner is cancelled mid-preflight.
+  if ! exec {find_fd}< <("${SUDO[@]}" find "$root" "$@" -print0); then
+    log "ERROR: cannot start cargo target enumeration under $root"
+    return 1
+  fi
+  find_pid=$!
+  while IFS= read -r -d '' -u "$find_fd" candidate; do
+    batch+=("$candidate")
+  done
+  if ! exec {find_fd}<&-; then
+    wait "$find_pid" || true
+    log "ERROR: cannot close cargo target enumeration pipe for $root"
+    return 1
+  fi
+  if wait "$find_pid"; then
+    output+=("${batch[@]}")
+    return 0
+  else
+    rc=$?
+    log "ERROR: cannot enumerate cargo target dirs under $root (find rc=$rc)"
+    return 1
+  fi
+}
+
 stage_target_dirs() {
   local candidates=() d count=0
+
+  # Enumerate every root successfully before touching any target.  A find in a
+  # process substitution has no status the parent while-loop can inspect, so a
+  # permission or I/O failure there used to look like an empty/successful root.
+  # collect_target_candidates explicitly waits for each producer and only then
+  # appends its batch; reject either failure rather than pruning a partial view
+  # of the runner.
   # Runner work-dir checkouts live at _work/<repo>/<repo>/target. -type d
   # skips the target→btrfs symlink the Makefile creates; that case is the
   # per-worktree child enumeration below.
   if dir_exists "$RUNNER_WORK_ROOT"; then
-    while IFS= read -r -d '' d; do
-      candidates+=("$d")
-    done < <("${SUDO[@]}" find "$RUNNER_WORK_ROOT" -mindepth 3 -maxdepth 3 -type d -name target -print0)
+    if ! collect_target_candidates candidates "$RUNNER_WORK_ROOT" \
+      -mindepth 3 -maxdepth 3 -type d -name target; then
+      return 1
+    fi
   fi
   if dir_exists "$BTRFS_ROOT/cargo-target"; then
-    while IFS= read -r -d '' d; do
-      candidates+=("$d")
-    done < <("${SUDO[@]}" find "$BTRFS_ROOT/cargo-target" -mindepth 1 -maxdepth 1 -type d -print0)
+    if ! collect_target_candidates candidates "$BTRFS_ROOT/cargo-target" \
+      -mindepth 1 -maxdepth 1 -type d; then
+      return 1
+    fi
   fi
   if ((${#candidates[@]} == 0)); then
     log "no cargo target dirs found"

--- a/scripts/runner-disk-preflight.sh
+++ b/scripts/runner-disk-preflight.sh
@@ -33,8 +33,8 @@
 #   1. podman system prune (rootless + root storage) — images/containers/
 #      volumes are re-pulled or re-built on demand.
 #   2. /tmp/fcvm-test-logs entries older than LOG_AGE_DAYS.
-#   3. cargo/nextest target dirs (runner _work checkouts and
-#      /mnt/fcvm-btrfs/cargo-target*) with no activity for TARGET_AGE_DAYS.
+#   3. cargo/nextest target dirs (runner _work checkouts and each child of
+#      /mnt/fcvm-btrfs/cargo-target/) with no activity for TARGET_AGE_DAYS.
 #   4. content-addressed caches on /mnt/fcvm-btrfs (image-cache entries,
 #      snapshot dirs, kernel/rootfs/initrd/firecracker assets) idle for
 #      CACHE_AGE_DAYS, plus core dumps older than LOG_AGE_DAYS.
@@ -58,18 +58,24 @@ CACHE_AGE_DAYS="${CACHE_AGE_DAYS:-4}"
 DRY_RUN="${DRY_RUN:-0}"
 
 QUARANTINE=0
+TARGET_DIRS_ONLY=0
 for arg in "$@"; do
   case "$arg" in
     --quarantine) QUARANTINE=1 ;;
+    # Operationally useful on a runner and a narrow entry point for the
+    # concurrency regression tests.  It runs as the caller and touches only
+    # the configured cargo target roots.
+    --target-dirs-only) TARGET_DIRS_ONLY=1 ;;
     *)
-      echo "usage: $0 [--quarantine]" >&2
+      echo "usage: $0 [--quarantine] [--target-dirs-only]" >&2
       exit 2
       ;;
   esac
 done
 
 GIB=$((1024 * 1024 * 1024))
-BTRFS_ROOT=/mnt/fcvm-btrfs
+BTRFS_ROOT="${BTRFS_ROOT:-/mnt/fcvm-btrfs}"
+RUNNER_WORK_ROOT="${RUNNER_WORK_ROOT:-/opt/actions-runner/_work}"
 
 # All logging goes to stderr: several stages pipe NUL-delimited candidate
 # paths between functions on stdout, and log lines must never enter that data
@@ -81,7 +87,12 @@ human() { numfmt --to=iec-i --suffix=B "$1"; }
 # podman storage). CI runners and dev boxes both have passwordless sudo; the
 # probe's stderr is suppressed only because we replace it with our own loud
 # error right below.
-if [[ $EUID -eq 0 ]]; then
+if ((TARGET_DIRS_ONLY)); then
+  # This mode is deliberately least-privilege: tests and operators point it at
+  # caller-owned roots.  The normal preflight still elevates for root-owned VM
+  # debris and caches.
+  SUDO=()
+elif [[ $EUID -eq 0 ]]; then
   SUDO=()
 else
   SUDO=(sudo -n)
@@ -241,35 +252,119 @@ stage_test_logs() {
     delete_candidates "stale test logs (>${LOG_AGE_DAYS}d)"
 }
 
+# Was any cargo artifact used since the cutoff?  Directory timestamps cannot be
+# used: merely enumerating a directory updates its atime.  This intentionally
+# examines files recursively, just like recently_used().
+target_recently_used() {
+  recently_used "$1" "$TARGET_CUTOFF"
+}
+
+# Prune one target while holding its directory inode exclusively.  Every Cargo
+# invocation from the Makefile holds a shared flock on that exact inode for its
+# whole process lifetime.  The first activity check is a cheap candidate gate;
+# the second, under the exclusive lease, closes the age-check -> delete race.
+prune_target_dir() {
+  local d="$1" lease_fd rc=0 before_id locked_id size
+
+  if target_recently_used "$d"; then
+    log "  keeping (active within ${TARGET_AGE_DAYS}d): $d"
+    return 0
+  fi
+  if ((DRY_RUN)); then
+    size="$("${SUDO[@]}" du -sb -- "$d" | awk '{print $1}')" || return 1
+    log "  would empty: $d ($(human "$size")); retaining the leased directory"
+    return 0
+  fi
+
+  # Opening the directory itself avoids a separate lock-file creation race and
+  # also covers targets left by older checkouts.  Never unlink this directory:
+  # its inode is the lock object.
+  if ! exec {lease_fd}<"$d"; then
+    log "  WARNING: cannot open target lease $d; keeping it"
+    return 0
+  fi
+  flock -n -x -E 42 "$lease_fd" || rc=$?
+  if ((rc != 0)); then
+    exec {lease_fd}<&-
+    if ((rc == 42)); then
+      log "  keeping (concurrent cargo holds target lease): $d"
+      return 0
+    fi
+    log "ERROR: locking target $d failed (rc=$rc)"
+    return 1
+  fi
+
+  # Fail closed if another cleanup implementation replaced the pathname while
+  # this process opened it.  Current fcvm cleanup never does so; it retains the
+  # directory specifically to keep this identity stable.
+  before_id="$(stat -Lc '%d:%i' -- "$d")" || {
+    exec {lease_fd}<&-
+    log "  keeping (target vanished before identity check): $d"
+    return 0
+  }
+  locked_id="$(stat -Lc '%d:%i' -- "/proc/$$/fd/$lease_fd")" || {
+    exec {lease_fd}<&-
+    log "ERROR: cannot identify locked target $d"
+    return 1
+  }
+  if [[ $before_id != "$locked_id" ]]; then
+    exec {lease_fd}<&-
+    log "  keeping (target path was replaced during lease acquisition): $d"
+    return 0
+  fi
+
+  if target_recently_used "$d"; then
+    exec {lease_fd}<&-
+    log "  keeping (became active before exclusive lease): $d"
+    return 0
+  fi
+
+  size="$("${SUDO[@]}" du -sb -- "$d" | awk '{print $1}')" || {
+    exec {lease_fd}<&-
+    return 1
+  }
+  # `-exec` keeps enumeration and deletion in one status-bearing command; a
+  # process-substitution loop would silently lose find(1)'s exit status and
+  # could report a permission failure as successful cleanup.
+  "${SUDO[@]}" find "$d" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} + || {
+    exec {lease_fd}<&-
+    return 1
+  }
+  exec {lease_fd}<&-
+  log "  emptied: $d ($(human "$size")); retained target directory"
+}
+
 # Stage 3: cargo/nextest build artifacts. Deleting one costs a rebuild, never
-# correctness, so only dirs with no read/write activity for TARGET_AGE_DAYS
-# are pruned (the active checkout's target is touched on every build).
+# correctness. Each per-worktree child is considered independently; the
+# cargo-target parent is only a namespace and must never be a candidate.
 stage_target_dirs() {
-  local candidates=() d
+  local candidates=() d count=0
   # Runner work-dir checkouts live at _work/<repo>/<repo>/target. -type d
   # skips the target→btrfs symlink the Makefile creates; that case is the
-  # cargo-target* glob below.
-  if dir_exists /opt/actions-runner/_work; then
+  # per-worktree child enumeration below.
+  if dir_exists "$RUNNER_WORK_ROOT"; then
     while IFS= read -r -d '' d; do
       candidates+=("$d")
-    done < <("${SUDO[@]}" find /opt/actions-runner/_work -mindepth 3 -maxdepth 3 -type d -name target -print0)
+    done < <("${SUDO[@]}" find "$RUNNER_WORK_ROOT" -mindepth 3 -maxdepth 3 -type d -name target -print0)
   fi
-  for d in "$BTRFS_ROOT"/cargo-target*; do
-    if [[ -d $d ]]; then
+  if dir_exists "$BTRFS_ROOT/cargo-target"; then
+    while IFS= read -r -d '' d; do
       candidates+=("$d")
-    fi
-  done
+    done < <("${SUDO[@]}" find "$BTRFS_ROOT/cargo-target" -mindepth 1 -maxdepth 1 -type d -print0)
+  fi
   if ((${#candidates[@]} == 0)); then
     log "no cargo target dirs found"
     return 0
   fi
   for d in "${candidates[@]}"; do
-    if recently_used "$d" "$TARGET_CUTOFF"; then
-      log "  keeping (active within ${TARGET_AGE_DAYS}d): $d"
-    else
-      printf '%s\0' "$d"
+    if ! prune_target_dir "$d"; then
+      return 1
     fi
-  done | delete_candidates "idle cargo target dirs (>${TARGET_AGE_DAYS}d)"
+    count=$((count + 1))
+  done
+  # Per-target logs report exact apparent sizes.  This summary deliberately
+  # reports candidates rather than pretending btrfs reflinked bytes equal df.
+  log "[idle cargo target dirs (>${TARGET_AGE_DAYS}d)] considered $count per-worktree targets; directories retained"
 }
 
 # Stage 4a helper: content-addressed image-cache entries
@@ -387,6 +482,10 @@ quarantine_runner() {
 }
 
 main() {
+  if ((TARGET_DIRS_ONLY)); then
+    stage_target_dirs
+    return
+  fi
   local runner_id="${RUNNER_NAME:-$(hostname)}"
   log "runner: $runner_id"
   log "monitored filesystems: ${MON[*]}"

--- a/scripts/setup-runner.sh
+++ b/scripts/setup-runner.sh
@@ -70,7 +70,7 @@ apt-get install -y curl wget git jq build-essential \
   podman uidmap passt fuse-overlayfs containernetworking-plugins \
   fuse3 libfuse3-dev libclang-dev clang musl-tools \
   iproute2 iptables dnsmasq qemu-utils e2fsprogs parted \
-  skopeo busybox-static cpio zstd autoconf automake libtool
+  skopeo busybox-static cpio zstd autoconf automake libtool python3 util-linux
 
 # Node.js 22.x
 curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
@@ -94,9 +94,7 @@ git clone --depth 1 https://github.com/ejc3/fcvm.git /tmp/fcvm-passt
 # caches out-of-band and, if the hard floor still cannot be met, stops the
 # runner service so the box goes offline and gets replaced instead of
 # poisoning jobs.
-install -m 755 /tmp/fcvm-passt/scripts/runner-disk-preflight.sh /usr/local/bin/runner-disk-preflight.sh
-install -m 644 /tmp/fcvm-passt/scripts/runner-disk-guard.service /etc/systemd/system/runner-disk-guard.service
-install -m 644 /tmp/fcvm-passt/scripts/runner-disk-guard.timer /etc/systemd/system/runner-disk-guard.timer
+/tmp/fcvm-passt/scripts/install-runner-disk-guard.sh /tmp/fcvm-passt
 systemctl daemon-reload
 systemctl enable --now runner-disk-guard.timer
 

--- a/tests/test_ami_hash_inputs.rs
+++ b/tests/test_ami_hash_inputs.rs
@@ -25,6 +25,8 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+const TEST_SOURCE_COMMIT: &str = "0000000000000000000000000000000000000000";
+
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
@@ -33,7 +35,11 @@ fn repo_root() -> PathBuf {
 /// fixture tree. `create_user_data` (its only helper call) is stubbed so this
 /// exercises the kernel-input behaviour in isolation.
 fn run_compute_hash(fixture: &Path) -> String {
-    let (ok, out, err) = try_compute_hash(fixture);
+    run_compute_hash_for_commit(fixture, TEST_SOURCE_COMMIT)
+}
+
+fn run_compute_hash_for_commit(fixture: &Path, source_commit: &str) -> String {
+    let (ok, out, err) = try_compute_hash_for_commit(fixture, source_commit);
     assert!(ok, "compute_hash failed: {err}");
     assert!(
         !out.is_empty(),
@@ -44,6 +50,10 @@ fn run_compute_hash(fixture: &Path) -> String {
 
 /// Same, but hands back the exit status so the fail-closed cases can assert on it.
 fn try_compute_hash(fixture: &Path) -> (bool, String, String) {
+    try_compute_hash_for_commit(fixture, TEST_SOURCE_COMMIT)
+}
+
+fn try_compute_hash_for_commit(fixture: &Path, source_commit: &str) -> (bool, String, String) {
     let script = std::fs::read_to_string(repo_root().join("scripts/build-ami.sh"))
         .expect("read scripts/build-ami.sh");
 
@@ -63,9 +73,9 @@ fn try_compute_hash(fixture: &Path) -> (bool, String, String) {
     // mutation test below would compare two copies of the empty-stream digest.
     let program = format!(
         "set -u\n\
-         create_user_data() {{ printf 'stub-user-data'; }}\n\
+         create_user_data() {{ printf 'stub-user-data:%s' \"$1\"; }}\n\
          {func}\n\
-         compute_hash\n",
+         compute_hash \"$SOURCE_COMMIT\"\n",
         func = func
     );
 
@@ -74,6 +84,7 @@ fn try_compute_hash(fixture: &Path) -> (bool, String, String) {
         .arg(&program)
         .env("KERNEL_DIR", fixture.join("kernel"))
         .env("SCRIPT_DIR", fixture.join("scripts"))
+        .env("SOURCE_COMMIT", source_commit)
         .output()
         .expect("run bash");
     (
@@ -81,6 +92,92 @@ fn try_compute_hash(fixture: &Path) -> (bool, String, String) {
         String::from_utf8_lossy(&out.stdout).trim().to_string(),
         String::from_utf8_lossy(&out.stderr).trim().to_string(),
     )
+}
+
+fn render_user_data(source_commit: &str) -> String {
+    let script = std::fs::read_to_string(repo_root().join("scripts/build-ami.sh"))
+        .expect("read scripts/build-ami.sh");
+    let start = script
+        .find("\ncreate_user_data() {")
+        .map(|offset| offset + 1)
+        .expect("build-ami.sh has no create_user_data()");
+    let rest = &script[start..];
+    let end = rest
+        .find("\nUSERDATA\n}")
+        .expect("create_user_data() has no USERDATA terminator")
+        + "\nUSERDATA\n}".len();
+    let function = &rest[..end];
+    let program = format!("{function}\ncreate_user_data \"$SOURCE_COMMIT\"\n");
+    let output = Command::new("bash")
+        .arg("-c")
+        .arg(program)
+        .env("SOURCE_COMMIT", source_commit)
+        .output()
+        .expect("render AMI user data");
+    assert!(
+        output.status.success(),
+        "create_user_data failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("user data is UTF-8")
+}
+
+fn materialize_pinned_tree(repo: &Path, commit: &str, destination: &Path) -> std::process::Output {
+    let script = std::fs::read_to_string(repo_root().join("scripts/build-ami.sh"))
+        .expect("read scripts/build-ami.sh");
+    let start = script
+        .find("materialize_pinned_source_tree()")
+        .expect("build-ami.sh has no pinned-tree materializer");
+    let rest = &script[start..];
+    let end = rest
+        .find("\n}\n")
+        .expect("materialize_pinned_source_tree() has no closing brace")
+        + 2;
+    let function = &rest[..end];
+    let program = format!(
+        "set -uo pipefail\n{function}\nmaterialize_pinned_source_tree \"$REPO\" \"$COMMIT\" \"$DEST\"\n"
+    );
+    Command::new("bash")
+        .arg("-c")
+        .arg(program)
+        .env("REPO", repo)
+        .env("COMMIT", commit)
+        .env("DEST", destination)
+        .output()
+        .expect("run pinned-tree materializer")
+}
+
+fn compute_pinned_hash(repo: &Path, commit: &str) -> std::process::Output {
+    let script = std::fs::read_to_string(repo_root().join("scripts/build-ami.sh"))
+        .expect("read scripts/build-ami.sh");
+    let extract = |name: &str| {
+        let marker = format!("{name}()");
+        let start = script
+            .find(&marker)
+            .unwrap_or_else(|| panic!("build-ami.sh has no {marker}"));
+        let rest = &script[start..];
+        let end = rest
+            .find("\n}\n")
+            .unwrap_or_else(|| panic!("{marker} has no closing brace"))
+            + 2;
+        rest[..end].to_string()
+    };
+    let materialize = extract("materialize_pinned_source_tree");
+    let compute = extract("compute_hash");
+    let pinned = extract("compute_pinned_hash");
+    let program = format!(
+        "set -uo pipefail\n\
+         create_user_data() {{ printf 'stub-user-data:%s' \"$1\"; }}\n\
+         {materialize}\n{compute}\n{pinned}\n\
+         compute_pinned_hash \"$REPO\" \"$COMMIT\"\n"
+    );
+    Command::new("bash")
+        .arg("-c")
+        .arg(program)
+        .env("REPO", repo)
+        .env("COMMIT", commit)
+        .output()
+        .expect("run pinned hash computation")
 }
 
 /// Build a minimal tree with the layout `compute_hash` reads.
@@ -124,10 +221,20 @@ fn make_fixture() -> tempfile::TempDir {
          kernel_version = \"6.18.3\"\n",
     );
     w("scripts/build-passt.sh", "#!/bin/sh\n");
+    w("scripts/install-runner-disk-guard.sh", "#!/bin/sh\n");
+    w(
+        "scripts/build-ami.sh",
+        "#!/bin/sh\n# pinned provisioning script\n",
+    );
     w("scripts/passt-0001.patch", "passt\n");
     w("scripts/runner-disk-preflight.sh", "#!/bin/sh\n");
+    w("scripts/prune-cargo-target.sh", "#!/bin/sh\n");
     w("scripts/runner-disk-guard.service", "[Unit]\n");
     w("scripts/runner-disk-guard.timer", "[Timer]\n");
+    w(
+        "src/setup/kernel.rs",
+        "// host-tool setup implementation revision one\n",
+    );
     dir
 }
 
@@ -275,5 +382,261 @@ fn ami_hash_ignores_unrelated_kernel_profiles() {
         "bumping [kernel_profiles.btrfs.arm64] moved the AMI hash. That profile cannot affect \
          the host kernel baked into this AMI, so the change only costs a full EC2 rebuild for \
          nothing"
+    );
+}
+
+/// The privileged target helper is installed into the AMI beside the timer entrypoint.  A
+/// helper change must therefore invalidate the same image cache key as a parent-script change;
+/// otherwise the builder silently reuses an AMI with an incompatible old protocol.
+#[test]
+fn ami_hash_changes_when_the_privileged_target_pruner_changes() {
+    let fx = make_fixture();
+    let base = run_compute_hash(fx.path());
+
+    let helper = fx.path().join("scripts/prune-cargo-target.sh");
+    std::fs::write(&helper, "#!/bin/sh\n# changed lease protocol\n").unwrap();
+    let mutated = run_compute_hash(fx.path());
+
+    assert_ne!(
+        base, mutated,
+        "editing the target-pruning helper left the AMI hash at {base}; build-ami.sh would \
+         reuse an image carrying the old helper beside the new preflight protocol"
+    );
+}
+
+#[test]
+fn ami_hash_changes_when_the_disk_guard_installer_changes() {
+    let fx = make_fixture();
+    let base = run_compute_hash(fx.path());
+    std::fs::write(
+        fx.path().join("scripts/install-runner-disk-guard.sh"),
+        "#!/bin/sh\n# changed deployment behavior\n",
+    )
+    .unwrap();
+    let mutated = run_compute_hash(fx.path());
+    assert_ne!(
+        base, mutated,
+        "editing the shared disk-guard installer did not invalidate the AMI cache key"
+    );
+}
+
+#[test]
+fn ami_hash_refuses_a_missing_privileged_target_pruner() {
+    let fx = make_fixture();
+    std::fs::remove_file(fx.path().join("scripts/prune-cargo-target.sh")).unwrap();
+    let (ok, out, error) = try_compute_hash(fx.path());
+    assert!(
+        !ok && out.is_empty() && error.contains("missing or unreadable"),
+        "compute_hash emitted a cache key without the installed target helper: \
+         ok={ok} out={out:?} error={error:?}"
+    );
+}
+
+/// Concatenating files without framing lets bytes move across a file boundary while the hash
+/// stays unchanged (`ab` + `cd` equals `abc` + `d`). Per-file digests include both identity and
+/// contents, so the cache key continues to identify the installed parent/helper pair.
+#[test]
+fn ami_hash_frames_the_disk_guard_files_independently() {
+    let fx = make_fixture();
+    std::fs::write(fx.path().join("scripts/runner-disk-preflight.sh"), "ab").unwrap();
+    std::fs::write(fx.path().join("scripts/prune-cargo-target.sh"), "cd").unwrap();
+    let base = run_compute_hash(fx.path());
+
+    std::fs::write(fx.path().join("scripts/runner-disk-preflight.sh"), "abc").unwrap();
+    std::fs::write(fx.path().join("scripts/prune-cargo-target.sh"), "d").unwrap();
+    let boundary_shifted = run_compute_hash(fx.path());
+
+    assert_ne!(
+        base, boundary_shifted,
+        "moving bytes across the parent/helper boundary left the AMI hash unchanged; the cache \
+         key does not frame the two installed files independently"
+    );
+}
+
+/// The builder must provision from the exact checkout whose files compute_hash read. Cloning
+/// moving `main` after hashing admits a different parent/helper pair if a merge lands while the
+/// cloud instance boots.
+#[test]
+fn ami_user_data_fetches_the_exact_hashed_source_commit() {
+    let source_commit = "1234567890abcdef1234567890abcdef12345678";
+    let user_data = render_user_data(source_commit);
+    assert!(
+        user_data.contains(&format!("FCVM_SOURCE_COMMIT=\"{source_commit}\""))
+            && user_data
+                .contains("git -C /tmp/fcvm fetch --depth 1 origin \"$FCVM_SOURCE_COMMIT\"")
+            && user_data.contains("/tmp/fcvm/scripts/install-runner-disk-guard.sh /tmp/fcvm")
+            && !user_data.contains("__FCVM_SOURCE_COMMIT__"),
+        "rendered AMI user data is not pinned to {source_commit}:\n{user_data}"
+    );
+    assert!(
+        user_data.contains("sudo -u ubuntu env HOME=/home/ubuntu bash -c")
+            && user_data
+                .contains("source \"$HOME/.cargo/env\"; cd /tmp/fcvm; make build-host-tools",)
+            && !user_data.contains("export HOME=/root")
+            && !user_data
+                .lines()
+                .any(|line| line == "make build-host-tools"),
+        "AMI user data invokes the host Make target as root even though the Makefile rejects and \
+         forbids root-owned build artifacts:\n{user_data}"
+    );
+
+    let script = std::fs::read_to_string(repo_root().join("scripts/build-ami.sh"))
+        .expect("read scripts/build-ami.sh");
+    assert!(
+        script.contains("create_user_data \"$source_commit\"")
+            && !script.contains("git clone --depth 1 https://github.com/ejc3/fcvm.git /tmp/fcvm"),
+        "AMI user data does not fetch the exact source commit selected before hashing"
+    );
+}
+
+/// Hash inputs must come from the same immutable tree the builder fetches, not from dirty
+/// working-tree bytes merely labelled with HEAD. Two commits differing only in otherwise-unlisted
+/// host-tool source prove the key binds the exact commit fetched and compiled by user data; an
+/// uncommitted helper mutation proves the archive wins. Mutating build-ami.sh itself must fail
+/// because that running function generates part of the hash and cannot safely disagree with the
+/// pinned script.
+#[test]
+fn ami_hash_materializes_the_pinned_tree_and_rejects_a_dirty_provisioner() {
+    let fx = make_fixture();
+    for args in [
+        ["init", "-q"].as_slice(),
+        ["config", "user.email", "test@example.invalid"].as_slice(),
+        ["config", "user.name", "fcvm test"].as_slice(),
+        ["add", "."].as_slice(),
+        ["commit", "-qm", "fixture"].as_slice(),
+    ] {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(fx.path())
+            .status()
+            .expect("run fixture git command");
+        assert!(status.success(), "git {args:?} failed: {status:?}");
+    }
+    let commit_output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(fx.path())
+        .output()
+        .expect("resolve fixture commit");
+    assert!(commit_output.status.success());
+    let commit = String::from_utf8(commit_output.stdout)
+        .expect("commit is UTF-8")
+        .trim()
+        .to_string();
+
+    let first_hash = compute_pinned_hash(fx.path(), &commit);
+    assert!(
+        first_hash.status.success(),
+        "clean pinned hash failed: {}",
+        String::from_utf8_lossy(&first_hash.stderr)
+    );
+    let first_hash_text = String::from_utf8(first_hash.stdout.clone())
+        .expect("first pinned hash is UTF-8")
+        .trim()
+        .to_string();
+    assert!(
+        first_hash_text.len() == 12 && first_hash_text.bytes().all(|byte| byte.is_ascii_hexdigit()),
+        "pinned hash is not a 12-digit hexadecimal cache key: {first_hash_text:?}"
+    );
+
+    let host_tool_source = fx.path().join("src/setup/kernel.rs");
+    std::fs::write(
+        &host_tool_source,
+        b"// host-tool setup implementation revision two\n",
+    )
+    .expect("write second committed host-tool revision");
+    for args in [
+        ["add", "src/setup/kernel.rs"].as_slice(),
+        ["commit", "-qm", "second provisioned host-tool source"].as_slice(),
+    ] {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(fx.path())
+            .status()
+            .expect("commit second hashed fixture revision");
+        assert!(status.success(), "git {args:?} failed: {status:?}");
+    }
+    let commit_output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(fx.path())
+        .output()
+        .expect("resolve second fixture commit");
+    assert!(commit_output.status.success());
+    let second_commit = String::from_utf8(commit_output.stdout)
+        .expect("second commit is UTF-8")
+        .trim()
+        .to_string();
+    let second_hash = compute_pinned_hash(fx.path(), &second_commit);
+    assert!(
+        second_hash.status.success(),
+        "second pinned hash failed: {}",
+        String::from_utf8_lossy(&second_hash.stderr)
+    );
+    let second_hash_text = String::from_utf8(second_hash.stdout.clone())
+        .expect("second pinned hash is UTF-8")
+        .trim()
+        .to_string();
+    assert!(
+        second_hash_text.len() == 12
+            && second_hash_text
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit())
+            && first_hash_text != second_hash_text,
+        "compute_pinned_hash ignored an otherwise-unlisted host-tool source change even though AMI user data fetches and compiles the new commit: first={first_hash_text:?} second={second_hash_text:?}"
+    );
+
+    let helper = fx.path().join("scripts/prune-cargo-target.sh");
+    let pinned_helper = std::fs::read(&helper).expect("read pinned helper");
+    std::fs::write(&helper, b"dirty helper bytes\n").expect("dirty helper");
+    let archived = tempfile::tempdir().expect("archived source tree");
+    let output = materialize_pinned_tree(fx.path(), &second_commit, archived.path());
+    assert!(
+        output.status.success(),
+        "materializing committed source failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        std::fs::read(archived.path().join("scripts/prune-cargo-target.sh")).unwrap(),
+        pinned_helper,
+        "pinned source tree copied dirty working-tree helper bytes"
+    );
+    let direct_archived_hash = run_compute_hash_for_commit(archived.path(), &second_commit);
+    assert_eq!(
+        second_hash_text, direct_archived_hash,
+        "compute_pinned_hash did not return compute_hash of the exact archived source tree"
+    );
+    let dirty_worktree_hash = compute_pinned_hash(fx.path(), &second_commit);
+    assert!(
+        dirty_worktree_hash.status.success(),
+        "pinned hash read dirty worktree state or failed: {}",
+        String::from_utf8_lossy(&dirty_worktree_hash.stderr)
+    );
+    assert_eq!(
+        second_hash.stdout, dirty_worktree_hash.stdout,
+        "dirty helper bytes changed the supposedly commit-pinned AMI hash"
+    );
+
+    std::fs::write(
+        fx.path().join("scripts/build-ami.sh"),
+        b"dirty provisioning script\n",
+    )
+    .expect("dirty provisioning script");
+    let rejected = tempfile::tempdir().expect("rejected source tree");
+    let output = materialize_pinned_tree(fx.path(), &second_commit, rejected.path());
+    assert!(
+        !output.status.success()
+            && String::from_utf8_lossy(&output.stderr).contains("differs from pinned commit"),
+        "dirty provisioning script was allowed to hash/provision different bytes: status={:?} stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let rejected_hash = compute_pinned_hash(fx.path(), &second_commit);
+    assert!(
+        !rejected_hash.status.success()
+            && String::from_utf8_lossy(&rejected_hash.stderr)
+                .contains("differs from pinned commit"),
+        "dirty running provisioner was allowed to compute a pinned hash: status={:?} stdout={} stderr={}",
+        rejected_hash.status,
+        String::from_utf8_lossy(&rejected_hash.stdout),
+        String::from_utf8_lossy(&rejected_hash.stderr)
     );
 }

--- a/tests/test_ami_hash_inputs.rs
+++ b/tests/test_ami_hash_inputs.rs
@@ -31,6 +31,16 @@ fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
+fn hermetic_git(repo: &Path) -> Command {
+    let mut command = Command::new("git");
+    command
+        .current_dir(repo)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_COUNT", "0");
+    command
+}
+
 /// Extract `compute_hash()` verbatim from the real script and run it against a
 /// fixture tree. `create_user_data` (its only helper call) is stubbed so this
 /// exercises the kernel-input behaviour in isolation.
@@ -54,6 +64,18 @@ fn try_compute_hash(fixture: &Path) -> (bool, String, String) {
 }
 
 fn try_compute_hash_for_commit(fixture: &Path, source_commit: &str) -> (bool, String, String) {
+    try_compute_hash_with_dirs(
+        &fixture.join("kernel"),
+        &fixture.join("scripts"),
+        source_commit,
+    )
+}
+
+fn try_compute_hash_with_dirs(
+    kernel_dir: &Path,
+    script_dir: &Path,
+    source_commit: &str,
+) -> (bool, String, String) {
     let script = std::fs::read_to_string(repo_root().join("scripts/build-ami.sh"))
         .expect("read scripts/build-ami.sh");
 
@@ -82,8 +104,8 @@ fn try_compute_hash_for_commit(fixture: &Path, source_commit: &str) -> (bool, St
     let out = Command::new("bash")
         .arg("-c")
         .arg(&program)
-        .env("KERNEL_DIR", fixture.join("kernel"))
-        .env("SCRIPT_DIR", fixture.join("scripts"))
+        .env("KERNEL_DIR", kernel_dir)
+        .env("SCRIPT_DIR", script_dir)
         .env("SOURCE_COMMIT", source_commit)
         .output()
         .expect("run bash");
@@ -92,6 +114,74 @@ fn try_compute_hash_for_commit(fixture: &Path, source_commit: &str) -> (bool, St
         String::from_utf8_lossy(&out.stdout).trim().to_string(),
         String::from_utf8_lossy(&out.stderr).trim().to_string(),
     )
+}
+
+/// Test repositories must not inherit the machine's Git policy. In particular, a developer's
+/// signing requirement, hooks, or init template cannot change whether fixture commits work or
+/// what bytes enter the fixture repository.
+#[test]
+fn ami_git_fixture_ignores_hostile_global_configuration() {
+    let hostile_home = tempfile::tempdir().expect("hostile Git home");
+    let hooks = hostile_home.path().join("hooks");
+    let template = hostile_home.path().join("template");
+    std::fs::create_dir_all(&hooks).expect("create hostile hooks directory");
+    std::fs::create_dir_all(&template).expect("create hostile template directory");
+    let pre_commit = hooks.join("pre-commit");
+    std::fs::write(&pre_commit, "#!/bin/sh\nexit 86\n").expect("write hostile pre-commit hook");
+    std::fs::set_permissions(
+        &pre_commit,
+        std::os::unix::fs::PermissionsExt::from_mode(0o755),
+    )
+    .expect("make hostile pre-commit hook executable");
+    std::fs::write(template.join("global-template-sentinel"), "leaked\n")
+        .expect("write hostile template sentinel");
+    std::fs::write(
+        hostile_home.path().join(".gitconfig"),
+        format!(
+            "[commit]\n\tgpgSign = true\n[core]\n\thooksPath = {}\n[init]\n\ttemplateDir = {}\n",
+            hooks.display(),
+            template.display()
+        ),
+    )
+    .expect("write hostile global Git configuration");
+
+    let repo = tempfile::tempdir().expect("hermetic Git repository");
+    for args in [
+        ["init", "-q"].as_slice(),
+        ["config", "user.email", "test@example.invalid"].as_slice(),
+        ["config", "user.name", "fcvm test"].as_slice(),
+    ] {
+        let output = hermetic_git(repo.path())
+            .env("HOME", hostile_home.path())
+            .args(args)
+            .output()
+            .expect("run hermetic fixture Git setup");
+        assert!(
+            output.status.success(),
+            "hermetic git {args:?} inherited global configuration: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    assert!(
+        !repo.path().join(".git/global-template-sentinel").exists(),
+        "fixture git init copied the developer's global init template"
+    );
+    std::fs::write(repo.path().join("fixture"), "fixture\n").expect("write fixture input");
+    for args in [
+        ["add", "fixture"].as_slice(),
+        ["commit", "-qm", "fixture commit"].as_slice(),
+    ] {
+        let output = hermetic_git(repo.path())
+            .env("HOME", hostile_home.path())
+            .args(args)
+            .output()
+            .expect("run hermetic fixture Git command");
+        assert!(
+            output.status.success(),
+            "fixture git {args:?} inherited signing or hook policy: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 }
 
 fn render_user_data(source_commit: &str) -> String {
@@ -112,6 +202,7 @@ fn render_user_data(source_commit: &str) -> String {
         .arg("-c")
         .arg(program)
         .env("SOURCE_COMMIT", source_commit)
+        .env("FCVM_SOURCE_REMOTE", "https://github.com/ejc3/fcvm.git")
         .output()
         .expect("render AMI user data");
     assert!(
@@ -120,6 +211,66 @@ fn render_user_data(source_commit: &str) -> String {
         String::from_utf8_lossy(&output.stderr)
     );
     String::from_utf8(output.stdout).expect("user data is UTF-8")
+}
+
+fn verify_source_commit_fetchable(
+    repo: &Path,
+    commit: &str,
+    remote: &Path,
+) -> std::process::Output {
+    let script = std::fs::read_to_string(repo_root().join("scripts/build-ami.sh"))
+        .expect("read scripts/build-ami.sh");
+    let start = script
+        .find("verify_source_commit_fetchable()")
+        .expect("build-ami.sh has no source-commit reachability check");
+    let rest = &script[start..];
+    let end = rest
+        .find("\n}\n")
+        .expect("verify_source_commit_fetchable() has no closing brace")
+        + 2;
+    let function = &rest[..end];
+    let program = format!(
+        "set -uo pipefail\n{function}\nverify_source_commit_fetchable \"$REPO\" \"$COMMIT\" \"$REMOTE\"\n"
+    );
+    Command::new("bash")
+        .arg("-c")
+        .arg(program)
+        .env("REPO", repo)
+        .env("COMMIT", commit)
+        .env("REMOTE", remote)
+        .output()
+        .expect("run source-commit reachability check")
+}
+
+fn run_ami_main_to_reachability_gate(repo: &Path, trace: &Path) -> std::process::Output {
+    let script = std::fs::read_to_string(repo_root().join("scripts/build-ami.sh"))
+        .expect("read scripts/build-ami.sh");
+    let start = script
+        .find("main()")
+        .expect("build-ami.sh has no main() reachability wiring");
+    let rest = &script[start..];
+    let end = rest.find("\n}\n").expect("main() has no closing brace") + 2;
+    let main = &rest[..end];
+    let program = format!(
+        "set -euo pipefail\n\
+         REGION=test-region\n\
+         KERNEL_DIR=\"$REPO/kernel\"\n\
+         FCVM_SOURCE_REMOTE=test-remote\n\
+         compute_pinned_hash() {{ printf 'fixturehash\\n'; }}\n\
+         check_existing_ami() {{ printf 'None\\n'; }}\n\
+         verify_source_commit_fetchable() {{ printf V >>\"$TRACE\"; return 1; }}\n\
+         aws() {{ return 0; }}\n\
+         get_base_ami() {{ printf B >>\"$TRACE\"; return 1; }}\n\
+         {main}\n\
+         main\n"
+    );
+    Command::new("bash")
+        .arg("-c")
+        .arg(program)
+        .env("REPO", repo)
+        .env("TRACE", trace)
+        .output()
+        .expect("run AMI main through the pre-launch reachability gate")
 }
 
 fn materialize_pinned_tree(repo: &Path, commit: &str, destination: &Path) -> std::process::Output {
@@ -420,6 +571,37 @@ fn ami_hash_changes_when_the_disk_guard_installer_changes() {
     );
 }
 
+/// `KERNEL_DIR` identifies the source checkout, while `SCRIPT_DIR` identifies the script tree
+/// whose bytes are validated and provisioned. Keep the digest rooted at `SCRIPT_DIR` too: reading
+/// the same basenames from `dirname(KERNEL_DIR)/scripts` can otherwise authenticate one tree and
+/// hash another.
+#[test]
+fn ami_hash_reads_disk_guard_bytes_from_script_dir() {
+    let kernel_tree = make_fixture();
+    let script_tree = make_fixture();
+    let run = || {
+        let (ok, hash, error) = try_compute_hash_with_dirs(
+            &kernel_tree.path().join("kernel"),
+            &script_tree.path().join("scripts"),
+            TEST_SOURCE_COMMIT,
+        );
+        assert!(ok, "split-root compute_hash failed: {error}");
+        hash
+    };
+
+    let base = run();
+    std::fs::write(
+        script_tree.path().join("scripts/runner-disk-preflight.sh"),
+        "#!/bin/sh\n# changed SCRIPT_DIR guard\n",
+    )
+    .expect("mutate SCRIPT_DIR disk guard");
+    let mutated = run();
+    assert_ne!(
+        base, mutated,
+        "compute_hash validated SCRIPT_DIR but digested the disk guard from the kernel checkout"
+    );
+}
+
 #[test]
 fn ami_hash_refuses_a_missing_privileged_target_pruner() {
     let fx = make_fixture();
@@ -462,10 +644,13 @@ fn ami_user_data_fetches_the_exact_hashed_source_commit() {
     let user_data = render_user_data(source_commit);
     assert!(
         user_data.contains(&format!("FCVM_SOURCE_COMMIT=\"{source_commit}\""))
+            && user_data.contains("FCVM_SOURCE_REMOTE=\"https://github.com/ejc3/fcvm.git\"",)
+            && user_data.contains("git -C /tmp/fcvm remote add origin \"$FCVM_SOURCE_REMOTE\"")
             && user_data
                 .contains("git -C /tmp/fcvm fetch --depth 1 origin \"$FCVM_SOURCE_COMMIT\"")
             && user_data.contains("/tmp/fcvm/scripts/install-runner-disk-guard.sh /tmp/fcvm")
-            && !user_data.contains("__FCVM_SOURCE_COMMIT__"),
+            && !user_data.contains("__FCVM_SOURCE_COMMIT__")
+            && !user_data.contains("__FCVM_SOURCE_REMOTE__"),
         "rendered AMI user data is not pinned to {source_commit}:\n{user_data}"
     );
     assert!(
@@ -489,12 +674,128 @@ fn ami_user_data_fetches_the_exact_hashed_source_commit() {
     );
 }
 
+/// The cloud builder fetches the selected source commit from a separate repository. Verify the
+/// exact fetch before launching EC2 so an unpushed local commit fails locally instead of failing
+/// minutes later in cloud-init after an instance has already been allocated.
+#[test]
+fn ami_build_refuses_a_source_commit_the_remote_cannot_fetch() {
+    let remote = tempfile::tempdir().expect("bare source remote");
+    let output = hermetic_git(remote.path())
+        .args(["init", "--bare", "-q"])
+        .output()
+        .expect("initialize bare source remote");
+    assert!(
+        output.status.success(),
+        "bare remote init failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let source = tempfile::tempdir().expect("source repository");
+    for args in [
+        ["init", "-q"].as_slice(),
+        ["config", "user.email", "test@example.invalid"].as_slice(),
+        ["config", "user.name", "fcvm test"].as_slice(),
+    ] {
+        let output = hermetic_git(source.path())
+            .args(args)
+            .output()
+            .expect("configure source repository");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    std::fs::write(source.path().join("source.rs"), b"revision one\n")
+        .expect("write first source revision");
+    for args in [
+        ["add", "source.rs"].as_slice(),
+        ["commit", "-qm", "first source revision"].as_slice(),
+    ] {
+        let output = hermetic_git(source.path())
+            .args(args)
+            .output()
+            .expect("commit first source revision");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    let remote_path = remote.path().to_string_lossy().into_owned();
+    let output = hermetic_git(source.path())
+        .args(["remote", "add", "origin", &remote_path])
+        .output()
+        .expect("add source remote");
+    assert!(output.status.success());
+    let output = hermetic_git(source.path())
+        .args(["push", "-q", "origin", "HEAD:refs/heads/main"])
+        .output()
+        .expect("push first source revision");
+    assert!(
+        output.status.success(),
+        "first source push failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    std::fs::write(source.path().join("source.rs"), b"revision two\n")
+        .expect("write unpushed source revision");
+    let output = hermetic_git(source.path())
+        .args(["commit", "-qam", "unpushed source revision"])
+        .output()
+        .expect("commit unpushed source revision");
+    assert!(output.status.success());
+    let output = hermetic_git(source.path())
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .expect("resolve unpushed source revision");
+    assert!(output.status.success());
+    let unpushed_commit = String::from_utf8(output.stdout)
+        .expect("source commit is UTF-8")
+        .trim()
+        .to_string();
+
+    let rejected = verify_source_commit_fetchable(source.path(), &unpushed_commit, remote.path());
+    assert!(
+        !rejected.status.success()
+            && String::from_utf8_lossy(&rejected.stderr).contains("not fetchable"),
+        "unreachable source commit was allowed to launch an AMI build: status={:?} stderr={}",
+        rejected.status,
+        String::from_utf8_lossy(&rejected.stderr)
+    );
+
+    let output = hermetic_git(source.path())
+        .args(["push", "-q", "origin", "HEAD:refs/heads/main"])
+        .output()
+        .expect("push second source revision");
+    assert!(output.status.success());
+    let accepted = verify_source_commit_fetchable(source.path(), &unpushed_commit, remote.path());
+    assert!(
+        accepted.status.success(),
+        "fetchable source commit was rejected: {}",
+        String::from_utf8_lossy(&accepted.stderr)
+    );
+
+    let trace = source.path().join("main-gate.trace");
+    let main = run_ami_main_to_reachability_gate(source.path(), &trace);
+    assert!(
+        !main.status.success(),
+        "AMI main ignored the failing pre-launch reachability gate"
+    );
+    assert_eq!(
+        std::fs::read(&trace).expect("read AMI main gate trace"),
+        b"V",
+        "AMI main reached builder allocation before validating the source commit"
+    );
+}
+
 /// Hash inputs must come from the same immutable tree the builder fetches, not from dirty
 /// working-tree bytes merely labelled with HEAD. Two commits differing only in otherwise-unlisted
-/// host-tool source prove the key binds the exact commit fetched and compiled by user data; an
-/// uncommitted helper mutation proves the archive wins. Mutating build-ami.sh itself must fail
-/// because that running function generates part of the hash and cannot safely disagree with the
-/// pinned script.
+/// host-tool source prove that pinned commit identity enters the key: user data fetches and compiles
+/// the entire commit even though `compute_hash` does not digest every Rust source individually.
+/// Uncommitted mutations under both archived path roots prove the archive wins. Mutating
+/// build-ami.sh itself must fail because that running function generates part of the hash and cannot
+/// safely disagree with the pinned script.
 #[test]
 fn ami_hash_materializes_the_pinned_tree_and_rejects_a_dirty_provisioner() {
     let fx = make_fixture();
@@ -505,16 +806,18 @@ fn ami_hash_materializes_the_pinned_tree_and_rejects_a_dirty_provisioner() {
         ["add", "."].as_slice(),
         ["commit", "-qm", "fixture"].as_slice(),
     ] {
-        let status = Command::new("git")
+        let output = hermetic_git(fx.path())
             .args(args)
-            .current_dir(fx.path())
-            .status()
+            .output()
             .expect("run fixture git command");
-        assert!(status.success(), "git {args:?} failed: {status:?}");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
-    let commit_output = Command::new("git")
+    let commit_output = hermetic_git(fx.path())
         .args(["rev-parse", "HEAD"])
-        .current_dir(fx.path())
         .output()
         .expect("resolve fixture commit");
     assert!(commit_output.status.success());
@@ -548,16 +851,18 @@ fn ami_hash_materializes_the_pinned_tree_and_rejects_a_dirty_provisioner() {
         ["add", "src/setup/kernel.rs"].as_slice(),
         ["commit", "-qm", "second provisioned host-tool source"].as_slice(),
     ] {
-        let status = Command::new("git")
+        let output = hermetic_git(fx.path())
             .args(args)
-            .current_dir(fx.path())
-            .status()
+            .output()
             .expect("commit second hashed fixture revision");
-        assert!(status.success(), "git {args:?} failed: {status:?}");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
-    let commit_output = Command::new("git")
+    let commit_output = hermetic_git(fx.path())
         .args(["rev-parse", "HEAD"])
-        .current_dir(fx.path())
         .output()
         .expect("resolve second fixture commit");
     assert!(commit_output.status.success());
@@ -581,12 +886,15 @@ fn ami_hash_materializes_the_pinned_tree_and_rejects_a_dirty_provisioner() {
                 .bytes()
                 .all(|byte| byte.is_ascii_hexdigit())
             && first_hash_text != second_hash_text,
-        "compute_pinned_hash ignored an otherwise-unlisted host-tool source change even though AMI user data fetches and compiles the new commit: first={first_hash_text:?} second={second_hash_text:?}"
+        "the pinned commit identity did not enter the AMI key even though user data fetches and compiles that complete commit: first={first_hash_text:?} second={second_hash_text:?}"
     );
 
     let helper = fx.path().join("scripts/prune-cargo-target.sh");
     let pinned_helper = std::fs::read(&helper).expect("read pinned helper");
     std::fs::write(&helper, b"dirty helper bytes\n").expect("dirty helper");
+    let passt_builder = fx.path().join("scripts/build-passt.sh");
+    let pinned_passt_builder = std::fs::read(&passt_builder).expect("read pinned passt builder");
+    std::fs::write(&passt_builder, b"dirty passt builder bytes\n").expect("dirty passt builder");
     let archived = tempfile::tempdir().expect("archived source tree");
     let output = materialize_pinned_tree(fx.path(), &second_commit, archived.path());
     assert!(
@@ -598,6 +906,11 @@ fn ami_hash_materializes_the_pinned_tree_and_rejects_a_dirty_provisioner() {
         std::fs::read(archived.path().join("scripts/prune-cargo-target.sh")).unwrap(),
         pinned_helper,
         "pinned source tree copied dirty working-tree helper bytes"
+    );
+    assert_eq!(
+        std::fs::read(archived.path().join("scripts/build-passt.sh")).unwrap(),
+        pinned_passt_builder,
+        "pinned source tree copied dirty SCRIPT_DIR bytes"
     );
     let direct_archived_hash = run_compute_hash_for_commit(archived.path(), &second_commit);
     assert_eq!(

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -460,6 +460,103 @@ exit "$rc"
     );
 }
 
+/// Both target roots must be completely enumerated before cleanup begins.
+/// Bash does not propagate a process substitution's exit status to the parent
+/// `while` loop, so the old implementation treated a failing `find` as an
+/// empty root, pruned candidates from the other root, and exited successfully.
+///
+/// A PATH-local shim makes either enumeration fail deterministically, including
+/// when this test binary runs as root (where filesystem permissions cannot
+/// reliably force `find` to fail). The surviving artifacts prove the script
+/// rejects the partial view before deleting anything.
+#[test]
+fn target_pruner_fails_closed_when_either_target_root_cannot_be_enumerated() {
+    for fail_runner_root in [true, false] {
+        let btrfs = tempfile::tempdir().expect("btrfs root");
+        let runner_work = tempfile::tempdir().expect("runner work root");
+        let runner_target = runner_work.path().join("project/project/target");
+        let btrfs_target = btrfs.path().join("cargo-target/worktree");
+        std::fs::create_dir_all(&runner_target).expect("create runner target");
+        std::fs::create_dir_all(&btrfs_target).expect("create btrfs target");
+
+        let runner_payload = runner_target.join("old-runner-artifact");
+        let btrfs_payload = btrfs_target.join("old-btrfs-artifact");
+        std::fs::write(&runner_payload, b"runner").expect("write runner artifact");
+        std::fs::write(&btrfs_payload, b"btrfs").expect("write btrfs artifact");
+        age_file(&runner_payload);
+        age_file(&btrfs_payload);
+
+        let (failed_root, partial_candidate) = if fail_runner_root {
+            (runner_work.path().to_path_buf(), runner_target.clone())
+        } else {
+            (btrfs.path().join("cargo-target"), btrfs_target.clone())
+        };
+
+        let shim_dir = tempfile::tempdir().expect("find shim dir");
+        let shim = shim_dir.path().join("find");
+        std::fs::write(
+            &shim,
+            r#"#!/usr/bin/env bash
+is_enumeration=0
+for arg in "$@"; do
+    [[ $arg == -print0 ]] && is_enumeration=1
+done
+if [[ ${1:-} == "$FAIL_TARGET_ENUM_ROOT" ]] && ((is_enumeration)); then
+    printf '%s\0' "$FAIL_TARGET_ENUM_CANDIDATE"
+    printf 'forced target enumeration failure: %s\n' "$1" >&2
+    exit 73
+fi
+exec /usr/bin/find "$@"
+"#,
+        )
+        .expect("write find shim");
+        let mut permissions = std::fs::metadata(&shim).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&shim, permissions).expect("make find shim executable");
+        let path = format!(
+            "{}:{}",
+            shim_dir.path().display(),
+            std::env::var("PATH").expect("PATH")
+        );
+
+        let out = Command::new(repo_root().join("scripts/runner-disk-preflight.sh"))
+            .arg("--target-dirs-only")
+            .env("BTRFS_ROOT", btrfs.path())
+            .env("RUNNER_WORK_ROOT", runner_work.path())
+            .env("TARGET_AGE_DAYS", "1")
+            .env("FAIL_TARGET_ENUM_ROOT", &failed_root)
+            .env("FAIL_TARGET_ENUM_CANDIDATE", &partial_candidate)
+            .env("PATH", path)
+            .output()
+            .expect("run target-dir preflight with find shim");
+        let text = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        assert!(
+            !out.status.success(),
+            "reported success after target enumeration failed for {failed_root:?}:\n{text}"
+        );
+        assert!(
+            text.contains("forced target enumeration failure")
+                && text.contains("cannot enumerate cargo target dirs under")
+                && text.contains("find rc=73")
+                && text.contains(failed_root.to_string_lossy().as_ref()),
+            "failure did not preserve find's error and identify the incomplete root \
+             {failed_root:?}:\n{text}"
+        );
+        assert!(
+            runner_payload.exists() && btrfs_payload.exists(),
+            "pruner deleted from a partial target view after {failed_root:?} could not be \
+             enumerated: runner_exists={} btrfs_exists={}\n{text}",
+            runner_payload.exists(),
+            btrfs_payload.exists()
+        );
+    }
+}
+
 /// All recipe-level Cargo executions must expand through the lease wrapper.
 /// Keeping the override in one variable makes this enforceable, while the raw
 /// command check catches one-off recipes that bypass `$(CARGO)`.

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -2,12 +2,12 @@
 //!
 //! Every build and test recipe runs cargo with `CARGO_TARGET_DIR=target`, where
 //! `target` is a symlink onto btrfs (the root filesystem is small and a link step
-//! dies with "No space left on device" mid-build). The symlink is created once and
-//! then trusted forever — but `/mnt/fcvm-btrfs` on the CI runners is EPHEMERAL and
-//! gets reset out from under a checkout that persists across jobs. The link is
-//! then dangling, and cargo does not create the directory through it: it builds a
-//! tempdir and `rename()`s it onto the path, which fails on an existing symlink
-//! with ENOTDIR.
+//! dies with "No space left on device" mid-build). `/mnt/fcvm-btrfs` on the CI
+//! runners is EPHEMERAL and gets reset out from under a checkout that persists
+//! across jobs. A dangling link cannot be repaired by Cargo: it builds a tempdir
+//! and `rename()`s it onto the path, which fails on an existing symlink with
+//! ENOTDIR. Idle-cache reclamation also rotates this symlink to a fresh physical
+//! generation so arbitrary build-script caches never reuse retained zero names.
 //!
 //! That is not a hypothetical. Host-arm64 on #771/#772 (2026-08-08) died with
 //!
@@ -27,10 +27,12 @@
 //! runs, `target/` is a directory cargo can write into. Asserting on the recipe's
 //! text instead would pass on a Makefile whose comments merely mention healing.
 
+use std::collections::HashSet;
 use std::fs::{FileTimes, OpenOptions};
-use std::os::unix::fs::PermissionsExt;
+use std::io::{Read, Write};
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command};
+use std::process::{Child, Command, Stdio};
 use std::thread;
 use std::time::{Duration, SystemTime};
 
@@ -80,13 +82,55 @@ fn assert_target_usable(dir: &Path, ctx: &str) {
 }
 
 fn age_file(path: &Path) {
-    let old = SystemTime::UNIX_EPOCH + Duration::from_secs(946_684_800);
+    set_file_time(path, 946_684_800);
+}
+
+fn set_file_time(path: &Path, unix_seconds: u64) {
+    let old = SystemTime::UNIX_EPOCH + Duration::from_secs(unix_seconds);
     let file = OpenOptions::new()
         .write(true)
         .open(path)
         .unwrap_or_else(|e| panic!("open {path:?} to age it: {e}"));
     file.set_times(FileTimes::new().set_accessed(old).set_modified(old))
         .unwrap_or_else(|e| panic!("age {path:?}: {e}"));
+}
+
+fn age_regular_tree(path: &Path, unix_seconds: u64) {
+    for entry in std::fs::read_dir(path).unwrap_or_else(|error| panic!("read {path:?}: {error}")) {
+        let entry = entry.unwrap_or_else(|error| panic!("read entry in {path:?}: {error}"));
+        let entry_path = entry.path();
+        let metadata = std::fs::symlink_metadata(&entry_path)
+            .unwrap_or_else(|error| panic!("stat {entry_path:?}: {error}"));
+        if metadata.file_type().is_dir() {
+            age_regular_tree(&entry_path, unix_seconds);
+        } else if metadata.file_type().is_file() {
+            set_file_time(&entry_path, unix_seconds);
+        }
+    }
+}
+
+fn unique_regular_blocks(path: &Path) -> u64 {
+    fn visit(path: &Path, seen: &mut HashSet<(u64, u64)>) -> u64 {
+        let mut blocks = 0;
+        for entry in
+            std::fs::read_dir(path).unwrap_or_else(|error| panic!("read {path:?}: {error}"))
+        {
+            let entry = entry.unwrap_or_else(|error| panic!("read entry in {path:?}: {error}"));
+            let entry_path = entry.path();
+            let metadata = std::fs::symlink_metadata(&entry_path)
+                .unwrap_or_else(|error| panic!("stat {entry_path:?}: {error}"));
+            if metadata.file_type().is_dir() {
+                blocks += visit(&entry_path, seen);
+            } else if metadata.file_type().is_file()
+                && seen.insert((metadata.dev(), metadata.ino()))
+            {
+                blocks += metadata.blocks() * 512;
+            }
+        }
+        blocks
+    }
+
+    visit(path, &mut HashSet::new())
 }
 
 fn run_target_pruner(btrfs_root: &Path, runner_work_root: &Path) -> (bool, String) {
@@ -244,6 +288,235 @@ fn cargo_target_link_heals_when_btrfs_is_gone_entirely() {
     );
 }
 
+/// A different textual spelling can still resolve to the same directory inode. Opening that
+/// candidate a second time and taking EX flock while already holding the old target EX lock
+/// deadlocks the process against itself; fd identity must select the already-held lease.
+#[test]
+fn cargo_target_link_reuses_the_lease_for_a_same_inode_path_alias() {
+    let work = tempfile::tempdir().expect("worktree");
+    let btrfs = tempfile::tempdir().expect("btrfs root");
+    let (ok, output) = run_link(work.path(), btrfs.path());
+    assert!(ok, "initial target link failed:\n{output}");
+    let target = work.path().join("target");
+    let physical = std::fs::read_link(&target).expect("read initial target link");
+    std::fs::remove_file(&target).expect("remove initial target link");
+    let aliased = format!(
+        "{}//{}",
+        physical.parent().expect("target parent").display(),
+        physical.file_name().expect("target name").to_string_lossy()
+    );
+    std::os::unix::fs::symlink(&aliased, &target).expect("link same inode through path alias");
+
+    let output = Command::new("timeout")
+        .args(["--kill-after=1s", "5s"])
+        .arg(repo_root().join("scripts/cargo-target-link.sh"))
+        .env("BTRFS_ROOT", btrfs.path())
+        .current_dir(work.path())
+        .output()
+        .expect("run target link against same-inode alias");
+    assert!(
+        output.status.success(),
+        "target link self-deadlocked or failed on a same-inode alias: {:?}\n{}{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        std::fs::canonicalize(&target).expect("resolve normalized target"),
+        physical,
+        "same-inode alias was repointed to a different physical target"
+    );
+}
+
+/// `make clean` must not recursively unlink target dentries outside the lease protocol. Logical
+/// cleanup durably retires the current generation and atomically publishes an empty sibling;
+/// the disk guard later reclaims the old payload without deleting its names.
+#[test]
+fn cargo_target_link_force_rotate_provides_a_fresh_logically_clean_target() {
+    let work = tempfile::tempdir().expect("worktree");
+    let btrfs = tempfile::tempdir().expect("btrfs root");
+    let (ok, output) = run_link(work.path(), btrfs.path());
+    assert!(ok, "initial target link failed:\n{output}");
+    let old_generation =
+        std::fs::read_link(work.path().join("target")).expect("read initial target generation");
+    let old_payload = old_generation.join("build-output");
+    std::fs::write(&old_payload, b"old bytes").expect("write old build output");
+
+    let output = Command::new(repo_root().join("scripts/cargo-target-link.sh"))
+        .arg("--rotate")
+        .env("BTRFS_ROOT", btrfs.path())
+        .current_dir(work.path())
+        .output()
+        .expect("force target generation rotation");
+    assert!(
+        output.status.success(),
+        "logical clean failed:\n{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let fresh_generation =
+        std::fs::read_link(work.path().join("target")).expect("read fresh target generation");
+    assert_ne!(
+        fresh_generation, old_generation,
+        "clean reused old generation"
+    );
+    assert!(
+        old_payload.exists() && !fresh_generation.join("build-output").exists(),
+        "clean deleted a physical old dentry or exposed old cache names in the fresh generation"
+    );
+    assert_target_usable(work.path(), "after logical target clean");
+
+    let local_work = tempfile::tempdir().expect("local-only worktree");
+    let missing_btrfs = local_work.path().join("missing-btrfs");
+    let local_target = local_work.path().join("target");
+    std::fs::create_dir(&local_target).expect("create unrotatable local target");
+    let local_payload = local_target.join("payload");
+    std::fs::write(&local_payload, b"local bytes").expect("write local payload");
+    let rejected = Command::new(repo_root().join("scripts/cargo-target-link.sh"))
+        .arg("--rotate")
+        .env("BTRFS_ROOT", &missing_btrfs)
+        .current_dir(local_work.path())
+        .output()
+        .expect("reject local-only target rotation");
+    assert!(
+        !rejected.status.success()
+            && String::from_utf8_lossy(&rejected.stderr).contains("refusing unsafe clean"),
+        "local-only clean silently succeeded without rotating or reclaiming: {:?}\n{}{}",
+        rejected.status,
+        String::from_utf8_lossy(&rejected.stdout),
+        String::from_utf8_lossy(&rejected.stderr)
+    );
+    assert_eq!(
+        std::fs::read(local_payload).expect("read local payload after rejected clean"),
+        b"local bytes"
+    );
+}
+
+/// A generation name becomes enumerable at mkdir, before link setup can lease it. Force the
+/// systemd pruner to win that interval: link setup must observe the durable retirement xattr,
+/// abandon that immutable sibling, and publish a different freshly leased generation.
+#[test]
+fn cargo_target_link_never_publishes_a_generation_retired_before_lease() {
+    let work = tempfile::tempdir().expect("worktree");
+    let btrfs = tempfile::tempdir().expect("btrfs root");
+    let (ok, output) = run_link(work.path(), btrfs.path());
+    assert!(ok, "initial target link failed:\n{output}");
+    let old_generation =
+        std::fs::read_link(work.path().join("target")).expect("read initial generation link");
+    let old_payload = old_generation.join("old-payload");
+    std::fs::write(&old_payload, b"old").expect("write old generation payload");
+    age_regular_tree(&old_generation, 946_684_800);
+    let managed_root = btrfs.path().join("cargo-target");
+    let retired = run_direct_target_pruner(&managed_root, false);
+    assert!(
+        retired.status.success(),
+        "retire initial generation failed:\n{}{}",
+        String::from_utf8_lossy(&retired.stdout),
+        String::from_utf8_lossy(&retired.stderr)
+    );
+
+    let signals = tempfile::tempdir().expect("generation race signals");
+    let ready = signals.path().join("ready.fifo");
+    let release = signals.path().join("release.fifo");
+    assert!(Command::new("mkfifo")
+        .args([ready.as_os_str(), release.as_os_str()])
+        .status()
+        .expect("create generation race FIFOs")
+        .success());
+    let ready_reader = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&ready)
+        .expect("open generation ready FIFO");
+    let mut release_writer = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&release)
+        .expect("open generation release FIFO");
+
+    let shim_dir = tempfile::tempdir().expect("mktemp shim directory");
+    let shim = shim_dir.path().join("mktemp");
+    let once = signals.path().join("intercepted");
+    std::fs::write(
+        &shim,
+        "#!/bin/bash\n\
+         if [[ $* == *generation-XXXXXXXX* && ! -e $ONCE ]]; then\n\
+           generation=$(\"$REAL_MKTEMP\" \"$@\") || exit $?\n\
+           : >\"$ONCE\"\n\
+           printf G >\"$READY\"\n\
+           IFS= read -r _ <\"$RELEASE\"\n\
+           printf '%s\\n' \"$generation\"\n\
+         else\n\
+           exec \"$REAL_MKTEMP\" \"$@\"\n\
+         fi\n",
+    )
+    .expect("write mktemp shim");
+    let mut permissions = std::fs::metadata(&shim)
+        .expect("stat mktemp shim")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&shim, permissions).expect("make mktemp shim executable");
+    let original_path = std::env::var_os("PATH").expect("PATH");
+    let real_mktemp = std::env::split_paths(&original_path)
+        .map(|directory| directory.join("mktemp"))
+        .find(|candidate| candidate.is_file())
+        .expect("find real mktemp");
+    let shim_path = std::env::join_paths(
+        std::iter::once(shim_dir.path().to_path_buf()).chain(std::env::split_paths(&original_path)),
+    )
+    .expect("build mktemp shim PATH");
+
+    let link = ChildGuard(Some(
+        Command::new(repo_root().join("scripts/cargo-target-link.sh"))
+            .env("BTRFS_ROOT", btrfs.path())
+            .env("PATH", shim_path)
+            .env("REAL_MKTEMP", real_mktemp)
+            .env("READY", &ready)
+            .env("RELEASE", &release)
+            .env("ONCE", &once)
+            .current_dir(work.path())
+            .spawn()
+            .expect("spawn target link with generation race"),
+    ));
+    assert_eq!(
+        read_marker_with_timeout(ready_reader, "fresh generation mkdir"),
+        b'G'
+    );
+    let raced_generation = std::fs::read_dir(&managed_root)
+        .expect("enumerate managed generations during race")
+        .map(|entry| entry.expect("read managed generation").path())
+        .find(|path| path != &old_generation && path.is_dir())
+        .expect("find unleased fresh generation");
+
+    let won_race = run_direct_target_pruner(&managed_root, false);
+    assert!(
+        won_race.status.success(),
+        "pruner did not retire the unleased generation:\n{}{}",
+        String::from_utf8_lossy(&won_race.stdout),
+        String::from_utf8_lossy(&won_race.stderr)
+    );
+    release_writer
+        .write_all(b"continue\n")
+        .expect("release generation creator");
+    let status = link
+        .wait()
+        .expect("wait for target link after generation race");
+    assert!(
+        status.success(),
+        "target link failed after lost lease race: {status:?}"
+    );
+    let published =
+        std::fs::read_link(work.path().join("target")).expect("read published generation");
+    assert_ne!(
+        published, raced_generation,
+        "link published a generation the pruner had already retired"
+    );
+    assert_eq!(
+        std::fs::read(published.join(".fcvm-generation")).expect("read fresh generation sentinel"),
+        b"v1\n"
+    );
+}
+
 /// `target` occupied by a regular file cannot be silently ignored: cargo would
 /// fail later with the same opaque `Not a directory (os error 20)` and no hint of
 /// why. Fail here, loudly, where the message can name the cause.
@@ -325,7 +598,7 @@ fn makefile_delegates_to_the_script() {
 ///
 /// This also exercises the lease rather than merely inspecting shell text: an
 /// old-looking target stays intact while a fake Cargo process holds the shared
-/// directory lease, while its idle sibling is emptied in the same preflight.
+/// directory lease, while its idle sibling payload is reclaimed in the same preflight.
 #[test]
 fn target_pruner_separates_idle_and_concurrently_active_worktrees() {
     let btrfs = tempfile::tempdir().expect("btrfs root");
@@ -376,14 +649,34 @@ fn target_pruner_separates_idle_and_concurrently_active_worktrees() {
         "pruner deleted artifacts while the Cargo shared lease was held"
     );
     assert!(
-        !idle_payload.exists(),
-        "idle sibling was not reclaimed independently:\n{out}"
+        idle_payload.metadata().ok().map(|metadata| metadata.len()) == Some(0),
+        "idle sibling payload was not reclaimed independently:\n{out}"
     );
     assert!(
         active_target.is_dir() && idle_target.is_dir(),
         "pruner removed a leased directory inode and dangled a worktree symlink"
     );
-    assert_target_usable(idle_work.path(), "after idle target pruning");
+    let status = Command::new(repo_root().join("scripts/cargo-target-run.sh"))
+        .args(["/bin/sh", "-c", "printf rebuilt >target/after-prune"])
+        .env("BTRFS_ROOT", btrfs.path())
+        .env("CARGO_TARGET_DIR", "target")
+        .current_dir(idle_work.path())
+        .status()
+        .expect("run Cargo stand-in after retiring idle generation");
+    assert!(
+        status.success(),
+        "Cargo wrapper did not rotate retired target"
+    );
+    let fresh_idle_target =
+        std::fs::read_link(idle_work.path().join("target")).expect("read fresh idle target link");
+    assert_ne!(
+        fresh_idle_target, idle_target,
+        "Cargo wrapper reused the retired physical generation"
+    );
+    assert_eq!(
+        std::fs::read(fresh_idle_target.join("after-prune")).expect("read fresh target output"),
+        b"rebuilt"
+    );
 
     std::fs::write(&release, b"release").unwrap();
     let status = build.wait().expect("wait for fake Cargo process");
@@ -395,87 +688,62 @@ fn target_pruner_separates_idle_and_concurrently_active_worktrees() {
     );
 }
 
-/// Pin the second half of the protocol: activity can begin after the cheap age
-/// check but before the pruner has acquired its exclusive lease.  A PATH-local
-/// flock shim refreshes an artifact immediately after the real exclusive flock
-/// succeeds; the production under-lock recheck must then retain it.
+/// A real checkout-local `target/` cannot be atomically replaced by a fresh generation without
+/// renaming its dentry, which can move a bind mount visible only in another mount namespace.
+/// Such pre-protocol targets are retained; the final disk hard floor quarantines the runner if
+/// managed btrfs generations do not recover enough space.
 #[test]
-fn target_pruner_rechecks_activity_after_acquiring_the_exclusive_lease() {
-    let btrfs = tempfile::tempdir().expect("btrfs root");
-    let runner_work = tempfile::tempdir().expect("runner work root");
-    let work = tempfile::tempdir().expect("worktree");
-    let (ok, out) = run_link(work.path(), btrfs.path());
-    assert!(ok, "cargo-target-link.sh failed:\n{out}");
-
-    let target = std::fs::read_link(work.path().join("target")).unwrap();
-    let payload = target.join("old-artifact");
-    std::fs::write(&payload, b"keep after refresh").unwrap();
+fn target_pruner_retains_an_unrotatable_local_target() {
+    let runner_root = tempfile::tempdir().expect("runner root");
+    let target = runner_root.path().join("repo/checkout/target");
+    std::fs::create_dir_all(&target).expect("create local runner target");
+    let payload = target.join("old-payload");
+    std::fs::write(&payload, b"must remain").expect("write local target payload");
     age_file(&payload);
 
-    let shim_dir = tempfile::tempdir().expect("flock shim dir");
-    let shim = shim_dir.path().join("flock");
-    std::fs::write(
-        &shim,
-        r#"#!/usr/bin/env bash
-/usr/bin/flock "$@"
-rc=$?
-if ((rc == 0)) && [[ " $* " == *" -x "* ]]; then
-    /usr/bin/touch -- "$REFRESH_AFTER_EXCLUSIVE_LOCK"
-fi
-exit "$rc"
-"#,
-    )
-    .unwrap();
-    let mut permissions = std::fs::metadata(&shim).unwrap().permissions();
-    permissions.set_mode(0o755);
-    std::fs::set_permissions(&shim, permissions).unwrap();
-    let path = format!(
-        "{}:{}",
-        shim_dir.path().display(),
-        std::env::var("PATH").expect("PATH")
-    );
-
-    let out = Command::new(repo_root().join("scripts/runner-disk-preflight.sh"))
-        .arg("--target-dirs-only")
-        .env("BTRFS_ROOT", btrfs.path())
-        .env("RUNNER_WORK_ROOT", runner_work.path())
-        .env("TARGET_AGE_DAYS", "1")
-        .env("REFRESH_AFTER_EXCLUSIVE_LOCK", &payload)
-        .env("PATH", path)
+    let output = Command::new(repo_root().join("scripts/prune-cargo-target.sh"))
+        .args([
+            std::ffi::OsStr::new("1 day ago"),
+            std::ffi::OsStr::new("0"),
+            runner_root.path().as_os_str(),
+            std::ffi::OsStr::new(""),
+        ])
         .output()
-        .expect("run target-dir preflight with flock shim");
+        .expect("run helper against unmanaged local target");
     let text = format!(
         "{}{}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr)
-    );
-    assert!(out.status.success(), "target-dir preflight failed:\n{text}");
-    assert!(
-        text.contains("became active before exclusive lease"),
-        "preflight did not perform the activity recheck under its exclusive lease:\n{text}"
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
     );
     assert!(
-        payload.exists(),
-        "artifact refreshed after exclusive acquisition was still deleted"
+        output.status.success() && text.contains("local target has no rotatable generation"),
+        "local target was not explicitly retained:\n{text}"
+    );
+    assert_eq!(
+        std::fs::read(payload).expect("read retained local payload"),
+        b"must remain"
     );
 }
 
 /// Both target roots must be completely enumerated before cleanup begins.
-/// Bash does not propagate a process substitution's exit status to the parent
-/// `while` loop, so the old implementation treated a failing `find` as an
-/// empty root, pruned candidates from the other root, and exited successfully.
-///
-/// A PATH-local shim makes either enumeration fail deterministically, including
-/// when this test binary runs as root (where filesystem permissions cannot
-/// reliably force `find` to fail). The surviving artifacts prove the script
-/// rejects the partial view before deleting anything.
+/// A symlinked root is rejected by component-wise O_NOFOLLOW regardless of uid;
+/// surviving artifacts prove the helper retains candidates but performs no
+/// deletion until every supplied root has been traversed successfully.
 #[test]
 fn target_pruner_fails_closed_when_either_target_root_cannot_be_enumerated() {
     for fail_runner_root in [true, false] {
-        let btrfs = tempfile::tempdir().expect("btrfs root");
-        let runner_work = tempfile::tempdir().expect("runner work root");
-        let runner_target = runner_work.path().join("project/project/target");
-        let btrfs_target = btrfs.path().join("cargo-target/worktree");
+        let namespace = tempfile::tempdir().expect("root namespace");
+        let runner_real = tempfile::tempdir().expect("real runner root");
+        let btrfs_real = tempfile::tempdir().expect("real btrfs target root");
+        let runner_link = namespace.path().join("runner-link");
+        let btrfs_link = namespace.path().join("btrfs-link");
+        std::os::unix::fs::symlink(runner_real.path(), &runner_link)
+            .expect("create runner root symlink");
+        std::os::unix::fs::symlink(btrfs_real.path(), &btrfs_link)
+            .expect("create btrfs root symlink");
+
+        let runner_target = runner_real.path().join("project/project/target");
+        let btrfs_target = btrfs_real.path().join("worktree");
         std::fs::create_dir_all(&runner_target).expect("create runner target");
         std::fs::create_dir_all(&btrfs_target).expect("create btrfs target");
 
@@ -486,49 +754,29 @@ fn target_pruner_fails_closed_when_either_target_root_cannot_be_enumerated() {
         age_file(&runner_payload);
         age_file(&btrfs_payload);
 
-        let (failed_root, partial_candidate) = if fail_runner_root {
-            (runner_work.path().to_path_buf(), runner_target.clone())
+        let (runner_arg, btrfs_arg, failed_root) = if fail_runner_root {
+            (
+                runner_link.as_path(),
+                btrfs_real.path(),
+                runner_link.as_path(),
+            )
         } else {
-            (btrfs.path().join("cargo-target"), btrfs_target.clone())
+            (
+                runner_real.path(),
+                btrfs_link.as_path(),
+                btrfs_link.as_path(),
+            )
         };
 
-        let shim_dir = tempfile::tempdir().expect("find shim dir");
-        let shim = shim_dir.path().join("find");
-        std::fs::write(
-            &shim,
-            r#"#!/usr/bin/env bash
-is_enumeration=0
-for arg in "$@"; do
-    [[ $arg == -print0 ]] && is_enumeration=1
-done
-if [[ ${1:-} == "$FAIL_TARGET_ENUM_ROOT" ]] && ((is_enumeration)); then
-    printf '%s\0' "$FAIL_TARGET_ENUM_CANDIDATE"
-    printf 'forced target enumeration failure: %s\n' "$1" >&2
-    exit 73
-fi
-exec /usr/bin/find "$@"
-"#,
-        )
-        .expect("write find shim");
-        let mut permissions = std::fs::metadata(&shim).unwrap().permissions();
-        permissions.set_mode(0o755);
-        std::fs::set_permissions(&shim, permissions).expect("make find shim executable");
-        let path = format!(
-            "{}:{}",
-            shim_dir.path().display(),
-            std::env::var("PATH").expect("PATH")
-        );
-
-        let out = Command::new(repo_root().join("scripts/runner-disk-preflight.sh"))
-            .arg("--target-dirs-only")
-            .env("BTRFS_ROOT", btrfs.path())
-            .env("RUNNER_WORK_ROOT", runner_work.path())
-            .env("TARGET_AGE_DAYS", "1")
-            .env("FAIL_TARGET_ENUM_ROOT", &failed_root)
-            .env("FAIL_TARGET_ENUM_CANDIDATE", &partial_candidate)
-            .env("PATH", path)
+        let out = Command::new(repo_root().join("scripts/prune-cargo-target.sh"))
+            .args([
+                std::ffi::OsStr::new("1 day ago"),
+                std::ffi::OsStr::new("0"),
+                runner_arg.as_os_str(),
+                btrfs_arg.as_os_str(),
+            ])
             .output()
-            .expect("run target-dir preflight with find shim");
+            .expect("run target helper with an untrusted symlink root");
         let text = format!(
             "{}{}",
             String::from_utf8_lossy(&out.stdout),
@@ -540,12 +788,9 @@ exec /usr/bin/find "$@"
             "reported success after target enumeration failed for {failed_root:?}:\n{text}"
         );
         assert!(
-            text.contains("forced target enumeration failure")
-                && text.contains("cannot enumerate cargo target dirs under")
-                && text.contains("find rc=73")
-                && text.contains(failed_root.to_string_lossy().as_ref()),
-            "failure did not preserve find's error and identify the incomplete root \
-             {failed_root:?}:\n{text}"
+            out.status.code() == Some(51)
+                && text.contains("cannot enumerate every cargo target root"),
+            "failure did not identify the no-follow root rejection {failed_root:?}:\n{text}"
         );
         assert!(
             runner_payload.exists() && btrfs_payload.exists(),
@@ -556,18 +801,1377 @@ exec /usr/bin/find "$@"
         );
     }
 }
+#[test]
+fn target_pruner_owns_discovery_and_cleanup_at_one_privilege() {
+    let script = std::fs::read_to_string(repo_root().join("scripts/runner-disk-preflight.sh"))
+        .expect("read runner-disk-preflight.sh");
+    let helper = std::fs::read_to_string(repo_root().join("scripts/prune-cargo-target.sh"))
+        .expect("read privileged target-pruning helper");
+
+    assert!(
+        script.contains("\"${SUDO[@]}\" env")
+            && script.contains("\"$TARGET_PRUNE_HELPER\"")
+            && script.contains(
+                "\"$TARGET_CUTOFF\" \"$DRY_RUN\" \"$runner_root\" \"$btrfs_target_root\""
+            ),
+        "target roots are not handed to one helper through the cleanup privilege boundary"
+    );
+    assert!(
+        !script.contains("-printf '%p\\0%D:%i\\0'")
+            && !script.contains("expected_identity")
+            && !helper.contains("expected_identity"),
+        "the cleanup still relies on a reusable cross-process dev:ino identity token"
+    );
+
+    let open = helper
+        .find("return open_beneath(parent_fd, name, OPEN_FLAGS)")
+        .expect("helper does not open candidates relative to the retained parent fd");
+    let lock = helper
+        .find("fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)")
+        .expect("helper does not acquire the exclusive target lease");
+    let reclaim = helper
+        .find("def reclaim_target(fd, census):")
+        .expect("helper reclaim is not rooted at the locked fd with a mount boundary");
+    assert!(
+        open < lock && lock < reclaim,
+        "candidate open, exclusive lock, and fd-rooted reclaim are not one helper critical section"
+    );
+    assert!(
+        helper.contains("os.O_DIRECTORY | os.O_NOFOLLOW")
+            && helper.contains("open_absolute_directory(path)")
+            && helper.contains("RESOLVE_NO_XDEV")
+            && helper.contains("RESOLVE_NO_SYMLINKS")
+            && helper.contains("validate_fingerprint_payloads(fd, census)")
+            && helper.contains("os.ftruncate(writer, 0)")
+            && helper.contains("os.fsync(writer)")
+            && !helper.contains("os.rmdir(")
+            && !helper.contains("os.unlink(")
+            && !helper.contains("os.rename(")
+            && !helper.contains("rm -rf"),
+        "helper does not no-follow components, durably invalidate fingerprints first, or retain every dentry"
+    );
+}
+
+fn spawn_synchronized_helper(
+    btrfs_target_root: &Path,
+) -> (
+    ChildGuard,
+    std::sync::mpsc::Receiver<()>,
+    std::sync::mpsc::Sender<()>,
+    std::thread::JoinHandle<()>,
+) {
+    let signals = tempfile::tempdir().expect("sync socket directory");
+    let socket_path = signals.path().join("enumerated.sock");
+    let listener = std::os::unix::net::UnixListener::bind(&socket_path).expect("bind sync socket");
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+    let (continue_tx, continue_rx) = std::sync::mpsc::channel();
+    let sync = std::thread::spawn(move || {
+        let _signals = signals;
+        let (mut channel, _) = listener.accept().expect("accept helper sync");
+        let mut marker = [0_u8; 1];
+        channel
+            .read_exact(&mut marker)
+            .expect("read enumeration marker");
+        assert_eq!(marker, [b'E']);
+        ready_tx.send(()).expect("signal enumeration ready");
+        continue_rx.recv().expect("wait for test mutation");
+        channel.write_all(b"C").expect("release helper");
+    });
+
+    let helper = ChildGuard(Some(
+        Command::new(repo_root().join("scripts/prune-cargo-target.sh"))
+            .args([
+                std::ffi::OsStr::new("1 day ago"),
+                std::ffi::OsStr::new("0"),
+                std::ffi::OsStr::new(""),
+                btrfs_target_root.as_os_str(),
+            ])
+            .env("FCVM_PRUNE_TEST_SYNC_SOCKET", &socket_path)
+            .spawn()
+            .expect("spawn synchronized target helper"),
+    ));
+    (helper, ready_rx, continue_tx, sync)
+}
+
+/// A fresh real directory can replace a candidate after discovery. The retained locked fd is the
+/// object authorized for cleanup: its old payload is removed even after rename, while the new
+/// pathname occupant is never opened or touched. Reopening the path would invert both results.
+#[test]
+fn target_pruner_cleans_only_the_locked_object_after_directory_replacement() {
+    let root = tempfile::tempdir().expect("target root");
+    let target = root.path().join("candidate");
+    let original = root.path().join("original-candidate");
+    std::fs::create_dir(&target).expect("create candidate");
+    let original_sentinel = target.join("original-must-survive");
+    std::fs::write(&original_sentinel, b"original data").expect("write original sentinel");
+    age_file(&original_sentinel);
+
+    let (helper, ready, release, sync) = spawn_synchronized_helper(root.path());
+    ready
+        .recv_timeout(Duration::from_secs(5))
+        .expect("helper did not retain the discovered target fd");
+
+    std::fs::rename(&target, &original).expect("rename candidate after discovery");
+    std::fs::create_dir(&target).expect("install fresh replacement directory");
+    let replacement_sentinel = target.join("replacement-must-survive");
+    std::fs::write(&replacement_sentinel, b"replacement data").expect("write replacement sentinel");
+    age_file(&replacement_sentinel);
+    release.send(()).expect("release helper after replacement");
+    let status = helper.wait().expect("wait for synchronized helper");
+    sync.join().expect("join synchronization peer");
+
+    assert!(
+        status.success(),
+        "replacement-safe helper failed: {status:?}"
+    );
+    assert!(
+        original
+            .join("original-must-survive")
+            .metadata()
+            .ok()
+            .map(|metadata| metadata.len())
+            == Some(0)
+            && replacement_sentinel.exists(),
+        "helper did not reclaim only the retained locked object: original_size={:?} replacement_exists={}",
+        original
+            .join("original-must-survive")
+            .metadata()
+            .map(|metadata| metadata.len()),
+        replacement_sentinel.exists()
+    );
+}
+
+/// A FIFO in the candidate namespace is not a directory and must be skipped without ever
+/// blocking in open(2). The outer timeout is an assertion boundary: rc=124 would be a failure,
+/// not a retry or an accepted outcome.
+#[test]
+fn target_pruner_does_not_block_on_a_candidate_fifo() {
+    let root = tempfile::tempdir().expect("target root");
+    let target = root.path().join("candidate");
+    let mkfifo = Command::new("mkfifo")
+        .arg(&target)
+        .status()
+        .expect("run mkfifo");
+    assert!(mkfifo.success(), "mkfifo failed: {mkfifo:?}");
+
+    let helper = repo_root().join("scripts/prune-cargo-target.sh");
+    let status = Command::new("/usr/bin/timeout")
+        .args([
+            std::ffi::OsStr::new("--kill-after=1s"),
+            std::ffi::OsStr::new("5s"),
+            helper.as_os_str(),
+            std::ffi::OsStr::new("1 day ago"),
+            std::ffi::OsStr::new("0"),
+            std::ffi::OsStr::new(""),
+            root.path().as_os_str(),
+        ])
+        .status()
+        .expect("run target helper against replacement FIFO");
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "FIFO discovery blocked or failed instead of skipping a non-directory: {status:?}"
+    );
+}
+
+/// A final-component symlink must be skipped rather than followed into an unrelated directory.
+/// The timeout is an assertion boundary, not a retry: timeout status is never accepted.
+#[test]
+fn target_pruner_never_follows_a_candidate_symlink() {
+    let root = tempfile::tempdir().expect("target root");
+    let victim = tempfile::tempdir().expect("symlink victim");
+    let sentinel = victim.path().join("must-survive");
+    std::fs::write(&sentinel, b"unrelated data").expect("write victim sentinel");
+    age_file(&sentinel);
+    std::os::unix::fs::symlink(victim.path(), root.path().join("candidate"))
+        .expect("create candidate symlink");
+
+    let helper = repo_root().join("scripts/prune-cargo-target.sh");
+    let status = Command::new("/usr/bin/timeout")
+        .args([
+            std::ffi::OsStr::new("--kill-after=1s"),
+            std::ffi::OsStr::new("5s"),
+            helper.as_os_str(),
+            std::ffi::OsStr::new("1 day ago"),
+            std::ffi::OsStr::new("0"),
+            std::ffi::OsStr::new(""),
+            root.path().as_os_str(),
+        ])
+        .status()
+        .expect("run target helper against candidate symlink");
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "candidate symlink was followed, blocked, or failed instead of being skipped: {status:?}"
+    );
+    assert!(
+        sentinel.exists(),
+        "helper followed a candidate symlink and deleted unrelated data"
+    );
+}
+
+/// O_NOFOLLOW on only the final component still lets an ancestor symlink redirect root open.
+/// Component-by-component opening must reject the root before touching the real target.
+#[test]
+fn target_pruner_rejects_a_symlinked_ancestor() {
+    let parent = tempfile::tempdir().expect("root parent");
+    let real_parent = parent.path().join("real-parent");
+    let linked_parent = parent.path().join("linked-parent");
+    let real_root = real_parent.join("target-root");
+    let linked_root = linked_parent.join("target-root");
+    let target = real_root.join("candidate");
+    std::fs::create_dir_all(&target).expect("create real candidate");
+    let sentinel = target.join("must-survive");
+    std::fs::write(&sentinel, b"data").expect("write sentinel");
+    age_file(&sentinel);
+    std::os::unix::fs::symlink(&real_parent, &linked_parent).expect("create ancestor symlink");
+
+    let status = Command::new(repo_root().join("scripts/prune-cargo-target.sh"))
+        .args([
+            std::ffi::OsStr::new("1 day ago"),
+            std::ffi::OsStr::new("0"),
+            std::ffi::OsStr::new(""),
+            linked_root.as_os_str(),
+        ])
+        .status()
+        .expect("run helper through symlinked root");
+    assert_eq!(
+        status.code(),
+        Some(51),
+        "symlinked root was not rejected: {status:?}"
+    );
+    assert!(
+        sentinel.exists(),
+        "helper followed an ancestor symlink into the real target"
+    );
+}
+
+#[cfg(feature = "privileged-tests")]
+struct BindMountGuard(PathBuf);
+
+#[cfg(feature = "privileged-tests")]
+impl BindMountGuard {
+    fn unmount(mut self) {
+        let status = Command::new("umount").arg(&self.0).status();
+        assert!(
+            matches!(status, Ok(status) if status.success()),
+            "failed to unmount test bind mount {:?}: {status:?}",
+            self.0
+        );
+        self.0.clear();
+    }
+}
+
+#[cfg(feature = "privileged-tests")]
+impl Drop for BindMountGuard {
+    fn drop(&mut self) {
+        if !self.0.as_os_str().is_empty() {
+            let _ = Command::new("umount").arg(&self.0).status();
+        }
+    }
+}
+
+/// `rm -rf` and `find -xdev` both cross a bind mount whose source has the same device number as
+/// the target. An aborted test can leave exactly such a mount under a Cargo target. Privileged
+/// cleanup must detect the mount ID boundary and fail before touching the mounted filesystem.
+#[cfg(feature = "privileged-tests")]
+#[test]
+fn target_pruner_never_deletes_through_a_descendant_bind_mount() {
+    let root = tempfile::tempdir().expect("target root");
+    let source = tempfile::tempdir().expect("bind source");
+    let target = root.path().join("candidate");
+    let mountpoint = target.join("mounted-source");
+    std::fs::create_dir_all(&mountpoint).expect("create target and mountpoint");
+
+    let sentinel = source.path().join("must-survive");
+    std::fs::write(&sentinel, b"mounted data").expect("write mounted sentinel");
+    age_file(&sentinel);
+    let status = Command::new("mount")
+        .args([
+            std::ffi::OsStr::new("--bind"),
+            source.path().as_os_str(),
+            mountpoint.as_os_str(),
+        ])
+        .status()
+        .expect("run bind mount");
+    assert!(status.success(), "bind mount failed: {status:?}");
+    let mount = BindMountGuard(mountpoint);
+
+    let status = Command::new(repo_root().join("scripts/prune-cargo-target.sh"))
+        .args([
+            std::ffi::OsStr::new("1 day ago"),
+            std::ffi::OsStr::new("0"),
+            std::ffi::OsStr::new(""),
+            root.path().as_os_str(),
+        ])
+        .status()
+        .expect("run target helper with descendant bind mount");
+
+    assert!(
+        sentinel.exists(),
+        "target cleanup crossed the bind mount and deleted unrelated mounted data"
+    );
+    assert_eq!(
+        status.code(),
+        Some(50),
+        "helper did not reject a target containing a descendant mount: {status:?}"
+    );
+    mount.unmount();
+}
+
+/// A mount at the target itself is not a descendant, so a prefix-only mountinfo check misses it.
+/// The helper must reject equality too, before touching the mounted source.
+#[cfg(feature = "privileged-tests")]
+#[test]
+fn target_pruner_rejects_an_exact_target_bind_mount() {
+    let root = tempfile::tempdir().expect("target root");
+    let source = tempfile::tempdir().expect("bind source");
+    let target = root.path().join("candidate");
+    std::fs::create_dir(&target).expect("create target mountpoint");
+    let sentinel = source.path().join("must-survive");
+    std::fs::write(&sentinel, b"mounted data").expect("write mounted sentinel");
+    age_file(&sentinel);
+
+    let status = Command::new("mount")
+        .args([
+            std::ffi::OsStr::new("--bind"),
+            source.path().as_os_str(),
+            target.as_os_str(),
+        ])
+        .status()
+        .expect("run exact-target bind mount");
+    assert!(status.success(), "bind mount failed: {status:?}");
+    let mount = BindMountGuard(target);
+
+    let status = Command::new(repo_root().join("scripts/prune-cargo-target.sh"))
+        .args([
+            std::ffi::OsStr::new("1 day ago"),
+            std::ffi::OsStr::new("0"),
+            std::ffi::OsStr::new(""),
+            root.path().as_os_str(),
+        ])
+        .status()
+        .expect("run helper with exact target bind mount");
+    assert_eq!(
+        status.code(),
+        Some(50),
+        "helper did not reject an exact-target mount: {status:?}"
+    );
+    assert!(
+        sentinel.exists(),
+        "helper deleted through an exact-target bind mount"
+    );
+    mount.unmount();
+}
+
+/// Mount safety is tied to the retained target fd, not its mutable cleanup name. Renaming a
+/// mounted candidate away and installing a fresh directory at the old path must still reject
+/// the mount in the locked original; a pathname-only validator silently skips this case.
+#[cfg(feature = "privileged-tests")]
+#[test]
+fn target_pruner_rejects_a_mounted_candidate_renamed_after_discovery() {
+    let root = tempfile::tempdir().expect("target root");
+    let source = tempfile::tempdir().expect("bind source");
+    let target = root.path().join("candidate");
+    let renamed = root.path().join("renamed-candidate");
+    let mountpoint = target.join("mounted-source");
+    std::fs::create_dir_all(&mountpoint).expect("create candidate mountpoint");
+    let sentinel = source.path().join("must-survive");
+    std::fs::write(&sentinel, b"mounted data").expect("write mounted sentinel");
+    age_file(&sentinel);
+    let status = Command::new("mount")
+        .args([
+            std::ffi::OsStr::new("--bind"),
+            source.path().as_os_str(),
+            mountpoint.as_os_str(),
+        ])
+        .status()
+        .expect("run descendant bind mount");
+    assert!(status.success(), "bind mount failed: {status:?}");
+    let mut mount = BindMountGuard(mountpoint);
+
+    let (helper, ready, release, sync) = spawn_synchronized_helper(root.path());
+    ready
+        .recv_timeout(Duration::from_secs(5))
+        .expect("helper did not retain mounted candidate fd");
+    std::fs::rename(&target, &renamed).expect("rename mounted candidate after discovery");
+    mount.0 = renamed.join("mounted-source");
+    std::fs::create_dir(&target).expect("install fresh path occupant");
+
+    release
+        .send(())
+        .expect("release helper after candidate rename");
+    let status = helper.wait().expect("wait for mounted target helper");
+    sync.join().expect("join synchronization peer");
+    assert_eq!(
+        status.code(),
+        Some(50),
+        "helper did not reject the mount through its retained target fd: {status:?}"
+    );
+    assert!(
+        sentinel.exists(),
+        "helper crossed a mount after the candidate pathname changed"
+    );
+    mount.unmount();
+}
+
+/// A host bind mount inserted after discovery must remain visible to the deleting helper. Hiding
+/// it in a private namespace is unsafe: VFS unlink/rmdir can detach a mount that exists in another
+/// namespace after the local mountpoint check passes. The dynamic openat2 traversal must reject
+/// the late descendant before any target payload is reclaimed, and the host mount must remain
+/// attached.
+#[cfg(feature = "privileged-tests")]
+#[test]
+fn target_pruner_rejects_a_host_bind_mount_added_after_discovery() {
+    let root = tempfile::tempdir().expect("target root");
+    let source = tempfile::tempdir().expect("bind source");
+    let target = root.path().join("candidate");
+    let late_mountpoint = target.join("late-mount");
+    std::fs::create_dir_all(&late_mountpoint).expect("create candidate mountpoint");
+    let old_payload = target.join("old-payload");
+    std::fs::write(&old_payload, b"old").expect("write old payload");
+    age_file(&old_payload);
+    let mounted_sentinel = source.path().join("must-survive");
+    std::fs::write(&mounted_sentinel, b"unrelated mounted data").expect("write mounted sentinel");
+
+    let (helper, ready, release, sync) = spawn_synchronized_helper(root.path());
+    ready
+        .recv_timeout(Duration::from_secs(5))
+        .expect("helper did not reach post-enumeration synchronization");
+
+    let status = Command::new("mount")
+        .args([
+            std::ffi::OsStr::new("--bind"),
+            source.path().as_os_str(),
+            late_mountpoint.as_os_str(),
+        ])
+        .status()
+        .expect("insert host bind mount after helper discovery");
+    assert!(status.success(), "bind mount failed: {status:?}");
+    let mount = BindMountGuard(late_mountpoint.clone());
+
+    release.send(()).expect("release helper after host mount");
+    let status = helper.wait().expect("wait for mount-aware helper");
+    sync.join().expect("join synchronization peer");
+    assert_eq!(
+        status.code(),
+        Some(50),
+        "helper did not reject the bind mount added after discovery: {status:?}"
+    );
+    assert!(
+        mounted_sentinel.exists(),
+        "helper traversed the host bind mount and deleted unrelated data"
+    );
+
+    mount.unmount();
+    assert!(
+        old_payload.exists() && target.is_dir(),
+        "helper partially reclaimed a target after detecting the late mount"
+    );
+}
+
+/// A mount can exist only in another mount namespace. `openat2(RESOLVE_NO_XDEV)` in the
+/// helper's namespace cannot see it, but unlink/rmdir of the underlying dentry calls the VFS
+/// global `detach_mounts()` path and silently tears the foreign mount down. Cleanup must reclaim
+/// the stale target without unlinking any dentry that another namespace can have mounted.
+#[cfg(feature = "privileged-tests")]
+#[test]
+fn target_pruner_never_detaches_a_foreign_namespace_mount() {
+    let root = tempfile::tempdir().expect("target root");
+    let source = tempfile::tempdir().expect("bind source");
+    let target = root.path().join("candidate");
+    let mountpoint = target.join("foreign-mount");
+    std::fs::create_dir_all(&mountpoint).expect("create foreign mountpoint");
+    let old_payload = mountpoint.join("old-underlying-payload");
+    std::fs::write(&old_payload, b"old").expect("write underlying target payload");
+    age_file(&old_payload);
+    let mounted_sentinel = source.path().join("must-survive");
+    std::fs::write(&mounted_sentinel, b"foreign mounted data")
+        .expect("write foreign mounted sentinel");
+
+    let mut holder = ChildGuard(Some(
+        Command::new("unshare")
+            .args([
+                std::ffi::OsStr::new("--mount"),
+                std::ffi::OsStr::new("--propagation"),
+                std::ffi::OsStr::new("private"),
+                std::ffi::OsStr::new("/bin/bash"),
+                std::ffi::OsStr::new("-c"),
+                std::ffi::OsStr::new(
+                    "set -euo pipefail\n\
+                     mount --bind -- \"$SOURCE\" \"$MOUNTPOINT\"\n\
+                     printf M\n\
+                     IFS= read -r _\n\
+                     mountpoint -q -- \"$MOUNTPOINT\" || exit 90\n\
+                     umount -- \"$MOUNTPOINT\"",
+                ),
+            ])
+            .env("SOURCE", source.path())
+            .env("MOUNTPOINT", &mountpoint)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn foreign mount-namespace holder"),
+    ));
+    let holder_stdout = holder
+        .child_mut()
+        .stdout
+        .take()
+        .expect("foreign holder stdout");
+    assert_eq!(
+        read_marker_with_timeout(holder_stdout, "foreign bind mount"),
+        b'M'
+    );
+
+    let status = Command::new(repo_root().join("scripts/prune-cargo-target.sh"))
+        .args([
+            std::ffi::OsStr::new("1 day ago"),
+            std::ffi::OsStr::new("0"),
+            std::ffi::OsStr::new(""),
+            root.path().as_os_str(),
+        ])
+        .status()
+        .expect("run helper while a foreign namespace holds a descendant mount");
+    assert!(
+        status.success(),
+        "foreign-mount-safe cleanup failed: {status:?}"
+    );
+
+    holder
+        .child_mut()
+        .stdin
+        .take()
+        .expect("foreign holder stdin")
+        .write_all(b"release\n")
+        .expect("release foreign mount holder");
+    let status = holder.wait().expect("wait for foreign mount holder");
+    assert!(
+        status.success(),
+        "cleanup detached a bind mount that existed only in another namespace: {status:?}"
+    );
+    assert!(
+        mounted_sentinel.exists(),
+        "cleanup modified data behind a foreign namespace mount"
+    );
+    assert!(
+        old_payload.metadata().ok().map(|metadata| metadata.len()) == Some(0),
+        "cleanup did not reclaim the stale underlying target payload"
+    );
+}
+
+fn run_cargo_fixture_build(project: &Path, btrfs_root: &Path) -> std::process::Output {
+    if !project.join("target").exists() {
+        let link = Command::new(repo_root().join("scripts/cargo-target-link.sh"))
+            .env("BTRFS_ROOT", btrfs_root)
+            .current_dir(project)
+            .output()
+            .expect("prepare initial managed Cargo cache generation");
+        assert!(
+            link.status.success(),
+            "prepare initial managed Cargo cache generation failed:\n{}{}",
+            String::from_utf8_lossy(&link.stdout),
+            String::from_utf8_lossy(&link.stderr)
+        );
+    }
+    Command::new(repo_root().join("scripts/cargo-target-run.sh"))
+        .args(["cargo", "build", "--offline", "--verbose"])
+        .env("BTRFS_ROOT", btrfs_root)
+        .env("CARGO_TARGET_DIR", "target")
+        .current_dir(project)
+        .output()
+        .expect("build Cargo cache fixture through target lease")
+}
+
+fn run_direct_target_pruner(
+    target_root: &Path,
+    fail_after_fingerprints: bool,
+) -> std::process::Output {
+    let mut command = Command::new(repo_root().join("scripts/prune-cargo-target.sh"));
+    command.args([
+        std::ffi::OsStr::new("1 day ago"),
+        std::ffi::OsStr::new("0"),
+        std::ffi::OsStr::new(""),
+        target_root.as_os_str(),
+    ]);
+    if fail_after_fingerprints {
+        command.env("FCVM_PRUNE_TEST_FAIL_AFTER_FINGERPRINTS", "1");
+    } else {
+        command.env_remove("FCVM_PRUNE_TEST_FAIL_AFTER_FINGERPRINTS");
+    }
+    command.output().expect("run target pruner directly")
+}
+
+fn find_fixture_rlib(target: &Path) -> PathBuf {
+    std::fs::read_dir(target.join("debug/deps"))
+        .expect("read Cargo fixture deps")
+        .map(|entry| entry.expect("read Cargo fixture dep entry").path())
+        .find(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("libcache_helper-") && name.ends_with(".rlib"))
+        })
+        .expect("find path-dependency rlib")
+}
+
+fn find_fixture_generated_source(target: &Path) -> PathBuf {
+    std::fs::read_dir(target.join("debug/build"))
+        .expect("read Cargo fixture build directories")
+        .map(|entry| entry.expect("read Cargo fixture build entry").path())
+        .map(|path| path.join("out/generated.rs"))
+        .find(|path| path.exists())
+        .expect("find build-script generated source")
+}
+
+/// Fingerprints are the commit record for Cargo's artifact cache. They must all become durably
+/// invalid before any output payload is reclaimed, so process failure or power loss cannot leave
+/// a valid fingerprint beside a zero-length binary. Internal Cargo hardlinks are counted once and
+/// reclaimed; the next build must compile despite source mtimes being older than every target
+/// entry, proving this is fingerprint invalidation rather than ordinary mtime invalidation.
+#[test]
+fn target_pruner_invalidates_cargo_before_reclaiming_hardlinked_payloads() {
+    let project = tempfile::tempdir().expect("Cargo fixture project");
+    let target_root = tempfile::tempdir().expect("Cargo fixture target root");
+    let managed_root = target_root.path().join("cargo-target");
+    std::fs::create_dir_all(project.path().join("src")).expect("create app source directory");
+    std::fs::create_dir_all(project.path().join("helper/src"))
+        .expect("create helper source directory");
+    std::fs::write(
+        project.path().join("Cargo.toml"),
+        "[package]\nname = \"cache-fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\nbuild = \"build.rs\"\n\
+         [dependencies]\ncache-helper = { path = \"helper\" }\n",
+    )
+    .expect("write app manifest");
+    std::fs::write(
+        project.path().join("build.rs"),
+        "use std::{env, fs, path::PathBuf};\n\
+         fn main() {\n\
+             let generated = PathBuf::from(env::var_os(\"OUT_DIR\").unwrap()).join(\"generated.rs\");\n\
+             if !generated.exists() {\n\
+                 fs::write(generated, \"fn generated_message() -> &'static str { \\\"generated-value\\\" }\\n\").unwrap();\n\
+             }\n\
+         }\n",
+    )
+    .expect("write build script");
+    std::fs::write(
+        project.path().join("src/main.rs"),
+        "include!(concat!(env!(\"OUT_DIR\"), \"/generated.rs\"));\n\
+         fn main() { println!(\"{} {}\", cache_helper::message(), generated_message()); }\n",
+    )
+    .expect("write app source");
+    std::fs::write(
+        project.path().join("helper/Cargo.toml"),
+        "[package]\nname = \"cache-helper\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .expect("write helper manifest");
+    std::fs::write(
+        project.path().join("helper/src/lib.rs"),
+        "pub fn message() -> &'static str { \"dependency-value\" }\n",
+    )
+    .expect("write helper source");
+
+    let first = run_cargo_fixture_build(project.path(), target_root.path());
+    assert!(
+        first.status.success(),
+        "initial Cargo fixture build failed:\n{}{}",
+        String::from_utf8_lossy(&first.stdout),
+        String::from_utf8_lossy(&first.stderr)
+    );
+    let first_generation = std::fs::canonicalize(project.path().join("target"))
+        .expect("resolve first managed Cargo generation");
+    let binary = first_generation.join("debug/cache-fixture");
+    let rlib = find_fixture_rlib(&first_generation);
+    let binary_metadata = binary.metadata().expect("stat root Cargo binary");
+    assert!(
+        binary_metadata.nlink() >= 2,
+        "fixture did not exercise Cargo's deps-to-root hardlink: {binary_metadata:?}"
+    );
+    assert!(
+        rlib.metadata().expect("stat helper rlib").blocks() > 0,
+        "path-dependency rlib has no allocated payload to reclaim"
+    );
+
+    // Source is deliberately older than target. A rebuild after pruning cannot be explained by
+    // Cargo's normal source-newer-than-output mtime rule.
+    age_regular_tree(project.path(), 915_148_800);
+    age_regular_tree(&first_generation, 946_684_800);
+    let before_blocks = unique_regular_blocks(&first_generation);
+    assert!(
+        before_blocks > 0,
+        "Cargo fixture target has no allocated blocks"
+    );
+
+    let interrupted = run_direct_target_pruner(&managed_root, true);
+    let interrupted_text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&interrupted.stdout),
+        String::from_utf8_lossy(&interrupted.stderr)
+    );
+    assert_eq!(
+        interrupted.status.code(),
+        Some(49),
+        "forced post-fingerprint failure did not stop before payload reclaim:\n{interrupted_text}"
+    );
+    assert!(
+        interrupted_text.contains("injected failure after durable fingerprint invalidation"),
+        "forced failure did not cross the durable fingerprint boundary:\n{interrupted_text}"
+    );
+    assert!(
+        binary
+            .metadata()
+            .expect("stat binary after forced failure")
+            .len()
+            > 0
+            && rlib
+                .metadata()
+                .expect("stat rlib after forced failure")
+                .len()
+                > 0,
+        "payload was truncated before every fingerprint became durable"
+    );
+
+    let rebuilt_after_interruption = run_cargo_fixture_build(project.path(), target_root.path());
+    let rebuilt_text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&rebuilt_after_interruption.stdout),
+        String::from_utf8_lossy(&rebuilt_after_interruption.stderr)
+    );
+    assert!(
+        rebuilt_after_interruption.status.success()
+            && rebuilt_text.contains("Compiling cache-helper")
+            && rebuilt_text.contains("Compiling cache-fixture"),
+        "Cargo accepted a cache after its durable fingerprints were invalidated:\n{rebuilt_text}"
+    );
+
+    let second_generation = std::fs::canonicalize(project.path().join("target"))
+        .expect("resolve second managed Cargo generation");
+    assert_ne!(
+        second_generation, first_generation,
+        "retired target generation was reused after interrupted reclaim"
+    );
+    age_regular_tree(&second_generation, 946_684_800);
+    let before_blocks = unique_regular_blocks(&second_generation);
+    let binary = second_generation.join("debug/cache-fixture");
+    let rlib = find_fixture_rlib(&second_generation);
+    let generated = find_fixture_generated_source(&second_generation);
+    let completed = run_direct_target_pruner(&managed_root, false);
+    let completed_text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&completed.stdout),
+        String::from_utf8_lossy(&completed.stderr)
+    );
+    assert!(
+        completed.status.success(),
+        "completed Cargo target reclaim failed:\n{completed_text}"
+    );
+    assert_eq!(
+        binary.metadata().expect("stat reclaimed root binary").len(),
+        0,
+        "internally hardlinked root binary payload was skipped"
+    );
+    assert_eq!(
+        rlib.metadata().expect("stat reclaimed helper rlib").len(),
+        0,
+        "path-dependency rlib payload was skipped"
+    );
+    assert_eq!(
+        generated
+            .metadata()
+            .expect("stat reclaimed build-script output")
+            .len(),
+        0,
+        "build-script output name was removed or its payload was exempted"
+    );
+    let after_blocks = unique_regular_blocks(&second_generation);
+    assert!(
+        after_blocks < before_blocks / 10,
+        "reclaim left most Cargo payload allocated: before={before_blocks} after={after_blocks}\n{completed_text}"
+    );
+
+    let immediate_resume = run_direct_target_pruner(&managed_root, false);
+    let immediate_text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&immediate_resume.stdout),
+        String::from_utf8_lossy(&immediate_resume.stderr)
+    );
+    assert!(
+        immediate_resume.status.success() && !immediate_text.contains("keeping (active"),
+        "reclaim refreshed its own idle files and blocked immediate resume:\n{immediate_text}"
+    );
+
+    let rebuilt = run_cargo_fixture_build(project.path(), target_root.path());
+    let rebuilt_text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&rebuilt.stdout),
+        String::from_utf8_lossy(&rebuilt.stderr)
+    );
+    assert!(
+        rebuilt.status.success()
+            && rebuilt_text.contains("Compiling cache-helper")
+            && rebuilt_text.contains("Compiling cache-fixture"),
+        "Cargo did not rebuild reclaimed hardlinked outputs:\n{rebuilt_text}"
+    );
+    let third_generation = std::fs::canonicalize(project.path().join("target"))
+        .expect("resolve third managed Cargo generation");
+    assert_ne!(
+        third_generation, second_generation,
+        "completed reclaim did not publish a fresh Cargo namespace"
+    );
+    let execution = Command::new(third_generation.join("debug/cache-fixture"))
+        .output()
+        .expect("execute rebuilt Cargo fixture");
+    assert!(execution.status.success());
+    assert_eq!(execution.stdout, b"dependency-value generated-value\n");
+    assert_eq!(
+        std::fs::read(find_fixture_generated_source(&third_generation))
+            .expect("read fresh build-script output"),
+        b"fn generated_message() -> &'static str { \"generated-value\" }\n",
+        "fresh generation did not regenerate the retained zero-length OUT_DIR name"
+    );
+    assert!(
+        find_fixture_rlib(&third_generation)
+            .metadata()
+            .expect("stat rebuilt helper rlib")
+            .blocks()
+            > 0,
+        "Cargo reported compilation but did not restore the helper payload"
+    );
+}
+
+/// Topology changes participate in the target lease. Once a shared-lease creator finishes, an
+/// alias outside the candidate makes the inode deliberately unreclaimable: truncating it would
+/// corrupt data outside the cleanup boundary.
+#[test]
+fn target_pruner_blocks_a_leased_link_creator_and_skips_external_aliases() {
+    let root = tempfile::tempdir().expect("target root");
+    let outside = tempfile::tempdir().expect("external alias root");
+    let target = root.path().join("candidate");
+    std::fs::create_dir(&target).expect("create target");
+    let payload = target.join("old-payload");
+    let alias = outside.path().join("outside-alias");
+    std::fs::write(&payload, b"must remain through both links").expect("write target payload");
+    age_file(&payload);
+
+    let mut creator = ChildGuard(Some(
+        Command::new("flock")
+            .args([
+                std::ffi::OsStr::new("-s"),
+                target.as_os_str(),
+                std::ffi::OsStr::new("/bin/bash"),
+                std::ffi::OsStr::new("-c"),
+                std::ffi::OsStr::new("ln -- \"$PAYLOAD\" \"$ALIAS\"; printf L; IFS= read -r _"),
+            ])
+            .env("PAYLOAD", &payload)
+            .env("ALIAS", &alias)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn shared-lease hardlink creator"),
+    ));
+    let creator_stdout = creator
+        .child_mut()
+        .stdout
+        .take()
+        .expect("hardlink creator stdout");
+    assert_eq!(
+        read_marker_with_timeout(creator_stdout, "leased hardlink creation"),
+        b'L'
+    );
+
+    let busy = run_direct_target_pruner(root.path(), false);
+    let busy_text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&busy.stdout),
+        String::from_utf8_lossy(&busy.stderr)
+    );
+    assert!(
+        busy.status.success() && busy_text.contains("concurrent cargo holds target lease"),
+        "pruner did not defer to shared-lease topology mutation:\n{busy_text}"
+    );
+
+    creator
+        .child_mut()
+        .stdin
+        .take()
+        .expect("hardlink creator stdin")
+        .write_all(b"release\n")
+        .expect("release hardlink creator");
+    let status = creator.wait().expect("reap hardlink creator");
+    assert!(status.success(), "hardlink creator failed: {status:?}");
+    assert_eq!(payload.metadata().expect("stat target link").nlink(), 2);
+
+    let skipped = run_direct_target_pruner(root.path(), false);
+    let skipped_text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&skipped.stdout),
+        String::from_utf8_lossy(&skipped.stderr)
+    );
+    assert!(
+        skipped.status.success() && skipped_text.contains("external-hardlink payload"),
+        "pruner did not report the out-of-boundary hardlink:\n{skipped_text}"
+    );
+    assert_eq!(
+        std::fs::read(&payload).expect("read retained target link"),
+        b"must remain through both links"
+    );
+    assert_eq!(
+        std::fs::read(&alias).expect("read retained external alias"),
+        b"must remain through both links"
+    );
+}
+
+/// Cargo follows its fingerprint paths. A symlink or special file inside `.fingerprint` cannot
+/// be invalidated through the no-follow target walker, so payload reclamation must fail before
+/// touching any output rather than leave an external valid fingerprint beside a zero binary.
+#[test]
+fn target_pruner_refuses_a_nonregular_fingerprint_before_payload_reclaim() {
+    let root = tempfile::tempdir().expect("target root");
+    let external = tempfile::tempdir().expect("external fingerprint root");
+    let target = root.path().join("candidate");
+    let fingerprint = target.join("debug/.fingerprint/cache-fixture");
+    std::fs::create_dir_all(&fingerprint).expect("create fingerprint directory");
+    let external_fingerprint = external.path().join("fingerprint");
+    std::fs::write(&external_fingerprint, b"valid external fingerprint")
+        .expect("write external fingerprint");
+    age_file(&external_fingerprint);
+    std::os::unix::fs::symlink(&external_fingerprint, fingerprint.join("state"))
+        .expect("symlink fingerprint outside target");
+    let output = target.join("debug/cache-fixture");
+    std::fs::write(&output, b"must survive invalidation failure").expect("write cached output");
+    age_file(&output);
+
+    let rejected = run_direct_target_pruner(root.path(), false);
+    let rejected_text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&rejected.stdout),
+        String::from_utf8_lossy(&rejected.stderr)
+    );
+    assert_eq!(
+        rejected.status.code(),
+        Some(49),
+        "nonregular fingerprint was accepted:\n{rejected_text}"
+    );
+    assert!(
+        rejected_text.contains("nonregular entry inside Cargo .fingerprint"),
+        "fingerprint rejection did not identify the unsafe entry:\n{rejected_text}"
+    );
+    assert_eq!(
+        std::fs::read(&output).expect("read output after fingerprint rejection"),
+        b"must survive invalidation failure"
+    );
+    assert_eq!(
+        std::fs::read(&external_fingerprint).expect("read external fingerprint"),
+        b"valid external fingerprint"
+    );
+}
+
+fn read_marker_with_timeout<R: Read + Send + 'static>(mut reader: R, context: &str) -> u8 {
+    let (sender, receiver) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut marker = [0_u8; 1];
+        let result = reader.read_exact(&mut marker).map(|()| marker[0]);
+        let _ = sender.send(result);
+    });
+    receiver
+        .recv_timeout(Duration::from_secs(5))
+        .unwrap_or_else(|_| panic!("timed out waiting for {context}"))
+        .unwrap_or_else(|error| panic!("failed reading {context}: {error}"))
+}
+
+/// Force the stale-inode interleaving deterministically: the wrapper resolves an old target
+/// symlink then waits for its shared lease while link setup wants to repoint it to this worktree's
+/// managed generation. The checkout lock must let the wrapper acquire the target lease first;
+/// link setup must then wait on that exact old target fd before atomically switching the symlink.
+#[test]
+fn cargo_target_runner_and_link_repoint_share_one_target_lease() {
+    let work = tempfile::tempdir().expect("worktree");
+    let btrfs = tempfile::tempdir().expect("btrfs root");
+    let target = work.path().join("target");
+    let old_target = work.path().join("old-target");
+    std::fs::create_dir(&old_target).expect("create old target generation");
+    std::fs::write(old_target.join("local-artifact"), b"local").expect("write old artifact");
+    std::os::unix::fs::symlink(&old_target, &target).expect("link old target generation");
+
+    let mut blocker = ChildGuard(Some(
+        Command::new("flock")
+            .args(["-x", "target", "/bin/sh", "-c", "printf L; IFS= read -r _"])
+            .current_dir(work.path())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("hold initial exclusive target lease"),
+    ));
+    let blocker_stdout = blocker
+        .child_mut()
+        .stdout
+        .take()
+        .expect("target blocker stdout");
+    assert_eq!(
+        read_marker_with_timeout(blocker_stdout, "initial target lease"),
+        b'L'
+    );
+
+    let signals = tempfile::tempdir().expect("link signal directory");
+    let checkout_signal = signals.path().join("checkout-lock.fifo");
+    let checkout_attempt_signal = signals.path().join("checkout-attempt.fifo");
+    let checkout_attempt_release = signals.path().join("checkout-attempt-release.fifo");
+    let target_attempt_signal = signals.path().join("target-attempt.fifo");
+    let lock_signal = signals.path().join("target-lock.fifo");
+    let status = Command::new("mkfifo")
+        .args([
+            checkout_signal.as_os_str(),
+            checkout_attempt_signal.as_os_str(),
+            checkout_attempt_release.as_os_str(),
+            target_attempt_signal.as_os_str(),
+            lock_signal.as_os_str(),
+        ])
+        .status()
+        .expect("create lease protocol FIFOs");
+    assert!(status.success(), "mkfifo failed: {status:?}");
+    let checkout_reader = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&checkout_signal)
+        .expect("open checkout-lock FIFO without blocking");
+    let checkout_attempt_reader = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&checkout_attempt_signal)
+        .expect("open checkout-attempt FIFO without blocking");
+    let mut checkout_attempt_releaser = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&checkout_attempt_release)
+        .expect("open checkout-attempt release FIFO without blocking");
+    let target_attempt_reader = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&target_attempt_signal)
+        .expect("open target-attempt FIFO without blocking");
+    let signal_reader = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&lock_signal)
+        .expect("open link-lock FIFO without blocking");
+
+    let shim_dir = tempfile::tempdir().expect("flock shim directory");
+    let shim = shim_dir.path().join("flock");
+    std::fs::write(
+        &shim,
+        "#!/bin/bash\n\
+         resolved=$(readlink \"/proc/$$/fd/${2:-0}\" 2>/dev/null || true)\n\
+         if [[ ${1:-} == \"$CHECKOUT_PATH\" ]]; then\n\
+           printf W >\"$CHECKOUT_ATTEMPT_SIGNAL\"\n\
+           IFS= read -r _ <\"$CHECKOUT_ATTEMPT_RELEASE\"\n\
+         fi\n\
+         if [[ ${1:-} == -x && $resolved == \"$TARGET_PATH\" ]]; then\n\
+           printf X >\"$LOCK_SIGNAL\"\n\
+         fi\n\
+         if [[ ${1:-} == -s && $resolved == \"$TARGET_PATH\" ]]; then\n\
+           printf T >\"$TARGET_ATTEMPT_SIGNAL\"\n\
+         fi\n\
+         \"$REAL_FLOCK\" \"$@\"\n\
+         rc=$?\n\
+         if ((rc == 0)) && [[ ${1:-} == -s && $resolved == \"$CHECKOUT_PATH\" ]]; then\n\
+           printf Q >\"$CHECKOUT_SIGNAL\"\n\
+         fi\n\
+         exit \"$rc\"\n",
+    )
+    .expect("write flock shim");
+    let mut permissions = std::fs::metadata(&shim)
+        .expect("stat flock shim")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&shim, permissions).expect("make flock shim executable");
+    let original_path = std::env::var_os("PATH").expect("PATH");
+    let real_flock = std::env::split_paths(&original_path)
+        .map(|directory| directory.join("flock"))
+        .find(|candidate| candidate.is_file())
+        .expect("find real flock");
+    let shim_path = std::env::join_paths(
+        std::iter::once(shim_dir.path().to_path_buf()).chain(std::env::split_paths(&original_path)),
+    )
+    .expect("build shim PATH");
+
+    let mut cargo = ChildGuard(Some(
+        Command::new(repo_root().join("scripts/cargo-target-run.sh"))
+            .args(["/bin/sh", "-c", "printf C; IFS= read -r _"])
+            .env("CARGO_TARGET_DIR", "target")
+            .env("PATH", &shim_path)
+            .env("REAL_FLOCK", &real_flock)
+            .env("CHECKOUT_PATH", work.path())
+            .env("CHECKOUT_SIGNAL", &checkout_signal)
+            .env("CHECKOUT_ATTEMPT_SIGNAL", &checkout_attempt_signal)
+            .env("CHECKOUT_ATTEMPT_RELEASE", &checkout_attempt_release)
+            .env("TARGET_PATH", &old_target)
+            .env("TARGET_ATTEMPT_SIGNAL", &target_attempt_signal)
+            .env("LOCK_SIGNAL", &lock_signal)
+            .current_dir(work.path())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn leased Cargo stand-in"),
+    ));
+    assert_eq!(
+        read_marker_with_timeout(checkout_reader, "wrapper checkout lease"),
+        b'Q',
+        "Cargo wrapper never acquired the checkout lease before waiting on target"
+    );
+    assert_eq!(
+        read_marker_with_timeout(target_attempt_reader, "wrapper target-lease attempt"),
+        b'T',
+        "Cargo wrapper never reached the blocked target flock while its checkout fd was live"
+    );
+
+    let link = ChildGuard(Some(
+        Command::new(repo_root().join("scripts/cargo-target-link.sh"))
+            .env("BTRFS_ROOT", btrfs.path())
+            .env("PATH", &shim_path)
+            .env("REAL_FLOCK", &real_flock)
+            .env("CHECKOUT_PATH", work.path())
+            .env("CHECKOUT_SIGNAL", &checkout_signal)
+            .env("CHECKOUT_ATTEMPT_SIGNAL", &checkout_attempt_signal)
+            .env("CHECKOUT_ATTEMPT_RELEASE", &checkout_attempt_release)
+            .env("TARGET_PATH", &old_target)
+            .env("TARGET_ATTEMPT_SIGNAL", &target_attempt_signal)
+            .env("LOCK_SIGNAL", &lock_signal)
+            .env_remove("CARGO_TARGET_LINK_LOCKED")
+            .current_dir(work.path())
+            .spawn()
+            .expect("spawn concurrent target repoint"),
+    ));
+    assert_eq!(
+        read_marker_with_timeout(checkout_attempt_reader, "link checkout-lock attempt"),
+        b'W',
+        "link setup never reached the exclusive checkout-lock acquisition"
+    );
+    let checkout_probe = Command::new(&real_flock)
+        .args(["-x", "-n", "-E", "42", ".", "/bin/true"])
+        .current_dir(work.path())
+        .status()
+        .expect("probe checkout lease while link setup is paused before flock");
+    assert_eq!(
+        checkout_probe.code(),
+        Some(42),
+        "checkout probe did not fail specifically on lock contention; the Cargo wrapper may have \
+         released its checkout lease before acquiring its target lease: {checkout_probe:?}"
+    );
+    checkout_attempt_releaser
+        .write_all(b"attempt\n")
+        .expect("release link checkout-lock attempt");
+
+    blocker
+        .child_mut()
+        .stdin
+        .take()
+        .expect("target blocker stdin")
+        .write_all(b"release\n")
+        .expect("release initial target lease");
+    let status = blocker.wait().expect("reap initial target blocker");
+    assert!(status.success(), "target blocker failed: {status:?}");
+
+    let cargo_stdout = cargo
+        .child_mut()
+        .stdout
+        .take()
+        .expect("Cargo stand-in stdout");
+    assert_eq!(
+        read_marker_with_timeout(cargo_stdout, "Cargo target lease"),
+        b'C',
+        "link setup acquired the checkout lock before the already-waiting Cargo wrapper"
+    );
+    assert_eq!(
+        read_marker_with_timeout(signal_reader, "link target lease attempt"),
+        b'X',
+        "link setup never attempted to lock the local target before migration"
+    );
+    assert!(
+        std::fs::symlink_metadata(&target)
+            .expect("stat target while repoint is blocked")
+            .file_type()
+            .is_symlink()
+            && std::fs::read_link(&target).expect("read blocked target link") == old_target,
+        "link setup rewired the old target before the Cargo target lease was released"
+    );
+
+    cargo
+        .child_mut()
+        .stdin
+        .take()
+        .expect("Cargo stand-in stdin")
+        .write_all(b"release\n")
+        .expect("release Cargo stand-in");
+    let status = cargo.wait().expect("reap Cargo stand-in");
+    assert!(status.success(), "Cargo stand-in failed: {status:?}");
+    let status = link.wait().expect("reap target repoint");
+    assert!(
+        status.success(),
+        "target repoint failed after Cargo released its target lease: {status:?}"
+    );
+    assert!(
+        std::fs::symlink_metadata(&target)
+            .expect("stat repointed target")
+            .file_type()
+            .is_symlink(),
+        "target was not repointed after the shared lease was released"
+    );
+    assert_ne!(
+        std::fs::read_link(&target).expect("read repointed target link"),
+        old_target,
+        "target still resolves to the old generation after its lease was released"
+    );
+    assert_target_usable(work.path(), "after synchronized target repoint");
+}
+
+#[test]
+fn disk_preflight_shell_scripts_parse() {
+    let status = Command::new("bash")
+        .arg("-n")
+        .args([
+            repo_root().join("scripts/runner-disk-preflight.sh"),
+            repo_root().join("scripts/prune-cargo-target.sh"),
+            repo_root().join("scripts/install-runner-disk-guard.sh"),
+        ])
+        .status()
+        .expect("run bash syntax check for disk-preflight scripts");
+    assert!(status.success(), "disk-preflight shell syntax is invalid");
+}
+
+/// Exercise the shared installer into a DESTDIR and verify both contents and modes. A string
+/// search for an `install` command is satisfiable by comments or dead code and cannot prove the
+/// timer entrypoint and privileged helper are deployed as one unit.
+#[test]
+fn disk_preflight_installs_its_privileged_helper_beside_the_timer_entrypoint() {
+    let destination = tempfile::tempdir().expect("installer DESTDIR");
+    let root = repo_root();
+    let status = Command::new(root.join("scripts/install-runner-disk-guard.sh"))
+        .args([root.as_os_str(), destination.path().as_os_str()])
+        .status()
+        .expect("run disk-guard installer");
+    assert!(status.success(), "disk-guard installer failed: {status:?}");
+
+    for (source, installed, mode) in [
+        (
+            "scripts/runner-disk-preflight.sh",
+            "usr/local/bin/runner-disk-preflight.sh",
+            0o755,
+        ),
+        (
+            "scripts/prune-cargo-target.sh",
+            "usr/local/bin/prune-cargo-target.sh",
+            0o755,
+        ),
+        (
+            "scripts/runner-disk-guard.service",
+            "etc/systemd/system/runner-disk-guard.service",
+            0o644,
+        ),
+        (
+            "scripts/runner-disk-guard.timer",
+            "etc/systemd/system/runner-disk-guard.timer",
+            0o644,
+        ),
+    ] {
+        let source = root.join(source);
+        let installed = destination.path().join(installed);
+        assert_eq!(
+            std::fs::read(&installed).expect("read installed disk-guard file"),
+            std::fs::read(&source).expect("read source disk-guard file"),
+            "installer deployed different bytes for {source:?}"
+        );
+        assert_eq!(
+            std::fs::metadata(&installed)
+                .expect("stat installed disk-guard file")
+                .permissions()
+                .mode()
+                & 0o777,
+            mode,
+            "installer used the wrong mode for {installed:?}"
+        );
+    }
+
+    let build = std::fs::read_to_string(repo_root().join("scripts/build-ami.sh"))
+        .expect("read build-ami.sh");
+    let setup = std::fs::read_to_string(repo_root().join("scripts/setup-runner.sh"))
+        .expect("read setup-runner.sh");
+    assert!(
+        build.contains("/tmp/fcvm/scripts/install-runner-disk-guard.sh /tmp/fcvm")
+            && setup
+                .contains("/tmp/fcvm-passt/scripts/install-runner-disk-guard.sh /tmp/fcvm-passt"),
+        "an AMI provisioning path does not invoke the behaviorally verified shared installer"
+    );
+}
 
 /// All recipe-level Cargo executions must expand through the lease wrapper.
 /// Keeping the override in one variable makes this enforceable, while the raw
 /// command check catches one-off recipes that bypass `$(CARGO)`.
+fn shell_command_segments(line: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut segment = String::new();
+    let mut quote = None;
+    let mut escaped = false;
+    let mut chars = line.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if escaped {
+            segment.push(ch);
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' && quote != Some('\'') {
+            segment.push(ch);
+            escaped = true;
+            continue;
+        }
+        if matches!(ch, '\'' | '"') {
+            if quote == Some(ch) {
+                quote = None;
+            } else if quote.is_none() {
+                quote = Some(ch);
+            }
+            segment.push(ch);
+            continue;
+        }
+        let chain_boundary = quote.is_none()
+            && (ch == ';' || ((ch == '&' || ch == '|') && chars.peek().copied() == Some(ch)));
+        if chain_boundary {
+            if ch != ';' {
+                chars.next();
+            }
+            segments.push(std::mem::take(&mut segment));
+        } else {
+            segment.push(ch);
+        }
+    }
+    segments.push(segment);
+    segments
+}
+
 #[test]
 fn makefile_routes_every_cargo_command_through_the_target_lease() {
     let mk = std::fs::read_to_string(repo_root().join("Makefile")).expect("read Makefile");
     assert!(
         mk.lines().any(|line| {
-            line.starts_with("override CARGO =") && line.contains("scripts/cargo-target-run.sh")
+            let Some(assignment) = line.trim_start().strip_prefix("override CARGO") else {
+                return false;
+            };
+            let assignment = assignment.trim_start();
+            (assignment.starts_with("::=")
+                || assignment.starts_with(":=")
+                || assignment.starts_with('='))
+                && assignment.contains("scripts/cargo-target-run.sh")
         }),
         "Makefile's CARGO command is not forced through scripts/cargo-target-run.sh"
+    );
+
+    assert_eq!(
+        shell_command_segments("echo building && cargo build"),
+        ["echo building ", " cargo build"],
+        "chained Cargo commands would escape the Makefile guard"
+    );
+    assert_eq!(
+        shell_command_segments("printf 'cargo test && quoted; only'"),
+        ["printf 'cargo test && quoted; only'"],
+        "quoted output text was split into a false command"
     );
 
     let raw_commands = [
@@ -582,24 +2186,101 @@ fn makefile_routes_every_cargo_command_through_the_target_lease() {
         "cargo deny",
         "cargo update",
     ];
-    let bypasses: Vec<&str> = mk
+    let bypasses: Vec<String> = mk
         .lines()
         .filter(|line| line.starts_with('\t'))
-        .map(str::trim)
-        .filter(|line| {
-            let command = line.trim_start_matches('@');
+        .flat_map(shell_command_segments)
+        .map(|segment| {
+            segment
+                .trim_start()
+                .trim_start_matches(['@', '-', '+'])
+                .trim_start()
+                .to_string()
+        })
+        .filter(|command| {
             !command.starts_with('#')
                 && !command.starts_with("echo ")
                 && !command.starts_with("printf ")
         })
-        .filter(|line| {
+        .filter(|command| {
             raw_commands
                 .iter()
-                .any(|command| line.starts_with(command) || line.contains(&format!(" {command}")))
+                .any(|raw| command.starts_with(raw) || command.contains(&format!(" {raw}")))
         })
         .collect();
     assert!(
         bypasses.is_empty(),
         "Makefile recipe(s) bypass the cargo-target shared lease: {bypasses:#?}"
     );
+    assert!(
+        !mk.contains("rm -rf target")
+            && mk.lines().any(|line| {
+                line.starts_with('\t')
+                    && line.contains("scripts/cargo-target-link.sh")
+                    && line.contains("--rotate")
+            }),
+        "Makefile clean mutates target dentries outside the generation/lease protocol"
+    );
+}
+
+/// The hourly guard runs outside Actions jobs, so self-hosted workflows and maintenance scripts
+/// must not bypass the target inode lease with a raw Cargo command. Hosted-only CI lanes do not
+/// share these persistent targets and are intentionally outside this assertion.
+#[test]
+fn persistent_runner_entrypoints_route_cargo_through_the_lease() {
+    let ci = std::fs::read_to_string(repo_root().join(".github/workflows/ci.yml"))
+        .expect("read primary CI workflow");
+    let self_hosted = ci
+        .split_once("# Runner 1a: Host")
+        .map(|(_, section)| section)
+        .expect("find self-hosted CI jobs");
+    assert_eq!(
+        self_hosted.matches("cache-targets: \"false\"").count(),
+        2,
+        "both persistent host matrices must prevent rust-cache from materializing an unleased \
+         real target directory after disk preflight"
+    );
+    let weekly = std::fs::read_to_string(repo_root().join(".github/workflows/weekly.yml"))
+        .expect("read weekly workflow");
+    assert!(
+        !weekly.lines().any(|line| {
+            let command = line.trim_start();
+            command.starts_with("sudo rm") && command.contains("/target")
+        }),
+        "weekly self-hosted cleanup recursively removes target outside the lease protocol"
+    );
+
+    let kernels = std::fs::read_to_string(repo_root().join(".github/workflows/kernels.yml"))
+        .expect("read kernel workflow");
+    assert_eq!(
+        kernels.matches("make build-host-tools").count(),
+        2,
+        "both persistent kernel-builder jobs must use the leased Make target"
+    );
+    assert!(
+        !kernels
+            .lines()
+            .any(|line| line.trim_start().starts_with("cargo build")),
+        "kernel workflow contains a raw Cargo build that can race the systemd pruner"
+    );
+
+    let fuse_runner = std::fs::read_to_string(repo_root().join("scripts/run_fuse_pipe_tests.sh"))
+        .expect("read fuse-pipe runner");
+    assert!(
+        fuse_runner.contains("make cargo-target-link")
+            && fuse_runner
+                .matches("\"${CARGO_RUNNER}\" cargo test")
+                .count()
+                == 4,
+        "fuse-pipe runner does not set up and lease all four Cargo test invocations"
+    );
+
+    for path in ["scripts/build-ami.sh", "scripts/fcvm-init.sh"] {
+        let source = std::fs::read_to_string(repo_root().join(path))
+            .unwrap_or_else(|error| panic!("read {path}: {error}"));
+        assert!(
+            source.contains("make build-host-tools") && !source.contains("cargo build"),
+            "{path} bypasses the leased host-tools Make target"
+        );
+    }
 }

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -27,8 +27,12 @@
 //! runs, `target/` is a directory cargo can write into. Asserting on the recipe's
 //! text instead would pass on a Makefile whose comments merely mention healing.
 
+use std::fs::{FileTimes, OpenOptions};
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Child, Command};
+use std::thread;
+use std::time::{Duration, SystemTime};
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -73,6 +77,66 @@ fn assert_target_usable(dir: &Path, ctx: &str) {
     let probe = target.join(".cargo-target-link-probe");
     std::fs::write(&probe, b"x").unwrap_or_else(|e| panic!("{ctx}: target/ is not writable: {e}"));
     let _ = std::fs::remove_file(&probe);
+}
+
+fn age_file(path: &Path) {
+    let old = SystemTime::UNIX_EPOCH + Duration::from_secs(946_684_800);
+    let file = OpenOptions::new()
+        .write(true)
+        .open(path)
+        .unwrap_or_else(|e| panic!("open {path:?} to age it: {e}"));
+    file.set_times(FileTimes::new().set_accessed(old).set_modified(old))
+        .unwrap_or_else(|e| panic!("age {path:?}: {e}"));
+}
+
+fn run_target_pruner(btrfs_root: &Path, runner_work_root: &Path) -> (bool, String) {
+    let out = Command::new(repo_root().join("scripts/runner-disk-preflight.sh"))
+        .arg("--target-dirs-only")
+        .env("BTRFS_ROOT", btrfs_root)
+        .env("RUNNER_WORK_ROOT", runner_work_root)
+        .env("TARGET_AGE_DAYS", "1")
+        .output()
+        .expect("run target-dir preflight");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (out.status.success(), text)
+}
+
+struct ChildGuard(Option<Child>);
+
+impl ChildGuard {
+    fn child_mut(&mut self) -> &mut Child {
+        self.0.as_mut().expect("child already reaped")
+    }
+
+    fn wait(mut self) -> std::io::Result<std::process::ExitStatus> {
+        let status = self.child_mut().wait()?;
+        self.0 = None;
+        Ok(status)
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if let Some(child) = self.0.as_mut() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+fn wait_for_path(path: &Path) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !path.exists() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for {path:?}"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
 }
 
 /// Fresh checkout: the link gets created, per-worktree.
@@ -251,5 +315,194 @@ fn makefile_delegates_to_the_script() {
         "the cargo-target-link recipe does not invoke scripts/cargo-target-link.sh, so the \
          behaviour every other test in this file verifies is not what `make` runs. Commands \
          found: {recipe:?}"
+    );
+}
+
+/// The disk preflight used to glob `cargo-target*`, which selected the parent
+/// `cargo-target/` directory instead of its per-worktree children.  One idle
+/// sibling could therefore never be reclaimed independently, and deleting the
+/// parent left every checkout's target symlink dangling.
+///
+/// This also exercises the lease rather than merely inspecting shell text: an
+/// old-looking target stays intact while a fake Cargo process holds the shared
+/// directory lease, while its idle sibling is emptied in the same preflight.
+#[test]
+fn target_pruner_separates_idle_and_concurrently_active_worktrees() {
+    let btrfs = tempfile::tempdir().expect("btrfs root");
+    let runner_work = tempfile::tempdir().expect("runner work root");
+    let active_work = tempfile::tempdir().expect("active worktree");
+    let idle_work = tempfile::tempdir().expect("idle worktree");
+
+    for work in [active_work.path(), idle_work.path()] {
+        let (ok, out) = run_link(work, btrfs.path());
+        assert!(ok, "cargo-target-link.sh failed in {work:?}:\n{out}");
+    }
+    let active_target = std::fs::read_link(active_work.path().join("target")).unwrap();
+    let idle_target = std::fs::read_link(idle_work.path().join("target")).unwrap();
+    let active_payload = active_target.join("old-active-artifact");
+    let idle_payload = idle_target.join("old-idle-artifact");
+    std::fs::write(&active_payload, b"active").unwrap();
+    std::fs::write(&idle_payload, b"idle").unwrap();
+    age_file(&active_payload);
+    age_file(&idle_payload);
+
+    let signals = tempfile::tempdir().expect("signals");
+    let ready = signals.path().join("ready");
+    let release = signals.path().join("release");
+    let build = ChildGuard(Some(
+        Command::new(repo_root().join("scripts/cargo-target-run.sh"))
+            .args([
+                "/bin/bash",
+                "-c",
+                "printf ready >\"$READY\"; while [[ ! -e $RELEASE ]]; do sleep 0.01; done; printf built >target/concurrent-build-output",
+            ])
+            .env("CARGO_TARGET_DIR", "target")
+            .env("READY", &ready)
+            .env("RELEASE", &release)
+            .current_dir(active_work.path())
+            .spawn()
+            .expect("spawn leased fake Cargo process"),
+    ));
+    wait_for_path(&ready);
+
+    let (ok, out) = run_target_pruner(btrfs.path(), runner_work.path());
+    assert!(ok, "target-dir preflight failed:\n{out}");
+    assert!(
+        out.contains("concurrent cargo holds target lease"),
+        "preflight did not report the held shared lease:\n{out}"
+    );
+    assert!(
+        active_payload.exists(),
+        "pruner deleted artifacts while the Cargo shared lease was held"
+    );
+    assert!(
+        !idle_payload.exists(),
+        "idle sibling was not reclaimed independently:\n{out}"
+    );
+    assert!(
+        active_target.is_dir() && idle_target.is_dir(),
+        "pruner removed a leased directory inode and dangled a worktree symlink"
+    );
+    assert_target_usable(idle_work.path(), "after idle target pruning");
+
+    std::fs::write(&release, b"release").unwrap();
+    let status = build.wait().expect("wait for fake Cargo process");
+    assert!(status.success(), "fake Cargo process failed: {status}");
+    assert_eq!(
+        std::fs::read(active_target.join("concurrent-build-output")).unwrap(),
+        b"built",
+        "concurrent build did not complete after retaining its target"
+    );
+}
+
+/// Pin the second half of the protocol: activity can begin after the cheap age
+/// check but before the pruner has acquired its exclusive lease.  A PATH-local
+/// flock shim refreshes an artifact immediately after the real exclusive flock
+/// succeeds; the production under-lock recheck must then retain it.
+#[test]
+fn target_pruner_rechecks_activity_after_acquiring_the_exclusive_lease() {
+    let btrfs = tempfile::tempdir().expect("btrfs root");
+    let runner_work = tempfile::tempdir().expect("runner work root");
+    let work = tempfile::tempdir().expect("worktree");
+    let (ok, out) = run_link(work.path(), btrfs.path());
+    assert!(ok, "cargo-target-link.sh failed:\n{out}");
+
+    let target = std::fs::read_link(work.path().join("target")).unwrap();
+    let payload = target.join("old-artifact");
+    std::fs::write(&payload, b"keep after refresh").unwrap();
+    age_file(&payload);
+
+    let shim_dir = tempfile::tempdir().expect("flock shim dir");
+    let shim = shim_dir.path().join("flock");
+    std::fs::write(
+        &shim,
+        r#"#!/usr/bin/env bash
+/usr/bin/flock "$@"
+rc=$?
+if ((rc == 0)) && [[ " $* " == *" -x "* ]]; then
+    /usr/bin/touch -- "$REFRESH_AFTER_EXCLUSIVE_LOCK"
+fi
+exit "$rc"
+"#,
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(&shim).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&shim, permissions).unwrap();
+    let path = format!(
+        "{}:{}",
+        shim_dir.path().display(),
+        std::env::var("PATH").expect("PATH")
+    );
+
+    let out = Command::new(repo_root().join("scripts/runner-disk-preflight.sh"))
+        .arg("--target-dirs-only")
+        .env("BTRFS_ROOT", btrfs.path())
+        .env("RUNNER_WORK_ROOT", runner_work.path())
+        .env("TARGET_AGE_DAYS", "1")
+        .env("REFRESH_AFTER_EXCLUSIVE_LOCK", &payload)
+        .env("PATH", path)
+        .output()
+        .expect("run target-dir preflight with flock shim");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(out.status.success(), "target-dir preflight failed:\n{text}");
+    assert!(
+        text.contains("became active before exclusive lease"),
+        "preflight did not perform the activity recheck under its exclusive lease:\n{text}"
+    );
+    assert!(
+        payload.exists(),
+        "artifact refreshed after exclusive acquisition was still deleted"
+    );
+}
+
+/// All recipe-level Cargo executions must expand through the lease wrapper.
+/// Keeping the override in one variable makes this enforceable, while the raw
+/// command check catches one-off recipes that bypass `$(CARGO)`.
+#[test]
+fn makefile_routes_every_cargo_command_through_the_target_lease() {
+    let mk = std::fs::read_to_string(repo_root().join("Makefile")).expect("read Makefile");
+    assert!(
+        mk.lines().any(|line| {
+            line.starts_with("override CARGO =") && line.contains("scripts/cargo-target-run.sh")
+        }),
+        "Makefile's CARGO command is not forced through scripts/cargo-target-run.sh"
+    );
+
+    let raw_commands = [
+        "cargo build",
+        "cargo test",
+        "cargo nextest",
+        "cargo install",
+        "cargo bench",
+        "cargo fmt",
+        "cargo clippy",
+        "cargo audit",
+        "cargo deny",
+        "cargo update",
+    ];
+    let bypasses: Vec<&str> = mk
+        .lines()
+        .filter(|line| line.starts_with('\t'))
+        .map(str::trim)
+        .filter(|line| {
+            let command = line.trim_start_matches('@');
+            !command.starts_with('#')
+                && !command.starts_with("echo ")
+                && !command.starts_with("printf ")
+        })
+        .filter(|line| {
+            raw_commands
+                .iter()
+                .any(|command| line.starts_with(command) || line.contains(&format!(" {command}")))
+        })
+        .collect();
+    assert!(
+        bypasses.is_empty(),
+        "Makefile recipe(s) bypass the cargo-target shared lease: {bypasses:#?}"
     );
 }

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -161,6 +161,13 @@ impl ChildGuard {
         self.0 = None;
         Ok(status)
     }
+
+    fn wait_with_output(mut self) -> std::io::Result<std::process::Output> {
+        self.0
+            .take()
+            .expect("child already reaped")
+            .wait_with_output()
+    }
 }
 
 impl Drop for ChildGuard {
@@ -941,6 +948,175 @@ fn target_pruner_cleans_only_the_locked_object_after_directory_replacement() {
     );
 }
 
+/// Once one candidate has been fully inspected and reclaimed, its exclusive lease no longer
+/// protects any pending decision. Release that lease immediately while retaining later candidate
+/// leases, so a slow sibling cannot unnecessarily block Cargo on an already completed target.
+fn assert_target_pruner_releases_each_completed_candidate_lease(fail_reclaim: bool) {
+    let root = tempfile::tempdir().expect("target root");
+    let first = root.path().join("candidate-a");
+    let second = root.path().join("candidate-b");
+    for candidate in [&first, &second] {
+        std::fs::create_dir(candidate).expect("create candidate");
+        let payload = candidate.join("old-payload");
+        std::fs::write(&payload, b"old payload").expect("write old payload");
+        age_file(&payload);
+    }
+
+    let signals = tempfile::tempdir().expect("release sync socket directory");
+    let socket_path = signals.path().join("released.sock");
+    let listener = std::os::unix::net::UnixListener::bind(&socket_path)
+        .expect("bind candidate-release sync socket");
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+    let (continue_tx, continue_rx) = std::sync::mpsc::channel();
+    let expected_releases = if fail_reclaim { 1 } else { 2 };
+    let sync = std::thread::spawn(move || {
+        let _signals = signals;
+        for index in 0..expected_releases {
+            let (mut channel, _) = listener.accept().expect("accept candidate-release sync");
+            let mut path = Vec::new();
+            loop {
+                let mut byte = [0_u8; 1];
+                channel
+                    .read_exact(&mut byte)
+                    .expect("read released candidate path");
+                if byte == [0] {
+                    break;
+                }
+                path.push(byte[0]);
+            }
+            if index == 0 {
+                let path = PathBuf::from(String::from_utf8(path).expect("candidate path is UTF-8"));
+                ready_tx
+                    .send(path)
+                    .expect("signal first released candidate");
+                continue_rx.recv().expect("wait for candidate lease probes");
+            }
+            channel.write_all(b"C").expect("release target helper");
+        }
+    });
+
+    let mut helper_command = Command::new(repo_root().join("scripts/prune-cargo-target.sh"));
+    helper_command
+        .args([
+            std::ffi::OsStr::new("1 day ago"),
+            std::ffi::OsStr::new("0"),
+            std::ffi::OsStr::new(""),
+            root.path().as_os_str(),
+        ])
+        .env("FCVM_PRUNE_TEST_AFTER_RELEASE_SOCKET", &socket_path);
+    if fail_reclaim {
+        helper_command.env("FCVM_PRUNE_TEST_FAIL_AFTER_FINGERPRINTS", "1");
+    }
+    let helper = ChildGuard(Some(
+        helper_command
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn release-synchronized target helper"),
+    ));
+
+    let released = ready_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("helper did not announce a released candidate lease");
+    let retained = if released == first { &second } else { &first };
+    assert!(
+        released == first || released == second,
+        "helper announced an unknown candidate path: {released:?}"
+    );
+    let released_probe = Command::new("flock")
+        .args(["-x", "-n", "-E", "42"])
+        .arg(&released)
+        .arg("/bin/true")
+        .status()
+        .expect("probe released candidate lease");
+    assert!(
+        released_probe.success(),
+        "completed candidate still held its exclusive lease: {released:?} {released_probe:?}"
+    );
+    let retained_probe = Command::new("flock")
+        .args(["-x", "-n", "-E", "42"])
+        .arg(retained)
+        .arg("/bin/true")
+        .status()
+        .expect("probe retained candidate lease");
+    assert_eq!(
+        retained_probe.code(),
+        Some(42),
+        "later candidate was unlocked before its safety checks and reclaim: {retained:?} \
+         {retained_probe:?}"
+    );
+
+    continue_tx.send(()).expect("continue target helper");
+    let output = helper.wait_with_output().expect("wait for target helper");
+    let status = output.status;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    sync.join().expect("join candidate-release sync peer");
+    if fail_reclaim {
+        assert_eq!(
+            status.code(),
+            Some(49),
+            "injected reclaim failure did not propagate after releasing its lease: {status:?}"
+        );
+    } else {
+        assert!(status.success(), "target helper failed: {status:?}");
+    }
+    let mut duration_paths = HashSet::new();
+    for line in stderr.lines() {
+        let Some((_, metric)) = line.split_once("candidate lease released after ") else {
+            continue;
+        };
+        let (seconds, path) = metric
+            .split_once("s: ")
+            .unwrap_or_else(|| panic!("malformed candidate lease duration metric: {line}"));
+        let seconds: f64 = seconds.parse().unwrap_or_else(|error| {
+            panic!("invalid candidate lease duration {seconds:?}: {error}")
+        });
+        assert!(
+            seconds.is_finite() && seconds >= 0.0,
+            "candidate lease duration is not finite and nonnegative: {line}"
+        );
+        let path = PathBuf::from(path);
+        assert!(
+            path == first || path == second,
+            "duration metric named an unknown candidate: {line}"
+        );
+        assert!(
+            duration_paths.insert(path),
+            "candidate emitted more than one lease duration metric: {line}"
+        );
+    }
+    assert_eq!(
+        duration_paths.len(),
+        expected_releases,
+        "target helper did not report exactly one lease duration for each completed candidate:\n{stderr}"
+    );
+    for candidate in [&first, &second] {
+        let length = std::fs::metadata(candidate.join("old-payload"))
+            .expect("stat candidate payload")
+            .len();
+        if fail_reclaim {
+            assert_eq!(
+                length, 11,
+                "failed reclaim changed a candidate payload: {candidate:?}"
+            );
+        } else {
+            assert_eq!(
+                length, 0,
+                "candidate payload was not reclaimed: {candidate:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn target_pruner_releases_each_completed_candidate_lease() {
+    assert_target_pruner_releases_each_completed_candidate_lease(false);
+}
+
+#[test]
+fn target_pruner_releases_the_failed_candidate_lease() {
+    assert_target_pruner_releases_each_completed_candidate_lease(true);
+}
+
 /// A FIFO in the candidate namespace is not a directory and must be skipped without ever
 /// blocking in open(2). The outer timeout is an assertion boundary: rc=124 would be a failure,
 /// not a retry or an accepted outcome.
@@ -1377,9 +1553,31 @@ fn run_cargo_fixture_build(project: &Path, btrfs_root: &Path) -> std::process::O
         .args(["cargo", "build", "--offline", "--verbose"])
         .env("BTRFS_ROOT", btrfs_root)
         .env("CARGO_TARGET_DIR", "target")
+        .env("RUSTC_WRAPPER", project.join(".fcvm-rustc-wrapper.sh"))
+        .env("FCVM_RUSTC_LOG", project.join(".fcvm-rustc-invocations"))
         .current_dir(project)
         .output()
         .expect("build Cargo cache fixture through target lease")
+}
+
+fn assert_fixture_crates_compiled(project: &Path, diagnostics: &str) {
+    let invocations = std::fs::read_to_string(project.join(".fcvm-rustc-invocations"))
+        .unwrap_or_else(|error| panic!("read fixture rustc invocations: {error}; {diagnostics}"));
+    let crates: Vec<_> = invocations.lines().collect();
+    for expected in ["cache_helper", "cache_fixture"] {
+        assert!(
+            crates.contains(&expected),
+            "rustc was not invoked for {expected} after cache invalidation; crates={crates:?}\n{diagnostics}"
+        );
+    }
+}
+
+fn clear_fixture_compile_log(project: &Path) {
+    match std::fs::remove_file(project.join(".fcvm-rustc-invocations")) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => panic!("clear fixture rustc invocations: {error}"),
+    }
 }
 
 fn run_direct_target_pruner(
@@ -1468,6 +1666,24 @@ fn target_pruner_invalidates_cargo_before_reclaiming_hardlinked_payloads() {
         "pub fn message() -> &'static str { \"dependency-value\" }\n",
     )
     .expect("write helper source");
+    let rustc_wrapper = project.path().join(".fcvm-rustc-wrapper.sh");
+    std::fs::write(
+        &rustc_wrapper,
+        "#!/bin/sh\n\
+         rustc=$1\n\
+         shift\n\
+         previous=\n\
+         for argument do\n\
+             if [ \"$previous\" = --crate-name ]; then\n\
+                 printf '%s\\n' \"$argument\" >>\"$FCVM_RUSTC_LOG\"\n\
+             fi\n\
+             previous=$argument\n\
+         done\n\
+         exec \"$rustc\" \"$@\"\n",
+    )
+    .expect("write fixture rustc wrapper");
+    std::fs::set_permissions(&rustc_wrapper, std::fs::Permissions::from_mode(0o755))
+        .expect("make fixture rustc wrapper executable");
 
     let first = run_cargo_fixture_build(project.path(), target_root.path());
     assert!(
@@ -1476,6 +1692,13 @@ fn target_pruner_invalidates_cargo_before_reclaiming_hardlinked_payloads() {
         String::from_utf8_lossy(&first.stdout),
         String::from_utf8_lossy(&first.stderr)
     );
+    let first_text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&first.stdout),
+        String::from_utf8_lossy(&first.stderr)
+    );
+    assert_fixture_crates_compiled(project.path(), &first_text);
+    clear_fixture_compile_log(project.path());
     let first_generation = std::fs::canonicalize(project.path().join("target"))
         .expect("resolve first managed Cargo generation");
     let binary = first_generation.join("debug/cache-fixture");
@@ -1536,11 +1759,11 @@ fn target_pruner_invalidates_cargo_before_reclaiming_hardlinked_payloads() {
         String::from_utf8_lossy(&rebuilt_after_interruption.stderr)
     );
     assert!(
-        rebuilt_after_interruption.status.success()
-            && rebuilt_text.contains("Compiling cache-helper")
-            && rebuilt_text.contains("Compiling cache-fixture"),
+        rebuilt_after_interruption.status.success(),
         "Cargo accepted a cache after its durable fingerprints were invalidated:\n{rebuilt_text}"
     );
+    assert_fixture_crates_compiled(project.path(), &rebuilt_text);
+    clear_fixture_compile_log(project.path());
 
     let second_generation = std::fs::canonicalize(project.path().join("target"))
         .expect("resolve second managed Cargo generation");
@@ -1605,11 +1828,10 @@ fn target_pruner_invalidates_cargo_before_reclaiming_hardlinked_payloads() {
         String::from_utf8_lossy(&rebuilt.stderr)
     );
     assert!(
-        rebuilt.status.success()
-            && rebuilt_text.contains("Compiling cache-helper")
-            && rebuilt_text.contains("Compiling cache-fixture"),
+        rebuilt.status.success(),
         "Cargo did not rebuild reclaimed hardlinked outputs:\n{rebuilt_text}"
     );
+    assert_fixture_crates_compiled(project.path(), &rebuilt_text);
     let third_generation = std::fs::canonicalize(project.path().join("target"))
         .expect("resolve third managed Cargo generation");
     assert_ne!(
@@ -2030,10 +2252,133 @@ fn disk_preflight_shell_scripts_parse() {
             repo_root().join("scripts/runner-disk-preflight.sh"),
             repo_root().join("scripts/prune-cargo-target.sh"),
             repo_root().join("scripts/install-runner-disk-guard.sh"),
+            repo_root().join("scripts/cargo-target-lib.sh"),
+            repo_root().join("scripts/cargo-target-link.sh"),
+            repo_root().join("scripts/cargo-target-run.sh"),
+            repo_root().join("scripts/run_fuse_pipe_tests.sh"),
         ])
         .status()
         .expect("run bash syntax check for disk-preflight scripts");
     assert!(status.success(), "disk-preflight shell syntax is invalid");
+}
+
+#[test]
+fn disk_preflight_initializes_candidate_roots_without_sc1007() {
+    let source = std::fs::read_to_string(repo_root().join("scripts/runner-disk-preflight.sh"))
+        .expect("read runner disk preflight");
+    let stage = source
+        .split_once("stage_target_dirs() {")
+        .expect("stage_target_dirs function is missing")
+        .1
+        .split_once("\n}")
+        .expect("stage_target_dirs function is unterminated")
+        .0;
+    let declaration = stage
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("local runner_root"))
+        .expect("stage_target_dirs does not declare its candidate roots");
+    assert_eq!(
+        declaration, "local runner_root='' btrfs_target_root=''",
+        "candidate-root locals must use explicit empty assignments accepted by ShellCheck SC1007"
+    );
+}
+
+#[test]
+fn cargo_target_wrappers_share_one_retirement_protocol() {
+    let library = std::fs::read_to_string(repo_root().join("scripts/cargo-target-lib.sh"))
+        .expect("read shared cargo-target library");
+    assert!(
+        library.contains("target_is_retired()")
+            && library.contains("user.fcvm.retired")
+            && library.contains("unsupported retired-generation marker"),
+        "shared cargo-target library does not own the retirement protocol"
+    );
+    for wrapper in [
+        "scripts/cargo-target-link.sh",
+        "scripts/cargo-target-run.sh",
+    ] {
+        let source = std::fs::read_to_string(repo_root().join(wrapper))
+            .unwrap_or_else(|error| panic!("read {wrapper}: {error}"));
+        assert!(
+            source.contains("cargo-target-lib.sh") && !source.contains("target_is_retired()"),
+            "{wrapper} does not source the shared retirement protocol exactly once"
+        );
+    }
+}
+
+/// `sudo` resets the environment on the privileged half of the fuse-pipe
+/// sweep. Run the real orchestration script with an environment-clearing sudo
+/// shim and observe the Cargo process, proving both managed-target variables
+/// cross that boundary as values rather than merely appearing in source text.
+#[test]
+fn fuse_pipe_privileged_cargo_preserves_target_protocol_environment() {
+    let fixture = tempfile::tempdir().expect("fuse-pipe environment fixture");
+    let shims = fixture.path().join("bin");
+    let log_dir = fixture.path().join("logs");
+    let cargo_target = fixture.path().join("cargo-target");
+    let btrfs_root = fixture.path().join("btrfs-root");
+    let observed = fixture.path().join("cargo-environment.log");
+    for directory in [&shims, &log_dir, &cargo_target, &btrfs_root] {
+        std::fs::create_dir_all(directory).expect("create fuse-pipe fixture directory");
+    }
+
+    for (name, source) in [
+        ("make", "#!/bin/sh\nexit 0\n"),
+        (
+            "cargo",
+            "#!/bin/sh\nprintf '%s|%s|%s\\n' \"$*\" \"${CARGO_TARGET_DIR-unset}\" \"${BTRFS_ROOT-unset}\" >>\"$FCVM_TEST_LOG\"\n",
+        ),
+        (
+            "sudo",
+            "#!/bin/sh\nexec /usr/bin/env -i PATH=\"$PATH\" FCVM_TEST_LOG=\"$FCVM_TEST_LOG\" \"$@\"\n",
+        ),
+    ] {
+        let path = shims.join(name);
+        std::fs::write(&path, source).expect("write fuse-pipe command shim");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .expect("make fuse-pipe command shim executable");
+    }
+
+    let inherited_path = std::env::var_os("PATH").expect("PATH is set");
+    let mut path = shims.into_os_string();
+    path.push(":");
+    path.push(inherited_path);
+    let output = Command::new(repo_root().join("scripts/run_fuse_pipe_tests.sh"))
+        .env("PATH", path)
+        .env("FCVM_TEST_LOG", &observed)
+        .env("LOG_DIR", &log_dir)
+        .env("STEP_TIMEOUT", "5")
+        .env("CARGO_TARGET_DIR", &cargo_target)
+        .env("BTRFS_ROOT", &btrfs_root)
+        .output()
+        .expect("run real fuse-pipe orchestration with command shims");
+    assert!(
+        output.status.success(),
+        "fuse-pipe orchestration failed: {}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let observed = std::fs::read_to_string(&observed).expect("read observed Cargo environment");
+    for test_name in ["stress", "pjdfstest_matrix"] {
+        let expected_prefix = format!("test -p fuse-pipe --test {test_name} -- --nocapture|");
+        let line = observed
+            .lines()
+            .find(|line| line.starts_with(&expected_prefix))
+            .unwrap_or_else(|| {
+                panic!("privileged {test_name} Cargo command was not observed:\n{observed}")
+            });
+        assert_eq!(
+            line,
+            format!(
+                "test -p fuse-pipe --test {test_name} -- --nocapture|{}|{}",
+                cargo_target.display(),
+                btrfs_root.display()
+            ),
+            "privileged {test_name} lost the managed-target environment through sudo"
+        );
+    }
 }
 
 /// Exercise the shared installer into a DESTDIR and verify both contents and modes. A string
@@ -2273,6 +2618,20 @@ fn persistent_runner_entrypoints_route_cargo_through_the_lease() {
                 .count()
                 == 4,
         "fuse-pipe runner does not set up and lease all four Cargo test invocations"
+    );
+    assert_eq!(
+        fuse_runner
+            .matches("CARGO_TARGET_DIR=\"${CARGO_TARGET_DIR:-target}\"")
+            .count(),
+        2,
+        "both privileged fuse-pipe Cargo runs must preserve CARGO_TARGET_DIR through sudo"
+    );
+    assert_eq!(
+        fuse_runner
+            .matches("BTRFS_ROOT=\"${BTRFS_ROOT:-/mnt/fcvm-btrfs}\"")
+            .count(),
+        2,
+        "both privileged fuse-pipe Cargo runs must preserve BTRFS_ROOT through sudo"
     );
 
     for path in ["scripts/build-ami.sh", "scripts/fcvm-init.sh"] {


### PR DESCRIPTION
**Stacked on:** main (PR #777 merged as `14579baa`)

## Problem

Persistent self-hosted runners could fill their root disk with Cargo artifacts. The preflight cleanup did not share an inode lease with every Cargo/topology writer, and recursive deletion could cross or detach mounts that existed only in another mount namespace. In-place truncation alone was also not a valid Cargo reset: build-script output names remained present and could be reused after fingerprint invalidation.

AMI provisioning had a second coherence boundary: the cache key and the cloud-init checkout had to describe the same immutable, remotely fetchable source. Otherwise a cached image could carry an older guard or host-tool implementation, or a builder could be allocated for an unpushed commit that cloud-init cannot fetch.

## Solution

- Route persistent-runner Cargo invocations through one checkout/target lease protocol and disable self-hosted target caching that mutates the target outside that lease.
- Use immutable physical target generations. The pruner exclusively locks an idle generation, durably marks it retired, invalidates and fsyncs Cargo fingerprints, then reclaims regular-file blocks without unlinking, renaming, or removing dentries.
- Make the wrapper rotate a retired target to a freshly locked generation before Cargo starts. Atomic symlink publication changes only the checkout pointer; old physical paths stay stable for foreign-namespace mounts.
- Make `make clean` perform the same safe logical rotation and fail closed for unmanaged local targets.
- Install the privileged disk guard from the exact pinned source tree. Bind the AMI hash to the same source commit that user data fetches and compiles, and verify that commit is fetchable from the configured remote before allocating EC2.
- Keep cache cleanup fail-closed: enumerate and retain candidate FDs before mutation, reject visible mount boundaries, skip external hardlinks, and stop the runner if the hard free-space floor still cannot be restored.
- Release each candidate lease immediately after its own terminal reclaim decision and emit one per-candidate hold-duration metric.
- Preserve `CARGO_TARGET_DIR` and `BTRFS_ROOT` through privileged FUSE test invocations, and centralize the target-retirement protocol in one sourced library.

## Red verification

Every review/CI claim was checked with fixed GREEN, a controlled revert to the broken behavior, observed RED, and restored GREEN:

- `ami_build_refuses_a_source_commit_the_remote_cannot_fetch` rejects a locally present but unpushed commit; reverting to local-object validation alone fails the test.
- `fuse_pipe_privileged_cargo_preserves_target_protocol_environment` observes the real privileged commands through an environment-clearing sudo shim; removing either forwarded target variable fails the test.
- `ami_git_fixture_ignores_hostile_global_configuration` injects global signing, hooks, and init-template policy; removing the hermetic Git environment copies the hostile template and fails.
- `ami_hash_reads_disk_guard_bytes_from_script_dir` separates `KERNEL_DIR` and `SCRIPT_DIR`; reverting the digest base to the kernel checkout leaves the hash unchanged and fails.
- `disk_preflight_initializes_candidate_roots_without_sc1007` fails on the SC1007-producing implicit empty assignments.
- `cargo_target_wrappers_share_one_retirement_protocol` fails when a wrapper-local retirement helper is restored.
- `target_pruner_releases_each_completed_candidate_lease` and `target_pruner_releases_the_failed_candidate_lease` prove the completed inode is unlocked while a later inode remains exclusively leased, on both success and failure. Moving close after the handoff fails the lock probe; removing the metric fails the per-path duration assertions.
- `target_pruner_invalidates_cargo_before_reclaiming_hardlinked_payloads` uses a fixture-owned `RUSTC_WRAPPER` to observe exact compiler invocations. It fails when durable fingerprint invalidation is moved after reclaim and passes with `CARGO_TERM_COLOR=always`, closing the six-job CI failure without parsing human-formatted Cargo output.

## Test results

```text
$ make _test-fast FILTER="-E 'binary(test_ami_hash_inputs)'" STREAM=1
Summary: 16 tests run: 16 passed, 0 skipped

$ make _test-fast FILTER="-E 'binary(test_cargo_target_link)'" STREAM=1
Summary: 30 tests run: 30 passed, 0 skipped

$ make _test-root FILTER="-E 'binary(test_cargo_target_link)'" STREAM=1
Summary: 35 tests run: 35 passed, 0 skipped

$ CARGO_TERM_COLOR=always make _test-fast FILTER=target_pruner_invalidates_cargo_before_reclaiming_hardlinked_payloads STREAM=1
Summary: 1 test run: 1 passed

$ make _test-unit
Summary: 507 tests run: 507 passed, 0 skipped

$ make lint
passed

$ git diff --check
passed
```
