### PR TITLE
Fix five review findings on the merged benchmark changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -717,15 +717,20 @@ define run_privileged_bench
 	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='$(ROOT_TEST_RUNNER)' \
 	$(CARGO) bench -p fuse-pipe --bench $(1) $(BENCH_SEPARATED); \
 	bench_rc=$$?; \
-	if [ -d '$(CRITERION_HOME)' ]; then \
-		if ! root_owned=$$(find '$(CRITERION_HOME)' -user root -print -quit); then \
-			echo "ERROR: cannot scan $(CRITERION_HOME) for root-owned files, so the ownership repair after --bench $(1) never ran" >&2; \
+	if [ ! -d '$(CRITERION_HOME)' ]; then \
+		if [ $$bench_rc -eq 0 ]; then \
+			echo "ERROR: --bench $(1) exited 0 but $(CRITERION_HOME) does not exist. criterion logs persistence failures and still returns 0, so the suite printed timings and saved no sample.json, estimates.json or baseline: nothing can be compared and no regression can ever be reported" >&2; \
 			exit 1; \
 		fi; \
-		if [ -n "$$root_owned" ] && ! sudo chown -R $$(id -u):$$(id -g) '$(CRITERION_HOME)'; then \
-			echo "ERROR: $(CRITERION_HOME) is still root-owned after --bench $(1); bench-protocol cannot persist criterion output and _test-root will refuse to start" >&2; \
-			exit 1; \
-		fi; \
+		exit $$bench_rc; \
+	fi; \
+	if ! root_owned=$$(find '$(CRITERION_HOME)' -user root -print -quit); then \
+		echo "ERROR: cannot scan $(CRITERION_HOME) for root-owned files, so the ownership repair after --bench $(1) never ran" >&2; \
+		exit 1; \
+	fi; \
+	if [ -n "$$root_owned" ] && ! sudo chown -R $$(id -u):$$(id -g) '$(CRITERION_HOME)'; then \
+		echo "ERROR: $(CRITERION_HOME) is still root-owned after --bench $(1); bench-protocol cannot persist criterion output and _test-root will refuse to start" >&2; \
+		exit 1; \
 	fi; \
 	exit $$bench_rc
 endef
@@ -733,7 +738,13 @@ endef
 # One criterion suite as the invoking user. Nothing here writes as root, so
 # there is no ownership to repair.
 define run_unprivileged_bench
-	CRITERION_HOME='$(CRITERION_HOME)' $(CARGO) bench -p fuse-pipe --bench $(1) $(BENCH_SEPARATED)
+	CRITERION_HOME='$(CRITERION_HOME)' $(CARGO) bench -p fuse-pipe --bench $(1) $(BENCH_SEPARATED); \
+	bench_rc=$$?; \
+	if [ ! -d '$(CRITERION_HOME)' ] && [ $$bench_rc -eq 0 ]; then \
+		echo "ERROR: --bench $(1) exited 0 but $(CRITERION_HOME) does not exist. criterion logs persistence failures and still returns 0, so the suite printed timings and saved no sample.json, estimates.json or baseline: nothing can be compared and no regression can ever be reported" >&2; \
+		exit 1; \
+	fi; \
+	exit $$bench_rc
 endef
 
 # The three fuse-pipe suites, in order.

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,31 @@ export CARGO_TARGET_DIR := target
 NEXTEST := $(CARGO) nextest $(NEXTEST_CMD) --release
 TEST_CONFIG_WRAPPER := ./scripts/with-test-config.sh
 # Extra flags forwarded to every criterion bench recipe (see bench-quick).
+#
+# Criterion's flags belong to the BENCH BINARY, so they have to follow `--`.
+# Given to cargo directly they are rejected by its own argument parser before
+# any benchmark starts:
+#
+#     $ cargo bench -p fuse-pipe --bench throughput --sample-size 10
+#     error: unexpected argument '--sample-size' found
+#       tip: to pass '--sample-size' as a value, use '-- --sample-size'
+#     Usage: cargo bench --package [<SPEC>] --bench [<NAME>] [-- [ARGS]...]
+#
+# BENCH_SEPARATED is what the recipes interpolate, and it stays empty when
+# BENCH_ARGS is, so plain `make bench` carries no trailing separator.
 BENCH_ARGS ?=
+BENCH_SEPARATED = $(if $(strip $(BENCH_ARGS)),-- $(BENCH_ARGS))
+
+# Where criterion keeps baselines and reports. Pinned to an absolute path
+# because criterion's default is not the directory it looks like.
+#
+# Its second choice after CRITERION_HOME is `$CARGO_TARGET_DIR/criterion`, and
+# CARGO_TARGET_DIR here is the relative string `target`, which criterion
+# resolves inside the bench binary, whose working directory cargo sets to the
+# package root. Every suite was therefore writing to `fuse-pipe/target/criterion`
+# while the ownership repair scanned `target/` at the repo root and found
+# nothing to do. Overridable so tests can point it at a scratch directory.
+CRITERION_HOME ?= $(CURDIR)/target/criterion
 
 # cargo/nextest target runner for the privileged suites. cargo-nextest stays unprivileged
 # and only the test binary is elevated, so the `sudo` hop sits in the middle of the process
@@ -668,15 +692,9 @@ test-chromium-request:
 test-ci-infrastructure:
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_ci_infrastructure.py'
 
-# The three fuse-pipe suites, in order. Prerequisites rather than recursive
-# $(MAKE) calls: a sub-make RUNS even under `make -n`, so the delegating form
-# turned a dry run into a real build. Do not run this under -j; concurrent
-# benchmarks measure each other.
-bench: bench-throughput bench-operations bench-protocol
-
-# throughput and operations mount a real FUSE filesystem, so they take the
-# privileged runner the root tests use; protocol is pure serialization and
-# stays unprivileged.
+# One criterion suite under the privileged runner. throughput and operations
+# mount a real FUSE filesystem, so they take the runner the root tests use;
+# protocol is pure serialization and stays unprivileged.
 #
 # Each privileged suite hands target/ back afterwards. criterion writes its
 # results from inside the bench binary, so under that runner target/criterion
@@ -687,33 +705,74 @@ bench: bench-throughput bench-operations bench-protocol
 # refuses to start until the ownership is repaired. The repair is inline rather
 # than a $(MAKE) call because a sub-make runs even under `make -n`, and this
 # one would invoke sudo.
-bench-throughput: build
+#
+# The repair's own status decides the recipe's. Keeping only the benchmark's
+# status reports the suite green while target/ is still root-owned, which is
+# precisely the state the repair exists to prevent, and the next unprivileged
+# run is the one that pays for it. The scan is treated the same way: a find
+# that cannot read target/ has not established that no repair is needed.
+define run_privileged_bench
+	CRITERION_HOME='$(CRITERION_HOME)' \
 	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='$(ROOT_TEST_RUNNER)' \
 	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='$(ROOT_TEST_RUNNER)' \
-	$(CARGO) bench -p fuse-pipe --bench throughput $(BENCH_ARGS); \
-	RC=$$?; \
-	if find target/ -user root -print -quit 2>/dev/null | grep -q .; then \
-		sudo chown -R $$(id -u):$$(id -g) target/; \
+	$(CARGO) bench -p fuse-pipe --bench $(1) $(BENCH_SEPARATED); \
+	bench_rc=$$?; \
+	if [ -d '$(CRITERION_HOME)' ]; then \
+		if ! root_owned=$$(find '$(CRITERION_HOME)' -user root -print -quit); then \
+			echo "ERROR: cannot scan $(CRITERION_HOME) for root-owned files, so the ownership repair after --bench $(1) never ran" >&2; \
+			exit 1; \
+		fi; \
+		if [ -n "$$root_owned" ] && ! sudo chown -R $$(id -u):$$(id -g) '$(CRITERION_HOME)'; then \
+			echo "ERROR: $(CRITERION_HOME) is still root-owned after --bench $(1); bench-protocol cannot persist criterion output and _test-root will refuse to start" >&2; \
+			exit 1; \
+		fi; \
 	fi; \
