### PR TITLE
Build firecracker under sudo on a cold store, without poisoning it for rootless runs

### DIFF
--- a/.github/workflows/kernels.yml
+++ b/.github/workflows/kernels.yml
@@ -336,6 +336,8 @@ jobs:
             sudo mount /var/fcvm-btrfs.img /mnt/fcvm-btrfs
           fi
           sudo chown $USER:$USER /mnt/fcvm-btrfs
+          # Heal root-owned store entries (see the script header for why)
+          ./fcvm/scripts/normalize-store-ownership.sh /mnt/fcvm-btrfs
 
       - name: Build kernel using fcvm
         if: steps.check.outputs.exists == 'false' || inputs.force_build == true
@@ -559,6 +561,8 @@ jobs:
             sudo mount /var/fcvm-btrfs.img /mnt/fcvm-btrfs
           fi
           sudo chown $USER:$USER /mnt/fcvm-btrfs
+          # Heal root-owned store entries (see the script header for why)
+          ./fcvm/scripts/normalize-store-ownership.sh /mnt/fcvm-btrfs
 
       - name: Build kernel using fcvm
         if: steps.check.outputs.exists == 'false' || inputs.force_build == true

--- a/Makefile
+++ b/Makefile
@@ -604,6 +604,8 @@ setup-btrfs:
 	@# Ensure these dirs exist with correct permissions (may be missing after reboot/corruption)
 	@sudo mkdir -p /mnt/fcvm-btrfs/image-cache /mnt/fcvm-btrfs/containers
 	@sudo chown $$(id -un):$$(id -gn) /mnt/fcvm-btrfs/image-cache /mnt/fcvm-btrfs/containers
+	@# Heal root-owned store entries (see the script header for why)
+	@./scripts/normalize-store-ownership.sh /mnt/fcvm-btrfs
 	@# Enable IP forwarding (required for bridged networking)
 	@sudo sysctl -q -w net.ipv4.ip_forward=1
 	@# Create per-mode data directories (state, snapshots, vm-disks)

--- a/scripts/normalize-store-ownership.sh
+++ b/scripts/normalize-store-ownership.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Hand root-owned content-addressed store entries back to the current user.
+#
+# A root-invoked `fcvm setup` that failed mid-build used to leave a root-owned
+# store directory and 0600 lock file behind, after which every rootless setup
+# on the same machine died with EACCES opening the lock (the Build Btrfs
+# Kernel / Host-arm64 pair on runner i-0d8e07f6732c331cc). fcvm now hands
+# entries back to the sudo invoker as it creates them; this script heals
+# stores poisoned before that fix, covering the ordering fcvm cannot: a
+# rootless job scheduled onto the machine before any root run touches the
+# store again. It runs from `make setup-btrfs` and the kernels workflow
+# bootstrap.
+#
+# Only the content-addressed asset stores are touched (the list mirrors
+# src/paths.rs — keep them in sync). state/, vm-disks/, snapshots/,
+# containers/ and image-cache/ are left alone: root-mode runs own entries
+# there legitimately, and container storage carries subuid-mapped ownership
+# that a blanket chown would destroy.
+set -euo pipefail
+
+STORE="${1:-/mnt/fcvm-btrfs}"
+user="$(id -un)"
+group="$(id -gn)"
+
+# Nothing to hand back when the whole run is root (container CI).
+[ "$user" = "root" ] && exit 0
+
+dirs=()
+for d in kernels pasta firecracker cloud-hypervisor initrd rootfs cache; do
+    [ -d "$STORE/$d" ] && dirs+=("$STORE/$d")
+done
+[ "${#dirs[@]}" -eq 0 ] && exit 0
+
+# One traversal as root; -h so a symlink is re-owned itself, never its target.
+sudo find "${dirs[@]}" ! -user "$user" -exec chown -h "$user:$group" {} +

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -87,6 +87,10 @@ pub fn assets_dir_if_initialized() -> Option<PathBuf> {
 }
 
 // === Content-addressed assets (use assets_dir) ===
