### PR TITLE
Add fcvm podman prepare with a nameable, keepable snapshot

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -25,6 +25,26 @@ The stale `db.sql` disaster happened because setup "usually" cleaned up before s
 
 **Before committing, ask:** "Can any other process/thread/test touch this state at the same time?" If yes, add synchronization or make it atomic. No exceptions.
 
+## WRITE PLAINLY, ENGINEER TO ENGINEER
+
+Commit messages, PR descriptions, code comments, docs: all of it is one engineer telling
+another what changed and why. Say that and stop.
+
+- State the change, the reason, and the evidence. Nothing else belongs there.
+- No selling. Cut "worth having", "the real win", "makes it trustworthy", "elegant",
+  "powerful", "seamless", "comprehensive", "robust".
+- No throat-clearing. First sentence names the change. Skip the scene-setting paragraph.
+- No rhetorical scaffolding: "Two things follow from that", "Four properties make this
+  work", "Here's the thing". Make the point instead of announcing it.
+- No staccato triples ("No traceback. No crash. No exception."). One normal sentence.
+- No em dashes. Comma, parenthesis, or a new sentence.
+- Don't narrate the journey. "I first tried X, then found Y" belongs nowhere. Describe the
+  end state.
+- Don't restate the diff in prose. If the code already says it, delete the sentence.
+- A claim needs a number or a command. "Faster" is not a claim; `2.4s -> 0.3s` is.
+- Read it back as if a colleague sent it to you. If it reads like marketing or an essay,
+  rewrite it.
+
 ## VERIFY PLAN AND RUN NEW TESTS LOCALLY
 
 **Before committing, ALWAYS:**

