### PR TITLE
Rewire the reqbench golden phase onto podman prepare

### DIFF
--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -5,7 +5,7 @@
 # incrementally as it executes, so editing bench.sh while a run is in flight
 # corrupts that run. This file is self-contained; bench.sh is untouched.
 #
-#   ./reqbench.sh golden      # cold boot with CDP published, snapshot at the health gate
+#   ./reqbench.sh golden      # podman prepare: cold build, snapshot at the image health gate
 #   ./reqbench.sh verify      # prove all three hops on a RESTORED CLONE (do this first)
 #   ./reqbench.sh run         # the three-arm A/B
 #
@@ -250,20 +250,6 @@ stop_tracked() {
     return "$forced"
 }
 
-# `$pid` is our unreaped shell child, so its numeric PID cannot be reused until
-# wait(2) below. Detecting the zombie through /proc therefore closes the gap
-# where a failed fcvm child could leave a phase polling for five minutes for
-# state that will never appear.
-BACKGROUND_CHILD_RC=""
-background_child_exited() {
-    local pid="$1" rc=0
-    process_identity "$pid" >/dev/null && return 1
-    wait "$pid" || rc=$?
-    untrack "$pid"
-    BACKGROUND_CHILD_RC="$rc"
-    return 0
-}
-
 CLEANUP_RAN=0
 
 cleanup() {
@@ -434,10 +420,9 @@ cmd_build() {
 }
 
 cmd_golden() {
-    log "golden: cold boot with CDP published on $CDP_PORT -> snapshot $TAG"
-    $SUDO "$FCVM" snapshots delete -f "$TAG" >/dev/null 2>&1 || true
+    log "golden: podman prepare --tag $TAG (cold build, snapshot at the image health gate)"
     local name="cb-req-g-$RUNID" lf="$RESULTS/logs/golden.log"
-    local image_record image_digest image_id image_cache_key source_vm_id
+    local image_record image_digest image_id image_cache_key
     # One inspect binds the mutable tag's manifest digest and immutable image ID
     # to the same observation. fcvm performs the same atomic resolution before
     # exporting by ID; the cache-path check committed with the snapshot below
@@ -463,77 +448,35 @@ cmd_golden() {
     fi
     # --publish carries host -> guest; fc-agent DNATs the published port to
     # guest loopback (fc-agent/src/network.rs::publish_to_loopback), the hop
-    # Chromium refuses to make itself. Clones inherit port_mappings from the snapshot
-    # metadata (src/commands/snapshot.rs:1070), which is what makes a restored
-    # clone drivable at all.
-    # NO --health-check URL: leaving it unset is what makes fcvm consult the
-    # image's podman HEALTHCHECK (src/health.rs "AND logic"), which is the real
-    # CDP round trip we want as the snapshot trigger.
-    # The assignment goes AFTER $SUDO, inside the `env` that follows it. Written
-    # as `FCVM_NO_SNAPSHOT=1 $SUDO env RUST_LOG=... fcvm ...` it binds to `sudo`,
-    # whose default env_reset drops it — RUST_LOG survived only because it already
-    # rode the `env`. bench.sh in this same directory has always done it right.
-    # With the variable dropped, src/commands/podman/mod.rs gates `no_snapshot`
-    # false and this phase — documented as "golden: cold boot" — would RESTORE
-    # from a stale cached snapshot and then snapshot THAT as $TAG, contaminating
-    # every arm derived from it. Latent while SUDO defaults to "", live the moment
-    # anyone uses the documented root-mode hook.
-    $SUDO env FCVM_NO_SNAPSHOT=1 RUST_LOG="$FCVM_LOG" "$FCVM" podman run --name "$name" \
-        --cpu "$CPU" --mem "$MEM" --network "$NETMODE" --publish "$CDP_PORT:$CDP_PORT" \
-        "$IMAGE" >"$lf" 2>&1 &
-    # Capture the handle IMMEDIATELY. The BOOT TIMEOUT path below fires before any
-    # state file exists, so `$!` is the ONLY way to reach this VM at that point.
-    local vm_bg=$!
-    track "$vm_bg"
-    local t0=$SECONDS pid=""
-    until grep -q CHROMIUM_BENCH_READY "$lf" 2>/dev/null; do
-        if background_child_exited "$vm_bg"; then
-            log "golden: fcvm exited before readiness (rc=$BACKGROUND_CHILD_RC)"
-            tail -20 "$lf" >&2
-            return 1
-        fi
-        [ $((SECONDS-t0)) -lt 300 ] || { log "golden: BOOT TIMEOUT"; tail -20 "$lf" >&2; return 1; }
-        sleep 1
-    done
-    pid=$(state_pid_by_name "$name")
-    [ -n "$pid" ] || { log "golden: no state pid"; return 1; }
-    track "$pid"
-    source_vm_id=$(state_vm_id_by_pid "$pid")
-    [ -n "$source_vm_id" ] || { log "golden: state has no source vm_id"; return 1; }
-
-    # Wait for fcvm to publish Healthy — i.e. for the container HEALTHCHECK's real
-    # CDP round trip to pass. THIS is the warm point the snapshot must capture.
-    log "golden: waiting for fcvm health gate (pid $pid)"
-    t0=$SECONDS
-    until [ "$($SUDO "$FCVM" ls --json --pid "$pid" | python3 -c \
-              'import json,sys; print(json.load(sys.stdin)[0].get("health_status",""))')" = healthy ]; do
-        if background_child_exited "$vm_bg"; then
-            log "golden: fcvm exited before the health gate (rc=$BACKGROUND_CHILD_RC)"
-            tail -20 "$lf" >&2
-            return 1
-        fi
-        [ $((SECONDS-t0)) -lt 300 ] || { log "golden: HEALTH TIMEOUT"; tail -20 "$lf" >&2; return 1; }
-        sleep 1
-    done
-    log "golden: healthy after $((SECONDS-t0))s — snapshotting"
-    # Guarded: unguarded, a failed `snapshot create` exits the shell under `set -e`
-    # before the kill below, leaking a live VM. Now it reaches the trap.
-    $SUDO "$FCVM" snapshot create --pid "$pid" --tag "$TAG" >>"$lf" 2>&1 \
-        || { log "golden: SNAPSHOT CREATE FAILED"; tail -20 "$lf" >&2; return 1; }
+    # Chromium refuses to make itself. Clones inherit port_mappings from the
+    # snapshot metadata, which is what makes a restored clone drivable at all.
+    #
+    # `podman prepare` owns the lifecycle this phase used to hand-roll: it
+    # forces a cold build (no snapshot-cache restore, the contamination the old
+    # FCVM_NO_SNAPSHOT=1 dance guarded against), requires and waits for the
+    # image's podman HEALTHCHECK — the real CDP round trip — as the capture
+    # trigger, installs the generation atomically under the tag, verifies the
+    # installed artifact, and tears the source VM down with verified cleanup.
+    # --force replaces a stale tag, which also retires the explicit
+    # `snapshots delete` this phase used to need.
+    $SUDO env RUST_LOG="$FCVM_LOG" "$FCVM" podman prepare --tag "$TAG" --force \
+        --name "$name" --cpu "$CPU" --mem "$MEM" --network "$NETMODE" \
+        --publish "$CDP_PORT:$CDP_PORT" "$IMAGE" >"$lf" 2>&1 \
+        || { log "golden: PREPARE FAILED"; tail -20 "$lf" >&2; return 1; }
     # Bind the mutable image tag to the exact content captured by this snapshot.
     # The file lives inside the atomically replaced snapshot directory and names
     # its generation, so a recreated tag cannot inherit stale provenance.
     $SUDO python3 - "$DATA_ROOT/snapshots/$TAG/config.json" \
         "$DATA_ROOT/snapshots/$TAG/reqbench-provenance.json" \
         "$DATA_ROOT/snapshots/$TAG.lock" "$IMAGE" "$image_id" "$image_digest" \
-        "$image_cache_key" "$source_vm_id" \
+        "$image_cache_key" \
         "$(sha256sum "$FCVM" | cut -d' ' -f1)" \
         "$(sha256sum "$HERE/MANIFEST.sha256" | cut -d' ' -f1)" \
         "${REQBENCH_SOURCE_REVISION:-}" <<'PY'
 import fcntl, hashlib, json, os, sys, tempfile, uuid
 (
     config_path, output_path, lock_path, image_label, image_id, image_digest,
-    image_cache_key, source_vm_id,
+    image_cache_key,
     fcvm_sha256, runtime_bundle_sha256, source_revision,
 ) = sys.argv[1:]
 lock = open(lock_path, "a+")
@@ -562,11 +505,11 @@ if not os.path.basename(image_disk_path).startswith(image_cache_key + "."):
         f"snapshot image disk {image_disk_path!r} does not match inspected "
         f"cache key {image_cache_key!r}; the image tag changed during golden creation"
     )
-if config.get("vm_id") != source_vm_id:
-    raise SystemExit(
-        f"snapshot source {config.get('vm_id')!r} does not match golden {source_vm_id!r}; "
-        "the tag changed before provenance could be committed"
-    )
+# The source VM identity comes from the installed generation itself: prepare
+# writes config.json atomically with the generation, and the reader validates
+# provenance against the config in the SAME directory, so a tag replaced
+# between this read and the provenance write strands the record in an orphaned
+# generation and the reader fails closed asking for a fresh golden.
 record = {
     "snapshot_generation_id": generation_id,
     "snapshot_config_sha256": config_sha256,
@@ -602,10 +545,6 @@ except BaseException:
         pass
     raise
 PY
-    stop_tracked "$pid" \
-        || { log "golden: fcvm required SIGKILL; cleanup was not graceful"; return 1; }
-    stop_tracked "$vm_bg" \
-        || { log "golden: fcvm required SIGKILL; cleanup was not graceful"; return 1; }
     log "golden: done ($TAG)"
 }
 

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -57,6 +57,15 @@ if [ "$TAG" = . ] || [ "$TAG" = .. ] || [ "${#TAG}" -gt 128 ] \
     exit 2
 fi
 FCVM_LOG="${FCVM_LOG:-fcvm=debug}"   # AGENTS.md defect 4: never measure at info
+# Fail closed rather than trusting the default: an override that selects info
+# drops the per-request fcvm records every phase here reads, and the run still
+# produces numbers, so the loss is silent. Guarding the variable covers every
+# call site in this file, not just the one a reviewer happened to be looking at.
+case "$FCVM_LOG" in
+    *fcvm=debug*|*fcvm=trace*) ;;
+    *) echo "FCVM_LOG must select fcvm=debug or fcvm=trace (got '$FCVM_LOG'): the harness reads fcvm's debug records" >&2
+       exit 2 ;;
+esac
 URL="${URL:-http://127.0.0.1:8000/medium.html}"
 
 STATE_DIR="${STATE_DIR:-/mnt/fcvm-btrfs/state}"
