### PR TITLE
Let Summary pass when the VM matrix is skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -927,10 +927,15 @@ jobs:
       - uses: actions/checkout@v7
         if: needs.skip-check.outputs.skip != 'true'
       - name: Download all artifacts
-        if: needs.skip-check.outputs.skip != 'true'
+        if: needs.skip-check.outputs.skip != 'true' && needs.changes.outputs.code == 'true'
         uses: actions/download-artifact@v7
         with:
           path: /tmp/ci-artifacts
+      # Also gated on `changes`: this analyses the VM matrix's artifacts, and a
+      # docs-only PR skips that matrix, so there is nothing to analyse and the
+      # script exits non-zero on the empty directory. Summary must still be
+      # green for those PRs — it is the required check that proves the gate
+      # ran, not a claim that the matrix did.
       - name: Analyze CI run
-        if: needs.skip-check.outputs.skip != 'true'
+        if: needs.skip-check.outputs.skip != 'true' && needs.changes.outputs.code == 'true'
         run: python3 scripts/analyze_ci_vms.py /tmp/ci-artifacts

--- a/tests/test_ci_workflow_coverage.rs
+++ b/tests/test_ci_workflow_coverage.rs
@@ -746,3 +746,47 @@ fn workflow_changes_get_a_relevant_gated_check() {
          it fails"
     );
 }
+
+/// Summary must be able to pass when the VM matrix is skipped.
+///
+/// Making Summary run on every PR (so it can be a required check) means it now
+/// runs for PRs where `changes` skips the matrix. Its artifact steps analyse
+/// that matrix's output, and `analyze_ci_vms.py` exits non-zero on an empty
+/// directory — so on the first docs-only PR after that change, Summary failed
+/// at `Analyze CI run` while every gating job was correctly skipped. A
+/// required check that cannot pass for a whole class of PR blocks them all.
+#[test]
+fn summary_artifact_steps_are_gated_on_the_changes_job() {
+    let ci = parse_workflow("ci.yml");
+    let steps = workflow_job(&ci, "summary")
+        .get("steps")
+        .and_then(Value::as_sequence)
+        .expect("ci.yml `summary` job has no steps");
+
+    let mut checked = 0usize;
+    for step in steps {
+        let name = step.get("name").and_then(Value::as_str).unwrap_or("");
+        let uses = step.get("uses").and_then(Value::as_str).unwrap_or("");
+        let touches_artifacts = uses.contains("download-artifact") || name == "Analyze CI run";
+        if !touches_artifacts {
+            continue;
+        }
+        checked += 1;
+        let cond = step
+            .get("if")
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| panic!("summary step `{name}` has no `if:` gate"));
+        assert!(
+            cond.contains("needs.changes.outputs.code == 'true'"),
+            "summary step `{name}` consumes the VM matrix's artifacts but is not gated on the \
+             `changes` job, so it runs — and fails on an empty artifact directory — for every \
+             PR that skips the matrix"
+        );
+    }
+
+    assert!(
+        checked >= 2,
+        "expected to find the download-artifact and Analyze CI run steps in `summary`; found \
+         {checked}, so this test is not inspecting what it claims"
+    );
+}


### PR DESCRIPTION
Making `Summary` run on every PR (#787) so it can be a required check means it now runs for PRs where the `changes` job skips the VM matrix. Two of its steps consume that matrix's artifacts, and `analyze_ci_vms.py` exits non-zero on an empty directory.

So the very first docs-only PR after #787 merged — **#785**, which touches only `.github/workflows/claude*.yml` — produced:

```
Changes             pass
actionlint          pass
Lint                skipping
Host-*/Container-*  skipping
Summary             FAIL      <- at "Analyze CI run"
```

Every gating job behaved exactly as designed and the required check still failed. A required check that cannot pass for a whole class of PR blocks that class outright — worse than the hole #787 closed.

Both artifact steps now carry the same `changes` gate the matrix does. Summary's own "fail if a gating job did not succeed" step is untouched and still treats skipped as non-failure, failure as failure.

## Test evidence (red first)

```
$ git checkout .github/workflows/ci.yml   # drop the gate
$ cargo nextest run --test test_ci_workflow_coverage -E 'test(summary_artifact_steps)'
  FAIL summary_artifact_steps_are_gated_on_the_changes_job
$ # restore
  11 tests run: 11 passed, 0 skipped
```

`actionlint -shellcheck=` and `cargo fmt --check` both clean.

The new guard asserts it found at least two artifact-consuming steps before checking them, so a rename cannot make it pass vacuously.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CI summaries now skip artifact processing and test analysis for documentation-only or other non-code changes.
  * Prevented unnecessary CI analysis when the self-hosted test matrix is skipped.

* **Tests**
  * Added coverage to verify that summary processing runs only for code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->