-	exit $$RC
+	exit $$bench_rc
+endef
+
+# One criterion suite as the invoking user. Nothing here writes as root, so
+# there is no ownership to repair.
+define run_unprivileged_bench
+	CRITERION_HOME='$(CRITERION_HOME)' $(CARGO) bench -p fuse-pipe --bench $(1) $(BENCH_SEPARATED)
+endef
+
+# The three fuse-pipe suites, in order.
+#
+# One target with three recipe lines, not three prerequisites. Make
+# parallelizes prerequisites but never the lines of a single recipe, so this
+# cannot start two suites at once under `make -j`, nor under a -j inherited
+# through MAKEFLAGS from a parent make. The prerequisite form did: with a stub
+# cargo under `make -j8 bench`, all three suites were running together.
+# Concurrent suites time each other, and the unprivileged protocol suite races
+# the privileged suites for ownership of target/criterion. A comment saying
+# "do not use -j" is not a control.
+#
+# GNU Make 4.3 is what this repo builds on, and neither of make's own
+# mechanisms is usable there: `.NOTPARALLEL` ignores its prerequisites before
+# 4.4 and serializes the whole makefile rather than this target, and `.WAIT`
+# arrived in 4.4.
+bench: build
+	@echo "==> Running fuse-pipe benchmarks: throughput, operations, protocol"
+	$(call run_privileged_bench,throughput)
+	$(call run_privileged_bench,operations)
+	$(call run_unprivileged_bench,protocol)
+
+bench-throughput: build
+	$(call run_privileged_bench,throughput)
 
 bench-operations: build
-	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='$(ROOT_TEST_RUNNER)' \
-	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='$(ROOT_TEST_RUNNER)' \
-	$(CARGO) bench -p fuse-pipe --bench operations $(BENCH_ARGS); \
-	RC=$$?; \
-	if find target/ -user root -print -quit 2>/dev/null | grep -q .; then \
-		sudo chown -R $$(id -u):$$(id -g) target/; \
-	fi; \
-	exit $$RC
+	$(call run_privileged_bench,operations)
 
 bench-protocol: build
-	$(CARGO) bench -p fuse-pipe --bench protocol $(BENCH_ARGS)
+	$(call run_unprivileged_bench,protocol)
 
-# The same three suites at criterion's smallest honest sample count, for
-# iteration. A target-specific variable reaches the prerequisites, so this
-# needs no recursive make. Quote `make bench` in any report: a 10-sample
-# interval is wide.
+# The same three suites, shortened for iteration. A target-specific variable
+# reaches the prerequisite, so this needs no recursive make.
+#
+# Quote `make bench` in any report, never this: the intervals are wide. Note
+# also that a group calling `sample_size()` in code keeps its own count, so
+# --sample-size only reaches the groups that do not, while --warm-up-time and
+# --measurement-time reach all of them.
 bench-quick: BENCH_ARGS := --sample-size 10 --warm-up-time 1 --measurement-time 3
 bench-quick: bench
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -80,8 +80,8 @@ Individual FUSE operation overhead (256 readers):
 
 | Operation | Host | FUSE | Overhead |
 |-----------|------|------|----------|
-| getattr | 791ns | 832ns | 1.05× |
-| lookup | 784ns | 832ns | 1.06× |
+| getattr, attribute-cache hit | 791ns | 832ns | 1.05× |
+| lookup, dentry-cache hit | 784ns | 832ns | 1.06× |
 | read 4KB | 853ns | 796ns | **0.93× (faster!)** |
 | write 4KB | 1.0µs | 119µs | 119× |
 | open+close | 1.4µs | 98µs | 68× |
@@ -90,7 +90,16 @@ Individual FUSE operation overhead (256 readers):
 
 **Observations**:
 - **Cached reads are faster** than host due to kernel page cache
-- **Metadata ops** (getattr, lookup) have ~5% overhead
+- **The first two rows never reach the server.** A FUSE mount defaults to a 1s
+  attr_timeout and entry_timeout, so restating one path is answered by the
+  kernel's own caches. This table used to call them "getattr" and "lookup" and
+  conclude that metadata operations cost ~5% more than the host, which is a
+  claim about fuse-pipe drawn from a measurement fuse-pipe took no part in. The
+  round trips are two to three orders of magnitude dearer: `make
+  bench-operations` reports them as
+  `single_op/getattr/fuse_256_readers_forced_round_trip` and
+  `single_op/lookup/fuse_256_readers_miss_round_trip`, each of which asserts it
+  reached the server before it measures anything.
 - **Mutating ops** (write, create) have significant overhead due to fsync
 
 ---

