### PR TITLE
Fix the runner AMI bake on spot instances and deflake a kernel test

### DIFF
--- a/Containerfile.pjdfstest
+++ b/Containerfile.pjdfstest
@@ -8,10 +8,14 @@
 
 FROM docker.io/library/debian:bookworm-slim
 
-# Install only what's needed for pjdfstest
+# Install only what's needed for pjdfstest. ca-certificates is explicit:
+# the git clone below is https, and leaving the CA store to git's apt
+# recommends chain produced a CI runner where the clone died with
+# "server certificate verification failed. CAfile: none".
 RUN apt-get update && apt-get install -y \
     autoconf \
     automake \
+    ca-certificates \
     libtool \
     gcc \
     make \

--- a/scripts/build-ami.sh
+++ b/scripts/build-ami.sh
@@ -422,24 +422,43 @@ wait_for_build() {
 
     # Show progress
     echo "[$i/$timeout] Build status: $status (instance: $instance_id)"
-    if [ "$status" = "building" ]; then
-      # Try SSM first
+    if [ "$status" = "building" ] && [ "${SSM_LOG_FETCH_DENIED:-0}" != 1 ]; then
+      # Try SSM first. The `|| true` matters even though this function's only
+      # call site is an `if !` condition (which already suppresses `set -e`):
+      # a future direct call must not turn a failed advisory fetch into a
+      # build abort.
       echo "  Fetching logs via SSM..."
       cmd_id=$(aws ssm send-command \
         --region "$REGION" \
         --instance-ids "$instance_id" \
         --document-name "AWS-RunShellScript" \
         --parameters 'commands=["tail -15 /var/log/ami-build.log"]' \
-        --query 'Command.CommandId' --output text 2>&1)
+        --query 'Command.CommandId' --output text 2>&1) || true
       echo "  SSM command: $cmd_id"
+      # The progress fetch is advisory. When the workflow role lacks
+      # ssm:SendCommand, every poll prints the same AccessDeniedException;
+      # note it once and stop asking instead of spamming 100+ error lines.
+      if [[ "$cmd_id" == *AccessDeniedException* ]]; then
+        echo "  SSM log fetch not authorized for this role; skipping further fetches"
+        SSM_LOG_FETCH_DENIED=1
+        cmd_id=""
+      fi
       if [ -n "$cmd_id" ] && [[ ! "$cmd_id" =~ "error" ]]; then
         sleep 5
         echo "  Getting SSM output..."
-        aws ssm get-command-invocation \
+        ssm_output=$(aws ssm get-command-invocation \
           --region "$REGION" \
           --command-id "$cmd_id" \
           --instance-id "$instance_id" \
-          --output text 2>&1 | head -20
+          --output text 2>&1) || true
+        # A role allowed SendCommand but denied GetCommandInvocation would
+        # otherwise spam the same denial on every poll.
+        if [[ "$ssm_output" == *AccessDeniedException* ]]; then
+          echo "  SSM invocation fetch not authorized for this role; skipping further fetches"
+          SSM_LOG_FETCH_DENIED=1
+        else
+          printf '%s\n' "$ssm_output" | head -20
+        fi
       fi
     fi
 