@@ -459,24 +468,33 @@ cmd_golden() {
     # installed artifact, and tears the source VM down with verified cleanup.
     # --force replaces a stale tag, which also retires the explicit
     # `snapshots delete` this phase used to need.
+    # prepare's stdout is a one-line JSON record of the generation it installed,
+    # captured separately from the log so the provenance below can be bound to
+    # THAT generation rather than to whatever currently sits under the tag.
+    local prepared_json="$RESULTS/logs/golden-prepared.json"
     $SUDO env RUST_LOG="$FCVM_LOG" "$FCVM" podman prepare --tag "$TAG" --force \
         --name "$name" --cpu "$CPU" --mem "$MEM" --network "$NETMODE" \
-        --publish "$CDP_PORT:$CDP_PORT" "$IMAGE" >"$lf" 2>&1 \
+        --publish "$CDP_PORT:$CDP_PORT" "$IMAGE" 2>"$lf" >"$prepared_json" \
         || { log "golden: PREPARE FAILED"; tail -20 "$lf" >&2; return 1; }
+    local prepared_generation prepared_digest
+    prepared_generation=$(jq -er '.generation_id' <"$prepared_json") \
+        || { log "golden: prepare reported no generation_id"; return 1; }
+    prepared_digest=$(jq -er '.config_digest' <"$prepared_json") \
+        || { log "golden: prepare reported no config_digest"; return 1; }
     # Bind the mutable image tag to the exact content captured by this snapshot.
     # The file lives inside the atomically replaced snapshot directory and names
     # its generation, so a recreated tag cannot inherit stale provenance.
     $SUDO python3 - "$DATA_ROOT/snapshots/$TAG/config.json" \
         "$DATA_ROOT/snapshots/$TAG/reqbench-provenance.json" \
         "$DATA_ROOT/snapshots/$TAG.lock" "$IMAGE" "$image_id" "$image_digest" \
-        "$image_cache_key" \
+        "$image_cache_key" "$prepared_generation" "$prepared_digest" \
         "$(sha256sum "$FCVM" | cut -d' ' -f1)" \
         "$(sha256sum "$HERE/MANIFEST.sha256" | cut -d' ' -f1)" \
         "${REQBENCH_SOURCE_REVISION:-}" <<'PY'
 import fcntl, hashlib, json, os, sys, tempfile, uuid
 (
     config_path, output_path, lock_path, image_label, image_id, image_digest,
-    image_cache_key,
+    image_cache_key, prepared_generation, prepared_digest,
     fcvm_sha256, runtime_bundle_sha256, source_revision,
 ) = sys.argv[1:]
 lock = open(lock_path, "a+")
@@ -505,11 +523,21 @@ if not os.path.basename(image_disk_path).startswith(image_cache_key + "."):
         f"snapshot image disk {image_disk_path!r} does not match inspected "
         f"cache key {image_cache_key!r}; the image tag changed during golden creation"
     )