--- a/fuse-pipe/benches/operations.rs
+++ b/fuse-pipe/benches/operations.rs
@@ -106,23 +106,34 @@ fn assert_forced_getattr_reaches_server(backing: &Path, via_mount: &Path, fd: Ra
     use std::os::unix::fs::PermissionsExt;
 
     let before = 0o644;
-    fs::set_permissions(backing, fs::Permissions::from_mode(before)).unwrap();
-    assert_eq!(
-        forced_statx_mode(fd) as u32,
-        before,
-        "the mount does not agree with the backing file even before anything is changed \
-         behind its back, so neither half of this check would mean anything"
-    );
-
     let after = 0o600;
-    fs::set_permissions(backing, fs::Permissions::from_mode(after)).unwrap();
 
-    let cached = fs::metadata(via_mount).unwrap().permissions().mode() & 0o7777;
-    assert_eq!(
-        cached,
-        before,
-        "a plain stat through {} already saw the out-of-band chmod, so the attribute cache is \
-         not in play here and the forced case proves nothing",
+    // The cached half is only meaningful while the mount's 1s attr_timeout has
+    // not elapsed between the priming statx and the plain stat. A descheduling
+    // longer than that (a loaded CI host) expires the cache and the plain stat
+    // reports the new mode — a scheduling artifact, not the property under
+    // test — so that half retries. The forced half stays a hard assertion.
+    let mut cache_held = false;
+    for _ in 0..5 {
+        fs::set_permissions(backing, fs::Permissions::from_mode(before)).unwrap();
+        assert_eq!(
+            forced_statx_mode(fd) as u32,
+            before,
+            "the mount does not agree with the backing file even before anything is changed \
+             behind its back, so neither half of this check would mean anything"
+        );
+
+        fs::set_permissions(backing, fs::Permissions::from_mode(after)).unwrap();
+
+        if fs::metadata(via_mount).unwrap().permissions().mode() & 0o7777 == before {
+            cache_held = true;
+            break;
+        }
+    }
+    assert!(
+        cache_held,
+        "a plain stat through {} saw the out-of-band chmod on five consecutive attempts, so \
+         the attribute cache is not in play here and the forced case proves nothing",
         via_mount.display()
     );
 

--- a/fuse-pipe/benches/operations.rs
+++ b/fuse-pipe/benches/operations.rs
@@ -7,7 +7,8 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
-use std::path::PathBuf;
+use std::os::fd::{AsRawFd, RawFd};
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Once;
@@ -46,29 +47,124 @@ fn setup_test_files(dir: &PathBuf) {
         let path = subdir.join(format!("file_{}.txt", i));
         fs::write(&path, format!("content {}", i)).unwrap();
     }
-
-    // Distinct files for the uncached metadata probes. Restating a path the
-    // kernel already has cached measures the cache, so those benchmarks walk
-    // this pool instead, and the pool is larger than any run's sample count so
-    // a single iteration never revisits an entry.
-    let pool = dir.join(METADATA_POOL_DIR);
-    fs::create_dir_all(&pool).unwrap();
-    for i in 0..METADATA_POOL_FILES {
-        fs::write(pool.join(format!("m_{i}.dat")), b"m").unwrap();
-    }
 }
 
-/// Directory holding the uncached-metadata file pool.
-const METADATA_POOL_DIR: &str = "metadata_pool";
+/// Name the lookup benchmarks resolve to get a server round trip. Nothing ever
+/// creates it.
+const MISSING_NAME: &str = "no_such_file.dat";
 
-/// How many distinct files the uncached metadata probes rotate through.
-const METADATA_POOL_FILES: usize = 20_000;
+/// `statx` on an open descriptor, forcing the filesystem to answer rather than
+/// the kernel's cached attributes. Returns the reported permission bits.
+///
+/// `AT_STATX_FORCE_SYNC` makes fuse's `getattr` inode operation call
+/// `fuse_do_getattr()` unconditionally instead of serving the cached
+/// attributes, and `AT_EMPTY_PATH` keeps name resolution out of the
+/// measurement entirely. One call is therefore one GETATTR round trip and
+/// nothing else. On a local filesystem the flag has nothing to revalidate
+/// against; the `host_fs_forced` control prices that case so the FUSE figure
+/// can be attributed to the round trip rather than to the flag.
+///
+/// The mode is returned rather than the size because fuse-pipe negotiates
+/// `FUSE_WRITEBACK_CACHE`, under which the kernel owns `i_size` for regular
+/// files and discards whatever size the server reports. Size therefore cannot
+/// witness a round trip; permission bits are copied straight out of every
+/// reply.
+fn forced_statx_mode(fd: RawFd) -> u16 {
+    let mut stx: libc::statx = unsafe { std::mem::zeroed() };
+    let empty = b"\0";
+    let rc = unsafe {
+        libc::statx(
+            fd,
+            empty.as_ptr() as *const libc::c_char,
+            libc::AT_EMPTY_PATH | libc::AT_STATX_FORCE_SYNC,
+            libc::STATX_BASIC_STATS,
+            &mut stx,
+        )
+    };
+    assert_eq!(
+        rc,
+        0,
+        "forced statx failed: {}",
+        std::io::Error::last_os_error()
+    );
+    stx.stx_mode & 0o7777
+}
 
-/// Nth file in the pool, wrapping. Callers pass a monotonically increasing
-/// counter, so consecutive iterations touch different inodes.
-fn pool_file(root: &std::path::Path, n: u64) -> PathBuf {
-    root.join(METADATA_POOL_DIR)
-        .join(format!("m_{}.dat", (n as usize) % METADATA_POOL_FILES))
+/// Prove, before publishing a number from it, that [`forced_statx_mode`] on a
+/// FUSE descriptor reaches the server on every call.
+///
+/// Chmod the backing file behind the mount's back, then read the mode back two
+/// ways. A plain stat still reports the old mode, because the mount's 1s
+/// attr_timeout has not elapsed; the forced stat must report the new one. The
+/// first half is what makes the second half meaningful: it shows the cache was
+/// live and would have hidden the change.
+///
+/// Without this the benchmark could quietly become the attribute-cache
+/// measurement it was written to replace, because an unhonoured
+/// `AT_STATX_FORCE_SYNC` looks exactly like a very fast FUSE.
+fn assert_forced_getattr_reaches_server(backing: &Path, via_mount: &Path, fd: RawFd) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let before = 0o644;
+    fs::set_permissions(backing, fs::Permissions::from_mode(before)).unwrap();
+    assert_eq!(
+        forced_statx_mode(fd) as u32,
+        before,
+        "the mount does not agree with the backing file even before anything is changed \
+         behind its back, so neither half of this check would mean anything"
+    );
+
+    let after = 0o600;
+    fs::set_permissions(backing, fs::Permissions::from_mode(after)).unwrap();
+
+    let cached = fs::metadata(via_mount).unwrap().permissions().mode() & 0o7777;
+    assert_eq!(
+        cached,
+        before,
+        "a plain stat through {} already saw the out-of-band chmod, so the attribute cache is \
+         not in play here and the forced case proves nothing",
+        via_mount.display()
+    );
+
+    let forced = forced_statx_mode(fd) as u32;
+    assert_eq!(
+        forced, after,
+        "AT_STATX_FORCE_SYNC returned the cached mode, so this benchmark would measure the \
+         attribute cache rather than a GETATTR round trip"
+    );
+}
+
+/// Prove that resolving [`MISSING_NAME`] reaches the server on every call.
+///
+/// fuse only caches a negative dentry when the server answers with a zero
+/// nodeid and an entry timeout. fuse-pipe answers a miss with a plain ENOENT,
+/// so `fuse_lookup()` invalidates the entry instead of caching it and every
+/// resolution of an absent name is a fresh LOOKUP, with no pool of distinct
+/// paths to exhaust and no dependence on how many iterations criterion decides
+/// to run.
+///
+/// Checked rather than assumed: resolve a probe name, create it behind the
+/// mount's back, resolve again. A cached negative answer still reports it
+/// missing. The probe uses its own name so the positive dentry it leaves
+/// behind cannot bleed into the benchmark's.
+fn assert_missing_lookup_reaches_server(mount: &Path, backing: &Path) {
+    let probe = "negative_cache_probe.dat";
+    let via_mount = mount.join(probe);
+    let via_backing = backing.join(probe);
+
+    assert!(
+        !via_mount.exists(),
+        "{} must start absent for this check to mean anything",
+        via_mount.display()
+    );
+    fs::write(&via_backing, b"x").unwrap();
+    assert!(
+        via_mount.exists(),
+        "the mount still reports {} absent after it was created behind its back, so misses are \
+         answered from a cached negative dentry and the benchmark below would measure that cache",
+        via_mount.display()
+    );
+    fs::remove_file(&via_backing).unwrap();
 }
 
 fn cleanup(data_dir: &PathBuf, mount_dir: &PathBuf) {
@@ -102,6 +198,18 @@ fn bench_getattr(c: &mut Criterion) {
         })
     });
 
+    // Control for the forced case below: the identical call on a local
+    // filesystem, which has nothing to revalidate against and so answers from
+    // its in-core inode either way. It is not directly comparable to `host_fs`
+    // (no name to resolve, so it comes out lower), and it is not meant to be.
+    // Its job is to price the syscall and the flag on their own, so that the
+    // FUSE figure below can be read as the round trip rather than as the cost
+    // of asking synchronously.
+    let host_fd = File::open(&test_file).unwrap();
+    group.bench_function("host_fs_forced", |b| {
+        b.iter(|| forced_statx_mode(host_fd.as_raw_fd()))
+    });
+
     // FUSE with 256 readers (our recommended default)
     let fuse = FuseMount::new(&data_dir, &mount_dir, 256);
     let fuse_file = fuse.mount_path().join("test.dat");
@@ -116,17 +224,20 @@ fn bench_getattr(c: &mut Criterion) {
         })
     });
 
-    // The round trip. Each iteration stats a file this mount has not seen, so
-    // the request reaches the server.
-    let pool_root = fuse.mount_path().to_path_buf();
-    let counter = AtomicU64::new(0);
-    group.bench_function("fuse_256_readers_uncached", |b| {
-        b.iter(|| {
-            let n = counter.fetch_add(1, Ordering::Relaxed);
-            let _ = fs::metadata(pool_file(&pool_root, n)).unwrap();
-        })
+    // The GETATTR round trip.
+    //
+    // Statting a path the mount has not seen does NOT measure this: pathname
+    // resolution sends a LOOKUP whose reply already carries attributes, so the
+    // stat is satisfied without a GETATTR ever being issued. That is a LOOKUP
+    // measurement, and it lives in `single_op/lookup`. Isolating GETATTR takes
+    // a descriptor (no name to resolve) plus a forced revalidation.
+    let fuse_fd = File::open(&fuse_file).unwrap();
+    assert_forced_getattr_reaches_server(&test_file, &fuse_file, fuse_fd.as_raw_fd());
+    group.bench_function("fuse_256_readers_forced_round_trip", |b| {
+        b.iter(|| forced_statx_mode(fuse_fd.as_raw_fd()))
     });
 
+    drop(fuse_fd);
     drop(fuse);
     group.finish();
     cleanup(&data_dir, &mount_dir);
@@ -152,6 +263,15 @@ fn bench_lookup(c: &mut Criterion) {
         })
     });
 
+    // Control for the miss case below: what resolving an absent name costs
+    // when there is no server to ask.
+    let host_missing = data_dir.join(MISSING_NAME);
+    group.bench_function("host_fs_miss", |b| {
+        b.iter(|| {
+            let _ = host_missing.exists();
+        })
+    });
+
     // FUSE
     let fuse = FuseMount::new(&data_dir, &mount_dir, 256);
     let fuse_file = fuse.mount_path().join("test.dat");
@@ -164,12 +284,24 @@ fn bench_lookup(c: &mut Criterion) {
         })
     });
 