+//
+// The asset store subdirectories listed here are also enumerated in
+// scripts/normalize-store-ownership.sh (the root-owned-entry heal); keep the
+// two lists in sync when adding a store.
 
 /// Directory for kernel images (vmlinux-*.bin files).
 pub fn kernel_dir() -> PathBuf {

--- a/src/setup/kernel.rs
+++ b/src/setup/kernel.rs
@@ -1,6 +1,5 @@
 use anyhow::{bail, Context, Result};
 use glob::glob;
-use nix::fcntl::{Flock, FlockArg};
 use sha2::{Digest, Sha256};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -99,21 +98,11 @@ pub async fn rebuild_kernel_from_source(profile_name: &str) -> Result<PathBuf> {
     let kernel_dir = paths::kernel_dir();
     let kernel_path = kernel_dir.join(&filename);
 
-    tokio::fs::create_dir_all(&kernel_dir)
-        .await
-        .context("creating kernel directory")?;
-    let lock_file = kernel_dir.join(format!("{}.lock", filename));
-    use std::os::unix::fs::OpenOptionsExt;
-    let lock_fd = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(&lock_file)
-        .context("opening kernel lock file")?;
-    let flock = Flock::lock(lock_fd, FlockArg::LockExclusive)
-        .map_err(|(_, err)| err)
-        .context("acquiring exclusive lock for kernel")?;
+    let flock = super::lock_store_dir(
+        &kernel_dir.join(format!("{}.lock", filename)),
+        "kernel rebuild",
+    )
+    .await?;
 
     // Build to a unique sibling and rename into place, so a build that fails
     // partway leaves the existing artifact untouched instead of destroying a
@@ -125,15 +114,7 @@ pub async fn rebuild_kernel_from_source(profile_name: &str) -> Result<PathBuf> {
     println!("⚙️  Rebuilding kernel from source (profile: {profile_name})...");
     info!(profile = %profile_name, path = %kernel_path.display(), staging = %staging_path.display(), "forced source rebuild, skipping release download");
     let publish_result = match build_kernel_locally(&profile, profile_name, &staging_path).await {
-        Ok(()) => tokio::fs::rename(&staging_path, &kernel_path)
-            .await
-            .with_context(|| {
-                format!(
-                    "publishing rebuilt kernel {} -> {}",
-                    staging_path.display(),
-                    kernel_path.display()
-                )
-            }),
+        Ok(()) => super::publish_store_entry(&staging_path, &kernel_path, "rebuilt kernel").await,
         Err(error) => {
             let _ = tokio::fs::remove_file(&staging_path).await;
             Err(error)
@@ -245,23 +226,11 @@ async fn ensure_url_kernel(profile: &KernelProfile, allow_create: bool) -> Resul
     }
 
     // Create directory and acquire lock
-    tokio::fs::create_dir_all(&kernel_dir)
-        .await
-        .context("creating kernel directory")?;
-
-    let lock_file = kernel_dir.join(format!("vmlinux-{}.lock", url_hash));
-    use std::os::unix::fs::OpenOptionsExt;
-    let lock_fd = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(&lock_file)
-        .context("opening kernel lock file")?;
-
-    let flock = Flock::lock(lock_fd, FlockArg::LockExclusive)
-        .map_err(|(_, err)| err)
-        .context("acquiring exclusive lock for kernel download")?;
+    let flock = super::lock_store_dir(
+        &kernel_dir.join(format!("vmlinux-{}.lock", url_hash)),
+        "kernel download",
+    )
+    .await?;
 
     // Double-check after lock
     if kernel_path.exists() {
@@ -276,6 +245,7 @@ async fn ensure_url_kernel(profile: &KernelProfile, allow_create: bool) -> Resul
 
     let cache_dir = paths::cache_dir();
     tokio::fs::create_dir_all(&cache_dir).await?;
+    super::give_store_entry_to_invoker(&cache_dir);
 
     let tarball_path = cache_dir.join(format!("kernel-{}.tar.zst", url_hash));
     let tarball_temp = cache_dir.join(format!("kernel-{}.tar.zst.downloading", url_hash));
@@ -301,9 +271,8 @@ async fn ensure_url_kernel(profile: &KernelProfile, allow_create: bool) -> Resul
         }
 
         // Atomic rename on success
-        tokio::fs::rename(&tarball_temp, &tarball_path)
-            .await
-            .context("renaming downloaded tarball")?;
+        super::publish_store_entry(&tarball_temp, &tarball_path, "downloaded kernel tarball")
+            .await?;
     } else {
         info!(path = %tarball_path.display(), "using cached tarball");
     }
@@ -313,6 +282,9 @@ async fn ensure_url_kernel(profile: &KernelProfile, allow_create: bool) -> Resul
     let extract_temp = cache_dir.join(format!("kernel-{}-extract", url_hash));
     let _ = tokio::fs::remove_dir_all(&extract_temp).await;
     tokio::fs::create_dir_all(&extract_temp).await?;
+    // Deterministic name: a killed root run would otherwise leave a directory
+    // whose contents the next rootless run's remove_dir_all cannot unlink.
+    super::give_store_entry_to_invoker(&extract_temp);
 
     let extract_path = format!("./{}", archive_path);
     let output = Command::new("tar")
@@ -356,11 +328,13 @@ async fn ensure_url_kernel(profile: &KernelProfile, allow_create: bool) -> Resul
         let _ = flock.unlock();
         return Err(e).context("copying kernel to staging location");
     }
-    if let Err(e) = tokio::fs::rename(&kernel_temp, &kernel_path).await {
+    if let Err(e) =
+        super::publish_store_entry(&kernel_temp, &kernel_path, "downloaded kernel").await
+    {
         let _ = tokio::fs::remove_file(&kernel_temp).await;
         let _ = tokio::fs::remove_dir_all(&extract_temp).await;
         let _ = flock.unlock();
-        return Err(e).context("moving kernel to final location");
+        return Err(e);
     }
 
     // Clean up temp extraction dir
@@ -416,23 +390,8 @@ async fn ensure_custom_kernel(
     }
 
     // Create directory and acquire lock
-    tokio::fs::create_dir_all(&kernel_dir)
-        .await
-        .context("creating kernel directory")?;
-
-    let lock_file = kernel_dir.join(format!("{}.lock", filename));
-    use std::os::unix::fs::OpenOptionsExt;
-    let lock_fd = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(&lock_file)
-        .context("opening kernel lock file")?;
-
-    let flock = Flock::lock(lock_fd, FlockArg::LockExclusive)
-        .map_err(|(_, err)| err)
-        .context("acquiring exclusive lock for kernel")?;
+    let flock =
+        super::lock_store_dir(&kernel_dir.join(format!("{}.lock", filename)), "kernel").await?;
 
     // Double-check after lock
     if kernel_path.exists() {
@@ -736,9 +695,7 @@ async fn download_kernel_binary(url: &str, dest: &Path) -> Result<()> {
         bail!("Downloaded file is not a valid kernel: {}", file_type);
     }
 
-    tokio::fs::rename(&temp_path, dest)
-        .await
-        .context("moving kernel to final location")?;
+    super::publish_store_entry(&temp_path, dest, "release kernel").await?;
 
     Ok(())
 }
@@ -1054,7 +1011,12 @@ async fn build_kernel_locally(
 
     info!(script = %script_path.display(), "generated kernel build script");
 
-    let cmd = Command::new(&script_path);
+    // Kernel compilation needs no privilege (the rootless Makefile path runs
+    // this same script as the user); under sudo, drop the child so a failed
+    // build cannot leave a root-owned /tmp build tree that blocks the next
+    // rootless build of the same profile.
+    let mut cmd = Command::new(&script_path);
+    super::run_build_as_sudo_invoker(&mut cmd);
     let status = run_streaming(cmd, "kernel_build")
         .await
         .context("running build script")?;
@@ -1391,6 +1353,8 @@ pub async fn install_host_kernel(profile: &KernelProfile, boot_args: Option<&str
 
     info!(script = %script_path.display(), "generated host kernel build script");
 
+    // Stays root by design: this interactive EC2 flow pairs the build with
+    // dpkg -i and update-grub, which require root anyway.
     let cmd = Command::new(&script_path);
     let status = run_streaming(cmd, "host_kernel_build")
         .await
@@ -2013,7 +1977,98 @@ fn write_json_atomic<T: serde::Serialize>(final_path: &Path, value: &T) -> Resul
         let _ = std::fs::remove_file(&tmp);
         return Err(e).with_context(|| format!("renaming into {}", final_path.display()));
     }
+    super::give_store_entry_to_invoker(final_path);
     Ok(())
+}
+
+/// Locate `cargo` for source builds (firecracker, cloud-hypervisor).
+///
+/// `sudo fcvm setup` runs with root's PATH, which does not carry the invoking
+/// user's rustup cargo, so spawning bare "cargo" dies with ENOENT (proven by
+/// the Build Btrfs Kernel job: `building firecracker: No such file or
+/// directory`). Resolution order: `$CARGO`, then PATH, then `.cargo/bin/cargo`
+/// under `$HOME` and under the sudo invoker's home.
+fn cargo_program() -> Result<PathBuf> {
+    let homes = cargo_fallback_homes();
+    resolve_cargo(std::env::var_os("CARGO"), std::env::var_os("PATH"), &homes).ok_or_else(|| {
+        anyhow::anyhow!(
+            "cargo not found: not in $CARGO, not on PATH, and no .cargo/bin/cargo under {}. \
+             Building this component needs a Rust toolchain — install rustup, or when running \
+             under sudo keep the invoking user's rustup install in place",
+            homes
+                .iter()
+                .map(|h| h.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+        )
+    })
+}
+
+fn cargo_fallback_homes() -> Vec<PathBuf> {
+    fallback_homes_for(
+        crate::setup::sudo_invoker().map(|user| user.dir.clone()),
+        std::env::var_os("HOME").map(PathBuf::from),
+    )
+}
+
+/// Resolve for the identity that will execute. With a sudo invoker, the build
+/// child drops to that user, so only their home is a usable fallback: root's
+/// $HOME (/root) is typically 0700 and a cargo found there would fail the
+/// dropped child's spawn with EACCES despite the invoker's own cargo working.
+fn fallback_homes_for(invoker_home: Option<PathBuf>, env_home: Option<PathBuf>) -> Vec<PathBuf> {
+    match invoker_home {
+        Some(home) => vec![home],
+        None => env_home.into_iter().collect(),
+    }
+}
+
+/// Absolutize a candidate against the caller's cwd, then require a regular
+/// executable file. The build command sets current_dir(build_dir), so a
+/// relative candidate must be pinned to the file that was validated — the
+/// child would otherwise re-resolve it inside the cloned repo. The exec check
+/// matches execvp, which skips a PATH candidate it cannot execute and keeps
+/// searching.
+fn absolute_executable(candidate: &Path) -> Option<PathBuf> {
+    let candidate = std::path::absolute(candidate).ok()?;
+    let executable = std::fs::metadata(&candidate)
+        .map(|m| m.is_file() && (m.permissions().mode() & 0o111) != 0)
+        .unwrap_or(false);
+    executable.then_some(candidate)
+}
+
+/// The `which` crate is not used here on purpose: `which_in` implements the
+/// full POSIX rule where an empty PATH entry means the working directory, and
+/// this resolver frequently runs as root — it must never pick up a ./cargo
+/// from whatever directory setup happens to run in. Empty entries are skipped
+/// instead, and the five tests below pin the rest of the ladder.
+fn resolve_cargo(
+    cargo_env: Option<std::ffi::OsString>,
+    path_env: Option<std::ffi::OsString>,
+    homes: &[PathBuf],
+) -> Option<PathBuf> {
+    if let Some(cargo) = cargo_env {
+        if !cargo.is_empty() {
+            if let Some(cargo) = absolute_executable(&PathBuf::from(cargo)) {
+                return Some(cargo);
+            }
+        }
+    }
+    if let Some(path) = path_env {
+        for dir in std::env::split_paths(&path) {
+            if dir.as_os_str().is_empty() {
+                continue;
+            }
+            if let Some(cargo) = absolute_executable(&dir.join("cargo")) {
+                return Some(cargo);
+            }
+        }
+    }
+    for home in homes {
+        if let Some(cargo) = absolute_executable(&home.join(".cargo/bin/cargo")) {
+            return Some(cargo);
+        }
+    }
+    None
 }
 
 /// Get the content-addressed path for profile firecracker binary.
@@ -2266,25 +2321,16 @@ pub async fn ensure_profile_firecracker(
         return Ok(Some(bin_path));
     }
 
-    // Create directory
-    tokio::fs::create_dir_all(&firecracker_dir)
-        .await
-        .context("creating firecracker directory")?;
+    // Resolve the build toolchain before creating anything: a missing cargo
+    // must not cost a network clone or leave a fresh dir/lock behind.
+    let cargo = cargo_program()?;
 
-    // Acquire lock
-    let lock_file = firecracker_dir.join(format!("{}.lock", filename));
-    use std::os::unix::fs::OpenOptionsExt;
-    let lock_fd = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(&lock_file)
-        .context("opening firecracker lock file")?;
-
-    let flock = Flock::lock(lock_fd, FlockArg::LockExclusive)
-        .map_err(|(_, err)| err)
-        .context("acquiring exclusive lock for firecracker build")?;
+    // Create directory and acquire lock
+    let flock = super::lock_store_dir(
+        &firecracker_dir.join(format!("{}.lock", filename)),
+        "firecracker build",
+    )
+    .await?;
 
     // Double-check after lock (another process may have built it)
     if bin_path.exists() {
@@ -2313,19 +2359,21 @@ pub async fn ensure_profile_firecracker(
             .context("removing old firecracker build directory")?;
     }
 
-    // Clone repo
+    // Clone repo (as the sudo invoker, so the checkout is not root-owned)
     let clone_url = format!("https://github.com/{}", repo);
-    let status = Command::new("git")
-        .args([
-            "clone",
-            "--depth=1",
-            "--single-branch",
-            "--no-tags",
-            "-b",
-            branch,
-            &clone_url,
-            build_dir.to_str().unwrap(),
-        ])
+    let mut clone_cmd = Command::new("git");
+    clone_cmd.args([
+        "clone",
+        "--depth=1",
+        "--single-branch",
+        "--no-tags",
+        "-b",
+        branch,
+        &clone_url,
+        build_dir.to_str().unwrap(),
+    ]);
+    super::run_build_as_sudo_invoker(&mut clone_cmd);
+    let status = clone_cmd
         .status()
         .await
         .context("cloning firecracker repo")?;
@@ -2356,12 +2404,12 @@ pub async fn ensure_profile_firecracker(
     }
 
     // Build firecracker
-    let status = Command::new("cargo")
+    let mut build_cmd = Command::new(&cargo);
+    build_cmd
         .args(["build", "--release", "-p", "firecracker"])
-        .current_dir(&build_dir)
-        .status()
-        .await
-        .context("building firecracker")?;
+        .current_dir(&build_dir);
+    super::run_build_as_sudo_invoker(&mut build_cmd);
+    let status = build_cmd.status().await.context("building firecracker")?;
 
     if !status.success() {
         flock.unlock().map_err(|(_, err)| err)?;
@@ -2395,10 +2443,10 @@ pub async fn ensure_profile_firecracker(
         let _ = flock.unlock();
         return Err(e).context("installing firecracker binary");
     }
-    if let Err(e) = tokio::fs::rename(&temp_path, &bin_path).await {
+    if let Err(e) = super::publish_store_entry(&temp_path, &bin_path, "firecracker binary").await {
         let _ = tokio::fs::remove_file(&temp_path).await;
         let _ = flock.unlock();
-        return Err(e).context("moving firecracker binary into place");
+        return Err(e);
     }
 
     // Clean up the build tree on success (failures keep it for debugging)
@@ -2497,24 +2545,16 @@ pub async fn ensure_cloud_hypervisor(repo: &str, branch: &str) -> Result<PathBuf
         return Ok(bin_path);
     }
 
-    tokio::fs::create_dir_all(&ch_dir)
-        .await
-        .context("creating cloud-hypervisor directory")?;
+    // Resolve the build toolchain before creating anything: a missing cargo
+    // must not cost a network clone or leave a fresh dir/lock behind.
+    let cargo = cargo_program()?;
 
     // Acquire per-filename lock so concurrent setups don't collide
-    let lock_file = ch_dir.join(format!("{}.lock", filename));
-    use std::os::unix::fs::OpenOptionsExt;
-    let lock_fd = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(&lock_file)
-        .context("opening cloud-hypervisor lock file")?;
-
-    let flock = Flock::lock(lock_fd, FlockArg::LockExclusive)
-        .map_err(|(_, err)| err)
-        .context("acquiring exclusive lock for cloud-hypervisor build")?;
+    let flock = super::lock_store_dir(
+        &ch_dir.join(format!("{}.lock", filename)),
+        "cloud-hypervisor build",
+    )
+    .await?;
 
     // Double-check after lock (another process may have built it)
     if bin_path.exists() {
@@ -2545,17 +2585,20 @@ pub async fn ensure_cloud_hypervisor(repo: &str, branch: &str) -> Result<PathBuf
             .context("removing old cloud-hypervisor build directory")?;
     }
 
-    // Clone repo (shallow, single branch)
+    // Clone repo (shallow, single branch, as the sudo invoker so the
+    // checkout is not root-owned)
     let clone_url = format!("https://github.com/{}", repo);
-    let status = Command::new("git")
-        .args([
-            "clone",
-            "--depth=1",
-            "-b",
-            branch,
-            &clone_url,
-            build_dir.to_str().unwrap(),
-        ])
+    let mut clone_cmd = Command::new("git");
+    clone_cmd.args([
+        "clone",
+        "--depth=1",
+        "-b",
+        branch,
+        &clone_url,
+        build_dir.to_str().unwrap(),
+    ]);
+    super::run_build_as_sudo_invoker(&mut clone_cmd);
+    let status = clone_cmd
         .status()
         .await
         .context("cloning cloud-hypervisor repo")?;
@@ -2600,9 +2643,12 @@ pub async fn ensure_cloud_hypervisor(repo: &str, branch: &str) -> Result<PathBuf
     }
 
     // Build cloud-hypervisor
-    let status = Command::new("cargo")
+    let mut build_cmd = Command::new(&cargo);
+    build_cmd
         .args(["build", "--release", "--bin", "cloud-hypervisor"])
-        .current_dir(&build_dir)
+        .current_dir(&build_dir);
+    super::run_build_as_sudo_invoker(&mut build_cmd);
+    let status = build_cmd
         .status()
         .await
         .context("building cloud-hypervisor")?;
@@ -2628,10 +2674,12 @@ pub async fn ensure_cloud_hypervisor(repo: &str, branch: &str) -> Result<PathBuf
         let _ = flock.unlock();
         return Err(e).context("installing cloud-hypervisor binary");
     }
-    if let Err(e) = tokio::fs::rename(&temp_path, &bin_path).await {
+    if let Err(e) =
+        super::publish_store_entry(&temp_path, &bin_path, "cloud-hypervisor binary").await
+    {
         let _ = tokio::fs::remove_file(&temp_path).await;
         let _ = flock.unlock();
-        return Err(e).context("moving cloud-hypervisor binary into place");
+        return Err(e);
     }
 
     // Clean up the build tree on success (failures keep it for debugging)
@@ -3466,5 +3514,132 @@ cp vmlinux arch/arm64/boot/Image
             parse_resolve_ttl(Some("")),
             FIRECRACKER_RESOLVE_TTL_DEFAULT_SECS
         );
+    }
+
+    // resolve_cargo: `sudo fcvm setup` gets root's PATH, which has no cargo,
+    // and the old bare Command::new("cargo") died with ENOENT there (the
+    // Build Btrfs Kernel job). These pin the fallback ladder.
+
+    fn fake_cargo_in(dir: &Path) -> PathBuf {
+        std::fs::create_dir_all(dir).unwrap();
+        let cargo = dir.join("cargo");
+        write_executable(&cargo, "#!/bin/sh\nexit 0\n");
+        cargo
+    }
+
+    #[test]
+    fn resolve_cargo_prefers_cargo_env() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env_cargo = fake_cargo_in(&tmp.path().join("env-bin"));
+        let path_cargo_dir = tmp.path().join("path-bin");
+        fake_cargo_in(&path_cargo_dir);
+        let found = resolve_cargo(
+            Some(env_cargo.clone().into_os_string()),
+            Some(path_cargo_dir.into_os_string()),
+            &[],
+        );
+        assert_eq!(found, Some(env_cargo));
+    }
+
+    #[test]
+    fn resolve_cargo_ignores_dangling_cargo_env() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path_dir = tmp.path().join("path-bin");
+        let path_cargo = fake_cargo_in(&path_dir);
+        let found = resolve_cargo(
+            Some(tmp.path().join("missing/cargo").into_os_string()),
+            Some(path_dir.into_os_string()),
+            &[],
+        );
+        assert_eq!(found, Some(path_cargo));
+    }
+
+    #[test]
+    fn resolve_cargo_scans_path_entries_in_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        let without = tmp.path().join("without-cargo");
+        std::fs::create_dir_all(&without).unwrap();
+        let with = tmp.path().join("with-cargo");
+        let path_cargo = fake_cargo_in(&with);
+        let joined = std::env::join_paths([without, with]).unwrap();
+        let found = resolve_cargo(None, Some(joined), &[]);
+        assert_eq!(found, Some(path_cargo));
+    }
+
+    #[test]
+    fn resolve_cargo_falls_back_to_home_rustup_install() {
+        // The sudo case: PATH carries no cargo, but the invoking user's home
+        // has the standard rustup layout. The old code had no fallback at all.
+        let tmp = tempfile::tempdir().unwrap();
+        let empty_path_dir = tmp.path().join("no-cargo-here");
+        std::fs::create_dir_all(&empty_path_dir).unwrap();
+        let home = tmp.path().join("home");
+        let home_cargo = fake_cargo_in(&home.join(".cargo/bin"));
+        let found = resolve_cargo(None, Some(empty_path_dir.into_os_string()), &[home]);
+        assert_eq!(found, Some(home_cargo));
+    }
+
+    #[test]
+    fn resolve_cargo_skips_non_executable_candidates() {
+        // execvp skips a PATH entry it cannot execute and keeps searching;
+        // resolution must do the same or a stray non-executable "cargo"
+        // file turns into a hard EACCES at spawn time.
+        let tmp = tempfile::tempdir().unwrap();
+        let broken_dir = tmp.path().join("broken");
+        std::fs::create_dir_all(&broken_dir).unwrap();
+        std::fs::write(broken_dir.join("cargo"), "not a program").unwrap();
+        let good_dir = tmp.path().join("good");
+        let good = fake_cargo_in(&good_dir);
+        let joined = std::env::join_paths([broken_dir, good_dir]).unwrap();
+        let found = resolve_cargo(None, Some(joined), &[]);
+        assert_eq!(found, Some(good));
+    }
+
+    #[test]
+    fn resolve_cargo_returns_absolute_paths_for_relative_candidates() {
+        // The build command sets current_dir(build_dir), so a relative
+        // candidate validated against the caller's cwd would be re-resolved
+        // by the child inside the cloned repo — a different file entirely.
+        let tmp = tempfile::tempdir().unwrap();
+        fake_cargo_in(&tmp.path().join("bin"));
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(tmp.path()).unwrap();
+        let found = resolve_cargo(None, Some(std::ffi::OsString::from("bin")), &[]);
+        std::env::set_current_dir(prev).unwrap();
+        let found = found.expect("relative PATH entry with a real cargo resolves");
+        assert!(
+            found.is_absolute(),
+            "resolved cargo must be absolute, got {}",
+            found.display()
+        );
+    }
+
+    #[test]
+    fn fallback_homes_prefer_the_identity_that_executes() {
+        // With a sudo invoker the child drops to that user, who typically
+        // cannot traverse root's 0700 $HOME — root's cargo would spawn-fail
+        // EACCES for the child, so it must not even be a candidate.
+        let invoker = PathBuf::from("/home/operator");
+        let root_home = PathBuf::from("/root");
+        assert_eq!(
+            fallback_homes_for(Some(invoker.clone()), Some(root_home.clone())),
+            vec![invoker]
+        );
+        assert_eq!(
+            fallback_homes_for(None, Some(root_home.clone())),
+            vec![root_home]
+        );
+        assert!(fallback_homes_for(None, None).is_empty());
+    }
+
+    #[test]
+    fn resolve_cargo_reports_nothing_when_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let empty = tmp.path().join("empty");
+        std::fs::create_dir_all(&empty).unwrap();
+        let bare_home = tmp.path().join("bare-home");
+        std::fs::create_dir_all(&bare_home).unwrap();
+        let found = resolve_cargo(None, Some(empty.into_os_string()), &[bare_home]);
+        assert_eq!(found, None);
     }
 }

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -3,6 +3,184 @@ pub mod pasta;
 pub mod rootfs;
 pub mod storage;
 