--- a/README.md
+++ b/README.md
@@ -105,6 +105,29 @@ Snapshot a running VM and restore clones from it. Two modes: UFFD (memory server
 ./fcvm snapshot run --pid <serve_pid> --exec "curl localhost"
 ```
 
+### Building a Snapshot Without Leaving a VM Behind
+
+`podman prepare` takes the same arguments as `podman run`, boots one disposable VM,
+waits for the container to report healthy, installs the startup snapshot, and reaps
+every host resource. It prints one JSON line and exits; there is no VM to clean up.
+
+```bash
+# Build (or verify) the snapshot, then address it by name
+./fcvm podman prepare --name golden --tag nginx-warm nginx:alpine
+{"status":"prepared","cache":"created","snapshot_key":"nginx-warm",
+ "content_key":"a1b2c3d4e5f6-startup","snapshot_type":"user",
+ "generation_id":"...","config_digest":"..."}
+
+./fcvm snapshot serve nginx-warm
+./fcvm snapshot run --pid <serve_pid> --name clone1
+```
+
+The snapshot is keyed by the content of the arguments. Change the image or the VM
+shape and the next `prepare` rebuilds; change the image behind a tag that keeps the
+same reference and use `--force`. Without `--tag` the snapshot is installed under its
+content key as cache, which `snapshots prune` reclaims; with `--tag` it is a user
+snapshot that survives a prune.
+
 ### Disk-Only (Cold-Boot) Clones
 
 `--disk-only` captures just the disk — no vCPU pause, no memory image. The guest
@@ -341,6 +364,7 @@ See [`Containerfile`](Containerfile) for the complete dependency list used in CI
 | `fcvm setup` | Download kernel and create rootfs (5-10 min first run, then cached) |
 | `fcvm setup --cloud-hypervisor` | Build the Cloud Hypervisor backend binary (content-addressed, on demand) |
 | `fcvm podman run` | Run container in a microVM (backend selected with `--hypervisor`, default `firecracker`) |
+| `fcvm podman prepare` | Build and verify a startup snapshot, then reap the VM that produced it (`--tag`, `--force`) |
 | `fcvm exec` | Execute command in running VM/container |
 | `fcvm ls` | List running VMs (`--json` for JSON) |
 | `fcvm snapshot create` | Snapshot a running VM |

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -117,6 +117,8 @@ pub struct PodmanArgs {
 pub enum PodmanCommands {
     /// Run a container in a microVM (Firecracker or Cloud Hypervisor)
     Run(RunArgs),
+    /// Build and verify the healthy startup snapshot, then reap the disposable VM
+    Prepare(RunArgs),
 }
 
 #[derive(Args, Debug)]
@@ -709,9 +711,41 @@ mod tests {
         match cli.cmd {
             Commands::Podman(podman) => match podman.cmd {
                 PodmanCommands::Run(run) => run,
+                PodmanCommands::Prepare(_) => panic!("expected `podman run` command"),
             },
             _ => panic!("expected `podman run` command"),
         }
+    }
+
+    #[test]
+    fn prepare_accepts_the_run_configuration_shape() {
+        let cli = Cli::try_parse_from([
+            "fcvm",
+            "podman",
+            "prepare",
+            "--name",
+            "prepared-web",
+            "--cpu",
+            "4",
+            "--health-check",
+            "http://web.internal/ready",
+            "nginx:alpine",
+        ])
+        .expect("prepare CLI should parse");
+
+        let Commands::Podman(podman) = cli.cmd else {
+            panic!("expected podman command");
+        };
+        let PodmanCommands::Prepare(args) = podman.cmd else {
+            panic!("expected podman prepare command");
+        };
+        assert_eq!(args.name, "prepared-web");
+        assert_eq!(args.cpu, 4);
+        assert_eq!(args.image, "nginx:alpine");
+        assert_eq!(
+            args.health_check.as_deref(),
+            Some("http://web.internal/ready")
+        );
     }
 
     #[test]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -118,7 +118,43 @@ pub enum PodmanCommands {
     /// Run a container in a microVM (Firecracker or Cloud Hypervisor)
     Run(RunArgs),
     /// Build and verify the healthy startup snapshot, then reap the disposable VM
-    Prepare(RunArgs),
+    ///
+    /// Takes the same arguments as `run`. On a cache miss it boots one disposable VM,
+    /// waits for the container to report healthy, installs a full memory+disk snapshot,
+    /// reaps every host resource, and prints one JSON line naming the installed
+    /// generation. On a hit it verifies that generation and prints the same line without
+    /// booting. Nothing else is left running.
+    ///
+    /// The snapshot is keyed by the content of these arguments. `--tag` installs it under
+    /// a name you choose so `fcvm snapshot serve` and `fcvm snapshot run` can address it,
+    /// and marks it a user snapshot so `fcvm snapshots prune` keeps it. `--force` rebuilds
+    /// content whose cache key did not change.
+    Prepare(PrepareArgs),
+}
+
+/// `podman prepare` takes every `podman run` argument plus the two that only make
+/// sense for a build-and-exit command: where to install the result, and whether to
+/// rebuild one that is already installed.
+#[derive(Args, Debug)]
+pub struct PrepareArgs {
+    /// Install the startup snapshot under this name instead of the content-addressed
+    /// cache key, and mark it a user snapshot so `fcvm snapshots prune` keeps it.
+    /// The name is an ordinary snapshot name: `fcvm snapshot serve <tag>`,
+    /// `fcvm snapshot run --snapshot <tag>`, `fcvm snapshots ls` and
+    /// `fcvm snapshots delete <tag>` all address it the same way they address a
+    /// `fcvm snapshot create --tag` snapshot. A tag holding a different image or VM
+    /// shape is rebuilt, so the result always matches the arguments you passed.
+    #[arg(long)]
+    pub tag: Option<String>,
+
+    /// Rebuild even when the installed generation already matches these arguments.
+    /// Needed when the content changed without the cache key changing, e.g. a remote
+    /// image reference repointed to a new digest.
+    #[arg(long)]
+    pub force: bool,
+
+    #[command(flatten)]
+    pub run: RunArgs,
 }
 
 #[derive(Args, Debug)]
@@ -717,12 +753,22 @@ mod tests {
         }
     }
 
+    fn parse_prepare(extra: &[&str]) -> PrepareArgs {
+        let mut argv = vec!["fcvm", "podman", "prepare"];
+        argv.extend_from_slice(extra);
+        let cli = Cli::try_parse_from(argv).expect("prepare CLI should parse");
+        let Commands::Podman(podman) = cli.cmd else {
+            panic!("expected podman command");
+        };
+        let PodmanCommands::Prepare(args) = podman.cmd else {
+            panic!("expected podman prepare command");
+        };
+        args
+    }
+
     #[test]
     fn prepare_accepts_the_run_configuration_shape() {
-        let cli = Cli::try_parse_from([
-            "fcvm",
-            "podman",
-            "prepare",
+        let args = parse_prepare(&[
             "--name",
             "prepared-web",
             "--cpu",
@@ -730,22 +776,39 @@ mod tests {
             "--health-check",
             "http://web.internal/ready",
             "nginx:alpine",
-        ])
-        .expect("prepare CLI should parse");
+        ]);
 
-        let Commands::Podman(podman) = cli.cmd else {
-            panic!("expected podman command");
-        };
-        let PodmanCommands::Prepare(args) = podman.cmd else {
-            panic!("expected podman prepare command");
-        };
-        assert_eq!(args.name, "prepared-web");
-        assert_eq!(args.cpu, 4);
-        assert_eq!(args.image, "nginx:alpine");
+        assert_eq!(args.run.name, "prepared-web");
+        assert_eq!(args.run.cpu, 4);
+        assert_eq!(args.run.image, "nginx:alpine");
         assert_eq!(
-            args.health_check.as_deref(),
+            args.run.health_check.as_deref(),
             Some("http://web.internal/ready")
         );
+        assert_eq!(args.tag, None);
+        assert!(!args.force);
+    }
+
+    /// `--tag` and `--force` have to reach `prepare` alongside the run configuration,
+    /// including the trailing container command that `RunArgs` collects.
+    #[test]
+    fn prepare_accepts_a_tag_and_a_forced_rebuild() {
+        let args = parse_prepare(&[
+            "--name",
+            "golden",
+            "--tag",
+            "cb-req-golden",
+            "--force",
+            "localhost/chromium-bench",
+            "sh",
+            "-c",
+            "entry.sh",
+        ]);
+
+        assert_eq!(args.tag.as_deref(), Some("cb-req-golden"));
+        assert!(args.force);
+        assert_eq!(args.run.image, "localhost/chromium-bench");
+        assert_eq!(args.run.command_args, vec!["sh", "-c", "entry.sh"]);
     }
 
     #[test]

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -724,6 +724,27 @@ impl LifecycleReadyGate {
         self.cancel.cancel();
     }
 
+    /// Claim a terminal, synchronous publication without writing VM readiness state.
+    ///
+    /// Finite lifecycle commands use this immediately before their final response. A signal
+    /// that claims setup first prevents the response; once publication claims the gate, a
+    /// later signal cannot turn an already-linearized success into a cancellation race.
+    pub fn claim_terminal_publication(&self) -> Result<LifecycleReadyOutcome> {
+        match self.phase.compare_exchange(
+            LIFECYCLE_SETTING_UP,
+            LIFECYCLE_READY,
+            std::sync::atomic::Ordering::SeqCst,
+            std::sync::atomic::Ordering::SeqCst,
+        ) {
+            Ok(_) | Err(LIFECYCLE_READY) => Ok(LifecycleReadyOutcome::Published),
+            Err(LIFECYCLE_CANCELLED) => Ok(LifecycleReadyOutcome::Cancelled),
+            Err(LIFECYCLE_PUBLISHING) => {
+                bail!("lifecycle readiness publication is already in progress")
+            }
+            Err(phase) => bail!("invalid lifecycle readiness phase {phase}"),
+        }
+    }
+
     /// Publish readiness only if cancellation did not claim the setup phase first.
     pub async fn publish(
         &self,
@@ -786,6 +807,36 @@ pub struct CleanupContext {
     pub output_listener_handle: Option<JoinHandle<Vec<(String, String)>>>,
 }
 
+/// Errors observed while tearing down independent VM resources.
+///
+/// Cleanup must always attempt every resource even when an earlier action fails.  Normal
+/// `run` keeps its existing best-effort contract, while `prepare` uses the verified wrapper
+/// below and refuses to publish success when this collection is non-empty.
+#[derive(Default)]
+struct CleanupFailures {
+    failures: Vec<String>,
+}
+
+impl CleanupFailures {
+    /// Log and collect a failed teardown action. `action` is a gerund phrase naming the
+    /// resource ("cleaning network"), so it reads as a sentence in both the warning and
+    /// the aggregated error.
+    fn record<T>(&mut self, action: &str, result: Result<T>) {
+        if let Err(error) = result {
+            warn!("failed while {action}: {error:#}");
+            self.failures.push(format!("{action}: {error:#}"));
+        }
+    }
+
+    fn into_result(self) -> Result<()> {
+        if self.failures.is_empty() {
+            Ok(())
+        } else {
+            bail!("verified VM cleanup failed: {}", self.failures.join("; "))
+        }
+    }
+}
+
 /// How long teardown waits for the health monitor to observe its cancellation before
 /// moving on. It only writes state through the per-VM flock, which `delete_state` takes
 /// too, so an unjoined straggler is safe — this is a courtesy join, not a barrier.
@@ -842,6 +893,20 @@ fn process_cpu(pid: u32) -> std::time::Duration {
     std::time::Duration::from_nanos(ticks.saturating_mul(1_000_000_000 / hz as u64))
 }
 
+fn verify_process_reaped(label: &str, identity: Option<(u32, u64)>) -> Result<()> {
+    let Some((pid, start_time)) = identity else {
+        return Ok(());
+    };
+    anyhow::ensure!(
+        crate::utils::process_start_time(pid) != Some(start_time),
+        "{} process {} with start time {} is still running after cleanup",
+        label,
+        pid,
+        start_time
+    );
+    Ok(())
+}
+
 /// Tear down every resource a VM owns. Used by both the podman and snapshot commands.
 ///
 /// Ordered to minimize how long the caller is blocked without deferring any of the work:
@@ -882,6 +947,35 @@ pub async fn cleanup_vm(
     network: &mut dyn NetworkManager,
     state_manager: &StateManager,
 ) {
+    // Normal runs intentionally retain their best-effort teardown contract.  Prepare calls
+    // `cleanup_vm_verified` so it can fail closed instead of reporting a durable artifact
+    // while host resources remain.
+    let _ = cleanup_vm_inner(ctx, vm_manager, holder_child, network, state_manager, false).await;
+}
+
+/// Tear down every VM resource and return an error if any cleanup action failed.
+///
+/// All actions are attempted before the aggregated error is returned.  This is the cleanup
+/// contract used by finite lifecycle operations such as `podman prepare`, where a successful
+/// response is also a claim that the disposable source VM has been fully reaped.
+pub async fn cleanup_vm_verified(
+    ctx: CleanupContext,
+    vm_manager: &mut dyn Hypervisor,
+    holder_child: &mut Option<tokio::process::Child>,
+    network: &mut dyn NetworkManager,
+    state_manager: &StateManager,
+) -> Result<()> {
+    cleanup_vm_inner(ctx, vm_manager, holder_child, network, state_manager, true).await
+}
+
+async fn cleanup_vm_inner(
+    ctx: CleanupContext,
+    vm_manager: &mut dyn Hypervisor,
+    holder_child: &mut Option<tokio::process::Child>,
+    network: &mut dyn NetworkManager,
+    state_manager: &StateManager,
+    verified: bool,
+) -> Result<()> {
     let CleanupContext {
         vm_id,
         mut volume_server_handles,
@@ -895,6 +989,7 @@ pub async fn cleanup_vm(
     // caller actually waits for, including our own bookkeeping.
     let cleanup_start = std::time::Instant::now();
     let cpu_before = reaped_children_cpu();
+    let mut failures = CleanupFailures::default();
     info!("cleaning up resources");
 
     // --- Phase 1: signal everything. No `await` until all signals are out. -------------
@@ -906,15 +1001,24 @@ pub async fn cleanup_vm(
             .and_then(|h| h.id())
             .map(process_cpu)
             .unwrap_or_default();
+    let vm_process_identity = vm_manager
+        .pid()
+        .ok()
+        .and_then(|pid| crate::utils::process_start_time(pid).map(|start| (pid, start)));
+    let holder_process_identity = holder_child.as_ref().and_then(|holder| {
+        holder
+            .id()
+            .and_then(|pid| crate::utils::process_start_time(pid).map(|start| (pid, start)))
+    });
 
     let kill_start = std::time::Instant::now();
-    if let Err(e) = vm_manager.start_kill() {
-        warn!("failed to signal VM process: {}", e);
-    }
+    failures.record("signalling VM process", vm_manager.start_kill());
     if let Some(ref mut holder) = holder_child {
-        if let Err(e) = holder.start_kill() {
-            warn!("failed to signal namespace holder process: {}", e);
-        }
+        failures.record(
+            "signalling namespace holder process",
+            // `record` names the action, so no duplicate `.context` here.
+            holder.start_kill().map_err(anyhow::Error::from),
+        );
     }
     network.start_kill_processes();
 
@@ -934,29 +1038,76 @@ pub async fn cleanup_vm(
     let holder_reaped = async {
         if let Some(ref mut holder) = holder_child {
             // Reap the zombie left by the SIGKILL above.
-            let _ = holder.wait().await;
+            holder
+                .wait()
+                .await
+                .context("waiting for namespace holder process")?;
         }
+        Ok::<(), anyhow::Error>(())
     };
     let health_stopped = async {
-        let Some(handle) = health_monitor_handle else {
-            return;
+        let Some(mut handle) = health_monitor_handle else {
+            return Ok::<(), anyhow::Error>(());
         };
         tokio::select! {
-            _ = handle => debug!("health monitor stopped gracefully"),
+            result = &mut handle => {
+                match result {
+                    Ok(()) => debug!("health monitor stopped gracefully"),
+                    Err(error) if error.is_cancelled() => {}
+                    Err(error) => return Err(error).context("joining health monitor"),
+                }
+            }
             _ = tokio::time::sleep(HEALTH_MONITOR_STOP_BUDGET) => {
-                debug!("health monitor didn't stop in time, continuing cleanup");
+                if verified {
+                    handle.abort();
+                    match handle.await {
+                        Ok(()) => {}
+                        Err(error) if error.is_cancelled() => {}
+                        Err(error) => return Err(error).context("joining aborted health monitor"),
+                    }
+                    debug!("health monitor didn't stop in time; aborted and joined it");
+                } else {
+                    debug!("health monitor didn't stop in time, continuing cleanup");
+                }
             }
         }
+        Ok(())
     };
     let listeners_stopped = async {
+        let mut errors = Vec::new();
         if let Some(handle) = output_listener_handle.take() {
-            let _ = handle.await;
+            if let Err(error) = handle.await {
+                if !error.is_cancelled() {
+                    errors.push(format!("joining output listener: {error}"));
+                }
+            }
         }
         for handle in volume_server_handles.drain(..) {
-            let _ = handle.await;
+            if let Err(error) = handle.await {
+                if !error.is_cancelled() {
+                    errors.push(format!("joining volume server: {error}"));
+                }
+            }
+        }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            bail!(errors.join("; "))
         }
     };
-    tokio::join!(vmm_reaped, holder_reaped, health_stopped, listeners_stopped);
+    let ((), holder_reaped, health_stopped, listeners_stopped) =
+        tokio::join!(vmm_reaped, holder_reaped, health_stopped, listeners_stopped);
+    failures.record("reaping namespace holder process", holder_reaped);
+    failures.record("stopping health monitor", health_stopped);
+    failures.record("stopping VM listeners", listeners_stopped);
+    failures.record(
+        "verifying VM process reap",
+        verify_process_reaped("VM", vm_process_identity),
+    );
+    failures.record(
+        "verifying namespace holder process reap",
+        verify_process_reaped("namespace holder", holder_process_identity),
+    );
     let processes_us = kill_start.elapsed().as_micros();
 
     // Sampled HERE, before network cleanup reaps pasta, so the delta covers exactly the two
@@ -968,9 +1119,7 @@ pub async fn cleanup_vm(
 
     // --- Phase 3: network teardown, now that nothing is using the namespace. -----------
     let network_start = std::time::Instant::now();
-    if let Err(e) = network.cleanup().await {
-        warn!("failed to cleanup network: {}", e);
-    }
+    failures.record("cleaning network", network.cleanup().await);
     let network_us = network_start.elapsed().as_micros();
 
     // --- Phase 4: on-disk reaping. Synchronous — cleanup_vm does not return until every
@@ -982,11 +1131,7 @@ pub async fn cleanup_vm(
     // path — podman run, converge teardown, restored clones. A leftover entry for a deleted
     // directory makes every later `exportfs -ra` fail until the self-heal prunes it.
     let exports_removed = super::podman::cleanup_nfs_exports(&vm_id);
-    let state_deleted = async {
-        if let Err(e) = state_manager.delete_state(&vm_id).await {
-            warn!("failed to delete state file: {}", e);
-        }
-    };
+    let state_deleted = state_manager.delete_state(&vm_id);
     let data_dir_removed = async {
         // Preserve the Firecracker log (for debugging snapshot restore failures) BEFORE
         // removing the directory it lives in.
@@ -1001,13 +1146,21 @@ pub async fn cleanup_vm(
         }
 
         // Includes disks, sockets, everything under the VM's runtime directory.
-        if let Err(e) = tokio::fs::remove_dir_all(&data_dir).await {
-            warn!(vm_id = %vm_id, error = %e, "failed to cleanup VM data directory");
-        } else {
-            info!(vm_id = %vm_id, "cleaned up VM data directory");
+        match tokio::fs::remove_dir_all(&data_dir).await {
+            Ok(()) => {
+                info!(vm_id = %vm_id, "cleaned up VM data directory");
+                Ok(())
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error)
+                .with_context(|| format!("removing VM data directory {}", data_dir.display())),
         }
     };
-    tokio::join!(exports_removed, state_deleted, data_dir_removed);
+    let (exports_removed, state_deleted, data_dir_removed) =
+        tokio::join!(exports_removed, state_deleted, data_dir_removed);
+    failures.record("removing NFS exports", exports_removed);
+    failures.record("deleting state", state_deleted);
+    failures.record("removing VM data directory", data_dir_removed);
     let disk_us = disk_start.elapsed().as_micros();
 
     info!(
@@ -1020,6 +1173,8 @@ pub async fn cleanup_vm(
         disk_us,
         "vm teardown complete"
     );
+
+    failures.into_result()
 }
 
 /// Memory backend configuration for snapshot restore
@@ -2516,6 +2671,15 @@ pub(crate) fn validate_snapshot_vm_identity(
 /// portable-volume inode tables.
 pub type SnapshotExtraFiles<'a> = Option<&'a (dyn Fn() -> Vec<(String, Vec<u8>)> + Send + Sync)>;
 
+/// What to do with the source VM after capturing its memory and disks.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SnapshotSourceDisposition {
+    /// The source is the caller's workload and must continue running.
+    Resume,
+    /// The source is disposable and remains paused until verified cleanup reaps it.
+    LeavePaused,
+}
+
 /// Disk-only capture: quiesce the guest, reflink only the disk (no memory dump,
 /// no vCPU pause — `fsfreeze` provides consistency), unfreeze, and finalize a
 /// `DiskOnly` snapshot. Clones cold-boot from this disk. See
@@ -2763,13 +2927,16 @@ async fn record_vsock_reset_for_snapshot(vm_id: &str, snapshot_name: &str) {
 /// before calling this function.
 ///
 /// # Returns
-/// Ok(()) on success, Err on failure. VM is resumed regardless of success/failure.
+/// Ok(()) on success, Err on failure. A normal source is resumed regardless of
+/// success/failure after a successful pause. A disposable source remains paused on every
+/// post-pause return so it cannot mutate after its prepared startup point.
 pub async fn create_snapshot_core(
     client: &crate::firecracker::FirecrackerClient,
     mut snapshot_config: crate::storage::snapshot::SnapshotConfig,
     disk_path: &Path,
     parent_snapshot_dir: Option<&Path>,
     extra_files: SnapshotExtraFiles<'_>,
+    source_disposition: SnapshotSourceDisposition,
 ) -> Result<()> {
     use crate::firecracker::api::{SnapshotCreate, VmState as ApiVmState};
 
@@ -2968,17 +3135,20 @@ pub async fn create_snapshot_core(
                         );
                     }
                     Err(e) => {
-                        // Full retry failed — record the vsock reset, resume VM, abort.
+                        // Full retry failed — record the vsock reset, then either resume the
+                        // normal workload or leave the disposable prepare source paused.
                         record_vsock_reset_for_snapshot(
                             &snapshot_config.vm_id,
                             &snapshot_config.name,
                         )
                         .await;
-                        let _ = snapshot_client
-                            .patch_vm_state(ApiVmState {
-                                state: "Resumed".to_string(),
-                            })
-                            .await;
+                        if source_disposition == SnapshotSourceDisposition::Resume {
+                            let _ = snapshot_client
+                                .patch_vm_state(ApiVmState {
+                                    state: "Resumed".to_string(),
+                                })
+                                .await;
+                        }
                         let _ = tokio::fs::remove_dir_all(&temp_snapshot_dir).await;
                         return Err(e)
                             .context("Full snapshot retry failed after diff tracking failure");
@@ -3006,17 +3176,23 @@ pub async fn create_snapshot_core(
     // orphan detection race-free.
     record_vsock_reset_for_snapshot(&snapshot_config.vm_id, &snapshot_config.name).await;
 
-    // Resume VM (ALWAYS, regardless of snapshot/disk copy result).
+    // Resume a normal source regardless of snapshot/disk copy result. A prepare source is
+    // disposable and intentionally remains paused until verified cleanup reaps it.
     // Memory merge happens after resume since it operates on snapshot files, not live disk.
     // failpoint: hold after the snapshot save (VM still paused) and before resume —
     // makes "client observes a saved-but-still-paused VM" (stalled exec/curl/vsock
     // across an arbitrarily long pause) deterministic.
     failpoint::hit_async("snapshot.post_save_pre_resume").await;
-    let resume_result = snapshot_client
-        .patch_vm_state(ApiVmState {
-            state: "Resumed".to_string(),
-        })
-        .await;
+    let resume_result = match source_disposition {
+        SnapshotSourceDisposition::Resume => {
+            snapshot_client
+                .patch_vm_state(ApiVmState {
+                    state: "Resumed".to_string(),
+                })
+                .await
+        }
+        SnapshotSourceDisposition::LeavePaused => Ok(()),
+    };
 
     if let Err(e) = &resume_result {
         // Resume failure is critical — VM may be stuck paused.
@@ -3038,7 +3214,14 @@ pub async fn create_snapshot_core(
         return Err(e).context("resuming VM after snapshot");
     }
 
-    info!(snapshot = %snapshot_config.name, "VM resumed, processing snapshot");
+    match source_disposition {
+        SnapshotSourceDisposition::Resume => {
+            info!(snapshot = %snapshot_config.name, "VM resumed, processing snapshot");
+        }
+        SnapshotSourceDisposition::LeavePaused => {
+            info!(snapshot = %snapshot_config.name, "disposable source remains paused, processing snapshot");
+        }
+    }
 
     // NOTE: Do NOT bump restore-epoch here. Snapshot create (pause → dump → resume)
     // does NOT reset vsock connections — empirically verified with scratch VMs.
@@ -3286,6 +3469,40 @@ mod tests {
     use crate::state::VmState;
     use crate::storage::SnapshotType;
     use std::path::Path;
+
+    #[test]
+    fn verified_cleanup_reports_every_failure_after_all_attempts() {
+        let mut failures = CleanupFailures::default();
+        failures.record(
+            "signalling VMM",
+            Err::<(), _>(anyhow::anyhow!("kill denied")),
+        );
+        failures.record(
+            "cleaning network",
+            Err::<(), _>(anyhow::anyhow!("netlink denied")),
+        );
+        failures.record("deleting state", Ok(()));
+
+        let error = failures
+            .into_result()
+            .expect_err("verified cleanup must fail when any cleanup action failed");
+        assert_eq!(
+            format!("{error:#}"),
+            "verified VM cleanup failed: signalling VMM: kill denied; cleaning network: netlink denied"
+        );
+    }
+
+    #[test]
+    fn verified_cleanup_checks_exact_process_identity_is_gone() {
+        let pid = std::process::id();
+        let start = crate::utils::process_start_time(pid).unwrap();
+        let error = verify_process_reaped("test", Some((pid, start))).unwrap_err();
+        assert!(format!("{error:#}").contains("is still running after cleanup"));
+
+        verify_process_reaped("test", Some((pid, start + 1)))
+            .expect("a reused PID with a different start time is not the owned process");
+        verify_process_reaped("test", None).expect("an unstarted process owns no resource");
+    }
 
     /// Regression guard for the deaf-clone bug: a snapshot taken from a restored
     /// VM embeds the ancestor's restore epoch in guest memory, so two restores in

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -804,7 +804,7 @@ pub struct CleanupContext {
     pub data_dir: PathBuf,
     pub health_cancel_token: Option<tokio_util::sync::CancellationToken>,
     pub health_monitor_handle: Option<JoinHandle<()>>,
-    pub output_listener_handle: Option<JoinHandle<Vec<(String, String)>>>,
+    pub output_listener_handle: Option<JoinHandle<()>>,
 }
 
 /// Errors observed while tearing down independent VM resources.

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -2375,6 +2375,9 @@ pub fn build_snapshot_config(
         generation_id: uuid::Uuid::new_v4(),
         original_vsock_vm_id: Some(original_vsock_vm_id),
         parent_snapshot: None, // Set by create_snapshot_core after determining diff base
+        // Set by create_podman_snapshot, the only caller whose snapshot holds the
+        // content of a cache key. `snapshot create` captures a live VM, not a config.
+        content_key: None,
         memory_path: snapshot_dir.join("memory.bin"),
         vmstate_path: snapshot_dir.join("vmstate.bin"),
         disk_path: snapshot_dir.join("disk.raw"),

--- a/src/commands/podman/listeners.rs
+++ b/src/commands/podman/listeners.rs
@@ -397,7 +397,9 @@ async fn serve_bootplan(listener: tokio::net::UnixListener, payload: Vec<u8>) {
 ///   Guest -> Host: "stdout:content" or "stderr:content"
 ///   Host -> Guest: "stdin:content" (written to container stdin)
 ///
-/// Returns collected output lines as Vec<(stream, line)>.
+/// Lines are forwarded (to stdout/stderr and to `log_tx`) as they arrive and are
+/// never retained: the listener runs for the whole life of the VM, so holding
+/// every line would grow without bound.
 pub(crate) async fn run_output_listener(
     socket_path: &str,
     vm_id: &str,
@@ -406,7 +408,7 @@ pub(crate) async fn run_output_listener(
     non_blocking_output: bool,
     emit_output: bool,
     connected_tx: Option<tokio::sync::oneshot::Sender<()>>,
-) -> Result<Vec<(String, String)>> {
+) -> Result<()> {
     use tokio::io::{AsyncBufReadExt, BufReader};
     use tokio::net::UnixListener;
 
@@ -441,7 +443,7 @@ pub(crate) async fn run_output_listener(
 
     info!(socket = %socket_path, "Output listener started");
 
-    let mut output_lines: Vec<(String, String)> = Vec::new();
+    let mut lines_forwarded: u64 = 0;
     let mut connection_count: u64 = 0;
     let mut lines_read = 0u64;
 
@@ -451,7 +453,7 @@ pub(crate) async fn run_output_listener(
         Err(e) => {
             warn!(vm_id = %vm_id, error = %e, "Error accepting initial output connection");
             let _ = std::fs::remove_file(socket_path);
-            return Ok(output_lines);
+            return Ok(());
         }
     };
     connection_count += 1;
@@ -509,7 +511,7 @@ pub(crate) async fn run_output_listener(
                                 let is_stdout = stream == "stdout";
                                 // `podman prepare` reserves stdout for its single JSON result
                                 // and stderr for host diagnostics, so it forwards nothing here.
-                                // The line is still read and recorded below, so a silenced guest
+                                // The line is still read and discarded, so a silenced guest
                                 // can never backpressure container startup.
                                 if emit_output {
                                     if let Some(ref tx) = nb_tx {
@@ -522,7 +524,7 @@ pub(crate) async fn run_output_listener(
                                         let _ = writeln!(std::io::stderr(), "{}", content);
                                     }
                                 }
-                                output_lines.push((stream.to_string(), content.to_string()));
+                                lines_forwarded += 1;
                             }
                             if let Some(ref tx) = log_tx {
                                 let _ = tx.send(LogLine {
@@ -575,8 +577,8 @@ pub(crate) async fn run_output_listener(
     // Clean up
     let _ = std::fs::remove_file(socket_path);
 
-    info!(vm_id = %vm_id, lines = output_lines.len(), "Output listener finished");
-    Ok(output_lines)
+    info!(vm_id = %vm_id, lines = lines_forwarded, "Output listener finished");
+    Ok(())
 }
 
 #[cfg(test)]
@@ -639,7 +641,7 @@ mod tests {
     async fn spawn_listener(
         socket_path: &std::path::Path,
         lossy: bool,
-    ) -> tokio::task::JoinHandle<Result<Vec<(String, String)>>> {
+    ) -> tokio::task::JoinHandle<Result<()>> {
         let socket_str = socket_path.to_string_lossy().to_string();
         let reconnect = std::sync::Arc::new(tokio::sync::Notify::new());
         let handle = tokio::spawn(async move {
@@ -653,6 +655,100 @@ mod tests {
         }
         assert!(socket_path.exists(), "output socket not created");
         handle
+    }
+
+    /// Resident set size of this process, in bytes.
+    fn resident_bytes() -> u64 {
+        let status = std::fs::read_to_string("/proc/self/status").unwrap();
+        let line = status
+            .lines()
+            .find(|l| l.starts_with("VmRSS:"))
+            .expect("VmRSS in /proc/self/status");
+        let kb: u64 = line
+            .split_whitespace()
+            .nth(1)
+            .and_then(|v| v.parse().ok())
+            .expect("VmRSS value");
+        kb * 1024
+    }
+
+    /// The listener runs for the whole life of the VM, so it must not retain the
+    /// guest output it forwards. `podman prepare` is the worst case: it passes
+    /// emit_output=false and drops the listener's result, so anything the listener
+    /// keeps is unreachable memory held for the full startup budget.
+    #[tokio::test]
+    async fn test_output_listener_does_not_retain_forwarded_lines() {
+        const LINES: usize = 150_000;
+        const CONTENT_BYTES: usize = 512;
+        // Retaining every line costs >75 MB; forwarding without retaining costs
+        // the read buffer plus the broadcast backlog, both well under a megabyte.
+        const MAX_GROWTH_BYTES: u64 = 24 * 1024 * 1024;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let socket_path = temp_dir.path().join("output-retain.sock");
+        let socket_str = socket_path.to_string_lossy().to_string();
+
+        // log_tx fires for every line regardless of emit_output, so counting its
+        // deliveries is a deterministic "the listener has processed all N lines".
+        let (log_tx, mut log_rx) = tokio::sync::broadcast::channel::<LogLine>(1024);
+        let reconnect = std::sync::Arc::new(tokio::sync::Notify::new());
+        let listener = tokio::spawn(async move {
+            run_output_listener(
+                &socket_str,
+                "test-vm",
+                Some(log_tx),
+                reconnect,
+                false,
+                false, // emit_output=false: the `podman prepare` path
+                None,
+            )
+            .await
+        });
+        for _ in 0..50 {
+            if socket_path.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(socket_path.exists(), "output socket not created");
+
+        let mut stream = tokio::net::UnixStream::connect(&socket_path).await.unwrap();
+        let baseline = resident_bytes();
+
+        let writer = tokio::spawn(async move {
+            let line = format!("stdout:{}\n", "x".repeat(CONTENT_BYTES));
+            for _ in 0..LINES {
+                stream.write_all(line.as_bytes()).await.unwrap();
+            }
+            stream.flush().await.unwrap();
+            drop(stream);
+        });
+
+        let mut seen = 0usize;
+        while seen < LINES {
+            match log_rx.recv().await {
+                Ok(_) => seen += 1,
+                // The receiver is slower than the listener; skipped lines were
+                // still processed, which is what this test is counting.
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => seen += n as usize,
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    panic!("listener dropped log channel after {seen}/{LINES} lines")
+                }
+            }
+        }
+        let growth = resident_bytes().saturating_sub(baseline);
+        writer.await.unwrap();
+        listener.abort();
+
+        assert!(
+            growth < MAX_GROWTH_BYTES,
+            "listener grew {} MiB while forwarding {} lines of {} bytes; it is retaining \
+             output that no caller can read (limit {} MiB)",
+            growth / (1024 * 1024),
+            LINES,
+            CONTENT_BYTES,
+            MAX_GROWTH_BYTES / (1024 * 1024),
+        );
     }
 
     /// With --non-blocking-output, the listener processes all input without blocking.

--- a/src/commands/podman/listeners.rs
+++ b/src/commands/podman/listeners.rs
@@ -50,6 +50,10 @@ pub(crate) async fn run_status_listener(
 
     let ready_file = runtime_dir.join("container-ready");
     let exit_file = runtime_dir.join("container-exit");
+    // Cache-close drains must not block the accept loop, but they remain children of this
+    // listener. Dropping the JoinSet on listener shutdown aborts every outstanding drain,
+    // which makes a joined status-listener handle proof that no detached socket task remains.
+    let mut cache_close_drains = tokio::task::JoinSet::new();
 
     // Accept connections for the lifetime of the VM ("cache-ready", "ready",
     // "exit:", "reboot", host-side "drain" probes). No idle timeout: a VM can run
@@ -57,6 +61,11 @@ pub(crate) async fn run_status_listener(
     // listener (plus its socket) would silently break reboot-in-place and exit
     // reporting. The run loop's cleanup aborts this task.
     loop {
+        while let Some(result) = cache_close_drains.try_join_next() {
+            if let Err(error) = result {
+                warn!(vm_id = %vm_id, error = %error, "cache-close drain task failed");
+            }
+        }
         let (stream, _) = match listener.accept().await {
             Ok(conn) => conn,
             Err(e) => {
@@ -267,13 +276,13 @@ pub(crate) async fn run_status_listener(
                 // window cannot give that guarantee — a probe landing one
                 // millisecond after it expires reopens exactly the same race.
                 //
-                // Detached so the accept loop is never held up. The next
+                // Concurrent so the accept loop is never held up. The next
                 // connection carries "ready", and it must not queue behind a
                 // guest that is slow to close — or never closes, which is the
                 // normal outcome when the ack was suppressed above and this VM is
                 // being torn down and replaced by a restore.
                 let drain_vm_id = vm_id.to_string();
-                tokio::spawn(async move {
+                cache_close_drains.spawn(async move {
                     let deadline = tokio::time::Instant::now() + CACHE_ACK_CLOSE_TIMEOUT;
                     let mut probe = String::new();
                     loop {
@@ -395,6 +404,7 @@ pub(crate) async fn run_output_listener(
     log_tx: Option<tokio::sync::broadcast::Sender<LogLine>>,
     reconnect_notify: Arc<tokio::sync::Notify>,
     non_blocking_output: bool,
+    emit_output: bool,
     connected_tx: Option<tokio::sync::oneshot::Sender<()>>,
 ) -> Result<Vec<(String, String)>> {
     use tokio::io::{AsyncBufReadExt, BufReader};
@@ -409,7 +419,7 @@ pub(crate) async fn run_output_listener(
     // In non-blocking mode, use a bounded channel + writer thread so the
     // listener never blocks on stdout/stderr. Messages are dropped when the
     // channel is full, preventing backpressure from cascading into the container.
-    let nb_tx = if non_blocking_output {
+    let nb_tx = if non_blocking_output && emit_output {
         let (tx, rx) = std::sync::mpsc::sync_channel::<(bool, String)>(1024);
         std::thread::Builder::new()
             .name("output-writer".into())
@@ -497,14 +507,20 @@ pub(crate) async fn run_output_listener(
                                 // error, which kills the listener task and stops
                                 // draining the vsock — deadlocking the container.
                                 let is_stdout = stream == "stdout";
-                                if let Some(ref tx) = nb_tx {
-                                    // Non-blocking mode: try_send drops if channel full.
-                                    // Writer thread handles the blocking stdout write.
-                                    let _ = tx.try_send((is_stdout, content.to_string()));
-                                } else if is_stdout {
-                                    let _ = writeln!(std::io::stdout(), "{}", content);
-                                } else {
-                                    let _ = writeln!(std::io::stderr(), "{}", content);
+                                // `podman prepare` reserves stdout for its single JSON result
+                                // and stderr for host diagnostics, so it forwards nothing here.
+                                // The line is still read and recorded below, so a silenced guest
+                                // can never backpressure container startup.
+                                if emit_output {
+                                    if let Some(ref tx) = nb_tx {
+                                        // Non-blocking mode: try_send drops if channel full.
+                                        // Writer thread handles the blocking stdout write.
+                                        let _ = tx.try_send((is_stdout, content.to_string()));
+                                    } else if is_stdout {
+                                        let _ = writeln!(std::io::stdout(), "{}", content);
+                                    } else {
+                                        let _ = writeln!(std::io::stderr(), "{}", content);
+                                    }
                                 }
                                 output_lines.push((stream.to_string(), content.to_string()));
                             }
@@ -627,7 +643,7 @@ mod tests {
         let socket_str = socket_path.to_string_lossy().to_string();
         let reconnect = std::sync::Arc::new(tokio::sync::Notify::new());
         let handle = tokio::spawn(async move {
-            run_output_listener(&socket_str, "test-vm", None, reconnect, lossy, None).await
+            run_output_listener(&socket_str, "test-vm", None, reconnect, lossy, true, None).await
         });
         for _ in 0..50 {
             if socket_path.exists() {

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -13,7 +13,7 @@ mod snapshot;
 mod types;
 mod vm_config;
 
-pub use types::{CacheRequest, LogLine, SnapshotOutcome, VmContext, VmHandle};
+pub use types::{CacheRequest, LogLine, PreparedTarget, SnapshotOutcome, VmContext, VmHandle};
 // Re-exported for the snapshot restore path's up-front reboot plan (a rebooted VM
 // relaunches in place via the same shared primitive, on every lifecycle path).
 pub(crate) use types::{RebootSpec, VolumeMapping};
@@ -27,7 +27,7 @@ pub(crate) use listeners::{run_output_listener, run_status_listener, spawn_bootp
 use snapshot::{build_firecracker_config, snapshot_run_firecracker_overrides};
 pub use snapshot::{
     check_podman_snapshot, create_snapshot_interruptible, startup_snapshot_key,
-    CreateSnapshotParams, SnapshotInstall,
+    CreateSnapshotParams, ExistingGeneration, SnapshotInstall,
 };
 pub(crate) use vm_config::{
     build_launch_config, build_runtime_boot_args, cleanup_nfs_exports, configure_and_boot_vm,
@@ -203,18 +203,32 @@ pub async fn cmd_podman(args: PodmanArgs) -> Result<()> {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 enum PodmanLifecycle {
     Run,
-    Prepare,
+    Prepare(PrepareOptions),
+}
+
+impl PodmanLifecycle {
+    fn is_prepare(&self) -> bool {
+        matches!(self, PodmanLifecycle::Prepare(_))
+    }
+}
+
+/// The two `podman prepare` arguments that decide where the startup snapshot is
+/// installed and whether an installed one is rebuilt.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct PrepareOptions {
+    tag: Option<String>,
+    force: bool,
 }
 
 fn snapshot_source_disposition(
-    lifecycle: PodmanLifecycle,
+    lifecycle: &PodmanLifecycle,
 ) -> super::common::SnapshotSourceDisposition {
     match lifecycle {
         PodmanLifecycle::Run => super::common::SnapshotSourceDisposition::Resume,
-        PodmanLifecycle::Prepare => super::common::SnapshotSourceDisposition::LeavePaused,
+        PodmanLifecycle::Prepare(_) => super::common::SnapshotSourceDisposition::LeavePaused,
     }
 }
 
@@ -255,11 +269,83 @@ fn should_arm_startup_snapshot(
     skip_snapshot_creation: bool,
     has_snapshot_key: bool,
     has_explicit_http_health_check: bool,
-    lifecycle: PodmanLifecycle,
+    lifecycle: &PodmanLifecycle,
 ) -> bool {
     !skip_snapshot_creation
         && has_snapshot_key
-        && (lifecycle == PodmanLifecycle::Prepare || has_explicit_http_health_check)
+        && (lifecycle.is_prepare() || has_explicit_http_health_check)
+}
+
+/// Where one `podman prepare` invocation installs its startup snapshot, and what an
+/// already-installed generation there has to look like to answer for it.
+///
+/// The content-addressed key is the identity either way. `--tag` only chooses the name
+/// it is installed under, so a tag whose generation holds different content is a miss
+/// and gets rebuilt, exactly as a changed cache key would be.
+fn prepare_install_target(options: &PrepareOptions, content_key: &str) -> Result<PreparedTarget> {
+    let (name, snapshot_type) = match options.tag.as_deref() {
+        // A caller-named artifact. It is a User snapshot because that is what naming one
+        // is for: `snapshots prune` must not reclaim a golden snapshot out from under the
+        // caller that asked for it by name.
+        Some(tag) => {
+            crate::storage::validate_snapshot_name(tag).context("invalid --tag")?;
+            (tag.to_string(), crate::storage::SnapshotType::User)
+        }
+        // The content-addressed cache entry `podman run` would have built. Prunable.
+        None => (
+            content_key.to_string(),
+            crate::storage::SnapshotType::System,
+        ),
+    };
+    Ok(PreparedTarget {
+        // `--force` is the only thing that rebuilds content whose cache key did not
+        // change, which is what a repointed remote image reference does.
+        publish_installed: !options.force,
+        // Under the content-addressed key, an installed generation holds this same
+        // content, so losing that race is a result worth reusing. A caller-chosen name is
+        // only reached past `publish_installed` when it held nothing or held other
+        // content, and `--force` asks for a rebuild either way.
+        existing: if options.tag.is_some() || options.force {
+            ExistingGeneration::Replace
+        } else {
+            ExistingGeneration::Reuse
+        },
+        name,
+        content_key: content_key.to_string(),
+        snapshot_type,
+    })
+}
+
+/// Whether an installed generation is the one this invocation asked for.
+///
+/// Returns the reason it is not, for the log line that explains a rebuild.
+fn prepared_generation_mismatch(
+    config: &crate::storage::SnapshotConfig,
+    target: &PreparedTarget,
+) -> Option<String> {
+    if config.name != target.name {
+        return Some(format!(
+            "config names snapshot {} instead of {}",
+            config.name, target.name
+        ));
+    }
+    if config.content_key() != target.content_key {
+        return Some(format!(
+            "holds content {} instead of {}",
+            config.content_key(),
+            target.content_key
+        ));
+    }
+    if config.snapshot_type != target.snapshot_type {
+        return Some(format!(
+            "is a {} snapshot instead of a {} snapshot",
+            config.snapshot_type, target.snapshot_type
+        ));
+    }
+    if config.kind != crate::storage::SnapshotKind::Full {
+        return Some(format!("is a {} snapshot, not a full one", config.kind));
+    }
+    None
 }
 
 #[derive(Clone, Copy, Debug, serde::Serialize, PartialEq, Eq)]
@@ -273,7 +359,13 @@ enum PreparedCache {
 struct PreparedSnapshotOutput {
     status: &'static str,
     cache: PreparedCache,
+    /// Snapshot name every other command addresses this artifact by.
     snapshot_key: String,
+    /// Content-addressed key whose content it holds. Equal to `snapshot_key` without `--tag`.
+    content_key: String,
+    /// `user` for a `--tag` artifact `snapshots prune` keeps, `system` for a prunable
+    /// cache entry.
+    snapshot_type: String,
     generation_id: String,
     config_digest: String,
 }
@@ -292,17 +384,25 @@ enum VmPreparation {
 }
 
 async fn verify_prepared_snapshot(
-    snapshot_key: &str,
+    target: &PreparedTarget,
     cache: PreparedCache,
 ) -> Result<Option<PreparedSnapshot>> {
-    verify_prepared_snapshot_in(&paths::snapshot_dir(), snapshot_key, cache).await
+    verify_prepared_snapshot_in(&paths::snapshot_dir(), target, cache).await
 }
 
+/// Verify the generation installed at `target.name`.
+///
+/// `Ok(None)` means this invocation has nothing to publish: either nothing is installed
+/// there, or a caller-chosen name holds something else. Both are cache misses and the
+/// caller rebuilds. `Err` means the generation cannot be published and rebuilding it
+/// would not help: it is truncated, points outside itself, or sits at the
+/// content-addressed key while describing different content.
 async fn verify_prepared_snapshot_in(
     snapshot_root: &std::path::Path,
-    snapshot_key: &str,
+    target: &PreparedTarget,
     cache: PreparedCache,
 ) -> Result<Option<PreparedSnapshot>> {
+    let snapshot_key = target.name.as_str();
     let snapshot_dir = snapshot_root.join(snapshot_key);
     tokio::fs::create_dir_all(snapshot_root)
         .await
@@ -323,25 +423,28 @@ async fn verify_prepared_snapshot_in(
         .await
         .with_context(|| format!("loading prepared snapshot {snapshot_key}"))?;
 
-    anyhow::ensure!(
-        config.name == snapshot_key,
-        "prepared snapshot key mismatch: requested {}, config names {}",
-        snapshot_key,
-        config.name
-    );
+    if let Some(reason) = prepared_generation_mismatch(&config, target) {
+        // A caller-chosen name can legitimately hold anything, so a generation that is
+        // not this one is a miss and gets rebuilt. The content-addressed key cannot hold
+        // anything else by construction, so a mismatch there is a hand-edited or corrupt
+        // generation: say so now instead of after a ten-minute rebuild that then refuses
+        // to publish it. `--force` skips this check entirely and replaces it.
+        anyhow::ensure!(
+            target.name != target.content_key,
+            "prepared snapshot {} {}",
+            snapshot_key,
+            reason
+        );
+        info!(
+            snapshot_key = %snapshot_key,
+            reason = %reason,
+            "installed snapshot does not answer for these arguments; rebuilding"
+        );
+        return Ok(None);
+    }
     anyhow::ensure!(
         config.generation_id != uuid::Uuid::nil(),
         "prepared snapshot {} has a nil generation ID",
-        snapshot_key
-    );
-    anyhow::ensure!(
-        config.snapshot_type == crate::storage::SnapshotType::System,
-        "prepared snapshot {} is not a system cache snapshot",
-        snapshot_key
-    );
-    anyhow::ensure!(
-        config.kind == crate::storage::SnapshotKind::Full,
-        "prepared snapshot {} is not a full memory snapshot",
         snapshot_key
     );
 
@@ -426,6 +529,8 @@ async fn verify_prepared_snapshot_in(
             status: "prepared",
             cache,
             snapshot_key: snapshot_key.to_string(),
+            content_key: config.content_key().to_string(),
+            snapshot_type: config.snapshot_type.to_string(),
             generation_id: generation.generation_id().to_string(),
             config_digest: generation.config_digest_hex(),
         },
@@ -554,7 +659,7 @@ async fn prepare_vm_for_lifecycle(
         "Starting fcvm podman lifecycle"
     );
 
-    if lifecycle == PodmanLifecycle::Prepare {
+    if lifecycle.is_prepare() {
         validate_prepare_args(&args)?;
     }
 
@@ -756,9 +861,10 @@ async fn prepare_vm_for_lifecycle(
         // restored VM (no exec rebind / output reconnect). Forcing the transport is a
         // test/debug path with no need to populate the shared cache, so skip caching for it.
         || std::env::var("FCVM_BOOTPLAN").as_deref() == Ok("vsock");
-    let (fc_config, snapshot_key): (
+    let (fc_config, snapshot_key, prepare_target): (
         Option<crate::firecracker::FirecrackerConfig>,
         Option<String>,
+        Option<PreparedTarget>,
     ) = if !no_snapshot {
         let resolved_mode = resolve_image_mode(&args);
         let config = build_firecracker_config(
@@ -776,22 +882,30 @@ async fn prepare_vm_for_lifecycle(
         // Check if cached snapshot exists - prefer startup snapshot over pre-start snapshot
         let startup_key = startup_snapshot_key(&key);
 
-        if lifecycle == PodmanLifecycle::Prepare {
-            if let Some(prepared) =
-                verify_prepared_snapshot(&startup_key, PreparedCache::Hit).await?
+        let mut prepare_target = None;
+        if let PodmanLifecycle::Prepare(options) = &lifecycle {
+            let target = prepare_install_target(options, &startup_key)?;
+            if !target.publish_installed {
+                info!(
+                    snapshot_key = %target.name,
+                    content_key = %target.content_key,
+                    "Rebuilding prepared startup snapshot (--force)"
+                );
+            } else if let Some(prepared) =
+                verify_prepared_snapshot(&target, PreparedCache::Hit).await?
             {
                 info!(
-                    snapshot_key = %startup_key,
+                    snapshot_key = %target.name,
                     generation_id = %prepared.output.generation_id,
                     "Prepared startup snapshot hit"
                 );
                 return Ok(VmPreparation::Prepared(prepared));
             }
+            prepare_target = Some(target);
         }
 
         // Check for startup snapshot first (fully initialized application)
-        if lifecycle == PodmanLifecycle::Run && check_podman_snapshot(&startup_key).await.is_some()
-        {
+        if !lifecycle.is_prepare() && check_podman_snapshot(&startup_key).await.is_some() {
             info!(
                 snapshot_key = %startup_key,
                 image = %args.image,
@@ -829,7 +943,7 @@ async fn prepare_vm_for_lifecycle(
         }
 
         // Check for pre-start snapshot (container loaded but not initialized)
-        if lifecycle == PodmanLifecycle::Run && check_podman_snapshot(&key).await.is_some() {
+        if !lifecycle.is_prepare() && check_podman_snapshot(&key).await.is_some() {
             info!(
                 snapshot_key = %key,
                 image = %args.image,
@@ -871,7 +985,7 @@ async fn prepare_vm_for_lifecycle(
             image = %args.image,
             "Snapshot miss, will create snapshot after image load"
         );
-        (Some(config), Some(key))
+        (Some(config), Some(key), prepare_target)
     } else {
         if std::env::var("FCVM_NO_SNAPSHOT")
             .map(|v| !v.is_empty())
@@ -881,7 +995,7 @@ async fn prepare_vm_for_lifecycle(
         } else {
             info!("Snapshot disabled via --no-snapshot flag");
         }
-        (None, None)
+        (None, None, None)
     };
 
     // Generate VM ID
@@ -1263,7 +1377,7 @@ async fn prepare_vm_for_lifecycle(
     let (cache_tx, cache_rx): (
         Option<mpsc::Sender<CacheRequest>>,
         Option<mpsc::Receiver<CacheRequest>>,
-    ) = if !skip_snapshot_creation && lifecycle == PodmanLifecycle::Run {
+    ) = if !skip_snapshot_creation && !lifecycle.is_prepare() {
         let (tx, rx) = mpsc::channel(1);
         (Some(tx), Some(rx))
     } else {
@@ -1282,7 +1396,7 @@ async fn prepare_vm_for_lifecycle(
         skip_snapshot_creation,
         snapshot_key.is_some(),
         args.health_check.is_some(),
-        lifecycle,
+        &lifecycle,
     ) {
         let (tx, rx) = tokio::sync::oneshot::channel();
         (Some(tx), Some(rx))
@@ -1358,7 +1472,7 @@ async fn prepare_vm_for_lifecycle(
                 log_tx_clone,
                 reconnect,
                 non_blocking_output,
-                lifecycle == PodmanLifecycle::Run,
+                !lifecycle.is_prepare(),
                 None,
             )
             .await
@@ -1487,6 +1601,7 @@ async fn prepare_vm_for_lifecycle(
         cache_rx,
         startup_rx,
         snapshot_key,
+        prepare_target,
         volume_configs,
         args,
         disk_path,
@@ -1752,18 +1867,18 @@ pub async fn run_vm_loop(ctx: &mut VmContext, cancel: CancellationToken) -> Resu
                         .as_any()
                         .downcast_ref::<FirecrackerBackend>()
                         .context("snapshot creation requires the Firecracker backend")?;
-                    let snap = CreateSnapshotParams {
-                        vm_manager: fc_backend,
-                        snapshot_key: key,
-                        vm_state: &ctx.vm_state,
-                        disk_path: &ctx.disk_path,
-                        volume_configs: &ctx.volume_configs,
-                        remap_refs: &ctx.volume_servers.remap_refs,
-                    };
+                    let snap = CreateSnapshotParams::cache_entry(
+                        fc_backend,
+                        key,
+                        &ctx.vm_state,
+                        &ctx.disk_path,
+                        &ctx.volume_configs,
+                        &ctx.volume_servers.remap_refs,
+                    );
                     match create_snapshot_interruptible(
                         &snap,
                         &cancel,
-                        snapshot_source_disposition(PodmanLifecycle::Run),
+                        snapshot_source_disposition(&PodmanLifecycle::Run),
                     )
                     .await
                     {
@@ -1852,19 +1967,19 @@ pub async fn run_vm_loop(ctx: &mut VmContext, cancel: CancellationToken) -> Resu
                             .as_any()
                             .downcast_ref::<FirecrackerBackend>()
                             .context("snapshot creation requires the Firecracker backend")?;
-                        let snap = CreateSnapshotParams {
-                            vm_manager: fc_backend,
-                            snapshot_key: &startup_key,
-                            vm_state: &ctx.vm_state,
-                            disk_path: &ctx.disk_path,
-                            volume_configs: &ctx.volume_configs,
-                            remap_refs: &ctx.volume_servers.remap_refs,
-                        };
+                        let snap = CreateSnapshotParams::cache_entry(
+                            fc_backend,
+                            &startup_key,
+                            &ctx.vm_state,
+                            &ctx.disk_path,
+                            &ctx.volume_configs,
+                            &ctx.volume_servers.remap_refs,
+                        );
                         tokio::select! {
                             outcome = create_snapshot_interruptible(
                                 &snap,
                                 &cancel,
-                                snapshot_source_disposition(PodmanLifecycle::Run),
+                                snapshot_source_disposition(&PodmanLifecycle::Run),
                             ) => {
                                 match outcome {
                                     SnapshotOutcome::Interrupted => {
@@ -1950,6 +2065,7 @@ where
 /// optional HTTP health check retain exactly the same authority as a normal run.
 async fn run_prepare_loop(
     ctx: &mut VmContext,
+    lifecycle: &PodmanLifecycle,
     cancel: &CancellationToken,
 ) -> Result<PreparedSnapshot> {
     let startup_rx = ctx
@@ -1960,12 +2076,18 @@ async fn run_prepare_loop(
     let vm_exited = ctx.vm_manager.wait();
     let startup_ack = await_prepare_healthy(startup_rx, cancel, vm_exited).await?;
 
-    let base_key = ctx
-        .snapshot_key
-        .as_deref()
-        .context("prepare lifecycle has no content-addressed snapshot key")?;
-    let startup_key = startup_snapshot_key(base_key);
-    info!(snapshot_key = %startup_key, "Creating prepared startup snapshot (VM healthy)");
+    // Resolved before the boot, so the generation this installs is the one the pre-boot
+    // cache check looked for.
+    let target = ctx
+        .prepare_target
+        .clone()
+        .context("prepare lifecycle has no snapshot install target")?;
+    info!(
+        snapshot_key = %target.name,
+        content_key = %target.content_key,
+        snapshot_type = %target.snapshot_type,
+        "Creating prepared startup snapshot (VM healthy)"
+    );
 
     let fc_backend = ctx
         .vm_manager
@@ -1974,18 +2096,18 @@ async fn run_prepare_loop(
         .context("podman prepare requires the Firecracker backend")?;
     let snap = CreateSnapshotParams {
         vm_manager: fc_backend,
-        snapshot_key: &startup_key,
+        snapshot_key: &target.name,
+        content_key: &target.content_key,
+        snapshot_type: target.snapshot_type,
+        existing: target.existing,
         vm_state: &ctx.vm_state,
         disk_path: &ctx.disk_path,
         volume_configs: &ctx.volume_configs,
         remap_refs: &ctx.volume_servers.remap_refs,
     };
-    let install = snapshot::create_podman_snapshot(
-        &snap,
-        snapshot_source_disposition(PodmanLifecycle::Prepare),
-    )
-    .await
-    .with_context(|| format!("creating prepared startup snapshot {startup_key}"))?;
+    let install = snapshot::create_podman_snapshot(&snap, snapshot_source_disposition(lifecycle))
+        .await
+        .with_context(|| format!("creating prepared startup snapshot {}", target.name))?;
 
     if cancel.is_cancelled() {
         bail!("interrupted while creating prepared startup snapshot");
@@ -1997,12 +2119,12 @@ async fn run_prepare_loop(
         SnapshotInstall::Created => PreparedCache::Created,
         SnapshotInstall::Existing => PreparedCache::Hit,
     };
-    let prepared = verify_prepared_snapshot(&startup_key, cache)
+    let prepared = verify_prepared_snapshot(&target, cache)
         .await?
         .with_context(|| {
             format!(
-                "prepared startup snapshot {} disappeared after atomic installation",
-                startup_key
+                "prepared startup snapshot {} no longer names the generation this prepare installed",
+                target.name
             )
         })?;
 
@@ -2234,12 +2356,16 @@ pub async fn cmd_podman_run(args: RunArgs) -> Result<()> {
 /// a VM. A miss boots one disposable source, waits for normal health, atomically installs a
 /// startup snapshot while leaving the source paused, reaps every host resource, then emits one
 /// JSON record while holding a shared lease on that exact generation.
-pub async fn cmd_podman_prepare(args: RunArgs) -> Result<()> {
+pub async fn cmd_podman_prepare(args: crate::cli::PrepareArgs) -> Result<()> {
     let lifecycle_gate = super::common::LifecycleReadyGate::new();
     let cancel = lifecycle_gate.cancellation_token();
     spawn_lifecycle_signal_handler(&lifecycle_gate, "cancelling podman prepare")?;
 
-    match prepare_vm_for_lifecycle(args, PodmanLifecycle::Prepare).await? {
+    let lifecycle = PodmanLifecycle::Prepare(PrepareOptions {
+        tag: args.tag,
+        force: args.force,
+    });
+    match prepare_vm_for_lifecycle(args.run, lifecycle.clone()).await? {
         VmPreparation::Prepared(prepared) => {
             publish_prepared_snapshot_gated(&lifecycle_gate, &prepared)
         }
@@ -2253,7 +2379,7 @@ pub async fn cmd_podman_prepare(args: RunArgs) -> Result<()> {
                 }
                 // The source is an implementation detail, not a runnable workload. Leave its
                 // lifecycle barrier unpublished so external commands cannot adopt/snapshot it.
-                run_prepare_loop(&mut ctx, &cancel).await
+                run_prepare_loop(&mut ctx, &lifecycle, &cancel).await
             }
             .await;
 
@@ -2390,14 +2516,18 @@ mod tests {
         assert_eq!(resolve_image_mode(&args), ImageMode::Btrfs);
     }
 
+    fn prepare_lifecycle() -> PodmanLifecycle {
+        PodmanLifecycle::Prepare(PrepareOptions::default())
+    }
+
     #[test]
     fn prepare_and_run_have_explicit_source_dispositions() {
         assert_eq!(
-            snapshot_source_disposition(PodmanLifecycle::Run),
+            snapshot_source_disposition(&PodmanLifecycle::Run),
             super::super::common::SnapshotSourceDisposition::Resume
         );
         assert_eq!(
-            snapshot_source_disposition(PodmanLifecycle::Prepare),
+            snapshot_source_disposition(&prepare_lifecycle()),
             super::super::common::SnapshotSourceDisposition::LeavePaused
         );
     }
@@ -2408,19 +2538,19 @@ mod tests {
             false,
             true,
             false,
-            PodmanLifecycle::Prepare
+            &prepare_lifecycle()
         ));
         assert!(!should_arm_startup_snapshot(
             false,
             true,
             false,
-            PodmanLifecycle::Run
+            &PodmanLifecycle::Run
         ));
         assert!(should_arm_startup_snapshot(
             false,
             true,
             true,
-            PodmanLifecycle::Run
+            &PodmanLifecycle::Run
         ));
     }
 
@@ -2580,7 +2710,7 @@ mod tests {
             1,
             512,
         );
-        let config = super::super::common::build_snapshot_config(
+        let mut config = super::super::common::build_snapshot_config(
             &vm_state,
             snapshot_key,
             crate::storage::SnapshotType::System,
@@ -2588,6 +2718,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
         );
+        config.content_key = Some(snapshot_key.to_string());
         for path in [&config.memory_path, &config.vmstate_path, &config.disk_path] {
             tokio::fs::write(path, b"durable-artifact").await.unwrap();
         }
@@ -2598,11 +2729,11 @@ mod tests {
         .await
         .unwrap();
 
-        let prepared =
-            verify_prepared_snapshot_in(temp.path(), snapshot_key, PreparedCache::Created)
-                .await
-                .unwrap()
-                .expect("complete installed generation should verify");
+        let target = prepare_install_target(&PrepareOptions::default(), snapshot_key).unwrap();
+        let prepared = verify_prepared_snapshot_in(temp.path(), &target, PreparedCache::Created)
+            .await
+            .unwrap()
+            .expect("complete installed generation should verify");
         assert_eq!(prepared.output.status, "prepared");
         assert_eq!(prepared.output.cache, PreparedCache::Created);
         assert_eq!(prepared.output.snapshot_key, snapshot_key);
@@ -2631,16 +2762,308 @@ mod tests {
         drop(exclusive);
 
         tokio::fs::remove_file(&config.disk_path).await.unwrap();
-        let error = match verify_prepared_snapshot_in(temp.path(), snapshot_key, PreparedCache::Hit)
-            .await
-        {
-            Ok(_) => panic!("missing disk artifact must fail verification"),
-            Err(error) => error,
-        };
+        let error =
+            match verify_prepared_snapshot_in(temp.path(), &target, PreparedCache::Hit).await {
+                Ok(_) => panic!("missing disk artifact must fail verification"),
+                Err(error) => error,
+            };
         assert!(
             format!("{error:#}").contains("disk artifact"),
             "unexpected verification error: {error:#}"
         );
+    }
+
+    const CONTENT_KEY: &str = "0123456789ab-startup";
+
+    fn tagged(tag: &str) -> PrepareOptions {
+        PrepareOptions {
+            tag: Some(tag.to_string()),
+            force: false,
+        }
+    }
+
+    /// Write one installed generation to `root/<name>` and return its config.
+    async fn install_generation(
+        root: &std::path::Path,
+        name: &str,
+        content_key: Option<&str>,
+        snapshot_type: crate::storage::SnapshotType,
+    ) -> crate::storage::SnapshotConfig {
+        let dir = root.join(name);
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        let vm_state = VmState::new(
+            "vm-prepare-target".to_string(),
+            "alpine:latest".to_string(),
+            1,
+            512,
+        );
+        let mut config = super::super::common::build_snapshot_config(
+            &vm_state,
+            name,
+            snapshot_type,
+            &dir,
+            Vec::new(),
+            Vec::new(),
+        );
+        config.content_key = content_key.map(str::to_string);
+        for path in [&config.memory_path, &config.vmstate_path, &config.disk_path] {
+            tokio::fs::write(path, b"durable-artifact").await.unwrap();
+        }
+        tokio::fs::write(
+            dir.join("config.json"),
+            serde_json::to_vec_pretty(&config).unwrap(),
+        )
+        .await
+        .unwrap();
+        config
+    }
+
+    /// `--tag` puts the artifact where `snapshot serve`, `snapshot run --snapshot`,
+    /// `snapshots ls` and `snapshots delete` already look: a snapshot directory named by
+    /// the caller, with `config.name` matching, exactly as `snapshot create --tag` writes it.
+    #[test]
+    fn a_tag_names_the_installed_snapshot_and_no_tag_uses_the_content_key() {
+        let untagged = prepare_install_target(&PrepareOptions::default(), CONTENT_KEY).unwrap();
+        assert_eq!(untagged.name, CONTENT_KEY);
+        assert_eq!(untagged.content_key, CONTENT_KEY);
+
+        let tagged = prepare_install_target(&tagged("cb-req-golden"), CONTENT_KEY).unwrap();
+        assert_eq!(tagged.name, "cb-req-golden");
+        assert_eq!(
+            tagged.content_key, CONTENT_KEY,
+            "the tag renames the artifact, it does not change what identifies its content"
+        );
+    }
+
+    /// The tag becomes a directory name, so it takes the same validation every other
+    /// snapshot name takes rather than a second, weaker rule.
+    #[test]
+    fn a_tag_that_is_not_a_valid_snapshot_name_is_rejected() {
+        for bad in ["../escape", "has space", "", "."] {
+            let error = prepare_install_target(&tagged(bad), CONTENT_KEY)
+                .unwrap_err()
+                .to_string();
+            assert_eq!(error, "invalid --tag", "tag {bad:?} was accepted");
+        }
+    }
+
+    /// The tag composes with the content-addressed cache instead of replacing it: the
+    /// generation under the tag answers only for the content it was built from.
+    #[tokio::test]
+    async fn a_tag_hits_only_for_the_content_it_holds() {
+        let temp = tempfile::tempdir().unwrap();
+        install_generation(
+            temp.path(),
+            "cb-req-golden",
+            Some(CONTENT_KEY),
+            crate::storage::SnapshotType::User,
+        )
+        .await;
+
+        let matching = prepare_install_target(&tagged("cb-req-golden"), CONTENT_KEY).unwrap();
+        let hit = verify_prepared_snapshot_in(temp.path(), &matching, PreparedCache::Hit)
+            .await
+            .unwrap()
+            .expect("a tag holding this content is a hit");
+        assert_eq!(hit.output.snapshot_key, "cb-req-golden");
+        assert_eq!(hit.output.content_key, CONTENT_KEY);
+        assert_eq!(hit.output.snapshot_type, "user");
+        drop(hit);
+
+        // The image changed, so the cache key changed, so the tag is stale.
+        let other_content =
+            prepare_install_target(&tagged("cb-req-golden"), "ffffffffffff-startup").unwrap();
+        assert!(
+            verify_prepared_snapshot_in(temp.path(), &other_content, PreparedCache::Hit)
+                .await
+                .unwrap()
+                .is_none(),
+            "a tag holding other content must be a miss so prepare rebuilds it"
+        );
+    }
+
+    /// The content-addressed key cannot hold another config's content, so a generation
+    /// there that does not match is corrupt. Report it instead of rebuilding for ten
+    /// minutes and then refusing to publish the result.
+    #[tokio::test]
+    async fn a_mismatch_at_the_content_addressed_key_is_an_error_not_a_rebuild() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut config = install_generation(
+            temp.path(),
+            CONTENT_KEY,
+            Some(CONTENT_KEY),
+            crate::storage::SnapshotType::System,
+        )
+        .await;
+        config.kind = crate::storage::SnapshotKind::DiskOnly;
+        tokio::fs::write(
+            temp.path().join(CONTENT_KEY).join("config.json"),
+            serde_json::to_vec_pretty(&config).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let target = prepare_install_target(&PrepareOptions::default(), CONTENT_KEY).unwrap();
+        let error =
+            match verify_prepared_snapshot_in(temp.path(), &target, PreparedCache::Hit).await {
+                Ok(_) => panic!("a disk-only generation at the cache key cannot be published"),
+                Err(error) => error,
+            };
+        assert_eq!(
+            format!("{error:#}"),
+            format!("prepared snapshot {CONTENT_KEY} is a disk-only snapshot, not a full one")
+        );
+    }
+
+    /// A generation installed under its own content-addressed key self-identifies, so the
+    /// cache entries that exist on disk today keep hitting without a migration.
+    #[tokio::test]
+    async fn a_generation_without_a_recorded_content_key_falls_back_to_its_name() {
+        let temp = tempfile::tempdir().unwrap();
+        install_generation(
+            temp.path(),
+            CONTENT_KEY,
+            None,
+            crate::storage::SnapshotType::System,
+        )
+        .await;
+
+        let target = prepare_install_target(&PrepareOptions::default(), CONTENT_KEY).unwrap();
+        let hit = verify_prepared_snapshot_in(temp.path(), &target, PreparedCache::Hit)
+            .await
+            .unwrap()
+            .expect("a pre-existing cache entry named by its key must still hit");
+        assert_eq!(hit.output.content_key, CONTENT_KEY);
+    }
+
+    /// A `podman prepare --tag` artifact and a `snapshot create --tag` artifact are the
+    /// same kind of thing, so `snapshots prune` has to treat them the same: keep both by
+    /// default, reclaim only the content-addressed cache.
+    #[test]
+    fn a_default_prune_keeps_a_tagged_prepare_and_reclaims_an_untagged_one() {
+        let vm_state = VmState::new("vm-prune".to_string(), "alpine:latest".to_string(), 1, 512);
+        let config_for = |target: &PreparedTarget| {
+            super::super::common::build_snapshot_config(
+                &vm_state,
+                &target.name,
+                target.snapshot_type,
+                std::path::Path::new("/snapshots"),
+                Vec::new(),
+                Vec::new(),
+            )
+        };
+
+        let tagged_config =
+            config_for(&prepare_install_target(&tagged("cb-req-golden"), CONTENT_KEY).unwrap());
+        let untagged_config =
+            config_for(&prepare_install_target(&PrepareOptions::default(), CONTENT_KEY).unwrap());
+
+        assert!(
+            !crate::commands::snapshots::prune_reclaims(&tagged_config, false, None),
+            "a golden snapshot must not evaporate on the next prune"
+        );
+        assert!(crate::commands::snapshots::prune_reclaims(
+            &untagged_config,
+            false,
+            None
+        ));
+        assert!(
+            crate::commands::snapshots::prune_reclaims(&tagged_config, true, None),
+            "--all still reclaims it"
+        );
+    }
+
+    /// A generation whose type does not match what this invocation would install is not a
+    /// hit: a `snapshot create` artifact sitting on the tag cannot be republished as if
+    /// `prepare` had built it.
+    #[tokio::test]
+    async fn a_tag_holding_a_snapshot_this_prepare_did_not_build_is_a_miss() {
+        let temp = tempfile::tempdir().unwrap();
+        // `snapshot create --tag cb-req-golden` writes exactly this: User type, no content key.
+        install_generation(
+            temp.path(),
+            "cb-req-golden",
+            None,
+            crate::storage::SnapshotType::User,
+        )
+        .await;
+
+        let target = prepare_install_target(&tagged("cb-req-golden"), CONTENT_KEY).unwrap();
+        assert!(
+            verify_prepared_snapshot_in(temp.path(), &target, PreparedCache::Hit)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(
+            target.existing,
+            ExistingGeneration::Replace,
+            "and the rebuild must replace it rather than short-circuit on it"
+        );
+    }
+
+    /// `--force` has to defeat both short circuits, or an installed generation still wins:
+    /// the pre-boot cache check that publishes without booting, and the under-lock check
+    /// that reuses whatever is installed once the source is healthy.
+    #[test]
+    fn force_rebuilds_instead_of_reusing_an_installed_generation() {
+        for tag in [None, Some("cb-req-golden")] {
+            let forced = PrepareOptions {
+                tag: tag.map(str::to_string),
+                force: true,
+            };
+            let target = prepare_install_target(&forced, CONTENT_KEY).unwrap();
+            assert!(
+                !target.publish_installed,
+                "--force must not publish an installed generation (tag {tag:?})"
+            );
+            assert_eq!(
+                target.existing,
+                ExistingGeneration::Replace,
+                "--force must install over whatever is there (tag {tag:?})"
+            );
+        }
+
+        let unforced = prepare_install_target(&PrepareOptions::default(), CONTENT_KEY).unwrap();
+        assert!(unforced.publish_installed);
+        assert_eq!(
+            unforced.existing,
+            ExistingGeneration::Reuse,
+            "without --force the content-addressed key reuses what is installed"
+        );
+
+        let unforced_tag = prepare_install_target(&tagged("cb-req-golden"), CONTENT_KEY).unwrap();
+        assert!(
+            unforced_tag.publish_installed,
+            "a tag holding the right content still skips the boot"
+        );
+        assert_eq!(
+            unforced_tag.existing,
+            ExistingGeneration::Replace,
+            "a caller-chosen name is only reached past the hit check when it held \
+             nothing or held other content"
+        );
+    }
+
+    /// The install decision `create_podman_snapshot` makes under the generation lock.
+    #[test]
+    fn only_a_reuse_policy_keeps_a_generation_installed_by_another_process() {
+        assert!(snapshot::keeps_installed_generation(
+            ExistingGeneration::Reuse,
+            true
+        ));
+        assert!(!snapshot::keeps_installed_generation(
+            ExistingGeneration::Reuse,
+            false
+        ));
+        assert!(!snapshot::keeps_installed_generation(
+            ExistingGeneration::Replace,
+            true
+        ));
+        assert!(!snapshot::keeps_installed_generation(
+            ExistingGeneration::Replace,
+            false
+        ));
     }
 
     #[tokio::test]

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -27,7 +27,7 @@ pub(crate) use listeners::{run_output_listener, run_status_listener, spawn_bootp
 use snapshot::{build_firecracker_config, snapshot_run_firecracker_overrides};
 pub use snapshot::{
     check_podman_snapshot, create_snapshot_interruptible, startup_snapshot_key,
-    CreateSnapshotParams,
+    CreateSnapshotParams, SnapshotInstall,
 };
 pub(crate) use vm_config::{
     build_launch_config, build_runtime_boot_args, cleanup_nfs_exports, configure_and_boot_vm,
@@ -199,7 +199,252 @@ pub async fn start_vm(mut args: RunArgs) -> Result<VmHandle> {
 pub async fn cmd_podman(args: PodmanArgs) -> Result<()> {
     match args.cmd {
         PodmanCommands::Run(run_args) => cmd_podman_run(run_args).await,
+        PodmanCommands::Prepare(run_args) => cmd_podman_prepare(run_args).await,
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PodmanLifecycle {
+    Run,
+    Prepare,
+}
+
+fn snapshot_source_disposition(
+    lifecycle: PodmanLifecycle,
+) -> super::common::SnapshotSourceDisposition {
+    match lifecycle {
+        PodmanLifecycle::Run => super::common::SnapshotSourceDisposition::Resume,
+        PodmanLifecycle::Prepare => super::common::SnapshotSourceDisposition::LeavePaused,
+    }
+}
+
+fn validate_prepare_args(args: &RunArgs) -> Result<()> {
+    anyhow::ensure!(
+        !args.no_snapshot,
+        "podman prepare cannot be used with --no-snapshot"
+    );
+    anyhow::ensure!(!args.tty, "podman prepare does not support --tty");
+    anyhow::ensure!(
+        !args.interactive,
+        "podman prepare does not support --interactive"
+    );
+    anyhow::ensure!(
+        args.vsock_dir.is_none(),
+        "podman prepare does not support --vsock-dir because its source VM is disposable"
+    );
+    anyhow::ensure!(
+        args.hypervisor == crate::cli::args::Hypervisor::Firecracker,
+        "podman prepare currently requires --hypervisor firecracker"
+    );
+    anyhow::ensure!(
+        args.rootfs_override.is_none(),
+        "podman prepare cannot prepare an internal disk-only clone"
+    );
+    anyhow::ensure!(
+        std::env::var("FCVM_NO_SNAPSHOT").map_or(true, |value| value.is_empty()),
+        "podman prepare cannot run while FCVM_NO_SNAPSHOT disables snapshots"
+    );
+    anyhow::ensure!(
+        std::env::var("FCVM_BOOTPLAN").as_deref() != Ok("vsock"),
+        "podman prepare does not support the forced FCVM_BOOTPLAN=vsock debug path"
+    );
+    Ok(())
+}
+
+fn should_arm_startup_snapshot(
+    skip_snapshot_creation: bool,
+    has_snapshot_key: bool,
+    has_explicit_http_health_check: bool,
+    lifecycle: PodmanLifecycle,
+) -> bool {
+    !skip_snapshot_creation
+        && has_snapshot_key
+        && (lifecycle == PodmanLifecycle::Prepare || has_explicit_http_health_check)
+}
+
+#[derive(Clone, Copy, Debug, serde::Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum PreparedCache {
+    Hit,
+    Created,
+}
+
+#[derive(Debug, serde::Serialize, PartialEq, Eq)]
+struct PreparedSnapshotOutput {
+    status: &'static str,
+    cache: PreparedCache,
+    snapshot_key: String,
+    generation_id: String,
+    config_digest: String,
+}
+
+struct PreparedSnapshot {
+    output: PreparedSnapshotOutput,
+    // Held through JSON publication so a concurrent creator/deleter cannot replace the
+    // generation between verification and the successful command response.
+    _generation_lock: std::fs::File,
+}
+
+enum VmPreparation {
+    Active(Box<VmContext>),
+    RunCompleted,
+    Prepared(PreparedSnapshot),
+}
+
+async fn verify_prepared_snapshot(
+    snapshot_key: &str,
+    cache: PreparedCache,
+) -> Result<Option<PreparedSnapshot>> {
+    verify_prepared_snapshot_in(&paths::snapshot_dir(), snapshot_key, cache).await
+}
+
+async fn verify_prepared_snapshot_in(
+    snapshot_root: &std::path::Path,
+    snapshot_key: &str,
+    cache: PreparedCache,
+) -> Result<Option<PreparedSnapshot>> {
+    let snapshot_dir = snapshot_root.join(snapshot_key);
+    tokio::fs::create_dir_all(snapshot_root)
+        .await
+        .context("creating snapshot directory")?;
+    let generation_lock = super::common::acquire_snapshot_dir_lock(&snapshot_dir, false).await?;
+
+    let config_path = snapshot_dir.join("config.json");
+    if !tokio::fs::try_exists(&config_path)
+        .await
+        .with_context(|| format!("checking prepared snapshot {}", config_path.display()))?
+    {
+        return Ok(None);
+    }
+
+    let manager = crate::storage::SnapshotManager::new(snapshot_root.to_path_buf());
+    let (config, generation) = manager
+        .load_snapshot_with_generation(snapshot_key)
+        .await
+        .with_context(|| format!("loading prepared snapshot {snapshot_key}"))?;
+
+    anyhow::ensure!(
+        config.name == snapshot_key,
+        "prepared snapshot key mismatch: requested {}, config names {}",
+        snapshot_key,
+        config.name
+    );
+    anyhow::ensure!(
+        config.generation_id != uuid::Uuid::nil(),
+        "prepared snapshot {} has a nil generation ID",
+        snapshot_key
+    );
+    anyhow::ensure!(
+        config.snapshot_type == crate::storage::SnapshotType::System,
+        "prepared snapshot {} is not a system cache snapshot",
+        snapshot_key
+    );
+    anyhow::ensure!(
+        config.kind == crate::storage::SnapshotKind::Full,
+        "prepared snapshot {} is not a full memory snapshot",
+        snapshot_key
+    );
+
+    for (label, configured, expected) in [
+        (
+            "memory",
+            &config.memory_path,
+            snapshot_dir.join("memory.bin"),
+        ),
+        (
+            "VM state",
+            &config.vmstate_path,
+            snapshot_dir.join("vmstate.bin"),
+        ),
+        ("disk", &config.disk_path, snapshot_dir.join("disk.raw")),
+    ] {
+        anyhow::ensure!(
+            configured == &expected,
+            "prepared snapshot {} {} path points outside its generation: {}",
+            snapshot_key,
+            label,
+            configured.display()
+        );
+        let metadata = tokio::fs::metadata(configured).await.with_context(|| {
+            format!(
+                "reading prepared snapshot {} {} artifact {}",
+                snapshot_key,
+                label,
+                configured.display()
+            )
+        })?;
+        anyhow::ensure!(
+            metadata.is_file() && metadata.len() > 0,
+            "prepared snapshot {} {} artifact is not a non-empty regular file: {}",
+            snapshot_key,
+            label,
+            configured.display()
+        );
+    }
+
+    // `prepare` is a durability boundary, not merely a namespace rename. Flush every file
+    // in the installed generation, then the generation and snapshot-root directories, while
+    // the shared generation lease prevents replacement. Success therefore survives a host
+    // crash after the JSON response rather than depending on eventual writeback.
+    let sync_dir = snapshot_dir.clone();
+    let sync_root = snapshot_root.to_path_buf();
+    tokio::task::spawn_blocking(move || -> Result<()> {
+        for entry in std::fs::read_dir(&sync_dir)
+            .with_context(|| format!("reading prepared generation {}", sync_dir.display()))?
+        {
+            let entry = entry.context("reading prepared generation entry")?;
+            if entry
+                .file_type()
+                .context("reading prepared generation entry type")?
+                .is_file()
+            {
+                std::fs::File::open(entry.path())
+                    .with_context(|| {
+                        format!("opening prepared artifact {}", entry.path().display())
+                    })?
+                    .sync_all()
+                    .with_context(|| {
+                        format!("syncing prepared artifact {}", entry.path().display())
+                    })?;
+            }
+        }
+        std::fs::File::open(&sync_dir)
+            .with_context(|| format!("opening prepared generation {}", sync_dir.display()))?
+            .sync_all()
+            .with_context(|| format!("syncing prepared generation {}", sync_dir.display()))?;
+        std::fs::File::open(&sync_root)
+            .with_context(|| format!("opening snapshot root {}", sync_root.display()))?
+            .sync_all()
+            .with_context(|| format!("syncing snapshot root {}", sync_root.display()))?;
+        Ok(())
+    })
+    .await
+    .context("joining prepared snapshot durability sync")??;
+
+    Ok(Some(PreparedSnapshot {
+        output: PreparedSnapshotOutput {
+            status: "prepared",
+            cache,
+            snapshot_key: snapshot_key.to_string(),
+            generation_id: generation.generation_id().to_string(),
+            config_digest: generation.config_digest_hex(),
+        },
+        _generation_lock: generation_lock,
+    }))
+}
+
+fn publish_prepared_snapshot(prepared: &PreparedSnapshot) -> Result<()> {
+    use std::io::Write;
+
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    serde_json::to_writer(&mut stdout, &prepared.output)
+        .context("serializing prepared snapshot result")?;
+    writeln!(&mut stdout).context("writing prepared snapshot result")?;
+    stdout
+        .flush()
+        .context("flushing prepared snapshot result")?;
+    Ok(())
 }
 
 /// Best-effort removal of host state persisted during a failed `prepare_vm`.
@@ -292,8 +537,26 @@ async fn cleanup_failed_prepare(
     }
 }
 
-pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
-    info!("Starting fcvm podman run");
+pub async fn prepare_vm(args: RunArgs) -> Result<Option<VmContext>> {
+    match prepare_vm_for_lifecycle(args, PodmanLifecycle::Run).await? {
+        VmPreparation::Active(ctx) => Ok(Some(*ctx)),
+        VmPreparation::RunCompleted => Ok(None),
+        VmPreparation::Prepared(_) => unreachable!("run lifecycle cannot prepare an artifact"),
+    }
+}
+
+async fn prepare_vm_for_lifecycle(
+    mut args: RunArgs,
+    lifecycle: PodmanLifecycle,
+) -> Result<VmPreparation> {
+    info!(
+        lifecycle = ?lifecycle,
+        "Starting fcvm podman lifecycle"
+    );
+
+    if lifecycle == PodmanLifecycle::Prepare {
+        validate_prepare_args(&args)?;
+    }
 
     // Validate VM name before any setup work
     validate_vm_name(&args.name).context("invalid VM name")?;
@@ -513,8 +776,22 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
         // Check if cached snapshot exists - prefer startup snapshot over pre-start snapshot
         let startup_key = startup_snapshot_key(&key);
 
+        if lifecycle == PodmanLifecycle::Prepare {
+            if let Some(prepared) =
+                verify_prepared_snapshot(&startup_key, PreparedCache::Hit).await?
+            {
+                info!(
+                    snapshot_key = %startup_key,
+                    generation_id = %prepared.output.generation_id,
+                    "Prepared startup snapshot hit"
+                );
+                return Ok(VmPreparation::Prepared(prepared));
+            }
+        }
+
         // Check for startup snapshot first (fully initialized application)
-        if check_podman_snapshot(&startup_key).await.is_some() {
+        if lifecycle == PodmanLifecycle::Run && check_podman_snapshot(&startup_key).await.is_some()
+        {
             info!(
                 snapshot_key = %startup_key,
                 image = %args.image,
@@ -541,7 +818,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
             };
             let attempt = super::snapshot::cmd_snapshot_run_attempt(snapshot_args).await;
             match attempt.result {
-                Ok(()) => return Ok(None),
+                Ok(()) => return Ok(VmPreparation::RunCompleted),
                 Err(e) if is_snapshot_load_failure(&e) => {
                     invalidate_unusable_snapshot(&startup_key, attempt.generation.as_ref(), &e)
                         .await;
@@ -552,7 +829,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
         }
 
         // Check for pre-start snapshot (container loaded but not initialized)
-        if check_podman_snapshot(&key).await.is_some() {
+        if lifecycle == PodmanLifecycle::Run && check_podman_snapshot(&key).await.is_some() {
             info!(
                 snapshot_key = %key,
                 image = %args.image,
@@ -580,7 +857,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
             };
             let attempt = super::snapshot::cmd_snapshot_run_attempt(snapshot_args).await;
             match attempt.result {
-                Ok(()) => return Ok(None),
+                Ok(()) => return Ok(VmPreparation::RunCompleted),
                 Err(e) if is_snapshot_load_failure(&e) => {
                     invalidate_unusable_snapshot(&key, attempt.generation.as_ref(), &e).await;
                     // fall through to a fresh boot (which re-creates the snapshot)
@@ -986,7 +1263,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
     let (cache_tx, cache_rx): (
         Option<mpsc::Sender<CacheRequest>>,
         Option<mpsc::Receiver<CacheRequest>>,
-    ) = if !skip_snapshot_creation {
+    ) = if !skip_snapshot_creation && lifecycle == PodmanLifecycle::Run {
         let (tx, rx) = mpsc::channel(1);
         (Some(tx), Some(rx))
     } else {
@@ -1001,7 +1278,12 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
     let (startup_tx, startup_rx): (
         Option<tokio::sync::oneshot::Sender<crate::health::StartupSnapshotAck>>,
         Option<tokio::sync::oneshot::Receiver<crate::health::StartupSnapshotAck>>,
-    ) = if !skip_snapshot_creation && snapshot_key.is_some() && args.health_check.is_some() {
+    ) = if should_arm_startup_snapshot(
+        skip_snapshot_creation,
+        snapshot_key.is_some(),
+        args.health_check.is_some(),
+        lifecycle,
+    ) {
         let (tx, rx) = tokio::sync::oneshot::channel();
         (Some(tx), Some(rx))
     } else {
@@ -1076,6 +1358,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
                 log_tx_clone,
                 reconnect,
                 non_blocking_output,
+                lifecycle == PodmanLifecycle::Run,
                 None,
             )
             .await
@@ -1182,7 +1465,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
 
     let disk_path = data_dir.join("disks/rootfs.raw");
 
-    Ok(Some(VmContext {
+    Ok(VmPreparation::Active(Box::new(VmContext {
         restore_from_cache: None,
         vm_id,
         vm_name,
@@ -1213,7 +1496,7 @@ pub async fn prepare_vm(mut args: RunArgs) -> Result<Option<VmContext>> {
         reboot_requested,
         container_exit_seen,
         reboot_spec,
-    }))
+    })))
 }
 
 /// Resolve a UID to a username via the host's /etc/passwd.
@@ -1477,7 +1760,13 @@ pub async fn run_vm_loop(ctx: &mut VmContext, cancel: CancellationToken) -> Resu
                         volume_configs: &ctx.volume_configs,
                         remap_refs: &ctx.volume_servers.remap_refs,
                     };
-                    match create_snapshot_interruptible(&snap, &cancel).await {
+                    match create_snapshot_interruptible(
+                        &snap,
+                        &cancel,
+                        snapshot_source_disposition(PodmanLifecycle::Run),
+                    )
+                    .await
+                    {
                         SnapshotOutcome::Interrupted => {
                             return Ok(None);
                         }
@@ -1572,7 +1861,11 @@ pub async fn run_vm_loop(ctx: &mut VmContext, cancel: CancellationToken) -> Resu
                             remap_refs: &ctx.volume_servers.remap_refs,
                         };
                         tokio::select! {
-                            outcome = create_snapshot_interruptible(&snap, &cancel) => {
+                            outcome = create_snapshot_interruptible(
+                                &snap,
+                                &cancel,
+                                snapshot_source_disposition(PodmanLifecycle::Run),
+                            ) => {
                                 match outcome {
                                     SnapshotOutcome::Interrupted => {
                                         return Ok(None);
@@ -1612,6 +1905,113 @@ pub async fn run_vm_loop(ctx: &mut VmContext, cancel: CancellationToken) -> Resu
     }
 }
 
+/// How long `podman prepare` waits for its disposable source to first report Healthy.
+///
+/// Generous, because this covers guest boot plus container startup on a loaded runner. It
+/// exists so an image whose container never becomes healthy fails with a diagnostic instead
+/// of hanging the command until its caller runs out of wall clock.
+const PREPARE_HEALTH_BUDGET: std::time::Duration = std::time::Duration::from_secs(600);
+
+/// Resolve why the wait for the disposable source's first Healthy transition ended.
+///
+/// Split out of [`run_prepare_loop`] so every outcome is exercised without a VM: the
+/// VM-exit arm takes its future from the caller.
+async fn await_prepare_healthy<F>(
+    startup_rx: tokio::sync::oneshot::Receiver<crate::health::StartupSnapshotAck>,
+    cancel: &CancellationToken,
+    vm_exited: F,
+) -> Result<crate::health::StartupSnapshotAck>
+where
+    F: std::future::Future<Output = Result<std::process::ExitStatus>>,
+{
+    tokio::select! {
+        _ = cancel.cancelled() => {
+            bail!("interrupted before the container became healthy")
+        }
+        status = vm_exited => {
+            let status = status.context("waiting for disposable prepare VM")?;
+            bail!("disposable prepare VM exited before the container became healthy: {status}")
+        }
+        _ = tokio::time::sleep(PREPARE_HEALTH_BUDGET) => {
+            bail!(
+                "disposable prepare VM did not report a healthy container within {}s",
+                PREPARE_HEALTH_BUDGET.as_secs()
+            )
+        }
+        startup_ack = startup_rx => {
+            startup_ack.context("health monitor stopped before prepare snapshot creation")
+        }
+    }
+}
+
+/// Wait for the ordinary health monitor's first Healthy transition, capture the startup
+/// artifact, and leave the disposable source paused. No prepare-specific readiness probe
+/// exists: image HEALTHCHECK (when present), container-running state otherwise, and the
+/// optional HTTP health check retain exactly the same authority as a normal run.
+async fn run_prepare_loop(
+    ctx: &mut VmContext,
+    cancel: &CancellationToken,
+) -> Result<PreparedSnapshot> {
+    let startup_rx = ctx
+        .startup_rx
+        .take()
+        .context("prepare lifecycle has no startup health trigger")?;
+
+    let vm_exited = ctx.vm_manager.wait();
+    let startup_ack = await_prepare_healthy(startup_rx, cancel, vm_exited).await?;
+
+    let base_key = ctx
+        .snapshot_key
+        .as_deref()
+        .context("prepare lifecycle has no content-addressed snapshot key")?;
+    let startup_key = startup_snapshot_key(base_key);
+    info!(snapshot_key = %startup_key, "Creating prepared startup snapshot (VM healthy)");
+
+    let fc_backend = ctx
+        .vm_manager
+        .as_any()
+        .downcast_ref::<FirecrackerBackend>()
+        .context("podman prepare requires the Firecracker backend")?;
+    let snap = CreateSnapshotParams {
+        vm_manager: fc_backend,
+        snapshot_key: &startup_key,
+        vm_state: &ctx.vm_state,
+        disk_path: &ctx.disk_path,
+        volume_configs: &ctx.volume_configs,
+        remap_refs: &ctx.volume_servers.remap_refs,
+    };
+    let install = snapshot::create_podman_snapshot(
+        &snap,
+        snapshot_source_disposition(PodmanLifecycle::Prepare),
+    )
+    .await
+    .with_context(|| format!("creating prepared startup snapshot {startup_key}"))?;
+
+    if cancel.is_cancelled() {
+        bail!("interrupted while creating prepared startup snapshot");
+    }
+
+    // Acquire a shared generation lease immediately after the creator releases its exclusive
+    // install lock. Keep it through verified cleanup and JSON publication.
+    let cache = match install {
+        SnapshotInstall::Created => PreparedCache::Created,
+        SnapshotInstall::Existing => PreparedCache::Hit,
+    };
+    let prepared = verify_prepared_snapshot(&startup_key, cache)
+        .await?
+        .with_context(|| {
+            format!(
+                "prepared startup snapshot {} disappeared after atomic installation",
+                startup_key
+            )
+        })?;
+
+    // Never acknowledge Healthy in the disposable source. It remains paused until cleanup;
+    // dropping this ack only releases the monitor so its task can observe cancellation.
+    drop(startup_ack);
+    Ok(prepared)
+}
+
 /// Clean up all resources associated with a VM.
 pub async fn cleanup_vm_context(mut ctx: VmContext) {
     // Cancel status listener (podman-specific)
@@ -1646,34 +2046,114 @@ pub async fn cleanup_vm_context(mut ctx: VmContext) {
     .await;
 }
 
+/// Verified counterpart to [`cleanup_vm_context`] for finite lifecycle commands.
+async fn cleanup_vm_context_verified(mut ctx: VmContext) -> Result<()> {
+    let mut companion_errors = Vec::new();
+
+    let mut companions = vec![("status listener", ctx.status_handle)];
+    if let Some(handle) = ctx.egress_proxy_handle.take() {
+        companions.push(("egress proxy", handle));
+    }
+    if let Some(handle) = ctx.bootplan_handle.take() {
+        companions.push(("boot-plan listener", handle));
+    }
+    for (_, handle) in &companions {
+        handle.abort();
+    }
+    for (name, handle) in companions {
+        if let Err(error) = handle.await {
+            if !error.is_cancelled() {
+                companion_errors.push(format!("joining {name}: {error}"));
+            }
+        }
+    }
+
+    let cleanup_result = super::common::cleanup_vm_verified(
+        super::common::CleanupContext {
+            vm_id: ctx.vm_id,
+            volume_server_handles: ctx.volume_servers.handles,
+            remap_refs: ctx.volume_servers.remap_refs,
+            data_dir: ctx.data_dir,
+            health_cancel_token: Some(ctx.health_cancel_token),
+            health_monitor_handle: Some(ctx.health_monitor_handle),
+            output_listener_handle: ctx.output_handle,
+        },
+        ctx.vm_manager.as_mut(),
+        &mut ctx.holder_child,
+        ctx.network.as_mut(),
+        &ctx.state_manager,
+    )
+    .await;
+
+    if let Err(error) = cleanup_result {
+        companion_errors.push(format!("common VM resources: {error:#}"));
+    }
+    if companion_errors.is_empty() {
+        Ok(())
+    } else {
+        bail!(
+            "verified prepare cleanup failed: {}",
+            companion_errors.join("; ")
+        )
+    }
+}
+
+fn finish_prepare<T>(operation: Result<T>, cleanup: Result<()>) -> Result<T> {
+    match (operation, cleanup) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Err(operation), Ok(())) => Err(operation),
+        (Ok(_), Err(cleanup)) => Err(cleanup),
+        (Err(operation), Err(cleanup)) => Err(anyhow::anyhow!(
+            "prepare failed: {operation:#}; cleanup also failed: {cleanup:#}"
+        )),
+    }
+}
+
+/// Cancel `gate` on SIGTERM/SIGINT, describing the resulting shutdown as `shutdown_action`.
+///
+/// Installed before the VM is created so a signal during the (potentially long) setup phase
+/// is recorded instead of killing the process and leaving host network state, the persisted
+/// VM state file, and the data directory behind. Shutdown is deferred until setup finishes,
+/// then the caller's cleanup runs.
+fn spawn_lifecycle_signal_handler(
+    gate: &super::common::LifecycleReadyGate,
+    shutdown_action: &'static str,
+) -> Result<()> {
+    let gate = gate.clone();
+    let mut sigterm = signal(SignalKind::terminate()).context("installing SIGTERM handler")?;
+    let mut sigint = signal(SignalKind::interrupt()).context("installing SIGINT handler")?;
+    tokio::spawn(async move {
+        let signal_name = tokio::select! {
+            _ = sigterm.recv() => "SIGTERM",
+            _ = sigint.recv() => "SIGINT",
+        };
+        gate.cancel();
+        info!("received {signal_name}, {shutdown_action}");
+    });
+    Ok(())
+}
+
+fn publish_prepared_snapshot_gated(
+    lifecycle_gate: &super::common::LifecycleReadyGate,
+    prepared: &PreparedSnapshot,
+) -> Result<()> {
+    match lifecycle_gate.claim_terminal_publication()? {
+        super::common::LifecycleReadyOutcome::Published => publish_prepared_snapshot(prepared),
+        super::common::LifecycleReadyOutcome::Cancelled => {
+            bail!("interrupted before prepared snapshot publication")
+        }
+    }
+}
+
 /// CLI entrypoint for `fcvm podman run`. Thin wrapper around prepare_vm/run_vm_loop/cleanup.
 ///
 /// Public so the disk-only `snapshot run` dispatcher can reuse the exact same
 /// boot/loop/cleanup sequence after synthesizing RunArgs (rootfs_override set to
 /// the captured disk).
 pub async fn cmd_podman_run(args: RunArgs) -> Result<()> {
-    // Setup signal handlers → cancellation token.
-    // Installed before prepare_vm so a SIGTERM/SIGINT during the (potentially long)
-    // setup phase is recorded instead of killing the process and leaving host network
-    // state, the persisted VM state file, and the data directory behind. Shutdown is
-    // deferred until setup finishes, then full cleanup runs below.
     let lifecycle_gate = super::common::LifecycleReadyGate::new();
     let cancel = lifecycle_gate.cancellation_token();
-    let signal_gate = lifecycle_gate.clone();
-    let mut sigterm = signal(SignalKind::terminate()).context("installing SIGTERM handler")?;
-    let mut sigint = signal(SignalKind::interrupt()).context("installing SIGINT handler")?;
-    tokio::spawn(async move {
-        tokio::select! {
-            _ = sigterm.recv() => {
-                signal_gate.cancel();
-                info!("received SIGTERM, shutting down VM");
-            }
-            _ = sigint.recv() => {
-                signal_gate.cancel();
-                info!("received SIGINT, shutting down VM");
-            }
-        }
-    });
+    spawn_lifecycle_signal_handler(&lifecycle_gate, "shutting down VM")?;
 
     let Some(mut ctx) = prepare_vm(args).await? else {
         return Ok(()); // Snapshot cache hit, already handled
@@ -1746,6 +2226,42 @@ pub async fn cmd_podman_run(args: RunArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// CLI entrypoint for `fcvm podman prepare`.
+///
+/// A cache hit verifies and publishes the exact installed startup generation without booting
+/// a VM. A miss boots one disposable source, waits for normal health, atomically installs a
+/// startup snapshot while leaving the source paused, reaps every host resource, then emits one
+/// JSON record while holding a shared lease on that exact generation.
+pub async fn cmd_podman_prepare(args: RunArgs) -> Result<()> {
+    let lifecycle_gate = super::common::LifecycleReadyGate::new();
+    let cancel = lifecycle_gate.cancellation_token();
+    spawn_lifecycle_signal_handler(&lifecycle_gate, "cancelling podman prepare")?;
+
+    match prepare_vm_for_lifecycle(args, PodmanLifecycle::Prepare).await? {
+        VmPreparation::Prepared(prepared) => {
+            publish_prepared_snapshot_gated(&lifecycle_gate, &prepared)
+        }
+        VmPreparation::RunCompleted => {
+            unreachable!("prepare lifecycle never runs a cached snapshot")
+        }
+        VmPreparation::Active(mut ctx) => {
+            let operation = async {
+                if cancel.is_cancelled() {
+                    bail!("interrupted during disposable VM setup");
+                }
+                // The source is an implementation detail, not a runnable workload. Leave its
+                // lifecycle barrier unpublished so external commands cannot adopt/snapshot it.
+                run_prepare_loop(&mut ctx, &cancel).await
+            }
+            .await;
+
+            let cleanup = cleanup_vm_context_verified(*ctx).await;
+            let prepared = finish_prepare(operation, cleanup)?;
+            publish_prepared_snapshot_gated(&lifecycle_gate, &prepared)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1872,6 +2388,259 @@ mod tests {
         args.image_mode = Some(CliImageMode::Btrfs);
 
         assert_eq!(resolve_image_mode(&args), ImageMode::Btrfs);
+    }
+
+    #[test]
+    fn prepare_and_run_have_explicit_source_dispositions() {
+        assert_eq!(
+            snapshot_source_disposition(PodmanLifecycle::Run),
+            super::super::common::SnapshotSourceDisposition::Resume
+        );
+        assert_eq!(
+            snapshot_source_disposition(PodmanLifecycle::Prepare),
+            super::super::common::SnapshotSourceDisposition::LeavePaused
+        );
+    }
+
+    #[test]
+    fn prepare_arms_normal_health_without_requiring_an_http_override() {
+        assert!(should_arm_startup_snapshot(
+            false,
+            true,
+            false,
+            PodmanLifecycle::Prepare
+        ));
+        assert!(!should_arm_startup_snapshot(
+            false,
+            true,
+            false,
+            PodmanLifecycle::Run
+        ));
+        assert!(should_arm_startup_snapshot(
+            false,
+            true,
+            true,
+            PodmanLifecycle::Run
+        ));
+    }
+
+    #[test]
+    fn prepare_rejects_modes_that_cannot_produce_a_finite_verified_artifact() {
+        let mut args = test_args();
+        let error = validate_prepare_args(&args).unwrap_err();
+        assert_eq!(
+            format!("{error:#}"),
+            "podman prepare cannot be used with --no-snapshot"
+        );
+
+        args.no_snapshot = false;
+        args.tty = true;
+        let error = validate_prepare_args(&args).unwrap_err();
+        assert_eq!(
+            format!("{error:#}"),
+            "podman prepare does not support --tty"
+        );
+
+        args.tty = false;
+        args.vsock_dir = Some("/tmp/external-vsock".to_string());
+        let error = validate_prepare_args(&args).unwrap_err();
+        assert!(format!("{error:#}").contains("does not support --vsock-dir"));
+    }
+
+    #[test]
+    fn prepare_publication_requires_successful_cleanup_and_no_cancellation() {
+        assert_eq!(finish_prepare(Ok("artifact"), Ok(())).unwrap(), "artifact");
+
+        let cleanup_error =
+            finish_prepare(Ok("artifact"), Err(anyhow::anyhow!("holder still alive"))).unwrap_err();
+        assert_eq!(format!("{cleanup_error:#}"), "holder still alive");
+
+        let combined = finish_prepare::<()>(
+            Err(anyhow::anyhow!("snapshot install failed")),
+            Err(anyhow::anyhow!("network cleanup failed")),
+        )
+        .unwrap_err();
+        assert_eq!(
+            format!("{combined:#}"),
+            "prepare failed: snapshot install failed; cleanup also failed: network cleanup failed"
+        );
+
+        let cancelled_gate = super::super::common::LifecycleReadyGate::new();
+        cancelled_gate.cancel();
+        assert_eq!(
+            cancelled_gate.claim_terminal_publication().unwrap(),
+            super::super::common::LifecycleReadyOutcome::Cancelled
+        );
+
+        let publication_gate = super::super::common::LifecycleReadyGate::new();
+        assert_eq!(
+            publication_gate.claim_terminal_publication().unwrap(),
+            super::super::common::LifecycleReadyOutcome::Published
+        );
+        publication_gate.cancel();
+        assert_eq!(
+            publication_gate.claim_terminal_publication().unwrap(),
+            super::super::common::LifecycleReadyOutcome::Published,
+            "a terminal publication that linearized first remains the winner"
+        );
+    }
+
+    /// A never-healthy container must end `prepare` with a diagnostic, not hang it.
+    ///
+    /// `run` has no equivalent deadline because an unhealthy VM is still a VM the caller
+    /// owns and can inspect. `prepare` is finite, so without a bound this arm waits
+    /// forever and the only symptom is a CI job that eventually runs out of wall clock.
+    #[tokio::test(start_paused = true)]
+    async fn prepare_gives_up_when_the_container_never_becomes_healthy() {
+        // Held, so the startup channel stays pending instead of resolving to a closed error.
+        let (_startup_tx, startup_rx) = tokio::sync::oneshot::channel();
+        let cancel = CancellationToken::new();
+
+        let error = await_prepare_healthy(
+            startup_rx,
+            &cancel,
+            // The disposable VM stays up; only the container never reports healthy.
+            std::future::pending::<Result<std::process::ExitStatus>>(),
+        )
+        .await
+        .expect_err("a container that never becomes healthy must not hang prepare");
+
+        assert_eq!(
+            format!("{error:#}"),
+            format!(
+                "disposable prepare VM did not report a healthy container within {}s",
+                PREPARE_HEALTH_BUDGET.as_secs()
+            )
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn prepare_health_wait_reports_each_non_healthy_outcome() {
+        // Cancellation (SIGTERM/SIGINT) outranks the deadline.
+        let (_startup_tx, startup_rx) = tokio::sync::oneshot::channel();
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let error = await_prepare_healthy(
+            startup_rx,
+            &cancel,
+            std::future::pending::<Result<std::process::ExitStatus>>(),
+        )
+        .await
+        .expect_err("cancellation must end the wait");
+        assert_eq!(
+            format!("{error:#}"),
+            "interrupted before the container became healthy"
+        );
+
+        // A source that dies before reporting healthy names its exit status.
+        let (_startup_tx, startup_rx) = tokio::sync::oneshot::channel();
+        let cancel = CancellationToken::new();
+        let exited = async {
+            Ok(std::os::unix::process::ExitStatusExt::from_raw(
+                256, // WEXITSTATUS 1
+            ))
+        };
+        let error = await_prepare_healthy(startup_rx, &cancel, exited)
+            .await
+            .expect_err("a dead source must end the wait");
+        assert!(
+            format!("{error:#}")
+                .starts_with("disposable prepare VM exited before the container became healthy:"),
+            "unexpected error: {error:#}"
+        );
+
+        // The health monitor going away without a first Healthy is not a silent success.
+        let (startup_tx, startup_rx) = tokio::sync::oneshot::channel();
+        drop(startup_tx);
+        let cancel = CancellationToken::new();
+        let error = await_prepare_healthy(
+            startup_rx,
+            &cancel,
+            std::future::pending::<Result<std::process::ExitStatus>>(),
+        )
+        .await
+        .expect_err("a dropped health trigger must end the wait");
+        assert!(
+            format!("{error:#}")
+                .starts_with("health monitor stopped before prepare snapshot creation"),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn prepared_snapshot_verification_pins_exact_complete_generation() {
+        let temp = tempfile::tempdir().unwrap();
+        let snapshot_key = "0123456789ab-startup";
+        let snapshot_dir = temp.path().join(snapshot_key);
+        tokio::fs::create_dir_all(&snapshot_dir).await.unwrap();
+
+        let vm_state = VmState::new(
+            "vm-prepare-verify".to_string(),
+            "alpine:latest".to_string(),
+            1,
+            512,
+        );
+        let config = super::super::common::build_snapshot_config(
+            &vm_state,
+            snapshot_key,
+            crate::storage::SnapshotType::System,
+            &snapshot_dir,
+            Vec::new(),
+            Vec::new(),
+        );
+        for path in [&config.memory_path, &config.vmstate_path, &config.disk_path] {
+            tokio::fs::write(path, b"durable-artifact").await.unwrap();
+        }
+        tokio::fs::write(
+            snapshot_dir.join("config.json"),
+            serde_json::to_vec_pretty(&config).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let prepared =
+            verify_prepared_snapshot_in(temp.path(), snapshot_key, PreparedCache::Created)
+                .await
+                .unwrap()
+                .expect("complete installed generation should verify");
+        assert_eq!(prepared.output.status, "prepared");
+        assert_eq!(prepared.output.cache, PreparedCache::Created);
+        assert_eq!(prepared.output.snapshot_key, snapshot_key);
+        assert_eq!(
+            prepared.output.generation_id,
+            config.generation_id.to_string()
+        );
+        assert_eq!(prepared.output.config_digest.len(), 64);
+
+        let contender_dir = snapshot_dir.clone();
+        let contender = tokio::spawn(async move {
+            super::super::common::acquire_snapshot_dir_lock(&contender_dir, true)
+                .await
+                .unwrap()
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        assert!(
+            !contender.is_finished(),
+            "verified generation must stay pinned until publication"
+        );
+        drop(prepared);
+        let exclusive = tokio::time::timeout(std::time::Duration::from_secs(1), contender)
+            .await
+            .expect("exclusive replacement did not acquire released generation lease")
+            .unwrap();
+        drop(exclusive);
+
+        tokio::fs::remove_file(&config.disk_path).await.unwrap();
+        let error = match verify_prepared_snapshot_in(temp.path(), snapshot_key, PreparedCache::Hit)
+            .await
+        {
+            Ok(_) => panic!("missing disk artifact must fail verification"),
+            Err(error) => error,
+        };
+        assert!(
+            format!("{error:#}").contains("disk artifact"),
+            "unexpected verification error: {error:#}"
+        );
     }
 
     #[tokio::test]

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -485,6 +485,61 @@ async fn verify_prepared_snapshot_in(
         );
     }
 
+    // The three core artifacts are not the whole generation. A clone also opens every
+    // extra disk and, for a portable volume, its inode table — so a generation missing
+    // one of those would report `prepared` here and fail (or silently renumber inodes)
+    // at restore, after the cache entry is already durable and shared.
+    for disk in &config.metadata.extra_disks {
+        let mut components = std::path::Path::new(&disk.filename).components();
+        let contained = matches!(components.next(), Some(std::path::Component::Normal(_)))
+            && components.next().is_none();
+        anyhow::ensure!(
+            contained,
+            "prepared snapshot {} extra disk {} names a path outside its generation: {}",
+            snapshot_key,
+            disk.drive_id,
+            disk.filename
+        );
+        let path = snapshot_dir.join(&disk.filename);
+        let metadata = tokio::fs::metadata(&path).await.with_context(|| {
+            format!(
+                "reading prepared snapshot {} extra disk {} artifact {}",
+                snapshot_key,
+                disk.drive_id,
+                path.display()
+            )
+        })?;
+        anyhow::ensure!(
+            metadata.is_file() && metadata.len() > 0,
+            "prepared snapshot {} extra disk {} artifact is not a non-empty regular file: {}",
+            snapshot_key,
+            disk.drive_id,
+            path.display()
+        );
+    }
+
+    // Portable volumes restore their inode numbering from a table written into the
+    // generation before its atomic rename (see create_podman_snapshot). A clone that
+    // finds no table renumbers inodes, which is exactly the glitch the table prevents.
+    for volume in config.metadata.volumes.iter().filter(|v| v.portable) {
+        let path = snapshot_dir.join(format!("volume-{}-inode-table.json", volume.vsock_port));
+        let metadata = tokio::fs::metadata(&path).await.with_context(|| {
+            format!(
+                "reading prepared snapshot {} portable volume {} inode table {}",
+                snapshot_key,
+                volume.guest_path,
+                path.display()
+            )
+        })?;
+        anyhow::ensure!(
+            metadata.is_file() && metadata.len() > 0,
+            "prepared snapshot {} portable volume {} inode table is not a non-empty regular file: {}",
+            snapshot_key,
+            volume.guest_path,
+            path.display()
+        );
+    }
+
     // `prepare` is a durability boundary, not merely a namespace rename. Flush every file
     // in the installed generation, then the generation and snapshot-root directories, while
     // the shared generation lease prevents replacement. Success therefore survives a host
@@ -1477,10 +1532,9 @@ async fn prepare_vm_for_lifecycle(
             )
             .await
             {
-                Ok(lines) => lines,
+                Ok(()) => {}
                 Err(e) => {
                     tracing::warn!("Output listener error: {}", e);
-                    Vec::new()
                 }
             }
         }))
@@ -2970,6 +3024,154 @@ mod tests {
         assert!(
             crate::commands::snapshots::prune_reclaims(&tagged_config, true, None),
             "--all still reclaims it"
+        );
+    }
+
+    /// A generation is only complete if every artifact a clone opens is in it. The three
+    /// core files are not the whole set: an extra disk or a portable volume's inode table
+    /// can be absent while memory, vmstate and disk are all present and non-empty.
+    #[tokio::test]
+    async fn a_generation_missing_a_disk_or_inode_table_is_not_prepared() {
+        async fn verify_with(
+            temp: &std::path::Path,
+            extra_disks: Vec<crate::storage::snapshot::SnapshotExtraDisk>,
+            volumes: Vec<crate::storage::SnapshotVolumeConfig>,
+            side_files: &[(&str, &[u8])],
+        ) -> Result<bool> {
+            let snapshot_key = "0123456789ab-startup";
+            let snapshot_dir = temp.join(snapshot_key);
+            tokio::fs::create_dir_all(&snapshot_dir).await.unwrap();
+
+            let vm_state = VmState::new(
+                "vm-prepare-parts".to_string(),
+                "alpine:latest".to_string(),
+                1,
+                512,
+            );
+            let mut config = super::super::common::build_snapshot_config(
+                &vm_state,
+                snapshot_key,
+                crate::storage::SnapshotType::System,
+                &snapshot_dir,
+                Vec::new(),
+                Vec::new(),
+            );
+            config.content_key = Some(snapshot_key.to_string());
+            config.metadata.extra_disks = extra_disks;
+            config.metadata.volumes = volumes;
+            for path in [&config.memory_path, &config.vmstate_path, &config.disk_path] {
+                tokio::fs::write(path, b"durable-artifact").await.unwrap();
+            }
+            for (name, bytes) in side_files {
+                tokio::fs::write(snapshot_dir.join(name), bytes)
+                    .await
+                    .unwrap();
+            }
+            tokio::fs::write(
+                snapshot_dir.join("config.json"),
+                serde_json::to_vec_pretty(&config).unwrap(),
+            )
+            .await
+            .unwrap();
+
+            let target = prepare_install_target(&PrepareOptions::default(), snapshot_key).unwrap();
+            // The lease is released with the returned value; these cases only ask
+            // whether the generation verified at all.
+            Ok(
+                verify_prepared_snapshot_in(temp, &target, PreparedCache::Hit)
+                    .await?
+                    .is_some(),
+            )
+        }
+
+        fn disk(filename: &str) -> crate::storage::snapshot::SnapshotExtraDisk {
+            crate::storage::snapshot::SnapshotExtraDisk {
+                filename: filename.to_string(),
+                mount_path: "/data".to_string(),
+                read_only: false,
+                drive_id: "disk0".to_string(),
+            }
+        }
+
+        fn volume(portable: bool) -> crate::storage::SnapshotVolumeConfig {
+            crate::storage::SnapshotVolumeConfig {
+                host_path: std::path::PathBuf::from("/srv/data"),
+                guest_path: "/data".to_string(),
+                read_only: false,
+                vsock_port: 5001,
+                portable,
+            }
+        }
+
+        // An extra disk recorded in metadata but absent from the generation.
+        let temp = tempfile::tempdir().unwrap();
+        let error = verify_with(temp.path(), vec![disk("disk-dir-0.raw")], Vec::new(), &[])
+            .await
+            .expect_err("a missing extra disk must not verify");
+        assert!(
+            format!("{error:#}").contains("extra disk disk0 artifact"),
+            "unexpected error: {error:#}"
+        );
+
+        // Present but empty is the same failure at restore.
+        let temp = tempfile::tempdir().unwrap();
+        let error = verify_with(
+            temp.path(),
+            vec![disk("disk-dir-0.raw")],
+            Vec::new(),
+            &[("disk-dir-0.raw", b"")],
+        )
+        .await
+        .expect_err("an empty extra disk must not verify");
+        assert!(
+            format!("{error:#}").contains("is not a non-empty regular file"),
+            "unexpected error: {error:#}"
+        );
+
+        // A filename that escapes the generation is never followed.
+        let temp = tempfile::tempdir().unwrap();
+        let error = verify_with(temp.path(), vec![disk("../escape.raw")], Vec::new(), &[])
+            .await
+            .expect_err("an escaping extra disk filename must not verify");
+        assert!(
+            format!("{error:#}").contains("names a path outside its generation"),
+            "unexpected error: {error:#}"
+        );
+
+        // A portable volume with no inode table renumbers inodes on the clone.
+        let temp = tempfile::tempdir().unwrap();
+        let error = verify_with(temp.path(), Vec::new(), vec![volume(true)], &[])
+            .await
+            .expect_err("a missing inode table must not verify");
+        assert!(
+            format!("{error:#}").contains("portable volume /data inode table"),
+            "unexpected error: {error:#}"
+        );
+
+        // A non-portable volume writes no table, so its absence is correct.
+        let temp = tempfile::tempdir().unwrap();
+        assert!(
+            verify_with(temp.path(), Vec::new(), vec![volume(false)], &[])
+                .await
+                .unwrap(),
+            "a non-portable volume needs no inode table"
+        );
+
+        // Complete generation: both artifacts present and non-empty.
+        let temp = tempfile::tempdir().unwrap();
+        assert!(
+            verify_with(
+                temp.path(),
+                vec![disk("disk-dir-0.raw")],
+                vec![volume(true)],
+                &[
+                    ("disk-dir-0.raw", b"disk-bytes"),
+                    ("volume-5001-inode-table.json", b"{}"),
+                ],
+            )
+            .await
+            .unwrap(),
+            "a complete generation must verify"
         );
     }
 

--- a/src/commands/podman/snapshot.rs
+++ b/src/commands/podman/snapshot.rs
@@ -42,10 +42,16 @@ pub struct CreateSnapshotParams<'a> {
     pub remap_refs: &'a [Option<std::sync::Arc<fuse_pipe::RemapFs<fuse_pipe::PassthroughFs>>>],
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SnapshotInstall {
+    Created,
+    Existing,
+}
+
 /// Create a podman snapshot from a running VM.
 ///
-/// This pauses the VM, creates a Firecracker snapshot, copies the disk,
-/// saves metadata using SnapshotManager, and resumes the VM.
+/// This pauses the VM, creates a Firecracker snapshot, copies the disk, saves metadata,
+/// and applies the requested source disposition.
 ///
 /// The snapshot is stored in snapshot_dir with snapshot_key as the name,
 /// making it accessible via `fcvm snapshot run --snapshot <snapshot_key>`.
@@ -54,7 +60,10 @@ pub struct CreateSnapshotParams<'a> {
 /// lock is held, so a concurrent `fcvm snapshot create` (which resets the KVM
 /// dirty bitmap and updates `snapshot_name`) can never leave us merging a diff
 /// onto a stale base.
-pub async fn create_podman_snapshot(snap: &CreateSnapshotParams<'_>) -> Result<()> {
+pub async fn create_podman_snapshot(
+    snap: &CreateSnapshotParams<'_>,
+    source_disposition: crate::commands::common::SnapshotSourceDisposition,
+) -> Result<SnapshotInstall> {
     let CreateSnapshotParams {
         vm_manager,
         snapshot_key,
@@ -88,7 +97,7 @@ pub async fn create_podman_snapshot(snap: &CreateSnapshotParams<'_>) -> Result<(
         // waited for its generation lock.
         if snapshot_dir.join("config.json").exists() {
             info!(snapshot_key = %snapshot_key, "Snapshot already exists (created by another process)");
-            return Ok(());
+            return Ok(SnapshotInstall::Existing);
         }
 
         // Serialize dirty-bitmap resets, then ensure both the owning process identity and
@@ -170,10 +179,11 @@ pub async fn create_podman_snapshot(snap: &CreateSnapshotParams<'_>) -> Result<(
         disk_path,
         parent_dir.as_deref(),
         Some(&extra_files),
+        source_disposition,
     )
     .await?;
 
-    Ok(())
+    Ok(SnapshotInstall::Created)
 }
 
 /// Create a snapshot with signal interruption support.
@@ -186,21 +196,20 @@ pub async fn create_podman_snapshot(snap: &CreateSnapshotParams<'_>) -> Result<(
 pub async fn create_snapshot_interruptible(
     snap: &CreateSnapshotParams<'_>,
     cancel: &CancellationToken,
+    source_disposition: crate::commands::common::SnapshotSourceDisposition,
 ) -> SnapshotOutcome {
-    // CRITICAL: Do NOT use tokio::select! to interrupt the snapshot future.
-    // create_snapshot_core pauses the VM, creates the snapshot, then resumes.
-    // If we drop the future between pause and resume (via select!), the VM
-    // stays paused forever. Instead, check cancellation before starting and
-    // let the snapshot run to completion once started.
+    // CRITICAL: Do NOT interrupt the snapshot future after it starts. A normal source must
+    // reach its resume step; a disposable source must finish atomic artifact installation.
+    // Check cancellation before starting and let the snapshot reach its requested terminal
+    // disposition once started.
     if cancel.is_cancelled() {
         info!("snapshot creation skipped -- already cancelled");
         return SnapshotOutcome::Interrupted;
     }
 
-    // Run snapshot to completion. create_snapshot_core always resumes the VM
-    // before returning, even on error, so this is safe.
-    match create_podman_snapshot(snap).await {
-        Ok(()) => {
+    // Run snapshot to completion so its source disposition is always honored.
+    match create_podman_snapshot(snap, source_disposition).await {
+        Ok(_) => {
             if cancel.is_cancelled() {
                 // Snapshot succeeded but we're shutting down
                 SnapshotOutcome::Interrupted

--- a/src/commands/podman/snapshot.rs
+++ b/src/commands/podman/snapshot.rs
@@ -28,18 +28,72 @@ pub fn startup_snapshot_key(base_key: &str) -> String {
     format!("{}-startup", base_key)
 }
 
+/// What to do when a generation is already installed at the target name.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExistingGeneration {
+    /// Keep it and report [`SnapshotInstall::Existing`]. The name is the content-addressed
+    /// key, so an installed generation holds this same content and another process
+    /// installing it first is a race worth losing.
+    Reuse,
+    /// Replace it. `podman prepare --force` asks for a rebuild, and `podman prepare --tag`
+    /// installs under a caller-chosen name that can hold any content at all.
+    Replace,
+}
+
 /// Parameters for cache snapshot creation.
 ///
 /// Uses VmState as the single source of truth for snapshot metadata,
 /// ensuring fields like `original_vsock_vm_id` are always preserved correctly.
 pub struct CreateSnapshotParams<'a> {
     pub vm_manager: &'a FirecrackerBackend,
+    /// Directory name the generation is installed under, and its `config.name`.
     pub snapshot_key: &'a str,
+    /// Content-addressed key whose content this generation holds. Equals `snapshot_key`
+    /// for the cache entries `podman run` installs; differs under `prepare --tag`.
+    pub content_key: &'a str,
+    /// `System` for a content-addressed cache entry `snapshots prune` may reclaim,
+    /// `User` for a caller-named artifact it must keep.
+    pub snapshot_type: SnapshotType,
+    pub existing: ExistingGeneration,
     pub vm_state: &'a VmState,
     pub disk_path: &'a Path,
     pub volume_configs: &'a [VolumeConfig],
     /// RemapFs references for portable volumes — used to serialize inode tables at snapshot time.
     pub remap_refs: &'a [Option<std::sync::Arc<fuse_pipe::RemapFs<fuse_pipe::PassthroughFs>>>],
+}
+
+impl CreateSnapshotParams<'_> {
+    /// The parameters `podman run` uses for its content-addressed cache entries: the name
+    /// is the key, the entry is prunable cache, and another process winning the race is
+    /// a reusable result.
+    pub fn cache_entry<'a>(
+        vm_manager: &'a FirecrackerBackend,
+        snapshot_key: &'a str,
+        vm_state: &'a VmState,
+        disk_path: &'a Path,
+        volume_configs: &'a [VolumeConfig],
+        remap_refs: &'a [Option<std::sync::Arc<fuse_pipe::RemapFs<fuse_pipe::PassthroughFs>>>],
+    ) -> CreateSnapshotParams<'a> {
+        CreateSnapshotParams {
+            vm_manager,
+            snapshot_key,
+            content_key: snapshot_key,
+            snapshot_type: SnapshotType::System,
+            existing: ExistingGeneration::Reuse,
+            vm_state,
+            disk_path,
+            volume_configs,
+            remap_refs,
+        }
+    }
+}
+
+/// Whether a generation already installed at the target name ends this create.
+///
+/// Read under the exclusive generation lock, so `installed` is the state no other
+/// creator can change until this create finishes.
+pub(crate) fn keeps_installed_generation(existing: ExistingGeneration, installed: bool) -> bool {
+    installed && existing == ExistingGeneration::Reuse
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -67,6 +121,9 @@ pub async fn create_podman_snapshot(
     let CreateSnapshotParams {
         vm_manager,
         snapshot_key,
+        content_key,
+        snapshot_type,
+        existing,
         vm_state,
         disk_path,
         volume_configs,
@@ -95,7 +152,7 @@ pub async fn create_podman_snapshot(
 
         // Another VM process may have finished this content-addressed snapshot while we
         // waited for its generation lock.
-        if snapshot_dir.join("config.json").exists() {
+        if keeps_installed_generation(*existing, snapshot_dir.join("config.json").exists()) {
             info!(snapshot_key = %snapshot_key, "Snapshot already exists (created by another process)");
             return Ok(SnapshotInstall::Existing);
         }
@@ -135,14 +192,16 @@ pub async fn create_podman_snapshot(
     // Build snapshot config from VmState (single source of truth)
     let snapshot_volumes = crate::commands::common::volume_configs_to_snapshot(volume_configs);
     let extra_disks = crate::commands::common::extra_disks_to_snapshot(vm_state);
-    let snapshot_config = crate::commands::common::build_snapshot_config(
+    let mut snapshot_config = crate::commands::common::build_snapshot_config(
         vm_state,
         snapshot_key,
-        SnapshotType::System,
+        *snapshot_type,
         &snapshot_dir,
         snapshot_volumes,
         extra_disks,
     );
+    // The only record of which content a caller-named generation holds.
+    snapshot_config.content_key = Some(content_key.to_string());
 
     // Inode tables for portable volumes are written into the temp (.creating) directory
     // by create_snapshot_core BEFORE the atomic rename, so a finalized snapshot can never

--- a/src/commands/podman/types.rs
+++ b/src/commands/podman/types.rs
@@ -35,6 +35,28 @@ pub struct RebootSpec {
     pub bootplan_over_vsock: bool,
 }
 
+/// Where one `podman prepare` installs its startup snapshot, and what an already-installed
+/// generation there has to look like to answer for that invocation.
+///
+/// Resolved once during setup and carried on [`VmContext`] so the pre-boot cache check and
+/// the post-health install cannot disagree about the name, the type, or the content.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PreparedTarget {
+    /// Snapshot name the generation is installed under: the content-addressed key, or the
+    /// caller's `--tag`. Every consumer that takes a snapshot name addresses this.
+    pub name: String,
+    /// Content-addressed key whose content the generation must hold.
+    pub content_key: String,
+    /// `System` for the content-addressed cache entry, `User` for a `--tag` artifact.
+    pub snapshot_type: crate::storage::SnapshotType,
+    /// Whether a matching installed generation may be published without booting.
+    /// Cleared by `--force`.
+    pub publish_installed: bool,
+    /// What to do with a generation already installed at `name` once the disposable
+    /// source is healthy.
+    pub existing: super::ExistingGeneration,
+}
+
 /// All state accumulated during VM setup, bundled for the event loop and cleanup.
 pub struct VmContext {
     pub vm_id: String,
@@ -64,6 +86,8 @@ pub struct VmContext {
     /// snapshot path must send (or drop) before the monitor publishes Healthy.
     pub startup_rx: Option<oneshot::Receiver<crate::health::StartupSnapshotAck>>,
     pub snapshot_key: Option<String>,
+    /// Set only for the `podman prepare` lifecycle: where its startup snapshot goes.
+    pub prepare_target: Option<PreparedTarget>,
     pub volume_configs: Vec<VolumeConfig>,
     pub args: RunArgs,
     pub disk_path: PathBuf,

--- a/src/commands/podman/types.rs
+++ b/src/commands/podman/types.rs
@@ -78,7 +78,7 @@ pub struct VmContext {
     /// Host-side Unix socket path for the TTY vsock port (set when running with -t).
     /// Used to unblock the TTY accept thread if the guest never connected.
     pub tty_socket_path: Option<String>,
-    pub output_handle: Option<tokio::task::JoinHandle<Vec<(String, String)>>>,
+    pub output_handle: Option<tokio::task::JoinHandle<()>>,
     /// Egress proxy task (rootless mode only); aborted during cleanup.
     pub egress_proxy_handle: Option<tokio::task::JoinHandle<()>>,
     pub cache_rx: Option<mpsc::Receiver<CacheRequest>>,

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -835,21 +835,36 @@ pub(crate) async fn setup_nfs_exports(
     Ok(())
 }
 
-/// Clean up NFS exports for VM
-pub(crate) async fn cleanup_nfs_exports(vm_id: &str) {
+/// Clean up NFS exports for VM.
+///
+/// NotFound is success because cleanup is idempotent.  Other removal failures and an
+/// unsuccessful `exportfs -ra` are returned so finite lifecycle operations can verify that
+/// no host registration remains.
+pub(crate) async fn cleanup_nfs_exports(vm_id: &str) -> Result<()> {
     let exports_path = format!("/etc/exports.d/fcvm-{}.exports", vm_id);
-    if std::path::Path::new(&exports_path).exists() {
-        if let Err(e) = tokio::fs::remove_file(&exports_path).await {
-            warn!("Failed to remove NFS exports file: {}", e);
-        } else {
-            // Refresh exports to unregister
-            let _ = tokio::process::Command::new("exportfs")
-                .arg("-ra")
-                .status()
-                .await;
-            debug!("Cleaned up NFS exports: {}", exports_path);
+    match tokio::fs::remove_file(&exports_path).await {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error).with_context(|| format!("removing NFS export {exports_path}"));
         }
     }
+
+    let status = tokio::process::Command::new("exportfs")
+        .arg("-ra")
+        .status()
+        .await
+        .context("refreshing NFS exports after cleanup")?;
+    if !status.success() {
+        anyhow::bail!(
+            "exportfs -ra failed after removing NFS export {} with status {}",
+            exports_path,
+            status
+        );
+    }
+
+    debug!("Cleaned up NFS exports: {}", exports_path);
+    Ok(())
 }
 
 /// Parameters for VM setup, grouping the many read-only inputs.
@@ -934,7 +949,9 @@ pub(super) async fn run_vm_setup(
         }
         // NFS exports may have been written before the failing step; remove them
         // (no-op when the exports file was never created).
-        cleanup_nfs_exports(&vm_id).await;
+        if let Err(cleanup_error) = cleanup_nfs_exports(&vm_id).await {
+            warn!("failed to clean NFS exports after VM setup error: {cleanup_error:#}");
+        }
         return Err(e);
     }
 

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -174,7 +174,11 @@ impl CloneSetupResources {
         // through exportfs. Data is removed only after all socket owners are
         // joined; state is the final deletion, so a disk-removal failure keeps
         // its identifying pointer instead of creating an unattributed orphan.
-        crate::commands::podman::cleanup_nfs_exports(&self.vm_id).await;
+        if let Err(error) = crate::commands::podman::cleanup_nfs_exports(&self.vm_id).await {
+            errors.push(format!(
+                "removing NFS exports after failed clone setup: {error:#}"
+            ));
+        }
         let mut data_removed = true;
         match tokio::fs::remove_dir_all(&self.data_dir).await {
             Ok(()) => {}
@@ -566,6 +570,7 @@ async fn cmd_snapshot_create(args: SnapshotCreateArgs) -> Result<()> {
                     &vm_disk_path,
                     parent_dir.as_deref(),
                     None,
+                    super::common::SnapshotSourceDisposition::Resume,
                 )
                 .await?;
             }
@@ -1383,6 +1388,7 @@ async fn cmd_snapshot_run_inner(
                 None,
                 reconnect,
                 non_blocking_output,
+                true,
                 Some(output_connected_tx),
             )
             .await
@@ -2495,7 +2501,11 @@ async fn cmd_snapshot_run_inner(
                                 remap_refs: &volume_servers.remap_refs,
                             };
                             tokio::select! {
-                                outcome = create_snapshot_interruptible(&snap, &cancel) => {
+                                outcome = create_snapshot_interruptible(
+                                    &snap,
+                                    &cancel,
+                                    super::common::SnapshotSourceDisposition::Resume,
+                                ) => {
                                     match outcome {
                                         SnapshotOutcome::Interrupted => {
                                             container_exit_code = None;

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -2492,14 +2492,14 @@ async fn cmd_snapshot_run_inner(
                             // The diff parent is resolved inside create_podman_snapshot under
                             // the per-VM snapshot lock (re-read from the state file), so a
                             // concurrent `fcvm snapshot create` cannot leave us with a stale base.
-                            let snap = CreateSnapshotParams {
-                                vm_manager: fc_backend,
-                                snapshot_key: &startup_key,
-                                vm_state: &vm_state,
-                                disk_path: &disk_path,
-                                volume_configs: &volume_configs,
-                                remap_refs: &volume_servers.remap_refs,
-                            };
+                            let snap = CreateSnapshotParams::cache_entry(
+                                fc_backend,
+                                &startup_key,
+                                &vm_state,
+                                &disk_path,
+                                &volume_configs,
+                                &volume_servers.remap_refs,
+                            );
                             tokio::select! {
                                 outcome = create_snapshot_interruptible(
                                     &snap,

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -54,7 +54,7 @@ struct CloneSetupResources {
     volume_servers: Option<SpawnedVolumes>,
     tty_cancel: tokio_util::sync::CancellationToken,
     tty_handle: Option<std::thread::JoinHandle<Result<i32>>>,
-    output_handle: Option<tokio::task::JoinHandle<Vec<(String, String)>>>,
+    output_handle: Option<tokio::task::JoinHandle<()>>,
     egress_proxy_handle: Option<tokio::task::JoinHandle<()>>,
     network: Option<Box<dyn NetworkManager>>,
     implicit_uffd_cancel: tokio_util::sync::CancellationToken,
@@ -1393,10 +1393,9 @@ async fn cmd_snapshot_run_inner(
             )
             .await
             {
-                Ok(lines) => lines,
+                Ok(()) => {}
                 Err(e) => {
                     tracing::warn!("Output listener error: {}", e);
-                    Vec::new()
                 }
             }
         }));

--- a/src/commands/snapshots.rs
+++ b/src/commands/snapshots.rs
@@ -324,6 +324,26 @@ async fn cmd_snapshots_delete(args: SnapshotsDeleteArgs) -> Result<()> {
     Ok(())
 }
 
+/// Whether `snapshots prune` reclaims this snapshot.
+///
+/// Without `--all` it reclaims only the content-addressed cache, which is what `System`
+/// means. Anything a caller named — `snapshot create --tag`, `podman prepare --tag` — is a
+/// `User` snapshot and survives, because a golden snapshot that took ten minutes to build
+/// must not disappear on the next prune.
+pub(crate) fn prune_reclaims(
+    config: &SnapshotConfig,
+    prune_all: bool,
+    image: Option<&str>,
+) -> bool {
+    if !prune_all && config.snapshot_type != SnapshotType::System {
+        return false;
+    }
+    match image {
+        Some(image) => config.metadata.image == image,
+        None => true,
+    }
+}
+
 /// Delete snapshots (system-only by default, or all with --all)
 async fn cmd_snapshots_prune(args: SnapshotsPruneArgs) -> Result<()> {
     let prune_all = args.all;
@@ -339,17 +359,9 @@ async fn cmd_snapshots_prune(args: SnapshotsPruneArgs) -> Result<()> {
 
     for name in snapshot_names {
         if let Ok(config) = snapshot_manager.load_snapshot(&name).await {
-            // Filter by type
-            if !prune_all && config.snapshot_type != SnapshotType::System {
-                continue;
+            if prune_reclaims(&config, prune_all, args.image.as_deref()) {
+                snapshots_to_delete.push((name, config));
             }
-            // Filter by image if specified
-            if let Some(ref image) = args.image {
-                if config.metadata.image != *image {
-                    continue;
-                }
-            }
-            snapshots_to_delete.push((name, config));
         }
     }
 
@@ -420,4 +432,47 @@ async fn cmd_snapshots_prune(args: SnapshotsPruneArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(snapshot_type: SnapshotType, image: &str) -> SnapshotConfig {
+        let mut vm_state =
+            crate::state::VmState::new("vm-prune".to_string(), image.to_string(), 1, 512);
+        vm_state.config.image = image.to_string();
+        crate::commands::common::build_snapshot_config(
+            &vm_state,
+            "snap",
+            snapshot_type,
+            std::path::Path::new("/snapshots/snap"),
+            Vec::new(),
+            Vec::new(),
+        )
+    }
+
+    #[test]
+    fn default_prune_reclaims_the_cache_and_keeps_named_snapshots() {
+        let cache = config(SnapshotType::System, "nginx:alpine");
+        let named = config(SnapshotType::User, "nginx:alpine");
+
+        assert!(prune_reclaims(&cache, false, None));
+        assert!(!prune_reclaims(&named, false, None));
+        assert!(prune_reclaims(&named, true, None));
+    }
+
+    #[test]
+    fn the_image_filter_applies_to_both_types() {
+        let cache = config(SnapshotType::System, "nginx:alpine");
+
+        assert!(prune_reclaims(&cache, false, Some("nginx:alpine")));
+        assert!(!prune_reclaims(&cache, false, Some("redis:7")));
+        // --all widens the type, not the image.
+        assert!(!prune_reclaims(
+            &config(SnapshotType::User, "nginx:alpine"),
+            true,
+            Some("redis:7")
+        ));
+    }
 }

--- a/src/storage/snapshot.rs
+++ b/src/storage/snapshot.rs
@@ -125,6 +125,16 @@ impl SnapshotGeneration {
             config_digest: Sha256::digest(config_json).into(),
         }
     }
+
+    /// UUID written into the exact installed `config.json` generation.
+    pub fn generation_id(&self) -> uuid::Uuid {
+        self.generation_id
+    }
+
+    /// SHA-256 of the exact installed `config.json` bytes.
+    pub fn config_digest_hex(&self) -> String {
+        hex::encode(self.config_digest)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/storage/snapshot.rs
+++ b/src/storage/snapshot.rs
@@ -97,6 +97,17 @@ pub struct SnapshotConfig {
     /// restore-source to avoid memory corruption.
     #[serde(default)]
     pub parent_snapshot: Option<String>,
+    /// Content-addressed cache key whose content this generation holds.
+    ///
+    /// Set for every snapshot the podman cache installs. A generation installed under
+    /// its own key repeats that key here; `podman prepare --tag` installs the same
+    /// content under a caller-chosen `name`, and this is the only record of which
+    /// content it holds. `None` for `snapshot create`, which captures a live VM rather
+    /// than a config, and for generations written before this field existed — those
+    /// self-identify through `name`, so read this through
+    /// `SnapshotConfig::content_key()` rather than directly.
+    #[serde(default)]
+    pub content_key: Option<String>,
     pub memory_path: PathBuf,
     pub vmstate_path: PathBuf,
     pub disk_path: PathBuf,
@@ -106,6 +117,17 @@ pub struct SnapshotConfig {
     /// Full (memory+disk) vs DiskOnly (no memory image — clones cold-boot).
     pub kind: SnapshotKind,
     pub metadata: SnapshotMetadata,
+}
+
+impl SnapshotConfig {
+    /// The content-addressed cache key this generation holds.
+    ///
+    /// Falls back to `name` so a generation installed under its own key — every
+    /// podman cache entry before `content_key` existed, and every untagged one since —
+    /// answers the same question without a migration.
+    pub fn content_key(&self) -> &str {
+        self.content_key.as_deref().unwrap_or(self.name.as_str())
+    }
 }
 
 /// Identity of one installed snapshot generation.
@@ -533,6 +555,7 @@ mod tests {
             generation_id: uuid::Uuid::new_v4(),
             original_vsock_vm_id: None,
             parent_snapshot: None,
+            content_key: None,
             memory_path: PathBuf::from("/path/to/memory.bin"),
             vmstate_path: PathBuf::from("/path/to/vmstate.bin"),
             disk_path: PathBuf::from("/path/to/disk.raw"),
@@ -632,6 +655,46 @@ mod tests {
             config.metadata.network_config.guest_mac,
             "11:22:33:44:55:66"
         );
+        // Written before content_key existed, so it answers for its own name.
+        assert_eq!(config.content_key, None);
+        assert_eq!(config.content_key(), "nginx-snap");
+    }
+
+    /// A generation installed under a caller-chosen name records the cache key whose
+    /// content it holds, and that survives the on-disk round trip.
+    #[test]
+    fn a_recorded_content_key_survives_the_json_round_trip() {
+        let json = r#"{
+            "name": "cb-req-golden",
+            "vm_id": "def456",
+            "generation_id": "fc9642dc-babd-4876-8c7f-48bccd9554e8",
+            "content_key": "0123456789ab-startup",
+            "memory_path": "/mnt/fcvm-btrfs/snapshots/cb-req-golden/memory.bin",
+            "vmstate_path": "/mnt/fcvm-btrfs/snapshots/cb-req-golden/vmstate.bin",
+            "disk_path": "/mnt/fcvm-btrfs/snapshots/cb-req-golden/disk.raw",
+            "created_at": "2024-01-15T10:30:00Z",
+            "snapshot_type": "User",
+            "kind": "Full",
+            "metadata": {
+                "image": "localhost/chromium-bench",
+                "vcpu": 4,
+                "memory_mib": 1024,
+                "network_config": {
+                    "tap_device": "tap-def456",
+                    "guest_mac": "11:22:33:44:55:66",
+                    "guest_ip": null,
+                    "host_ip": null
+                }
+            }
+        }"#;
+
+        let config: SnapshotConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.content_key(), "0123456789ab-startup");
+        assert_eq!(config.name, "cb-req-golden");
+
+        let reparsed: SnapshotConfig =
+            serde_json::from_str(&serde_json::to_string(&config).unwrap()).unwrap();
+        assert_eq!(reparsed.content_key(), "0123456789ab-startup");
     }
 
     #[test]
@@ -669,6 +732,7 @@ mod tests {
             generation_id: uuid::Uuid::new_v4(),
             original_vsock_vm_id: None,
             parent_snapshot: None,
+            content_key: None,
             memory_path: PathBuf::from("/memory.bin"),
             vmstate_path: PathBuf::from("/vmstate.bin"),
             disk_path: PathBuf::from("/disk.raw"),
@@ -746,6 +810,7 @@ mod tests {
                 generation_id: uuid::Uuid::new_v4(),
                 original_vsock_vm_id: None,
                 parent_snapshot: None,
+                content_key: None,
                 memory_path: PathBuf::from("/memory.bin"),
                 vmstate_path: PathBuf::from("/vmstate.bin"),
                 disk_path: PathBuf::from("/disk.raw"),
@@ -810,6 +875,7 @@ mod tests {
             generation_id: uuid::Uuid::new_v4(),
             original_vsock_vm_id: None,
             parent_snapshot: None,
+            content_key: None,
             memory_path: PathBuf::from("/memory.bin"),
             vmstate_path: PathBuf::from("/vmstate.bin"),
             disk_path: PathBuf::from("/disk.raw"),
@@ -996,6 +1062,7 @@ mod tests {
             generation_id: uuid::Uuid::new_v4(),
             original_vsock_vm_id: None,
             parent_snapshot: None,
+            content_key: None,
             memory_path: PathBuf::from("/memory.bin"),
             vmstate_path: PathBuf::from("/vmstate.bin"),
             disk_path: PathBuf::from("/disk.raw"),


### PR DESCRIPTION
Adds `fcvm podman prepare`: build a startup snapshot, verify it, reap the VM that produced it, and let the caller name, keep, and rebuild the result.

**Stacked on:** main (817ed25b)

## Problem

Startup snapshots only get created as a side effect of `podman run`, and only when the run was given an explicit `--health-check` URL. To build one deliberately you have to script it: run `podman run` in the background, grep its log for a readiness line, poll `fcvm ls --json` until `health_status` is healthy, run `snapshot create --tag`, kill the VM. Teardown at the end is best-effort, so the script cannot tell whether host resources survived.

There is also no way to check that a snapshot on disk is complete. `check_podman_snapshot` returns `Some` as soon as a `config.json` parses. It never checks that the memory, vmstate and disk artifacts exist, are non-empty, or belong to the generation the config names.

## What it does

`prepare` takes the same arguments as `podman run`.

Cache miss: boot one disposable VM, wait for the health monitor's first Healthy transition, install a full startup snapshot with the source left paused, reap every host resource, print one JSON line.

Cache hit: verify the installed generation and print the same line without booting anything.

```
{"status":"prepared","cache":"created","snapshot_key":"cb-req-golden",
 "content_key":"a1b2c3d4e5f6-startup","snapshot_type":"user",
 "generation_id":"<uuid>","config_digest":"<sha256>"}
```

- Readiness uses the existing health monitor. Image HEALTHCHECK, container-running state and the optional HTTP check keep the authority they have in a run. The only difference is that `prepare` arms the startup trigger unconditionally, where `run` arms it only for an explicit HTTP check.
- `create_snapshot_core` takes a new `SnapshotSourceDisposition`. `run` resumes its VM as before. `prepare` leaves the source paused on every post-pause return, including failure paths, so it cannot mutate past the captured point.
- `cleanup_vm_verified` attempts every teardown action, checks the VMM and namespace holder are gone by `(pid, start_time)` rather than pid alone, and returns an aggregated error. `prepare` does not print its JSON if that fails. `cleanup_nfs_exports` returns its failures for the same reason. `run` keeps best-effort teardown.
- Verification holds a shared lease on the snapshot directory and fsyncs each artifact, the generation directory and the snapshot root before returning. The lease is held until the JSON is written, so a concurrent creator or deleter cannot swap the generation between verification and the answer.
- stdout carries only the JSON line. The output listener still drains the guest so it cannot backpressure, it just does not forward. Logs go to stderr and Firecracker's stdio goes to `/dev/null`.
- The wait for first Healthy is bounded at 600s. `run` needs no equivalent because an unhealthy VM is still a VM the caller owns.

## Naming, keeping, and rebuilding the artifact

`--tag <name>` installs the generation under that name with `SnapshotType::User`, the same contract `snapshot create --tag` writes: the tag is a snapshot directory name, validated by `validate_snapshot_name`, with `config.name` matching. `snapshots ls`, `snapshot serve <tag>`, `snapshot run --snapshot <tag>` and `snapshots delete <tag>` address a prepared tag and a created one identically. Without `--tag` the generation stays at the content-addressed key as `System`.

The prune rule follows from that one choice instead of being a second rule. `snapshots prune` reclaims `System` by default, so an untagged prepare is cache and a tagged one survives until `--all`. The predicate is now one function, `prune_reclaims`.

The tag renames the artifact; it does not replace the cache key. `SnapshotConfig` gains `content_key`, recording the key whose content a generation holds, and `SnapshotConfig::content_key()` falls back to `name`, so every generation already on disk answers the same question without a migration. A `prepare --tag` whose tag holds different content is a miss and rebuilds, exactly as a changed cache key would. A mismatch at the content-addressed key itself is a corrupt generation rather than other content, so it stays an error instead of a ten-minute rebuild that then refuses to publish.

`--force` clears both short circuits: `PreparedTarget::publish_installed` gates the pre-boot check that publishes without booting, and `ExistingGeneration` gates the under-lock check that reuses whatever another process installed. `prepare` never restores from the pre-start cache, so a forced rebuild is a genuine cold boot. It is the only way to rebuild content whose cache key did not change, which is what a repointed remote image reference does.

`CreateSnapshotParams` carries the install name, the content key, the snapshot type and the existing-generation policy. `podman run`'s three call sites take them from `CreateSnapshotParams::cache_entry`, which reproduces the old behaviour by construction: name equals key, `System`, `Reuse`.

## What this unlocks for `bench/chromium`

`reqbench.sh`'s `golden` phase hand-rolls exactly this: background `podman run`, log grep for readiness, `fcvm ls --json` poll, `snapshot create --tag "$TAG"`, kill. It can become one blocking command whose exit status is the answer:

```bash
fcvm podman prepare --name "$TAG-src" --tag "$TAG" ${FORCE:+--force} \
  --network "$EGRESS" --publish 9222:9222 "$IMAGE" > golden.json
```

Four things the benchmark gets that the script could not have:

- `snapshot serve "$TAG"` and `snapshot run --snapshot "$TAG"` keep working unchanged, because a prepared tag is an ordinary snapshot name. The matrix (egress paths x memory backends x page sizes) addresses `$TAG` the same way in every cell.
- The golden snapshot survives `snapshots prune`, so a cleanup between matrix cells cannot silently delete ten minutes of work and turn the next cell into a cold build the report would attribute to the cell.
- A changed image rebuilds by itself, because the content key changes. The benchmark cannot measure a stale golden while believing it measured the new one, which is the class of defect `bench/chromium/AGENTS.md` exists to prevent. `--force` covers the case where the content moved but the reference did not.
- Teardown is verified rather than best-effort. A leftover VM, holder, or pasta from the golden build would sit on the box for the whole measurement run and inflate every number; `prepare` fails loudly instead of printing a durable-looking artifact next to surviving host state.

## Test evidence

`make lint` is fmt + clippy `-D warnings` + audit + deny.

```
$ make lint
cargo fmt -p fcvm -p fuse-pipe -p fc-agent -p failpoint --check
cargo clippy --all-targets -- -D warnings
cargo audit
    Scanning Cargo.lock for vulnerabilities (376 crate dependencies)
warning: 1 allowed warning found          # RUSTSEC-2025-0141 bincode, pre-existing
cargo deny check
advisories ok, bans ok, licenses ok, sources ok
EXIT=0
```

clippy printed nothing under `-D warnings`. The audit warning is the allowlisted unmaintained `bincode`. `cargo deny` also prints pre-existing warnings for the `fuser` git source, seven duplicate crate versions, and an unmatched `Zlib` license allowance; this branch changes no `Cargo.toml`, `Cargo.lock` or `deny.toml`.

```
$ make test-unit
     Summary [  50.901s] 639 tests run: 632 passed, 7 failed, 0 skipped
```

The 7 failures need `/dev/userfaultfd`, which this host refuses:

```
thread 'uffd::server::tests::test_handler_failure_kills_the_clones_vmm' panicked at src/uffd/server.rs:
creating userfaultfd (via /dev/userfaultfd):
OpenDevUserfaultfd(Os { code: 13, kind: PermissionDenied, message: "Permission denied" })

$ sysctl vm.unprivileged_userfaultfd
vm.unprivileged_userfaultfd = 0
$ ls -l /dev/userfaultfd
crw------- 1 root root 10, 256 /dev/userfaultfd
```

The same 7 fail on untouched `origin/main` in a separate worktree:

```
$ git worktree add --detach ../wt-mainbase-verify origin/main
$ make test-unit FILTER="-E 'test(/uffd::/)'"
     Summary [   5.477s] 68 tests run: 61 passed, 7 failed, 548 skipped
```

Six `make test-unit` runs on the final tree, two of them after forcing a full rebuild, all reported the same 632/7 and the same seven test names. One earlier run, taken in the minute two sibling worktrees were also building, reported `617 passed, 22 failed`; its per-test output was not captured and it has not recurred. Flagging it rather than explaining it away.

### Red/green

Each gap was reverted on its own and the failure witnessed. The podman+snapshots suite is 27 tests, all green before each revert.

The readiness deadline. Against the unbounded wait the test hangs and nextest terminates it:

```
$ make test-unit FILTER="prepare_gives_up_when_the_container_never_becomes_healthy"
   TRY 2 TMT [ 120.004s] (1/1) fcvm commands::podman::tests::prepare_gives_up_when_the_container_never_becomes_healthy
     Summary [ 245.011s] 1 test run: 0 passed, 1 timed out, 577 skipped
```

The tag. Reverting the install name to the content key:

```
thread 'a_tag_names_the_installed_snapshot_and_no_tag_uses_the_content_key' panicked:
assertion `left == right` failed
  left: "0123456789ab-startup"
 right: "cb-req-golden"
thread 'a_tag_hits_only_for_the_content_it_holds' panicked:
a tag holding this content is a hit
     Summary 27 tests run: 25 passed, 2 failed
```

The type. Reverting a tagged prepare to `SnapshotType::System`:

```
thread 'a_default_prune_keeps_a_tagged_prepare_and_reclaims_an_untagged_one' panicked:
a golden snapshot must not evaporate on the next prune
thread 'a_tag_hits_only_for_the_content_it_holds' panicked:
a tag holding this content is a hit
     Summary 27 tests run: 25 passed, 2 failed
```

`--force`. Reverting `publish_installed` to `true` and dropping `existing` from the under-lock check:

```
thread 'force_rebuilds_instead_of_reusing_an_installed_generation' panicked:
--force must not publish an installed generation (tag None)
thread 'only_a_reuse_policy_keeps_a_generation_installed_by_another_process' panicked:
assertion failed: !snapshot::keeps_installed_generation(ExistingGeneration::Replace, true)
     Summary 2 tests run: 0 passed, 2 failed
```

The cache-key guard. Dropping the `ensure!` so a corrupt generation there becomes a rebuild:

```
thread 'a_mismatch_at_the_content_addressed_key_is_an_error_not_a_rebuild' panicked:
a disk-only generation at the cache key cannot be published
     Summary 1 test run: 0 passed, 1 failed
```

All reverts undone, the affected suite green:

```
$ make test-unit FILTER="-E 'test(/commands::podman::tests::/) or test(/commands::snapshots::tests::/) or test(/cli::args::tests::prepare/) or test(/storage::snapshot::tests::/)'"
     Summary [   0.128s] 49 tests run: 49 passed, 590 skipped
```

`await_prepare_healthy` takes the VM-exit future from its caller so the cancelled, VM-exited, monitor-dropped and deadline outcomes are all reachable without a hypervisor. `prepare_install_target`, `prepared_generation_mismatch`, `keeps_installed_generation` and `prune_reclaims` are pure, and `verify_prepared_snapshot_in` takes its snapshot root as an argument, so the tag, type, content-match and force decisions are all exercised on a tempdir.

## Needs privileged CI

Root VM tests do not run on this host, so `prepare` has never booted a VM. Unproven here:

- Readiness firing against a real container, with an image HEALTHCHECK and with an explicit `--health-check` URL.
- `LeavePaused` holding the source paused through the whole capture, including the diff-tracking retry path.
- `cleanup_vm_verified` succeeding on a real teardown, and returning the aggregated error when a resource survives. This makes `prepare` fail on teardown failures that `run` only logs, so a network cleanup that is flaky under load becomes a command failure.
- The cache-hit path verifying and republishing without booting.
- A tagged generation restoring under `snapshot serve` (UFFD) and `snapshot run --snapshot` (file-backed).
- `--force` reaching the create path and installing over a real generation, and a rebuilt tag leaving no stale artifacts behind.
- The 600s deadline against a slow first boot on a loaded runner.
