### PR TITLE
Cover readiness interleavings and harden VM diagnostics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ libfuse-test = []
 [dev-dependencies]
 serial_test = "3"
 criterion = "0.5"
+tokio = { version = "1", features = ["test-util"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # small_rng: SmallRng for the seeded chaos harness (tests/test_fuzz_chaos.rs)

--- a/fc-agent/Cargo.toml
+++ b/fc-agent/Cargo.toml
@@ -19,3 +19,6 @@ failpoint = { path = "../failpoint" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["test-util"] }

--- a/fc-agent/src/mmds.rs
+++ b/fc-agent/src/mmds.rs
@@ -141,6 +141,87 @@ async fn fetch_latest_metadata(client: &reqwest::Client) -> Result<LatestMetadat
     Ok(metadata)
 }
 
+/// Why the restore-epoch watcher woke up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RestoreEpochWake {
+    PollInterval,
+    TransportReset,
+    ResetSenderClosed,
+}
+
+/// Latching transport-reset wakeup plus the original periodic fallback.
+///
+/// `watch::Receiver::changed` observes a generation published before the wait
+/// future is created, which closes the check-to-park lost-wakeup window. Once
+/// the sender closes, the reset arm is permanently disarmed so a perpetually
+/// ready `changed()` error cannot spin the metadata fetch loop.
+struct RestoreEpochSchedule {
+    reset_rx: tokio::sync::watch::Receiver<u64>,
+    reset_armed: bool,
+    poll_interval: Duration,
+    fast_interval: Duration,
+    fast_until: Option<tokio::time::Instant>,
+}
+
+impl RestoreEpochSchedule {
+    const FAST_WINDOW: Duration = Duration::from_secs(1);
+
+    fn new(
+        transport: crate::bootplan::Transport,
+        reset_rx: tokio::sync::watch::Receiver<u64>,
+    ) -> Self {
+        let poll_interval = match transport {
+            crate::bootplan::Transport::Mmds => Duration::from_millis(50),
+            crate::bootplan::Transport::Vsock => Duration::from_millis(250),
+        };
+        // Post-reset fast cadence: MMDS gets are cheap local HTTP; vsock polls
+        // reopen the boot-plan connection, so keep them a bit gentler.
+        let fast_interval = match transport {
+            crate::bootplan::Transport::Mmds => Duration::from_millis(2),
+            crate::bootplan::Transport::Vsock => Duration::from_millis(10),
+        };
+        Self {
+            reset_rx,
+            reset_armed: true,
+            poll_interval,
+            fast_interval,
+            fast_until: None,
+        }
+    }
+
+    async fn wait(&mut self) -> RestoreEpochWake {
+        let interval = match self.fast_until {
+            Some(t) if tokio::time::Instant::now() < t => self.fast_interval,
+            _ => {
+                self.fast_until = None;
+                self.poll_interval
+            }
+        };
+
+        tokio::select! {
+            _ = sleep(interval) => RestoreEpochWake::PollInterval,
+            changed = self.reset_rx.changed(), if self.reset_armed => {
+                match changed {
+                    Ok(()) => {
+                        self.fast_until = Some(
+                            tokio::time::Instant::now() + Self::FAST_WINDOW
+                        );
+                        RestoreEpochWake::TransportReset
+                    }
+                    Err(_) => {
+                        self.reset_armed = false;
+                        RestoreEpochWake::ResetSenderClosed
+                    }
+                }
+            }
+        }
+    }
+
+    fn clear_fast_window(&mut self) {
+        self.fast_until = None;
+    }
+}
+
 /// Watch for restore-epoch changes and handle clone restore, over either transport.
 ///
 /// Firecracker polls MMDS; Cloud Hypervisor polls the host's boot-plan vsock port