+use anyhow::{Context, Result};
+use nix::fcntl::{Flock, FlockArg, OFlag};
+use std::os::fd::AsRawFd;
+use std::path::Path;
+use tracing::warn;
+
+/// The user who invoked sudo, resolved from SUDO_USER via passwd.
+///
+/// `None` when not running as root, when SUDO_USER is unset (a genuine root
+/// login, container CI), or when the name does not resolve. Memoized: euid,
+/// SUDO_USER, and the passwd entry are process-constant, and the store paths
+/// consult this on every entry they create.
+pub(crate) fn sudo_invoker() -> Option<&'static nix::unistd::User> {
+    static INVOKER: std::sync::OnceLock<Option<nix::unistd::User>> = std::sync::OnceLock::new();
+    INVOKER
+        .get_or_init(|| {
+            if !nix::unistd::Uid::effective().is_root() {
+                return None;
+            }
+            let sudo_user = std::env::var("SUDO_USER").ok()?;
+            match nix::unistd::User::from_name(&sudo_user) {
+                Ok(Some(user)) => Some(user),
+                Ok(None) => {
+                    warn!(%sudo_user, "SUDO_USER not found in passwd; store entries stay root-owned");
+                    None
+                }
+                Err(err) => {
+                    warn!(%sudo_user, %err, "passwd lookup for SUDO_USER failed; store entries stay root-owned");
+                    None
+                }
+            }
+        })
+        .as_ref()
+}
+
+/// Open a store entry for an ownership hand-back, refusing to follow symlinks.
+///
+/// The hand-back runs as root inside a user-owned tree, so a path-based chown
+/// would follow a symlink the user planted and change the ownership of
+/// whatever it points at. Opening with O_NOFOLLOW and chowning the descriptor
+/// makes that impossible: a symlink fails the open (ELOOP) and is skipped.
+fn open_store_entry_nofollow(path: &Path) -> nix::Result<std::os::fd::OwnedFd> {
+    let raw = nix::fcntl::open(
+        path,
+        OFlag::O_RDONLY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+        nix::sys::stat::Mode::empty(),
+    )?;
+    // SAFETY: open just returned this descriptor; nothing else owns it.
+    Ok(unsafe { std::os::fd::FromRawFd::from_raw_fd(raw) })
+}
+
+/// Hand a content-addressed store entry back to the user who invoked sudo.
+///
+/// The stores under assets_dir (kernels, pasta, firecracker, cloud-hypervisor,
+/// initrd, rootfs, cache; the list lives in src/paths.rs and in
+/// scripts/normalize-store-ownership.sh) belong to the operator; root only
+/// writes there on the operator's behalf (`sudo fcvm setup`). Anything root
+/// leaves behind blocks the next rootless run from writing: a failed root
+/// build left a root-owned firecracker/ directory and 0600 lock file on a CI
+/// runner, and every rootless setup on that machine then died with EACCES
+/// opening the lock.
+///
+/// No-op unless running as root with SUDO_USER set. Failure is logged rather
+/// than propagated: a store on a fuse-pipe mapped directory (nested runs map
+/// the host store into the guest) legitimately refuses chown while everything
+/// else works, and a genuinely lost hand-back surfaces at the next rootless
+/// write with a clear EACCES rather than silently.
+pub(crate) fn give_store_entry_to_invoker(path: &Path) {
+    let Some(user) = sudo_invoker() else {
+        return;
+    };
+    let fd = match open_store_entry_nofollow(path) {
+        Ok(fd) => fd,
+        Err(err) => {
+            warn!(
+                path = %path.display(),
+                %err,
+                "not handing store entry back (symlink or unreadable)"
+            );
+            return;
+        }
+    };
+    if let Err(err) = nix::unistd::fchown(fd.as_raw_fd(), Some(user.uid), Some(user.gid)) {
+        warn!(
+            path = %path.display(),
+            invoker = %user.name,
+            %err,
+            "failed to hand store entry back to the invoking user"
+        );
+    }
+}
+
+/// Publish a completed store artifact: atomically rename the staged temp onto
+/// the content-addressed final path, then hand it back to the sudo invoker.
+///
+/// Every store builder stages to a temp name and renames, so an interrupted
+/// build never leaves a partial artifact behind; this owns the rename half of
+/// that ritual so the ownership hand-back cannot be forgotten at a call site.
+pub(crate) async fn publish_store_entry(temp: &Path, dest: &Path, what: &str) -> Result<()> {
+    tokio::fs::rename(temp, dest)
+        .await
+        .with_context(|| format!("renaming {what} into {}", dest.display()))?;
+    give_store_entry_to_invoker(dest);
+    Ok(())
+}
+
+/// Run a build child as the user who invoked sudo instead of as root.
+///
+/// The store builders clone repos and run the operator's toolchains. As root
+/// those misbehave: the rustup shim keys its toolchain lookup off $HOME, so it
+/// tries to download a whole toolchain into /root/.rustup (observed live), and
+/// everything the build writes — checkout, target/, registry cache — lands
+/// root-owned. Dropping the child to the invoking user makes the build behave
+/// exactly as if the operator ran it themselves; root keeps only the store
+/// lock and the install into the shared store.
+///
+/// The drop is complete: supplementary groups, gid, then uid, in one
+/// pre-exec, so the child holds none of root's group privileges. CARGO_HOME
+/// and RUSTUP_HOME are cleared so a value inherited from root's environment
+/// cannot point the build at root-owned trees.
+///
+/// No-op unless running as root with a resolvable SUDO_USER.
+pub(crate) fn run_build_as_sudo_invoker(
+    cmd: &mut tokio::process::Command,
+) -> &mut tokio::process::Command {
+    let Some(user) = sudo_invoker() else {
+        return cmd;
+    };
+    cmd.env("HOME", &user.dir);
+    cmd.env_remove("CARGO_HOME");
+    cmd.env_remove("RUSTUP_HOME");
+    let uid = user.uid;
+    let gid = user.gid;
+    unsafe {
+        cmd.pre_exec(move || {
+            let errno_to_io = |e: nix::errno::Errno| std::io::Error::from_raw_os_error(e as i32);
+            nix::unistd::setgroups(&[gid]).map_err(errno_to_io)?;
+            nix::unistd::setgid(gid).map_err(errno_to_io)?;
+            nix::unistd::setuid(uid).map_err(errno_to_io)?;
+            Ok(())
+        });
+    }
+    cmd
+}
+
+/// Create the store directory holding `lock_path` and take an exclusive flock
+/// on it.
+///
+/// Every store builder (kernel, pasta, firecracker, cloud-hypervisor, rootfs,
+/// initrd) serializes concurrent builds of the same artifact this way. The
+/// directory and lock file are handed back to the sudo invoker immediately on
+/// creation, so a root-invoked build that later fails cannot leave entries a
+/// rootless run is unable to open.
+pub(crate) async fn lock_store_dir(lock_path: &Path, what: &str) -> Result<Flock<std::fs::File>> {
+    let dir = lock_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("store lock {} has no parent", lock_path.display()))?;
+    tokio::fs::create_dir_all(dir)
+        .await
+        .with_context(|| format!("creating {what} directory"))?;
+    give_store_entry_to_invoker(dir);
+
+    use std::os::unix::fs::OpenOptionsExt;
+    let lock_fd = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(lock_path)
+        .with_context(|| format!("opening {what} lock file"))?;
+    give_store_entry_to_invoker(lock_path);
+
+    Flock::lock(lock_fd, FlockArg::LockExclusive)
+        .map_err(|(_, err)| err)
+        .with_context(|| format!("acquiring exclusive lock for {what}"))
+}
+
 pub use kernel::{
     ensure_cloud_hypervisor, ensure_kernel, ensure_profile_firecracker,
     get_configured_firecracker_for_profile, get_firecracker_for_profile, get_kernel_path,
@@ -14,3 +192,63 @@ pub use rootfs::{
     ensure_fc_agent_initrd, ensure_rootfs, get_kernel_profile, resolve_rootfs_type, KernelProfile,
 };
 pub use storage::ensure_storage;
+
+#[cfg(test)]
+mod store_ownership_tests {
+    use super::*;
+
+    #[test]
+    fn give_store_entry_is_a_no_op_without_root() {
+        // Must never error or alter anything when running unprivileged —
+        // this is the path every rootless setup takes.
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("entry");
+        std::fs::write(&file, b"x").unwrap();
+        let before = std::fs::metadata(&file).unwrap();
+        give_store_entry_to_invoker(&file);
+        let after = std::fs::metadata(&file).unwrap();
+        use std::os::unix::fs::MetadataExt;
+        assert_eq!(before.uid(), after.uid());
+        assert_eq!(before.gid(), after.gid());
+    }
+
+    #[test]
+    fn ownership_handback_refuses_symlinks() {
+        // A path-based chown would follow a symlink planted in the
+        // user-owned store and change the ownership of its target; the
+        // hand-back must open the entry itself or skip it.
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("target");
+        std::fs::write(&target, b"x").unwrap();
+        let link = tmp.path().join("link");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        assert!(open_store_entry_nofollow(&link).is_err());
+        assert!(open_store_entry_nofollow(&target).is_ok());
+        assert!(open_store_entry_nofollow(tmp.path()).is_ok());
+    }
+
+    #[tokio::test]
+    async fn lock_store_dir_creates_dir_and_lock() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("firecracker");
+        let flock = lock_store_dir(&dir.join("x.lock"), "test store")
+            .await
+            .unwrap();
+        assert!(dir.is_dir());
+        assert!(dir.join("x.lock").is_file());
+        flock.unlock().map_err(|(_, e)| e).unwrap();
+    }
+
+    #[tokio::test]
+    async fn publish_store_entry_renames_into_place() {
+        let tmp = tempfile::tempdir().unwrap();
+        let staged = tmp.path().join("artifact.tmp");
+        std::fs::write(&staged, b"bytes").unwrap();
+        let dest = tmp.path().join("artifact.bin");
+        publish_store_entry(&staged, &dest, "test artifact")
+            .await
+            .unwrap();
+        assert!(!staged.exists());
+        assert_eq!(std::fs::read(&dest).unwrap(), b"bytes");
+    }
+}

