### PR TITLE
Fix three defects in the benchmark suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,8 @@ MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 export CARGO_TARGET_DIR := target
 NEXTEST := $(CARGO) nextest $(NEXTEST_CMD) --release
 TEST_CONFIG_WRAPPER := ./scripts/with-test-config.sh
+# Extra flags forwarded to every criterion bench recipe (see bench-quick).
+BENCH_ARGS ?=
 
 # cargo/nextest target runner for the privileged suites. cargo-nextest stays unprivileged
 # and only the test binary is elevated, so the `sudo` hop sits in the middle of the process
@@ -204,6 +206,7 @@ CONTAINER_RUN := $(CONTAINER_RUN_BASE) --ulimit nproc=65536:65536 --pids-limit=6
 	container-setup-fcvm container-shell container-clean container-bench \
 	cargo-target-link build-host-tools setup-btrfs setup-default setup-fcvm setup-pjdfstest setup-hugepages bench bench-vm bench-hugepages bench-hugepages-test \
 	bench-container-import bench-chromium bench-chromium-request analyze-chromium-request bench-clone-latency test-chromium-request \
+	bench-quick bench-throughput bench-operations bench-protocol \
 	lint fmt update-dependency ssh test-serve-sdk
 
 all: build
@@ -665,15 +668,54 @@ test-chromium-request:
 test-ci-infrastructure:
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_ci_infrastructure.py'
 
-bench: build
-	@echo "==> Running benchmarks..."
+# The three fuse-pipe suites, in order. Prerequisites rather than recursive
+# $(MAKE) calls: a sub-make RUNS even under `make -n`, so the delegating form
+# turned a dry run into a real build. Do not run this under -j; concurrent
+# benchmarks measure each other.
+bench: bench-throughput bench-operations bench-protocol
+
+# throughput and operations mount a real FUSE filesystem, so they take the
+# privileged runner the root tests use; protocol is pure serialization and
+# stays unprivileged.
+#
+# Each privileged suite hands target/ back afterwards. criterion writes its
+# results from inside the bench binary, so under that runner target/criterion
+# ends up root-owned, and two things break: bench-protocol, which is
+# deliberately unprivileged, fails every write with `Permission denied (os
+# error 13)` — it still prints timings but persists nothing, so criterion never
+# holds a baseline for it and can never report a change — and `_test-root`
+# refuses to start until the ownership is repaired. The repair is inline rather
+# than a $(MAKE) call because a sub-make runs even under `make -n`, and this
+# one would invoke sudo.
+bench-throughput: build
 	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='$(ROOT_TEST_RUNNER)' \
 	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='$(ROOT_TEST_RUNNER)' \
-	$(CARGO) bench -p fuse-pipe --bench throughput
+	$(CARGO) bench -p fuse-pipe --bench throughput $(BENCH_ARGS); \
+	RC=$$?; \
+	if find target/ -user root -print -quit 2>/dev/null | grep -q .; then \
+		sudo chown -R $$(id -u):$$(id -g) target/; \
+	fi; \
+	exit $$RC
+
+bench-operations: build
 	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='$(ROOT_TEST_RUNNER)' \
 	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='$(ROOT_TEST_RUNNER)' \
-	$(CARGO) bench -p fuse-pipe --bench operations
-	$(CARGO) bench -p fuse-pipe --bench protocol
+	$(CARGO) bench -p fuse-pipe --bench operations $(BENCH_ARGS); \
+	RC=$$?; \
+	if find target/ -user root -print -quit 2>/dev/null | grep -q .; then \
+		sudo chown -R $$(id -u):$$(id -g) target/; \
+	fi; \
+	exit $$RC
+
+bench-protocol: build
+	$(CARGO) bench -p fuse-pipe --bench protocol $(BENCH_ARGS)
+
+# The same three suites at criterion's smallest honest sample count, for
+# iteration. A target-specific variable reaches the prerequisites, so this
+# needs no recursive make. Quote `make bench` in any report: a 10-sample
+# interval is wide.
+bench-quick: BENCH_ARGS := --sample-size 10 --warm-up-time 1 --measurement-time 3
+bench-quick: bench
 
 # VM benchmarks (exec, clone) - require KVM, Firecracker, setup
 bench-vm: build setup-default

--- a/bench/chromium/AGENTS.md
+++ b/bench/chromium/AGENTS.md
@@ -67,6 +67,25 @@ nothing. Every rule below exists because one of them broke.
 - **`scripts/ci-stray-vm-guard.sh` is DESTRUCTIVE** — it SIGKILLs everything matching,
   with no interlock against a concurrent job. An agent ran it "to exercise it" and
   killed another agent's live test. Use `--dry-run`. Never run it on a shared box.
