### PR TITLE
Salvage the unlanded work from the archived WIP branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,6 +231,7 @@ CONTAINER_RUN := $(CONTAINER_RUN_BASE) --ulimit nproc=65536:65536 --pids-limit=6
 	cargo-target-link build-host-tools setup-btrfs setup-default setup-fcvm setup-pjdfstest setup-hugepages bench bench-vm bench-hugepages bench-hugepages-test \
 	bench-container-import bench-chromium bench-chromium-request analyze-chromium-request bench-clone-latency test-chromium-request \
 	bench-chromium-scale analyze-chromium-scale report-chromium-scale test-chromium-scale \
+	test-chromium-fault \
 	bench-quick bench-throughput bench-operations bench-protocol \
 	lint fmt update-dependency ssh test-serve-sdk
 
@@ -295,6 +296,7 @@ help:
 	@echo "  analyze-chromium-scale  Validate a scale run and write deterministic JSON"
 	@echo "  report-chromium-scale   Validate a scale run and write plain Markdown"
 	@echo "  test-chromium-scale  Run the scale harness's deterministic unit tests"
+	@echo "  test-chromium-fault  Run the fault harness's deterministic unit tests"
 	@echo "  bench-clone-latency  Clone spawn->exec-ready latency (LABEL=, N=)"
 	@echo ""
 	@echo "CI merge train (pooled CI for a batch of PRs, see docs/ci-train.md):"
@@ -697,6 +699,10 @@ test-chromium-request:
 
 test-chromium-scale:
 	@python3 -m unittest discover -s bench/chromium -p 'test_reqscale.py' \
+		$(if $(FILTER),-k '$(FILTER)',)
+
+test-chromium-fault:
+	@python3 -m unittest discover -s bench/chromium -p 'test_faultbench.py' \
 		$(if $(FILTER),-k '$(FILTER)',)
 
 # Open-loop CDP-fast scalability and page-fault measurement. Unlike

--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ CONTAINER_RUN_BASE := podman run --rm --privileged \
 CONTAINER_RUN := $(CONTAINER_RUN_BASE) --ulimit nproc=65536:65536 --pids-limit=65536
 
 .PHONY: all help build clean clean-test-data check-disk \
-	test test-unit test-fast test-all test-root test-packaging test-ci-infrastructure fuzz \
+	test test-unit test-fast test-all test-root test-packaging test-ci-infrastructure test-clone-floor-overlap fuzz \
 	_test-unit _test-fast _test-all _test-root _setup-fcvm _bench \
 	container-build container-test container-test-unit container-test-fast container-test-all container-test-fc-mock \
 	container-setup-fcvm container-shell container-clean container-bench \
@@ -251,6 +251,7 @@ help:
 	@echo "  test-all           + slow VM tests (rootless, no sudo)"
 	@echo "  test-root, test    + privileged tests (bridged, pjdfstest, sudo)"
 	@echo "  test-fc-mock       Run tests with fc-mock (no KVM required)"
+	@echo "  test-clone-floor-overlap  Reproduce the clone/CH/hugepage lifecycle overlap"
 	@echo "  test-ci-infrastructure  Deterministic runner-failure classifier fixtures"
 	@echo "  fuzz               Seeded lifecycle chaos fuzz (SEEDS=N|list OPS=M, defaults 1/10)"
 	@echo ""
@@ -744,6 +745,32 @@ report-chromium-scale:
 	@test -n "$(SCALE_REPORT)" || (echo "ERROR: SCALE_REPORT required"; exit 1)
 	python3 bench/chromium/reqscale_analyze.py \
 		--run-dir "$(SCALE_RUN_DIR)" --markdown-out "$(SCALE_REPORT)"
+
+# Run three ordinary nextest lanes concurrently. Each lane keeps the repository's
+# normal scheduling (in particular, hugepage tests remain serialized by their
+# configured test group); separate lanes are needed on one-CPU test hosts where a
+# single nextest process cannot overlap the clone stress test with lifecycle tests.
+# Standard helpers keep writing their per-fcvm debug logs, while each lane also
+# captures its complete nextest and cleanup transcript.
+CLONE_FLOOR_CLONE_FILTER := -E 'package(fcvm) & test(=test_snapshot_clone_stress_100_bridged)'
+CLONE_FLOOR_CH_FILTER := -E 'package(fcvm) & test(=test_cloud_hypervisor_cold_boot)'
+CLONE_FLOOR_HUGEPAGE_FILTER := -E 'package(fcvm) & (test(=test_hugepage_vm_boot) | test(=test_hugepage_cache_restore_uses_uffd) | test(=test_hugepage_snapshot_clone))'
+test-clone-floor-overlap: show-notes check-disk setup-fcvm setup-hugepages
+	@mkdir -p $(TEST_LOG_DIR)
+	@set -uo pipefail; \
+		run_lane() { \
+			lane="$$1"; filter="$$2"; \
+			$(MAKE) --no-print-directory _test-root STREAM=1 FILTER="$$filter" 2>&1 | \
+				tee "$(TEST_LOG_DIR)/clone-floor-overlap-$${lane}.log"; \
+		}; \
+		run_lane clones "$(CLONE_FLOOR_CLONE_FILTER)" & clones_job=$$!; \
+		run_lane cloud-hypervisor "$(CLONE_FLOOR_CH_FILTER)" & ch_job=$$!; \
+		run_lane hugepages "$(CLONE_FLOOR_HUGEPAGE_FILTER)" & hugepages_job=$$!; \
+		clones_rc=0; wait "$$clones_job" || clones_rc=$$?; \
+		ch_rc=0; wait "$$ch_job" || ch_rc=$$?; \
+		hugepages_rc=0; wait "$$hugepages_job" || hugepages_rc=$$?; \
+		echo "clone-floor overlap results: clones=$$clones_rc cloud-hypervisor=$$ch_rc hugepages=$$hugepages_rc"; \
+		test "$$clones_rc" -eq 0 -a "$$ch_rc" -eq 0 -a "$$hugepages_rc" -eq 0
 
 test-ci-infrastructure:
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_ci_infrastructure.py'

--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,7 @@ CONTAINER_RUN := $(CONTAINER_RUN_BASE) --ulimit nproc=65536:65536 --pids-limit=6
 	container-setup-fcvm container-shell container-clean container-bench \
 	cargo-target-link build-host-tools setup-btrfs setup-default setup-fcvm setup-pjdfstest setup-hugepages bench bench-vm bench-hugepages bench-hugepages-test \
 	bench-container-import bench-chromium bench-chromium-request analyze-chromium-request bench-clone-latency test-chromium-request \
+	bench-chromium-scale analyze-chromium-scale report-chromium-scale test-chromium-scale \
 	bench-quick bench-throughput bench-operations bench-protocol \
 	lint fmt update-dependency ssh test-serve-sdk
 
@@ -289,6 +290,10 @@ help:
 	@echo "  bench-chromium-request  Run the gated request benchmark (PHASE=, BACKEND=, REPS=, WARMUP=, RESULTS=)"
 	@echo "  analyze-chromium-request  Re-run publication gates for RESULTS=/path/to/run"
 	@echo "  test-chromium-request  Run the request benchmark's deterministic unit tests"
+	@echo "  bench-chromium-scale  Open-loop FILE/UFFD Chromium request scalability run"
+	@echo "  analyze-chromium-scale  Validate a scale run and write deterministic JSON"
+	@echo "  report-chromium-scale   Validate a scale run and write plain Markdown"
+	@echo "  test-chromium-scale  Run the scale harness's deterministic unit tests"
 	@echo "  bench-clone-latency  Clone spawn->exec-ready latency (LABEL=, N=)"
 	@echo ""
 	@echo "CI merge train (pooled CI for a batch of PRs, see docs/ci-train.md):"
@@ -688,6 +693,57 @@ analyze-chromium-request:
 test-chromium-request:
 	@python3 -m unittest discover -s bench/chromium -p 'test_reqbench.py' \
 		$(if $(FILTER),-k '$(FILTER)',)
+
+test-chromium-scale:
+	@python3 -m unittest discover -s bench/chromium -p 'test_reqscale.py' \
+		$(if $(FILTER),-k '$(FILTER)',)
+
+# Open-loop CDP-fast scalability and page-fault measurement. Unlike
+# `bench-chromium-request`, whose driver loops `for rep in range(...)` and so can
+# only ever measure a closed loop, this one launches on absolute deadlines and can
+# therefore hold an arrival RATE. It also interleaves FILE and UFFD inside each
+# rate interval rather than across separate runs, so the backend comparison is not
+# confounded with drift.
+#
+# Every cell and every publication gate is required: an accidental benchmark is
+# worse than no benchmark, so there are no defaults to fall back on.
+bench-chromium-scale: build
+	@test -n "$(SCALE_RATES)" || (echo "ERROR: SCALE_RATES required (for example 2,4,8)"; exit 1)
+	@test -n "$(SCALE_BURSTS)" || (echo "ERROR: SCALE_BURSTS required (must be at least 5)"; exit 1)
+	@test -n "$(SCALE_SEED)" || (echo "ERROR: SCALE_SEED required"; exit 1)
+	@test -n "$(SCALE_OUT)" || (echo "ERROR: SCALE_OUT required"; exit 1)
+	@test -n "$(SCALE_URL)" || (echo "ERROR: SCALE_URL required"; exit 1)
+	@test -n "$(SCALE_TAG)" || (echo "ERROR: SCALE_TAG required"; exit 1)
+	@test -n "$(SCALE_CONTROL_CHROMIUM)" || (echo "ERROR: SCALE_CONTROL_CHROMIUM required"; exit 1)
+	@test -n "$(SCALE_MAX_OFFERED_ERROR_PCT)" || (echo "ERROR: SCALE_MAX_OFFERED_ERROR_PCT required"; exit 1)
+	@test -n "$(SCALE_MIN_DEPARTURE_RATIO)" || (echo "ERROR: SCALE_MIN_DEPARTURE_RATIO required"; exit 1)
+	@test -n "$(SCALE_MAX_BACKLOG)" || (echo "ERROR: SCALE_MAX_BACKLOG required"; exit 1)
+	@test -n "$(SCALE_MAX_LAUNCH_LAG_MS)" || (echo "ERROR: SCALE_MAX_LAUNCH_LAG_MS required"; exit 1)
+	@test -n "$(SCALE_MAX_CONTROL_DRIFT_PCT)" || (echo "ERROR: SCALE_MAX_CONTROL_DRIFT_PCT required"; exit 1)
+	@echo "==> Running open-loop Chromium request scalability benchmark..."
+	sudo -E env RUST_LOG=fcvm=debug python3 bench/chromium/reqscale.py \
+		--fcvm ./target/release/fcvm --snapshot-tag "$(SCALE_TAG)" \
+		--url "$(SCALE_URL)" --rates "$(SCALE_RATES)" \
+		--bursts "$(SCALE_BURSTS)" --control-chromium "$(SCALE_CONTROL_CHROMIUM)" \
+		--max-offered-rps-error-pct "$(SCALE_MAX_OFFERED_ERROR_PCT)" \
+		--min-departure-ratio "$(SCALE_MIN_DEPARTURE_RATIO)" \
+		--max-score-end-backlog "$(SCALE_MAX_BACKLOG)" \
+		--max-p95-launch-lag-ms "$(SCALE_MAX_LAUNCH_LAG_MS)" \
+		--max-control-median-drift-pct "$(SCALE_MAX_CONTROL_DRIFT_PCT)" \
+		--seed "$(SCALE_SEED)" \
+		--out-dir "$(SCALE_OUT)" $(SCALE_TRACE_ARGS)
+
+analyze-chromium-scale:
+	@test -n "$(SCALE_RUN_DIR)" || (echo "ERROR: SCALE_RUN_DIR required"; exit 1)
+	@test -n "$(SCALE_ANALYSIS_JSON)" || (echo "ERROR: SCALE_ANALYSIS_JSON required"; exit 1)
+	python3 bench/chromium/reqscale_analyze.py \
+		--run-dir "$(SCALE_RUN_DIR)" --json-out "$(SCALE_ANALYSIS_JSON)"
+
+report-chromium-scale:
+	@test -n "$(SCALE_RUN_DIR)" || (echo "ERROR: SCALE_RUN_DIR required"; exit 1)
+	@test -n "$(SCALE_REPORT)" || (echo "ERROR: SCALE_REPORT required"; exit 1)
+	python3 bench/chromium/reqscale_analyze.py \
+		--run-dir "$(SCALE_RUN_DIR)" --markdown-out "$(SCALE_REPORT)"
 
 test-ci-infrastructure:
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_ci_infrastructure.py'

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ Run `fcvm --help` or `fcvm <command> --help` for full options.
 | `FCVM_NO_SNAPSHOT` | unset | `1` to disable snapshot creation (same as `--no-snapshot`) |
 | `FCVM_NO_WRITEBACK_CACHE` | unset | `1` to disable FUSE writeback cache |
 | `FCVM_SNAPSHOT_CONCURRENCY` | `10` | Max concurrent snapshot creations |
-| `FCVM_UFFD_MAX_CLONES` | `256` | Clones one `fcvm snapshot serve` will accept. They share that server's failure and fairness domain, so raising it widens the blast radius; splitting across a second serve process does not |
+| `FCVM_UFFD_MAX_CLONES` | `256` | Clones one `fcvm snapshot serve` will accept. They share that server's failure and fairness domain, so raising it widens the blast radius. Running two serve processes with half the clones each halves what one crashed or overloaded handler takes down |
 | `FCVM_CLOUD_HYPERVISOR_BIN` | unset | Path to `cloud-hypervisor` binary (falls back to PATH) |
 | `FCVM_FIRECRACKER_RESOLVE_TTL_SECS` | `3600` | How long a cached firecracker-fork resolution stays valid before a launch re-queries the remote; `0` forces a query every launch |
 | `RUST_LOG` | `warn` | Logging level (`info`, `debug` for verbose) |

--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ Run `fcvm --help` or `fcvm <command> --help` for full options.
 | `FCVM_NO_SNAPSHOT` | unset | `1` to disable snapshot creation (same as `--no-snapshot`) |
 | `FCVM_NO_WRITEBACK_CACHE` | unset | `1` to disable FUSE writeback cache |
 | `FCVM_SNAPSHOT_CONCURRENCY` | `10` | Max concurrent snapshot creations |
+| `FCVM_UFFD_MAX_CLONES` | `256` | Clones one `fcvm snapshot serve` will accept. They share that server's failure and fairness domain, so raising it widens the blast radius; splitting across a second serve process does not |
 | `FCVM_CLOUD_HYPERVISOR_BIN` | unset | Path to `cloud-hypervisor` binary (falls back to PATH) |
 | `FCVM_FIRECRACKER_RESOLVE_TTL_SECS` | `3600` | How long a cached firecracker-fork resolution stays valid before a launch re-queries the remote; `0` forces a query every launch |
 | `RUST_LOG` | `warn` | Logging level (`info`, `debug` for verbose) |

--- a/bench/chromium/AGENTS.md
+++ b/bench/chromium/AGENTS.md
@@ -369,10 +369,14 @@ to rootless for this reason.
 With no `--health-check` URL, fcvm's `Healthy` = container running AND podman's
 `HEALTHCHECK` healthy (`src/health.rs`, "AND logic"). So the image's HEALTHCHECK
 decides what gets frozen. `cdp_health.py` requires BOTH a warm marker (entry.sh
-touches it only after a full navigate+screenshot) AND a live CDP round trip that
-finds a page target. Healthy therefore means *provably able to screenshot*, not
-*port is open*. Caveat to verify: podman healthchecks need systemd timers in the
-guest; `src/health.rs` notes they can fail to schedule in some rootless setups.
+touches it only after a full navigate+screenshot and a loader-correlated
+`about:blank` lifecycle `load`; render.py then verifies `location.href` and
+`document.readyState == complete`) AND a live CDP round trip that finds a page
+target. The blank transition is fail-closed: its timeout is not best-effort, and
+entry.sh's `set -e` exits before publishing the marker. Healthy therefore means
+*warm, quiescent, and provably able to screenshot*, not *port is open*. Caveat to
+verify: podman healthchecks need systemd timers in the guest; `src/health.rs`
+notes they can fail to schedule in some rootless setups.
 
 ### Fast teardown: one signal, kernel-enforced — scope the guarantee, don't blanket it
 

--- a/bench/chromium/AGENTS.md
+++ b/bench/chromium/AGENTS.md
@@ -152,6 +152,17 @@ the egress proxy. The host side of any port is a `{uds_path}_{port}` Unix socket
 next to `vsock.sock` — the same `{uds_path}_{port}` convention for both Firecracker
 and Cloud Hypervisor.
 
+### UFFD queue depth is not observable today, and one `read(2)` per fault is why
+
+`drain_events` (`src/uffd/server.rs`) pulls faults with `uffd.read_event()`, which is
+one `read(2)` per message, inside a loop bounded by `MAX_EVENTS_PER_BATCH` (128). So
+the batch bound is the only depth signal available, and it cannot distinguish "128
+queued" from "10,000 queued" — a saturated server looks the same as a busy one. The
+userfaultfd crate's `read_events(EventBuffer)` fills a buffer in a single `read(2)`
+and returns how many messages came back, which both cuts the syscall count under load
+and makes true queue depth histogrammable. Worth doing when UFFD serving is next on
+the critical path; nothing in the tree measures it now.
+
 ### fc-agent's 2 s optimistic-accept fallback is a mio artifact, not a vsock law
 
 `fc-agent/src/vsock.rs::accept()` wakes every 2 s to retry a non-blocking `accept4`,

--- a/bench/chromium/AGENTS.md
+++ b/bench/chromium/AGENTS.md
@@ -556,6 +556,34 @@ this list now points at it rather than contradicting it.
 
 `REVIEW.md` is the ledger of what holds and what doesn't. **Update it every run.**
 
+## The fault harness refuses to report a number it cannot stand behind
+
+`faultbench.py` measures per-request page faults and `faultanalyze.py` reduces them.
+Both instruments attribute costs to a specific request, so each one has a rule about
+when it must report NOTHING rather than something plausible. A wrong number here is
+worse than a missing one, because it reads exactly like a real one and `agg` would
+average it in. `make test-chromium-fault` guards all four.
+
+- **An ambiguous UFFD trace attributes to neither request.** A trace is written when
+  its handler exits, so it trails `t1` by the clone's teardown, and its filename
+  carries the serve process's own connection counter, which nothing in the request
+  record maps to. With two candidates inside one window there is no identity to break
+  the tie, so `match_trace` returns None and stamps `trace_ambiguous`. Taking the
+  newest would hand a request the NEXT one's faults and corrupt counts, locality and
+  service time together. `agg` then reports a smaller `n`, which is the honest signal.
+- **A clone that outlives its request stops the run.** Serial isolation is what makes
+  attribution possible; a surviving clone keeps faulting and burning CPU while the next
+  request is measured. `require_clones_gone` raises rather than letting the run
+  continue, and the records already written stay valid.
+- **An output directory is used once.** `requests.jsonl` is appended to and traces are
+  matched by mtime, so reusing `--out` blends two runs, possibly taken with different
+  arguments, into one analysis. `require_fresh_out_dir` refuses anything non-empty.
+- **A parked CONTINUE is timed to its retry.** When `UFFDIO_CONTINUE` returns EAGAIN
+  the vCPU stays blocked, so `src/uffd/server.rs` keeps the trace interval open across
+  the park and closes it at the retry that actually resolved the fault. Closing it
+  around the failed ioctl would report the EAGAIN as the resolution cost, and these
+  intervals are read as exact ioctl service time.
+
 ## Deliverables
 
 The end product is a **readable markdown benchmark with inline visualizations**, in

--- a/bench/chromium/entry.sh
+++ b/bench/chromium/entry.sh
@@ -2,7 +2,8 @@
 # chromium-bench container entry: fixture pageserver + WARM headless Chromium.
 #
 # Sequence: start pageserver -> launch Chromium with CDP -> warm it (navigate a
-# fixture, screenshot once to heat the raster/encode path, park on about:blank)
+# fixture, screenshot once to heat the raster/encode path, prove the same loader
+# reached a complete about:blank document)
 # -> touch the ready file (which the container HEALTHCHECK gates on) -> print the
 # READY marker -> hold the browser open.
 #
@@ -217,10 +218,14 @@ echo "chromium-bench: warming renderer"
 python3 /opt/bench/render.py "http://127.0.0.1:$HTTP_PORT/warmup.html" \
     --out-prefix /tmp/warmup --then-blank
 
-# Warm marker. The container HEALTHCHECK (cdp_health.py) requires BOTH this file
-# AND a live CDP round trip that finds a page target, so fcvm's health gate — the
-# trigger for the golden snapshot — cannot fire on a browser that is merely
-# listening. "Healthy" therefore means "warm and provably able to screenshot".
+# Warm marker. render.py returns zero only after the about:blank navigation's
+# own loader emits lifecycle `load` and Runtime.evaluate confirms both
+# location.href=about:blank and readyState=complete. Because this script uses
+# `set -e`, any missing/incorrect blank transition exits before this touch. The
+# container HEALTHCHECK (cdp_health.py) then requires BOTH this file and a live
+# CDP round trip that finds a page target, so fcvm's health gate — the trigger
+# for the golden snapshot — cannot fire on a browser that is merely listening or
+# whose warmup document was not proven quiescent.
 touch "$READY_FILE"
 echo "CHROMIUM_BENCH_READY cdp=127.0.0.1:$CDP_PORT pages=http://127.0.0.1:$HTTP_PORT"
 

--- a/bench/chromium/faultanalyze.py
+++ b/bench/chromium/faultanalyze.py
@@ -123,6 +123,27 @@ def locality(offsets_in_order, granule):
     }
 
 
+# A trace is written when its handler EXITS, which trails the request's own t1 by the
+# clone's teardown. This is how much of that trailing edge still counts as "this request".
+TRACE_GRACE_S = 5.0
+
+
+def match_trace(traces, t0, t1):
+    """The one trace belonging to a request, as `(trace_file, ambiguous_names)`.
+
+    Exactly one candidate in the window is the answer. Zero is a request that produced
+    no trace. Two or more cannot be told apart: the name carries the serve process's own
+    connection counter, which nothing in the request record maps to, so there is no
+    identity to break the tie with. Returning None there costs one request's UFFD
+    numbers; guessing the newest would hand this request the NEXT one's faults and
+    corrupt counts, locality and service time together.
+    """
+    cands = [f for f in traces if t0 <= f.stat().st_mtime <= t1 + TRACE_GRACE_S]
+    if len(cands) == 1:
+        return cands[0], []
+    return None, [c.name for c in cands]
+
+
 def jaccard(a, b):
     if not a and not b:
         return 1.0
@@ -136,6 +157,7 @@ def stability(sets):
     js = [jaccard(sets[i], sets[j]) for i in range(len(sets)) for j in range(i + 1, len(sets))]
     inter = set.intersection(*sets)
     union = set.union(*sets)
+    mean_size = sum(len(s) for s in sets) / len(sets)
     cov, waste = [], []
     for i, s in enumerate(sets):
         others = set.union(*[t for j, t in enumerate(sets) if j != i])
@@ -149,7 +171,9 @@ def stability(sets):
         "jaccard_max": max(js),
         "core_size": len(inter),
         "union_size": len(union),
-        "core_frac_of_mean_set": len(inter) / (sum(len(s) for s in sets) / len(sets)),
+        # Every set can be empty (a trace with no faults), and a fraction of nothing
+        # is not zero, it is undefined.
+        "core_frac_of_mean_set": (len(inter) / mean_size) if mean_size else None,
         "loo_coverage_mean": sum(cov) / len(cov),
         "loo_coverage_min": min(cov),
         "loo_waste_mean": sum(waste) / len(waste),
@@ -237,12 +261,11 @@ def main():
             # silently attribute every later trace to the wrong run.
             tf = None
             if r["memarm"] == "uffd":
-                cands = [f for f in traces if r["t0"] <= f.stat().st_mtime <= r["t1"] + 5]
-                if len(cands) == 1:
-                    tf = cands[0]
-                elif cands:
-                    item["trace_ambiguous"] = [c.name for c in cands]
-                    tf = cands[-1]
+                # An ambiguous window reports nothing rather than a wrong number:
+                # `agg` skips the absent keys and reports the smaller `n`.
+                tf, ambiguous = match_trace(traces, r["t0"], r["t1"])
+                if ambiguous:
+                    item["trace_ambiguous"] = ambiguous
             if tf is not None:
                 tr = read_fault_trace(tf)
                 item["uffd_trace_file"] = tf.name

--- a/bench/chromium/faultanalyze.py
+++ b/bench/chromium/faultanalyze.py
@@ -144,6 +144,25 @@ def match_trace(traces, t0, t1):
     return None, [c.name for c in cands]
 
 
+def kvm_events_for_request(events, fc_tids):
+    """This request's kvm faults, as `(events, discarded)`.
+
+    ftrace runs host-wide with no pid filter, so any other Firecracker alive during
+    the window lands in the same dump and inflates every count derived from it. The
+    tracepoint fires in vCPU thread context, so its pid field is a TID: comparing it
+    against the firecracker PID would discard everything. `faultbench.py` records the
+    process's thread ids while the request runs, and that set is the filter.
+
+    Without a recorded tid set (a run from before this was captured) the events cannot
+    be attributed at all, so none are returned and every one is counted as discarded.
+    """
+    wanted = set(fc_tids or ())
+    if not wanted:
+        return [], len(events)
+    kept = [e for e in events if e[1] in wanted]
+    return kept, len(events) - len(kept)
+
+
 def jaccard(a, b):
     if not a and not b:
         return 1.0
@@ -304,8 +323,15 @@ def main():
                     item["serve_cpu_us_per_fault"] = item["serve_cpu_ms"] * 1000.0 / item["uffd_faults"]
 
             # --- instrument 4: kvm:kvm_guest_fault (exact, every backend)
-            if r.get("kvm_trace") and Path(r["kvm_trace"]).exists():
-                ev = read_kvm_trace(Path(r["kvm_trace"]))
+            lost = r.get("ftrace_lost_events")
+            if lost:
+                # A ring-buffer overrun truncates the fault set, so every count derived
+                # from it is a lower bound. Report the loss instead of the numbers.
+                item["kvm_trace_lossy"] = lost
+            elif r.get("kvm_trace") and Path(r["kvm_trace"]).exists():
+                ev, discarded = kvm_events_for_request(
+                    read_kvm_trace(Path(r["kvm_trace"])), r.get("fc_tids"))
+                item["kvm_events_other_pids"] = discarded
                 item["kvm_guest_faults"] = len(ev)
                 if ev:
                     ipas = [e[4] for e in ev]

--- a/bench/chromium/faultanalyze.py
+++ b/bench/chromium/faultanalyze.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Turn faultbench raw output into the five ground-truth numbers.
+
+  1. fault count (three instruments, each labelled with what it actually counts)
+  2. bytes faulted vs guest RAM  -> the real working set
+  3. per-fault cost              -> serve CPU / fault, and the in-handler ioctl time
+  4. locality                    -> run-length of the faulted SET, sequentiality of the ORDER
+  5. stability across clones     -> Jaccard, plus leave-one-out coverage/waste, which is
+                                    what a prefetcher would actually experience
+
+Reads: <out>/requests.jsonl, <out>/traces/<cell>/*.faults, <out>/traces/kvm/*.trace
+Writes: <out>/summary.json and a text report on stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics as stats
+import struct
+from collections import defaultdict
+from pathlib import Path
+
+PAGE = 4096
+CLK_TCK = 100  # kernel USER_HZ on aarch64 Linux
+
+
+# ---------------------------------------------------------------------------
+# parsers
+# ---------------------------------------------------------------------------
+
+
+def read_fault_trace(path: Path):
+    """[(file_offset, t_before_ns, t_after_ns)] from the in-handler UFFD trace."""
+    data = path.read_bytes()
+    n = len(data) // 24
+    out = []
+    for i in range(n):
+        off, t0, t1 = struct.unpack_from("<QQQ", data, i * 24)
+        out.append((off, t0, t1))
+    return out
+
+
+# firecracker names its vCPU threads "fc_vcpu 0" -- with a space -- so the comm field
+# must be matched non-greedily, not as \S+, or every vCPU fault line is silently dropped.
+KVM_RE = re.compile(
+    r"^\s*(.*?)-(\d+)\s+\[(\d+)\]\s+\S+\s+([\d.]+):\s+kvm_guest_fault:\s+ipa 0x([0-9a-f]+)")
+
+
+def read_kvm_trace(path: Path):
+    """[(comm, pid, cpu, ts, ipa)] from an ftrace text dump of kvm:kvm_guest_fault."""
+    out = []
+    with open(path, "r", errors="replace") as f:
+        for line in f:
+            if "kvm_guest_fault" not in line:
+                continue
+            m = KVM_RE.match(line)
+            if m:
+                out.append((m.group(1), int(m.group(2)), int(m.group(3)),
+                            float(m.group(4)), int(m.group(5), 16)))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# metrics
+# ---------------------------------------------------------------------------
+
+
+def runs_of(sorted_offsets, granule):
+    """Maximal runs of consecutive granules in a sorted offset list -> [run_len_in_granules]."""
+    if not sorted_offsets:
+        return []
+    runs, cur = [], 1
+    for a, b in zip(sorted_offsets, sorted_offsets[1:]):
+        if b == a + granule:
+            cur += 1
+        else:
+            runs.append(cur)
+            cur = 1
+    runs.append(cur)
+    return runs
+
+
+def locality(offsets_in_order, granule):
+    """Spatial clustering of the SET and sequentiality of the ORDER.
+
+    The two answer different questions. Run-length of the sorted set says how big a
+    fault-around window could be useful. Sequentiality of the temporal order says
+    whether a naive read-ahead-after-fault would hit anything.
+    """
+    uniq = sorted(set(offsets_in_order))
+    rl = runs_of(uniq, granule)
+    total = len(uniq)
+    if total == 0:
+        return {}
+
+    def frac_in_runs_at_least(k):
+        return sum(r for r in rl if r >= k) / total
+
+    fwd = near16 = 0
+    for a, b in zip(offsets_in_order, offsets_in_order[1:]):
+        d = b - a
+        if d == granule:
+            fwd += 1
+        if 0 < abs(d) <= 16 * granule:
+            near16 += 1
+    npairs = max(1, len(offsets_in_order) - 1)
+    return {
+        "unique_granules": total,
+        "runs": len(rl),
+        "run_len_mean": sum(rl) / len(rl),
+        "run_len_median": stats.median(rl),
+        "run_len_p90": sorted(rl)[int(0.9 * (len(rl) - 1))],
+        "run_len_max": max(rl),
+        "frac_in_runs_ge2": frac_in_runs_at_least(2),
+        "frac_in_runs_ge4": frac_in_runs_at_least(4),
+        "frac_in_runs_ge16": frac_in_runs_at_least(16),
+        "frac_in_runs_ge64": frac_in_runs_at_least(64),
+        "frac_in_runs_ge512": frac_in_runs_at_least(512),
+        "order_frac_next_is_plus1": fwd / npairs,
+        "order_frac_next_within_16": near16 / npairs,
+    }
+
+
+def jaccard(a, b):
+    if not a and not b:
+        return 1.0
+    return len(a & b) / len(a | b)
+
+
+def stability(sets):
+    """Pairwise Jaccard + the leave-one-out numbers a prefetcher would actually see."""
+    if len(sets) < 2:
+        return {}
+    js = [jaccard(sets[i], sets[j]) for i in range(len(sets)) for j in range(i + 1, len(sets))]
+    inter = set.intersection(*sets)
+    union = set.union(*sets)
+    cov, waste = [], []
+    for i, s in enumerate(sets):
+        others = set.union(*[t for j, t in enumerate(sets) if j != i])
+        cov.append(len(s & others) / max(1, len(s)))
+        waste.append(len(others - s) / max(1, len(others)))
+    return {
+        "n_runs": len(sets),
+        "set_sizes": [len(s) for s in sets],
+        "jaccard_mean": sum(js) / len(js),
+        "jaccard_min": min(js),
+        "jaccard_max": max(js),
+        "core_size": len(inter),
+        "union_size": len(union),
+        "core_frac_of_mean_set": len(inter) / (sum(len(s) for s in sets) / len(sets)),
+        "loo_coverage_mean": sum(cov) / len(cov),
+        "loo_coverage_min": min(cov),
+        "loo_waste_mean": sum(waste) / len(waste),
+    }
+
+
+def pct(xs, p):
+    if not xs:
+        return None
+    xs = sorted(xs)
+    return xs[min(len(xs) - 1, int(p / 100 * len(xs)))]
+
+
+# ---------------------------------------------------------------------------
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("out")
+    ap.add_argument("--include-warmup", action="store_true")
+    args = ap.parse_args()
+    out = Path(args.out)
+
+    recs = [json.loads(l) for l in open(out / "requests.jsonl")]
+    if not args.include_warmup:
+        recs = [r for r in recs if not r.get("warmup")]
+    recs = [r for r in recs if r.get("rc") == 0]
+
+    # UFFD traces are written per (serve_pid, vm_id) and the vm_ids increment per serve
+    # process, so bind them to requests by mtime order within a cell.
+    trace_by_cell = defaultdict(list)
+    for cell_dir in (out / "traces").iterdir() if (out / "traces").exists() else []:
+        if cell_dir.is_dir() and cell_dir.name != "kvm":
+            for f in sorted(cell_dir.glob("*.faults"), key=lambda p: p.stat().st_mtime):
+                trace_by_cell[cell_dir.name].append(f)
+
+    by_cell = defaultdict(list)
+    for r in recs:
+        by_cell[(r["cell"], r.get("page", "?"))].append(r)
+
+    summary = {}
+    for (cell, page), rs in sorted(by_cell.items()):
+        rs.sort(key=lambda r: r["t0"])
+        granule = rs[0].get("granule", PAGE)
+        guest_bytes = rs[0].get("guest_bytes", 2 << 30)
+        traces = trace_by_cell.get(cell, [])
+        # traces accumulate across pages within a cell; align by chronological order
+        entry = {"cell": cell, "page": page, "n": len(rs), "granule": granule,
+                 "guest_bytes": guest_bytes, "requests": []}
+
+        sets_uffd, sets_pm, sets_kvm = [], [], []
+        for idx, r in enumerate(rs):
+            item = {"name": r["name"], "wall_ms": r["wall_ms"], "rep": r.get("rep")}
+
+            # --- instrument 1: pagemap resident granules (works for every backend)
+            snap = r.get("hold_snapshot")
+            if snap and snap.get("pagemap"):
+                # Key pages as (vma_rank_by_start, granule_index). Host virtual addresses
+                # differ per clone, so an absolute address is not comparable between runs;
+                # the VMA layout of a given snapshot is, so its rank is a stable key.
+                present = set()
+                nres = 0
+                for vi, v in enumerate(sorted(snap["pagemap"], key=lambda x: x["start"])):
+                    for pidx in v["present"]:
+                        present.add((vi, (pidx * PAGE) // granule))
+                        nres += 1
+                item["pagemap_resident_4k"] = nres
+                item["pagemap_resident_bytes"] = nres * PAGE
+                item["pagemap_frac_of_guest"] = nres * PAGE / guest_bytes
+                item["pagemap_resident_granules"] = len(present)
+                sets_pm.append(present)
+                item["vma_total_bytes"] = sum(v["size"] for v in snap["vmas"])
+                item["vma_paths"] = [v["path"] for v in snap["vmas"]]
+
+            # --- instrument 2: min_flt on firecracker (guest RAM is NOT in here; see note)
+            ser = r.get("stat_series") or []
+            if ser:
+                item["fc_minflt_total"] = ser[-1][1] - ser[0][1]
+                item["fc_majflt_total"] = ser[-1][2] - ser[0][2]
+                item["fc_cpu_ms"] = ((ser[-1][3] + ser[-1][4]) - (ser[0][3] + ser[0][4])) * 1000.0 / CLK_TCK
+
+            # --- instrument 3: UFFD handler trace (exact, UFFD arms only)
+            # Bind the trace to the request by mtime falling inside the request window,
+            # not by position: one failed request would shift a positional mapping and
+            # silently attribute every later trace to the wrong run.
+            tf = None
+            if r["memarm"] == "uffd":
+                cands = [f for f in traces if r["t0"] <= f.stat().st_mtime <= r["t1"] + 5]
+                if len(cands) == 1:
+                    tf = cands[0]
+                elif cands:
+                    item["trace_ambiguous"] = [c.name for c in cands]
+                    tf = cands[-1]
+            if tf is not None:
+                tr = read_fault_trace(tf)
+                item["uffd_trace_file"] = tf.name
+                item["uffd_faults"] = len(tr)
+                item["uffd_bytes"] = len(tr) * granule
+                item["uffd_frac_of_guest"] = len(tr) * granule / guest_bytes
+                svc = [(t1 - t0) / 1000.0 for _, t0, t1 in tr]  # us, ioctl service time
+                if svc:
+                    item["uffd_ioctl_us_p50"] = pct(svc, 50)
+                    item["uffd_ioctl_us_p90"] = pct(svc, 90)
+                    item["uffd_ioctl_us_p99"] = pct(svc, 99)
+                    item["uffd_ioctl_us_mean"] = sum(svc) / len(svc)
+                    item["uffd_ioctl_us_total"] = sum(svc)
+                # The ioctl time is only the RESOLUTION. What the guest actually pays per
+                # fault is the whole round trip: vCPU traps -> kernel queues the event ->
+                # this process is woken through epoll -> read_event -> ioctl -> vCPU resumes.
+                # The gap between one fault's resolution and the next fault's arrival
+                # bounds the part the ioctl time does not see, and span/count is the
+                # end-to-end mean while the guest is fault-bound.
+                gaps = [(tr[i + 1][1] - tr[i][2]) / 1000.0 for i in range(len(tr) - 1)]
+                if gaps:
+                    item["uffd_interfault_us_p50"] = pct(gaps, 50)
+                    item["uffd_interfault_us_mean"] = sum(gaps) / len(gaps)
+                offs = [o for o, _, _ in tr]
+                item["locality"] = locality(offs, granule)
+                item["fault_span_ms"] = (tr[-1][2] - tr[0][1]) / 1e6 if tr else 0.0
+                if tr:
+                    item["uffd_wall_us_per_fault"] = item["fault_span_ms"] * 1000.0 / len(tr)
+                sets_uffd.append(set(offs))
+
+            # serve-process CPU attributable to this request (requests are serial)
+            sb, sa = r.get("serve_stat_before"), r.get("serve_stat_after")
+            if sb and sa:
+                item["serve_cpu_ms"] = ((sa[2] + sa[3]) - (sb[2] + sb[3])) * 1000.0 / CLK_TCK
+                if item.get("uffd_faults"):
+                    item["serve_cpu_us_per_fault"] = item["serve_cpu_ms"] * 1000.0 / item["uffd_faults"]
+
+            # --- instrument 4: kvm:kvm_guest_fault (exact, every backend)
+            if r.get("kvm_trace") and Path(r["kvm_trace"]).exists():
+                ev = read_kvm_trace(Path(r["kvm_trace"]))
+                item["kvm_guest_faults"] = len(ev)
+                if ev:
+                    ipas = [e[4] for e in ev]
+                    base = min(ipas)
+                    item["kvm_ipa_min"] = hex(base)
+                    item["kvm_ipa_max"] = hex(max(ipas))
+                    item["kvm_unique_4k"] = len({i // PAGE for i in ipas})
+                    item["kvm_unique_granule"] = len({i // granule for i in ipas})
+                    item["kvm_locality"] = locality([(i - base) // granule * granule for i in ipas], granule)
+                    sets_kvm.append({(i - base) // granule for i in ipas})
+                    item["kvm_bytes_unique_granule"] = item["kvm_unique_granule"] * granule
+                    item["kvm_frac_of_guest"] = item["kvm_bytes_unique_granule"] / guest_bytes
+
+            entry["requests"].append(item)
+
+        entry["stability_uffd_offsets"] = stability(sets_uffd) if len(sets_uffd) >= 2 else {}
+        entry["stability_pagemap"] = stability(sets_pm) if len(sets_pm) >= 2 else {}
+        entry["stability_kvm_ipa"] = stability(sets_kvm) if len(sets_kvm) >= 2 else {}
+
+        def agg(key):
+            vs = [i[key] for i in entry["requests"] if i.get(key) is not None]
+            if not vs:
+                return None
+            return {"mean": sum(vs) / len(vs), "min": min(vs), "max": max(vs),
+                    "median": stats.median(vs), "n": len(vs)}
+
+        entry["agg"] = {k: agg(k) for k in (
+            "wall_ms", "uffd_faults", "uffd_bytes", "uffd_frac_of_guest",
+            "uffd_ioctl_us_p50", "uffd_ioctl_us_mean", "uffd_ioctl_us_total",
+            "uffd_interfault_us_p50", "uffd_interfault_us_mean", "uffd_wall_us_per_fault",
+            "serve_cpu_ms", "serve_cpu_us_per_fault", "fault_span_ms",
+            "pagemap_resident_4k", "pagemap_resident_bytes", "pagemap_frac_of_guest",
+            "fc_minflt_total", "fc_majflt_total", "fc_cpu_ms",
+            "kvm_guest_faults", "kvm_unique_4k", "kvm_unique_granule", "kvm_frac_of_guest",
+        )}
+        summary[f"{cell}|{page}"] = entry
+
+    (out / "summary.json").write_text(json.dumps(summary, indent=2, default=str))
+
+    # ---- text report
+    print(f"\n{'cell':<18} {'page':<14} {'n':>3} {'wall ms':>9} {'uffd flt':>9} "
+          f"{'kvm flt':>9} {'pm 4k pg':>9} {'MiB in':>8} {'%RAM':>6} {'us/flt':>7} {'srv us/f':>9}")
+    print("-" * 120)
+    for k, e in summary.items():
+        a = e["agg"]
+
+        def g(name, f="{:.0f}"):
+            v = a.get(name)
+            return f.format(v["mean"]) if v else "-"
+
+        pm = a.get("pagemap_resident_bytes")
+        mib = f"{pm['mean']/1024/1024:.0f}" if pm else "-"
+        fr = a.get("pagemap_frac_of_guest")
+        frs = f"{fr['mean']*100:.1f}" if fr else "-"
+        print(f"{e['cell']:<18} {e['page']:<14} {e['n']:>3} {g('wall_ms'):>9} {g('uffd_faults'):>9} "
+              f"{g('kvm_guest_faults'):>9} {g('pagemap_resident_4k'):>9} {mib:>8} {frs:>6} "
+              f"{g('uffd_ioctl_us_p50','{:.1f}'):>7} {g('serve_cpu_us_per_fault','{:.1f}'):>9}")
+
+    print("\n=== stability across clones (same snapshot, repeated restores) ===")
+    for k, e in summary.items():
+        for label, st in (("uffd-offsets", e["stability_uffd_offsets"]),
+                          ("kvm-ipa", e["stability_kvm_ipa"]),
+                          ("pagemap", e["stability_pagemap"])):
+            if st:
+                print(f"{k:<28} {label:<13} n={st['n_runs']} jaccard={st['jaccard_mean']:.4f} "
+                      f"[{st['jaccard_min']:.4f}-{st['jaccard_max']:.4f}] "
+                      f"core={st['core_size']} union={st['union_size']} "
+                      f"loo_cov={st['loo_coverage_mean']:.4f} loo_waste={st['loo_waste_mean']:.4f}")
+
+    print("\n=== locality ===")
+    for k, e in summary.items():
+        for r in e["requests"][:1]:
+            for label in ("locality", "kvm_locality"):
+                L = r.get(label)
+                if L:
+                    print(f"{k:<28} {label:<13} uniq={L['unique_granules']} runs={L['runs']} "
+                          f"mean_run={L['run_len_mean']:.1f} p90={L['run_len_p90']} max={L['run_len_max']} "
+                          f"ge4={L['frac_in_runs_ge4']:.3f} ge16={L['frac_in_runs_ge16']:.3f} "
+                          f"ge64={L['frac_in_runs_ge64']:.3f} seq+1={L['order_frac_next_is_plus1']:.3f} "
+                          f"near16={L['order_frac_next_within_16']:.3f}")
+    print(f"\nsummary.json -> {out / 'summary.json'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/chromium/faultbench.py
+++ b/bench/chromium/faultbench.py
@@ -549,7 +549,8 @@ def stop_serve(proc, pid, tag=None, umode=None):
         time.sleep(0.2)
     if not serve_pid_for_pid_gone(pid):
         raise SystemExit(
-            f"[faultbench] serve pid {pid} is gone but /proc/{pid} remains after 10s"
+            f"[faultbench] serve pid {pid} was killed but /proc/{pid} still exists 10s "
+            f"later; something is holding the process"
         )
     if tag is not None and serve_pid_for(tag, umode) is not None:
         raise SystemExit(
@@ -825,13 +826,23 @@ def main():
             require_clones_gone(f"fb-{runid}", 120, f"{cell} {page} rep{i}")
             time.sleep(1.0)
     finally:
+        # Every step runs even if an earlier one fails, then the failures are
+        # reported together. Letting stop_serve's SystemExit propagate from here
+        # skipped the remaining serves, the load sampler, the host server and the
+        # ftrace instance, so one bad teardown leaked all of them.
+        teardown_errors = []
         for cell, (proc, pid, tag, umode) in serves.items():
-            stop_serve(proc, pid, tag, umode)
+            try:
+                stop_serve(proc, pid, tag, umode)
+            except SystemExit as error:
+                teardown_errors.append(f"{cell}: {error}")
         load_stop.set()
         load_sampler.join(timeout=5)
         srv.terminate()
         if args.ftrace:
             ftrace_teardown()
+        if teardown_errors:
+            raise SystemExit("[faultbench] teardown failed:\n  " + "\n  ".join(teardown_errors))
 
     print(f"[faultbench] done: {len(results)} requests -> {out}", flush=True)
 

--- a/bench/chromium/faultbench.py
+++ b/bench/chromium/faultbench.py
@@ -1,0 +1,616 @@
+#!/usr/bin/env python3
+"""Ground truth: how many guest page faults does one Chromium render request take,
+and what does each one cost, for every memory backend.
+
+This measures, per request, on a matched basis across all four backends:
+
+  1. FAULT COUNT
+       UFFD arms  : exact, from an in-handler trace (one record per UFFD event).
+       file arm   : `min_flt` delta on the firecracker process (kernel fault entries).
+       ALL arms   : resident-page count of the guest-RAM VMAs, read from
+                    /proc/<fc>/pagemap. This is the ONLY number that means the same
+                    thing for every backend ("granules materialised"), so it is the
+                    basis for the cross-backend comparison. For UFFD it must equal the
+                    handler's fault count; for file-backed it does NOT equal min_flt,
+                    and the ratio is the kernel's fault-around factor.
+  2. BYTES faulted in vs guest RAM size (the real working set).
+  3. PER-FAULT COST: serve-process CPU / fault count, plus the per-fault ioctl service
+     time straight out of the trace (t_after - t_before around the UFFDIO_*).
+  4. LOCALITY: every faulted offset is recorded, so runs/clustering are measurable.
+  5. STABILITY ACROSS CLONES: Jaccard over the faulted-offset sets of repeated clones
+     of the SAME snapshot -- the input that decides whether record-once-then-prefetch
+     is viable.
+
+Nothing here optimises anything. It establishes the numbers everything else rests on.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import signal
+import struct
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+# Overridable so this can run against an instrumented build in a separate target dir
+# without swapping the binary that a concurrently running bench.sh is invoking.
+FCVM = Path(os.environ.get("FCVM", REPO_ROOT / "target" / "release" / "fcvm"))
+STATE_DIR = Path("/mnt/fcvm-btrfs/state")
+SNAP_DIR = Path("/mnt/fcvm-btrfs/snapshots")
+
+PAGE = 4096
+HUGE = 2 * 1024 * 1024
+
+# ---------------------------------------------------------------------------
+# driver: reuse bench.sh's DRIVER_TEMPLATE verbatim so the workload measured here
+# is byte-identical to the workload whose 241/295/324/904 ms file-vs-UFFD gaps
+# motivated this measurement. Re-deriving it here would silently measure something
+# else.
+# ---------------------------------------------------------------------------
+
+
+def driver_template() -> str:
+    src = (SCRIPT_DIR / "bench.sh").read_text()
+    m = re.search(r"^DRIVER_TEMPLATE='(.*?)'\s*$", src, re.S | re.M)
+    if not m:
+        sys.exit("could not extract DRIVER_TEMPLATE from bench.sh")
+    return m.group(1)
+
+
+def build_driver(url: str, fmt: str, qual: int, hold: float) -> str:
+    host, port = re.match(r"https?://([^:/]+):(\d+)", url).groups()
+    code = driver_template()
+    for k, v in (
+        ("@PHOST@", host),
+        ("@PPORT@", port),
+        ("@URL@", url),
+        ("@FMT@", fmt),
+        ("@QUAL@", str(qual)),
+        ("@HOLD@", str(hold)),
+    ):
+        code = code.replace(k, v)
+    return "python3 -c '" + code + "'"
+
+
+# ---------------------------------------------------------------------------
+# /proc helpers
+# ---------------------------------------------------------------------------
+
+
+def proc_stat(pid: int):
+    """(min_flt, maj_flt, utime_ticks, stime_ticks) or None if the process is gone."""
+    try:
+        with open(f"/proc/{pid}/stat", "rb") as f:
+            data = f.read()
+    except OSError:
+        return None
+    # comm can contain spaces and ')' -- split after the LAST ')'
+    rest = data[data.rindex(b")") + 2 :].split()
+    # rest[0] is field 3 (state); min_flt is field 10 -> rest[7]
+    return (int(rest[7]), int(rest[9]), int(rest[11]), int(rest[12]))
+
+
+def read_maps(pid: int):
+    out = []
+    try:
+        with open(f"/proc/{pid}/maps") as f:
+            for line in f:
+                parts = line.split(maxsplit=5)
+                a, b = parts[0].split("-")
+                out.append(
+                    {
+                        "start": int(a, 16),
+                        "end": int(b, 16),
+                        "perms": parts[1],
+                        "path": parts[5].strip() if len(parts) > 5 else "",
+                    }
+                )
+    except OSError:
+        return []
+    return out
+
+
+def guest_ram_vmas(pid: int, want_bytes: int):
+    """The VMAs that hold guest RAM, for every backend.
+
+    file arm  : MAP_PRIVATE of <snap>/memory.bin
+    copy arm  : anonymous
+    minor arm : MAP_PRIVATE of a memfd (shmem or hugetlb)
+
+    Selected by size, not by name, so one rule covers all three. Firecracker may
+    split guest RAM into several regions; every large VMA is returned and the caller
+    checks the total against the configured guest RAM.
+    """
+    vmas = [v for v in read_maps(pid) if (v["end"] - v["start"]) >= 64 * 1024 * 1024]
+    vmas = [v for v in vmas if "memory.bin" in v["path"] or "memfd" in v["path"] or v["path"] == ""]
+    vmas.sort(key=lambda v: -(v["end"] - v["start"]))
+    keep, total = [], 0
+    for v in vmas:
+        if total >= want_bytes:
+            break
+        keep.append(v)
+        total += v["end"] - v["start"]
+    return keep
+
+
+def pagemap_resident(pid: int, vmas):
+    """Resident 4KiB page offsets per VMA, straight from /proc/<pid>/pagemap.
+
+    Bit 63 = present. PFNs are zeroed for unprivileged readers but the present bit
+    is not, which is all this needs. Works identically for file-backed, anonymous
+    and memfd mappings -- that is the point: it is the one comparable basis.
+    """
+    res = []
+    try:
+        fd = os.open(f"/proc/{pid}/pagemap", os.O_RDONLY)
+    except OSError:
+        return None
+    try:
+        for v in vmas:
+            npages = (v["end"] - v["start"]) // PAGE
+            os.lseek(fd, (v["start"] // PAGE) * 8, os.SEEK_SET)
+            buf = b""
+            remaining = npages * 8
+            while remaining > 0:
+                chunk = os.read(fd, min(remaining, 1 << 22))
+                if not chunk:
+                    break
+                buf += chunk
+                remaining -= len(chunk)
+            present = []
+            n = len(buf) // 8
+            for i, word in enumerate(struct.unpack_from(f"<{n}Q", buf)):
+                if word & (1 << 63):
+                    present.append(i)
+            res.append({"start": v["start"], "path": v["path"], "npages": npages, "present": present})
+    finally:
+        os.close(fd)
+    return res
+
+
+def smaps_rss(pid: int, vmas):
+    """Rss/Pss per selected VMA (bytes). Cross-check on pagemap."""
+    want = {v["start"] for v in vmas}
+    out = {}
+    try:
+        with open(f"/proc/{pid}/smaps") as f:
+            cur = None
+            for line in f:
+                if "-" in line.split()[0] and ":" not in line.split()[0]:
+                    start = int(line.split("-")[0], 16)
+                    cur = start if start in want else None
+                    if cur is not None:
+                        out[cur] = {}
+                elif cur is not None:
+                    k, _, v = line.partition(":")
+                    if k in ("Rss", "Pss", "Private_Dirty", "Shared_Clean", "Private_Clean"):
+                        out[cur][k] = int(v.split()[0]) * 1024
+    except OSError:
+        return {}
+    return out
+
+
+# ---------------------------------------------------------------------------
+# ftrace: kvm:kvm_guest_fault
+#
+# This is the ONE fault instrument that means the same thing for every backend.
+# `min_flt` does NOT work here: a guest memory access traps to KVM's
+# user_mem_abort(), which resolves the host page via get_user_pages(), and
+# mm_account_fault() skips accounting when regs == NULL (the GUP case). So guest
+# RAM faults never reach the firecracker process's min_flt counter. The arm64
+# tracepoint fires once per stage-2 abort and carries the faulting guest physical
+# address, which is exactly one "guest page fault" -- and exactly the event that,
+# on the UFFD arms, turns into a userspace round trip.
+# ---------------------------------------------------------------------------
+
+FTRACE = Path("/sys/kernel/tracing/instances/faultbench")
+
+
+def _sudo_write(path, value):
+    subprocess.run(["sudo", "sh", "-c", f"echo {value} > {path}"], check=True,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def ftrace_setup(bufsize_kb=8192):
+    subprocess.run(["sudo", "mkdir", "-p", str(FTRACE)], check=True)
+    _sudo_write(FTRACE / "tracing_on", 0)
+    _sudo_write(FTRACE / "buffer_size_kb", bufsize_kb)
+    _sudo_write(FTRACE / "events/kvm/kvm_guest_fault/enable", 1)
+    _sudo_write(FTRACE / "trace", "")
+
+
+def ftrace_teardown():
+    subprocess.run(["sudo", "sh", "-c",
+                    f"echo 0 > {FTRACE}/tracing_on; echo 0 > {FTRACE}/events/kvm/kvm_guest_fault/enable; "
+                    f"rmdir {FTRACE} 2>/dev/null || true"], check=False,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def ftrace_start():
+    _sudo_write(FTRACE / "trace", "")
+    _sudo_write(FTRACE / "tracing_on", 1)
+
+
+def ftrace_stop_dump(dest: Path):
+    _sudo_write(FTRACE / "tracing_on", 0)
+    with open(dest, "wb") as f:
+        subprocess.run(["sudo", "cat", str(FTRACE / "trace")], stdout=f, check=False)
+    # overflow check: a dropped event silently truncates the fault set, which would
+    # understate every downstream number. Surface it rather than average it away.
+    st = subprocess.run(["sudo", "cat", str(FTRACE / "per_cpu/cpu0/stats")],
+                        capture_output=True, text=True, check=False)
+    return st.stdout
+
+
+# ---------------------------------------------------------------------------
+# fcvm process discovery
+# ---------------------------------------------------------------------------
+
+
+def firecracker_pids():
+    out = set()
+    for d in os.listdir("/proc"):
+        if not d.isdigit():
+            continue
+        try:
+            with open(f"/proc/{d}/comm") as f:
+                if f.read().strip() == "firecracker":
+                    out.add(int(d))
+        except OSError:
+            pass
+    return out
+
+
+def serve_pid_for(tag: str):
+    for p in STATE_DIR.glob("*.json"):
+        try:
+            st = json.loads(p.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        cfg = st.get("config") or {}
+        if cfg.get("process_type") == "serve" and cfg.get("snapshot_name") == tag:
+            return st.get("pid")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# one request, fully instrumented
+# ---------------------------------------------------------------------------
+
+
+class Sampler(threading.Thread):
+    """Follows the clone's firecracker process for the life of the request.
+
+    High frequency on /proc/<fc>/stat (one small read -> min_flt/maj_flt/CPU), and
+    pagemap+smaps only at the hold point, where the render is finished and the
+    process is quiescent enough for a 4 MiB pagemap walk not to perturb anything.
+    """
+
+    def __init__(self, pre_pids, guest_bytes, hold_evt, stop_evt):
+        super().__init__(daemon=True)
+        self.pre_pids = pre_pids
+        self.guest_bytes = guest_bytes
+        self.hold_evt = hold_evt
+        self.stop_evt = stop_evt
+        self.fc_pid = None
+        self.series = []          # (t_wall, min_flt, maj_flt, utime, stime)
+        self.snapshot = None      # pagemap/smaps at hold
+        self.first_seen = None
+        self.last = None
+        self.error = None
+
+    def run(self):
+        try:
+            self._run()
+        except Exception as e:  # a sampler crash must not look like a clean measurement
+            self.error = repr(e)
+
+    def _run(self):
+        t_dead = time.time() + 120
+        while time.time() < t_dead and not self.stop_evt.is_set():
+            new = firecracker_pids() - self.pre_pids
+            if new:
+                self.fc_pid = sorted(new)[0]
+                self.first_seen = time.time()
+                break
+            time.sleep(0.001)
+        if self.fc_pid is None:
+            return
+
+        pid = self.fc_pid
+        took_snapshot = False
+        while not self.stop_evt.is_set():
+            st = proc_stat(pid)
+            if st is None:
+                break
+            self.series.append((time.time(), *st))
+            self.last = st
+            if self.hold_evt.is_set() and not took_snapshot:
+                # give the render a moment to settle, then take the one expensive read
+                time.sleep(0.25)
+                vmas = guest_ram_vmas(pid, self.guest_bytes)
+                pm = pagemap_resident(pid, vmas)
+                sm = smaps_rss(pid, vmas)
+                st2 = proc_stat(pid)
+                self.snapshot = {
+                    "t": time.time(),
+                    "vmas": [{"start": v["start"], "size": v["end"] - v["start"], "path": v["path"]} for v in vmas],
+                    "pagemap": pm,
+                    "smaps": {str(k): v for k, v in sm.items()},
+                    "stat_at_snapshot": st2,
+                }
+                took_snapshot = True
+            time.sleep(0.002)
+
+
+def run_request(*, cell, tag, memarm, umode, serve_pid, url, name, out_dir, hold,
+                fmt="jpeg", qual=80, guest_bytes=2 << 30, req_timeout=120, ftrace=False):
+    log_path = out_dir / "requests" / f"{name}.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    execcmd = build_driver(url, fmt, qual, hold)
+    src = ["--pid", str(serve_pid)] if memarm == "uffd" else ["--snapshot", tag]
+    cmd = [
+        "timeout", "-k", "10", str(req_timeout),
+        str(FCVM), "snapshot", "run", *src, "--name", name,
+        "--no-dirty-tracking", "--no-swap", "--exec", execcmd,
+    ]
+    env = dict(os.environ, RUST_LOG="fcvm=debug")
+
+    pre = firecracker_pids()
+    hold_evt, stop_evt = threading.Event(), threading.Event()
+    serve_before = proc_stat(serve_pid) if memarm == "uffd" else None
+    sampler = Sampler(pre, guest_bytes, hold_evt, stop_evt)
+    sampler.start()
+
+    if ftrace:
+        ftrace_start()
+    t0 = time.time()
+    lines = []
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                            text=True, bufsize=1, env=env)
+    marks = {}
+    with open(log_path, "w") as lf:
+        lf.write(f"{t0:.6f} BENCH_T0\n")
+        for line in proc.stdout:
+            ts = time.time()
+            lf.write(f"{ts:.6f} {line}")
+            lines.append((ts, line.rstrip("\n")))
+            for mk in ("BENCH_EXEC_UP", "BENCH_NET_UP", "RENDER_OK", "BENCH_HOLD_START"):
+                if mk in line and mk not in marks:
+                    marks[mk] = ts
+            if "BENCH_HOLD_START" in line:
+                hold_evt.set()
+        rc = proc.wait()
+    t1 = time.time()
+    stop_evt.set()
+    ftrace_stats = None
+    kvm_trace_path = None
+    if ftrace:
+        kvm_trace_path = out_dir / "traces" / "kvm" / f"{name}.trace"
+        kvm_trace_path.parent.mkdir(parents=True, exist_ok=True)
+        ftrace_stats = ftrace_stop_dump(kvm_trace_path)
+    sampler.join(timeout=10)
+    serve_after = proc_stat(serve_pid) if memarm == "uffd" else None
+
+    rec = {
+        "cell": cell, "name": name, "url": url, "memarm": memarm, "umode": umode,
+        "tag": tag, "hold_s": hold, "rc": rc,
+        "t0": t0, "t1": t1, "wall_ms": (t1 - t0) * 1000.0,
+        "marks": marks,
+        "fc_pid": sampler.fc_pid,
+        "fc_first_seen": sampler.first_seen,
+        "sampler_error": sampler.error,
+        "stat_series": sampler.series,
+        "hold_snapshot": sampler.snapshot,
+        "serve_pid": serve_pid if memarm == "uffd" else None,
+        "serve_stat_before": serve_before,
+        "serve_stat_after": serve_after,
+        "ftrace": bool(ftrace),
+        "kvm_trace": str(kvm_trace_path) if kvm_trace_path else None,
+        "ftrace_cpu0_stats": ftrace_stats,
+        "render_line": next((ln for _, ln in lines if ln.startswith("RENDER_OK")), None),
+    }
+    return rec
+
+
+# ---------------------------------------------------------------------------
+# serve lifecycle
+# ---------------------------------------------------------------------------
+
+
+def start_serve(tag, umode, trace_dir, log_dir):
+    args = [str(FCVM), "snapshot", "serve", tag]
+    if umode == "minor":
+        args += ["--uffd-mode", "minor"]
+    env = dict(os.environ, RUST_LOG="fcvm=debug", FCVM_UFFD_FAULT_TRACE=str(trace_dir))
+    log_dir.mkdir(parents=True, exist_ok=True)
+    lf = open(log_dir / f"serve-{tag}-{umode}.log", "w")
+    proc = subprocess.Popen(args, stdout=lf, stderr=subprocess.STDOUT, env=env)
+    t_dead = time.time() + 60
+    while time.time() < t_dead:
+        pid = serve_pid_for(tag)
+        if pid and Path(f"/proc/{pid}").exists():
+            return proc, pid
+        if proc.poll() is not None:
+            sys.exit(f"serve for {tag} ({umode}) exited early rc={proc.returncode}")
+        time.sleep(0.2)
+    sys.exit(f"serve for {tag} ({umode}) did not register in state")
+
+
+def stop_serve(proc, pid):
+    if proc is None:
+        return
+    try:
+        proc.send_signal(signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    t_dead = time.time() + 90
+    while time.time() < t_dead:
+        if proc.poll() is not None and serve_pid_for_pid_gone(pid):
+            return
+        time.sleep(0.2)
+    try:
+        proc.kill()
+    except ProcessLookupError:
+        pass
+
+
+def serve_pid_for_pid_gone(pid):
+    return not Path(f"/proc/{pid}").exists()
+
+
+def wait_clones_gone(prefix, timeout=120):
+    t_dead = time.time() + timeout
+    while time.time() < t_dead:
+        alive = 0
+        for p in STATE_DIR.glob("*.json"):
+            try:
+                st = json.loads(p.read_text())
+            except (OSError, json.JSONDecodeError):
+                continue
+            cfg = st.get("config") or {}
+            if cfg.get("process_type") == "clone" and (cfg.get("name") or "").startswith(prefix):
+                alive += 1
+        if alive == 0:
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def prewarm(tag):
+    """Pull memory.bin into the page cache so the file arm is measured warm.
+
+    Without this the file arm takes major faults off NVMe and the comparison
+    becomes 'page cache vs disk', not 'file-backed vs UFFD'.
+    """
+    p = SNAP_DIR / tag / "memory.bin"
+    try:
+        with open(p, "rb") as f:
+            while f.read(1 << 24):
+                pass
+    except OSError:
+        subprocess.run(["sudo", "sh", "-c", f"cat {p} > /dev/null"], check=False)
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+CELLS = {
+    # cell               (memarm, uffd mode, snapshot key, granule bytes)
+    "file-4k":          ("file", None,    "rootless", PAGE),
+    "uffd-4k-copy":     ("uffd", "copy",  "rootless", PAGE),
+    "uffd-4k-minor":    ("uffd", "minor", "rootless", PAGE),
+    "uffd-huge-minor":  ("uffd", "minor", "huge",     HUGE),
+    "uffd-huge-copy":   ("uffd", "copy",  "huge",     HUGE),
+}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--reps", type=int, default=6)
+    ap.add_argument("--warmup", type=int, default=2, help="discarded leading reps per cell")
+    ap.add_argument("--hold", type=float, default=3.0)
+    ap.add_argument("--page", default="medium.html")
+    ap.add_argument("--pages", default="", help="comma list of pages to sweep (overrides --page)")
+    ap.add_argument("--cells", default="file-4k,uffd-4k-copy,uffd-4k-minor,uffd-huge-minor")
+    ap.add_argument("--http-port", type=int, default=19578)
+    ap.add_argument("--guest-mib", type=int, default=2048)
+    ap.add_argument("--ftrace", action="store_true",
+                    help="capture kvm:kvm_guest_fault (exact per-backend fault events + IPAs). "
+                         "Perturbs latency, so run it as a SEPARATE pass from the timing pass.")
+    ap.add_argument("--label", default="", help="tag written into every record")
+    args = ap.parse_args()
+
+    out = Path(args.out)
+    (out / "requests").mkdir(parents=True, exist_ok=True)
+    (out / "traces").mkdir(parents=True, exist_ok=True)
+    (out / "logs").mkdir(parents=True, exist_ok=True)
+
+    host4 = subprocess.run(
+        "ip -4 route get 1.1.1.1 | grep -oP 'src \\K\\S+' | head -1",
+        shell=True, capture_output=True, text=True).stdout.strip()
+    srv = subprocess.Popen(
+        [sys.executable, str(SCRIPT_DIR / "hostserver.py"), "--root", str(SCRIPT_DIR / "pages"),
+         "--port", str(args.http_port)],
+        stdout=open(out / "logs" / "hostserver.log", "w"), stderr=subprocess.STDOUT)
+    time.sleep(1.0)
+
+    # golden snapshot tags, resolved the same way bench.sh does (content-addressed)
+    tags = {}
+    for d in SNAP_DIR.glob("cb-golden-*"):
+        if d.is_dir():
+            key = d.name.split("-")[2]
+            tags[key] = d.name
+
+    runid = time.strftime("%H%M%S")
+    results = []
+    pages = [p.strip() for p in args.pages.split(",") if p.strip()] or [args.page]
+    if args.ftrace:
+        ftrace_setup()
+
+    try:
+        for cell in [c.strip() for c in args.cells.split(",") if c.strip()]:
+            memarm, umode, snapkey, granule = CELLS[cell]
+            tag = tags.get(snapkey)
+            if not tag:
+                print(f"[faultbench] SKIP {cell}: no golden snapshot for {snapkey}", flush=True)
+                continue
+
+            trace_dir = out / "traces" / cell
+            trace_dir.mkdir(parents=True, exist_ok=True)
+            serve_proc = serve_pid = None
+            if memarm == "uffd":
+                serve_proc, serve_pid = start_serve(tag, umode, trace_dir, out / "logs")
+                print(f"[faultbench] {cell}: serve pid={serve_pid} tag={tag} mode={umode}", flush=True)
+            else:
+                prewarm(tag)
+                print(f"[faultbench] {cell}: file-backed, memory.bin prewarmed", flush=True)
+
+            for page in pages:
+                url = f"http://{host4}:{args.http_port}/{page}"
+                for i in range(1, args.reps + args.warmup + 1):
+                    name = f"fb-{runid}-{cell}-{page.split('.')[0]}-{i}"
+                    rec = run_request(
+                        cell=cell, tag=tag, memarm=memarm, umode=umode,
+                        serve_pid=serve_pid, url=url, name=name, out_dir=out,
+                        hold=args.hold, guest_bytes=args.guest_mib << 20,
+                        ftrace=args.ftrace)
+                    rec["rep"] = i
+                    rec["page"] = page
+                    rec["label"] = args.label
+                    rec["warmup"] = i <= args.warmup
+                    rec["granule"] = granule
+                    rec["guest_bytes"] = args.guest_mib << 20
+                    results.append(rec)
+                    with open(out / "requests.jsonl", "a") as f:
+                        f.write(json.dumps(rec) + "\n")
+                    print(f"[faultbench] {cell} {page} rep{i}{' (warmup)' if rec['warmup'] else ''}: "
+                          f"rc={rec['rc']} wall={rec['wall_ms']:.0f}ms fc_pid={rec['fc_pid']}", flush=True)
+                    wait_clones_gone(f"fb-{runid}", 120)
+                    time.sleep(1.0)
+
+            if memarm == "uffd":
+                stop_serve(serve_proc, serve_pid)
+    finally:
+        srv.terminate()
+        if args.ftrace:
+            ftrace_teardown()
+
+    print(f"[faultbench] done: {len(results)} requests -> {out}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/chromium/faultbench.py
+++ b/bench/chromium/faultbench.py
@@ -469,6 +469,37 @@ def serve_pid_for_pid_gone(pid):
     return not Path(f"/proc/{pid}").exists()
 
 
+def require_clones_gone(prefix, timeout_s, context):
+    """Stop the run if a clone outlived its request.
+
+    Serial isolation is what makes every later number attributable. A clone still up
+    keeps faulting and burning CPU while the NEXT request is measured, so its cost
+    lands on the wrong VM in both the per-request and the serve-CPU figures. The
+    records already written stay valid, which is why this stops rather than skips.
+    """
+    if not wait_clones_gone(prefix, timeout_s):
+        raise SystemExit(
+            f"[faultbench] clone cleanup for {prefix} did not finish within "
+            f"{timeout_s}s after {context}; refusing to measure the next request "
+            f"alongside a surviving clone"
+        )
+
+
+def require_fresh_out_dir(out):
+    """Refuse an output directory that already holds a run.
+
+    requests.jsonl is APPENDED to and traces are matched by mtime, so reusing a
+    directory blends two runs, possibly taken with different arguments, into one
+    analysis. Absent or empty is fine; anything already in it is not.
+    """
+    if out.exists() and any(out.iterdir()):
+        raise SystemExit(
+            f"[faultbench] --out {out} is not empty; a run appends to requests.jsonl "
+            f"and matches traces by mtime, so reusing it would blend two runs into one "
+            f"analysis. Name a fresh directory."
+        )
+
+
 def wait_clones_gone(prefix, timeout=120):
     t_dead = time.time() + timeout
     while time.time() < t_dead:
@@ -535,6 +566,7 @@ def main():
     args = ap.parse_args()
 
     out = Path(args.out)
+    require_fresh_out_dir(out)
     (out / "requests").mkdir(parents=True, exist_ok=True)
     (out / "traces").mkdir(parents=True, exist_ok=True)
     (out / "logs").mkdir(parents=True, exist_ok=True)
@@ -599,7 +631,7 @@ def main():
                         f.write(json.dumps(rec) + "\n")
                     print(f"[faultbench] {cell} {page} rep{i}{' (warmup)' if rec['warmup'] else ''}: "
                           f"rc={rec['rc']} wall={rec['wall_ms']:.0f}ms fc_pid={rec['fc_pid']}", flush=True)
-                    wait_clones_gone(f"fb-{runid}", 120)
+                    require_clones_gone(f"fb-{runid}", 120, f"{cell} {page} rep{i}")
                     time.sleep(1.0)
 
             if memarm == "uffd":

--- a/bench/chromium/faultbench.py
+++ b/bench/chromium/faultbench.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import random
 import re
 import shutil
 import signal
@@ -49,6 +50,10 @@ SNAP_DIR = Path("/mnt/fcvm-btrfs/snapshots")
 
 PAGE = 4096
 HUGE = 2 * 1024 * 1024
+
+# A busy host moves every latency number in the run, and the effect is invisible in
+# the results afterwards. One idle core's worth of background work is the ceiling.
+MAX_START_LOAD = 1.0
 
 # ---------------------------------------------------------------------------
 # driver: reuse bench.sh's DRIVER_TEMPLATE verbatim so the workload measured here
@@ -126,9 +131,11 @@ def guest_ram_vmas(pid: int, want_bytes: int):
     copy arm  : anonymous
     minor arm : MAP_PRIVATE of a memfd (shmem or hugetlb)
 
-    Selected by size, not by name, so one rule covers all three. Firecracker may
-    split guest RAM into several regions; every large VMA is returned and the caller
-    checks the total against the configured guest RAM.
+    Selected by size, not by name, so one rule covers all three. Firecracker may split
+    guest RAM into several regions, so every large VMA is returned; the caller records
+    the total and whether it matches the configured guest RAM
+    (`vma_total_matches_guest`), because a mismatch means this snapshot is not
+    comparable with the other arms.
     """
     vmas = [v for v in read_maps(pid) if (v["end"] - v["start"]) >= 64 * 1024 * 1024]
     vmas = [v for v in vmas if "memory.bin" in v["path"] or "memfd" in v["path"] or v["path"] == ""]
@@ -246,9 +253,31 @@ def ftrace_stop_dump(dest: Path):
         subprocess.run(["sudo", "cat", str(FTRACE / "trace")], stdout=f, check=False)
     # overflow check: a dropped event silently truncates the fault set, which would
     # understate every downstream number. Surface it rather than average it away.
-    st = subprocess.run(["sudo", "cat", str(FTRACE / "per_cpu/cpu0/stats")],
-                        capture_output=True, text=True, check=False)
-    return st.stdout
+    # Every CPU has its own ring buffer and guest faults arrive on the vCPU threads,
+    # which are not pinned to cpu0. Reading cpu0 alone reports "no drops" while another
+    # CPU's buffer overran, which silently truncates the fault set.
+    st = subprocess.run(
+        ["sudo", "sh", "-c",
+         f'for s in {FTRACE}/per_cpu/cpu*/stats; do echo "== $s"; cat "$s"; done'],
+        capture_output=True, text=True, check=False)
+    return {"raw": st.stdout, "lost": ftrace_lost_events(st.stdout)}
+
+
+def ftrace_lost_events(stats_text):
+    """Total `overrun` + `dropped events` across every CPU's ring buffer.
+
+    Non-zero means the fault set is incomplete, so every count derived from it is a
+    lower bound rather than a measurement.
+    """
+    lost = 0
+    for line in stats_text.splitlines():
+        key, _, value = line.partition(":")
+        if key.strip() in ("overrun", "dropped events"):
+            try:
+                lost += int(value.strip())
+            except ValueError:
+                continue
+    return lost
 
 
 # ---------------------------------------------------------------------------
@@ -270,14 +299,24 @@ def firecracker_pids():
     return out
 
 
-def serve_pid_for(tag: str):
+def serve_pid_for(tag: str, umode: str):
+    """The pid of the serve for this tag AND this UFFD mode.
+
+    The tag alone is not an identity: the same snapshot is served in both `copy` and
+    `minor` mode, and matching on the tag would return whichever serve happened to be
+    running. The harness would then sample serve CPU on a process it did not start and
+    later signal it, so both the measurement and the teardown would land on a stranger.
+    `uffd_mode` is written into the serve's own state entry by `snapshot serve`.
+    """
     for p in STATE_DIR.glob("*.json"):
         try:
             st = json.loads(p.read_text())
         except (OSError, json.JSONDecodeError):
             continue
         cfg = st.get("config") or {}
-        if cfg.get("process_type") == "serve" and cfg.get("snapshot_name") == tag:
+        if (cfg.get("process_type") == "serve"
+                and cfg.get("snapshot_name") == tag
+                and (cfg.get("uffd_mode") or "copy") == umode):
             return st.get("pid")
     return None
 
@@ -304,6 +343,11 @@ class Sampler(threading.Thread):
         self.fc_pid = None
         self.series = []          # (t_wall, min_flt, maj_flt, utime, stime)
         self.snapshot = None      # pagemap/smaps at hold
+        # Every thread this firecracker ran during the request. kvm:kvm_guest_fault is
+        # emitted in vCPU thread context, so its ftrace pid is a TID, not the process
+        # id: without this set the analyzer cannot tell this VM's faults from another
+        # VM's in a host-wide trace.
+        self.fc_tids = set()
         self.first_seen = None
         self.last = None
         self.error = None
@@ -332,6 +376,10 @@ class Sampler(threading.Thread):
             st = proc_stat(pid)
             if st is None:
                 break
+            try:
+                self.fc_tids.update(int(t) for t in os.listdir(f"/proc/{pid}/task"))
+            except OSError:
+                pass  # the process exited between the stat and the task listing
             self.series.append((time.time(), *st))
             self.last = st
             if self.hold_evt.is_set() and not took_snapshot:
@@ -341,8 +389,15 @@ class Sampler(threading.Thread):
                 pm = pagemap_resident(pid, vmas)
                 sm = smaps_rss(pid, vmas)
                 st2 = proc_stat(pid)
+                # The selector takes any anonymous VMA of 64 MiB or more, so a large
+                # non-guest mapping can displace a real guest-RAM region. When the
+                # total does not match, pagemap and smaps are measuring a different
+                # accounting base than the other arms and must not be compared.
+                vma_total = sum(v["end"] - v["start"] for v in vmas)
                 self.snapshot = {
                     "t": time.time(),
+                    "vma_total_bytes": vma_total,
+                    "vma_total_matches_guest": vma_total == self.guest_bytes,
                     "vmas": [{"start": v["start"], "size": v["end"] - v["start"], "path": v["path"]} for v in vmas],
                     "pagemap": pm,
                     "smaps": {str(k): v for k, v in sm.items()},
@@ -408,6 +463,7 @@ def run_request(*, cell, tag, memarm, umode, serve_pid, url, name, out_dir, hold
         "t0": t0, "t1": t1, "wall_ms": (t1 - t0) * 1000.0,
         "marks": marks,
         "fc_pid": sampler.fc_pid,
+        "fc_tids": sorted(sampler.fc_tids),
         "fc_first_seen": sampler.first_seen,
         "sampler_error": sampler.error,
         "stat_series": sampler.series,
@@ -417,7 +473,8 @@ def run_request(*, cell, tag, memarm, umode, serve_pid, url, name, out_dir, hold
         "serve_stat_after": serve_after,
         "ftrace": bool(ftrace),
         "kvm_trace": str(kvm_trace_path) if kvm_trace_path else None,
-        "ftrace_cpu0_stats": ftrace_stats,
+        "ftrace_stats": ftrace_stats,
+        "ftrace_lost_events": (ftrace_stats or {}).get("lost"),
         "render_line": next((ln for _, ln in lines if ln.startswith("RENDER_OK")), None),
     }
     return rec
@@ -438,16 +495,32 @@ def start_serve(tag, umode, trace_dir, log_dir):
     proc = subprocess.Popen(args, stdout=lf, stderr=subprocess.STDOUT, env=env)
     t_dead = time.time() + 60
     while time.time() < t_dead:
-        pid = serve_pid_for(tag)
-        if pid and Path(f"/proc/{pid}").exists():
+        pid = serve_pid_for(tag, umode)
+        # Only the process this call spawned may be measured or signalled later.
+        if pid == proc.pid and Path(f"/proc/{pid}").exists():
             return proc, pid
+        if pid is not None and pid != proc.pid:
+            proc.kill()
+            proc.wait()
+            sys.exit(
+                f"serve for {tag} ({umode}) is already running as pid {pid}; this run "
+                f"spawned {proc.pid} and will not measure or signal a process it does "
+                f"not own"
+            )
         if proc.poll() is not None:
             sys.exit(f"serve for {tag} ({umode}) exited early rc={proc.returncode}")
         time.sleep(0.2)
     sys.exit(f"serve for {tag} ({umode}) did not register in state")
 
 
-def stop_serve(proc, pid):
+def stop_serve(proc, pid, tag=None, umode=None):
+    """Stop a serve and prove it is gone: process reaped, state entry removed.
+
+    A serve that outlives its cell keeps its UFFD socket and state entry, so the next
+    cell's `start_serve` can bind to it and measure the wrong process. Returning
+    silently after a `kill()` that was never reaped leaves a zombie holding the state
+    entry, which looks exactly like a live serve to `serve_pid_for`.
+    """
     if proc is None:
         return
     try:
@@ -463,6 +536,26 @@ def stop_serve(proc, pid):
         proc.kill()
     except ProcessLookupError:
         pass
+    # SIGKILL is not instant and an unreaped corpse still owns its pid.
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        raise SystemExit(
+            f"[faultbench] serve pid {pid} did not die within 10s of SIGKILL; refusing "
+            f"to continue with a serve still holding its UFFD socket"
+        )
+    t_dead = time.time() + 10
+    while time.time() < t_dead and not serve_pid_for_pid_gone(pid):
+        time.sleep(0.2)
+    if not serve_pid_for_pid_gone(pid):
+        raise SystemExit(
+            f"[faultbench] serve pid {pid} is gone but /proc/{pid} remains after 10s"
+        )
+    if tag is not None and serve_pid_for(tag, umode) is not None:
+        raise SystemExit(
+            f"[faultbench] serve state entry for {tag} ({umode}) outlived pid {pid}; a "
+            f"later cell would bind to a serve this run already stopped"
+        )
 
 
 def serve_pid_for_pid_gone(pid):
@@ -518,6 +611,73 @@ def wait_clones_gone(prefix, timeout=120):
     return False
 
 
+def build_schedule(cells, pages, reps, warmup, seed):
+    """The (cell, page, rep) request list, shuffled from a recorded seed.
+
+    Walking cells in argument order attributes any host drift during the run entirely
+    to whichever cell ran last, which is indistinguishable from a real difference
+    between the arms. Shuffling spreads drift across all of them.
+
+    Warmups stay in front, and in cell order: they exist to reach steady state, and
+    interleaving them would leave a cell measured before it is warm.
+    """
+    warm = [(c, p, i, True)
+            for c in cells for p in pages for i in range(1, warmup + 1)]
+    measured = [(c, p, warmup + i, False)
+                for c in cells for p in pages for i in range(1, reps + 1)]
+    random.Random(seed).shuffle(measured)
+    return warm + measured
+
+
+def host_precheck(expected_firecrackers=0):
+    """Refuse to start on a host that is already busy or already running VMs.
+
+    A foreign Firecracker competes for CPU and shows up in a host-wide ftrace dump;
+    background load moves every latency number. Both are invisible after the fact,
+    which is why this runs before the first request rather than being reported with
+    the results.
+    """
+    load1 = os.getloadavg()[0]
+    foreign = firecracker_pids()
+    info = {"loadavg_1m": load1, "firecracker_pids": sorted(foreign),
+            "uptime_s": float(Path("/proc/uptime").read_text().split()[0])}
+    if len(foreign) > expected_firecrackers:
+        raise SystemExit(
+            f"[faultbench] {len(foreign)} firecracker processes already running "
+            f"({sorted(foreign)}); they would compete for CPU and pollute the host-wide "
+            f"ftrace dump. Stop them first."
+        )
+    if load1 > MAX_START_LOAD:
+        raise SystemExit(
+            f"[faultbench] 1-minute load average is {load1:.2f}, above {MAX_START_LOAD}; "
+            f"every latency number would be measuring the other workload too"
+        )
+    return info
+
+
+class LoadSampler(threading.Thread):
+    """Append /proc/loadavg to samples/loadavg.jsonl for the life of the run.
+
+    Drift that a precheck cannot see is only detectable against a continuous record.
+    """
+
+    def __init__(self, dest: Path, stop_evt, period_s=1.0):
+        super().__init__(daemon=True)
+        self.dest = dest
+        self.stop_evt = stop_evt
+        self.period_s = period_s
+
+    def run(self):
+        self.dest.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.dest, "a") as f:
+            while not self.stop_evt.is_set():
+                one, five, fifteen = os.getloadavg()
+                f.write(json.dumps({"t": time.time(), "load1": one, "load5": five,
+                                    "load15": fifteen}) + "\n")
+                f.flush()
+                self.stop_evt.wait(self.period_s)
+
+
 def prewarm(tag):
     """Pull memory.bin into the page cache so the file arm is measured warm.
 
@@ -563,6 +723,9 @@ def main():
                     help="capture kvm:kvm_guest_fault (exact per-backend fault events + IPAs). "
                          "Perturbs latency, so run it as a SEPARATE pass from the timing pass.")
     ap.add_argument("--label", default="", help="tag written into every record")
+    ap.add_argument("--seed", type=int, default=None,
+                    help="request-order shuffle seed; recorded in run.json and in every "
+                         "record so a run can be replayed in the same order")
     args = ap.parse_args()
 
     out = Path(args.out)
@@ -590,53 +753,82 @@ def main():
     runid = time.strftime("%H%M%S")
     results = []
     pages = [p.strip() for p in args.pages.split(",") if p.strip()] or [args.page]
+    # The seed is recorded, so a suspicious run can be replayed in the same order.
+    seed = args.seed if args.seed is not None else int(time.time())
+    cells = [c.strip() for c in args.cells.split(",") if c.strip()]
+    unknown = [c for c in cells if c not in CELLS]
+    if unknown:
+        raise SystemExit(f"[faultbench] unknown cells {unknown}; known: {sorted(CELLS)}")
+    for c in [c for c in cells if not tags.get(CELLS[c][2])]:
+        print(f"[faultbench] SKIP {c}: no golden snapshot for {CELLS[c][2]}", flush=True)
+    cells = [c for c in cells if tags.get(CELLS[c][2])]
+    if not cells:
+        raise SystemExit("[faultbench] no cell has a golden snapshot; nothing to measure")
+
+    precheck = host_precheck()
+    print(f"[faultbench] host at start: load1={precheck['loadavg_1m']:.2f} "
+          f"firecrackers={len(precheck['firecracker_pids'])}", flush=True)
+    (out / "run.json").write_text(json.dumps({
+        "runid": runid, "seed": seed, "cells": cells, "pages": pages,
+        "reps": args.reps, "warmup": args.warmup, "label": args.label,
+        "precheck": precheck,
+    }, indent=2))
+
+    load_stop = threading.Event()
+    load_sampler = LoadSampler(out / "samples" / "loadavg.jsonl", load_stop)
+    load_sampler.start()
     if args.ftrace:
         ftrace_setup()
 
+    # Every serve is started up front and torn down on the way out, whatever happens in
+    # between: the schedule interleaves cells, and an exception between start and stop
+    # used to leave the serve, its trace directory and its state entry behind.
+    serves = {}
     try:
-        for cell in [c.strip() for c in args.cells.split(",") if c.strip()]:
+        for cell in cells:
             memarm, umode, snapkey, granule = CELLS[cell]
-            tag = tags.get(snapkey)
-            if not tag:
-                print(f"[faultbench] SKIP {cell}: no golden snapshot for {snapkey}", flush=True)
-                continue
-
+            tag = tags[snapkey]
             trace_dir = out / "traces" / cell
             trace_dir.mkdir(parents=True, exist_ok=True)
-            serve_proc = serve_pid = None
             if memarm == "uffd":
-                serve_proc, serve_pid = start_serve(tag, umode, trace_dir, out / "logs")
-                print(f"[faultbench] {cell}: serve pid={serve_pid} tag={tag} mode={umode}", flush=True)
+                proc, pid = start_serve(tag, umode, trace_dir, out / "logs")
+                serves[cell] = (proc, pid, tag, umode)
+                print(f"[faultbench] {cell}: serve pid={pid} tag={tag} mode={umode}", flush=True)
             else:
                 prewarm(tag)
                 print(f"[faultbench] {cell}: file-backed, memory.bin prewarmed", flush=True)
 
-            for page in pages:
-                url = f"http://{host4}:{args.http_port}/{page}"
-                for i in range(1, args.reps + args.warmup + 1):
-                    name = f"fb-{runid}-{cell}-{page.split('.')[0]}-{i}"
-                    rec = run_request(
-                        cell=cell, tag=tag, memarm=memarm, umode=umode,
-                        serve_pid=serve_pid, url=url, name=name, out_dir=out,
-                        hold=args.hold, guest_bytes=args.guest_mib << 20,
-                        ftrace=args.ftrace)
-                    rec["rep"] = i
-                    rec["page"] = page
-                    rec["label"] = args.label
-                    rec["warmup"] = i <= args.warmup
-                    rec["granule"] = granule
-                    rec["guest_bytes"] = args.guest_mib << 20
-                    results.append(rec)
-                    with open(out / "requests.jsonl", "a") as f:
-                        f.write(json.dumps(rec) + "\n")
-                    print(f"[faultbench] {cell} {page} rep{i}{' (warmup)' if rec['warmup'] else ''}: "
-                          f"rc={rec['rc']} wall={rec['wall_ms']:.0f}ms fc_pid={rec['fc_pid']}", flush=True)
-                    require_clones_gone(f"fb-{runid}", 120, f"{cell} {page} rep{i}")
-                    time.sleep(1.0)
-
-            if memarm == "uffd":
-                stop_serve(serve_proc, serve_pid)
+        schedule = build_schedule(cells, pages, args.reps, args.warmup, seed)
+        for cell, page, i, is_warmup in schedule:
+            memarm, umode, snapkey, granule = CELLS[cell]
+            tag = tags[snapkey]
+            serve_pid = serves.get(cell, (None, None, None, None))[1]
+            url = f"http://{host4}:{args.http_port}/{page}"
+            name = f"fb-{runid}-{cell}-{page.split('.')[0]}-{i}"
+            rec = run_request(
+                cell=cell, tag=tag, memarm=memarm, umode=umode,
+                serve_pid=serve_pid, url=url, name=name, out_dir=out,
+                hold=args.hold, guest_bytes=args.guest_mib << 20,
+                ftrace=args.ftrace)
+            rec["rep"] = i
+            rec["page"] = page
+            rec["label"] = args.label
+            rec["warmup"] = is_warmup
+            rec["granule"] = granule
+            rec["guest_bytes"] = args.guest_mib << 20
+            rec["seed"] = seed
+            results.append(rec)
+            with open(out / "requests.jsonl", "a") as f:
+                f.write(json.dumps(rec) + "\n")
+            print(f"[faultbench] {cell} {page} rep{i}{' (warmup)' if is_warmup else ''}: "
+                  f"rc={rec['rc']} wall={rec['wall_ms']:.0f}ms fc_pid={rec['fc_pid']}", flush=True)
+            require_clones_gone(f"fb-{runid}", 120, f"{cell} {page} rep{i}")
+            time.sleep(1.0)
     finally:
+        for cell, (proc, pid, tag, umode) in serves.items():
+            stop_serve(proc, pid, tag, umode)
+        load_stop.set()
+        load_sampler.join(timeout=5)
         srv.terminate()
         if args.ftrace:
             ftrace_teardown()

--- a/bench/chromium/faulttrace.bt
+++ b/bench/chromium/faulttrace.bt
@@ -1,0 +1,59 @@
+/*
+ * Per-process handle_mm_fault latency for the FILE and UFFD reqscale cgroups.
+ *
+ * reqscale.py replaces both cgroup paths and __HARNESS_PID__ before invoking
+ * bpftrace. The harness brackets the ready-to-artifact interval with two
+ * harmless kill(firecracker_pid, 0) probes. Only signal-0 calls made by this
+ * exact harness tgid toggle a target, so ordinary liveness probes elsewhere
+ * cannot open or close a measurement interval.
+ *
+ * Maps are keyed by Firecracker tgid (`pid` in bpftrace), then joined to the
+ * exact pid/start-time recorded for each request. This deliberately counts all
+ * Firecracker-process VMAs; it is not a guest-RAM-VMA or UFFD-event metric.
+ * opened == closed == 1 and entered == completed are publication gates.
+ */
+
+BEGIN
+{
+    printf("REQSCALE_TRACE_READY\n");
+}
+
+tracepoint:syscalls:sys_enter_kill
+/pid == __HARNESS_PID__ && args->sig == 0/
+{
+    if (@active[args->pid]) {
+        @closed[args->pid] = count();
+        delete(@active[args->pid]);
+    } else {
+        @active[args->pid] = 1;
+        @opened[args->pid] = count();
+    }
+}
+
+kprobe:handle_mm_fault
+/(cgroup == cgroupid("__FILE_CGROUP_PATH__") ||
+  cgroup == cgroupid("__UFFD_CGROUP_PATH__")) && @active[pid]/
+{
+    @started_ns[tid] = nsecs;
+    @started_pid[tid] = pid;
+    @entered[pid] = count();
+}
+
+kretprobe:handle_mm_fault
+/@started_ns[tid]/
+{
+    $elapsed = nsecs - @started_ns[tid];
+    $process = @started_pid[tid];
+    @completed[$process] = count();
+    @total_ns[$process] = sum($elapsed);
+    @latency_ns[$process] = hist($elapsed);
+    delete(@started_ns[tid]);
+    delete(@started_pid[tid]);
+}
+
+END
+{
+    clear(@active);
+    clear(@started_ns);
+    clear(@started_pid);
+}

--- a/bench/chromium/guardexec.py
+++ b/bench/chromium/guardexec.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Enter one cgroup, arm parent-death, and replace this process.
+
+The expected parent PID is supplied before ``fork()``.  Checking it on both
+sides of ``PR_SET_PDEATHSIG`` closes the usual parent-exits-before-prctl race:
+the child either observes its original parent, or exits without executing the
+workload.  ``execvpe`` preserves the PID, so state files and pidfds still name
+the real fcvm/bpftrace/Chromium process rather than a wrapper.
+"""
+
+import argparse
+import ctypes
+import os
+import signal
+import sys
+
+
+PR_SET_PDEATHSIG = 1
+
+
+def arm_parent_death(expected_parent: int) -> None:
+    if expected_parent <= 1:
+        raise RuntimeError("expected parent PID must be greater than 1")
+    if os.getppid() != expected_parent:
+        raise RuntimeError(
+            f"parent changed before PR_SET_PDEATHSIG: expected {expected_parent}, "
+            f"found {os.getppid()}"
+        )
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.prctl(PR_SET_PDEATHSIG, signal.SIGKILL, 0, 0, 0) != 0:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
+    if os.getppid() != expected_parent:
+        raise RuntimeError(
+            f"parent changed while arming PR_SET_PDEATHSIG: expected {expected_parent}, "
+            f"found {os.getppid()}"
+        )
+
+
+def enter_cgroup(cgroup_procs: str) -> None:
+    if not os.path.isabs(cgroup_procs) or os.path.basename(cgroup_procs) != "cgroup.procs":
+        raise RuntimeError(f"unsafe cgroup.procs path: {cgroup_procs!r}")
+    with open(cgroup_procs, "w") as stream:
+        stream.write(f"{os.getpid()}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--expected-parent", required=True, type=int)
+    parser.add_argument("--cgroup-procs", required=True)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    command = list(args.command)
+    if command[:1] == ["--"]:
+        command.pop(0)
+    if not command:
+        parser.error("a command is required after --")
+
+    try:
+        arm_parent_death(args.expected_parent)
+        enter_cgroup(args.cgroup_procs)
+        if os.getppid() != args.expected_parent:
+            raise RuntimeError(
+                f"parent changed before exec: expected {args.expected_parent}, "
+                f"found {os.getppid()}"
+            )
+        os.execvpe(command[0], command, os.environ)
+    except (OSError, RuntimeError) as error:
+        print(f"guardexec: {type(error).__name__}: {error}", file=sys.stderr)
+        return 125
+    return 125
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/chromium/guardsupervise.py
+++ b/bench/chromium/guardsupervise.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Supervise a third-party process tree with parent-death cgroup cleanup.
+
+Unlike guardexec, this wrapper remains alive because Chromium creates process
+hops we cannot teach to arm PR_SET_PDEATHSIG.  If the harness dies, the wrapper
+receives SIGTERM and atomically kills its owned cgroup, including Chromium's
+browser, renderer, utility, and crash-handler processes.
+"""
+
+import argparse
+import ctypes
+import os
+import signal
+import subprocess
+import sys
+
+
+PR_SET_PDEATHSIG = 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--expected-parent", required=True, type=int)
+    parser.add_argument("--cgroup-procs", required=True)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    command = list(args.command)
+    if command[:1] == ["--"]:
+        command.pop(0)
+    if not command:
+        parser.error("a command is required after --")
+    cgroup_procs = os.path.abspath(args.cgroup_procs)
+    if os.path.basename(cgroup_procs) != "cgroup.procs":
+        parser.error("--cgroup-procs must name cgroup.procs")
+    if args.expected_parent <= 1 or os.getppid() != args.expected_parent:
+        print("guardsupervise: expected parent is already gone", file=sys.stderr)
+        return 125
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.prctl(PR_SET_PDEATHSIG, signal.SIGTERM, 0, 0, 0) != 0:
+        error = ctypes.get_errno()
+        print(f"guardsupervise: prctl failed: {os.strerror(error)}", file=sys.stderr)
+        return 125
+    if os.getppid() != args.expected_parent:
+        print("guardsupervise: parent changed while arming parent-death", file=sys.stderr)
+        return 125
+    try:
+        with open(cgroup_procs, "w") as stream:
+            stream.write(f"{os.getpid()}\n")
+    except OSError as error:
+        print(f"guardsupervise: cannot enter cgroup: {error}", file=sys.stderr)
+        return 125
+    if os.getppid() != args.expected_parent:
+        print("guardsupervise: parent changed before child launch", file=sys.stderr)
+        return 125
+
+    child = None
+
+    def terminate(_signum, _frame):
+        kill_path = os.path.join(os.path.dirname(cgroup_procs), "cgroup.kill")
+        try:
+            with open(kill_path, "w") as stream:
+                stream.write("1\n")
+        except OSError:
+            if child is not None and child.poll() is None:
+                try:
+                    os.killpg(child.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+        raise SystemExit(0)
+
+    signal.signal(signal.SIGTERM, terminate)
+    signal.signal(signal.SIGINT, terminate)
+    try:
+        child = subprocess.Popen(command, start_new_session=True)
+        return child.wait()
+    except (OSError, subprocess.SubprocessError) as error:
+        print(f"guardsupervise: cannot run child: {error}", file=sys.stderr)
+        return 125
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/chromium/guardsupervise.py
+++ b/bench/chromium/guardsupervise.py
@@ -13,9 +13,16 @@ import os
 import signal
 import subprocess
 import sys
+import time
 
 
 PR_SET_PDEATHSIG = 1
+
+
+# `cgroup.kill` is synchronous for the signal delivery but not for the reaping, so a
+# short drain is needed to tell "killed" from "still running". A signal handler is
+# running against someone else's shutdown clock, so this stays small.
+KILL_DRAIN_SECONDS = 2.0
 
 
 def main() -> int:
@@ -55,10 +62,28 @@ def main() -> int:
         return 125
 
     child = None
+    cgroup_dir = os.path.dirname(cgroup_procs)
 
-    def terminate(_signum, _frame):
-        kill_path = os.path.join(os.path.dirname(cgroup_procs), "cgroup.kill")
+    def kill_cgroup():
+        """Kill everything left in the owned cgroup, and say whether it emptied.
+
+        The browser process exiting does not mean its tree has: the zygote, utility
+        and crash-handler hops cannot arm PR_SET_PDEATHSIG, which is why this wrapper
+        owns a cgroup at all. Those survivors keep running while the harness believes
+        the request is over.
+
+        Draining is only checked when `cgroup.kill` actually took. Without a real
+        cgroup there is nothing that empties `cgroup.procs`, so polling it would just
+        burn the shutdown budget and report survivors that the fallback already
+        killed.
+        """
+        kill_path = os.path.join(cgroup_dir, "cgroup.kill")
+        # Opening for write CREATES a regular file, so a successful write proves
+        # nothing. Every cgroup v2 directory already has this attribute; a path that
+        # does not is not a cgroup and has no kill semantics at all.
         try:
+            if not os.path.exists(kill_path):
+                raise OSError(f"{kill_path} is not a cgroup v2 attribute")
             with open(kill_path, "w") as stream:
                 stream.write("1\n")
         except OSError:
@@ -67,13 +92,35 @@ def main() -> int:
                     os.killpg(child.pid, signal.SIGKILL)
                 except ProcessLookupError:
                     pass
+            return []
+        deadline = time.monotonic() + KILL_DRAIN_SECONDS
+        while True:
+            try:
+                with open(cgroup_procs) as stream:
+                    remaining = [line for line in stream.read().split() if line]
+            except OSError:
+                return []
+            if not remaining or time.monotonic() >= deadline:
+                return remaining
+            time.sleep(0.01)
+
+    def terminate(_signum, _frame):
+        kill_cgroup()
         raise SystemExit(0)
 
     signal.signal(signal.SIGTERM, terminate)
     signal.signal(signal.SIGINT, terminate)
     try:
         child = subprocess.Popen(command, start_new_session=True)
-        return child.wait()
+        rc = child.wait()
+        # The normal path needs the same sweep as the signal path: the child exiting
+        # says nothing about the hops it spawned.
+        remaining = kill_cgroup()
+        if remaining:
+            print(f"guardsupervise: {len(remaining)} process(es) still in {cgroup_dir} "
+                  f"after cgroup.kill: {remaining}", file=sys.stderr)
+            return 126
+        return rc
     except (OSError, subprocess.SubprocessError) as error:
         print(f"guardsupervise: cannot run child: {error}", file=sys.stderr)
         return 125

--- a/bench/chromium/guardsupervise.py
+++ b/bench/chromium/guardsupervise.py
@@ -52,7 +52,10 @@ def main() -> int:
         print("guardsupervise: parent changed while arming parent-death", file=sys.stderr)
         return 125
     try:
-        with open(cgroup_procs, "w") as stream:
+        # Appending, not truncating: writing to a real cgroup.procs MOVES one pid into
+        # the cgroup and never replaces its membership, so "w" misrepresents what this
+        # write does and, on any file-backed stand-in, silently drops every other member.
+        with open(cgroup_procs, "a") as stream:
             stream.write(f"{os.getpid()}\n")
     except OSError as error:
         print(f"guardsupervise: cannot enter cgroup: {error}", file=sys.stderr)
@@ -105,7 +108,13 @@ def main() -> int:
             time.sleep(0.01)
 
     def terminate(_signum, _frame):
-        kill_cgroup()
+        # The signal path owes the same answer as the normal one: a cgroup that will
+        # not empty is not a clean shutdown just because a signal started it.
+        remaining = kill_cgroup()
+        if remaining:
+            print(f"guardsupervise: {len(remaining)} process(es) still in {cgroup_dir} "
+                  f"after cgroup.kill: {remaining}", file=sys.stderr)
+            raise SystemExit(126)
         raise SystemExit(0)
 
     signal.signal(signal.SIGTERM, terminate)

--- a/bench/chromium/render.py
+++ b/bench/chromium/render.py
@@ -247,6 +247,7 @@ def main() -> int:
     t0 = time.monotonic()
     deadline = t0 + args.timeout
     stage = "connect"
+    ws = None
     try:
         ws = WsClient(find_page_ws_url(args.cdp_host, deadline), deadline)
         cdp = Cdp(ws)
@@ -311,17 +312,53 @@ def main() -> int:
         dom_ms = (time.monotonic() - t_dom) * 1000
 
         if args.then_blank:
-            stage = "blank"
-            cdp.cmd("Page.navigate", {"url": "about:blank"}, deadline=deadline)
+            stage = "blank-navigate"
+            blank_nav = cdp.cmd(
+                "Page.navigate", {"url": "about:blank"}, deadline=deadline
+            )
+            if "errorText" in blank_nav:
+                raise RuntimeError(
+                    f"about:blank navigation failed: {blank_nav['errorText']}"
+                )
+            blank_loader = blank_nav.get("loaderId")
+            if not blank_loader:
+                raise RuntimeError("about:blank navigation returned no loaderId")
+
+            # Page.navigate's command response only acknowledges the request.  A
+            # generic Page.loadEventFired can be left over from another loader,
+            # so it is not proof that the page frozen into the golden snapshot is
+            # blank and quiescent.  Lifecycle events carry the loader identity.
+            stage = "blank-load"
             try:
                 cdp.wait_event(
-                    lambda ev: ev["method"] == "Page.loadEventFired",
+                    lambda ev: ev["method"] == "Page.lifecycleEvent"
+                    and ev["params"].get("name") == "load"
+                    and ev["params"].get("loaderId") == blank_loader,
                     min(deadline, time.monotonic() + 2),
                 )
-            except TimeoutError:
-                pass  # blank settle is best-effort
-        ws.close()
+            except TimeoutError as error:
+                raise TimeoutError(
+                    f"about:blank loader {blank_loader} never reached lifecycle load"
+                ) from error
 
+            stage = "blank-verify"
+            blank_state = cdp.cmd(
+                "Runtime.evaluate",
+                {
+                    "expression": (
+                        "({href: location.href, readyState: document.readyState})"
+                    ),
+                    "returnByValue": True,
+                },
+                deadline=deadline,
+            )["result"]["value"]
+            if blank_state != {
+                "href": "about:blank",
+                "readyState": "complete",
+            }:
+                raise RuntimeError(
+                    f"about:blank did not settle completely: {blank_state!r}"
+                )
         total_ms = (time.monotonic() - t0) * 1000
         print(
             f"RENDER_OK url={args.url} connect_ms={connect_ms:.1f} "
@@ -335,6 +372,9 @@ def main() -> int:
     except (OSError, RuntimeError, TimeoutError, WsClosed, KeyError) as e:
         print(f'RENDER_FAIL url={args.url} stage={stage} error="{e}"', flush=True)
         return 1
+    finally:
+        if ws is not None:
+            ws.close()
 
 
 if __name__ == "__main__":

--- a/bench/chromium/reqscale.py
+++ b/bench/chromium/reqscale.py
@@ -1,0 +1,3822 @@
+#!/usr/bin/env python3
+"""Auditable open-loop CDP-fast scalability and page-fault measurements.
+
+This is deliberately an extension of ``reqbench.py`` rather than a revival of
+``bench.sh``'s old phase4b. Every request uses the production CDP-fast path:
+restore one clone, drive Chromium's CDP endpoint from the host, return the
+artifact milestone, then synchronously prove teardown and disk cleanup.
+
+The experimental unit is a burst.  At each declared per-backend rate, every
+rate interval contains one FILE request and one UFFD request separated by half
+an interval.  Their within-pair order comes from the recorded seed, so backend
+is interleaved request-by-request rather than confounded with wall-clock blocks.
+One full warmup burst is excluded, then at least five scored bursts each contain
+a 15 second ramp and a 60 second scoring interval.  Launches follow absolute
+monotonic deadlines and never wait for an earlier request to finish; artifact
+completion and final teardown drain are separate milestones.
+
+Sibling driver, host-control, FILE, and UFFD cgroups keep the accounting bases
+separate.  A persistent host-native Chromium is driven every 10 seconds at a
+seeded phase while a 5-second sampler records complete /proc/stat, load, PSI,
+MemAvailable, and every cgroup's cpu.stat.  Per-request fault counters are
+explicitly Firecracker-process counters sampled from endpoint-ready through the
+artifact return.  Optional handle_mm_fault count/total/histogram data has that
+same process scope; it is not a guest-RAM-VMA or UFFD-event measurement.
+
+No chart or finding is produced here. This file produces measurement records;
+the dataviz skill required by bench/chromium/AGENTS.md is not installed in this
+session, so visualization stays a separate, later step.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import fcntl
+import hashlib
+import json
+import math
+import os
+import platform
+import queue
+import re
+import select
+import signal
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Callable, Iterable, Optional
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.abspath(os.path.join(HERE, "..", ".."))
+sys.path.insert(0, HERE)
+
+import reqbench  # noqa: E402
+
+
+SCHEDULE_SCHEMA = "fcvm.chromium.reqscale.schedule.v2"
+RECORD_SCHEMA = "fcvm.chromium.reqscale.record.v2"
+RUN_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+CGROUP_NAME_RE = re.compile(r"^fcvm-reqscale-[0-9a-f]{32}$")
+SNAPSHOT_TAG_RE = re.compile(r"^[A-Za-z0-9_.-]{1,128}$")
+RAMP_SECONDS = 15.0
+SCORE_SECONDS = 60.0
+WARMUP_BURSTS = 1
+CONTROL_INTERVAL_SECONDS = 10.0
+SAMPLE_INTERVAL_SECONDS = 5.0
+GUARDEXEC = os.path.join(HERE, "guardexec.py")
+GUARDSUPERVISE = os.path.join(HERE, "guardsupervise.py")
+CPU_FIELDS = (
+    "user", "nice", "system", "idle", "iowait", "irq", "softirq",
+    "steal", "guest", "guest_nice",
+)
+
+
+class MeasurementInvalid(RuntimeError):
+    """The harness cannot defend the measurement and therefore stops."""
+
+    def __init__(self, message: str, details=None):
+        super().__init__(message)
+        self.details = details
+
+
+class MeasurementInterrupted(BaseException):
+    """A requested shutdown that must wait for in-flight request cleanup."""
+
+    def __init__(self, signum: int):
+        self.signum = signum
+        super().__init__(f"measurement interrupted by signal {signum}")
+
+
+_TERMINATION_SIGNALS = (signal.SIGINT, signal.SIGTERM)
+
+
+class TerminationFence:
+    """Turn the first SIGINT/SIGTERM into a cleanup-capable interruption.
+
+    Later signals are remembered but do not interrupt the bounded teardown.  An
+    uncatchable process death is covered separately by every long-lived child's
+    parent-death contract.
+    """
+
+    def __init__(self):
+        self.previous = {}
+        self.received: list[int] = []
+
+    def _handle(self, signum, _frame):
+        self.received.append(signum)
+        if len(self.received) == 1:
+            raise MeasurementInterrupted(signum)
+
+    def __enter__(self):
+        if threading.current_thread() is not threading.main_thread():
+            raise MeasurementInvalid("termination fencing requires the main thread")
+        if getattr(_termination_state, "fence", None) is not None:
+            raise MeasurementInvalid("termination fencing cannot be nested")
+        prior_mask = signal.pthread_sigmask(signal.SIG_BLOCK, _TERMINATION_SIGNALS)
+        installed = []
+        try:
+            for signum in _TERMINATION_SIGNALS:
+                self.previous[signum] = signal.getsignal(signum)
+                signal.signal(signum, self._handle)
+                installed.append(signum)
+            _termination_state.fence = self
+        except BaseException:
+            for signum in reversed(installed):
+                signal.signal(signum, self.previous[signum])
+            signal.pthread_sigmask(signal.SIG_SETMASK, prior_mask)
+            raise
+        try:
+            signal.pthread_sigmask(signal.SIG_SETMASK, prior_mask)
+        except BaseException:
+            # __enter__ will not receive a matching __exit__ when a pending signal
+            # is delivered by the unmask. Restore the process-wide handlers here.
+            signal.pthread_sigmask(signal.SIG_BLOCK, _TERMINATION_SIGNALS)
+            for signum in reversed(installed):
+                signal.signal(signum, self.previous[signum])
+            _termination_state.fence = None
+            signal.pthread_sigmask(signal.SIG_SETMASK, prior_mask)
+            raise
+        return self
+
+    def __exit__(self, _type, _value, _traceback):
+        prior_mask = signal.pthread_sigmask(signal.SIG_BLOCK, _TERMINATION_SIGNALS)
+        try:
+            for signum, handler in self.previous.items():
+                signal.signal(signum, handler)
+        finally:
+            _termination_state.fence = None
+            signal.pthread_sigmask(signal.SIG_SETMASK, prior_mask)
+
+
+_termination_state = threading.local()
+
+
+class DeferredTermination:
+    """Record termination signals while one bounded critical section drains."""
+
+    def __init__(self):
+        self.previous = {}
+        self.received: list[int] = []
+
+    def _handle(self, signum, _frame):
+        self.received.append(signum)
+
+    def __enter__(self):
+        if threading.current_thread() is not threading.main_thread():
+            return self
+        prior_mask = signal.pthread_sigmask(signal.SIG_BLOCK, _TERMINATION_SIGNALS)
+        installed = []
+        try:
+            for signum in _TERMINATION_SIGNALS:
+                self.previous[signum] = signal.getsignal(signum)
+                signal.signal(signum, self._handle)
+                installed.append(signum)
+        except BaseException:
+            for signum in reversed(installed):
+                signal.signal(signum, self.previous[signum])
+            raise
+        finally:
+            signal.pthread_sigmask(signal.SIG_SETMASK, prior_mask)
+        return self
+
+    def __exit__(self, error_type, _value, _traceback):
+        if threading.current_thread() is not threading.main_thread():
+            return
+        prior_mask = signal.pthread_sigmask(signal.SIG_BLOCK, _TERMINATION_SIGNALS)
+        fence = getattr(_termination_state, "fence", None)
+        if self.received:
+            # The outer fence must know that the first signal already happened.
+            # Otherwise a second SIGINT/SIGTERM during teardown would look like the
+            # first one and interrupt cleanup.  Keep every later signal inert until
+            # the bounded cleanup path has finished.
+            if fence is not None:
+                fence.received.extend(self.received)
+        try:
+            for signum, handler in self.previous.items():
+                signal.signal(signum, handler)
+        finally:
+            signal.pthread_sigmask(signal.SIG_SETMASK, prior_mask)
+        if self.received:
+            if error_type is None:
+                raise MeasurementInterrupted(self.received[0])
+
+
+def guard_prefix(cgroup_path: str, parent_pid: Optional[int] = None) -> list[str]:
+    """Prefix a later command with cgroup placement and parent-death fencing."""
+    parent_pid = os.getpid() if parent_pid is None else parent_pid
+    if parent_pid <= 1:
+        raise MeasurementInvalid(f"invalid guard parent pid {parent_pid}")
+    if not os.path.isabs(cgroup_path):
+        raise MeasurementInvalid(f"child cgroup path is not absolute: {cgroup_path}")
+    return [
+        sys.executable,
+        GUARDEXEC,
+        "--expected-parent", str(parent_pid),
+        "--cgroup-procs", os.path.join(cgroup_path, "cgroup.procs"),
+        "--",
+    ]
+
+
+def guarded_command(cgroup_path: str, argv: Iterable[str], parent_pid: Optional[int] = None) -> list[str]:
+    """Build the only allowed command path for measured child processes."""
+    command = list(argv)
+    if not command:
+        raise MeasurementInvalid("guarded child command is empty")
+    return guard_prefix(cgroup_path, parent_pid) + command
+
+
+def supervised_command(
+    cgroup_path: str, argv: Iterable[str], parent_pid: Optional[int] = None,
+) -> list[str]:
+    command = list(argv)
+    if not command:
+        raise MeasurementInvalid("supervised child command is empty")
+    parent_pid = os.getpid() if parent_pid is None else parent_pid
+    if parent_pid <= 1 or not os.path.isabs(cgroup_path):
+        raise MeasurementInvalid("invalid supervised child ownership")
+    return [
+        sys.executable, GUARDSUPERVISE,
+        "--expected-parent", str(parent_pid),
+        "--cgroup-procs", os.path.join(cgroup_path, "cgroup.procs"),
+        "--", *command,
+    ]
+
+
+@dataclass(frozen=True)
+class CapacityCriteria:
+    max_offered_rps_error_pct: float
+    min_departure_ratio: float
+    max_score_end_backlog: int
+    max_p95_launch_lag_ms: float
+    max_control_median_drift_pct: float
+
+
+@dataclass(frozen=True)
+class ScheduleConfig:
+    rates: tuple[float, ...]
+    scored_bursts: int
+    seed: int
+    criteria: CapacityCriteria
+    warmup_bursts: int = WARMUP_BURSTS
+    ramp_seconds: float = RAMP_SECONDS
+    score_seconds: float = SCORE_SECONDS
+    trace_rate: Optional[float] = None
+    trace_pairs: int = 0
+
+
+@dataclass(frozen=True)
+class RequestPlan:
+    request_index: int
+    pair_index: int
+    segment: str
+    backend: str
+    scheduled_offset_ns: int
+    seed: int
+
+    @classmethod
+    def from_dict(cls, value: dict) -> "RequestPlan":
+        fields = {field.name for field in dataclasses.fields(cls)}
+        if set(value) != fields:
+            raise MeasurementInvalid(
+                f"request plan fields differ: missing={sorted(fields - set(value))} "
+                f"extra={sorted(set(value) - fields)}"
+            )
+        return cls(**{key: value[key] for key in fields})
+
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+
+@dataclass(frozen=True)
+class BurstSpec:
+    burst_id: str
+    block_id: str
+    population: str
+    target_rps: float
+    repeat: int
+    seed: int
+    traced: bool
+    trace_pair_id: Optional[str]
+    ramp_seconds: float
+    score_seconds: float
+    requests: tuple[RequestPlan, ...]
+
+    @classmethod
+    def from_dict(cls, value: dict) -> "BurstSpec":
+        fields = {field.name for field in dataclasses.fields(cls)}
+        missing = fields - set(value)
+        extra = set(value) - fields
+        if missing:
+            raise MeasurementInvalid(f"burst is missing fields {sorted(missing)}")
+        if extra:
+            raise MeasurementInvalid(f"burst has unknown fields {sorted(extra)}")
+        converted = dict(value)
+        raw_requests = converted.pop("requests")
+        if not isinstance(raw_requests, list):
+            raise MeasurementInvalid("burst requests are not a list")
+        converted["requests"] = tuple(RequestPlan.from_dict(item) for item in raw_requests)
+        return cls(**converted)
+
+    def to_dict(self) -> dict:
+        value = dataclasses.asdict(self)
+        value["requests"] = [request.to_dict() for request in self.requests]
+        return value
+
+
+def _validate_run_id(run_id: str) -> None:
+    if not RUN_ID_RE.fullmatch(run_id):
+        raise ValueError("run_id must be 32 lowercase hexadecimal characters")
+
+
+def _validate_snapshot_tag(snapshot_tag: str) -> None:
+    if (
+        not SNAPSHOT_TAG_RE.fullmatch(snapshot_tag)
+        or snapshot_tag in (".", "..")
+    ):
+        raise ValueError(
+            "snapshot tag must be 1..128 ASCII letters, digits, '.', '-', or '_', "
+            "excluding '.' and '..'"
+        )
+
+
+def _rate_slug(rate: float) -> str:
+    return format(rate, ".12g").replace(".", "p")
+
+
+def _planned_count(rate: float, duration_s: float) -> int:
+    product = rate * duration_s
+    count = round(product)
+    if count < 1 or not math.isclose(product, count, rel_tol=0.0, abs_tol=1e-9):
+        raise ValueError(
+            f"target_rps * window_seconds must be a positive integer, got "
+            f"{rate} * {duration_s} = {product}"
+        )
+    return int(count)
+
+
+def _validate_schedule_config(config: ScheduleConfig) -> None:
+    if config.scored_bursts < 5:
+        raise ValueError("every cell needs at least 5 independent scored bursts")
+    if config.warmup_bursts != WARMUP_BURSTS:
+        raise ValueError("exactly 1 explicit warmup burst is required")
+    if config.ramp_seconds != RAMP_SECONDS or config.score_seconds != SCORE_SECONDS:
+        raise ValueError("scored bursts must use exactly a 15s ramp and 60s score")
+    if not config.rates:
+        raise ValueError("at least one target rate is required")
+    if len(set(config.rates)) != len(config.rates):
+        raise ValueError("target rates must be unique")
+    for rate in config.rates:
+        if not math.isfinite(rate) or rate <= 0:
+            raise ValueError(f"target rate must be finite and positive: {rate}")
+        _planned_count(rate, config.ramp_seconds)
+        _planned_count(rate, config.score_seconds)
+        if config.scored_bursts * _planned_count(rate, config.score_seconds) < 200:
+            raise ValueError(
+                f"rate {rate:g} supplies fewer than 200 scored requests per backend "
+                f"across {config.scored_bursts} bursts"
+            )
+    criteria = dataclasses.asdict(config.criteria)
+    for field in (
+        "max_offered_rps_error_pct", "max_p95_launch_lag_ms",
+        "max_control_median_drift_pct",
+    ):
+        value = criteria[field]
+        if not math.isfinite(value) or value < 0:
+            raise ValueError(f"{field} must be finite and nonnegative")
+    if (
+        not math.isfinite(config.criteria.min_departure_ratio)
+        or not 0 < config.criteria.min_departure_ratio <= 1
+    ):
+        raise ValueError("min_departure_ratio must be in (0, 1]")
+    if (
+        isinstance(config.criteria.max_score_end_backlog, bool)
+        or not isinstance(config.criteria.max_score_end_backlog, int)
+        or config.criteria.max_score_end_backlog < 0
+    ):
+        raise ValueError("max_score_end_backlog must be a nonnegative integer")
+    if (config.trace_rate is None) != (config.trace_pairs == 0):
+        raise ValueError("trace_rate and trace_pairs must be supplied together")
+    if config.trace_rate is not None:
+        if config.trace_rate not in config.rates:
+            raise ValueError("trace_rate must name one of the scale cells")
+        if config.trace_pairs < 3:
+            raise ValueError("fault tracing needs at least 3 matched perturbation pairs")
+
+
+def _derive_u64(seed: int, *parts) -> int:
+    """Version-independent seeded derivation used by every durable schedule."""
+    payload = json.dumps(
+        ["fcvm-reqscale-seed-v1", seed, *parts],
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode()
+    return int.from_bytes(hashlib.sha256(payload).digest()[:8], "big")
+
+
+def _stable_shuffle(items: Iterable[dict], seed: int, domain: str) -> list[dict]:
+    """Return a hash-ranked order independent of Python's random implementation."""
+    return sorted(
+        items,
+        key=lambda item: (
+            hashlib.sha256(json.dumps(
+                ["fcvm-reqscale-order-v1", seed, domain, item],
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            ).encode()).digest(),
+            json.dumps(item, sort_keys=True, separators=(",", ":"), allow_nan=False),
+        ),
+    )
+
+
+def _build_request_plan(
+    rate: float, ramp_seconds: float, score_seconds: float, seed: int,
+) -> tuple[RequestPlan, ...]:
+    """Return a fully materialized mixed-backend schedule for one burst."""
+    requests = []
+    request_index = 0
+    pair_base = 0
+    for segment, start_s, duration_s in (
+        ("ramp", 0.0, ramp_seconds),
+        ("score", ramp_seconds, score_seconds),
+    ):
+        count = _planned_count(rate, duration_s)
+        for local_pair in range(count):
+            pair_index = pair_base + local_pair
+            first = (
+                "file"
+                if _derive_u64(seed, "backend-order", segment, local_pair) & 1 == 0
+                else "uffd"
+            )
+            order = (first, "uffd" if first == "file" else "file")
+            pair_start = start_s + local_pair / rate
+            for half, backend in enumerate(order):
+                offset_s = pair_start + half / (2.0 * rate)
+                requests.append(RequestPlan(
+                    request_index=request_index,
+                    pair_index=pair_index,
+                    segment=segment,
+                    backend=backend,
+                    scheduled_offset_ns=round(offset_s * 1_000_000_000),
+                    seed=_derive_u64(seed, "request", segment, local_pair, backend),
+                ))
+                request_index += 1
+        pair_base += count
+    offsets = [request.scheduled_offset_ns for request in requests]
+    if offsets != sorted(offsets) or len(offsets) != len(set(offsets)):
+        raise ValueError(f"rate {rate:g} cannot be represented as unique nanosecond deadlines")
+    return tuple(requests)
+
+
+def build_schedule(config: ScheduleConfig, run_id: str) -> dict:
+    """Build the complete schedule before any workload process exists.
+
+    Every request deadline and backend assignment is serialized.  Warmups are
+    shuffled by rate but always precede scored work.  Scored bursts are shuffled
+    by rate/repeat.  Each trace pair uses one identical request plan for its
+    traced and untraced members, with their order chosen by the recorded seed.
+    """
+    _validate_run_id(run_id)
+    _validate_schedule_config(config)
+    warmup_blocks = [{
+        "population": "warmup",
+        "block_id": f"warmup-r{_rate_slug(rate)}",
+        "repeat": 0,
+        "rate": rate,
+    } for rate in config.rates]
+    warmup_blocks = _stable_shuffle(warmup_blocks, config.seed, "warmup-bursts")
+
+    measurement_blocks: list[dict] = []
+    for repeat in range(config.scored_bursts):
+        for rate in config.rates:
+            measurement_blocks.append({
+                "population": "scored",
+                "block_id": f"scored-r{_rate_slug(rate)}-n{repeat}",
+                "repeat": repeat,
+                "rate": rate,
+            })
+    measurement_blocks = _stable_shuffle(
+        measurement_blocks, config.seed, "scored-bursts"
+    )
+    blocks = warmup_blocks + measurement_blocks
+    if config.trace_rate is not None:
+        trace_blocks = []
+        for pair in range(config.trace_pairs):
+            trace_pair_id = f"trace:{pair}"
+            members = [False, True]
+            if _derive_u64(config.seed, "trace-member-order", pair) & 1:
+                members.reverse()
+            plan_seed = _derive_u64(config.seed, "trace-plan", pair)
+            for traced in members:
+                trace_blocks.append({
+                    "population": "trace-perturbation",
+                    "block_id": f"trace-n{pair}-{'on' if traced else 'off'}",
+                    "trace_pair_id": trace_pair_id,
+                    "repeat": pair,
+                    "rate": config.trace_rate,
+                    "traced": traced,
+                    "plan_seed": plan_seed,
+                })
+        pair_order = sorted(
+            range(config.trace_pairs),
+            key=lambda pair: (_derive_u64(config.seed, "trace-pair-order", pair), pair),
+        )
+        blocks.extend([
+            block for pair in pair_order for block in trace_blocks
+            if block["repeat"] == pair
+        ])
+
+    bursts = []
+    for index, block in enumerate(blocks):
+        traced = bool(block.get("traced", False))
+        plan_seed = (
+            block["plan_seed"] if "plan_seed" in block else _derive_u64(
+                config.seed, "burst-plan", block["block_id"]
+            )
+        )
+        spec = BurstSpec(
+            burst_id=f"b{index:04d}-r{_rate_slug(block['rate'])}"
+                     f"{'-trace' if traced else ''}",
+            block_id=block["block_id"],
+            population=block["population"],
+            target_rps=block["rate"],
+            repeat=block["repeat"],
+            seed=plan_seed,
+            traced=traced,
+            trace_pair_id=block.get("trace_pair_id"),
+            ramp_seconds=config.ramp_seconds,
+            score_seconds=config.score_seconds,
+            requests=_build_request_plan(
+                block["rate"], config.ramp_seconds, config.score_seconds, plan_seed
+            ),
+        )
+        bursts.append(spec.to_dict())
+
+    control_phase_ns = _derive_u64(
+        config.seed, "control-phase"
+    ) % round(CONTROL_INTERVAL_SECONDS * 1e9)
+
+    return {
+        "schema": SCHEDULE_SCHEMA,
+        "run_id": run_id,
+        "seed": config.seed,
+        "rates": list(config.rates),
+        "cells": [
+            {
+                "cell_id": f"{backend}:r{format(rate, '.12g')}",
+                "backend": backend,
+                "target_rps": rate,
+                "independent_bursts": config.scored_bursts,
+                "planned_scored_requests_per_burst": _planned_count(
+                    rate, config.score_seconds
+                ),
+                "planned_scored_requests_total": (
+                    config.scored_bursts * _planned_count(rate, config.score_seconds)
+                ),
+                "warmup_bursts": config.warmup_bursts,
+            }
+            for rate in config.rates
+            for backend in ("file", "uffd")
+        ],
+        "randomization": {
+            "unit": "burst",
+            "burst_order": "rates and repeats shuffled",
+            "request_order": (
+                "one FILE and one UFFD per rate interval; seeded order within each "
+                "pair; half-interval separation"
+            ),
+            "warmup_precedes_measurement": True,
+        },
+        "independent_bursts_per_cell": config.scored_bursts,
+        "warmup_bursts_per_rate": config.warmup_bursts,
+        "warmup_included_in_primary_measurement": False,
+        "ramp_seconds": config.ramp_seconds,
+        "score_seconds": config.score_seconds,
+        "capacity_criteria": dataclasses.asdict(config.criteria) | {
+            "require_zero_failures": True,
+        },
+        "control": {
+            "kind": "persistent-host-native-chromium",
+            "interval_ns": round(CONTROL_INTERVAL_SECONDS * 1e9),
+            "phase_seed": config.seed,
+            "phase_derivation": "sha256 fcvm-reqscale-seed-v1/control-phase",
+            "phase_offset_ns": control_phase_ns,
+            "warmup_requests": 1,
+        },
+        "host_sample_interval_ns": round(SAMPLE_INTERVAL_SECONDS * 1e9),
+        "trace_rate": config.trace_rate,
+        "trace_pairs": config.trace_pairs,
+        "fault_metric_scope": (
+            "Firecracker process endpoint-ready through artifact return; includes all "
+            "Firecracker VMAs and is not a guest-RAM-VMA or UFFD-event count"
+        ),
+        "bursts": bursts,
+    }
+
+
+def canonical_json(value) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+
+
+def _strict_json_object(pairs):
+    value = {}
+    for key, item in pairs:
+        if key in value:
+            raise MeasurementInvalid(f"JSON object has duplicate key {key!r}")
+        value[key] = item
+    return value
+
+
+def _reject_json_constant(value):
+    raise MeasurementInvalid(f"JSON contains non-standard constant {value}")
+
+
+def strict_json_loads(raw: str | bytes, source: str):
+    try:
+        return json.loads(
+            raw,
+            object_pairs_hook=_strict_json_object,
+            parse_constant=_reject_json_constant,
+        )
+    except (json.JSONDecodeError, UnicodeError) as error:
+        raise MeasurementInvalid(f"malformed JSON in {source}: {error}") from error
+
+
+def schedule_sha256(schedule: dict) -> str:
+    return hashlib.sha256(canonical_json(schedule)).hexdigest()
+
+
+# ---------------------------------------------------------------- open-loop launch
+
+
+@dataclass(frozen=True)
+class RequestContext:
+    run_id: str
+    burst_id: str
+    population: str
+    segment: str
+    backend: str
+    target_rps: float
+    request_index: int
+    pair_index: int
+    request_id: str
+    scheduled_ns: int
+    actual_launch_ns: int
+    request_seed: int
+
+
+class SystemClock:
+    def monotonic_ns(self) -> int:
+        return time.monotonic_ns()
+
+    def sleep_until_ns(self, deadline_ns: int) -> None:
+        while True:
+            remaining_ns = deadline_ns - time.monotonic_ns()
+            if remaining_ns <= 0:
+                return
+            time.sleep(remaining_ns / 1_000_000_000)
+
+
+@dataclass
+class _ThreadHandle:
+    thread: threading.Thread
+    result: queue.Queue
+
+
+class ThreadLauncher:
+    """One short-lived client thread per request; no executor queue or cap.
+
+    A fixed worker pool creates a hidden closed-loop ceiling once its queue fills.
+    Here each thread exits with its request, so peak threads track actual in-flight
+    work and the scheduler never waits for capacity before launching the next one.
+    """
+
+    def launch(self, context: RequestContext, request_fn: Callable) -> _ThreadHandle:
+        result: queue.Queue = queue.Queue(maxsize=1)
+
+        def worker():
+            actual_ns = time.monotonic_ns()
+            owned = dataclasses.replace(context, actual_launch_ns=actual_ns)
+            try:
+                record = request_fn(owned)
+                if not isinstance(record, dict):
+                    raise TypeError(f"request_fn returned {type(record).__name__}, not dict")
+            except Exception as error:  # preserve a durable failed request
+                supplied = getattr(error, "record", None)
+                record = dict(supplied) if isinstance(supplied, dict) else {}
+                record["ok"] = False
+                record.setdefault("error", f"{type(error).__name__}: {error}")
+                elapsed_ms = (time.monotonic_ns() - actual_ns) / 1_000_000
+                record.setdefault("blocking_ms", elapsed_ms)
+                record.setdefault("wall_ms", elapsed_ms)
+            except BaseException as fatal:
+                # Signals represented by reqbench's BaseException subclass must
+                # unwind the run. They are delivered to drain only after every
+                # already-launched client thread has joined, so cleanup cannot
+                # race requests that were still tearing down.
+                result.put(("fatal", fatal))
+                return
+            record.setdefault("request_id", owned.request_id)
+            record.setdefault("request_index", owned.request_index)
+            record.setdefault("pair_index", owned.pair_index)
+            record.setdefault("burst_id", owned.burst_id)
+            record.setdefault("population", owned.population)
+            record.setdefault("segment", owned.segment)
+            record.setdefault("backend", owned.backend)
+            record.setdefault("target_rps", owned.target_rps)
+            record.setdefault("request_seed", owned.request_seed)
+            record.setdefault("scheduled_ns", owned.scheduled_ns)
+            record.setdefault("actual_launch_ns", owned.actual_launch_ns)
+            record.setdefault("finished_ns", time.monotonic_ns())
+            result.put(("record", record))
+
+        thread = threading.Thread(
+            target=worker,
+            name=f"reqscale-{context.burst_id}-{context.request_index}",
+            daemon=False,
+        )
+        thread.start()
+        return _ThreadHandle(thread=thread, result=result)
+
+    def drain(self, handles: Iterable[_ThreadHandle]) -> list[dict]:
+        records = []
+        fatals = []
+        for handle in handles:
+            handle.thread.join()
+            try:
+                kind, value = handle.result.get_nowait()
+            except queue.Empty:
+                fatals.append(MeasurementInvalid(
+                    f"client thread {handle.thread.name} exited without a result"
+                ))
+                continue
+            if kind == "fatal":
+                fatals.append(value)
+            elif kind == "record":
+                records.append(value)
+            else:
+                fatals.append(MeasurementInvalid(
+                    f"client thread {handle.thread.name} returned unknown result kind {kind!r}"
+                ))
+        if fatals:
+            raise fatals[0]
+        return records
+
+
+def _percentile(values: list[float], q: float) -> float:
+    ordered = sorted(values)
+    if not ordered:
+        raise MeasurementInvalid("cannot summarize an empty measurement")
+    # Nearest-rank keeps the raw observation instead of interpolating a latency
+    # the run never observed.
+    index = max(0, min(len(ordered) - 1, math.ceil(q * len(ordered)) - 1))
+    return float(ordered[index])
+
+
+def distribution(values: list[float]) -> dict:
+    if not values:
+        return {"n": 0, "min": None, "median": None, "p95": None, "max": None}
+    return {
+        "n": len(values),
+        "min": float(min(values)),
+        "median": float(statistics.median(values)),
+        "p95": _percentile(values, 0.95),
+        "max": float(max(values)),
+    }
+
+
+def _validate_request_record(record: dict) -> None:
+    required = (
+        "request_id", "request_index", "scheduled_ns", "actual_launch_ns",
+        "finished_ns", "blocking_ms", "wall_ms", "ok",
+    )
+    for field in required:
+        if field not in record:
+            raise MeasurementInvalid(f"request record is missing {field}: {record}")
+    for field in ("request_index", "scheduled_ns", "actual_launch_ns", "finished_ns"):
+        if not isinstance(record[field], int) or isinstance(record[field], bool):
+            raise MeasurementInvalid(f"request record {field} is not an integer: {record}")
+        if record[field] < 0:
+            raise MeasurementInvalid(f"request record {field} is negative: {record}")
+    if not isinstance(record["request_id"], str) or not record["request_id"]:
+        raise MeasurementInvalid(f"request record has invalid request_id: {record}")
+    if not isinstance(record["ok"], bool):
+        raise MeasurementInvalid(f"request record ok is not boolean: {record}")
+    for field in ("blocking_ms", "wall_ms"):
+        value = record[field]
+        if (
+            not isinstance(value, (int, float))
+            or isinstance(value, bool)
+            or not math.isfinite(value)
+            or value < 0
+        ):
+            raise MeasurementInvalid(f"request record {field} is invalid: {record}")
+    if record.get("ok") and "artifact_ns" not in record:
+        raise MeasurementInvalid(f"successful request record is missing artifact_ns: {record}")
+    scheduled = record["scheduled_ns"]
+    launched = record["actual_launch_ns"]
+    finished = record["finished_ns"]
+    artifact = record.get("artifact_ns")
+    if artifact is not None and (not isinstance(artifact, int) or isinstance(artifact, bool)):
+        raise MeasurementInvalid(f"request record artifact_ns is not an integer: {record}")
+    if launched < scheduled:
+        raise MeasurementInvalid(f"request launched before its deadline: {record}")
+    if artifact is not None and artifact < launched:
+        raise MeasurementInvalid(f"request artifact predates launch: {record}")
+    if artifact is not None and finished < artifact:
+        raise MeasurementInvalid(f"request drain predates artifact: {record}")
+    if record["blocking_ms"] > record["wall_ms"] + 1.0:
+        raise MeasurementInvalid(f"request blocking time exceeds wall time: {record}")
+    if artifact is not None:
+        artifact_elapsed_ms = (artifact - launched) / 1_000_000
+        if record["blocking_ms"] > artifact_elapsed_ms + 1.0:
+            raise MeasurementInvalid(
+                f"request blocking time exceeds its artifact milestone: {record}"
+            )
+    wall_elapsed_ms = (finished - launched) / 1_000_000
+    if record["wall_ms"] > wall_elapsed_ms + 1.0:
+        raise MeasurementInvalid(
+            f"request wall time exceeds its finished milestone: {record}"
+        )
+
+
+def _backlog_at(records: list[dict], backend: str, at_ns: int) -> int:
+    return sum(
+        record["backend"] == backend
+        and record["actual_launch_ns"] <= at_ns
+        and (record.get("artifact_ns") is None or record["artifact_ns"] > at_ns)
+        for record in records
+    )
+
+
+def _max_backlog(records: list[dict], backend: str, start_ns: int, end_ns: int) -> int:
+    backlog = _backlog_at(records, backend, start_ns)
+    maximum = backlog
+    events = []
+    for record in records:
+        if record["backend"] != backend:
+            continue
+        launched = record["actual_launch_ns"]
+        artifact = record.get("artifact_ns")
+        if start_ns < launched <= end_ns:
+            events.append((launched, 1))
+        if artifact is not None and start_ns < artifact <= end_ns:
+            events.append((artifact, -1))
+    by_timestamp = {}
+    for timestamp, delta in events:
+        by_timestamp.setdefault(timestamp, []).append(delta)
+    for timestamp in sorted(by_timestamp):
+        deltas = by_timestamp[timestamp]
+        # Count same-timestamp launches before completions. This handles a
+        # zero-duration request without allowing its completion to drive the
+        # pre-existing backlog negative.
+        backlog += sum(delta == 1 for delta in deltas)
+        maximum = max(maximum, backlog)
+        backlog -= sum(delta == -1 for delta in deltas)
+        if backlog < 0:
+            raise MeasurementInvalid("artifact completion drove burst backlog below zero")
+    return maximum
+
+
+def _burst_metadata(spec: BurstSpec) -> dict:
+    value = spec.to_dict()
+    requests = value.pop("requests")
+    value["request_plan_count"] = len(requests)
+    value["request_plan_sha256"] = hashlib.sha256(canonical_json(requests)).hexdigest()
+    return value
+
+
+def run_open_loop_burst(
+    run_id: str,
+    spec: BurstSpec,
+    request_fn: Callable[[RequestContext], dict],
+    clock=None,
+    launcher=None,
+) -> tuple[list[dict], dict]:
+    """Launch the serialized mixed-backend burst, then enter drain once."""
+    _validate_run_id(run_id)
+    clock = clock or SystemClock()
+    launcher = launcher or ThreadLauncher()
+    if not spec.requests:
+        raise MeasurementInvalid(f"burst {spec.burst_id} has no requests")
+    indices = [request.request_index for request in spec.requests]
+    if indices != list(range(len(spec.requests))):
+        raise MeasurementInvalid(f"burst {spec.burst_id} request indices are not contiguous")
+    offsets = [request.scheduled_offset_ns for request in spec.requests]
+    if offsets != sorted(offsets) or len(offsets) != len(set(offsets)):
+        raise MeasurementInvalid(f"burst {spec.burst_id} request deadlines are not unique and sorted")
+    burst_start_ns = clock.monotonic_ns()
+    handles = []
+    launch_error = None
+    try:
+        for request in spec.requests:
+            scheduled_ns = burst_start_ns + request.scheduled_offset_ns
+            clock.sleep_until_ns(scheduled_ns)
+            actual_ns = clock.monotonic_ns()
+            context = RequestContext(
+                run_id=run_id,
+                burst_id=spec.burst_id,
+                population=spec.population,
+                segment=request.segment,
+                backend=request.backend,
+                target_rps=spec.target_rps,
+                request_index=request.request_index,
+                pair_index=request.pair_index,
+                request_id=f"{run_id}:{spec.burst_id}:{request.request_index}",
+                scheduled_ns=scheduled_ns,
+                actual_launch_ns=actual_ns,
+                request_seed=request.seed,
+            )
+            # A termination signal cannot land after the worker starts but before
+            # its handle becomes owned by this burst.  The deferred signal is
+            # raised immediately after ownership is recorded.
+            with DeferredTermination():
+                handle = launcher.launch(context, request_fn)
+                handles.append(handle)
+    except BaseException as error:
+        launch_error = error
+    schedule_submission_end_ns = clock.monotonic_ns()
+
+    try:
+        # Signals are deferred until every launched request finishes its bounded
+        # teardown.  This prevents outer cleanup from racing live clone workers.
+        with DeferredTermination():
+            records = launcher.drain(handles)
+    except BaseException as drain_error:
+        if launch_error is not None:
+            raise MeasurementInvalid(
+                "open-loop launch stopped and in-flight request drain also failed",
+                {
+                    "launch_error": f"{type(launch_error).__name__}: {launch_error}",
+                    "drain_error": f"{type(drain_error).__name__}: {drain_error}",
+                    "launched": len(handles),
+                    "planned": len(spec.requests),
+                },
+            ) from drain_error
+        raise
+    if launch_error is not None:
+        raise launch_error
+    records.sort(key=lambda record: record.get("request_index", -1))
+    count = len(spec.requests)
+    if len(records) != count:
+        raise MeasurementInvalid(f"burst drained {len(records)} records for {count} launches")
+    if len({record.get("request_id") for record in records}) != count:
+        raise MeasurementInvalid("burst has duplicate or missing request ids")
+    for record, planned in zip(records, spec.requests):
+        _validate_request_record(record)
+        expected = {
+            "request_index": planned.request_index,
+            "pair_index": planned.pair_index,
+            "segment": planned.segment,
+            "backend": planned.backend,
+            "request_seed": planned.seed,
+            "burst_id": spec.burst_id,
+            "population": spec.population,
+            "target_rps": spec.target_rps,
+        }
+        mismatched = {
+            field: {"expected": value, "actual": record.get(field)}
+            for field, value in expected.items() if record.get(field) != value
+        }
+        if mismatched:
+            raise MeasurementInvalid(
+                f"burst {spec.burst_id} request metadata diverged from schedule: {mismatched}"
+            )
+
+    artifact_ns = [record["artifact_ns"] for record in records if "artifact_ns" in record]
+    finished_ns = [record["finished_ns"] for record in records]
+    score_start_ns = burst_start_ns + round(spec.ramp_seconds * 1_000_000_000)
+    score_end_ns = score_start_ns + round(spec.score_seconds * 1_000_000_000)
+    scored = [record for record in records if record["segment"] == "score"]
+    per_backend = {}
+    for backend in ("file", "uffd"):
+        rows = [record for record in scored if record["backend"] == backend]
+        planned = _planned_count(spec.target_rps, spec.score_seconds)
+        if len(rows) != planned:
+            raise MeasurementInvalid(
+                f"burst {spec.burst_id} has {len(rows)} scored {backend} requests, "
+                f"expected {planned}"
+            )
+        launched_by_end = sum(row["actual_launch_ns"] <= score_end_ns for row in rows)
+        artifact_by_end = sum(
+            row.get("artifact_ns") is not None and row["artifact_ns"] <= score_end_ns
+            for row in rows
+        )
+        launch_lags = [
+            (row["actual_launch_ns"] - row["scheduled_ns"]) / 1_000_000
+            for row in rows
+        ]
+        artifact_latencies = [
+            (row["artifact_ns"] - row["actual_launch_ns"]) / 1_000_000
+            for row in rows if row.get("artifact_ns") is not None
+        ]
+        drain_latencies = [
+            (row["finished_ns"] - row["artifact_ns"]) / 1_000_000
+            for row in rows if row.get("artifact_ns") is not None
+        ]
+        wall_latencies = [
+            (row["finished_ns"] - row["actual_launch_ns"]) / 1_000_000
+            for row in rows
+        ]
+        per_backend[backend] = {
+            "cell_id": f"{backend}:r{format(spec.target_rps, '.12g')}",
+            "planned": planned,
+            "launched": len(rows),
+            "launched_by_score_end": launched_by_end,
+            "artifact_completed": sum(row.get("artifact_ns") is not None for row in rows),
+            "artifact_completed_by_score_end": artifact_by_end,
+            "drained": sum("finished_ns" in row for row in rows),
+            "cleanup_confirmed": sum(
+                isinstance(row.get("teardown"), dict)
+                and row["teardown"].get("all_gone") is True
+                for row in rows
+            ),
+            "ok": sum(bool(row.get("ok")) for row in rows),
+            "failed": sum(not bool(row.get("ok")) for row in rows),
+            "offered_rps": launched_by_end / spec.score_seconds,
+            "departure_rps": artifact_by_end / spec.score_seconds,
+            "departure_ratio": artifact_by_end / planned,
+            "score_start_backlog": _backlog_at(records, backend, score_start_ns),
+            "score_end_backlog": _backlog_at(records, backend, score_end_ns),
+            "max_backlog_during_score": _max_backlog(
+                records, backend, score_start_ns, score_end_ns
+            ),
+            "launch_lag_ms": distribution(launch_lags),
+            "artifact_latency_ms": distribution(artifact_latencies),
+            "drain_latency_ms": distribution(drain_latencies),
+            "wall_latency_ms": distribution(wall_latencies),
+            "blocking_latency_ms": distribution([
+                float(row["blocking_ms"]) for row in rows if row.get("ok")
+            ]),
+        }
+    summary = {
+        "schema": RECORD_SCHEMA,
+        "kind": "burst",
+        **_burst_metadata(spec),
+        "burst_start_ns": burst_start_ns,
+        "score_start_ns": score_start_ns,
+        "score_end_ns": score_end_ns,
+        "planned": len(scored),
+        "launched": len(scored),
+        "artifact_completed": sum("artifact_ns" in row for row in scored),
+        "drained": sum("finished_ns" in row for row in scored),
+        "cleanup_confirmed": sum(
+            record.get("teardown", {}).get("all_gone") is True
+            for record in scored
+            if isinstance(record.get("teardown"), dict)
+        ),
+        "ok": sum(bool(record.get("ok")) for record in scored),
+        "failed": sum(not bool(record.get("ok")) for record in records),
+        "total_planned": count,
+        "total_artifact_completed": len(artifact_ns),
+        "total_drained": len(finished_ns),
+        "total_cleanup_confirmed": sum(
+            isinstance(record.get("teardown"), dict)
+            and record["teardown"].get("all_gone") is True
+            for record in records
+        ),
+        "schedule_submission_span_ms": (
+            schedule_submission_end_ns - burst_start_ns
+        ) / 1_000_000,
+        "launch_span_ms": (
+            max(record["actual_launch_ns"] for record in records) - burst_start_ns
+        ) / 1_000_000,
+        "completion_span_ms": (
+            (max(artifact_ns) - burst_start_ns) / 1_000_000 if artifact_ns else None
+        ),
+        "drain_span_ms": (max(finished_ns) - burst_start_ns) / 1_000_000,
+        "launch_lag_ms": distribution([
+            (record["actual_launch_ns"] - record["scheduled_ns"]) / 1_000_000
+            for record in scored
+        ]),
+        "latency_ms": distribution([
+            float(record["blocking_ms"]) for record in scored if record.get("ok")
+        ]),
+        "backends": per_backend,
+    }
+    return records, summary
+
+
+# ---------------------------------------------------------------- procfs/cgroup
+
+
+@dataclass(frozen=True)
+class ProcessStat:
+    pid: int
+    state: str
+    minor_faults: int
+    major_faults: int
+    start_time_ticks: int
+
+
+def parse_process_stat(raw: str) -> ProcessStat:
+    """Parse /proc/PID/stat without being fooled by parentheses in comm."""
+    try:
+        pid_text, rest = raw.split(" ", 1)
+        fields = rest.rsplit(") ", 1)[1].split()
+        return ProcessStat(
+            pid=int(pid_text),
+            state=fields[0],
+            minor_faults=int(fields[7]),   # field 10
+            major_faults=int(fields[9]),   # field 12
+            start_time_ticks=int(fields[19]),  # field 22
+        )
+    except (IndexError, ValueError) as error:
+        raise MeasurementInvalid(f"malformed /proc stat record: {error}") from error
+
+
+def parse_cpu_stat(raw: str) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for number, line in enumerate(raw.splitlines(), 1):
+        parts = line.split()
+        if not parts:
+            continue
+        if len(parts) != 2 or not parts[1].isdigit():
+            raise MeasurementInvalid(f"malformed cpu.stat line {number}: {line!r}")
+        if parts[0] in out:
+            raise MeasurementInvalid(f"duplicate cpu.stat counter {parts[0]!r}")
+        out[parts[0]] = int(parts[1])
+    if "usage_usec" not in out:
+        raise MeasurementInvalid("cpu.stat has no usage_usec counter")
+    return out
+
+
+def counter_delta(before: dict[str, int], after: dict[str, int]) -> dict[str, int]:
+    if set(before) != set(after):
+        raise MeasurementInvalid(
+            f"counter set changed during window: before={sorted(before)} after={sorted(after)}"
+        )
+    out = {key: after[key] - before[key] for key in before}
+    negative = {key: value for key, value in out.items() if value < 0}
+    if negative:
+        raise MeasurementInvalid(f"counters moved backwards: {negative}")
+    return out
+
+
+def read_machine_proc_stat(path: str = "/proc/stat") -> dict:
+    """Capture the complete machine-wide /proc/stat plus its aggregate CPU row."""
+    with open(path) as stream:
+        raw = stream.read()
+    lines = raw.splitlines()
+    first = lines[0].split() if lines else []
+    if not first or first[0] != "cpu" or len(first) < 5:
+        raise MeasurementInvalid(f"{path} has no aggregate cpu line")
+    try:
+        values = [int(value) for value in first[1:]]
+    except ValueError as error:
+        raise MeasurementInvalid(f"{path} aggregate cpu line is malformed") from error
+    names = list(CPU_FIELDS)
+    if len(values) > len(names):
+        names.extend(f"field_{index}" for index in range(len(names), len(values)))
+    return {
+        "path": path,
+        "captured_wall_ns": time.time_ns(),
+        "captured_monotonic_ns": time.monotonic_ns(),
+        "clk_tck": os.sysconf("SC_CLK_TCK"),
+        # Preserve every kernel-supplied row.  The aggregate is parsed separately
+        # for a checked delta, but dropping intr/ctxt/processes/per-CPU rows would
+        # not satisfy the run's whole-/proc/stat accounting contract.
+        "raw": raw,
+        "raw_sha256": hashlib.sha256(raw.encode()).hexdigest(),
+        "cpu": dict(zip(names, values)),
+    }
+
+
+def _read_text_artifact(path: str) -> dict:
+    try:
+        with open(path) as stream:
+            raw = stream.read()
+    except OSError as error:
+        raise MeasurementInvalid(f"cannot read host accounting input {path}: {error}") from error
+    return {"path": path, "raw": raw, "raw_sha256": hashlib.sha256(raw.encode()).hexdigest()}
+
+
+def parse_loadavg(raw: str, source: str) -> dict:
+    fields = raw.split()
+    try:
+        if len(fields) != 5:
+            raise ValueError(f"expected 5 fields, found {len(fields)}")
+        running, total = fields[3].split("/", 1)
+        parsed = {
+            "load_1": float(fields[0]),
+            "load_5": float(fields[1]),
+            "load_15": float(fields[2]),
+            "running_tasks": int(running),
+            "total_tasks": int(total),
+            "last_pid": int(fields[4]),
+        }
+    except (ValueError, IndexError) as error:
+        raise MeasurementInvalid(f"malformed loadavg {source}: {error}") from error
+    if any(not math.isfinite(parsed[key]) or parsed[key] < 0 for key in ("load_1", "load_5", "load_15")):
+        raise MeasurementInvalid(f"invalid load averages in {source}")
+    if (
+        parsed["running_tasks"] < 0
+        or parsed["total_tasks"] < parsed["running_tasks"]
+        or parsed["last_pid"] < 0
+    ):
+        raise MeasurementInvalid(f"invalid task counts in loadavg {source}")
+    return parsed
+
+
+def read_loadavg(path: str = "/proc/loadavg") -> dict:
+    captured = _read_text_artifact(path)
+    return {**captured, "parsed": parse_loadavg(captured["raw"], path)}
+
+
+def parse_psi(raw: str, source: str) -> dict:
+    parsed = {}
+    for number, line in enumerate(raw.splitlines(), 1):
+        fields = line.split()
+        if not fields:
+            continue
+        category = fields[0]
+        if category not in ("some", "full") or category in parsed:
+            raise MeasurementInvalid(f"malformed PSI category at {source}:{number}: {line!r}")
+        values = {}
+        for field in fields[1:]:
+            key, separator, raw_value = field.partition("=")
+            if not separator or key in values:
+                raise MeasurementInvalid(f"malformed PSI field at {source}:{number}: {field!r}")
+            try:
+                values[key] = int(raw_value) if key == "total" else float(raw_value)
+            except ValueError as error:
+                raise MeasurementInvalid(
+                    f"non-numeric PSI field at {source}:{number}: {field!r}"
+                ) from error
+        if set(values) != {"avg10", "avg60", "avg300", "total"}:
+            raise MeasurementInvalid(f"incomplete PSI row at {source}:{number}: {line!r}")
+        if any(not math.isfinite(values[key]) or values[key] < 0 for key in ("avg10", "avg60", "avg300")) or values["total"] < 0:
+            raise MeasurementInvalid(f"invalid PSI values at {source}:{number}")
+        parsed[category] = values
+    if "some" not in parsed:
+        raise MeasurementInvalid(f"PSI input {source} has no some row")
+    return parsed
+
+
+def read_psi(root: str = "/proc/pressure") -> dict:
+    out = {}
+    for resource in ("cpu", "memory", "io"):
+        captured = _read_text_artifact(os.path.join(root, resource))
+        captured["parsed"] = parse_psi(captured["raw"], captured["path"])
+        out[resource] = captured
+    return out
+
+
+def parse_meminfo(raw: str, source: str) -> dict:
+    values = {}
+    for number, line in enumerate(raw.splitlines(), 1):
+        key, separator, rest = line.partition(":")
+        fields = rest.split()
+        if not separator or not key or not fields or len(fields) > 2 or key in values:
+            raise MeasurementInvalid(
+                f"malformed meminfo line {source}:{number}: {line!r}"
+            )
+        try:
+            value = int(fields[0])
+        except ValueError as error:
+            raise MeasurementInvalid(
+                f"non-numeric meminfo line {source}:{number}: {line!r}"
+            ) from error
+        if value < 0:
+            raise MeasurementInvalid(
+                f"negative meminfo value at {source}:{number}: {line!r}"
+            )
+        values[key] = {"value": value, "unit": fields[1] if len(fields) > 1 else None}
+    if "MemAvailable" not in values:
+        raise MeasurementInvalid(f"{source} has no MemAvailable")
+    return values
+
+
+def read_meminfo(path: str = "/proc/meminfo") -> dict:
+    captured = _read_text_artifact(path)
+    return {**captured, "parsed": parse_meminfo(captured["raw"], path)}
+
+
+class ProcReader:
+    def __init__(self, root: str = "/proc"):
+        self.root = root
+
+    def children_of(self, pid: int) -> list[int]:
+        children = []
+        try:
+            tids = os.listdir(os.path.join(self.root, str(pid), "task"))
+        except OSError as error:
+            raise MeasurementInvalid(f"cannot enumerate children of pid {pid}: {error}")
+        for tid in tids:
+            try:
+                with open(os.path.join(self.root, str(pid), "task", tid, "children")) as f:
+                    children.extend(int(value) for value in f.read().split())
+            except OSError:
+                continue
+        return sorted(set(children))
+
+    def comm(self, pid: int) -> str:
+        try:
+            with open(os.path.join(self.root, str(pid), "comm")) as stream:
+                return stream.read().strip()
+        except OSError as error:
+            raise MeasurementInvalid(f"cannot read comm for pid {pid}: {error}")
+
+    def stat(self, pid: int) -> ProcessStat:
+        try:
+            with open(os.path.join(self.root, str(pid), "stat")) as stream:
+                return parse_process_stat(stream.read())
+        except OSError as error:
+            raise MeasurementInvalid(f"cannot read stat for pid {pid}: {error}")
+
+    def identity(self, pid: int) -> "ProcIdentity":
+        return ProcIdentity(self.root, pid)
+
+
+class ProcIdentity:
+    """An open /proc/PID directory that cannot drift onto a reused pathname."""
+
+    def __init__(self, proc_root: str, pid: int):
+        self.pid = pid
+        try:
+            self.fd = os.open(
+                os.path.join(proc_root, str(pid)),
+                os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+            )
+        except OSError as error:
+            raise MeasurementInvalid(f"cannot open /proc identity for pid {pid}: {error}")
+
+    def read(self, name: str) -> str:
+        if self.fd is None:
+            raise MeasurementInvalid(f"/proc identity for pid {self.pid} is closed")
+        try:
+            return _read_proc_member(self.fd, name)
+        except (OSError, UnicodeError) as error:
+            raise MeasurementInvalid(
+                f"cannot read {name} for pinned pid {self.pid}: {error}"
+            ) from error
+
+    def stat(self) -> ProcessStat:
+        value = parse_process_stat(self.read("stat"))
+        if value.pid != self.pid:
+            raise MeasurementInvalid(
+                f"pinned proc identity says pid {value.pid}, expected {self.pid}"
+            )
+        return value
+
+    def comm(self) -> str:
+        return self.read("comm").strip()
+
+    def cgroup(self) -> str:
+        return _unified_cgroup_from_raw(self.read("cgroup"), f"pinned pid {self.pid} cgroup")
+
+    def close(self) -> None:
+        if self.fd is not None:
+            os.close(self.fd)
+            self.fd = None
+
+
+def _read_unified_cgroup(path: str) -> str:
+    with open(path) as stream:
+        rows = [line.rstrip("\n") for line in stream]
+    unified = [line.partition("::")[2] for line in rows if "::" in line]
+    if len(unified) != 1 or not unified[0].startswith("/"):
+        raise MeasurementInvalid(f"{path} has no single cgroup-v2 membership: {rows}")
+    return unified[0]
+
+
+def _read_proc_member(pid_dir_fd: int, name: str) -> str:
+    """Read one file through an already-open /proc/PID directory identity."""
+    fd = os.open(name, os.O_RDONLY, dir_fd=pid_dir_fd)
+    try:
+        chunks = []
+        while True:
+            chunk = os.read(fd, 64 * 1024)
+            if not chunk:
+                return b"".join(chunks).decode()
+            chunks.append(chunk)
+    finally:
+        os.close(fd)
+
+
+def _unified_cgroup_from_raw(raw: str, source: str) -> str:
+    rows = raw.splitlines()
+    unified = [line.partition("::")[2] for line in rows if "::" in line]
+    if len(unified) != 1 or not unified[0].startswith("/"):
+        raise MeasurementInvalid(f"{source} has no single cgroup-v2 membership: {rows}")
+    return unified[0]
+
+
+class CgroupAudit:
+    """Read-only membership and run-level cpu.stat accounting."""
+
+    def __init__(self, path: str, proc_root: str = "/proc", cgroup_root: str = "/sys/fs/cgroup"):
+        self.path = os.path.realpath(path)
+        self.proc_root = proc_root
+        self.cgroup_root = os.path.realpath(cgroup_root)
+        relative = os.path.relpath(self.path, self.cgroup_root)
+        if relative == ".." or relative.startswith(f"..{os.sep}"):
+            raise MeasurementInvalid(f"run cgroup {path} is outside {cgroup_root}")
+        self.relative = "/" if relative == "." else "/" + relative
+        self.observed: dict[tuple[int, int], dict] = {}
+        self.observed_lock = threading.Lock()
+
+    def observe(self, pid: int, role: str) -> ProcessStat:
+        # Open /proc/PID once and perform every read relative to that directory.
+        # A pathname re-open could silently bind the cgroup row and stat row to
+        # different processes if the first process exits and the PID is reused.
+        # The directory fd pins the procfs identity; a disappearing member fails
+        # this measurement instead of being relabelled as its replacement.
+        identity = ProcIdentity(self.proc_root, pid)
+        try:
+            return self.observe_identity(identity, role)
+        finally:
+            identity.close()
+
+    def observe_identity(self, identity: ProcIdentity, role: str) -> ProcessStat:
+        before = identity.stat()
+        membership = identity.cgroup()
+        comm = identity.comm()
+        after = identity.stat()
+        if before.start_time_ticks != after.start_time_ticks:
+            raise MeasurementInvalid(
+                f"{role} pid {identity.pid} changed identity while cgroup membership was sampled"
+            )
+        if membership != self.relative and not membership.startswith(self.relative.rstrip("/") + "/"):
+            raise MeasurementInvalid(
+                f"{role} pid {identity.pid} is outside run cgroup {self.relative}: {membership}"
+            )
+        key = (identity.pid, before.start_time_ticks)
+        with self.observed_lock:
+            existing = self.observed.get(key)
+            if existing is not None and existing["role"] != role:
+                raise MeasurementInvalid(
+                    f"process {key} was observed as both {existing['role']} and {role}"
+                )
+            self.observed[key] = {"role": role, "comm": comm}
+        return before
+
+    def cpu_snapshot(self) -> dict[str, int]:
+        with open(os.path.join(self.path, "cpu.stat")) as stream:
+            return parse_cpu_stat(stream.read())
+
+    def live_pids(self) -> list[int]:
+        try:
+            with open(os.path.join(self.path, "cgroup.procs")) as stream:
+                return sorted(int(value) for value in stream.read().split())
+        except (OSError, ValueError) as error:
+            raise MeasurementInvalid(f"cannot read run cgroup.procs: {error}")
+
+    def record(self) -> dict:
+        with self.observed_lock:
+            observed = dict(self.observed)
+        return {
+            "path": self.relative,
+            "observed": [
+                {"pid": pid, "pid_start_time_ticks": start, **observed[(pid, start)]}
+                for pid, start in sorted(observed)
+            ],
+            "live_pids": self.live_pids(),
+            "cpu_stat": self.cpu_snapshot(),
+        }
+
+
+class FirecrackerFaultProbe:
+    """Minor/major faults during one render, bound to an exact VMM process."""
+
+    def __init__(
+        self,
+        proc_reader: ProcReader,
+        cgroup_audit: CgroupAudit,
+        trace_marker: Optional[Callable[[int], None]] = None,
+    ):
+        self.proc = proc_reader
+        self.audit = cgroup_audit
+        self.trace_marker = trace_marker
+        self.before: Optional[ProcessStat] = None
+        self.identity: Optional[ProcIdentity] = None
+        self.trace_open = False
+
+    def begin(self, fcvm_pid: int) -> None:
+        self.audit.observe(fcvm_pid, "fcvm")
+        children = self.proc.children_of(fcvm_pid)
+        named = []
+        observed = []
+        try:
+            for pid in children:
+                identity = self.proc.identity(pid)
+                try:
+                    comm = identity.comm()
+                    self.audit.observe_identity(identity, comm or "unnamed-child")
+                    observed.append((pid, comm))
+                    if comm == "firecracker":
+                        named.append(identity)
+                        identity = None
+                finally:
+                    if identity is not None:
+                        identity.close()
+            if len(named) != 1:
+                raise MeasurementInvalid(
+                    f"fcvm pid {fcvm_pid} has {len(named)} firecracker children; "
+                    f"expected exactly one: {observed}"
+                )
+            self.identity = named[0]
+            self.before = self.identity.stat()
+            if self.trace_marker is not None:
+                self.trace_marker(self.before.pid)
+                self.trace_open = True
+        except BaseException:
+            for identity in named:
+                identity.close()
+            self.identity = None
+            self.before = None
+            raise
+
+    def finish(self) -> dict:
+        if self.before is None or self.identity is None:
+            raise MeasurementInvalid("Firecracker fault probe finish called before begin")
+        try:
+            if self.trace_open:
+                self.trace_marker(self.before.pid)
+                self.trace_open = False
+            after = self.identity.stat()
+            if after.start_time_ticks != self.before.start_time_ticks:
+                raise MeasurementInvalid(
+                    f"Firecracker pid {after.pid} identity changed from "
+                    f"{self.before.start_time_ticks} to {after.start_time_ticks}"
+                )
+            minor = after.minor_faults - self.before.minor_faults
+            major = after.major_faults - self.before.major_faults
+            if minor < 0 or major < 0:
+                raise MeasurementInvalid(
+                    f"Firecracker fault counters moved backwards: minor={minor} major={major}"
+                )
+            return {
+                "pid": after.pid,
+                "pid_start_time_ticks": after.start_time_ticks,
+                "minor_faults": minor,
+                "major_faults": major,
+                "before": {
+                    "minor_faults": self.before.minor_faults,
+                    "major_faults": self.before.major_faults,
+                },
+                "after": {
+                    "minor_faults": after.minor_faults,
+                    "major_faults": after.major_faults,
+                },
+                "scope": (
+                    "Firecracker process endpoint-ready through artifact return; "
+                    "all process VMAs, not guest-RAM-filtered and not UFFD events"
+                ),
+            }
+        finally:
+            self.identity.close()
+            self.identity = None
+
+
+# ---------------------------------------------------------------- output and gates
+
+
+def _fsync_directory(path: str) -> None:
+    fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def write_json_exclusive(path: str, value) -> None:
+    """Atomically create one JSON artifact; never replace an earlier run."""
+    directory = os.path.dirname(os.path.abspath(path))
+    os.makedirs(directory, exist_ok=True)
+    temp = os.path.join(directory, f".{os.path.basename(path)}.{uuid.uuid4().hex}.tmp")
+    try:
+        fd = os.open(temp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(json.dumps(value, indent=2, sort_keys=True, allow_nan=False).encode())
+            stream.write(b"\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.link(temp, path)  # atomic and fails with FileExistsError
+        _fsync_directory(directory)
+    finally:
+        try:
+            os.unlink(temp)
+        except FileNotFoundError:
+            pass
+
+
+class JsonlSink:
+    def __init__(self, path: str):
+        directory = os.path.dirname(os.path.abspath(path))
+        os.makedirs(directory, exist_ok=True)
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+        self.directory = directory
+        self.stream = os.fdopen(fd, "w", buffering=1)
+        self.lock = threading.Lock()
+        _fsync_directory(directory)
+
+    def write(self, value) -> None:
+        encoded = json.dumps(value, sort_keys=True, allow_nan=False)
+        with self.lock:
+            self.stream.write(encoded + "\n")
+            self.stream.flush()
+
+    def sync(self) -> None:
+        with self.lock:
+            self.stream.flush()
+            os.fsync(self.stream.fileno())
+
+    def close(self) -> None:
+        if not self.stream.closed:
+            self.sync()
+            self.stream.close()
+            _fsync_directory(self.directory)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _type, _value, _traceback):
+        self.close()
+
+
+class HostSampleSource:
+    """Injectable boundary for one complete host/cgroup accounting sample."""
+
+    def __init__(
+        self,
+        proc_stat: str = "/proc/stat",
+        loadavg: str = "/proc/loadavg",
+        pressure_root: str = "/proc/pressure",
+        meminfo: str = "/proc/meminfo",
+    ):
+        self.proc_stat = proc_stat
+        self.loadavg = loadavg
+        self.pressure_root = pressure_root
+        self.meminfo = meminfo
+
+    def capture(self, audits: dict[str, CgroupAudit], phase: dict) -> dict:
+        captured_wall_ns = time.time_ns()
+        captured_monotonic_ns = time.monotonic_ns()
+        cgroups = {}
+        seen_pids = {}
+        for name, audit in sorted(audits.items()):
+            pids = audit.live_pids()
+            if name != "run":
+                for pid in pids:
+                    prior = seen_pids.setdefault(pid, name)
+                    if prior != name:
+                        raise MeasurementInvalid(
+                            f"pid {pid} appears in both {prior} and {name} leaf cgroups"
+                        )
+            cgroups[name] = {
+                "path": audit.relative,
+                "live_pids": pids,
+                "cpu_stat": audit.cpu_snapshot(),
+            }
+        sample = {
+            "schema": "fcvm.chromium.reqscale.host-sample.v1",
+            "captured_wall_ns": captured_wall_ns,
+            "captured_monotonic_ns": captured_monotonic_ns,
+            "phase": dict(phase),
+            "proc_stat": read_machine_proc_stat(self.proc_stat),
+            "loadavg": read_loadavg(self.loadavg),
+            "pressure": read_psi(self.pressure_root),
+            "meminfo": read_meminfo(self.meminfo),
+            "cgroups": cgroups,
+        }
+        sample["completed_wall_ns"] = time.time_ns()
+        sample["completed_monotonic_ns"] = time.monotonic_ns()
+        return sample
+
+
+class RunPhase:
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.value = {"name": "setup", "burst_id": None}
+
+    def set(self, name: str, burst_id: Optional[str] = None) -> None:
+        with self.lock:
+            self.value = {"name": name, "burst_id": burst_id}
+
+    def snapshot(self) -> dict:
+        with self.lock:
+            return dict(self.value)
+
+
+class HostSampler:
+    """Continuous absolute-deadline sampler with durable per-sample writes."""
+
+    def __init__(
+        self,
+        sink: JsonlSink,
+        audits: dict[str, CgroupAudit],
+        phase_provider: Callable[[], dict],
+        interval_ns: int,
+        source: Optional[HostSampleSource] = None,
+    ):
+        if interval_ns != round(SAMPLE_INTERVAL_SECONDS * 1_000_000_000):
+            raise MeasurementInvalid("host sample interval must be exactly 5 seconds")
+        self.sink = sink
+        self.audits = audits
+        self.phase_provider = phase_provider
+        self.interval_ns = interval_ns
+        self.source = source or HostSampleSource()
+        self.stop_event = threading.Event()
+        self.thread = None
+        self.error = None
+        self.error_lock = threading.Lock()
+        self.origin_ns = None
+        self.samples = 0
+
+    def _run(self) -> None:
+        assert self.origin_ns is not None
+        index = 0
+        try:
+            while True:
+                deadline_ns = self.origin_ns + index * self.interval_ns
+                remaining_s = (deadline_ns - time.monotonic_ns()) / 1_000_000_000
+                if remaining_s > 0 and self.stop_event.wait(remaining_s):
+                    return
+                if self.stop_event.is_set():
+                    return
+                sample = self.source.capture(self.audits, self.phase_provider())
+                sample.update(
+                    sample_index=index,
+                    scheduled_monotonic_ns=deadline_ns,
+                    launch_lag_ms=(sample["captured_monotonic_ns"] - deadline_ns) / 1_000_000,
+                )
+                self.sink.write(sample)
+                self.sink.sync()
+                self.samples += 1
+                index += 1
+        except BaseException as error:
+            with self.error_lock:
+                self.error = error
+            self.stop_event.set()
+
+    def start(self) -> None:
+        if self.thread is not None:
+            raise MeasurementInvalid("host sampler started twice")
+        self.origin_ns = time.monotonic_ns()
+        self.thread = threading.Thread(
+            target=self._run, name="reqscale-host-sampler", daemon=False
+        )
+        self.thread.start()
+
+    def check(self) -> None:
+        with self.error_lock:
+            error = self.error
+        if error is not None:
+            raise MeasurementInvalid(
+                f"host sampler failed: {type(error).__name__}: {error}"
+            ) from error
+
+    def stop(self, timeout_s: float = 15.0) -> dict:
+        if self.thread is None:
+            return {"samples": 0, "started": False}
+        stop_requested_ns = time.monotonic_ns()
+        self.stop_event.set()
+        self.thread.join(timeout_s)
+        if self.thread.is_alive():
+            raise MeasurementInvalid("host sampler thread survived stop")
+        self.check()
+        terminal = self.source.capture(self.audits, self.phase_provider())
+        terminal.update(
+            sample_index=self.samples,
+            scheduled_monotonic_ns=None,
+            launch_lag_ms=None,
+            terminal=True,
+        )
+        self.sink.write(terminal)
+        self.samples += 1
+        self.sink.sync()
+        return {
+            "samples": self.samples,
+            "periodic_samples": self.samples - 1,
+            "terminal_sample": True,
+            "started": True,
+            "origin_monotonic_ns": self.origin_ns,
+            "interval_ns": self.interval_ns,
+            "stop_requested_monotonic_ns": stop_requested_ns,
+        }
+
+
+def evaluate_trace_perturbation(summaries: list[dict], max_delta_pct: float) -> dict:
+    """Gate each predeclared traced/control pair; no unpaired aggregate."""
+    if not math.isfinite(max_delta_pct) or max_delta_pct < 0:
+        raise MeasurementInvalid("trace perturbation limit must be finite and nonnegative")
+    grouped: dict[str, list[dict]] = {}
+    for summary in summaries:
+        pair_id = summary.get("trace_pair_id")
+        if pair_id:
+            grouped.setdefault(pair_id, []).append(summary)
+    if not grouped:
+        raise MeasurementInvalid("no matched trace perturbation pairs were recorded")
+    rows = []
+    failures = []
+    for pair_id in sorted(grouped):
+        pair = grouped[pair_id]
+        controls = [item for item in pair if item.get("traced") is False]
+        traces = [item for item in pair if item.get("traced") is True]
+        if len(controls) != 1 or len(traces) != 1:
+            raise MeasurementInvalid(
+                f"trace pair {pair_id} is not matched: controls={len(controls)} traced={len(traces)}"
+            )
+        control, traced = controls[0], traces[0]
+        shape_fields = ("target_rps", "request_plan_count", "request_plan_sha256")
+        if any(control.get(field) != traced.get(field) for field in shape_fields):
+            raise MeasurementInvalid(f"trace pair {pair_id} has mismatched cells")
+        for item in (control, traced):
+            if (
+                item.get("total_artifact_completed") != item.get("request_plan_count")
+                or item.get("total_drained") != item.get("request_plan_count")
+                or item.get("total_cleanup_confirmed") != item.get("request_plan_count")
+                or item.get("failed", 0) != 0
+            ):
+                raise MeasurementInvalid(f"trace pair {pair_id} has incomplete requests")
+        for backend in ("file", "uffd"):
+            control_cell = control.get("backends", {}).get(backend, {})
+            traced_cell = traced.get("backends", {}).get(backend, {})
+            base = control_cell.get("artifact_latency_ms", {}).get("median")
+            measured = traced_cell.get("artifact_latency_ms", {}).get("median")
+            if (
+                not isinstance(base, (int, float)) or isinstance(base, bool)
+                or not math.isfinite(base) or base <= 0
+                or not isinstance(measured, (int, float)) or isinstance(measured, bool)
+                or not math.isfinite(measured) or measured <= 0
+            ):
+                raise MeasurementInvalid(
+                    f"trace pair {pair_id} {backend} has no positive median"
+                )
+            delta = (measured - base) * 100.0 / base
+            row = {
+                "trace_pair_id": pair_id,
+                "backend": backend,
+                "target_rps": control["target_rps"],
+                "control_median_ms": base,
+                "traced_median_ms": measured,
+                "median_delta_pct": delta,
+                "limit_pct": max_delta_pct,
+                "passed": abs(delta) <= max_delta_pct,
+            }
+            rows.append(row)
+            if not row["passed"]:
+                failures.append(row)
+    verdict = {"passed": not failures, "limit_pct": max_delta_pct, "pairs": rows}
+    if failures:
+        raise MeasurementInvalid(
+            f"fault tracing perturbation exceeded {max_delta_pct}% in {len(failures)} pair(s)",
+            verdict,
+        )
+    return verdict
+
+
+# ---------------------------------------------------------------- bpftrace fault cost
+
+
+def _numeric_pid_map(value, name: str) -> dict[int, int]:
+    if not isinstance(value, dict):
+        raise MeasurementInvalid(f"bpftrace {name} is not a map")
+    out = {}
+    for pid_text, count in value.items():
+        try:
+            pid = int(pid_text)
+        except (TypeError, ValueError) as error:
+            raise MeasurementInvalid(f"bpftrace {name} has non-pid key {pid_text!r}") from error
+        if pid <= 0 or str(pid) != pid_text or pid in out:
+            raise MeasurementInvalid(f"bpftrace {name} has invalid pid key {pid_text!r}")
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+            raise MeasurementInvalid(f"bpftrace {name}[{pid}] is not a nonnegative integer")
+        out[pid] = count
+    return out
+
+
+def _strict_trace_object(pairs):
+    value = {}
+    for key, item in pairs:
+        if key in value:
+            raise MeasurementInvalid(f"bpftrace JSON has duplicate key {key!r}")
+        value[key] = item
+    return value
+
+
+def _reject_trace_constant(value):
+    raise MeasurementInvalid(f"bpftrace JSON has non-standard constant {value}")
+
+
+def parse_fault_trace(lines: Iterable[str]) -> dict:
+    """Parse bpftrace ``-f json`` output and prove every aggregate reconciles."""
+    ready = False
+    maps: dict[str, dict] = {}
+    histogram = None
+    for number, line in enumerate(lines, 1):
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(
+                line,
+                object_pairs_hook=_strict_trace_object,
+                parse_constant=_reject_trace_constant,
+            )
+        except (json.JSONDecodeError, ValueError) as error:
+            raise MeasurementInvalid(f"bpftrace output line {number} is not JSON: {error}")
+        if not isinstance(event, dict):
+            raise MeasurementInvalid(f"bpftrace output line {number} is not an object")
+        if event.get("type") == "printf" and event.get("data") == "REQSCALE_TRACE_READY\\n":
+            ready = True
+        if event.get("type") == "map":
+            data = event.get("data")
+            if not isinstance(data, dict) or len(data) != 1:
+                raise MeasurementInvalid(f"malformed bpftrace map event on line {number}")
+            name, value = next(iter(data.items()))
+            if name in maps:
+                raise MeasurementInvalid(f"bpftrace printed {name} more than once")
+            maps[name] = _numeric_pid_map(value, name)
+        if event.get("type") == "hist":
+            data = event.get("data")
+            if not isinstance(data, dict) or set(data) != {"@latency_ns"}:
+                raise MeasurementInvalid(f"unexpected bpftrace histogram event on line {number}")
+            if histogram is not None:
+                raise MeasurementInvalid("bpftrace printed @latency_ns more than once")
+            raw_hist = data["@latency_ns"]
+            if not isinstance(raw_hist, dict):
+                raise MeasurementInvalid("bpftrace @latency_ns is not keyed by pid")
+            histogram = {}
+            for pid_text, buckets in raw_hist.items():
+                try:
+                    pid = int(pid_text)
+                except (TypeError, ValueError) as error:
+                    raise MeasurementInvalid(f"histogram has non-pid key {pid_text!r}") from error
+                if pid <= 0 or str(pid) != pid_text or pid in histogram:
+                    raise MeasurementInvalid(f"histogram has invalid pid key {pid_text!r}")
+                if not isinstance(buckets, list):
+                    raise MeasurementInvalid(f"histogram for pid {pid} is not a list")
+                checked = []
+                for bucket in buckets:
+                    if (
+                        not isinstance(bucket, dict)
+                        or set(bucket) != {"min", "max", "count"}
+                        or not all(
+                            isinstance(bucket[key], int)
+                            and not isinstance(bucket[key], bool)
+                            for key in bucket
+                        )
+                        or bucket["min"] < 0
+                        or bucket["max"] < bucket["min"]
+                        or bucket["count"] < 0
+                    ):
+                        raise MeasurementInvalid(f"malformed histogram bucket for pid {pid}: {bucket}")
+                    checked.append(dict(bucket))
+                if any(
+                    current["min"] <= previous["max"]
+                    for previous, current in zip(checked, checked[1:])
+                ):
+                    raise MeasurementInvalid(
+                        f"histogram buckets overlap or are unordered for pid {pid}"
+                    )
+                histogram[pid] = checked
+
+    if not ready:
+        raise MeasurementInvalid("bpftrace never emitted REQSCALE_TRACE_READY")
+    required_markers = {"@opened", "@closed"}
+    missing = required_markers - set(maps)
+    if missing:
+        raise MeasurementInvalid(f"bpftrace output is missing marker maps {sorted(missing)}")
+    # A legitimate interval can contain zero handle_mm_fault calls. bpftrace
+    # does not materialize a map (or histogram key) until its first update, so
+    # absent event maps mean zero only for a pid whose open+close markers exist.
+    for name in ("@entered", "@completed", "@total_ns"):
+        maps.setdefault(name, {})
+    histogram = histogram or {}
+    event_maps = {"@entered", "@completed", "@total_ns"}
+    stray = set().union(*(set(maps[name]) for name in event_maps), set(histogram)) - set(maps["@opened"])
+    if stray:
+        raise MeasurementInvalid(f"bpftrace recorded unmarked pids {sorted(stray)}")
+    pids = set(maps["@opened"]) | set(maps["@closed"])
+    processes = {}
+    for pid in sorted(pids):
+        values = {
+            "@opened": maps["@opened"].get(pid),
+            "@closed": maps["@closed"].get(pid),
+            "@entered": maps["@entered"].get(pid, 0),
+            "@completed": maps["@completed"].get(pid, 0),
+            "@total_ns": maps["@total_ns"].get(pid, 0),
+        }
+        buckets = histogram.get(pid, [])
+        if values["@opened"] is None or values["@closed"] is None:
+            raise MeasurementInvalid(f"bpftrace marker aggregates are incomplete for pid {pid}")
+        if values["@opened"] != 1 or values["@closed"] != 1:
+            raise MeasurementInvalid(
+                f"bpftrace pid {pid} marker mismatch: opened={values['@opened']} "
+                f"closed={values['@closed']}"
+            )
+        if values["@entered"] != values["@completed"]:
+            raise MeasurementInvalid(
+                f"bpftrace pid {pid} entered {values['@entered']} faults but completed "
+                f"{values['@completed']}"
+            )
+        histogram_count = sum(bucket["count"] for bucket in buckets)
+        if histogram_count != values["@completed"]:
+            raise MeasurementInvalid(
+                f"bpftrace pid {pid} histogram counts {histogram_count}, expected "
+                f"{values['@completed']}"
+            )
+        processes[pid] = {
+            "count": values["@completed"],
+            "total_ns": values["@total_ns"],
+            "histogram": buckets,
+        }
+    return {"ready": True, "processes": processes}
+
+
+def _is_trace_ready_line(line: str) -> bool:
+    """Recognize only bpftrace's exact JSON readiness event."""
+    try:
+        event = json.loads(
+            line,
+            object_pairs_hook=_strict_trace_object,
+            parse_constant=_reject_trace_constant,
+        )
+    except (json.JSONDecodeError, ValueError, MeasurementInvalid):
+        return False
+    return (
+        isinstance(event, dict)
+        and event.get("type") == "printf"
+        and event.get("data") == "REQSCALE_TRACE_READY\\n"
+    )
+
+
+def join_fault_trace(records: list[dict], trace: dict) -> None:
+    """Join aggregate fault cost to exact per-request Firecracker identities."""
+    identities: dict[int, int] = {}
+    for record in records:
+        faults = record.get("firecracker_process_faults_ready_to_artifact")
+        if not isinstance(faults, dict):
+            if record.get("ok"):
+                raise MeasurementInvalid(
+                    f"successful request {record.get('request_id')} has no Firecracker fault sample"
+                )
+            continue
+        pid = faults.get("pid")
+        start = faults.get("pid_start_time_ticks")
+        if not isinstance(pid, int) or not isinstance(start, int):
+            raise MeasurementInvalid(f"request has invalid Firecracker identity: {faults}")
+        if pid in identities:
+            if identities[pid] != start:
+                raise MeasurementInvalid(
+                    f"Firecracker pid {pid} was reused inside one traced window: "
+                    f"{identities[pid]} then {start}"
+                )
+            raise MeasurementInvalid(f"Firecracker identity ({pid}, {start}) served two requests")
+        identities[pid] = start
+        measurement = trace.get("processes", {}).get(pid)
+        if measurement is None:
+            raise MeasurementInvalid(
+                f"request {record.get('request_id')} has no handle_mm_fault aggregate for pid {pid}"
+            )
+        record["firecracker_process_handle_mm_fault_ready_to_artifact"] = {
+            **measurement,
+            "scope": (
+                "all Firecracker-process VMAs; not filtered to guest RAM and not an "
+                "UFFD-event count"
+            ),
+        }
+    extra = set(trace.get("processes", {})) - set(identities)
+    if extra:
+        raise MeasurementInvalid(
+            f"handle_mm_fault aggregates have no exact request identity: pids {sorted(extra)}"
+        )
+
+
+class BpftraceFaultTracer:
+    """One actively-drained bpftrace process for one traced burst."""
+
+    def __init__(
+        self,
+        backend_cgroup_paths: dict[str, str],
+        driver_cgroup_path: str,
+        harness_pid: int,
+        out_dir: str,
+        burst_id: str,
+        cgroup_audit: CgroupAudit,
+        bpftrace: str = "bpftrace",
+    ):
+        if set(backend_cgroup_paths) != {"file", "uffd"}:
+            raise MeasurementInvalid("bpftrace requires exact FILE and UFFD cgroup paths")
+        for path in (*backend_cgroup_paths.values(), driver_cgroup_path):
+            if not os.path.isabs(path) or not path.startswith("/sys/fs/cgroup/"):
+                raise MeasurementInvalid(f"unsafe cgroup path for bpftrace: {path}")
+            if not re.fullmatch(r"[A-Za-z0-9_./@-]+", path):
+                raise MeasurementInvalid(f"cgroup path contains unsupported characters: {path}")
+        if harness_pid <= 0:
+            raise MeasurementInvalid(f"invalid harness pid {harness_pid}")
+        self.backend_cgroup_paths = dict(backend_cgroup_paths)
+        self.driver_cgroup_path = driver_cgroup_path
+        self.harness_pid = harness_pid
+        self.out_dir = out_dir
+        self.burst_id = burst_id
+        self.audit = cgroup_audit
+        self.bpftrace = bpftrace
+        self.process = None
+        self.lines: list[str] = []
+        self.reader_woke = threading.Event()
+        self.ready_seen = False
+        self.reader_error = None
+        self.reader_state_lock = threading.Lock()
+        self.stdout_thread = None
+        self.stderr_thread = None
+        self.stdout_stream = None
+        self.stderr_stream = None
+        self.program_path = None
+        self.raw_path = None
+        self.stderr_path = None
+
+    def _generated_program(self) -> str:
+        with open(os.path.join(HERE, "faulttrace.bt")) as stream:
+            program = stream.read()
+        program = program.replace(
+            "__FILE_CGROUP_PATH__", self.backend_cgroup_paths["file"]
+        )
+        program = program.replace(
+            "__UFFD_CGROUP_PATH__", self.backend_cgroup_paths["uffd"]
+        )
+        program = program.replace("__HARNESS_PID__", str(self.harness_pid))
+        if re.search(r"__[A-Z_]+__", program):
+            raise MeasurementInvalid("faulttrace template substitution was incomplete")
+        path = os.path.join(self.out_dir, f"{self.burst_id}.faulttrace.bt")
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+        with os.fdopen(fd, "w") as stream:
+            stream.write(program)
+            stream.flush()
+            os.fsync(stream.fileno())
+        _fsync_directory(self.out_dir)
+        self.program_path = path
+        return path
+
+    def start(self, timeout_s: float = 30.0) -> None:
+        program = self._generated_program()
+        self.raw_path = os.path.join(self.out_dir, f"{self.burst_id}.bpftrace.jsonl")
+        self.stderr_path = os.path.join(
+            self.out_dir, f"{self.burst_id}.bpftrace.stderr"
+        )
+        try:
+            self.stdout_stream = open(self.raw_path, "x", buffering=1)
+            self.stderr_stream = open(self.stderr_path, "x", buffering=1)
+            _fsync_directory(self.out_dir)
+            self.process = subprocess.Popen(
+                guarded_command(
+                    self.driver_cgroup_path,
+                    [self.bpftrace, "-q", "-f", "json", program],
+                    self.harness_pid,
+                ),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+            )
+            def read_stdout():
+                try:
+                    for line in self.process.stdout:
+                        self.lines.append(line.rstrip("\n"))
+                        self.stdout_stream.write(line)
+                        if _is_trace_ready_line(line):
+                            with self.reader_state_lock:
+                                self.ready_seen = True
+                            self.reader_woke.set()
+                except BaseException as error:
+                    with self.reader_state_lock:
+                        if self.reader_error is None:
+                            self.reader_error = error
+                finally:
+                    # EOF and reader failures must wake start() immediately. Waiting
+                    # the full readiness timeout would hide a tracer that already died.
+                    self.reader_woke.set()
+
+            def read_stderr():
+                try:
+                    for line in self.process.stderr:
+                        self.stderr_stream.write(line)
+                except BaseException as error:
+                    with self.reader_state_lock:
+                        if self.reader_error is None:
+                            self.reader_error = error
+                    self.reader_woke.set()
+
+            self.stdout_thread = threading.Thread(target=read_stdout, name="reqscale-bpf-out")
+            self.stderr_thread = threading.Thread(target=read_stderr, name="reqscale-bpf-err")
+            self.stdout_thread.start()
+            self.stderr_thread.start()
+            woke = self.reader_woke.wait(timeout_s)
+            with self.reader_state_lock:
+                ready_seen = self.ready_seen
+                reader_error = self.reader_error
+            if not woke or not ready_seen:
+                rc = self.process.poll()
+                if reader_error is not None:
+                    raise MeasurementInvalid(
+                        f"bpftrace output reader failed before readiness: "
+                        f"{type(reader_error).__name__}: {reader_error}"
+                    ) from reader_error
+                raise MeasurementInvalid(
+                    f"bpftrace did not become ready within {timeout_s}s (exit={rc})"
+                )
+            self.audit.observe(self.process.pid, "bpftrace")
+        except BaseException:
+            self.abort()
+            raise
+
+    def marker(self, firecracker_pid: int) -> None:
+        if self.process is None or self.process.poll() is not None:
+            raise MeasurementInvalid("bpftrace marker used while tracer is not running")
+        # Signal 0 performs only existence/permission checks. The generated
+        # tracepoint program filters on this exact harness tgid and toggles the
+        # target Firecracker pid; no signal is delivered.
+        os.kill(firecracker_pid, 0)
+
+    def stop(self, timeout_s: float = 30.0) -> dict:
+        if self.process is None:
+            raise MeasurementInvalid("bpftrace stop called before start")
+        try:
+            self.process.send_signal(signal.SIGINT)
+        except ProcessLookupError:
+            # Reap and inspect the process below.  Exiting between poll/kill is
+            # not itself an error, but a nonzero terminal status still is.
+            pass
+        try:
+            rc = self.process.wait(timeout=timeout_s)
+        except subprocess.TimeoutExpired as error:
+            self.abort()
+            raise MeasurementInvalid(f"bpftrace did not stop within {timeout_s}s") from error
+        live_threads = []
+        for thread in (self.stdout_thread, self.stderr_thread):
+            if thread is None:
+                live_threads.append("missing-reader")
+                continue
+            thread.join(timeout=10)
+            if thread.is_alive():
+                live_threads.append(thread.name)
+        if live_threads:
+            raise MeasurementInvalid(
+                f"bpftrace reader threads did not stop after process exit: {live_threads}"
+            )
+        close_errors = []
+        for stream in (self.stdout_stream, self.stderr_stream):
+            if stream is None:
+                close_errors.append("missing bpftrace artifact stream")
+                continue
+            if stream.closed:
+                continue
+            try:
+                stream.flush()
+                os.fsync(stream.fileno())
+            except OSError as error:
+                close_errors.append(f"{stream.name}: {error}")
+            finally:
+                try:
+                    stream.close()
+                except OSError as error:
+                    close_errors.append(f"{stream.name} close: {error}")
+        try:
+            _fsync_directory(self.out_dir)
+        except OSError as error:
+            close_errors.append(f"{self.out_dir}: {error}")
+        if close_errors:
+            raise MeasurementInvalid(
+                f"cannot durably close bpftrace artifacts: {close_errors}"
+            )
+        with self.reader_state_lock:
+            reader_error = self.reader_error
+        if reader_error is not None:
+            raise MeasurementInvalid(
+                f"bpftrace output reader failed: {type(reader_error).__name__}: {reader_error}"
+            ) from reader_error
+        if rc != 0:
+            raise MeasurementInvalid(f"bpftrace exited with status {rc}")
+        return parse_fault_trace(self.lines)
+
+    def abort(self) -> None:
+        cleanup_errors = []
+        if self.process is not None and self.process.poll() is None:
+            try:
+                self.process.kill()
+            except ProcessLookupError:
+                pass
+            except OSError as error:
+                cleanup_errors.append(f"cannot SIGKILL bpftrace: {error}")
+            try:
+                self.process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                cleanup_errors.append("bpftrace survived SIGKILL")
+            except OSError as error:
+                cleanup_errors.append(f"cannot reap bpftrace: {error}")
+        live_threads = []
+        for thread in (self.stdout_thread, self.stderr_thread):
+            if thread is not None:
+                thread.join(timeout=10)
+                if thread.is_alive():
+                    live_threads.append(thread.name)
+        if live_threads:
+            cleanup_errors.append(
+                f"bpftrace reader threads survived process exit: {live_threads}"
+            )
+        if not live_threads:
+            for stream in (self.stdout_stream, self.stderr_stream):
+                if stream is not None and not stream.closed:
+                    try:
+                        stream.flush()
+                        os.fsync(stream.fileno())
+                    except OSError as error:
+                        cleanup_errors.append(f"{stream.name}: {error}")
+                    finally:
+                        try:
+                            stream.close()
+                        except OSError as error:
+                            cleanup_errors.append(f"{stream.name} close: {error}")
+            try:
+                _fsync_directory(self.out_dir)
+            except OSError as error:
+                cleanup_errors.append(f"{self.out_dir}: {error}")
+        if cleanup_errors:
+            raise MeasurementInvalid(
+                f"cannot fully stop and durably close bpftrace: {cleanup_errors}"
+            )
+
+
+# ---------------------------------------------------------------- production orchestration
+
+
+def sha256_file(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def harness_sha256() -> str:
+    digest = hashlib.sha256(b"fcvm-reqscale-harness-v1\0")
+    for name in (
+        "reqscale.py", "reqscale_analyze.py", "reqbench.py", "cdpdrive.py",
+        "render.py", "faulttrace.bt", "guardexec.py", "guardsupervise.py",
+    ):
+        encoded = name.encode()
+        digest.update(len(encoded).to_bytes(4, "big"))
+        digest.update(encoded)
+        with open(os.path.join(HERE, name), "rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _command(argv: list[str]) -> str:
+    try:
+        return subprocess.check_output(argv, text=True, stderr=subprocess.STDOUT).strip()
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise MeasurementInvalid(f"provenance command failed: {argv}: {error}") from error
+
+
+def parse_vm_process_rows(raw: str) -> list[dict]:
+    """Return active fcvm/VMM rows from ``ps -eo stat=,comm=`` output."""
+    matches = []
+    for number, line in enumerate(raw.splitlines(), 1):
+        if not line.strip():
+            continue
+        parts = line.strip().split(maxsplit=1)
+        if len(parts) != 2:
+            raise MeasurementInvalid(f"malformed ps process row {number}: {line!r}")
+        state, comm = parts
+        if state.startswith("Z"):
+            continue
+        if comm == "fcvm" or comm.startswith("firecracker") or comm.startswith("cloud-hypervis"):
+            matches.append({"state": state, "comm": comm})
+    return matches
+
+
+def quiet_host_snapshot(
+    loadavg_path: str = "/proc/loadavg", process_rows: Optional[str] = None,
+) -> dict:
+    """Fail-closed inputs for the repo's established quiet-host gate."""
+    if process_rows is None:
+        process_rows = _command(["ps", "-eo", "stat=,comm="])
+    try:
+        with open(loadavg_path) as stream:
+            fields = stream.read().split()
+        loadavg1 = float(fields[0])
+    except (OSError, IndexError, ValueError) as error:
+        raise MeasurementInvalid(f"cannot read quiet-host load from {loadavg_path}: {error}")
+    if not math.isfinite(loadavg1) or loadavg1 < 0:
+        raise MeasurementInvalid(f"quiet-host load is invalid: {loadavg1}")
+    processes = parse_vm_process_rows(process_rows)
+    return {
+        "loadavg1": loadavg1,
+        "loadavg1_limit": 2.0,
+        "vm_process_count": len(processes),
+        "vm_processes": processes,
+    }
+
+
+def snapshot_identity(data_root: str, snapshot_tag: str) -> dict:
+    """Durable identity of the exact snapshot generation and runtime shape."""
+    snapshots_root = os.path.realpath(os.path.join(data_root, "snapshots"))
+    snapshot_dir = os.path.realpath(os.path.join(snapshots_root, snapshot_tag))
+    if os.path.commonpath((snapshots_root, snapshot_dir)) != snapshots_root:
+        raise MeasurementInvalid(f"snapshot tag escapes the snapshot root: {snapshot_tag!r}")
+    config_path = os.path.join(snapshot_dir, "config.json")
+    try:
+        with open(config_path, "rb") as stream:
+            raw = stream.read()
+        config = strict_json_loads(raw, config_path)
+    except OSError as error:
+        raise MeasurementInvalid(f"cannot identify snapshot from {config_path}: {error}")
+    if not isinstance(config, dict):
+        raise MeasurementInvalid(f"snapshot config {config_path} is not an object")
+    generation_id = config.get("generation_id")
+    try:
+        canonical_generation_id = str(uuid.UUID(generation_id))
+    except (AttributeError, TypeError, ValueError) as error:
+        raise MeasurementInvalid(
+            f"snapshot config {config_path} has invalid generation_id"
+        ) from error
+    if canonical_generation_id != generation_id:
+        raise MeasurementInvalid(
+            f"snapshot config {config_path} has non-canonical generation_id"
+        )
+    metadata = config.get("metadata")
+    required_top = ("created_at", "vm_id")
+    if any(not isinstance(config.get(field), str) or not config[field] for field in required_top):
+        raise MeasurementInvalid(f"snapshot config {config_path} has no generation identity")
+    if not isinstance(metadata, dict):
+        raise MeasurementInvalid(f"snapshot config {config_path} has no metadata object")
+    required_shape = ("image", "vcpu", "memory_mib", "network_mode", "port_mappings")
+    missing = [field for field in required_shape if field not in metadata]
+    if missing:
+        raise MeasurementInvalid(f"snapshot config {config_path} lacks shape fields {missing}")
+    files = {}
+    for field in ("memory_path", "vmstate_path", "disk_path"):
+        value = config.get(field)
+        if not isinstance(value, str) or not value:
+            raise MeasurementInvalid(f"snapshot config {config_path} has no {field}")
+        path = os.path.realpath(value)
+        if path != snapshot_dir and not path.startswith(snapshot_dir + os.sep):
+            raise MeasurementInvalid(f"snapshot {field} escapes its generation directory: {path}")
+        try:
+            stat = os.stat(path, follow_symlinks=False)
+        except FileNotFoundError as error:
+            raise MeasurementInvalid(f"snapshot artifact is missing: {path}") from error
+        if not os.path.isfile(path):
+            raise MeasurementInvalid(f"snapshot artifact is not a regular file: {path}")
+        files[field] = {
+            "path": os.path.relpath(path, snapshot_dir),
+            "size": stat.st_size,
+            "mtime_ns": stat.st_mtime_ns,
+            "inode": stat.st_ino,
+        }
+    config_stat = os.stat(config_path, follow_symlinks=False)
+    files["config"] = {
+        "path": "config.json", "size": config_stat.st_size,
+        "mtime_ns": config_stat.st_mtime_ns, "inode": config_stat.st_ino,
+    }
+    return {
+        "tag": snapshot_tag,
+        "generation_id": generation_id,
+        "created_at": config["created_at"],
+        "vm_id": config["vm_id"],
+        "config_sha256": hashlib.sha256(raw).hexdigest(),
+        "shape": {field: metadata[field] for field in required_shape},
+        "files": files,
+    }
+
+
+class SnapshotGenerationLease:
+    """Hold fcvm's shared tag lock for the complete mixed-backend run."""
+
+    def __init__(self, data_root: str, snapshot_tag: str):
+        _validate_snapshot_tag(snapshot_tag)
+        self.data_root = data_root
+        self.snapshot_tag = snapshot_tag
+        self.path = os.path.join(data_root, "snapshots", f"{snapshot_tag}.lock")
+        self.stream = None
+        self.identity = None
+
+    def __enter__(self) -> "SnapshotGenerationLease":
+        try:
+            self.stream = open(self.path, "a+")
+            fcntl.flock(self.stream, fcntl.LOCK_SH)
+            self.identity = snapshot_identity(self.data_root, self.snapshot_tag)
+        except BaseException:
+            self.close()
+            raise
+        return self
+
+    def verify(self) -> dict:
+        if self.stream is None or self.identity is None:
+            raise MeasurementInvalid("snapshot generation lease is not held")
+        current = snapshot_identity(self.data_root, self.snapshot_tag)
+        if current != self.identity:
+            raise MeasurementInvalid(
+                "snapshot identity changed while its shared generation lease was held",
+                {"before": self.identity, "after": current},
+            )
+        return current
+
+    def close(self) -> None:
+        if self.stream is not None:
+            try:
+                fcntl.flock(self.stream, fcntl.LOCK_UN)
+            finally:
+                self.stream.close()
+                self.stream = None
+
+    def __exit__(self, _type, _value, _traceback):
+        self.close()
+
+
+def collect_provenance(args, schedule: dict, snapshot: dict) -> dict:
+    fcvm = os.path.abspath(args.fcvm)
+    if not os.path.isfile(fcvm):
+        raise MeasurementInvalid(f"fcvm binary is missing: {fcvm}")
+    revision = _command(["git", "-C", REPO, "rev-parse", "HEAD"])
+    if not re.fullmatch(r"[0-9a-f]{40}", revision):
+        raise MeasurementInvalid(f"git returned invalid revision {revision!r}")
+    dirty = _command(["git", "-C", REPO, "status", "--porcelain=v1", "--untracked-files=all"])
+    if dirty:
+        raise MeasurementInvalid(
+            "benchmark source tree is dirty; commit the harness before measuring"
+        )
+    quiet = quiet_host_snapshot()
+    if quiet["loadavg1"] > quiet["loadavg1_limit"] or quiet["vm_process_count"]:
+        raise MeasurementInvalid(
+            "quiet-host gate refused the run: "
+            f"load={quiet['loadavg1']} vm-processes={quiet['vm_process_count']}",
+            quiet,
+        )
+    return {
+        "schema": "fcvm.chromium.reqscale.provenance.v1",
+        "run_id": schedule["run_id"],
+        "created_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "argv": list(sys.argv),
+        "schedule_sha256": schedule_sha256(schedule),
+        "source_revision": revision,
+        "source_dirty": bool(dirty),
+        "source_status_sha256": hashlib.sha256(dirty.encode()).hexdigest(),
+        "harness_sha256": harness_sha256(),
+        "fcvm_path": fcvm,
+        "fcvm_sha256": sha256_file(fcvm),
+        "fcvm_version": _command([fcvm, "--version"]),
+        "host_control": {
+            "chromium_path": args.control_chromium,
+            "chromium_sha256": sha256_file(args.control_chromium),
+            "chromium_version": _command([args.control_chromium, "--version"]),
+            "url": args.control_url,
+            "interval_seconds": CONTROL_INTERVAL_SECONDS,
+            "timeout_seconds": args.control_timeout,
+        },
+        "snapshot": snapshot,
+        "snapshot_generation_lease": {
+            "path": os.path.abspath(args.snapshot_generation_lease.path),
+            "mode": "shared",
+            "held_from_identity_read_through_terminal_verification": True,
+        },
+        "host": {
+            "hostname": platform.node(),
+            "kernel": platform.release(),
+            "machine": platform.machine(),
+            "python": platform.python_version(),
+            "cpu_count": os.cpu_count(),
+            "quiet_gate": quiet,
+        },
+        "fault_trace": {
+            "enabled": bool(args.trace_faults),
+            "bpftrace_version": (
+                _command([args.bpftrace, "--version"]) if args.trace_faults else None
+            ),
+            "max_median_delta_pct": args.max_trace_perturbation_pct,
+            "scope": (
+                "Firecracker process endpoint-ready through artifact return; all VMAs, "
+                "not guest-RAM-filtered and not UFFD events"
+            ),
+        },
+    }
+
+
+class RunCgroups:
+    """One empty accounting root with four exclusive process leaves."""
+
+    LEAVES = ("driver", "control", "file", "uffd")
+
+    def __init__(self, run_id: str, root: str = "/sys/fs/cgroup", proc_root: str = "/proc"):
+        _validate_run_id(run_id)
+        self.run_id = run_id
+        self.root = os.path.realpath(root)
+        self.proc_root = proc_root
+        self.original_relative = _read_unified_cgroup(os.path.join(proc_root, "self", "cgroup"))
+        self.original_path = os.path.realpath(
+            os.path.join(self.root, self.original_relative.lstrip("/"))
+        )
+        if os.path.commonpath((self.root, self.original_path)) != self.root:
+            raise MeasurementInvalid(
+                f"original cgroup {self.original_relative} escapes root {self.root}"
+            )
+        self.name = f"fcvm-reqscale-{run_id}"
+        if not CGROUP_NAME_RE.fullmatch(self.name):
+            raise MeasurementInvalid(f"unsafe run cgroup name {self.name}")
+        self.path = os.path.join(self.original_path, self.name)
+        self.paths = {name: os.path.join(self.path, name) for name in self.LEAVES}
+        self.audits = None
+        self.entered = False
+
+    def enter(self) -> dict[str, CgroupAudit]:
+        if self.entered:
+            raise MeasurementInvalid("run cgroups entered twice")
+        os.mkdir(self.path, 0o755)
+        created = []
+        moved = False
+        try:
+            for name in self.LEAVES:
+                os.mkdir(self.paths[name], 0o755)
+                created.append(self.paths[name])
+            with open(os.path.join(self.paths["driver"], "cgroup.procs"), "w") as stream:
+                stream.write(f"{os.getpid()}\n")
+            moved = True
+            self.audits = {
+                "run": CgroupAudit(self.path, self.proc_root, self.root),
+                **{
+                    name: CgroupAudit(path, self.proc_root, self.root)
+                    for name, path in self.paths.items()
+                },
+            }
+            self.audits["run"].observe(os.getpid(), "reqscale")
+            self.audits["driver"].observe(os.getpid(), "reqscale")
+            # cpu.stat on the empty parent is the recursive total; every leaf
+            # must expose the same accounting interface before any child starts.
+            for audit in self.audits.values():
+                audit.cpu_snapshot()
+            self.entered = True
+            return self.audits
+        except BaseException as enter_error:
+            cleanup_errors = []
+            if moved:
+                try:
+                    with open(os.path.join(self.original_path, "cgroup.procs"), "w") as stream:
+                        stream.write(f"{os.getpid()}\n")
+                except BaseException as move_error:
+                    cleanup_errors.append(f"move-back: {type(move_error).__name__}: {move_error}")
+            for path in reversed(created):
+                try:
+                    os.rmdir(path)
+                except OSError as remove_error:
+                    cleanup_errors.append(
+                        f"rmdir {path}: {type(remove_error).__name__}: {remove_error}"
+                    )
+            try:
+                os.rmdir(self.path)
+            except OSError as remove_error:
+                cleanup_errors.append(
+                    f"rmdir {self.path}: {type(remove_error).__name__}: {remove_error}"
+                )
+            if cleanup_errors:
+                raise MeasurementInvalid(
+                    f"run cgroup enter failed and cleanup was incomplete: {enter_error}",
+                    {"enter_error": f"{type(enter_error).__name__}: {enter_error}",
+                     "cleanup_errors": cleanup_errors},
+                ) from enter_error
+            raise
+
+    def leave(self) -> dict:
+        if not self.entered:
+            return {}
+        final = None
+        accounting_error = None
+        try:
+            final = {
+                name: audit.record() for name, audit in sorted(self.audits.items())
+            }
+        except BaseException as error:
+            accounting_error = error
+        expected_members = {
+            "run": [],
+            "driver": [os.getpid()],
+            "control": [],
+            "file": [],
+            "uffd": [],
+        }
+        unexpected = {} if final is None else {
+            name: {"expected": expected_members[name], "actual": row["live_pids"]}
+            for name, row in final.items()
+            if row["live_pids"] != expected_members[name]
+        }
+        # Move the harness first so it can report a failed cleanup. Never rmdir a
+        # cgroup that still owns an unaccounted workload process.
+        try:
+            with open(os.path.join(self.original_path, "cgroup.procs"), "w") as stream:
+                stream.write(f"{os.getpid()}\n")
+        except BaseException as move_error:
+            raise MeasurementInvalid(
+                f"cannot move reqscale back to its original cgroup: {move_error}",
+                {"final_cgroups": final},
+            ) from move_error
+        self.entered = False
+        cleanup_errors = []
+        if accounting_error is not None or unexpected:
+            # The harness is now outside the owned tree, so recursive cgroup.kill
+            # cannot kill the reporter.  Use it even when the audit itself failed:
+            # inability to enumerate members must never become permission to
+            # leave an unknown workload running.
+            try:
+                with open(os.path.join(self.path, "cgroup.kill"), "w") as stream:
+                    stream.write("1\n")
+            except OSError as error:
+                cleanup_errors.append(f"cgroup.kill {self.path}: {error}")
+            deadline = time.monotonic() + 10.0
+            while True:
+                try:
+                    survivors = {}
+                    for name, audit in sorted(self.audits.items()):
+                        live = audit.live_pids()
+                        if live:
+                            survivors[name] = live
+                except BaseException as error:
+                    cleanup_errors.append(
+                        f"cannot verify run cgroups after cgroup.kill: "
+                        f"{type(error).__name__}: {error}"
+                    )
+                    break
+                if not survivors:
+                    break
+                if time.monotonic() >= deadline:
+                    cleanup_errors.append(
+                        f"run cgroup processes survived cgroup.kill: {survivors}"
+                    )
+                    break
+                time.sleep(0.01)
+        removal_errors = []
+        for name in reversed(self.LEAVES):
+            try:
+                os.rmdir(self.paths[name])
+            except OSError as error:
+                removal_errors.append(
+                    f"cannot remove {name} cgroup {self.paths[name]}: {error}"
+                )
+        try:
+            os.rmdir(self.path)
+        except OSError as error:
+            removal_errors.append(f"cannot remove run cgroup {self.path}: {error}")
+        cleanup_errors.extend(removal_errors)
+        if accounting_error is not None:
+            raise MeasurementInvalid(
+                f"cannot audit the run cgroups before removal: {accounting_error}",
+                {
+                    "final_cgroups": final,
+                    "accounting_error": (
+                        f"{type(accounting_error).__name__}: {accounting_error}"
+                    ),
+                    "cleanup_errors": cleanup_errors,
+                },
+            ) from accounting_error
+        if unexpected:
+            raise MeasurementInvalid(
+                f"run cgroups have unexpected final membership {unexpected}",
+                {"final_cgroups": final, "cleanup_errors": cleanup_errors},
+            )
+        if cleanup_errors:
+            raise MeasurementInvalid(
+                f"cannot remove empty run cgroup tree: {cleanup_errors}",
+                {"final_cgroups": final, "cleanup_errors": cleanup_errors},
+            )
+        return final
+
+
+class UffdServe:
+    """One guarded UFFD server, confined to the UFFD accounting leaf."""
+
+    def __init__(self, args, audit: CgroupAudit, cgroup_path: str, log_dir: str):
+        self.args = args
+        self.audit = audit
+        self.cgroup_path = cgroup_path
+        self.log_path = os.path.join(log_dir, "uffd-serve.log")
+        self.proc = None
+        self.log_stream = None
+        self.state_path = None
+        self.state = None
+        self.record = None
+
+    def start(self) -> int:
+        watch = reqbench.DirWatch(self.args.state_dir)
+        try:
+            baseline = {
+                os.path.join(self.args.state_dir, name)
+                for name in os.listdir(self.args.state_dir)
+                if name.endswith(".json")
+            }
+            self.log_stream = open(self.log_path, "xb")
+            self.proc = subprocess.Popen(
+                guarded_command(
+                    self.cgroup_path,
+                    [self.args.fcvm, "snapshot", "serve", self.args.snapshot_tag],
+                ),
+                stdout=self.log_stream,
+                stderr=self.log_stream,
+                stdin=subprocess.DEVNULL,
+                env=dict(os.environ, RUST_LOG=self.args.rust_log),
+            )
+            pidfd = reqbench.pidfd_open(self.proc.pid)
+            poller = select.poll()
+            poller.register(watch.fd, select.POLLIN)
+            if pidfd is not None:
+                poller.register(pidfd, select.POLLIN)
+            deadline = time.monotonic() + self.args.timeout
+            try:
+                while True:
+                    watch.drain()
+                    for name in os.listdir(self.args.state_dir):
+                        path = os.path.join(self.args.state_dir, name)
+                        if not name.endswith(".json") or path in baseline:
+                            continue
+                        try:
+                            with open(path) as stream:
+                                state = json.load(stream)
+                        except (OSError, ValueError):
+                            continue
+                        if (
+                            state.get("pid") == self.proc.pid
+                        ):
+                            identity = self.audit.observe(self.proc.pid, "uffd-serve")
+                            if state.get("pid_start_time") != identity.start_time_ticks:
+                                raise MeasurementInvalid(
+                                    f"serve state {path} has pid start "
+                                    f"{state.get('pid_start_time')}, expected "
+                                    f"{identity.start_time_ticks}"
+                                )
+                            config = state.get("config") or {}
+                            if config.get("process_type") != "serve":
+                                raise MeasurementInvalid(f"state {path} is not a serve process")
+                            if config.get("snapshot_name") != self.args.snapshot_tag:
+                                raise MeasurementInvalid(
+                                    f"serve state names {config.get('snapshot_name')!r}, expected "
+                                    f"{self.args.snapshot_tag!r}"
+                                )
+                            if config.get("uffd_mode") not in ("copy", "minor"):
+                                raise MeasurementInvalid(f"serve state {path} has invalid UFFD mode")
+                            self.state_path, self.state = path, state
+                            self.record = {
+                                "schema": RECORD_SCHEMA,
+                                "kind": "uffd-serve",
+                                "run_id": self.args.run_id,
+                                "pid": self.proc.pid,
+                                "pid_start_time_ticks": identity.start_time_ticks,
+                                "state_path": os.path.relpath(path, self.args.data_root),
+                                "uffd_mode": config["uffd_mode"],
+                                "snapshot_tag": self.args.snapshot_tag,
+                                "snapshot_generation_id": self.args.snapshot_identity[
+                                    "generation_id"
+                                ],
+                                "snapshot_config_sha256": self.args.snapshot_identity[
+                                    "config_sha256"
+                                ],
+                            }
+                            return self.proc.pid
+                    if self.proc.poll() is not None:
+                        raise MeasurementInvalid(
+                            f"UFFD serve exited with {self.proc.returncode} before publishing state"
+                        )
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise MeasurementInvalid("UFFD serve did not publish state before deadline")
+                    poller.poll(min(remaining, 0.25) * 1000)
+            finally:
+                if pidfd is not None:
+                    os.close(pidfd)
+        finally:
+            watch.close()
+
+    def stop(self) -> None:
+        errors = []
+        if self.proc is not None:
+            if self.proc.poll() is None:
+                try:
+                    self.proc.send_signal(signal.SIGTERM)
+                except ProcessLookupError:
+                    # The process exited between poll() and kill(2).  wait()
+                    # below still has to reap it and establish its status.
+                    pass
+                try:
+                    self.proc.wait(timeout=self.args.teardown_timeout)
+                except subprocess.TimeoutExpired:
+                    try:
+                        self.proc.kill()
+                    except ProcessLookupError:
+                        pass
+                    try:
+                        self.proc.wait(timeout=10)
+                    except subprocess.TimeoutExpired:
+                        errors.append("UFFD serve survived SIGKILL")
+                    errors.append("UFFD serve required SIGKILL during shutdown")
+            if self.proc.returncode is None:
+                errors.append("UFFD serve has no terminal status after shutdown")
+            elif self.proc.returncode not in (0, -signal.SIGTERM):
+                errors.append(f"UFFD serve exited with status {self.proc.returncode}")
+        if self.log_stream is not None and not self.log_stream.closed:
+            try:
+                self.log_stream.flush()
+                os.fsync(self.log_stream.fileno())
+            except OSError as error:
+                errors.append(f"UFFD serve log sync failed: {error}")
+            finally:
+                try:
+                    self.log_stream.close()
+                except OSError as error:
+                    errors.append(f"UFFD serve log close failed: {error}")
+        if self.state_path and os.path.exists(self.state_path):
+            errors.append(f"UFFD serve state survived shutdown: {self.state_path}")
+        audit_failed = False
+        try:
+            remaining = self.audit.live_pids()
+        except BaseException as error:
+            remaining = []
+            audit_failed = True
+            errors.append(f"cannot verify UFFD cgroup cleanup: {error}")
+        if remaining or audit_failed:
+            if remaining:
+                errors.append(
+                    f"UFFD cgroup remained populated after serve shutdown: {remaining}"
+                )
+            fds = [reqbench.pidfd_open(pid) for pid in remaining]
+            try:
+                with open(os.path.join(self.cgroup_path, "cgroup.kill"), "w") as stream:
+                    stream.write("1\n")
+            except OSError as error:
+                errors.append(f"UFFD cgroup.kill failed: {error}")
+            if fds and not reqbench.wait_pidfds(fds, 10.0):
+                errors.append(f"UFFD processes survived cgroup.kill: {remaining}")
+            for fd in fds:
+                if fd is not None:
+                    os.close(fd)
+            try:
+                survivors = self.audit.live_pids()
+            except BaseException as error:
+                errors.append(f"cannot verify UFFD cgroup after cgroup.kill: {error}")
+            else:
+                if survivors:
+                    errors.append(
+                        f"UFFD cgroup is still populated after cgroup.kill: {survivors}"
+                    )
+        if errors:
+            raise MeasurementInvalid("; ".join(errors), {"cleanup_errors": errors})
+
+
+class NativeChromiumControl:
+    """One persistent host-native Chromium process in the control cgroup."""
+
+    def __init__(self, args, audit: CgroupAudit, cgroup_path: str, log_dir: str):
+        self.args = args
+        self.audit = audit
+        self.cgroup_path = cgroup_path
+        self.log_path = os.path.join(log_dir, "host-control-chromium.log")
+        self.proc = None
+        self.log_stream = None
+        self.profile_dir = None
+        self.endpoint = None
+
+    def _drive_args(self, timeout_s: float) -> argparse.Namespace:
+        return argparse.Namespace(
+            cdp_host=self.endpoint,
+            url=self.args.control_url,
+            format=self.args.format,
+            quality=self.args.quality,
+            timeout=timeout_s,
+            idle_wait_ms=0.0,
+            out_prefix="",
+            ws_url="",
+            connect_retries=200,
+            nav_timing=True,
+            print_target=False,
+            host_header="",
+            render_module=os.path.join(HERE, "render.py"),
+        )
+
+    def drive(self) -> dict:
+        import cdpdrive
+
+        if self.proc is None or self.proc.poll() is not None or not self.endpoint:
+            raise MeasurementInvalid("host control Chromium is not running")
+        return cdpdrive.drive(self._drive_args(self.args.control_timeout))
+
+    def start(self) -> dict:
+        self.profile_dir = tempfile.mkdtemp(
+            prefix=f"fcvm-reqscale-control-{self.args.run_id}-",
+            dir=self.args.control_tmp_root,
+        )
+        watch = reqbench.DirWatch(self.profile_dir)
+        pidfd = None
+        try:
+            self.log_stream = open(self.log_path, "xb")
+            command = [
+                self.args.control_chromium,
+                "--headless=new",
+                "--no-sandbox",
+                "--remote-debugging-address=127.0.0.1",
+                "--remote-debugging-port=0",
+                "--remote-allow-origins=*",
+                "--ignore-certificate-errors",
+                "--disable-gpu",
+                "--disable-dev-shm-usage",
+                "--window-size=1280,800",
+                "--hide-scrollbars",
+                "--mute-audio",
+                "--no-first-run",
+                "--no-default-browser-check",
+                "--disable-background-networking",
+                "--disable-breakpad",
+                "--disable-component-update",
+                f"--user-data-dir={self.profile_dir}",
+                "about:blank",
+            ]
+            self.proc = subprocess.Popen(
+                supervised_command(self.cgroup_path, command),
+                stdout=self.log_stream,
+                stderr=self.log_stream,
+                stdin=subprocess.DEVNULL,
+            )
+            pidfd = reqbench.pidfd_open(self.proc.pid)
+            poller = select.poll()
+            poller.register(watch.fd, select.POLLIN)
+            if pidfd is not None:
+                poller.register(pidfd, select.POLLIN)
+            port_path = os.path.join(self.profile_dir, "DevToolsActivePort")
+            deadline = time.monotonic() + self.args.timeout
+            while True:
+                watch.drain()
+                try:
+                    with open(port_path) as stream:
+                        fields = stream.read().splitlines()
+                    port = int(fields[0])
+                    if not 1 <= port <= 65535 or len(fields) < 2 or not fields[1].startswith("/"):
+                        raise ValueError("incomplete DevToolsActivePort")
+                except (FileNotFoundError, IndexError, ValueError):
+                    port = 0
+                if port:
+                    self.endpoint = f"127.0.0.1:{port}"
+                    self.audit.observe(self.proc.pid, "host-control-chromium")
+                    warmup_start_ns = time.monotonic_ns()
+                    warmup = self.drive()
+                    warmup_end_ns = time.monotonic_ns()
+                    if not isinstance(warmup, dict) or not warmup.get("ok"):
+                        raise MeasurementInvalid(
+                            f"host control Chromium warmup failed: {warmup}"
+                        )
+                    return {
+                        "schema": RECORD_SCHEMA,
+                        "kind": "host-control-warmup",
+                        "included_in_analysis": False,
+                        "started_monotonic_ns": warmup_start_ns,
+                        "artifact_monotonic_ns": warmup_end_ns,
+                        "latency_ms": (warmup_end_ns - warmup_start_ns) / 1_000_000,
+                        "result": warmup,
+                    }
+                if self.proc.poll() is not None:
+                    raise MeasurementInvalid(
+                        f"host control Chromium exited with {self.proc.returncode} before CDP ready"
+                    )
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise MeasurementInvalid("host control Chromium did not publish CDP readiness")
+                poller.poll(min(remaining, 0.25) * 1000)
+        except BaseException as start_error:
+            try:
+                self.stop()
+            except BaseException as cleanup_error:
+                raise MeasurementInvalid(
+                    f"host control start failed and cleanup also failed: {start_error}",
+                    {
+                        "start_error": f"{type(start_error).__name__}: {start_error}",
+                        "cleanup_error": f"{type(cleanup_error).__name__}: {cleanup_error}",
+                    },
+                ) from start_error
+            raise
+        finally:
+            if pidfd is not None:
+                os.close(pidfd)
+            watch.close()
+
+    def stop(self) -> None:
+        errors = []
+        pids = []
+        pidfds = []
+        audit_failed = False
+        if self.proc is not None:
+            try:
+                pids = self.audit.live_pids()
+                pidfds = [reqbench.pidfd_open(pid) for pid in pids]
+            except BaseException as error:
+                audit_failed = True
+                errors.append(f"cannot snapshot control cgroup before stop: {error}")
+            if self.proc.poll() is None:
+                try:
+                    self.proc.send_signal(signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+            if pidfds:
+                if not reqbench.wait_pidfds(pidfds, self.args.teardown_timeout):
+                    errors.append(
+                        f"control processes did not all exit after SIGTERM: {pids}"
+                    )
+            try:
+                remaining = self.audit.live_pids()
+            except BaseException as error:
+                remaining = []
+                audit_failed = True
+                errors.append(f"cannot verify control cgroup after SIGTERM: {error}")
+            if remaining or audit_failed:
+                if remaining:
+                    errors.append(
+                        f"control cgroup remained populated after SIGTERM: {remaining}"
+                    )
+                remaining_fds = [reqbench.pidfd_open(pid) for pid in remaining]
+                try:
+                    with open(os.path.join(self.cgroup_path, "cgroup.kill"), "w") as stream:
+                        stream.write("1\n")
+                except OSError as error:
+                    errors.append(f"control cgroup.kill failed: {error}")
+                if remaining_fds and not reqbench.wait_pidfds(remaining_fds, 10.0):
+                    errors.append(f"control processes survived cgroup.kill: {remaining}")
+                for fd in remaining_fds:
+                    if fd is not None:
+                        os.close(fd)
+                try:
+                    survivors = self.audit.live_pids()
+                except BaseException as error:
+                    errors.append(
+                        f"cannot verify control cgroup after cgroup.kill: {error}"
+                    )
+                else:
+                    if survivors:
+                        errors.append(
+                            "control cgroup is still populated after cgroup.kill: "
+                            f"{survivors}"
+                        )
+            for fd in pidfds:
+                if fd is not None:
+                    os.close(fd)
+            try:
+                self.proc.wait(timeout=1.0)
+            except subprocess.TimeoutExpired:
+                errors.append("control Chromium parent survived cleanup")
+            if self.proc.returncode is None:
+                errors.append("control Chromium parent has no terminal status")
+            elif self.proc.returncode not in (0, -signal.SIGTERM, -signal.SIGKILL):
+                errors.append(f"control Chromium exited with status {self.proc.returncode}")
+        if self.log_stream is not None and not self.log_stream.closed:
+            try:
+                self.log_stream.flush()
+                os.fsync(self.log_stream.fileno())
+            except OSError as error:
+                errors.append(f"control log sync failed: {error}")
+            finally:
+                try:
+                    self.log_stream.close()
+                except OSError as error:
+                    errors.append(f"control log close failed: {error}")
+        if self.profile_dir is not None and os.path.exists(self.profile_dir):
+            try:
+                shutil.rmtree(self.profile_dir)
+            except OSError as error:
+                errors.append(f"control profile cleanup failed: {error}")
+        if errors:
+            raise MeasurementInvalid("; ".join(errors), {"cleanup_errors": errors})
+
+
+class ControlScheduler:
+    """Drive persistent Chromium on global 10-second absolute deadlines."""
+
+    def __init__(self, control: NativeChromiumControl, sink: JsonlSink, schedule: dict):
+        interval_ns = schedule.get("interval_ns")
+        if interval_ns != round(CONTROL_INTERVAL_SECONDS * 1_000_000_000):
+            raise MeasurementInvalid("host control interval must be exactly 10 seconds")
+        phase_ns = schedule.get("phase_offset_ns")
+        if not isinstance(phase_ns, int) or isinstance(phase_ns, bool) or not 0 <= phase_ns < interval_ns:
+            raise MeasurementInvalid("host control phase offset is invalid")
+        self.control = control
+        self.sink = sink
+        self.interval_ns = interval_ns
+        self.phase_ns = phase_ns
+        self.stop_event = threading.Event()
+        self.thread = None
+        self.origin_ns = None
+        self.records = []
+        self.lock = threading.Lock()
+        self.error = None
+
+    def _run(self) -> None:
+        assert self.origin_ns is not None
+        index = 0
+        try:
+            while True:
+                scheduled_ns = self.origin_ns + self.phase_ns + index * self.interval_ns
+                remaining_s = (scheduled_ns - time.monotonic_ns()) / 1_000_000_000
+                if remaining_s > 0 and self.stop_event.wait(remaining_s):
+                    return
+                if self.stop_event.is_set():
+                    return
+                actual_ns = time.monotonic_ns()
+                record = {
+                    "schema": RECORD_SCHEMA,
+                    "kind": "host-control",
+                    "control_index": index,
+                    "scheduled_ns": scheduled_ns,
+                    "actual_launch_ns": actual_ns,
+                    "launch_lag_ms": (actual_ns - scheduled_ns) / 1_000_000,
+                }
+                try:
+                    result = self.control.drive()
+                    artifact_ns = time.monotonic_ns()
+                    record.update(
+                        artifact_ns=artifact_ns,
+                        latency_ms=(artifact_ns - actual_ns) / 1_000_000,
+                        ok=bool(result.get("ok")),
+                        result=result,
+                    )
+                    if not record["ok"]:
+                        record["error"] = result.get("error", "control drive returned ok=false")
+                except Exception as error:
+                    artifact_ns = time.monotonic_ns()
+                    record.update(
+                        artifact_ns=artifact_ns,
+                        latency_ms=(artifact_ns - actual_ns) / 1_000_000,
+                        ok=False,
+                        error=f"{type(error).__name__}: {error}",
+                    )
+                self.sink.write(record)
+                self.sink.sync()
+                with self.lock:
+                    self.records.append(record)
+                index += 1
+        except BaseException as error:
+            with self.lock:
+                self.error = error
+            self.stop_event.set()
+
+    def start(self) -> None:
+        if self.thread is not None:
+            raise MeasurementInvalid("host control scheduler started twice")
+        self.origin_ns = time.monotonic_ns()
+        self.thread = threading.Thread(
+            target=self._run, name="reqscale-host-control", daemon=False
+        )
+        self.thread.start()
+
+    def check(self) -> None:
+        with self.lock:
+            error = self.error
+            failures = [record for record in self.records if not record.get("ok")]
+        if error is not None:
+            raise MeasurementInvalid(
+                f"host control scheduler failed: {type(error).__name__}: {error}"
+            ) from error
+        if failures:
+            raise MeasurementInvalid(
+                f"host control arm has {len(failures)} failed requests", failures
+            )
+
+    def stop(self) -> dict:
+        if self.thread is None:
+            return {"started": False, "requests": 0}
+        stop_requested_ns = time.monotonic_ns()
+        self.stop_event.set()
+        self.thread.join(self.control.args.control_timeout + 5.0)
+        if self.thread.is_alive():
+            cleanup_error = None
+            try:
+                self.control.stop()
+            except BaseException as error:
+                cleanup_error = error
+            self.thread.join(10.0)
+            if self.thread.is_alive():
+                raise MeasurementInvalid(
+                    "host control scheduler thread survived browser termination",
+                    {"control_cleanup_error": repr(cleanup_error)},
+                )
+            raise MeasurementInvalid(
+                "host control scheduler required browser termination to stop",
+                {"control_cleanup_error": repr(cleanup_error)},
+            )
+        self.check()
+        self.sink.sync()
+        with self.lock:
+            records = list(self.records)
+        return {
+            "started": True,
+            "origin_monotonic_ns": self.origin_ns,
+            "phase_offset_ns": self.phase_ns,
+            "interval_ns": self.interval_ns,
+            "requests": len(records),
+            "stop_requested_monotonic_ns": stop_requested_ns,
+        }
+
+
+def _request_args(
+    args, context: RequestContext, serve_pid: int, log_dir: str, probe,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        serve_pid=serve_pid if context.backend == "uffd" else 0,
+        snapshot_tag=args.snapshot_tag if context.backend == "file" else "",
+        url=args.url,
+        format=args.format,
+        quality=args.quality,
+        cdp_port=args.cdp_port,
+        ws_url=args.ws_url,
+        fcvm=args.fcvm,
+        data_root=args.data_root,
+        state_dir=args.state_dir,
+        out_dir=log_dir,
+        timeout=args.timeout,
+        teardown_timeout=args.teardown_timeout,
+        rust_log=args.rust_log,
+        run_id=args.run_id,
+        firecracker_fault_probe=probe,
+        spawn_prefix=guard_prefix(args.cgroup_paths[context.backend]),
+    )
+
+
+def _make_request_fn(args, spec, serve_pid, log_dir, audits, tracer, global_base):
+    def request(context: RequestContext) -> dict:
+        marker = tracer.marker if tracer is not None else None
+        probe = FirecrackerFaultProbe(ProcReader(), audits[context.backend], marker)
+        request_args = _request_args(args, context, serve_pid, log_dir, probe)
+        rep = global_base + context.request_index
+        record = reqbench.run_cdp_request(request_args, rep, fast=True)
+        record.update(
+            schema=RECORD_SCHEMA,
+            kind="request",
+            run_id=args.run_id,
+            burst_id=spec.burst_id,
+            block_id=spec.block_id,
+            cell_id=f"{context.backend}:r{format(spec.target_rps, '.12g')}",
+            population=spec.population,
+            segment=context.segment,
+            pair_index=context.pair_index,
+            backend=context.backend,
+            target_rps=spec.target_rps,
+            traced=spec.traced,
+            trace_pair_id=spec.trace_pair_id,
+            request_seed=context.request_seed,
+            snapshot_generation_id=args.snapshot_identity["generation_id"],
+            snapshot_config_sha256=args.snapshot_identity["config_sha256"],
+        )
+        record["actual_launch_ns"] = record.pop(
+            "started_monotonic_ns", context.actual_launch_ns
+        )
+        if "artifact_monotonic_ns" in record:
+            record["artifact_ns"] = record.pop("artifact_monotonic_ns")
+        record["finished_ns"] = record.pop(
+            "finished_monotonic_ns", time.monotonic_ns()
+        )
+        return record
+
+    return request
+
+
+def _augment_burst_accounting(summary, proc_before, proc_after, cpu_before, cpu_after):
+    summary["machine_proc_stat_before"] = proc_before
+    summary["machine_proc_stat_after"] = proc_after
+    summary["machine_proc_stat_delta"] = counter_delta(
+        proc_before["cpu"], proc_after["cpu"]
+    )
+    summary["cgroup_cpu_stat_before"] = cpu_before
+    summary["cgroup_cpu_stat_after"] = cpu_after
+    if set(cpu_before) != set(cpu_after):
+        raise MeasurementInvalid("cgroup accounting set changed during burst")
+    summary["cgroup_cpu_stat_delta"] = {
+        name: counter_delta(cpu_before[name], cpu_after[name])
+        for name in sorted(cpu_before)
+    }
+
+
+def _failure_record(phase: str, error: BaseException) -> dict:
+    details = getattr(error, "details", None)
+    try:
+        canonical_json(details)
+    except (TypeError, ValueError):
+        details = repr(details)
+    return {
+        "phase": phase,
+        "type": type(error).__name__,
+        "message": str(error),
+        "details": details,
+    }
+
+
+def _cpu_snapshots(audits: dict[str, CgroupAudit]) -> dict:
+    return {name: audit.cpu_snapshot() for name, audit in sorted(audits.items())}
+
+
+def _cgroup_records(audits: dict[str, CgroupAudit]) -> dict:
+    return {name: audit.record() for name, audit in sorted(audits.items())}
+
+
+def _interburst_membership(
+    audits: dict[str, CgroupAudit], serve_pid: int, control_pid: int,
+) -> dict[str, list[int]]:
+    members = {name: audit.live_pids() for name, audit in sorted(audits.items())}
+    expected_exact = {
+        "run": [],
+        "driver": [os.getpid()],
+        "file": [],
+        "uffd": [serve_pid],
+    }
+    mismatch = {
+        name: {"expected": expected, "actual": members.get(name)}
+        for name, expected in expected_exact.items() if members.get(name) != expected
+    }
+    if control_pid not in members.get("control", []):
+        mismatch["control"] = {
+            "expected_to_contain": control_pid,
+            "actual": members.get("control"),
+        }
+    if mismatch:
+        raise MeasurementInvalid(f"inter-burst cgroup membership is not quiescent: {mismatch}")
+    return members
+
+
+def execute(args, schedule: dict, provenance: dict) -> int:
+    os.mkdir(args.out_dir)
+    _fsync_directory(os.path.dirname(args.out_dir))
+    log_dir = os.path.join(args.out_dir, "logs")
+    trace_dir = os.path.join(args.out_dir, "fault-trace")
+    os.mkdir(log_dir)
+    os.mkdir(trace_dir)
+    _fsync_directory(args.out_dir)
+    write_json_exclusive(os.path.join(args.out_dir, "schedule.json"), schedule)
+    write_json_exclusive(os.path.join(args.out_dir, "provenance.json"), provenance)
+
+    scope = None
+    audits = None
+    serve = None
+    control = None
+    control_scheduler = None
+    sampler = None
+    active_tracer = None
+    sinks = {"request": None, "burst": None, "control": None, "sample": None}
+    summaries = []
+    run_before = None
+    run_after = None
+    final_cgroups = None
+    control_summary = None
+    sampler_summary = None
+    final_snapshot_identity = None
+    failures = []
+    phase = RunPhase()
+    try:
+        scope = RunCgroups(args.run_id, args.cgroup_root)
+        audits = scope.enter()
+        args.cgroup_paths = dict(scope.paths)
+        run_before = {
+            "machine_proc_stat": read_machine_proc_stat(),
+            "cgroup_cpu_stat": _cpu_snapshots(audits),
+            "cgroups": _cgroup_records(audits),
+        }
+        sinks["request"] = JsonlSink(os.path.join(args.out_dir, "requests.jsonl"))
+        sinks["burst"] = JsonlSink(os.path.join(args.out_dir, "bursts.jsonl"))
+        sinks["control"] = JsonlSink(os.path.join(args.out_dir, "host-control.jsonl"))
+        sinks["sample"] = JsonlSink(os.path.join(args.out_dir, "host-samples.jsonl"))
+        sampler = HostSampler(
+            sinks["sample"], audits, phase.snapshot, schedule["host_sample_interval_ns"]
+        )
+        sampler.start()
+
+        serve = UffdServe(args, audits["uffd"], scope.paths["uffd"], log_dir)
+        serve_pid = serve.start()
+        write_json_exclusive(
+            os.path.join(args.out_dir, "uffd-serve.json"), serve.record
+        )
+        control = NativeChromiumControl(
+            args, audits["control"], scope.paths["control"], log_dir
+        )
+        control_warmup = control.start()
+        write_json_exclusive(
+            os.path.join(args.out_dir, "host-control-warmup.json"), control_warmup
+        )
+        control_scheduler = ControlScheduler(control, sinks["control"], schedule["control"])
+        control_scheduler.start()
+
+        global_base = 0
+        for raw_spec in schedule["bursts"]:
+            sampler.check()
+            control_scheduler.check()
+            spec = BurstSpec.from_dict(raw_spec)
+            phase.set("burst", spec.burst_id)
+            if spec.traced:
+                active_tracer = BpftraceFaultTracer(
+                    {name: scope.paths[name] for name in ("file", "uffd")},
+                    scope.paths["driver"], os.getpid(), trace_dir, spec.burst_id,
+                    audits["driver"], args.bpftrace,
+                )
+                active_tracer.start(args.trace_start_timeout)
+            proc_before = read_machine_proc_stat()
+            cpu_before = _cpu_snapshots(audits)
+            records = None
+            try:
+                request_fn = _make_request_fn(
+                    args, spec, serve_pid, log_dir, audits, active_tracer, global_base
+                )
+                records, summary = run_open_loop_burst(
+                    args.run_id, spec, request_fn, SystemClock(), ThreadLauncher()
+                )
+            finally:
+                if active_tracer is not None and records is None:
+                    active_tracer.abort()
+                    active_tracer = None
+            if active_tracer is not None:
+                trace = active_tracer.stop(args.trace_stop_timeout)
+                join_fault_trace(records, trace)
+                trace_paths = {
+                    "raw": active_tracer.raw_path,
+                    "stderr": active_tracer.stderr_path,
+                    "program": active_tracer.program_path,
+                }
+                if any(not isinstance(path, str) for path in trace_paths.values()):
+                    raise MeasurementInvalid("bpftrace did not retain every artifact path")
+                summary["fault_trace"] = {
+                    "scope": (
+                        "Firecracker process endpoint-ready through artifact return; all "
+                        "VMAs, not guest-RAM-filtered and not UFFD events"
+                    ),
+                    "processes": len(trace["processes"]),
+                    "artifacts": {
+                        name: {
+                            "path": os.path.relpath(path, args.out_dir),
+                            "sha256": sha256_file(path),
+                            "bytes": os.stat(path).st_size,
+                        }
+                        for name, path in sorted(trace_paths.items())
+                    },
+                }
+                active_tracer = None
+            _augment_burst_accounting(
+                summary, proc_before, read_machine_proc_stat(),
+                cpu_before, _cpu_snapshots(audits),
+            )
+            summary["interburst_cgroup_membership"] = _interburst_membership(
+                audits, serve_pid, control.proc.pid
+            )
+            for record in records:
+                sinks["request"].write(record)
+            sinks["request"].sync()
+            sinks["burst"].write(summary)
+            sinks["burst"].sync()
+            summaries.append(summary)
+            global_base += summary["total_planned"]
+            print(
+                f"{spec.burst_id} target={spec.target_rps:g}rps/backend "
+                f"file={summary['backends']['file']['artifact_completed']}/"
+                f"{summary['backends']['file']['planned']} "
+                f"uffd={summary['backends']['uffd']['artifact_completed']}/"
+                f"{summary['backends']['uffd']['planned']} "
+                f"drain={summary['drain_span_ms']:.1f}ms",
+                flush=True,
+            )
+            if (
+                summary["failed"]
+                or summary["total_artifact_completed"] != summary["total_planned"]
+                or summary["total_drained"] != summary["total_planned"]
+                or summary["total_cleanup_confirmed"] != summary["total_planned"]
+            ):
+                raise MeasurementInvalid(
+                    f"burst {spec.burst_id} has failed or unconfirmed-clean requests", summary
+                )
+            sampler.check()
+            control_scheduler.check()
+        if args.trace_faults:
+            gate_path = os.path.join(args.out_dir, "trace-perturbation.json")
+            try:
+                verdict = evaluate_trace_perturbation(
+                    summaries, args.max_trace_perturbation_pct
+                )
+            except MeasurementInvalid as gate_error:
+                if isinstance(gate_error.details, dict):
+                    write_json_exclusive(gate_path, gate_error.details)
+                raise
+            write_json_exclusive(gate_path, verdict)
+    except BaseException as caught:
+        failures.append(_failure_record("run", caught))
+    finally:
+        phase.set("teardown")
+        if active_tracer is not None:
+            try:
+                active_tracer.abort()
+            except BaseException as abort_error:
+                failures.append(_failure_record("tracer-abort", abort_error))
+        if control_scheduler is not None:
+            try:
+                control_summary = control_scheduler.stop()
+            except BaseException as stop_error:
+                failures.append(_failure_record("control-scheduler-stop", stop_error))
+        if control is not None:
+            try:
+                control.stop()
+            except BaseException as stop_error:
+                failures.append(_failure_record("control-stop", stop_error))
+        if serve is not None:
+            try:
+                serve.stop()
+            except BaseException as stop_error:
+                failures.append(_failure_record("serve-stop", stop_error))
+        if sampler is not None:
+            try:
+                sampler_summary = sampler.stop()
+            except BaseException as stop_error:
+                failures.append(_failure_record("sampler-stop", stop_error))
+        lease = getattr(args, "snapshot_generation_lease", None)
+        if lease is not None:
+            try:
+                final_snapshot_identity = lease.verify()
+            except BaseException as generation_error:
+                failures.append(_failure_record("snapshot-generation-verify", generation_error))
+        else:
+            failures.append(_failure_record(
+                "snapshot-generation-verify",
+                MeasurementInvalid("measured run has no snapshot generation lease"),
+            ))
+        if audits is not None:
+            try:
+                run_after = {
+                    "machine_proc_stat": read_machine_proc_stat(),
+                    "cgroup_cpu_stat": _cpu_snapshots(audits),
+                    "cgroups": _cgroup_records(audits),
+                }
+            except BaseException as accounting_error:
+                failures.append(_failure_record("final-accounting", accounting_error))
+        for name, sink in sinks.items():
+            if sink is not None:
+                try:
+                    sink.close()
+                except BaseException as close_error:
+                    failures.append(_failure_record(f"{name}-sink-close", close_error))
+        if scope is not None:
+            try:
+                final_cgroups = scope.leave()
+            except BaseException as leave_error:
+                failures.append(_failure_record("cgroup-leave", leave_error))
+
+    primary = failures[0] if failures else None
+    status = {
+        "schema": "fcvm.chromium.reqscale.status.v2",
+        "run_id": args.run_id,
+        "valid": not failures,
+        "bursts_completed": len(summaries),
+        "bursts_planned": len(schedule["bursts"]),
+        "control": control_summary,
+        "sampler": sampler_summary,
+        "snapshot_identity_after": final_snapshot_identity,
+        "run_before": run_before,
+        "run_after": run_after,
+        "final_cgroups": final_cgroups,
+        "error": (
+            f"{primary['type']}: {primary['message']}" if primary is not None else None
+        ),
+        "error_details": primary["details"] if primary is not None else None,
+        "errors": failures,
+    }
+    write_json_exclusive(os.path.join(args.out_dir, "status.json"), status)
+    if failures:
+        print(status["error"], file=sys.stderr)
+        return 4
+    return 0
+
+
+def _parse_rates(value: str) -> tuple[float, ...]:
+    try:
+        rates = tuple(float(item.strip()) for item in value.split(",") if item.strip())
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(f"invalid comma-separated rates: {value}") from error
+    if not rates:
+        raise argparse.ArgumentTypeError("at least one rate is required")
+    return rates
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--snapshot-tag", required=True)
+    parser.add_argument("--url", required=True)
+    parser.add_argument("--rates", required=True, type=_parse_rates)
+    parser.add_argument("--bursts", type=int, required=True)
+    parser.add_argument("--seed", type=int, required=True)
+    parser.add_argument("--max-offered-rps-error-pct", type=float, required=True)
+    parser.add_argument("--min-departure-ratio", type=float, required=True)
+    parser.add_argument("--max-score-end-backlog", type=int, required=True)
+    parser.add_argument("--max-p95-launch-lag-ms", type=float, required=True)
+    parser.add_argument("--max-control-median-drift-pct", type=float, required=True)
+    parser.add_argument("--run-id", default="")
+    parser.add_argument("--out-dir", required=True)
+    parser.add_argument("--fcvm", default=os.path.join(REPO, "target", "release", "fcvm"))
+    parser.add_argument("--data-root", default="/mnt/fcvm-btrfs")
+    parser.add_argument("--state-dir", default="")
+    parser.add_argument("--cgroup-root", default="/sys/fs/cgroup")
+    parser.add_argument("--control-chromium", default="chromium")
+    parser.add_argument("--control-url", default="")
+    parser.add_argument("--control-timeout", type=float, default=8.0)
+    parser.add_argument("--control-tmp-root", default="/tmp")
+    parser.add_argument("--format", choices=("png", "jpeg"), default="jpeg")
+    parser.add_argument("--quality", type=int, default=80)
+    parser.add_argument("--cdp-port", type=int, default=9222)
+    parser.add_argument("--ws-url", default="")
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument("--teardown-timeout", type=float, default=60.0)
+    parser.add_argument("--rust-log", default="fcvm=debug")
+    parser.add_argument("--trace-faults", action="store_true")
+    parser.add_argument("--trace-rate", type=float)
+    parser.add_argument("--trace-pairs", type=int, default=0)
+    parser.add_argument("--max-trace-perturbation-pct", type=float)
+    parser.add_argument("--trace-start-timeout", type=float, default=30.0)
+    parser.add_argument("--trace-stop-timeout", type=float, default=30.0)
+    parser.add_argument("--bpftrace", default="bpftrace")
+    parser.add_argument(
+        "--plan-only", action="store_true",
+        help="write only a schedule.json; no cgroup, serve, clone, or benchmark",
+    )
+    args = parser.parse_args()
+
+    args.run_id = args.run_id or uuid.uuid4().hex
+    args.fcvm = os.path.abspath(args.fcvm)
+    args.data_root = os.path.abspath(args.data_root)
+    args.state_dir = args.state_dir or os.path.join(args.data_root, "state")
+    args.out_dir = os.path.abspath(args.out_dir)
+    args.control_url = args.control_url or args.url
+    args.control_tmp_root = os.path.abspath(args.control_tmp_root)
+    try:
+        _validate_snapshot_tag(args.snapshot_tag)
+    except ValueError as error:
+        parser.error(str(error))
+    if args.rust_log != "fcvm=debug":
+        parser.error("--rust-log must be exactly fcvm=debug for measured runs")
+    if args.trace_faults:
+        if args.trace_rate is None or args.trace_pairs < 3:
+            parser.error("--trace-faults requires --trace-rate and --trace-pairs >= 3")
+        if args.max_trace_perturbation_pct is None:
+            parser.error(
+                "--trace-faults requires a predeclared --max-trace-perturbation-pct"
+            )
+    elif (
+        args.trace_rate is not None
+        or args.trace_pairs
+        or args.max_trace_perturbation_pct is not None
+    ):
+        parser.error("trace options require --trace-faults")
+
+    config = ScheduleConfig(
+        rates=args.rates,
+        scored_bursts=args.bursts,
+        seed=args.seed,
+        criteria=CapacityCriteria(
+            max_offered_rps_error_pct=args.max_offered_rps_error_pct,
+            min_departure_ratio=args.min_departure_ratio,
+            max_score_end_backlog=args.max_score_end_backlog,
+            max_p95_launch_lag_ms=args.max_p95_launch_lag_ms,
+            max_control_median_drift_pct=args.max_control_median_drift_pct,
+        ),
+        trace_rate=args.trace_rate,
+        trace_pairs=args.trace_pairs,
+    )
+    try:
+        schedule = build_schedule(config, args.run_id)
+    except ValueError as error:
+        parser.error(str(error))
+    if args.plan_only:
+        os.mkdir(args.out_dir)
+        _fsync_directory(os.path.dirname(args.out_dir))
+        write_json_exclusive(os.path.join(args.out_dir, "schedule.json"), schedule)
+        return 0
+    if os.geteuid() != 0:
+        parser.error("measured runs must be root so owned accounting cgroups can be created")
+    resolved_chromium = (
+        args.control_chromium if os.path.isabs(args.control_chromium)
+        else shutil.which(args.control_chromium)
+    )
+    if not resolved_chromium or not os.path.isfile(resolved_chromium):
+        parser.error(f"host control Chromium is missing: {args.control_chromium}")
+    args.control_chromium = os.path.abspath(resolved_chromium)
+    if (
+        not math.isfinite(args.control_timeout)
+        or not 0 < args.control_timeout < CONTROL_INTERVAL_SECONDS
+    ):
+        parser.error("--control-timeout must be finite, positive, and below 10 seconds")
+    if not os.path.isdir(args.control_tmp_root):
+        parser.error(f"--control-tmp-root is not a directory: {args.control_tmp_root}")
+    try:
+        with SnapshotGenerationLease(args.data_root, args.snapshot_tag) as lease:
+            args.snapshot_generation_lease = lease
+            args.snapshot_identity = dict(lease.identity)
+            provenance = collect_provenance(args, schedule, args.snapshot_identity)
+            with TerminationFence():
+                return execute(args, schedule, provenance)
+    except (MeasurementInvalid, OSError, ValueError) as error:
+        print(f"{type(error).__name__}: {error}", file=sys.stderr)
+        return 4
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/chromium/reqscale_analyze.py
+++ b/bench/chromium/reqscale_analyze.py
@@ -1749,7 +1749,7 @@ def analyze(run_dir: str) -> dict:
     control_warmup = _load_json(os.path.join(run_dir, "host-control-warmup.json"))
     uffd_serve = _load_json(os.path.join(run_dir, "uffd-serve.json"))
 
-    _validate_schedule(schedule)
+    config = _validate_schedule(schedule)
     generation_id, config_sha256 = _validate_provenance(provenance, schedule)
     _validate_status(status, schedule, provenance)
     _validate_uffd_serve(uffd_serve, schedule, provenance, status)
@@ -1921,6 +1921,28 @@ def analyze(run_dir: str) -> dict:
         "run_id": run_id,
         "snapshot_generation_id": generation_id,
         "publishable": True,
+        # The report is the publication document, so the numbers that describe HOW the
+        # run was scheduled, and on WHAT, have to come from the validated artifacts
+        # rather than from prose written when the defaults happened to be these.
+        "schedule": {
+            "ramp_seconds": config.ramp_seconds,
+            "score_seconds": config.score_seconds,
+            "warmup_bursts": config.warmup_bursts,
+            "scored_bursts": config.scored_bursts,
+            "seed": config.seed,
+        },
+        "provenance": {
+            "hostname": provenance["host"]["hostname"],
+            "kernel": provenance["host"]["kernel"],
+            "machine": provenance["host"]["machine"],
+            "cpu_count": provenance["host"]["cpu_count"],
+            "fcvm_version": provenance["fcvm_version"],
+            "fcvm_sha256": provenance["fcvm_sha256"],
+            "source_revision": provenance["source_revision"],
+            "source_dirty": provenance["source_dirty"],
+            "chromium_version": provenance["host_control"]["chromium_version"],
+            "hostinfo": "provenance.json",
+        },
         "experimental_unit": "burst",
         "analysis_seed": analysis_seed,
         "bootstrap_draws": BOOTSTRAP_DRAWS,
@@ -1937,7 +1959,15 @@ def analyze(run_dir: str) -> dict:
     }
 
 
+def _format_seconds(value):
+    """`15 second` / `2.5 second`, without a trailing `.0` on whole numbers."""
+    return f"{int(value)} second" if float(value).is_integer() else f"{value} second"
+
+
 def markdown_report(analysis: dict) -> str:
+    sched = analysis["schedule"]
+    prov = analysis["provenance"]
+    warmup = sched["warmup_bursts"]
     lines = [
         "# Chromium request scalability",
         "",
@@ -1945,11 +1975,27 @@ def markdown_report(analysis: dict) -> str:
         f"`{analysis['snapshot_generation_id']}`. The run passed its provenance, "
         "continuous-accounting, and host drift-control checks.",
         "",
+        f"Measured on `{prov['hostname']}` ({prov['machine']}, {prov['cpu_count']} CPUs, "
+        f"kernel `{prov['kernel']}`) with fcvm `{prov['fcvm_version']}` "
+        f"(`{prov['fcvm_sha256'][:12]}`) at source revision "
+        f"`{prov['source_revision'][:12]}`"
+        f"{' with a DIRTY tree' if prov['source_dirty'] else ''}, driving "
+        f"Chromium `{prov['chromium_version']}`. Full host and binary provenance is in "
+        f"`{prov['hostinfo']}`.",
+        "",
         "FILE and UFFD were offered the same per-backend rate in one mixed stream. "
         "Each rate interval contained one request for each backend, separated by "
-        "half an interval with seeded order. One warmup burst was excluded. Each "
-        "scored burst used a 15 second ramp and 60 second score, and confidence "
+        f"half an interval with seeded order (seed `{sched['seed']}`). "
+        f"{warmup} warmup burst{'' if warmup == 1 else 's'} per rate "
+        f"{'was' if warmup == 1 else 'were'} excluded, leaving "
+        f"{sched['scored_bursts']} scored per cell. Each scored burst used a "
+        f"{_format_seconds(sched['ramp_seconds'])} ramp and "
+        f"{_format_seconds(sched['score_seconds'])} score, and confidence "
         "intervals resample whole bursts rather than requests.",
+        "",
+        "Every figure below is computed from `requests.jsonl` and `bursts.jsonl` in "
+        "this run directory; the analysis field backing each table is named in its "
+        "caption.",
         "",
         "## Capacity gates",
         "",

--- a/bench/chromium/reqscale_analyze.py
+++ b/bench/chromium/reqscale_analyze.py
@@ -1,0 +1,2064 @@
+#!/usr/bin/env python3
+"""Validate and summarize one reqscale run without inventing missing evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import stat
+import statistics
+import sys
+import uuid
+from collections import defaultdict
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+import reqscale  # noqa: E402
+
+
+ANALYSIS_SCHEMA = "fcvm.chromium.reqscale.analysis.v1"
+BOOTSTRAP_DRAWS = 10_000
+
+
+class AnalysisInvalid(RuntimeError):
+    pass
+
+
+def _strict_object(pairs):
+    value = {}
+    for key, item in pairs:
+        if key in value:
+            raise AnalysisInvalid(f"duplicate JSON object key {key!r}")
+        value[key] = item
+    return value
+
+
+def _reject_json_constant(value):
+    raise AnalysisInvalid(f"non-standard JSON constant {value}")
+
+
+def _strict_load(stream):
+    return json.load(
+        stream,
+        object_pairs_hook=_strict_object,
+        parse_constant=_reject_json_constant,
+    )
+
+
+def _load_json(path: str):
+    try:
+        with open(path) as stream:
+            value = _strict_load(stream)
+        if not isinstance(value, dict):
+            raise AnalysisInvalid(f"top-level JSON artifact {path} is not an object")
+        return value
+    except (OSError, ValueError) as error:
+        raise AnalysisInvalid(f"cannot read JSON artifact {path}: {error}") from error
+
+
+def _load_jsonl(path: str) -> list[dict]:
+    rows = []
+    try:
+        with open(path) as stream:
+            for number, line in enumerate(stream, 1):
+                if not line.strip():
+                    raise AnalysisInvalid(f"blank JSONL row at {path}:{number}")
+                try:
+                    row = json.loads(
+                        line,
+                        object_pairs_hook=_strict_object,
+                        parse_constant=_reject_json_constant,
+                    )
+                except ValueError as error:
+                    raise AnalysisInvalid(f"malformed JSONL at {path}:{number}: {error}") from error
+                if not isinstance(row, dict):
+                    raise AnalysisInvalid(f"non-object JSONL row at {path}:{number}")
+                rows.append(row)
+    except OSError as error:
+        raise AnalysisInvalid(f"cannot read JSONL artifact {path}: {error}") from error
+    return rows
+
+
+def _nearest(values: list[float], quantile: float) -> float:
+    ordered = sorted(values)
+    if not ordered:
+        raise AnalysisInvalid("cannot take a quantile of no values")
+    index = max(0, min(len(ordered) - 1, math.ceil(quantile * len(ordered)) - 1))
+    return float(ordered[index])
+
+
+def bootstrap_mean_ci(
+    values: list[float], seed: int, draws: int | None = None,
+) -> dict:
+    """A deterministic burst-resampling CI; requests are never resampled."""
+    draws = BOOTSTRAP_DRAWS if draws is None else draws
+    if len(values) < 5:
+        raise AnalysisInvalid("a burst-level CI needs at least 5 independent bursts")
+    if draws < 1000:
+        raise AnalysisInvalid("bootstrap draw count is too small for a 95% interval")
+    if any(not isinstance(value, (int, float)) or not math.isfinite(value) for value in values):
+        raise AnalysisInvalid(f"bootstrap input contains a non-finite value: {values}")
+    means = []
+    count = len(values)
+    for draw in range(draws):
+        total = 0.0
+        for sample in range(count):
+            index = reqscale._derive_u64(seed, "bootstrap", draw, sample) % count
+            total += values[index]
+        means.append(total / count)
+    return {
+        "unit": "burst",
+        "n": count,
+        "point": statistics.mean(values),
+        "ci95_low": _nearest(means, 0.025),
+        "ci95_high": _nearest(means, 0.975),
+        "method": "seeded percentile bootstrap of the burst mean",
+        "draws": draws,
+        "seed": seed,
+    }
+
+
+def _canonical_generation(value) -> str:
+    try:
+        canonical = str(uuid.UUID(value))
+    except (AttributeError, TypeError, ValueError) as error:
+        raise AnalysisInvalid("provenance has an invalid snapshot generation_id") from error
+    if canonical != value:
+        raise AnalysisInvalid("provenance has a non-canonical snapshot generation_id")
+    return canonical
+
+
+def _validate_schedule(schedule: dict) -> reqscale.ScheduleConfig:
+    if not isinstance(schedule, dict):
+        raise AnalysisInvalid("schedule is not an object")
+    if schedule.get("schema") != reqscale.SCHEDULE_SCHEMA:
+        raise AnalysisInvalid(f"unsupported schedule schema {schedule.get('schema')!r}")
+    try:
+        raw_criteria = schedule["capacity_criteria"]
+        if not isinstance(raw_criteria, dict):
+            raise AnalysisInvalid("capacity criteria are not an object")
+        if raw_criteria.get("require_zero_failures") is not True:
+            raise AnalysisInvalid("zero failures must be a mandatory capacity gate")
+        criteria = reqscale.CapacityCriteria(
+            max_offered_rps_error_pct=raw_criteria["max_offered_rps_error_pct"],
+            min_departure_ratio=raw_criteria["min_departure_ratio"],
+            max_score_end_backlog=raw_criteria["max_score_end_backlog"],
+            max_p95_launch_lag_ms=raw_criteria["max_p95_launch_lag_ms"],
+            max_control_median_drift_pct=raw_criteria[
+                "max_control_median_drift_pct"
+            ],
+        )
+        config = reqscale.ScheduleConfig(
+            rates=tuple(schedule["rates"]),
+            scored_bursts=schedule["independent_bursts_per_cell"],
+            seed=schedule["seed"],
+            criteria=criteria,
+            warmup_bursts=schedule["warmup_bursts_per_rate"],
+            ramp_seconds=schedule["ramp_seconds"],
+            score_seconds=schedule["score_seconds"],
+            trace_rate=schedule["trace_rate"],
+            trace_pairs=schedule["trace_pairs"],
+        )
+        rebuilt = reqscale.build_schedule(config, schedule["run_id"])
+    except (
+        KeyError, TypeError, ValueError, OverflowError, reqscale.MeasurementInvalid,
+    ) as error:
+        raise AnalysisInvalid(f"durable schedule is invalid: {error}") from error
+    if reqscale.canonical_json(rebuilt) != reqscale.canonical_json(schedule):
+        raise AnalysisInvalid(
+            "durable schedule does not match its seed, cells, and declared experiment shape"
+        )
+    return config
+
+
+def _finite_number(value, name: str, *, minimum=None, maximum=None) -> float:
+    if (
+        not isinstance(value, (int, float))
+        or isinstance(value, bool)
+        or not math.isfinite(value)
+    ):
+        raise AnalysisInvalid(f"{name} is not a finite number")
+    if minimum is not None and value < minimum:
+        raise AnalysisInvalid(f"{name} is below {minimum}")
+    if maximum is not None and value > maximum:
+        raise AnalysisInvalid(f"{name} is above {maximum}")
+    return float(value)
+
+
+def _validate_fault_metric(row: dict, traced: bool) -> None:
+    faults = row.get("firecracker_process_faults_ready_to_artifact")
+    if not isinstance(faults, dict):
+        raise AnalysisInvalid(f"request {row.get('request_id')} lacks Firecracker fault counters")
+    for field in ("pid", "pid_start_time_ticks", "minor_faults", "major_faults"):
+        value = faults.get(field)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise AnalysisInvalid(
+                f"request {row.get('request_id')} has invalid fault field {field}"
+            )
+    for side in ("before", "after"):
+        counters = faults.get(side)
+        if not isinstance(counters, dict) or set(counters) != {"minor_faults", "major_faults"}:
+            raise AnalysisInvalid(
+                f"request {row.get('request_id')} has incomplete fault {side} counters"
+            )
+        if any(
+            not isinstance(value, int) or isinstance(value, bool) or value < 0
+            for value in counters.values()
+        ):
+            raise AnalysisInvalid(
+                f"request {row.get('request_id')} has invalid fault {side} counters"
+            )
+    if faults["after"]["minor_faults"] - faults["before"]["minor_faults"] != faults["minor_faults"]:
+        raise AnalysisInvalid(f"request {row.get('request_id')} minor faults do not reconcile")
+    if faults["after"]["major_faults"] - faults["before"]["major_faults"] != faults["major_faults"]:
+        raise AnalysisInvalid(f"request {row.get('request_id')} major faults do not reconcile")
+    if (
+        not isinstance(faults.get("scope"), str)
+        or "not guest-RAM-filtered" not in faults["scope"]
+    ):
+        raise AnalysisInvalid(f"request {row.get('request_id')} overclaims fault scope")
+    traced_faults = row.get("firecracker_process_handle_mm_fault_ready_to_artifact")
+    if traced and not isinstance(traced_faults, dict):
+        raise AnalysisInvalid(f"traced request {row.get('request_id')} lacks joined fault timing")
+    if not traced and traced_faults is not None:
+        raise AnalysisInvalid(f"untraced request {row.get('request_id')} has trace-only fault timing")
+    if traced:
+        count = traced_faults.get("count")
+        total = traced_faults.get("total_ns")
+        histogram = traced_faults.get("histogram")
+        valid_histogram = False
+        histogram_count = -1
+        if isinstance(histogram, list):
+            valid_histogram = all(
+                isinstance(bucket, dict)
+                and set(bucket) == {"min", "max", "count"}
+                and all(
+                    isinstance(bucket[field], int) and not isinstance(bucket[field], bool)
+                    for field in ("min", "max", "count")
+                )
+                and 0 <= bucket["min"] <= bucket["max"]
+                and bucket["count"] >= 0
+                for bucket in histogram
+            )
+            if valid_histogram:
+                histogram_count = sum(bucket["count"] for bucket in histogram)
+                valid_histogram = all(
+                    current["min"] > previous["max"]
+                    for previous, current in zip(histogram, histogram[1:])
+                )
+        if (
+            not isinstance(count, int) or isinstance(count, bool) or count < 0
+            or not isinstance(total, int) or isinstance(total, bool) or total < 0
+            or not valid_histogram
+            or histogram_count != count
+            or not isinstance(traced_faults.get("scope"), str)
+            or "not filtered to guest RAM" not in traced_faults["scope"]
+        ):
+            raise AnalysisInvalid(f"traced request {row.get('request_id')} has invalid fault timing")
+
+
+def _recompute_backend_metrics(spec: reqscale.BurstSpec, records: list[dict], backend: str) -> dict:
+    score_start_ns = records[0]["scheduled_ns"] - spec.requests[0].scheduled_offset_ns
+    score_start_ns += round(spec.ramp_seconds * 1_000_000_000)
+    score_end_ns = score_start_ns + round(spec.score_seconds * 1_000_000_000)
+    rows = [
+        row for row in records
+        if row["segment"] == "score" and row["backend"] == backend
+    ]
+    planned = reqscale._planned_count(spec.target_rps, spec.score_seconds)
+    if len(rows) != planned:
+        raise AnalysisInvalid(
+            f"burst {spec.burst_id} has {len(rows)} raw scored {backend} requests, "
+            f"expected {planned}"
+        )
+    launched_by_end = sum(row["actual_launch_ns"] <= score_end_ns for row in rows)
+    artifact_by_end = sum(row["artifact_ns"] <= score_end_ns for row in rows)
+    return {
+        "cell_id": f"{backend}:r{format(spec.target_rps, '.12g')}",
+        "planned": planned,
+        "launched": len(rows),
+        "launched_by_score_end": launched_by_end,
+        "artifact_completed": len(rows),
+        "artifact_completed_by_score_end": artifact_by_end,
+        "drained": len(rows),
+        "cleanup_confirmed": sum(row["teardown"]["all_gone"] is True for row in rows),
+        "ok": sum(row["ok"] is True for row in rows),
+        "failed": sum(row["ok"] is not True for row in rows),
+        "offered_rps": launched_by_end / spec.score_seconds,
+        "departure_rps": artifact_by_end / spec.score_seconds,
+        "departure_ratio": artifact_by_end / planned,
+        "score_start_backlog": reqscale._backlog_at(records, backend, score_start_ns),
+        "score_end_backlog": reqscale._backlog_at(records, backend, score_end_ns),
+        "max_backlog_during_score": reqscale._max_backlog(
+            records, backend, score_start_ns, score_end_ns
+        ),
+        "launch_lag_ms": reqscale.distribution([
+            (row["actual_launch_ns"] - row["scheduled_ns"]) / 1_000_000
+            for row in rows
+        ]),
+        "artifact_latency_ms": reqscale.distribution([
+            (row["artifact_ns"] - row["actual_launch_ns"]) / 1_000_000
+            for row in rows
+        ]),
+        "drain_latency_ms": reqscale.distribution([
+            (row["finished_ns"] - row["artifact_ns"]) / 1_000_000
+            for row in rows
+        ]),
+        "wall_latency_ms": reqscale.distribution([
+            (row["finished_ns"] - row["actual_launch_ns"]) / 1_000_000
+            for row in rows
+        ]),
+        "blocking_latency_ms": reqscale.distribution([
+            float(row["blocking_ms"]) for row in rows
+        ]),
+    }
+
+
+def _validate_burst_accounting(summary: dict) -> None:
+    machine = {}
+    for side in ("before", "after"):
+        value = summary.get(f"machine_proc_stat_{side}")
+        if (
+            not isinstance(value, dict)
+            or value.get("path") != "/proc/stat"
+            or not isinstance(value.get("raw"), str)
+            or not value["raw"]
+        ):
+            raise AnalysisInvalid(f"burst {summary.get('burst_id')} lacks whole /proc/stat {side}")
+        raw = value["raw"]
+        if value.get("raw_sha256") != hashlib.sha256(raw.encode()).hexdigest():
+            raise AnalysisInvalid(f"burst {summary.get('burst_id')} /proc/stat {side} digest differs")
+        _validate_whole_proc_stat(
+            raw, f"burst {summary.get('burst_id')} /proc/stat {side}"
+        )
+        parsed = _proc_cpu_from_raw(raw, f"burst {summary.get('burst_id')} /proc/stat {side}")
+        if value.get("cpu") != parsed:
+            raise AnalysisInvalid(f"burst {summary.get('burst_id')} /proc/stat {side} parsing differs")
+        for field in ("captured_wall_ns", "captured_monotonic_ns", "clk_tck"):
+            captured = value.get(field)
+            if (
+                not isinstance(captured, int)
+                or isinstance(captured, bool)
+                or captured <= 0
+            ):
+                raise AnalysisInvalid(
+                    f"burst {summary.get('burst_id')} /proc/stat {side} lacks {field}"
+                )
+        machine[side] = parsed
+    before_capture = summary["machine_proc_stat_before"]["captured_monotonic_ns"]
+    after_capture = summary["machine_proc_stat_after"]["captured_monotonic_ns"]
+    if before_capture > after_capture:
+        raise AnalysisInvalid(f"burst {summary.get('burst_id')} /proc/stat timestamps moved backwards")
+    if (
+        summary["machine_proc_stat_before"]["clk_tck"]
+        != summary["machine_proc_stat_after"]["clk_tck"]
+    ):
+        raise AnalysisInvalid(f"burst {summary.get('burst_id')} /proc/stat clock changed")
+    try:
+        expected_machine_delta = reqscale.counter_delta(machine["before"], machine["after"])
+    except (TypeError, reqscale.MeasurementInvalid) as error:
+        raise AnalysisInvalid(f"burst machine counters are invalid: {error}") from error
+    if summary.get("machine_proc_stat_delta") != expected_machine_delta:
+        raise AnalysisInvalid(f"burst {summary.get('burst_id')} machine CPU delta differs")
+
+    required = {"run", "driver", "control", "file", "uffd"}
+    before = summary.get("cgroup_cpu_stat_before")
+    after = summary.get("cgroup_cpu_stat_after")
+    deltas = summary.get("cgroup_cpu_stat_delta")
+    if not all(isinstance(value, dict) and set(value) == required for value in (before, after, deltas)):
+        raise AnalysisInvalid(f"burst {summary.get('burst_id')} lacks split cgroup CPU accounting")
+    for name in required:
+        before_value = _validate_counter_snapshot(
+            before[name], f"burst {summary.get('burst_id')} {name} cpu.stat before"
+        )
+        after_value = _validate_counter_snapshot(
+            after[name], f"burst {summary.get('burst_id')} {name} cpu.stat after"
+        )
+        delta_value = _validate_counter_snapshot(
+            deltas[name], f"burst {summary.get('burst_id')} {name} cpu.stat delta"
+        )
+        try:
+            expected = reqscale.counter_delta(before_value, after_value)
+        except (TypeError, reqscale.MeasurementInvalid) as error:
+            raise AnalysisInvalid(f"burst {summary.get('burst_id')} {name} CPU counters are invalid: {error}") from error
+        if delta_value != expected:
+            raise AnalysisInvalid(f"burst {summary.get('burst_id')} {name} CPU delta differs")
+    membership = summary.get("interburst_cgroup_membership")
+    if not isinstance(membership, dict) or set(membership) != required:
+        raise AnalysisInvalid(f"burst {summary.get('burst_id')} lacks inter-burst membership")
+    if membership["run"] != [] or membership["file"] != []:
+        raise AnalysisInvalid(f"burst {summary.get('burst_id')} cgroups are not quiescent")
+    for name, pids in membership.items():
+        if (
+            not isinstance(pids, list)
+            or any(
+                not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0
+                for pid in pids
+            )
+            or pids != sorted(set(pids))
+        ):
+            raise AnalysisInvalid(
+                f"burst {summary.get('burst_id')} {name} membership is invalid"
+            )
+    if (
+        len(membership["driver"]) != 1
+        or len(membership["uffd"]) != 1
+        or not membership["control"]
+    ):
+        raise AnalysisInvalid(f"burst {summary.get('burst_id')} persistent cgroup members are missing")
+    leaf_pids = [
+        pid for name in required - {"run"} for pid in membership[name]
+    ]
+    if len(leaf_pids) != len(set(leaf_pids)):
+        raise AnalysisInvalid(f"burst {summary.get('burst_id')} PID appears in multiple leaf cgroups")
+
+
+def _validate_requests(
+    schedule: dict,
+    summaries: list[dict],
+    requests: list[dict],
+    generation_id: str,
+    config_sha256: str,
+) -> dict[str, list[dict]]:
+    summary_by_id = {}
+    for summary in summaries:
+        if summary.get("schema") != reqscale.RECORD_SCHEMA or summary.get("kind") != "burst":
+            raise AnalysisInvalid("burst summary has an unsupported schema or kind")
+        burst_id = summary.get("burst_id")
+        if not isinstance(burst_id, str) or burst_id in summary_by_id:
+            raise AnalysisInvalid(f"duplicate or invalid burst summary id {burst_id!r}")
+        summary_by_id[burst_id] = summary
+        _validate_burst_accounting(summary)
+    expected_bursts = [reqscale.BurstSpec.from_dict(raw) for raw in schedule["bursts"]]
+    expected_ids = [spec.burst_id for spec in expected_bursts]
+    if [summary.get("burst_id") for summary in summaries] != expected_ids:
+        raise AnalysisInvalid("ordered burst summaries do not exactly match the durable schedule")
+
+    rows_by_key = {}
+    firecracker_identities = set()
+    for row in requests:
+        key = (row.get("burst_id"), row.get("request_index"))
+        if key in rows_by_key:
+            raise AnalysisInvalid(f"duplicate request record {key}")
+        rows_by_key[key] = row
+    expected_count = sum(len(spec.requests) for spec in expected_bursts)
+    if len(rows_by_key) != expected_count:
+        raise AnalysisInvalid(
+            f"request artifact has {len(rows_by_key)} rows, expected {expected_count}"
+        )
+    previous_drain_ns = None
+    previous_machine_after = None
+    previous_cgroup_after = None
+    for spec in expected_bursts:
+        summary = summary_by_id[spec.burst_id]
+        start_ns = summary.get("burst_start_ns")
+        if not isinstance(start_ns, int):
+            raise AnalysisInvalid(f"burst {spec.burst_id} has no monotonic start")
+        if previous_drain_ns is not None and start_ns < previous_drain_ns:
+            raise AnalysisInvalid(f"burst {spec.burst_id} overlaps the preceding burst drain")
+        try:
+            if previous_machine_after is not None:
+                reqscale.counter_delta(
+                    previous_machine_after, summary["machine_proc_stat_before"]["cpu"]
+                )
+            if previous_cgroup_after is not None:
+                for name in ("run", "driver", "control", "file", "uffd"):
+                    reqscale.counter_delta(
+                        previous_cgroup_after[name],
+                        summary["cgroup_cpu_stat_before"][name],
+                    )
+        except reqscale.MeasurementInvalid as error:
+            raise AnalysisInvalid(
+                f"burst {spec.burst_id} accounting moved backwards between bursts: {error}"
+            ) from error
+        if summary.get("request_plan_sha256") != hashlib.sha256(
+            reqscale.canonical_json([item.to_dict() for item in spec.requests])
+        ).hexdigest():
+            raise AnalysisInvalid(f"burst {spec.burst_id} summary names a different request plan")
+        expected_summary_metadata = {
+            "block_id": spec.block_id,
+            "population": spec.population,
+            "target_rps": spec.target_rps,
+            "repeat": spec.repeat,
+            "seed": spec.seed,
+            "traced": spec.traced,
+            "trace_pair_id": spec.trace_pair_id,
+            "ramp_seconds": spec.ramp_seconds,
+            "score_seconds": spec.score_seconds,
+            "request_plan_count": len(spec.requests),
+        }
+        mismatch = {
+            name: {"expected": value, "actual": summary.get(name)}
+            for name, value in expected_summary_metadata.items()
+            if summary.get(name) != value
+        }
+        if mismatch:
+            raise AnalysisInvalid(
+                f"burst {spec.burst_id} summary metadata diverges from schedule: {mismatch}"
+            )
+        burst_rows = []
+        for planned in spec.requests:
+            key = (spec.burst_id, planned.request_index)
+            row = rows_by_key.get(key)
+            if row is None:
+                raise AnalysisInvalid(f"missing request record {key}")
+            expected = {
+                "schema": reqscale.RECORD_SCHEMA,
+                "kind": "request",
+                "run_id": schedule["run_id"],
+                "request_id": f"{schedule['run_id']}:{spec.burst_id}:{planned.request_index}",
+                "block_id": spec.block_id,
+                "cell_id": f"{planned.backend}:r{format(spec.target_rps, '.12g')}",
+                "backend": planned.backend,
+                "segment": planned.segment,
+                "pair_index": planned.pair_index,
+                "request_seed": planned.seed,
+                "population": spec.population,
+                "target_rps": spec.target_rps,
+                "scheduled_ns": start_ns + planned.scheduled_offset_ns,
+                "traced": spec.traced,
+                "trace_pair_id": spec.trace_pair_id,
+                "snapshot_generation_id": generation_id,
+                "snapshot_config_sha256": config_sha256,
+            }
+            mismatch = {
+                name: {"expected": value, "actual": row.get(name)}
+                for name, value in expected.items() if row.get(name) != value
+            }
+            if mismatch:
+                raise AnalysisInvalid(f"request {key} diverges from schedule: {mismatch}")
+            try:
+                reqscale._validate_request_record(row)
+            except reqscale.MeasurementInvalid as error:
+                raise AnalysisInvalid(f"request {key} is invalid: {error}") from error
+            if row.get("ok") is not True:
+                raise AnalysisInvalid(f"request {key} failed")
+            if not isinstance(row.get("teardown"), dict) or row["teardown"].get("all_gone") is not True:
+                raise AnalysisInvalid(f"request {key} lacks confirmed teardown")
+            _validate_fault_metric(row, spec.traced)
+            faults = row["firecracker_process_faults_ready_to_artifact"]
+            identity = (faults["pid"], faults["pid_start_time_ticks"])
+            if identity in firecracker_identities:
+                raise AnalysisInvalid(f"Firecracker identity {identity} served multiple requests")
+            firecracker_identities.add(identity)
+            burst_rows.append(row)
+
+        expected_start_ns = start_ns + round(spec.ramp_seconds * 1_000_000_000)
+        expected_end_ns = expected_start_ns + round(spec.score_seconds * 1_000_000_000)
+        if summary.get("score_start_ns") != expected_start_ns or summary.get("score_end_ns") != expected_end_ns:
+            raise AnalysisInvalid(f"burst {spec.burst_id} score boundaries are inconsistent")
+        expected_backends = {
+            backend: _recompute_backend_metrics(spec, burst_rows, backend)
+            for backend in ("file", "uffd")
+        }
+        if summary.get("backends") != expected_backends:
+            raise AnalysisInvalid(
+                f"burst {spec.burst_id} derived backend metrics differ from raw requests"
+            )
+        scored = [row for row in burst_rows if row["segment"] == "score"]
+        expected_totals = {
+            "planned": len(scored),
+            "launched": len(scored),
+            "artifact_completed": len(scored),
+            "drained": len(scored),
+            "cleanup_confirmed": len(scored),
+            "ok": len(scored),
+            "failed": 0,
+            "total_planned": len(burst_rows),
+            "total_artifact_completed": len(burst_rows),
+            "total_drained": len(burst_rows),
+            "total_cleanup_confirmed": len(burst_rows),
+        }
+        mismatch = {
+            name: {"expected": value, "actual": summary.get(name)}
+            for name, value in expected_totals.items() if summary.get(name) != value
+        }
+        if mismatch:
+            raise AnalysisInvalid(
+                f"burst {spec.burst_id} totals differ from raw requests: {mismatch}"
+            )
+        expected_spans = {
+            "launch_span_ms": (
+                max(row["actual_launch_ns"] for row in burst_rows) - start_ns
+            ) / 1_000_000,
+            "completion_span_ms": (
+                max(row["artifact_ns"] for row in burst_rows) - start_ns
+            ) / 1_000_000,
+            "drain_span_ms": (
+                max(row["finished_ns"] for row in burst_rows) - start_ns
+            ) / 1_000_000,
+            "launch_lag_ms": reqscale.distribution([
+                (row["actual_launch_ns"] - row["scheduled_ns"]) / 1_000_000
+                for row in scored
+            ]),
+            "latency_ms": reqscale.distribution([
+                float(row["blocking_ms"]) for row in scored
+            ]),
+        }
+        mismatch = {
+            name: {"expected": value, "actual": summary.get(name)}
+            for name, value in expected_spans.items() if summary.get(name) != value
+        }
+        if mismatch:
+            raise AnalysisInvalid(
+                f"burst {spec.burst_id} milestone summaries differ from raw requests: {mismatch}"
+            )
+        last_deadline_ns = start_ns + spec.requests[-1].scheduled_offset_ns
+        submission_span = _finite_number(
+            summary.get("schedule_submission_span_ms"),
+            f"burst {spec.burst_id} schedule submission span",
+            minimum=0,
+        )
+        submission_ns = start_ns + round(submission_span * 1_000_000)
+        if submission_ns < last_deadline_ns:
+            raise AnalysisInvalid(
+                f"burst {spec.burst_id} claims submission before its last deadline"
+            )
+        previous_drain_ns = max(row["finished_ns"] for row in burst_rows)
+        proc_before_ns = summary["machine_proc_stat_before"]["captured_monotonic_ns"]
+        proc_after_ns = summary["machine_proc_stat_after"]["captured_monotonic_ns"]
+        if proc_before_ns > start_ns or proc_after_ns < previous_drain_ns:
+            raise AnalysisInvalid(
+                f"burst {spec.burst_id} /proc/stat samples do not bracket launch through drain"
+            )
+        if submission_ns > previous_drain_ns:
+            raise AnalysisInvalid(
+                f"burst {spec.burst_id} schedule submission follows its final drain"
+            )
+        previous_machine_after = summary["machine_proc_stat_after"]["cpu"]
+        previous_cgroup_after = summary["cgroup_cpu_stat_after"]
+    return {
+        spec.burst_id: [
+            rows_by_key[(spec.burst_id, planned.request_index)]
+            for planned in spec.requests
+        ]
+        for spec in expected_bursts
+    }
+
+
+def evaluate_cell_burst(cell: dict, criteria: dict) -> dict:
+    target = _finite_number(cell.get("target_rps"), "target_rps", minimum=0)
+    if target == 0:
+        raise AnalysisInvalid("target_rps must be positive")
+    planned = cell.get("planned")
+    if not isinstance(planned, int) or isinstance(planned, bool) or planned <= 0:
+        raise AnalysisInvalid("planned request count must be a positive integer")
+    count_fields = (
+        "launched", "launched_by_score_end", "artifact_completed",
+        "artifact_completed_by_score_end", "drained", "cleanup_confirmed", "ok", "failed",
+    )
+    for field in count_fields:
+        value = cell.get(field)
+        if not isinstance(value, int) or isinstance(value, bool) or not 0 <= value <= planned:
+            raise AnalysisInvalid(f"{field} is not a valid request count")
+    if cell["ok"] + cell["failed"] != planned:
+        raise AnalysisInvalid("successful and failed request counts do not reconcile")
+    offered = _finite_number(cell.get("offered_rps"), "offered_rps", minimum=0)
+    departure = _finite_number(cell.get("departure_rps"), "departure_rps", minimum=0)
+    ratio = _finite_number(cell.get("departure_ratio"), "departure_ratio", minimum=0, maximum=1)
+    score_seconds = planned / target
+    if not math.isclose(offered, cell["launched_by_score_end"] / score_seconds):
+        raise AnalysisInvalid("offered rate does not reconcile with launch count")
+    if not math.isclose(departure, cell["artifact_completed_by_score_end"] / score_seconds):
+        raise AnalysisInvalid("departure rate does not reconcile with completion count")
+    if not math.isclose(ratio, cell["artifact_completed_by_score_end"] / planned):
+        raise AnalysisInvalid("departure ratio does not reconcile with completion count")
+    backlog = cell.get("score_end_backlog")
+    if not isinstance(backlog, int) or isinstance(backlog, bool) or not 0 <= backlog <= planned:
+        raise AnalysisInvalid("score-end backlog is not a valid request count")
+    launch_distribution = cell.get("launch_lag_ms")
+    if not isinstance(launch_distribution, dict):
+        raise AnalysisInvalid("launch lag distribution is missing")
+    p95_lag = _finite_number(
+        launch_distribution.get("p95"), "p95 launch lag", minimum=0
+    )
+    offered_error = abs(offered - target) * 100.0 / target
+    gates = {
+        "offered": (
+            cell.get("launched") == planned
+            and offered_error <= criteria["max_offered_rps_error_pct"]
+        ),
+        "departure": (
+            ratio >= criteria["min_departure_ratio"]
+        ),
+        "backlog": (
+            backlog <= criteria["max_score_end_backlog"]
+        ),
+        "lag": (
+            p95_lag <= criteria["max_p95_launch_lag_ms"]
+        ),
+        "zero_failure": (
+            cell.get("failed") == 0
+            and cell.get("ok") == planned
+            and cell.get("artifact_completed") == planned
+            and cell.get("drained") == planned
+            and cell.get("cleanup_confirmed") == planned
+        ),
+    }
+    return {
+        "passed": all(gates.values()),
+        "gates": gates,
+        "offered_rps_error_pct": offered_error,
+    }
+
+
+def _control_gate(
+    records: list[dict], schedule: dict, status: dict,
+    measurement_start_ns: int, measurement_end_ns: int,
+) -> dict:
+    if len(records) < 4:
+        raise AnalysisInvalid("host drift control has fewer than 4 scored observations")
+    control_schedule = schedule["control"]
+    interval = control_schedule["interval_ns"]
+    expected_origin = status.get("control", {}).get("origin_monotonic_ns")
+    if not isinstance(expected_origin, int):
+        raise AnalysisInvalid("status has no host-control origin")
+    control_status = status["control"]
+    stop_ns = control_status.get("stop_requested_monotonic_ns")
+    if (
+        control_status.get("started") is not True
+        or control_status.get("requests") != len(records)
+        or control_status.get("interval_ns") != interval
+        or control_status.get("phase_offset_ns") != control_schedule["phase_offset_ns"]
+        or not isinstance(stop_ns, int)
+        or stop_ns < expected_origin
+        or expected_origin > measurement_start_ns
+    ):
+        raise AnalysisInvalid("status does not reconcile with the host-control arm")
+    if measurement_end_ns > stop_ns:
+        raise AnalysisInvalid("host-control arm stopped before the request workload drained")
+    first_deadline = expected_origin + control_schedule["phase_offset_ns"]
+    expected_count = max(0, (stop_ns - 1 - first_deadline) // interval + 1)
+    if len(records) != expected_count:
+        raise AnalysisInvalid(
+            f"host-control arm recorded {len(records)} requests but {expected_count} "
+            "ten-second deadlines elapsed"
+        )
+    for index, row in enumerate(records):
+        if row.get("control_index") != index:
+            raise AnalysisInvalid("host-control indices are not contiguous")
+        expected = expected_origin + control_schedule["phase_offset_ns"] + index * interval
+        if row.get("scheduled_ns") != expected:
+            raise AnalysisInvalid(f"host-control row {index} diverges from its seeded schedule")
+        if row.get("schema") != reqscale.RECORD_SCHEMA or row.get("kind") != "host-control":
+            raise AnalysisInvalid(f"host-control row {index} has an invalid schema or kind")
+        if row.get("ok") is not True:
+            raise AnalysisInvalid(f"host-control row {index} failed")
+        actual = row.get("actual_launch_ns")
+        artifact = row.get("artifact_ns")
+        if (
+            not isinstance(actual, int) or isinstance(actual, bool)
+            or not isinstance(artifact, int) or isinstance(artifact, bool)
+            or not expected <= actual <= artifact < expected + interval
+        ):
+            raise AnalysisInvalid(
+                f"host-control row {index} missed or overran its ten-second interval"
+            )
+        latency = _finite_number(row.get("latency_ms"), "host-control latency", minimum=0)
+        lag = _finite_number(row.get("launch_lag_ms"), "host-control launch lag", minimum=0)
+        if not math.isclose(latency, (artifact - actual) / 1_000_000):
+            raise AnalysisInvalid(f"host-control row {index} latency does not match timestamps")
+        if not math.isclose(lag, (actual - expected) / 1_000_000):
+            raise AnalysisInvalid(f"host-control row {index} launch lag does not match timestamps")
+        result = row.get("result")
+        if not isinstance(result, dict) or result.get("ok") is not True:
+            raise AnalysisInvalid(f"host-control row {index} has no successful CDP result")
+    midpoint = len(records) // 2
+    first = statistics.median(float(row["latency_ms"]) for row in records[:midpoint])
+    second = statistics.median(float(row["latency_ms"]) for row in records[midpoint:])
+    if first <= 0:
+        raise AnalysisInvalid("host-control first-half median is not positive")
+    drift_pct = (second - first) * 100.0 / first
+    limit = schedule["capacity_criteria"]["max_control_median_drift_pct"]
+    return {
+        "passed": abs(drift_pct) <= limit,
+        "n": len(records),
+        "first_half_median_ms": first,
+        "second_half_median_ms": second,
+        "drift_pct": drift_pct,
+        "absolute_limit_pct": limit,
+    }
+
+
+def _validate_control_warmup(warmup: dict, schedule: dict, status: dict) -> None:
+    if (
+        warmup.get("schema") != reqscale.RECORD_SCHEMA
+        or warmup.get("kind") != "host-control-warmup"
+        or warmup.get("included_in_analysis") is not False
+        or not isinstance(warmup.get("result"), dict)
+        or warmup["result"].get("ok") is not True
+    ):
+        raise AnalysisInvalid("host-control warmup artifact is invalid")
+    started = warmup.get("started_monotonic_ns")
+    artifact = warmup.get("artifact_monotonic_ns")
+    origin = status.get("control", {}).get("origin_monotonic_ns")
+    if (
+        not isinstance(started, int) or not isinstance(artifact, int)
+        or not isinstance(origin, int) or not started <= artifact <= origin
+    ):
+        raise AnalysisInvalid("host-control warmup is not ordered before scored controls")
+    latency = _finite_number(warmup.get("latency_ms"), "host-control warmup latency", minimum=0)
+    if not math.isclose(latency, (artifact - started) / 1_000_000):
+        raise AnalysisInvalid("host-control warmup latency does not match timestamps")
+    if schedule.get("control", {}).get("warmup_requests") != 1:
+        raise AnalysisInvalid("schedule does not declare exactly one control warmup")
+
+
+def _validate_raw_artifact(
+    value: dict, name: str, expected_path: str | None = None,
+) -> str:
+    if not isinstance(value, dict):
+        raise AnalysisInvalid(f"{name} is not an artifact object")
+    raw = value.get("raw")
+    digest = value.get("raw_sha256")
+    if not isinstance(value.get("path"), str) or not isinstance(raw, str) or not raw:
+        raise AnalysisInvalid(f"{name} lacks its raw source")
+    if expected_path is not None and value["path"] != expected_path:
+        raise AnalysisInvalid(
+            f"{name} came from {value['path']!r}, expected {expected_path!r}"
+        )
+    if digest != hashlib.sha256(raw.encode()).hexdigest():
+        raise AnalysisInvalid(f"{name} raw digest does not match")
+    return raw
+
+
+def _proc_cpu_from_raw(raw: str, name: str) -> dict[str, int]:
+    lines = raw.splitlines()
+    fields = lines[0].split() if lines else []
+    if not fields or fields[0] != "cpu" or len(fields) < 5:
+        raise AnalysisInvalid(f"{name} has no aggregate cpu row")
+    try:
+        values = [int(value) for value in fields[1:]]
+    except ValueError as error:
+        raise AnalysisInvalid(f"{name} has a malformed aggregate cpu row") from error
+    if any(value < 0 for value in values):
+        raise AnalysisInvalid(f"{name} has a negative aggregate cpu counter")
+    names = list(reqscale.CPU_FIELDS)
+    names.extend(f"field_{index}" for index in range(len(names), len(values)))
+    return dict(zip(names, values))
+
+
+def _validate_whole_proc_stat(raw: str, name: str) -> None:
+    labels = [line.split(maxsplit=1)[0] for line in raw.splitlines() if line.strip()]
+    required = {
+        "cpu0", "intr", "ctxt", "btime", "processes", "procs_running",
+        "procs_blocked", "softirq",
+    }
+    missing = required - set(labels)
+    if missing:
+        raise AnalysisInvalid(f"{name} is truncated; missing rows {sorted(missing)}")
+
+
+def _validate_counter_snapshot(value, name: str) -> dict[str, int]:
+    if (
+        not isinstance(value, dict)
+        or "usage_usec" not in value
+        or any(
+            not isinstance(counter, int)
+            or isinstance(counter, bool)
+            or counter < 0
+            for counter in value.values()
+        )
+    ):
+        raise AnalysisInvalid(f"{name} is not a complete nonnegative cpu.stat snapshot")
+    return value
+
+
+def _validate_samples(
+    samples: list[dict], schedule: dict, status: dict,
+    measurement_start_ns: int, measurement_end_ns: int,
+) -> dict:
+    if len(samples) < 3:
+        raise AnalysisInvalid("continuous host accounting has fewer than 2 periodic samples and a terminal sample")
+    interval = schedule["host_sample_interval_ns"]
+    required_cgroups = {"run", "driver", "control", "file", "uffd"}
+    sampler_status = status.get("sampler")
+    if not isinstance(sampler_status, dict):
+        raise AnalysisInvalid("status has no host sampler result")
+    origin = sampler_status.get("origin_monotonic_ns")
+    stop_ns = sampler_status.get("stop_requested_monotonic_ns")
+    periodic = samples[:-1]
+    terminal = samples[-1]
+    if (
+        sampler_status.get("started") is not True
+        or sampler_status.get("samples") != len(samples)
+        or sampler_status.get("periodic_samples") != len(periodic)
+        or sampler_status.get("terminal_sample") is not True
+        or sampler_status.get("interval_ns") != interval
+        or not isinstance(origin, int)
+        or not isinstance(stop_ns, int)
+        or not origin <= measurement_start_ns <= measurement_end_ns <= stop_ns
+    ):
+        raise AnalysisInvalid("status does not reconcile with continuous host accounting")
+    expected_periodic = max(0, (stop_ns - 1 - origin) // interval + 1)
+    if len(periodic) != expected_periodic:
+        raise AnalysisInvalid(
+            f"host accounting recorded {len(periodic)} periodic samples but "
+            f"{expected_periodic} five-second deadlines elapsed"
+        )
+    stable_paths = None
+    stable_clk_tck = None
+    previous_cpu = None
+    previous_capture = None
+    scheduled_bursts = {
+        raw.get("burst_id") for raw in schedule.get("bursts", [])
+        if isinstance(raw, dict) and isinstance(raw.get("burst_id"), str)
+    }
+    for index, sample in enumerate(samples):
+        if sample.get("sample_index") != index:
+            raise AnalysisInvalid("host sample indices are not contiguous")
+        if sample.get("schema") != "fcvm.chromium.reqscale.host-sample.v1":
+            raise AnalysisInvalid(f"host sample {index} has an unsupported schema")
+        captured = sample.get("captured_monotonic_ns")
+        completed = sample.get("completed_monotonic_ns")
+        captured_wall = sample.get("captured_wall_ns")
+        completed_wall = sample.get("completed_wall_ns")
+        if (
+            not isinstance(captured, int) or isinstance(captured, bool) or captured <= 0
+            or not isinstance(completed, int) or isinstance(completed, bool)
+            or completed < captured
+            or not isinstance(captured_wall, int) or isinstance(captured_wall, bool)
+            or captured_wall <= 0
+            or not isinstance(completed_wall, int) or isinstance(completed_wall, bool)
+            or completed_wall < captured_wall
+        ):
+            raise AnalysisInvalid(f"host sample {index} has invalid capture boundaries")
+        if previous_capture is not None and captured < previous_capture:
+            raise AnalysisInvalid("host sample capture times moved backwards")
+        previous_capture = captured
+        if index < len(periodic):
+            expected_deadline = origin + index * interval
+            if sample.get("scheduled_monotonic_ns") != expected_deadline:
+                raise AnalysisInvalid("host samples do not use exact 5-second deadlines")
+            if not expected_deadline <= captured <= completed < expected_deadline + interval:
+                raise AnalysisInvalid(f"host sample {index} missed its five-second interval")
+            lag = _finite_number(sample.get("launch_lag_ms"), "host sample launch lag", minimum=0)
+            if not math.isclose(lag, (captured - expected_deadline) / 1_000_000):
+                raise AnalysisInvalid(f"host sample {index} launch lag does not match timestamps")
+            if sample.get("terminal") is True:
+                raise AnalysisInvalid(f"periodic host sample {index} is marked terminal")
+        else:
+            if (
+                sample.get("terminal") is not True
+                or sample.get("scheduled_monotonic_ns") is not None
+                or sample.get("launch_lag_ms") is not None
+                or captured < stop_ns
+                or completed >= stop_ns + interval
+                or captured < measurement_end_ns
+            ):
+                raise AnalysisInvalid("terminal host sample does not bracket the workload")
+        phase = sample.get("phase")
+        if not isinstance(phase, dict) or set(phase) != {"name", "burst_id"}:
+            raise AnalysisInvalid(f"host sample {index} has no exact run phase")
+        if phase["name"] == "burst":
+            if phase["burst_id"] not in scheduled_bursts:
+                raise AnalysisInvalid(f"host sample {index} names an unknown burst phase")
+        elif phase["name"] not in ("setup", "teardown") or phase["burst_id"] is not None:
+            raise AnalysisInvalid(f"host sample {index} has an invalid run phase")
+        if set(sample.get("cgroups", {})) != required_cgroups:
+            raise AnalysisInvalid(f"host sample {index} lacks split cgroup accounting")
+        proc_value = sample.get("proc_stat")
+        raw_proc = _validate_raw_artifact(
+            proc_value, f"host sample {index} /proc/stat", "/proc/stat"
+        )
+        _validate_whole_proc_stat(raw_proc, f"host sample {index} /proc/stat")
+        if proc_value.get("cpu") != _proc_cpu_from_raw(raw_proc, f"host sample {index} /proc/stat"):
+            raise AnalysisInvalid(f"host sample {index} parsed /proc/stat differs from raw input")
+        if (
+            not isinstance(proc_value.get("clk_tck"), int)
+            or isinstance(proc_value.get("clk_tck"), bool)
+            or proc_value["clk_tck"] <= 0
+        ):
+            raise AnalysisInvalid(f"host sample {index} /proc/stat lacks clock frequency")
+        proc_captured = proc_value.get("captured_monotonic_ns")
+        proc_captured_wall = proc_value.get("captured_wall_ns")
+        if (
+            not isinstance(proc_captured, int)
+            or isinstance(proc_captured, bool)
+            or not captured <= proc_captured <= completed
+            or not isinstance(proc_captured_wall, int)
+            or isinstance(proc_captured_wall, bool)
+            or not captured_wall <= proc_captured_wall <= completed_wall
+        ):
+            raise AnalysisInvalid(
+                f"host sample {index} /proc/stat capture escapes its sample boundary"
+            )
+        if stable_clk_tck is None:
+            stable_clk_tck = proc_value["clk_tck"]
+        elif proc_value["clk_tck"] != stable_clk_tck:
+            raise AnalysisInvalid("host /proc/stat clock frequency changed during measurement")
+        loadavg = sample.get("loadavg")
+        raw_loadavg = _validate_raw_artifact(
+            loadavg, f"host sample {index} loadavg", "/proc/loadavg"
+        )
+        try:
+            parsed_loadavg = reqscale.parse_loadavg(raw_loadavg, "/proc/loadavg")
+        except reqscale.MeasurementInvalid as error:
+            raise AnalysisInvalid(f"host sample {index} loadavg is invalid: {error}") from error
+        if loadavg.get("parsed") != parsed_loadavg:
+            raise AnalysisInvalid(f"host sample {index} parsed loadavg differs from raw input")
+        pressure = sample.get("pressure", {})
+        if set(pressure) != {"cpu", "memory", "io"}:
+            raise AnalysisInvalid(f"host sample {index} lacks complete PSI")
+        for resource, value in pressure.items():
+            expected_path = f"/proc/pressure/{resource}"
+            raw = _validate_raw_artifact(
+                value, f"host sample {index} {resource} PSI", expected_path
+            )
+            try:
+                parsed_psi = reqscale.parse_psi(raw, expected_path)
+            except reqscale.MeasurementInvalid as error:
+                raise AnalysisInvalid(
+                    f"host sample {index} {resource} PSI is invalid: {error}"
+                ) from error
+            if value.get("parsed") != parsed_psi:
+                raise AnalysisInvalid(f"host sample {index} parsed {resource} PSI differs from raw input")
+        meminfo = sample.get("meminfo")
+        raw_meminfo = _validate_raw_artifact(
+            meminfo, f"host sample {index} meminfo", "/proc/meminfo"
+        )
+        try:
+            parsed_meminfo = reqscale.parse_meminfo(raw_meminfo, "/proc/meminfo")
+        except reqscale.MeasurementInvalid as error:
+            raise AnalysisInvalid(f"host sample {index} meminfo is invalid: {error}") from error
+        if meminfo.get("parsed") != parsed_meminfo:
+            raise AnalysisInvalid(f"host sample {index} parsed meminfo differs from raw input")
+        paths = {name: sample["cgroups"][name].get("path") for name in required_cgroups}
+        if any(not isinstance(path, str) or not path.startswith("/") for path in paths.values()):
+            raise AnalysisInvalid(f"host sample {index} has invalid cgroup paths")
+        if len(set(paths.values())) != len(paths):
+            raise AnalysisInvalid(f"host sample {index} cgroup paths are not distinct")
+        if any(
+            not paths[name].startswith(paths["run"].rstrip("/") + "/")
+            for name in required_cgroups - {"run"}
+        ):
+            raise AnalysisInvalid(f"host sample {index} leaf cgroup is outside the run cgroup")
+        if stable_paths is None:
+            stable_paths = paths
+        elif paths != stable_paths:
+            raise AnalysisInvalid("host cgroup paths changed during measurement")
+        seen_pids = {}
+        current_cpu = {}
+        for name in required_cgroups:
+            row = sample["cgroups"][name]
+            pids = row.get("live_pids")
+            if (
+                not isinstance(pids, list)
+                or any(not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0 for pid in pids)
+                or pids != sorted(set(pids))
+            ):
+                raise AnalysisInvalid(f"host sample {index} {name} has invalid PID membership")
+            if name != "run":
+                for pid in pids:
+                    if pid in seen_pids:
+                        raise AnalysisInvalid(
+                            f"host sample {index} pid {pid} appears in {seen_pids[pid]} and {name}"
+                        )
+                    seen_pids[pid] = name
+            cpu_stat = _validate_counter_snapshot(
+                row.get("cpu_stat"), f"host sample {index} {name} cpu.stat"
+            )
+            current_cpu[name] = cpu_stat
+        if sample["cgroups"]["run"]["live_pids"] != []:
+            raise AnalysisInvalid(f"host sample {index} run parent contains direct processes")
+        harness_pid = status["final_cgroups"]["driver"]["live_pids"][0]
+        if harness_pid not in sample["cgroups"]["driver"]["live_pids"]:
+            raise AnalysisInvalid(f"host sample {index} driver omits the harness")
+        if previous_cpu is not None:
+            try:
+                for name in required_cgroups:
+                    reqscale.counter_delta(previous_cpu[name], current_cpu[name])
+            except reqscale.MeasurementInvalid as error:
+                raise AnalysisInvalid(f"host cgroup counters are not monotonic: {error}") from error
+        previous_cpu = current_cpu
+    final = status["final_cgroups"]
+    expected_paths = {name: final[name]["path"] for name in required_cgroups}
+    if stable_paths != expected_paths:
+        raise AnalysisInvalid("host sample cgroup paths differ from the terminal cgroup audit")
+    if {
+        name: terminal["cgroups"][name]["live_pids"] for name in required_cgroups
+    } != {
+        name: final[name]["live_pids"] for name in required_cgroups
+    }:
+        raise AnalysisInvalid("terminal host sample membership differs from final cgroup audit")
+    try:
+        reqscale.counter_delta(
+            status["run_before"]["machine_proc_stat"]["cpu"],
+            samples[0]["proc_stat"]["cpu"],
+        )
+        reqscale.counter_delta(
+            terminal["proc_stat"]["cpu"],
+            status["run_after"]["machine_proc_stat"]["cpu"],
+        )
+        for name in required_cgroups:
+            reqscale.counter_delta(
+                terminal["cgroups"][name]["cpu_stat"], final[name]["cpu_stat"]
+            )
+            reqscale.counter_delta(
+                status["run_before"]["cgroup_cpu_stat"][name],
+                samples[0]["cgroups"][name]["cpu_stat"],
+            )
+            reqscale.counter_delta(
+                terminal["cgroups"][name]["cpu_stat"],
+                status["run_after"]["cgroup_cpu_stat"][name],
+            )
+    except reqscale.MeasurementInvalid as error:
+        raise AnalysisInvalid(
+            f"host sample counters escape the run-level accounting window: {error}"
+        ) from error
+    return {
+        "passed": True,
+        "samples": len(samples),
+        "periodic_samples": len(periodic),
+        "terminal_sample": True,
+        "interval_ns": interval,
+    }
+
+
+def _require_hex(value, length: int, name: str) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != length
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise AnalysisInvalid(f"{name} is not {length}-character lowercase hex")
+    return value
+
+
+def _validate_snapshot_provenance(snapshot: dict) -> tuple[str, str]:
+    required = {
+        "tag", "generation_id", "created_at", "vm_id", "config_sha256",
+        "shape", "files",
+    }
+    if not isinstance(snapshot, dict) or set(snapshot) != required:
+        raise AnalysisInvalid("provenance snapshot identity is incomplete")
+    tag = snapshot.get("tag")
+    try:
+        reqscale._validate_snapshot_tag(tag)
+    except (TypeError, ValueError) as error:
+        raise AnalysisInvalid(f"provenance has an invalid snapshot tag: {error}") from error
+    for field in ("created_at", "vm_id"):
+        if not isinstance(snapshot.get(field), str) or not snapshot[field]:
+            raise AnalysisInvalid(f"provenance snapshot lacks {field}")
+    generation_id = _canonical_generation(snapshot.get("generation_id"))
+    config_sha256 = _require_hex(
+        snapshot.get("config_sha256"), 64, "snapshot config digest"
+    )
+    shape = snapshot.get("shape")
+    shape_fields = {"image", "vcpu", "memory_mib", "network_mode", "port_mappings"}
+    if not isinstance(shape, dict) or set(shape) != shape_fields:
+        raise AnalysisInvalid("provenance snapshot shape is incomplete")
+    if (
+        not isinstance(shape["image"], str) or not shape["image"]
+        or not isinstance(shape["network_mode"], str) or not shape["network_mode"]
+        or not isinstance(shape["vcpu"], int) or isinstance(shape["vcpu"], bool)
+        or shape["vcpu"] <= 0
+        or not isinstance(shape["memory_mib"], int)
+        or isinstance(shape["memory_mib"], bool)
+        or shape["memory_mib"] <= 0
+        or not isinstance(shape["port_mappings"], list)
+        or any(not isinstance(value, str) or not value for value in shape["port_mappings"])
+    ):
+        raise AnalysisInvalid("provenance snapshot shape contains invalid values")
+    files = snapshot.get("files")
+    expected_files = {"memory_path", "vmstate_path", "disk_path", "config"}
+    if not isinstance(files, dict) or set(files) != expected_files:
+        raise AnalysisInvalid("provenance snapshot artifact identity is incomplete")
+    for name, value in files.items():
+        if not isinstance(value, dict) or set(value) != {"path", "size", "mtime_ns", "inode"}:
+            raise AnalysisInvalid(f"provenance snapshot artifact {name} is incomplete")
+        path = value.get("path")
+        if (
+            not isinstance(path, str) or not path
+            or os.path.isabs(path)
+            or os.path.normpath(path).startswith("..")
+        ):
+            raise AnalysisInvalid(f"provenance snapshot artifact {name} has an unsafe path")
+        for field in ("size", "mtime_ns", "inode"):
+            number = value.get(field)
+            if (
+                not isinstance(number, int)
+                or isinstance(number, bool)
+                or number < 0
+            ):
+                raise AnalysisInvalid(
+                    f"provenance snapshot artifact {name} has invalid {field}"
+                )
+    return generation_id, config_sha256
+
+
+def _validate_provenance(provenance: dict, schedule: dict) -> tuple[str, str]:
+    required = {
+        "schema", "run_id", "created_at", "argv", "schedule_sha256",
+        "source_revision", "source_dirty", "source_status_sha256",
+        "harness_sha256", "fcvm_path", "fcvm_sha256", "fcvm_version",
+        "host_control", "snapshot", "snapshot_generation_lease", "host",
+        "fault_trace",
+    }
+    if not isinstance(provenance, dict) or set(provenance) != required:
+        raise AnalysisInvalid("provenance fields are incomplete or unknown")
+    if provenance.get("schema") != "fcvm.chromium.reqscale.provenance.v1":
+        raise AnalysisInvalid("unsupported provenance schema")
+    if provenance.get("run_id") != schedule["run_id"]:
+        raise AnalysisInvalid("run identity differs between schedule and provenance")
+    if provenance.get("source_dirty") is not False:
+        raise AnalysisInvalid("measurement source tree was dirty")
+    _require_hex(provenance.get("source_revision"), 40, "source revision")
+    for name in ("source_status_sha256", "harness_sha256", "fcvm_sha256"):
+        _require_hex(provenance.get(name), 64, name)
+    if not isinstance(provenance.get("created_at"), str) or not provenance["created_at"]:
+        raise AnalysisInvalid("provenance has no creation time")
+    if (
+        not isinstance(provenance.get("argv"), list)
+        or not provenance["argv"]
+        or any(not isinstance(value, str) for value in provenance["argv"])
+    ):
+        raise AnalysisInvalid("provenance argv is incomplete")
+    if (
+        not isinstance(provenance.get("fcvm_path"), str)
+        or not os.path.isabs(provenance["fcvm_path"])
+        or not isinstance(provenance.get("fcvm_version"), str)
+        or not provenance["fcvm_version"]
+    ):
+        raise AnalysisInvalid("fcvm executable provenance is incomplete")
+    if provenance.get("source_status_sha256") != hashlib.sha256(b"").hexdigest():
+        raise AnalysisInvalid("clean source status digest is not the digest of empty output")
+    if provenance.get("schedule_sha256") != reqscale.schedule_sha256(schedule):
+        raise AnalysisInvalid("schedule hash differs from provenance")
+    snapshot = provenance.get("snapshot")
+    generation_id, config_sha256 = _validate_snapshot_provenance(snapshot)
+    lease = provenance.get("snapshot_generation_lease")
+    if (
+        not isinstance(lease, dict)
+        or lease.get("mode") != "shared"
+        or lease.get("held_from_identity_read_through_terminal_verification") is not True
+        or not isinstance(lease.get("path"), str)
+        or not os.path.isabs(lease["path"])
+        or os.path.basename(lease["path"]) != f"{snapshot['tag']}.lock"
+    ):
+        raise AnalysisInvalid("snapshot generation lease provenance is incomplete")
+    host = provenance.get("host")
+    if not isinstance(host, dict) or set(host) != {
+        "hostname", "kernel", "machine", "python", "cpu_count", "quiet_gate",
+    }:
+        raise AnalysisInvalid("host provenance is incomplete")
+    for field in ("hostname", "kernel", "machine", "python"):
+        if not isinstance(host.get(field), str) or not host[field]:
+            raise AnalysisInvalid(f"host provenance lacks {field}")
+    if (
+        not isinstance(host.get("cpu_count"), int)
+        or isinstance(host["cpu_count"], bool)
+        or host["cpu_count"] <= 0
+    ):
+        raise AnalysisInvalid("host provenance has an invalid CPU count")
+    quiet = host.get("quiet_gate")
+    if (
+        not isinstance(quiet, dict)
+        or quiet.get("vm_process_count") != 0
+        or quiet.get("vm_processes") != []
+        or _finite_number(quiet.get("loadavg1"), "quiet-host load", minimum=0)
+        > _finite_number(quiet.get("loadavg1_limit"), "quiet-host load limit", minimum=0)
+    ):
+        raise AnalysisInvalid("quiet-host provenance did not pass")
+    host_control = provenance.get("host_control")
+    if (
+        not isinstance(host_control, dict)
+        or set(host_control) != {
+            "chromium_path", "chromium_sha256", "chromium_version", "url",
+            "interval_seconds", "timeout_seconds",
+        }
+        or host_control.get("interval_seconds") != reqscale.CONTROL_INTERVAL_SECONDS
+        or not isinstance(host_control.get("chromium_path"), str)
+        or not os.path.isabs(host_control["chromium_path"])
+        or not isinstance(host_control.get("chromium_version"), str)
+        or not host_control["chromium_version"]
+        or not isinstance(host_control.get("url"), str)
+        or not host_control["url"]
+        or not 0 < _finite_number(
+            host_control.get("timeout_seconds"), "host-control timeout", minimum=0,
+        ) < reqscale.CONTROL_INTERVAL_SECONDS
+    ):
+        raise AnalysisInvalid("host-control provenance is incomplete")
+    _require_hex(host_control.get("chromium_sha256"), 64, "host Chromium digest")
+    fault_trace = provenance.get("fault_trace")
+    if (
+        not isinstance(fault_trace, dict)
+        or set(fault_trace) != {
+            "enabled", "bpftrace_version", "max_median_delta_pct", "scope",
+        }
+        or not isinstance(fault_trace.get("enabled"), bool)
+        or not isinstance(fault_trace.get("scope"), str)
+        or "not guest-RAM-filtered" not in fault_trace["scope"]
+    ):
+        raise AnalysisInvalid("fault-trace provenance is incomplete")
+    if fault_trace["enabled"]:
+        if (
+            not isinstance(fault_trace.get("bpftrace_version"), str)
+            or not fault_trace["bpftrace_version"]
+        ):
+            raise AnalysisInvalid("enabled fault tracing lacks a bpftrace version")
+        _finite_number(
+            fault_trace.get("max_median_delta_pct"),
+            "fault-trace perturbation limit",
+            minimum=0,
+        )
+    elif (
+        fault_trace.get("bpftrace_version") is not None
+        or fault_trace.get("max_median_delta_pct") is not None
+    ):
+        raise AnalysisInvalid("disabled fault tracing contains active trace settings")
+    return generation_id, config_sha256
+
+
+def _validate_status(status: dict, schedule: dict, provenance: dict) -> None:
+    required_status = {
+        "schema", "run_id", "valid", "bursts_completed", "bursts_planned",
+        "control", "sampler", "snapshot_identity_after", "run_before",
+        "run_after", "final_cgroups", "error", "error_details", "errors",
+    }
+    if not isinstance(status, dict) or set(status) != required_status:
+        raise AnalysisInvalid("terminal status fields are incomplete or unknown")
+    if status.get("schema") != "fcvm.chromium.reqscale.status.v2":
+        raise AnalysisInvalid("unsupported terminal status schema")
+    if status.get("valid") is not True or status.get("errors") != []:
+        raise AnalysisInvalid("run status is not valid and error-free")
+    if status.get("error") is not None or status.get("error_details") is not None:
+        raise AnalysisInvalid("valid run status contains an error")
+    if status.get("run_id") != schedule["run_id"]:
+        raise AnalysisInvalid("run identity differs between schedule and status")
+    if (
+        status.get("bursts_completed") != len(schedule["bursts"])
+        or status.get("bursts_planned") != len(schedule["bursts"])
+    ):
+        raise AnalysisInvalid("terminal status does not cover every scheduled burst")
+    if status.get("snapshot_identity_after") != provenance.get("snapshot"):
+        raise AnalysisInvalid("terminal snapshot identity differs from starting provenance")
+    final = status.get("final_cgroups")
+    required = {"run", "driver", "control", "file", "uffd"}
+    if not isinstance(final, dict) or set(final) != required:
+        raise AnalysisInvalid("terminal status lacks all split cgroups")
+    run_path = final.get("run", {}).get("path")
+    if (
+        not isinstance(run_path, str)
+        or not run_path.startswith("/")
+        or not run_path.endswith(f"/fcvm-reqscale-{schedule['run_id']}")
+    ):
+        raise AnalysisInvalid("terminal run cgroup has an invalid path")
+    leaf_identities = {}
+    harness_identity = None
+    for name in required:
+        row = final[name]
+        if not isinstance(row, dict) or set(row) != {"path", "observed", "live_pids", "cpu_stat"}:
+            raise AnalysisInvalid(f"terminal {name} cgroup record is incomplete")
+        expected_path = run_path if name == "run" else f"{run_path}/{name}"
+        if row["path"] != expected_path:
+            raise AnalysisInvalid(f"terminal {name} cgroup path differs")
+        _validate_counter_snapshot(row.get("cpu_stat"), f"terminal {name} cpu.stat")
+        live = row.get("live_pids")
+        if (
+            not isinstance(live, list)
+            or any(
+                not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0
+                for pid in live
+            )
+            or live != sorted(set(live))
+        ):
+            raise AnalysisInvalid(f"terminal {name} cgroup has invalid membership")
+        observed = row.get("observed")
+        if not isinstance(observed, list):
+            raise AnalysisInvalid(f"terminal {name} cgroup has no process audit")
+        identities = []
+        for item in observed:
+            if (
+                not isinstance(item, dict)
+                or set(item) != {"pid", "pid_start_time_ticks", "role", "comm"}
+                or not isinstance(item["pid"], int) or isinstance(item["pid"], bool)
+                or item["pid"] <= 0
+                or not isinstance(item["pid_start_time_ticks"], int)
+                or isinstance(item["pid_start_time_ticks"], bool)
+                or item["pid_start_time_ticks"] <= 0
+                or not isinstance(item["role"], str) or not item["role"]
+                or not isinstance(item["comm"], str) or not item["comm"]
+            ):
+                raise AnalysisInvalid(f"terminal {name} cgroup has an invalid process audit")
+            identity = (item["pid"], item["pid_start_time_ticks"])
+            identities.append(identity)
+            if name != "run":
+                prior = leaf_identities.setdefault(identity, name)
+                if prior != name:
+                    raise AnalysisInvalid(
+                        f"process identity {identity} appears in both {prior} and {name}"
+                    )
+        if identities != sorted(set(identities)):
+            raise AnalysisInvalid(f"terminal {name} cgroup process audit is not unique and sorted")
+        if name == "driver":
+            if len(live) != 1:
+                raise AnalysisInvalid("terminal driver cgroup does not contain exactly the harness")
+            harness_pid = live[0]
+            harness_rows = [
+                item for item in observed
+                if item["pid"] == harness_pid and item["role"] == "reqscale"
+            ]
+            if len(harness_rows) != 1:
+                raise AnalysisInvalid("terminal driver cgroup does not identify its harness")
+            harness_identity = (
+                harness_rows[0]["pid"], harness_rows[0]["pid_start_time_ticks"]
+            )
+        elif live != []:
+            raise AnalysisInvalid(f"terminal {name} cgroup is not empty")
+    if not any(
+        item["pid"] == harness_identity[0]
+        and item["pid_start_time_ticks"] == harness_identity[1]
+        and item["role"] == "reqscale"
+        for item in final["run"]["observed"]
+    ):
+        raise AnalysisInvalid("terminal run cgroup does not identify the harness")
+
+
+def _validate_machine_accounting_artifact(value, name: str) -> dict[str, int]:
+    raw = _validate_raw_artifact(value, name, "/proc/stat")
+    _validate_whole_proc_stat(raw, name)
+    parsed = _proc_cpu_from_raw(raw, name)
+    if value.get("cpu") != parsed:
+        raise AnalysisInvalid(f"{name} parsed counters differ from raw /proc/stat")
+    for field in ("captured_wall_ns", "captured_monotonic_ns", "clk_tck"):
+        number = value.get(field)
+        if (
+            not isinstance(number, int)
+            or isinstance(number, bool)
+            or number <= 0
+        ):
+            raise AnalysisInvalid(f"{name} lacks {field}")
+    return parsed
+
+
+def _validate_run_accounting(
+    status: dict, summaries: list[dict],
+    measurement_start_ns: int, measurement_end_ns: int,
+) -> None:
+    required = {"run", "driver", "control", "file", "uffd"}
+    final = status["final_cgroups"]
+    sides = {}
+    for side in ("before", "after"):
+        record = status.get(f"run_{side}")
+        if (
+            not isinstance(record, dict)
+            or set(record) != {"machine_proc_stat", "cgroup_cpu_stat", "cgroups"}
+        ):
+            raise AnalysisInvalid(f"run-level {side} accounting is incomplete")
+        machine = _validate_machine_accounting_artifact(
+            record["machine_proc_stat"], f"run-level {side} /proc/stat"
+        )
+        cpu = record["cgroup_cpu_stat"]
+        cgroups = record["cgroups"]
+        if (
+            not isinstance(cpu, dict) or set(cpu) != required
+            or not isinstance(cgroups, dict) or set(cgroups) != required
+        ):
+            raise AnalysisInvalid(f"run-level {side} accounting lacks split cgroups")
+        for name in required:
+            cpu_value = _validate_counter_snapshot(
+                cpu[name], f"run-level {side} {name} cpu.stat"
+            )
+            row = cgroups[name]
+            if (
+                not isinstance(row, dict)
+                or set(row) != {"path", "observed", "live_pids", "cpu_stat"}
+                or row["path"] != final[name]["path"]
+                or row["live_pids"] != final[name]["live_pids"]
+                or not isinstance(row["observed"], list)
+            ):
+                raise AnalysisInvalid(f"run-level {side} {name} cgroup audit differs")
+            row_cpu = _validate_counter_snapshot(
+                row["cpu_stat"], f"run-level {side} {name} cgroup audit cpu.stat"
+            )
+            try:
+                reqscale.counter_delta(cpu_value, row_cpu)
+                reqscale.counter_delta(row_cpu, final[name]["cpu_stat"])
+            except reqscale.MeasurementInvalid as error:
+                raise AnalysisInvalid(
+                    f"run-level {side} {name} counters are out of order: {error}"
+                ) from error
+            final_observed = {
+                (item["pid"], item["pid_start_time_ticks"], item["role"], item["comm"])
+                for item in final[name]["observed"]
+            }
+            observed = []
+            for item in row["observed"]:
+                if not isinstance(item, dict) or set(item) != {
+                    "pid", "pid_start_time_ticks", "role", "comm"
+                }:
+                    raise AnalysisInvalid(
+                        f"run-level {side} {name} has an invalid process audit"
+                    )
+                identity = (
+                    item["pid"], item["pid_start_time_ticks"],
+                    item["role"], item["comm"],
+                )
+                if identity not in final_observed:
+                    raise AnalysisInvalid(
+                        f"run-level {side} {name} process audit is absent from final evidence"
+                    )
+                observed.append(identity)
+            if observed != sorted(set(observed)):
+                raise AnalysisInvalid(
+                    f"run-level {side} {name} process audit is not unique and sorted"
+                )
+            if side == "after" and row["observed"] != final[name]["observed"]:
+                raise AnalysisInvalid(
+                    f"run-level after {name} process audit differs from final evidence"
+                )
+        sides[side] = {"machine": machine, "cpu": cpu, "record": record}
+    if (
+        sides["before"]["record"]["machine_proc_stat"]["captured_monotonic_ns"]
+        > measurement_start_ns
+        or sides["after"]["record"]["machine_proc_stat"]["captured_monotonic_ns"]
+        < measurement_end_ns
+    ):
+        raise AnalysisInvalid("run-level accounting does not bracket the measured workload")
+    try:
+        reqscale.counter_delta(sides["before"]["machine"], sides["after"]["machine"])
+        for name in required:
+            reqscale.counter_delta(
+                sides["before"]["cpu"][name], sides["after"]["cpu"][name]
+            )
+    except reqscale.MeasurementInvalid as error:
+        raise AnalysisInvalid(f"run-level accounting moved backwards: {error}") from error
+    if (
+        sides["before"]["record"]["machine_proc_stat"]["clk_tck"]
+        != sides["after"]["record"]["machine_proc_stat"]["clk_tck"]
+    ):
+        raise AnalysisInvalid("run-level /proc/stat clock frequency changed")
+    try:
+        reqscale.counter_delta(
+            sides["before"]["machine"], summaries[0]["machine_proc_stat_before"]["cpu"]
+        )
+        reqscale.counter_delta(
+            summaries[-1]["machine_proc_stat_after"]["cpu"], sides["after"]["machine"]
+        )
+        for name in required:
+            reqscale.counter_delta(
+                sides["before"]["cpu"][name],
+                summaries[0]["cgroup_cpu_stat_before"][name],
+            )
+            reqscale.counter_delta(
+                summaries[-1]["cgroup_cpu_stat_after"][name],
+                sides["after"]["cpu"][name],
+            )
+    except reqscale.MeasurementInvalid as error:
+        raise AnalysisInvalid(
+            f"burst accounting escapes the run-level accounting window: {error}"
+        ) from error
+
+
+def _validate_uffd_serve(
+    serve: dict, schedule: dict, provenance: dict, status: dict,
+) -> None:
+    required_fields = {
+        "schema", "kind", "run_id", "pid", "pid_start_time_ticks",
+        "state_path", "uffd_mode", "snapshot_tag", "snapshot_generation_id",
+        "snapshot_config_sha256",
+    }
+    if not isinstance(serve, dict) or set(serve) != required_fields:
+        raise AnalysisInvalid("UFFD serve record fields are incomplete or unknown")
+    snapshot = provenance["snapshot"]
+    expected = {
+        "schema": reqscale.RECORD_SCHEMA,
+        "kind": "uffd-serve",
+        "run_id": schedule["run_id"],
+        "snapshot_tag": snapshot["tag"],
+        "snapshot_generation_id": snapshot["generation_id"],
+        "snapshot_config_sha256": snapshot["config_sha256"],
+    }
+    mismatch = {
+        name: {"expected": value, "actual": serve.get(name)}
+        for name, value in expected.items() if serve.get(name) != value
+    }
+    if mismatch:
+        raise AnalysisInvalid(f"UFFD serve is not bound to this snapshot generation: {mismatch}")
+    if serve.get("uffd_mode") not in ("copy", "minor"):
+        raise AnalysisInvalid("UFFD serve has an invalid memory mode")
+    state_path = serve.get("state_path")
+    if (
+        not isinstance(state_path, str)
+        or not state_path
+        or os.path.isabs(state_path)
+        or os.path.normpath(state_path).startswith("..")
+    ):
+        raise AnalysisInvalid("UFFD serve has an unsafe state path")
+    pid = serve.get("pid")
+    start = serve.get("pid_start_time_ticks")
+    if (
+        not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0
+        or not isinstance(start, int) or isinstance(start, bool) or start <= 0
+    ):
+        raise AnalysisInvalid("UFFD serve has an invalid process identity")
+    observed = status["final_cgroups"]["uffd"].get("observed", [])
+    if not any(
+        item.get("pid") == pid
+        and item.get("pid_start_time_ticks") == start
+        and item.get("role") == "uffd-serve"
+        for item in observed if isinstance(item, dict)
+    ):
+        raise AnalysisInvalid("UFFD cgroup audit does not contain the recorded serve identity")
+
+
+def _validate_fault_cgroup_membership(requests: list[dict], status: dict) -> None:
+    final = status["final_cgroups"]
+    observed = {
+        backend: {
+            (item.get("pid"), item.get("pid_start_time_ticks"), item.get("role"))
+            for item in final[backend].get("observed", []) if isinstance(item, dict)
+        }
+        for backend in ("file", "uffd")
+    }
+    for row in requests:
+        faults = row["firecracker_process_faults_ready_to_artifact"]
+        identity = (faults["pid"], faults["pid_start_time_ticks"], "firecracker")
+        if identity not in observed[row["backend"]]:
+            raise AnalysisInvalid(
+                f"request {row['request_id']} Firecracker identity is absent from its "
+                f"{row['backend']} cgroup audit"
+            )
+
+
+def _trace_artifact_path(
+    run_dir: str, record: dict, expected_relative: str, name: str,
+) -> str:
+    if not isinstance(record, dict) or set(record) != {"path", "sha256", "bytes"}:
+        raise AnalysisInvalid(f"{name} trace artifact record is incomplete")
+    if record.get("path") != expected_relative:
+        raise AnalysisInvalid(
+            f"{name} trace artifact path is {record.get('path')!r}, "
+            f"expected {expected_relative!r}"
+        )
+    expected_digest = _require_hex(record.get("sha256"), 64, f"{name} trace digest")
+    expected_bytes = record.get("bytes")
+    if (
+        not isinstance(expected_bytes, int)
+        or isinstance(expected_bytes, bool)
+        or expected_bytes < 0
+    ):
+        raise AnalysisInvalid(f"{name} trace artifact has an invalid byte count")
+    root = os.path.realpath(run_dir)
+    path = os.path.join(root, expected_relative)
+    if os.path.realpath(path) != os.path.abspath(path):
+        raise AnalysisInvalid(f"{name} trace artifact traverses a symbolic link")
+    try:
+        metadata = os.lstat(path)
+    except OSError as error:
+        raise AnalysisInvalid(f"cannot stat {name} trace artifact: {error}") from error
+    if not stat.S_ISREG(metadata.st_mode):
+        raise AnalysisInvalid(f"{name} trace artifact is not a regular file")
+    if metadata.st_size != expected_bytes:
+        raise AnalysisInvalid(f"{name} trace artifact byte count differs")
+    if reqscale.sha256_file(path) != expected_digest:
+        raise AnalysisInvalid(f"{name} trace artifact digest differs")
+    return path
+
+
+def _validate_fault_trace_artifacts(
+    run_dir: str,
+    schedule: dict,
+    summaries: list[dict],
+    requests_by_burst: dict[str, list[dict]],
+) -> None:
+    specs = {
+        spec.burst_id: spec
+        for spec in (reqscale.BurstSpec.from_dict(raw) for raw in schedule["bursts"])
+    }
+    for summary in summaries:
+        burst_id = summary["burst_id"]
+        spec = specs[burst_id]
+        trace_record = summary.get("fault_trace")
+        if not spec.traced:
+            if trace_record is not None:
+                raise AnalysisInvalid(f"untraced burst {burst_id} names trace artifacts")
+            continue
+        if (
+            not isinstance(trace_record, dict)
+            or set(trace_record) != {"scope", "processes", "artifacts"}
+            or not isinstance(trace_record.get("scope"), str)
+            or "not guest-RAM-filtered" not in trace_record["scope"]
+            or not isinstance(trace_record.get("processes"), int)
+            or isinstance(trace_record.get("processes"), bool)
+            or trace_record["processes"] < 0
+        ):
+            raise AnalysisInvalid(f"traced burst {burst_id} has incomplete trace provenance")
+        artifacts = trace_record.get("artifacts")
+        if not isinstance(artifacts, dict) or set(artifacts) != {"raw", "stderr", "program"}:
+            raise AnalysisInvalid(f"traced burst {burst_id} lacks every trace artifact")
+        prefix = os.path.join("fault-trace", burst_id)
+        raw_path = _trace_artifact_path(
+            run_dir, artifacts["raw"], f"{prefix}.bpftrace.jsonl", "raw bpftrace",
+        )
+        _trace_artifact_path(
+            run_dir, artifacts["stderr"], f"{prefix}.bpftrace.stderr", "bpftrace stderr",
+        )
+        _trace_artifact_path(
+            run_dir, artifacts["program"], f"{prefix}.faulttrace.bt", "bpftrace program",
+        )
+        try:
+            with open(raw_path) as stream:
+                trace = reqscale.parse_fault_trace(stream)
+        except (OSError, UnicodeError, reqscale.MeasurementInvalid) as error:
+            raise AnalysisInvalid(
+                f"cannot reconstruct traced burst {burst_id}: {error}"
+            ) from error
+        if trace_record["processes"] != len(trace["processes"]):
+            raise AnalysisInvalid(f"traced burst {burst_id} process count differs from raw trace")
+        evidence_rows = [
+            {
+                "request_id": row["request_id"],
+                "ok": row["ok"],
+                "firecracker_process_faults_ready_to_artifact": row[
+                    "firecracker_process_faults_ready_to_artifact"
+                ],
+            }
+            for row in requests_by_burst[burst_id]
+        ]
+        try:
+            reqscale.join_fault_trace(evidence_rows, trace)
+        except reqscale.MeasurementInvalid as error:
+            raise AnalysisInvalid(
+                f"raw trace cannot be joined to burst {burst_id}: {error}"
+            ) from error
+        for actual, reconstructed in zip(requests_by_burst[burst_id], evidence_rows):
+            if actual.get(
+                "firecracker_process_handle_mm_fault_ready_to_artifact"
+            ) != reconstructed.get(
+                "firecracker_process_handle_mm_fault_ready_to_artifact"
+            ):
+                raise AnalysisInvalid(
+                    f"request {actual['request_id']} fault timing differs from raw bpftrace"
+                )
+
+
+def analyze(run_dir: str) -> dict:
+    schedule = _load_json(os.path.join(run_dir, "schedule.json"))
+    provenance = _load_json(os.path.join(run_dir, "provenance.json"))
+    status = _load_json(os.path.join(run_dir, "status.json"))
+    summaries = _load_jsonl(os.path.join(run_dir, "bursts.jsonl"))
+    requests = _load_jsonl(os.path.join(run_dir, "requests.jsonl"))
+    controls = _load_jsonl(os.path.join(run_dir, "host-control.jsonl"))
+    samples = _load_jsonl(os.path.join(run_dir, "host-samples.jsonl"))
+    control_warmup = _load_json(os.path.join(run_dir, "host-control-warmup.json"))
+    uffd_serve = _load_json(os.path.join(run_dir, "uffd-serve.json"))
+
+    _validate_schedule(schedule)
+    generation_id, config_sha256 = _validate_provenance(provenance, schedule)
+    _validate_status(status, schedule, provenance)
+    _validate_uffd_serve(uffd_serve, schedule, provenance, status)
+    requests_by_burst = _validate_requests(
+        schedule, summaries, requests, generation_id, config_sha256
+    )
+    _validate_fault_cgroup_membership(requests, status)
+    _validate_fault_trace_artifacts(
+        run_dir, schedule, summaries, requests_by_burst
+    )
+    run_id = schedule["run_id"]
+    measurement_start_ns = min(summary["burst_start_ns"] for summary in summaries)
+    measurement_end_ns = max(row["finished_ns"] for row in requests)
+    _validate_run_accounting(
+        status, summaries, measurement_start_ns, measurement_end_ns
+    )
+    sample_gate = _validate_samples(
+        samples, schedule, status, measurement_start_ns, measurement_end_ns
+    )
+    _validate_control_warmup(control_warmup, schedule, status)
+    control_gate = _control_gate(
+        controls, schedule, status, measurement_start_ns, measurement_end_ns
+    )
+    if not control_gate["passed"]:
+        raise AnalysisInvalid(
+            f"host drift control changed {control_gate['drift_pct']:.3f}%, beyond "
+            f"{control_gate['absolute_limit_pct']:.3f}%"
+        )
+
+    criteria = schedule.get("capacity_criteria")
+    required_criteria = {
+        "max_offered_rps_error_pct", "min_departure_ratio",
+        "max_score_end_backlog", "max_p95_launch_lag_ms",
+        "max_control_median_drift_pct", "require_zero_failures",
+    }
+    if not isinstance(criteria, dict) or set(criteria) != required_criteria:
+        raise AnalysisInvalid("capacity criteria are missing or undeclared")
+    if criteria["require_zero_failures"] is not True:
+        raise AnalysisInvalid("zero failures must be a mandatory capacity gate")
+
+    grouped = defaultdict(list)
+    for summary in summaries:
+        if summary.get("population") != "scored":
+            continue
+        for backend in ("file", "uffd"):
+            grouped[(backend, summary["target_rps"])].append(summary)
+    cells = []
+    analysis_seed = schedule["seed"] ^ 0xA11A515
+    for cell_index, declared in enumerate(schedule["cells"]):
+        key = (declared["backend"], declared["target_rps"])
+        bursts = sorted(grouped.get(key, []), key=lambda row: row["repeat"])
+        if len(bursts) != declared["independent_bursts"] or len(bursts) < 5:
+            raise AnalysisInvalid(f"cell {declared['cell_id']} lacks independent bursts")
+        cell_rows = []
+        for burst in bursts:
+            metrics = burst.get("backends", {}).get(declared["backend"])
+            if not isinstance(metrics, dict):
+                raise AnalysisInvalid(
+                    f"burst {burst.get('burst_id')} lacks {declared['backend']} metrics"
+                )
+            verdict = evaluate_cell_burst(
+                {**metrics, "target_rps": declared["target_rps"]}, criteria
+            )
+            cell_rows.append({
+                "burst_id": burst["burst_id"],
+                "repeat": burst["repeat"],
+                **verdict,
+            })
+        metric_seed = analysis_seed + cell_index * 100
+        departure = [burst["backends"][declared["backend"]]["departure_rps"] for burst in bursts]
+        offered = [burst["backends"][declared["backend"]]["offered_rps"] for burst in bursts]
+        latency = [
+            burst["backends"][declared["backend"]]["artifact_latency_ms"]["p95"]
+            for burst in bursts
+        ]
+        drain_latency = [
+            burst["backends"][declared["backend"]]["drain_latency_ms"]["p95"]
+            for burst in bursts
+        ]
+        backlog = [
+            float(burst["backends"][declared["backend"]]["score_end_backlog"])
+            for burst in bursts
+        ]
+        minor_faults = []
+        major_faults = []
+        for burst in bursts:
+            rows = [
+                row for row in requests_by_burst[burst["burst_id"]]
+                if row["segment"] == "score" and row["backend"] == declared["backend"]
+            ]
+            minor_faults.append(statistics.mean(
+                row["firecracker_process_faults_ready_to_artifact"]["minor_faults"]
+                for row in rows
+            ))
+            major_faults.append(statistics.mean(
+                row["firecracker_process_faults_ready_to_artifact"]["major_faults"]
+                for row in rows
+            ))
+        cells.append({
+            **declared,
+            "passed": all(row["passed"] for row in cell_rows),
+            "burst_verdicts": cell_rows,
+            "offered_rps": bootstrap_mean_ci(offered, metric_seed),
+            "departure_rps": bootstrap_mean_ci(departure, metric_seed + 1),
+            "artifact_latency_p95_ms": bootstrap_mean_ci(latency, metric_seed + 2),
+            "drain_latency_p95_ms": bootstrap_mean_ci(drain_latency, metric_seed + 3),
+            "score_end_backlog": bootstrap_mean_ci(backlog, metric_seed + 4),
+            "firecracker_process_minor_faults_per_request_ready_to_artifact": (
+                bootstrap_mean_ci(minor_faults, metric_seed + 5)
+            ),
+            "firecracker_process_major_faults_per_request_ready_to_artifact": (
+                bootstrap_mean_ci(major_faults, metric_seed + 6)
+            ),
+        })
+
+    capacities = {}
+    for backend in ("file", "uffd"):
+        backend_cells = sorted(
+            (cell for cell in cells if cell["backend"] == backend),
+            key=lambda cell: cell["target_rps"],
+        )
+        capacity = None
+        prefix_passes = True
+        for cell in backend_cells:
+            prefix_passes = prefix_passes and cell["passed"]
+            if prefix_passes:
+                capacity = cell["target_rps"]
+        capacities[backend] = {
+            "highest_contiguous_passing_rate_per_second": capacity,
+            "all_declared_rates": [
+                {"target_rps": cell["target_rps"], "passed": cell["passed"]}
+                for cell in backend_cells
+            ],
+        }
+    joint = None
+    for rate in sorted(schedule["rates"]):
+        at_rate = [cell for cell in cells if cell["target_rps"] == rate]
+        if len(at_rate) != 2 or not all(cell["passed"] for cell in at_rate):
+            break
+        joint = rate
+
+    trace_provenance = provenance.get("fault_trace")
+    trace_enabled = schedule["trace_rate"] is not None
+    if (
+        not isinstance(trace_provenance, dict)
+        or trace_provenance.get("enabled") is not trace_enabled
+    ):
+        raise AnalysisInvalid("fault-trace provenance differs from the schedule")
+    if trace_enabled:
+        limit = _finite_number(
+            trace_provenance.get("max_median_delta_pct"),
+            "fault-trace perturbation limit",
+            minimum=0,
+        )
+        try:
+            recomputed_trace_gate = reqscale.evaluate_trace_perturbation(summaries, limit)
+        except reqscale.MeasurementInvalid as error:
+            raise AnalysisInvalid(f"fault tracing perturbation gate failed: {error}") from error
+        trace_gate = _load_json(os.path.join(run_dir, "trace-perturbation.json"))
+        if trace_gate != recomputed_trace_gate:
+            raise AnalysisInvalid("fault tracing perturbation artifact differs from raw burst data")
+        if len(trace_gate.get("pairs", [])) != schedule["trace_pairs"] * 2:
+            raise AnalysisInvalid("fault tracing perturbation artifact lacks matched backend pairs")
+    else:
+        trace_gate = {"enabled": False}
+
+    return {
+        "schema": ANALYSIS_SCHEMA,
+        "run_id": run_id,
+        "snapshot_generation_id": generation_id,
+        "publishable": True,
+        "experimental_unit": "burst",
+        "analysis_seed": analysis_seed,
+        "bootstrap_draws": BOOTSTRAP_DRAWS,
+        "criteria": criteria,
+        "control_gate": control_gate,
+        "host_sample_gate": sample_gate,
+        "trace_perturbation_gate": trace_gate,
+        "fault_metric_scope": schedule["fault_metric_scope"],
+        "cells": cells,
+        "capacity": {
+            "by_backend": capacities,
+            "joint_highest_contiguous_passing_rate_per_second": joint,
+        },
+    }
+
+
+def markdown_report(analysis: dict) -> str:
+    lines = [
+        "# Chromium request scalability",
+        "",
+        f"Run `{analysis['run_id']}` used snapshot generation "
+        f"`{analysis['snapshot_generation_id']}`. The run passed its provenance, "
+        "continuous-accounting, and host drift-control checks.",
+        "",
+        "FILE and UFFD were offered the same per-backend rate in one mixed stream. "
+        "Each rate interval contained one request for each backend, separated by "
+        "half an interval with seeded order. One warmup burst was excluded. Each "
+        "scored burst used a 15 second ramp and 60 second score, and confidence "
+        "intervals resample whole bursts rather than requests.",
+        "",
+        "## Capacity gates",
+        "",
+        "A burst passes only when offered-rate error, departure ratio, score-end "
+        "backlog, launch lag, and zero-failure cleanup all meet the limits recorded "
+        "before the run.",
+        "",
+        "| Backend | Target rps/backend | Pass | Offered rps mean (95% CI) | "
+        "Departure rps mean (95% CI) | Artifact p95 ms mean (95% CI) | "
+        "Drain p95 ms mean (95% CI) | Backlog mean (95% CI) |",
+        "|---|---:|:---:|---:|---:|---:|---:|---:|",
+    ]
+    for cell in sorted(analysis["cells"], key=lambda row: (row["target_rps"], row["backend"])):
+        departure = cell["departure_rps"]
+        offered = cell["offered_rps"]
+        latency = cell["artifact_latency_p95_ms"]
+        drain = cell["drain_latency_p95_ms"]
+        backlog = cell["score_end_backlog"]
+        lines.append(
+            f"| {cell['backend'].upper()} | {cell['target_rps']:g} | "
+            f"{'yes' if cell['passed'] else 'no'} | "
+            f"{offered['point']:.3g} ({offered['ci95_low']:.3g}–{offered['ci95_high']:.3g}) | "
+            f"{departure['point']:.3g} ({departure['ci95_low']:.3g}–{departure['ci95_high']:.3g}) | "
+            f"{latency['point']:.3g} ({latency['ci95_low']:.3g}–{latency['ci95_high']:.3g}) | "
+            f"{drain['point']:.3g} ({drain['ci95_low']:.3g}–{drain['ci95_high']:.3g}) | "
+            f"{backlog['point']:.3g} ({backlog['ci95_low']:.3g}–{backlog['ci95_high']:.3g}) |"
+        )
+    lines.extend([
+        "",
+        "The reported capacity is the highest contiguous declared rate for which "
+        "every lower rate also passed. This avoids selecting an isolated high-rate "
+        "pass after a lower-rate failure.",
+        "",
+        f"- FILE: {analysis['capacity']['by_backend']['file']['highest_contiguous_passing_rate_per_second']} requests/s",
+        f"- UFFD: {analysis['capacity']['by_backend']['uffd']['highest_contiguous_passing_rate_per_second']} requests/s",
+        f"- Joint: {analysis['capacity']['joint_highest_contiguous_passing_rate_per_second']} requests/s per backend",
+        "",
+        "## Firecracker process faults",
+        "",
+        "These counters cover endpoint readiness through artifact return. Values are "
+        "per-request means with confidence intervals over burst means.",
+        "",
+        "| Backend | Target rps/backend | Minor faults/request mean (95% CI) | "
+        "Major faults/request mean (95% CI) |",
+        "|---|---:|---:|---:|",
+    ])
+    for cell in sorted(analysis["cells"], key=lambda row: (row["target_rps"], row["backend"])):
+        minor = cell["firecracker_process_minor_faults_per_request_ready_to_artifact"]
+        major = cell["firecracker_process_major_faults_per_request_ready_to_artifact"]
+        lines.append(
+            f"| {cell['backend'].upper()} | {cell['target_rps']:g} | "
+            f"{minor['point']:.3g} ({minor['ci95_low']:.3g}–{minor['ci95_high']:.3g}) | "
+            f"{major['point']:.3g} ({major['ci95_low']:.3g}–{major['ci95_high']:.3g}) |"
+        )
+    lines.extend([
+        "",
+        "## Drift and fault scope",
+        "",
+        f"The persistent host-native Chromium control changed "
+        f"{analysis['control_gate']['drift_pct']:.3g}% between its first- and "
+        f"second-half medians (absolute limit "
+        f"{analysis['control_gate']['absolute_limit_pct']:.3g}%).",
+        "",
+        "Fault counters and optional handle_mm_fault timings cover the Firecracker "
+        "process from endpoint readiness through artifact return. They include all "
+        "Firecracker VMAs. They are not guest-RAM-filtered page faults and are not "
+        "UFFD event counts.",
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-dir", required=True)
+    parser.add_argument("--json-out")
+    parser.add_argument("--markdown-out")
+    args = parser.parse_args()
+    if not args.json_out and not args.markdown_out:
+        parser.error("at least one of --json-out or --markdown-out is required")
+    try:
+        analysis = analyze(os.path.abspath(args.run_dir))
+        if args.json_out:
+            reqscale.write_json_exclusive(os.path.abspath(args.json_out), analysis)
+        if args.markdown_out:
+            report_path = os.path.abspath(args.markdown_out)
+            directory = os.path.dirname(report_path)
+            os.makedirs(directory, exist_ok=True)
+            temp = os.path.join(
+                directory, f".{os.path.basename(report_path)}.{uuid.uuid4().hex}.tmp"
+            )
+            try:
+                fd = os.open(temp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+                with os.fdopen(fd, "w") as stream:
+                    stream.write(markdown_report(analysis))
+                    stream.flush()
+                    os.fsync(stream.fileno())
+                os.link(temp, report_path)
+                reqscale._fsync_directory(directory)
+            finally:
+                try:
+                    os.unlink(temp)
+                except FileNotFoundError:
+                    pass
+    except (AnalysisInvalid, reqscale.MeasurementInvalid, OSError, ValueError) as error:
+        print(f"{type(error).__name__}: {error}", file=sys.stderr)
+        return 4
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/chromium/test_faultbench.py
+++ b/bench/chromium/test_faultbench.py
@@ -5,6 +5,7 @@ No VM, no root, no clock beyond mtimes we set ourselves. Every test here guards 
 rule about what the harness is allowed to REPORT, which is the part a wrong answer
 survives: a corrupt number reads exactly like a real one.
 """
+import json
 import os
 import sys
 import tempfile
@@ -121,6 +122,129 @@ class Stability(unittest.TestCase):
         result = faultanalyze.stability([{1, 2, 3, 4}, {3, 4, 5, 6}])
         self.assertEqual(result["core_size"], 2)
         self.assertAlmostEqual(result["core_frac_of_mean_set"], 0.5)
+
+
+class KvmAttribution(unittest.TestCase):
+    """A host-wide ftrace dump contains other VMs' faults too."""
+
+    # (comm, pid, cpu, ts, ipa) as read_kvm_trace returns them.
+    EVENTS = [
+        ("fc_vcpu 0", 1001, 0, 1.0, 0x40000000),
+        ("fc_vcpu 1", 1002, 1, 1.1, 0x40001000),
+        ("fc_vcpu 0", 2001, 2, 1.2, 0x40002000),  # a different firecracker
+    ]
+
+    def test_only_this_request_s_threads_are_counted(self):
+        """The tracepoint fires in vCPU thread context, so the filter is a TID set."""
+        kept, discarded = faultanalyze.kvm_events_for_request(self.EVENTS, [1001, 1002])
+        self.assertEqual([e[1] for e in kept], [1001, 1002])
+        self.assertEqual(discarded, 1, "the foreign VM's fault must be counted as discarded")
+
+    def test_the_process_id_is_not_a_thread_id(self):
+        """Filtering on fc_pid, which is never a vCPU tid, would silently keep nothing."""
+        kept, discarded = faultanalyze.kvm_events_for_request(self.EVENTS, [1000])
+        self.assertEqual(kept, [])
+        self.assertEqual(discarded, 3)
+
+    def test_a_run_without_recorded_tids_attributes_nothing(self):
+        kept, discarded = faultanalyze.kvm_events_for_request(self.EVENTS, None)
+        self.assertEqual(kept, [], "with no tid set there is no basis to attribute")
+        self.assertEqual(discarded, 3)
+
+
+class FtraceOverflow(unittest.TestCase):
+    """A dropped event truncates the fault set on whichever CPU dropped it."""
+
+    STATS = (
+        "== /sys/kernel/tracing/instances/faultbench/per_cpu/cpu0/stats\n"
+        "entries: 10\noverrun: 0\ndropped events: 0\n"
+        "== /sys/kernel/tracing/instances/faultbench/per_cpu/cpu3/stats\n"
+        "entries: 10\noverrun: 42\ndropped events: 7\n"
+    )
+
+    def test_a_drop_on_any_cpu_is_counted(self):
+        self.assertEqual(faultbench.ftrace_lost_events(self.STATS), 49,
+                         "cpu0 alone reports zero while cpu3 overran")
+
+    def test_a_clean_trace_reports_no_loss(self):
+        clean = self.STATS.replace("overrun: 42", "overrun: 0").replace("dropped events: 7",
+                                                                        "dropped events: 0")
+        self.assertEqual(faultbench.ftrace_lost_events(clean), 0)
+
+
+class Schedule(unittest.TestCase):
+    """Request order, so host drift is not attributed to whichever cell ran last."""
+
+    CELLS = ["file-4k", "uffd-4k-copy"]
+    PAGES = ["a.html", "b.html"]
+
+    def build(self, seed):
+        return faultbench.build_schedule(self.CELLS, self.PAGES, reps=3, warmup=1, seed=seed)
+
+    def test_the_same_seed_gives_the_same_order(self):
+        self.assertEqual(self.build(7), self.build(7))
+
+    def test_a_different_seed_gives_a_different_order(self):
+        self.assertNotEqual(self.build(7), self.build(8))
+
+    def test_every_request_is_scheduled_exactly_once(self):
+        schedule = self.build(7)
+        self.assertEqual(len(schedule), len(set(schedule)))
+        self.assertEqual(len(schedule), 2 * 2 * (3 + 1))
+        for cell in self.CELLS:
+            measured = [r for r in schedule if r[0] == cell and not r[3]]
+            self.assertEqual(len(measured), 6, f"{cell} must keep all reps x pages")
+
+    def test_warmups_run_first(self):
+        schedule = self.build(7)
+        first_measured = next(i for i, r in enumerate(schedule) if not r[3])
+        self.assertTrue(all(r[3] for r in schedule[:first_measured]))
+        self.assertTrue(all(not r[3] for r in schedule[first_measured:]),
+                        "a warmup after a measured rep would leave a cell measured cold")
+
+    def test_measured_reps_are_not_grouped_by_cell(self):
+        """The defect: with cells walked in order, the last cell absorbs all late drift."""
+        measured = [r[0] for r in self.build(7) if not r[3]]
+        blocked = sorted(measured, key=measured.index)
+        self.assertNotEqual(measured, blocked, "the measured order must not be cell-blocked")
+
+
+class ServeIdentity(unittest.TestCase):
+    """A serve is identified by tag AND uffd mode."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        real = faultbench.STATE_DIR
+        faultbench.STATE_DIR = Path(self.tmp.name)
+        self.addCleanup(setattr, faultbench, "STATE_DIR", real)
+
+    def write_serve(self, name, tag, umode, pid):
+        (Path(self.tmp.name) / f"{name}.json").write_text(json.dumps({
+            "pid": pid,
+            "config": {"process_type": "serve", "snapshot_name": tag, "uffd_mode": umode},
+        }))
+
+    def test_the_other_mode_s_serve_is_not_this_one(self):
+        self.write_serve("a", "cb-golden-rootless", "minor", 4242)
+        self.assertIsNone(faultbench.serve_pid_for("cb-golden-rootless", "copy"),
+                          "a minor-mode serve must not answer for the copy-mode cell")
+        self.assertEqual(faultbench.serve_pid_for("cb-golden-rootless", "minor"), 4242)
+
+    def test_both_modes_can_be_told_apart(self):
+        self.write_serve("a", "cb-golden-rootless", "minor", 4242)
+        self.write_serve("b", "cb-golden-rootless", "copy", 4343)
+        self.assertEqual(faultbench.serve_pid_for("cb-golden-rootless", "minor"), 4242)
+        self.assertEqual(faultbench.serve_pid_for("cb-golden-rootless", "copy"), 4343)
+
+    def test_a_serve_without_a_recorded_mode_reads_as_copy(self):
+        """`snapshot serve` defaults to the copy backend when no mode is given."""
+        (Path(self.tmp.name) / "c.json").write_text(json.dumps({
+            "pid": 4444,
+            "config": {"process_type": "serve", "snapshot_name": "t"},
+        }))
+        self.assertEqual(faultbench.serve_pid_for("t", "copy"), 4444)
+        self.assertIsNone(faultbench.serve_pid_for("t", "minor"))
 
 
 if __name__ == "__main__":

--- a/bench/chromium/test_faultbench.py
+++ b/bench/chromium/test_faultbench.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Deterministic tests for the fault benchmark's measurement-integrity rules.
+
+No VM, no root, no clock beyond mtimes we set ourselves. Every test here guards a
+rule about what the harness is allowed to REPORT, which is the part a wrong answer
+survives: a corrupt number reads exactly like a real one.
+"""
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import faultanalyze  # noqa: E402
+import faultbench  # noqa: E402
+
+
+def trace_file(directory, name, mtime):
+    path = Path(directory) / name
+    path.write_bytes(b"")
+    os.utime(path, (mtime, mtime))
+    return path
+
+
+class TraceAttribution(unittest.TestCase):
+    """Which UFFD trace belongs to which request."""
+
+    def test_one_trace_in_the_window_is_the_request_s_trace(self):
+        with tempfile.TemporaryDirectory() as d:
+            mine = trace_file(d, "1000-vm-0.faults", 150.0)
+            trace_file(d, "1000-vm-1.faults", 400.0)  # a later request's
+            tf, ambiguous = faultanalyze.match_trace([mine] + list(Path(d).glob("*vm-1*")),
+                                                     100.0, 160.0)
+            self.assertEqual(tf, mine)
+            self.assertEqual(ambiguous, [])
+
+    def test_a_trace_written_during_teardown_still_counts(self):
+        """The trace lands when the handler exits, which trails t1 by the teardown."""
+        with tempfile.TemporaryDirectory() as d:
+            late = trace_file(d, "1000-vm-0.faults", 163.0)
+            tf, ambiguous = faultanalyze.match_trace([late], 100.0, 160.0)
+            self.assertEqual(tf, late, "a trace inside the grace period is still this run's")
+            self.assertEqual(ambiguous, [])
+            self.assertLessEqual(163.0, 160.0 + faultanalyze.TRACE_GRACE_S)
+
+    def test_two_traces_in_the_window_attribute_to_neither(self):
+        """The reviewer's case: the next request starts 1s later, so the grace overlaps.
+
+        Taking the newest would give this request the NEXT one's faults.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            mine = trace_file(d, "1000-vm-0.faults", 155.0)
+            theirs = trace_file(d, "1000-vm-1.faults", 163.0)
+            tf, ambiguous = faultanalyze.match_trace([mine, theirs], 100.0, 160.0)
+            self.assertIsNone(tf, "an ambiguous window must not be attributed to either")
+            self.assertEqual(ambiguous, ["1000-vm-0.faults", "1000-vm-1.faults"],
+                             "the record must name what could not be told apart")
+
+    def test_no_trace_in_the_window_is_not_an_ambiguity(self):
+        with tempfile.TemporaryDirectory() as d:
+            other = trace_file(d, "1000-vm-9.faults", 900.0)
+            tf, ambiguous = faultanalyze.match_trace([other], 100.0, 160.0)
+            self.assertIsNone(tf)
+            self.assertEqual(ambiguous, [], "absence is not ambiguity")
+
+
+class SerialIsolation(unittest.TestCase):
+    """A request may only be measured with no clone left over from the previous one."""
+
+    def setUp(self):
+        self.real = faultbench.wait_clones_gone
+        self.addCleanup(setattr, faultbench, "wait_clones_gone", self.real)
+
+    def test_a_cleanup_timeout_stops_the_run(self):
+        faultbench.wait_clones_gone = lambda prefix, timeout: False
+        with self.assertRaises(SystemExit) as caught:
+            faultbench.require_clones_gone("fb-abc", 120, "uffd 4k rep3")
+        message = str(caught.exception)
+        self.assertIn("fb-abc", message)
+        self.assertIn("uffd 4k rep3", message, "the message must name where it stopped")
+        self.assertIn("surviving clone", message)
+
+    def test_a_clean_teardown_continues(self):
+        faultbench.wait_clones_gone = lambda prefix, timeout: True
+        faultbench.require_clones_gone("fb-abc", 120, "uffd 4k rep3")
+
+
+class OutputDirectory(unittest.TestCase):
+    """A run's raw record has to be its own."""
+
+    def test_an_existing_run_directory_is_refused(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = Path(d) / "run"
+            (out / "requests").mkdir(parents=True)
+            (out / "requests.jsonl").write_text('{"rep": 0}\n')
+            with self.assertRaises(SystemExit) as caught:
+                faultbench.require_fresh_out_dir(out)
+            self.assertIn("not empty", str(caught.exception))
+
+    def test_an_absent_or_empty_directory_is_accepted(self):
+        with tempfile.TemporaryDirectory() as d:
+            faultbench.require_fresh_out_dir(Path(d) / "fresh")
+            empty = Path(d) / "empty"
+            empty.mkdir()
+            faultbench.require_fresh_out_dir(empty)
+
+
+class Stability(unittest.TestCase):
+    """The cross-run working-set numbers."""
+
+    def test_all_empty_sets_do_not_abort_the_analysis(self):
+        """A trace with no faults is a real outcome, not a reason to lose the run."""
+        result = faultanalyze.stability([set(), set()])
+        self.assertEqual(result["core_size"], 0)
+        self.assertIsNone(result["core_frac_of_mean_set"],
+                          "a fraction of an empty mean set is undefined, not zero")
+
+    def test_non_empty_sets_still_report_the_fraction(self):
+        result = faultanalyze.stability([{1, 2, 3, 4}, {3, 4, 5, 6}])
+        self.assertEqual(result["core_size"], 2)
+        self.assertAlmostEqual(result["core_frac_of_mean_set"], 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/chromium/test_reqscale.py
+++ b/bench/chromium/test_reqscale.py
@@ -1,0 +1,2241 @@
+#!/usr/bin/env python3
+"""Deterministic tests for the open-loop Chromium request scalability harness.
+
+No test in this file starts a VM, writes the real cgroup tree, or attaches BPF.
+The production boundaries are injected so scheduling, accounting, provenance,
+and fail-closed verdicts can be exercised with exact synthetic records.
+"""
+
+import hashlib
+import io
+import json
+import os
+import select
+import signal
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from types import SimpleNamespace
+from unittest import mock
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+import reqscale  # noqa: E402
+import reqscale_analyze  # noqa: E402
+
+
+RUN_ID = "0123456789abcdef0123456789abcdef"
+
+
+class ScheduleIsAnArtifact(unittest.TestCase):
+    def config(self, **overrides):
+        values = dict(
+            rates=(2.0, 4.0),
+            scored_bursts=5,
+            seed=776,
+            criteria=reqscale.CapacityCriteria(
+                max_offered_rps_error_pct=1.0,
+                min_departure_ratio=0.95,
+                max_score_end_backlog=8,
+                max_p95_launch_lag_ms=25.0,
+                max_control_median_drift_pct=10.0,
+            ),
+            trace_rate=None,
+            trace_pairs=0,
+        )
+        values.update(overrides)
+        return reqscale.ScheduleConfig(**values)
+
+    def test_same_seed_produces_the_same_interleaved_schedule(self):
+        a = reqscale.build_schedule(self.config(), RUN_ID)
+        b = reqscale.build_schedule(self.config(), RUN_ID)
+        self.assertEqual(a, b)
+        self.assertEqual(reqscale.schedule_sha256(a), reqscale.schedule_sha256(b))
+
+        bursts = a["bursts"]
+        self.assertEqual(len(bursts), 2 * 6)  # rate x (one warmup + five scored)
+        self.assertEqual(a["randomization"]["unit"], "burst")
+        self.assertEqual(len(a["cells"]), 4)
+        self.assertTrue(all(cell["independent_bursts"] == 5 for cell in a["cells"]))
+        self.assertTrue(all(cell["warmup_bursts"] == 1 for cell in a["cells"]))
+        self.assertTrue(all(cell["planned_scored_requests_total"] >= 200 for cell in a["cells"]))
+        first_measured = next(
+            i for i, burst in enumerate(bursts) if burst["population"] != "warmup"
+        )
+        self.assertGreater(first_measured, 0)
+        self.assertTrue(
+            all(burst["population"] == "warmup" for burst in bursts[:first_measured])
+        )
+        self.assertNotIn(
+            "warmup", {burst["population"] for burst in bursts[first_measured:]}
+        )
+        for burst in bursts:
+            requests = burst["requests"]
+            by_pair = {}
+            for request in requests:
+                by_pair.setdefault(request["pair_index"], []).append(request)
+            for pair in by_pair.values():
+                self.assertEqual({request["backend"] for request in pair}, {"file", "uffd"})
+                self.assertEqual(len(pair), 2)
+                self.assertEqual(
+                    pair[1]["scheduled_offset_ns"] - pair[0]["scheduled_offset_ns"],
+                    round(1_000_000_000 / (2 * burst["target_rps"])),
+                )
+
+    def test_a_different_seed_changes_order_and_window_seeds(self):
+        a = reqscale.build_schedule(self.config(seed=1), RUN_ID)
+        b = reqscale.build_schedule(self.config(seed=2), RUN_ID)
+        self.assertNotEqual(a["bursts"], b["bursts"])
+
+    def test_fewer_than_five_independent_windows_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "at least 5"):
+            reqscale.build_schedule(self.config(scored_bursts=4), RUN_ID)
+
+    def test_missing_explicit_warmup_window_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "warmup"):
+            reqscale.build_schedule(self.config(warmup_bursts=0), RUN_ID)
+
+    def test_fewer_than_200_scored_requests_per_backend_rate_is_rejected(self):
+        # 0.2/s is the largest rate that both divides the 15s ramp and the 60s score
+        # into whole requests and still starves the cell: 5 bursts x 12 = 60 < 200.
+        # A rate of 0.5 cannot reach this branch at all, because 0.5 * 15 = 7.5 trips
+        # the whole-request guard first.
+        with self.assertRaisesRegex(ValueError, "fewer than 200"):
+            reqscale.build_schedule(self.config(rates=(0.2,)), RUN_ID)
+
+    def test_trace_pairs_are_explicit_and_randomized_with_their_controls(self):
+        schedule = reqscale.build_schedule(
+            self.config(trace_rate=4.0, trace_pairs=3), RUN_ID
+        )
+        pairs = {}
+        for burst in schedule["bursts"]:
+            if burst["population"] != "trace-perturbation":
+                continue
+            pairs.setdefault(burst["trace_pair_id"], []).append(burst)
+        self.assertEqual(len(pairs), 3)
+        for pair in pairs.values():
+            self.assertEqual(len(pair), 2)
+            self.assertEqual({burst["traced"] for burst in pair}, {False, True})
+            self.assertEqual({burst["target_rps"] for burst in pair}, {4.0})
+            self.assertEqual(pair[0]["requests"], pair[1]["requests"])
+
+
+class FakeClock:
+    def __init__(self):
+        self.now_ns = 1_000_000_000
+        self.sleeps = []
+
+    def monotonic_ns(self):
+        return self.now_ns
+
+    def sleep_until_ns(self, deadline_ns):
+        self.sleeps.append(deadline_ns)
+        self.now_ns = max(self.now_ns, deadline_ns)
+
+
+class DeferredLauncher:
+    """Records every launch; creates results only when drain() is called."""
+
+    def __init__(self):
+        self.contexts = []
+        self.drain_called = False
+
+    def launch(self, context, request_fn):
+        self.assert_not_draining()
+        self.contexts.append(context)
+        return context, request_fn
+
+    def assert_not_draining(self):
+        if self.drain_called:
+            raise AssertionError("scheduler launched after entering drain")
+
+    def drain(self, handles):
+        self.drain_called = True
+        self.assert_all_launched(handles)
+        records = []
+        for context, request_fn in handles:
+            # Synthetic, exact monotonic milestones. request_fn is still called
+            # so its metadata path is covered without making launch closed-loop.
+            rec = request_fn(context)
+            launch_ns = context.actual_launch_ns
+            rec.update(
+                request_id=context.request_id,
+                request_index=context.request_index,
+                pair_index=context.pair_index,
+                burst_id=context.burst_id,
+                population=context.population,
+                segment=context.segment,
+                backend=context.backend,
+                target_rps=context.target_rps,
+                request_seed=context.request_seed,
+                scheduled_ns=context.scheduled_ns,
+                actual_launch_ns=launch_ns,
+                artifact_ns=launch_ns + 300_000_000,
+                finished_ns=launch_ns + 500_000_000,
+                blocking_ms=300.0,
+                wall_ms=500.0,
+                ok=True,
+                teardown={"all_gone": True},
+            )
+            records.append(rec)
+        return records
+
+    def assert_all_launched(self, handles):
+        if len(handles) != len(self.contexts):
+            raise AssertionError("drain began before every open-loop launch")
+
+
+class OpenLoopIsActuallyOpenLoop(unittest.TestCase):
+    @staticmethod
+    def one_request_spec():
+        return reqscale.BurstSpec(
+            burst_id="b0", block_id="b0", population="scored",
+            target_rps=1.0, repeat=0, seed=4, traced=False,
+            trace_pair_id=None, ramp_seconds=0.0, score_seconds=1.0,
+            requests=(
+                reqscale.RequestPlan(0, 0, "score", "file", 0, 10),
+                reqscale.RequestPlan(1, 0, "score", "uffd", 500_000_000, 11),
+            ),
+        )
+
+    def test_launches_follow_absolute_deadlines_and_drain_only_after_last_launch(self):
+        spec = reqscale.BurstSpec(
+            burst_id="b0",
+            block_id="b0",
+            population="scored",
+            target_rps=2.0,
+            repeat=0,
+            seed=4,
+            traced=False,
+            trace_pair_id=None,
+            ramp_seconds=0.0,
+            score_seconds=2.0,
+            requests=tuple(
+                reqscale.RequestPlan(
+                    request_index=index,
+                    pair_index=index // 2,
+                    segment="score",
+                    backend="file" if index % 2 == 0 else "uffd",
+                    scheduled_offset_ns=index * 250_000_000,
+                    seed=100 + index,
+                )
+                for index in range(8)
+            ),
+        )
+        clock = FakeClock()
+        launcher = DeferredLauncher()
+        records, summary = reqscale.run_open_loop_burst(
+            RUN_ID, spec, lambda context: {"backend": context.backend}, clock, launcher
+        )
+
+        self.assertTrue(launcher.drain_called)
+        self.assertEqual(len(launcher.contexts), 8)
+        base = launcher.contexts[0].scheduled_ns
+        self.assertEqual(
+            [c.scheduled_ns - base for c in launcher.contexts],
+            [
+                0, 250_000_000, 500_000_000, 750_000_000,
+                1_000_000_000, 1_250_000_000, 1_500_000_000, 1_750_000_000,
+            ],
+        )
+        self.assertEqual([r["request_index"] for r in records], list(range(8)))
+        self.assertEqual(summary["planned"], 8)
+        self.assertEqual(summary["launched"], 8)
+        self.assertEqual(summary["artifact_completed"], 8)
+        self.assertEqual(summary["drained"], 8)
+        self.assertEqual(summary["launch_span_ms"], 1750.0)
+        self.assertEqual(summary["completion_span_ms"], 2050.0)
+        self.assertEqual(summary["drain_span_ms"], 2250.0)
+        self.assertEqual(summary["latency_ms"]["median"], 300.0)
+        self.assertEqual(summary["backends"]["file"]["planned"], 4)
+        self.assertEqual(summary["backends"]["uffd"]["planned"], 4)
+
+    def test_a_missing_milestone_invalidates_the_window(self):
+        spec = self.one_request_spec()
+
+        class Broken(DeferredLauncher):
+            def drain(self, handles):
+                rows = super().drain(handles)
+                del rows[0]["artifact_ns"]
+                return rows
+
+        with self.assertRaisesRegex(reqscale.MeasurementInvalid, "artifact_ns"):
+            reqscale.run_open_loop_burst(
+                RUN_ID, spec, lambda _context: {}, FakeClock(), Broken()
+            )
+
+    def test_a_reqbench_exception_keeps_its_teardown_evidence(self):
+        class RecordedFailure(RuntimeError):
+            def __init__(self):
+                super().__init__("a child survived")
+                # ThreadLauncher stamps real monotonic milestones, so a fabricated
+                # 20ms wall time for a call that raises immediately is rejected by
+                # the record validator before this test can assert anything. The
+                # timings are incidental here; the teardown evidence is the subject.
+                self.record = {
+                    "blocking_ms": 0.0, "wall_ms": 0.0,
+                    "teardown": {"all_gone": False, "survivors": [321]},
+                }
+
+        def fail(_context):
+            raise RecordedFailure()
+
+        records, summary = reqscale.run_open_loop_burst(
+            RUN_ID, self.one_request_spec(), fail, FakeClock(), reqscale.ThreadLauncher()
+        )
+        # one_request_spec plans a file/uffd pair, so both requests raise and both
+        # must keep their evidence — the survivor list is the whole point of the
+        # record surviving an exception.
+        self.assertEqual(len(records), 2)
+        for record in records:
+            self.assertEqual(record["teardown"]["survivors"], [321])
+            self.assertIn("RecordedFailure", record["error"])
+        self.assertEqual(summary["failed"], 2)
+
+    def test_a_base_exception_unwinds_only_after_the_worker_joins(self):
+        class Interrupt(BaseException):
+            pass
+
+        def interrupt(_context):
+            raise Interrupt("stop")
+
+        with self.assertRaisesRegex(Interrupt, "stop"):
+            reqscale.run_open_loop_burst(
+                RUN_ID, self.one_request_spec(), interrupt,
+                FakeClock(), reqscale.ThreadLauncher(),
+            )
+
+    def test_a_scheduler_interruption_drains_every_already_owned_request(self):
+        class InterruptingClock(FakeClock):
+            def sleep_until_ns(self, deadline_ns):
+                if self.sleeps:
+                    raise KeyboardInterrupt("stop scheduling")
+                super().sleep_until_ns(deadline_ns)
+
+        launcher = DeferredLauncher()
+        with self.assertRaisesRegex(KeyboardInterrupt, "stop scheduling"):
+            reqscale.run_open_loop_burst(
+                RUN_ID, self.one_request_spec(), lambda _context: {},
+                InterruptingClock(), launcher,
+            )
+        self.assertTrue(launcher.drain_called)
+        self.assertEqual(len(launcher.contexts), 1)
+
+
+class ProcAndCgroupAccounting(unittest.TestCase):
+    @staticmethod
+    def write_proc_stat(root, pid, start_time):
+        # fields 3..22; minflt=101, majflt=303, starttime supplied by caller.
+        raw = (
+            f"{pid} (worker {pid}) S 1 2 3 4 5 6 101 8 303 10 "
+            f"11 12 13 14 15 16 17 18 {start_time}\n"
+        )
+        with open(os.path.join(root, str(pid), "stat"), "w") as f:
+            f.write(raw)
+        with open(os.path.join(root, str(pid), "comm"), "w") as f:
+            f.write(f"worker-{pid}\n")
+
+    def test_proc_stat_parsing_survives_parentheses_and_extracts_faults(self):
+        # fields 3..22 after a comm containing both a space and a right paren.
+        raw = (
+            "42 (fc vcpu) worker) R 1 2 3 4 5 6 101 8 303 10 "
+            "11 12 13 14 15 16 17 18 999\n"
+        )
+        stat = reqscale.parse_process_stat(raw)
+        self.assertEqual(stat.pid, 42)
+        self.assertEqual(stat.state, "R")
+        self.assertEqual(stat.minor_faults, 101)
+        self.assertEqual(stat.major_faults, 303)
+        self.assertEqual(stat.start_time_ticks, 999)
+
+    def test_cpu_stat_keeps_every_counter_and_delta(self):
+        before = reqscale.parse_cpu_stat(
+            "usage_usec 100\nuser_usec 60\nsystem_usec 40\nnr_throttled 2\n"
+        )
+        after = reqscale.parse_cpu_stat(
+            "usage_usec 175\nuser_usec 100\nsystem_usec 75\nnr_throttled 5\n"
+        )
+        self.assertEqual(
+            reqscale.counter_delta(before, after),
+            {"usage_usec": 75, "user_usec": 40, "system_usec": 35, "nr_throttled": 3},
+        )
+
+    def test_machine_proc_stat_preserves_every_row_not_only_aggregate_cpu(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "stat")
+            raw = (
+                "cpu  10 1 2 30 4 5 6 7 8 9\n"
+                "cpu0 5 0 1 15 2 2 3 3 4 4\n"
+                "intr 99 1 2\nctxt 123\nprocesses 45\nprocs_running 2\n"
+            )
+            with open(path, "w") as f:
+                f.write(raw)
+            captured = reqscale.read_machine_proc_stat(path)
+            self.assertEqual(captured["raw"], raw)
+            self.assertEqual(captured["cpu"]["user"], 10)
+            self.assertEqual(
+                captured["raw_sha256"], hashlib.sha256(raw.encode()).hexdigest()
+            )
+
+    def test_cgroup_audit_fails_when_any_observed_process_is_outside_the_run(self):
+        with tempfile.TemporaryDirectory() as d:
+            proc = os.path.join(d, "proc")
+            group = os.path.join(d, "sys", "fs", "cgroup", "run")
+            os.makedirs(os.path.join(proc, "10"))
+            os.makedirs(os.path.join(proc, "11"))
+            os.makedirs(group)
+            with open(os.path.join(proc, "10", "cgroup"), "w") as f:
+                f.write("0::/run\n")
+            with open(os.path.join(proc, "11", "cgroup"), "w") as f:
+                f.write("0::/somewhere-else\n")
+            self.write_proc_stat(proc, 10, 1000)
+            self.write_proc_stat(proc, 11, 1100)
+            with open(os.path.join(group, "cgroup.procs"), "w") as f:
+                f.write("10\n")
+            with open(os.path.join(group, "cpu.stat"), "w") as f:
+                f.write("usage_usec 1\n")
+            audit = reqscale.CgroupAudit(group, proc_root=proc, cgroup_root=os.path.join(d, "sys", "fs", "cgroup"))
+            audit.observe(10, "harness")
+            self.assertEqual(
+                audit.record()["observed"],
+                [{
+                    "pid": 10, "pid_start_time_ticks": 1000,
+                    "role": "harness", "comm": "worker-10",
+                }],
+            )
+            with self.assertRaisesRegex(reqscale.MeasurementInvalid, "outside run cgroup"):
+                audit.observe(11, "firecracker")
+
+    def test_cgroup_audit_does_not_collapse_reused_pids(self):
+        with tempfile.TemporaryDirectory() as d:
+            proc = os.path.join(d, "proc")
+            group = os.path.join(d, "sys", "fs", "cgroup", "run")
+            os.makedirs(os.path.join(proc, "10"))
+            os.makedirs(group)
+            with open(os.path.join(proc, "10", "cgroup"), "w") as f:
+                f.write("0::/run\n")
+            with open(os.path.join(group, "cgroup.procs"), "w") as f:
+                f.write("10\n")
+            with open(os.path.join(group, "cpu.stat"), "w") as f:
+                f.write("usage_usec 1\n")
+            audit = reqscale.CgroupAudit(
+                group, proc_root=proc,
+                cgroup_root=os.path.join(d, "sys", "fs", "cgroup"),
+            )
+            self.write_proc_stat(proc, 10, 1000)
+            audit.observe(10, "first")
+            self.write_proc_stat(proc, 10, 2000)
+            audit.observe(10, "replacement")
+            self.assertEqual(
+                [(row["pid_start_time_ticks"], row["role"]) for row in audit.record()["observed"]],
+                [(1000, "first"), (2000, "replacement")],
+            )
+
+    def test_quiet_guard_matches_comm_not_an_fcvm_path_in_an_argv(self):
+        rows = (
+            "S codex\n"
+            "S firecracker-a1b2\n"
+            "Z fcvm\n"
+            "S cloud-hypervis\n"
+        )
+        self.assertEqual(
+            reqscale.parse_vm_process_rows(rows),
+            [
+                {"state": "S", "comm": "firecracker-a1b2"},
+                {"state": "S", "comm": "cloud-hypervis"},
+            ],
+        )
+        # A repository path lived in argv in the old pgrep -f guard. `comm` is
+        # just codex here, so this is deliberately not a VM process.
+        self.assertEqual(reqscale.parse_vm_process_rows("S codex\n"), [])
+
+    def test_quiet_host_snapshot_records_the_gate_inputs(self):
+        with tempfile.TemporaryDirectory() as d:
+            loadavg = os.path.join(d, "loadavg")
+            with open(loadavg, "w") as f:
+                f.write("1.25 0.50 0.25 1/100 10\n")
+            snapshot = reqscale.quiet_host_snapshot(loadavg, "S bash\n")
+            self.assertEqual(snapshot["loadavg1"], 1.25)
+            self.assertEqual(snapshot["vm_process_count"], 0)
+            self.assertEqual(snapshot["loadavg1_limit"], 2.0)
+
+
+class FakeProcReader:
+    def __init__(self):
+        self.children = {100: [200, 201, 202]}
+        self.comms = {200: "firecracker", 201: "sleep", 202: "pasta"}
+        self.samples = {
+            200: [
+                reqscale.ProcessStat(200, "R", 10, 1, 500),
+                reqscale.ProcessStat(200, "R", 37, 3, 500),
+            ]
+        }
+
+    def children_of(self, pid):
+        return list(self.children.get(pid, []))
+
+    def comm(self, pid):
+        return self.comms.get(pid, "")
+
+    def stat(self, pid):
+        values = self.samples[pid]
+        return values.pop(0) if len(values) > 1 else values[0]
+
+    def identity(self, pid):
+        return FakeProcIdentity(self, pid)
+
+
+class FakeProcIdentity:
+    def __init__(self, proc, pid):
+        self.proc = proc
+        self.pid = pid
+        self.closed = False
+
+    def comm(self):
+        return self.proc.comm(self.pid)
+
+    def stat(self):
+        return self.proc.stat(self.pid)
+
+    def close(self):
+        self.closed = True
+
+
+class FakeAudit:
+    def __init__(self):
+        self.observed = []
+
+    def observe(self, pid, role):
+        self.observed.append((pid, role))
+
+    def observe_identity(self, identity, role):
+        self.observed.append((identity.pid, role))
+
+
+class PerFirecrackerFaults(unittest.TestCase):
+    def test_fault_delta_is_bound_to_one_exact_firecracker_identity(self):
+        proc = FakeProcReader()
+        audit = FakeAudit()
+        probe = reqscale.FirecrackerFaultProbe(proc, audit)
+        probe.begin(100)
+        out = probe.finish()
+        self.assertEqual(
+            audit.observed,
+            [(100, "fcvm"), (200, "firecracker"), (201, "sleep"), (202, "pasta")],
+        )
+        self.assertEqual(out["pid"], 200)
+        self.assertEqual(out["pid_start_time_ticks"], 500)
+        self.assertEqual(out["minor_faults"], 27)
+        self.assertEqual(out["major_faults"], 2)
+
+    def test_zero_or_multiple_firecrackers_fails_closed(self):
+        proc = FakeProcReader()
+        proc.comms[201] = "firecracker"
+        with self.assertRaisesRegex(reqscale.MeasurementInvalid, "exactly one"):
+            reqscale.FirecrackerFaultProbe(proc, FakeAudit()).begin(100)
+
+    def test_pid_reuse_is_rejected(self):
+        proc = FakeProcReader()
+        proc.samples[200][1] = reqscale.ProcessStat(200, "R", 37, 3, 501)
+        probe = reqscale.FirecrackerFaultProbe(proc, FakeAudit())
+        probe.begin(100)
+        with self.assertRaisesRegex(reqscale.MeasurementInvalid, "identity changed"):
+            probe.finish()
+
+
+class ContinuousAccounting(unittest.TestCase):
+    class Audit:
+        def __init__(self, name):
+            self.relative = f"/run/{name}"
+
+        def live_pids(self):
+            return []
+
+        def cpu_snapshot(self):
+            return {"usage_usec": 10, "user_usec": 6, "system_usec": 4}
+
+    def test_one_sample_keeps_proc_load_psi_memavailable_and_every_cgroup(self):
+        with tempfile.TemporaryDirectory() as d:
+            proc_stat = os.path.join(d, "stat")
+            loadavg = os.path.join(d, "loadavg")
+            meminfo = os.path.join(d, "meminfo")
+            pressure = os.path.join(d, "pressure")
+            os.mkdir(pressure)
+            with open(proc_stat, "w") as f:
+                f.write("cpu 1 2 3 4 5 6 7 8 9 10\ncpu0 1 2 3 4 5 6 7 8 9 10\nctxt 3\n")
+            with open(loadavg, "w") as f:
+                f.write("0.10 0.20 0.30 2/100 4321\n")
+            with open(meminfo, "w") as f:
+                f.write("MemTotal: 1000 kB\nMemAvailable: 750 kB\n")
+            for resource in ("cpu", "memory", "io"):
+                with open(os.path.join(pressure, resource), "w") as f:
+                    f.write("some avg10=0.10 avg60=0.20 avg300=0.30 total=42\n")
+                    if resource != "cpu":
+                        f.write("full avg10=0.00 avg60=0.00 avg300=0.00 total=0\n")
+            source = reqscale.HostSampleSource(proc_stat, loadavg, pressure, meminfo)
+            audits = {
+                name: self.Audit(name)
+                for name in ("run", "driver", "control", "file", "uffd")
+            }
+            sample = source.capture(audits, {"name": "burst", "burst_id": "b3"})
+            self.assertEqual(set(sample["cgroups"]), set(audits))
+            self.assertIn("cpu0", sample["proc_stat"]["raw"])
+            self.assertEqual(sample["loadavg"]["parsed"]["running_tasks"], 2)
+            self.assertEqual(
+                sample["meminfo"]["parsed"]["MemAvailable"],
+                {"value": 750, "unit": "kB"},
+            )
+            self.assertEqual(sample["pressure"]["io"]["parsed"]["some"]["total"], 42)
+
+    def test_split_cgroup_paths_are_fixed_before_entry(self):
+        with tempfile.TemporaryDirectory() as d:
+            proc = os.path.join(d, "proc")
+            root = os.path.join(d, "cgroup")
+            os.makedirs(os.path.join(proc, "self"))
+            os.mkdir(root)
+            with open(os.path.join(proc, "self", "cgroup"), "w") as f:
+                f.write("0::/\n")
+            scope = reqscale.RunCgroups(RUN_ID, root, proc)
+            self.assertEqual(set(scope.paths), {"driver", "control", "file", "uffd"})
+            self.assertTrue(all(path.startswith(scope.path + os.sep) for path in scope.paths.values()))
+
+
+class ChildLifecycle(unittest.TestCase):
+    def test_a_deferred_first_signal_makes_later_cleanup_signals_inert(self):
+        fence = reqscale.TerminationFence()
+        with fence:
+            deferred = reqscale.DeferredTermination()
+            deferred.__enter__()
+            deferred._handle(reqscale.signal.SIGTERM, None)
+            with self.assertRaises(reqscale.MeasurementInterrupted):
+                deferred.__exit__(None, None, None)
+            self.assertEqual(fence.received, [reqscale.signal.SIGTERM])
+            # This represents a user pressing Ctrl-C again while execute() is in
+            # its finally block. Cleanup must continue instead of being unwound.
+            fence._handle(reqscale.signal.SIGINT, None)
+            self.assertEqual(
+                fence.received, [reqscale.signal.SIGTERM, reqscale.signal.SIGINT]
+            )
+
+    def test_every_measured_command_uses_guardexec_and_the_selected_leaf(self):
+        command = reqscale.guarded_command(
+            "/sys/fs/cgroup/fcvm-reqscale-" + RUN_ID + "/file",
+            ["/bin/echo", "ok"],
+            parent_pid=123,
+        )
+        self.assertEqual(command[0], sys.executable)
+        self.assertEqual(command[1], reqscale.GUARDEXEC)
+        # The leaf must be asserted on the VALUE of --cgroup-procs. `assertIn` against
+        # the argv list tests element equality, so a substring never matches and the
+        # assertion can only ever fail.
+        self.assertEqual(
+            command[command.index("--cgroup-procs") + 1],
+            "/sys/fs/cgroup/fcvm-reqscale-" + RUN_ID + "/file/cgroup.procs",
+        )
+        self.assertEqual(command[-2:], ["/bin/echo", "ok"])
+        supervised = reqscale.supervised_command(
+            "/sys/fs/cgroup/fcvm-reqscale-" + RUN_ID + "/control",
+            ["chromium", "about:blank"],
+            parent_pid=123,
+        )
+        self.assertEqual(supervised[1], reqscale.GUARDSUPERVISE)
+        self.assertEqual(
+            supervised[supervised.index("--cgroup-procs") + 1],
+            "/sys/fs/cgroup/fcvm-reqscale-" + RUN_ID + "/control/cgroup.procs",
+        )
+
+    def test_run_scope_kills_owned_tree_after_a_survivor_audit(self):
+        class Audit:
+            def __init__(self, live):
+                self.live = live
+
+            def record(self):
+                return {"live_pids": list(self.live)}
+
+            def live_pids(self):
+                # The synthetic cgroup.kill takes effect before verification.
+                return []
+
+        scope = object.__new__(reqscale.RunCgroups)
+        scope.entered = True
+        scope.original_path = "/fake/original"
+        scope.path = "/fake/run"
+        scope.paths = {
+            name: f"/fake/run/{name}" for name in reqscale.RunCgroups.LEAVES
+        }
+        scope.audits = {
+            "run": Audit([]),
+            "driver": Audit([123]),
+            "control": Audit([]),
+            "file": Audit([456]),
+            "uffd": Audit([]),
+        }
+        opened = mock.mock_open()
+        with mock.patch("builtins.open", opened), mock.patch.object(
+            reqscale.os, "getpid", return_value=123
+        ), mock.patch.object(reqscale.os, "rmdir") as rmdir:
+            with self.assertRaisesRegex(
+                reqscale.MeasurementInvalid, "unexpected final membership"
+            ):
+                scope.leave()
+        self.assertFalse(scope.entered)
+        self.assertIn(
+            mock.call("/fake/run/cgroup.kill", "w"), opened.mock_calls
+        )
+        self.assertEqual(rmdir.call_count, len(reqscale.RunCgroups.LEAVES) + 1)
+
+    def test_guardexec_kills_the_execed_child_when_its_expected_parent_exits(self):
+        parent_code = r'''
+import os
+import subprocess
+import sys
+
+guard, cgroup_procs = sys.argv[1:]
+ready_read, ready_write = os.pipe()
+target = [
+    sys.executable, "-c",
+    f"import os,time; os.write({ready_write}, b'x'); time.sleep(30)",
+]
+child = subprocess.Popen(
+    [sys.executable, guard, "--expected-parent", str(os.getpid()),
+     "--cgroup-procs", cgroup_procs, "--", *target],
+    pass_fds=(ready_write,),
+)
+os.close(ready_write)
+if os.read(ready_read, 1) != b'x':
+    raise SystemExit("guarded child never reached exec")
+os.close(ready_read)
+print(child.pid, flush=True)
+'''
+        with tempfile.TemporaryDirectory() as d:
+            cgroup_procs = os.path.join(d, "cgroup.procs")
+            with open(cgroup_procs, "w"):
+                pass
+            parent = subprocess.run(
+                [sys.executable, "-c", parent_code, reqscale.GUARDEXEC, cgroup_procs],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            self.assertEqual(parent.returncode, 0, parent.stderr)
+            child_pid = int(parent.stdout.strip())
+            with open(cgroup_procs) as f:
+                self.assertEqual(int(f.read().strip()), child_pid)
+            pidfd = reqscale.reqbench.pidfd_open(child_pid)
+            if pidfd is not None:
+                try:
+                    poller = select.poll()
+                    poller.register(pidfd, select.POLLIN)
+                    self.assertTrue(poller.poll(2000), "guarded child survived parent exit")
+                finally:
+                    os.close(pidfd)
+
+    def test_guardsupervise_terminates_the_third_party_process_group(self):
+        with tempfile.TemporaryDirectory() as d:
+            cgroup_procs = os.path.join(d, "cgroup.procs")
+            with open(cgroup_procs, "w"):
+                pass
+            target = [
+                sys.executable,
+                "-c",
+                "import os,time; print(os.getpid(), flush=True); time.sleep(30)",
+            ]
+            supervisor = subprocess.Popen(
+                [
+                    sys.executable, reqscale.GUARDSUPERVISE,
+                    "--expected-parent", str(os.getpid()),
+                    "--cgroup-procs", cgroup_procs,
+                    "--", *target,
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            target_pid = int(supervisor.stdout.readline().strip())
+            target_pidfd = reqscale.reqbench.pidfd_open(target_pid)
+            supervisor.send_signal(15)
+            self.assertEqual(supervisor.wait(timeout=5), 0, supervisor.stderr.read())
+            if target_pidfd is not None:
+                try:
+                    poller = select.poll()
+                    poller.register(target_pidfd, select.POLLIN)
+                    self.assertTrue(
+                        poller.poll(2000), "supervised process survived supervisor shutdown"
+                    )
+                finally:
+                    os.close(target_pidfd)
+
+    def test_tracer_abort_kills_waits_and_closes_all_streams(self):
+        class Process:
+            def __init__(self):
+                self.killed = False
+                self.waited = False
+
+            def poll(self):
+                return None if not self.killed else -9
+
+            def kill(self):
+                self.killed = True
+
+            def wait(self, timeout):
+                self.waited = True
+                return -9
+
+        with tempfile.TemporaryDirectory() as d:
+            tracer = object.__new__(reqscale.BpftraceFaultTracer)
+            tracer.process = Process()
+            tracer.stdout_thread = None
+            tracer.stderr_thread = None
+            tracer.stdout_stream = open(os.path.join(d, "stdout"), "w")
+            tracer.stderr_stream = open(os.path.join(d, "stderr"), "w")
+            tracer.out_dir = d
+            tracer.abort()
+            self.assertTrue(tracer.process.killed)
+            self.assertTrue(tracer.process.waited)
+            self.assertTrue(tracer.stdout_stream.closed)
+            self.assertTrue(tracer.stderr_stream.closed)
+
+    def test_tracer_stop_reaps_an_exit_race_and_bounds_reader_joins(self):
+        class Process:
+            def send_signal(self, _signum):
+                raise ProcessLookupError
+
+            def wait(self, timeout):
+                self.timeout = timeout
+                return 0
+
+        class Reader:
+            name = "fake-reader"
+
+            def __init__(self):
+                self.timeout = None
+
+            def join(self, timeout):
+                self.timeout = timeout
+
+            def is_alive(self):
+                return False
+
+        with tempfile.TemporaryDirectory() as d, mock.patch.object(
+            reqscale, "parse_fault_trace", return_value={"ready": True, "processes": {}}
+        ):
+            tracer = object.__new__(reqscale.BpftraceFaultTracer)
+            tracer.process = Process()
+            tracer.stdout_thread = Reader()
+            tracer.stderr_thread = Reader()
+            tracer.stdout_stream = open(os.path.join(d, "stdout"), "w")
+            tracer.stderr_stream = open(os.path.join(d, "stderr"), "w")
+            tracer.out_dir = d
+            tracer.reader_state_lock = reqscale.threading.Lock()
+            tracer.reader_error = None
+            tracer.lines = []
+            self.assertEqual(
+                tracer.stop(timeout_s=3.0), {"ready": True, "processes": {}}
+            )
+            self.assertEqual(tracer.process.timeout, 3.0)
+            self.assertEqual(tracer.stdout_thread.timeout, 10)
+            self.assertEqual(tracer.stderr_thread.timeout, 10)
+            self.assertTrue(tracer.stdout_stream.closed)
+            self.assertTrue(tracer.stderr_stream.closed)
+
+    def test_uffd_stop_reaps_an_exit_that_races_with_sigterm(self):
+        class Process:
+            returncode = None
+
+            def poll(self):
+                return self.returncode
+
+            def send_signal(self, _signum):
+                raise ProcessLookupError
+
+            def wait(self, timeout):
+                self.returncode = -signal.SIGTERM
+                return self.returncode
+
+        class Audit:
+            def live_pids(self):
+                return []
+
+        with tempfile.TemporaryDirectory() as d:
+            serve = object.__new__(reqscale.UffdServe)
+            serve.args = SimpleNamespace(teardown_timeout=1.0)
+            serve.proc = Process()
+            serve.audit = Audit()
+            serve.cgroup_path = d
+            serve.state_path = None
+            serve.log_stream = open(os.path.join(d, "serve.log"), "w")
+            serve.stop()
+            self.assertTrue(serve.log_stream.closed)
+            self.assertEqual(serve.proc.returncode, -signal.SIGTERM)
+
+    def test_uffd_stop_kills_the_leaf_when_initial_membership_audit_fails(self):
+        class Audit:
+            def __init__(self):
+                self.calls = 0
+
+            def live_pids(self):
+                self.calls += 1
+                if self.calls == 1:
+                    raise OSError("synthetic cgroup read failure")
+                return []
+
+        with tempfile.TemporaryDirectory() as d:
+            kill_path = os.path.join(d, "cgroup.kill")
+            with open(kill_path, "w"):
+                pass
+            serve = object.__new__(reqscale.UffdServe)
+            serve.args = SimpleNamespace(teardown_timeout=1.0)
+            serve.proc = None
+            serve.audit = Audit()
+            serve.cgroup_path = d
+            serve.state_path = None
+            serve.log_stream = open(os.path.join(d, "serve.log"), "w")
+            with self.assertRaisesRegex(
+                reqscale.MeasurementInvalid, "cannot verify UFFD cgroup cleanup"
+            ):
+                serve.stop()
+            with open(kill_path) as stream:
+                self.assertEqual(stream.read(), "1\n")
+            self.assertTrue(serve.log_stream.closed)
+
+    def test_control_stop_kills_the_leaf_when_membership_audit_fails(self):
+        class Process:
+            returncode = 0
+
+            def poll(self):
+                return self.returncode
+
+            def wait(self, timeout):
+                return self.returncode
+
+        class Audit:
+            def __init__(self):
+                self.calls = 0
+
+            def live_pids(self):
+                self.calls += 1
+                if self.calls < 3:
+                    raise OSError("synthetic cgroup read failure")
+                return []
+
+        with tempfile.TemporaryDirectory() as d:
+            kill_path = os.path.join(d, "cgroup.kill")
+            with open(kill_path, "w"):
+                pass
+            profile = os.path.join(d, "profile")
+            os.mkdir(profile)
+            control = object.__new__(reqscale.NativeChromiumControl)
+            control.args = SimpleNamespace(teardown_timeout=1.0)
+            control.proc = Process()
+            control.audit = Audit()
+            control.cgroup_path = d
+            control.log_stream = open(os.path.join(d, "control.log"), "w")
+            control.profile_dir = profile
+            with self.assertRaisesRegex(
+                reqscale.MeasurementInvalid, "cannot snapshot control cgroup"
+            ):
+                control.stop()
+            with open(kill_path) as stream:
+                self.assertEqual(stream.read(), "1\n")
+            self.assertTrue(control.log_stream.closed)
+            self.assertFalse(os.path.exists(profile))
+
+
+class CapacityGates(unittest.TestCase):
+    CRITERIA = {
+        "max_offered_rps_error_pct": 1.0,
+        "min_departure_ratio": 0.95,
+        "max_score_end_backlog": 2,
+        "max_p95_launch_lag_ms": 20.0,
+        "max_control_median_drift_pct": 10.0,
+        "require_zero_failures": True,
+    }
+
+    @staticmethod
+    def cell():
+        return {
+            "target_rps": 4.0,
+            "planned": 240,
+            "launched": 240,
+            "launched_by_score_end": 240,
+            "offered_rps": 4.0,
+            "departure_rps": 3.85,
+            "departure_ratio": 231 / 240,
+            "artifact_completed_by_score_end": 231,
+            "score_end_backlog": 2,
+            "launch_lag_ms": {"p95": 5.0},
+            "failed": 0,
+            "ok": 240,
+            "artifact_completed": 240,
+            "drained": 240,
+            "cleanup_confirmed": 240,
+        }
+
+    def test_every_declared_capacity_gate_is_independent_and_fail_closed(self):
+        clean = reqscale_analyze.evaluate_cell_burst(self.cell(), self.CRITERIA)
+        self.assertTrue(clean["passed"])
+        mutations = {
+            "offered": {"launched_by_score_end": 180, "offered_rps": 3.0},
+            "departure": {
+                "artifact_completed_by_score_end": 216,
+                "departure_rps": 3.6,
+                "departure_ratio": 0.9,
+            },
+            "backlog": {"score_end_backlog": 3},
+            "lag": {"launch_lag_ms": {"p95": 21.0}},
+            "zero_failure": {"failed": 1, "ok": 239},
+        }
+        for gate, changes in mutations.items():
+            cell = self.cell()
+            cell.update(changes)
+            verdict = reqscale_analyze.evaluate_cell_burst(cell, self.CRITERIA)
+            self.assertFalse(verdict["gates"][gate], gate)
+            self.assertFalse(verdict["passed"], gate)
+
+    def test_bootstrap_is_deterministic_and_resamples_bursts(self):
+        values = [1.0, 2.0, 3.0, 4.0, 5.0]
+        first = reqscale_analyze.bootstrap_mean_ci(values, seed=776, draws=1000)
+        second = reqscale_analyze.bootstrap_mean_ci(values, seed=776, draws=1000)
+        self.assertEqual(first, second)
+        self.assertEqual(first["unit"], "burst")
+        self.assertEqual(first["n"], 5)
+        self.assertLessEqual(first["ci95_low"], first["point"])
+        self.assertGreaterEqual(first["ci95_high"], first["point"])
+
+    def test_seeded_control_deadlines_and_drift_gate_are_exact(self):
+        schedule = {
+            "control": {"interval_ns": 10_000_000_000, "phase_offset_ns": 123},
+            "capacity_criteria": self.CRITERIA,
+        }
+        origin = 1000
+        records = [
+            {
+                "schema": reqscale.RECORD_SCHEMA,
+                "kind": "host-control",
+                "control_index": index,
+                "scheduled_ns": 1123 + index * 10_000_000_000,
+                "actual_launch_ns": 1_000_000 + 1123 + index * 10_000_000_000,
+                "artifact_ns": 1_000_000 + 1123 + index * 10_000_000_000
+                               + round(latency * 1_000_000),
+                "latency_ms": latency,
+                "launch_lag_ms": 1.0,
+                "ok": True,
+                "result": {"ok": True},
+            }
+            for index, latency in enumerate((100.0, 100.0, 105.0, 105.0))
+        ]
+        stop_ns = records[-1]["scheduled_ns"] + 1_000_000_000
+        status = {"control": {
+            "started": True,
+            "origin_monotonic_ns": origin,
+            "phase_offset_ns": 123,
+            "interval_ns": 10_000_000_000,
+            "requests": 4,
+            "stop_requested_monotonic_ns": stop_ns,
+        }}
+        self.assertTrue(reqscale_analyze._control_gate(
+            records, schedule, status, origin, records[-1]["artifact_ns"]
+        )["passed"])
+        records[2]["scheduled_ns"] += 1
+        with self.assertRaisesRegex(reqscale_analyze.AnalysisInvalid, "seeded schedule"):
+            reqscale_analyze._control_gate(
+                records, schedule, status, origin, records[-1]["artifact_ns"]
+            )
+
+    def test_impossible_cell_metrics_are_invalid_not_publishable_failures(self):
+        cell = self.cell()
+        cell["departure_ratio"] = float("inf")
+        with self.assertRaisesRegex(reqscale_analyze.AnalysisInvalid, "finite"):
+            reqscale_analyze.evaluate_cell_burst(cell, self.CRITERIA)
+
+
+class AnalyzerRejectsCorruptEvidence(unittest.TestCase):
+    GENERATION = "11111111-1111-4111-8111-111111111111"
+    CONFIG_SHA = "a" * 64
+
+    @staticmethod
+    def _proc_stat(user):
+        return (
+            f"cpu {user} 0 0 100 0 0 0 0 0 0\n"
+            f"cpu0 {user} 0 0 100 0 0 0 0 0 0\n"
+            "intr 1\nctxt 1\nbtime 1\nprocesses 1\nprocs_running 1\n"
+            "procs_blocked 0\nsoftirq 1 1\n"
+        )
+
+    @staticmethod
+    def _machine(raw, captured_ns):
+        return {
+            "path": "/proc/stat",
+            "raw": raw,
+            "raw_sha256": hashlib.sha256(raw.encode()).hexdigest(),
+            "cpu": reqscale_analyze._proc_cpu_from_raw(raw, "test"),
+            "captured_wall_ns": captured_ns + 1_000_000_000_000,
+            "captured_monotonic_ns": captured_ns,
+            "clk_tck": 100,
+        }
+
+    @classmethod
+    def fixture(cls):
+        spec = OpenLoopIsActuallyOpenLoop.one_request_spec()
+        records, summary = reqscale.run_open_loop_burst(
+            RUN_ID, spec, lambda context: {"backend": context.backend},
+            FakeClock(), DeferredLauncher(),
+        )
+        for index, row in enumerate(records):
+            row.update(
+                schema=reqscale.RECORD_SCHEMA,
+                kind="request",
+                run_id=RUN_ID,
+                block_id=spec.block_id,
+                cell_id=f"{row['backend']}:r1",
+                traced=False,
+                trace_pair_id=None,
+                snapshot_generation_id=cls.GENERATION,
+                snapshot_config_sha256=cls.CONFIG_SHA,
+                firecracker_process_faults_ready_to_artifact={
+                    "pid": 1000 + index,
+                    "pid_start_time_ticks": 5000 + index,
+                    "minor_faults": 3,
+                    "major_faults": 1,
+                    "before": {"minor_faults": 10, "major_faults": 2},
+                    "after": {"minor_faults": 13, "major_faults": 3},
+                    "scope": (
+                        "Firecracker process endpoint-ready through artifact return; "
+                        "all process VMAs, not guest-RAM-filtered and not UFFD events"
+                    ),
+                },
+            )
+        before = cls._machine(cls._proc_stat(1), 900_000_000)
+        after = cls._machine(cls._proc_stat(2), 3_000_000_000)
+        summary.update(
+            machine_proc_stat_before=before,
+            machine_proc_stat_after=after,
+            machine_proc_stat_delta=reqscale.counter_delta(before["cpu"], after["cpu"]),
+            cgroup_cpu_stat_before={
+                name: {"usage_usec": 10}
+                for name in ("run", "driver", "control", "file", "uffd")
+            },
+            cgroup_cpu_stat_after={
+                name: {"usage_usec": 20}
+                for name in ("run", "driver", "control", "file", "uffd")
+            },
+            cgroup_cpu_stat_delta={
+                name: {"usage_usec": 10}
+                for name in ("run", "driver", "control", "file", "uffd")
+            },
+            interburst_cgroup_membership={
+                "run": [], "driver": [10], "control": [11],
+                "file": [], "uffd": [12],
+            },
+        )
+        schedule = {"run_id": RUN_ID, "bursts": [spec.to_dict()]}
+        return schedule, [summary], records
+
+    def test_green_summary_cannot_hide_a_failed_raw_request(self):
+        schedule, summaries, records = self.fixture()
+        records[0]["ok"] = False
+        with self.assertRaisesRegex(reqscale_analyze.AnalysisInvalid, "failed"):
+            reqscale_analyze._validate_requests(
+                schedule, summaries, records, self.GENERATION, self.CONFIG_SHA
+            )
+
+    def test_request_generation_must_match_run_provenance(self):
+        schedule, summaries, records = self.fixture()
+        records[0]["snapshot_generation_id"] = "22222222-2222-4222-8222-222222222222"
+        with self.assertRaisesRegex(reqscale_analyze.AnalysisInvalid, "diverges"):
+            reqscale_analyze._validate_requests(
+                schedule, summaries, records, self.GENERATION, self.CONFIG_SHA
+            )
+
+    def test_seeded_schedule_is_rebuilt_before_analysis(self):
+        config = ScheduleIsAnArtifact().config(rates=(1.0,))
+        schedule = reqscale.build_schedule(config, RUN_ID)
+        request = schedule["bursts"][0]["requests"][0]
+        request["backend"] = "uffd" if request["backend"] == "file" else "file"
+        with self.assertRaisesRegex(reqscale_analyze.AnalysisInvalid, "does not match"):
+            reqscale_analyze._validate_schedule(schedule)
+
+    def test_strict_loader_rejects_duplicate_keys_and_nonstandard_constants(self):
+        with tempfile.TemporaryDirectory() as d:
+            duplicate = os.path.join(d, "duplicate.json")
+            constant = os.path.join(d, "constant.json")
+            with open(duplicate, "w") as stream:
+                stream.write('{"run_id":"a","run_id":"b"}')
+            with open(constant, "w") as stream:
+                stream.write('{"value":NaN}')
+            with self.assertRaisesRegex(reqscale_analyze.AnalysisInvalid, "duplicate"):
+                reqscale_analyze._load_json(duplicate)
+            with self.assertRaisesRegex(reqscale_analyze.AnalysisInvalid, "non-standard"):
+                reqscale_analyze._load_json(constant)
+
+    @staticmethod
+    def _raw(path, raw, parsed=None):
+        value = {
+            "path": path,
+            "raw": raw,
+            "raw_sha256": hashlib.sha256(raw.encode()).hexdigest(),
+        }
+        if parsed is not None:
+            value["parsed"] = parsed
+        return value
+
+    @classmethod
+    def _host_samples(cls):
+        origin = 1_000_000_000
+        interval = 5_000_000_000
+        rows = []
+        psi_raw = "some avg10=0.10 avg60=0.20 avg300=0.30 total=42\n"
+        psi_parsed = reqscale.parse_psi(psi_raw, "/proc/pressure/test")
+        for index in range(3):
+            scheduled = origin + index * interval
+            captured = scheduled + 1_000_000
+            proc_raw = cls._proc_stat(10 + index)
+            rows.append({
+                "schema": "fcvm.chromium.reqscale.host-sample.v1",
+                "sample_index": index,
+                "scheduled_monotonic_ns": scheduled,
+                "captured_monotonic_ns": captured,
+                "completed_monotonic_ns": captured + 1_000_000,
+                "captured_wall_ns": 1_000_000_000_000 + captured,
+                "completed_wall_ns": 1_000_000_001_000 + captured,
+                "launch_lag_ms": 1.0,
+                "phase": {"name": "setup", "burst_id": None},
+                "proc_stat": {
+                    **cls._raw("/proc/stat", proc_raw),
+                    "captured_monotonic_ns": captured,
+                    "captured_wall_ns": 1_000_000_000_000 + captured,
+                    "cpu": reqscale_analyze._proc_cpu_from_raw(proc_raw, "test"),
+                    "clk_tck": 100,
+                },
+                "loadavg": cls._raw(
+                    "/proc/loadavg", "0.1 0.2 0.3 1/10 99\n",
+                    reqscale.parse_loadavg(
+                        "0.1 0.2 0.3 1/10 99\n", "/proc/loadavg"
+                    ),
+                ),
+                "pressure": {
+                    resource: cls._raw(
+                        f"/proc/pressure/{resource}", psi_raw, psi_parsed
+                    )
+                    for resource in ("cpu", "memory", "io")
+                },
+                "meminfo": cls._raw(
+                    "/proc/meminfo", "MemAvailable: 100 kB\n",
+                    {"MemAvailable": {"value": 100, "unit": "kB"}},
+                ),
+                "cgroups": {
+                    name: {
+                        "path": "/run" if name == "run" else f"/run/{name}",
+                        "live_pids": [] if name == "run" else [10 + offset],
+                        "cpu_stat": {"usage_usec": index * 10 + offset},
+                    }
+                    for offset, name in enumerate(
+                        ("run", "driver", "control", "file", "uffd")
+                    )
+                },
+            })
+        stop_ns = origin + 11_000_000_000
+        terminal = dict(rows[-1])
+        terminal.update(
+            sample_index=3,
+            scheduled_monotonic_ns=None,
+            captured_monotonic_ns=stop_ns + 1_000_000,
+            completed_monotonic_ns=stop_ns + 2_000_000,
+            captured_wall_ns=1_000_000_000_000 + stop_ns + 1_000_000,
+            completed_wall_ns=1_000_000_000_000 + stop_ns + 2_000_000,
+            launch_lag_ms=None,
+            terminal=True,
+            phase={"name": "teardown", "burst_id": None},
+        )
+        terminal["cgroups"] = {
+            name: {
+                **value,
+                "live_pids": [11] if name == "driver" else [],
+                "cpu_stat": {"usage_usec": 40 + offset},
+            }
+            for offset, (name, value) in enumerate(terminal["cgroups"].items())
+        }
+        # The terminal row is copied from the last periodic row and then moved past
+        # stop_ns, so its nested /proc/stat stamps have to move with it. Leaving them
+        # behind puts the capture outside the row's own boundary, which the sample gate
+        # rejects before any of this test's assertions run.
+        terminal["proc_stat"] = {
+            **terminal["proc_stat"],
+            "captured_monotonic_ns": terminal["captured_monotonic_ns"],
+            "captured_wall_ns": terminal["captured_wall_ns"],
+        }
+        rows.append(terminal)
+        status = {
+            "sampler": {
+                "started": True,
+                "samples": 4,
+                "periodic_samples": 3,
+                "terminal_sample": True,
+                "origin_monotonic_ns": origin,
+                "interval_ns": interval,
+                "stop_requested_monotonic_ns": stop_ns,
+            },
+            "final_cgroups": {
+                name: {
+                    "path": "/run" if name == "run" else f"/run/{name}",
+                    "live_pids": [11] if name == "driver" else [],
+                    "cpu_stat": {"usage_usec": 50 + offset},
+                }
+                for offset, name in enumerate(
+                    ("run", "driver", "control", "file", "uffd")
+                )
+            },
+            "run_before": {
+                "machine_proc_stat": {
+                    "cpu": reqscale_analyze._proc_cpu_from_raw(
+                        cls._proc_stat(9), "test"
+                    )
+                },
+                "cgroup_cpu_stat": {
+                    name: {"usage_usec": offset}
+                    for offset, name in enumerate(
+                        ("run", "driver", "control", "file", "uffd")
+                    )
+                },
+            },
+            "run_after": {
+                "machine_proc_stat": {
+                    "cpu": reqscale_analyze._proc_cpu_from_raw(
+                        cls._proc_stat(13), "test"
+                    )
+                },
+                "cgroup_cpu_stat": {
+                    name: {"usage_usec": 45 + offset}
+                    for offset, name in enumerate(
+                        ("run", "driver", "control", "file", "uffd")
+                    )
+                },
+            },
+        }
+        schedule = {"host_sample_interval_ns": interval, "bursts": []}
+        return rows, schedule, status, origin + 1, origin + 10_000_000_000
+
+    def test_sample_gate_reconciles_cadence_coverage_and_terminal_sample(self):
+        rows, schedule, status, start, end = self._host_samples()
+        verdict = reqscale_analyze._validate_samples(
+            rows, schedule, status, start, end
+        )
+        self.assertTrue(verdict["passed"])
+        rows[1]["captured_monotonic_ns"] += schedule["host_sample_interval_ns"]
+        rows[1]["completed_monotonic_ns"] += schedule["host_sample_interval_ns"]
+        with self.assertRaisesRegex(reqscale_analyze.AnalysisInvalid, "missed"):
+            reqscale_analyze._validate_samples(rows, schedule, status, start, end)
+
+    def test_truncated_samples_cannot_claim_continuous_accounting(self):
+        rows, schedule, status, start, end = self._host_samples()
+        del rows[1]
+        status["sampler"]["samples"] -= 1
+        status["sampler"]["periodic_samples"] -= 1
+        with self.assertRaisesRegex(reqscale_analyze.AnalysisInvalid, "deadlines elapsed"):
+            reqscale_analyze._validate_samples(rows, schedule, status, start, end)
+
+
+class CompleteAnalyzerFixture(unittest.TestCase):
+    """Exercise every artifact boundary together without a VM or wall-clock wait."""
+
+    GENERATION = AnalyzerRejectsCorruptEvidence.GENERATION
+    CONFIG_SHA = AnalyzerRejectsCorruptEvidence.CONFIG_SHA
+    HARNESS_PID = 10
+    CONTROL_PID = 20
+    SERVE_PID = 30
+
+    @staticmethod
+    def _write_json(path, value):
+        with open(path, "w") as stream:
+            json.dump(value, stream, sort_keys=True, allow_nan=False)
+            stream.write("\n")
+
+    @staticmethod
+    def _write_jsonl(path, rows):
+        with open(path, "w") as stream:
+            for row in rows:
+                stream.write(json.dumps(row, sort_keys=True, allow_nan=False) + "\n")
+
+    @classmethod
+    def _snapshot(cls):
+        files = {
+            name: {
+                "path": path, "size": 100 + index,
+                "mtime_ns": 1_000 + index, "inode": 2_000 + index,
+            }
+            for index, (name, path) in enumerate((
+                ("memory_path", "memory.bin"),
+                ("vmstate_path", "vmstate.bin"),
+                ("disk_path", "disk.raw"),
+                ("config", "config.json"),
+            ))
+        }
+        return {
+            "tag": "golden",
+            "generation_id": cls.GENERATION,
+            "created_at": "2026-08-09T00:00:00+00:00",
+            "vm_id": "vm-golden",
+            "config_sha256": cls.CONFIG_SHA,
+            "shape": {
+                "image": "chromium:test", "vcpu": 2, "memory_mib": 1024,
+                "network_mode": "rootless", "port_mappings": ["9222:9222"],
+            },
+            "files": files,
+        }
+
+    @classmethod
+    def _proc_capture(cls, user, captured_ns):
+        raw = AnalyzerRejectsCorruptEvidence._proc_stat(user)
+        return {
+            "path": "/proc/stat",
+            "captured_wall_ns": 1_000_000_000_000 + captured_ns,
+            "captured_monotonic_ns": captured_ns,
+            "clk_tck": 100,
+            "raw": raw,
+            "raw_sha256": hashlib.sha256(raw.encode()).hexdigest(),
+            "cpu": reqscale_analyze._proc_cpu_from_raw(raw, "fixture"),
+        }
+
+    @classmethod
+    def _final_cgroups(cls, run_path, requests):
+        harness = {
+            "pid": cls.HARNESS_PID, "pid_start_time_ticks": 100,
+            "role": "reqscale", "comm": "python3",
+        }
+        observed = {
+            "run": [dict(harness)],
+            "driver": [dict(harness)],
+            "control": [{
+                "pid": cls.CONTROL_PID, "pid_start_time_ticks": 200,
+                "role": "host-control-chromium", "comm": "python3",
+            }],
+            "file": [],
+            "uffd": [{
+                "pid": cls.SERVE_PID, "pid_start_time_ticks": 300,
+                "role": "uffd-serve", "comm": "fcvm",
+            }],
+        }
+        for row in requests:
+            faults = row["firecracker_process_faults_ready_to_artifact"]
+            observed[row["backend"]].append({
+                "pid": faults["pid"],
+                "pid_start_time_ticks": faults["pid_start_time_ticks"],
+                "role": "firecracker", "comm": "firecracker",
+            })
+        return {
+            name: {
+                "path": run_path if name == "run" else f"{run_path}/{name}",
+                "observed": sorted(
+                    rows, key=lambda row: (row["pid"], row["pid_start_time_ticks"])
+                ),
+                "live_pids": [cls.HARNESS_PID] if name == "driver" else [],
+                "cpu_stat": {"usage_usec": 100_000 + index},
+            }
+            for index, (name, rows) in enumerate(observed.items())
+        }
+
+    @classmethod
+    def _sample(cls, index, scheduled, terminal, phase, run_path):
+        captured = scheduled + 1_000_000
+        proc = cls._proc_capture(1_000 + index, captured)
+        load_raw = "0.1 0.2 0.3 1/10 99\n"
+        psi_raw = "some avg10=0.10 avg60=0.20 avg300=0.30 total=42\n"
+        mem_raw = "MemTotal: 1000 kB\nMemAvailable: 900 kB\n"
+        return {
+            "schema": "fcvm.chromium.reqscale.host-sample.v1",
+            "sample_index": index,
+            "scheduled_monotonic_ns": None if terminal else scheduled,
+            "captured_monotonic_ns": captured,
+            "completed_monotonic_ns": captured + 1_000_000,
+            "captured_wall_ns": 1_000_000_000_000 + captured,
+            "completed_wall_ns": 1_000_000_001_000 + captured,
+            "launch_lag_ms": None if terminal else 1.0,
+            **({"terminal": True} if terminal else {}),
+            "phase": phase,
+            "proc_stat": proc,
+            "loadavg": AnalyzerRejectsCorruptEvidence._raw(
+                "/proc/loadavg", load_raw,
+                reqscale.parse_loadavg(load_raw, "/proc/loadavg"),
+            ),
+            "pressure": {
+                resource: AnalyzerRejectsCorruptEvidence._raw(
+                    f"/proc/pressure/{resource}", psi_raw,
+                    reqscale.parse_psi(psi_raw, f"/proc/pressure/{resource}"),
+                )
+                for resource in ("cpu", "memory", "io")
+            },
+            "meminfo": AnalyzerRejectsCorruptEvidence._raw(
+                "/proc/meminfo", mem_raw,
+                reqscale.parse_meminfo(mem_raw, "/proc/meminfo"),
+            ),
+            "cgroups": {
+                name: {
+                    "path": run_path if name == "run" else f"{run_path}/{name}",
+                    "live_pids": (
+                        [cls.HARNESS_PID] if name == "driver"
+                        else [] if terminal or name in ("run", "file")
+                        else [cls.CONTROL_PID] if name == "control"
+                        else [cls.SERVE_PID]
+                    ),
+                    "cpu_stat": {"usage_usec": index * 100 + offset},
+                }
+                for offset, name in enumerate(
+                    ("run", "driver", "control", "file", "uffd")
+                )
+            },
+        }
+
+    @classmethod
+    def build_run(cls, directory):
+        criteria = reqscale.CapacityCriteria(
+            max_offered_rps_error_pct=1.0,
+            min_departure_ratio=0.95,
+            max_score_end_backlog=2,
+            max_p95_launch_lag_ms=20.0,
+            max_control_median_drift_pct=10.0,
+        )
+        schedule = reqscale.build_schedule(
+            reqscale.ScheduleConfig(
+                rates=(0.8,), scored_bursts=5, seed=776, criteria=criteria,
+            ),
+            RUN_ID,
+        )
+        summaries = []
+        requests = []
+        next_start = 100_000_000_000
+        next_pid = 1_000
+        for burst_number, raw_spec in enumerate(schedule["bursts"]):
+            spec = reqscale.BurstSpec.from_dict(raw_spec)
+            clock = FakeClock()
+            clock.now_ns = next_start
+            burst_rows, summary = reqscale.run_open_loop_burst(
+                RUN_ID, spec, lambda context: {"backend": context.backend},
+                clock, DeferredLauncher(),
+            )
+            for row in burst_rows:
+                row.update(
+                    schema=reqscale.RECORD_SCHEMA,
+                    kind="request",
+                    run_id=RUN_ID,
+                    block_id=spec.block_id,
+                    cell_id=f"{row['backend']}:r0.8",
+                    traced=False,
+                    trace_pair_id=None,
+                    snapshot_generation_id=cls.GENERATION,
+                    snapshot_config_sha256=cls.CONFIG_SHA,
+                    firecracker_process_faults_ready_to_artifact={
+                        "pid": next_pid,
+                        "pid_start_time_ticks": 10_000 + next_pid,
+                        "minor_faults": 2,
+                        "major_faults": 0,
+                        "before": {"minor_faults": 10, "major_faults": 1},
+                        "after": {"minor_faults": 12, "major_faults": 1},
+                        "scope": (
+                            "Firecracker process endpoint-ready through artifact return; "
+                            "all process VMAs, not guest-RAM-filtered and not UFFD events"
+                        ),
+                    },
+                )
+                next_pid += 1
+            drain_ns = max(row["finished_ns"] for row in burst_rows)
+            proc_before = cls._proc_capture(
+                10 + burst_number * 2, summary["burst_start_ns"] - 1_000_000
+            )
+            proc_after = cls._proc_capture(
+                11 + burst_number * 2, drain_ns + 1_000_000
+            )
+            cpu_before = {
+                name: {"usage_usec": burst_number * 1_000 + offset}
+                for offset, name in enumerate(
+                    ("run", "driver", "control", "file", "uffd")
+                )
+            }
+            cpu_after = {
+                name: {"usage_usec": value["usage_usec"] + 100}
+                for name, value in cpu_before.items()
+            }
+            summary.update(
+                machine_proc_stat_before=proc_before,
+                machine_proc_stat_after=proc_after,
+                machine_proc_stat_delta=reqscale.counter_delta(
+                    proc_before["cpu"], proc_after["cpu"]
+                ),
+                cgroup_cpu_stat_before=cpu_before,
+                cgroup_cpu_stat_after=cpu_after,
+                cgroup_cpu_stat_delta={
+                    name: reqscale.counter_delta(cpu_before[name], cpu_after[name])
+                    for name in cpu_before
+                },
+                interburst_cgroup_membership={
+                    "run": [], "driver": [cls.HARNESS_PID],
+                    "control": [cls.CONTROL_PID], "file": [],
+                    "uffd": [cls.SERVE_PID],
+                },
+            )
+            requests.extend(burst_rows)
+            summaries.append(summary)
+            next_start = drain_ns + 1_000_000_000
+
+        snapshot = cls._snapshot()
+        provenance = {
+            "schema": "fcvm.chromium.reqscale.provenance.v1",
+            "run_id": RUN_ID,
+            "created_at": "2026-08-09T00:00:00+00:00",
+            "argv": ["reqscale.py", "--fixture"],
+            "source_revision": "1" * 40,
+            "source_dirty": False,
+            "source_status_sha256": hashlib.sha256(b"").hexdigest(),
+            "harness_sha256": "2" * 64,
+            "fcvm_path": "/usr/bin/fcvm",
+            "fcvm_sha256": "3" * 64,
+            "fcvm_version": "fcvm fixture",
+            "schedule_sha256": reqscale.schedule_sha256(schedule),
+            "snapshot": snapshot,
+            "snapshot_generation_lease": {
+                "path": "/mnt/fcvm-btrfs/snapshots/golden.lock",
+                "mode": "shared",
+                "held_from_identity_read_through_terminal_verification": True,
+            },
+            "host": {
+                "hostname": "fixture", "kernel": "fixture", "machine": "aarch64",
+                "python": "3.13", "cpu_count": 64,
+                "quiet_gate": {
+                    "loadavg1": 0.1, "loadavg1_limit": 2.0,
+                    "vm_process_count": 0, "vm_processes": [],
+                },
+            },
+            "host_control": {
+                "interval_seconds": 10.0,
+                "chromium_path": "/usr/bin/chromium",
+                "chromium_version": "Chromium fixture",
+                "chromium_sha256": "4" * 64,
+                "url": "http://127.0.0.1/fixture",
+                "timeout_seconds": 8.0,
+            },
+            "fault_trace": {
+                "enabled": False, "bpftrace_version": None,
+                "max_median_delta_pct": None,
+                "scope": (
+                    "Firecracker process endpoint-ready through artifact return; "
+                    "all VMAs, not guest-RAM-filtered and not UFFD events"
+                ),
+            },
+        }
+        run_path = f"/bench/fcvm-reqscale-{RUN_ID}"
+        final_cgroups = cls._final_cgroups(run_path, requests)
+        measurement_start = summaries[0]["burst_start_ns"]
+        measurement_end = max(row["finished_ns"] for row in requests)
+
+        control_origin = measurement_start - 10_000_000_000
+        control_stop = measurement_end + 1
+        first_deadline = control_origin + schedule["control"]["phase_offset_ns"]
+        controls = []
+        deadline = first_deadline
+        while deadline < control_stop:
+            actual = deadline + 1_000_000
+            artifact = actual + 100_000_000
+            controls.append({
+                "schema": reqscale.RECORD_SCHEMA, "kind": "host-control",
+                "control_index": len(controls), "scheduled_ns": deadline,
+                "actual_launch_ns": actual, "artifact_ns": artifact,
+                "launch_lag_ms": 1.0, "latency_ms": 100.0,
+                "ok": True, "result": {"ok": True},
+            })
+            deadline += schedule["control"]["interval_ns"]
+
+        sample_origin = measurement_start - 1_000_000_000
+        sample_stop = measurement_end + 1
+        samples = []
+        deadline = sample_origin
+        while deadline < sample_stop:
+            captured = deadline + 1_000_000
+            preceding = [
+                summary for summary in summaries
+                if summary["burst_start_ns"] <= captured
+            ]
+            phase = (
+                {"name": "setup", "burst_id": None}
+                if not preceding
+                else {"name": "burst", "burst_id": preceding[-1]["burst_id"]}
+            )
+            samples.append(cls._sample(
+                len(samples), deadline, False, phase, run_path
+            ))
+            deadline += schedule["host_sample_interval_ns"]
+        terminal = cls._sample(
+            len(samples), sample_stop, True,
+            {"name": "teardown", "burst_id": None}, run_path,
+        )
+        samples.append(terminal)
+        final_cgroups = {
+            name: {
+                **row,
+                "cpu_stat": {
+                    "usage_usec": terminal["cgroups"][name]["cpu_stat"]["usage_usec"] + 30
+                },
+            }
+            for name, row in final_cgroups.items()
+        }
+        before_cpu = {
+            name: {"usage_usec": offset}
+            for offset, name in enumerate(
+                ("run", "driver", "control", "file", "uffd")
+            )
+        }
+        after_cpu = {
+            name: {
+                "usage_usec": terminal["cgroups"][name]["cpu_stat"]["usage_usec"] + 10
+            }
+            for name in final_cgroups
+        }
+        harness_rows = {
+            "run": [dict(final_cgroups["run"]["observed"][0])],
+            "driver": [dict(final_cgroups["driver"]["observed"][0])],
+            "control": [], "file": [], "uffd": [],
+        }
+        run_before = {
+            "machine_proc_stat": cls._proc_capture(1, measurement_start - 2_000_000),
+            "cgroup_cpu_stat": before_cpu,
+            "cgroups": {
+                name: {
+                    "path": final_cgroups[name]["path"],
+                    "observed": harness_rows[name],
+                    "live_pids": final_cgroups[name]["live_pids"],
+                    "cpu_stat": dict(before_cpu[name]),
+                }
+                for name in final_cgroups
+            },
+        }
+        run_after = {
+            "machine_proc_stat": cls._proc_capture(10_000, measurement_end + 2_000_000),
+            "cgroup_cpu_stat": after_cpu,
+            "cgroups": {
+                name: {
+                    "path": final_cgroups[name]["path"],
+                    "observed": [dict(item) for item in final_cgroups[name]["observed"]],
+                    "live_pids": final_cgroups[name]["live_pids"],
+                    "cpu_stat": {
+                        "usage_usec": after_cpu[name]["usage_usec"] + 10
+                    },
+                }
+                for name in final_cgroups
+            },
+        }
+        status = {
+            "schema": "fcvm.chromium.reqscale.status.v2",
+            "run_id": RUN_ID, "valid": True,
+            "bursts_completed": len(summaries),
+            "bursts_planned": len(schedule["bursts"]),
+            "control": {
+                "started": True, "origin_monotonic_ns": control_origin,
+                "phase_offset_ns": schedule["control"]["phase_offset_ns"],
+                "interval_ns": schedule["control"]["interval_ns"],
+                "requests": len(controls),
+                "stop_requested_monotonic_ns": control_stop,
+            },
+            "sampler": {
+                "started": True, "origin_monotonic_ns": sample_origin,
+                "interval_ns": schedule["host_sample_interval_ns"],
+                "samples": len(samples), "periodic_samples": len(samples) - 1,
+                "terminal_sample": True,
+                "stop_requested_monotonic_ns": sample_stop,
+            },
+            "snapshot_identity_after": snapshot,
+            "final_cgroups": final_cgroups,
+            "run_before": run_before, "run_after": run_after,
+            "error": None, "error_details": None, "errors": [],
+        }
+        warmup = {
+            "schema": reqscale.RECORD_SCHEMA,
+            "kind": "host-control-warmup", "included_in_analysis": False,
+            "started_monotonic_ns": control_origin - 200_000_000,
+            "artifact_monotonic_ns": control_origin - 100_000_000,
+            "latency_ms": 100.0, "result": {"ok": True},
+        }
+        serve = {
+            "schema": reqscale.RECORD_SCHEMA, "kind": "uffd-serve",
+            "run_id": RUN_ID, "pid": cls.SERVE_PID,
+            "pid_start_time_ticks": 300, "state_path": "state/serve.json",
+            "uffd_mode": "copy", "snapshot_tag": snapshot["tag"],
+            "snapshot_generation_id": cls.GENERATION,
+            "snapshot_config_sha256": cls.CONFIG_SHA,
+        }
+        cls._write_json(os.path.join(directory, "schedule.json"), schedule)
+        cls._write_json(os.path.join(directory, "provenance.json"), provenance)
+        cls._write_json(os.path.join(directory, "status.json"), status)
+        cls._write_json(os.path.join(directory, "host-control-warmup.json"), warmup)
+        cls._write_json(os.path.join(directory, "uffd-serve.json"), serve)
+        cls._write_jsonl(os.path.join(directory, "bursts.jsonl"), summaries)
+        cls._write_jsonl(os.path.join(directory, "requests.jsonl"), requests)
+        cls._write_jsonl(os.path.join(directory, "host-control.jsonl"), controls)
+        cls._write_jsonl(os.path.join(directory, "host-samples.jsonl"), samples)
+
+    def test_complete_raw_fixture_is_publishable_and_reportable(self):
+        with tempfile.TemporaryDirectory() as d, mock.patch.object(
+            reqscale_analyze, "BOOTSTRAP_DRAWS", 1000
+        ):
+            self.build_run(d)
+            analysis = reqscale_analyze.analyze(d)
+            self.assertTrue(analysis["publishable"])
+            self.assertEqual(
+                analysis["capacity"]["joint_highest_contiguous_passing_rate_per_second"],
+                0.8,
+            )
+            report = reqscale_analyze.markdown_report(analysis)
+            self.assertIn("Firecracker VMAs", report)
+            self.assertIn("0.8", report)
+
+
+class TracePerturbationIsAGate(unittest.TestCase):
+    def pair(self, control_ms, traced_ms, pair_id="p0"):
+        common = dict(
+            trace_pair_id=pair_id, target_rps=4.0,
+            request_plan_count=40, request_plan_sha256="a" * 64,
+            total_artifact_completed=40, total_drained=40,
+            total_cleanup_confirmed=40, failed=0,
+        )
+        cells = lambda value: {
+            backend: {"artifact_latency_ms": {"median": value}}
+            for backend in ("file", "uffd")
+        }
+        return [
+            dict(common, traced=False, backends=cells(control_ms)),
+            dict(common, traced=True, backends=cells(traced_ms)),
+        ]
+
+    def test_a_declared_limit_is_applied_to_each_matched_pair(self):
+        verdict = reqscale.evaluate_trace_perturbation(self.pair(100.0, 103.0), 5.0)
+        self.assertTrue(verdict["passed"])
+        self.assertEqual(len(verdict["pairs"]), 2)
+        self.assertAlmostEqual(verdict["pairs"][0]["median_delta_pct"], 3.0)
+
+    def test_excess_perturbation_and_missing_controls_block_publication(self):
+        with self.assertRaisesRegex(reqscale.MeasurementInvalid, "perturbation"):
+            reqscale.evaluate_trace_perturbation(self.pair(100.0, 108.0), 5.0)
+        with self.assertRaisesRegex(reqscale.MeasurementInvalid, "matched"):
+            reqscale.evaluate_trace_perturbation(self.pair(100.0, 103.0)[:1], 5.0)
+
+
+class FaultTraceIsJoinable(unittest.TestCase):
+    def trace_lines(self):
+        return [
+            json.dumps({"type": "attached_probes", "data": {"probes": 4}}),
+            json.dumps({"type": "printf", "data": "REQSCALE_TRACE_READY\\n"}),
+            json.dumps({"type": "map", "data": {"@opened": {"200": 1}}}),
+            json.dumps({"type": "map", "data": {"@closed": {"200": 1}}}),
+            json.dumps({"type": "map", "data": {"@entered": {"200": 3}}}),
+            json.dumps({"type": "map", "data": {"@completed": {"200": 3}}}),
+            json.dumps({"type": "map", "data": {"@total_ns": {"200": 90}}}),
+            json.dumps({"type": "hist", "data": {
+                "@latency_ns": {"200": [
+                    {"min": 16, "max": 31, "count": 1},
+                    {"min": 32, "max": 63, "count": 2},
+                ]}
+            }}),
+        ]
+
+    def test_count_total_and_histogram_join_to_the_exact_firecracker(self):
+        parsed = reqscale.parse_fault_trace(self.trace_lines())
+        rows = [{
+            "request_id": "r0",
+            "firecracker_process_faults_ready_to_artifact": {
+                "pid": 200, "pid_start_time_ticks": 500,
+            },
+        }]
+        reqscale.join_fault_trace(rows, parsed)
+        metric = rows[0]["firecracker_process_handle_mm_fault_ready_to_artifact"]
+        self.assertEqual(metric["count"], 3)
+        self.assertEqual(metric["total_ns"], 90)
+        self.assertEqual(
+            sum(bucket["count"] for bucket in metric["histogram"]),
+            3,
+        )
+        self.assertIn("not filtered to guest RAM", metric["scope"])
+
+    def test_zero_fault_interval_is_a_complete_measurement(self):
+        parsed = reqscale.parse_fault_trace([
+            json.dumps({"type": "printf", "data": "REQSCALE_TRACE_READY\\n"}),
+            json.dumps({"type": "map", "data": {"@opened": {"200": 1}}}),
+            json.dumps({"type": "map", "data": {"@closed": {"200": 1}}}),
+        ])
+        self.assertEqual(
+            parsed["processes"][200],
+            {"count": 0, "total_ns": 0, "histogram": []},
+        )
+
+    def test_readiness_requires_the_exact_json_printf_event(self):
+        self.assertTrue(reqscale._is_trace_ready_line(json.dumps({
+            "type": "printf", "data": "REQSCALE_TRACE_READY\\n",
+        })))
+        self.assertFalse(reqscale._is_trace_ready_line(json.dumps({
+            "type": "log", "data": "mentions REQSCALE_TRACE_READY but is not readiness",
+        })))
+        self.assertFalse(reqscale._is_trace_ready_line("REQSCALE_TRACE_READY"))
+
+    def test_incomplete_probes_or_pid_reuse_fail_closed(self):
+        lines = self.trace_lines()
+        lines[5] = json.dumps({"type": "map", "data": {"@completed": {"200": 2}}})
+        with self.assertRaisesRegex(reqscale.MeasurementInvalid, "entered"):
+            reqscale.parse_fault_trace(lines)
+
+        parsed = reqscale.parse_fault_trace(self.trace_lines())
+        rows = [
+            {"request_id": "r0", "firecracker_process_faults_ready_to_artifact": {
+                "pid": 200, "pid_start_time_ticks": 500}},
+            {"request_id": "r1", "firecracker_process_faults_ready_to_artifact": {
+                "pid": 200, "pid_start_time_ticks": 501}},
+        ]
+        with self.assertRaisesRegex(reqscale.MeasurementInvalid, "reused"):
+            reqscale.join_fault_trace(rows, parsed)
+
+    def test_a_successful_request_missing_from_the_trace_is_invalid(self):
+        parsed = reqscale.parse_fault_trace(self.trace_lines())
+        rows = [{
+            "request_id": "r0", "ok": True,
+            "firecracker_process_faults_ready_to_artifact": {
+                "pid": 201, "pid_start_time_ticks": 600,
+            },
+        }]
+        with self.assertRaisesRegex(reqscale.MeasurementInvalid, "no handle_mm_fault"):
+            reqscale.join_fault_trace(rows, parsed)
+
+    def test_an_unjoined_trace_process_is_invalid(self):
+        parsed = reqscale.parse_fault_trace(self.trace_lines())
+        with self.assertRaisesRegex(reqscale.MeasurementInvalid, "no exact request"):
+            reqscale.join_fault_trace([], parsed)
+
+    def test_trace_json_rejects_duplicate_keys_and_nonstandard_constants(self):
+        lines = self.trace_lines()
+        lines.append('{"type":"map","type":"hist","data":{}}')
+        with self.assertRaisesRegex(reqscale.MeasurementInvalid, "duplicate"):
+            reqscale.parse_fault_trace(lines)
+        with self.assertRaisesRegex(reqscale.MeasurementInvalid, "non-standard"):
+            reqscale.parse_fault_trace(["{\"value\":NaN}"])
+
+    def test_analyzer_reconstructs_joined_fault_metrics_from_raw_bpftrace(self):
+        spec = reqscale.BurstSpec(
+            burst_id="b-traced", block_id="trace-on",
+            population="trace-perturbation", target_rps=1.0, repeat=0,
+            seed=1, traced=True, trace_pair_id="trace:0",
+            ramp_seconds=0.0, score_seconds=1.0,
+            requests=(reqscale.RequestPlan(0, 0, "score", "file", 0, 1),),
+        )
+        row = {
+            "request_id": "request-0", "ok": True,
+            "firecracker_process_faults_ready_to_artifact": {
+                "pid": 200, "pid_start_time_ticks": 500,
+            },
+        }
+        reqscale.join_fault_trace([row], reqscale.parse_fault_trace(self.trace_lines()))
+        with tempfile.TemporaryDirectory() as d:
+            trace_dir = os.path.join(d, "fault-trace")
+            os.mkdir(trace_dir)
+            paths = {
+                "raw": os.path.join(trace_dir, "b-traced.bpftrace.jsonl"),
+                "stderr": os.path.join(trace_dir, "b-traced.bpftrace.stderr"),
+                "program": os.path.join(trace_dir, "b-traced.faulttrace.bt"),
+            }
+            with open(paths["raw"], "w") as stream:
+                stream.write("\n".join(self.trace_lines()) + "\n")
+            with open(paths["stderr"], "w") as stream:
+                stream.write("")
+            with open(paths["program"], "w") as stream:
+                stream.write("test program\n")
+            artifacts = {
+                name: {
+                    "path": os.path.relpath(path, d),
+                    "sha256": reqscale.sha256_file(path),
+                    "bytes": os.stat(path).st_size,
+                }
+                for name, path in paths.items()
+            }
+            summary = {
+                "burst_id": spec.burst_id,
+                "fault_trace": {
+                    "scope": (
+                        "Firecracker process endpoint-ready through artifact return; "
+                        "all VMAs, not guest-RAM-filtered and not UFFD events"
+                    ),
+                    "processes": 1,
+                    "artifacts": artifacts,
+                },
+            }
+            reqscale_analyze._validate_fault_trace_artifacts(
+                d, {"bursts": [spec.to_dict()]}, [summary], {spec.burst_id: [row]}
+            )
+            row["firecracker_process_handle_mm_fault_ready_to_artifact"]["count"] = 4
+            with self.assertRaisesRegex(reqscale_analyze.AnalysisInvalid, "differs from raw"):
+                reqscale_analyze._validate_fault_trace_artifacts(
+                    d,
+                    {"bursts": [spec.to_dict()]},
+                    [summary],
+                    {spec.burst_id: [row]},
+                )
+
+
+class ProvenanceFailsClosed(unittest.TestCase):
+    def make_snapshot(self, root):
+        snapshot_dir = os.path.join(root, "snapshots", "golden")
+        os.makedirs(snapshot_dir)
+        paths = {}
+        for field, name in (
+            ("memory_path", "memory.bin"),
+            ("vmstate_path", "vmstate.bin"),
+            ("disk_path", "disk.raw"),
+        ):
+            paths[field] = os.path.join(snapshot_dir, name)
+            with open(paths[field], "wb") as f:
+                f.write(field.encode())
+        config = {
+            "name": "golden", "vm_id": "vm-source",
+            "generation_id": "11111111-1111-4111-8111-111111111111",
+            "created_at": "2026-08-09T00:00:00Z", **paths,
+            "metadata": {
+                "image": "chromium:test", "vcpu": 2, "memory_mib": 1024,
+                "network_mode": "rootless", "port_mappings": ["9222:9222"],
+            },
+        }
+        config_path = os.path.join(snapshot_dir, "config.json")
+        with open(config_path, "w") as f:
+            json.dump(config, f)
+        return config_path, config
+
+    def test_snapshot_identity_covers_shape_config_and_exact_artifact_stats(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.make_snapshot(d)
+            identity = reqscale.snapshot_identity(d, "golden")
+            self.assertEqual(identity["vm_id"], "vm-source")
+            self.assertEqual(identity["shape"]["vcpu"], 2)
+            self.assertEqual(set(identity["files"]), {
+                "memory_path", "vmstate_path", "disk_path", "config",
+            })
+            self.assertRegex(identity["config_sha256"], r"^[0-9a-f]{64}$")
+            self.assertEqual(
+                identity["generation_id"], "11111111-1111-4111-8111-111111111111"
+            )
+
+    def test_missing_or_noncanonical_generation_id_is_rejected(self):
+        with tempfile.TemporaryDirectory() as d:
+            config_path, config = self.make_snapshot(d)
+            del config["generation_id"]
+            with open(config_path, "w") as f:
+                json.dump(config, f)
+            with self.assertRaisesRegex(reqscale.MeasurementInvalid, "generation_id"):
+                reqscale.snapshot_identity(d, "golden")
+
+    def test_duplicate_generation_id_is_rejected_instead_of_taking_the_last(self):
+        with tempfile.TemporaryDirectory() as d:
+            config_path, config = self.make_snapshot(d)
+            encoded = json.dumps(config)
+            encoded = encoded.replace(
+                '"generation_id":',
+                '"generation_id":"22222222-2222-4222-8222-222222222222",'
+                '"generation_id":',
+                1,
+            )
+            with open(config_path, "w") as stream:
+                stream.write(encoded)
+            with self.assertRaisesRegex(reqscale.MeasurementInvalid, "duplicate"):
+                reqscale.snapshot_identity(d, "golden")
+
+    def test_snapshot_artifact_outside_its_generation_directory_is_rejected(self):
+        with tempfile.TemporaryDirectory() as d:
+            config_path, config = self.make_snapshot(d)
+            outside = os.path.join(d, "outside-memory.bin")
+            with open(outside, "wb") as f:
+                f.write(b"outside")
+            config["memory_path"] = outside
+            with open(config_path, "w") as f:
+                json.dump(config, f)
+            with self.assertRaisesRegex(reqscale.MeasurementInvalid, "escapes"):
+                reqscale.snapshot_identity(d, "golden")
+
+    def test_generation_lease_blocks_tag_replacement_and_verifies_terminal_identity(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.make_snapshot(d)
+            lock_path = os.path.join(d, "snapshots", "golden.lock")
+            with reqscale.SnapshotGenerationLease(d, "golden") as lease:
+                self.assertEqual(lease.verify(), lease.identity)
+                contender = open(lock_path, "a+")
+                try:
+                    with self.assertRaises(BlockingIOError):
+                        reqscale.fcntl.flock(
+                            contender,
+                            reqscale.fcntl.LOCK_EX | reqscale.fcntl.LOCK_NB,
+                        )
+                finally:
+                    contender.close()
+
+    def test_unsafe_snapshot_tag_is_rejected_before_a_lock_path_is_opened(self):
+        with tempfile.TemporaryDirectory() as d:
+            os.mkdir(os.path.join(d, "snapshots"))
+            with self.assertRaisesRegex(ValueError, "snapshot tag"):
+                reqscale.SnapshotGenerationLease(d, "../escape")
+            self.assertFalse(os.path.exists(os.path.join(d, "escape.lock")))
+
+
+class DurableOutput(unittest.TestCase):
+    def test_schedule_is_exclusive_and_fsynced_before_records(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "schedule.json")
+            reqscale.write_json_exclusive(path, {"schema": "x", "windows": []})
+            with open(path) as f:
+                self.assertEqual(json.load(f)["schema"], "x")
+            with self.assertRaises(FileExistsError):
+                reqscale.write_json_exclusive(path, {"schema": "replacement"})
+
+    def test_jsonl_sink_never_appends_to_an_old_run(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "requests.jsonl")
+            with reqscale.JsonlSink(path) as sink:
+                sink.write({"record_id": "r0"})
+            with self.assertRaises(FileExistsError):
+                reqscale.JsonlSink(path)
+
+    def test_terminal_status_preserves_run_and_every_cleanup_failure(self):
+        class Audit:
+            def cpu_snapshot(self):
+                return {"usage_usec": 1}
+
+            def record(self):
+                return {"path": "/fake", "live_pids": [], "observed": []}
+
+        audit = Audit()
+
+        class Scope:
+            def __init__(self, *_args):
+                self.path = "/sys/fs/cgroup/fake"
+                self.paths = {
+                    name: f"/sys/fs/cgroup/fake/{name}"
+                    for name in ("driver", "control", "file", "uffd")
+                }
+
+            def enter(self):
+                return {
+                    name: audit for name in ("run", "driver", "control", "file", "uffd")
+                }
+
+            def leave(self):
+                raise reqscale.MeasurementInvalid("leave failed", {"left": False})
+
+        class Serve:
+            def __init__(self, *_args):
+                pass
+
+            def start(self):
+                raise reqscale.MeasurementInvalid("start failed")
+
+            def stop(self):
+                raise reqscale.MeasurementInvalid("stop failed")
+
+        class Sampler:
+            def __init__(self, *_args):
+                pass
+
+            def start(self):
+                pass
+
+            def stop(self):
+                return {"samples": 0}
+
+        class Lease:
+            def verify(self):
+                return {"generation_id": "11111111-1111-4111-8111-111111111111"}
+
+        with tempfile.TemporaryDirectory() as d, mock.patch.object(
+            reqscale, "RunCgroups", Scope
+        ), mock.patch.object(reqscale, "UffdServe", Serve), mock.patch.object(
+            reqscale, "HostSampler", Sampler
+        ), mock.patch.object(
+            reqscale,
+            "read_machine_proc_stat",
+            return_value={"cpu": {"user": 1}, "raw": "cpu 1\n"},
+        ):
+            args = SimpleNamespace(
+                out_dir=os.path.join(d, "run"), run_id=RUN_ID,
+                cgroup_root="/sys/fs/cgroup", trace_faults=False,
+                snapshot_generation_lease=Lease(),
+            )
+            with redirect_stderr(io.StringIO()):
+                rc = reqscale.execute(
+                    args,
+                    {
+                        "run_id": RUN_ID, "bursts": [],
+                        "host_sample_interval_ns": 5_000_000_000,
+                        "control": {},
+                    },
+                    {"schema": "test"},
+                )
+            self.assertEqual(rc, 4)
+            with open(os.path.join(args.out_dir, "status.json")) as f:
+                status = json.load(f)
+            self.assertFalse(status["valid"])
+            self.assertEqual(
+                [row["phase"] for row in status["errors"]],
+                ["run", "serve-stop", "cgroup-leave"],
+            )
+            self.assertEqual(status["errors"][2]["details"], {"left": False})
+
+
+class PlanOnlyCli(unittest.TestCase):
+    SCRIPT = os.path.join(HERE, "reqscale.py")
+
+    @staticmethod
+    def criteria_args():
+        return [
+            "--max-offered-rps-error-pct", "1",
+            "--min-departure-ratio", "0.95",
+            "--max-score-end-backlog", "8",
+            "--max-p95-launch-lag-ms", "25",
+            "--max-control-median-drift-pct", "10",
+        ]
+
+    def test_plan_only_writes_the_complete_schedule_without_touching_a_vm(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "plan")
+            result = subprocess.run(
+                [
+                    sys.executable, self.SCRIPT,
+                    "--snapshot-tag", "not-opened-in-plan-mode",
+                    "--url", "http://127.0.0.1:8000/medium.html",
+                    "--rates", "2,4", "--bursts", "5",
+                    "--seed", "776", "--run-id", RUN_ID,
+                    "--out-dir", out, "--plan-only",
+                    *self.criteria_args(),
+                ],
+                capture_output=True, text=True, timeout=30,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            with open(os.path.join(out, "schedule.json")) as f:
+                schedule = json.load(f)
+            self.assertEqual(schedule["schema"], reqscale.SCHEDULE_SCHEMA)
+            self.assertEqual(len(schedule["bursts"]), 12)
+            self.assertEqual(schedule["ramp_seconds"], 15.0)
+            self.assertEqual(schedule["score_seconds"], 60.0)
+            self.assertFalse(os.path.exists(os.path.join(out, "requests.jsonl")))
+
+    def test_tracing_without_a_predeclared_perturbation_limit_is_rejected(self):
+        with tempfile.TemporaryDirectory() as d:
+            result = subprocess.run(
+                [
+                    sys.executable, self.SCRIPT,
+                    "--snapshot-tag", "x", "--url", "http://x/",
+                    "--rates", "2", "--bursts", "5",
+                    "--seed", "776", "--run-id", RUN_ID,
+                    "--out-dir", os.path.join(d, "out"),
+                    "--trace-faults", "--trace-rate", "2", "--trace-pairs", "3",
+                    "--plan-only",
+                    *self.criteria_args(),
+                ],
+                capture_output=True, text=True, timeout=30,
+            )
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("max-trace-perturbation-pct", result.stderr)
+            self.assertFalse(os.path.exists(os.path.join(d, "out")))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/bench/chromium/test_reqscale.py
+++ b/bench/chromium/test_reqscale.py
@@ -733,6 +733,44 @@ print(child.pid, flush=True)
                 finally:
                     os.close(pidfd)
 
+    def test_guardsupervise_sweeps_the_cgroup_when_the_child_exits_normally(self):
+        """A child exiting says nothing about the hops it spawned.
+
+        Chromium's zygote, utility and crash-handler processes cannot arm
+        PR_SET_PDEATHSIG, which is the whole reason this wrapper owns a cgroup. If
+        cleanup only ran from the signal handler, a normal exit would leave them
+        running while the harness treated the request as finished.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            cgroup_procs = os.path.join(tmp, "cgroup.procs")
+            # A cgroup v2 directory always carries cgroup.kill; the wrapper uses its
+            # presence to tell a real cgroup from an ordinary directory.
+            open(os.path.join(tmp, "cgroup.kill"), "w").close()
+            # The wrapper writes its child's pid here on startup, and nothing removes
+            # it from an ordinary file, so this stands in for a member that outlives
+            # the child.
+            open(cgroup_procs, "w").close()
+
+            done = subprocess.run(
+                [
+                    sys.executable,
+                    reqscale.GUARDSUPERVISE,
+                    "--expected-parent", str(os.getpid()),
+                    "--cgroup-procs", cgroup_procs,
+                    "--", sys.executable, "-c", "raise SystemExit(0)",
+                ],
+                capture_output=True, text=True, timeout=30,
+            )
+            self.assertEqual(
+                done.returncode, 126,
+                "a cgroup that will not empty must fail the request, not report the "
+                f"child's own status: {done.stderr}",
+            )
+            self.assertRegex(
+                done.stderr, r"process\(es\) still in .* after cgroup\.kill: \['\d+'\]",
+                "the survivors must be named so they can be chased",
+            )
+
     def test_guardsupervise_terminates_the_third_party_process_group(self):
         with tempfile.TemporaryDirectory() as d:
             cgroup_procs = os.path.join(d, "cgroup.procs")
@@ -754,19 +792,35 @@ print(child.pid, flush=True)
                 stderr=subprocess.PIPE,
                 text=True,
             )
-            target_pid = int(supervisor.stdout.readline().strip())
-            target_pidfd = reqscale.reqbench.pidfd_open(target_pid)
-            supervisor.send_signal(15)
-            self.assertEqual(supervisor.wait(timeout=5), 0, supervisor.stderr.read())
-            if target_pidfd is not None:
-                try:
-                    poller = select.poll()
-                    poller.register(target_pidfd, select.POLLIN)
-                    self.assertTrue(
-                        poller.poll(2000), "supervised process survived supervisor shutdown"
-                    )
-                finally:
-                    os.close(target_pidfd)
+            try:
+                # A target that never prints its pid would otherwise block the whole
+                # suite here, with a 30 second child still running behind it.
+                handshake = select.poll()
+                handshake.register(supervisor.stdout, select.POLLIN)
+                self.assertTrue(
+                    handshake.poll(10_000),
+                    "supervisor did not report the target pid within 10s",
+                )
+                target_pid = int(supervisor.stdout.readline().strip())
+                target_pidfd = reqscale.reqbench.pidfd_open(target_pid)
+                supervisor.send_signal(15)
+                self.assertEqual(supervisor.wait(timeout=5), 0, supervisor.stderr.read())
+                if target_pidfd is not None:
+                    try:
+                        poller = select.poll()
+                        poller.register(target_pidfd, select.POLLIN)
+                        self.assertTrue(
+                            poller.poll(2000), "supervised process survived supervisor shutdown"
+                        )
+                    finally:
+                        os.close(target_pidfd)
+            finally:
+                # Any failure above leaks the supervisor and its 30 second target.
+                if supervisor.poll() is None:
+                    supervisor.kill()
+                    supervisor.wait(timeout=5)
+                supervisor.stdout.close()
+                supervisor.stderr.close()
 
     def test_tracer_abort_kills_waits_and_closes_all_streams(self):
         class Process:

--- a/bench/chromium/test_reqscale.py
+++ b/bench/chromium/test_reqscale.py
@@ -746,10 +746,15 @@ print(child.pid, flush=True)
             # A cgroup v2 directory always carries cgroup.kill; the wrapper uses its
             # presence to tell a real cgroup from an ordinary directory.
             open(os.path.join(tmp, "cgroup.kill"), "w").close()
-            # The wrapper writes its child's pid here on startup, and nothing removes
-            # it from an ordinary file, so this stands in for a member that outlives
-            # the child.
-            open(cgroup_procs, "w").close()
+            # A THIRD-PARTY survivor, not the supervisor's own enrollment: the wrapper
+            # writes its own pid here at startup, and in a real cgroup `cgroup.kill`
+            # would take that process too, so asserting on it would not distinguish
+            # "a child outlived the browser" from "the supervisor enrolled itself".
+            survivor = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+            self.addCleanup(survivor.wait)
+            self.addCleanup(survivor.kill)
+            with open(cgroup_procs, "w") as handle:
+                handle.write(f"{survivor.pid}\n")
 
             done = subprocess.run(
                 [
@@ -766,9 +771,9 @@ print(child.pid, flush=True)
                 "a cgroup that will not empty must fail the request, not report the "
                 f"child's own status: {done.stderr}",
             )
-            self.assertRegex(
-                done.stderr, r"process\(es\) still in .* after cgroup\.kill: \['\d+'\]",
-                "the survivors must be named so they can be chased",
+            self.assertIn(
+                str(survivor.pid), done.stderr,
+                "the third-party survivor must be named so it can be chased",
             )
 
     def test_guardsupervise_terminates_the_third_party_process_group(self):

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -838,9 +838,40 @@ impl CleanupFailures {
 }
 
 /// How long teardown waits for the health monitor to observe its cancellation before
-/// moving on. It only writes state through the per-VM flock, which `delete_state` takes
-/// too, so an unjoined straggler is safe — this is a courtesy join, not a barrier.
+/// aborting it. Cleanup must then await the abort before tearing down network resources:
+/// dropping a live `JoinHandle` detaches its task, which could otherwise keep using the
+/// network namespace after cleanup has begun destroying it.
 const HEALTH_MONITOR_STOP_BUDGET: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// Stop and reap the exact health-monitor task before resource teardown continues.
+///
+/// The timeout borrows the handle. If graceful cancellation misses its budget, ownership
+/// therefore remains here so the task can be aborted and awaited; moving the handle directly
+/// into a `select!` arm would drop and detach it when the timeout arm wins.
+async fn stop_health_monitor(mut handle: JoinHandle<()>) {
+    match tokio::time::timeout(HEALTH_MONITOR_STOP_BUDGET, &mut handle).await {
+        Ok(Ok(())) => debug!("health monitor stopped gracefully"),
+        Ok(Err(error)) => {
+            warn!(?error, "health monitor task failed while stopping");
+        }
+        Err(_) => {
+            debug!(
+                budget_ms = HEALTH_MONITOR_STOP_BUDGET.as_millis(),
+                "health monitor didn't stop in time; aborting it"
+            );
+            handle.abort();
+            match handle.await {
+                Ok(()) => debug!("health monitor completed while its abort was being delivered"),
+                Err(error) if error.is_cancelled() => {
+                    debug!("health monitor aborted and reaped");
+                }
+                Err(error) => {
+                    warn!(?error, "health monitor task failed while being aborted");
+                }
+            }
+        }
+    }
+}
 
 /// Total CPU charged to this process's REAPED children so far (`RUSAGE_CHILDREN`).
 ///
@@ -1046,32 +1077,13 @@ async fn cleanup_vm_inner(
         Ok::<(), anyhow::Error>(())
     };
     let health_stopped = async {
-        let Some(mut handle) = health_monitor_handle else {
-            return Ok::<(), anyhow::Error>(());
-        };
-        tokio::select! {
-            result = &mut handle => {
-                match result {
-                    Ok(()) => debug!("health monitor stopped gracefully"),
-                    Err(error) if error.is_cancelled() => {}
-                    Err(error) => return Err(error).context("joining health monitor"),
-                }
-            }
-            _ = tokio::time::sleep(HEALTH_MONITOR_STOP_BUDGET) => {
-                if verified {
-                    handle.abort();
-                    match handle.await {
-                        Ok(()) => {}
-                        Err(error) if error.is_cancelled() => {}
-                        Err(error) => return Err(error).context("joining aborted health monitor"),
-                    }
-                    debug!("health monitor didn't stop in time; aborted and joined it");
-                } else {
-                    debug!("health monitor didn't stop in time, continuing cleanup");
-                }
-            }
+        // Unconditional abort-and-reap: dropping a live JoinHandle detaches its
+        // task, which could keep using the network namespace after cleanup has
+        // begun destroying it — on the fast path as much as the verified one.
+        if let Some(handle) = health_monitor_handle {
+            stop_health_monitor(handle).await;
         }
-        Ok(())
+        Ok::<(), anyhow::Error>(())
     };
     let listeners_stopped = async {
         let mut errors = Vec::new();
@@ -3505,6 +3517,61 @@ mod tests {
         verify_process_reaped("test", Some((pid, start + 1)))
             .expect("a reused PID with a different start time is not the owned process");
         verify_process_reaped("test", None).expect("an unstarted process owns no resource");
+    }
+
+    /// A health monitor that ignores cooperative cancellation must still be gone before the
+    /// stop barrier returns. Before the fix, the timeout branch dropped its `JoinHandle`,
+    /// detaching the task; this test then observed `dropped == false`.
+    #[tokio::test(start_paused = true)]
+    async fn health_monitor_timeout_aborts_and_reaps_task() {
+        struct DropOracle(std::sync::Arc<std::sync::atomic::AtomicBool>);
+
+        impl Drop for DropOracle {
+            fn drop(&mut self) {
+                self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let ignored_cancel = cancel.clone();
+        let dropped = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let task_dropped = std::sync::Arc::clone(&dropped);
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let health_monitor = tokio::spawn(async move {
+            let _drop_oracle = DropOracle(task_dropped);
+            let _ignored_cancel = ignored_cancel;
+            started_tx.send(()).unwrap();
+            // Deliberately ignore graceful cancellation forever. Tokio abort must destroy
+            // this future, and awaiting its JoinHandle must observe that destruction.
+            std::future::pending::<()>().await;
+        });
+        started_rx.await.unwrap();
+        cancel.cancel();
+
+        let stopper = tokio::spawn(stop_health_monitor(health_monitor));
+        tokio::task::yield_now().await;
+        assert!(
+            !stopper.is_finished(),
+            "the graceful-stop budget must be honored"
+        );
+
+        tokio::time::advance(HEALTH_MONITOR_STOP_BUDGET - std::time::Duration::from_millis(1))
+            .await;
+        tokio::task::yield_now().await;
+        assert!(
+            !dropped.load(std::sync::atomic::Ordering::SeqCst),
+            "the monitor must not be aborted before its graceful-stop budget"
+        );
+
+        tokio::time::advance(std::time::Duration::from_millis(1)).await;
+        tokio::time::timeout(std::time::Duration::from_secs(1), stopper)
+            .await
+            .expect("health-monitor stop remained blocked after abort")
+            .expect("health-monitor stopper task panicked");
+        assert!(
+            dropped.load(std::sync::atomic::Ordering::SeqCst),
+            "the timed-out health-monitor future must be dropped before the stop barrier returns"
+        );
     }
 
     /// Regression guard for the deaf-clone bug: a snapshot taken from a restored

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -981,7 +981,7 @@ pub async fn cleanup_vm(
     // Normal runs intentionally retain their best-effort teardown contract.  Prepare calls
     // `cleanup_vm_verified` so it can fail closed instead of reporting a durable artifact
     // while host resources remain.
-    let _ = cleanup_vm_inner(ctx, vm_manager, holder_child, network, state_manager, false).await;
+    let _ = cleanup_vm_inner(ctx, vm_manager, holder_child, network, state_manager).await;
 }
 
 /// Tear down every VM resource and return an error if any cleanup action failed.
@@ -996,7 +996,7 @@ pub async fn cleanup_vm_verified(
     network: &mut dyn NetworkManager,
     state_manager: &StateManager,
 ) -> Result<()> {
-    cleanup_vm_inner(ctx, vm_manager, holder_child, network, state_manager, true).await
+    cleanup_vm_inner(ctx, vm_manager, holder_child, network, state_manager).await
 }
 
 async fn cleanup_vm_inner(
@@ -1005,7 +1005,6 @@ async fn cleanup_vm_inner(
     holder_child: &mut Option<tokio::process::Child>,
     network: &mut dyn NetworkManager,
     state_manager: &StateManager,
-    verified: bool,
 ) -> Result<()> {
     let CleanupContext {
         vm_id,

--- a/src/uffd/server.rs
+++ b/src/uffd/server.rs
@@ -1115,6 +1115,88 @@ async fn wait_for_peer_vmm_exit(
     Ok(())
 }
 
+/// Per-fault trace, enabled only by `FCVM_UFFD_FAULT_TRACE=<dir>`.
+///
+/// Records `(guest_file_offset, ns_before_resolve, ns_after_resolve)` for every fault this
+/// handler serves and writes them to `<dir>/<serve_pid>-<vm_id>.faults` as little-endian u64
+/// triples when the handler exits. The offset is into the snapshot memory file, NOT a host
+/// virtual address: host addresses differ per clone, so only the file offset can be compared
+/// between clones of the same snapshot.
+///
+/// This is what `bench/chromium/faultbench.py` collects and `faultanalyze.py` reduces; it is
+/// the instrument behind the fault-count, cross-clone Jaccard and sequentiality figures the
+/// `working_set` module cites.
+///
+/// It is a measurement facility, not part of serving: it costs one `Vec::push` and two
+/// `Instant::elapsed()` calls per fault, and is entirely inert unless the env var is set.
+/// The flush lives in `Drop` so that every handler exit path — clean VM exit, `VmGone`
+/// mid-CONTINUE, or an error return — writes the trace.
+struct FaultTrace {
+    path: PathBuf,
+    origin: std::time::Instant,
+    records: Vec<[u64; 3]>,
+}
+
+impl FaultTrace {
+    fn from_env(vm_id: &str, origin: std::time::Instant) -> Option<Self> {
+        let dir = PathBuf::from(std::env::var(FAULT_TRACE_ENV).ok()?);
+        if let Err(e) = std::fs::create_dir_all(&dir) {
+            warn!(
+                target: "uffd",
+                dir = %dir.display(),
+                error = %e,
+                "FCVM_UFFD_FAULT_TRACE directory not usable - fault tracing disabled"
+            );
+            return None;
+        }
+        Some(Self {
+            path: dir.join(format!("{}-{}.faults", std::process::id(), vm_id)),
+            origin,
+            // 2GiB of 4KiB granules is 512Ki faults worst case; start big enough that
+            // the hot path does not reallocate for a typical restore working set.
+            records: Vec::with_capacity(1 << 16),
+        })
+    }
+
+    #[inline]
+    fn now_ns(&self) -> u64 {
+        self.origin.elapsed().as_nanos() as u64
+    }
+
+    #[inline]
+    fn record(&mut self, file_offset: u64, before_ns: u64, after_ns: u64) {
+        self.records.push([file_offset, before_ns, after_ns]);
+    }
+}
+
+impl Drop for FaultTrace {
+    fn drop(&mut self) {
+        let mut buf = Vec::with_capacity(self.records.len() * 24);
+        for rec in &self.records {
+            for v in rec {
+                buf.extend_from_slice(&v.to_le_bytes());
+            }
+        }
+        match std::fs::write(&self.path, &buf) {
+            Ok(()) => info!(
+                target: "uffd",
+                path = %self.path.display(),
+                faults = self.records.len(),
+                "wrote UFFD fault trace"
+            ),
+            Err(e) => warn!(
+                target: "uffd",
+                path = %self.path.display(),
+                error = %e,
+                "failed to write UFFD fault trace"
+            ),
+        }
+    }
+}
+
+/// Record every served fault into `<dir>` as a binary trace. Unset means no tracing.
+pub const FAULT_TRACE_ENV: &str = "FCVM_UFFD_FAULT_TRACE";
+
 struct VmContext<'a> {
     vm_id: &'a str,
     mappings: &'a [GuestRegionUffdMapping],
@@ -1129,6 +1211,8 @@ struct VmState {
     pending_continues: std::collections::BTreeMap<usize, std::time::Instant>,
     recorded: Option<PageSet>,
     started: std::time::Instant,
+    /// `Some` only under `FCVM_UFFD_FAULT_TRACE`; see [`FaultTrace`].
+    trace: Option<FaultTrace>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1229,11 +1313,13 @@ async fn handle_vm_page_faults(
         page_mask,
         mem_size,
     };
+    let started = std::time::Instant::now();
     let mut state = VmState {
         fault_count: 0,
         pending_continues: std::collections::BTreeMap::new(),
         recorded: working_set.as_deref().map(WorkingSetStore::recorder),
-        started: std::time::Instant::now(),
+        started,
+        trace: FaultTrace::from_env(&vm_id, started),
     };
 
     let result = replay_then_serve(
@@ -1564,6 +1650,10 @@ fn drain_events(uffd: &Uffd, ctx: &VmContext<'_>, state: &mut VmState) -> Result
                         recorder.insert_range(offset_in_file as u64, page_size as u64);
                     }
 
+                    // Stamped before the resolve so each trace record brackets exactly the
+                    // ioctl that releases the faulting vCPU. Zero when tracing is off.
+                    let trace_t0 = state.trace.as_ref().map(FaultTrace::now_ns).unwrap_or(0);
+
                     let mmap = match source {
                         PageSource::Minor { .. } => {
                             // MINOR mode: the page is already in the page cache of the shared
@@ -1605,6 +1695,10 @@ fn drain_events(uffd: &Uffd, ctx: &VmContext<'_>, state: &mut VmState) -> Result
                                         .or_insert_with(std::time::Instant::now);
                                 }
                             }
+                            if let Some(t) = state.trace.as_mut() {
+                                let t1 = t.now_ns();
+                                t.record(offset_in_file as u64, trace_t0, t1);
+                            }
                             continue;
                         }
                         PageSource::Copy { mmap } => mmap,
@@ -1642,6 +1736,10 @@ fn drain_events(uffd: &Uffd, ctx: &VmContext<'_>, state: &mut VmState) -> Result
                                 "UFFD zero-page copy failed"
                             );
                             return Err(e.into());
+                        }
+                        if let Some(t) = state.trace.as_mut() {
+                            let t1 = t.now_ns();
+                            t.record(offset_in_file as u64, trace_t0, t1);
                         }
                         continue;
                     }
@@ -1689,6 +1787,10 @@ fn drain_events(uffd: &Uffd, ctx: &VmContext<'_>, state: &mut VmState) -> Result
                                     fault_addr = format!("0x{:x}", fault_page),
                                     "UFFD copy skipped - page already filled (EEXIST)"
                                 );
+                                if let Some(t) = state.trace.as_mut() {
+                                    let t1 = t.now_ns();
+                                    t.record(offset_in_file as u64, trace_t0, t1);
+                                }
                                 continue;
                             }
                         }
@@ -1717,6 +1819,11 @@ fn drain_events(uffd: &Uffd, ctx: &VmContext<'_>, state: &mut VmState) -> Result
                             "UFFD copy failed"
                         );
                         return Err(e.into());
+                    }
+
+                    if let Some(t) = state.trace.as_mut() {
+                        let t1 = t.now_ns();
+                        t.record(offset_in_file as u64, trace_t0, t1);
                     }
                 }
                 Event::Remove { start, end } => {
@@ -2268,6 +2375,41 @@ pub fn preflight_clone_hugepages(memory_mib: usize) -> Result<()> {
 mod tests {
     use super::*;
     use nix::fcntl::{Flock, FlockArg};
+
+    /// The fault trace is only useful if `faultanalyze.py` can read it, and that reader is
+    /// hardcoded to `struct.unpack_from("<QQQ", data, i * 24)`. Encoding drift here would not
+    /// fail anything — it would silently reinterpret offsets as timestamps and yield a
+    /// confident wrong answer, so the layout is pinned against the exact reader.
+    #[test]
+    fn fault_trace_writes_the_little_endian_triples_faultanalyze_reads() {
+        const RECORD_BYTES: usize = 24;
+        let dir = tempfile::tempdir().expect("create trace directory");
+        let path = dir.path().join("trace.faults");
+
+        let mut trace = FaultTrace {
+            path: path.clone(),
+            origin: std::time::Instant::now(),
+            records: Vec::new(),
+        };
+        trace.record(0x1000, 10, 20);
+        trace.record(u64::MAX, 0, u64::MAX);
+        drop(trace);
+
+        let raw = std::fs::read(&path).expect("trace file written on drop");
+        assert_eq!(raw.len(), 2 * RECORD_BYTES, "one 24-byte triple per fault");
+
+        // Decode exactly as faultanalyze.py does.
+        let decoded: Vec<[u64; 3]> = raw
+            .chunks_exact(RECORD_BYTES)
+            .map(|rec| {
+                let field = |i: usize| {
+                    u64::from_le_bytes(rec[i * 8..i * 8 + 8].try_into().expect("8-byte field"))
+                };
+                [field(0), field(1), field(2)]
+            })
+            .collect();
+        assert_eq!(decoded, vec![[0x1000, 10, 20], [u64::MAX, 0, u64::MAX]]);
+    }
 
     /// A full demand batch means events remain queued. Speculative replay must not issue an
     /// ioctl until those faults have had another bounded drain turn.

--- a/src/uffd/server.rs
+++ b/src/uffd/server.rs
@@ -1206,13 +1206,47 @@ struct VmContext<'a> {
     mem_size: usize,
 }
 
+/// A fault whose `UFFDIO_CONTINUE` returned EAGAIN and is waiting for a retry.
+struct PendingContinue {
+    parked_at: std::time::Instant,
+    /// `(file_offset, t0_ns)` for the trace interval this fault opened, carried so the
+    /// retry that actually releases the vCPU is what closes it. Closing it around the
+    /// FAILED ioctl instead would report the EAGAIN as the fault's resolution cost, and
+    /// `faultanalyze.py` reads these intervals as exact ioctl service time.
+    /// `None` when tracing is off.
+    trace: Option<(u64, u64)>,
+}
+
 struct VmState {
     fault_count: u64,
-    pending_continues: std::collections::BTreeMap<usize, std::time::Instant>,
+    pending_continues: std::collections::BTreeMap<usize, PendingContinue>,
     recorded: Option<PageSet>,
     started: std::time::Instant,
     /// `Some` only under `FCVM_UFFD_FAULT_TRACE`; see [`FaultTrace`].
     trace: Option<FaultTrace>,
+}
+
+impl VmState {
+    /// Park a fault whose CONTINUE returned EAGAIN, keeping the trace interval OPEN.
+    ///
+    /// A fault already parked keeps its original start: the vCPU has been blocked
+    /// since that first attempt, and that is the cost the trace is measuring.
+    fn park_continue(&mut self, page: usize, trace: Option<(u64, u64)>) {
+        self.pending_continues
+            .entry(page)
+            .or_insert(PendingContinue {
+                parked_at: std::time::Instant::now(),
+                trace,
+            });
+    }
+
+    /// Close a parked fault's trace interval at the retry that resolved it.
+    fn close_parked_trace(&mut self, trace: Option<(u64, u64)>) {
+        if let (Some((offset, t0)), Some(t)) = (trace, self.trace.as_mut()) {
+            let t1 = t.now_ns();
+            t.record(offset, t0, t1);
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1548,23 +1582,25 @@ fn log_clone_finished(ctx: &VmContext<'_>, state: &VmState, reason: &str) {
 
 fn retry_pending_continues(ctx: &VmContext<'_>, uffd: &Uffd, state: &mut VmState) -> Result<bool> {
     let mut resolved = Vec::new();
-    for (&page, parked_at) in &state.pending_continues {
+    for (&page, pending) in &state.pending_continues {
         match continue_page(uffd, ctx.vm_id, page, ctx.page_size)? {
-            ContinueOutcome::Resolved => resolved.push(page),
+            ContinueOutcome::Resolved => resolved.push((page, pending.trace)),
             ContinueOutcome::VmGone => return Ok(false),
-            ContinueOutcome::Retry if parked_at.elapsed() >= MAX_CONTINUE_WAIT => {
+            ContinueOutcome::Retry if pending.parked_at.elapsed() >= MAX_CONTINUE_WAIT => {
                 return Err(anyhow!(
                     "UFFDIO_CONTINUE at 0x{page:x} still EAGAIN after {:?}; refusing to drop \
                      a fault that would permanently hang a vCPU for vm {}",
-                    parked_at.elapsed(),
+                    pending.parked_at.elapsed(),
                     ctx.vm_id
                 ));
             }
             ContinueOutcome::Retry => {}
         }
     }
-    for page in resolved {
+    for (page, trace) in resolved {
         state.pending_continues.remove(&page);
+        // This retry is what released the vCPU, so it is what ends the interval.
+        state.close_parked_trace(trace);
     }
     Ok(true)
 }
@@ -1676,28 +1712,32 @@ fn drain_events(uffd: &Uffd, ctx: &VmContext<'_>, state: &mut VmState) -> Result
                                     fault_page
                                 ));
                             }
+                            let trace_start = state
+                                .trace
+                                .as_ref()
+                                .map(|_| (offset_in_file as u64, trace_t0));
                             match continue_page(uffd, vm_id, fault_page, page_size)? {
-                                ContinueOutcome::Resolved => {}
+                                ContinueOutcome::Resolved => {
+                                    if let Some(t) = state.trace.as_mut() {
+                                        let t1 = t.now_ns();
+                                        t.record(offset_in_file as u64, trace_t0, t1);
+                                    }
+                                }
                                 ContinueOutcome::VmGone => return Ok(DrainOutcome::VmExited),
                                 ContinueOutcome::Retry => {
                                     // mmap_changing is set and the event that raised it is
-                                    // somewhere in THIS queue. Don't spin here — park the
+                                    // somewhere in THIS queue. Don't spin here, park the
                                     // fault; the caller retries it right after the drain.
+                                    // The trace interval stays OPEN across the park: the
+                                    // vCPU is still blocked, and the retry is what frees it.
                                     debug!(
                                         target: "uffd",
                                         vm_id = %vm_id,
                                         fault_addr = format!("0x{:x}", fault_page),
                                         "UFFDIO_CONTINUE EAGAIN (mmap_changing) - parked for retry"
                                     );
-                                    state
-                                        .pending_continues
-                                        .entry(fault_page)
-                                        .or_insert_with(std::time::Instant::now);
+                                    state.park_continue(fault_page, trace_start);
                                 }
-                            }
-                            if let Some(t) = state.trace.as_mut() {
-                                let t1 = t.now_ns();
-                                t.record(offset_in_file as u64, trace_t0, t1);
                             }
                             continue;
                         }
@@ -2409,6 +2449,61 @@ mod tests {
             })
             .collect();
         assert_eq!(decoded, vec![[0x1000, 10, 20], [u64::MAX, 0, u64::MAX]]);
+    }
+
+    /// A fault parked on EAGAIN is still blocking its vCPU, so its trace interval must
+    /// end at the retry that resolved it. Closing it around the FAILED ioctl reports the
+    /// EAGAIN as the resolution cost, and faultanalyze.py reads these intervals as exact
+    /// ioctl service time, so every MINOR-mode mmap-changing event would understate it.
+    #[test]
+    fn a_parked_continue_is_timed_to_its_retry_not_to_the_eagain() {
+        const PAGE: usize = 0x4000;
+        const OFFSET: u64 = 0x8000;
+        const PARKED: std::time::Duration = std::time::Duration::from_millis(20);
+
+        let dir = tempfile::tempdir().expect("create trace directory");
+        let path = dir.path().join("parked.faults");
+        let origin = std::time::Instant::now();
+        let mut state = VmState {
+            fault_count: 0,
+            pending_continues: std::collections::BTreeMap::new(),
+            recorded: None,
+            started: origin,
+            trace: Some(FaultTrace {
+                path: path.clone(),
+                origin,
+                records: Vec::new(),
+            }),
+        };
+
+        let t0 = state.trace.as_ref().expect("trace").now_ns();
+        state.park_continue(PAGE, Some((OFFSET, t0)));
+        assert_eq!(
+            state.trace.as_ref().expect("trace").records.len(),
+            0,
+            "parking must not close the interval; the vCPU is still blocked"
+        );
+
+        // The vCPU stays blocked for as long as the fault is parked.
+        std::thread::sleep(PARKED);
+
+        let parked = state
+            .pending_continues
+            .remove(&PAGE)
+            .expect("the fault is parked");
+        state.close_parked_trace(parked.trace);
+
+        let recorded = state.trace.as_ref().expect("trace").records.clone();
+        assert_eq!(recorded.len(), 1, "one interval per resolved fault");
+        let [offset, start, end] = recorded[0];
+        assert_eq!(offset, OFFSET);
+        assert_eq!(start, t0, "the interval still starts at the first attempt");
+        let held_ms = (end - start) / 1_000_000;
+        assert!(
+            held_ms >= 15,
+            "the interval must span the park: {held_ms}ms recorded for a fault held \
+             {PARKED:?}, so the retry that freed the vCPU was not what closed it"
+        );
     }
 
     /// A full demand batch means events remain queued. Speculative replay must not issue an

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -783,6 +783,127 @@ pub fn install_namespace_pre_exec(
 mod tests {
     use super::*;
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn wait_for_stderr_eof_waits_for_delayed_bulk_output() {
+        use std::sync::{Arc, Mutex};
+        use tokio::io::AsyncWriteExt;
+
+        const BULK_LINES: usize = 512;
+        let (read_end, mut write_end) = tokio::io::duplex(256);
+        let captured = Arc::new(Mutex::new(Vec::<String>::new()));
+        let reader_captured = Arc::clone(&captured);
+        let reader = tokio::spawn(async move {
+            let mut lines = BufReader::new(read_end).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                reader_captured
+                    .lock()
+                    .expect("captured stderr mutex poisoned")
+                    .push(line);
+            }
+        });
+
+        let (bulk_written_tx, bulk_written_rx) = tokio::sync::oneshot::channel();
+        let (write_final_tx, write_final_rx) = tokio::sync::oneshot::channel();
+        let writer = tokio::spawn(async move {
+            for index in 0..BULK_LINES {
+                write_end
+                    .write_all(format!("bulk-{index}\n").as_bytes())
+                    .await
+                    .expect("writing bulk stderr");
+            }
+            bulk_written_tx
+                .send(())
+                .expect("bulk-write observer dropped");
+            write_final_rx.await.expect("final-line gate dropped");
+            write_end
+                .write_all(b"delayed-final\n")
+                .await
+                .expect("writing delayed final stderr");
+            write_end.shutdown().await.expect("closing stderr writer");
+        });
+        bulk_written_rx.await.expect("bulk writer exited early");
+
+        let (wait_started_tx, wait_started_rx) = tokio::sync::oneshot::channel();
+        let waiter = tokio::spawn(async move {
+            let mut reader = Some(reader);
+            wait_started_tx
+                .send(())
+                .expect("wait-start observer dropped");
+            wait_for_stderr_eof(&mut reader, Duration::from_secs(2)).await;
+            reader
+        });
+        wait_started_rx.await.expect("stderr waiter exited early");
+        assert!(
+            !waiter.is_finished(),
+            "stderr waiter returned while the writer still held the pipe open"
+        );
+
+        write_final_tx
+            .send(())
+            .expect("stderr waiter dropped the final-line gate");
+        let remaining_reader = waiter.await.expect("stderr waiter panicked");
+        writer.await.expect("stderr writer panicked");
+        assert!(
+            remaining_reader.is_none(),
+            "stderr waiter must consume its reader handle"
+        );
+
+        let captured = captured.lock().expect("captured stderr mutex poisoned");
+        assert_eq!(captured.len(), BULK_LINES + 1);
+        assert_eq!(captured.first().map(String::as_str), Some("bulk-0"));
+        assert_eq!(captured.last().map(String::as_str), Some("delayed-final"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn wait_for_stderr_eof_accepts_a_late_waiter_after_eof() {
+        use std::sync::{Arc, Mutex};
+        use tokio::io::AsyncWriteExt;
+
+        let (read_end, mut write_end) = tokio::io::duplex(64);
+        let captured = Arc::new(Mutex::new(Vec::<String>::new()));
+        let reader_captured = Arc::clone(&captured);
+        let (eof_tx, eof_rx) = tokio::sync::oneshot::channel();
+        let reader = tokio::spawn(async move {
+            let mut lines = BufReader::new(read_end).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                reader_captured
+                    .lock()
+                    .expect("captured stderr mutex poisoned")
+                    .push(line);
+            }
+            eof_tx.send(()).expect("EOF observer dropped");
+        });
+
+        write_end
+            .write_all(b"already-drained\n")
+            .await
+            .expect("writing stderr before EOF");
+        write_end.shutdown().await.expect("closing stderr writer");
+        drop(write_end);
+        eof_rx.await.expect("stderr reader exited before EOF");
+        assert!(
+            reader.is_finished(),
+            "reader must be terminal before waiting"
+        );
+
+        let mut reader = Some(reader);
+        wait_for_stderr_eof(&mut reader, Duration::from_secs(2)).await;
+        assert!(
+            reader.is_none(),
+            "late waiter must consume the reader handle"
+        );
+        assert_eq!(
+            captured
+                .lock()
+                .expect("captured stderr mutex poisoned")
+                .as_slice(),
+            ["already-drained"]
+        );
+
+        // A second waiter is explicitly a no-op, not an error or another wait.
+        wait_for_stderr_eof(&mut reader, Duration::ZERO).await;
+    }
+
     #[tokio::test]
     async fn dir_watch_consumes_event_queued_between_check_and_park() {
         let dir = tempfile::tempdir().expect("create watched directory");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -841,8 +841,16 @@ mod tests {
         write_final_tx
             .send(())
             .expect("stderr waiter dropped the final-line gate");
-        let remaining_reader = waiter.await.expect("stderr waiter panicked");
-        writer.await.expect("stderr writer panicked");
+        // Bounded: a regression that never reaches EOF would otherwise hang the whole
+        // suite here instead of failing this test.
+        let remaining_reader = tokio::time::timeout(Duration::from_secs(10), waiter)
+            .await
+            .expect("stderr waiter did not finish within 10s of the final line")
+            .expect("stderr waiter panicked");
+        tokio::time::timeout(Duration::from_secs(10), writer)
+            .await
+            .expect("stderr writer did not finish within 10s")
+            .expect("stderr writer panicked");
         assert!(
             remaining_reader.is_none(),
             "stderr waiter must consume its reader handle"
@@ -880,7 +888,10 @@ mod tests {
             .expect("writing stderr before EOF");
         write_end.shutdown().await.expect("closing stderr writer");
         drop(write_end);
-        eof_rx.await.expect("stderr reader exited before EOF");
+        tokio::time::timeout(Duration::from_secs(10), eof_rx)
+            .await
+            .expect("stderr reader did not observe EOF within 10s")
+            .expect("stderr reader exited before EOF");
         assert!(
             reader.is_finished(),
             "reader must be terminal before waiting"


### PR DESCRIPTION
# Salvage six items out of the archived WIP branches

Each commit stands alone and can be dropped without disturbing the others. Six
archived branches were reduced to what is actually worth keeping; the branches
themselves carry nothing else.

## 1. A live bug on main: the health monitor was detached, not cancelled

`cleanup_vm` moved the health-monitor `JoinHandle` into a `tokio::select!` racing
a 100 ms sleep. Dropping a tokio `JoinHandle` **detaches** its task rather than
cancelling it, so whenever the sleep arm won, a health monitor that had not yet
observed its cancellation token kept running while cleanup proceeded to destroy
its network namespace.

This is the same defect as the one already fixed in `wait_for_stderr_eof`
(`src/utils.rs`), which uses the borrow-then-abort shape. `stop_health_monitor`
now does the same: `tokio::time::timeout(budget, &mut handle)` keeps ownership,
so the budget can expire without consuming the handle, and the task is aborted
**and awaited** before teardown continues.

Witnessed red against the unfixed code:

```
$ make _test-unit FILTER="-E 'test(=commands::common::tests::health_monitor_timeout_aborts_and_reaps_task)'"
thread '...health_monitor_timeout_aborts_and_reaps_task' panicked at src/commands/common.rs:3343:9:
the timed-out health-monitor future must be dropped before the stop barrier returns
Summary [   5.015s] 1 test run: 0 passed, 1 failed, 616 skipped

# after the fix
Summary [   0.009s] 1 test run: 1 passed, 616 skipped
```

### Other instances of the same shape

The whole repo was swept for a `JoinHandle` consumed by value in a construct
whose other arm can win. Nine sites match the shape; none is the same bug, and
the reasoning for each is in the review notes below.

## 2. Two tests that close a real hole in `wait_for_stderr_eof`

The fix landed inline on main but its tests did not, and main covers only the
timeout branch. An implementation that abandoned the reader immediately would
satisfy the existing test while silently truncating the stderr tail on every
error path that renders one.

Demonstrated by stubbing the function to abort and return without waiting: the
**existing** test still passes, and the new one fails.

```
# stubbed
PASS [   0.206s] (2/3) fcvm utils::tests::stderr_eof_timeout_aborts_the_reader
TRY 2 FAIL [   0.007s] (3/3) fcvm utils::tests::wait_for_stderr_eof_waits_for_delayed_bulk_output
  stderr waiter returned while the writer still held the pipe open
Summary [   5.016s] 3 tests run: 2 passed, 1 failed, 616 skipped

# stub removed
Summary [   0.261s] 3 tests run: 3 passed, 616 skipped
```

## 3. The instrument behind the headline UFFD numbers

`src/uffd/working_set.rs` opens by citing a cross-clone Jaccard median of 0.927,
~56,300 faults per Chromium clone, and 8.6% sequential faults. Nothing in the
tree could re-derive any of it. `FaultTrace` plus `faultbench.py` and
`faultanalyze.py` are what produced those figures.

Hand-ported rather than cherry-picked: `server.rs` was restructured around
`PeerVmm`/`VmContext`/`VmState` since. The trace lives in `VmState`, reuses its
existing `started` instant, and hooks the four points in `drain_events` where a
fault is actually resolved.

The measurement needs a golden snapshot and a working userfaultfd, so the
runnable claim is the wire format between the Rust writer and the Python reader
(`struct.unpack_from("<QQQ", data, i * 24)`) — pinned by a test, witnessed red by
flipping the writer to `to_be_bytes`.

## 4. An open-loop scale harness

`bench-chromium-request` cannot drive an arrival rate: its driver is
`for rep in range(...)`, so offered load is whatever the system served and a
slower backend is handed a lighter load. It also compares FILE and UFFD across
separate runs, confounding the backend with drift — the defect
`bench/chromium/AGENTS.md` records as "interleave, never block".

`reqscale.py` launches on absolute deadlines and interleaves both backends
*within* each rate interval. Four make targets, written to this Makefile's
conventions rather than the ones the harness shipped with, so the existing
`test-chromium-request` is left intact and `FILTER=` keeps working.

`test_reqscale.py` arrived with five fixture bugs, each a test that could never
reach the assertion it advertised (an `assertIn` against an argv list, a rate
that tripped an earlier guard, a terminal sample whose nested timestamps stayed
behind, a physically impossible `wall_ms`, and an expectation of 1 failure from a
spec that plans a pair). All five fail identically on the branch they came from,
so none is port damage.

```
$ make test-chromium-scale
Ran 65 tests in 31.110s
OK
```

Every new target was run, not dry-run — a target has shipped broken before
because it was only checked with `make -n`.

## 5. One runner and two documentation gaps

`test-clone-floor-overlap` runs three concurrent nextest lanes. A single nextest
process cannot produce the interleaving, because `stress-tests` and
`hugepage-tests` are pinned to `max-threads = 1`.

Also documents `FCVM_UFFD_MAX_CLONES` (default **256**; it was the only `FCVM_*`
variable living solely in `src/`) and records why UFFD queue depth is not
observable today, so `agent/archive-uffd-profile-20260810` can be deleted.

## Gates

```
$ make lint          # fmt, clippy -D warnings, audit, deny — all clean, exit 0

$ make test-unit
Summary [  50.744s] 621 tests run: 614 passed, 7 failed, 0 skipped
```

The four added tests all pass, and the run that selects only them reports
`617 skipped`, which is the base's own test count:

```
PASS fcvm utils::tests::wait_for_stderr_eof_accepts_a_late_waiter_after_eof
PASS fcvm utils::tests::wait_for_stderr_eof_waits_for_delayed_bulk_output
PASS fcvm commands::common::tests::health_monitor_timeout_aborts_and_reaps_task
PASS fcvm uffd::server::tests::fault_trace_writes_the_little_endian_triples_faultanalyze_reads
Summary [   0.009s] 4 tests run: 4 passed, 617 skipped
```

617 + 4 = 621, so the series adds exactly four tests and four passes. The
failing set is **byte-identical** to the baseline measured on untouched main
(`616 tests run: 609 passed, 7 failed` at the older tip) — seven uffd tests that
need `vm.unprivileged_userfaultfd`, which is `0` on this host.

```
$ make test-chromium-request
Ran 105 tests in 104.802s
FAILED (failures=20, errors=4)
```

Also identical to this host's baseline, measured with the touched files reverted
(`Ran 105 tests in 103.876s / FAILED (failures=20, errors=4)`, same test names).
Every one is a process-forking test failing with "pid N never forked a child".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Chromium request-scalability benchmarking with JSON analysis, Markdown reports, and reproducible tests.
  - Added fault benchmarking and reporting for memory usage, latency, locality, stability, and fault activity.
  - Added optional UFFD fault tracing through `FCVM_UFFD_FAULT_TRACE`.
  - Added `FCVM_UFFD_MAX_CLONES`, defaulting to 256 clones per snapshot-serving process.

- **Bug Fixes**
  - Improved Chromium page cleanup and readiness validation.
  - Improved health-monitor shutdown and delayed output handling.
  - Added stronger process and cgroup cleanup safeguards.

- **Documentation**
  - Expanded CLI and benchmarking documentation, including tracing limitations and health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->