-    let pool_root = fuse.mount_path().to_path_buf();
-    let counter = AtomicU64::new(0);
-    group.bench_function("fuse_256_readers_uncached", |b| {
+    // The LOOKUP round trip, via a name that does not exist.
+    //
+    // A pool of distinct existing files also produces cold lookups, but only
+    // until the walk wraps, and sizing the pool against `sample_size` does not
+    // prevent that: `sample_size` bounds criterion's samples, not its `iter`
+    // calls. Measured at criterion's defaults, a 20,000-file pool got 20,000
+    // measurement iterations plus an untimed warm-up that had already walked
+    // thousands. Past the wrap, whether a revisited inode is still cached comes
+    // down to how long one pass takes against the 1s entry_timeout, which is a
+    // property of the host rather than of the benchmark, and the case cannot
+    // report which blend it measured. An absent name has no such dependence:
+    // fuse-pipe answers a miss with a plain ENOENT, which fuse does not cache,
+    // so iteration one and iteration ten million both reach the server.
+    assert_missing_lookup_reaches_server(fuse.mount_path(), &data_dir);
+    let fuse_missing = fuse.mount_path().join(MISSING_NAME);
+    group.bench_function("fuse_256_readers_miss_round_trip", |b| {
         b.iter(|| {
-            let n = counter.fetch_add(1, Ordering::Relaxed);
-            let _ = pool_file(&pool_root, n).exists();
+            let _ = fuse_missing.exists();
         })
     });
 

--- a/tests/test_documented_make_targets.rs
+++ b/tests/test_documented_make_targets.rs
@@ -111,11 +111,19 @@ fn readme_only_names_targets_that_exist() {
 /// Both shapes are worth publishing; they just have to be named. This keeps a
 /// bare `fuse_256_readers` case from creeping back in, since its name would
 /// claim to be the round trip while measuring the cache.
+///
+/// Naming is not enough on its own, so each round-trip case also has to carry
+/// the runtime check that it reaches the server. The first attempt at one did
+/// not: it walked a pool of 20,000 distinct files, which produces cold lookups
+/// only until the walk wraps, and nothing in it could tell whether it had.
 #[test]
 fn metadata_benchmarks_name_the_cache_they_measure() {
     let src = repo_file("fuse-pipe/benches/operations.rs");
 
-    for op in ["bench_getattr", "bench_lookup"] {
+    for (op, check) in [
+        ("bench_getattr", "assert_forced_getattr_reaches_server("),
+        ("bench_lookup", "assert_missing_lookup_reaches_server("),
+    ] {
         let start = src
             .find(&format!("fn {op}("))
             .unwrap_or_else(|| panic!("operations.rs has no {op}"));
@@ -124,20 +132,58 @@ fn metadata_benchmarks_name_the_cache_they_measure() {
         let body = &body[..end];
 
         assert!(
-            body.contains("_uncached"),
-            "{op} has no `_uncached` case, so nothing in it measures a FUSE round trip: a \
+            body.contains("_cache_hit"),
+            "{op} no longer names its cached case for the cache it measures"
+        );
+        assert!(
+            body.contains("_round_trip"),
+            "{op} has no `_round_trip` case, so nothing in it measures a FUSE round trip: a \
              repeated path is answered by the kernel's attribute/dentry cache"
         );
         assert!(
-            body.contains("pool_file("),
-            "{op}'s uncached case must walk the distinct-file pool; restating one path \
-             measures the cache no matter what the case is called"
+            body.contains(check),
+            "{op}'s round-trip case must call {check}..) first. A case that is merely named \
+             for the round trip and never checked is how the cached measurement got published \
+             the first time."
         );
         assert!(
             !body.contains("\"fuse_256_readers\""),
             "{op} still has a case named plainly `fuse_256_readers`. Name it for the cache \
-             it measures (`_attr_cache_hit` / `_dentry_cache_hit`) or make it uncached; an \
-             unqualified name reads as the round-trip cost and is off by ~100x."
+             it measures (`_attr_cache_hit` / `_dentry_cache_hit`) or make it a checked round \
+             trip; an unqualified name reads as the round-trip cost and is off by ~300x."
+        );
+    }
+}
+
+/// No metadata case may depend on a finite pool of distinct paths.
+///
+/// `sample_size` bounds criterion's samples, not its `iter` calls, so a pool
+/// sized against the sample count does not bound anything. Measured on the
+/// merged version at criterion's defaults, `single_op/getattr`:
+///
+///     fuse_256_readers_attr_cache_hit: 17M iterations   [297.38 ns .. 310.12 ns]
+///     fuse_256_readers_uncached:       20k iterations   [181.50 µs .. 465.15 µs]
+///
+/// 20,000 measurement iterations against a 20,000-file pool, on top of a
+/// warm-up phase that is untimed, uncounted and had already walked thousands of
+/// entries. The walk wraps. Whether a revisited inode is then still cached
+/// depends on how long one pass takes against the mount's 1s entry_timeout,
+/// which is a property of the host and the flags rather than of the benchmark.
+/// The case reports whatever blend it got without being able to say so, and
+/// 17M against 20k is the scale it degrades toward as more revisits land inside
+/// the timeout.
+///
+/// The replacements have no pool and no such dependence: a forced statx cannot
+/// be served from the attribute cache, and an absent name is never cached.
+#[test]
+fn metadata_benchmarks_cannot_wrap_a_fixed_pool() {
+    let src = repo_file("fuse-pipe/benches/operations.rs");
+    for banned in ["METADATA_POOL", "pool_file("] {
+        assert!(
+            !src.contains(banned),
+            "operations.rs is back on a fixed path pool ({banned}). A pool only produces cold \
+             metadata operations until it wraps, and criterion runs orders of magnitude more \
+             iterations than a pool can hold."
         );
     }
 }

--- a/tests/test_documented_make_targets.rs
+++ b/tests/test_documented_make_targets.rs
@@ -21,6 +21,47 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+/// The identity `make` must run as, when the harness itself is root.
+///
+/// The Host-Root CI legs run this whole test binary as root (their nextest
+/// runner is `sudo -E`), and the Makefile refuses root on the host: its guard
+/// exists so build plumbing can never leave root-owned files in `target/`.
+/// A bypass variable would disarm that guard for real users, so the harness
+/// instead runs `make` as the user sudo recorded — the identity the guard
+/// tells a person to use. Inside containers the guard already permits root
+/// and no drop happens.
+fn harness_user() -> Option<(u32, u32)> {
+    if unsafe { libc::geteuid() } != 0
+        || Path::new("/.dockerenv").exists()
+        || Path::new("/run/.containerenv").exists()
+    {
+        return None;
+    }
+    let parse = |key: &str| -> Option<u32> { std::env::var(key).ok()?.parse().ok() };
+    match (parse("SUDO_UID"), parse("SUDO_GID")) {
+        (Some(uid), Some(gid)) => Some((uid, gid)),
+        _ => panic!(
+            "BLOCKED: running as root on a host with no SUDO_UID/SUDO_GID; the Makefile \
+             refuses root and the harness has no user to hand make to"
+        ),
+    }
+}
+
+/// Hand the scratch tree to the user `make` will run as, so the cargo stub
+/// can record into it.
+fn chown_tree(root: &Path, uid: u32, gid: u32) {
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        std::os::unix::fs::chown(&path, Some(uid), Some(gid))
+            .unwrap_or_else(|e| panic!("chown {}: {e}", path.display()));
+        if path.is_dir() {
+            for entry in fs::read_dir(&path).unwrap() {
+                stack.push(entry.unwrap().path());
+            }
+        }
+    }
+}
+
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
@@ -412,6 +453,11 @@ impl<'a> Harness<'a> {
         if self.criterion_home_missing {
             cmd.env("BENCH_STUB_NO_OUTPUT", "1");
         }
+        if let Some((uid, gid)) = harness_user() {
+            use std::os::unix::process::CommandExt;
+            chown_tree(scratch.path(), uid, gid);
+            cmd.uid(uid).gid(gid);
+        }
 
         let out = cmd.output().expect("run make");
         let read = |f: &str| fs::read_to_string(rec.join(f)).unwrap_or_default();
@@ -450,6 +496,11 @@ fn bench_quick_passes_criterion_flags_after_the_cargo_separator() {
     let control = Command::new(&cargo)
         .current_dir(empty.path())
         .args(["bench", "--bench", "throughput", "--sample-size", "10"])
+        // CI exports CARGO_TERM_COLOR=always, and cargo then wraps the argument
+        // name in ANSI codes INSIDE the quotes — `'\x1b[1m\x1b[33m--sample-size...'`
+        // — which broke the substring match below on every CI leg while passing
+        // locally, where cargo sees a pipe and turns color off on its own.
+        .env("CARGO_TERM_COLOR", "never")
         .output()
         .expect("run cargo");
     let control_err = String::from_utf8_lossy(&control.stderr);

--- a/tests/test_documented_make_targets.rs
+++ b/tests/test_documented_make_targets.rs
@@ -263,6 +263,9 @@ struct Harness<'a> {
     scratch_criterion_home: bool,
     find_reports_root_owned: bool,
     sudo_succeeds: bool,
+    /// Leave `CRITERION_HOME` uncreated, standing in for a criterion that
+    /// could not write it (a read-only or root-squashed mount).
+    criterion_home_missing: bool,
 }
 
 impl<'a> Harness<'a> {
@@ -274,7 +277,13 @@ impl<'a> Harness<'a> {
             scratch_criterion_home: true,
             find_reports_root_owned: false,
             sudo_succeeds: true,
+            criterion_home_missing: false,
         }
+    }
+
+    fn without_criterion_output(mut self) -> Self {
+        self.criterion_home_missing = true;
+        self
     }
 
     fn make_flags(mut self, flags: &'a [&'a str]) -> Self {
@@ -305,7 +314,9 @@ impl<'a> Harness<'a> {
         let scratch = Scratch::new(self.name);
         let rec = scratch.path().join("rec");
         let criterion_home = scratch.path().join("criterion");
-        fs::create_dir_all(&criterion_home).unwrap();
+        if !self.criterion_home_missing {
+            fs::create_dir_all(&criterion_home).unwrap();
+        }
 
         scratch.write_exec(
             "cargo-stub.sh",
@@ -599,4 +610,43 @@ fn a_failed_ownership_repair_fails_the_privileged_bench_target() {
         "bench-throughput failed with no root-owned files to repair: {}",
         nothing_to_repair.stderr
     );
+}
+
+/// A criterion run that persisted nothing must not report success.
+///
+/// criterion logs its persistence failures and still exits 0, so if
+/// `CRITERION_HOME` points somewhere it cannot create — a read-only or
+/// root-squashed mount — the suite prints timings, writes no `sample.json`,
+/// no `estimates.json` and no baseline, and the recipe passes that 0 straight
+/// through. Nothing can then be compared against the run and no regression can
+/// ever be reported against it, which is the same shape as the defect this
+/// file already guards on the ownership side: a benchmark that looks like it
+/// ran and left nothing behind.
+#[test]
+fn a_bench_that_persisted_nothing_fails_its_target() {
+    for goal in ["bench-throughput", "bench-protocol"] {
+        let missing = Harness::new("criterion-home-missing", &[goal])
+            .without_criterion_output()
+            .run();
+        assert!(
+            !missing.ok,
+            "{goal} reported success with no criterion output directory, so the suite              persisted nothing and its numbers cannot be compared against anything.              stderr: {}",
+            missing.stderr
+        );
+        assert!(
+            missing.stderr.contains("does not exist"),
+            "{goal}'s failure must name the missing criterion output; stderr was: {}",
+            missing.stderr
+        );
+
+        // Control: the same run passes when criterion did write its directory,
+        // so the failure above is attributable to the missing output and not
+        // to the harness.
+        let present = Harness::new("criterion-home-present", &[goal]).run();
+        assert!(
+            present.ok,
+            "{goal} failed even though the criterion output directory exists: {}",
+            present.stderr
+        );
+    }
 }

--- a/tests/test_documented_make_targets.rs
+++ b/tests/test_documented_make_targets.rs
@@ -693,7 +693,9 @@ fn a_bench_that_persisted_nothing_fails_its_target() {
             .run();
         assert!(
             !missing.ok,
-            "{goal} reported success with no criterion output directory, so the suite              persisted nothing and its numbers cannot be compared against anything.              stderr: {}",
+            "{goal} reported success with no criterion output directory, so the suite \
+             persisted nothing and its numbers cannot be compared against anything. \
+             stderr: {}",
             missing.stderr
         );
         assert!(

--- a/tests/test_documented_make_targets.rs
+++ b/tests/test_documented_make_targets.rs
@@ -1,4 +1,4 @@
-//! Every `make` target PERFORMANCE.md tells a reader to run must exist.
+//! The benchmark targets have to exist, run, and run one at a time.
 //!
 //! PERFORMANCE.md's "Quick Reference" listed `make bench-quick`,
 //! `bench-throughput`, `bench-operations` and `bench-protocol`. None of the
@@ -7,12 +7,26 @@
 //! that silently was not there), and it is worse in a performance guide,
 //! because the reader's first move after reading a benchmark table is to run
 //! the command that reproduces it.
+//!
+//! The targets that replaced them were verified with `make -n`, which prints a
+//! command line without asking cargo whether it would accept one. Four of the
+//! tests below therefore drive real `make` against the real Makefile with a
+//! stub standing in for cargo, so a recipe that make expands happily but cargo
+//! rejects, or that runs two benchmark suites at once, or that writes its
+//! results somewhere its own ownership repair never looks, fails here instead
+//! of on a reader's box.
 
 use std::collections::BTreeSet;
-use std::path::PathBuf;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
 
 fn repo_file(rel: &str) -> String {
-    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let path = repo_root().join(rel);
     std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
 }
 
@@ -126,4 +140,417 @@ fn metadata_benchmarks_name_the_cache_they_measure() {
              unqualified name reads as the round-trip cost and is off by ~100x."
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// Harness: drive the real Makefile with a stub in place of cargo.
+// ---------------------------------------------------------------------------
+
+/// Scratch directory for one harness run.
+struct Scratch(PathBuf);
+
+impl Scratch {
+    fn new(name: &str) -> Self {
+        let dir = std::env::temp_dir().join(format!(
+            "fcvm-make-harness-{name}-{}-{:?}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(dir.join("bin")).expect("create scratch bin");
+        fs::create_dir_all(dir.join("rec")).expect("create scratch rec");
+        Scratch(dir)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+
+    fn write_exec(&self, name: &str, body: &str) {
+        use std::os::unix::fs::PermissionsExt;
+        let path = self.0.join("bin").join(name);
+        fs::write(&path, body).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+/// What one harness run observed.
+struct MakeRun {
+    ok: bool,
+    stderr: String,
+    /// Arguments of every stub-cargo invocation, in start order.
+    invocations: Vec<String>,
+    /// One entry per stub-cargo invocation that started while another was
+    /// still running.
+    overlaps: Vec<String>,
+    /// `CRITERION_HOME` as each stub-cargo invocation received it.
+    criterion_homes: Vec<String>,
+}
+
+/// Drive `make` against the real Makefile with cargo, find and sudo stubbed.
+///
+/// `CARGO_BIN` is the toolchain-selection hook the Makefile leaves overridable;
+/// `CARGO` itself is `override`n, so the stub still runs through the real
+/// `cargo-target-run.sh` wrapper. Only `build` is neutralised, so nothing here
+/// compiles anything.
+///
+/// `find` and `sudo` are stubbed on PATH in every run, for two reasons. They
+/// set up the ownership-repair precondition without needing an actually
+/// root-owned file, and they make it impossible for a unit test to `chown -R`
+/// a developer's real criterion output.
+struct Harness<'a> {
+    name: &'a str,
+    goals: &'a [&'a str],
+    make_flags: &'a [&'a str],
+    /// Point `CRITERION_HOME` at a scratch directory. Cleared by
+    /// [`Harness::keep_default_criterion_home`] for the test that checks what
+    /// the Makefile picks on its own.
+    scratch_criterion_home: bool,
+    find_reports_root_owned: bool,
+    sudo_succeeds: bool,
+}
+
+impl<'a> Harness<'a> {
+    fn new(name: &'a str, goals: &'a [&'a str]) -> Self {
+        Harness {
+            name,
+            goals,
+            make_flags: &[],
+            scratch_criterion_home: true,
+            find_reports_root_owned: false,
+            sudo_succeeds: true,
+        }
+    }
+
+    fn make_flags(mut self, flags: &'a [&'a str]) -> Self {
+        self.make_flags = flags;
+        self
+    }
+
+    fn keep_default_criterion_home(mut self) -> Self {
+        self.scratch_criterion_home = false;
+        self
+    }
+
+    fn with_root_owned_output(mut self) -> Self {
+        self.find_reports_root_owned = true;
+        self
+    }
+
+    fn with_failing_sudo(mut self) -> Self {
+        self.sudo_succeeds = false;
+        self
+    }
+
+    fn run(self) -> MakeRun {
+        let make = which("make").expect(
+            "BLOCKED: `make` is not on PATH, so this test cannot evaluate the Makefile it guards",
+        );
+
+        let scratch = Scratch::new(self.name);
+        let rec = scratch.path().join("rec");
+        let criterion_home = scratch.path().join("criterion");
+        fs::create_dir_all(&criterion_home).unwrap();
+
+        scratch.write_exec(
+            "cargo-stub.sh",
+            "#!/bin/sh\n\
+             # Stands in for cargo inside the bench recipes: records its arguments\n\
+             # and its criterion home, and stays alive long enough for an\n\
+             # overlapping suite to be visible.\n\
+             set -u\n\
+             printf '%s\\n' \"$*\" >> \"$BENCH_RECORD_DIR/argv.log\"\n\
+             printf '%s\\n' \"${CRITERION_HOME:-<unset>}\" >> \"$BENCH_RECORD_DIR/home.log\"\n\
+             live=\"$BENCH_RECORD_DIR/live.$$\"\n\
+             : > \"$live\"\n\
+             if [ \"$(ls \"$BENCH_RECORD_DIR\"/live.* | wc -l)\" -gt 1 ]; then\n\
+             \tprintf '%s\\n' \"$*\" >> \"$BENCH_RECORD_DIR/overlap.log\"\n\
+             fi\n\
+             sleep 0.5\n\
+             rm -f \"$live\"\n\
+             exit 0\n",
+        );
+        scratch.write_exec(
+            "find",
+            if self.find_reports_root_owned {
+                "#!/bin/sh\necho criterion/single_op_getattr\nexit 0\n"
+            } else {
+                "#!/bin/sh\nexit 0\n"
+            },
+        );
+        scratch.write_exec(
+            "sudo",
+            if self.sudo_succeeds {
+                "#!/bin/sh\nexit 0\n"
+            } else {
+                "#!/bin/sh\necho 'sudo: a password is required' >&2\nexit 1\n"
+            },
+        );
+        // Neutralise everything below the bench recipes. `build` keeps this
+        // from compiling anything, and `cargo-target-link` must go too: it
+        // takes the target generation's lease EXCLUSIVELY, while the `cargo
+        // nextest` running this test holds that same lease shared for its
+        // whole lifetime, so a harness that calls it deadlocks against its own
+        // test runner. Measured: four harness runs plus
+        // tests/test_cargo_target_link.rs left a `flock -x` on
+        // <checkout>/target parked behind the runner's `flock -s`, and all
+        // five tests hit nextest's 120s timeout.
+        //
+        // Skipping it is sound because `target/` already exists by then:
+        // nextest itself reaches these tests through cargo-target-run.sh,
+        // which refuses to start without it.
+        assert!(
+            repo_root().join("target").is_dir(),
+            "BLOCKED: {} does not exist, so this harness cannot run make without publishing a \
+             target generation, which would deadlock against the test runner's own lease",
+            repo_root().join("target").display()
+        );
+        fs::write(
+            scratch.path().join("stub.mk"),
+            "build:\n\t@:\ncargo-target-link:\n\t@:\n",
+        )
+        .unwrap();
+
+        let path = format!(
+            "{}:{}",
+            scratch.path().join("bin").display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+
+        let mut cmd = Command::new(make);
+        cmd.current_dir(repo_root())
+            .arg("-f")
+            .arg("Makefile")
+            .arg("-f")
+            .arg(scratch.path().join("stub.mk"))
+            .args(self.make_flags)
+            .args(self.goals)
+            .arg(format!(
+                "CARGO_BIN={}",
+                scratch.path().join("bin/cargo-stub.sh").display()
+            ));
+        if self.scratch_criterion_home {
+            cmd.arg(format!("CRITERION_HOME={}", criterion_home.display()));
+        }
+        // A -j inherited from the make that started the test suite would
+        // otherwise decide what these tests measure.
+        cmd.env_remove("MAKEFLAGS")
+            .env_remove("MFLAGS")
+            .env_remove("CRITERION_HOME")
+            .env("PATH", path)
+            .env("BENCH_RECORD_DIR", &rec);
+
+        let out = cmd.output().expect("run make");
+        let read = |f: &str| fs::read_to_string(rec.join(f)).unwrap_or_default();
+
+        MakeRun {
+            ok: out.status.success(),
+            stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+            invocations: read("argv.log").lines().map(str::to_owned).collect(),
+            overlaps: read("overlap.log").lines().map(str::to_owned).collect(),
+            criterion_homes: read("home.log").lines().map(str::to_owned).collect(),
+        }
+    }
+}
+
+fn which(bin: &str) -> Option<PathBuf> {
+    std::env::var_os("PATH").and_then(|paths| {
+        std::env::split_paths(&paths)
+            .map(|d| d.join(bin))
+            .find(|p| p.is_file())
+    })
+}
+
+/// Criterion's flags have to reach the bench binary, not cargo.
+///
+/// `bench-quick` expanded them straight into the cargo command line, so it
+/// could not run at all: cargo rejects the first one before any benchmark
+/// starts. It shipped because it was checked with `make -n`, which prints a
+/// command line without asking cargo whether it would accept one.
+#[test]
+fn bench_quick_passes_criterion_flags_after_the_cargo_separator() {
+    // Positive control: this is why the separator matters. Run in an empty
+    // directory, where the argument parser still rejects the flag before cargo
+    // has looked for a manifest.
+    let cargo = which("cargo").expect("BLOCKED: `cargo` is not on PATH");
+    let empty = Scratch::new("cargo-control");
+    let control = Command::new(&cargo)
+        .current_dir(empty.path())
+        .args(["bench", "--bench", "throughput", "--sample-size", "10"])
+        .output()
+        .expect("run cargo");
+    let control_err = String::from_utf8_lossy(&control.stderr);
+    assert!(
+        !control.status.success() && control_err.contains("unexpected argument '--sample-size'"),
+        "cargo no longer rejects criterion flags given to it directly, so this test is guarding \
+         a rule that no longer holds. cargo said: {control_err}"
+    );
+
+    let quick = Harness::new("bench-quick", &["bench-quick"]).run();
+    assert!(
+        quick.ok,
+        "make bench-quick failed: {stderr}",
+        stderr = quick.stderr
+    );
+    assert_eq!(
+        quick.invocations.len(),
+        3,
+        "expected throughput, operations and protocol; got {:?}",
+        quick.invocations
+    );
+    for argv in &quick.invocations {
+        let sep = argv.find(" -- ").unwrap_or(usize::MAX);
+        let flag = argv.find("--sample-size").unwrap_or_else(|| {
+            panic!("bench-quick did not forward its criterion flags at all: {argv}")
+        });
+        assert!(
+            sep < flag,
+            "bench-quick puts criterion flags on cargo's own command line, where cargo rejects \
+             them with `unexpected argument`: {argv}"
+        );
+    }
+
+    // And the default path carries no separator with nothing behind it.
+    let plain = Harness::new("bench-plain", &["bench"]).run();
+    assert!(
+        plain.ok,
+        "make bench failed: {stderr}",
+        stderr = plain.stderr
+    );
+    for argv in &plain.invocations {
+        let argv = argv.trim_end();
+        assert!(
+            !argv.contains(" -- ") && !argv.ends_with(" --"),
+            "plain `make bench` should pass nothing to the bench binary, separator included: \
+             {argv}"
+        );
+    }
+}
+
+/// `make -j bench` must not start two benchmark suites at once.
+///
+/// As prerequisites of an empty `bench` target they did: measured with this
+/// harness at `-j8`, all three ran together. Concurrent suites time each other,
+/// and the unprivileged protocol suite races the privileged suites for
+/// ownership of target/criterion. The recipe comment saying "do not run this
+/// under -j" was not a control, and a -j can also arrive unasked through
+/// MAKEFLAGS.
+#[test]
+fn parallel_make_never_runs_two_benchmark_suites_at_once() {
+    let run = Harness::new("bench-parallel", &["bench"])
+        .make_flags(&["-j8"])
+        .run();
+
+    assert!(
+        run.ok,
+        "make -j8 bench failed: {stderr}",
+        stderr = run.stderr
+    );
+    assert_eq!(
+        run.invocations.len(),
+        3,
+        "the harness saw {} suites, not 3, so it is not exercising `bench`: {:?}",
+        run.invocations.len(),
+        run.invocations
+    );
+    assert!(
+        run.overlaps.is_empty(),
+        "`make -j8 bench` ran benchmark suites concurrently: {:?}",
+        run.overlaps
+    );
+}
+
+/// Every suite has to agree on where criterion writes, and it has to be a path
+/// the recipes name rather than one criterion picks.
+///
+/// Criterion's default is `$CARGO_TARGET_DIR/criterion`, and this Makefile sets
+/// `CARGO_TARGET_DIR` to the relative string `target`, which criterion resolves
+/// inside the bench binary, whose working directory cargo sets to the package
+/// root. Every suite was writing to `fuse-pipe/target/criterion` while the
+/// ownership repair scanned `target/` at the repo root and found nothing to do.
+/// Measured on that arrangement: `make bench-quick` finished at exit 0 leaving
+/// `single_op_getattr`, `parallel_reads` and `parallel_writes` root-owned, and
+/// the next unprivileged `make bench-protocol` printed `Failed to access file
+/// "target/criterion/serialize_lookup_request/new/sample.json": Permission
+/// denied (os error 13)` for every result file, also at exit 0, because
+/// criterion reports the failure and carries on.
+#[test]
+fn bench_recipes_pin_criterion_output_to_an_absolute_path() {
+    let run = Harness::new("criterion-home", &["bench"])
+        .keep_default_criterion_home()
+        .run();
+    assert!(run.ok, "make bench failed: {}", run.stderr);
+    assert_eq!(
+        run.criterion_homes.len(),
+        3,
+        "expected one criterion home per suite; got {:?}",
+        run.criterion_homes
+    );
+
+    let target = repo_root().join("target/criterion");
+    for home in &run.criterion_homes {
+        assert_eq!(
+            Path::new(home),
+            target,
+            "a bench recipe leaves criterion to choose its own output directory. Its second \
+             choice is $CARGO_TARGET_DIR/criterion, relative to the bench binary's working \
+             directory, which is the package root and not the repo root."
+        );
+    }
+}
+
+/// A failed ownership repair must fail the target.
+///
+/// The privileged suites kept only the benchmark's exit status, so a `chown`
+/// that could not run reported the suite green and left the criterion output
+/// root-owned, which is the state the repair exists to prevent and the one that
+/// makes the next `bench-protocol` persist nothing and `_test-root` refuse to
+/// start.
+#[test]
+fn a_failed_ownership_repair_fails_the_privileged_bench_target() {
+    let repair_failed = Harness::new("repair-fails", &["bench-throughput"])
+        .with_root_owned_output()
+        .with_failing_sudo()
+        .run();
+    assert!(
+        !repair_failed.ok,
+        "bench-throughput reported success while the ownership repair failed, leaving the \
+         criterion output root-owned. stderr: {}",
+        repair_failed.stderr
+    );
+    assert!(
+        repair_failed.stderr.contains("still root-owned"),
+        "the failure should say what is now wrong with the criterion output; stderr was: {}",
+        repair_failed.stderr
+    );
+
+    // Controls, so the failure above is attributable to the repair and not to
+    // the harness: the same run passes when the repair succeeds, and when
+    // there is nothing to repair.
+    let repair_worked = Harness::new("repair-works", &["bench-throughput"])
+        .with_root_owned_output()
+        .run();
+    assert!(
+        repair_worked.ok,
+        "bench-throughput failed even though the repair succeeded: {}",
+        repair_worked.stderr
+    );
+
+    let nothing_to_repair = Harness::new("repair-skipped", &["bench-throughput"])
+        .with_failing_sudo()
+        .run();
+    assert!(
+        nothing_to_repair.ok,
+        "bench-throughput failed with no root-owned files to repair: {}",
+        nothing_to_repair.stderr
+    );
 }

--- a/tests/test_documented_make_targets.rs
+++ b/tests/test_documented_make_targets.rs
@@ -327,6 +327,10 @@ impl<'a> Harness<'a> {
              set -u\n\
              printf '%s\\n' \"$*\" >> \"$BENCH_RECORD_DIR/argv.log\"\n\
              printf '%s\\n' \"${CRITERION_HOME:-<unset>}\" >> \"$BENCH_RECORD_DIR/home.log\"\n\
+             # A real `cargo bench` writes criterion output; the persistence guard in\n\
+             # the bench recipes checks for it. BENCH_STUB_NO_OUTPUT stands in for the\n\
+             # criterion that logged a persistence failure and still exited 0.\n\
+             [ -n \"${BENCH_STUB_NO_OUTPUT:-}\" ] || mkdir -p \"${CRITERION_HOME:-.}\"\n\
              live=\"$BENCH_RECORD_DIR/live.$$\"\n\
              : > \"$live\"\n\
              if [ \"$(ls \"$BENCH_RECORD_DIR\"/live.* | wc -l)\" -gt 1 ]; then\n\
@@ -405,6 +409,9 @@ impl<'a> Harness<'a> {
             .env_remove("CRITERION_HOME")
             .env("PATH", path)
             .env("BENCH_RECORD_DIR", &rec);
+        if self.criterion_home_missing {
+            cmd.env("BENCH_STUB_NO_OUTPUT", "1");
+        }
 
         let out = cmd.output().expect("run make");
         let read = |f: &str| fs::read_to_string(rec.join(f)).unwrap_or_default();
@@ -446,10 +453,15 @@ fn bench_quick_passes_criterion_flags_after_the_cargo_separator() {
         .output()
         .expect("run cargo");
     let control_err = String::from_utf8_lossy(&control.stderr);
+    // The rejection MESSAGE is the property, not the exit status: a `cargo` shim on
+    // PATH can forward the diagnostic and still exit 0, which is what CI has. Keying
+    // the control on the status made this test pass locally and fail there.
     assert!(
-        !control.status.success() && control_err.contains("unexpected argument '--sample-size'"),
+        control_err.contains("unexpected argument '--sample-size'"),
         "cargo no longer rejects criterion flags given to it directly, so this test is guarding \
-         a rule that no longer holds. cargo said: {control_err}"
+         a rule that no longer holds. cargo at {cargo} exited {status:?} and said: {control_err}",
+        cargo = cargo.display(),
+        status = control.status.code(),
     );
 
     let quick = Harness::new("bench-quick", &["bench-quick"]).run();


### PR DESCRIPTION
`make bench-quick` shipped in #790 unable to run. Its recipe expanded criterion's
flags straight onto cargo's own command line, and cargo rejects the first one
before any benchmark starts:

```
$ make bench-quick
... cargo bench -p fuse-pipe --bench throughput --sample-size 10 --warm-up-time 1 --measurement-time 3
error: unexpected argument '--sample-size' found
  tip: to pass '--sample-size' as a value, use '-- --sample-size'
make: *** [Makefile:691: bench-throughput] Error 1
```

That is the same defect #790 set out to remove, a documented target that does not
work, and it got there because the recipe was checked with `make -n`. A dry run
prints a command line; it does not ask cargo whether the command line is one it
would accept. This PR is five review findings on that PR, all read after it
merged, and every fix here is verified by running the thing rather than printing
it.

**Stacked on:** main.

## What changed

### `make bench-quick` reaches cargo correctly

Criterion's flags now follow `--`. The separator is omitted when there is nothing
behind it, so plain `make bench` is unchanged.

```
$ make bench-quick
==> Running fuse-pipe benchmarks: throughput, operations, protocol
     Running benches/throughput.rs (target/release/deps/throughput-5ba9d7c400bdd285)
     Running benches/operations.rs (target/release/deps/operations-8df94d73b357a580)
     Running benches/protocol.rs  (target/release/deps/protocol-b3bff7af4daa0dc5)
MAKE EXIT=0
```

Note while you are in here: a group that calls `sample_size()` in code keeps its
own count, so `--sample-size` reaches only the groups that do not.
`--warm-up-time` and `--measurement-time` reach all of them. The recipe comment
says so.

### `make -j bench` no longer runs the three suites at once

They were prerequisites, and make parallelizes prerequisites. `bench` is now one
target with three recipe lines, which make never parallelizes, so neither an
explicit `-j` nor one inherited through `MAKEFLAGS` can reach it. The suites stay
separate targets sharing one canned recipe, so nothing is duplicated.

GNU Make 4.3 is what this repo builds on and neither of make's own mechanisms
works there: `.NOTPARALLEL` ignores its prerequisites before 4.4 and serializes
the whole makefile rather than one target, and `.WAIT` arrived in 4.4.

### The ownership repair can now both fire and fail

Two problems, and the second is why the first never mattered.

It kept cargo's exit status across the `chown`, so a repair that could not run
reported the suite green.

It also scanned a directory criterion never writes to. Criterion's second choice
of output directory is `$CARGO_TARGET_DIR/criterion`, and `CARGO_TARGET_DIR` here
is the relative string `target`, which criterion resolves inside the bench
binary, whose working directory cargo sets to the package root:

```
$ make bench-quick                                    # exit 0
$ find target/ -user root -print -quit                # the repair scans here: nothing
$ find fuse-pipe/target/criterion -user root -maxdepth 1
fuse-pipe/target/criterion/single_op_getattr
fuse-pipe/target/criterion/parallel_reads
fuse-pipe/target/criterion/parallel_writes

$ sudo chown -R root:root fuse-pipe/target/criterion  # what a first privileged run leaves
$ make bench-protocol                                 # exit 0
Criterion.rs ERROR: error: Failed to access file
  "target/criterion/serialize_lookup_request/new/sample.json": Permission denied (os error 13)
```

`CRITERION_HOME` now pins the output to one absolute path, the repair scans and
repairs that path, and both the scan and the `chown` decide the recipe's exit
status. After the fix:

```
$ make bench-protocol
0 permission errors
$ ls target/criterion/serialize_lookup_request/new/
benchmark.json  estimates.json  sample.json  tukey.json
$ make bench-operations && find target/criterion -user root -print -quit
                                # empty: the repair fired and succeeded
```

### `single_op/getattr` measures GETATTR

The `_uncached` case did not. For a path the mount has not seen, pathname
resolution sends a LOOKUP whose reply already carries attributes, so the stat is
satisfied and no GETATTR is issued. It measured cold path resolution, which is
what the lookup group is for.

Isolating GETATTR needs a descriptor, so there is no name to resolve, and a
forced revalidation: `statx(fd, "", AT_EMPTY_PATH|AT_STATX_FORCE_SYNC, ...)`
makes fuse call `fuse_do_getattr()` instead of answering from the attribute
cache. The case is now `fuse_256_readers_forced_round_trip`, with
`host_fs_forced` beside it to price the syscall and the flag where there is
nothing to revalidate.

### Neither round-trip case can silently revert to measuring a cache

The pool of 20,000 distinct files is gone. `sample_size` bounds criterion's
samples, not its `iter` calls, so sizing a pool against it bounds nothing.
Measured on the merged version at criterion's defaults, the case ran 20,000
measurement iterations against that pool, after an untimed warm-up that had
already walked thousands of entries. Past the wrap, whether a revisited inode is
still cached depends on how long one pass takes against the 1s `entry_timeout`,
which is a property of the host rather than of the benchmark, and the case cannot
report which blend it got:

```
single_op/getattr/fuse_256_readers_attr_cache_hit   17M iterations   [297.38 ns .. 310.12 ns]
single_op/getattr/fuse_256_readers_uncached         20k iterations   [181.50 µs .. 465.15 µs]
```

The replacements have no such dependence. A forced statx cannot be served from
the attribute cache, and a name that does not exist is never cached, because
fuse-pipe answers a miss with a plain ENOENT and `fuse_lookup()` invalidates the
entry rather than caching it.

Both cases also assert they reach the server before measuring anything. Chmod the
backing file behind the mount's back and the forced statx must report the new
mode while a plain stat still reports the old one; create the probe name behind
the mount's back and the mount must see it appear. The first of these earned its
place on its first run, failing because the probe read the file's size:
fuse-pipe negotiates `FUSE_WRITEBACK_CACHE`, under which the kernel owns `i_size`
for regular files and discards the server's. Permission bits come out of every
reply.

```
single_op/getattr/host_fs                              283.80 ns
single_op/getattr/host_fs_forced                       153.72 ns
single_op/getattr/fuse_256_readers_attr_cache_hit      297.90 ns
single_op/getattr/fuse_256_readers_forced_round_trip    83.143 µs
single_op/lookup/host_fs                               303.47 ns
single_op/lookup/host_fs_miss                          184.50 ns
single_op/lookup/fuse_256_readers_dentry_cache_hit     291.60 ns
single_op/lookup/fuse_256_readers_miss_round_trip      120.33 µs
```

x86_64 devserver, 3s windows, not the c7gd.metal the published table came from,
so these are shapes rather than a replacement for it. The cache-hit cases sit on
the host baseline, which is where the published 1.05x came from; the round trips
cost 293x and 396x it. PERFORMANCE.md's two rows are relabelled for the caches
they measure, and its "metadata ops have ~5% overhead" conclusion is replaced by
what those rows are plus a pointer to the round-trip cases.

## Tests

`tests/test_documented_make_targets.rs` gains a harness that runs the real
Makefile with a stub in place of cargo, plus find and sudo stubs that set up the
ownership-repair precondition without needing a root-owned file and keep a unit
test from chowning a developer's tree. It skips `cargo-target-link`, which takes
the target generation's lease exclusively while the `cargo nextest` running the
test holds that lease shared; a harness that calls it deadlocks against its own
test runner, and did, for 120s, five times, before that was fixed.

Every new guard was watched failing on the merged code first.

Against the merged Makefile:

```
$ git checkout origin/main -- Makefile
$ cargo nextest run --release --no-default-features --test test_documented_make_targets
FAIL bench_quick_passes_criterion_flags_after_the_cargo_separator
  bench-quick puts criterion flags on cargo's own command line, where cargo
  rejects them with `unexpected argument`:
  bench -p fuse-pipe --bench throughput --sample-size 10 --warm-up-time 1 --measurement-time 3
FAIL parallel_make_never_runs_two_benchmark_suites_at_once
  `make -j8 bench` ran benchmark suites concurrently:
  ["bench -p fuse-pipe --bench protocol", "bench -p fuse-pipe --bench operations"]
FAIL a_failed_ownership_repair_fails_the_privileged_bench_target
  bench-throughput reported success while the ownership repair failed
FAIL bench_recipes_pin_criterion_output_to_an_absolute_path
  left: "<unset>"  right: "<repo>/target/criterion"
Summary: 8 tests run: 4 passed, 4 failed
```

Against the merged `operations.rs`:

```
$ git checkout origin/main -- fuse-pipe/benches/operations.rs
FAIL metadata_benchmarks_name_the_cache_they_measure
  bench_getattr has no `_round_trip` case, so nothing in it measures a FUSE
  round trip: a repeated path is answered by the kernel's attribute/dentry cache
FAIL metadata_benchmarks_cannot_wrap_a_fixed_pool
  operations.rs is back on a fixed path pool (METADATA_POOL)
Summary: 8 tests run: 6 passed, 2 failed
```

Green with the fixes:

```
$ cargo nextest run --release --no-default-features --test test_documented_make_targets
Summary [3.4s] 8 tests run: 8 passed, 0 skipped
```

## Gates

```
$ cargo fmt --all -- --check                      # clean
$ cargo clippy --all-targets -- -D warnings       # clean
$ make test-unit
Summary [51.0s] 622 tests run: 615 passed, 7 failed, 0 skipped
```

The 7 are `uffd::` tests, and they fail the same way on untouched `origin/main`
(`68 tests run: 61 passed, 7 failed`, same names) on this host, which has
`vm.unprivileged_userfaultfd=0`:

```
creating userfaultfd (via /dev/userfaultfd):
  OpenDevUserfaultfd(Os { code: 13, kind: PermissionDenied, message: "Permission denied" })
```

`bench-throughput` and `bench-operations` mount a real FUSE filesystem under the
privileged runner and both ran here, so every claim above is from a real run.

## Two pre-existing things noticed while running this, neither touched here

`src/uffd/server.rs`'s `spawn_victim()` starts `sleep 600` as a stand-in VMM. On
a host where the uffd tests fail before killing it, that child is orphaned and
survives, and it inherits the shared lease that `cargo-target-run.sh` holds on
the worktree's cargo target generation. `cargo-target-link.sh` then blocks on its
exclusive lease, so the next `make` sits in `build` until the sleep expires:

```
2011850 fd=10 -> /mnt/fcvm-btrfs/cargo-target/wt-bfix-...  scripts/cargo-target-link.sh
2011887 fd=10 -> /mnt/fcvm-btrfs/cargo-target/wt-bfix-...  flock -x 10
1971440 fd=11 -> /mnt/fcvm-btrfs/cargo-target/wt-bfix-...  sleep 600   (orphan, PPID 1)
1975387 fd=11 -> /mnt/fcvm-btrfs/cargo-target/wt-bfix-...  sleep 600   (orphan, PPID 1)
```

A five-minute wedge cleared the moment those two were killed. It needs the uffd
tests to be failing to happen at all, so it does not reach CI, but a victim that
outlives its test should not be holding a build lease.

`tests/test_serve.rs` warns `unused import: std::time::Duration` under
`--no-default-features`, because its uses sit behind
`#[cfg(feature = "integration-slow")]`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved benchmark command handling, including clearer separation of benchmark options and a configurable results location.
  - Benchmark suites now run sequentially and safely handle privileged operations.
  - Added validation that benchmark results are saved successfully and remain accessible.

- **Bug Fixes**
  - Corrected metadata benchmarks to measure actual server round trips instead of cache hits.
  - Improved handling of benchmark result ownership and failure reporting.

- **Documentation**
  - Updated performance documentation to distinguish cached operations from server-reaching round trips and reflect the revised measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->