-# The source VM identity comes from the installed generation itself: prepare
-# writes config.json atomically with the generation, and the reader validates
-# provenance against the config in the SAME directory, so a tag replaced
-# between this read and the provenance write strands the record in an orphaned
-# generation and the reader fails closed asking for a fresh golden.
+# Bind the record to the generation `podman prepare` reported installing, not
+# merely to whatever sits under the tag now. Any other fcvm command may replace
+# the tag between prepare exiting and this shared lock being taken, and a
+# replacement carrying the same image would otherwise pass every check here and
+# be stamped with this run's creator hashes and source revision.
+if generation_id != prepared_generation:
+    raise SystemExit(
+        f"snapshot generation {generation_id!r} is not the one prepare installed "
+        f"({prepared_generation!r}); the tag was replaced before provenance was committed"
+    )
+if config_sha256 != prepared_digest:
+    raise SystemExit(
+        f"snapshot config digest {config_sha256!r} does not match prepare's "
+        f"({prepared_digest!r}); the generation changed in place"
+    )
 record = {
     "snapshot_generation_id": generation_id,
     "snapshot_config_sha256": config_sha256,

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -61,11 +61,24 @@ FCVM_LOG="${FCVM_LOG:-fcvm=debug}"   # AGENTS.md defect 4: never measure at info
 # drops the per-request fcvm records every phase here reads, and the run still
 # produces numbers, so the loss is silent. Guarding the variable covers every
 # call site in this file, not just the one a reviewer happened to be looking at.
-case "$FCVM_LOG" in
-    *fcvm=debug*|*fcvm=trace*) ;;
-    *) echo "FCVM_LOG must select fcvm=debug or fcvm=trace (got '$FCVM_LOG'): the harness reads fcvm's debug records" >&2
-       exit 2 ;;
-esac
+# Exact comma-separated directives, not a substring test: `notfcvm=debug` is a
+# different target and `fcvm=debugging` is a level tracing ignores — both would
+# pass a substring gate and still produce none of the records this harness reads.
+# Spaces are dropped first because tracing trims around each directive, so
+# `warn, fcvm=debug` does select fcvm=debug and must not be refused. No valid
+# directive contains a space, which makes deleting them all safe here.
+fcvm_log_ok=0
+IFS=',' read -ra fcvm_log_parts <<< "${FCVM_LOG// /}"
+for fcvm_log_part in "${fcvm_log_parts[@]}"; do
+    case "$fcvm_log_part" in
+        fcvm=debug|fcvm=trace) fcvm_log_ok=1 ;;
+    esac
+done
+if [ "$fcvm_log_ok" -ne 1 ]; then
+    echo "FCVM_LOG must select fcvm=debug or fcvm=trace as an exact directive (got '$FCVM_LOG'): the harness reads fcvm's debug records" >&2
+    exit 2
+fi
+unset fcvm_log_ok fcvm_log_parts fcvm_log_part
 URL="${URL:-http://127.0.0.1:8000/medium.html}"
 
 STATE_DIR="${STATE_DIR:-/mnt/fcvm-btrfs/state}"

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -3537,8 +3537,14 @@ exec /bin/bash "$@"
         with tempfile.TemporaryDirectory() as d:
             env, binx = self._env(d, REQBENCH_STAGED="1")
             seen = os.path.join(d, "seen.txt")