@@ -168,46 +249,11 @@ pub async fn watch_restore_epoch(
     let mut egress_gen_at_last_stable: Option<u64> =
         signals.egress_gen_rx.as_ref().map(|rx| *rx.borrow());
 
-    let poll_interval = match transport {
-        crate::bootplan::Transport::Mmds => Duration::from_millis(50),
-        crate::bootplan::Transport::Vsock => Duration::from_millis(250),
-    };
-    // Post-reset fast cadence: MMDS gets are cheap local HTTP; vsock polls
-    // reopen the boot-plan connection, so keep them a bit gentler.
-    let fast_interval = match transport {
-        crate::bootplan::Transport::Mmds => Duration::from_millis(2),
-        crate::bootplan::Transport::Vsock => Duration::from_millis(10),
-    };
-    const FAST_WINDOW: Duration = Duration::from_secs(1);
-
-    let mut reset_rx = signals.vsock_reset_rx.clone();
-    // Once the watch sender is gone (writer task ended — shutdown), stop
-    // selecting on it so a closed channel can't busy-loop the watcher.
-    let mut reset_armed = true;
-    let mut fast_until: Option<tokio::time::Instant> = None;
+    let mut schedule = RestoreEpochSchedule::new(transport, signals.vsock_reset_rx.clone());
 
     loop {
-        let interval = match fast_until {
-            Some(t) if tokio::time::Instant::now() < t => fast_interval,
-            _ => {
-                fast_until = None;
-                poll_interval
-            }
-        };
-        tokio::select! {
-            _ = sleep(interval) => {}
-            changed = reset_rx.changed(), if reset_armed => {
-                match changed {
-                    Ok(()) => {
-                        eprintln!(
-                            "[fc-agent] vsock transport reset observed; fast-polling restore-epoch"
-                        );
-                        fast_until = Some(tokio::time::Instant::now() + FAST_WINDOW);
-                        // Fall through to an immediate fetch.
-                    }
-                    Err(_) => reset_armed = false,
-                }
-            }
+        if schedule.wait().await == RestoreEpochWake::TransportReset {
+            eprintln!("[fc-agent] vsock transport reset observed; fast-polling restore-epoch");
         }
 
         let metadata = match crate::bootplan::fetch_metadata(transport).await {
@@ -251,7 +297,7 @@ pub async fn watch_restore_epoch(
                         signals.egress_gen_rx.as_ref().map(|rx| *rx.borrow());
                     last_epoch = metadata.restore_epoch;
                     // Epoch found and handled — the fast window did its job.
-                    fast_until = None;
+                    schedule.clear_fast_window();
                 }
                 Some(prev) if prev != current => {
                     eprintln!("[fc-agent] restore-epoch changed: {} -> {}", prev, current,);
@@ -271,7 +317,7 @@ pub async fn watch_restore_epoch(
                         signals.egress_gen_rx.as_ref().map(|rx| *rx.borrow());
                     last_epoch = metadata.restore_epoch;
                     // Epoch found and handled — the fast window did its job.
-                    fast_until = None;
+                    schedule.clear_fast_window();
                 }
                 _ => {}
             }
@@ -312,4 +358,80 @@ pub async fn sync_clock_from_host() -> Result<()> {
         serde_json::from_str(&body).context("parsing host-time from MMDS")?;
 
     crate::bootplan::set_system_clock(&metadata.host_time).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::future::{poll_fn, Future};
+    use std::pin::Pin;
+    use std::task::Poll;
+
+    async fn assert_pending_once<F>(mut future: Pin<&mut F>)
+    where
+        F: Future,
+    {
+        poll_fn(|cx| match future.as_mut().poll(cx) {
+            Poll::Pending => Poll::Ready(()),
+            Poll::Ready(_) => panic!("future completed before its signal"),
+        })
+        .await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn transport_reset_generation_published_before_park_wakes_immediately() {
+        let (reset_tx, reset_rx) = tokio::sync::watch::channel(0u64);
+        let mut schedule = RestoreEpochSchedule::new(crate::bootplan::Transport::Mmds, reset_rx);
+
+        // Publish before `wait()` creates its `changed()` future. A one-shot
+        // notification would lose this edge; the retained watch generation must
+        // make the subsequent wait immediately ready.
+        reset_tx.send(1).expect("reset receiver remains alive");
+        let before = tokio::time::Instant::now();
+
+        assert_eq!(schedule.wait().await, RestoreEpochWake::TransportReset);
+        assert_eq!(
+            tokio::time::Instant::now(),
+            before,
+            "fallback clock advanced"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn closed_reset_sender_is_disarmed_instead_of_spinning() {
+        let (reset_tx, reset_rx) = tokio::sync::watch::channel(0u64);
+        let mut schedule = RestoreEpochSchedule::new(crate::bootplan::Transport::Mmds, reset_rx);
+        drop(reset_tx);
+
+        assert_eq!(schedule.wait().await, RestoreEpochWake::ResetSenderClosed);
+
+        // `changed()` on a closed channel remains immediately ready forever.
+        // The second wait must use only the 50ms fallback, proving the closed
+        // arm was permanently removed from the select.
+        let mut next = Box::pin(schedule.wait());
+        assert_pending_once(next.as_mut()).await;
+        tokio::time::advance(Duration::from_millis(49)).await;
+        assert_pending_once(next.as_mut()).await;
+        tokio::time::advance(Duration::from_millis(1)).await;
+        assert_eq!(next.await, RestoreEpochWake::PollInterval);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn missing_transport_reset_uses_periodic_fallback() {
+        let (_reset_tx, reset_rx) = tokio::sync::watch::channel(0u64);
+        let mut schedule = RestoreEpochSchedule::new(crate::bootplan::Transport::Mmds, reset_rx);
+        let before = tokio::time::Instant::now();
+
+        let mut wait = Box::pin(schedule.wait());
+        assert_pending_once(wait.as_mut()).await;
+        tokio::time::advance(Duration::from_millis(49)).await;
+        assert_pending_once(wait.as_mut()).await;
+        tokio::time::advance(Duration::from_millis(1)).await;
+
+        assert_eq!(wait.await, RestoreEpochWake::PollInterval);
+        assert_eq!(
+            tokio::time::Instant::now() - before,
+            Duration::from_millis(50)
+        );
+    }
 }

--- a/scripts/ci-stray-vm-guard.sh
+++ b/scripts/ci-stray-vm-guard.sh
@@ -1,103 +1,223 @@
 #!/usr/bin/env bash
-# Report and reap stray microVM processes on a self-hosted runner.
+# Report and reap stray microVM process groups on a self-hosted runner.
 #
-# Self-hosted runners are reused forever, so anything a job leaves behind is inherited by
-# every later job on that box. In August 2026 two ARM runners wedged for 21 hours with ~498
-# live `firecracker` processes (load average 523, 103 tasks in D-state, 420 zombies) that had
-# accumulated silently across runs — nothing in any job log ever mentioned them.
+# The guard deliberately reads only the process/thread identity fields exposed by
+# `ps`: TGID, TID, PPID, state, and thread name. In particular it never asks procfs
+# for argv/cmdline: reading /proc/<pid>/cmdline can block behind a wedged mm and made
+# the diagnostic guard itself hang after the ARM KVM failure in August 2026.
 #
-# This is defense in depth, NOT the fix: the leak itself is fixed by the kernel-enforced
-# PR_SET_PDEATHSIG chain (scripts/root-test-runner.sh, src/utils.rs::install_namespace_pre_exec).
-# It also acts only at job BOUNDARIES, so it cannot stop a host that wedges mid-job — that
-# remediation belongs on the AWS side (terminate and replace the instance).
-# Run this at the start of a job (what the previous job left) and at the end (what this job
-# left). Either way the count lands in the job log and, when non-zero, in a GitHub annotation.
+# Every thread in a matching task group is reported. A zombie leader is harmless
+# only when every sibling thread is also a zombie; a D-state vCPU sibling still owns
+# live KVM/MM resources and makes the whole group actionable.
 #
 # Usage: ci-stray-vm-guard.sh <pre|post> [--dry-run]
 #
-#   --dry-run  report only, kill nothing. The default mode SIGKILLs every match, which is
-#              correct on a dedicated CI runner and destructive anywhere else — use this to
-#              exercise the script on a shared dev box, where the matches are someone's
-#              running VMs, not garbage.
+#   --dry-run  report only, kill nothing. The default SIGKILL behavior is intended
+#              only for dedicated CI runners.
 set -uo pipefail
 
 PHASE="${1:-post}"
 DRY_RUN=0
 [ "${2:-}" = "--dry-run" ] && DRY_RUN=1
 
-# `comm` is the executable basename truncated to 15 chars, so the content-addressed
-# `firecracker-default-<sha>.bin` shows up as `firecracker-def`. Matching on comm (not the
-# full argv) means this can never match a grep/ps/pgrep of its own patterns.
-STRAY_RE='^(firecracker|cloud-hypervisor|fcvm)'
+SCAN_TIMEOUT_SECONDS="${FCVM_GUARD_SCAN_TIMEOUT_SECONDS:-10}"
+LOG_DIR="${FCVM_TEST_LOG_DIR:-/tmp/fcvm-test-logs}"
+if ! mkdir -p "$LOG_DIR" 2>/dev/null; then
+	LOG_DIR="/tmp/fcvm-test-logs"
+	mkdir -p "$LOG_DIR"
+fi
 
-# Zombies are EXCLUDED ($4 is stat; Z may carry modifiers like `Z+`). A zombie is already
-# dead — it holds no memory, no KVM fd and no vCPU thread, only a process-table slot until
-# its parent reaps it. It is therefore not a leaked microVM, and more importantly it can
-# never be killed: SIGKILL to a zombie is a no-op, so counting them would put them in
-# SURVIVORS forever and fire the "survived SIGKILL, this runner needs a reboot" annotation
-# on every run. The 2026-08-06 incident had 420 zombies alongside the real leak, so this is
-# the difference between a signal and a permanent false alarm.
-list_strays() {
-	ps -eo pid=,ppid=,etimes=,stat=,comm=,args= |
-		awk -v re="$STRAY_RE" '$5 ~ re && $4 !~ /^Z/ { print }'
+REPORT="$LOG_DIR/stray-vm-guard-${PHASE}.log"
+THREADS_BEFORE="$LOG_DIR/stray-vm-threads-${PHASE}-before.tsv"
+THREADS_AFTER="$LOG_DIR/stray-vm-threads-${PHASE}-after.tsv"
+: >"$REPORT"
+: >"$THREADS_BEFORE"
+: >"$THREADS_AFTER"
+exec > >(tee -a "$REPORT") 2>&1
+
+# Linux comm is limited to 15 bytes. `cloud-hypervisor` is therefore observed as
+# `cloud-hypervis`; the prefix intentionally covers both that and the full spelling.
+STRAY_RE='^(firecracker|cloud-hypervis|fcvm)'
+
+TEMPORARY_PREFIX="$LOG_DIR/.stray-vm-guard.$$"
+cleanup_temporary_files() {
+	rm -f -- "${TEMPORARY_PREFIX}".*
+}
+trap cleanup_temporary_files EXIT
+
+new_temporary_file() {
+	mktemp "${TEMPORARY_PREFIX}.XXXXXX"
 }
 
-# Counted and reported, never killed: a high zombie count is a symptom worth seeing (it means
-# something is not reaping its children) but it is not actionable by this script.
-count_zombies() {
-	ps -eo stat=,comm= | awk -v re="$STRAY_RE" '$2 ~ re && $1 ~ /^Z/' | wc -l
+# Capture one process-table snapshot behind a hard deadline. We do not wait for a
+# timed-out reader after SIGKILL: if the kernel has already parked it in D state,
+# waiting would recreate the guard hang this script exists to diagnose.
+capture_all_threads() {
+	local destination=$1
+	local raw scan_pid deadline rc
+	raw=$(new_temporary_file) || return 1
+	printf 'TGID\tTID\tPPID\tSTATE\tTHREAD\n' >"$destination"
+
+	ps -eL -o pid= -o lwp= -o ppid= -o state= -o comm= >"$raw" &
+	scan_pid=$!
+	deadline=$((SECONDS + SCAN_TIMEOUT_SECONDS))
+	while kill -0 "$scan_pid" 2>/dev/null; do
+		if [ "$SECONDS" -ge "$deadline" ]; then
+			kill -9 "$scan_pid" 2>/dev/null || true
+			disown "$scan_pid" 2>/dev/null || true
+			echo "process/thread scan timed out after ${SCAN_TIMEOUT_SECONDS}s"
+			return 124
+		fi
+		sleep 0.05
+	done
+
+	wait "$scan_pid"
+	rc=$?
+	if [ "$rc" -ne 0 ]; then
+		echo "process/thread scan failed with status ${rc}"
+		return "$rc"
+	fi
+
+	# Normalize the variable-width comm column to a tab-separated artifact. Thread
+	# names can contain spaces, so fields 5..NF are joined back together.
+	awk '
+		BEGIN { OFS = "\t" }
+		NF >= 5 {
+			thread = $5
+			for (i = 6; i <= NF; i++)
+				thread = thread " " $i
+			print $1, $2, $3, $4, thread
+		}
+	' "$raw" >>"$destination"
 }
 
-mapfile -t STRAYS < <(list_strays)
-COUNT=${#STRAYS[@]}
-ZOMBIES=$(count_zombies)
-[ "$ZOMBIES" -gt 0 ] && echo "note (${PHASE}): ignoring ${ZOMBIES} unreaped zombie(s) — already dead, hold no resources, cannot be killed"
+# Select complete task groups whose leader name is a VM process. Outputs one TGID
+# per live group and one per zombie-only group; the thread artifact always contains
+# every sibling, including the zombie leader itself.
+select_vm_groups() {
+	local all_threads=$1
+	local selected_threads=$2
+	local live_groups=$3
+	local zombie_groups=$4
 
-echo "=== stray microVM guard (${PHASE}): ${COUNT} stray process(es) ==="
+	awk -F '\t' -v re="$STRAY_RE" \
+		-v selected="$selected_threads" \
+		-v live_out="$live_groups" \
+		-v zombie_out="$zombie_groups" '
+		BEGIN { OFS = "\t" }
+		NR == 1 { header = $0; next }
+		{
+			rows[++count] = $0
+			tgid[count] = $1
+			if ($1 == $2 && $5 ~ re)
+				target[$1] = 1
+			if ($4 !~ /^Z/)
+				live[$1] = 1
+		}
+		END {
+			print header > selected
+			for (i = 1; i <= count; i++)
+				if (tgid[i] in target)
+					print rows[i] >> selected
+			for (id in target) {
+				if (live[id])
+					print id > live_out
+				else
+					print id > zombie_out
+			}
+		}
+	' "$all_threads"
+}
+
+print_thread_table() {
+	local table=$1
+	printf '%8s %8s %8s %-5s %s\n' TGID TID PPID STATE THREAD
+	while IFS=$'\t' read -r tgid tid ppid state thread; do
+		[ "$tgid" = "TGID" ] && continue
+		printf '%8s %8s %8s %-5s %s\n' "$tgid" "$tid" "$ppid" "$state" "$thread"
+	done <"$table"
+}
+
+scan_vm_groups() {
+	local selected=$1
+	local live=$2
+	local zombies=$3
+	local all
+	all=$(new_temporary_file) || return 1
+	: >"$live"
+	: >"$zombies"
+	if ! capture_all_threads "$all"; then
+		# Preserve a syntactically useful artifact even when enumeration failed.
+		printf 'TGID\tTID\tPPID\tSTATE\tTHREAD\n' >"$selected"
+		return 1
+	fi
+	select_vm_groups "$all" "$selected" "$live" "$zombies"
+}
+
+LIVE_BEFORE=$(new_temporary_file)
+ZOMBIE_BEFORE=$(new_temporary_file)
+if ! scan_vm_groups "$THREADS_BEFORE" "$LIVE_BEFORE" "$ZOMBIE_BEFORE"; then
+	echo "=== stray microVM guard (${PHASE}): scan incomplete ==="
+	echo "::warning title=Stray microVM scan incomplete (${PHASE})::Process enumeration timed out or failed; no destructive cleanup attempted. Diagnostics were saved to ${LOG_DIR}."
+	[ -n "${GITHUB_STEP_SUMMARY:-}" ] &&
+		echo "- stray microVM guard (${PHASE}): scan incomplete; diagnostics saved" >>"$GITHUB_STEP_SUMMARY"
+	exit 0
+fi
+
+mapfile -t STRAY_TGIDS <"$LIVE_BEFORE"
+mapfile -t ZOMBIE_TGIDS <"$ZOMBIE_BEFORE"
+COUNT=${#STRAY_TGIDS[@]}
+ZOMBIES=${#ZOMBIE_TGIDS[@]}
+
+[ "$ZOMBIES" -gt 0 ] &&
+	echo "note (${PHASE}): ignoring ${ZOMBIES} zombie-only process group(s); every thread is already dead"
+
+echo "=== stray microVM guard (${PHASE}): ${COUNT} stray process group(s) ==="
 
 if [ "$COUNT" -eq 0 ]; then
-	echo "✓ no stray fcvm/firecracker/cloud-hypervisor processes"
+	echo "✓ no live fcvm/firecracker/cloud-hypervisor process groups"
 	[ -n "${GITHUB_STEP_SUMMARY:-}" ] &&
-		echo "- stray microVM guard (${PHASE}): 0" >>"$GITHUB_STEP_SUMMARY"
+		echo "- stray microVM guard (${PHASE}): 0; zombie-only groups ${ZOMBIES}" >>"$GITHUB_STEP_SUMMARY"
 	exit 0
 fi
 
-printf '%8s %8s %9s %-5s %s\n' PID PPID ELAPSED STAT COMMAND
-for row in "${STRAYS[@]}"; do
-	# shellcheck disable=SC2086 # deliberate word splitting into positional fields
-	set -- $row
-	printf '%8s %8s %8ss %-5s %s\n' "$1" "$2" "$3" "$4" "${*:5:12}"
-done
+print_thread_table "$THREADS_BEFORE"
 
-# A GitHub annotation surfaces on the run page, not just buried in the step log.
 if [ "$DRY_RUN" -eq 1 ]; then
-	echo "::warning title=Stray microVMs (${PHASE}, dry-run)::${COUNT} fcvm/firecracker process(es) are alive on this runner; NOT killing them (--dry-run)."
+	echo "::warning title=Stray microVMs (${PHASE}, dry-run)::${COUNT} live process group(s) found; NOT killing them (--dry-run)."
 	echo "--dry-run: reporting only, killing nothing"
 	[ -n "${GITHUB_STEP_SUMMARY:-}" ] &&
-		echo "- stray microVM guard (${PHASE}, dry-run): found ${COUNT}, zombies ${ZOMBIES}" >>"$GITHUB_STEP_SUMMARY"
+		echo "- stray microVM guard (${PHASE}, dry-run): found ${COUNT}, zombie-only groups ${ZOMBIES}" >>"$GITHUB_STEP_SUMMARY"
 	exit 0
 fi
 
-echo "::warning title=Stray microVMs (${PHASE})::${COUNT} fcvm/firecracker process(es) were alive on this runner; killing them. A non-zero 'post' count means this job leaked VMs."
+echo "::warning title=Stray microVMs (${PHASE})::${COUNT} live process group(s) were present; killing each TGID once. A non-zero post count means this job leaked VMs."
 
-for row in "${STRAYS[@]}"; do
-	# shellcheck disable=SC2086
-	set -- $row
-	sudo kill -9 "$1" 2>/dev/null || true
+for tgid in "${STRAY_TGIDS[@]}"; do
+	# `kill` needs only the numeric TGID and never reads the target mm/cmdline.
+	timeout --signal=KILL 2 sudo kill -9 -- "$tgid" 2>/dev/null || true
 done
 sleep 2
 
-mapfile -t SURVIVORS < <(list_strays)
-echo "killed ${COUNT}, still present after SIGKILL: ${#SURVIVORS[@]}"
-if [ "${#SURVIVORS[@]}" -gt 0 ]; then
-	# SIGKILL is not delivered to a task blocked in uninterruptible (D) state — that is the
-	# shape of the 21-hour wedge, and it needs a reboot, not another kill.
-	printf '%s\n' "${SURVIVORS[@]}"
-	echo "::warning title=Unkillable microVMs (${PHASE})::${#SURVIVORS[@]} process(es) survived SIGKILL (likely D-state); this runner needs a reboot."
+LIVE_AFTER=$(new_temporary_file)
+ZOMBIE_AFTER=$(new_temporary_file)
+if ! scan_vm_groups "$THREADS_AFTER" "$LIVE_AFTER" "$ZOMBIE_AFTER"; then
+	echo "post-kill process/thread scan timed out; survivor count is unknown"
+	echo "::warning title=Unkillable microVM scan incomplete (${PHASE})::Post-kill enumeration did not complete; runner replacement is required."
+	[ -n "${GITHUB_STEP_SUMMARY:-}" ] &&
+		echo "- stray microVM guard (${PHASE}): found ${COUNT}, survivor scan incomplete" >>"$GITHUB_STEP_SUMMARY"
+	exit 0
+fi
+
+mapfile -t SURVIVOR_TGIDS <"$LIVE_AFTER"
+echo "killed ${COUNT} process group(s), still live after SIGKILL: ${#SURVIVOR_TGIDS[@]}"
+if [ "${#SURVIVOR_TGIDS[@]}" -gt 0 ]; then
+	print_thread_table "$THREADS_AFTER"
+	echo "::warning title=Unkillable microVMs (${PHASE})::${#SURVIVOR_TGIDS[@]} process group(s) survived SIGKILL; D-state means this runner needs replacement."
 fi
 
 if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-	echo "- stray microVM guard (${PHASE}): found ${COUNT}, unkillable ${#SURVIVORS[@]}" >>"$GITHUB_STEP_SUMMARY"
+	echo "- stray microVM guard (${PHASE}): found ${COUNT}, unkillable ${#SURVIVOR_TGIDS[@]}" >>"$GITHUB_STEP_SUMMARY"
 fi
 
 exit 0

--- a/scripts/ci-stray-vm-guard.sh
+++ b/scripts/ci-stray-vm-guard.sh
@@ -54,17 +54,24 @@ new_temporary_file() {
 # waiting would recreate the guard hang this script exists to diagnose.
 capture_all_threads() {
 	local destination=$1
-	local raw scan_pid deadline rc
+	local raw scan_stderr scan_pid deadline rc line
 	raw=$(new_temporary_file) || return 1
+	scan_stderr=$(new_temporary_file) || return 1
 	printf 'TGID\tTID\tPPID\tSTATE\tTHREAD\n' >"$destination"
 
-	ps -eL -o pid= -o lwp= -o ppid= -o state= -o comm= >"$raw" &
+	# Do not let the scanner inherit the report pipe. If ps wedges in D state,
+	# SIGKILL remains pending and every inherited pipe writer stays open, making
+	# the workflow caller wait forever for EOF even after this guard exits.
+	ps -eL -o pid= -o lwp= -o ppid= -o state= -o comm= >"$raw" 2>"$scan_stderr" &
 	scan_pid=$!
 	deadline=$((SECONDS + SCAN_TIMEOUT_SECONDS))
 	while kill -0 "$scan_pid" 2>/dev/null; do
 		if [ "$SECONDS" -ge "$deadline" ]; then
 			kill -9 "$scan_pid" 2>/dev/null || true
 			disown "$scan_pid" 2>/dev/null || true
+			while IFS= read -r line || [ -n "$line" ]; do
+				printf 'process/thread scanner stderr: %s\n' "$line"
+			done <"$scan_stderr"
 			echo "process/thread scan timed out after ${SCAN_TIMEOUT_SECONDS}s"
 			return 124
 		fi
@@ -73,6 +80,9 @@ capture_all_threads() {
 
 	wait "$scan_pid"
 	rc=$?
+	while IFS= read -r line || [ -n "$line" ]; do
+		printf 'process/thread scanner stderr: %s\n' "$line"
+	done <"$scan_stderr"
 	if [ "$rc" -ne 0 ]; then
 		echo "process/thread scan failed with status ${rc}"
 		return "$rc"

--- a/src/firecracker/vm.rs
+++ b/src/firecracker/vm.rs
@@ -27,6 +27,25 @@ const STDERR_TAIL_LINES: usize = 10;
 /// only bounds the pathological case of an inherited, still-open pipe.
 const STDERR_EOF_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Connection probe boundary for the API-socket readiness state machine.
+///
+/// Production uses Tokio's Unix stream. Tests provide exact NotFound,
+/// ConnectionRefused, and ready sequences so every check-to-park interleave is
+/// exercised without scheduler timing or a retry loop.
+trait ApiSocketProbe {
+    async fn connect(&mut self, socket_path: &Path) -> std::io::Result<()>;
+}
+
+struct TokioApiSocketProbe;
+
+impl ApiSocketProbe for TokioApiSocketProbe {
+    async fn connect(&mut self, socket_path: &Path) -> std::io::Result<()> {
+        let stream = tokio::net::UnixStream::connect(socket_path).await?;
+        drop(stream);
+        Ok(())
+    }
+}
+
 /// Manages a Firecracker VM process
 ///
 /// IMPORTANT: PID Tracking Architecture
@@ -361,8 +380,6 @@ impl VmManager {
     /// connections, fail with its exit status and recent stderr output instead
     /// of timing out with a generic socket error.
     async fn wait_for_socket(&mut self) -> Result<()> {
-        use tokio::time::sleep;
-
         let mut watch =
             self.socket_path
                 .parent()
@@ -376,6 +393,17 @@ impl VmManager {
                         None
                     }
                 });
+        let mut probe = TokioApiSocketProbe;
+
+        self.wait_for_socket_with(&mut probe, &mut watch).await
+    }
+
+    async fn wait_for_socket_with<P, E>(&mut self, probe: &mut P, watch: &mut E) -> Result<()>
+    where
+        P: ApiSocketProbe,
+        E: crate::utils::DirEventSource,
+    {
+        use tokio::time::sleep;
 
         let deadline = tokio::time::Instant::now() + SOCKET_WAIT_TIMEOUT;
         loop {
@@ -386,12 +414,8 @@ impl VmManager {
             // forever, and skipping try_wait would spin out the whole deadline
             // and report a generic timeout instead of the exit status + stderr.
             let mut refused = false;
-            match tokio::net::UnixStream::connect(&self.socket_path).await {
-                Ok(stream) => {
-                    // Only probing readiness — drop the connection immediately.
-                    drop(stream);
-                    return Ok(());
-                }
+            match probe.connect(&self.socket_path).await {
+                Ok(()) => return Ok(()),
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     // Socket file not created yet — wait for a directory event below.
                 }
@@ -429,25 +453,24 @@ impl VmManager {
                 continue;
             }
 
-            match watch.as_mut() {
-                Some(w) => {
-                    tokio::select! {
-                        event = w.next_event() => {
-                            // Directory activity — loop re-probes the socket.
-                            // A (persistent) watch error degrades to the old
-                            // fixed cadence via this sleep, bounded by deadline.
-                            if event.is_err() {
-                                sleep(SOCKET_WAIT_RETRY_DELAY).await;
-                            }
-                        }
-                        _ = tokio::time::sleep_until(deadline) => {}
-                        _ = sleep(Duration::from_millis(100)) => {
-                            // Safety tick: re-check child liveness + socket
-                            // even if no event arrives.
+            if watch.is_available() {
+                tokio::select! {
+                    event = watch.next_event() => {
+                        // Directory activity — loop re-probes the socket.
+                        // A (persistent) watch error degrades to the old
+                        // fixed cadence via this sleep, bounded by deadline.
+                        if event.is_err() {
+                            sleep(SOCKET_WAIT_RETRY_DELAY).await;
                         }
                     }
+                    _ = tokio::time::sleep_until(deadline) => {}
+                    _ = sleep(Duration::from_millis(100)) => {
+                        // Safety tick: re-check child liveness + socket
+                        // even if no event arrives.
+                    }
                 }
-                None => sleep(SOCKET_WAIT_RETRY_DELAY).await,
+            } else {
+                sleep(SOCKET_WAIT_RETRY_DELAY).await;
             }
         }
 
@@ -612,7 +635,231 @@ impl Drop for VmManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::DirEventSource;
+    use std::future::{poll_fn, Future};
     use std::os::unix::fs::PermissionsExt;
+    use std::pin::Pin;
+    use std::task::Poll;
+
+    #[derive(Clone, Copy)]
+    enum ProbeStep {
+        Ready,
+        NotFound,
+        Refused,
+    }
+
+    struct ScriptedProbe {
+        steps: VecDeque<ProbeStep>,
+        repeat: Option<ProbeStep>,
+        calls: usize,
+    }
+
+    impl ScriptedProbe {
+        fn once(steps: impl IntoIterator<Item = ProbeStep>) -> Self {
+            Self {
+                steps: steps.into_iter().collect(),
+                repeat: None,
+                calls: 0,
+            }
+        }
+
+        fn repeating(step: ProbeStep) -> Self {
+            Self {
+                steps: VecDeque::new(),
+                repeat: Some(step),
+                calls: 0,
+            }
+        }
+    }
+
+    impl ApiSocketProbe for ScriptedProbe {
+        async fn connect(&mut self, _socket_path: &Path) -> std::io::Result<()> {
+            self.calls += 1;
+            let step = self
+                .steps
+                .pop_front()
+                .or(self.repeat)
+                .expect("scripted API-socket probe exhausted");
+            match step {
+                ProbeStep::Ready => Ok(()),
+                ProbeStep::NotFound => Err(std::io::Error::from(std::io::ErrorKind::NotFound)),
+                ProbeStep::Refused => {
+                    Err(std::io::Error::from(std::io::ErrorKind::ConnectionRefused))
+                }
+            }
+        }
+    }
+
+    enum EventStep {
+        Wake,
+        ReadError,
+    }
+
+    struct ScriptedEvents {
+        steps: VecDeque<EventStep>,
+        calls: usize,
+    }
+
+    impl ScriptedEvents {
+        fn new(steps: impl IntoIterator<Item = EventStep>) -> Self {
+            Self {
+                steps: steps.into_iter().collect(),
+                calls: 0,
+            }
+        }
+    }
+
+    impl DirEventSource for ScriptedEvents {
+        fn is_available(&self) -> bool {
+            true
+        }
+
+        async fn next_event(&mut self) -> anyhow::Result<()> {
+            self.calls += 1;
+            let step = self.steps.pop_front().expect("event script exhausted");
+            match step {
+                EventStep::Wake => Ok(()),
+                EventStep::ReadError => Err(anyhow!("injected inotify read failure")),
+            }
+        }
+    }
+
+    fn manager_with_live_child(socket_path: PathBuf) -> VmManager {
+        let mut command = Command::new("cat");
+        command
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+        let child = command.spawn().expect("spawn live child");
+
+        let mut vm = VmManager::new("wait-test".to_string(), socket_path, None);
+        vm.process = Some(child);
+        vm
+    }
+
+    async fn assert_pending_once<F>(mut future: Pin<&mut F>)
+    where
+        F: Future,
+    {
+        poll_fn(|cx| match future.as_mut().poll(cx) {
+            Poll::Pending => Poll::Ready(()),
+            Poll::Ready(_) => panic!("future completed before its required signal"),
+        })
+        .await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn api_socket_event_queued_after_check_wakes_without_clock_fallback() {
+        let dir = tempfile::tempdir().expect("create socket directory");
+        let mut vm = manager_with_live_child(dir.path().join("api.sock"));
+        let mut probe = ScriptedProbe::once([ProbeStep::NotFound, ProbeStep::Ready]);
+        let mut events = ScriptedEvents::new([EventStep::Wake]);
+        let before = tokio::time::Instant::now();
+
+        vm.wait_for_socket_with(&mut probe, &mut events)
+            .await
+            .expect("queued directory event should trigger a second probe");
+
+        assert_eq!(probe.calls, 2);
+        assert_eq!(events.calls, 1);
+        assert_eq!(tokio::time::Instant::now(), before, "safety tick fired");
+        vm.kill().await.expect("stop live child");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn api_socket_unavailable_watch_uses_ten_millisecond_fallback() {
+        let dir = tempfile::tempdir().expect("create socket directory");
+        let mut vm = manager_with_live_child(dir.path().join("api.sock"));
+        let mut probe = ScriptedProbe::once([ProbeStep::NotFound, ProbeStep::Ready]);
+        let mut no_watch = None::<crate::utils::DirWatch>;
+        let before = tokio::time::Instant::now();
+
+        vm.wait_for_socket_with(&mut probe, &mut no_watch)
+            .await
+            .expect("poll fallback should re-probe without inotify");
+
+        assert_eq!(probe.calls, 2);
+        assert_eq!(
+            tokio::time::Instant::now() - before,
+            SOCKET_WAIT_RETRY_DELAY
+        );
+        vm.kill().await.expect("stop live child");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn api_socket_inotify_read_error_uses_ten_millisecond_fallback() {
+        let dir = tempfile::tempdir().expect("create socket directory");
+        let mut vm = manager_with_live_child(dir.path().join("api.sock"));
+        let mut probe = ScriptedProbe::once([ProbeStep::NotFound, ProbeStep::Ready]);
+        let mut events = ScriptedEvents::new([EventStep::ReadError]);
+        let before = tokio::time::Instant::now();
+
+        vm.wait_for_socket_with(&mut probe, &mut events)
+            .await
+            .expect("watch read failure should degrade to polling");
+
+        assert_eq!(probe.calls, 2);
+        assert_eq!(events.calls, 1);
+        assert_eq!(
+            tokio::time::Instant::now() - before,
+            SOCKET_WAIT_RETRY_DELAY
+        );
+        vm.kill().await.expect("stop live child");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn persistent_refusal_reports_child_exit_after_complete_stderr() {
+        let dir = tempfile::tempdir().expect("create socket directory");
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("exit 23")
+            .spawn()
+            .expect("spawn exited child");
+        let status = child.wait().await.expect("reap exited child");
+        assert_eq!(status.code(), Some(23));
+
+        let mut vm = VmManager::new(
+            "refused-test".to_string(),
+            dir.path().join("api.sock"),
+            None,
+        );
+        vm.process = Some(child);
+
+        let (reader_started_tx, reader_started_rx) = tokio::sync::oneshot::channel();
+        let (release_reader_tx, release_reader_rx) = tokio::sync::oneshot::channel();
+        let stderr_tail = Arc::clone(&vm.stderr_tail);
+        vm.stderr_reader = Some(tokio::spawn(async move {
+            let _ = reader_started_tx.send(());
+            let _ = release_reader_rx.await;
+            stderr_tail
+                .lock()
+                .expect("stderr tail lock")
+                .push_back("final stderr line".to_string());
+        }));
+        reader_started_rx.await.expect("stderr reader parked");
+
+        let mut probe = ScriptedProbe::repeating(ProbeStep::Refused);
+        let mut no_watch = None::<crate::utils::DirWatch>;
+        let mut wait = Box::pin(vm.wait_for_socket_with(&mut probe, &mut no_watch));
+
+        // The exited-child diagnosis must park on the reader. If the
+        // ECONNREFUSED branch skips liveness, or error formatting races EOF,
+        // this future either retries or completes here instead.
+        assert_pending_once(wait.as_mut()).await;
+        release_reader_tx.send(()).expect("release stderr reader");
+        let err = wait
+            .await
+            .expect_err("an exited child cannot become API-ready");
+        let message = format!("{err:#}");
+
+        assert_eq!(probe.calls, 1, "ECONNREFUSED skipped child liveness");
+        assert!(
+            message.contains("Firecracker exited with exit status: 23"),
+            "{message}"
+        );
+        assert!(message.contains("final stderr line"), "{message}");
+        assert!(!message.contains("socket not ready"), "{message}");
+    }
 
     /// A Firecracker process that exits before creating its API socket must fail
     /// `start()` with its exit status and stderr output, not the generic

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -715,7 +715,29 @@ impl PastaNetwork {
             }));
         }
 
-        // Wait for the PID file to appear (pasta writes it once ready).
+        self.wait_for_pid_file(&mut child, &pid_file, &mut pid_file_watch)
+            .await?;
+
+        self.pasta_process = Some(child);
+        self.pid_file = Some(pid_file);
+
+        Ok(())
+    }
+
+    /// Wait until pasta publishes its readiness PID file while supervising the
+    /// child and retaining a bounded polling fallback.
+    ///
+    /// The event source is a narrow injection boundary for deterministic tests;
+    /// production passes the inotify watch registered before pasta was spawned.
+    async fn wait_for_pid_file<E>(
+        &mut self,
+        child: &mut Child,
+        pid_file: &std::path::Path,
+        pid_file_events: &mut E,
+    ) -> Result<()>
+    where
+        E: crate::utils::DirEventSource,
+    {
         // Event-driven: the inotify watch registered before spawn wakes us the
         // instant the file lands (the old 50ms poll noticed a +2.3ms file at
         // +52.8ms on every rootless clone). pasta death interrupts the wait via
@@ -726,7 +748,7 @@ impl PastaNetwork {
         loop {
             if pid_file.exists() {
                 info!("pasta ready (PID file created)");
-                break;
+                return Ok(());
             }
 
             tokio::select! {
@@ -748,7 +770,7 @@ impl PastaNetwork {
                         Err(e) => anyhow::bail!("failed to check pasta status: {}", e),
                     }
                 }
-                event = crate::utils::DirWatch::next_event_opt(&mut pid_file_watch) => {
+                event = pid_file_events.next_event() => {
                     // Filesystem activity in the data dir — loop re-checks the
                     // PID file. A watch error degrades to the safety tick.
                     if event.is_err() {
@@ -757,6 +779,13 @@ impl PastaNetwork {
                 }
                 _ = tokio::time::sleep_until(deadline) => {
                     let _ = child.kill().await;
+                    // kill() reaped the child and closed its pipe; wait for the
+                    // reader to drain it before rendering the diagnostic tail.
+                    crate::utils::wait_for_stderr_eof(
+                        &mut self.stderr_reader,
+                        PASTA_STDERR_EOF_TIMEOUT,
+                    )
+                    .await;
                     anyhow::bail!(
                         "pasta did not become ready within {:?}{}",
                         PASTA_READY_TIMEOUT,
@@ -768,11 +797,6 @@ impl PastaNetwork {
                 }
             }
         }
-
-        self.pasta_process = Some(child);
-        self.pid_file = Some(pid_file);
-
-        Ok(())
     }
 
     /// Render the captured pasta stderr tail for error messages.
@@ -1250,6 +1274,217 @@ impl NetworkManager for PastaNetwork {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::{DirEventSource, ProcessWatch};
+    use std::future::{poll_fn, Future};
+    use std::pin::Pin;
+    use std::task::Poll;
+
+    enum EventStep {
+        Wake,
+        ReadError,
+    }
+
+    struct PublishingEvents {
+        pid_file: PathBuf,
+        steps: VecDeque<EventStep>,
+        calls: usize,
+    }
+
+    impl PublishingEvents {
+        fn new(pid_file: PathBuf, steps: impl IntoIterator<Item = EventStep>) -> Self {
+            Self {
+                pid_file,
+                steps: steps.into_iter().collect(),
+                calls: 0,
+            }
+        }
+    }
+
+    impl DirEventSource for PublishingEvents {
+        fn is_available(&self) -> bool {
+            true
+        }
+
+        async fn next_event(&mut self) -> anyhow::Result<()> {
+            self.calls += 1;
+            let step = self.steps.pop_front().expect("event script exhausted");
+            let pid_file = self.pid_file.clone();
+            std::fs::write(pid_file, b"123\n").expect("publish pasta PID file");
+            match step {
+                EventStep::Wake => Ok(()),
+                EventStep::ReadError => Err(anyhow::anyhow!("injected inotify read failure")),
+            }
+        }
+    }
+
+    fn live_child() -> Child {
+        let mut command = Command::new("cat");
+        command
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+        command.spawn().expect("spawn live child")
+    }
+
+    async fn assert_pending_once<F>(mut future: Pin<&mut F>)
+    where
+        F: Future,
+    {
+        poll_fn(|cx| match future.as_mut().poll(cx) {
+            Poll::Pending => Poll::Ready(()),
+            Poll::Ready(_) => panic!("future completed before its required signal"),
+        })
+        .await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pid_file_event_queued_after_check_wakes_without_clock_fallback() {
+        let dir = tempfile::tempdir().expect("create PID-file directory");
+        let pid_file = dir.path().join("pasta.pid");
+        let mut events = PublishingEvents::new(pid_file.clone(), [EventStep::Wake]);
+        let mut child = live_child();
+        let mut net = PastaNetwork::new("wait-test".to_string(), "tap0".to_string(), vec![]);
+        let before = tokio::time::Instant::now();
+
+        net.wait_for_pid_file(&mut child, &pid_file, &mut events)
+            .await
+            .expect("queued PID-file event should trigger a condition recheck");
+
+        assert_eq!(events.calls, 1);
+        assert_eq!(tokio::time::Instant::now(), before, "safety tick fired");
+        child.kill().await.expect("stop live child");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pid_file_unavailable_watch_uses_safety_tick_fallback() {
+        let dir = tempfile::tempdir().expect("create PID-file directory");
+        let pid_file = dir.path().join("pasta.pid");
+        let publish_path = pid_file.clone();
+        let mut no_watch = None::<crate::utils::DirWatch>;
+        let mut child = live_child();
+        let mut net = PastaNetwork::new("wait-test".to_string(), "tap0".to_string(), vec![]);
+        let before = tokio::time::Instant::now();
+
+        let wait = net.wait_for_pid_file(&mut child, &pid_file, &mut no_watch);
+        let publish = async move {
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            std::fs::write(publish_path, b"123\n").expect("publish pasta PID file");
+        };
+        let (result, ()) = tokio::join!(wait, publish);
+        result.expect("safety tick should recheck without inotify");
+
+        assert_eq!(
+            tokio::time::Instant::now() - before,
+            std::time::Duration::from_millis(250)
+        );
+        child.kill().await.expect("stop live child");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pid_file_inotify_read_error_uses_poll_fallback() {
+        let dir = tempfile::tempdir().expect("create PID-file directory");
+        let pid_file = dir.path().join("pasta.pid");
+        let mut events = PublishingEvents::new(pid_file.clone(), [EventStep::ReadError]);
+        let mut child = live_child();
+        let mut net = PastaNetwork::new("wait-test".to_string(), "tap0".to_string(), vec![]);
+        let before = tokio::time::Instant::now();
+
+        net.wait_for_pid_file(&mut child, &pid_file, &mut events)
+            .await
+            .expect("watch read failure should degrade to polling");
+
+        assert_eq!(events.calls, 1);
+        assert_eq!(
+            tokio::time::Instant::now() - before,
+            std::time::Duration::from_millis(50)
+        );
+        child.kill().await.expect("stop live child");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pid_file_child_exit_waits_for_complete_stderr() {
+        let dir = tempfile::tempdir().expect("create PID-file directory");
+        let pid_file = dir.path().join("pasta.pid");
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("exit 17")
+            .spawn()
+            .expect("spawn exited child");
+        let status = child.wait().await.expect("reap exited child");
+        assert_eq!(status.code(), Some(17));
+
+        let mut net = PastaNetwork::new("wait-test".to_string(), "tap0".to_string(), vec![]);
+        let (reader_started_tx, reader_started_rx) = tokio::sync::oneshot::channel();
+        let (release_reader_tx, release_reader_rx) = tokio::sync::oneshot::channel();
+        let stderr_tail = Arc::clone(&net.stderr_tail);
+        net.stderr_reader = Some(tokio::spawn(async move {
+            let _ = reader_started_tx.send(());
+            let _ = release_reader_rx.await;
+            stderr_tail
+                .lock()
+                .expect("stderr tail lock")
+                .push_back("final pasta stderr".to_string());
+        }));
+        reader_started_rx.await.expect("stderr reader parked");
+
+        let mut no_watch = None::<crate::utils::DirWatch>;
+        let mut wait = Box::pin(net.wait_for_pid_file(&mut child, &pid_file, &mut no_watch));
+        assert_pending_once(wait.as_mut()).await;
+        release_reader_tx.send(()).expect("release stderr reader");
+        let err = wait.await.expect_err("exited pasta cannot become ready");
+        let message = format!("{err:#}");
+
+        assert!(message.contains("status: exit status: 17"), "{message}");
+        assert!(message.contains("final pasta stderr"), "{message}");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pid_file_timeout_waits_for_complete_stderr() {
+        let dir = tempfile::tempdir().expect("create PID-file directory");
+        let pid_file = dir.path().join("pasta.pid");
+        let mut no_watch = None::<crate::utils::DirWatch>;
+        let mut child = live_child();
+        let child_pid = child.id().expect("live child PID");
+        let mut child_exit = ProcessWatch::open(child_pid)
+            .expect("open child pidfd")
+            .expect("child remains alive");
+
+        let mut net = PastaNetwork::new("wait-test".to_string(), "tap0".to_string(), vec![]);
+        let (reader_started_tx, reader_started_rx) = tokio::sync::oneshot::channel();
+        let (release_reader_tx, release_reader_rx) = tokio::sync::oneshot::channel();
+        let stderr_tail = Arc::clone(&net.stderr_tail);
+        net.stderr_reader = Some(tokio::spawn(async move {
+            let _ = reader_started_tx.send(());
+            let _ = release_reader_rx.await;
+            stderr_tail
+                .lock()
+                .expect("stderr tail lock")
+                .push_back("stderr written immediately before timeout kill".to_string());
+        }));
+        reader_started_rx.await.expect("stderr reader parked");
+
+        let mut wait = Box::pin(net.wait_for_pid_file(&mut child, &pid_file, &mut no_watch));
+        assert_pending_once(wait.as_mut()).await;
+        tokio::time::advance(PASTA_READY_TIMEOUT).await;
+        // Drive the deadline arm far enough to signal the child, then use the
+        // pidfd edge instead of sleeping/retrying for process exit.
+        assert_pending_once(wait.as_mut()).await;
+        child_exit.exited().await;
+
+        // Even after kill/reap completes, the diagnostic must remain blocked on
+        // the stderr EOF reader. This assertion is red if the timeout branch
+        // formats the tail immediately after `child.kill()`.
+        assert_pending_once(wait.as_mut()).await;
+        release_reader_tx.send(()).expect("release stderr reader");
+        let err = wait.await.expect_err("missing PID file must time out");
+        let message = format!("{err:#}");
+
+        assert!(message.contains("did not become ready"), "{message}");
+        assert!(
+            message.contains("stderr written immediately before timeout kill"),
+            "{message}"
+        );
+    }
 
     #[test]
     fn test_network_creation() {

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -693,6 +693,7 @@ impl PastaNetwork {
         }
 
         debug!(cmd = ?cmd, "pasta command");
+        let stderr_tail = self.begin_stderr_attempt();
         let mut child = cmd.spawn().context("failed to spawn pasta")?;
 
         // Stream pasta's stderr: log every line and keep a tail so error paths
@@ -700,7 +701,6 @@ impl PastaNetwork {
         // silently discarded and a dead pasta only surfaces later as an
         // unrelated bridge setup failure.
         if let Some(stderr) = child.stderr.take() {
-            let stderr_tail = Arc::clone(&self.stderr_tail);
             self.stderr_reader = Some(tokio::spawn(async move {
                 let mut lines = BufReader::new(stderr).lines();
                 while let Ok(Some(line)) = lines.next_line().await {
@@ -722,6 +722,23 @@ impl PastaNetwork {
         self.pid_file = Some(pid_file);
 
         Ok(())
+    }
+
+    /// Start an attempt-local stderr capture.
+    ///
+    /// A failed attempt's pipe reader can outlive the child (for example, when a
+    /// descendant inherited stderr). Merely clearing the shared deque leaves a
+    /// race where that old reader appends after the next attempt starts. Give
+    /// every attempt a distinct tail and cancel any reader we no longer own so
+    /// stale output is structurally unable to enter the current diagnostic.
+    fn begin_stderr_attempt(&mut self) -> Arc<Mutex<VecDeque<String>>> {
+        if let Some(previous_reader) = self.stderr_reader.take() {
+            previous_reader.abort();
+        }
+
+        let stderr_tail = Arc::new(Mutex::new(VecDeque::new()));
+        self.stderr_tail = Arc::clone(&stderr_tail);
+        stderr_tail
     }
 
     /// Wait until pasta publishes its readiness PID file while supervising the
@@ -1484,6 +1501,35 @@ mod tests {
             message.contains("stderr written immediately before timeout kill"),
             "{message}"
         );
+    }
+
+    #[test]
+    fn pasta_retry_stderr_isolated_from_late_previous_attempt_output() {
+        let mut net = PastaNetwork::new("wait-test".to_string(), "tap0".to_string(), vec![]);
+
+        let previous_attempt = net.begin_stderr_attempt();
+        previous_attempt
+            .lock()
+            .expect("previous stderr tail lock")
+            .push_back("previous attempt before retry".to_string());
+
+        let current_attempt = net.begin_stderr_attempt();
+        previous_attempt
+            .lock()
+            .expect("previous stderr tail lock")
+            .push_back("previous attempt after retry".to_string());
+        current_attempt
+            .lock()
+            .expect("current stderr tail lock")
+            .push_back("current attempt output".to_string());
+
+        let message = net.stderr_tail_message();
+        assert!(
+            !Arc::ptr_eq(&previous_attempt, &current_attempt),
+            "a retry must publish a fresh tail so a detached old reader cannot append to it"
+        );
+        assert!(message.contains("current attempt output"), "{message}");
+        assert!(!message.contains("previous attempt"), "{message}");
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -345,10 +345,14 @@ pub async fn wait_for_stderr_eof(
     reader: &mut Option<tokio::task::JoinHandle<()>>,
     timeout: Duration,
 ) {
-    let Some(handle) = reader.take() else {
+    let Some(mut handle) = reader.take() else {
         return;
     };
-    if tokio::time::timeout(timeout, handle).await.is_err() {
+    if tokio::time::timeout(timeout, &mut handle).await.is_err() {
+        // Timing out must also stop the reader: dropping a JoinHandle only
+        // detaches the task, which would leave it consuming the pipe (and
+        // logging under this attempt's context) while the next attempt runs.
+        handle.abort();
         warn!(
             timeout_ms = timeout.as_millis() as u64,
             "stderr pipe did not reach EOF within the bound; error output may be truncated"
@@ -864,5 +868,38 @@ mod tests {
     #[test]
     fn test_strip_firecracker_prefix_plain() {
         assert_eq!(strip_firecracker_prefix("plain message"), "plain message");
+    }
+
+    #[tokio::test]
+    async fn stderr_eof_timeout_aborts_the_reader() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        // A reader whose pipe never reaches EOF: the sender side stays held,
+        // standing in for a grandchild that inherited the write end.
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<u8>(4);
+        let reads = Arc::new(AtomicUsize::new(0));
+        let reads_in_task = reads.clone();
+        let mut reader = Some(tokio::spawn(async move {
+            while rx.recv().await.is_some() {
+                reads_in_task.fetch_add(1, Ordering::SeqCst);
+            }
+        }));
+
+        // The channel is still open, so this must take the timeout path.
+        wait_for_stderr_eof(&mut reader, Duration::from_millis(50)).await;
+        assert!(reader.is_none(), "the handle must be taken either way");
+
+        // The timed-out reader must be aborted, not detached: data arriving
+        // after the bound must never be consumed under the old attempt's
+        // context. Detached (the bug), the still-live task consumes the send
+        // immediately; aborted, its receiver is gone and the send just fails.
+        let _ = tx.send(1).await;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(
+            reads.load(Ordering::SeqCst),
+            0,
+            "stderr reader survived its EOF timeout and kept consuming the pipe"
+        );
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -52,17 +52,6 @@ impl DirWatch {
         Ok(Self { async_fd, inotify })
     }
 
-    /// [`next_event`](Self::next_event) over an optional watch: a `None` watch
-    /// (inotify init failed — e.g. `fs.inotify.max_user_instances` exhausted by
-    /// many concurrent fcvm processes) never completes, so a `select!` caller
-    /// degrades to its safety-tick/deadline arms instead of failing hard.
-    pub async fn next_event_opt(watch: &mut Option<Self>) -> anyhow::Result<()> {
-        match watch {
-            Some(w) => w.next_event().await,
-            None => std::future::pending().await,
-        }
-    }
-
     /// Wait until at least one filesystem event has been consumed.
     ///
     /// Drains everything currently queued (the event batch is only a wakeup —
@@ -82,6 +71,32 @@ impl DirWatch {
                 }
                 Err(e) => return Err(anyhow::anyhow!("reading inotify events: {e}")),
             }
+        }
+    }
+}
+
+/// Filesystem-event source used by readiness loops.
+///
+/// Keeping the wait loops generic over this tiny boundary lets their rare
+/// inotify-unavailable and inotify-read-error paths be driven deterministically
+/// in unit tests. Production uses `Option<DirWatch>`: `None` is an unavailable
+/// watch whose event future never resolves, leaving the caller's safety tick and
+/// deadline as the correctness path.
+pub(crate) trait DirEventSource {
+    fn is_available(&self) -> bool;
+
+    async fn next_event(&mut self) -> anyhow::Result<()>;
+}
+
+impl DirEventSource for Option<DirWatch> {
+    fn is_available(&self) -> bool {
+        self.is_some()
+    }
+
+    async fn next_event(&mut self) -> anyhow::Result<()> {
+        match self {
+            Some(watch) => watch.next_event().await,
+            None => std::future::pending().await,
         }
     }
 }
@@ -763,6 +778,23 @@ pub fn install_namespace_pre_exec(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn dir_watch_consumes_event_queued_between_check_and_park() {
+        let dir = tempfile::tempdir().expect("create watched directory");
+        let appeared = dir.path().join("appeared");
+        let mut watch = DirWatch::new(dir.path()).expect("register directory watch");
+
+        // This is the readiness-loop ordering: watch first, condition check,
+        // then the producer wins immediately before `next_event()` is polled.
+        assert!(!appeared.exists());
+        std::fs::write(&appeared, b"ready").expect("publish watched file");
+
+        tokio::time::timeout(Duration::from_secs(1), watch.next_event())
+            .await
+            .expect("queued inotify event was lost")
+            .expect("consume queued inotify event");
+    }
 
     #[test]
     fn test_is_process_alive_current_process() {

--- a/tests/test_ci_infrastructure.py
+++ b/tests/test_ci_infrastructure.py
@@ -1,6 +1,7 @@
 import importlib.util
 import json
 import os
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -163,9 +164,11 @@ class StrayVmGuardTests(unittest.TestCase):
         self,
         ps_output: str,
         *,
+        ps_output_after: str | None = None,
         hang_ps: bool = False,
+        dry_run: bool = True,
         outer_timeout: float = 5,
-    ) -> tuple[subprocess.CompletedProcess[str], Path, str, float]:
+    ) -> tuple[subprocess.CompletedProcess[str], Path, str, str, float]:
         temporary = tempfile.TemporaryDirectory()
         self.addCleanup(temporary.cleanup)
         root = Path(temporary.name)
@@ -174,6 +177,7 @@ class StrayVmGuardTests(unittest.TestCase):
         bin_dir.mkdir()
         log_dir.mkdir()
         ps_calls = root / "ps-calls"
+        sudo_calls = root / "sudo-calls"
 
         fake_ps = bin_dir / "ps"
         fake_ps.write_text(
@@ -183,9 +187,21 @@ class StrayVmGuardTests(unittest.TestCase):
             "  *args*|*cmdline*|*command*) exit 93 ;;\n"
             "esac\n"
             "if [ \"${MOCK_PS_HANG:-0}\" = 1 ]; then exec sleep 30; fi\n"
-            "printf '%s' \"${MOCK_PS_OUTPUT:-}\"\n"
+            "call_count=$(wc -l <\"$MOCK_PS_CALLS\")\n"
+            "if [ \"$call_count\" -gt 1 ]; then\n"
+            "  printf '%s' \"$MOCK_PS_OUTPUT_AFTER\"\n"
+            "else\n"
+            "  printf '%s' \"${MOCK_PS_OUTPUT:-}\"\n"
+            "fi\n"
         )
         fake_ps.chmod(0o755)
+
+        fake_sudo = bin_dir / "sudo"
+        fake_sudo.write_text(
+            "#!/usr/bin/env bash\n"
+            "printf '%s\\n' \"$*\" >>\"$MOCK_SUDO_CALLS\"\n"
+        )
+        fake_sudo.chmod(0o755)
 
         env = os.environ.copy()
         env.update(
@@ -196,11 +212,18 @@ class StrayVmGuardTests(unittest.TestCase):
                 "MOCK_PS_CALLS": str(ps_calls),
                 "MOCK_PS_HANG": "1" if hang_ps else "0",
                 "MOCK_PS_OUTPUT": ps_output,
+                "MOCK_PS_OUTPUT_AFTER": (
+                    ps_output if ps_output_after is None else ps_output_after
+                ),
+                "MOCK_SUDO_CALLS": str(sudo_calls),
             }
         )
+        command = [str(STRAY_GUARD), "post"]
+        if dry_run:
+            command.append("--dry-run")
         started = time.monotonic()
         result = subprocess.run(
-            [str(STRAY_GUARD), "post", "--dry-run"],
+            command,
             cwd=ROOT,
             env=env,
             text=True,
@@ -209,7 +232,108 @@ class StrayVmGuardTests(unittest.TestCase):
             check=False,
         )
         elapsed = time.monotonic() - started
-        return result, log_dir, ps_calls.read_text() if ps_calls.exists() else "", elapsed
+        return (
+            result,
+            log_dir,
+            ps_calls.read_text() if ps_calls.exists() else "",
+            sudo_calls.read_text() if sudo_calls.exists() else "",
+            elapsed,
+        )
+
+    def run_guard_with_scanner_descendant_holding_stderr(
+        self,
+    ) -> tuple[subprocess.CompletedProcess[str], Path, bool, float]:
+        """Keep a scanner descendant alive until the test releases it.
+
+        The scanner itself exceeds the guard deadline and is killed. Before the
+        fix, its descendant inherits the guard's stderr-to-tee descriptor, so
+        communicate() cannot observe EOF even after the guard exits.
+        """
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        bin_dir = root / "bin"
+        log_dir = root / "logs"
+        release = root / "release-scanner-descendant"
+        descendant_ready = root / "scanner-descendant-ready"
+        descendant_done = root / "scanner-descendant-done"
+        bin_dir.mkdir()
+        log_dir.mkdir()
+
+        fake_ps = bin_dir / "ps"
+        fake_ps.write_text(
+            "#!/usr/bin/env bash\n"
+            "(\n"
+            "  : >\"$MOCK_PS_DESCENDANT_READY\"\n"
+            "  while [ ! -e \"$MOCK_PS_RELEASE\" ]; do /bin/sleep 0.05; done\n"
+            "  exec 2>&-\n"
+            "  : >\"$MOCK_PS_DESCENDANT_DONE\"\n"
+            ") &\n"
+            "exec /bin/sleep 30\n"
+        )
+        fake_ps.chmod(0o755)
+
+        # The guard calls sleep between scanner polls. Hold that first poll until
+        # the descriptor-holding descendant exists, then advance past the scan
+        # deadline. This makes the inherited-FD interleaving deterministic even
+        # on a heavily loaded runner.
+        fake_sleep = bin_dir / "sleep"
+        fake_sleep.write_text(
+            "#!/usr/bin/env bash\n"
+            "while [ ! -e \"$MOCK_PS_DESCENDANT_READY\" ]; do /bin/sleep 0.01; done\n"
+            "exec /bin/sleep 1.1\n"
+        )
+        fake_sleep.chmod(0o755)
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{bin_dir}:{env['PATH']}",
+                "FCVM_TEST_LOG_DIR": str(log_dir),
+                "FCVM_GUARD_SCAN_TIMEOUT_SECONDS": "1",
+                "MOCK_PS_RELEASE": str(release),
+                "MOCK_PS_DESCENDANT_READY": str(descendant_ready),
+                "MOCK_PS_DESCENDANT_DONE": str(descendant_done),
+            }
+        )
+        started = time.monotonic()
+        process = subprocess.Popen(
+            [str(STRAY_GUARD), "post", "--dry-run"],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        drained_before_release = True
+        try:
+            stdout, stderr = process.communicate(timeout=2.5)
+        except subprocess.TimeoutExpired:
+            drained_before_release = False
+            release.touch()
+            stdout, stderr = process.communicate(timeout=3)
+        finally:
+            release.touch(exist_ok=True)
+            if process.poll() is None:
+                process.kill()
+                process.wait(timeout=3)
+        descendant_deadline = time.monotonic() + 3
+        while not descendant_done.exists() and time.monotonic() < descendant_deadline:
+            time.sleep(0.01)
+        if not descendant_done.exists():
+            raise AssertionError("scanner descendant did not exit after release")
+        elapsed = time.monotonic() - started
+        return (
+            subprocess.CompletedProcess(
+                args=process.args,
+                returncode=process.returncode,
+                stdout=stdout,
+                stderr=stderr,
+            ),
+            log_dir,
+            drained_before_release,
+            elapsed,
+        )
 
     def test_enumerates_every_thread_without_reading_command_lines(self) -> None:
         # ps columns: TGID TID PPID STATE COMM. The leader is already a zombie,
@@ -221,7 +345,7 @@ class StrayVmGuardTests(unittest.TestCase):
             "200 200 1 S unrelated\n"
         )
 
-        result, log_dir, ps_calls, _elapsed = self.run_guard(output)
+        result, log_dir, ps_calls, _sudo_calls, _elapsed = self.run_guard(output)
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertNotRegex(ps_calls, r"args|cmdline|command")
@@ -234,7 +358,9 @@ class StrayVmGuardTests(unittest.TestCase):
         self.assertIn("100\t101\t1\tD\tfc_vcpu 0", thread_report.read_text())
 
     def test_scan_timeout_is_bounded_and_still_emits_artifacts(self) -> None:
-        result, log_dir, ps_calls, elapsed = self.run_guard("", hang_ps=True)
+        result, log_dir, ps_calls, _sudo_calls, elapsed = self.run_guard(
+            "", hang_ps=True
+        )
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertLess(elapsed, 4)
@@ -244,12 +370,55 @@ class StrayVmGuardTests(unittest.TestCase):
         self.assertTrue((log_dir / "stray-vm-threads-post-before.tsv").is_file())
 
     def test_zero_target_scan_still_emits_diagnostics(self) -> None:
-        result, log_dir, _ps_calls, _elapsed = self.run_guard("")
+        result, log_dir, _ps_calls, _sudo_calls, _elapsed = self.run_guard("")
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("0 stray process group", result.stdout)
         self.assertTrue((log_dir / "stray-vm-guard-post.log").is_file())
         self.assertTrue((log_dir / "stray-vm-threads-post-before.tsv").is_file())
+
+    def test_scan_timeout_does_not_leave_the_report_pipe_open(self) -> None:
+        result, log_dir, drained_before_release, elapsed = (
+            self.run_guard_with_scanner_descendant_holding_stderr()
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(
+            drained_before_release,
+            "a scanner descendant inherited stderr and kept the report pipe open",
+        )
+        self.assertLess(elapsed, 2.5)
+        self.assertIn("timed out", result.stdout.lower())
+        self.assertTrue((log_dir / "stray-vm-guard-post.log").is_file())
+
+    def test_cleanup_kills_each_group_once_and_reports_survivors(self) -> None:
+        before = (
+            "100 100 1 S firecracker\n"
+            "100 101 1 D fc_vcpu 0\n"
+            "200 200 1 S fcvm\n"
+            "200 201 1 S worker\n"
+        )
+        after = "100 100 1 D firecracker\n100 101 1 D fc_vcpu 0\n"
+
+        result, log_dir, _ps_calls, sudo_calls, _elapsed = self.run_guard(
+            before,
+            ps_output_after=after,
+            dry_run=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        commands = [shlex.split(line) for line in sudo_calls.splitlines()]
+        self.assertCountEqual(
+            commands,
+            [["kill", "-9", "--", "100"], ["kill", "-9", "--", "200"]],
+        )
+        self.assertIn(
+            "killed 2 process group(s), still live after SIGKILL: 1", result.stdout
+        )
+        self.assertIn("Unkillable microVMs", result.stdout)
+        after_report = log_dir / "stray-vm-threads-post-after.tsv"
+        self.assertTrue(after_report.is_file())
+        self.assertIn("100\t101\t1\tD\tfc_vcpu 0", after_report.read_text())
 
 
 if __name__ == "__main__":

--- a/tests/test_ci_infrastructure.py
+++ b/tests/test_ci_infrastructure.py
@@ -1,7 +1,10 @@
 import importlib.util
 import json
+import os
 import subprocess
 import sys
+import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -10,6 +13,7 @@ from unittest import mock
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "classify_ci_failure.py"
 FIXTURES = ROOT / "tests" / "fixtures" / "ci-infrastructure"
+STRAY_GUARD = ROOT / "scripts" / "ci-stray-vm-guard.sh"
 
 CLASSIFIER_SPEC = importlib.util.spec_from_file_location(
     "classify_ci_failure", SCRIPT
@@ -152,6 +156,100 @@ class CiInfrastructureClassificationTests(unittest.TestCase):
         self.assertEqual(result["run_attempt"], 2)
         self.assertEqual(result["classification"], "infrastructure")
         self.assertFalse(result["rerun_failed_jobs"])
+
+
+class StrayVmGuardTests(unittest.TestCase):
+    def run_guard(
+        self,
+        ps_output: str,
+        *,
+        hang_ps: bool = False,
+        outer_timeout: float = 5,
+    ) -> tuple[subprocess.CompletedProcess[str], Path, str, float]:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        bin_dir = root / "bin"
+        log_dir = root / "logs"
+        bin_dir.mkdir()
+        log_dir.mkdir()
+        ps_calls = root / "ps-calls"
+
+        fake_ps = bin_dir / "ps"
+        fake_ps.write_text(
+            "#!/usr/bin/env bash\n"
+            "printf '%s\\n' \"$*\" >>\"$MOCK_PS_CALLS\"\n"
+            "case \"$*\" in\n"
+            "  *args*|*cmdline*|*command*) exit 93 ;;\n"
+            "esac\n"
+            "if [ \"${MOCK_PS_HANG:-0}\" = 1 ]; then exec sleep 30; fi\n"
+            "printf '%s' \"${MOCK_PS_OUTPUT:-}\"\n"
+        )
+        fake_ps.chmod(0o755)
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{bin_dir}:{env['PATH']}",
+                "FCVM_TEST_LOG_DIR": str(log_dir),
+                "FCVM_GUARD_SCAN_TIMEOUT_SECONDS": "1",
+                "MOCK_PS_CALLS": str(ps_calls),
+                "MOCK_PS_HANG": "1" if hang_ps else "0",
+                "MOCK_PS_OUTPUT": ps_output,
+            }
+        )
+        started = time.monotonic()
+        result = subprocess.run(
+            [str(STRAY_GUARD), "post", "--dry-run"],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=outer_timeout,
+            check=False,
+        )
+        elapsed = time.monotonic() - started
+        return result, log_dir, ps_calls.read_text() if ps_calls.exists() else "", elapsed
+
+    def test_enumerates_every_thread_without_reading_command_lines(self) -> None:
+        # ps columns: TGID TID PPID STATE COMM. The leader is already a zombie,
+        # but its vCPU sibling is blocked in D state and still owns KVM resources.
+        output = (
+            "100 100 1 Z firecracker-def\n"
+            "100 101 1 D fc_vcpu 0\n"
+            "100 102 1 S fc_vcpu 1\n"
+            "200 200 1 S unrelated\n"
+        )
+
+        result, log_dir, ps_calls, _elapsed = self.run_guard(output)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotRegex(ps_calls, r"args|cmdline|command")
+        self.assertRegex(result.stdout, r"100\s+101")
+        self.assertIn("fc_vcpu 0", result.stdout)
+        self.assertRegex(result.stdout, r"100\s+102")
+        self.assertTrue((log_dir / "stray-vm-guard-post.log").is_file())
+        thread_report = log_dir / "stray-vm-threads-post-before.tsv"
+        self.assertTrue(thread_report.is_file())
+        self.assertIn("100\t101\t1\tD\tfc_vcpu 0", thread_report.read_text())
+
+    def test_scan_timeout_is_bounded_and_still_emits_artifacts(self) -> None:
+        result, log_dir, ps_calls, elapsed = self.run_guard("", hang_ps=True)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertLess(elapsed, 4)
+        self.assertNotRegex(ps_calls, r"args|cmdline|command")
+        self.assertIn("timed out", result.stdout.lower())
+        self.assertTrue((log_dir / "stray-vm-guard-post.log").is_file())
+        self.assertTrue((log_dir / "stray-vm-threads-post-before.tsv").is_file())
+
+    def test_zero_target_scan_still_emits_diagnostics(self) -> None:
+        result, log_dir, _ps_calls, _elapsed = self.run_guard("")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("0 stray process group", result.stdout)
+        self.assertTrue((log_dir / "stray-vm-guard-post.log").is_file())
+        self.assertTrue((log_dir / "stray-vm-threads-post-before.tsv").is_file())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Base:** `main` (former stack base PR #778 is merged)

Advances #776.

## Problem

The Firecracker API-socket wait, pasta PID-file wait, and guest restore-epoch watcher are event-driven, but their important wakeup and fallback interleavings were not independently schedulable in unit tests. That left queued signals, unavailable or failed watches, closed reset senders, child exits, and timeout diagnostics vulnerable to regressions that ordinary wall-clock tests would not reliably expose.

The pasta deadline path also formatted its failure tail immediately after killing pasta instead of waiting for the stderr reader to drain to EOF, so the most relevant final diagnostic lines could be omitted. On a retry, every attempt reused the same stderr-tail allocation and overwrote the prior reader handle. A prior reader that outlived its child could therefore append old output after the new attempt began; clearing the deque alone would still race that late writer.

The arm64 SnapshotEnabled run then exposed a separate diagnostic failure: the post-test stray-VM guard read target command lines and inspected only process leaders. A task blocked behind a dying address space could hang the guard itself, while a zombie leader with a still-live vCPU sibling was incorrectly treated as harmless.

The bounded replacement scanner still inherited the guard's stderr-to-`tee` descriptor. If that scanner or one of its descendants became uninterruptible, SIGKILL could remain pending while the inherited writer kept the workflow caller blocked waiting for EOF.

## Solution

- Extract narrow probe/event schedules for the Firecracker API socket, pasta PID file, and guest restore epoch.
- Use paused Tokio time and scripted event sources to cover all signal, fallback, exit, and deadline interleavings deterministically.
- Wait for pasta's stderr reader after a deadline kill before constructing the failure diagnostic.
- Give each pasta startup attempt a fresh stderr-tail allocation and abort the obsolete reader, so a late old writer cannot contaminate the current attempt by construction.
- Replace the optional-watch helper with a shared `DirEventSource` boundary used by production and tests.
- Preserve #771's ARP-neighbor readiness predicate and shared five-second port-forwarding deadline.
- Make the CI stray-VM guard inspect bounded TGID/TID/PPID/state/comm snapshots only—never argv/cmdline.
- Report complete task groups, including live siblings beneath zombie leaders, and always publish before/after thread artifacts even when enumeration times out.
- Signal each matching task group once without waiting on a timed-out scanner.
- Redirect each background scanner's stderr to a temporary regular file before launch, then replay available diagnostics without allowing a wedged scanner to retain the report pipe.
- Exercise the actual non-dry-run kill and post-scan path, including one signal per TGID and D-state survivor reporting.

The guard change makes the failure observable and keeps diagnostics bounded; it deliberately does not serialize tests or claim to fix the underlying concurrent VM-lifecycle failure.

## Red verification

`test_scan_timeout_does_not_leave_the_report_pipe_open` deterministically starts a scanner descendant that retains stderr. With the production redirect removed, the scanner timeout fires but the caller cannot observe EOF; the test is the only failure. Restoring the redirect returns the complete gate to green.

`pasta_retry_stderr_isolated_from_late_previous_attempt_output` writes through the prior attempt's retained tail after beginning the next attempt. The unfixed full unit gate failed only this test (520/521); the fixed gate passed 521/521; restoring only the shared-tail behavior failed the focused test twice; restoring the fix passed the identical command.

## Test Results

```text
$ make test-ci-infrastructure
Ran 14 tests
OK

$ make test-unit STREAM=1
Summary: 521 passed, 0 skipped

$ make test-fast FILTER=pasta_retry_stderr_isolated_from_late_previous_attempt_output STREAM=1
Summary: 1 passed

$ make lint
fmt, clippy -D warnings, audit, and deny passed

$ bash -n scripts/ci-stray-vm-guard.sh
passed

$ git diff --check
clean
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved VM and networking startup reliability when waiting for sockets, process readiness, or PID files.
  - Preserved complete error output after child-process failures and timeouts.
  - Improved restore polling responsiveness and fallback behavior when notifications are unavailable or closed.
  - Strengthened cleanup and reporting for leftover virtual machine processes.

- **Tests**
  - Added comprehensive coverage for readiness events, polling fallbacks, diagnostics, retries, and CI process cleanup.

- **Chores**
  - Updated development tooling to support enhanced asynchronous test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->