+- **All phases must use ONE podman store.** `build` and `golden` have to run under
+  the same identity fcvm runs as. The harness invokes fcvm through `$SUDO`, so with
+  `SUDO=sudo` from an unprivileged shell the image is built in the *rootless* store
+  and consumed from *root's* — two stores, two different images under one tag. The
+  golden phase's identity guard catches it and is right to:
+  `snapshot image disk '<...>/67de414c….storage-v2.img' does not match inspected
+  cache key '592250fc…'`. That is not a corrupt cache; it is the tag resolving to a
+  different image in the store fcvm actually read. Run the whole chain as one user.
+- **Rootless podman needs a runtime dir, and says something else when it lacks one.**
+  On a fresh box `podman info` fails with `default OCI runtime "crun" not found:
+  invalid argument` while `/usr/bin/crun` is installed and executable. `--log-level=debug`
+  names the real cause: `Configured OCI runtime crun initialization failed: creating
+  OCI runtime exit files directory: mkdir /run/user/1000: permission denied`. A user
+  with no login session has no `XDG_RUNTIME_DIR`; `sudo -u <user>` does not create one.
+  Fix is `loginctl enable-linger <user>`. Do not go looking for crun.
+- **`fcvm setup` must have run, and `build` will not tell you.** Without the fc-agent
+  initrd the golden phase dies one second in with `setting up fc-agent initrd:
+  fc-agent initrd not found`, after `build` reported success — the two phases check
+  nothing about each other.
 - **Poisoned CI caches are real.** A runner that dies mid-write with
   `CACHE_ON_FAILURE: true` persists a truncated cache that later restores and makes
   `cargo build` segfault in 70 ms. If a build fails impossibly fast, check cache

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -3432,10 +3432,29 @@ exec /bin/bash "$@"
         Observed with an env_reset-emulating sudo stub: FCVM_NO_SNAPSHOT=<unset>.
         """
         with tempfile.TemporaryDirectory() as d:
-            env, binx = self._env(d)
+            # Staged, like the sibling shell tests: the unstaged path re-execs
+            # itself through a content-addressed copy and first requires real
+            # fcvm and fc-agent binaries for THIS host's arch. That is a
+            # property of the box, not of the quoting under test, and on an
+            # x86 checkout of an arm64 tree it stops the phase before fcvm.
+            env, binx = self._env(d, REQBENCH_STAGED="1")
             seen = os.path.join(d, "seen.txt")
             self._write(os.path.join(binx, "sudo"),
                         '#!/bin/bash\nexec env -i PATH="$PATH" HOME="$HOME" "$@"\n')
+            # `golden` inspects the benchmark image before it ever reaches fcvm.
+            # Without this stub the test needs a real podman AND a real
+            # localhost/chromium-bench-req on the box: where either is missing
+            # the phase returns at the inspect, fcvm is never invoked, and the
+            # assertion below reports "the assignment did not survive sudo"
+            # about a command that never ran. Seen on a box whose podman had no
+            # crun: `default OCI runtime "crun" not found`.
+            self._write(os.path.join(binx, "podman"), '''#!/bin/bash
+if [ "$1 $2" = "image inspect" ]; then
+    echo '[{"Digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","Id":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}]'
+    exit 0
+fi
+exit 1
+''')
             fcvm = os.path.join(d, "fcvm")
             self._write(fcvm, f"""#!/bin/bash
 case "$1 $2" in
@@ -3457,6 +3476,14 @@ esac
             r = subprocess.run([self.SH, "golden"], env=dict(env, SUDO="sudo", FCVM=fcvm),
                                capture_output=True, text=True, timeout=120)
             got = self._read_if_exists(seen, "<no invocation>")
+            # Separate "fcvm never ran" from "fcvm ran without the variable".
+            # One is a broken harness, the other is the defect under test, and
+            # attributing the first to the second sends the reader after sudo's
+            # env_reset for a phase that returned long before sudo.
+            self.assertNotEqual(
+                got, "<no invocation>",
+                "golden never invoked fcvm, so this test observed nothing about "
+                f"the assignment: {r.stderr[-800:]}")
             self.assertIn("FCVM_NO_SNAPSHOT=1", got,
                           f"the assignment did not survive sudo: {got}\n{r.stderr[-800:]}")
 

--- a/fuse-pipe/benches/operations.rs
+++ b/fuse-pipe/benches/operations.rs
@@ -46,6 +46,29 @@ fn setup_test_files(dir: &PathBuf) {
         let path = subdir.join(format!("file_{}.txt", i));
         fs::write(&path, format!("content {}", i)).unwrap();
     }