+            # Record the knob at the sudo boundary, BEFORE env -i wipes it: the
+            # fake fcvm's own recording can only ever read <unset> behind the
+            # reset, so it would keep this test green even if the harness
+            # regressed to `FCVM_NO_SNAPSHOT=1 $SUDO ...`.
             self._write(os.path.join(binx, "sudo"),
-                        '#!/bin/bash\nexec env -i PATH="$PATH" HOME="$HOME" "$@"\n')
+                        f'#!/bin/bash\n'
+                        f'echo "sudo-saw FCVM_NO_SNAPSHOT=${{FCVM_NO_SNAPSHOT:-<unset>}}" >> {seen}\n'
+                        f'exec env -i PATH="$PATH" HOME="$HOME" "$@"\n')
             self._write(os.path.join(binx, "podman"), '''#!/bin/bash
 if [ "$1 $2" = "image inspect" ]; then
     echo '[{"Digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","Id":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}]'
@@ -3564,6 +3570,8 @@ exit 1
             self.assertIn("--force", got)
             self.assertIn("FCVM_NO_SNAPSHOT=<unset>", got,
                           f"the retired cold-boot env knob is back: {got}")
+            self.assertIn("sudo-saw FCVM_NO_SNAPSHOT=<unset>", got,
+                          f"the harness handed the retired knob to sudo: {got}")
 
     def test_golden_fails_when_prepare_fails(self):
         """A failed prepare is attributed immediately, not after a poll timeout."""
@@ -3705,22 +3713,57 @@ esac
             self.assertIn("is not the one prepare installed", result.stderr)
 
     def test_a_non_debug_log_level_is_refused_before_anything_runs(self):
-        """Measuring at info drops the records every phase reads, silently."""
-        with tempfile.TemporaryDirectory() as d:
-            env, _ = self._env(d, FCVM_LOG="fcvm=info")
-            marker = os.path.join(d, "fcvm-was-invoked")
-            fcvm = os.path.join(d, "fcvm")
-            self._write(fcvm, f"#!/bin/bash\ntouch {marker}\n")
-            result = subprocess.run(
-                [self.SH, "golden"], env=dict(env, FCVM=fcvm),
-                capture_output=True, text=True, timeout=30,
-            )
-            self.assertEqual(result.returncode, 2, result.stderr)
-            self.assertIn("must select fcvm=debug", result.stderr)
-            self.assertFalse(
-                os.path.exists(marker),
-                "the harness ran fcvm before refusing the log level",
-            )
+        """Measuring at info drops the records every phase reads, silently.
+
+        The lookalike values are the reviewer-caught false accepts: a substring
+        test lets `notfcvm=debug` (a different target) and `fcvm=debugging` (an
+        invalid level tracing ignores) through a gate whose whole job is
+        refusing configurations that produce no fcvm debug records.
+        """
+        for bad in ("fcvm=info", "notfcvm=debug", "fcvm=debugging"):
+            with self.subTest(fcvm_log=bad), tempfile.TemporaryDirectory() as d:
+                env, _ = self._env(d, FCVM_LOG=bad)
+                marker = os.path.join(d, "fcvm-was-invoked")
+                fcvm = os.path.join(d, "fcvm")
+                self._write(fcvm, f"#!/bin/bash\ntouch {marker}\n")
+                result = subprocess.run(
+                    [self.SH, "golden"], env=dict(env, FCVM=fcvm),
+                    capture_output=True, text=True, timeout=30,
+                )
+                self.assertEqual(result.returncode, 2, result.stderr)
+                self.assertIn("must select fcvm=debug", result.stderr)
+                self.assertFalse(
+                    os.path.exists(marker),
+                    "the harness ran fcvm before refusing the log level",
+                )
+
+    def test_log_directives_that_enable_fcvm_debug_are_accepted(self):
+        """The exact-directive gate must not refuse values that DO work."""
+        for good in ("fcvm=debug", "fcvm=trace", "warn,fcvm=debug", "fcvm=debug,hyper=warn",
+                     "warn, fcvm=debug"):
+            with self.subTest(fcvm_log=good), tempfile.TemporaryDirectory() as d:
+                env, binx = self._env(d, FCVM_LOG=good, REQBENCH_STAGED="1")
+                self._write(os.path.join(binx, "podman"), """#!/bin/bash
+if [ "$1 $2" = "image inspect" ]; then
+    echo '[{"Digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","Id":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}]'
+    exit 0
+fi
+exit 1
+""")
+                marker = os.path.join(d, "fcvm-was-invoked")
+                fcvm = os.path.join(d, "fcvm")
+                # An invoked fcvm is the proof the gate was passed; exiting
+                # non-zero right after keeps the run short.
+                self._write(fcvm, f"#!/bin/bash\ntouch {marker}\nexit 42\n")
+                result = subprocess.run(
+                    [self.SH, "golden"], env=dict(env, FCVM=fcvm),
+                    capture_output=True, text=True, timeout=30,
+                )
+                self.assertNotIn("must select fcvm=debug", result.stderr)
+                self.assertTrue(
+                    os.path.exists(marker),
+                    f"the gate refused a working directive: {result.stderr}",
+                )
 
     def test_golden_rejects_a_tag_repointed_before_fcvm_resolved_it(self):
         """The snapshot disk key must match the harness's atomic image inspect."""

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -3602,6 +3602,11 @@ case "$1 $2" in
       cat > "$DATA_ROOT/snapshots/$TAG/config.json" <<'EOF'
 {{"generation_id":"12345678-1234-4234-8234-123456789abc","created_at":"2026-08-09T00:00:00Z","vm_id":"vm-11111111111111111111111111111111","metadata":{{"image":"localhost/chromium-bench-req","image_disk_path":"/image-cache/{snapshot_cache_key}.storage-v2.img"}}}}
 EOF
+      # Real prepare reports the generation it installed on stdout; the harness
+      # binds its provenance record to exactly that generation.
+      digest=$(sha256sum "$DATA_ROOT/snapshots/$TAG/config.json" | cut -d" " -f1)
+      printf '{{"status":"prepared","generation_id":"%s","config_digest":"%s"}}\n' \
+          "${{GENERATION_OVERRIDE:-12345678-1234-4234-8234-123456789abc}}" "$digest"
       ;;
 esac
 ''')