@@ -551,10 +570,11 @@ main() {
     exit 1
   fi
 
-  # Stop instance for AMI creation
-  echo "Stopping instance..."
-  aws ec2 stop-instances --region "$REGION" --instance-ids "$instance_id"
-  aws ec2 wait instance-stopped --region "$REGION" --instance-ids "$instance_id"
+  # No stop before create-image: the builder is launched as a one-time spot
+  # instance when spot capacity exists, and AWS rejects StopInstances on
+  # one-time spot requests (UnsupportedOperation). create-image's default
+  # reboot is permitted on spot and gives the same filesystem consistency a
+  # stopped instance would.
 
   # Get kernel version from instance tags
   kernel_version=$(aws ec2 describe-tags \

--- a/src/setup/kernel.rs
+++ b/src/setup/kernel.rs
@@ -2282,6 +2282,35 @@ pub async fn get_configured_firecracker_for_profile(
 /// resolution (`git ls-remote`), then rewrites the launch-time resolution cache
 /// read by [`get_profile_firecracker_path`]. That is what makes an updated fork
 /// take effect for VM launches immediately rather than after the cache TTL —
+/// What setup should do after trying to resolve the remote firecracker commit.
+#[derive(Debug)]
+enum RemoteResolutionOutcome {
+    /// The remote answered; build or reuse against this commit.
+    Resolved(String),
+    /// The remote did not answer, but this machine already has a recorded
+    /// binary for the profile. Keep it, and say why.
+    ReuseCached { path: PathBuf, error: anyhow::Error },
+}
+
+/// Decide between the freshly resolved commit and an already-built binary.
+///
+/// Split out from `ensure_profile_firecracker` so the degrade-on-unreachable
+/// decision is testable without a network or the global assets dir.
+fn resolve_or_reuse_cached(
+    fetched: Result<String>,
+    cached: impl FnOnce() -> Result<Option<PathBuf>>,
+) -> Result<RemoteResolutionOutcome> {
+    match fetched {
+        Ok(commit) => Ok(RemoteResolutionOutcome::Resolved(commit)),
+        Err(error) => match cached()? {
+            Some(path) => Ok(RemoteResolutionOutcome::ReuseCached { path, error }),
+            // Nothing cached: an unreachable remote really is fatal here,
+            // because there is no binary to fall back to.
+            None => Err(error),
+        },
+    }
+}
+
 /// `fcvm setup` is the sanctioned way to pick up a new firecracker build.
 pub async fn ensure_profile_firecracker(
     profile: &KernelProfile,
@@ -2298,8 +2327,36 @@ pub async fn ensure_profile_firecracker(
 
     let branch = profile.firecracker_branch.as_deref().unwrap_or("main");
 
-    // Fetch latest commit hash to detect updates
-    let resolved_commit = fetch_remote_firecracker_commit(repo, branch).await?;
+    // Fetch latest commit hash to detect updates. A transient failure to
+    // reach the remote is not a reason to fail setup when this machine has
+    // already built and recorded a binary for this profile: setup exists to
+    // make the assets present, and they are. `get_firecracker_for_profile`
+    // has always degraded this way; the ensure path failing hard on the same
+    // blip took a CI job down with every asset already on disk (all 764 unit
+    // tests had passed; `git ls-remote` then could not reach GitHub).
+    let fetched = fetch_remote_firecracker_commit(repo, branch).await;
+    let firecracker_dir = paths::assets_dir().join("firecracker");
+    let resolved_commit = match resolve_or_reuse_cached(fetched, || {
+        offline_cached_firecracker_resolution_in(
+            &firecracker_dir,
+            profile_name,
+            repo,
+            branch,
+            std::env::consts::ARCH,
+            &libc_version_tag(),
+        )
+    })? {
+        RemoteResolutionOutcome::Resolved(commit) => commit,
+        RemoteResolutionOutcome::ReuseCached { path, error } => {
+            warn!(
+                profile = %profile_name,
+                %error,
+                path = %path.display(),
+                "could not query remote firecracker commit; keeping the cached binary"
+            );
+            return Ok(Some(path));
+        }
+    };
     let commit_hash =
         select_firecracker_commit(profile.firecracker_commit.as_deref(), &resolved_commit)?;
     let sha = compute_profile_firecracker_sha_with_commit(profile, &commit_hash);
@@ -3395,6 +3452,59 @@ cp vmlinux arch/arm64/boot/Image
             "offline launch must not select an arbitrary same-profile binary: {}",
             unidentified.display()
         );
+    }
+
+    #[test]
+    fn an_unreachable_remote_keeps_the_binary_this_machine_already_built() {
+        // The CI shape: every asset present, `git ls-remote` momentarily
+        // unable to reach GitHub. Setup exists to make the assets present,
+        // and they are, so it must not fail the job.
+        let cached = PathBuf::from("/assets/firecracker/firecracker-default-abc.bin");
+        let outcome = resolve_or_reuse_cached(
+            Err(anyhow::anyhow!(
+                "git ls-remote failed: could not resolve host"
+            )),
+            || Ok(Some(cached.clone())),
+        )
+        .expect("a cached binary must satisfy setup when the remote is unreachable");
+        match outcome {
+            RemoteResolutionOutcome::ReuseCached { path, error } => {
+                assert_eq!(path, cached);
+                assert!(
+                    format!("{error:#}").contains("ls-remote"),
+                    "the degrade must carry why the remote failed: {error:#}"
+                );
+            }
+            RemoteResolutionOutcome::Resolved(commit) => {
+                panic!("an unreachable remote must not yield a commit: {commit}")
+            }
+        }
+    }
+
+    #[test]
+    fn an_unreachable_remote_with_nothing_cached_still_fails() {
+        // No binary to fall back to: degrading here would report success and
+        // leave the caller without firecracker.
+        let error = resolve_or_reuse_cached(
+            Err(anyhow::anyhow!(
+                "git ls-remote failed: could not resolve host"
+            )),
+            || Ok(None),
+        )
+        .expect_err("an unreachable remote with no cached binary must fail setup");
+        assert!(format!("{error:#}").contains("ls-remote"), "{error:#}");
+    }
+
+    #[test]
+    fn a_reachable_remote_always_wins_over_the_cache() {
+        let outcome = resolve_or_reuse_cached(Ok("deadbeef".to_string()), || {
+            panic!("the cache must not be consulted when the remote answered")
+        })
+        .unwrap();
+        assert!(matches!(
+            outcome,
+            RemoteResolutionOutcome::Resolved(commit) if commit == "deadbeef"
+        ));
     }
 
     #[test]

--- a/src/setup/kernel.rs
+++ b/src/setup/kernel.rs
@@ -2767,6 +2767,84 @@ mod tests {
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
     }
 
+    /// Whether a finished child failed only because a fixture executable was
+    /// still open for writing somewhere.
+    ///
+    /// The outer script execs fixtures of its own (the fake `curl`, `make`,
+    /// `cargo` on its PATH), and a shell reports that as exit 126 with "Text
+    /// file busy" on stderr. Retrying only the direct spawn error misses
+    /// every one of those, which is the shape that actually flakes.
+    fn child_hit_text_file_busy(output: &std::process::Output) -> bool {
+        output.status.code() == Some(126)
+            && String::from_utf8_lossy(&output.stderr).contains("Text file busy")
+    }
+
+    /// Run a freshly written script, retrying "Text file busy" briefly.
+    ///
+    /// A sibling test thread can fork while `write_executable`'s descriptor is
+    /// open; until that child execs (closing its CLOEXEC copy), execve of the
+    /// script fails with ETXTBSY. The window cannot be closed from here: the
+    /// libtest harness runs tests as threads in one process, so an unrelated
+    /// test's `Command::spawn` can fork at any instant, and neither writing
+    /// through a temp file nor renaming helps (an inherited descriptor names
+    /// the same inode). Retrying both shapes — the direct spawn error and a
+    /// child's 126 — covers what is observable; a still-busy fixture after
+    /// the deadline fails loudly with the child's own output rather than an
+    /// unwrap panic that names neither.
+    fn output_retrying_etxtbsy(command: &mut std::process::Command) -> std::process::Output {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let retryable = match command.output() {
+                Err(error) if error.raw_os_error() == Some(libc::ETXTBSY) => None,
+                Err(error) => panic!("running the generated kernel build script: {error}"),
+                Ok(output) if child_hit_text_file_busy(&output) => Some(output),
+                Ok(output) => return output,
+            };
+            if std::time::Instant::now() >= deadline {
+                match retryable {
+                    Some(output) => panic!(
+                        "a fixture executable stayed busy for the whole retry budget\n\
+                         stdout:\n{}\nstderr:\n{}",
+                        String::from_utf8_lossy(&output.stdout),
+                        String::from_utf8_lossy(&output.stderr)
+                    ),
+                    None => panic!(
+                        "the generated kernel build script stayed busy for the whole \
+                         retry budget"
+                    ),
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
+    #[test]
+    fn a_busy_fixture_is_recognised_from_the_childs_own_report() {
+        use std::os::unix::process::ExitStatusExt;
+        let busy = std::process::Output {
+            status: std::process::ExitStatus::from_raw(126 << 8),
+            stdout: Vec::new(),
+            stderr: b"/tmp/bin/curl: Text file busy\n".to_vec(),
+        };
+        assert!(child_hit_text_file_busy(&busy));
+
+        // A genuine 126 (not executable) must NOT be retried away.
+        let not_executable = std::process::Output {
+            status: std::process::ExitStatus::from_raw(126 << 8),
+            stdout: Vec::new(),
+            stderr: b"/tmp/bin/curl: Permission denied\n".to_vec(),
+        };
+        assert!(!child_hit_text_file_busy(&not_executable));
+
+        // Nor may an ordinary failure be mistaken for it.
+        let ordinary = std::process::Output {
+            status: std::process::ExitStatus::from_raw(1 << 8),
+            stdout: Vec::new(),
+            stderr: b"Text file busy\n".to_vec(),
+        };
+        assert!(!child_hit_text_file_busy(&ordinary));
+    }
+
     #[test]
     fn vm_kernel_build_replaces_interrupted_cached_source_archive() {
         let tmp = tempfile::tempdir().unwrap();
@@ -2852,16 +2930,16 @@ cp vmlinux arch/arm64/boot/Image
         write_executable(&script_path, &script);
 
         let path = std::env::var_os("PATH").unwrap_or_default();
-        let status = std::process::Command::new(&script_path)
-            .env("BUILD_DIR", &build_dir)
-            .env("FCVM_TEST_CACHED_TARBALL", &cached_tarball)
-            .env("FCVM_TEST_KERNEL_TARBALL", &valid_tarball)
-            .env(
-                "PATH",
-                format!("{}:{}", fake_bin.display(), path.to_string_lossy()),
-            )
-            .output()
-            .unwrap();
+        let status = output_retrying_etxtbsy(
+            std::process::Command::new(&script_path)
+                .env("BUILD_DIR", &build_dir)
+                .env("FCVM_TEST_CACHED_TARBALL", &cached_tarball)
+                .env("FCVM_TEST_KERNEL_TARBALL", &valid_tarball)
+                .env(
+                    "PATH",
+                    format!("{}:{}", fake_bin.display(), path.to_string_lossy()),
+                ),
+        );
 
         assert!(
             status.status.success(),


### PR DESCRIPTION
Three CI fixes, independent of each other but all small.

**Build Runner AMI: create the image from the running builder.** The builder launches as a one-time spot instance when spot capacity exists, and AWS rejects `StopInstances` on one-time spot requests (`UnsupportedOperation`). The bake reached `Build status: complete`, died at the stop, and terminated the instance before `create-image` ever ran — which is why the Build Runner AMI job on main failed after an otherwise successful build (run 31569575489). `create-image`'s default reboot is permitted on spot and provides the same filesystem consistency the stop existed for. The advisory SSM log fetch also now goes quiet after the first `AccessDeniedException` (send or get) instead of printing the same denial on 100+ polls.

**Declare ca-certificates in the pjdfstest image.** The image clones pjdfstest over https and the CA store only arrived via git's apt recommends chain; a fresh runner hit `server certificate verification failed. CAfile: none` (this PR's own first CI round: Host-Root-arm64-SnapshotEnabled, `test_pjdfstest_vm_mknod`, then a 900s retry timeout behind the same broken build). The dependency the build needs is now declared by the build.

**Deflake the interrupted-archive kernel test.** Under parallel `cargo test`, a sibling thread forking between `write_executable` and the exec holds a CLOEXEC copy of the script's descriptor until its own exec; running the script in that window fails with ETXTBSY. Observed once in a parallel run, passed serially. The spawn now retries ETXTBSY for up to five seconds; every other error still fails immediately.

Test evidence:
```
$ bash -n scripts/build-ami.sh                                     # clean
$ cargo test -p fcvm --lib vm_kernel_build_replaces_interrupted    # ok
```
AMI failure mechanism verified against the run 31569575489 log (`You can't stop the Spot Instance ... one-time Spot Instance request`, exit 254 before create-image). The pjdfstest image builds end-to-end on the Graviton box (direct internet, same as CI): clone, configure, make all completed, tagged 805cb54661c9.

**Stacked on:** box-quickstart-docs (PR #802)

**Keep setup working when the firecracker remote is briefly unreachable.** `fcvm setup` resolved the firecracker branch with `git ls-remote` and failed the whole run when that call failed, even on a machine that had already built and recorded the binary. A Host-arm64 job on the child PR died exactly that way: all 764 unit tests passed, then the post-test setup step could not reach GitHub with every asset already on disk. The read path (`get_firecracker_for_profile`) has always degraded to the cached binary here; only the ensure path failed hard. Both now behave the same, and with nothing cached an unreachable remote is still fatal. Covered by three new cases against the extracted `resolve_or_reuse_cached` decision (no network, no global assets dir).