--- a/src/setup/pasta.rs
+++ b/src/setup/pasta.rs
@@ -18,7 +18,6 @@
 //!   flock, double-checked after acquisition.
 
 use anyhow::{bail, Context, Result};
-use nix::fcntl::{Flock, FlockArg};
 use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 use tokio::process::Command;
@@ -99,24 +98,8 @@ pub async fn ensure_pasta(config: Option<&PastaConfig>) -> Result<Option<PathBuf
         return Ok(Some(bin_path));
     }
 
-    let pasta_dir = bin_path.parent().expect("pasta path has parent");
-    tokio::fs::create_dir_all(&pasta_dir)
-        .await
-        .context("creating pasta assets directory")?;
-
     // Serialize concurrent builds of the same binary (parallel `fcvm setup`).
-    let lock_file = bin_path.with_extension("lock");
-    use std::os::unix::fs::OpenOptionsExt;
-    let lock_fd = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(&lock_file)
-        .context("opening pasta build lock file")?;
-    let flock = Flock::lock(lock_fd, FlockArg::LockExclusive)
-        .map_err(|(_, err)| err)
-        .context("acquiring exclusive lock for pasta build")?;
+    let flock = super::lock_store_dir(&bin_path.with_extension("lock"), "pasta build").await?;
 
     // Another process may have finished the build while we waited.
     if bin_path.exists() {
@@ -163,21 +146,30 @@ async fn build_pasta(
     // arbitrary SHA need uploadpack.allowReachableSHA1InWant on the server,
     // which passt.top does not advertise. The repo is ~15MB; correctness
     // over cleverness.
-    let status = Command::new("git")
-        .args(["clone", &config.repo, build_dir.to_str().unwrap()])
-        .status()
-        .await
-        .context("cloning pasta repo")?;
+    // The whole build runs as the sudo invoker (see run_build_as_sudo_invoker):
+    // the deterministic /tmp/pasta-build-{sha} tree must never be left
+    // root-owned by a failed root build, or the next rootless build dies
+    // removing it.
+    let status = super::run_build_as_sudo_invoker(Command::new("git").args([
+        "clone",
+        &config.repo,
+        build_dir.to_str().unwrap(),
+    ]))
+    .status()
+    .await
+    .context("cloning pasta repo")?;
     if !status.success() {
         bail!("failed to clone pasta repo from {}", config.repo);
     }
 
-    let status = Command::new("git")
-        .args(["checkout", "--detach", &config.commit])
-        .current_dir(build_dir)
-        .status()
-        .await
-        .context("checking out pinned pasta commit")?;
+    let status = super::run_build_as_sudo_invoker(
+        Command::new("git")
+            .args(["checkout", "--detach", &config.commit])
+            .current_dir(build_dir),
+    )
+    .status()
+    .await
+    .context("checking out pinned pasta commit")?;
     if !status.success() {
         bail!(
             "pinned pasta commit {} not found in {} — the pin and repo must agree",
@@ -191,12 +183,14 @@ async fn build_pasta(
         tokio::fs::write(&patch_path, content)
             .await
             .with_context(|| format!("writing embedded patch {}", name))?;
-        let status = Command::new("git")
-            .args(["apply", "--verbose", name])
-            .current_dir(build_dir)
-            .status()
-            .await
-            .with_context(|| format!("applying pasta patch {}", name))?;
+        let status = super::run_build_as_sudo_invoker(
+            Command::new("git")
+                .args(["apply", "--verbose", name])
+                .current_dir(build_dir),
+        )
+        .status()
+        .await
+        .with_context(|| format!("applying pasta patch {}", name))?;
         if !status.success() {
             bail!(
                 "pasta patch {} does not apply to {} @ {} — rebase the patch or move the pin",
@@ -207,12 +201,11 @@ async fn build_pasta(
         }
     }
 
-    let status = Command::new("make")
-        .arg("pasta")
-        .current_dir(build_dir)
-        .status()
-        .await
-        .context("building pasta (is a C toolchain installed? apt install gcc make)")?;
+    let status =
+        super::run_build_as_sudo_invoker(Command::new("make").arg("pasta").current_dir(build_dir))
+            .status()
+            .await
+            .context("building pasta (is a C toolchain installed? apt install gcc make)")?;
     if !status.success() {
         bail!(
             "pasta build failed (build tree kept at {})",
@@ -232,8 +225,6 @@ async fn build_pasta(
     tokio::fs::copy(&built, &temp_path)
         .await
         .context("staging pasta binary")?;
-    tokio::fs::rename(&temp_path, bin_path)
-        .await
-        .context("installing pasta binary")?;
+    super::publish_store_entry(&temp_path, bin_path, "pasta binary").await?;
     Ok(())
 }

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -1,6 +1,5 @@
 use anyhow::{bail, Context, Result};
 use directories::ProjectDirs;
-use nix::fcntl::{Flock, FlockArg};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
@@ -1141,26 +1140,9 @@ pub async fn ensure_rootfs(allow_create: bool, rootfs_type: Option<&str>) -> Res
         bail!("Rootfs not found. Run 'fcvm setup' first, or use --setup flag.");
     }
 
-    // Create directory for lock file
-    tokio::fs::create_dir_all(&rootfs_dir)
-        .await
-        .context("creating rootfs directory")?;
-
     // Acquire lock to prevent concurrent rootfs creation
     info!("acquiring rootfs creation lock");
-    use std::os::unix::fs::OpenOptionsExt;
-    let lock_fd = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(&lock_file)
-        .context("opening rootfs creation lock file")?;
-
-    use nix::fcntl::{Flock, FlockArg};
-    let flock = Flock::lock(lock_fd, FlockArg::LockExclusive)
-        .map_err(|(_, err)| err)
-        .context("acquiring rootfs creation lock")?;
+    let flock = super::lock_store_dir(&lock_file, "rootfs creation").await?;
 
     // Check again after acquiring lock
     if rootfs_path.exists() {
@@ -1194,9 +1176,7 @@ pub async fn ensure_rootfs(allow_create: bool, rootfs_type: Option<&str>) -> Res
     .await;
 
     if result.is_ok() {
-        tokio::fs::rename(&temp_rootfs_path, &rootfs_path)
-            .await
-            .context("renaming temp rootfs to final path")?;
+        super::publish_store_entry(&temp_rootfs_path, &rootfs_path, "rootfs").await?;
         info!(
             path = %rootfs_path.display(),
             script_sha = %script_sha_short,
@@ -1521,25 +1501,12 @@ pub async fn ensure_fc_agent_initrd(allow_create: bool) -> Result<PathBuf> {
         bail!("fc-agent initrd not found. Run 'fcvm setup' first, or use --setup flag.");
     }
 
-    // Create initrd directory (needed for lock file)
-    tokio::fs::create_dir_all(&initrd_dir)
-        .await
-        .context("creating initrd directory")?;
-
     // Acquire exclusive lock to prevent race conditions
-    let lock_file = initrd_dir.join(format!("fc-agent-{}.lock", initrd_sha_short));
-    use std::os::unix::fs::OpenOptionsExt;
-    let lock_fd = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(&lock_file)
-        .context("opening initrd lock file")?;
-
-    let flock = Flock::lock(lock_fd, FlockArg::LockExclusive)
-        .map_err(|(_, err)| err)
-        .context("acquiring exclusive lock for initrd creation")?;
+    let flock = super::lock_store_dir(
+        &initrd_dir.join(format!("fc-agent-{}.lock", initrd_sha_short)),
+        "initrd creation",
+    )
+    .await?;
 
     // Double-check after acquiring lock - another process may have created it
     if initrd_path.exists() {
@@ -1570,6 +1537,9 @@ pub async fn ensure_fc_agent_initrd(allow_create: bool) -> Result<PathBuf> {
     ));
     let _ = tokio::fs::remove_dir_all(&temp_dir).await;
     tokio::fs::create_dir_all(&temp_dir).await?;
+    // A killed root run would otherwise leave a directory whose contents a
+    // rootless run's remove_dir_all cannot unlink.
+    super::give_store_entry_to_invoker(&temp_dir);
 
     // Create directory structure
     for dir in &["bin", "sbin", "dev", "proc", "sys", "newroot"] {
@@ -1637,7 +1607,7 @@ pub async fn ensure_fc_agent_initrd(allow_create: bool) -> Result<PathBuf> {
     }
 
     // Rename to final path (atomic)
-    tokio::fs::rename(&temp_initrd, &initrd_path).await?;
+    super::publish_store_entry(&temp_initrd, &initrd_path, "initrd").await?;
 
     // Cleanup temp directory
     let _ = tokio::fs::remove_dir_all(&temp_dir).await;
@@ -2073,6 +2043,7 @@ async fn download_packages(plan: &Plan, script_sha_short: &str) -> Result<PathBu
     let _ = tokio::fs::remove_dir_all(&packages_dir).await;
     let _ = tokio::fs::remove_dir_all(&download_dir).await;
     tokio::fs::create_dir_all(&download_dir).await?;
+    super::give_store_entry_to_invoker(&cache_dir);
 
     let codename = &plan.base.codename;
     let container_image = format!("ubuntu:{}", codename);
@@ -2164,10 +2135,11 @@ async fn download_packages(plan: &Plan, script_sha_short: &str) -> Result<PathBu
         );
     }
 
-    // Atomically publish the completed download as the cache directory
-    tokio::fs::rename(&download_dir, &packages_dir)
-        .await
-        .context("renaming downloaded packages directory into place")?;
+    // Atomically publish the completed download as the cache directory.
+    // The .deb files inside may stay root-owned after a sudo run; that is
+    // fine — the handed-back parent directory is what governs a rootless
+    // run's ability to read, replace, or unlink them.
+    super::publish_store_entry(&download_dir, &packages_dir, "downloaded packages").await?;
 
     info!(path = %packages_dir.display(), count = count, "packages downloaded");
     Ok(packages_dir)
@@ -2179,6 +2151,7 @@ async fn download_cloud_image(plan: &Plan) -> Result<PathBuf> {
     tokio::fs::create_dir_all(&cache_dir)
         .await
         .context("creating cache directory")?;
+    super::give_store_entry_to_invoker(&cache_dir);
 
     // Get arch-specific config
     let arch_config = match std::env::consts::ARCH {
@@ -2239,9 +2212,7 @@ async fn download_cloud_image(plan: &Plan) -> Result<PathBuf> {
     }
 
     // Rename to final path
-    tokio::fs::rename(&temp_path, &image_path)
-        .await
-        .context("renaming downloaded image")?;
+    super::publish_store_entry(&temp_path, &image_path, "downloaded cloud image").await?;
 
     info!(
         path = %image_path.display(),

--- a/src/setup/storage.rs
+++ b/src/setup/storage.rs
@@ -235,21 +235,10 @@ pub fn ensure_storage(config_path: Option<&str>) -> Result<()> {
         }
     }
 
-    // Set ownership to the user who invoked sudo (if SUDO_USER is set)
-    if let Ok(sudo_user) = std::env::var("SUDO_USER") {
-        info!("Setting ownership to {}", sudo_user);
-        // Chown the mount point itself (non-recursive since we just created it)
-        let status = Command::new("chown")
-            .arg(format!("{}:{}", sudo_user, sudo_user))
-            .arg(&mount_point)
-            .status()
-            .context("executing chown")?;
-
-        if !status.success() {
-            // Non-fatal, just warn
-            tracing::warn!("Failed to set ownership to {}", sudo_user);
-        }
-    }
+    // Hand the mount point back to the user who invoked sudo (non-recursive:
+    // we just created it). Uses the shared helper, which resolves the real
+    // primary group from passwd instead of assuming group == user name.
+    super::give_store_entry_to_invoker(&mount_point);
 
     info!(
         "✓ btrfs storage ready at {} ({})",


### PR DESCRIPTION
Main went red on the #797 merge from one cold runner. `kernel/btrfs.conf` changed, so no btrfs kernel release existed for the new content-address, and the Build Btrfs Kernel job had to build on a runner whose persistent store had no firecracker binary. Two latent defects fired in sequence on instance `i-0d8e07f6732c331cc`:

1. **`sudo fcvm setup` spawned bare `cargo`**, which is not on root's PATH → `building firecracker: No such file or directory (os error 2)` (Build Btrfs Kernel, run 31556968810).
2. The failed root run left a **root-owned `firecracker/` dir and 0600 lock** in the shared store → the next CI job on the same instance (Host-arm64, rootless, run 31557212028) died with `opening firecracker lock file: Permission denied (os error 13)`.

Everything else in the post-merge run passed, including both SnapshotEnabled suites.

## The fix

- **Resolve cargo instead of assuming it**: `$CARGO`, then PATH, then `.cargo/bin/cargo` under `$HOME` and under the sudo invoker's home.
- **Drop the builder children (git clone, cargo build) to the sudo invoker.** Run as root, the rustup shim keys its toolchain lookup off `$HOME` and tries to download a whole toolchain into `/root/.rustup` (observed live); run as the invoker it uses their installed toolchain and writes nothing root-owned.
- **Hand every store entry root does create back to `SUDO_USER` at creation** (dirs, locks, installed binaries, caches) — the same ownership model `ensure_storage` already applies to the mount point. The seven copies of the create-dir/open-lock/flock block collapse into one `lock_store_dir` helper.
- **`scripts/normalize-store-ownership.sh` heals already-poisoned runners** (the live one included), from `make setup-btrfs` and both kernels.yml bootstrap steps. It touches only the content-addressed asset dirs; `state/`, `containers/`, and `image-cache/` keep their root- and subuid-mapped owners.

## Test evidence

RED — unfixed binary, scratch store via `--config`, PATH stripped of cargo (this devserver has the exact CI precondition: user rustup, no root cargo):

```
  ✓ Kernel ready: /tmp/fcvm-red/store/kernels/vmlinux-default-6.18.44-x86_64-3e4584a92571.bin
  ✓ Pasta ready: /tmp/fcvm-red/store/pasta/pasta-403728e3b3aa.bin
  → Building firecracker from ejc3/firecracker (branch: bump-vsock-max-connections, sha: 17ce9520731f)...
ERROR fcvm: Error: setting up default firecracker: building firecracker: No such file or directory (os error 2)
```

then rootless against the store that failure left behind:

```
ERROR fcvm: Error: setting up default firecracker: opening firecracker lock file: Permission denied (os error 13)
```

Byte-for-byte the two CI failures.

GREEN — fixed binary, same sudo command, same poisoned store:

```
  → Building firecracker from ejc3/firecracker (branch: bump-vsock-max-connections, sha: 17ce9520731f)...
  ✓ Firecracker ready: /tmp/fcvm-red/store/firecracker/firecracker-default-17ce9520731f.bin
```

Mid-build `ps` showed the compile running as the invoking user on their own toolchain:

```
ejc3  /home/ejc3/.rustup/toolchains/1.93.0-x86_64-unknown-linux-gnu/bin/cargo build --release -p firecracker
```

and afterwards the binary, lock, resolution cache, and directory were all user-owned:

```
-rw-r--r-- 1 ejc3 users     260 default-…resolved.json
-rwxr-xr-x 1 ejc3 users 4916912 firecracker-default-17ce9520731f.bin
-rw------- 1 ejc3 users       0 firecracker-default-17ce9520731f.bin.lock
```

The rootless rerun then passed the whole firecracker stage (no EACCES, binary found). `normalize-store-ownership.sh` handed kernels/, pasta/, initrd/, rootfs/, cache/ back and left image-cache/ alone; shellcheck clean.

- `cargo nextest run -p fcvm --lib` (resolve_cargo, store_ownership, lock_store_dir, publish_store_entry, ownership_handback): 10 passed
- `cargo clippy --release -p fcvm --all-targets -- -D warnings`: clean

After merge: `workflow_dispatch` Build Kernels on main publishes the missing `kernel-btrfs-6.18.44-aarch64-0514c11fb54d` release, which also re-triggers the Runner AMI bake.

## Adversarial review round (folded into this commit)

codex/GPT-5.6 and a four-lens simplification review ran against the first version; every finding was worked:

- **Symlink-safe hand-back** (codex P1): the chown now opens the entry with `O_NOFOLLOW` and chowns the descriptor; a planted `firecracker -> /etc/sudoers.d` can no longer redirect a root chown. The heal script got `chown -h` for the same reason (fixture-verified: a planted `evil -> /etc` symlink is re-owned itself, `/etc` untouched).
- **Complete privilege drop** (codex P1): supplementary groups, gid, uid in one pre-exec; `CARGO_HOME`/`RUSTUP_HOME` cleared. Verified live: `ps -o user,supgrp` shows the build as `ejc3 users`.
- **Exec-bit in cargo resolution** (codex P2): test written first and watched fail on the `is_file()`-only resolver. The POSIX empty-PATH-entry-means-cwd rule is refused on purpose (root must never run `./cargo`), documented in code — also why the `which` crate isn't used here.
- **Dedup**: one memoized `sudo_invoker()` (was three ladders), `publish_store_entry` owns rename+hand-back at all eight install sites, `lock_store_dir` takes the lock path, `ensure_storage`'s shell-out chown uses the helper.
- **Latent same-class holes closed**: pasta's build and the generated kernel-build script also drop to the invoker (their deterministic /tmp trees could be left root-owned by a failed root build); the kernel extract temp and initrd temp dirs are handed back. The host-kernel build stays root by design (its paired dpkg/update-grub need root).
- **Refuted with evidence**: making hand-back failure fatal (a fuse-pipe-mapped store legitimately refuses chown in nested runs while everything else works); recursive chown of package .debs (the user-owned parent dir is what governs unlink/replace).
- Deferred: deduplicating the two kernels.yml btrfs bootstrap blocks against `make setup-btrfs` — it changes runner provisioning (image size, branch order) that can't be validated without a cold kernels runner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed root-owned build and cache files that could prevent subsequent builds.
  - Improved ownership handling for generated kernels, images, caches, and other stored artifacts.
  - Prevented ownership changes from following symbolic links.

- **Improvements**
  - Builds initiated through elevated commands now run under the invoking user where appropriate.
  - Added safer shared locking and atomic publication to reduce conflicts and incomplete artifacts.
  - Added automatic ownership normalization during environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->