### PR TITLE
Capture guest and host state when a CDP request fails

### DIFF
--- a/bench/chromium/AGENTS.md
+++ b/bench/chromium/AGENTS.md
@@ -452,6 +452,46 @@ Caveat: synthetic dirty-anon pages, not Firecracker's MAP_PRIVATE file-backed
 guest memory; clean file-backed pages may unmap cheaper. Corroboration: the
 observed ~78 ms VM teardown for a ~1 GB VM sits on the ~60 ms/GiB line.
 
+## Failure-time evidence capture: what the probe takes, and what it cannot say
+
+An 808-clone run produced 3 CDP failures. Every one came from a clone whose
+ARP-triggering readiness ping got no reply (5 clones had no reply, 3 of them
+failed; of the 803 whose ping replied, none failed), the guest stayed alive for
+the whole 100+ seconds, and the `exec` and `noop` arms, which reach the guest
+over vsock, never failed. **Why the guest stopped answering on the IP path, and
+why it never recovered, is UNSOLVED.** The leading hypothesis, which nothing has
+yet proved, is that the guest's post-restore network re-initialisation never
+ran or never finished for that clone.
+
+`reqbench.py`'s `FailureProbe` exists because vsock exec keeps working while the
+IP path does not, so the broken guest is interrogable at exactly the moment it
+is broken, and the harness used to delete it. On a failed CDP request, and once
+per run on a healthy one as the control, it writes `<request-name>.probe.json`
+next to that request's clone log and references it from the JSONL record.
+
+- Guest, over `fcvm exec --vm`: addresses, routes, the neighbour table,
+  interface counters, listening sockets, the Chromium process table, `dmesg`,
+  the guest clock, an in-guest CDP connect, an MMDS read of the current
+  restore-epoch, and an arping of the gateway.
+- Host, for the same clone: the state file, the fcvm process tree, pasta's pid
+  and process state, the holder's namespace via `nsenter` and via its procfs, a
+  fresh TCP connect to the published port, and the restore and readiness lines
+  from that clone's own fcvm log.
+
+Read the failure dump against the control; a dump with nothing to compare
+against proves little, which is why the control is captured whether or not the
+run ends up failing. Read `role`, `budget_exhausted` and each command's
+`budget_limited` before reading anything else: a `timed_out` step that was
+`budget_limited` is the probe running out of budget, not a wedged guest.
+
+**What it cannot settle.** The passive capture is taken ~100 s after the request
+gave up, so it describes the STEADY state of the failure, not the moment it
+began; ordering questions still need the clone's log. It cannot see anything
+Firecracker's MMDS server did or did not serve, only what the guest can now read
+back. Its host-side namespace view is one `nsenter` snapshot, so it cannot show
+a neighbour entry that expired earlier. And the active section mutates what the
+passive section just recorded, deliberately and last.
+
 ## Claims currently REFUTED — status per `REVIEW.md`
 
 This list and `REVIEW.md` disagreed for a while: everything here said "do not

--- a/bench/chromium/AGENTS.md
+++ b/bench/chromium/AGENTS.md
@@ -480,9 +480,29 @@ next to that request's clone log and references it from the JSONL record.
 
 Read the failure dump against the control; a dump with nothing to compare
 against proves little, which is why the control is captured whether or not the
-run ends up failing. Read `role`, `budget_exhausted` and each command's
+run ends up failing, and why a control whose dump fails to WRITE does not count
+as taken: the next healthy clone gets another go, bounded at three attempts so a
+systematically broken probe cannot tax every healthy rep in the run. Read
+`role`, `budget_exhausted`, `interrupted_by_signal` and each command's
 `budget_limited` before reading anything else: a `timed_out` step that was
-`budget_limited` is the probe running out of budget, not a wedged guest.
+`budget_limited` is the probe running out of budget, not a wedged guest, and a
+short dump carrying `interrupted_by_signal` is one that stood aside for a
+shutdown.
+
+**It stands aside for INT/TERM, and it is bounded by a process-group kill.** The
+harness's signal handler only records the signal, so nothing in the probe is
+interrupted asynchronously; without a check of its own a capture would spend its
+whole budget with the clone still up and the teardown queued behind it, which is
+long enough for a job runner to escalate to SIGKILL and leave behind exactly the
+clone the probe came to explain. A pending signal therefore skips the capture,
+and one arriving mid-capture stops it at the next step. Each probe command runs
+in its own session, so the timeout kills the whole process GROUP rather than the
+`fcvm exec` wrapper alone, and it names that group by the spawned pid rather
+than by asking the leader for it: a wrapper that exits while its child holds the
+pipe open makes `os.getpgid` raise ESRCH exactly when the kill is needed. The
+kill verifies itself, and `group_kill.survivors` on the command's record is what
+it found, with zombies excluded because a corpse keeps a group present without
+being alive in it.
 
 **What it cannot settle.** The passive capture is taken ~100 s after the request
 gave up, so it describes the STEADY state of the failure, not the moment it

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -1175,6 +1175,18 @@ def record_harness_interrupt(signum, _frame):
         _pending_harness_signal = signum
 
 
+def harness_interrupt_pending() -> int:
+    """The recorded INT/TERM, or 0. For work that must yield without unwinding.
+
+    `raise_if_harness_interrupted` is for the request scope, which owns a clone
+    and has to reach its teardown before it unwinds. Anything OPTIONAL that runs
+    between the request and that teardown has the opposite obligation: get out
+    of the way, because the shutdown clock is already running and whoever sent
+    the signal may escalate to SIGKILL.
+    """
+    return _pending_harness_signal
+
+
 def raise_if_harness_interrupted() -> None:
     if _pending_harness_signal:
         raise HarnessInterrupted(f"received signal {_pending_harness_signal}")
@@ -2263,9 +2275,26 @@ class FailureProbe:
 
         Wrapped whole: a probe that raises would abort a request that had
         already produced its answer, which is strictly worse than no probe.
