### PR TITLE
Capture and reproduce the SIGKILL-survivor teardown wedge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,6 +641,11 @@ jobs:
       - name: test-root
         working-directory: fcvm
         run: |
+          # Stream teardown-wedge evidence into THIS step's live log. When a
+          # SIGKILLed VMM wedges the runner (run 31363886999), the ephemeral
+          # instance is terminated with its artifacts — the live log pipe is
+          # the only channel that survives, so the watchdog must share it.
+          sudo ./scripts/ci-dstate-watchdog.sh & WD=$!
           SNAPSHOT_DIR="${FCVM_DATA_DIR:-/mnt/fcvm-btrfs/root}/snapshots"
           for i in $(seq 1 ${{ matrix.test_runs }}); do
             echo ""
@@ -659,6 +664,7 @@ jobs:
               echo "✓ Run 2 complete - snapshot hit paths tested"
             fi
           done
+          sudo kill $WD 2>/dev/null || true
       - name: bench-vm
         if: matrix.mode == 'SnapshotEnabled'
         working-directory: fcvm

--- a/.github/workflows/teardown-evidence.yml
+++ b/.github/workflows/teardown-evidence.yml
@@ -1,0 +1,134 @@
+name: Teardown Evidence
+
+# Manual harness for the SIGKILL-survivor teardown class (a killed firecracker
+# staying non-zombie in D state during clone teardown). Two modes:
+#   folio-lock       deterministic RED — swap on a dm device, suspend it, touch
+#                    swapped pages, SIGKILL mid-fault; exit 3 = did not manifest
+#   compaction-storm bounded probe of the original race (clone churn + SIGKILL
+#                    under a manual-compaction loop)
+# Both archive their evidence as an artifact; the wild strike archived nothing
+# because the runner was recycled with the stacks still unread.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Which reproduction to run'
+        type: choice
+        options:
+          - folio-lock
+          - compaction-storm
+        default: folio-lock
+      storm_iterations:
+        description: 'Bounded clone-churn iterations (compaction-storm mode)'
+        default: '10'
+      red_window_seconds:
+        description: 'Seconds a SIGKILLed VMM must stay unreaped to count as reproduced'
+        default: '20'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  evidence:
+    name: Teardown-Evidence-arm64
+    runs-on: [self-hosted, Linux, ARM64]
+    timeout-minutes: 90
+    steps:
+      # Fix ownership of root-owned files from previous test runs (sudo test runner)
+      - name: Fix workspace permissions (pre-checkout)
+        run: |
+          sudo chown -R $USER:$USER ${{ github.workspace }}/fcvm 2>/dev/null || true
+          sudo chmod -R u+w ~/.cargo/advisory-db* 2>/dev/null || true
+          sudo chown -R $USER:$USER ~/.cargo/advisory-db* 2>/dev/null || true
+      - uses: actions/checkout@v7
+        with:
+          path: fcvm
+      - uses: ./fcvm/.github/actions/checkout-deps
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          # rust-toolchain.toml handles version + components; just trigger install
+          rustup show active-toolchain || true
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y fuse3 libfuse3-dev libclang-dev clang musl-tools \
+            iproute2 iptables passt dnsmasq qemu-utils e2fsprogs parted patch \
+            podman skopeo busybox-static cpio zstd autoconf automake libtool cmake \
+            libseccomp-dev dmsetup
+      - name: Build passt from source
+        working-directory: fcvm
+        run: ./scripts/build-passt.sh
+      - name: Install Firecracker
+        run: |
+          ARCH=$(uname -m)
+          FC_VERSION="1.14.0"
+          curl -L -o /tmp/firecracker.tgz \
+            "https://github.com/firecracker-microvm/firecracker/releases/download/v${FC_VERSION}/firecracker-v${FC_VERSION}-${ARCH}.tgz"
+          sudo tar -xzf /tmp/firecracker.tgz -C /usr/local/bin --strip-components=1 \
+            "release-v${FC_VERSION}-${ARCH}/firecracker-v${FC_VERSION}-${ARCH}" \
+            "release-v${FC_VERSION}-${ARCH}/jailer-v${FC_VERSION}-${ARCH}"
+          sudo mv "/usr/local/bin/firecracker-v${FC_VERSION}-${ARCH}" /usr/local/bin/firecracker
+          sudo mv "/usr/local/bin/jailer-v${FC_VERSION}-${ARCH}" /usr/local/bin/jailer
+      - name: Setup KVM and networking
+        run: |
+          sudo chmod 666 /dev/kvm
+          sudo mkdir -p /var/run/netns
+          if [ ! -e /dev/userfaultfd ]; then
+            sudo mknod /dev/userfaultfd c 10 126
+          fi
+          sudo chmod 666 /dev/userfaultfd
+          sudo sysctl -w vm.unprivileged_userfaultfd=1
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 2>/dev/null || true
+          sudo sysctl -w net.ipv4.conf.all.forwarding=1
+          sudo sysctl -w net.ipv4.conf.default.forwarding=1
+          sudo sysctl -w net.ipv6.conf.all.forwarding=1
+          sudo sysctl -w net.ipv6.conf.default.forwarding=1
+          # Keep accepting Router Advertisements with forwarding enabled (otherwise default route expires)
+          DEFAULT_IFACE=$(ip route show default | awk '/dev/{print $5; exit}')
+          sudo sysctl -w "net.ipv6.conf.${DEFAULT_IFACE}.accept_ra=2" 2>/dev/null || true
+          echo "user_allow_other" | sudo tee /etc/fuse.conf
+          # Move podman storage to btrfs (more space for container images)
+          mkdir -p ~/.config/containers
+          printf '[storage]\ndriver = "overlay"\ngraphroot = "/mnt/fcvm-btrfs/containers/storage"\n' > ~/.config/containers/storage.conf
+          podman system migrate || true
+      - name: Create test log directory
+        run: sudo rm -rf /tmp/fcvm-test-logs && mkdir -p /tmp/fcvm-test-logs
+      - name: Clean test data
+        working-directory: fcvm
+        run: make clean-test-data || true
+      - name: setup-fcvm
+        working-directory: fcvm
+        run: make setup-fcvm
+      - name: Run reproduction
+        working-directory: fcvm
+        env:
+          FUSE_BACKEND_RS: ${{ github.workspace }}/fuse-backend-rs
+          FUSER: ${{ github.workspace }}/fuser
+          # Inputs enter the shell through env, never expression interpolation.
+          MODE: ${{ inputs.mode }}
+          STORM_ITERATIONS: ${{ inputs.storm_iterations }}
+          RED_WINDOW: ${{ inputs.red_window_seconds }}
+        run: |
+          sudo rm -rf /tmp/fcvm-teardown-evidence
+          # Root reads its own fcvm config; setup-fcvm synced it for both users.
+          sudo ./target/release/fcvm setup --generate-config --force
+          if [ "$MODE" = "compaction-storm" ]; then
+            sudo env FCVM_RED_WINDOW_SECONDS="$RED_WINDOW" \
+              ./scripts/teardown-compaction-storm.sh "$STORM_ITERATIONS"
+          else
+            sudo env FCVM_RED_WINDOW_SECONDS="$RED_WINDOW" \
+              ./scripts/teardown-folio-lock-red.sh
+          fi
+      - name: Upload evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: teardown-evidence-${{ github.run_id }}
+          path: |
+            /tmp/fcvm-teardown-evidence/
+            /tmp/fcvm-test-logs/
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/ci-dstate-watchdog.sh
+++ b/scripts/ci-dstate-watchdog.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# In-job D-state watchdog: stream teardown-wedge evidence into the LIVE job log.
+#
+# Why stdout and nothing else: CI run 31363886999 (job 93378160536) wedged
+# test-root on an EPHEMERAL runner — the log stream stopped at 07:35:56, the
+# job failed at 07:47:53, and the instance was terminated. Post-job guard
+# steps and artifact uploads structurally cannot capture that class: the
+# runner dies with its evidence, every time. Whatever already reached the
+# step's log pipe is the only thing that survives, so this watchdog is
+# backgrounded INSIDE the test step and prints there.
+#
+# Detection: a firecracker/cloud-hypervis/fcvm task group with a D-state
+# sibling in two CONSECUTIVE samples (~40s at the default 20s interval), or a
+# zombie leader with a live sibling for two consecutive samples. One sample is
+# deliberately not enough — ordinary I/O passes through D for moments and an
+# exiting group is briefly zombie-led; persistence is what separates a wedge
+# from a snapshot of normal life. When healthy it prints NOTHING: a green run
+# pays zero log lines for this.
+#
+# On first detection it prints a delimited full dump (per-TID stack/wchan/
+# status, kcompactd/kswapd stack samples, vmstat compaction counters, memory
+# pressure, dmesg tail), then rate-limits to one dump per 3 minutes while the
+# condition persists. Same procfs discipline as ci-stray-vm-guard.sh: the scan
+# and the evidence readers never touch cmdline/argv (those reads fault the
+# target mm and hang exactly when the target is wedged).
+#
+# Usage: ci-dstate-watchdog.sh   (background it; SIGTERM stops it)
+#   FCVM_WATCHDOG_INTERVAL_SECONDS       sample interval (default 20)
+#   FCVM_WATCHDOG_DUMP_INTERVAL_SECONDS  min gap between dumps (default 180)
+#   FCVM_GUARD_SCAN_TIMEOUT_SECONDS      ps snapshot deadline (default 10)
+set -uo pipefail
+
+INTERVAL="${FCVM_WATCHDOG_INTERVAL_SECONDS:-20}"
+DUMP_GAP="${FCVM_WATCHDOG_DUMP_INTERVAL_SECONDS:-180}"
+SCAN_TIMEOUT="${FCVM_GUARD_SCAN_TIMEOUT_SECONDS:-10}"
+
+# shellcheck source=scripts/lib/vm-evidence.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/vm-evidence.sh"
+
+TEMPORARY_PREFIX="${TMPDIR:-/tmp}/.fcvm-dstate-watchdog.$$"
+# shellcheck disable=SC2317  # reached via `trap ... EXIT`, not fall-through
+cleanup_temporary_files() {
+	rm -f -- "${TEMPORARY_PREFIX}".*
+}
+trap cleanup_temporary_files EXIT
+trap 'exit 0' TERM INT
+
+# Suspect groups from a selected-threads artifact, one "tgid<TAB>reason" per
+# line. Reasons are part of the report contract, so name them precisely.
+suspects_of() {
+	awk -F '\t' '
+		NR == 1 { next }
+		{
+			seen[$1] = 1
+			if ($4 ~ /^D/) dstate[$1] = 1
+			if ($1 == $2 && $4 ~ /^Z/) zleader[$1] = 1
+			if ($4 !~ /^Z/) live[$1] = 1
+		}
+		END {
+			for (g in seen) {
+				if (dstate[g])
+					print g "\tD-state sibling"
+				else if (zleader[g] && live[g])
+					print g "\tzombie leader with live sibling"
+			}
+		}
+	' "$1"
+}
+
+dump_wedge_evidence() {
+	local selected=$1 persistent=$2
+	local tgids
+	mapfile -t tgids < <(printf '%s\n' "$persistent" | cut -f1)
+	echo "======== FCVM D-STATE WATCHDOG: wedged microVM task group(s) detected at $(date -u '+%Y-%m-%dT%H:%M:%SZ') ========"
+	echo "suspect groups persisting across two consecutive samples (interval ${INTERVAL}s):"
+	printf '%s\n' "$persistent"
+	echo "thread snapshot (TGID TID PPID STATE THREAD):"
+	awk -F '\t' -v list="${tgids[*]}" '
+		BEGIN { n = split(list, a, " "); for (i = 1; i <= n; i++) want[a[i]] = 1 }
+		NR == 1 || ($1 in want)
+	' "$selected"
+	vm_evidence_group "$selected" "d-state watchdog" "${tgids[@]}"
+	vm_evidence_mm_diagnostics 120
+	echo "======== END FCVM D-STATE WATCHDOG DUMP ========"
+}
+
+PREV_SUSPECTS=""
+LAST_DUMP=-1
+LAST_SCAN_NOTE=-1
+
+while :; do
+	ALL=$(mktemp "${TEMPORARY_PREFIX}.XXXXXX")
+	SELECTED=$(mktemp "${TEMPORARY_PREFIX}.XXXXXX")
+	LIVE=$(mktemp "${TEMPORARY_PREFIX}.XXXXXX")
+	ZOMBIE=$(mktemp "${TEMPORARY_PREFIX}.XXXXXX")
+
+	SCAN_NOTE=$(vm_scan_all_threads "$ALL" "$SCAN_TIMEOUT" "$TEMPORARY_PREFIX" 2>&1)
+	SCAN_RC=$?
+	if [ "$SCAN_RC" -ne 0 ]; then
+		# A ps that cannot finish is itself the wedge signature (the guard's
+		# header documents the D-state reader hang). Say so, rate-limited.
+		# The NOTE prefix is deliberately distinct from the dump header so
+		# log consumers counting dumps never conflate the two.
+		if [ "$LAST_SCAN_NOTE" -lt 0 ] || [ $((SECONDS - LAST_SCAN_NOTE)) -ge "$DUMP_GAP" ]; then
+			echo "FCVM D-STATE WATCHDOG NOTE: thread scan failed (rc=${SCAN_RC}): ${SCAN_NOTE}"
+			LAST_SCAN_NOTE=$SECONDS
+		fi
+		# No sample this round: leave PREV_SUSPECTS as-is — persistence is
+		# judged across successful scans only.
+	else
+		vm_select_vm_groups "$ALL" "$SELECTED" "$LIVE" "$ZOMBIE"
+		SUSPECTS=$(suspects_of "$SELECTED")
+		PERSISTENT=""
+		if [ -n "$SUSPECTS" ] && [ -n "$PREV_SUSPECTS" ]; then
+			# Persistence is keyed on the TGID; the reason reported is the
+			# CURRENT one (a group can move from D-sibling to zombie-led).
+			PERSISTENT=$(awk -F '\t' '
+				NR == FNR { prev[$1] = 1; next }
+				($1 in prev)
+			' <(printf '%s\n' "$PREV_SUSPECTS") <(printf '%s\n' "$SUSPECTS"))
+		fi
+		if [ -n "$PERSISTENT" ]; then
+			if [ "$LAST_DUMP" -lt 0 ] || [ $((SECONDS - LAST_DUMP)) -ge "$DUMP_GAP" ]; then
+				dump_wedge_evidence "$SELECTED" "$PERSISTENT"
+				LAST_DUMP=$SECONDS
+			fi
+		fi
+		PREV_SUSPECTS=$SUSPECTS
+	fi
+
+	rm -f -- "$ALL" "$SELECTED" "$LIVE" "$ZOMBIE"
+	# Interruptible sleep: SIGTERM must stop the watchdog now, not one full
+	# interval later.
+	sleep "$INTERVAL" &
+	wait $! || true
+done

--- a/scripts/ci-stray-vm-guard.sh
+++ b/scripts/ci-stray-vm-guard.sh
@@ -10,6 +10,12 @@
 # only when every sibling thread is also a zombie; a D-state vCPU sibling still owns
 # live KVM/MM resources and makes the whole group actionable.
 #
+# Every reported group also gets per-TID evidence (kernel stack, wchan, status)
+# captured BEFORE the kill attempt, and SIGKILL survivors get a second capture
+# plus reclaim/compaction diagnostics — see scripts/lib/vm-evidence.sh. The one
+# time this class struck (a SIGKILLed firecracker stuck non-zombie in D state),
+# the stacks were read by hand and lost with the recycled runner.
+#
 # Usage: ci-stray-vm-guard.sh <pre|post> [--dry-run]
 #
 #   --dry-run  report only, kill nothing. The default SIGKILL behavior is intended
@@ -26,6 +32,9 @@ if ! mkdir -p "$LOG_DIR" 2>/dev/null; then
 	LOG_DIR="/tmp/fcvm-test-logs"
 	mkdir -p "$LOG_DIR"
 fi
+
+# shellcheck source=scripts/lib/vm-evidence.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/vm-evidence.sh"
 
 REPORT="$LOG_DIR/stray-vm-guard-${PHASE}.log"
 THREADS_BEFORE="$LOG_DIR/stray-vm-threads-${PHASE}-before.tsv"
@@ -193,6 +202,11 @@ fi
 
 print_thread_table "$THREADS_BEFORE"
 
+# Evidence first, kill second: SIGKILL destroys exactly the state (stacks,
+# wchan, pending-signal masks) that explains a survivor, and the survivor case
+# is the one that recycles the runner before anything else can look.
+vm_evidence_group "$THREADS_BEFORE" "pre-kill, ${PHASE}" "${STRAY_TGIDS[@]}"
+
 if [ "$DRY_RUN" -eq 1 ]; then
 	echo "::warning title=Stray microVMs (${PHASE}, dry-run)::${COUNT} live process group(s) found; NOT killing them (--dry-run)."
 	echo "--dry-run: reporting only, killing nothing"
@@ -223,6 +237,12 @@ mapfile -t SURVIVOR_TGIDS <"$LIVE_AFTER"
 echo "killed ${COUNT} process group(s), still live after SIGKILL: ${#SURVIVOR_TGIDS[@]}"
 if [ "${#SURVIVOR_TGIDS[@]}" -gt 0 ]; then
 	print_thread_table "$THREADS_AFTER"
+	# A survivor is a task the kernel could not reap: its status now shows the
+	# pending SIGKILL bit on a non-zombie task, and whatever owns it (the ARM
+	# case: kcompactd holding a folio lock under do_swap_page) is visible only
+	# while the survivor exists. Capture both before this runner disappears.
+	vm_evidence_group "$THREADS_AFTER" "post-SIGKILL survivors, ${PHASE}" "${SURVIVOR_TGIDS[@]}"
+	vm_evidence_mm_diagnostics 150
 	echo "::warning title=Unkillable microVMs (${PHASE})::${#SURVIVOR_TGIDS[@]} process group(s) survived SIGKILL; D-state means this runner needs replacement."
 fi
 

--- a/scripts/ci-stray-vm-guard.sh
+++ b/scripts/ci-stray-vm-guard.sh
@@ -44,11 +44,12 @@ THREADS_AFTER="$LOG_DIR/stray-vm-threads-${PHASE}-after.tsv"
 : >"$THREADS_AFTER"
 exec > >(tee -a "$REPORT") 2>&1
 
-# Linux comm is limited to 15 bytes. `cloud-hypervisor` is therefore observed as
-# `cloud-hypervis`; the prefix intentionally covers both that and the full spelling.
-STRAY_RE='^(firecracker|cloud-hypervis|fcvm)'
+# The thread scan and group selection live in scripts/lib/vm-evidence.sh
+# (vm_scan_all_threads / vm_select_vm_groups), shared with the in-job D-state
+# watchdog so both report from the identical snapshot discipline.
 
 TEMPORARY_PREFIX="$LOG_DIR/.stray-vm-guard.$$"
+# shellcheck disable=SC2317  # reached via `trap ... EXIT`, not fall-through
 cleanup_temporary_files() {
 	rm -f -- "${TEMPORARY_PREFIX}".*
 }
@@ -56,96 +57,6 @@ trap cleanup_temporary_files EXIT
 
 new_temporary_file() {
 	mktemp "${TEMPORARY_PREFIX}.XXXXXX"
-}
-
-# Capture one process-table snapshot behind a hard deadline. We do not wait for a
-# timed-out reader after SIGKILL: if the kernel has already parked it in D state,
-# waiting would recreate the guard hang this script exists to diagnose.
-capture_all_threads() {
-	local destination=$1
-	local raw scan_stderr scan_pid deadline rc line
-	raw=$(new_temporary_file) || return 1
-	scan_stderr=$(new_temporary_file) || return 1
-	printf 'TGID\tTID\tPPID\tSTATE\tTHREAD\n' >"$destination"
-
-	# Do not let the scanner inherit the report pipe. If ps wedges in D state,
-	# SIGKILL remains pending and every inherited pipe writer stays open, making
-	# the workflow caller wait forever for EOF even after this guard exits.
-	ps -eL -o pid= -o lwp= -o ppid= -o state= -o comm= >"$raw" 2>"$scan_stderr" &
-	scan_pid=$!
-	deadline=$((SECONDS + SCAN_TIMEOUT_SECONDS))
-	while kill -0 "$scan_pid" 2>/dev/null; do
-		if [ "$SECONDS" -ge "$deadline" ]; then
-			kill -9 "$scan_pid" 2>/dev/null || true
-			disown "$scan_pid" 2>/dev/null || true
-			while IFS= read -r line || [ -n "$line" ]; do
-				printf 'process/thread scanner stderr: %s\n' "$line"
-			done <"$scan_stderr"
-			echo "process/thread scan timed out after ${SCAN_TIMEOUT_SECONDS}s"
-			return 124
-		fi
-		sleep 0.05
-	done
-
-	wait "$scan_pid"
-	rc=$?
-	while IFS= read -r line || [ -n "$line" ]; do
-		printf 'process/thread scanner stderr: %s\n' "$line"
-	done <"$scan_stderr"
-	if [ "$rc" -ne 0 ]; then
-		echo "process/thread scan failed with status ${rc}"
-		return "$rc"
-	fi
-
-	# Normalize the variable-width comm column to a tab-separated artifact. Thread
-	# names can contain spaces, so fields 5..NF are joined back together.
-	awk '
-		BEGIN { OFS = "\t" }
-		NF >= 5 {
-			thread = $5
-			for (i = 6; i <= NF; i++)
-				thread = thread " " $i
-			print $1, $2, $3, $4, thread
-		}
-	' "$raw" >>"$destination"
-}
-
-# Select complete task groups whose leader name is a VM process. Outputs one TGID
-# per live group and one per zombie-only group; the thread artifact always contains
-# every sibling, including the zombie leader itself.
-select_vm_groups() {
-	local all_threads=$1
-	local selected_threads=$2
-	local live_groups=$3
-	local zombie_groups=$4
-
-	awk -F '\t' -v re="$STRAY_RE" \
-		-v selected="$selected_threads" \
-		-v live_out="$live_groups" \
-		-v zombie_out="$zombie_groups" '
-		BEGIN { OFS = "\t" }
-		NR == 1 { header = $0; next }
-		{
-			rows[++count] = $0
-			tgid[count] = $1
-			if ($1 == $2 && $5 ~ re)
-				target[$1] = 1
-			if ($4 !~ /^Z/)
-				live[$1] = 1
-		}
-		END {
-			print header > selected
-			for (i = 1; i <= count; i++)
-				if (tgid[i] in target)
-					print rows[i] >> selected
-			for (id in target) {
-				if (live[id])
-					print id > live_out
-				else
-					print id > zombie_out
-			}
-		}
-	' "$all_threads"
 }
 
 print_thread_table() {
@@ -165,12 +76,12 @@ scan_vm_groups() {
 	all=$(new_temporary_file) || return 1
 	: >"$live"
 	: >"$zombies"
-	if ! capture_all_threads "$all"; then
+	if ! vm_scan_all_threads "$all" "$SCAN_TIMEOUT_SECONDS" "$TEMPORARY_PREFIX"; then
 		# Preserve a syntactically useful artifact even when enumeration failed.
 		printf 'TGID\tTID\tPPID\tSTATE\tTHREAD\n' >"$selected"
 		return 1
 	fi
-	select_vm_groups "$all" "$selected" "$live" "$zombies"
+	vm_select_vm_groups "$all" "$selected" "$live" "$zombies"
 }
 
 LIVE_BEFORE=$(new_temporary_file)

--- a/scripts/lib/vm-evidence.sh
+++ b/scripts/lib/vm-evidence.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Sourced evidence-capture helpers for microVM teardown diagnostics.
+#
+# Why this exists: during concurrent clone teardown on an ARM CI runner, a
+# SIGKILLed Firecracker stayed non-zombie in D state and wedged the runner. The
+# kernel stacks that named the owner (softleaf_entry_wait_on_locked ->
+# migration_entry_wait -> do_swap_page, with kcompactd holding the folio) were
+# read once by hand and then lost when the runner was recycled. These helpers
+# archive that evidence at the moment it exists, in the caller's report stream.
+#
+# Same procfs discipline as ci-stray-vm-guard.sh: only /proc/<tid>/{status,
+# wchan,stack}, /proc/<pid>/comm, /proc/vmstat, /proc/pressure/memory and dmesg
+# are read. Those describe scheduler/signal/MM state owned by the kernel and do
+# not fault the target's mm the way /proc/<pid>/cmdline does — but every read
+# still runs under `timeout` as a belt. Never add a cmdline/argv read here.
+#
+# This file defines functions only; it never exits and never writes files.
+
+# Test seam: unit tests point this at a synthetic tree. Production never sets it.
+VM_EVIDENCE_PROC_ROOT="${FCVM_PROC_ROOT:-/proc}"
+# Stack dumps are capped so one wedged group cannot flood a CI log.
+VM_EVIDENCE_STACK_LINES=60
+# Seconds between reclaim/compaction stack samples (tests set 0).
+VM_EVIDENCE_MM_INTERVAL="${FCVM_MM_SAMPLE_INTERVAL_SECONDS:-1}"
+
+# vm_evidence_tid <tgid> <tid>
+#
+# One thread's kernel-side state: status (State + SigPnd/ShdPnd prove "SIGKILL
+# pending on a non-zombie task"), wchan (the function it sleeps in), and the
+# kernel stack (root-only; capped). Unreadable files are reported, not fatal —
+# the thread may be reaped between the snapshot and this read.
+vm_evidence_tid() {
+	local tgid=$1 tid=$2
+	local task="${VM_EVIDENCE_PROC_ROOT}/${tgid}/task/${tid}"
+	echo "-- tgid=${tgid} tid=${tid}"
+	timeout 2 grep -E '^(Name|State|SigPnd|ShdPnd|SigBlk):' "${task}/status" 2>/dev/null ||
+		echo "status: <unreadable ${task}/status>"
+	local wchan
+	wchan=$(timeout 2 cat "${task}/wchan" 2>/dev/null) || true
+	echo "wchan: ${wchan:-<unreadable>}"
+	local stack
+	stack=$(timeout 2 head -n "$VM_EVIDENCE_STACK_LINES" "${task}/stack" 2>/dev/null) || true
+	if [ -n "$stack" ]; then
+		echo "stack (first ${VM_EVIDENCE_STACK_LINES} lines):"
+		printf '%s\n' "$stack"
+	else
+		echo "stack: <unreadable ${task}/stack (kernel stacks need root)>"
+	fi
+}
+
+# vm_evidence_group <thread-table.tsv> <label> <tgid>...
+#
+# Per-TID evidence for every thread of the listed task groups. The TID list
+# comes from the already-captured ps snapshot (TGID TID PPID STATE THREAD),
+# never from a fresh procfs walk, so a wedged task table cannot stall this loop.
+vm_evidence_group() {
+	local table=$1 label=$2
+	shift 2
+	[ "$#" -eq 0 ] && return 0
+	declare -A vm_evidence_wanted=()
+	local tgid
+	for tgid in "$@"; do
+		vm_evidence_wanted[$tgid]=1
+	done
+	echo "=== per-thread evidence (${label}) ==="
+	local tid
+	while IFS=$'\t' read -r tgid tid _ _ _; do
+		[ "$tgid" = "TGID" ] && continue
+		[ -n "${vm_evidence_wanted[$tgid]:-}" ] || continue
+		vm_evidence_tid "$tgid" "$tid"
+	done <"$table"
+	echo "=== end per-thread evidence (${label}) ==="
+}
+
+# vm_evidence_mm_diagnostics <dmesg-tail-lines>
+#
+# Reclaim/compaction context for a SIGKILL survivor. A task that ignores
+# SIGKILL is waiting uninterruptibly on something another kernel path owns; on
+# the ARM wedge that owner was kcompactd, visible only in its stack and the
+# compaction counters at that moment. Three samples one interval apart show
+# whether the owner is stuck or making progress.
+vm_evidence_mm_diagnostics() {
+	local dmesg_lines=$1
+	echo "=== memory-management diagnostics (SIGKILL survivor present) ==="
+	local pids
+	pids=$(timeout 2 pgrep '^(kcompactd|kswapd)' 2>/dev/null) || true
+	if [ -z "$pids" ]; then
+		echo "no kcompactd/kswapd tasks matched by pgrep"
+	else
+		local sample pid comm stack
+		for sample in 1 2 3; do
+			[ "$sample" -gt 1 ] && sleep "$VM_EVIDENCE_MM_INTERVAL"
+			echo "--- reclaim/compaction stack sample ${sample}/3 at $(date -u '+%Y-%m-%dT%H:%M:%S.%3NZ') ---"
+			while IFS= read -r pid; do
+				[ -n "$pid" ] || continue
+				comm=$(timeout 2 cat "${VM_EVIDENCE_PROC_ROOT}/${pid}/comm" 2>/dev/null) || true
+				echo "[${comm:-?}] pid=${pid}"
+				stack=$(timeout 2 head -n "$VM_EVIDENCE_STACK_LINES" "${VM_EVIDENCE_PROC_ROOT}/${pid}/stack" 2>/dev/null) || true
+				if [ -n "$stack" ]; then
+					printf '%s\n' "$stack"
+				else
+					echo "stack: <unreadable>"
+				fi
+			done <<<"$pids"
+		done
+	fi
+	echo "--- ${VM_EVIDENCE_PROC_ROOT}/vmstat compaction counters ---"
+	timeout 2 grep '^compact_' "${VM_EVIDENCE_PROC_ROOT}/vmstat" 2>/dev/null ||
+		echo "<unreadable ${VM_EVIDENCE_PROC_ROOT}/vmstat>"
+	echo "--- ${VM_EVIDENCE_PROC_ROOT}/pressure/memory ---"
+	timeout 2 cat "${VM_EVIDENCE_PROC_ROOT}/pressure/memory" 2>/dev/null ||
+		echo "<unreadable ${VM_EVIDENCE_PROC_ROOT}/pressure/memory>"
+	echo "--- dmesg tail (last ${dmesg_lines} lines, unfiltered) ---"
+	local dmesg_out
+	dmesg_out=$(timeout 5 dmesg 2>/dev/null | tail -n "$dmesg_lines") || true
+	if [ -z "$dmesg_out" ]; then
+		# kernel.dmesg_restrict may deny the unprivileged read; CI runners have
+		# passwordless sudo (the guard's kill path already relies on it).
+		dmesg_out=$(timeout 5 sudo dmesg 2>/dev/null | tail -n "$dmesg_lines") || true
+	fi
+	if [ -n "$dmesg_out" ]; then
+		printf '%s\n' "$dmesg_out"
+	else
+		echo "<dmesg unavailable>"
+	fi
+	echo "=== end memory-management diagnostics ==="
+}

--- a/scripts/lib/vm-evidence.sh
+++ b/scripts/lib/vm-evidence.sh
@@ -23,6 +23,107 @@ VM_EVIDENCE_STACK_LINES=60
 # Seconds between reclaim/compaction stack samples (tests set 0).
 VM_EVIDENCE_MM_INTERVAL="${FCVM_MM_SAMPLE_INTERVAL_SECONDS:-1}"
 
+# Linux comm is limited to 15 bytes. `cloud-hypervisor` is therefore observed as
+# `cloud-hypervis`; the prefix intentionally covers both that and the full spelling.
+VM_SCAN_RE='^(firecracker|cloud-hypervis|fcvm)'
+
+# vm_scan_all_threads <destination> <timeout_seconds> <tmp_prefix>
+#
+# One process-table snapshot behind a hard deadline, normalized to a
+# tab-separated TGID/TID/PPID/STATE/THREAD artifact. We do not wait for a
+# timed-out reader after SIGKILL: if the kernel has already parked it in D
+# state, waiting would recreate the guard hang this scan exists to diagnose.
+# Diagnostics go to stdout; callers that must stay silent capture them.
+vm_scan_all_threads() {
+	local destination=$1 scan_timeout=$2 tmp_prefix=$3
+	local raw scan_stderr scan_pid deadline rc line
+	raw=$(mktemp "${tmp_prefix}.XXXXXX") || return 1
+	scan_stderr=$(mktemp "${tmp_prefix}.XXXXXX") || return 1
+	printf 'TGID\tTID\tPPID\tSTATE\tTHREAD\n' >"$destination"
+
+	# Do not let the scanner inherit the caller's stdout/stderr pipes. If ps
+	# wedges in D state, SIGKILL remains pending and every inherited pipe
+	# writer stays open, making a workflow caller wait forever for EOF even
+	# after the calling script exits.
+	ps -eL -o pid= -o lwp= -o ppid= -o state= -o comm= >"$raw" 2>"$scan_stderr" &
+	scan_pid=$!
+	deadline=$((SECONDS + scan_timeout))
+	while kill -0 "$scan_pid" 2>/dev/null; do
+		if [ "$SECONDS" -ge "$deadline" ]; then
+			kill -9 "$scan_pid" 2>/dev/null || true
+			disown "$scan_pid" 2>/dev/null || true
+			while IFS= read -r line || [ -n "$line" ]; do
+				printf 'process/thread scanner stderr: %s\n' "$line"
+			done <"$scan_stderr"
+			echo "process/thread scan timed out after ${scan_timeout}s"
+			return 124
+		fi
+		sleep 0.05
+	done
+
+	wait "$scan_pid"
+	rc=$?
+	while IFS= read -r line || [ -n "$line" ]; do
+		printf 'process/thread scanner stderr: %s\n' "$line"
+	done <"$scan_stderr"
+	if [ "$rc" -ne 0 ]; then
+		echo "process/thread scan failed with status ${rc}"
+		return "$rc"
+	fi
+
+	# Normalize the variable-width comm column to a tab-separated artifact. Thread
+	# names can contain spaces, so fields 5..NF are joined back together.
+	awk '
+		BEGIN { OFS = "\t" }
+		NF >= 5 {
+			thread = $5
+			for (i = 6; i <= NF; i++)
+				thread = thread " " $i
+			print $1, $2, $3, $4, thread
+		}
+	' "$raw" >>"$destination"
+}
+
+# vm_select_vm_groups <all_threads> <selected_threads> <live_groups> <zombie_groups>
+#
+# Select complete task groups whose leader name is a VM process. Outputs one TGID
+# per live group and one per zombie-only group; the thread artifact always contains
+# every sibling, including the zombie leader itself.
+vm_select_vm_groups() {
+	local all_threads=$1
+	local selected_threads=$2
+	local live_groups=$3
+	local zombie_groups=$4
+
+	awk -F '\t' -v re="$VM_SCAN_RE" \
+		-v selected="$selected_threads" \
+		-v live_out="$live_groups" \
+		-v zombie_out="$zombie_groups" '
+		BEGIN { OFS = "\t" }
+		NR == 1 { header = $0; next }
+		{
+			rows[++count] = $0
+			tgid[count] = $1
+			if ($1 == $2 && $5 ~ re)
+				target[$1] = 1
+			if ($4 !~ /^Z/)
+				live[$1] = 1
+		}
+		END {
+			print header > selected
+			for (i = 1; i <= count; i++)
+				if (tgid[i] in target)
+					print rows[i] >> selected
+			for (id in target) {
+				if (live[id])
+					print id > live_out
+				else
+					print id > zombie_out
+			}
+		}
+	' "$all_threads"
+}
+
 # vm_evidence_tid <tgid> <tid>
 #
 # One thread's kernel-side state: status (State + SigPnd/ShdPnd prove "SIGKILL

--- a/scripts/teardown-compaction-storm.sh
+++ b/scripts/teardown-compaction-storm.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# Bounded compaction-storm probe for the SIGKILL-survivor teardown class.
+#
+# The wild ARM failure had kcompactd holding a folio lock while a SIGKILLed
+# firecracker waited on it (softleaf_entry_wait_on_locked -> migration_entry_wait
+# -> do_swap_page). scripts/teardown-folio-lock-red.sh freezes that owner
+# deterministically with dmsetup; this probe instead recreates the ORIGINAL
+# race shape: clones faulting in pages from a memory server while manual
+# compaction hammers page migration, and SIGKILL lands mid-fault.
+#
+#   loop N times (bounded, argument, default 10):
+#     spawn a clone, start touching its cold pages, SIGKILL its VMM + fcvm
+#     while `echo 1 > /proc/sys/vm/compact_memory` runs in a tight background
+#     loop; sample kcompactd/kswapd stacks each iteration; a VMM still
+#     non-zombie after the window (FCVM_RED_WINDOW_SECONDS, default 20s) is a
+#     reproduction and gets the full evidence dump.
+#
+# Exit codes:
+#   0  probe completed and the host is clean (summary says reproduced or not —
+#      this race is probabilistic, so a no-show is not a failure)
+#   4  a survivor never reaped even after the storm stopped; host wedged
+#   other  harness/setup failure
+#
+# Root required (compact_memory, kernel stacks).
+set -euo pipefail
+
+ITERATIONS="${1:-10}"
+FCVM_BIN="${FCVM_BIN:-./target/release/fcvm}"
+IMAGE="${FCVM_TEST_IMAGE:-nginx:alpine}"
+RED_WINDOW="${FCVM_RED_WINDOW_SECONDS:-20}"
+EVIDENCE_DIR="${FCVM_TEARDOWN_EVIDENCE_DIR:-/tmp/fcvm-teardown-evidence}"
+
+RUN_ID="$$-$(date +%s)"
+VM_NAME="storm-base-${RUN_ID}"
+TAG="storm-${RUN_ID}"
+
+# shellcheck source=scripts/lib/vm-evidence.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/vm-evidence.sh"
+
+mkdir -p "$EVIDENCE_DIR"
+exec > >(tee -a "${EVIDENCE_DIR}/compaction-storm.log") 2>&1
+
+[ "$(id -u)" -eq 0 ] || { echo "FATAL: must run as root"; exit 1; }
+[ -x "$FCVM_BIN" ] || { echo "FATAL: fcvm binary not found at $FCVM_BIN (run make build)"; exit 1; }
+[ -w /proc/sys/vm/compact_memory ] || { echo "FATAL: /proc/sys/vm/compact_memory not writable"; exit 1; }
+
+proc_state() {
+	awk '/^State:/{print $2}' "/proc/$1/status" 2>/dev/null
+}
+
+proc_ppid() {
+	local stat
+	stat=$(cat "/proc/$1/stat" 2>/dev/null) || return 1
+	stat=${stat##*') '}
+	read -r _ ppid _ <<<"$stat"
+	echo "$ppid"
+}
+
+is_descendant_of() {
+	local pid=$1 ancestor=$2 hop
+	for hop in $(seq 1 32); do
+		: "$hop"
+		[ "$pid" = "$ancestor" ] && return 0
+		[ "$pid" -le 1 ] && return 1
+		pid=$(proc_ppid "$pid") || return 1
+	done
+	return 1
+}
+
+find_firecracker_descendant() {
+	local root=$1 entry pid comm
+	for entry in /proc/[0-9]*; do
+		pid=${entry#/proc/}
+		comm=$(cat "$entry/comm" 2>/dev/null) || continue
+		case $comm in firecracker*) ;; *) continue ;; esac
+		if is_descendant_of "$pid" "$root"; then
+			echo "$pid"
+			return 0
+		fi
+	done
+	return 1
+}
+
+wait_exec_ready() {
+	local fcvm_pid=$1 deadline=$((SECONDS + 240))
+	until timeout 15 "$FCVM_BIN" exec --pid "$fcvm_pid" --vm -- true >/dev/null 2>&1; do
+		kill -0 "$fcvm_pid" 2>/dev/null || return 1
+		[ "$SECONDS" -lt "$deadline" ] || return 1
+		sleep 2
+	done
+}
+
+sample_kcompactd() {
+	local label=$1 pid
+	echo "-- kcompactd/kswapd sample (${label}) at $(date -u '+%Y-%m-%dT%H:%M:%S.%3NZ')"
+	while IFS= read -r pid; do
+		[ -n "$pid" ] || continue
+		echo "[$(cat "/proc/${pid}/comm" 2>/dev/null || echo '?')] pid=${pid}"
+		timeout 2 head -n 60 "/proc/${pid}/stack" 2>/dev/null || echo "stack: <unreadable>"
+	done < <(pgrep '^(kcompactd|kswapd)' || true)
+}
+
+dump_survivor_evidence() {
+	local pid=$1 label=$2 task
+	echo "===== survivor evidence (${label}) ====="
+	for task in "/proc/${pid}/task"/*; do
+		[ -d "$task" ] || continue
+		vm_evidence_tid "$pid" "${task##*/}"
+	done
+	vm_evidence_mm_diagnostics 150
+	echo "===== end survivor evidence (${label}) ====="
+}
+
+# Kill and reap one fcvm process, bounded.
+reap_fcvm() {
+	local pid=$1 deadline
+	[ -n "$pid" ] || return 0
+	kill -TERM "$pid" 2>/dev/null || true
+	deadline=$((SECONDS + 30))
+	while kill -0 "$pid" 2>/dev/null && [ "$SECONDS" -lt "$deadline" ]; do
+		sleep 1
+	done
+	kill -9 "$pid" 2>/dev/null || true
+}
+
+STORM_PID=""
+BASE_PID=""
+SERVE_PID=""
+CLONE_PID=""
+WEDGED=0
+
+# shellcheck disable=SC2317  # reached via `trap cleanup EXIT`, not fall-through
+cleanup() {
+	local rc=$?
+	set +e
+	echo "=== cleanup (script exiting with ${rc}) ==="
+	[ -n "$STORM_PID" ] && kill -9 "$STORM_PID" 2>/dev/null
+	reap_fcvm "$CLONE_PID"
+	reap_fcvm "$SERVE_PID"
+	reap_fcvm "$BASE_PID"
+	wait 2>/dev/null
+	"$FCVM_BIN" snapshots delete "$TAG" >/dev/null 2>&1
+	echo "=== cleanup done ==="
+	[ "$WEDGED" = 1 ] && exit 4
+}
+trap cleanup EXIT
+
+echo "=== fcvm teardown compaction-storm probe (${RUN_ID}) ==="
+echo "iterations=${ITERATIONS} window=${RED_WINDOW}s image=${IMAGE}"
+
+echo "--- setup: baseline VM, snapshot, memory server"
+"$FCVM_BIN" podman run --name "$VM_NAME" --network rootless "$IMAGE" \
+	>"${EVIDENCE_DIR}/storm-base-${RUN_ID}.log" 2>&1 &
+BASE_PID=$!
+wait_exec_ready "$BASE_PID" || { echo "FATAL: baseline never became exec-ready"; exit 1; }
+# 64 MiB pattern = fault surface the clones must pull from the server.
+timeout 120 "$FCVM_BIN" exec --pid "$BASE_PID" --vm -- \
+	sh -c "yes STORMPAGE | head -c 67108864 > /dev/shm/storm && sync" ||
+	{ echo "FATAL: could not write fault-surface pattern"; exit 1; }
+"$FCVM_BIN" snapshot create --pid "$BASE_PID" --tag "$TAG" ||
+	{ echo "FATAL: snapshot create failed"; exit 1; }
+"$FCVM_BIN" snapshot serve "$TAG" >"${EVIDENCE_DIR}/storm-serve-${RUN_ID}.log" 2>&1 &
+SERVE_PID=$!
+DEADLINE=$((SECONDS + 60))
+until find /mnt/fcvm-btrfs -maxdepth 2 -name "uffd-${TAG}-${SERVE_PID}.sock" 2>/dev/null | grep -q .; do
+	kill -0 "$SERVE_PID" 2>/dev/null || { echo "FATAL: serve exited; see its log"; exit 1; }
+	[ "$SECONDS" -lt "$DEADLINE" ] || { echo "FATAL: serve socket never appeared"; exit 1; }
+	sleep 1
+done
+echo "serve PID ${SERVE_PID} ready"
+
+echo "--- storm: manual compaction in a tight loop"
+(
+	while :; do
+		echo 1 >/proc/sys/vm/compact_memory 2>/dev/null || true
+		sleep 0.2
+	done
+) &
+STORM_PID=$!
+
+REPRODUCED=0
+for i in $(seq 1 "$ITERATIONS"); do
+	echo "--- iteration ${i}/${ITERATIONS}"
+	sample_kcompactd "iteration ${i}"
+	"$FCVM_BIN" snapshot run --pid "$SERVE_PID" --name "storm-clone-${RUN_ID}-${i}" \
+		>"${EVIDENCE_DIR}/storm-clone-${RUN_ID}-${i}.log" 2>&1 &
+	CLONE_PID=$!
+	if ! wait_exec_ready "$CLONE_PID"; then
+		echo "WARN: clone ${i} never became exec-ready; skipping iteration"
+		reap_fcvm "$CLONE_PID"
+		CLONE_PID=""
+		continue
+	fi
+	FC_PID=$(find_firecracker_descendant "$CLONE_PID") ||
+		{ echo "WARN: no VMM under clone ${i}"; reap_fcvm "$CLONE_PID"; CLONE_PID=""; continue; }
+
+	# Touch the cold pattern in the background so faults are in flight, give
+	# it a moment to start pulling pages, then kill mid-fault.
+	timeout 60 "$FCVM_BIN" exec --pid "$CLONE_PID" --vm -- \
+		sh -c "md5sum /dev/shm/storm" >/dev/null 2>&1 &
+	TOUCH_PID=$!
+	sleep 1
+
+	kill -9 "$FC_PID" 2>/dev/null || true
+	kill -TERM "$CLONE_PID" 2>/dev/null || true
+	KILLED_AT=$SECONDS
+	SURVIVED=1
+	while [ $((SECONDS - KILLED_AT)) -lt "$RED_WINDOW" ]; do
+		STATE=$(proc_state "$FC_PID")
+		if [ -z "$STATE" ] || [ "$STATE" = "Z" ]; then
+			SURVIVED=0
+			break
+		fi
+		sleep 0.5
+	done
+	kill -9 "$TOUCH_PID" 2>/dev/null || true
+	if [ "$SURVIVED" = 1 ]; then
+		echo "REPRODUCED at iteration ${i}: VMM ${FC_PID} state=$(proc_state "$FC_PID") ${RED_WINDOW}s after SIGKILL"
+		awk '/^(SigPnd|ShdPnd):/{print}' "/proc/${FC_PID}/status" 2>/dev/null || true
+		dump_survivor_evidence "$FC_PID" "compaction-storm iteration ${i}"
+		REPRODUCED=1
+		# Stop the storm and confirm the survivor eventually reaps — leaving a
+		# wedge behind is the one outcome this probe must never produce.
+		kill -9 "$STORM_PID" 2>/dev/null || true
+		STORM_PID=""
+		DEADLINE=$((SECONDS + 60))
+		while [ "$SECONDS" -lt "$DEADLINE" ]; do
+			STATE=$(proc_state "$FC_PID")
+			{ [ -z "$STATE" ] || [ "$STATE" = "Z" ]; } && break
+			kill -9 "$FC_PID" 2>/dev/null
+			sleep 1
+		done
+		STATE=$(proc_state "$FC_PID")
+		if [ -n "$STATE" ] && [ "$STATE" != "Z" ]; then
+			echo "FATAL: survivor ${FC_PID} still ${STATE} 60s after the storm stopped"
+			dump_survivor_evidence "$FC_PID" "post-storm, unrecovered"
+			WEDGED=1
+		fi
+		reap_fcvm "$CLONE_PID"
+		CLONE_PID=""
+		break
+	fi
+	echo "iteration ${i}: VMM reaped within the window"
+	reap_fcvm "$CLONE_PID"
+	CLONE_PID=""
+done
+
+echo "=== RESULT: reproduced=$([ "$REPRODUCED" = 1 ] && echo yes || echo no) after ${ITERATIONS} bounded iteration(s) ==="
+exit 0

--- a/scripts/teardown-folio-lock-red.sh
+++ b/scripts/teardown-folio-lock-red.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+# Deterministic reproduction (RED) of the SIGKILL-survivor teardown class.
+#
+# The class: during concurrent clone teardown on an ARM runner, a SIGKILLed
+# firecracker stayed non-zombie in D state (stacks:
+# softleaf_entry_wait_on_locked -> migration_entry_wait -> do_swap_page) and
+# wedged the runner. SIGKILL cannot reap a task waiting uninterruptibly on a
+# folio another kernel path holds locked. That owner was transient in the wild;
+# this harness makes it stand still by suspending the block device under the
+# folio's backing store:
+#
+#   1. swapfile on a dm-linear device (so it can be suspended), swapon at
+#      priority 100 so it takes the traffic even when the host already swaps
+#   2. one fcvm VM; its firecracker moved into a cgroup-v2 group with
+#      memory.max far below guest RAM, then the guest dirties enough anonymous
+#      memory that the host swaps guest pages out to the dm device
+#   3. dmsetup suspend — all swap I/O now blocks indefinitely
+#   4. an exec in the guest touches the swapped pages: vCPU threads enter
+#      do_swap_page and wait on folios locked under the suspended I/O
+#   5. SIGKILL the firecracker PID
+#   6. REPRODUCTION = the PID stays NON-zombie for the whole window (default
+#      20s, FCVM_RED_WINDOW_SECONDS) with the SIGKILL bit pending in its
+#      status — the exact signature the wild failure showed. Evidence
+#      (per-TID stack/wchan/status + reclaim/compaction diagnostics) is
+#      captured while the survivor exists.
+#   7. RECOVERY always runs from the EXIT trap: dmsetup resume lets the I/O
+#      complete, the pending SIGKILL lands, and the harness asserts the
+#      process reaps promptly, then removes swap/dm/loop/cgroup — the box is
+#      never left wedged.
+#
+# Exit codes:
+#   0  reproduced AND recovered AND cleaned up
+#   3  the class did not manifest here (SIGKILL reaped the VMM inside the
+#      window, or no uninterruptible fault could be staged) — meaningful
+#      negative result for this kernel
+#   4  the survivor did NOT reap after resume; the host needs attention
+#   other  harness/setup failure
+#
+# Root required (dmsetup, swapon, cgroup writes). Never run on a box whose
+# existing swap you care about: it adds and removes its own device only, but
+# the memory pressure it creates is real.
+set -euo pipefail
+
+FCVM_BIN="${FCVM_BIN:-./target/release/fcvm}"
+IMAGE="${FCVM_TEST_IMAGE:-nginx:alpine}"
+RED_WINDOW="${FCVM_RED_WINDOW_SECONDS:-20}"
+EVIDENCE_DIR="${FCVM_TEARDOWN_EVIDENCE_DIR:-/tmp/fcvm-teardown-evidence}"
+WORK_DIR="${FCVM_TEARDOWN_WORK_DIR:-/var/tmp}"
+SWAP_SIZE_MIB=2048
+CGROUP_LIMIT="${FCVM_TEARDOWN_CGROUP_LIMIT:-256M}"
+DIRTY_BYTES=400000000 # ~400 MB dirtied in-guest, >> the 256M cgroup limit
+
+RUN_ID="$$-$(date +%s)"
+DM_NAME="fcvm-teardown-red-${RUN_ID}"
+SWAPFILE="${WORK_DIR}/fcvm-teardown-red-${RUN_ID}.swap"
+CG="/sys/fs/cgroup/fcvm-teardown-red-${RUN_ID}"
+VM_NAME="teardown-red-${RUN_ID}"
+
+# shellcheck source=scripts/lib/vm-evidence.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/vm-evidence.sh"
+
+mkdir -p "$EVIDENCE_DIR"
+exec > >(tee -a "${EVIDENCE_DIR}/folio-lock-red.log") 2>&1
+
+[ "$(id -u)" -eq 0 ] || { echo "FATAL: must run as root"; exit 1; }
+for tool in dmsetup losetup mkswap swapon blockdev; do
+	command -v "$tool" >/dev/null || { echo "FATAL: $tool not installed"; exit 1; }
+done
+[ -x "$FCVM_BIN" ] || { echo "FATAL: fcvm binary not found at $FCVM_BIN (run make build)"; exit 1; }
+grep -qw memory /sys/fs/cgroup/cgroup.controllers 2>/dev/null ||
+	{ echo "FATAL: cgroup v2 memory controller unavailable"; exit 1; }
+
+proc_state() {
+	# Empty output = process gone.
+	awk '/^State:/{print $2}' "/proc/$1/status" 2>/dev/null
+}
+
+proc_ppid() {
+	local stat
+	stat=$(cat "/proc/$1/stat" 2>/dev/null) || return 1
+	stat=${stat##*') '}
+	read -r _ ppid _ <<<"$stat"
+	echo "$ppid"
+}
+
+is_descendant_of() {
+	local pid=$1 ancestor=$2 hop
+	for hop in $(seq 1 32); do
+		: "$hop"
+		[ "$pid" = "$ancestor" ] && return 0
+		[ "$pid" -le 1 ] && return 1
+		pid=$(proc_ppid "$pid") || return 1
+	done
+	return 1
+}
+
+find_firecracker_descendant() {
+	local root=$1 entry pid comm
+	for entry in /proc/[0-9]*; do
+		pid=${entry#/proc/}
+		comm=$(cat "$entry/comm" 2>/dev/null) || continue
+		case $comm in firecracker*) ;; *) continue ;; esac
+		if is_descendant_of "$pid" "$root"; then
+			echo "$pid"
+			return 0
+		fi
+	done
+	return 1
+}
+
+dump_survivor_evidence() {
+	local pid=$1 label=$2 task
+	echo "===== survivor evidence (${label}) ====="
+	for task in "/proc/${pid}/task"/*; do
+		[ -d "$task" ] || continue
+		vm_evidence_tid "$pid" "${task##*/}"
+	done
+	vm_evidence_mm_diagnostics 150
+	echo "===== end survivor evidence (${label}) ====="
+}
+
+SUSPENDED=0
+SWAP_ON=0
+WEDGED=0
+FC_PID=""
+FCVM_PID=""
+TOUCH_PID=""
+LOOPDEV=""
+
+# shellcheck disable=SC2317  # reached via `trap cleanup EXIT`, not fall-through
+cleanup() {
+	local rc=$? deadline state
+	set +e
+	echo "=== cleanup (script exiting with ${rc}) ==="
+
+	# Order matters: resume FIRST. Every later step (swapoff, dmsetup remove)
+	# performs I/O that would hang forever against a suspended device.
+	if [ "$SUSPENDED" = 1 ]; then
+		dmsetup resume "$DM_NAME" && SUSPENDED=0
+		echo "dm device resumed"
+	fi
+
+	# With I/O flowing again the pending SIGKILL must land. This is the
+	# recovery half of the reproduction: a survivor here means the host is
+	# genuinely wedged and a human (or runner replacement) is needed.
+	if [ -n "$FC_PID" ]; then
+		deadline=$((SECONDS + 30))
+		while [ "$SECONDS" -lt "$deadline" ]; do
+			state=$(proc_state "$FC_PID")
+			[ -z "$state" ] || [ "$state" = "Z" ] && break
+			kill -9 "$FC_PID" 2>/dev/null
+			sleep 1
+		done
+		state=$(proc_state "$FC_PID")
+		if [ -n "$state" ] && [ "$state" != "Z" ]; then
+			echo "FATAL: firecracker ${FC_PID} still ${state} 30s after resume — host wedged"
+			dump_survivor_evidence "$FC_PID" "post-resume, unrecovered"
+			WEDGED=1
+		else
+			echo "firecracker ${FC_PID} reaped after resume"
+		fi
+	fi
+
+	[ -n "$TOUCH_PID" ] && kill -9 "$TOUCH_PID" 2>/dev/null
+	if [ -n "$FCVM_PID" ] && kill -0 "$FCVM_PID" 2>/dev/null; then
+		kill -TERM "$FCVM_PID" 2>/dev/null
+		deadline=$((SECONDS + 30))
+		while kill -0 "$FCVM_PID" 2>/dev/null && [ "$SECONDS" -lt "$deadline" ]; do
+			sleep 1
+		done
+		kill -9 "$FCVM_PID" 2>/dev/null
+	fi
+	wait 2>/dev/null
+
+	[ "$SWAP_ON" = 1 ] && { timeout 60 swapoff "/dev/mapper/${DM_NAME}" || echo "WARN: swapoff failed"; }
+	if dmsetup info "$DM_NAME" >/dev/null 2>&1; then
+		timeout 30 dmsetup remove "$DM_NAME" ||
+			{ sleep 2; timeout 30 dmsetup remove "$DM_NAME" || echo "WARN: dmsetup remove failed"; }
+	fi
+	[ -n "$LOOPDEV" ] && { losetup -d "$LOOPDEV" 2>/dev/null || echo "WARN: losetup -d failed"; }
+	rm -f "$SWAPFILE"
+	[ -d "$CG" ] && { rmdir "$CG" 2>/dev/null || echo "WARN: cgroup ${CG} not removable (procs left?)"; }
+	echo "=== cleanup done ==="
+	[ "$WEDGED" = 1 ] && exit 4
+}
+trap cleanup EXIT
+
+echo "=== fcvm teardown folio-lock RED harness (${RUN_ID}) ==="
+echo "window=${RED_WINDOW}s cgroup-limit=${CGROUP_LIMIT} image=${IMAGE}"
+
+echo "--- step 1: swapfile on a suspendable dm-linear device"
+dd if=/dev/zero of="$SWAPFILE" bs=1M count="$SWAP_SIZE_MIB" status=none
+chmod 600 "$SWAPFILE"
+LOOPDEV=$(losetup --find --show "$SWAPFILE")
+dmsetup create "$DM_NAME" --table "0 $(blockdev --getsz "$LOOPDEV") linear ${LOOPDEV} 0"
+mkswap "/dev/mapper/${DM_NAME}" >/dev/null
+swapon --priority 100 "/dev/mapper/${DM_NAME}"
+SWAP_ON=1
+echo "swap device /dev/mapper/${DM_NAME} on ${LOOPDEV} (${SWAP_SIZE_MIB} MiB, prio 100)"
+
+echo "--- step 2: VM under a ${CGROUP_LIMIT} memory ceiling"
+mkdir "$CG"
+[ -f "${CG}/memory.max" ] || { echo "FATAL: ${CG} has no memory controller"; exit 1; }
+"$FCVM_BIN" podman run --name "$VM_NAME" --network rootless --mem 1024 "$IMAGE" \
+	>"${EVIDENCE_DIR}/vm-${RUN_ID}.log" 2>&1 &
+FCVM_PID=$!
+echo "fcvm PID ${FCVM_PID}; waiting for guest exec"
+DEADLINE=$((SECONDS + 240))
+until timeout 15 "$FCVM_BIN" exec --pid "$FCVM_PID" --vm -- true >/dev/null 2>&1; do
+	kill -0 "$FCVM_PID" 2>/dev/null || { echo "FATAL: fcvm exited during boot; see vm-${RUN_ID}.log"; exit 1; }
+	[ "$SECONDS" -lt "$DEADLINE" ] || { echo "FATAL: guest never became exec-ready"; exit 1; }
+	sleep 2
+done
+FC_PID=$(find_firecracker_descendant "$FCVM_PID") ||
+	{ echo "FATAL: no firecracker under fcvm ${FCVM_PID}"; exit 1; }
+echo "firecracker PID ${FC_PID}"
+# Constrain only the VMM (guest RAM is its anonymous memory). Boot ran
+# unconstrained so the pressure starts exactly when the experiment does.
+echo "$FC_PID" >"${CG}/cgroup.procs"
+echo "$CGROUP_LIMIT" >"${CG}/memory.max"
+
+echo "--- step 3: dirty ${DIRTY_BYTES} bytes in-guest so host pages swap out"
+timeout 300 "$FCVM_BIN" exec --pid "$FCVM_PID" --vm -- \
+	sh -c "yes SWAPME | head -c ${DIRTY_BYTES} > /dev/shm/swapme && sync" ||
+	{ echo "FATAL: could not dirty guest memory"; exit 1; }
+DEADLINE=$((SECONDS + 120))
+SWAPPED=0
+while [ "$SECONDS" -lt "$DEADLINE" ]; do
+	SWAPPED=$(cat "${CG}/memory.swap.current" 2>/dev/null || echo 0)
+	[ "$SWAPPED" -ge 104857600 ] && break
+	sleep 1
+done
+if [ "$SWAPPED" -lt 104857600 ]; then
+	echo "FATAL: only $((SWAPPED / 1048576)) MiB swapped; cannot stage the class here"
+	exit 3
+fi
+echo "cgroup swapped $((SWAPPED / 1048576)) MiB; device usage: $(awk -v d="/dev/mapper/${DM_NAME}" '$1==d{print $4" KiB"}' /proc/swaps)"
+
+echo "--- step 4: suspend the swap device; touch the swapped pages"
+dmsetup suspend "$DM_NAME"
+SUSPENDED=1
+timeout 180 "$FCVM_BIN" exec --pid "$FCVM_PID" --vm -- \
+	sh -c "md5sum /dev/shm/swapme" >"${EVIDENCE_DIR}/touch-${RUN_ID}.log" 2>&1 &
+TOUCH_PID=$!
+DEADLINE=$((SECONDS + 60))
+PARKED=""
+while [ -z "$PARKED" ] && [ "$SECONDS" -lt "$DEADLINE" ]; do
+	for task in "/proc/${FC_PID}/task"/*; do
+		[ -d "$task" ] || continue
+		if [ "$(awk '/^State:/{print $2}' "${task}/status" 2>/dev/null)" = "D" ]; then
+			PARKED="${task##*/}"
+			echo "task ${PARKED} uninterruptible (wchan: $(cat "${task}/wchan" 2>/dev/null))"
+			break
+		fi
+	done
+	[ -n "$PARKED" ] || sleep 0.5
+done
+if [ -z "$PARKED" ]; then
+	echo "FATAL: no vCPU entered D state under suspended swap; nothing to reproduce against"
+	exit 3
+fi
+
+echo "--- step 5: SIGKILL firecracker ${FC_PID} while the fault is wedged"
+kill -9 "$FC_PID"
+KILLED_AT=$SECONDS
+
+echo "--- step 6: watch the window (${RED_WINDOW}s): reproduced = still non-zombie at the end"
+REPRODUCED=1
+while [ $((SECONDS - KILLED_AT)) -lt "$RED_WINDOW" ]; do
+	STATE=$(proc_state "$FC_PID")
+	if [ -z "$STATE" ] || [ "$STATE" = "Z" ]; then
+		echo "firecracker reaped ${STATE:+(zombie) }after $((SECONDS - KILLED_AT))s — class did NOT manifest"
+		REPRODUCED=0
+		break
+	fi
+	sleep 1
+done
+
+if [ "$REPRODUCED" = 1 ]; then
+	STATE=$(proc_state "$FC_PID")
+	PENDING=$(awk '/^(SigPnd|ShdPnd):/{print}' "/proc/${FC_PID}/status" 2>/dev/null)
+	echo "REPRODUCED: firecracker ${FC_PID} state=${STATE} ${RED_WINDOW}s after SIGKILL"
+	printf '%s\n' "$PENDING"
+	# SIGKILL is signal 9 -> bit 0x100 of the pending masks.
+	KILL_PENDING=0
+	for mask in $(printf '%s\n' "$PENDING" | awk '{print $2}'); do
+		[ $((16#$mask & 16#100)) -ne 0 ] && KILL_PENDING=1
+	done
+	if [ "$KILL_PENDING" != 1 ]; then
+		echo "WARN: survivor exists but no pending SIGKILL bit found — inspect the status dump"
+	fi
+	dump_survivor_evidence "$FC_PID" "SIGKILL survivor, ${RED_WINDOW}s window"
+	echo "=== RESULT: reproduced (recovery follows in cleanup) ==="
+	exit 0
+fi
+
+echo "=== RESULT: not reproduced on this kernel/host ==="
+exit 3

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -2231,6 +2231,10 @@ async fn cmd_snapshot_run_inner(
                     // `bail!` turns it into a non-zero exit. `cleanup_vm` then kills the
                     // VMM — a wedged task waits in TASK_KILLABLE (`fs/userfaultfd.c`), so
                     // SIGKILL does reap it, measured under 2s on an already-parked clone.
+                    // That reap is enforced (5s ceiling, concurrent clones) by
+                    // `concurrent_sigkill_reaps_clones_parked_on_unserved_faults` in
+                    // tests/test_snapshot_clone.rs, so a kernel rebase that breaks the
+                    // killable property fails a test instead of wedging a runner.
                     clone_failure = Some(format!(
                         "its memory server (PID {}) exited while this clone was still \
                          running. Every page not already faulted in is unreachable, and \

--- a/tests/test_ci_infrastructure.py
+++ b/tests/test_ci_infrastructure.py
@@ -168,6 +168,9 @@ class StrayVmGuardTests(unittest.TestCase):
         hang_ps: bool = False,
         dry_run: bool = True,
         outer_timeout: float = 5,
+        proc_root: Path | None = None,
+        pgrep_output: str = "",
+        dmesg_output: str = "mock dmesg line\n",
     ) -> tuple[subprocess.CompletedProcess[str], Path, str, str, float]:
         temporary = tempfile.TemporaryDirectory()
         self.addCleanup(temporary.cleanup)
@@ -178,6 +181,30 @@ class StrayVmGuardTests(unittest.TestCase):
         log_dir.mkdir()
         ps_calls = root / "ps-calls"
         sudo_calls = root / "sudo-calls"
+        # Hermetic procfs: evidence reads must never touch the real /proc of the
+        # machine running the test suite, so every run gets a synthetic tree
+        # (empty unless the test builds one). pgrep and dmesg are mocked for the
+        # same reason — the guard samples real kcompactd/kswapd tasks and the
+        # real kernel ring buffer in production, which is exactly the
+        # nondeterminism a unit test must not depend on.
+        if proc_root is None:
+            proc_root = root / "proc"
+            proc_root.mkdir()
+
+        fake_pgrep = bin_dir / "pgrep"
+        fake_pgrep.write_text(
+            "#!/usr/bin/env bash\n"
+            'if [ -n "${MOCK_PGREP_OUTPUT:-}" ]; then\n'
+            '  printf \'%s\\n\' "$MOCK_PGREP_OUTPUT"\n'
+            "fi\n"
+        )
+        fake_pgrep.chmod(0o755)
+
+        fake_dmesg = bin_dir / "dmesg"
+        fake_dmesg.write_text(
+            "#!/usr/bin/env bash\n" 'printf \'%s\' "${MOCK_DMESG_OUTPUT:-}"\n'
+        )
+        fake_dmesg.chmod(0o755)
 
         fake_ps = bin_dir / "ps"
         fake_ps.write_text(
@@ -209,12 +236,16 @@ class StrayVmGuardTests(unittest.TestCase):
                 "PATH": f"{bin_dir}:{env['PATH']}",
                 "FCVM_TEST_LOG_DIR": str(log_dir),
                 "FCVM_GUARD_SCAN_TIMEOUT_SECONDS": "1",
+                "FCVM_PROC_ROOT": str(proc_root),
+                "FCVM_MM_SAMPLE_INTERVAL_SECONDS": "0",
                 "MOCK_PS_CALLS": str(ps_calls),
                 "MOCK_PS_HANG": "1" if hang_ps else "0",
                 "MOCK_PS_OUTPUT": ps_output,
                 "MOCK_PS_OUTPUT_AFTER": (
                     ps_output if ps_output_after is None else ps_output_after
                 ),
+                "MOCK_PGREP_OUTPUT": pgrep_output,
+                "MOCK_DMESG_OUTPUT": dmesg_output,
                 "MOCK_SUDO_CALLS": str(sudo_calls),
             }
         )
@@ -239,6 +270,77 @@ class StrayVmGuardTests(unittest.TestCase):
             sudo_calls.read_text() if sudo_calls.exists() else "",
             elapsed,
         )
+
+    @staticmethod
+    def make_fake_task(
+        proc_root: Path,
+        tgid: int,
+        tid: int,
+        *,
+        name: str,
+        state: str,
+        sigpnd: str = "0000000000000000",
+        shdpnd: str = "0000000000000000",
+        wchan: str = "0",
+        stack_lines: list[str] | None = None,
+    ) -> None:
+        """Materialize /proc/<tgid>/task/<tid>/{status,wchan,stack} in a fake tree."""
+        task = proc_root / str(tgid) / "task" / str(tid)
+        task.mkdir(parents=True)
+        (task / "status").write_text(
+            f"Name:\t{name}\n"
+            f"State:\t{state}\n"
+            f"SigPnd:\t{sigpnd}\n"
+            f"ShdPnd:\t{shdpnd}\n"
+            "SigBlk:\t0000000000000000\n"
+        )
+        (task / "wchan").write_text(wchan)
+        if stack_lines is not None:
+            (task / "stack").write_text("\n".join(stack_lines) + "\n")
+
+    def make_wedged_group_proc_root(self) -> Path:
+        """A firecracker group matching the ARM CI failure class: leader in D,
+        vCPU sibling parked under a migration entry with SIGKILL pending."""
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        proc_root = Path(temporary.name) / "proc"
+        proc_root.mkdir()
+        # SIGKILL is signal 9: bit 9 of the pending mask = 0x100.
+        stack = [
+            "[<0>] softleaf_entry_wait_on_locked+0x1c8/0x2d0",
+            "[<0>] migration_entry_wait+0x64/0x90",
+            "[<0>] do_swap_page+0x8a0/0xb60",
+        ] + [f"[<0>] filler_frame_{i:03d}+0x10/0x20" for i in range(4, 101)]
+        self.make_fake_task(
+            proc_root,
+            100,
+            100,
+            name="firecracker-def",
+            state="D (disk sleep)",
+            shdpnd="0000000000000100",
+            wchan="softleaf_entry_wait_on_locked",
+            stack_lines=stack,
+        )
+        self.make_fake_task(
+            proc_root,
+            100,
+            101,
+            name="fc_vcpu 0",
+            state="D (disk sleep)",
+            shdpnd="0000000000000100",
+            wchan="softleaf_entry_wait_on_locked",
+            stack_lines=stack,
+        )
+        self.make_fake_task(
+            proc_root,
+            200,
+            200,
+            name="fcvm",
+            state="S (sleeping)",
+            wchan="do_wait",
+            stack_lines=["[<0>] do_wait+0x100/0x200"],
+        )
+        return proc_root
 
     def run_guard_with_scanner_descendant_holding_stderr(
         self,
@@ -419,6 +521,110 @@ class StrayVmGuardTests(unittest.TestCase):
         after_report = log_dir / "stray-vm-threads-post-after.tsv"
         self.assertTrue(after_report.is_file())
         self.assertIn("100\t101\t1\tD\tfc_vcpu 0", after_report.read_text())
+
+    def test_evidence_is_captured_per_tid_before_the_kill_and_for_survivors(self) -> None:
+        """The August 2026 wedge was diagnosed by hand from /proc stacks that were
+        never archived; the runner was recycled and the evidence was lost. The
+        guard must capture stack/wchan/status for every reported thread BEFORE it
+        attempts the kill, and again for whatever survives SIGKILL."""
+        before = (
+            "100 100 1 D firecracker-def\n"
+            "100 101 1 D fc_vcpu 0\n"
+            "200 200 1 S fcvm\n"
+        )
+        after = "100 100 1 D firecracker-def\n100 101 1 D fc_vcpu 0\n"
+
+        result, _log_dir, _ps_calls, _sudo_calls, _elapsed = self.run_guard(
+            before,
+            ps_output_after=after,
+            dry_run=False,
+            proc_root=self.make_wedged_group_proc_root(),
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        # Capture precedes the kill attempt: a task that only becomes evidence
+        # after SIGKILL has already lost the state the kill may destroy.
+        pre = result.stdout.index("per-thread evidence (pre-kill")
+        kill = result.stdout.index("killed 2 process group(s)")
+        self.assertLess(pre, kill)
+
+        pre_section = result.stdout[pre:kill]
+        for tid_line in ["tgid=100 tid=100", "tgid=100 tid=101", "tgid=200 tid=200"]:
+            self.assertIn(tid_line, pre_section)
+        self.assertIn("State:\tD (disk sleep)", pre_section)
+        self.assertIn("wchan: softleaf_entry_wait_on_locked", pre_section)
+        self.assertIn("migration_entry_wait", pre_section)
+
+        # Stacks are capped so one wedged group cannot flood the CI log.
+        self.assertIn("filler_frame_060", pre_section)
+        self.assertNotIn("filler_frame_061", pre_section)
+
+        # Survivors get a second capture: State + SigPnd/ShdPnd is the proof of
+        # "SIGKILL pending on a non-zombie task".
+        post = result.stdout.index("per-thread evidence (post-SIGKILL survivors")
+        post_section = result.stdout[post:]
+        self.assertIn("tgid=100 tid=100", post_section)
+        self.assertIn("tgid=100 tid=101", post_section)
+        self.assertNotIn("tgid=200", post_section)
+        self.assertIn("ShdPnd:\t0000000000000100", post_section)
+
+    def test_survivors_trigger_memory_management_diagnostics(self) -> None:
+        """A SIGKILL survivor means some kernel path owns the task. The lost ARM
+        evidence pointed at compaction (kcompactd owning a folio lock), so the
+        guard must sample reclaim/compaction stacks and counters while the
+        survivor still exists."""
+        proc_root = self.make_wedged_group_proc_root()
+        for pid, comm in [(300, "kcompactd0"), (301, "kswapd0")]:
+            main = proc_root / str(pid)
+            main.mkdir()
+            (main / "comm").write_text(f"{comm}\n")
+            (main / "stack").write_text(
+                "[<0>] compaction_alloc+0x3c/0x68\n[<0>] migrate_pages+0x9c/0x200\n"
+            )
+        (proc_root / "vmstat").write_text(
+            "nr_free_pages 12345\ncompact_stall 42\ncompact_fail 7\n"
+        )
+        (proc_root / "pressure").mkdir()
+        (proc_root / "pressure" / "memory").write_text(
+            "some avg10=0.45 avg60=0.10 avg300=0.02 total=123456\n"
+            "full avg10=1.23 avg60=0.40 avg300=0.08 total=98765\n"
+        )
+        dmesg = "".join(f"DMESG_LINE_{i:03d}\n" for i in range(1, 201))
+
+        before = "100 100 1 D firecracker-def\n100 101 1 D fc_vcpu 0\n"
+
+        result, _log_dir, _ps_calls, _sudo_calls, _elapsed = self.run_guard(
+            before,
+            ps_output_after=before,
+            dry_run=False,
+            proc_root=proc_root,
+            pgrep_output="300\n301",
+            dmesg_output=dmesg,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("memory-management diagnostics", result.stdout)
+        for sample in ["sample 1/3", "sample 2/3", "sample 3/3"]:
+            self.assertIn(sample, result.stdout)
+        self.assertIn("[kcompactd0] pid=300", result.stdout)
+        self.assertIn("[kswapd0] pid=301", result.stdout)
+        self.assertIn("compaction_alloc", result.stdout)
+        self.assertIn("compact_stall 42", result.stdout)
+        self.assertIn("full avg10=1.23", result.stdout)
+        # dmesg is the LAST 150 lines, unfiltered: line 51 survives the cut,
+        # line 50 does not.
+        self.assertIn("DMESG_LINE_051", result.stdout)
+        self.assertNotIn("DMESG_LINE_050", result.stdout)
+
+    def test_healthy_and_dry_runs_stay_quiet_about_mm_diagnostics(self) -> None:
+        """No stray groups: no evidence sections at all. The guard's report must
+        stay empty-when-healthy so a green run's log carries zero noise."""
+        result, _log_dir, _ps_calls, _sudo_calls, _elapsed = self.run_guard("")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("per-thread evidence", result.stdout)
+        self.assertNotIn("memory-management diagnostics", result.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_ci_infrastructure.py
+++ b/tests/test_ci_infrastructure.py
@@ -15,6 +15,111 @@ ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "classify_ci_failure.py"
 FIXTURES = ROOT / "tests" / "fixtures" / "ci-infrastructure"
 STRAY_GUARD = ROOT / "scripts" / "ci-stray-vm-guard.sh"
+DSTATE_WATCHDOG = ROOT / "scripts" / "ci-dstate-watchdog.sh"
+
+# Mock process tools shared by the guard and watchdog suites. Both scripts must
+# stay hermetic under test: the real ps/pgrep/dmesg/proc of the machine running
+# the suite are exactly the nondeterminism these fixtures exist to remove.
+MOCK_PS_SCRIPT = (
+    "#!/usr/bin/env bash\n"
+    "printf '%s\\n' \"$*\" >>\"$MOCK_PS_CALLS\"\n"
+    "case \"$*\" in\n"
+    "  *args*|*cmdline*|*command*) exit 93 ;;\n"
+    "esac\n"
+    "if [ \"${MOCK_PS_HANG:-0}\" = 1 ]; then exec sleep 30; fi\n"
+    "call_count=$(wc -l <\"$MOCK_PS_CALLS\")\n"
+    "if [ \"$call_count\" -gt 1 ]; then\n"
+    "  printf '%s' \"$MOCK_PS_OUTPUT_AFTER\"\n"
+    "else\n"
+    "  printf '%s' \"${MOCK_PS_OUTPUT:-}\"\n"
+    "fi\n"
+)
+MOCK_PGREP_SCRIPT = (
+    "#!/usr/bin/env bash\n"
+    'if [ -n "${MOCK_PGREP_OUTPUT:-}" ]; then\n'
+    '  printf \'%s\\n\' "$MOCK_PGREP_OUTPUT"\n'
+    "fi\n"
+)
+MOCK_DMESG_SCRIPT = "#!/usr/bin/env bash\n" 'printf \'%s\' "${MOCK_DMESG_OUTPUT:-}"\n'
+MOCK_SUDO_SCRIPT = "#!/usr/bin/env bash\n" "printf '%s\\n' \"$*\" >>\"$MOCK_SUDO_CALLS\"\n"
+
+
+def write_mock_tool(bin_dir: Path, name: str, script: str) -> None:
+    tool = bin_dir / name
+    tool.write_text(script)
+    tool.chmod(0o755)
+
+
+def make_fake_task(
+    proc_root: Path,
+    tgid: int,
+    tid: int,
+    *,
+    name: str,
+    state: str,
+    sigpnd: str = "0000000000000000",
+    shdpnd: str = "0000000000000000",
+    wchan: str = "0",
+    stack_lines: list[str] | None = None,
+) -> None:
+    """Materialize /proc/<tgid>/task/<tid>/{status,wchan,stack} in a fake tree."""
+    task = proc_root / str(tgid) / "task" / str(tid)
+    task.mkdir(parents=True)
+    (task / "status").write_text(
+        f"Name:\t{name}\n"
+        f"State:\t{state}\n"
+        f"SigPnd:\t{sigpnd}\n"
+        f"ShdPnd:\t{shdpnd}\n"
+        "SigBlk:\t0000000000000000\n"
+    )
+    (task / "wchan").write_text(wchan)
+    if stack_lines is not None:
+        (task / "stack").write_text("\n".join(stack_lines) + "\n")
+
+
+def make_wedged_group_proc_root(case: unittest.TestCase) -> Path:
+    """A firecracker group matching the ARM CI failure class: leader in D,
+    vCPU sibling parked under a migration entry with SIGKILL pending."""
+    temporary = tempfile.TemporaryDirectory()
+    case.addCleanup(temporary.cleanup)
+    proc_root = Path(temporary.name) / "proc"
+    proc_root.mkdir()
+    # SIGKILL is signal 9: bit 9 of the pending mask = 0x100.
+    stack = [
+        "[<0>] softleaf_entry_wait_on_locked+0x1c8/0x2d0",
+        "[<0>] migration_entry_wait+0x64/0x90",
+        "[<0>] do_swap_page+0x8a0/0xb60",
+    ] + [f"[<0>] filler_frame_{i:03d}+0x10/0x20" for i in range(4, 101)]
+    make_fake_task(
+        proc_root,
+        100,
+        100,
+        name="firecracker-def",
+        state="D (disk sleep)",
+        shdpnd="0000000000000100",
+        wchan="softleaf_entry_wait_on_locked",
+        stack_lines=stack,
+    )
+    make_fake_task(
+        proc_root,
+        100,
+        101,
+        name="fc_vcpu 0",
+        state="D (disk sleep)",
+        shdpnd="0000000000000100",
+        wchan="softleaf_entry_wait_on_locked",
+        stack_lines=stack,
+    )
+    make_fake_task(
+        proc_root,
+        200,
+        200,
+        name="fcvm",
+        state="S (sleeping)",
+        wchan="do_wait",
+        stack_lines=["[<0>] do_wait+0x100/0x200"],
+    )
+    return proc_root
 
 CLASSIFIER_SPEC = importlib.util.spec_from_file_location(
     "classify_ci_failure", SCRIPT
@@ -171,6 +276,7 @@ class StrayVmGuardTests(unittest.TestCase):
         proc_root: Path | None = None,
         pgrep_output: str = "",
         dmesg_output: str = "mock dmesg line\n",
+        scan_timeout: str = "5",
     ) -> tuple[subprocess.CompletedProcess[str], Path, str, str, float]:
         temporary = tempfile.TemporaryDirectory()
         self.addCleanup(temporary.cleanup)
@@ -183,59 +289,26 @@ class StrayVmGuardTests(unittest.TestCase):
         sudo_calls = root / "sudo-calls"
         # Hermetic procfs: evidence reads must never touch the real /proc of the
         # machine running the test suite, so every run gets a synthetic tree
-        # (empty unless the test builds one). pgrep and dmesg are mocked for the
-        # same reason — the guard samples real kcompactd/kswapd tasks and the
-        # real kernel ring buffer in production, which is exactly the
-        # nondeterminism a unit test must not depend on.
+        # (empty unless the test builds one).
         if proc_root is None:
             proc_root = root / "proc"
             proc_root.mkdir()
 
-        fake_pgrep = bin_dir / "pgrep"
-        fake_pgrep.write_text(
-            "#!/usr/bin/env bash\n"
-            'if [ -n "${MOCK_PGREP_OUTPUT:-}" ]; then\n'
-            '  printf \'%s\\n\' "$MOCK_PGREP_OUTPUT"\n'
-            "fi\n"
-        )
-        fake_pgrep.chmod(0o755)
-
-        fake_dmesg = bin_dir / "dmesg"
-        fake_dmesg.write_text(
-            "#!/usr/bin/env bash\n" 'printf \'%s\' "${MOCK_DMESG_OUTPUT:-}"\n'
-        )
-        fake_dmesg.chmod(0o755)
-
-        fake_ps = bin_dir / "ps"
-        fake_ps.write_text(
-            "#!/usr/bin/env bash\n"
-            "printf '%s\\n' \"$*\" >>\"$MOCK_PS_CALLS\"\n"
-            "case \"$*\" in\n"
-            "  *args*|*cmdline*|*command*) exit 93 ;;\n"
-            "esac\n"
-            "if [ \"${MOCK_PS_HANG:-0}\" = 1 ]; then exec sleep 30; fi\n"
-            "call_count=$(wc -l <\"$MOCK_PS_CALLS\")\n"
-            "if [ \"$call_count\" -gt 1 ]; then\n"
-            "  printf '%s' \"$MOCK_PS_OUTPUT_AFTER\"\n"
-            "else\n"
-            "  printf '%s' \"${MOCK_PS_OUTPUT:-}\"\n"
-            "fi\n"
-        )
-        fake_ps.chmod(0o755)
-
-        fake_sudo = bin_dir / "sudo"
-        fake_sudo.write_text(
-            "#!/usr/bin/env bash\n"
-            "printf '%s\\n' \"$*\" >>\"$MOCK_SUDO_CALLS\"\n"
-        )
-        fake_sudo.chmod(0o755)
+        write_mock_tool(bin_dir, "ps", MOCK_PS_SCRIPT)
+        write_mock_tool(bin_dir, "pgrep", MOCK_PGREP_SCRIPT)
+        write_mock_tool(bin_dir, "dmesg", MOCK_DMESG_SCRIPT)
+        write_mock_tool(bin_dir, "sudo", MOCK_SUDO_SCRIPT)
 
         env = os.environ.copy()
         env.update(
             {
                 "PATH": f"{bin_dir}:{env['PATH']}",
                 "FCVM_TEST_LOG_DIR": str(log_dir),
-                "FCVM_GUARD_SCAN_TIMEOUT_SECONDS": "1",
+                # The scan deadline compares integer $SECONDS, so a scan begun
+                # near a second boundary can "time out" in milliseconds. 5s
+                # keeps instant mock responses safely inside the window; only
+                # hang tests pass 1 (they assert the timeout itself).
+                "FCVM_GUARD_SCAN_TIMEOUT_SECONDS": scan_timeout,
                 "FCVM_PROC_ROOT": str(proc_root),
                 "FCVM_MM_SAMPLE_INTERVAL_SECONDS": "0",
                 "MOCK_PS_CALLS": str(ps_calls),
@@ -270,77 +343,6 @@ class StrayVmGuardTests(unittest.TestCase):
             sudo_calls.read_text() if sudo_calls.exists() else "",
             elapsed,
         )
-
-    @staticmethod
-    def make_fake_task(
-        proc_root: Path,
-        tgid: int,
-        tid: int,
-        *,
-        name: str,
-        state: str,
-        sigpnd: str = "0000000000000000",
-        shdpnd: str = "0000000000000000",
-        wchan: str = "0",
-        stack_lines: list[str] | None = None,
-    ) -> None:
-        """Materialize /proc/<tgid>/task/<tid>/{status,wchan,stack} in a fake tree."""
-        task = proc_root / str(tgid) / "task" / str(tid)
-        task.mkdir(parents=True)
-        (task / "status").write_text(
-            f"Name:\t{name}\n"
-            f"State:\t{state}\n"
-            f"SigPnd:\t{sigpnd}\n"
-            f"ShdPnd:\t{shdpnd}\n"
-            "SigBlk:\t0000000000000000\n"
-        )
-        (task / "wchan").write_text(wchan)
-        if stack_lines is not None:
-            (task / "stack").write_text("\n".join(stack_lines) + "\n")
-
-    def make_wedged_group_proc_root(self) -> Path:
-        """A firecracker group matching the ARM CI failure class: leader in D,
-        vCPU sibling parked under a migration entry with SIGKILL pending."""
-        temporary = tempfile.TemporaryDirectory()
-        self.addCleanup(temporary.cleanup)
-        proc_root = Path(temporary.name) / "proc"
-        proc_root.mkdir()
-        # SIGKILL is signal 9: bit 9 of the pending mask = 0x100.
-        stack = [
-            "[<0>] softleaf_entry_wait_on_locked+0x1c8/0x2d0",
-            "[<0>] migration_entry_wait+0x64/0x90",
-            "[<0>] do_swap_page+0x8a0/0xb60",
-        ] + [f"[<0>] filler_frame_{i:03d}+0x10/0x20" for i in range(4, 101)]
-        self.make_fake_task(
-            proc_root,
-            100,
-            100,
-            name="firecracker-def",
-            state="D (disk sleep)",
-            shdpnd="0000000000000100",
-            wchan="softleaf_entry_wait_on_locked",
-            stack_lines=stack,
-        )
-        self.make_fake_task(
-            proc_root,
-            100,
-            101,
-            name="fc_vcpu 0",
-            state="D (disk sleep)",
-            shdpnd="0000000000000100",
-            wchan="softleaf_entry_wait_on_locked",
-            stack_lines=stack,
-        )
-        self.make_fake_task(
-            proc_root,
-            200,
-            200,
-            name="fcvm",
-            state="S (sleeping)",
-            wchan="do_wait",
-            stack_lines=["[<0>] do_wait+0x100/0x200"],
-        )
-        return proc_root
 
     def run_guard_with_scanner_descendant_holding_stderr(
         self,
@@ -461,7 +463,7 @@ class StrayVmGuardTests(unittest.TestCase):
 
     def test_scan_timeout_is_bounded_and_still_emits_artifacts(self) -> None:
         result, log_dir, ps_calls, _sudo_calls, elapsed = self.run_guard(
-            "", hang_ps=True
+            "", hang_ps=True, scan_timeout="1"
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -506,6 +508,7 @@ class StrayVmGuardTests(unittest.TestCase):
             before,
             ps_output_after=after,
             dry_run=False,
+            outer_timeout=20,
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -538,7 +541,8 @@ class StrayVmGuardTests(unittest.TestCase):
             before,
             ps_output_after=after,
             dry_run=False,
-            proc_root=self.make_wedged_group_proc_root(),
+            proc_root=make_wedged_group_proc_root(self),
+            outer_timeout=20,
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -574,7 +578,7 @@ class StrayVmGuardTests(unittest.TestCase):
         evidence pointed at compaction (kcompactd owning a folio lock), so the
         guard must sample reclaim/compaction stacks and counters while the
         survivor still exists."""
-        proc_root = self.make_wedged_group_proc_root()
+        proc_root = make_wedged_group_proc_root(self)
         for pid, comm in [(300, "kcompactd0"), (301, "kswapd0")]:
             main = proc_root / str(pid)
             main.mkdir()
@@ -601,6 +605,7 @@ class StrayVmGuardTests(unittest.TestCase):
             proc_root=proc_root,
             pgrep_output="300\n301",
             dmesg_output=dmesg,
+            outer_timeout=20,
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -625,6 +630,164 @@ class StrayVmGuardTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertNotIn("per-thread evidence", result.stdout)
         self.assertNotIn("memory-management diagnostics", result.stdout)
+
+
+class DStateWatchdogTests(unittest.TestCase):
+    """The watchdog streams wedge evidence into the LIVE job log. An ephemeral
+    runner that wedges is terminated with its artifacts (run 31363886999: log
+    stream stopped at 07:35:56, job failed 07:47:53, instance gone), so
+    post-job steps and uploads structurally cannot capture this class — only
+    what already reached stdout survives."""
+
+    DUMP_MARKER = "FCVM D-STATE WATCHDOG"
+
+    def start_watchdog(
+        self,
+        ps_first: str,
+        ps_rest: str,
+        *,
+        proc_root: Path | None = None,
+        dump_gap: str = "300",
+        pgrep_output: str = "",
+        dmesg_output: str = "mock dmesg line\n",
+    ) -> tuple[subprocess.Popen[str], Path, Path]:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        bin_dir = root / "bin"
+        bin_dir.mkdir()
+        ps_calls = root / "ps-calls"
+        sudo_calls = root / "sudo-calls"
+        if proc_root is None:
+            proc_root = root / "proc"
+            proc_root.mkdir()
+
+        write_mock_tool(bin_dir, "ps", MOCK_PS_SCRIPT)
+        write_mock_tool(bin_dir, "pgrep", MOCK_PGREP_SCRIPT)
+        write_mock_tool(bin_dir, "dmesg", MOCK_DMESG_SCRIPT)
+        write_mock_tool(bin_dir, "sudo", MOCK_SUDO_SCRIPT)
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{bin_dir}:{env['PATH']}",
+                "FCVM_WATCHDOG_INTERVAL_SECONDS": "0.2",
+                "FCVM_WATCHDOG_DUMP_INTERVAL_SECONDS": dump_gap,
+                # Integer-$SECONDS deadline: 1s can spuriously expire in
+                # milliseconds near a boundary; mocks answer instantly, so 5s
+                # keeps NOTE lines out of hermetic runs.
+                "FCVM_GUARD_SCAN_TIMEOUT_SECONDS": "5",
+                "FCVM_PROC_ROOT": str(proc_root),
+                "FCVM_MM_SAMPLE_INTERVAL_SECONDS": "0",
+                "MOCK_PS_CALLS": str(ps_calls),
+                "MOCK_PS_OUTPUT": ps_first,
+                "MOCK_PS_OUTPUT_AFTER": ps_rest,
+                "MOCK_PGREP_OUTPUT": pgrep_output,
+                "MOCK_DMESG_OUTPUT": dmesg_output,
+                "MOCK_SUDO_CALLS": str(sudo_calls),
+            }
+        )
+        process = subprocess.Popen(
+            [str(DSTATE_WATCHDOG)],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        return process, ps_calls, root
+
+    def stop_watchdog(self, process: subprocess.Popen[str]) -> tuple[str, str]:
+        process.terminate()
+        try:
+            stdout, stderr = process.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            stdout, stderr = process.communicate(timeout=10)
+            raise AssertionError("watchdog did not exit on SIGTERM")
+        return stdout, stderr
+
+    def wait_for_ps_calls(self, ps_calls: Path, count: int, deadline_s: float) -> None:
+        deadline = time.monotonic() + deadline_s
+        while time.monotonic() < deadline:
+            if ps_calls.exists() and len(ps_calls.read_text().splitlines()) >= count:
+                return
+            time.sleep(0.05)
+        raise AssertionError(f"watchdog never reached {count} scans in {deadline_s}s")
+
+    def test_healthy_runs_produce_zero_output(self) -> None:
+        """Green runs must not pay a single log line for the watchdog."""
+        process, ps_calls, _root = self.start_watchdog("", "")
+
+        self.wait_for_ps_calls(ps_calls, 5, 15)
+        stdout, stderr = self.stop_watchdog(process)
+
+        self.assertEqual(stdout, "")
+        self.assertEqual(stderr, "")
+        self.assertNotRegex(ps_calls.read_text(), r"args|cmdline|command")
+
+    def test_persistent_d_state_dumps_once_with_full_evidence(self) -> None:
+        """A D-state sibling seen in two consecutive samples is the wedge
+        signature; the dump must carry the same evidence the guard archives —
+        and exactly once until the rate-limit window passes."""
+        wedged = (
+            "100 100 1 D firecracker-def\n"
+            "100 101 1 D fc_vcpu 0\n"
+            "200 200 1 S fcvm\n"
+        )
+        dmesg = "".join(f"DMESG_LINE_{i:03d}\n" for i in range(1, 201))
+        process, ps_calls, _root = self.start_watchdog(
+            wedged,
+            wedged,
+            proc_root=make_wedged_group_proc_root(self),
+            pgrep_output="300",
+            dmesg_output=dmesg,
+        )
+
+        # Two samples arm the detector; a few more prove the rate limit holds.
+        self.wait_for_ps_calls(ps_calls, 6, 20)
+        stdout, _stderr = self.stop_watchdog(process)
+
+        self.assertEqual(stdout.count(self.DUMP_MARKER + ":"), 1, stdout)
+        self.assertIn("END FCVM D-STATE WATCHDOG DUMP", stdout)
+        # The healthy fcvm group (no D sibling, live leader) is not a suspect.
+        self.assertIn("tgid=100", stdout)
+        self.assertNotIn("tgid=200", stdout)
+        self.assertIn("State:\tD (disk sleep)", stdout)
+        self.assertIn("ShdPnd:\t0000000000000100", stdout)
+        self.assertIn("softleaf_entry_wait_on_locked", stdout)
+        self.assertIn("memory-management diagnostics", stdout)
+        # dmesg is cut to the last 120 lines here (live log budget): line 81
+        # survives, line 80 does not.
+        self.assertIn("DMESG_LINE_081", stdout)
+        self.assertNotIn("DMESG_LINE_080", stdout)
+        self.assertNotRegex(ps_calls.read_text(), r"args|cmdline|command")
+
+    def test_transient_d_state_stays_silent(self) -> None:
+        """One sample in D is normal life (ordinary I/O passes through D);
+        only persistence across consecutive samples may speak."""
+        wedged = "100 100 1 D firecracker-def\n"
+        process, ps_calls, _root = self.start_watchdog(wedged, "")
+
+        self.wait_for_ps_calls(ps_calls, 6, 15)
+        stdout, stderr = self.stop_watchdog(process)
+
+        self.assertEqual(stdout, "")
+        self.assertEqual(stderr, "")
+
+    def test_zombie_leader_with_live_sibling_dumps(self) -> None:
+        """The other wedge shape: the leader is already a zombie while a
+        sibling thread stays alive holding KVM/MM resources."""
+        half_dead = "100 100 1 Z firecracker-def\n100 101 1 S fc_vcpu 0\n"
+        process, ps_calls, _root = self.start_watchdog(
+            half_dead, half_dead, proc_root=make_wedged_group_proc_root(self)
+        )
+
+        self.wait_for_ps_calls(ps_calls, 4, 15)
+        stdout, _stderr = self.stop_watchdog(process)
+
+        self.assertEqual(stdout.count(self.DUMP_MARKER + ":"), 1, stdout)
+        self.assertIn("zombie leader", stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_snapshot_clone.rs
+++ b/tests/test_snapshot_clone.rs
@@ -2598,6 +2598,346 @@ async fn a_clone_dies_when_its_memory_server_dies() -> Result<()> {
     Ok(())
 }
 
+/// comm, state, ppid, starttime (fields 2, 3, 4, 22) from `/proc/<pid>/stat`.
+/// comm may contain spaces and parens, so parse around the LAST `)`.
+#[cfg(feature = "privileged-tests")]
+fn proc_stat(pid: u32) -> Option<(String, char, u32, u64)> {
+    let text = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let open = text.find('(')?;
+    let close = text.rfind(')')?;
+    let comm = text[open + 1..close].to_string();
+    let rest: Vec<&str> = text[close + 1..].split_whitespace().collect();
+    let state = rest.first()?.chars().next()?;
+    let ppid = rest.get(1)?.parse().ok()?;
+    let starttime = rest.get(19)?.parse().ok()?;
+    Some((comm, state, ppid, starttime))
+}
+
+#[cfg(feature = "privileged-tests")]
+fn is_descendant_of(mut pid: u32, ancestor: u32) -> bool {
+    for _ in 0..32 {
+        if pid == ancestor {
+            return true;
+        }
+        if pid <= 1 {
+            return false;
+        }
+        match proc_stat(pid) {
+            Some((_, _, ppid, _)) => pid = ppid,
+            None => return false,
+        }
+    }
+    false
+}
+
+/// The firecracker process under a given fcvm, as (pid, starttime). The
+/// starttime pins identity across the assertion window: a reused PID has a
+/// different starttime, so it can never masquerade as an unreaped VMM.
+#[cfg(feature = "privileged-tests")]
+fn find_firecracker_descendant(fcvm_pid: u32) -> Option<(u32, u64)> {
+    for entry in std::fs::read_dir("/proc").ok()?.flatten() {
+        let Ok(pid) = entry.file_name().to_string_lossy().parse::<u32>() else {
+            continue;
+        };
+        let Some((comm, _, _, starttime)) = proc_stat(pid) else {
+            continue;
+        };
+        // TASK_COMM_LEN truncates the binary name to `firecracker-def`-style prefixes.
+        if comm.starts_with("firecracker") && is_descendant_of(pid, fcvm_pid) {
+            return Some((pid, starttime));
+        }
+    }
+    None
+}
+
+/// "Reaped" for this test means the kernel released the task: fully gone, the
+/// PID reused by a different process, or a zombie awaiting its parent's wait().
+/// What it must NOT be is a live task ignoring SIGKILL — that is the wedge.
+#[cfg(feature = "privileged-tests")]
+fn reaped_zombie_or_gone(pid: u32, starttime: u64) -> bool {
+    match proc_stat(pid) {
+        None => true,
+        Some((_, _, _, st)) if st != starttime => true,
+        Some((_, state, _, _)) => state == 'Z',
+    }
+}
+
+/// Per-TID stack/wchan/status for a survivor, mirroring what
+/// scripts/ci-stray-vm-guard.sh archives on CI. Kernel stacks need root, which
+/// privileged-tests runs have.
+#[cfg(feature = "privileged-tests")]
+fn dump_task_evidence(pid: u32) -> String {
+    let task_dir = format!("/proc/{pid}/task");
+    let Ok(entries) = std::fs::read_dir(&task_dir) else {
+        return format!("\n<{task_dir} unreadable — process gone>");
+    };
+    let mut out = String::new();
+    for entry in entries.flatten() {
+        let tid = entry.file_name().to_string_lossy().to_string();
+        let read = |file: &str| {
+            std::fs::read_to_string(entry.path().join(file))
+                .unwrap_or_else(|e| format!("<unreadable: {e}>"))
+        };
+        let status = read("status");
+        let signal_lines: Vec<&str> = status
+            .lines()
+            .filter(|l| {
+                ["Name:", "State:", "SigPnd:", "ShdPnd:"]
+                    .iter()
+                    .any(|p| l.starts_with(p))
+            })
+            .collect();
+        out.push_str(&format!(
+            "\n-- tid {tid}\n{}\nwchan: {}\nstack:\n{}",
+            signal_lines.join("\n"),
+            read("wchan").trim(),
+            read("stack")
+        ));
+    }
+    out
+}
+
+/// Block until some task of `fc_pid` sleeps in the userfaultfd wait path. This
+/// is the precondition gate: without it, a clone that never reached a cold page
+/// would make the reap assertion pass vacuously.
+#[cfg(feature = "privileged-tests")]
+async fn wait_until_parked_on_userfault(fc_pid: u32, deadline: Duration) -> Result<()> {
+    let start = Instant::now();
+    let mut last_seen = Vec::new();
+    while start.elapsed() < deadline {
+        last_seen.clear();
+        if let Ok(entries) = std::fs::read_dir(format!("/proc/{fc_pid}/task")) {
+            for entry in entries.flatten() {
+                let wchan = std::fs::read_to_string(entry.path().join("wchan")).unwrap_or_default();
+                if wchan.contains("userfault") {
+                    return Ok(());
+                }
+                last_seen.push(format!(
+                    "{}: {}",
+                    entry.file_name().to_string_lossy(),
+                    wchan.trim()
+                ));
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    anyhow::bail!(
+        "no task of firecracker {fc_pid} parked in handle_userfault within {deadline:?} \
+         (last wchans: {last_seen:?}). The cold-memory exec never reached an unserved fault, \
+         so asserting the reap now would prove nothing."
+    )
+}
+
+/// Concurrent SIGKILL during unserved faults must reap every clone VMM within 5s.
+///
+/// This is the standing control for the ARM CI failure class: during concurrent
+/// clone teardown, a SIGKILLed firecracker stayed non-zombie in D state and
+/// wedged the runner, and the evidence died with the recycled runner. The clone
+/// supervise loop's comment (src/commands/snapshot.rs) claims the benign
+/// version of that moment: a task parked on an unserved fault waits in
+/// TASK_KILLABLE (`fs/userfaultfd.c`), so SIGKILL reaps it, "measured under
+/// 2s". A measurement made once proves nothing about the next kernel rebase —
+/// this test converts it into an enforced assertion.
+///
+/// Construction: SIGSTOP the memory server (fault handlers registered but
+/// never served — the parked-forever state, without killing the server the way
+/// `a_clone_dies_when_its_memory_server_dies` does), drive two clones onto
+/// cold pages, verify each has a task in `handle_userfault` by wchan, then
+/// SIGKILL both VMMs back to back and require every one to be zombie-or-gone
+/// within 5s. A survivor gets its stack/wchan/status dumped before the bail —
+/// on a wedge, that dump IS the artifact the ARM incident never archived.
+#[cfg(feature = "privileged-tests")]
+#[tokio::test]
+async fn concurrent_sigkill_reaps_clones_parked_on_unserved_faults() -> Result<()> {
+    const KILLABLE_FILE: &str = "/dev/shm/fcvm-killable";
+    const KILLABLE_BYTES: usize = 8 * 1024 * 1024;
+    const REAP_DEADLINE: Duration = Duration::from_secs(5);
+
+    let (baseline_name, clone_prefix, snapshot_name, _) = common::unique_names("killable");
+    let fcvm_path = common::find_fcvm_binary()?;
+
+    println!("Step 1: baseline VM with an 8 MiB pattern in guest RAM");
+    let (mut baseline_child, baseline_pid) = common::spawn_fcvm_with_logs(
+        &[
+            "podman",
+            "run",
+            "--name",
+            &baseline_name,
+            "--network",
+            "rootless",
+            common::TEST_IMAGE,
+        ],
+        &baseline_name,
+    )
+    .await?;
+    common::poll_health_by_pid(baseline_pid, 120).await?;
+    common::exec_in_vm(
+        baseline_pid,
+        &[&format!(
+            "yes KILLABLE | head -c {KILLABLE_BYTES} > {KILLABLE_FILE} && sync"
+        )],
+    )
+    .await
+    .context("writing the cold-memory pattern")?;
+
+    println!("Step 2: snapshot + memory server");
+    common::create_snapshot_by_pid(baseline_pid, &snapshot_name).await?;
+    let (_serve_child, serve_pid) =
+        common::spawn_fcvm_with_logs(&["snapshot", "serve", &snapshot_name], "killable-serve")
+            .await?;
+    common::poll_serve_ready(&snapshot_name, serve_pid, 60).await?;
+
+    println!("Step 3: two clones (served by PID {serve_pid})");
+    let serve_pid_str = serve_pid.to_string();
+    let mut clone_children = Vec::new();
+    let mut clone_pids = Vec::new();
+    for i in 0..2 {
+        let name = format!("{clone_prefix}-{i}");
+        let (child, pid) = common::spawn_fcvm_with_logs(
+            &["snapshot", "run", "--pid", &serve_pid_str, "--name", &name],
+            &name,
+        )
+        .await
+        .with_context(|| format!("spawning clone {i}"))?;
+        common::poll_health_by_pid(pid, 150)
+            .await
+            .with_context(|| format!("clone {i} never became healthy"))?;
+        clone_children.push(child);
+        clone_pids.push(pid);
+    }
+
+    let mut firecrackers = Vec::new();
+    for &pid in &clone_pids {
+        let fc = find_firecracker_descendant(pid)
+            .with_context(|| format!("no firecracker child found for clone fcvm PID {pid}"))?;
+        println!(
+            "  clone fcvm {pid} -> firecracker {} (starttime {})",
+            fc.0, fc.1
+        );
+        firecrackers.push(fc);
+    }
+
+    println!("Step 4: SIGSTOP the memory server — faults now go unserved");
+    nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(serve_pid as i32),
+        nix::sys::signal::Signal::SIGSTOP,
+    )
+    .context("SIGSTOP serve")?;
+
+    // Assertions run in a block so SIGCONT + teardown always happen.
+    let verdict = async {
+        println!("Step 5: drive each clone onto a cold page");
+        let mut exec_children = Vec::new();
+        for &pid in &clone_pids {
+            // These execs HANG by design (the fault they trigger is never
+            // served): spawn without awaiting, discard output, kill_on_drop.
+            let child = tokio::process::Command::new(&fcvm_path)
+                .args([
+                    "exec",
+                    "--pid",
+                    &pid.to_string(),
+                    "--vm",
+                    "--",
+                    "sh",
+                    "-c",
+                    &format!("md5sum {KILLABLE_FILE}"),
+                ])
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .kill_on_drop(true)
+                .spawn()
+                .context("spawning cold-memory exec")?;
+            exec_children.push(child);
+        }
+
+        for &(fc_pid, _) in &firecrackers {
+            wait_until_parked_on_userfault(fc_pid, Duration::from_secs(60)).await?;
+        }
+        println!("  ✓ every clone has a task parked on an unserved fault");
+
+        println!("Step 6: SIGKILL both firecrackers back to back");
+        let killed_at = Instant::now();
+        for &(fc_pid, _) in &firecrackers {
+            nix::sys::signal::kill(
+                nix::unistd::Pid::from_raw(fc_pid as i32),
+                nix::sys::signal::Signal::SIGKILL,
+            )
+            .with_context(|| format!("SIGKILL firecracker {fc_pid}"))?;
+        }
+
+        loop {
+            let survivors: Vec<u32> = firecrackers
+                .iter()
+                .filter(|&&(pid, start)| !reaped_zombie_or_gone(pid, start))
+                .map(|&(pid, _)| pid)
+                .collect();
+            if survivors.is_empty() {
+                break;
+            }
+            if killed_at.elapsed() > REAP_DEADLINE {
+                let evidence: String = survivors
+                    .iter()
+                    .map(|&pid| dump_task_evidence(pid))
+                    .collect();
+                anyhow::bail!(
+                    "firecracker PID(s) {survivors:?} still not reaped {REAP_DEADLINE:?} after \
+                     SIGKILL with tasks parked on unserved faults. handle_userfault waits in \
+                     TASK_KILLABLE, so a survivor means a kernel rebase broke the killable \
+                     property every fcvm teardown path relies on. Evidence:{evidence}"
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        println!(
+            "  ✓ both firecrackers reaped {}ms after SIGKILL (ceiling {REAP_DEADLINE:?})",
+            killed_at.elapsed().as_millis()
+        );
+        drop(exec_children);
+        anyhow::Ok(())
+    }
+    .await;
+
+    println!("Step 7: teardown");
+    // SIGCONT unconditionally: a stopped serve cannot run its own shutdown, and
+    // kill_process's SIGTERM would sit undelivered on it forever.
+    let _ = nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(serve_pid as i32),
+        nix::sys::signal::Signal::SIGCONT,
+    );
+    for (child, pid) in clone_children.iter_mut().zip(&clone_pids) {
+        // Each clone's VMM is gone; the supervise loop must notice and exit on
+        // its own. The forced reap is a bounded fallback, not the expectation.
+        if tokio::time::timeout(Duration::from_secs(30), child.wait())
+            .await
+            .is_err()
+        {
+            force_reap(child, *pid, "clone fcvm").await?;
+        }
+    }
+    common::kill_process(serve_pid).await;
+    common::kill_process(baseline_pid).await;
+    let _ = baseline_child.start_kill();
+    let _ = tokio::process::Command::new(&fcvm_path)
+        .args(["snapshots", "delete", &snapshot_name])
+        .output()
+        .await;
+
+    verdict?;
+
+    // Zero survivors: with every clone fcvm reaped above, even a zombie VMM
+    // here means teardown leaked into the next test — the runner-poisoning
+    // shape the stray-VM guard exists to catch.
+    for &(fc_pid, start) in &firecrackers {
+        anyhow::ensure!(
+            proc_stat(fc_pid).is_none_or(|(_, _, _, st)| st != start),
+            "firecracker PID {fc_pid} still exists after full teardown{}",
+            dump_task_evidence(fc_pid)
+        );
+    }
+    println!("✅ CONCURRENT SIGKILL REAP TEST PASSED");
+    Ok(())
+}
+
 /// An exited clone must release the memory server's concurrency slot.
 ///
 /// Firecracker keeps a reference to its userfaultfd, but the server owns a separate copy.


### PR DESCRIPTION
**Stacked on:** issue776-event-signals (PR #779)

Implements the evidence-and-reproduction program for the ARM teardown class gating #779 (issue #786): a SIGKILLed Firecracker staying non-zombie during concurrent clone teardown, wedging the runner. Every natural strike so far has destroyed its own evidence — the run's own guard/artifact steps never execute because the runner dies first (run 31320931655 on 2026-08-09, and again run 31363886999 on 2026-08-10, both with the silent test-root-in-progress shape, both ephemeral runners recycled before anything captured a stack).

Four commits, each red-green validated where runnable off-ARM:

1. **Guard evidence capture** — `scripts/lib/vm-evidence.sh`: per-TID `/proc/<tid>/{stack,wchan,status}` (State + SigPnd prove "SIGKILL pending on a non-zombie task"), kcompactd/kswapd stack samples, `compact_*` vmstat deltas, memory pressure, unfiltered dmesg tail — captured for every reported group before the kill and for survivors after. All reads bounded; never reads cmdline (the guard's own documented hang).
2. **TASK_KILLABLE control** — `concurrent_sigkill_reaps_clones_parked_on_unserved_faults`: converts the "SIGKILL reaps a parked clone in under 2s" code comment into an enforced privileged test (wchan-gated so it cannot pass vacuously), pinning the killable property across kernel rebases.
3. **Dispatchable reproduction harness** — `teardown-evidence.yml` (workflow_dispatch, ARM64): `teardown-folio-lock-red.sh` deterministically parks vCPU threads in uninterruptible folio-lock waits via dm-suspended swap + cgroup pressure, SIGKILLs the VMM, and asserts the non-zombie window with the pending-kill bit — always resuming in an EXIT trap so the runner is never left wedged. Plus a bounded compaction-storm mode for hunting the natural (migration-entry) trigger with kcompactd owner sampling.
4. **In-job D-state watchdog** — `ci-dstate-watchdog.sh`, started inside the test-root step: samples every 20s, and on a persistent D-state VM group streams the full evidence dump INTO the live job log — the only channel that survives a dying ephemeral runner. Prints nothing when healthy (asserted byte-for-byte in tests).

## Validation

- Commits 1 and 4 witnessed RED first (missing-evidence / missing-script failures), then green: `python3 -m unittest` over test_ci_infrastructure.py — 21 tests, OK, four consecutive runs (two real flakes in the additions found and root-caused before commit).
- `cargo check --release --features privileged-tests --tests`, clippy `-D warnings` with and without the feature, and fmt: clean.
- `bash -n` + `shellcheck -x` on all five scripts; `actionlint -shellcheck=` on both touched workflows; the workflow-coverage invariants (including chown-before-checkout across all workflows) stay green.
- Commit 2's runtime and the harness end-to-end need the ARM runners (KVM and userfaultfd are denied on the build host); that is exactly what the dispatch workflow exists for.