+
+    // Distinct files for the uncached metadata probes. Restating a path the
+    // kernel already has cached measures the cache, so those benchmarks walk
+    // this pool instead, and the pool is larger than any run's sample count so
+    // a single iteration never revisits an entry.
+    let pool = dir.join(METADATA_POOL_DIR);
+    fs::create_dir_all(&pool).unwrap();
+    for i in 0..METADATA_POOL_FILES {
+        fs::write(pool.join(format!("m_{i}.dat")), b"m").unwrap();
+    }
+}
+
+/// Directory holding the uncached-metadata file pool.
+const METADATA_POOL_DIR: &str = "metadata_pool";
+
+/// How many distinct files the uncached metadata probes rotate through.
+const METADATA_POOL_FILES: usize = 20_000;
+
+/// Nth file in the pool, wrapping. Callers pass a monotonically increasing
+/// counter, so consecutive iterations touch different inodes.
+fn pool_file(root: &std::path::Path, n: u64) -> PathBuf {
+    root.join(METADATA_POOL_DIR)
+        .join(format!("m_{}.dat", (n as usize) % METADATA_POOL_FILES))
 }
 
 fn cleanup(data_dir: &PathBuf, mount_dir: &PathBuf) {
@@ -82,9 +105,25 @@ fn bench_getattr(c: &mut Criterion) {
     // FUSE with 256 readers (our recommended default)
     let fuse = FuseMount::new(&data_dir, &mount_dir, 256);
     let fuse_file = fuse.mount_path().join("test.dat");
-    group.bench_function("fuse_256_readers", |b| {
+
+    // Restating one path measures the kernel's attribute cache: FUSE mounts
+    // default to a 1s attr_timeout, so after the first stat the daemon is not
+    // contacted at all. That is a real number for a hot working set, but it is
+    // not the cost of a FUSE getattr, so it is named for what it measures.
+    group.bench_function("fuse_256_readers_attr_cache_hit", |b| {
         b.iter(|| {
             let _ = fs::metadata(&fuse_file).unwrap();
+        })
+    });
+
+    // The round trip. Each iteration stats a file this mount has not seen, so
+    // the request reaches the server.
+    let pool_root = fuse.mount_path().to_path_buf();
+    let counter = AtomicU64::new(0);
+    group.bench_function("fuse_256_readers_uncached", |b| {
+        b.iter(|| {
+            let n = counter.fetch_add(1, Ordering::Relaxed);
+            let _ = fs::metadata(pool_file(&pool_root, n)).unwrap();
         })
     });
 
@@ -94,6 +133,8 @@ fn bench_getattr(c: &mut Criterion) {
 }
 
 fn bench_lookup(c: &mut Criterion) {
+    ensure_ulimit();
+
     let data_dir = PathBuf::from("/tmp/fuse-ops-data-lookup");
     let mount_dir = PathBuf::from("/tmp/fuse-ops-mount-lookup");
 
@@ -114,9 +155,21 @@ fn bench_lookup(c: &mut Criterion) {
     // FUSE
     let fuse = FuseMount::new(&data_dir, &mount_dir, 256);
     let fuse_file = fuse.mount_path().join("test.dat");
-    group.bench_function("fuse_256_readers", |b| {
+
+    // As with getattr: one repeated path is served by the kernel's dentry
+    // cache (entry_timeout), not by the server.
+    group.bench_function("fuse_256_readers_dentry_cache_hit", |b| {
         b.iter(|| {
             let _ = fuse_file.exists();
+        })
+    });
+
+    let pool_root = fuse.mount_path().to_path_buf();
+    let counter = AtomicU64::new(0);
+    group.bench_function("fuse_256_readers_uncached", |b| {
+        b.iter(|| {
+            let n = counter.fetch_add(1, Ordering::Relaxed);
+            let _ = pool_file(&pool_root, n).exists();
         })
     });
 

--- a/tests/test_documented_make_targets.rs
+++ b/tests/test_documented_make_targets.rs
@@ -1,0 +1,129 @@
+//! Every `make` target PERFORMANCE.md tells a reader to run must exist.
+//!
+//! PERFORMANCE.md's "Quick Reference" listed `make bench-quick`,
+//! `bench-throughput`, `bench-operations` and `bench-protocol`. None of the
+//! four existed: each died with `No rule to make target` at exit 2. That is
+//! the same shape as the `_test-unit` FILTER defect (an advertised interface
+//! that silently was not there), and it is worse in a performance guide,
+//! because the reader's first move after reading a benchmark table is to run
+//! the command that reproduces it.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+fn repo_file(rel: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+/// Collect `make <target>` mentions from a document.
+fn documented_make_targets(doc: &str) -> BTreeSet<String> {
+    let mut found = BTreeSet::new();
+    for line in doc.lines() {
+        let mut rest = line;
+        while let Some(idx) = rest.find("make ") {
+            rest = &rest[idx + "make ".len()..];
+            let target: String = rest
+                .chars()
+                .take_while(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+                .collect();
+            if !target.is_empty() {
+                found.insert(target);
+            }
+        }
+    }
+    found
+}
+
+/// Targets the Makefile actually defines, including `.PHONY`-only ones.
+fn makefile_targets(makefile: &str) -> BTreeSet<String> {
+    makefile
+        .lines()
+        .filter(|line| !line.starts_with(['\t', ' ', '#']))
+        .filter_map(|line| line.split_once(':'))
+        .filter(|(name, sep)| !name.is_empty() && !sep.starts_with('='))
+        .flat_map(|(names, _)| names.split_whitespace().map(str::to_owned))
+        .filter(|name| !name.starts_with('.') && !name.contains('$') && !name.contains('%'))
+        .collect()
+}
+
+#[test]
+fn performance_guide_only_names_targets_that_exist() {
+    let makefile = makefile_targets(&repo_file("Makefile"));
+    let documented = documented_make_targets(&repo_file("PERFORMANCE.md"));
+
+    assert!(
+        documented.contains("bench"),
+        "the scan found no `make bench` in PERFORMANCE.md, so it is not reading the document \
+         it thinks it is and cannot fail for the right reason"
+    );
+
+    let missing: Vec<&String> = documented.difference(&makefile).collect();
+    assert!(
+        missing.is_empty(),
+        "PERFORMANCE.md tells the reader to run make targets that do not exist: {missing:?}. \
+         Each one dies with `No rule to make target` at exit 2."
+    );
+}
+
+#[test]
+fn readme_only_names_targets_that_exist() {
+    let makefile = makefile_targets(&repo_file("Makefile"));
+    let documented = documented_make_targets(&repo_file("README.md"));
+
+    assert!(
+        !documented.is_empty(),
+        "the scan found no `make` targets in README.md, so it cannot fail for the right reason"
+    );
+
+    let missing: Vec<&String> = documented.difference(&makefile).collect();
+    assert!(
+        missing.is_empty(),
+        "README.md tells the reader to run make targets that do not exist: {missing:?}"
+    );
+}
+
+/// The metadata benchmarks must state which cache they are measuring.
+///
+/// `single_op/getattr` and `single_op/lookup` used to stat one fixed path in a
+/// loop. A FUSE mount defaults to a 1s `attr_timeout`/`entry_timeout`, so after
+/// the first call the kernel answered from its attribute and dentry caches and
+/// the server was never contacted. Measured on Graviton3 the two reported
+/// 1.06µs against a 1.02µs host baseline, and PERFORMANCE.md published that as
+/// "metadata ops (getattr, lookup) have ~5% overhead" — a claim about fuse-pipe
+/// drawn from a measurement fuse-pipe never took part in. Every operation that
+/// does reach the server on the same box costs 40-56x the host, not 1.05x.
+///
+/// Both shapes are worth publishing; they just have to be named. This keeps a
+/// bare `fuse_256_readers` case from creeping back in, since its name would
+/// claim to be the round trip while measuring the cache.
+#[test]
+fn metadata_benchmarks_name_the_cache_they_measure() {
+    let src = repo_file("fuse-pipe/benches/operations.rs");
+
+    for op in ["bench_getattr", "bench_lookup"] {
+        let start = src
+            .find(&format!("fn {op}("))
+            .unwrap_or_else(|| panic!("operations.rs has no {op}"));
+        let body = &src[start..];
+        let end = body.find("\nfn ").unwrap_or(body.len());
+        let body = &body[..end];
+
+        assert!(
+            body.contains("_uncached"),
+            "{op} has no `_uncached` case, so nothing in it measures a FUSE round trip: a \
+             repeated path is answered by the kernel's attribute/dentry cache"
+        );
+        assert!(
+            body.contains("pool_file("),
+            "{op}'s uncached case must walk the distinct-file pool; restating one path \
+             measures the cache no matter what the case is called"
+        );
+        assert!(
+            !body.contains("\"fuse_256_readers\""),
+            "{op} still has a case named plainly `fuse_256_readers`. Name it for the cache \
+             it measures (`_attr_cache_hit` / `_dentry_cache_hit`) or make it uncached; an \
+             unqualified name reads as the round-trip cost and is off by ~100x."
+        );
+    }
+}


### PR DESCRIPTION
Found by running the benchmark suite on a c7gd.metal box matching PERFORMANCE.md's documented environment (64× Neoverse-V1, 125 GiB, btrfs on NVMe).

## 1. Four documented targets did not exist

PERFORMANCE.md's Quick Reference tells the reader to run `make bench-quick`, `bench-throughput`, `bench-operations`, `bench-protocol`. All four:

```
$ make bench-throughput
make: *** No rule to make target 'bench-throughput'.  Stop.      (exit 2)
```

Same shape as the `_test-unit` FILTER defect, and worse in a performance guide — the first thing a reader does after seeing a benchmark table is run the command that reproduces it.

`bench` is now those three suites as prerequisites instead of a copy of their recipes, and `bench-quick` reaches them with a target-specific variable. Neither uses a recursive `$(MAKE)`: a sub-make runs even under `make -n`, so the delegating form turned a dry run into a real build (and, with the ownership repair in it, into a `sudo` prompt).

## 2. The published metadata latencies measure the kernel, not fuse-pipe

`single_op/getattr` and `single_op/lookup` stat **one fixed path** in a loop. A FUSE mount defaults to a 1s `attr_timeout`/`entry_timeout`, so after the first call the kernel answers from its attribute and dentry caches and the server is never contacted.

Measured on this box: getattr **1.062 µs** vs a 1.016 µs host baseline; lookup **1.059 µs** vs 1.021 µs. PERFORMANCE.md publishes that as *"metadata ops (getattr, lookup) have ~5% overhead"* — a claim about fuse-pipe drawn from a measurement fuse-pipe took no part in. Every operation that does reach the server on the same box costs 40–56× the host:

| op | host | FUSE | ratio |
|---|---|---|---|
| open+close | 1.685 µs | 93.9 µs | 56× |
| readdir | 6.591 µs | 267 µs | 40× |
| create+unlink | 12.73 µs | 348 µs | 27× |

Both benchmarks now also walk a 20,000-file pool, one new inode per iteration, so the request reaches the server. The repeated-path cases stay, renamed `_attr_cache_hit` / `_dentry_cache_hit` for what they measure. Both numbers are worth publishing; only one of them was named.

## 3. `make bench` poisoned its own output, and the test suite

throughput and operations run under `ROOT_TEST_RUNNER`, and criterion writes from inside the bench binary — so `target/criterion` ends up root-owned. The protocol suite then runs unprivileged and every write fails:

```
Criterion.rs ERROR: error: Failed to access file
  "target/criterion/serialize_lookup_request/new": Permission denied (os error 13)
```

It still prints timings, so the run looks fine, but it persists no `sample.json`, no `estimates.json` and no report: criterion can never hold a baseline for protocol and can never report a change on it. The same root-owned tree trips `_test-root`, which refuses to start until ownership is repaired. Each privileged suite now repairs it inline.

## Guard tests

`tests/test_documented_make_targets.rs` scans PERFORMANCE.md and README.md for `make <target>` and requires each to exist, and guards the metadata benchmarks against a bare `fuse_256_readers` case creeping back in. Every test asserts it found something to scan first, so a broken scan fails instead of passing vacuously.

Red first:

```
$ git checkout Makefile && cargo nextest run --test test_documented_make_targets
FAIL performance_guide_only_names_targets_that_exist
  PERFORMANCE.md tells the reader to run make targets that do not exist:
  ["bench-operations", "bench-protocol", "bench-quick", "bench-throughput"].
  Each one dies with `No rule to make target` at exit 2.
$ # restore
3 tests run: 3 passed, 0 skipped
```

Also: `make -n bench` → 3 cargo bench lines; `make -n bench-quick` → 3 with the reduced sample size; `cargo check --release -p fuse-pipe --benches` and `cargo fmt --check` clean.

## Not in this PR

PERFORMANCE.md's numbers themselves need a refresh against the corrected benchmarks — in particular the parallel-write table, where the **host** baseline alone came in at 863 ms against a documented 161 ms, and every reader count ≥4 now sits at that same host floor. That is a measurement to redo and reconcile, not a one-line edit, so it is deliberately left out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added separate benchmark commands for throughput, operations, and protocol testing.
  - Added a quick benchmark mode with reduced sampling for faster feedback.
  - Added support for passing custom benchmark options.

- **Benchmark Improvements**
  - Metadata benchmarks now distinguish cached and uncached filesystem operations using larger, varied file sets.
  - Benchmark execution now handles privileged test runs more reliably.

- **Documentation & Tests**
  - Added validation ensuring documented Make targets exist and benchmark coverage remains accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->