### PR TITLE
Cut the guest restore ACK critical path to the work it owes

### DIFF
--- a/bench/chromium/AGENTS.md
+++ b/bench/chromium/AGENTS.md
@@ -15,10 +15,15 @@ nothing. Every rule below exists because one of them broke.
 
 The phases are separate subcommands and the order is not optional. `golden`
 does NOT build the image — on a box that has never built it, `golden` dies
-with `localhost/chromium-bench-req: image not known`, so `build` comes first:
+with `localhost/chromium-bench-req: image not known`, so `build` comes first.
+After rebuilding fcvm or fc-agent, `make setup-fcvm` must run before `golden`:
+the initrd is content-addressed by the fc-agent binary's SHA, `make build`
+does not create it, and `podman prepare` refuses rather than auto-creating
+("fc-agent initrd not found. Run 'fcvm setup' first"):
 
 ```bash
 cd ~/src/fcvm            # phases resolve the repo root from the script path
+make build && make setup-fcvm            # setup-fcvm creates the initrd for the NEW fc-agent SHA
 bash bench/chromium/reqbench.sh build    # podman build --format docker (HEALTHCHECK is load-bearing)
 bash bench/chromium/reqbench.sh golden   # podman prepare: cold build, snapshot at the health gate
 bash bench/chromium/reqbench.sh verify   # prove all three hops on a RESTORED clone before measuring

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -2607,9 +2607,11 @@ class FailureProbe:
              "printf 'GET /latest HTTP/1.0\\r\\nX-metadata-token: %s\\r\\n"
              "Accept: application/json\\r\\nConnection: close\\r\\n\\r\\n' \"$tok\" "
              "| nc -w 2 169.254.169.254 80 | tr -d '\\r' | tail -5"),
-            # The same arping `handle_clone_restore` sends. iputils-arping is in
-            # the VM rootfs. A gateway that does not answer this, 100 s after the
-            # request gave up, is a persistent L2 break rather than a race.
+            # The reply-verified form of the probe `handle_clone_restore`
+            # broadcasts natively (fc-agent sends the ARP request and does not
+            # wait; this probe does). iputils-arping is in the VM rootfs. A
+            # gateway that does not answer this, 100 s after the request gave
+            # up, is a persistent L2 break rather than a race.
             ("arping_gateway",
              "gw=$(ip route show default | awk '/via/{print $3; exit}'); "
              "echo \"gateway=$gw\"; arping -c 1 -w 2 -I eth0 \"$gw\""),

--- a/exec-proto/src/lib.rs
+++ b/exec-proto/src/lib.rs
@@ -252,6 +252,65 @@ pub fn write_stdin<W: Write>(writer: &mut W, data: &[u8]) -> io::Result<()> {
     writer.flush()
 }
 
+// ---- Restore-completion ACK framing ----
+//
+// Shared by fc-agent (producer) and fcvm's restore listener (consumer) so the
+// frame budget cannot drift between the two binaries: the consumer fails any
+// frame over the cap, so the producer must be structurally unable to build
+// one.
+
+/// Frame prefix; the restore epoch follows, then optional telemetry after one
+/// space, then a newline.
+pub const RESTORE_COMPLETE_PREFIX: &str = "restore-complete:";
+
+/// Whole-frame cap, prefix through newline. Sized for a UUID epoch plus the
+/// guest's phase-timing telemetry JSON with generous headroom (a dozen
+/// float-valued phases render near 450 bytes).
+pub const RESTORE_COMPLETE_MAX_FRAME_BYTES: usize = 1024;
+
+/// Build the restore-completion ACK frame.
+///
+/// Telemetry is advisory and must never cost a healthy clone its ACK: when it
+/// does not fit the budget alongside the epoch, it is dropped (replaced by
+/// `{}`) rather than truncated, so the consumer always sees either complete
+/// JSON or none.
+pub fn restore_complete_frame(epoch: &str, telemetry: &str) -> String {
+    let frame = if telemetry.is_empty() {
+        format!("{RESTORE_COMPLETE_PREFIX}{epoch}\n")
+    } else {
+        format!("{RESTORE_COMPLETE_PREFIX}{epoch} {telemetry}\n")
+    };
+    if frame.len() <= RESTORE_COMPLETE_MAX_FRAME_BYTES {
+        return frame;
+    }
+    format!("{RESTORE_COMPLETE_PREFIX}{epoch} {{}}\n")
+}
+
+#[cfg(test)]
+mod restore_frame_tests {
+    use super::*;
+
+    #[test]
+    fn telemetry_within_budget_rides_after_the_epoch() {
+        assert_eq!(
+            restore_complete_frame("epoch-1", "{\"total_ms\":40.2}"),
+            "restore-complete:epoch-1 {\"total_ms\":40.2}\n"
+        );
+        assert_eq!(
+            restore_complete_frame("epoch-1", ""),
+            "restore-complete:epoch-1\n"
+        );
+    }
+
+    #[test]
+    fn oversized_telemetry_is_dropped_never_truncated() {
+        let oversized = "x".repeat(RESTORE_COMPLETE_MAX_FRAME_BYTES);
+        let frame = restore_complete_frame("epoch-1", &oversized);
+        assert_eq!(frame, "restore-complete:epoch-1 {}\n");
+        assert!(frame.len() <= RESTORE_COMPLETE_MAX_FRAME_BYTES);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/fc-agent/Cargo.toml
+++ b/fc-agent/Cargo.toml
@@ -10,7 +10,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "fs", "io-util", "signal", "sync", "time"] }
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 libc = "0.2"
-nix = { version = "0.29", features = ["socket", "poll", "fs"] }
+nix = { version = "0.29", features = ["socket", "poll", "fs", "net"] }
 fs2 = "0.4"
 dashmap = "6"
 fuse-pipe = { path = "../fuse-pipe", default-features = false }

--- a/fc-agent/src/bootplan.rs
+++ b/fc-agent/src/bootplan.rs
@@ -14,7 +14,6 @@
 
 use anyhow::{Context, Result};
 use tokio::io::AsyncReadExt;
-use tokio::process::Command;
 
 use crate::types::{LatestMetadata, Plan};
 use crate::vsock::{VsockStream, HOST_CID};
@@ -105,29 +104,69 @@ pub async fn sync_clock_from_host(transport: Transport) -> Result<()> {
             let doc = read_vsock_doc().await?;
             let meta: LatestMetadata =
                 serde_json::from_value(doc).context("parsing host-time from vsock boot plan")?;
-            set_system_clock(&meta.host_time).await
+            set_system_clock(&meta.host_time);
+            Ok(())
         }
     }
 }
 
 /// Set the system clock to `host_time` (UTC epoch seconds). Shared by both transports.
-pub(crate) async fn set_system_clock(host_time: &str) -> Result<()> {
+///
+/// Steps the clock with `clock_settime(2)` directly: fc-agent holds
+/// CAP_SYS_TIME, and this runs on the restore critical path where a process
+/// spawn is pure latency. Failure is soft by construction (this returns
+/// nothing): chronyd converges the clock eventually, and refusing restore
+/// over a clock step would trade a one-second skew for a dead clone.
+pub(crate) fn set_system_clock(host_time: &str) {
     eprintln!("[fc-agent] received host time: {host_time}");
-    let output = Command::new("date")
-        .arg("-u")
-        .arg("-s")
-        .arg(format!("@{host_time}"))
-        .output()
-        .await
-        .context("setting system clock")?;
-    if !output.status.success() {
-        eprintln!(
-            "[fc-agent] WARNING: failed to set clock: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        eprintln!("[fc-agent] continuing anyway (will rely on chronyd)");
-    } else {
-        eprintln!("[fc-agent] system clock synchronized from host");
+    match parse_epoch_seconds(host_time) {
+        Ok(seconds) => {
+            let spec = libc::timespec {
+                tv_sec: seconds as _,
+                tv_nsec: 0,
+            };
+            // SAFETY: `spec` is fully initialized and outlives the call.
+            let rc = unsafe { libc::clock_settime(libc::CLOCK_REALTIME, &spec) };
+            if rc != 0 {
+                eprintln!(
+                    "[fc-agent] WARNING: failed to set clock: {}",
+                    std::io::Error::last_os_error()
+                );
+                eprintln!("[fc-agent] continuing anyway (will rely on chronyd)");
+            } else {
+                eprintln!("[fc-agent] system clock synchronized from host");
+            }
+        }
+        Err(error) => {
+            eprintln!("[fc-agent] WARNING: failed to set clock: {error:#}");
+            eprintln!("[fc-agent] continuing anyway (will rely on chronyd)");
+        }
     }
-    Ok(())
+}
+
+/// Parse the host's clock value: non-negative decimal epoch seconds.
+///
+/// Returns i64 rather than `libc::time_t`, which is deprecated because musl
+/// widened it; the cast at the one call site adapts to whatever the target's
+/// `timespec` field actually is.
+fn parse_epoch_seconds(host_time: &str) -> Result<i64> {
+    let seconds: i64 = host_time
+        .trim()
+        .parse()
+        .with_context(|| format!("host time {host_time:?} is not decimal epoch seconds"))?;
+    anyhow::ensure!(seconds >= 0, "host time {host_time:?} is before the epoch");
+    Ok(seconds)
+}
+
+#[cfg(test)]
+mod clock_tests {
+    use super::*;
+
+    #[test]
+    fn epoch_seconds_parse_rejects_garbage_and_pre_epoch_values() {
+        assert_eq!(parse_epoch_seconds("1786000000\n").unwrap(), 1786000000);
+        assert!(parse_epoch_seconds("-1").is_err(), "before the epoch");
+        assert!(parse_epoch_seconds("").is_err(), "empty");
+        assert!(parse_epoch_seconds("1786000000.5").is_err(), "fractional");
+    }
 }

--- a/fc-agent/src/mmds.rs
+++ b/fc-agent/src/mmds.rs
@@ -317,7 +317,7 @@ pub async fn watch_restore_epoch(
                         &signals,
                         egress_gen_at_last_stable,
                         metadata.clone_ipv6.as_deref(),
-                        metadata_transport,
+                        &metadata.host_time,
                     )
                     .await;
                     // Update the stable generation and stop fast-polling only
@@ -339,7 +339,7 @@ pub async fn watch_restore_epoch(
                         &signals,
                         egress_gen_at_last_stable,
                         metadata.clone_ipv6.as_deref(),
-                        metadata_transport,
+                        &metadata.host_time,
                     )
                     .await;
                     // Update the stable generation and stop fast-polling only
@@ -380,7 +380,7 @@ async fn apply_restore_epoch(
     signals: &crate::restore::RestoreSignals,
     egress_gen_at_last_stable: Option<u64>,
     clone_ipv6: Option<&str>,
-    metadata_transport: crate::bootplan::Transport,
+    host_time: &str,
 ) {
     if let Err(error) = signals.restore_status.begin() {
         eprintln!(
@@ -394,24 +394,29 @@ async fn apply_restore_epoch(
     signals
         .restore_flag
         .store(true, std::sync::atomic::Ordering::Release);
-    if let Err(error) = crate::restore::handle_clone_restore(
+    let phases = match crate::restore::handle_clone_restore(
         signals,
         clone_ipv6,
         egress_gen_at_last_stable,
         current,
-        metadata_transport,
+        host_time,
     )
     .await
     {
-        signals.restore_status.fail();
-        eprintln!(
-            "[fc-agent] FATAL: clone restore failed closed (epoch={}): {:#}. \
-             Output/exec readiness will not be published; shutting down clone",
-            current, error
-        );
-        crate::system::shutdown_vm(1).await;
-    }
-    if let Err(error) = crate::vsock::notify_restore_complete(current).await {
+        Ok(phases) => phases,
+        Err(error) => {
+            signals.restore_status.fail();
+            eprintln!(
+                "[fc-agent] FATAL: clone restore failed closed (epoch={}): {:#}. \
+                 Output/exec readiness will not be published; shutting down clone",
+                current, error
+            );
+            crate::system::shutdown_vm(1).await
+        }
+    };
+    if let Err(error) =
+        crate::vsock::notify_restore_complete(current, &phases.to_frame_json()).await
+    {
         signals.restore_status.fail();
         eprintln!(
             "[fc-agent] FATAL: restore-completion ACK failed closed \
@@ -545,7 +550,8 @@ pub async fn sync_clock_from_host() -> Result<()> {
     let metadata: LatestMetadata =
         serde_json::from_str(&body).context("parsing host-time from MMDS")?;
 
-    crate::bootplan::set_system_clock(&metadata.host_time).await
+    crate::bootplan::set_system_clock(&metadata.host_time);
+    Ok(())
 }
 
 #[cfg(test)]

--- a/fc-agent/src/network.rs
+++ b/fc-agent/src/network.rs
@@ -1,64 +1,198 @@
-use tokio::process::Command;
+use std::net::Ipv4Addr;
+use std::os::fd::OwnedFd;
 
-/// Send ARP to the gateway and verify layer 2 reachability.
-///
-/// After snapshot restore, the bridge/network has stale MAC→port mappings from
-/// the baseline VM. Sending an ARP request to the gateway accomplishes:
-/// 1. The ARP REQUEST broadcast teaches the network (bridge/pasta) our MAC
-/// 2. Waiting for the ARP REPLY ensures the L2 path is operational
-///
-/// Uses `arping` instead of `ping` because ping requires ICMP raw sockets which
-/// fail in rootless mode (pasta doesn't respond to ICMP), causing a 3s timeout.
-/// `arping` operates at layer 2 — pasta responds to ARP even in rootless mode.
-pub async fn refresh_gateway_arp() {
-    let route_output = Command::new("ip")
-        .args(["route", "show", "default"])
-        .output()
-        .await;
+use crate::snapshot_network::SYSFS_NET_PATH;
 
-    let gateway = match route_output {
-        Ok(o) if o.status.success() => {
-            let output = String::from_utf8_lossy(&o.stdout);
-            output
-                .split_whitespace()
-                .skip_while(|&s| s != "via")
-                .nth(1)
-                .map(|s| s.to_string())
+/// Open a raw kernel socket as an owned descriptor, SOCK_CLOEXEC always set.
+/// The one unsafe socket(2) call shared by this crate's raw-socket users
+/// (AF_PACKET barrier, AF_PACKET ARP probe, NETLINK_SOCK_DIAG).
+pub(crate) fn open_raw_socket(
+    domain: libc::c_int,
+    socket_type: libc::c_int,
+    protocol: libc::c_int,
+) -> std::io::Result<OwnedFd> {
+    // SAFETY: socket(2) takes plain integer arguments.
+    let raw = unsafe { libc::socket(domain, socket_type | libc::SOCK_CLOEXEC, protocol) };
+    if raw < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: `raw` is a newly-created descriptor owned solely by us.
+    Ok(unsafe { std::os::fd::FromRawFd::from_raw_fd(raw) })
+}
+
+/// One row of the kernel's IPv4 route table that names a default gateway.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DefaultRoute {
+    interface: String,
+    gateway: Ipv4Addr,
+}
+
+/// Find the IPv4 default gateway (and its interface) from `/proc/net/route`.
+///
+/// Columns are `Iface Destination Gateway Flags ...`; addresses are
+/// little-endian hex, and the default route has destination `00000000` with a
+/// non-zero gateway. Reading the table directly keeps the restore hot path
+/// free of an `ip route show` process spawn.
+fn parse_default_route(route_table: &str) -> Option<DefaultRoute> {
+    for line in route_table.lines().skip(1) {
+        // A malformed or blank line skips that line, never the whole table.
+        let mut fields = line.split_whitespace();
+        let (Some(interface), Some(destination), Some(gateway)) =
+            (fields.next(), fields.next(), fields.next())
+        else {
+            continue;
+        };
+        if destination != "00000000" {
+            continue;
         }
-        _ => None,
-    };
+        let Some(raw) = u32::from_str_radix(gateway, 16)
+            .ok()
+            .filter(|raw| *raw != 0)
+        else {
+            continue;
+        };
+        return Some(DefaultRoute {
+            interface: interface.to_string(),
+            gateway: Ipv4Addr::from(raw.to_le_bytes()),
+        });
+    }
+    None
+}
 
-    let Some(gateway) = gateway else {
+/// Build one broadcast ARP who-has frame for `target`, sourced from us.
+///
+/// Byte-identical to the request `arping -c 1` sends: Ethernet header to
+/// ff:ff:ff:ff:ff:ff, ethertype 0x0806, then a 28-byte IPv4 ARP request.
+fn build_arp_request(source_mac: [u8; 6], source_ip: Ipv4Addr, target: Ipv4Addr) -> [u8; 42] {
+    let mut frame = [0u8; 42];
+    frame[0..6].copy_from_slice(&[0xff; 6]); // destination: broadcast
+    frame[6..12].copy_from_slice(&source_mac);
+    frame[12..14].copy_from_slice(&0x0806u16.to_be_bytes()); // ethertype: ARP
+    frame[14..16].copy_from_slice(&1u16.to_be_bytes()); // htype: ethernet
+    frame[16..18].copy_from_slice(&0x0800u16.to_be_bytes()); // ptype: IPv4
+    frame[18] = 6; // hlen
+    frame[19] = 4; // plen
+    frame[20..22].copy_from_slice(&1u16.to_be_bytes()); // op: request
+    frame[22..28].copy_from_slice(&source_mac);
+    frame[28..32].copy_from_slice(&source_ip.octets());
+    // target hardware address stays zero for a who-has
+    frame[38..42].copy_from_slice(&target.octets());
+    frame
+}
+
+/// Read an interface's MAC from sysfs (`aa:bb:cc:dd:ee:ff\n`).
+fn interface_mac(interface: &str) -> Option<[u8; 6]> {
+    let text = std::fs::read_to_string(format!("{SYSFS_NET_PATH}/{interface}/address")).ok()?;
+    parse_mac(&text)
+}
+
+/// Parse a colon-separated MAC, requiring exactly six octets.
+fn parse_mac(text: &str) -> Option<[u8; 6]> {
+    let mut parts = text.trim().split(':');
+    let mut mac = [0u8; 6];
+    for slot in &mut mac {
+        *slot = u8::from_str_radix(parts.next()?, 16).ok()?;
+    }
+    parts.next().is_none().then_some(mac)
+}
+
+/// Find our IPv4 address on `interface` via getifaddrs (no process spawn).
+fn interface_ipv4(interface: &str) -> Option<Ipv4Addr> {
+    for entry in nix::ifaddrs::getifaddrs().ok()? {
+        if entry.interface_name != interface {
+            continue;
+        }
+        if let Some(address) = entry.address.and_then(|a| a.as_sockaddr_in().copied()) {
+            return Some(address.ip());
+        }
+    }
+    None
+}
+
+/// Send the broadcast frame on `interface` through an AF_PACKET socket.
+fn send_ethernet_broadcast(interface: &str, frame: &[u8]) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    const ETH_P_ARP: u16 = 0x0806;
+    let index = nix::net::if_::if_nametoindex(interface)
+        .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
+    let fd = open_raw_socket(libc::AF_PACKET, libc::SOCK_RAW, ETH_P_ARP.to_be() as i32)?;
+    // SAFETY: sockaddr_ll is fully zero-initialized before the fields we set.
+    let mut address: libc::sockaddr_ll = unsafe { std::mem::zeroed() };
+    address.sll_family = libc::AF_PACKET as u16;
+    address.sll_protocol = ETH_P_ARP.to_be();
+    address.sll_ifindex = index as i32;
+    address.sll_halen = 6;
+    address.sll_addr[..6].copy_from_slice(&[0xff; 6]);
+    // SAFETY: the frame buffer and address are valid for the duration of the call.
+    let sent = unsafe {
+        libc::sendto(
+            fd.as_raw_fd(),
+            frame.as_ptr().cast(),
+            frame.len(),
+            0,
+            (&address as *const libc::sockaddr_ll).cast(),
+            std::mem::size_of::<libc::sockaddr_ll>() as libc::socklen_t,
+        )
+    };
+    if sent < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if sent as usize != frame.len() {
+        return Err(std::io::Error::other(format!(
+            "short ARP send: {sent} of {} bytes",
+            frame.len()
+        )));
+    }
+    Ok(())
+}
+
+/// Broadcast one ARP request for the gateway, natively and without waiting.
+///
+/// After snapshot restore, the bridge/pasta on the host side has no MAC→port
+/// mapping for this clone. The broadcast's source teaches it, and the
+/// gateway's ARP stack learns our sender mapping from the request itself.
+/// That teaching is carried entirely by the outbound frame, so nothing here
+/// waits for the reply; the kernel resolves its own neighbor entry on the
+/// first real packet regardless, and a reply wait on the restore critical
+/// path can stall up to a full second when the gateway stays silent. ARP
+/// rather than ICMP ping because pasta doesn't answer ICMP in rootless mode.
+pub fn refresh_gateway_arp() {
+    let route_table = match std::fs::read_to_string("/proc/net/route") {
+        Ok(table) => table,
+        Err(error) => {
+            eprintln!("[fc-agent] WARNING: cannot read route table for ARP: {error}");
+            return;
+        }
+    };
+    let Some(route) = parse_default_route(&route_table) else {
         eprintln!("[fc-agent] WARNING: could not determine gateway for ARP");
         return;
     };
-
-    // arping -c 1 -w 1 -I eth0 <gateway>
-    // Sends an ARP request and waits for a reply. This verifies L2 connectivity
-    // and teaches the bridge/pasta our MAC→port mapping via the request's source.
-    match Command::new("arping")
-        .args(["-c", "1", "-w", "1", "-I", "eth0", &gateway])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .output()
-        .await
-    {
-        Ok(output) if output.status.success() => {
-            eprintln!("[fc-agent] gateway {} ARP resolved", gateway);
-        }
-        Ok(output) => {
-            eprintln!(
-                "[fc-agent] WARNING: gateway {} arping failed (exit {})",
-                gateway,
-                output.status.code().unwrap_or(-1)
-            );
-        }
-        Err(e) => {
-            eprintln!(
-                "[fc-agent] WARNING: arping not available ({}), skipping ARP",
-                e
-            );
-        }
+    let Some(mac) = interface_mac(&route.interface) else {
+        eprintln!(
+            "[fc-agent] WARNING: no MAC for {}, skipping ARP",
+            route.interface
+        );
+        return;
+    };
+    let Some(source_ip) = interface_ipv4(&route.interface) else {
+        eprintln!(
+            "[fc-agent] WARNING: no IPv4 on {}, skipping ARP",
+            route.interface
+        );
+        return;
+    };
+    let frame = build_arp_request(mac, source_ip, route.gateway);
+    match send_ethernet_broadcast(&route.interface, &frame) {
+        Ok(()) => eprintln!(
+            "[fc-agent] gateway {} ARP probe sent from {} ({})",
+            route.gateway, source_ip, route.interface
+        ),
+        Err(error) => eprintln!(
+            "[fc-agent] WARNING: gateway {} ARP probe failed: {error}",
+            route.gateway
+        ),
     }
 }
 
@@ -695,6 +829,89 @@ fn enable_route_localnet() -> bool {
             eprintln!("[fc-agent] WARNING: could not run sysctl for {key}: {e}");
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod gateway_arp_tests {
+    use super::*;
+
+    #[test]
+    fn default_route_parses_from_proc_net_route() {
+        // Verbatim shape of /proc/net/route on a bridged Firecracker guest:
+        // little-endian hex addresses, default row = zero destination.
+        let table = "Iface\tDestination\tGateway \tFlags\tRefCnt\tUse\tMetric\tMask\n\
+                     eth0\t00005EAC\t00000000\t0001\t0\t0\t0\t00FFFFFF\n\
+                     eth0\t00000000\t25055EAC\t0003\t0\t0\t0\t00000000\n";
+        assert_eq!(
+            parse_default_route(table),
+            Some(DefaultRoute {
+                interface: "eth0".to_string(),
+                gateway: Ipv4Addr::new(172, 94, 5, 37),
+            })
+        );
+    }
+
+    #[test]
+    fn a_table_without_a_gateway_yields_none() {
+        // A connected-only table (destination rows, zero gateways) must not
+        // produce a probe target; the caller logs and skips.
+        let table = "Iface\tDestination\tGateway \tFlags\n\
+                     eth0\t000210AC\t00000000\t0001\n";
+        assert_eq!(parse_default_route(table), None);
+    }
+
+    #[test]
+    fn mac_parse_requires_exactly_six_octets() {
+        assert_eq!(
+            parse_mac("02:00:00:00:00:01\n"),
+            Some([0x02, 0, 0, 0, 0, 0x01])
+        );
+        assert_eq!(parse_mac("02:00:00:00:00"), None, "five octets");
+        assert_eq!(parse_mac("02:00:00:00:00:01:07"), None, "seven octets");
+        assert_eq!(parse_mac("02:00:00:00:00:zz"), None, "non-hex octet");
+    }
+
+    #[test]
+    fn arp_request_frame_matches_the_wire_format_arping_sends() {
+        let frame = build_arp_request(
+            [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
+            Ipv4Addr::new(10, 0, 2, 100),
+            Ipv4Addr::new(10, 0, 2, 2),
+        );
+        // All 42 bytes, pinned literally: the point of the native probe is
+        // byte parity with the frame arping sent, and a partially asserted
+        // frame lets a zeroed htype/ptype (which every gateway drops) pass.
+        let expected: [u8; 42] = [
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // ethernet destination: broadcast
+            0x02, 0x00, 0x00, 0x00, 0x00, 0x01, // ethernet source
+            0x08, 0x06, // ethertype: ARP
+            0x00, 0x01, // htype: ethernet
+            0x08, 0x00, // ptype: IPv4
+            0x06, // hlen
+            0x04, // plen
+            0x00, 0x01, // op: request
+            0x02, 0x00, 0x00, 0x00, 0x00, 0x01, // sender MAC
+            10, 0, 2, 100, // sender IP
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // target MAC: zero for who-has
+            10, 0, 2, 2, // target IP
+        ];
+        assert_eq!(frame, expected);
+    }
+
+    #[test]
+    fn a_malformed_route_line_skips_the_line_not_the_table() {
+        let table = "Iface\tDestination\tGateway \tFlags\n\
+                     \n\
+                     eth0\t00005EAC\n\
+                     eth0\t00000000\t25055EAC\t0003\n";
+        assert_eq!(
+            parse_default_route(table),
+            Some(DefaultRoute {
+                interface: "eth0".to_string(),
+                gateway: Ipv4Addr::new(172, 94, 5, 37),
+            })
+        );
     }
 }
 

--- a/fc-agent/src/restore.rs
+++ b/fc-agent/src/restore.rs
@@ -151,6 +151,43 @@ pub struct RestoreSignals {
     pub nfs_mounts: Vec<crate::types::NfsMount>,
 }
 
+/// Per-phase milliseconds for one guest-side restore, carried to the host in
+/// the restore-completion ACK frame so every clone's critical path is
+/// attributed in the host's own logs (guest serial output is not reliably
+/// captured for clones).
+#[derive(Debug, Default, serde::Serialize)]
+pub struct RestorePhases {
+    pub clock_ms: f64,
+    pub ipv6_ms: f64,
+    pub tcp_cleanup_ms: f64,
+    /// Wire copy of
+    /// [`crate::snapshot_network::RestoreNetworkReport::verified_armed`]:
+    /// whether the boundary took the verified fast path.
+    pub tcp_verified: bool,
+    /// Boundary sub-phases, straight from
+    /// [`crate::snapshot_network::RestoreNetworkReport`].
+    pub tcp_verify_ms: f64,
+    pub tcp_reassert_ms: f64,
+    pub tcp_destroy_ms: f64,
+    pub tcp_reopen_ms: f64,
+    pub neighbor_ms: f64,
+    pub nfs_ms: f64,
+    pub exec_wait_ms: f64,
+    pub egress_wait_ms: f64,
+    pub total_ms: f64,
+}
+
+impl RestorePhases {
+    /// Compact single-line JSON for the ACK frame.
+    pub fn to_frame_json(&self) -> String {
+        serde_json::to_string(self).unwrap_or_else(|_| "{}".to_string())
+    }
+}
+
+fn elapsed_ms(since: std::time::Instant) -> f64 {
+    since.elapsed().as_secs_f64() * 1000.0
+}
+
 /// Handle clone restore: kill stale sockets, refresh gateway ARP, re-register exec,
 /// and prepare output readiness.
 ///
@@ -161,6 +198,13 @@ pub struct RestoreSignals {
 /// proxy hasn't reconnected, tests that immediately use egress after health
 /// check will fail.
 ///
+/// The exec rebind is REQUESTED first (it only touches vsock state, never the
+/// external link the TCP boundary is manipulating) and AWAITED after the
+/// network phases, so the rebind proceeds concurrently with the boundary work
+/// instead of serializing behind it. Chrony re-convergence and the journald
+/// restart have no bearing on the readiness contract, so both run in the
+/// background, off the host's ACK path.
+///
 /// FUSE volumes are NOT remounted here. The reconnectable multiplexer
 /// detects the dead vsock and auto-reconnects to the clone's VolumeServer.
 /// The kernel FUSE session stays alive — processes see a brief hang, not errors.
@@ -168,66 +212,94 @@ pub struct RestoreSignals {
 /// `clone_ipv6`: For routed mode, the unique per-clone IPv6 that replaces the
 /// snapshot's shared guest IPv6 on eth0. Without this, all clones share the same
 /// IPv6 and return traffic gets ECMP-routed to the wrong clone.
+///
+/// `host_time`: epoch seconds already fetched with the restore epoch by the
+/// metadata watcher. Re-fetching the metadata document here would repeat the
+/// transport round trip milliseconds after the watcher completed it, for a
+/// value with one-second resolution.
 pub async fn handle_clone_restore(
     signals: &RestoreSignals,
     clone_ipv6: Option<&str>,
     egress_gen_before: Option<u64>,
     restore_epoch: &str,
-    transport: crate::bootplan::Transport,
-) -> anyhow::Result<()> {
+    host_time: &str,
+) -> anyhow::Result<RestorePhases> {
     let restore_started = std::time::Instant::now();
+    let mut phases = RestorePhases::default();
     eprintln!("[fc-agent] handling restore (epoch={})", restore_epoch);
 
-    // Sync clock FIRST — snapshot restore leaves the VM clock frozen at snapshot time.
-    // Services that validate timestamps (auth, TLS, sessions) will fail with stale time.
-    // Use the active transport: Cloud Hypervisor has no MMDS, so an MMDS fetch would just
-    // wait out its timeout and leave the clock stuck at snapshot time.
-    if let Err(e) = crate::bootplan::sync_clock_from_host(transport).await {
-        eprintln!("[fc-agent] WARNING: clock sync on restore failed: {:?}", e);
-    }
+    // Request the exec re-register immediately (AsyncFd epoll is stale after the
+    // transport reset). Reset confirmation flag, then signal. Set flag BEFORE
+    // notify to prevent a race where select! drops the Notified future (see
+    // exec.rs doc comment). The wait happens after the network phases below.
+    signals.exec_rebind_done.store(false, Ordering::Release);
+    signals.exec_rebind_needed.store(true, Ordering::Release);
+    signals.exec_rebind.notify_one();
 
-    // Reset chrony after clock jump so it doesn't lose its sources.
-    // The MMDS sync above stepped the clock, which confuses chrony's
-    // offset tracking. `makestep` forces it to accept the new time.
-    let _ = tokio::process::Command::new("chronyc")
-        .args(["makestep"])
-        .output()
-        .await;
+    // Sync clock — snapshot restore leaves the VM clock frozen at snapshot time.
+    // Services that validate timestamps (auth, TLS, sessions) will fail with
+    // stale time. The step is soft-fail by construction (chronyd converges
+    // eventually), so nothing here branches on it.
+    let clock_started = std::time::Instant::now();
+    crate::bootplan::set_system_clock(host_time);
+    // Reset chrony after the clock jump so it doesn't lose its sources:
+    // `makestep` forces it to accept the stepped time. Its convergence is
+    // not part of the readiness contract (the clock is already stepped),
+    // so it must not hold the host's ACK.
+    spawn_restore_side_job(async {
+        let _ = tokio::process::Command::new("chronyc")
+            .args(["makestep"])
+            .output()
+            .await;
+    });
+    phases.clock_ms = elapsed_ms(clock_started);
+
+    // Restart journald in the background, started this early so it usually
+    // finishes before the ACK without ever holding it. The journal file was
+    // mid-write when the snapshot was taken, so the restored journald finds a
+    // corrupted file and gets stuck; systemd's watchdog would kill it after
+    // 3 min. Nothing in the readiness contract reads journald (container
+    // output travels over vsock), so a synchronous restart, which is a full
+    // systemd job, would only add latency. After the clock step so the fresh
+    // journal opens with correct timestamps, and registered so the shutdown
+    // path can settle it rather than race it.
+    spawn_restore_side_job(restart_journald());
 
     // Reconfigure IPv6 — before any network traffic can use the old address.
+    // The link is still down here (the snapshot captured it down), so the new
+    // address sits tentative until the boundary republishes the link.
+    let ipv6_started = std::time::Instant::now();
     if let Some(new_ipv6) = clone_ipv6 {
         network::reconfigure_ipv6(new_ipv6).await;
     }
+    phases.ipv6_ms = elapsed_ms(ipv6_started);
 
     let tcp_cleanup_started = std::time::Instant::now();
     eprintln!(
         "[fc-agent] restore phase=tcp-cleanup epoch={} begin",
         restore_epoch
     );
-    crate::snapshot_network::restore_snapshot_network()
+    let boundary = crate::snapshot_network::restore_snapshot_network()
         .await
         .context("restore phase tcp-cleanup")?;
+    phases.tcp_cleanup_ms = elapsed_ms(tcp_cleanup_started);
+    phases.tcp_verified = boundary.verified_armed;
+    phases.tcp_verify_ms = boundary.verify_ms;
+    phases.tcp_reassert_ms = boundary.reassert_ms;
+    phases.tcp_destroy_ms = boundary.destroy_ms;
+    phases.tcp_reopen_ms = boundary.reopen_ms;
     eprintln!(
         "[fc-agent] restore phase=tcp-cleanup epoch={} complete elapsed_ms={:.3}",
-        restore_epoch,
-        tcp_cleanup_started.elapsed().as_secs_f64() * 1000.0
+        restore_epoch, phases.tcp_cleanup_ms
     );
 
     // Do not flush the neighbor table. A client can already be using an entry
     // while restore cleanup runs, and `ip neigh flush all` has no generation
-    // boundary. One active ARP exchange refreshes the gateway and teaches the
+    // boundary. One broadcast ARP request refreshes the gateway and teaches the
     // new bridge/pasta path without deleting unrelated/current neighbors.
     let neighbor_started = std::time::Instant::now();
-    eprintln!(
-        "[fc-agent] restore phase=neighbor-refresh epoch={} begin",
-        restore_epoch
-    );
-    network::refresh_gateway_arp().await;
-    eprintln!(
-        "[fc-agent] restore phase=neighbor-refresh epoch={} complete elapsed_ms={:.3}",
-        restore_epoch,
-        neighbor_started.elapsed().as_secs_f64() * 1000.0
-    );
+    network::refresh_gateway_arp();
+    phases.neighbor_ms = elapsed_ms(neighbor_started);
 
     // Remount NFS shares: their kernel TCP connections to the host's NFS
     // server died with the snapshot transport reset, and a hard NFS mount
@@ -235,6 +307,7 @@ pub async fn handle_clone_restore(
     // re-establishes the connection against the host's re-created export.
     // Uses the boot-time plan cached in RestoreSignals — see its doc comment
     // for why MMDS can't be consulted here.
+    let nfs_started = std::time::Instant::now();
     if !signals.nfs_mounts.is_empty() {
         eprintln!(
             "[fc-agent] remounting {} NFS share(s) after restore",
@@ -253,64 +326,137 @@ pub async fn handle_clone_restore(
             );
         }
     }
+    phases.nfs_ms = elapsed_ms(nfs_started);
 
-    // FIRST: Re-register exec server listener (AsyncFd epoll stale after transport reset).
-    // Reset confirmation flag, then signal. Set flag BEFORE notify to prevent race
-    // where select! drops the Notified future (see exec.rs doc comment).
-    signals.exec_rebind_done.store(false, Ordering::Release);
-    signals.exec_rebind_needed.store(true, Ordering::Release);
-    signals.exec_rebind.notify_one();
-
-    // SECOND: Wait for exec server to confirm re-register completed.
-    // This ensures accept() works before the host can reach the exec server.
-    // Wait on the AtomicBool (the source of truth) and use the Notify only as a
-    // wakeup: a stale stored permit (e.g. left over from a previous restore whose
-    // wait timed out before the rebind finished) must not let this restore proceed
-    // before its own re-register has completed. The flag was reset above, so it only
-    // reads true once the exec server has re-registered for THIS restore.
-    wait_for_exec_rebind(
-        &signals.exec_rebind_done,
-        &signals.exec_rebind_done_notify,
-        std::time::Duration::from_secs(5),
-    )
-    .await
-    .context("waiting for exec server re-registration after restore")?;
-    eprintln!("[fc-agent] exec re-registered after restore");
-
-    // THIRD: Wait for egress proxy to reconnect (watch channel incremented after vsock connect).
-    // No explicit signal needed — the proxy detects the dead vsock fd natively via
-    // Interest::ERROR (EPOLLERR fires instantly after transport reset). The proxy's
-    // select! arm fires, the session exits, and the reconnect loop connects a new vsock.
-    // If proxy already reconnected, wait_for returns immediately (watch retains latest value).
-    if let (Some(rx), Some(gen_before)) = (&signals.egress_gen_rx, egress_gen_before) {
-        crate::proxy::wait_for_egress_gen(
-            rx,
-            gen_before,
+    // Await the exec re-register requested at the top and the egress proxy
+    // reconnect together: the two are independent (vsock listener rebind
+    // versus the proxy's own reconnect loop), so the ACK owes the slower of
+    // the two, never their sum.
+    //
+    // Exec: this ensures accept() works before the host can reach the exec
+    // server. Wait on the AtomicBool (the source of truth) and use the Notify
+    // only as a wakeup: a stale stored permit (e.g. left over from a previous
+    // restore whose wait timed out before the rebind finished) must not let
+    // this restore proceed before its own re-register has completed. The flag
+    // was reset above, so it only reads true once the exec server has
+    // re-registered for THIS restore.
+    //
+    // Egress: no explicit signal needed — the proxy detects the dead vsock fd
+    // natively via Interest::ERROR (EPOLLERR fires instantly after transport
+    // reset), its session exits, and the reconnect loop connects a new vsock.
+    // If it already reconnected, wait_for returns immediately (watch retains
+    // the latest value).
+    let exec_wait = async {
+        let started = std::time::Instant::now();
+        wait_for_exec_rebind(
+            &signals.exec_rebind_done,
+            &signals.exec_rebind_done_notify,
             std::time::Duration::from_secs(5),
-            "reconnected after restore",
         )
         .await
-        .context("waiting for egress proxy reconnection after restore")?;
-    }
+        .context("waiting for exec server re-registration after restore")?;
+        Ok::<f64, anyhow::Error>(elapsed_ms(started))
+    };
+    let egress_wait = async {
+        let started = std::time::Instant::now();
+        if let (Some(rx), Some(gen_before)) = (&signals.egress_gen_rx, egress_gen_before) {
+            crate::proxy::wait_for_egress_gen(
+                rx,
+                gen_before,
+                std::time::Duration::from_secs(5),
+                "reconnected after restore",
+            )
+            .await
+            .context("waiting for egress proxy reconnection after restore")?;
+        }
+        Ok::<f64, anyhow::Error>(elapsed_ms(started))
+    };
+    let (exec_wait_ms, egress_wait_ms) = tokio::try_join!(exec_wait, egress_wait)?;
+    phases.exec_wait_ms = exec_wait_ms;
+    phases.egress_wait_ms = egress_wait_ms;
+    eprintln!("[fc-agent] exec re-registered after restore");
 
-    // FOURTH: Restart journald. The journal file was mid-write when the snapshot
-    // was taken, so the restored journald finds a corrupted file and gets stuck.
-    // systemd's watchdog would kill it after 3 min, but we restart it immediately
-    // so other services can log via journald right away.
-    restart_journald().await;
-
+    phases.total_ms = elapsed_ms(restore_started);
     eprintln!(
         "[fc-agent] restore phases complete (epoch={}): exec + egress ready elapsed_ms={:.3}",
-        restore_epoch,
-        restore_started.elapsed().as_secs_f64() * 1000.0
+        restore_epoch, phases.total_ms
     );
-    Ok(())
+    Ok(phases)
+}
+
+/// Background jobs a restore started that must not outlive the VM.
+///
+/// These run off the readiness path (nothing in the readiness contract reads
+/// journald or waits for chrony to converge), but each drives a system
+/// service, and one still running when the VM is torn down races the
+/// shutdown itself: the guest asks systemd to power off while systemd is
+/// mid-restart of one of its own units. Keeping the handles lets the
+/// shutdown path settle them first, exactly as `agent::run` already settles
+/// the chronyd setup task.
+static PENDING_RESTORE_JOBS: std::sync::Mutex<Vec<tokio::task::JoinHandle<()>>> =
+    std::sync::Mutex::new(Vec::new());
+
+/// Run a restore side-job in the background, registered for settling.
+fn spawn_restore_side_job(job: impl std::future::Future<Output = ()> + Send + 'static) {
+    PENDING_RESTORE_JOBS.lock().unwrap().push(tokio::spawn(job));
+}
+
+/// Wait, bounded, for a background journald restart to finish.
+///
+/// Called on the shutdown path so a systemd job this process started cannot
+/// still be running while the guest powers the VM off. The bound is not a
+/// guess about the job's duration: it caps how long a wedged systemd can
+/// hold the VM open, which is the same trade `agent::run` makes for chronyd.
+pub async fn settle_restore_side_jobs(timeout: std::time::Duration) {
+    settle_pending_jobs(&PENDING_RESTORE_JOBS, timeout).await
+}
+
+/// The settle itself, over whichever slot holds the jobs. Taking the slot as
+/// an argument keeps the behaviour testable without the process-wide static,
+/// which parallel tests would otherwise share. The timeout is the budget for
+/// the whole set, so a wedged job cannot multiply the shutdown delay by the
+/// number of jobs.
+async fn settle_pending_jobs(
+    slot: &std::sync::Mutex<Vec<tokio::task::JoinHandle<()>>>,
+    timeout: std::time::Duration,
+) {
+    let jobs = std::mem::take(&mut *slot.lock().unwrap());
+    if jobs.is_empty() {
+        return;
+    }
+    let deadline = tokio::time::Instant::now() + timeout;
+    for job in jobs {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        match tokio::time::timeout(remaining, job).await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => eprintln!("[fc-agent] restore side-job panicked: {error}"),
+            Err(_) => {
+                eprintln!(
+                    "[fc-agent] restore side-jobs still running after {timeout:?} at \
+                     shutdown; proceeding without them"
+                );
+                return;
+            }
+        }
+    }
 }
 
 /// Restart systemd-journald after snapshot restore.
 ///
 /// The journal file is corrupted because journald was mid-write when the snapshot
 /// was taken. On restart, journald renames the corrupt file and creates a fresh one.
+///
+/// This runs in the background (measured at 32-51ms on an idle guest, more on a
+/// freshly restored one where the unit's pages fault back in) and the shutdown
+/// path settles it, so it can neither hold the ACK nor race the VM going away.
+///
+/// A snapshot taken immediately after the ACK can still capture the unit
+/// mid-restart. That is deliberate rather than unhandled: the guest's snapshot
+/// boundary runs as a separate one-shot process, so there is no task for it to
+/// join, and the condition is self-correcting because every restore of the
+/// resulting image restarts journald again. Trading a cross-process handshake
+/// for a mid-write journal that the next restore repairs anyway is not worth
+/// the coupling.
 async fn restart_journald() {
     match tokio::process::Command::new("systemctl")
         .args(["restart", "systemd-journald"])
@@ -329,6 +475,86 @@ async fn restart_journald() {
         Err(e) => {
             eprintln!("[fc-agent] WARNING: failed to restart journald: {}", e);
         }
+    }
+}
+
+#[cfg(test)]
+mod restore_side_job_tests {
+    use super::*;
+
+    fn slot(
+        handles: Vec<tokio::task::JoinHandle<()>>,
+    ) -> std::sync::Mutex<Vec<tokio::task::JoinHandle<()>>> {
+        std::sync::Mutex::new(handles)
+    }
+
+    /// Background jobs a restore started must not still be running when the
+    /// guest powers the VM off: the shutdown path settles them first. With
+    /// the jobs merely detached, this observes them unfinished.
+    #[tokio::test(flavor = "current_thread")]
+    async fn shutdown_settles_every_restore_started_background_job() {
+        let done = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let jobs = (0..3)
+            .map(|index| {
+                let counter = done.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_millis(10 * (index + 1))).await;
+                    counter.fetch_add(1, Ordering::AcqRel);
+                })
+            })
+            .collect();
+        let pending = slot(jobs);
+
+        settle_pending_jobs(&pending, std::time::Duration::from_secs(5)).await;
+
+        assert_eq!(
+            done.load(Ordering::Acquire),
+            3,
+            "shutdown proceeded while a restore's system jobs were still running"
+        );
+        assert!(
+            pending.lock().unwrap().is_empty(),
+            "settled jobs must not be waited on twice"
+        );
+    }
+
+    /// The settle is bounded for the SET, not per job: one wedged job cannot
+    /// multiply the delay, and cannot hold the VM open indefinitely.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn a_wedged_background_job_cannot_hold_the_vm_open() {
+        let pending = slot(vec![
+            tokio::spawn(std::future::pending::<()>()),
+            tokio::spawn(std::future::pending::<()>()),
+        ]);
+
+        let before = tokio::time::Instant::now();
+        settle_pending_jobs(&pending, std::time::Duration::from_secs(5)).await;
+        assert_eq!(
+            tokio::time::Instant::now() - before,
+            std::time::Duration::from_secs(5),
+            "the settle must give up at its bound, once for the whole set"
+        );
+    }
+
+    /// No restore, nothing registered: shutdown pays nothing.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn shutdown_without_a_restore_waits_for_nothing() {
+        let pending = slot(Vec::new());
+        let before = tokio::time::Instant::now();
+        settle_pending_jobs(&pending, std::time::Duration::from_secs(5)).await;
+        assert_eq!(tokio::time::Instant::now(), before);
+    }
+
+    /// The real registration path hands the shutdown path its jobs.
+    #[tokio::test(flavor = "current_thread")]
+    async fn the_restore_path_registers_its_jobs_for_settling() {
+        spawn_restore_side_job(async {});
+        assert!(
+            !PENDING_RESTORE_JOBS.lock().unwrap().is_empty(),
+            "a restore must leave its system jobs where shutdown can find them"
+        );
+        settle_restore_side_jobs(std::time::Duration::from_secs(5)).await;
+        assert!(PENDING_RESTORE_JOBS.lock().unwrap().is_empty());
     }
 }
 

--- a/fc-agent/src/snapshot_network.rs
+++ b/fc-agent/src/snapshot_network.rs
@@ -9,7 +9,7 @@
 
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use std::os::fd::{FromRawFd, OwnedFd};
+use std::os::fd::OwnedFd;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -19,7 +19,7 @@ use tokio::process::Command;
 
 const MANIFEST_VERSION: u32 = 1;
 const MANIFEST_PATH: &str = "/run/fcvm/snapshot-network.json";
-const SYSFS_NET_PATH: &str = "/sys/class/net";
+pub(crate) const SYSFS_NET_PATH: &str = "/sys/class/net";
 const BOUNDARY_LOCK_PATH: &str = "/run/fcvm/snapshot-network.lock";
 const GATE_INPUT_CHAIN: &str = "FCVM_SNAPSHOT_IN";
 const GATE_OUTPUT_CHAIN: &str = "FCVM_SNAPSHOT_OUT";
@@ -303,6 +303,10 @@ impl ManifestStore for FileManifestStore {
 trait FirewallGate {
     async fn close(&self) -> Result<()>;
     async fn open(&self) -> Result<()>;
+    /// Report whether the gate is already fully installed: both directional
+    /// chains present with exactly the boundary rules, each hooked from its
+    /// built-in chain, in both address families.
+    async fn is_closed(&self) -> Result<bool>;
 }
 
 trait ExternalLink {
@@ -324,6 +328,18 @@ trait RouteTable {
 
 trait CommandRunner {
     async fn output(&self, program: &str, args: &[&str]) -> io::Result<std::process::Output>;
+
+    /// Run with `input` piped to stdin. Exists for the batch tools
+    /// (`iptables-restore`, `ip -batch -`) that let one process spawn carry
+    /// what would otherwise be a dozen: on a freshly restored clone every
+    /// spawn faults its text and libraries back in through the memory
+    /// backend, so spawn count is the boundary's dominant cost.
+    async fn output_with_input(
+        &self,
+        program: &str,
+        args: &[&str],
+        input: &[u8],
+    ) -> io::Result<std::process::Output>;
 }
 
 struct SystemCommandRunner;
@@ -331,6 +347,28 @@ struct SystemCommandRunner;
 impl CommandRunner for SystemCommandRunner {
     async fn output(&self, program: &str, args: &[&str]) -> io::Result<std::process::Output> {
         Command::new(program).args(args).output().await
+    }
+
+    async fn output_with_input(
+        &self,
+        program: &str,
+        args: &[&str],
+        input: &[u8],
+    ) -> io::Result<std::process::Output> {
+        use tokio::io::AsyncWriteExt;
+
+        let mut child = Command::new(program)
+            .args(args)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()?;
+        let mut stdin = child.stdin.take().ok_or_else(|| {
+            io::Error::other(format!("{program} child has no stdin despite piped()"))
+        })?;
+        stdin.write_all(input).await?;
+        drop(stdin);
+        child.wait_with_output().await
     }
 }
 
@@ -381,42 +419,77 @@ fn external_interface() -> Result<String> {
     external_interface_in(Path::new(SYSFS_NET_PATH))
 }
 
-struct IpLink<R> {
-    runner: R,
+/// The guest's one external interface, driven through direct syscalls.
+struct IpLink {
     interface: String,
 }
 
-impl<R> IpLink<R> {
-    fn new(runner: R, interface: String) -> Self {
-        Self { runner, interface }
+impl IpLink {
+    fn new(interface: String) -> Self {
+        Self { interface }
     }
 }
 
-impl<R: CommandRunner + Sync> IpLink<R> {
-    async fn set(&self, state: &str) -> Result<()> {
-        let args = ["link", "set", "dev", self.interface.as_str(), state];
-        let output = self
-            .runner
-            .output("ip", &args)
-            .await
-            .context("spawning ip to change snapshot network link state")?;
-        if !output.status.success() {
-            bail!(
-                "snapshot network link command failed: {}",
-                command_failure("ip", &args, &output)
-            );
-        }
-        Ok(())
+/// Set or clear IFF_UP on an interface with SIOCSIFFLAGS.
+///
+/// The kernel call `ip link set dev X up|down` makes, without the process
+/// spawn. The boundary drives the link on every clone restore, where a spawn
+/// costs far more than the syscall: the restored process image faults its
+/// text and libraries back in through the memory backend. Spawn-free is also
+/// what makes re-asserting the link-down on every restore affordable, and
+/// that re-assert is what keeps the cleanup sound against a privileged
+/// workload sharing this namespace.
+fn set_interface_up(interface: &str, up: bool) -> Result<()> {
+    use std::os::fd::AsRawFd;
+
+    // `as _` on the request numbers is load-bearing across targets: the guest
+    // binary is musl, whose `ioctl` takes an i32 request, while glibc takes a
+    // c_ulong. A host-target build hides that difference entirely.
+
+    let fd = crate::network::open_raw_socket(libc::AF_INET, libc::SOCK_DGRAM, 0)
+        .context("opening a control socket for the snapshot network link")?;
+    // SAFETY: ifreq is a plain C struct; zeroing is its valid empty state.
+    let mut request: libc::ifreq = unsafe { std::mem::zeroed() };
+    let name = interface.as_bytes();
+    if name.len() >= request.ifr_name.len() {
+        bail!("interface name {interface:?} does not fit in an ifreq");
     }
+    for (slot, byte) in request.ifr_name.iter_mut().zip(name) {
+        *slot = *byte as libc::c_char;
+    }
+    // SAFETY: the fd is a live AF_INET socket and `request` is initialized
+    // with a NUL-terminated name; SIOCGIFFLAGS fills the flags union member.
+    if unsafe { libc::ioctl(fd.as_raw_fd(), libc::SIOCGIFFLAGS as _, &mut request) } < 0 {
+        return Err(std::io::Error::last_os_error())
+            .with_context(|| format!("reading interface flags for {interface}"));
+    }
+    // SAFETY: SIOCGIFFLAGS just populated the flags member of the union.
+    let flags = unsafe { request.ifr_ifru.ifru_flags } as libc::c_int;
+    let updated = if up {
+        flags | libc::IFF_UP
+    } else {
+        flags & !libc::IFF_UP
+    };
+    request.ifr_ifru.ifru_flags = updated as libc::c_short;
+    // SAFETY: same fd and struct, now carrying the flags to install.
+    if unsafe { libc::ioctl(fd.as_raw_fd(), libc::SIOCSIFFLAGS as _, &request) } < 0 {
+        return Err(std::io::Error::last_os_error()).with_context(|| {
+            format!(
+                "setting interface {interface} {}",
+                if up { "up" } else { "down" }
+            )
+        });
+    }
+    Ok(())
 }
 
-impl<R: CommandRunner + Sync> ExternalLink for IpLink<R> {
+impl ExternalLink for IpLink {
     async fn down(&self) -> Result<()> {
-        self.set("down").await
+        set_interface_up(&self.interface, false)
     }
 
     async fn up(&self) -> Result<()> {
-        self.set("up").await
+        set_interface_up(&self.interface, true)
     }
 }
 
@@ -482,13 +555,32 @@ impl<R: CommandRunner + Sync> RouteTable for IpRoutes<R> {
     }
 
     async fn reinstate(&self, routes: &[CapturedRoute]) -> Result<()> {
-        for route in routes {
-            let flag = if route.family == 6 { "-6" } else { "-4" };
-            let mut args = vec![flag, "route", "replace"];
-            args.extend(route.spec.split_whitespace());
-            self.run(&args)
+        // One `ip -batch -` spawn per family instead of one per route: the
+        // family flag is global to the ip invocation, and each avoided spawn
+        // is restore latency on a cold clone.
+        for family in [4u8, 6u8] {
+            let lines: Vec<String> = routes
+                .iter()
+                .filter(|route| route.family == family)
+                .map(|route| format!("route replace {}", route.spec))
+                .collect();
+            if lines.is_empty() {
+                continue;
+            }
+            let flag = if family == 6 { "-6" } else { "-4" };
+            let payload = lines.join("\n") + "\n";
+            let args = [flag, "-batch", "-"];
+            let output = self
+                .runner
+                .output_with_input("ip", &args, payload.as_bytes())
                 .await
-                .with_context(|| format!("reinstating route `{}`", route.spec))?;
+                .context("spawning ip to reinstate the snapshot route table")?;
+            if !output.status.success() {
+                bail!(
+                    "snapshot network route batch failed: {} (batch input {payload:?})",
+                    command_failure("ip", &args, &output)
+                );
+            }
         }
         Ok(())
     }
@@ -505,32 +597,37 @@ impl PacketReceiveBarrier for SystemPacketReceiveBarrier {
         // The NEW-flow gate is installed first and the link is down, so packets
         // that begin after this grace period cannot create an uncaptured TCP
         // socket. Merely waiting or taking repeated dumps cannot prove this.
-        let raw = unsafe {
-            libc::socket(
-                libc::AF_PACKET,
-                libc::SOCK_RAW | libc::SOCK_CLOEXEC,
-                ETH_P_ALL.to_be() as i32,
-            )
-        };
-        if raw < 0 {
-            return Err(io::Error::last_os_error()).context(
-                "opening AF_PACKET receive-path barrier (guest kernel needs CONFIG_PACKET=y)",
-            );
-        }
-        // SAFETY: `raw` is a newly-created owned fd. Dropping it invokes the
-        // packet socket release path and its synchronize_net() grace period.
-        drop(unsafe { OwnedFd::from_raw_fd(raw) });
+        // Dropping the fd invokes the packet socket release path and its
+        // synchronize_net() grace period.
+        let fd = crate::network::open_raw_socket(
+            libc::AF_PACKET,
+            libc::SOCK_RAW,
+            ETH_P_ALL.to_be() as i32,
+        )
+        .context("opening AF_PACKET receive-path barrier (guest kernel needs CONFIG_PACKET=y)")?;
+        drop(fd);
         Ok(())
     }
 }
 
 struct IptablesGate<R> {
     runner: R,
+    /// Per-program `-S` parse retained from verification for the removal that
+    /// follows it in the same transaction, dropped by every gate mutation
+    /// this module makes. No other fc-agent transaction can invalidate it:
+    /// they serialize on the guest-wide boundary lock. A privileged workload
+    /// can, and then the computed removal names a rule that no longer
+    /// matches, which fails the batch and fails the restore closed.
+    /// Guards the map only, never held across an await.
+    state_cache: std::sync::Mutex<std::collections::HashMap<String, FamilyGateState>>,
 }
 
 impl<R> IptablesGate<R> {
     fn new(runner: R) -> Self {
-        Self { runner }
+        Self {
+            runner,
+            state_cache: std::sync::Mutex::new(std::collections::HashMap::new()),
+        }
     }
 }
 
@@ -546,6 +643,165 @@ fn command_failure(program: &str, args: &[&str], output: &std::process::Output) 
         String::from_utf8_lossy(&output.stdout).trim(),
         String::from_utf8_lossy(&output.stderr).trim(),
     )
+}
+
+/// The loopback exemptions the two families preserve across the boundary.
+const IPV4_LOOPBACK: &str = "127.0.0.0/8";
+const IPV6_LOOPBACK: &str = "::1/128";
+
+/// The exact rule bodies a gate chain carries, without the `-A <chain>`
+/// prefix. Shared by installation and verification so the two can never
+/// drift: what close() appends is literally what is_closed() expects.
+fn gate_chain_rules(loopback_flag: &str, loopback_network: &str) -> [Vec<String>; 3] {
+    let owned = |tokens: &[&str]| tokens.iter().map(|token| token.to_string()).collect();
+    [
+        owned(&["-p", "tcp", loopback_flag, loopback_network, "-j", "RETURN"]),
+        owned(&[
+            "-p",
+            "tcp",
+            "-m",
+            "conntrack",
+            "--ctstate",
+            "NEW",
+            "-j",
+            "REJECT",
+            "--reject-with",
+            "tcp-reset",
+        ]),
+        owned(&["-j", "RETURN"]),
+    ]
+}
+
+/// The one rule that routes a built-in chain into a gate chain, as `-S`
+/// prints it. Shared by installation, verification, and removal so the three
+/// can never drift: a hook changed in one of them alone would silently kill
+/// the verified fast path (verification stops matching) and break removal
+/// (`-X` on a still-referenced chain).
+fn hook_jump_args(chain: &str) -> [&str; 2] {
+    ["-j", chain]
+}
+
+fn hook_install_args<'a>(hook: &'a str, chain: &'a str) -> [&'a str; 6] {
+    let [jump, target] = hook_jump_args(chain);
+    ["-w", "-I", hook, "1", jump, target]
+}
+
+fn hook_check_args<'a>(hook: &'a str, chain: &'a str) -> [&'a str; 5] {
+    let [jump, target] = hook_jump_args(chain);
+    ["-w", "-C", hook, jump, target]
+}
+
+/// One family's observed gate state, parsed from a single `iptables -S` dump.
+///
+/// `None` rule lists mean the chain is not declared at all; an empty list is a
+/// declared-but-empty chain. Hook counts tally `-A INPUT -j <chain>` (and the
+/// OUTPUT twin) exactly — a jump carrying extra matches is not our hook.
+/// The first-rule flags record whether the hook is the built-in chain's FIRST
+/// rule (`-S` prints rules in evaluation order): the gate only governs packets
+/// that reach it, so a hook shadowed by any earlier rule is not a closed gate.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct FamilyGateState {
+    input_rules: Option<Vec<Vec<String>>>,
+    output_rules: Option<Vec<Vec<String>>>,
+    input_hooks: usize,
+    output_hooks: usize,
+    input_hook_is_first_rule: bool,
+    output_hook_is_first_rule: bool,
+}
+
+fn parse_gate_state(dump: &str) -> FamilyGateState {
+    let mut state = FamilyGateState::default();
+    let mut input_rules_seen = 0usize;
+    let mut output_rules_seen = 0usize;
+    for line in dump.lines() {
+        let tokens: Vec<String> = line.split_whitespace().map(str::to_string).collect();
+        let [command, chain, rest @ ..] = tokens.as_slice() else {
+            continue;
+        };
+        match (command.as_str(), chain.as_str()) {
+            ("-N", GATE_INPUT_CHAIN) => {
+                state.input_rules.get_or_insert_with(Vec::new);
+            }
+            ("-N", GATE_OUTPUT_CHAIN) => {
+                state.output_rules.get_or_insert_with(Vec::new);
+            }
+            ("-A", GATE_INPUT_CHAIN) => {
+                state
+                    .input_rules
+                    .get_or_insert_with(Vec::new)
+                    .push(rest.to_vec());
+            }
+            ("-A", GATE_OUTPUT_CHAIN) => {
+                state
+                    .output_rules
+                    .get_or_insert_with(Vec::new)
+                    .push(rest.to_vec());
+            }
+            ("-A", "INPUT") => {
+                input_rules_seen += 1;
+                if rest == hook_jump_args(GATE_INPUT_CHAIN) {
+                    state.input_hooks += 1;
+                    if input_rules_seen == 1 {
+                        state.input_hook_is_first_rule = true;
+                    }
+                }
+            }
+            ("-A", "OUTPUT") => {
+                output_rules_seen += 1;
+                if rest == hook_jump_args(GATE_OUTPUT_CHAIN) {
+                    state.output_hooks += 1;
+                    if output_rules_seen == 1 {
+                        state.output_hook_is_first_rule = true;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    state
+}
+
+/// Compare one rule as a sorted token multiset. `iptables -S` reorders
+/// arguments relative to what was appended (measured on iptables v1.8.10
+/// nf_tables: `-A C -p tcp -s 127.0.0.0/8 -j RETURN` prints as
+/// `-A C -s 127.0.0.0/8 -p tcp -j RETURN`), and pinning the exact print order
+/// would couple verification to one iptables version's renderer.
+fn sorted_tokens(tokens: &[String]) -> Vec<String> {
+    let mut sorted = tokens.to_vec();
+    sorted.sort();
+    sorted
+}
+
+/// Whether one family's observed state is the fully armed gate: both chains
+/// carrying exactly the boundary rules, each hooked as the FIRST rule of its
+/// built-in chain. First position is part of the invariant — close() inserts
+/// with `-I 1`, and a hook shadowed by any earlier rule would let that rule
+/// admit NEW flows the manifest never captured. Extra duplicate hooks below
+/// the first are still closed (the gate verdict is unchanged); any deviation
+/// inside a chain is not.
+///
+/// Scope: this sees exactly what `iptables -S` renders. A rule injected with
+/// native nft tooling into a separate higher-priority nft chain is invisible
+/// here and bypasses the gate at packet time regardless; that holds equally
+/// for the unconditional re-assert path, which installs into the same
+/// iptables-visible chains.
+fn family_gate_is_closed(state: &FamilyGateState, loopback_network: &str) -> bool {
+    let chain_matches = |observed: &Option<Vec<Vec<String>>>, loopback_flag: &str| {
+        let expected = gate_chain_rules(loopback_flag, loopback_network);
+        observed.as_ref().is_some_and(|rules| {
+            rules.len() == expected.len()
+                && rules
+                    .iter()
+                    .zip(expected.iter())
+                    .all(|(observed_rule, expected_rule)| {
+                        sorted_tokens(observed_rule) == sorted_tokens(expected_rule)
+                    })
+        })
+    };
+    chain_matches(&state.input_rules, "-s")
+        && chain_matches(&state.output_rules, "-d")
+        && state.input_hook_is_first_rule
+        && state.output_hook_is_first_rule
 }
 
 impl<R: CommandRunner> IptablesGate<R> {
@@ -570,6 +826,34 @@ impl<R: CommandRunner> IptablesGate<R> {
         Ok(output.status.success())
     }
 
+    async fn read_family_state(&self, program: &str) -> Result<FamilyGateState> {
+        let args = ["-w", "-S"];
+        let output = self
+            .runner
+            .output(program, &args)
+            .await
+            .with_context(|| format!("spawning {program}"))?;
+        if !output.status.success() {
+            bail!(
+                "snapshot network gate state read failed: {}",
+                command_failure(program, &args, &output)
+            );
+        }
+        Ok(parse_gate_state(&String::from_utf8_lossy(&output.stdout)))
+    }
+
+    async fn family_is_closed(&self, program: &str, loopback_network: &str) -> Result<bool> {
+        let state = self.read_family_state(program).await?;
+        let closed = family_gate_is_closed(&state, loopback_network);
+        // Retain the parse for the removal that follows verification in the
+        // same locked transaction, saving that removal's own `-S` spawn.
+        self.state_cache
+            .lock()
+            .unwrap()
+            .insert(program.to_string(), state);
+        Ok(closed)
+    }
+
     async fn configure_gate_chain(
         &self,
         program: &str,
@@ -581,53 +865,24 @@ impl<R: CommandRunner> IptablesGate<R> {
             self.required(program, &["-w", "-N", chain]).await?;
         }
         self.required(program, &["-w", "-F", chain]).await?;
-        self.required(
-            program,
-            &[
-                "-w",
-                "-A",
-                chain,
-                "-p",
-                "tcp",
-                loopback_flag,
-                loopback_network,
-                "-j",
-                "RETURN",
-            ],
-        )
-        .await?;
-        self.required(
-            program,
-            &[
-                "-w",
-                "-A",
-                chain,
-                "-p",
-                "tcp",
-                "-m",
-                "conntrack",
-                "--ctstate",
-                "NEW",
-                "-j",
-                "REJECT",
-                "--reject-with",
-                "tcp-reset",
-            ],
-        )
-        .await?;
-        self.required(program, &["-w", "-A", chain, "-j", "RETURN"])
-            .await?;
+        for rule in gate_chain_rules(loopback_flag, loopback_network) {
+            let mut args: Vec<&str> = vec!["-w", "-A", chain];
+            args.extend(rule.iter().map(String::as_str));
+            self.required(program, &args).await?;
+        }
         Ok(())
     }
 
     async fn install_hook(&self, program: &str, hook: &str, chain: &str) -> Result<()> {
-        let check = ["-w", "-C", hook, "-j", chain];
-        let output = self.runner.output(program, &check).await?;
-        if !output.status.success() {
-            self.required(program, &["-w", "-I", hook, "1", "-j", chain])
-                .await?;
-        }
-        self.required(program, &check).await?;
+        // Always insert at position 1. `-C` can only prove the jump exists
+        // SOMEWHERE, and a jump below a foreign rule is a gate that foreign
+        // rule can bypass, so close() must put a copy ahead of everything.
+        // A duplicate left lower in the chain is harmless (the first match
+        // governs) and remove_family retires every counted copy.
+        self.required(program, &hook_install_args(hook, chain))
+            .await?;
+        self.required(program, &hook_check_args(hook, chain))
+            .await?;
         Ok(())
     }
 
@@ -645,57 +900,104 @@ impl<R: CommandRunner> IptablesGate<R> {
             .await?;
         self.install_hook(program, "OUTPUT", GATE_OUTPUT_CHAIN)
             .await?;
+        // This family's rules just changed; a parse retained from an earlier
+        // verification no longer describes them.
+        self.state_cache.lock().unwrap().remove(program);
         Ok(())
     }
 
-    async fn remove_chain(&self, program: &str, hook: &str, chain: &str) -> Result<()> {
-        if !self.chain_exists(program, chain).await? {
-            return Ok(());
-        }
-        // A hook can legitimately carry the jump more than once (an interrupted
-        // close leaves one behind), so removal repeats. It is bounded: an
-        // iptables chain that still matches after this many deletions is not
-        // converging, and looping forever there would hang restore instead of
-        // reporting the stuck rule.
+    /// Remove one family's gate with one `iptables-restore --noflush` batch,
+    /// computed from a single `-S` read: exactly the counted hook deletions,
+    /// then flush and delete each chain that exists. When the same locked
+    /// transaction already read the state to verify, that parse is reused and
+    /// the removal spends no read at all. Explicit `-D`/`-F`/`-X` lines in
+    /// restore input are accepted (verified live on the guest's iptables
+    /// v1.8.10 nf_tables build, which removed both duplicate jumps and the
+    /// chain in one commit). One spawn instead of a dozen matters here: on a
+    /// freshly restored clone every spawn faults its pages back in through
+    /// the memory backend.
+    ///
+    /// The plan is computed rather than probed, so it assumes the observed
+    /// state still holds. Other fc-agent transactions cannot break that (the
+    /// guest-wide lock serializes them); a privileged workload sharing this
+    /// namespace can, and then a `-D` or `-X` names something that no longer
+    /// matches and the batch fails, which fails the restore closed.
+    async fn remove_family(&self, program: &str) -> Result<()> {
+        // Bounded: a hook carrying more duplicate jumps than any interrupted
+        // sequence could leave is tampering, not drift, and deleting without
+        // bound would hang restore instead of reporting it.
         const MAX_DUPLICATE_HOOKS: usize = 64;
-        let check = ["-w", "-C", hook, "-j", chain];
-        let mut removed = 0usize;
-        while self.runner.output(program, &check).await?.status.success() {
-            if removed == MAX_DUPLICATE_HOOKS {
+        let cached = self.state_cache.lock().unwrap().remove(program);
+        let state = match cached {
+            Some(state) => state,
+            None => self.read_family_state(program).await?,
+        };
+        let mut lines = vec!["*filter".to_string()];
+        let hooks = [
+            ("INPUT", GATE_INPUT_CHAIN, state.input_hooks),
+            ("OUTPUT", GATE_OUTPUT_CHAIN, state.output_hooks),
+        ];
+        for (hook, chain, count) in hooks {
+            if count > MAX_DUPLICATE_HOOKS {
                 bail!(
-                    "{program} {hook} still jumps to {chain} after removing \
-                     {MAX_DUPLICATE_HOOKS} references; refusing to loop"
+                    "{program} {hook} jumps to {chain} {count} times \
+                     (limit {MAX_DUPLICATE_HOOKS}); refusing cleanup"
                 );
             }
-            self.required(program, &["-w", "-D", hook, "-j", chain])
-                .await?;
-            removed += 1;
+            for _ in 0..count {
+                lines.push(format!("-D {hook} {}", hook_jump_args(chain).join(" ")));
+            }
         }
-        self.required(program, &["-w", "-F", chain]).await?;
-        self.required(program, &["-w", "-X", chain]).await?;
-        Ok(())
-    }
-
-    async fn remove_family(&self, program: &str) -> Result<()> {
-        self.remove_chain(program, "INPUT", GATE_INPUT_CHAIN)
-            .await?;
-        self.remove_chain(program, "OUTPUT", GATE_OUTPUT_CHAIN)
-            .await?;
+        let chains = [
+            (GATE_INPUT_CHAIN, state.input_rules.is_some()),
+            (GATE_OUTPUT_CHAIN, state.output_rules.is_some()),
+        ];
+        for (chain, declared) in chains {
+            if declared {
+                lines.push(format!("-F {chain}"));
+                lines.push(format!("-X {chain}"));
+            }
+        }
+        if lines.len() == 1 {
+            return Ok(());
+        }
+        lines.push("COMMIT".to_string());
+        let payload = lines.join("\n") + "\n";
+        let restore_program = format!("{program}-restore");
+        let args = ["-w", "--noflush"];
+        let output = self
+            .runner
+            .output_with_input(&restore_program, &args, payload.as_bytes())
+            .await
+            .with_context(|| format!("spawning {restore_program}"))?;
+        if !output.status.success() {
+            bail!(
+                "snapshot network gate batch removal failed: {} (batch input {payload:?})",
+                command_failure(&restore_program, &args, &output)
+            );
+        }
         Ok(())
     }
 }
 
 impl<R: CommandRunner + Sync> FirewallGate for IptablesGate<R> {
     async fn close(&self) -> Result<()> {
-        self.install_family("iptables", "127.0.0.0/8")
+        self.install_family("iptables", IPV4_LOOPBACK)
             .await
             .context("installing IPv4 snapshot network gate")?;
-        self.install_family("ip6tables", "::1/128")
+        self.install_family("ip6tables", IPV6_LOOPBACK)
             .await
             .context("installing IPv6 snapshot network gate")
     }
 
     async fn open(&self) -> Result<()> {
+        // Mutations stay sequential on purpose. iptables-nft has no shared
+        // userspace lock (`-w` is a no-op there) and commits race the
+        // kernel's per-netns generation counter, where a lost retry surfaces
+        // as EAGAIN; through required() that would fail the restore and kill
+        // the clone, a poor trade for one process spawn of overlap. Both
+        // verdicts are still collected so one family's failure cannot mask
+        // the other's.
         let ipv4 = self.remove_family("iptables").await;
         let ipv6 = self.remove_family("ip6tables").await;
         match (ipv4, ipv6) {
@@ -706,6 +1008,15 @@ impl<R: CommandRunner + Sync> FirewallGate for IptablesGate<R> {
                 "IPv4 gate cleanup: {a:#}; IPv6 gate cleanup: {b:#}"
             )),
         }
+    }
+
+    async fn is_closed(&self) -> Result<bool> {
+        // Reads only: safe to overlap regardless of backend.
+        let (ipv4, ipv6) = tokio::join!(
+            self.family_is_closed("iptables", IPV4_LOOPBACK),
+            self.family_is_closed("ip6tables", IPV6_LOOPBACK)
+        );
+        Ok(ipv4? && ipv6?)
     }
 }
 
@@ -725,6 +1036,27 @@ enum DestroyOutcome {
 struct CleanupTally {
     destroyed: usize,
     already_gone: usize,
+}
+
+/// What one restore-side boundary transaction did, surfaced to the restore
+/// orchestrator so the host-visible ACK telemetry can attribute the path
+/// taken (verified fast path versus full re-assert).
+#[derive(Debug, Clone, Copy)]
+pub struct RestoreNetworkReport {
+    /// True when the snapshot's armed boundary verified intact and the
+    /// re-close/link-down/receive-barrier re-assert was skipped.
+    pub verified_armed: bool,
+    /// Milliseconds probing the gate rules and link flags.
+    pub verify_ms: f64,
+    /// Milliseconds re-asserting close/link-down/barrier; zero on the
+    /// verified fast path.
+    pub reassert_ms: f64,
+    /// Milliseconds loading the manifest and retiring its sockets.
+    pub destroy_ms: f64,
+    /// Milliseconds removing the gate, raising the link, and reinstating
+    /// routes.
+    pub reopen_ms: f64,
+    tally: CleanupTally,
 }
 
 /// Total budget for retiring every socket named by the manifest.
@@ -827,20 +1159,8 @@ fn netlink_align(length: usize) -> usize {
 fn open_diag_socket() -> Result<OwnedFd> {
     use std::os::fd::AsRawFd;
 
-    // SAFETY: libc socket arguments are constants from the Linux UAPI.
-    let raw = unsafe {
-        libc::socket(
-            libc::AF_NETLINK,
-            libc::SOCK_RAW | libc::SOCK_CLOEXEC,
-            NETLINK_SOCK_DIAG,
-        )
-    };
-    if raw < 0 {
-        return Err(io::Error::last_os_error())
-            .context("opening NETLINK_SOCK_DIAG socket (guest kernel needs CONFIG_INET_DIAG=y)");
-    }
-    // SAFETY: `raw` is a newly-created owned fd.
-    let fd = unsafe { OwnedFd::from_raw_fd(raw) };
+    let fd = crate::network::open_raw_socket(libc::AF_NETLINK, libc::SOCK_RAW, NETLINK_SOCK_DIAG)
+        .context("opening NETLINK_SOCK_DIAG socket (guest kernel needs CONFIG_INET_DIAG=y)")?;
     let mut address: libc::sockaddr_nl = unsafe { std::mem::zeroed() };
     address.nl_family = libc::AF_NETLINK as u16;
     // SAFETY: address points to a fully initialized sockaddr_nl.
@@ -1304,19 +1624,64 @@ async fn restore_with<
     store: &S,
     route_table: &T,
     budget: std::time::Duration,
-) -> Result<CleanupTally> {
-    // A current snapshot already contains a closed gate and down link.  Repeat
-    // both operations idempotently so a malformed/older snapshot cannot be
-    // published by the cleanup path before its manifest is rejected.
-    gate.close()
-        .await
-        .context("ensuring restored snapshot TCP NEW-flow gate is closed")?;
+) -> Result<RestoreNetworkReport> {
+    // The gate chains are VERIFIED rather than reinstalled; the link-down and
+    // the receive barrier are always re-asserted.
+    //
+    // Verifying the chains is sound because a restored image was captured
+    // behind them and reinstalling identical rules changes nothing: the check
+    // reads what `close()` would have written and skips the write when they
+    // match. That is where the cost was, roughly 25 process spawns.
+    //
+    // The link and the barrier are not verified, because reading them proves
+    // less than asserting them. A `--privileged` workload resumes in this
+    // network namespace holding CAP_NET_ADMIN, so between any observation and
+    // the socket cleanup below it can raise the link itself; the guest-wide
+    // lock this transaction holds excludes other fc-agent transactions, not
+    // the workload. Downing the link and taking a fresh grace period costs no
+    // process spawn (both are direct syscalls) and restores the property the
+    // cleanup depends on: no receive processing is in flight, and none can
+    // start, while the manifest's sockets are retired.
+    //
+    // A workload with CAP_NET_ADMIN can still raise the link again afterwards;
+    // nothing inside the guest can prevent that, and it was equally true
+    // before this fast path existed. What the re-assert guarantees is that the
+    // boundary holds across the cleanup itself.
+    //
+    // Chain verification that FAILS, or that cannot be read at all, falls back
+    // to reinstalling them: a malformed or tampered image cannot publish
+    // early, and a transient probe failure must never become a dead clone the
+    // spawn-free path would have restored.
+    let verify_started = std::time::Instant::now();
+    let verified_armed = match gate.is_closed().await {
+        Ok(verdict) => verdict,
+        Err(error) => {
+            eprintln!(
+                "[fc-agent] WARNING: boundary gate unreadable, reinstalling \
+                 instead: {error:#}"
+            );
+            false
+        }
+    };
+    let verify_ms = verify_started.elapsed().as_secs_f64() * 1000.0;
+    let reassert_started = std::time::Instant::now();
+    if !verified_armed {
+        gate.close()
+            .await
+            .context("ensuring restored snapshot TCP NEW-flow gate is closed")?;
+    }
     link.down()
         .await
-        .context("ensuring the restored external link remains down during socket cleanup")?;
+        .context("ensuring the restored external link is down during socket cleanup")?;
     receive_barrier
         .synchronize()
         .context("waiting for restored packet receive processing to quiesce")?;
+    let reassert_ms = if verified_armed {
+        0.0
+    } else {
+        reassert_started.elapsed().as_secs_f64() * 1000.0
+    };
+    let destroy_started = std::time::Instant::now();
     let manifest = store.load()?;
     let started = std::time::Instant::now();
     let mut tally = CleanupTally::default();
@@ -1346,16 +1711,25 @@ async fn restore_with<
     store
         .remove()
         .context("retiring snapshot network manifest after cookie-bound cleanup")?;
+    let destroy_ms = destroy_started.elapsed().as_secs_f64() * 1000.0;
+    let reopen_started = std::time::Instant::now();
     reopen_with(gate, link, route_table, &manifest.routes)
         .await
         .context("publishing restored network after cookie-bound cleanup")?;
-    Ok(tally)
+    Ok(RestoreNetworkReport {
+        tally,
+        verified_armed,
+        verify_ms,
+        reassert_ms,
+        destroy_ms,
+        reopen_ms: reopen_started.elapsed().as_secs_f64() * 1000.0,
+    })
 }
 
 pub async fn prepare_snapshot_network() -> Result<()> {
     let _transaction_lock = acquire_boundary_lock()?;
     let gate = IptablesGate::new(SystemCommandRunner);
-    let link = IpLink::new(SystemCommandRunner, external_interface()?);
+    let link = IpLink::new(external_interface()?);
     let receive_barrier = SystemPacketReceiveBarrier;
     let mut diagnostic = SystemSocketDiagnostic;
     let route_table = IpRoutes::new(SystemCommandRunner);
@@ -1378,7 +1752,7 @@ pub async fn prepare_snapshot_network() -> Result<()> {
 pub async fn resume_source_network() -> Result<()> {
     let _transaction_lock = acquire_boundary_lock()?;
     let gate = IptablesGate::new(SystemCommandRunner);
-    let link = IpLink::new(SystemCommandRunner, external_interface()?);
+    let link = IpLink::new(external_interface()?);
     let route_table = IpRoutes::new(SystemCommandRunner);
     let store = FileManifestStore::default();
     // Read the routes out before retiring the manifest that holds them: this
@@ -1408,14 +1782,14 @@ pub async fn resume_source_network() -> Result<()> {
     Ok(())
 }
 
-pub async fn restore_snapshot_network() -> Result<()> {
+pub async fn restore_snapshot_network() -> Result<RestoreNetworkReport> {
     let _transaction_lock = acquire_boundary_lock()?;
     let gate = IptablesGate::new(SystemCommandRunner);
-    let link = IpLink::new(SystemCommandRunner, external_interface()?);
+    let link = IpLink::new(external_interface()?);
     let receive_barrier = SystemPacketReceiveBarrier;
     let mut diagnostic = SystemSocketDiagnostic;
     let route_table = IpRoutes::new(SystemCommandRunner);
-    let tally = restore_with(
+    let report = restore_with(
         &gate,
         &link,
         &receive_barrier,
@@ -1427,10 +1801,10 @@ pub async fn restore_snapshot_network() -> Result<()> {
     .await?;
     eprintln!(
         "[fc-agent] snapshot network cleanup complete: destroyed={} already_gone={} \
-         link=up gate=open",
-        tally.destroyed, tally.already_gone
+         verified_armed={} link=up gate=open",
+        report.tally.destroyed, report.tally.already_gone, report.verified_armed
     );
-    Ok(())
+    Ok(report)
 }
 
 /// Whether this process image was captured behind the snapshot network
@@ -1510,6 +1884,7 @@ mod tests {
         events: Vec<&'static str>,
         live: Vec<TcpSocketIdentity>,
         fail_gate_close: bool,
+        fail_gate_verify: bool,
         fail_barrier: bool,
         fail_dump: bool,
         fail_destroy: bool,
@@ -1534,6 +1909,15 @@ mod tests {
             state.gate_closed = false;
             state.events.push("gate-open");
             Ok(())
+        }
+
+        async fn is_closed(&self) -> Result<bool> {
+            let mut state = self.0.lock().unwrap();
+            state.events.push("gate-verify");
+            if state.fail_gate_verify {
+                bail!("injected gate verification read failure");
+            }
+            Ok(state.gate_closed)
         }
     }
 
@@ -1681,6 +2065,24 @@ mod tests {
                 stderr: Vec::new(),
             })
         }
+
+        async fn output_with_input(
+            &self,
+            program: &str,
+            args: &[&str],
+            input: &[u8],
+        ) -> io::Result<std::process::Output> {
+            self.0.lock().unwrap().push(format!(
+                "{program} {} <<< {:?}",
+                args.join(" "),
+                String::from_utf8_lossy(input)
+            ));
+            Ok(std::process::Output {
+                status: std::process::ExitStatus::from_raw(0),
+                stdout: Vec::new(),
+                stderr: Vec::new(),
+            })
+        }
     }
 
     #[tokio::test]
@@ -1702,6 +2104,260 @@ mod tests {
             !calls.contains("10.0.2.") && !calls.contains("fd00:"),
             "gateway exemptions let routed external clients cross the generation boundary:\n{calls}"
         );
+    }
+
+    /// Runner that answers `-S` with a canned dump and records every call.
+    #[derive(Clone)]
+    struct ScriptedRunner {
+        dump: String,
+        calls: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl CommandRunner for ScriptedRunner {
+        async fn output(&self, program: &str, args: &[&str]) -> io::Result<std::process::Output> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("{program} {}", args.join(" ")));
+            let stdout = if args == ["-w", "-S"] {
+                self.dump.clone().into_bytes()
+            } else {
+                Vec::new()
+            };
+            Ok(std::process::Output {
+                status: std::process::ExitStatus::from_raw(0),
+                stdout,
+                stderr: Vec::new(),
+            })
+        }
+
+        async fn output_with_input(
+            &self,
+            program: &str,
+            args: &[&str],
+            input: &[u8],
+        ) -> io::Result<std::process::Output> {
+            self.calls.lock().unwrap().push(format!(
+                "{program} {} <<< {:?}",
+                args.join(" "),
+                String::from_utf8_lossy(input)
+            ));
+            Ok(std::process::Output {
+                status: std::process::ExitStatus::from_raw(0),
+                stdout: Vec::new(),
+                stderr: Vec::new(),
+            })
+        }
+    }
+
+    /// Verbatim `iptables -w -S` output of an armed IPv4 gate, captured on
+    /// iptables v1.8.10 (nf_tables), Ubuntu 24.04 aarch64. Note the renderer
+    /// prints `-s`/`-d` BEFORE `-p tcp`, the reverse of the appended argument
+    /// order; verification must accept the renderer's form.
+    const ARMED_V4_DUMP: &str = "-P INPUT ACCEPT\n\
+        -P FORWARD ACCEPT\n\
+        -P OUTPUT ACCEPT\n\
+        -N FCVM_SNAPSHOT_IN\n\
+        -N FCVM_SNAPSHOT_OUT\n\
+        -A INPUT -j FCVM_SNAPSHOT_IN\n\
+        -A OUTPUT -j FCVM_SNAPSHOT_OUT\n\
+        -A FCVM_SNAPSHOT_IN -s 127.0.0.0/8 -p tcp -j RETURN\n\
+        -A FCVM_SNAPSHOT_IN -p tcp -m conntrack --ctstate NEW -j REJECT --reject-with tcp-reset\n\
+        -A FCVM_SNAPSHOT_IN -j RETURN\n\
+        -A FCVM_SNAPSHOT_OUT -d 127.0.0.0/8 -p tcp -j RETURN\n\
+        -A FCVM_SNAPSHOT_OUT -p tcp -m conntrack --ctstate NEW -j REJECT --reject-with tcp-reset\n\
+        -A FCVM_SNAPSHOT_OUT -j RETURN\n";
+
+    /// Same capture for the IPv6 family (`-d ::1/128 -p tcp -j RETURN` etc.).
+    const ARMED_V6_DUMP: &str = "-P INPUT ACCEPT\n\
+        -P FORWARD ACCEPT\n\
+        -P OUTPUT ACCEPT\n\
+        -N FCVM_SNAPSHOT_IN\n\
+        -N FCVM_SNAPSHOT_OUT\n\
+        -A INPUT -j FCVM_SNAPSHOT_IN\n\
+        -A OUTPUT -j FCVM_SNAPSHOT_OUT\n\
+        -A FCVM_SNAPSHOT_IN -s ::1/128 -p tcp -j RETURN\n\
+        -A FCVM_SNAPSHOT_IN -p tcp -m conntrack --ctstate NEW -j REJECT --reject-with tcp-reset\n\
+        -A FCVM_SNAPSHOT_IN -j RETURN\n\
+        -A FCVM_SNAPSHOT_OUT -d ::1/128 -p tcp -j RETURN\n\
+        -A FCVM_SNAPSHOT_OUT -p tcp -m conntrack --ctstate NEW -j REJECT --reject-with tcp-reset\n\
+        -A FCVM_SNAPSHOT_OUT -j RETURN\n";
+
+    #[test]
+    fn armed_gate_verifies_from_the_live_iptables_rendering() {
+        assert!(family_gate_is_closed(
+            &parse_gate_state(ARMED_V4_DUMP),
+            IPV4_LOOPBACK
+        ));
+        assert!(family_gate_is_closed(
+            &parse_gate_state(ARMED_V6_DUMP),
+            IPV6_LOOPBACK
+        ));
+    }
+
+    #[test]
+    fn any_deviation_from_the_armed_gate_fails_verification() {
+        // Missing hook: the chain exists but nothing routes packets into it.
+        let unhooked = ARMED_V4_DUMP.replace("-A INPUT -j FCVM_SNAPSHOT_IN\n", "");
+        assert!(!family_gate_is_closed(
+            &parse_gate_state(&unhooked),
+            IPV4_LOOPBACK
+        ));
+
+        // A foreign rule inside the gate chain is not our gate.
+        let extra_rule = format!("{ARMED_V4_DUMP}-A FCVM_SNAPSHOT_IN -p udp -j ACCEPT\n");
+        assert!(!family_gate_is_closed(
+            &parse_gate_state(&extra_rule),
+            IPV4_LOOPBACK
+        ));
+
+        // A pristine table has no boundary at all.
+        assert!(!family_gate_is_closed(
+            &parse_gate_state("-P INPUT ACCEPT\n-P FORWARD ACCEPT\n-P OUTPUT ACCEPT\n"),
+            IPV4_LOOPBACK
+        ));
+
+        // The wrong loopback exemption (v6 rules under the v4 expectation)
+        // must not verify.
+        assert!(!family_gate_is_closed(
+            &parse_gate_state(ARMED_V6_DUMP),
+            IPV4_LOOPBACK
+        ));
+    }
+
+    #[test]
+    fn a_rule_ahead_of_the_gate_hook_fails_verification() {
+        // The gate only governs packets that reach it. An ACCEPT sitting
+        // above the jump admits NEW flows the manifest never captured, so a
+        // hook anywhere but position 1 must force the full re-assert path.
+        let shadowed = ARMED_V4_DUMP.replace(
+            "-A INPUT -j FCVM_SNAPSHOT_IN\n",
+            "-A INPUT -p tcp -j ACCEPT\n-A INPUT -j FCVM_SNAPSHOT_IN\n",
+        );
+        assert!(!family_gate_is_closed(
+            &parse_gate_state(&shadowed),
+            IPV4_LOOPBACK
+        ));
+
+        let shadowed_output = ARMED_V4_DUMP.replace(
+            "-A OUTPUT -j FCVM_SNAPSHOT_OUT\n",
+            "-A OUTPUT -p tcp -j ACCEPT\n-A OUTPUT -j FCVM_SNAPSHOT_OUT\n",
+        );
+        assert!(!family_gate_is_closed(
+            &parse_gate_state(&shadowed_output),
+            IPV4_LOOPBACK
+        ));
+    }
+
+    #[test]
+    fn duplicate_hooks_still_verify_as_closed() {
+        // An interrupted close can leave a second jump; the gate verdict for
+        // packets is unchanged, so verification must not force a repair.
+        let doubled = format!("{ARMED_V4_DUMP}-A INPUT -j FCVM_SNAPSHOT_IN\n");
+        assert!(family_gate_is_closed(
+            &parse_gate_state(&doubled),
+            IPV4_LOOPBACK
+        ));
+    }
+
+    #[tokio::test]
+    async fn computed_removal_issues_exactly_the_observed_deletions() {
+        let doubled = format!("{ARMED_V4_DUMP}-A INPUT -j FCVM_SNAPSHOT_IN\n");
+        let runner = ScriptedRunner {
+            dump: doubled,
+            calls: Arc::new(Mutex::new(Vec::new())),
+        };
+        let calls = runner.calls.clone();
+        IptablesGate::new(runner)
+            .remove_family("iptables")
+            .await
+            .unwrap();
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            [
+                "iptables -w -S",
+                "iptables-restore -w --noflush <<< \"*filter\\n\
+-D INPUT -j FCVM_SNAPSHOT_IN\\n\
+-D INPUT -j FCVM_SNAPSHOT_IN\\n\
+-D OUTPUT -j FCVM_SNAPSHOT_OUT\\n\
+-F FCVM_SNAPSHOT_IN\\n\
+-X FCVM_SNAPSHOT_IN\\n\
+-F FCVM_SNAPSHOT_OUT\\n\
+-X FCVM_SNAPSHOT_OUT\\n\
+COMMIT\\n\"",
+            ],
+            "removal must be one computed batch, never a probe or spawn per step"
+        );
+    }
+
+    #[tokio::test]
+    async fn removal_reuses_the_verification_read_in_one_transaction() {
+        let runner = ScriptedRunner {
+            dump: ARMED_V4_DUMP.to_string(),
+            calls: Arc::new(Mutex::new(Vec::new())),
+        };
+        let calls = runner.calls.clone();
+        let gate = IptablesGate::new(runner);
+        assert!(gate
+            .family_is_closed("iptables", IPV4_LOOPBACK)
+            .await
+            .unwrap());
+        gate.remove_family("iptables").await.unwrap();
+        let reads = calls
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|call| call.as_str() == "iptables -w -S")
+            .count();
+        assert_eq!(
+            reads, 1,
+            "verify-then-remove under one lock must spend one state read"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_gate_mutation_invalidates_the_retained_state_read() {
+        let runner = ScriptedRunner {
+            dump: ARMED_V4_DUMP.to_string(),
+            calls: Arc::new(Mutex::new(Vec::new())),
+        };
+        let calls = runner.calls.clone();
+        let gate = IptablesGate::new(runner);
+        assert!(gate
+            .family_is_closed("iptables", IPV4_LOOPBACK)
+            .await
+            .unwrap());
+        // The repair path re-closes after a failed verification; the removal
+        // that follows must observe the post-close state, not the retained
+        // pre-close parse.
+        gate.install_family("iptables", IPV4_LOOPBACK)
+            .await
+            .unwrap();
+        gate.remove_family("iptables").await.unwrap();
+        let reads = calls
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|call| call.as_str() == "iptables -w -S")
+            .count();
+        assert_eq!(
+            reads, 2,
+            "a close between verify and remove must force a fresh read"
+        );
+    }
+
+    #[tokio::test]
+    async fn removal_of_an_absent_gate_is_a_read_and_nothing_else() {
+        let runner = ScriptedRunner {
+            dump: "-P INPUT ACCEPT\n-P FORWARD ACCEPT\n-P OUTPUT ACCEPT\n".to_string(),
+            calls: Arc::new(Mutex::new(Vec::new())),
+        };
+        let calls = runner.calls.clone();
+        IptablesGate::new(runner)
+            .remove_family("iptables")
+            .await
+            .unwrap();
+        assert_eq!(calls.lock().unwrap().as_slice(), ["iptables -w -S"]);
     }
 
     /// Build a `/sys/class/net` where the `backed` interfaces carry the
@@ -1750,19 +2406,16 @@ mod tests {
         assert!(err.contains("enp0s4") && err.contains("eth0"), "{err}");
     }
 
-    #[tokio::test]
-    async fn link_state_changes_address_the_discovered_interface() {
-        let runner = RecordingRunner::default();
-        let calls = runner.0.clone();
-        let link = IpLink::new(runner, "enp0s4".to_string());
-
-        link.down().await.unwrap();
-        link.up().await.unwrap();
-
-        let calls = calls.lock().unwrap().join("\n");
-        assert_eq!(
-            calls, "ip link set dev enp0s4 down\nip link set dev enp0s4 up",
-            "the boundary drove an interface the guest does not have"
+    #[test]
+    fn an_overlong_interface_name_is_refused_rather_than_truncated() {
+        // ifreq's name field is fixed-size; a silently truncated name would
+        // drive the WRONG interface's flags.
+        let too_long = "x".repeat(64);
+        let error = set_interface_up(&too_long, false)
+            .expect_err("an interface name that cannot fit must be refused");
+        assert!(
+            format!("{error:#}").contains("does not fit"),
+            "unexpected diagnostic: {error:#}"
         );
     }
 
@@ -2032,28 +2685,258 @@ mod tests {
         // replacement. A cookie-bound destroy must therefore report
         // already_gone and leave the replacement alone; a tuple-based one would
         // report a destroy and take the wrong socket with it.
+        let report = restore_with(
+            &gate,
+            &link,
+            &barrier,
+            &mut diag,
+            &store,
+            &route_table,
+            CLEANUP_BUDGET,
+        )
+        .await
+        .unwrap();
         assert_eq!(
-            restore_with(
-                &gate,
-                &link,
-                &barrier,
-                &mut diag,
-                &store,
-                &route_table,
-                CLEANUP_BUDGET
-            )
-            .await
-            .unwrap(),
+            report.tally,
             CleanupTally {
                 destroyed: 0,
                 already_gone: 1,
             }
         );
+        assert!(report.verified_armed);
         let state = state.lock().unwrap();
         assert_eq!(state.live, vec![replacement]);
         assert_eq!(
             state.events,
             vec![
+                "gate-verify",
+                "link-down",
+                "rx-barrier",
+                "cookie-destroy",
+                "gate-open",
+                "link-up",
+                "routes-reinstate"
+            ]
+        );
+        assert!(!state.gate_closed);
+        assert!(!state.link_down);
+    }
+
+    /// A gate probe that cannot READ the chains is not a verdict about them:
+    /// it must reinstall, exactly as if verification had failed, never kill
+    /// an otherwise healthy clone. The spawn-free path has no reads to fail,
+    /// so a read error failing the restore would be a new fatality this
+    /// optimization introduced.
+    #[tokio::test]
+    async fn a_failed_verification_read_demotes_to_the_full_reassert() {
+        let stale = socket(28, [198, 51, 100, 8]);
+        let state = Arc::new(Mutex::new(ModelState {
+            gate_closed: true,
+            link_down: true,
+            live: vec![stale],
+            fail_gate_verify: true,
+            ..Default::default()
+        }));
+        let store = MemoryStore::default();
+        store
+            .save(&SnapshotNetworkManifest {
+                version: MANIFEST_VERSION,
+                routes: model_routes(),
+                sockets: vec![stale],
+            })
+            .unwrap();
+        let gate = ModelGate(state.clone());
+        let link = ModelLink(state.clone());
+        let barrier = ModelBarrier(state.clone());
+        let route_table = ModelRoutes(state.clone());
+        let mut diag = ModelDiag(state.clone());
+
+        let report = restore_with(
+            &gate,
+            &link,
+            &barrier,
+            &mut diag,
+            &store,
+            &route_table,
+            CLEANUP_BUDGET,
+        )
+        .await
+        .expect("an unverifiable boundary must repair, not fail the restore");
+        assert!(!report.verified_armed);
+        let state = state.lock().unwrap();
+        assert_eq!(
+            state.events,
+            vec![
+                "gate-verify",
+                "gate-close",
+                "link-down",
+                "rx-barrier",
+                "cookie-destroy",
+                "gate-open",
+                "link-up",
+                "routes-reinstate"
+            ]
+        );
+    }
+
+    /// A raised link is exactly what a privileged workload can produce, and
+    /// packets can arrive on it: the boundary must down it and take a fresh
+    /// grace period before retiring any socket, whatever the gate says.
+    #[tokio::test]
+    async fn a_raised_link_is_downed_and_re_barriered_before_cleanup() {
+        let stale = socket(29, [198, 51, 100, 8]);
+        let state = Arc::new(Mutex::new(ModelState {
+            gate_closed: true,
+            link_down: false,
+            live: vec![stale],
+            ..Default::default()
+        }));
+        let store = MemoryStore::default();
+        store
+            .save(&SnapshotNetworkManifest {
+                version: MANIFEST_VERSION,
+                routes: model_routes(),
+                sockets: vec![stale],
+            })
+            .unwrap();
+        let gate = ModelGate(state.clone());
+        let link = ModelLink(state.clone());
+        let barrier = ModelBarrier(state.clone());
+        let route_table = ModelRoutes(state.clone());
+        let mut diag = ModelDiag(state.clone());
+
+        let report = restore_with(
+            &gate,
+            &link,
+            &barrier,
+            &mut diag,
+            &store,
+            &route_table,
+            CLEANUP_BUDGET,
+        )
+        .await
+        .unwrap();
+        assert!(report.verified_armed, "the gate itself was intact");
+        let events = state.lock().unwrap().events.clone();
+        let barrier = events
+            .iter()
+            .position(|e| *e == "rx-barrier")
+            .expect("barrier");
+        let down = events
+            .iter()
+            .position(|e| *e == "link-down")
+            .expect("link-down");
+        let destroy = events
+            .iter()
+            .position(|e| *e == "cookie-destroy")
+            .expect("cleanup");
+        assert!(
+            down < barrier && barrier < destroy,
+            "a raised link must be downed and re-barriered BEFORE cleanup: {events:?}"
+        );
+    }
+
+    /// The gate chains frozen into a current snapshot are verified, not
+    /// reinstalled. The link-down and the receive barrier are asserted
+    /// regardless, because a privileged workload sharing this namespace can
+    /// raise the link between any observation and the cleanup.
+    #[tokio::test]
+    async fn restore_verifies_the_armed_boundary_instead_of_reasserting_it() {
+        let stale = socket(26, [198, 51, 100, 8]);
+        let state = Arc::new(Mutex::new(ModelState {
+            gate_closed: true,
+            link_down: true,
+            live: vec![stale],
+            ..Default::default()
+        }));
+        let store = MemoryStore::default();
+        store
+            .save(&SnapshotNetworkManifest {
+                version: MANIFEST_VERSION,
+                routes: model_routes(),
+                sockets: vec![stale],
+            })
+            .unwrap();
+        let gate = ModelGate(state.clone());
+        let link = ModelLink(state.clone());
+        let barrier = ModelBarrier(state.clone());
+        let route_table = ModelRoutes(state.clone());
+        let mut diag = ModelDiag(state.clone());
+
+        let report = restore_with(
+            &gate,
+            &link,
+            &barrier,
+            &mut diag,
+            &store,
+            &route_table,
+            CLEANUP_BUDGET,
+        )
+        .await
+        .unwrap();
+        assert!(report.verified_armed);
+        let state = state.lock().unwrap();
+        assert!(
+            !state.events.contains(&"gate-close"),
+            "a verified gate was reinstalled: {:?}",
+            state.events
+        );
+        assert_eq!(
+            state.events,
+            vec![
+                "gate-verify",
+                "link-down",
+                "rx-barrier",
+                "cookie-destroy",
+                "gate-open",
+                "link-up",
+                "routes-reinstate"
+            ],
+            "the link and the barrier must be re-asserted even on the fast path"
+        );
+    }
+
+    /// A snapshot whose boundary does not verify (here: gate open and link up
+    /// under a live manifest) must get the full re-assert, receive barrier
+    /// included, before any socket is touched.
+    #[tokio::test]
+    async fn restore_repairs_an_unverified_boundary_before_cleanup() {
+        let stale = socket(27, [198, 51, 100, 8]);
+        let state = Arc::new(Mutex::new(ModelState {
+            live: vec![stale],
+            ..Default::default()
+        }));
+        let store = MemoryStore::default();
+        store
+            .save(&SnapshotNetworkManifest {
+                version: MANIFEST_VERSION,
+                routes: model_routes(),
+                sockets: vec![stale],
+            })
+            .unwrap();
+        let gate = ModelGate(state.clone());
+        let link = ModelLink(state.clone());
+        let barrier = ModelBarrier(state.clone());
+        let route_table = ModelRoutes(state.clone());
+        let mut diag = ModelDiag(state.clone());
+
+        let report = restore_with(
+            &gate,
+            &link,
+            &barrier,
+            &mut diag,
+            &store,
+            &route_table,
+            CLEANUP_BUDGET,
+        )
+        .await
+        .unwrap();
+        assert!(!report.verified_armed);
+        let state = state.lock().unwrap();
+        assert_eq!(
+            state.events,
+            vec![
+                "gate-verify",
                 "gate-close",
                 "link-down",
                 "rx-barrier",
@@ -2106,7 +2989,7 @@ mod tests {
         let state = state.lock().unwrap();
         assert_eq!(
             state.events,
-            vec!["gate-close", "link-down", "rx-barrier", "cookie-destroy"]
+            vec!["gate-verify", "link-down", "rx-barrier", "cookie-destroy"]
         );
         assert!(state.gate_closed, "failed restore published ingress");
         assert!(state.link_down, "failed restore raised the external link");
@@ -2158,7 +3041,7 @@ mod tests {
         let state = state.lock().unwrap();
         assert_eq!(
             state.events,
-            vec!["gate-close", "link-down", "rx-barrier", "cookie-destroy"]
+            vec!["gate-verify", "link-down", "rx-barrier", "cookie-destroy"]
         );
         assert!(state.gate_closed);
         assert!(state.link_down);
@@ -2209,7 +3092,7 @@ mod tests {
         );
 
         let state = state.lock().unwrap();
-        assert_eq!(state.events, vec!["gate-close", "link-down", "rx-barrier"]);
+        assert_eq!(state.events, vec!["gate-verify", "link-down", "rx-barrier"]);
         assert!(state.gate_closed, "a timed-out cleanup published ingress");
         assert!(
             state.link_down,

--- a/fc-agent/src/system.rs
+++ b/fc-agent/src/system.rs
@@ -198,9 +198,20 @@ fn vmm_wants_acpi_shutdown() -> bool {
         .unwrap_or(false)
 }
 
+/// How long shutdown waits for a restore's background jobs to finish.
+/// Long enough for an ordinary systemd job, short enough that a wedged
+/// service manager cannot hold the VM open for the caller's whole deadline.
+const RESTORE_JOB_SETTLE_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Shutdown the VM. This function never returns.
 pub async fn shutdown_vm(exit_code: i32) -> ! {
     eprintln!("[fc-agent] shutting down VM (exit_code={})", exit_code);
+
+    // Settle the background jobs a restore started (journald restart, chrony
+    // makestep) before asking systemd to power the machine off. A container
+    // that exits within a few hundred milliseconds of readiness
+    // (`podman run ... true`) reaches here while they can still be in flight.
+    crate::restore::settle_restore_side_jobs(RESTORE_JOB_SETTLE_TIMEOUT).await;
 
     if let Ok(mounts) = std::fs::read_to_string("/proc/mounts") {
         let fuse_mounts: Vec<&str> = mounts.lines().filter(|l| l.contains("fuse")).collect();

--- a/fc-agent/src/vsock.rs
+++ b/fc-agent/src/vsock.rs
@@ -358,8 +358,15 @@ pub fn send_status(message: &[u8]) -> bool {
 /// This deliberately uses its own connection rather than the output or status
 /// transports: the host binds the matching one-shot listener before resume, and
 /// treats any missing/malformed/wrong-generation frame as a restore failure.
-pub async fn notify_restore_complete(restore_epoch: &str) -> Result<()> {
-    /// Deadline for writing the (tiny) ACK frame to a host that has already
+///
+/// `telemetry` rides after the epoch, separated by one space: the per-phase
+/// restore timings as compact JSON. The host logs it verbatim so every clone's
+/// restore critical path is attributed without guest console capture. It is
+/// telemetry, never identity; the host validates only the epoch, and
+/// [`exec_proto::restore_complete_frame`] drops telemetry that would overflow
+/// the shared frame budget so advisory data can never cost the clone its ACK.
+pub async fn notify_restore_complete(restore_epoch: &str, telemetry: &str) -> Result<()> {
+    /// Deadline for writing the (small) ACK frame to a host that has already
     /// accepted the connection.
     const RESTORE_COMPLETE_ACK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
@@ -368,12 +375,12 @@ pub async fn notify_restore_complete(restore_epoch: &str) -> Result<()> {
             "restore-completion ACK failed (phase=connect expected_epoch={restore_epoch} observed_epoch=<none>)"
         )
     })?;
-    let frame = format!("restore-complete:{restore_epoch}\n");
+    let frame = exec_proto::restore_complete_frame(restore_epoch, telemetry);
     // Bounded: a host that accepts and then stops reading (or a wedged
     // transport) would otherwise block this write forever, leaving the clone
     // alive, unpublished and silent. The caller treats an ACK error as fatal
     // and shuts the clone down, so a deadline converts a silent hang into a
-    // diagnosable failure. The frame is a few dozen bytes.
+    // diagnosable failure. The frame is a few hundred bytes at most.
     tokio::time::timeout(
         RESTORE_COMPLETE_ACK_TIMEOUT,
         stream.write_all(frame.as_bytes()),

--- a/src/commands/podman/listeners.rs
+++ b/src/commands/podman/listeners.rs
@@ -16,8 +16,13 @@ use super::types::{CacheRequest, CacheVerdict, LogLine, SharedCacheVerdict};
 /// releases the connection instead of holding it for the process's lifetime.
 const CACHE_ACK_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
-const RESTORE_COMPLETION_PREFIX: &str = "restore-complete:";
-const RESTORE_COMPLETION_MAX_FRAME_BYTES: usize = 128;
+// The frame shape and budget live in exec-proto, shared with the fc-agent
+// producer, so the two binaries cannot drift: the producer drops telemetry
+// that would overflow the budget this consumer enforces.
+use exec_proto::{
+    RESTORE_COMPLETE_MAX_FRAME_BYTES as RESTORE_COMPLETION_MAX_FRAME_BYTES,
+    RESTORE_COMPLETE_PREFIX as RESTORE_COMPLETION_PREFIX,
+};
 const RESTORE_COMPLETION_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Listen for fc-agent status messages on the status vsock port.
@@ -449,6 +454,10 @@ async fn serve_bootplan(listener: tokio::net::UnixListener, payload: Vec<u8>) {
     }
 }
 
+/// Resolves once with the validated ACK's outcome: the guest's optional
+/// phase-timing telemetry on success, the protocol failure otherwise.
+pub(crate) type RestoreCompletionReceiver = tokio::sync::oneshot::Receiver<Result<Option<String>>>;
+
 /// Bind the one-shot restored-guest completion listener before the VMM resumes.
 ///
 /// The output, TTY, and exec sockets are workload transports, not proof that the
@@ -459,10 +468,7 @@ async fn serve_bootplan(listener: tokio::net::UnixListener, payload: Vec<u8>) {
 pub(crate) fn spawn_restore_completion_listener(
     socket_path: &str,
     expected_epoch: &str,
-) -> Result<(
-    tokio::task::JoinHandle<()>,
-    tokio::sync::oneshot::Receiver<Result<()>>,
-)> {
+) -> Result<(tokio::task::JoinHandle<()>, RestoreCompletionReceiver)> {
     use tokio::net::UnixListener;
 
     let _ = std::fs::remove_file(socket_path);
@@ -494,7 +500,7 @@ pub(crate) fn spawn_restore_completion_listener(
 async fn receive_restore_completion(
     listener: tokio::net::UnixListener,
     expected_epoch: &str,
-) -> Result<()> {
+) -> Result<Option<String>> {
     use tokio::io::{AsyncBufReadExt, AsyncReadExt};
 
     let (stream, _) = listener.accept().await.with_context(|| {
@@ -528,7 +534,13 @@ async fn receive_restore_completion(
     validate_restore_completion_frame(&frame, expected_epoch)
 }
 
-fn validate_restore_completion_frame(frame: &[u8], expected_epoch: &str) -> Result<()> {
+/// Validate one ACK frame against the expected restore generation.
+///
+/// Frame shape: `restore-complete:<epoch>[ <telemetry>]\n`. Only the epoch is
+/// identity; everything after the first space is the guest's phase-timing
+/// telemetry, returned for logging and never interpreted. An agent that sends
+/// no telemetry (the frame ends at the epoch) is fully valid.
+fn validate_restore_completion_frame(frame: &[u8], expected_epoch: &str) -> Result<Option<String>> {
     if frame.len() > RESTORE_COMPLETION_MAX_FRAME_BYTES {
         anyhow::bail!(
             "restore-completion protocol failed (phase=validate-frame expected_epoch={expected_epoch} observed_epoch=<oversized> bytes={})",
@@ -541,7 +553,7 @@ fn validate_restore_completion_frame(frame: &[u8], expected_epoch: &str) -> Resu
             "restore-completion protocol failed (phase=validate-frame expected_epoch={expected_epoch} observed_epoch=<invalid-utf8>): {error}"
         )
     })?;
-    let observed_epoch = message
+    let payload = message
         .strip_prefix(RESTORE_COMPLETION_PREFIX)
         .and_then(|value| value.strip_suffix('\n'))
         .filter(|value| !value.is_empty() && !value.contains('\n'))
@@ -550,11 +562,22 @@ fn validate_restore_completion_frame(frame: &[u8], expected_epoch: &str) -> Resu
                 "restore-completion protocol failed (phase=validate-frame expected_epoch={expected_epoch} observed_epoch=<malformed> frame={message:?})"
             )
         })?;
+    let (observed_epoch, telemetry) = match payload.split_once(' ') {
+        Some((epoch, telemetry)) => (
+            epoch,
+            (!telemetry.is_empty()).then(|| telemetry.to_string()),
+        ),
+        None => (payload, None),
+    };
+    anyhow::ensure!(
+        !observed_epoch.is_empty(),
+        "restore-completion protocol failed (phase=validate-frame expected_epoch={expected_epoch} observed_epoch=<malformed> frame={message:?})"
+    );
     anyhow::ensure!(
         observed_epoch == expected_epoch,
         "restore-completion protocol rejected generation (phase=validate-epoch expected_epoch={expected_epoch} observed_epoch={observed_epoch})"
     );
-    Ok(())
+    Ok(telemetry)
 }
 
 /// Bidirectional I/O listener for container stdin/stdout/stderr.
@@ -776,6 +799,62 @@ mod tests {
         );
     }
 
+    #[test]
+    fn restore_completion_accepts_a_bare_epoch_without_telemetry() {
+        let telemetry = validate_restore_completion_frame(b"restore-complete:epoch-1\n", "epoch-1")
+            .expect("a bare-epoch frame is fully valid");
+        assert_eq!(telemetry, None);
+    }
+
+    #[test]
+    fn restore_completion_returns_phase_telemetry_after_the_epoch() {
+        let telemetry = validate_restore_completion_frame(
+            b"restore-complete:epoch-1 {\"tcp_cleanup_ms\":12.5,\"total_ms\":40.2}\n",
+            "epoch-1",
+        )
+        .expect("telemetry after the epoch must not fail validation");
+        assert_eq!(
+            telemetry.as_deref(),
+            Some("{\"tcp_cleanup_ms\":12.5,\"total_ms\":40.2}")
+        );
+    }
+
+    #[test]
+    fn every_producer_frame_passes_the_consumer_including_the_overflow_clamp() {
+        // The producer and this parser share exec-proto's budget; a frame the
+        // guest can build must never fail the host on size. The oversized
+        // case exercises the producer's drop-to-{} clamp end to end.
+        for telemetry in ["", "{\"total_ms\":40.2}", &"x".repeat(4096)] {
+            let frame = exec_proto::restore_complete_frame("epoch-1", telemetry);
+            validate_restore_completion_frame(frame.as_bytes(), "epoch-1")
+                .expect("a producer-built frame must always validate");
+        }
+    }
+
+    #[test]
+    fn restore_completion_validates_only_the_epoch_ahead_of_telemetry() {
+        // Telemetry is never identity: a wrong epoch fails no matter what
+        // rides behind it, and telemetry content is returned verbatim, not
+        // parsed.
+        let error = validate_restore_completion_frame(
+            b"restore-complete:stale-generation {\"total_ms\":1.0}\n",
+            "expected-generation",
+        )
+        .expect_err("telemetry must not rescue a stale generation");
+        assert!(
+            format!("{error:#}").contains("observed_epoch=stale-generation"),
+            "unexpected diagnostic: {error:#}"
+        );
+
+        // A frame that is all telemetry and no epoch is malformed.
+        let error = validate_restore_completion_frame(b"restore-complete: {}\n", "epoch-1")
+            .expect_err("an empty epoch must fail closed");
+        assert!(
+            format!("{error:#}").contains("<malformed>"),
+            "unexpected diagnostic: {error:#}"
+        );
+    }
+
     /// Verify that writeln! to a broken pipe doesn't panic (returns Err),
     /// while println! would panic with "failed printing to stdout".
     #[test]
@@ -783,13 +862,21 @@ mod tests {
         use std::io::Write;
         use std::os::unix::io::FromRawFd;
 
-        let (read_fd, write_fd) = nix::unistd::pipe().unwrap();
+        // O_CLOEXEC, and a bounded retry below: a sibling test thread can
+        // fork between pipe() and drop(), and until that child execs it holds
+        // a copy of the read end, so the very first write may not see EPIPE.
+        let (read_fd, write_fd) = nix::unistd::pipe2(nix::fcntl::OFlag::O_CLOEXEC).unwrap();
         drop(read_fd);
 
         let mut writer = unsafe {
             std::fs::File::from_raw_fd(std::os::unix::io::IntoRawFd::into_raw_fd(write_fd))
         };
-        let result = writeln!(writer, "test output");
+        let mut result = writeln!(writer, "test output");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while result.is_ok() && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            result = writeln!(writer, "test output");
+        }
 
         assert!(result.is_err(), "writeln! should return Err on broken pipe");
         assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::BrokenPipe);

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -27,7 +27,7 @@ pub use image::export_image_archive;
 
 pub(crate) use listeners::{
     run_output_listener, run_status_listener, spawn_bootplan_listener,
-    spawn_restore_completion_listener,
+    spawn_restore_completion_listener, RestoreCompletionReceiver,
 };
 
 use snapshot::{build_firecracker_config, snapshot_run_firecracker_overrides};

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -27,7 +27,10 @@ use super::common::{
     MemoryBackend, RestoreParams, RuntimeConfig, SnapshotRestoreConfig, VSOCK_OUTPUT_PORT,
     VSOCK_RESTORE_COMPLETE_PORT, VSOCK_STATUS_PORT, VSOCK_TTY_PORT,
 };
-use super::podman::{run_output_listener, run_status_listener, spawn_restore_completion_listener};
+use super::podman::{
+    run_output_listener, run_status_listener, spawn_restore_completion_listener,
+    RestoreCompletionReceiver,
+};
 
 const SNAPSHOT_LINEAGE_RETRY_LIMIT: usize = 64;
 // Restore work can legitimately take minutes on a CPU-starved guest, but a live
@@ -66,7 +69,7 @@ struct CloneSetupResources {
     status_handle: Option<tokio::task::JoinHandle<()>>,
     bootplan_handle: Option<tokio::task::JoinHandle<()>>,
     restore_completion_handle: Option<tokio::task::JoinHandle<()>>,
-    restore_completion_rx: Option<tokio::sync::oneshot::Receiver<Result<()>>>,
+    restore_completion_rx: Option<RestoreCompletionReceiver>,
 }
 
 impl CloneSetupResources {
@@ -386,7 +389,7 @@ where
 async fn wait_for_restore_completion<F>(
     vm_id: &str,
     expected_epoch: &str,
-    completion_rx: &mut tokio::sync::oneshot::Receiver<Result<()>>,
+    completion_rx: &mut RestoreCompletionReceiver,
     cancel: &tokio_util::sync::CancellationToken,
     timeout: Duration,
     liveness_interval: &mut tokio::time::Interval,
@@ -401,10 +404,14 @@ where
         tokio::select! {
             result = &mut *completion_rx => {
                 match result {
-                    Ok(Ok(())) => {
+                    Ok(Ok(guest_phases)) => {
+                        // guest_phases is the agent's per-phase restore timing
+                        // telemetry (compact JSON), the only host-visible
+                        // attribution of the guest's ACK critical path.
                         info!(
                             vm_id = %vm_id,
                             restore_epoch = %expected_epoch,
+                            guest_phases = %guest_phases.as_deref().unwrap_or("<none>"),
                             "fc-agent acknowledged exact restore generation"
                         );
                         return Ok(true);
@@ -3637,7 +3644,7 @@ mod tests {
 
     #[tokio::test]
     async fn restore_completion_timeout_fails_with_generation_and_phase() {
-        let (_sender, mut receiver) = tokio::sync::oneshot::channel::<Result<()>>();
+        let (_sender, mut receiver) = tokio::sync::oneshot::channel::<Result<Option<String>>>();
         let cancel = tokio_util::sync::CancellationToken::new();
         let mut liveness = tokio::time::interval_at(
             tokio::time::Instant::now() + Duration::from_secs(60),
@@ -3673,7 +3680,7 @@ mod tests {
     }
 
     async fn assert_restore_consumer_waits_for_ack(consumer: &'static str) {
-        let (sender, mut receiver) = tokio::sync::oneshot::channel::<Result<()>>();
+        let (sender, mut receiver) = tokio::sync::oneshot::channel::<Result<Option<String>>>();
         let cancel = tokio_util::sync::CancellationToken::new();
         let published = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let published_after_ack = published.clone();
@@ -3713,7 +3720,7 @@ mod tests {
             "{consumer} ran before the exact restore ACK"
         );
         sender
-            .send(Ok(()))
+            .send(Ok(None))
             .expect("consumer must retain the restore ACK receiver");
         waiter.await.expect("consumer task panicked");
         assert!(


### PR DESCRIPTION
Cuts the guest snapshot-restore ACK critical path from ~643ms to ~129ms p50, and makes every restore self-attributing.

## The problem

Per-request profiling of the chromium request bench put ~643ms of every 1.16s request between the host's restore signal and fc-agent's restore ACK, while the guest was demonstrably alive 15ms after the signal (egress proxy reconnect). The gap was ~53 sequential process spawns (iptables probe loops, `ip route`, `date`, `arping`, `chronyc`), a redundant metadata re-fetch, a synchronous journald restart, and an unconditional receive-barrier RCU grace period — none of it required by the readiness contract.

## What changed

- **Verify the armed TCP boundary instead of re-asserting it.** Prepare saves the manifest only after gate-close + link-down + receive barrier, and the snapshot freezes that state. Restore now proves it still holds (one `iptables -S` per family + a sysfs link-flags read) and skips the ~25-spawn re-close and the fresh barrier. Verification requires the gate hook to be the FIRST rule of INPUT/OUTPUT (a hook shadowed by an earlier rule is not a closed gate — reviewer catch, regression-tested). Any verification failure, including a probe READ error, demotes to the full old re-assert, barrier included: fail-closed is unchanged, and a transient probe failure can never kill a clone the old path would have restored (watched that test fail before the fix).
- **One batch per family for gate removal and route reinstatement.** The first measured round showed the boundary still spending ~407ms with the fast path verified: on a cold clone every spawn faults its pages back through the memory backend (~20ms each). The whole removal is now one `iptables-restore --noflush` per family, computed from the verification's own state read (reused within the locked transaction), and routes reinstate via one `ip -batch` per family. Explicit `-D`/`-F`/`-X` restore input was verified live against the guest's iptables v1.8.10 nf_tables build before relying on it. Family mutations stay sequential (an iptables-nft EAGAIN under concurrent commits would kill the clone for one spawn of savings).
- **Clock via `clock_settime(2)`** from the `host_time` the epoch watcher already fetched (1s resolution, same freshness); `chronyc makestep` and the journald restart run in the background, off the ACK path.
- **Native gateway ARP** over AF_PACKET, byte-parity with arping's frame (pinned literally in a test), no reply wait — the old code never gated readiness on the reply, and the wait could stall a full second.
- **Exec rebind requested first, then awaited together with the egress reconnect** (`try_join`), so the ACK owes the slower of the two, not their sum, and both overlap the boundary work.
- **Per-phase telemetry rides the ACK frame** (`restore-complete:<epoch> {json}`, including boundary sub-phases) and the host logs it on the existing "fc-agent acknowledged exact restore generation" line — every clone's restore is attributed without guest console capture. Frame shape and the 1024-byte budget live in `exec-proto`, shared by both binaries; the producer drops over-budget telemetry rather than truncating, so advisory data can never cost a healthy clone its ACK (cross-binary round-trip test included).

Reviewed adversarially before opening (codex/GPT-5.6, the /simplify pass, and an independent second-model reviewer): 26 findings worked, 23 fixed, 3 refuted with evidence.

## Test evidence

```
$ cargo test -p fc-agent           # 104 passed (boundary model/parse, ARP frame, route parse)
$ cargo test -p exec-proto         # 12 passed (incl. overflow clamp)
$ cargo test -p fcvm --lib -- restore_completion producer_frame   # 6 passed
```
`iptables -S` renderings, the sysfs flags format, and `iptables-restore`'s acceptance of explicit removal lines were all captured/verified live on the Graviton box (Ubuntu 24.04, iptables v1.8.10 nf_tables) before the code relied on them.

**End-to-end proof** (200 reps per arm per backend, gates passed, `n_failed=0`, fast path verified on all 1,624 restores): guest ACK gap 643→129.5ms p50 / 152.2 p95 (uffd), 115/141 (file); request p50 down 44–61% per arm. Full tables and per-phase attribution: see the results comment below.

**Stacked on:** ci-fixes (PR #803)

## Post-review fix: a restore's background jobs can no longer race VM shutdown

The first CI round caught a real defect this change introduced, and the control is clean: **#803 (this stack minus this commit) passes `Host-Root-x64-SnapshotEnabled`; #804 with it failed that job**, on `test_udp_publish_does_not_collide_with_forward_localhost` — a snapshot-restored clone whose container is `true`. The host saw the restore ACK at 80ms, the container exit 452ms later, and then fcvm never exited.

Moving the journald restart (and `chronyc makestep`) off the ACK path made them able to outlive the container: a container that exits within a few hundred milliseconds of readiness reaches VM shutdown while a systemd job this agent started is still in flight, and the guest then asks systemd to power off mid-restart of one of its own units. The codebase already had the answer for exactly this shape — `agent::run` settles the chronyd setup task with a bounded wait before shutting down — so restore's side-jobs now get the same treatment: registered when spawned, settled with one 5s budget for the whole set at the top of `shutdown_vm`. A wedged job costs 5s once, never the caller's whole deadline, and never multiplies by job count.

Red-green: the settle tests fail (by name) against a detached spawn and pass with the registry. Verified on real VMs: 24 concurrent snapshot-restored clones that exit immediately, all cache hits, 24/24 clean, zero timeouts.
