### PR TITLE
Wait for the console recovery summary itself

### DIFF
--- a/fc-agent/src/console.rs
+++ b/fc-agent/src/console.rs
@@ -677,14 +677,22 @@ mod tests {
         // Recover the console: drain everything. The writer must flush its
         // pending bytes and append ONE summary line about the dropped bytes.
         let mut sunk: Vec<u8> = Vec::new();
-        assert!(wait_until(
-            || {
-                // Keep draining until the writer reports fully flushed.
-                drain_console(&mut console_rd, &mut sunk);
-                state.flushed() && state.dropped.load(Ordering::SeqCst) == 0
-            },
-            Duration::from_secs(10)
-        ));
+        assert!(
+            wait_until(
+                || {
+                    // Observe the promised external effect itself. `dropped` is
+                    // cleared immediately before the summary is appended to the
+                    // writer's pending queue, so `flushed() && dropped == 0` has
+                    // a legitimate transient window before the summary is
+                    // visible on the console.
+                    drain_console(&mut console_rd, &mut sunk);
+                    String::from_utf8_lossy(&sunk)
+                        .contains("bytes of log output while the console was stalled")
+                },
+                Duration::from_secs(10)
+            ),
+            "writer must emit the recovery summary after the console drains"
+        );
 
         let text = String::from_utf8_lossy(&sunk);
         let summaries = text.matches("dropped").count();


### PR DESCRIPTION
## The problem

`test_console_stall_drops_and_summarizes_on_recovery` waited for `flushed() && dropped == 0`, then immediately inspected the console bytes for the recovery summary. The writer clears `dropped` immediately before it appends that summary to its pending queue, so the predicate has a legitimate transient window where the promised output is not observable yet. In a full unit run this produced a first-attempt failure with zero summaries, followed by a passing nextest retry.

## The fix

Wait for the externally observable recovery-summary bytes themselves. The existing exact-one-summary assertion remains unchanged, so this does not weaken what the test proves.

## Test results

```text
$ make cargo-target-link _test-fast FILTER="-E 'test(test_console_stall_drops_and_summarizes_on_recovery)'" STREAM=1
Summary: 1 test run: 1 passed, 558 skipped

$ make test-unit
Summary: 471 tests run: 471 passed, 0 skipped

$ make lint
passed
```