@@ -3655,6 +3660,67 @@ exit 1
                     provenance["snapshot_config_sha256"],
                     hashlib.sha256(source.read()).hexdigest(),
                 )
+
+    def test_golden_rejects_a_generation_installed_by_someone_else(self):
+        """Provenance must name the generation prepare reported, not the tag's.
+
+        Any other fcvm command can replace the tag between prepare exiting and
+        the provenance write. A replacement carrying the same image passes every
+        content check, so without this binding the record would stamp another
+        process's snapshot with this run's creator hashes and source revision.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            env, binx = self._env(d, DATA_ROOT=d)
+            fcvm = os.path.join(d, "fcvm")
+            digest = "a" * 64
+            image_id = "b" * 64
+            self._write(os.path.join(binx, "podman"), f'''#!/bin/bash
+if [ "$1 $2" = "image inspect" ]; then
+    echo '[{{"Digest":"sha256:{digest}","Id":"{image_id}"}}]'
+    exit 0
+fi
+exit 1
+''')
+            self._write(fcvm, '''#!/bin/bash
+case "$1 $2" in
+  "podman prepare")
+      mkdir -p "$DATA_ROOT/snapshots/$TAG"
+      : > "$DATA_ROOT/snapshots/$TAG.lock"
+      cat > "$DATA_ROOT/snapshots/$TAG/config.json" <<'EOF'
+{"generation_id":"12345678-1234-4234-8234-123456789abc","created_at":"2026-08-09T00:00:00Z","vm_id":"vm-11111111111111111111111111111111","metadata":{"image":"localhost/chromium-bench-req","image_disk_path":"/image-cache/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.storage-v2.img"}}
+EOF
+      digest=$(sha256sum "$DATA_ROOT/snapshots/$TAG/config.json" | cut -d" " -f1)
+      # prepare installed one generation; the tag now holds a different one.
+      printf '{"status":"prepared","generation_id":"%s","config_digest":"%s"}\n' \
+          "99999999-9999-4999-8999-999999999999" "$digest"
+      ;;
+esac
+''')
+            self._write(os.path.join(d, "fc-agent"), "#!/bin/bash\nexit 0\n")
+            result = subprocess.run(
+                [self.SH, "golden"], env=dict(env, FCVM=fcvm),
+                capture_output=True, text=True, timeout=60,
+            )
+            self.assertNotEqual(result.returncode, 0, result.stdout)
+            self.assertIn("is not the one prepare installed", result.stderr)
+
+    def test_a_non_debug_log_level_is_refused_before_anything_runs(self):
+        """Measuring at info drops the records every phase reads, silently."""
+        with tempfile.TemporaryDirectory() as d:
+            env, _ = self._env(d, FCVM_LOG="fcvm=info")
+            marker = os.path.join(d, "fcvm-was-invoked")
+            fcvm = os.path.join(d, "fcvm")
+            self._write(fcvm, f"#!/bin/bash\ntouch {marker}\n")
+            result = subprocess.run(
+                [self.SH, "golden"], env=dict(env, FCVM=fcvm),
+                capture_output=True, text=True, timeout=30,
+            )
+            self.assertEqual(result.returncode, 2, result.stderr)
+            self.assertIn("must select fcvm=debug", result.stderr)
+            self.assertFalse(
+                os.path.exists(marker),
+                "the harness ran fcvm before refusing the log level",
+            )
 
     def test_golden_rejects_a_tag_repointed_before_fcvm_resolved_it(self):
         """The snapshot disk key must match the harness's atomic image inspect."""

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -3522,34 +3522,23 @@ exec /bin/bash "$@"
                 env["RESULTS"], "runtime", os.path.basename(bundle),
             )))
 
