### PR TITLE
Document the fresh bare-metal box quickstart

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -240,6 +240,54 @@ means the reviewer never started.
 Enforcement: `tests/test_ci_workflow_coverage.rs` fails if `ci.yml` reintroduces a
 `branches:`/`branches-ignore:` filter on `pull_request`, or if a gating job leaves that file.
 
+## Fresh Bare-Metal Box Quickstart
+
+Bring up a new ARM (or x86) KVM-capable box to building-and-benching in ~20 minutes.
+The ordering below matters; each step's trap is noted inline.
+
+```bash
+# 1. KVM access (new login session required after; a live ssh master keeps old groups)
+sudo usermod -aG kvm $USER
+
+# 2. Fast local storage. Instance-store NVMe is WIPED by a cloud stop/start —
+#    put /mnt/fcvm-btrfs on it (rebuildable cache), keep sources on the durable root.
+lsblk -d -o NAME,SIZE,MODEL          # identify instance-store drives BEFORE mkfs
+sudo mkfs.btrfs -f -d raid0 -m raid0 /dev/nvme0n1 /dev/nvme1n1   # your names WILL differ
+sudo mkdir -p /mnt/fcvm-btrfs && sudo mount /dev/nvme0n1 /mnt/fcvm-btrfs
+sudo chown $USER:$USER /mnt/fcvm-btrfs
+
+# 3. Packages (Ubuntu 24.04)
+sudo apt-get install -y build-essential git jq qemu-utils busybox-static \
+    pkg-config libssl-dev clang make podman skopeo uidmap slirp4netns fuse3 passt
+
+# 4. Rust. If ~/.cargo is a dangling symlink left from a wiped NVMe (make
+#    check-disk moves it there), recreate the target first: mkdir -p /mnt/fcvm-btrfs/cargo
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+# 5. Sources on the DURABLE disk, sibling layout is required (fuse-pipe uses
+#    a ../fuse-backend-rs path dependency)
+mkdir -p ~/src && cd ~/src
+git clone https://github.com/ejc3/fcvm.git
+git clone https://github.com/ejc3/fuse-backend-rs.git
+git clone https://github.com/ejc3/fuser.git
+
+# 6. Build + full setup (downloads released kernels, builds pasta + the
+#    firecracker fork, creates the rootfs; ~10 min on 64 cores when the kernel
+#    releases exist, plus a local kernel build when one does not)
+cd ~/src/fcvm && make build && make setup-fcvm
+```
+
+Run everything as the unprivileged user; `make` shells out to sudo exactly where
+root is needed. `sudo fcvm setup` also works — builds drop back to the invoking
+user and store entries are handed back to them (see src/setup/mod.rs) — but the
+rootless path is the default one CI exercises.
+
+Sanity check the result before benching:
+
+```bash
+make test-root FILTER=sanity
+```
+
 ## Sending Email
 
 Use `aws ses send-email --region us-east-1` (recipient must be verified in SES sandbox).

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -249,23 +249,38 @@ The ordering below matters; each step's trap is noted inline.
 # 1. KVM access (new login session required after; a live ssh master keeps old groups)
 sudo usermod -aG kvm $USER
 