+
+        A pending INT/TERM outranks the evidence. The signal handler only
+        RECORDS the signal, so nothing here is interrupted asynchronously and a
+        capture that began before the signal would run its full budget with the
+        clone still up and the harness's teardown behind it — long enough for a
+        job runner to escalate to SIGKILL and leave behind exactly the clone this
+        probe exists to diagnose. So a signal that is already pending skips the
+        capture outright, and one that arrives mid-capture stops it at the next
+        step (`capture`'s `interrupted`).
         """
         role = self.role_for(rec)
         if role is None:
+            return
+        pending = harness_interrupt_pending()
+        if pending:
+            rec["probe"] = {
+                "role": role,
+                "path": "",
+                "skipped": f"termination signal {pending} pending",
+            }
             return
         try:
             dump = self.capture(
@@ -2284,6 +2313,7 @@ class FailureProbe:
                 "control_path": dump.get("control_path", ""),
                 "elapsed_ms": dump.get("elapsed_ms"),
                 "budget_exhausted": dump.get("budget_exhausted", False),
+                "interrupted_by_signal": dump.get("interrupted_by_signal", 0),
                 "errors": errors[:10],
                 "error_count": len(errors),
             }
@@ -2350,13 +2380,29 @@ class FailureProbe:
         def remaining():
             return deadline - time.monotonic()
 
+        def interrupted(step):
+            """Has a termination signal arrived since the capture began?
+
+            Every step is optional evidence and the teardown waiting behind them
+            is not, so the first step to notice ends the capture. Recorded on the
+            dump, so a short dump reads as "we left early" rather than as a guest
+            that answered nothing.
+            """
+            pending = harness_interrupt_pending()
+            if pending:
+                dump["interrupted_by_signal"] = pending
+                note(step, f"skipped, termination signal {pending} pending")
+            return bool(pending)
+
         def budget_for(step):
-            """Timeout for one step, or None when the budget is spent.
+            """Timeout for one step, or None when the step must not run.
 
             Returns `(timeout, budget_limited)` so a step that got a shortened
             timeout can say so on its own record instead of reporting an
             indistinguishable `timed_out`.
             """
+            if interrupted(step):
+                return None
             left = remaining()
             if left <= 0:
                 dump["budget_exhausted"] = True
@@ -2416,9 +2462,10 @@ class FailureProbe:
         else:
             note("holder_procfs", f"no holder pid in state: {holder_pid!r}")
 
-        dump["host"]["cdp_connect_now"] = probe_tcp_connect(
-            dump["endpoint"], min(2.0, max(0.1, remaining()))
-        )
+        if not interrupted("cdp_connect_now"):
+            dump["host"]["cdp_connect_now"] = probe_tcp_connect(
+                dump["endpoint"], min(2.0, max(0.1, remaining()))
+            )
 
         # ---- guest, passive. The reason this probe exists: vsock exec still
         # works while the IP path does not, so the broken guest can be asked.
@@ -2464,6 +2511,7 @@ class FailureProbe:
         dump["host"]["log_markers"] = probe_log_markers(log_path)
         dump["elapsed_ms"] = (time.monotonic() - started) * 1000
         dump.setdefault("budget_exhausted", False)
+        dump.setdefault("interrupted_by_signal", 0)
         return dump
 
     def guest_active_sections(self):
@@ -2531,6 +2579,13 @@ class FailureProbe:
         attempts = []
         resolved = None
         for variant, flags in variants:
+            pending = harness_interrupt_pending()
+            if pending:
+                attempts.append({
+                    "nsenter_variant": variant,
+                    "error": f"skipped, termination signal {pending} pending",
+                })
+                continue
             timeout = min(self.command_timeout_s, deadline - time.monotonic())
             if timeout <= 0:
                 attempts.append({"nsenter_variant": variant,

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -2071,6 +2071,72 @@ def clip(text: str, limit: int) -> str:
     return text[:limit] + "\n...[truncated]"
 
 
+def live_group_members(pgid: int) -> list:
+    """Pids in `pgid` that are not zombies.
+
+    A zombie is dead, so it is not a survivor, but it does keep the group
+    present, which is why `killpg(pgid, 0)` cannot answer this question on a
+    host whose PID 1 does not reap. Reading each candidate's state answers it on
+    every host. One /proc walk, only ever on the timeout path.
+    """
+    live = []
+    try:
+        entries = os.listdir("/proc")
+    except OSError:
+        return live
+    for entry in entries:
+        if not entry.isdigit():
+            continue
+        try:
+            with open(f"/proc/{entry}/stat") as handle:
+                raw = handle.read()
+        except OSError:
+            continue  # exited between listdir and open
+        try:
+            fields = raw.rsplit(") ", 1)[1].split()
+            state, group = fields[0], int(fields[2])
+        except (IndexError, ValueError):
+            continue
+        if group == pgid and state != "Z":
+            live.append(int(entry))
+    return live
+
+
+def kill_process_group(leader_pid: int, timeout_s: float = 2.0) -> dict:
+    """SIGKILL a group by its LEADER's pid, then verify no live member is left.
+
+    `start_new_session=True` makes the spawned child both session and process
+    group leader, so the group id IS that pid. That identifier stays valid for
+    as long as the group has any member, because a member's `pgid` reference
+    pins the number against reuse. Reading it back with
+    `os.getpgid(leader_pid)` instead asks the LEADER, which is precisely the
+    process that may already be gone: a wrapper that spawns its real work and
+    exits leaves `communicate()` blocked on the still-open pipe, so by the time
+    the timeout fires the leader can be reaped and `getpgid` raises ESRCH.
+    Falling back to `proc.kill()` there re-targets that same dead leader and
+    every descendant keeps running.
+    """
+    outcome: dict = {"pgid": leader_pid}
+    try:
+        os.killpg(leader_pid, signal.SIGKILL)
+        outcome["signalled"] = True
+    except ProcessLookupError:
+        # No member left to signal: the group is already gone.
+        outcome["signalled"] = False
+        outcome["survivors"] = []
+        return outcome
+    except OSError as error:
+        outcome["signalled"] = False
+        outcome["error"] = f"{type(error).__name__}: {error}"
+    deadline = time.monotonic() + timeout_s
+    while True:
+        survivors = live_group_members(leader_pid)
+        if not survivors or time.monotonic() >= deadline:
+            outcome["survivors"] = survivors
+            return outcome
+        time.sleep(0.01)
+
+
 def run_probe_command(argv, timeout_s: float, budget_limited: bool = False,
                       output_limit: int = PROBE_BATCH_LIMIT) -> dict:
     """Run one probe command in its own session; never raise, always record.
@@ -2110,13 +2176,7 @@ def run_probe_command(argv, timeout_s: float, budget_limited: bool = False,
         out, err = proc.communicate(timeout=timeout_s)
     except subprocess.TimeoutExpired:
         timed_out = True
-        try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        except (ProcessLookupError, PermissionError, OSError):
-            try:
-                proc.kill()
-            except OSError:
-                pass
+        record["group_kill"] = kill_process_group(proc.pid)
         try:
             out, err = proc.communicate(timeout=5)
         except subprocess.TimeoutExpired:
@@ -2237,7 +2297,7 @@ class FailureProbe:
     """
 
     # A control that failed to WRITE is not a control, so the next healthy clone
-    # gets another go -- bounded, because each attempt costs up to the full
+    # gets another go. Bounded, because each attempt costs up to the full
     # budget and perturbs the rep it lands on, and a systematically broken probe
     # would otherwise tax every healthy request in the run.
     CONTROL_ATTEMPTS = 3
@@ -2287,7 +2347,7 @@ class FailureProbe:
         A pending INT/TERM outranks the evidence. The signal handler only
         RECORDS the signal, so nothing here is interrupted asynchronously and a
         capture that began before the signal would run its full budget with the
-        clone still up and the harness's teardown behind it — long enough for a
+        clone still up and the harness's teardown behind it, long enough for a
         job runner to escalate to SIGKILL and leave behind exactly the clone this
         probe exists to diagnose. So a signal that is already pending skips the
         capture outright, and one that arrives mid-capture stops it at the next

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -1851,6 +1851,705 @@ def teardown_normal(
     return out
 
 
+# -------------------------------------------------------------- failure probe
+#
+# EVIDENCE CAPTURE FOR AN UNSOLVED ROOT CAUSE. Nothing here fixes anything and
+# nothing here is measured.
+#
+# The 808-clone run produced 3 CDP failures. Every one came from a clone whose
+# ARP-triggering readiness ping got no reply (5 clones, 3 failed; of the 803
+# whose ping replied, none failed), and in each the guest stayed ALIVE for the
+# full 100+ seconds (its Chromium kept writing to the serial console) while
+# the host-driven CDP path either never connected or was reset mid-session. The
+# `exec` and `noop` arms reach the guest over VSOCK and never failed.
+#
+# What is NOT known is why the guest stopped answering on the IP path and why it
+# never recovered. A transient startup race resolves in milliseconds; these ran
+# out the client's own deadline. The leading and UNPROVEN hypothesis is that the
+# guest's post-restore network re-initialisation never happened or never
+# finished for that clone: fcvm PUTs a `restore-epoch` per clone, fc-agent's
+# `watch_restore_epoch` reacts to it by flushing the ARP cache, sending a
+# gratuitous ARP and re-registering exec, and a clone that misses that keeps
+# stale IP networking for life while vsock keeps working.
+#
+# VSOCK EXEC KEEPS WORKING DURING THE FAILURE, so the broken guest is
+# interrogable at exactly the moment it is broken. Until now the harness tore the
+# clone down and the evidence died with it.
+#
+# Three properties this code has to hold, in priority order:
+#   1. It must not perturb what is measured. Every probe runs AFTER the record's
+#      `blocking_ms` is stamped, so the caller-visible latency is already
+#      closed, and only on the failure path, plus exactly one healthy control per run.
+#   2. It must be bounded. It runs against a guest that may be wedged, so every
+#      command has a hard timeout enforced by killing the process GROUP (an
+#      `fcvm exec` that hangs has a guest-side child behind it), and the whole
+#      capture has a budget that skips the steps it cannot afford.
+#   3. It must never take the request or the run with it. Every failure inside
+#      the probe is recorded as data. The dump is the artifact even when most of
+#      it failed to collect.
+
+
+PROBE_COMMAND_TIMEOUT_S = 20.0
+"""Hard bound on one probe command. `fcvm exec`'s own connect ladder spans ~54 s
+(41 attempts from 5 ms, 1.5x, capped at 2 s, in `src/commands/exec.rs`), so an
+unbounded probe against a wedged exec server would outlast the request that
+failed. A live restored clone re-registers exec within single-digit
+milliseconds, so 20 s is not a race with a healthy guest: hitting this bound is
+itself the finding, and it is recorded as `timed_out`."""
+
+PROBE_BUDGET_S = 60.0
+"""Hard bound on one whole capture, checked before each step. A step that does not
+fit records why it was skipped rather than being silently absent."""
+
+PROBE_SECTION_LIMIT = 64 * 1024
+"""Per-section output cap. `dmesg` and `cat /proc/net/tcp` are unbounded in
+principle."""
+
+PROBE_BATCH_LIMIT = 512 * 1024
+"""Cap on a whole batch's stdout, applied BEFORE it is split into sections.
+Deliberately larger than the per-section cap: clipping the stream at the section
+cap would cut the last section's status line off and report a completed section
+as unknown."""
+
+PROBE_STREAM_LIMIT = 16 * 1024
+"""Cap on a probe process's own stderr (where `fcvm exec` reports why it could
+not reach the guest)."""
+
+PROBE_SECTION_MARK = "===fcvm-probe-section"
+PROBE_RC_MARK = "===fcvm-probe-rc"
+
+PROBE_GUEST_PASSIVE_SECTIONS = (
+    # Restore syncs the guest clock from the host (`fc-agent/src/restore.rs`
+    # calls `sync_clock_from_host` FIRST), so a guest still sitting at the
+    # snapshot's wall time is direct evidence the restore handler never ran.
+    ("guest_date", "date -u +%Y-%m-%dT%H:%M:%SZ"),
+    ("guest_uptime", "cat /proc/uptime"),
+    ("ip_addr", "ip addr"),
+    ("ip_link_stats", "ip -s link"),
+    ("ip_route", "ip route"),
+    # Does the guest hold a stale gateway MAC? `handle_clone_restore` flushes
+    # this table and re-ARPs; an entry pointing at the pre-snapshot bridge port,
+    # or a FAILED/INCOMPLETE one, is the shape the hypothesis predicts.
+    ("ip_neigh", "ip neigh"),
+    ("proc_net_arp", "cat /proc/net/arp"),
+    ("proc_net_dev", "cat /proc/net/dev"),
+    # Is Chromium still listening on the CDP port INSIDE the guest? The
+    # container runs `--network=host` (`fc-agent/src/container.rs`), so the VM's
+    # netns is the container's netns and this sees the container's listener.
+    ("listening_sockets", "ss -ltnp"),
+    ("proc_net_tcp", "cat /proc/net/tcp"),
+    # `awk '/[c]hrom/'`, not `grep chrom`: the bracket keeps the matcher's own
+    # argv from matching, and the full `args` column is the point: which
+    # Chromium flags are live, and on which port.
+    ("chromium_processes",
+     "ps -eo pid,ppid,stat,etimes,comm,args | awk 'NR==1 || /[c]hrom/'"),
+    ("dmesg_tail", "dmesg | tail -50"),
+    # fc-agent writes its restore-epoch narration to stderr, which lands on the
+    # serial console rather than in a file, so this is usually empty. The
+    # authoritative copy is the host-side log-marker capture below. It is here
+    # because "usually" is not "always" and an empty section costs nothing.
+    ("fc_agent_journal",
+     "journalctl -b --no-pager -o cat -n 400 | grep -F '[fc-agent]' | tail -40"),
+)
+
+PROBE_HOLDER_NS_SECTIONS = (
+    ("ns_ip_addr", "ip addr"),
+    ("ns_ip_link_stats", "ip -s link"),
+    # The host half of the same question `ip_neigh` asks in the guest. This is
+    # the exact table `verify_port_forwarding` reads before it declares the
+    # clone ready (`src/network/pasta.rs`: `ip neigh show to 10.0.2.100 dev br0`).
+    ("ns_ip_neigh", "ip neigh"),
+    ("ns_ip_route", "ip route"),
+    ("ns_bridge_link", "bridge link"),
+    ("ns_listening_sockets", "ss -ltn"),
+)
+
+PROBE_LOG_MARKERS = (
+    # fc-agent's restore narration, straight off the guest serial console:
+    # "detected restore-epoch", "handling restore", "ARP cache flushed",
+    # "exec re-registered after restore", "restore complete", and the
+    # "restore metadata fetch failed" line that fires when MMDS is unreachable.
+    "[fc-agent]",
+    "restore-epoch",
+    # pasta's readiness verdict, including the `ping_replied=` field that
+    # separated the 5 no-reply clones from the other 803.
+    "ping_replied",
+    "ARP",
+    "neighbour",
+    "port forward",
+    "pasta",
+)
+
+PROBE_LOG_MAX_LINES = 200
+
+
+def probe_batch_script(sections) -> str:
+    """One shell script that runs every section and frames its output and status.
+
+    Batched deliberately: one `fcvm exec` per batch instead of one per command
+    means one handshake, one timeout to enforce, and one instant that all the
+    state comes from. Each section still carries its OWN exit status, so a
+    missing binary inside the batch is recorded as that section's `rc` rather
+    than discarding the batch.
+
+    Each section runs in a SUBSHELL, not a brace group. A brace group shares the
+    batch's shell, so one section calling `exit` ends the whole batch and every
+    later section vanishes with no status line, and silently, since the frame
+    that would have said so was never printed. The subshell also keeps a section's
+    `cd`, variables and traps out of the next one.
+    """
+    parts = []
+    for name, command in sections:
+        quoted = shlex.quote(name)
+        parts.append(
+            f"printf '{PROBE_SECTION_MARK} %s\\n' {quoted}; "
+            f"( {command} ) 2>&1; "
+            f"printf '{PROBE_RC_MARK} %s %s\\n' {quoted} \"$?\""
+        )
+    return "\n".join(parts)
+
+
+def parse_probe_batch(text: str) -> dict:
+    """Split framed batch output into {section: {"output", "rc"}}.
+
+    A section whose RC line never arrived keeps `rc: None`. That is what a batch
+    cut off by the timeout looks like, and it must not read as rc 0.
+    """
+    sections: dict = {}
+    current = None
+    buffered: list = []
+
+    def close(name, rc):
+        body = "\n".join(buffered)
+        if len(body) > PROBE_SECTION_LIMIT:
+            body = body[:PROBE_SECTION_LIMIT] + "\n...[truncated]"
+            sections[name]["truncated"] = True
+        sections[name]["output"] = body
+        sections[name]["rc"] = rc
+
+    for line in text.splitlines():
+        if line.startswith(PROBE_SECTION_MARK + " "):
+            if current is not None:
+                close(current, None)
+            current = line[len(PROBE_SECTION_MARK) + 1:].strip()
+            sections[current] = {"output": "", "rc": None}
+            buffered = []
+        elif current is not None and line.startswith(PROBE_RC_MARK + " "):
+            rest = line[len(PROBE_RC_MARK) + 1:].strip()
+            name, _, status = rest.rpartition(" ")
+            if name == current:
+                try:
+                    close(current, int(status))
+                except ValueError:
+                    close(current, None)
+                current = None
+                buffered = []
+            else:
+                buffered.append(line)
+        elif current is not None:
+            buffered.append(line)
+    if current is not None:
+        close(current, None)
+    return sections
+
+
+def clip(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "\n...[truncated]"
+
+
+def run_probe_command(argv, timeout_s: float, budget_limited: bool = False,
+                      output_limit: int = PROBE_BATCH_LIMIT) -> dict:
+    """Run one probe command in its own session; never raise, always record.
+
+    `start_new_session` plus a process-GROUP kill is the whole reason this is
+    not `subprocess.run(timeout=...)`: that kills only the direct child, and the
+    direct child here is `fcvm exec`, which is holding a vsock session with a
+    command running inside the guest.
+
+    `budget_limited` says this command got less than the full per-command
+    timeout because the capture's own budget was nearly spent. Without it a
+    `timed_out: True` from a 40 ms residual budget is indistinguishable from a
+    genuinely wedged guest, which is the whole thing the dump exists to tell
+    apart.
+    """
+    started = time.monotonic()
+    record: dict = {"argv": list(argv), "timeout_s": timeout_s,
+                    "budget_limited": budget_limited}
+    try:
+        proc = subprocess.Popen(
+            list(argv),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+            text=True,
+            errors="replace",
+        )
+    except OSError as error:
+        record["rc"] = None
+        record["timed_out"] = False
+        record["error"] = f"{type(error).__name__}: {error}"
+        record["elapsed_ms"] = (time.monotonic() - started) * 1000
+        return record
+    timed_out = False
+    try:
+        out, err = proc.communicate(timeout=timeout_s)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            try:
+                proc.kill()
+            except OSError:
+                pass
+        try:
+            out, err = proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            out, err = "", ""
+    record["rc"] = proc.returncode
+    record["timed_out"] = timed_out
+    record["stdout"] = clip(out or "", output_limit)
+    record["stderr"] = clip(err or "", PROBE_STREAM_LIMIT)
+    record["elapsed_ms"] = (time.monotonic() - started) * 1000
+    return record
+
+
+def probe_log_markers(log_path: str, markers=PROBE_LOG_MARKERS,
+                      max_lines: int = PROBE_LOG_MAX_LINES) -> dict:
+    """Pull the restore/readiness narration out of THIS clone's own fcvm log.
+
+    fc-agent's restore lines arrive on the guest serial console and pasta's
+    readiness verdict is fcvm's own `info!`, so both are already in the per-clone
+    log, but a dump that says "go read a 20 000 line log" is not
+    self-describing. Keeps the head and the tail of the matches, since the
+    restore evidence is at the start and the failure at the end.
+    """
+    out: dict = {"path": log_path, "matched": 0, "lines": [], "truncated": False}
+    if not log_path:
+        out["error"] = "no log path for this request"
+        return out
+    head: list = []
+    tail: list = []
+    half = max(1, max_lines // 2)
+    try:
+        with open(log_path, "r", errors="replace") as handle:
+            for line in handle:
+                if not any(marker in line for marker in markers):
+                    continue
+                out["matched"] += 1
+                line = line.rstrip("\n")
+                if len(head) < half:
+                    head.append(line)
+                else:
+                    tail.append(line)
+                    if len(tail) > half:
+                        tail.pop(0)
+    except OSError as error:
+        out["error"] = f"{type(error).__name__}: {error}"
+        return out
+    omitted = out["matched"] - len(head) - len(tail)
+    if omitted > 0:
+        out["truncated"] = True
+        out["lines"] = head + [f"...[{omitted} lines omitted]"] + tail
+    else:
+        out["lines"] = head + tail
+    return out
+
+
+def read_probe_file(path: str, limit: int = PROBE_SECTION_LIMIT) -> dict:
+    try:
+        with open(path, "r", errors="replace") as handle:
+            return {"path": path, "content": clip(handle.read(limit + 1), limit)}
+    except OSError as error:
+        return {"path": path, "error": f"{type(error).__name__}: {error}"}
+
+
+def probe_process_facts(pid) -> dict:
+    """pid, comm, scheduler state and argv for one host process, or why not."""
+    facts: dict = {"pid": pid}
+    if not isinstance(pid, int) or pid <= 0:
+        facts["error"] = f"not a usable pid: {pid!r}"
+        return facts
+    fields = proc_stat_fields(pid)
+    if fields is None:
+        facts["alive"] = False
+        return facts
+    facts["alive"] = True
+    facts["state"] = fields[0]
+    facts["utime_ms"] = fields[1] * 1000.0 / CLK_TCK
+    facts["stime_ms"] = fields[2] * 1000.0 / CLK_TCK
+    facts["start_time"] = fields[3]
+    facts["comm"] = proc_comm(pid)
+    try:
+        with open(f"/proc/{pid}/cmdline", "rb") as handle:
+            facts["cmdline"] = handle.read(4096).replace(b"\0", b" ").decode(
+                "utf8", "replace").strip()
+    except OSError as error:
+        facts["cmdline_error"] = f"{type(error).__name__}: {error}"
+    return facts
+
+
+def probe_tcp_connect(endpoint: str, timeout_s: float = 2.0) -> dict:
+    """Does the host->guest published port answer RIGHT NOW?
+
+    The failure is defined by this path not working; asking it again at probe
+    time is what separates "still broken 100 s later" from "recovered and the
+    client had already given up".
+    """
+    import socket
+
+    out: dict = {"endpoint": endpoint, "timeout_s": timeout_s}
+    if not endpoint or ":" not in endpoint:
+        out["error"] = f"no usable endpoint: {endpoint!r}"
+        return out
+    host, _, port = endpoint.rpartition(":")
+    started = time.monotonic()
+    try:
+        socket.create_connection((host, int(port)), timeout_s).close()
+        out["connected"] = True
+    except (OSError, ValueError) as error:
+        out["connected"] = False
+        out["error"] = f"{type(error).__name__}: {error}"
+    out["elapsed_ms"] = (time.monotonic() - started) * 1000
+    return out
+
+
+class FailureProbe:
+    """Capture guest-side and host-side state for a clone that just failed.
+
+    One instance per run. It owns the once-per-run control capture, so the
+    control cannot be taken twice or taken from a clone that also failed.
+    """
+
+    def __init__(self, fcvm: str, data_root: str, out_dir: str, run_id: str,
+                 cdp_port: int, command_timeout_s: float = PROBE_COMMAND_TIMEOUT_S,
+                 budget_s: float = PROBE_BUDGET_S):
+        self.fcvm = fcvm
+        self.data_root = data_root
+        self.out_dir = out_dir
+        self.run_id = run_id
+        self.cdp_port = cdp_port
+        self.command_timeout_s = command_timeout_s
+        self.budget_s = budget_s
+        self.control_captured = False
+        self.control_path = ""
+        self.is_warmup = False
+
+    def begin_request(self, is_warmup: bool) -> None:
+        """Tell the probe whether the rep about to run is a discarded warmup.
+
+        The control has to come from a HEALTHY clone, so it is the one capture
+        that touches a request the analyzer might read. Placing it on a warmup
+        rep makes that free: warmups are discarded explicitly at analysis. When
+        no warmup rep is available the control still runs, because a failure dump
+        with nothing to compare against proves little, and the record it perturbs is
+        stamped `probe_perturbed_timings` so it is excludable by hand.
+        """
+        self.is_warmup = bool(is_warmup)
+
+    def role_for(self, rec: dict):
+        if rec.get("ok") is False:
+            return "failure"
+        if rec.get("ok") is True and not self.control_captured:
+            return "control"
+        return None
+
+    def observe(self, rec: dict, *, name: str, fcvm_pid: int, state_path,
+                log_path: str, endpoint: str = "") -> None:
+        """Capture if this record earns it, and stamp the record either way.
+
+        Wrapped whole: a probe that raises would abort a request that had
+        already produced its answer, which is strictly worse than no probe.
+        """
+        role = self.role_for(rec)
+        if role is None:
+            return
+        try:
+            dump = self.capture(
+                role=role, rec=rec, name=name, fcvm_pid=fcvm_pid,
+                state_path=state_path, log_path=log_path, endpoint=endpoint,
+            )
+            path = self.write(name, dump)
+            errors = dump.get("errors", [])
+            rec["probe"] = {
+                "role": role,
+                "path": path,
+                # A dump with nothing to compare against proves little, so the
+                # failing record names the run's healthy control too. Empty when
+                # the failure preceded any healthy CDP rep, which is itself worth
+                # knowing rather than looking like an absent file.
+                "control_path": dump.get("control_path", ""),
+                "elapsed_ms": dump.get("elapsed_ms"),
+                "budget_exhausted": dump.get("budget_exhausted", False),
+                "errors": errors[:10],
+                "error_count": len(errors),
+            }
+            if role == "control":
+                self.control_path = path
+        except Exception as error:  # noqa: BLE001 - the probe is never fatal
+            rec["probe"] = {
+                "role": role,
+                "path": "",
+                "probe_error": f"{type(error).__name__}: {error}",
+            }
+        if role == "control":
+            self.control_captured = True
+            if not self.is_warmup:
+                rec["probe_perturbed_timings"] = True
+                print(
+                    f"probe: control captured on MEASURED rep {rec.get('rep')} "
+                    f"({name}); its wall_ms and teardown are perturbed and the "
+                    "record is stamped probe_perturbed_timings",
+                    file=sys.stderr, flush=True,
+                )
+
+    def write(self, name: str, dump: dict) -> str:
+        """Write the dump atomically, next to this request's clone log."""
+        path = os.path.join(self.out_dir, f"{name}.probe.json")
+        tmp = f"{path}.tmp"
+        with open(tmp, "w") as handle:
+            json.dump(dump, handle, indent=2, sort_keys=True)
+        os.replace(tmp, path)
+        return path
+
+    def capture(self, *, role, rec, name, fcvm_pid, state_path, log_path,
+                endpoint) -> dict:
+        started = time.monotonic()
+        deadline = started + self.budget_s
+        dump: dict = {
+            "schema": "fcvm-cdp-failure-probe-v1",
+            "role": role,
+            "run_id": self.run_id,
+            "name": name,
+            "arm": rec.get("arm"),
+            "rep": rec.get("rep"),
+            "vm_id": rec.get("vm_id"),
+            "endpoint": endpoint or rec.get("endpoint", ""),
+            "request_error": rec.get("error"),
+            "failure_class": rec.get("failure_class"),
+            "failure_stage": rec.get("failure_stage"),
+            "blocking_ms": rec.get("blocking_ms"),
+            "fcvm_pid": fcvm_pid,
+            "state_path": state_path or "",
+            "log_path": log_path,
+            "captured_at": time.time(),
+            "command_timeout_s": self.command_timeout_s,
+            "budget_s": self.budget_s,
+            "control_path": "" if role == "control" else self.control_path,
+            "host": {},
+            "guest": {},
+            "errors": [],
+        }
+
+        def note(where, detail):
+            dump["errors"].append(f"{where}: {detail}")
+
+        def remaining():
+            return deadline - time.monotonic()
+
+        def budget_for(step):
+            """Timeout for one step, or None when the budget is spent.
+
+            Returns `(timeout, budget_limited)` so a step that got a shortened
+            timeout can say so on its own record instead of reporting an
+            indistinguishable `timed_out`.
+            """
+            left = remaining()
+            if left <= 0:
+                dump["budget_exhausted"] = True
+                note(step, "skipped, probe budget exhausted")
+                return None
+            return (min(self.command_timeout_s, left), left < self.command_timeout_s)
+
+        # ---- host, instantaneous: no subprocess, nothing that can hang.
+        state = None
+        if state_path:
+            try:
+                with open(state_path) as handle:
+                    state = json.load(handle)
+            except (OSError, ValueError) as error:
+                note("clone_state", f"{type(error).__name__}: {error}")
+        else:
+            note("clone_state", "no state file was ever found for this clone")
+        dump["host"]["clone_state"] = state
+        holder_pid = (state or {}).get("holder_pid")
+        vm_id = (state or {}).get("vm_id") or rec.get("vm_id") or ""
+        dump["host"]["holder_pid"] = holder_pid
+        dump["host"]["fcvm_process"] = probe_process_facts(fcvm_pid)
+        dump["host"]["fcvm_children"] = [
+            probe_process_facts(child) for child in children_of(fcvm_pid)
+        ]
+        try:
+            dump["host"]["loadavg"] = read_trimmed("/proc/loadavg")
+        except OSError as error:
+            note("loadavg", f"{type(error).__name__}: {error}")
+
+        # pasta identifies itself by a per-VM pid file (`src/network/pasta.rs`
+        # writes `pasta-<vm_id[:8]>.pid` under the data dir), which is the only
+        # way to name THIS clone's pasta rather than one of the others'.
+        pasta: dict = {}
+        if valid_vm_id(vm_id):
+            pid_path = os.path.join(self.data_root, f"pasta-{vm_id[:8]}.pid")
+            pasta["pid_file"] = pid_path
+            try:
+                with open(pid_path) as handle:
+                    pasta["pid"] = int(handle.read().strip())
+            except (OSError, ValueError) as error:
+                pasta["error"] = f"{type(error).__name__}: {error}"
+        else:
+            pasta["error"] = f"no usable vm_id to locate the pasta pid file: {vm_id!r}"
+        if isinstance(pasta.get("pid"), int):
+            pasta["process"] = probe_process_facts(pasta["pid"])
+        dump["host"]["pasta"] = pasta
+
+        # The holder's own procfs exposes its network namespace with no
+        # privilege and no nsenter, so this half survives even when entering the
+        # namespace does not.
+        if isinstance(holder_pid, int):
+            dump["host"]["holder_procfs"] = {
+                which: read_probe_file(f"/proc/{holder_pid}/net/{which}")
+                for which in ("arp", "dev", "route", "tcp")
+            }
+        else:
+            note("holder_procfs", f"no holder pid in state: {holder_pid!r}")
+
+        dump["host"]["cdp_connect_now"] = probe_tcp_connect(
+            dump["endpoint"], min(2.0, max(0.1, remaining()))
+        )
+
+        # ---- guest, passive. The reason this probe exists: vsock exec still
+        # works while the IP path does not, so the broken guest can be asked.
+        allowance = budget_for("guest_passive")
+        if allowance is not None:
+            dump["guest"]["passive"] = self.exec_batch(
+                fcvm_pid, PROBE_GUEST_PASSIVE_SECTIONS, *allowance
+            )
+
+        # ---- host, inside the clone's network namespace. `-U -n` is exactly
+        # what fcvm itself uses (`PastaNetwork::build_nsenter_prefix`), so it
+        # needs no privilege in rootless mode; the retry without `-U` covers the
+        # modes that have no user namespace. Both attempts are recorded.
+        if isinstance(holder_pid, int) and budget_for("holder_namespace") is not None:
+            dump["host"]["holder_namespace"] = self.nsenter_batch(
+                holder_pid, PROBE_HOLDER_NS_SECTIONS, deadline
+            )
+        loopback = ((state or {}).get("config", {}).get("network", {}) or {}).get(
+            "loopback_ip"
+        )
+        if loopback:
+            allowance = budget_for("host_listeners")
+            if allowance is not None:
+                # Does pasta's host-side listener for this clone still exist?
+                # That is the socket `wait_for_port_forwarding_until` connected
+                # to before the clone was declared ready.
+                dump["host"]["listeners"] = run_probe_command(
+                    ["ss", "-H", "-ltn", "src", loopback], *allowance
+                )
+
+        # ---- guest, ACTIVE and last. These three mutate state: arping refills
+        # the neighbour table this dump has already recorded. Passive capture
+        # runs first for exactly that reason. Their value is that they answer
+        # "is this still broken NOW", which the unsolved question is about.
+        allowance = budget_for("guest_active")
+        if allowance is not None:
+            dump["guest"]["active_mutating"] = self.exec_batch(
+                fcvm_pid, self.guest_active_sections(), *allowance
+            )
+            dump["guest"]["active_mutating"]["mutates_guest_state"] = True
+
+        # Last, so it includes anything the probe itself provoked.
+        dump["host"]["log_markers"] = probe_log_markers(log_path)
+        dump["elapsed_ms"] = (time.monotonic() - started) * 1000
+        dump.setdefault("budget_exhausted", False)
+        return dump
+
+    def guest_active_sections(self):
+        port = self.cdp_port
+        return (
+            # Chromium answering on guest loopback while the host cannot reach
+            # it puts the fault in the network path, not in the browser.
+            ("cdp_from_guest_loopback",
+             f"printf 'GET /json/version HTTP/1.0\\r\\n\\r\\n' "
+             f"| nc -w 2 127.0.0.1 {port}"),
+            # What restore-epoch does the guest see RIGHT NOW, and can it see
+            # MMDS at all? `fetch_latest_metadata` is MMDS V2, so the token PUT
+            # comes first. netcat-openbsd is installed in the VM rootfs
+            # (`rootfs-config.toml` [packages] debug); curl is not.
+            ("mmds_latest",
+             "tok=$(printf 'PUT /latest/api/token HTTP/1.0\\r\\n"
+             "X-metadata-token-ttl-seconds: 60\\r\\nConnection: close\\r\\n\\r\\n' "
+             "| nc -w 2 169.254.169.254 80 | tr -d '\\r' | tail -1); "
+             "printf 'GET /latest HTTP/1.0\\r\\nX-metadata-token: %s\\r\\n"
+             "Accept: application/json\\r\\nConnection: close\\r\\n\\r\\n' \"$tok\" "
+             "| nc -w 2 169.254.169.254 80 | tr -d '\\r' | tail -5"),
+            # The same arping `handle_clone_restore` sends. iputils-arping is in
+            # the VM rootfs. A gateway that does not answer this, 100 s after the
+            # request gave up, is a persistent L2 break rather than a race.
+            ("arping_gateway",
+             "gw=$(ip route show default | awk '/via/{print $3; exit}'); "
+             "echo \"gateway=$gw\"; arping -c 1 -w 2 -I eth0 \"$gw\""),
+        )
+
+    def exec_batch(self, fcvm_pid: int, sections, timeout_s: float,
+                   budget_limited: bool = False) -> dict:
+        """Run a section batch in the guest VM over vsock exec.
+
+        `--vm`, not the container: the container runs `--network=host`, so the
+        VM's view already covers the container's sockets and processes, and one
+        exec is one thing that can hang instead of two.
+        """
+        script = probe_batch_script(sections)
+        # fcvm logs to stderr and keeps stdout clean for command output
+        # (`src/main.rs`: "Logs to stderr, keep stdout clean"), so the framed
+        # sections parse out of stdout while the exec client's own retry ladder
+        # and connect errors stay readable in `stderr`.
+        argv = [self.fcvm, "exec", "--pid", str(fcvm_pid), "--vm",
+                "--", "sh", "-c", script]
+        result = run_probe_command(argv, timeout_s, budget_limited)
+        result["sections"] = parse_probe_batch(result.get("stdout", ""))
+        result.pop("stdout", None)
+        return result
+
+    def nsenter_batch(self, holder_pid: int, sections, deadline: float) -> dict:
+        """Enter the clone's network namespace, preferring the way fcvm does it.
+
+        `-U -n --preserve-credentials` is `PastaNetwork::build_nsenter_prefix`
+        verbatim, and it needs no privilege in rootless mode because the holder's
+        user namespace makes the caller root inside it. Dropping `-U` is the
+        retry for a mode with no user namespace. Each attempt is separately
+        bounded against the capture deadline, so a hanging first attempt cannot
+        buy the second one a fresh budget.
+        """
+        script = probe_batch_script(sections)
+        variants = (
+            ("user+net", ["-t", str(holder_pid), "-U", "-n", "--preserve-credentials"]),
+            ("net", ["-t", str(holder_pid), "-n", "--preserve-credentials"]),
+        )
+        attempts = []
+        resolved = None
+        for variant, flags in variants:
+            timeout = min(self.command_timeout_s, deadline - time.monotonic())
+            if timeout <= 0:
+                attempts.append({"nsenter_variant": variant,
+                                 "error": "skipped, probe budget exhausted"})
+                continue
+            result = run_probe_command(
+                ["nsenter", *flags, "--", "sh", "-c", script], timeout,
+                budget_limited=timeout < self.command_timeout_s,
+            )
+            result["nsenter_variant"] = variant
+            result["sections"] = parse_probe_batch(result.get("stdout", ""))
+            result.pop("stdout", None)
+            attempts.append(result)
+            if result.get("rc") == 0 and result["sections"]:
+                resolved = variant
+                break
+        return {"attempts": attempts, "resolved_variant": resolved}
+
+
 # ----------------------------------------------------------------- one request
 
 
@@ -1895,7 +2594,7 @@ def spawn_clone_process(cmd: list[str], log: str, env: dict) -> subprocess.Popen
         signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
 
 
-def run_cdp_request(args, rep: int, fast: bool) -> dict:
+def run_cdp_request(args, rep: int, fast: bool, probe=None) -> dict:
     import cdpdrive
 
     name = f"rb-{args.run_id}-{rep}-{'fast' if fast else 'norm'}"
@@ -2030,6 +2729,22 @@ def run_cdp_request(args, rep: int, fast: bool) -> dict:
                         rec["state_error"] = str(data_error)
     finally:
         watch.close()
+
+    # EVIDENCE, NOT MEASUREMENT. `rec["blocking_ms"]` is the caller-visible
+    # latency and the only number this arm publishes as a response time, and it
+    # is already stamped on both the success and the failure path above, so nothing
+    # below can move it. The clone is still up, and on the failure path its vsock
+    # exec still works while its IP path does not, which is the whole reason to
+    # ask it anything before the teardown deletes it.
+    if probe is not None:
+        probe.observe(
+            rec,
+            name=name,
+            fcvm_pid=fcvm_pid,
+            state_path=state_path,
+            log_path=log,
+            endpoint=rec.get("endpoint", ""),
+        )
 
     if fast:
         try:
@@ -2596,6 +3311,23 @@ def run_exec_request(args, rep: int) -> dict:
     return rec
 
 
+def dispatch_request(args, rep: int, arm: str, is_warmup: bool, probe=None) -> dict:
+    """Route one scheduled attempt to its arm, carrying the failure probe.
+
+    Extracted from `main`'s loop so the wiring is testable: the probe reaching
+    the CDP arms is the difference between a failure that leaves evidence and one
+    that does not, and a wiring gap inside a 90-line loop body is invisible until
+    the next unexplained failure has already been torn down.
+    """
+    if probe is not None:
+        probe.begin_request(is_warmup)
+    if arm == "exec":
+        return run_exec_request(args, rep)
+    if arm == "noop":
+        return run_noop_request(args, rep)
+    return run_cdp_request(args, rep, fast=(arm == "cdp-fast"), probe=probe)
+
+
 def main() -> int:
     """Run one schedule and release every whole-run resource on every exit."""
     with ExitStack() as resources:
@@ -2765,6 +3497,15 @@ def main_with_resources(resources: ExitStack) -> int:
 
     out_path = os.path.join(args.out_dir, "reqbench.jsonl")
     run_id = args.run_id
+    # One probe per run: it owns the once-per-run healthy control, so the
+    # control cannot be taken twice or taken from a clone that also failed.
+    probe = FailureProbe(
+        fcvm=args.fcvm,
+        data_root=args.data_root,
+        out_dir=args.out_dir,
+        run_id=args.run_id,
+        cdp_port=args.cdp_port,
+    )
     try:
         quiet_guard_loadavg1 = float(os.environ["REQBENCH_GUARD_LOADAVG1"])
         quiet_guard_vm_processes = int(
@@ -2825,12 +3566,7 @@ def main_with_resources(resources: ExitStack) -> int:
             # leave no trace in the artifact, so `n=` was the only evidence that
             # anything had been dropped.
             try:
-                if arm == "exec":
-                    rec = run_exec_request(args, rep)
-                elif arm == "noop":
-                    rec = run_noop_request(args, rep)
-                else:
-                    rec = run_cdp_request(args, rep, fast=(arm == "cdp-fast"))
+                rec = dispatch_request(args, rep, arm, is_warmup, probe)
                 fatal = None
             except SurvivedTeardown as e:
                 rec = dict(e.record) or {"arm": arm, "rep": rep}

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -2297,9 +2297,9 @@ class FailureProbe:
     """
 
     # A control that failed to WRITE is not a control, so the next healthy clone
-    # gets another go. Bounded, because each attempt costs up to the full
-    # budget and perturbs the rep it lands on, and a systematically broken probe
-    # would otherwise tax every healthy request in the run.
+    # gets another go. Bounded, because each attempt costs up to the full budget
+    # and perturbs the rep it lands on, so an unbounded retry against a
+    # systematically broken probe would tax every healthy request in the run.
     CONTROL_ATTEMPTS = 3
 
     def __init__(self, fcvm: str, data_root: str, out_dir: str, run_id: str,

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -2236,6 +2236,12 @@ class FailureProbe:
     control cannot be taken twice or taken from a clone that also failed.
     """
 
+    # A control that failed to WRITE is not a control, so the next healthy clone
+    # gets another go -- bounded, because each attempt costs up to the full
+    # budget and perturbs the rep it lands on, and a systematically broken probe
+    # would otherwise tax every healthy request in the run.
+    CONTROL_ATTEMPTS = 3
+
     def __init__(self, fcvm: str, data_root: str, out_dir: str, run_id: str,
                  cdp_port: int, command_timeout_s: float = PROBE_COMMAND_TIMEOUT_S,
                  budget_s: float = PROBE_BUDGET_S):
@@ -2247,6 +2253,7 @@ class FailureProbe:
         self.command_timeout_s = command_timeout_s
         self.budget_s = budget_s
         self.control_captured = False
+        self.control_attempts = 0
         self.control_path = ""
         self.is_warmup = False
 
@@ -2265,7 +2272,8 @@ class FailureProbe:
     def role_for(self, rec: dict):
         if rec.get("ok") is False:
             return "failure"
-        if rec.get("ok") is True and not self.control_captured:
+        if (rec.get("ok") is True and not self.control_captured
+                and self.control_attempts < self.CONTROL_ATTEMPTS):
             return "control"
         return None
 
@@ -2296,6 +2304,8 @@ class FailureProbe:
                 "skipped": f"termination signal {pending} pending",
             }
             return
+        if role == "control":
+            self.control_attempts += 1
         try:
             dump = self.capture(
                 role=role, rec=rec, name=name, fcvm_pid=fcvm_pid,
@@ -2318,23 +2328,27 @@ class FailureProbe:
                 "error_count": len(errors),
             }
             if role == "control":
+                # A WRITTEN dump is what makes this the control. Setting the
+                # flag on the exception path below instead retired the control
+                # for the whole run over one transient error, and every later
+                # failure dump then had nothing to be read against.
                 self.control_path = path
+                self.control_captured = True
         except Exception as error:  # noqa: BLE001 - the probe is never fatal
             rec["probe"] = {
                 "role": role,
                 "path": "",
                 "probe_error": f"{type(error).__name__}: {error}",
             }
-        if role == "control":
-            self.control_captured = True
-            if not self.is_warmup:
-                rec["probe_perturbed_timings"] = True
-                print(
-                    f"probe: control captured on MEASURED rep {rec.get('rep')} "
-                    f"({name}); its wall_ms and teardown are perturbed and the "
-                    "record is stamped probe_perturbed_timings",
-                    file=sys.stderr, flush=True,
-                )
+        if role == "control" and not self.is_warmup:
+            rec["probe_perturbed_timings"] = True
+            print(
+                f"probe: control capture attempt {self.control_attempts} on "
+                f"MEASURED rep {rec.get('rep')} ({name}); its wall_ms and "
+                "teardown are perturbed and the record is stamped "
+                "probe_perturbed_timings",
+                file=sys.stderr, flush=True,
+            )
 
     def write(self, name: str, dump: dict) -> str:
         """Write the dump atomically, next to this request's clone log."""

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -4634,7 +4634,7 @@ class FailureProbeCapture(unittest.TestCase):
         command running inside the guest, so killing only the direct child would
         leave the real work behind. The bound therefore kills the process GROUP,
         and this asserts the grandchild was KILLED rather than asserting its
-        procfs entry went away — those are different claims, and the second one
+        procfs entry went away. Those are different claims, and the second one
         is about the reaper rather than about the kill. This test adopts the
         orphan and reads its exit status, so it says what it means.
         """
@@ -4660,6 +4660,118 @@ class FailureProbeCapture(unittest.TestCase):
             note = ("the timeout killed the exec wrapper but left its "
                     "guest-side work")
             assert_sigkilled(self, grandchild, reap_orphan(grandchild, note), note)
+
+    def test_a_zombie_group_member_is_not_counted_as_a_survivor(self):
+        """The kill's verification has to tell a corpse from a survivor.
+
+        `killpg(pgid, 0)` cannot: an unreaped zombie keeps the whole group
+        present, so on a host whose PID 1 does not reap it would report the
+        group alive forever. `live_group_members` reads each member's state, and
+        this checks it against a group holding one of each.
+        """
+        code = (
+            "import subprocess,sys,time;"
+            "corpse=subprocess.Popen(['true']);"          # never waited on
+            "live=subprocess.Popen(['sleep','300']);"
+            "open(sys.argv[1],'w').write(f'{corpse.pid} {live.pid}');"
+            "time.sleep(300)"
+        )
+        with tempfile.TemporaryDirectory() as d:
+            pid_file = os.path.join(d, "members.pid")
+            leader = subprocess.Popen([sys.executable, "-c", code, pid_file],
+                                      start_new_session=True)
+            try:
+                deadline = time.monotonic() + 10
+                corpse = live = None
+                while time.monotonic() < deadline:
+                    try:
+                        with open(pid_file) as handle:
+                            corpse, live = (int(x) for x in
+                                            handle.read().split())
+                    except (OSError, ValueError):
+                        time.sleep(0.02)
+                        continue
+                    state = reqbench.proc_stat_fields(corpse)
+                    if state and state[0] == "Z":
+                        break
+                    time.sleep(0.02)
+                self.assertIsNotNone(corpse, "the group never came up")
+                # Without this the assertion below passes for the wrong reason.
+                self.assertEqual(reqbench.proc_stat_fields(corpse)[0], "Z",
+                                 "the corpse was reaped, so it proves nothing")
+                members = reqbench.live_group_members(leader.pid)
+                self.assertIn(leader.pid, members)
+                self.assertIn(live, members)
+                self.assertNotIn(corpse, members,
+                                 "a zombie is dead, so it is not a survivor")
+            finally:
+                outcome = reqbench.kill_process_group(leader.pid)
+                leader.wait(timeout=5)
+            self.assertEqual(outcome["survivors"], [],
+                             "the group outlived its own kill")
+
+    def test_the_bound_kills_the_group_when_the_leader_is_already_gone(self):
+        """RED BEFORE THE FIX: the group was named by asking the leader for it.
+
+        `os.getpgid(proc.pid)` raises ESRCH once the leader is gone, and the
+        `proc.kill()` fallback then re-signals that same dead leader while the
+        work it spawned keeps running:
+
+            AssertionError: the group kill missed the descendant the vanished
+            leader left behind: pid 4193142 is still running 5s later, state
+            ('S', 0, 0, 254146417)
+
+        The window is real and this reproduces it rather than racing for it. The
+        wrapper exits immediately, its child keeps the stdout pipe open, so
+        `communicate()` still blocks for the whole timeout. A SIGCHLD reaper
+        makes the leader's pid VANISH inside that window instead of lingering as
+        a zombie, which is what turns `getpgid` into ESRCH; any harness that
+        reaps its own children supplies one.
+        """
+        with tempfile.TemporaryDirectory() as d, child_subreaper():
+            survivor_pid_file = os.path.join(d, "survivor.pid")
+            wrapper = os.path.join(d, "vanishing-leader")
+            with open(wrapper, "w") as f:
+                f.write(
+                    "#!/bin/sh\n"
+                    "sleep 300 &\n"
+                    f"echo $! > {shlex.quote(survivor_pid_file)}\n"
+                    "exit 0\n"
+                )
+            os.chmod(wrapper, 0o755)
+            statuses = {}
+
+            def reap_any_child(_signum, _frame):
+                while True:
+                    try:
+                        pid, status = os.waitpid(-1, os.WNOHANG)
+                    except ChildProcessError:
+                        return
+                    if pid == 0:
+                        return
+                    statuses[pid] = status
+
+            previous = signal.signal(signal.SIGCHLD, reap_any_child)
+            try:
+                record = reqbench.run_probe_command([wrapper], 1.0)
+            finally:
+                signal.signal(signal.SIGCHLD, previous)
+
+            self.assertIs(record["timed_out"], True)
+            self.assertTrue(
+                statuses,
+                "the leader was never reaped, so the ESRCH window never opened",
+            )
+            with open(survivor_pid_file) as f:
+                survivor = int(f.read().strip())
+            note = ("the group kill missed the descendant the vanished leader "
+                    "left behind")
+            status = statuses.get(survivor)
+            if status is None:
+                status = reap_orphan(survivor, note)
+            assert_sigkilled(self, survivor, status, note)
+            self.assertEqual(record["group_kill"]["survivors"], [],
+                             "the kill was not verified against the group")
 
     def test_a_pending_termination_signal_skips_the_probe_entirely(self):
         """A probe that delays a shutdown can leak the clone it came to explain.

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -1802,7 +1802,14 @@ class SnapshotGenerationIdentity(unittest.TestCase):
             def run_noop(_args, rep):
                 return record("noop", rep)
 
-            def run_cdp(_args, rep, fast):
+            # `probe` is recorded, not ignored: this is the only test that
+            # drives the real `main`, so it is the only place the failure
+            # probe's arrival at a CDP arm can be observed end to end rather
+            # than asserted about the source.
+            cdp_probes = []
+
+            def run_cdp(_args, rep, fast, probe=None):
+                cdp_probes.append(probe)
                 return record("cdp-fast" if fast else "cdp", rep)
 
             saved = {
@@ -1897,6 +1904,11 @@ class SnapshotGenerationIdentity(unittest.TestCase):
                         os.environ[key] = value
 
             self.assertEqual(rc, 0)
+            self.assertTrue(cdp_probes, "the cdp-fast arm never ran")
+            self.assertTrue(
+                all(isinstance(p, reqbench.FailureProbe) for p in cdp_probes),
+                f"main must hand every CDP arm a real failure probe: {cdp_probes}",
+            )
             self.assertEqual(contender_errors, [])
             self.assertEqual(request_observations, [{
                 "attempt_completed": True,
@@ -4110,6 +4122,502 @@ class DocLint(unittest.TestCase):
                         f"{name}: the verification exits 0 on a MISSING healthcheck "
                         f"(fcvm treats a missing healthcheck as a PASS, so the golden "
                         f"snapshot would fire on a cold browser).\n{snippet}")
+
+
+def probe_stub_source(clone_pid_file, exec_log, sleep_pid_file, exec_mode="canned"):
+    """An fcvm stub that is BOTH a clone and an exec client.
+
+    The clone half is the usual shape (a pdeathsig child, a state file, wait).
+    The exec half is what makes the failure probe testable without a microVM: it
+    answers `fcvm exec --pid N --vm -- sh -c <script>` with a canned framed
+    reply, and records whether the clone was still ALIVE when the exec arrived.
+    That liveness flag is the ordering proof: teardown's first act kills the
+    clone, so an exec that finds it alive provably ran before teardown.
+
+    `exec_mode="hang"` sleeps instead, with the sleep's pid recorded, so a test
+    can check that the bound killed the process GROUP and not just the stub.
+    """
+    if exec_mode == "hang":
+        exec_body = f"""
+    sleep 120 &
+    printf '%s\\n' "$!" > {shlex.quote(sleep_pid_file)}
+    wait
+    exit 0
+"""
+    else:
+        exec_body = """
+    for section in guest_date ip_neigh listening_sockets; do
+        printf '===fcvm-probe-section %s\\n' "$section"
+        printf 'stub output for %s\\n' "$section"
+        printf '===fcvm-probe-rc %s 0\\n' "$section"
+    done
+    exit 0
+"""
+    return f"""#!/bin/bash
+if [ "$1" = "exec" ]; then
+    clone_pid=$(cat {shlex.quote(clone_pid_file)} 2>/dev/null || echo 0)
+    if kill -0 "$clone_pid" 2>/dev/null; then alive=yes; else alive=no; fi
+    printf 'exec clone_alive=%s\\n' "$alive" >> {shlex.quote(exec_log)}
+{exec_body}
+fi
+python3 -c 'import ctypes,signal,time; ctypes.CDLL("libc.so.6").prctl(1, signal.SIGKILL); time.sleep(600)' &
+printf '%s\\n' "$$" > {shlex.quote(clone_pid_file)}
+"""
+
+
+class ProbeBatchFraming(unittest.TestCase):
+    """The framing has to survive a real shell and a cut-off batch.
+
+    A batch is one `fcvm exec`, so every section's status rides back inside one
+    stdout stream. Two things must hold: a section that failed reports ITS exit
+    status rather than the batch's, and a batch the timeout cut in half reports
+    the unterminated section as unknown rather than as success.
+    """
+
+    SECTIONS = (
+        ("healthy", "echo hello"),
+        ("failing", "exit 7"),
+        ("absent", "fcvm-probe-no-such-binary-xyzzy"),
+        ("piped", "printf 'a\\nb\\nc\\n' | tail -2"),
+    )
+
+    def test_each_section_carries_its_own_status_through_a_real_shell(self):
+        script = reqbench.probe_batch_script(self.SECTIONS)
+        result = subprocess.run(["sh", "-c", script], capture_output=True,
+                                text=True, timeout=30)
+        parsed = reqbench.parse_probe_batch(result.stdout)
+        self.assertEqual(sorted(parsed), ["absent", "failing", "healthy", "piped"])
+        self.assertEqual(parsed["healthy"]["rc"], 0)
+        self.assertEqual(parsed["healthy"]["output"], "hello")
+        self.assertEqual(parsed["failing"]["rc"], 7)
+        self.assertEqual(parsed["absent"]["rc"], 127)
+        self.assertIn("not found", parsed["absent"]["output"])
+        self.assertEqual(parsed["piped"]["rc"], 0)
+        self.assertEqual(parsed["piped"]["output"], "b\nc")
+
+    def test_a_truncated_batch_reports_unknown_status_not_success(self):
+        script = reqbench.probe_batch_script(self.SECTIONS)
+        result = subprocess.run(["sh", "-c", script], capture_output=True,
+                                text=True, timeout=30)
+        cut = result.stdout.split(f"{reqbench.PROBE_RC_MARK} piped")[0]
+        parsed = reqbench.parse_probe_batch(cut)
+        self.assertEqual(parsed["healthy"]["rc"], 0)
+        self.assertIsNone(
+            parsed["piped"]["rc"],
+            "a section whose status line never arrived must not read as rc 0",
+        )
+        self.assertEqual(parsed["piped"]["output"], "b\nc")
+
+
+class ProbeLogMarkers(unittest.TestCase):
+    """The dump quotes the clone's own restore narration instead of citing it."""
+
+    def test_matching_lines_are_kept_head_and_tail_with_the_gap_named(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "clone.log")
+            with open(path, "w") as f:
+                f.write("boring line\n")
+                for i in range(500):
+                    f.write(f"[fc-agent] restore line {i}\n")
+                    f.write(f"unrelated chatter {i}\n")
+                f.write("guest MAC resolved ping_replied=false\n")
+            out = reqbench.probe_log_markers(path, max_lines=10)
+        self.assertEqual(out["matched"], 501)
+        self.assertTrue(out["truncated"])
+        self.assertIn("[fc-agent] restore line 0", out["lines"])
+        self.assertIn("guest MAC resolved ping_replied=false", out["lines"])
+        self.assertTrue(any("lines omitted" in line for line in out["lines"]))
+        self.assertNotIn("boring line", out["lines"])
+
+    def test_a_missing_log_is_recorded_rather_than_raised(self):
+        out = reqbench.probe_log_markers("/nonexistent/clone.log")
+        self.assertIn("error", out)
+        self.assertEqual(out["matched"], 0)
+
+
+class FailureProbeCapture(unittest.TestCase):
+    """Guest-side and host-side evidence for a CDP failure, before teardown.
+
+    RED BEFORE THE FIX (`test_a_failed_cdp_request_leaves_a_dump...`): the CDP
+    arms tore the clone down the instant the request resolved, so the only record
+    of a failure was its one-line `error` string. The 808-clone run's three
+    failures had a live, interrogable guest, since vsock exec kept working the
+    whole time, and every one of them was deleted before anything asked it a
+    question.
+    """
+
+    def _args(self, d, stub, port, state_dir):
+        return argparse.Namespace(
+            fcvm=stub, out_dir=d, url="http://x/", format="jpeg", quality=80,
+            snapshot_tag="", serve_pid=1, rust_log="off",
+            timeout=10.0, teardown_timeout=5.0, cdp_port=port,
+            state_dir=state_dir, data_root=d, ws_url="", run_id="0" * 32,
+        )
+
+    def _stub_clone(self, d, state_dir, name, port, exec_mode="canned"):
+        """Write the stub plus the state file it will publish. Returns paths."""
+        vm_id = "vm-22222222222222222222222222222222"
+        clone_pid_file = os.path.join(d, "clone.pid")
+        exec_log = os.path.join(d, "exec.log")
+        sleep_pid_file = os.path.join(d, "sleep.pid")
+        stub = os.path.join(d, "fcvm-stub")
+        state_path = os.path.join(state_dir, f"{vm_id}.json")
+        body = probe_stub_source(clone_pid_file, exec_log, sleep_pid_file, exec_mode)
+        state = json.dumps({
+            "vm_id": vm_id, "name": name, "pid": "PID", "pid_start_time": "START",
+            "lifecycle_ready": True,
+            "config": {"network": {"loopback_ip": "127.0.0.1"}},
+        })
+        body += (
+            "read -r proc_stat < /proc/$$/stat; proc_stat=${proc_stat##*) }; "
+            "read -ra proc_fields <<< \"$proc_stat\"; start=${proc_fields[19]}\n"
+            f"printf '%s\\n' {shlex.quote(state)} "
+            f"| sed -e \"s/\\\"PID\\\"/$$/\" -e \"s/\\\"START\\\"/$start/\" > {state_path}\n"
+            f": > {state_path}.lock\n"
+            "wait\n"
+        )
+        with open(stub, "w") as f:
+            f.write(body)
+        os.chmod(stub, 0o755)
+        return stub, state_path, exec_log, sleep_pid_file
+
+    def _drive(self, args, probe, fast=True):
+        """Run one CDP rep and return its record however the rep ended.
+
+        `teardown_fast` needs `/proc/<pid>/task/<tid>/children`, which a kernel
+        built without `CONFIG_PROC_CHILDREN` does not have; there it raises
+        `SurvivedTeardown` carrying the same record. The probe runs BEFORE
+        teardown either way, which is the property under test, so both endings
+        are accepted and neither is silently treated as a pass.
+        """
+        try:
+            return reqbench.run_cdp_request(args, 0, fast=fast, probe=probe)
+        except reqbench.SurvivedTeardown as error:
+            return error.record
+
+    def test_a_failed_cdp_request_leaves_a_dump_taken_while_the_clone_was_alive(self):
+        import cdpdrive
+        import socket
+
+        with tempfile.TemporaryDirectory() as d:
+            state_dir = os.path.join(d, "state")
+            os.makedirs(state_dir)
+            server = socket.socket()
+            server.bind(("127.0.0.1", 0))
+            server.listen(8)
+            port = server.getsockname()[1]
+            name = f"rb-{'0' * 32}-0-fast"
+            stub, state_path, exec_log, _ = self._stub_clone(d, state_dir, name, port)
+            real_drive = cdpdrive.drive
+            cdpdrive.drive = lambda _a: {
+                "ok": False, "error": "TimeoutError: timed out",
+                "failure_class": "transport", "stage": "connect", "stages": {},
+            }
+            probe = reqbench.FailureProbe(
+                fcvm=stub, data_root=d, out_dir=d, run_id="0" * 32, cdp_port=port,
+                command_timeout_s=10.0, budget_s=30.0,
+            )
+            clone_pid_file = os.path.join(d, "clone.pid")
+            try:
+                rec = self._drive(self._args(d, stub, port, state_dir), probe)
+            finally:
+                cdpdrive.drive = real_drive
+                server.close()
+                # The stub clone outlives a teardown that refused to prove its
+                # child set. Tests must not leak either (AGENTS.md).
+                try:
+                    with open(clone_pid_file) as f:
+                        os.kill(int(f.read().strip()), signal.SIGKILL)
+                except (OSError, ValueError, ProcessLookupError):
+                    pass
+
+            self.assertIs(rec["ok"], False)
+            self.assertIn("probe", rec, f"no probe stamp on a failed record: {rec}")
+            self.assertEqual(rec["probe"]["role"], "failure")
+            dump_path = rec["probe"]["path"]
+            self.assertTrue(os.path.exists(dump_path), dump_path)
+            with open(dump_path) as f:
+                dump = json.load(f)
+
+            # The dump names its own request, so the artifact stands alone.
+            self.assertEqual(dump["name"], name)
+            self.assertEqual(dump["run_id"], "0" * 32)
+            self.assertEqual(dump["failure_stage"], "connect")
+            self.assertIn("TimeoutError", dump["request_error"])
+
+            # Guest side, over the vsock exec path that keeps working.
+            self.assertEqual(
+                sorted(dump["guest"]["passive"]["sections"]),
+                ["guest_date", "ip_neigh", "listening_sockets"],
+            )
+            self.assertIn("--vm", dump["guest"]["passive"]["argv"])
+            self.assertIn("active_mutating", dump["guest"])
+            self.assertIs(dump["guest"]["active_mutating"]["mutates_guest_state"], True)
+
+            # Host side for the same clone.
+            self.assertEqual(dump["host"]["clone_state"]["vm_id"],
+                             "vm-22222222222222222222222222222222")
+            self.assertIs(dump["host"]["cdp_connect_now"]["connected"], True)
+            self.assertIn("log_markers", dump["host"])
+            self.assertIn("pasta", dump["host"])
+
+            # Ordering: the clone was still alive when the probe reached it, and
+            # teardown's first act is to kill it.
+            with open(exec_log) as f:
+                execs = f.read().split()
+            self.assertTrue(execs, "the probe never ran an exec against the clone")
+            self.assertNotIn(
+                "clone_alive=no", execs,
+                "the probe must run BEFORE teardown, while the guest still exists",
+            )
+
+    def test_a_success_after_the_control_writes_no_dump(self):
+        with tempfile.TemporaryDirectory() as d:
+            probe = reqbench.FailureProbe(
+                fcvm="/nonexistent/fcvm", data_root=d, out_dir=d,
+                run_id="0" * 32, cdp_port=9222,
+            )
+            probe.control_captured = True
+            rec = {"arm": "cdp", "rep": 3, "ok": True}
+            probe.observe(rec, name="rb-x-3-fast", fcvm_pid=os.getpid(),
+                          state_path="", log_path="", endpoint="")
+            self.assertNotIn("probe", rec)
+            self.assertEqual(
+                [n for n in os.listdir(d) if n.endswith(".probe.json")], [],
+                "a healthy request past the control must write nothing",
+            )
+
+    def test_the_healthy_control_is_taken_once_and_only_from_a_healthy_clone(self):
+        with tempfile.TemporaryDirectory() as d:
+            probe = reqbench.FailureProbe(
+                fcvm="/nonexistent/fcvm", data_root=d, out_dir=d,
+                run_id="0" * 32, cdp_port=9222, budget_s=5.0,
+            )
+            probe.begin_request(True)
+            first = {"arm": "cdp", "rep": 0, "ok": True}
+            probe.observe(first, name="rb-x-0-fast", fcvm_pid=os.getpid(),
+                          state_path="", log_path="", endpoint="")
+            second = {"arm": "cdp", "rep": 1, "ok": True}
+            probe.observe(second, name="rb-x-1-fast", fcvm_pid=os.getpid(),
+                          state_path="", log_path="", endpoint="")
+            self.assertEqual(first["probe"]["role"], "control")
+            self.assertNotIn("probe", second)
+            self.assertNotIn(
+                "probe_perturbed_timings", first,
+                "a warmup rep is discarded at analysis, so it is not a perturbation",
+            )
+            dumps = [n for n in os.listdir(d) if n.endswith(".probe.json")]
+            self.assertEqual(dumps, ["rb-x-0-fast.probe.json"],
+                             "the second healthy rep must write nothing")
+
+            # A later failure has to be able to find the control it is read
+            # against; the control itself has nothing earlier to point at.
+            self.assertEqual(first["probe"]["control_path"], "")
+            failed = {"arm": "cdp", "rep": 2, "ok": False}
+            probe.observe(failed, name="rb-x-2-fast", fcvm_pid=os.getpid(),
+                          state_path="", log_path="", endpoint="")
+            self.assertEqual(failed["probe"]["control_path"],
+                             first["probe"]["path"])
+
+    def test_a_control_taken_from_a_measured_rep_is_stamped_as_perturbing(self):
+        with tempfile.TemporaryDirectory() as d:
+            probe = reqbench.FailureProbe(
+                fcvm="/nonexistent/fcvm", data_root=d, out_dir=d,
+                run_id="0" * 32, cdp_port=9222, budget_s=5.0,
+            )
+            probe.begin_request(False)
+            rec = {"arm": "cdp", "rep": 4, "ok": True}
+            with io.StringIO() as buf:
+                stderr, sys.stderr = sys.stderr, buf
+                try:
+                    probe.observe(rec, name="rb-x-4-fast", fcvm_pid=os.getpid(),
+                                  state_path="", log_path="", endpoint="")
+                finally:
+                    sys.stderr = stderr
+                warning = buf.getvalue()
+            self.assertIs(rec["probe_perturbed_timings"], True)
+            self.assertIn("probe_perturbed_timings", warning)
+
+    def test_a_probe_that_raises_is_recorded_and_the_request_survives(self):
+        """RED BEFORE THE FIX: `observe` called `capture` bare, so anything the
+        probe got wrong took down a request that had ALREADY produced its answer
+        and, through `main`'s `fatal` path, the rest of the schedule."""
+        with tempfile.TemporaryDirectory() as d:
+            probe = reqbench.FailureProbe(
+                fcvm="/nonexistent/fcvm", data_root=d, out_dir=d,
+                run_id="0" * 32, cdp_port=9222,
+            )
+
+            def explode(**_kwargs):
+                raise RuntimeError("probe blew up")
+
+            probe.capture = explode
+            rec = {"arm": "cdp", "rep": 2, "ok": False, "error": "original failure"}
+            probe.observe(rec, name="rb-x-2-fast", fcvm_pid=os.getpid(),
+                          state_path="", log_path="", endpoint="")
+            self.assertIn("probe blew up", rec["probe"]["probe_error"])
+            self.assertEqual(rec["error"], "original failure",
+                             "the probe must not overwrite the real failure")
+
+    def test_a_hung_guest_exec_is_cut_off_at_the_bound_with_its_group(self):
+        """A wedged guest must cost the bound, not the request's whole budget.
+
+        `fcvm exec`'s own connect ladder spans ~54 s, and the exec holds a
+        command running inside the guest, so killing only the direct child would
+        leave the real work behind. The bound therefore kills the process GROUP,
+        and this checks the grandchild is gone rather than checking the wrapper
+        returned.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            state_dir = os.path.join(d, "state")
+            os.makedirs(state_dir)
+            stub, state_path, _, sleep_pid_file = self._stub_clone(
+                d, state_dir, "rb-x-0-fast", 9222, exec_mode="hang"
+            )
+            probe = reqbench.FailureProbe(
+                fcvm=stub, data_root=d, out_dir=d, run_id="0" * 32, cdp_port=9222,
+                command_timeout_s=1.0, budget_s=30.0,
+            )
+            started = time.monotonic()
+            result = probe.exec_batch(os.getpid(), (("noop", "true"),), 1.0)
+            elapsed = time.monotonic() - started
+            self.assertIs(result["timed_out"], True)
+            self.assertLess(elapsed, 15.0, f"the bound did not hold: {elapsed:.1f}s")
+            self.assertEqual(result["sections"], {},
+                             "a cut-off batch has no completed sections")
+            with open(sleep_pid_file) as f:
+                grandchild = int(f.read().strip())
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                if reqbench.proc_stat_fields(grandchild) is None:
+                    break
+                time.sleep(0.02)
+            self.assertIsNone(
+                reqbench.proc_stat_fields(grandchild),
+                "the timeout killed the exec wrapper but left its guest-side work",
+            )
+
+    def test_the_capture_stops_at_its_budget_and_says_so(self):
+        with tempfile.TemporaryDirectory() as d:
+            probe = reqbench.FailureProbe(
+                fcvm="/nonexistent/fcvm", data_root=d, out_dir=d,
+                run_id="0" * 32, cdp_port=9222,
+                command_timeout_s=5.0, budget_s=0.0,
+            )
+            dump = probe.capture(
+                role="failure", rec={"arm": "cdp", "rep": 0, "ok": False},
+                name="rb-x-0-fast", fcvm_pid=os.getpid(), state_path="",
+                log_path="", endpoint="",
+            )
+            self.assertIs(dump["budget_exhausted"], True)
+            self.assertNotIn("passive", dump["guest"])
+            self.assertNotIn("active_mutating", dump["guest"])
+            self.assertTrue(
+                [e for e in dump["errors"] if "budget" in e],
+                f"the skipped steps must be named: {dump['errors']}",
+            )
+            # Even a fully skipped capture is a usable artifact.
+            self.assertIn("fcvm_process", dump["host"])
+            self.assertIn("log_markers", dump["host"])
+
+    def test_a_step_given_a_shortened_timeout_says_so_on_its_own_record(self):
+        """`timed_out` from a nearly-spent budget is not a wedged guest.
+
+        Without this label the two are the same boolean, and telling them apart
+        is the entire job of the dump.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            state_dir = os.path.join(d, "state")
+            os.makedirs(state_dir)
+            stub, _, _, _ = self._stub_clone(d, state_dir, "rb-x-0-fast", 9222)
+            probe = reqbench.FailureProbe(
+                fcvm=stub, data_root=d, out_dir=d, run_id="0" * 32, cdp_port=9222,
+                command_timeout_s=30.0, budget_s=5.0,
+            )
+            dump = probe.capture(
+                role="failure", rec={"arm": "cdp", "rep": 0, "ok": False},
+                name="rb-x-0-fast", fcvm_pid=os.getpid(), state_path="",
+                log_path="", endpoint="",
+            )
+            passive = dump["guest"]["passive"]
+            self.assertIs(passive["budget_limited"], True)
+            self.assertLess(passive["timeout_s"], 30.0)
+            self.assertIs(passive["timed_out"], False)
+            self.assertEqual(sorted(passive["sections"]),
+                             ["guest_date", "ip_neigh", "listening_sockets"])
+
+
+class FailureProbeWiring(unittest.TestCase):
+    """The probe has to REACH the CDP arms; a gap here is invisible until the
+    next unexplained failure has already been torn down."""
+
+    def _recorders(self):
+        calls = []
+
+        def cdp(args, rep, fast, probe=None):
+            calls.append(("cdp-fast" if fast else "cdp", probe))
+            return {"arm": "cdp", "rep": rep}
+
+        def other(name):
+            def run(args, rep):
+                calls.append((name, None))
+                return {"arm": name, "rep": rep}
+            return run
+
+        return calls, cdp, other
+
+    def test_both_cdp_arms_get_the_probe_and_the_warmup_flag(self):
+        calls, cdp, other = self._recorders()
+        seen = []
+
+        class Recorder(reqbench.FailureProbe):
+            def __init__(self):
+                super().__init__(fcvm="", data_root="", out_dir="",
+                                 run_id="", cdp_port=0)
+
+            def begin_request(self, is_warmup):
+                seen.append(is_warmup)
+                super().begin_request(is_warmup)
+
+        probe = Recorder()
+        saved = (reqbench.run_cdp_request, reqbench.run_exec_request,
+                 reqbench.run_noop_request)
+        reqbench.run_cdp_request = cdp
+        reqbench.run_exec_request = other("exec")
+        reqbench.run_noop_request = other("noop")
+        try:
+            for arm, warm in (("cdp", True), ("cdp-fast", False),
+                              ("exec", False), ("noop", True)):
+                reqbench.dispatch_request(argparse.Namespace(), 0, arm, warm, probe)
+        finally:
+            (reqbench.run_cdp_request, reqbench.run_exec_request,
+             reqbench.run_noop_request) = saved
+        self.assertEqual([name for name, _ in calls],
+                         ["cdp", "cdp-fast", "exec", "noop"])
+        self.assertIs(calls[0][1], probe)
+        self.assertIs(calls[1][1], probe)
+        self.assertEqual(seen, [True, False, False, True],
+                         "every arm must set the warmup flag, not just the CDP ones")
+
+    def test_the_dispatcher_is_the_only_request_call_site_in_the_schedule(self):
+        """`main` must not reach an arm around the dispatcher.
+
+        That `main` hands a REAL probe to a CDP arm is proved behaviourally, by
+        `SnapshotGenerationIdentity.test_main_holds_the_generation_lease_through_the_full_schedule`,
+        which drives the actual `main` and asserts on the object the arm
+        received. What that cannot see is a second call site added later that
+        bypasses the dispatcher, since it would simply not be exercised by that
+        run's schedule, so this reads the loop body.
+        """
+        with open(os.path.join(HERE, "reqbench.py")) as f:
+            body = f.read().split("for rep, arm, is_warmup in schedule:", 1)
+        self.assertEqual(len(body), 2, "the schedule loop moved; update this lint")
+        for arm_call in ("run_cdp_request(", "run_exec_request(", "run_noop_request("):
+            self.assertNotIn(
+                arm_call, body[1],
+                f"the schedule loop calls {arm_call} directly instead of "
+                "dispatch_request, so the probe is not carried",
+            )
 
 
 if __name__ == "__main__":

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -4509,6 +4509,84 @@ class FailureProbeCapture(unittest.TestCase):
             self.assertEqual(failed["probe"]["control_path"],
                              first["probe"]["path"])
 
+    def _healthy(self, probe, rep):
+        rec = {"arm": "cdp", "rep": rep, "ok": True}
+        probe.observe(rec, name=f"rb-x-{rep}-fast", fcvm_pid=os.getpid(),
+                      state_path="", log_path="", endpoint="")
+        return rec
+
+    def test_a_control_that_fails_to_write_retries_on_the_next_healthy_clone(self):
+        """RED BEFORE THE FIX: `control_captured` was set in a block that also
+        ran on the exception path, so one failed write retired the control for
+        the whole run and every later failure dump had nothing to be read
+        against:
+
+            AssertionError: True is not false : a dump that was never written
+            is not the control
+        """
+        with tempfile.TemporaryDirectory() as d:
+            probe = reqbench.FailureProbe(
+                fcvm="/nonexistent/fcvm", data_root=d, out_dir=d,
+                run_id="0" * 32, cdp_port=9222, budget_s=5.0,
+            )
+            probe.begin_request(True)
+            real_write = probe.write
+            written = []
+
+            def fail_the_first_write(name, dump):
+                written.append(name)
+                if len(written) == 1:
+                    raise OSError(28, "No space left on device")
+                return real_write(name, dump)
+
+            probe.write = fail_the_first_write
+            first = self._healthy(probe, 0)
+            self.assertIn("No space left on device", first["probe"]["probe_error"])
+            self.assertEqual(first["probe"]["path"], "")
+            self.assertFalse(probe.control_captured,
+                             "a dump that was never written is not the control")
+
+            second = self._healthy(probe, 1)
+            self.assertEqual(second["probe"]["role"], "control")
+            self.assertTrue(second["probe"]["path"].endswith(
+                "rb-x-1-fast.probe.json"))
+            self.assertTrue(probe.control_captured)
+
+            # The point of retrying: a later failure has something to read the
+            # dump against.
+            failed = {"arm": "cdp", "rep": 2, "ok": False}
+            probe.observe(failed, name="rb-x-2-fast", fcvm_pid=os.getpid(),
+                          state_path="", log_path="", endpoint="")
+            self.assertEqual(failed["probe"]["control_path"],
+                             second["probe"]["path"])
+
+            # And the retry does not become a second control.
+            third = self._healthy(probe, 3)
+            self.assertNotIn("probe", third)
+
+    def test_a_control_that_never_writes_stops_taxing_healthy_reps(self):
+        """Retrying forever is the other way to get this wrong: each attempt
+        costs up to the full budget and perturbs the measured rep it lands on,
+        so a systematically broken probe would tax every healthy request in the
+        run."""
+        with tempfile.TemporaryDirectory() as d:
+            probe = reqbench.FailureProbe(
+                fcvm="/nonexistent/fcvm", data_root=d, out_dir=d,
+                run_id="0" * 32, cdp_port=9222, budget_s=5.0,
+            )
+            probe.begin_request(True)
+
+            def never_writes(name, dump):
+                raise OSError(28, "No space left on device")
+
+            probe.write = never_writes
+            attempted = [rep for rep in range(probe.CONTROL_ATTEMPTS + 2)
+                         if "probe" in self._healthy(probe, rep)]
+            self.assertEqual(attempted, list(range(probe.CONTROL_ATTEMPTS)),
+                             "the control retry is not bounded")
+            self.assertEqual(probe.control_attempts, probe.CONTROL_ATTEMPTS)
+            self.assertFalse(probe.control_captured)
+
     def test_a_control_taken_from_a_measured_rep_is_stamped_as_perturbing(self):
         with tempfile.TemporaryDirectory() as d:
             probe = reqbench.FailureProbe(

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -12,6 +12,7 @@ There is no pytest in this repo, so this is stdlib `unittest` only.
 """
 
 import argparse
+import ctypes
 import fcntl
 import hashlib
 import io
@@ -28,7 +29,7 @@ import threading
 import time
 import unittest
 import urllib.request
-from contextlib import redirect_stdout
+from contextlib import contextmanager, redirect_stdout
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, HERE)
@@ -120,6 +121,76 @@ def kill_tree(p):
         p.wait(timeout=5)
     except subprocess.TimeoutExpired:
         pass
+
+
+PR_SET_CHILD_SUBREAPER = 36
+PR_GET_CHILD_SUBREAPER = 37
+
+
+@contextmanager
+def child_subreaper():
+    """Adopt orphaned grandchildren for the duration, so this process reaps them.
+
+    Whether a killed orphan's `/proc/<pid>` entry disappears is a property of
+    whoever inherits it, not of the kill. Under a PID 1 that reaps (systemd on a
+    normal host) it vanishes; under a PID 1 that does not (a container, or
+    `unshare --pid --fork`) the corpse stays in state `Z` forever and a test
+    that waits for the entry to go away waits out its whole deadline and then
+    fails, while the process it was asking about has in fact been dead the whole
+    time. Becoming the subreaper makes the orphan OURS, so the test can reap it
+    itself and read how it died instead of inferring death from an absence.
+    """
+    libc = ctypes.CDLL("libc.so.6", use_errno=True)
+    previous = ctypes.c_int(0)
+    restore = libc.prctl(PR_GET_CHILD_SUBREAPER, ctypes.byref(previous),
+                         0, 0, 0) == 0
+    if libc.prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0:
+        raise OSError(ctypes.get_errno(), "PR_SET_CHILD_SUBREAPER")
+    try:
+        yield
+    finally:
+        libc.prctl(PR_SET_CHILD_SUBREAPER,
+                   previous.value if restore else 0, 0, 0, 0)
+
+
+def reap_orphan(pid, note, timeout=5.0):
+    """Reap an adopted orphan and return its raw wait status.
+
+    Returns None when the pid is not ours to wait for, which is the case on a
+    host whose PID 1 got there first; the caller then has to settle for the
+    weaker evidence. Raises `note` if it is ours and still running at the
+    deadline, because that is the defect the caller is testing for.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            reaped, status = os.waitpid(pid, os.WNOHANG)
+        except ChildProcessError:
+            return None
+        if reaped == pid:
+            return status
+        if time.monotonic() >= deadline:
+            raise AssertionError(
+                f"{note}: pid {pid} is still running {timeout:.0f}s later, "
+                f"state {reqbench.proc_stat_fields(pid)}"
+            )
+        time.sleep(0.01)
+
+
+def assert_sigkilled(test, pid, status, note):
+    """Assert `pid` was KILLED, from its exit status where we have one.
+
+    The status is the direct evidence and says which signal did it. Only when
+    the orphan was never ours does this fall back to the procfs entry being
+    gone, which is a claim about the reaper as much as about the kill.
+    """
+    if status is None:
+        test.assertIsNone(reqbench.proc_stat_fields(pid), note)
+        return
+    test.assertTrue(
+        os.WIFSIGNALED(status) and os.WTERMSIG(status) == signal.SIGKILL,
+        f"{note}: it ended on its own with wait status {status:#x}",
+    )
 
 
 def write_graceful_clone_stub(path, state_path, data_dir, name, term_path):
@@ -4465,10 +4536,12 @@ class FailureProbeCapture(unittest.TestCase):
         `fcvm exec`'s own connect ladder spans ~54 s, and the exec holds a
         command running inside the guest, so killing only the direct child would
         leave the real work behind. The bound therefore kills the process GROUP,
-        and this checks the grandchild is gone rather than checking the wrapper
-        returned.
+        and this asserts the grandchild was KILLED rather than asserting its
+        procfs entry went away — those are different claims, and the second one
+        is about the reaper rather than about the kill. This test adopts the
+        orphan and reads its exit status, so it says what it means.
         """
-        with tempfile.TemporaryDirectory() as d:
+        with tempfile.TemporaryDirectory() as d, child_subreaper():
             state_dir = os.path.join(d, "state")
             os.makedirs(state_dir)
             stub, state_path, _, sleep_pid_file = self._stub_clone(
@@ -4487,15 +4560,9 @@ class FailureProbeCapture(unittest.TestCase):
                              "a cut-off batch has no completed sections")
             with open(sleep_pid_file) as f:
                 grandchild = int(f.read().strip())
-            deadline = time.monotonic() + 5
-            while time.monotonic() < deadline:
-                if reqbench.proc_stat_fields(grandchild) is None:
-                    break
-                time.sleep(0.02)
-            self.assertIsNone(
-                reqbench.proc_stat_fields(grandchild),
-                "the timeout killed the exec wrapper but left its guest-side work",
-            )
+            note = ("the timeout killed the exec wrapper but left its "
+                    "guest-side work")
+            assert_sigkilled(self, grandchild, reap_orphan(grandchild, note), note)
 
     def test_the_capture_stops_at_its_budget_and_says_so(self):
         with tempfile.TemporaryDirectory() as d:

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -177,6 +177,25 @@ def reap_orphan(pid, note, timeout=5.0):
         time.sleep(0.01)
 
 
+@contextmanager
+def pending_harness_signal(signum):
+    """Leave the harness in the state a real INT/TERM leaves it in, then clear.
+
+    `record_harness_interrupt` is the harness's own handler, so this is the same
+    module state a delivered signal produces; `signum=0` arms nothing and only
+    guarantees the flag is cleared afterwards for whoever injects it later. The
+    flag is global, so an uncleared one would make every later test in the
+    process behave as though the run were shutting down.
+    """
+    reqbench._pending_harness_signal = 0
+    if signum:
+        reqbench.record_harness_interrupt(signum, None)
+    try:
+        yield
+    finally:
+        reqbench._pending_harness_signal = 0
+
+
 def assert_sigkilled(test, pid, status, note):
     """Assert `pid` was KILLED, from its exit status where we have one.
 
@@ -4563,6 +4582,93 @@ class FailureProbeCapture(unittest.TestCase):
             note = ("the timeout killed the exec wrapper but left its "
                     "guest-side work")
             assert_sigkilled(self, grandchild, reap_orphan(grandchild, note), note)
+
+    def test_a_pending_termination_signal_skips_the_probe_entirely(self):
+        """A probe that delays a shutdown can leak the clone it came to explain.
+
+        RED BEFORE THE FIX: the handler only RECORDS INT/TERM, so a signal that
+        landed after the request's last interrupt poll left the probe free to
+        spend its whole budget before teardown started, which is where a job
+        runner escalates to SIGKILL:
+
+            AssertionError: 2.017 not less than 0.5 : the probe ran with a
+            termination signal pending
+
+        The signal is injected through the harness's own handler, so this is the
+        state a real INT/TERM leaves behind, not a stand-in for it.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            state_dir = os.path.join(d, "state")
+            os.makedirs(state_dir)
+            stub, _, _, _ = self._stub_clone(d, state_dir, "rb-x-0-fast", 9222,
+                                             exec_mode="hang")
+            probe = reqbench.FailureProbe(
+                fcvm=stub, data_root=d, out_dir=d, run_id="0" * 32, cdp_port=9222,
+                command_timeout_s=1.0, budget_s=60.0,
+            )
+            rec = {"arm": "cdp", "rep": 0, "ok": False, "error": "TimeoutError"}
+            with pending_harness_signal(signal.SIGTERM):
+                started = time.monotonic()
+                probe.observe(rec, name="rb-x-0-fast", fcvm_pid=os.getpid(),
+                              state_path="", log_path="", endpoint="")
+                elapsed = time.monotonic() - started
+            self.assertLess(elapsed, 0.5,
+                            "the probe ran with a termination signal pending")
+            self.assertEqual(rec["probe"]["skipped"],
+                             f"termination signal {int(signal.SIGTERM)} pending")
+            self.assertEqual(rec["probe"]["path"], "")
+            self.assertEqual(
+                [n for n in os.listdir(d) if n.endswith(".probe.json")], [],
+                "a skipped probe must not leave a half-written dump",
+            )
+
+    def test_a_signal_arriving_mid_capture_stops_the_remaining_steps(self):
+        """RED BEFORE THE FIX: nothing inside `capture` looked at the pending
+        signal, so a capture already under way kept going step by step:
+
+            AssertionError: 'active_mutating' unexpectedly found in
+            dict_keys(['passive', 'active_mutating'])
+             : the steps after the signal must not run
+
+        The signal is injected from inside the first probe command, which is
+        where a capture spends nearly all of its time and therefore where a real
+        one is most likely to land.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            probe = reqbench.FailureProbe(
+                fcvm="/nonexistent/fcvm", data_root=d, out_dir=d,
+                run_id="0" * 32, cdp_port=9222, command_timeout_s=1.0,
+                budget_s=60.0,
+            )
+            real_run = reqbench.run_probe_command
+            fired = []
+
+            def signal_during_the_first_command(*args, **kwargs):
+                if not fired:
+                    fired.append(True)
+                    reqbench.record_harness_interrupt(signal.SIGINT, None)
+                return real_run(*args, **kwargs)
+
+            reqbench.run_probe_command = signal_during_the_first_command
+            try:
+                with pending_harness_signal(0):
+                    dump = probe.capture(
+                        role="failure", rec={"arm": "cdp", "rep": 0, "ok": False},
+                        name="rb-x-0-fast", fcvm_pid=os.getpid(), state_path="",
+                        log_path="", endpoint="127.0.0.1:9",
+                    )
+            finally:
+                reqbench.run_probe_command = real_run
+            self.assertTrue(fired, "no probe command ran, so nothing was injected")
+            self.assertIn("passive", dump["guest"],
+                          "the step that was already running must be kept")
+            self.assertNotIn("active_mutating", dump["guest"],
+                             "the steps after the signal must not run")
+            self.assertEqual(dump["interrupted_by_signal"], int(signal.SIGINT))
+            self.assertTrue(
+                [e for e in dump["errors"] if "termination signal" in e],
+                f"the skipped steps must name the signal: {dump['errors']}",
+            )
 
     def test_the_capture_stops_at_its_budget_and_says_so(self):
         with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
Capture guest-side and host-side state from a clone whose CDP request just
failed, before the harness tears it down.

**This fixes nothing.** It collects evidence for a root cause that is still
unsolved, and it deliberately changes no measurement.

## The unsolved question

An 808-clone run of the shared-nothing benchmark (`reqbench.sh run`, UFFD
backend, one clone restored per request, requests strictly sequential, host
loadavg 0.43-0.67) produced 3 failures. What is established:

- Every failure came from a clone whose ARP-triggering readiness ping got no
  reply. Five clones had no reply and three of those failed; of the 803 whose
  ping replied, none failed.
- The guest was alive throughout. Its Chromium kept writing to the serial
  console for the full 100+ seconds.
- Only the two CDP arms failed. `exec` and `noop` reach the guest over vsock and
  never failed, so the break is on the host to guest IP path.
- The shapes were one `TimeoutError` at CDP stage `connect` (120.1 s) and two
  `ConnectionResetError` at stage `enable` (104.7 s, 107.0 s). A healthy request
  finishes in 0.24-0.55 s, so these are hard hangs to the client's own deadline.
- Ruled out with evidence: host load, endpoint collision between concurrent
  clones, and the Firecracker log-volume difference.

What is **not** known is why those guests stopped answering on the IP path and
why they never recovered. A transient startup race resolves in milliseconds.
The leading and unproven hypothesis is that the guest's post-restore network
re-initialisation never ran or never finished: fcvm PUTs a `restore-epoch` per
clone, fc-agent's `watch_restore_epoch` reacts by flushing the ARP cache,
sending a gratuitous ARP and re-registering exec, and a clone that misses that
keeps stale IP networking for life while vsock keeps working.

There is a separate, known proximate bug: `src/network/pasta.rs` only LOGS
`ping_replied=` and returns success on `neighbor_is_resolved` alone, and the
port check that follows connects to pasta's host-side listener, which accepts
regardless of guest state. That is being fixed elsewhere and is not this change.

## What this adds

Vsock exec keeps working during the failure, so the broken guest is
interrogable at exactly the moment it is broken. Until now the harness deleted
it first. `reqbench.py` grows a `FailureProbe` that, on a failed CDP request,
writes `<request-name>.probe.json` into the run's results directory next to that
request's clone log, and references it from the JSONL record.

Guest side, in one bounded `fcvm exec --vm` batch: `ip addr`, `ip -s link`,
`ip route`, `ip neigh`, `/proc/net/arp`, `/proc/net/dev`, `ss -ltnp`,
`/proc/net/tcp`, the Chromium process table with full argv, `dmesg | tail -50`,
any `[fc-agent]` lines in the journal, and the guest clock (restore syncs it
from the host, so a guest still at snapshot time is direct evidence the restore
handler never ran). Then a second, explicitly mutating batch that answers "is it
still broken now": an in-guest CDP connect to `127.0.0.1:9222`, an MMDS read of
the restore-epoch the guest can currently see, and an arping of the gateway.

Host side, for the same clone: the state file, the fcvm process tree, pasta's
pid and process state from its per-VM pid file, the holder's network namespace
through `nsenter -U -n` and independently through the holder's own procfs, a
fresh TCP connect to the published port, and the restore and readiness lines
from that clone's own fcvm log.

One healthy clone per run is captured the same way as the control, because a
dump with nothing to compare against proves little. The failing record names the
control's path so the pair is findable from either end.

## How it stays off the measurement

- The probe runs only after `rec["blocking_ms"]` is stamped, on both the success
  and failure paths. That is the caller-visible latency and the only response
  time these arms publish, and nothing in the probe can move it.
- Only failed CDP requests are probed, plus exactly one healthy control.
- The control is preferentially taken on a warmup rep, which analysis discards
  explicitly. If a run has no warmup rep the control still runs and the record
  it perturbs is stamped `probe_perturbed_timings`, with a line on stderr naming
  it, so its `wall_ms` and teardown are excludable rather than silently mixed in.
- `reqanalyze.py` is untouched. No latency is computed differently.

## Bounding

Every probe command runs in its own session with a hard 20 s timeout enforced by
killing the process GROUP, because `fcvm exec`'s connect ladder spans ~54 s and
the exec holds a command running inside the guest. The whole capture has a 60 s
budget checked before each step; a step that does not fit records why it was
skipped. A command given a shortened timeout is stamped `budget_limited`, so a
`timed_out` caused by the probe's own budget is distinguishable from a wedged
guest. Nothing in the probe can raise into the request: a probe error is
recorded on the record as `probe_error`.

## What the dumps will and will not settle

They will separate the two big branches. If the guest holds a stale or
FAILED gateway neighbour entry, its clock is still at snapshot time, and the
clone log has no `[fc-agent] handling restore` line, the restore handler did not
run and the hypothesis is supported. If the restore narration is complete and
the guest's neighbour table is correct, it is refuted for that clone and the
`ip -s link` and `/proc/net/dev` counters on both sides of the tap say which
direction the packets stop in. The in-guest CDP connect separates a browser
fault from a network fault. The MMDS read says whether the guest could see the
epoch at all.

They will not settle when the failure began: the passive capture is taken ~100 s
after the request gave up, so it describes the steady state, and ordering still
needs the clone's log. They cannot show what Firecracker's MMDS server served at
restore time, only what the guest can read back now. The host-side namespace
view is a single snapshot, so a neighbour entry that expired earlier is
invisible. And the active batch mutates what the passive batch just recorded,
which is why it runs last and is labelled.

## Test evidence

14 new deterministic tests in `bench/chromium/test_reqbench.py`; no VM, no
podman, no built image. Three reds were witnessed by removing the fix under test
from the working code and watching the named test fail, one each for the call
site wiring, the error guard and the process-group kill; all three are quoted in
the commit message.

```
base   817ed25b   Ran 105 tests in 105.137s   FAILED (failures=20, errors=4)
branch             Ran 119 tests in 105.935s   FAILED (failures=20, errors=4)
```

Same box, same built binaries. The failing sets are identical (22 distinct
tests, NEW=[] GONE=[]) and every one is pre-existing on the base, from two
causes both root-caused on this host rather than assumed:

- 20 need `/proc/<pid>/task/<tid>/children`, and
  `grep CONFIG_PROC_CHILDREN /boot/config-$(uname -r)` on this kernel reports
  `# CONFIG_PROC_CHILDREN is not set`, so `children_of()` returns `[]` for every
  process and the whole child-attribution family fails.
- 4 need an `fc-agent` at `reqbench.sh`'s hardcoded
  `target/aarch64-unknown-linux-musl/release/fc-agent`, which cannot exist on an
  x86_64 box. The Makefile already derives `MUSL_TARGET` from the host arch;
  `reqbench.sh` does not. That is a real non-hermeticity, it is not this
  change's, and it is left for its own PR.

Generated probe shell passes `bash -n`, `shellcheck -s sh` and
`shellcheck -s bash` at exit 0, and the passive batch was run against this host
to prove every section command parses and returns a real status (13/13 sections,
471 ms). No Rust changed, so `make lint` was not run.