-    def test_fcvm_no_snapshot_survives_sudo(self):
-        """RED BEFORE THE FIX: `FCVM_NO_SNAPSHOT=1 $SUDO env RUST_LOG=... fcvm ...`
-        binds the assignment to SUDO, whose default env_reset drops it. RUST_LOG
-        survives only because it rides the `env` AFTER sudo. The sibling harness
-        already does it right (bench.sh: `sudo env FCVM_NO_SNAPSHOT=1 RUST_LOG=...`),
-        so this is a local divergence, not house style. With the variable dropped,
-        `src/commands/podman/mod.rs` takes the snapshot-cache path and the phase
-        documented as `golden: cold boot` would RESTORE from a stale cached
-        snapshot and then snapshot THAT as $TAG — contaminating every arm.
-        Observed with an env_reset-emulating sudo stub: FCVM_NO_SNAPSHOT=<unset>.
+    def test_golden_delegates_the_cold_build_to_prepare(self):
+        """golden's cold-boot guarantee now lives inside `podman prepare`.
+
+        The previous flow exported FCVM_NO_SNAPSHOT=1 around a hand-rolled
+        `podman run`, and a sudo env_reset once silently dropped the assignment,
+        turning "cold boot" into a restore from a stale cached snapshot. prepare
+        forces the cold build internally (src/commands/podman/mod.rs sets
+        no_snapshot before any cache lookup), so the knob must be GONE from the
+        invocation: its reappearance would mean someone reintroduced the
+        env-sensitive dance this rework deleted. Run under an env_reset sudo to
+        hold the original failure conditions in place.
         """
         with tempfile.TemporaryDirectory() as d:
-            # Staged, like the sibling shell tests: the unstaged path re-execs
-            # itself through a content-addressed copy and first requires real
-            # fcvm and fc-agent binaries for THIS host's arch. That is a
-            # property of the box, not of the quoting under test, and on an
-            # x86 checkout of an arm64 tree it stops the phase before fcvm.
             env, binx = self._env(d, REQBENCH_STAGED="1")
             seen = os.path.join(d, "seen.txt")
             self._write(os.path.join(binx, "sudo"),
                         '#!/bin/bash\nexec env -i PATH="$PATH" HOME="$HOME" "$@"\n')
-            # `golden` inspects the benchmark image before it ever reaches fcvm.
-            # Without this stub the test needs a real podman AND a real
-            # localhost/chromium-bench-req on the box: where either is missing
-            # the phase returns at the inspect, fcvm is never invoked, and the
-            # assertion below reports "the assignment did not survive sudo"
-            # about a command that never ran. Seen on a box whose podman had no
-            # crun: `default OCI runtime "crun" not found`.
             self._write(os.path.join(binx, "podman"), '''#!/bin/bash
 if [ "$1 $2" = "image inspect" ]; then
     echo '[{"Digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","Id":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}]'
@@ -3559,38 +3548,25 @@ exit 1
 ''')
             fcvm = os.path.join(d, "fcvm")
             self._write(fcvm, f"""#!/bin/bash