-# 2. Fast local storage. Instance-store NVMe is WIPED by a cloud stop/start —
-#    put /mnt/fcvm-btrfs on it (rebuildable cache), keep sources on the durable root.
-lsblk -d -o NAME,SIZE,MODEL          # identify instance-store drives BEFORE mkfs
-sudo mkfs.btrfs -f -d raid0 -m raid0 /dev/nvme0n1 /dev/nvme1n1   # your names WILL differ
-sudo mkdir -p /mnt/fcvm-btrfs && sudo mount /dev/nvme0n1 /mnt/fcvm-btrfs
+# 2. Packages (Ubuntu 24.04). btrfs-progs is needed by the very next step;
+#    bc/bison/flex/libelf-dev are the kernel fallback build's dependencies —
+#    setup builds a kernel locally whenever a profile's release artifact is
+#    absent, and a fresh box hits that path.
+sudo apt-get install -y build-essential git jq qemu-utils busybox-static \
+    pkg-config libssl-dev clang make podman skopeo uidmap slirp4netns fuse3 passt \
+    btrfs-progs bc bison flex libelf-dev
+
+# 3. Fast local storage. Instance-store NVMe is WIPED by a cloud stop/start —
+#    put /mnt/fcvm-btrfs on it (rebuildable cache), keep sources on the durable
+#    root. NEVER hardcode device names: the EBS/root disk is also an nvme
+#    device and its number is NOT stable across boxes (this box's root is
+#    nvme2n1). The guard below refuses to run mkfs rather than printing a
+#    warning and formatting anyway, because the failure mode is a destroyed
+#    operating system disk.
+ROOT_DISK=$(lsblk -no PKNAME "$(findmnt -no SOURCE /)")
+mapfile -t STORE_DEVS < <(lsblk -dno NAME,MODEL | awk '/Instance Storage/ {print "/dev/"$1}')
+printf 'root=/dev/%s  store=%s\n' "$ROOT_DISK" "${STORE_DEVS[*]:-<none>}"
+[ "${#STORE_DEVS[@]}" -gt 0 ] || { echo "no instance-store devices; do NOT format anything"; return 2>/dev/null || exit 1; }
+for dev in "${STORE_DEVS[@]}"; do
+  [ "$dev" != "/dev/$ROOT_DISK" ] || { echo "REFUSING: $dev backs /"; return 2>/dev/null || exit 1; }
+done
+sudo mkfs.btrfs -f -d raid0 -m raid0 "${STORE_DEVS[@]}"
+sudo mkdir -p /mnt/fcvm-btrfs && sudo mount "${STORE_DEVS[0]}" /mnt/fcvm-btrfs
 sudo chown $USER:$USER /mnt/fcvm-btrfs
 
-# 3. Rootless UFFD (snapshot restores). The device is 0600 root by default,
+# 4. Rootless UFFD (snapshot restores). The device is 0600 root by default,
 #    so every rootless clone restore fails with "Error accessing
 #    /dev/userfaultfd: Permission denied" until this runs (CI does the same):
 [ -e /dev/userfaultfd ] || sudo mknod /dev/userfaultfd c 10 126
 sudo chmod 666 /dev/userfaultfd
 sudo sysctl -w vm.unprivileged_userfaultfd=1
-
-# 4. Packages (Ubuntu 24.04)
-sudo apt-get install -y build-essential git jq qemu-utils busybox-static \
-    pkg-config libssl-dev clang make podman skopeo uidmap slirp4netns fuse3 passt
 
 # 5. Rust. If ~/.cargo is a dangling symlink left from a wiped NVMe (make
 #    check-disk moves it there), recreate the target first: mkdir -p /mnt/fcvm-btrfs/cargo

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -332,6 +332,27 @@ Shows which branch you're on and what it's based on.
 
 **Don't confuse local vs remote:** After rebasing locally, `origin/<branch>` shows the old history until you force-push. They're the same branch at different points in time.
 
+## fc-agent is a MUSL BINARY: check it against musl, not the host target
+
+`cargo check -p fc-agent` builds for the host's glibc target and proves
+nothing about the binary that actually ships in the guest, which `make build`
+cross-compiles for `*-unknown-linux-musl`. The two libcs disagree on real
+signatures: `ioctl`'s request argument is `i32` on musl and `c_ulong` on
+glibc, so an ioctl call that compiles cleanly on the host fails the guest
+build with a type error. A host-only check let exactly that reach CI, where
+it broke every job that builds the guest agent.
+
+Before believing fc-agent compiles:
+
+```bash
+cargo check -p fc-agent --target x86_64-unknown-linux-musl
+cargo check -p fc-agent --target aarch64-unknown-linux-musl
+```
+
+Or just run `make build`, which does the real thing. When calling libc from
+fc-agent, prefer `as _` over a named integer type on any argument whose width
+or signedness the libc chooses.
+
 ## ALWAYS USE THE MAKEFILE
 
 **Never run raw cargo/podman commands. Use make targets.**

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -256,22 +256,29 @@ sudo mkfs.btrfs -f -d raid0 -m raid0 /dev/nvme0n1 /dev/nvme1n1   # your names WI
 sudo mkdir -p /mnt/fcvm-btrfs && sudo mount /dev/nvme0n1 /mnt/fcvm-btrfs
 sudo chown $USER:$USER /mnt/fcvm-btrfs
 
-# 3. Packages (Ubuntu 24.04)
+# 3. Rootless UFFD (snapshot restores). The device is 0600 root by default,
+#    so every rootless clone restore fails with "Error accessing
+#    /dev/userfaultfd: Permission denied" until this runs (CI does the same):
+[ -e /dev/userfaultfd ] || sudo mknod /dev/userfaultfd c 10 126
+sudo chmod 666 /dev/userfaultfd
+sudo sysctl -w vm.unprivileged_userfaultfd=1
+
+# 4. Packages (Ubuntu 24.04)
 sudo apt-get install -y build-essential git jq qemu-utils busybox-static \
     pkg-config libssl-dev clang make podman skopeo uidmap slirp4netns fuse3 passt
 
-# 4. Rust. If ~/.cargo is a dangling symlink left from a wiped NVMe (make
+# 5. Rust. If ~/.cargo is a dangling symlink left from a wiped NVMe (make
 #    check-disk moves it there), recreate the target first: mkdir -p /mnt/fcvm-btrfs/cargo
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
-# 5. Sources on the DURABLE disk, sibling layout is required (fuse-pipe uses
+# 6. Sources on the DURABLE disk, sibling layout is required (fuse-pipe uses
 #    a ../fuse-backend-rs path dependency)
 mkdir -p ~/src && cd ~/src
 git clone https://github.com/ejc3/fcvm.git
 git clone https://github.com/ejc3/fuse-backend-rs.git
 git clone https://github.com/ejc3/fuser.git
 
-# 6. Build + full setup (downloads released kernels, builds pasta + the
+# 7. Build + full setup (downloads released kernels, builds pasta + the
 #    firecracker fork, creates the rootfs; ~10 min on 64 cores when the kernel
 #    releases exist, plus a local kernel build when one does not)
 cd ~/src/fcvm && make build && make setup-fcvm

--- a/bench/chromium/AGENTS.md
+++ b/bench/chromium/AGENTS.md
@@ -11,6 +11,29 @@ memory density, egress-mode ordering, throughput, and part of the file-vs-UFFD g
 all failed review. The measurements were real; the *methodology* made them mean
 nothing. Every rule below exists because one of them broke.
 
+## Running the gated request benchmark end to end
+
+The phases are separate subcommands and the order is not optional. `golden`
+does NOT build the image — on a box that has never built it, `golden` dies
+with `localhost/chromium-bench-req: image not known`, so `build` comes first:
+
+```bash
+cd ~/src/fcvm            # phases resolve the repo root from the script path
+bash bench/chromium/reqbench.sh build    # podman build --format docker (HEALTHCHECK is load-bearing)
+bash bench/chromium/reqbench.sh golden   # podman prepare: cold build, snapshot at the health gate
+bash bench/chromium/reqbench.sh verify   # prove all three hops on a RESTORED clone before measuring
+BACKEND=uffd REPS=200 RESULTS=/mnt/fcvm-btrfs/reqbench-uffd-200 bash bench/chromium/reqbench.sh run
+BACKEND=file REPS=200 RESULTS=/mnt/fcvm-btrfs/reqbench-file-200 bash bench/chromium/reqbench.sh run
+```
+
+The acceptance gate is >=200 measured requests PER BACKEND (`uffd` and `file`)
+at zero failures. For anything long-running on a remote box, write the chain
+into a script file, run it detached with output to a log, and append an
+explicit `RC=$?` marker line the poller can key on — a dropped ssh/SSM session
+must not kill the run, and "the log stopped growing" is not a completion
+signal. Fresh-box prerequisites (packages, NVMe store, sibling checkouts) are
+in the repo-root AGENTS.md quickstart.
+
 ## Six methodology defects — do not reintroduce
 
 1. **Matched accounting basis.** Sum memory over the SAME process set for every


### PR DESCRIPTION
Bringing up a new KVM-capable box has a fixed order and four traps that each
cost a bootstrap round this week: instance-store NVMe is wiped by a cloud
stop/start (so sources belong on the durable root and only the rebuildable
store on NVMe), a wiped NVMe leaves ~/.cargo as a dangling symlink that makes
rustup fail with "File exists", the fuse-backend-rs sibling checkout is a path
dependency, and a live ssh master hides a fresh kvm group membership. Write
the sequence down where the next box setup will look.

Test Plan:
- This exact sequence brought i-0fc89dc88dd1e699a (c7gd.metal, Ubuntu 24.04)
  from a wiped instance-store to `make build && make setup-fcvm` green,
  including a local btrfs kernel build, on 2026-08-11.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a bare-metal setup quickstart covering system access, package installation, storage initialization, security configuration, project setup, and validation.
  - Documented safeguards to prevent accidental formatting of the root disk.
  - Added end-to-end instructions for running gated Chromium benchmarks with multiple backends.
  - Documented benchmark setup, execution, completion checks, result locations, repetition requirements, and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->