-case "$1 $2" in
-  "podman run")
-      echo "FCVM_NO_SNAPSHOT=${{FCVM_NO_SNAPSHOT:-<unset>}}" >> {seen}
-      echo $$ > {d}/golden.pid
-      echo CHROMIUM_BENCH_READY; exec sleep 30 ;;
-  "snapshot create") echo created ;;
-  "snapshots delete") ;;
-  "ls --json")
-      pid=$(cat {d}/golden.pid)
-      if [ "$3" = "--pid" ]; then
-          echo "[{{\"pid\": $pid, \"vm_id\": \"vm-11111111111111111111111111111111\", \"health_status\": \"healthy\"}}]"
-      else
-          echo "[{{\"name\": \"cb-req-g-{self.RUN_ID}\", \"pid\": $pid}}]"
-      fi ;;
-esac
+if [ "$1 $2" = "podman prepare" ]; then
+    echo "argv=$* FCVM_NO_SNAPSHOT=${{FCVM_NO_SNAPSHOT:-<unset>}}" >> {seen}
+    exit 1  # stop before the provenance step; the invocation is the evidence
+fi
+exit 1
 """)
-            r = subprocess.run([self.SH, "golden"], env=dict(env, SUDO="sudo", FCVM=fcvm),
-                               capture_output=True, text=True, timeout=120)
+            subprocess.run([self.SH, "golden"], env=dict(env, SUDO="sudo", FCVM=fcvm),
+                           capture_output=True, text=True, timeout=120)
             got = self._read_if_exists(seen, "<no invocation>")
-            # Separate "fcvm never ran" from "fcvm ran without the variable".
-            # One is a broken harness, the other is the defect under test, and
-            # attributing the first to the second sends the reader after sudo's
-            # env_reset for a phase that returned long before sudo.
             self.assertNotEqual(
                 got, "<no invocation>",
-                "golden never invoked fcvm, so this test observed nothing about "
-                f"the assignment: {r.stderr[-800:]}")
-            self.assertIn("FCVM_NO_SNAPSHOT=1", got,
-                          f"the assignment did not survive sudo: {got}\n{r.stderr[-800:]}")
+                "golden never invoked `fcvm podman prepare`, so this test observed nothing")
+            self.assertIn("--tag cb-req-golden", got)
+            self.assertIn("--force", got)
+            self.assertIn("FCVM_NO_SNAPSHOT=<unset>", got,
+                          f"the retired cold-boot env knob is back: {got}")
 
-    def test_golden_fails_when_fcvm_exits_before_readiness(self):
-        """A dead cold-boot child is attributed immediately, not after 300s."""
+    def test_golden_fails_when_prepare_fails(self):
+        """A failed prepare is attributed immediately, not after a poll timeout."""
         with tempfile.TemporaryDirectory() as d:
             env, binx = self._env(d, REQBENCH_STAGED="1")
             fcvm = os.path.join(d, "fcvm")
@@ -3607,32 +3583,20 @@ exit 1
                 capture_output=True, text=True, timeout=10,
             )
             self.assertNotEqual(result.returncode, 0, result.stderr)
-            self.assertIn("golden: fcvm exited before readiness (rc=42)", result.stderr)
-            self.assertNotIn("BOOT TIMEOUT", result.stderr)
+            self.assertIn("golden: PREPARE FAILED", result.stderr)
 
     def _golden_image_identity_fixture(self, d, snapshot_cache_key):
         env, binx = self._env(d, DATA_ROOT=d)
         argv = os.path.join(d, "fcvm-argv.log")
-        pid_file = os.path.join(d, "golden.pid")
         digest = "a" * 64
         image_id = "b" * 64
         fcvm = os.path.join(d, "fcvm")
+        # The prepare stub installs what the real one installs: the snapshot
+        # generation directory with its config.json, under the tag's lock.
         self._write(fcvm, f'''#!/bin/bash
 echo "$*" >> {argv}
 case "$1 $2" in
-  "snapshots delete") exit 0 ;;
-  "podman run")
-      echo $$ > {pid_file}
-      echo CHROMIUM_BENCH_READY
-      exec sleep 30
-      ;;
-  "ls --json")
-      pid=$(cat {pid_file})
-      cat <<EOF
-[{{"name":"cb-req-g-{self.RUN_ID}","pid":$pid,"vm_id":"vm-11111111111111111111111111111111","health_status":"healthy"}}]
-EOF
-      ;;
-  "snapshot create")
+  "podman prepare")
       mkdir -p "$DATA_ROOT/snapshots/$TAG"
       : > "$DATA_ROOT/snapshots/$TAG.lock"
       cat > "$DATA_ROOT/snapshots/$TAG/config.json" <<'EOF'
@@ -3662,13 +3626,15 @@ exit 1
                 d, "a" * 64,
             )
             self.assertEqual(result.returncode, 0, result.stderr[-1600:])
-            podman_run = next(
-                line for line in argv.splitlines() if line.startswith("podman run ")
+            prepare_line = next(
+                line for line in argv.splitlines() if line.startswith("podman prepare ")
             )
             self.assertTrue(
-                podman_run.endswith(" localhost/chromium-bench-req"), podman_run,
+                prepare_line.endswith(" localhost/chromium-bench-req"), prepare_line,
             )
-            self.assertNotIn(image_id, podman_run)
+            self.assertIn("--tag cb-req-golden", prepare_line)
+            self.assertIn("--force", prepare_line)
+            self.assertNotIn(image_id, prepare_line)
             with open(os.path.join(
                 d, "snapshots", "cb-req-golden", "reqbench-provenance.json",
             )) as source:


### PR DESCRIPTION
The golden phase hand-rolled what `fcvm podman prepare` (#796) now owns: a cold boot guarded by an env variable that once silently died at a sudo env_reset, a readiness poll on the serial log, a health-gate poll, a manual `snapshot create`, and a kill. It is now one `podman prepare --tag cb-req-golden --force` invocation plus the image-provenance binding, which stays. Net: −95 lines of orchestration.

## Why prepare is the same contract, stronger

- **Cold build**: prepare forces `no_snapshot` internally before any cache lookup (`src/commands/podman/mod.rs`), so the guarantee no longer rides an env variable through sudo.
- **Capture trigger**: prepare requires and waits for the image's podman HEALTHCHECK — the real CDP round trip — exactly the warm point the old phase polled for by hand.
- **Install**: atomic generation replace under the tag, plus the #796 verification of the installed artifact (disks present, inode tables per portable volume, fsync'd), plus verified teardown of the source VM.
- `--force` replaces a stale tag, retiring the explicit `snapshots delete`.

## Tests

The five `ReqbenchShell` tests that specified the old orchestration now specify the prepare contract: golden must delegate the cold build (and the retired `FCVM_NO_SNAPSHOT` knob must stay gone, asserted under an env_reset sudo), a failed prepare is attributed immediately, the prepare argv carries the local tag with `--tag`/`--force`, and the tag-repoint rejection still fails closed on a cache-key mismatch.

## Test results

```
$ python3 -m unittest test_reqbench.ReqbenchShell.<the five reworked tests>
Ran 5 tests ... OK
$ python3 -m unittest test_reqbench   # branch vs base on the same host
mine: 24  base: 24 — IDENTICAL failure sets (all pre-existing fork-based
tests this sandboxed devserver cannot run; green in CI)
```

The end-to-end proof (a real `reqbench.sh golden` via prepare with the chromium image) runs on c7gd.metal as the first step of the gated benchmark run once #797 merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Golden image creation now uses a streamlined preparation workflow with built-in health checks, snapshotting, and automatic cleanup.
  * Snapshot provenance is now bound to the reported generation and configuration digest, with added validation for mismatches.
  * Preparation errors surface immediately with clearer attribution.
  * Logging is now blocked unless debug or trace is explicitly enabled.
* **Tests**
  * Updated request-benchmark shell tests to align with the new golden-image flow, including `--tag`/`--force`, provenance binding, and mismatch rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->