### PR TITLE
Pass the host's containers config through the isolated test XDG_CONFIG_HOME

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,9 +439,6 @@ jobs:
           fi
           echo ""
           sudo chmod 666 /dev/kvm
-          # The AMI can bake a contaminated default rootless store (live builder
-          # snapshot, 8a9c564f); CI never legitimately uses it, so remove it.
-          ./fcvm/scripts/runner-podman-hygiene.sh
           sudo mkdir -p /var/run/netns
           if [ ! -e /dev/userfaultfd ]; then
             sudo mknod /dev/userfaultfd c 10 126
@@ -471,6 +468,13 @@ jobs:
           printf '[storage]\ndriver = "overlay"\ngraphroot = "/mnt/fcvm-btrfs/containers/storage"\n' > ~/.config/containers/storage.conf
           # Reset podman state if corrupted from previous runs
           podman system migrate || true
+          # The AMI can bake a contaminated default rootless store (live builder
+          # snapshot, 8a9c564f). Runs AFTER the config writes above so podman's
+          # own `system reset` tears db+stores down against the FINAL storage
+          # layout — placed earlier, it left the bolt db referencing paths that
+          # no longer matched ("database static dir ... does not match", podman
+          # exit 125 before any test ran, 2026-08-13).
+          ./fcvm/scripts/runner-podman-hygiene.sh
       - name: Create test log directory
         run: sudo rm -rf /tmp/fcvm-test-logs && mkdir -p /tmp/fcvm-test-logs
       - name: Clean test data
@@ -492,9 +496,6 @@ jobs:
       - name: Refresh KVM permissions
         run: |
           sudo chmod 666 /dev/kvm
-          # The AMI can bake a contaminated default rootless store (live builder
-          # snapshot, 8a9c564f); CI never legitimately uses it, so remove it.
-          ./fcvm/scripts/runner-podman-hygiene.sh
       # #61: provision the optional Cloud Hypervisor backend so the
       # --hypervisor cloud-hypervisor sanity tests run (instead of skipping).
       # Built from the [cloud_hypervisor] fork (SVE register fix, CH #8268) and
@@ -660,9 +661,6 @@ jobs:
       - name: Setup KVM and networking
         run: |
           sudo chmod 666 /dev/kvm
-          # The AMI can bake a contaminated default rootless store (live builder
-          # snapshot, 8a9c564f); CI never legitimately uses it, so remove it.
-          ./fcvm/scripts/runner-podman-hygiene.sh
           sudo mkdir -p /var/run/netns
           if [ ! -e /dev/userfaultfd ]; then
             sudo mknod /dev/userfaultfd c 10 126
@@ -690,6 +688,13 @@ jobs:
           mkdir -p ~/.config/containers
           printf '[storage]\ndriver = "overlay"\ngraphroot = "/mnt/fcvm-btrfs/containers/storage"\n' > ~/.config/containers/storage.conf
           podman system migrate || true
+          # The AMI can bake a contaminated default rootless store (live builder
+          # snapshot, 8a9c564f). Runs AFTER the config writes above so podman's
+          # own `system reset` tears db+stores down against the FINAL storage
+          # layout — placed earlier, it left the bolt db referencing paths that
+          # no longer matched ("database static dir ... does not match", podman
+          # exit 125 before any test ran, 2026-08-13).
+          ./fcvm/scripts/runner-podman-hygiene.sh
           # Install iperf3 for network benchmarks
           sudo apt-get update && sudo apt-get install -y iperf3 || true
       - name: Create test log directory
@@ -715,9 +720,6 @@ jobs:
       - name: Refresh KVM permissions
         run: |
           sudo chmod 666 /dev/kvm
-          # The AMI can bake a contaminated default rootless store (live builder
-          # snapshot, 8a9c564f); CI never legitimately uses it, so remove it.
-          ./fcvm/scripts/runner-podman-hygiene.sh
       - name: Allocate hugepages
         run: |
           echo 512 | sudo tee /proc/sys/vm/nr_hugepages
@@ -837,9 +839,6 @@ jobs:
       - name: Setup KVM and rootless podman
         run: |
           sudo chmod 666 /dev/kvm
-          # The AMI can bake a contaminated default rootless store (live builder
-          # snapshot, 8a9c564f); CI never legitimately uses it, so remove it.
-          ./fcvm/scripts/runner-podman-hygiene.sh
           # Enable userfaultfd syscall for snapshot cloning
           sudo sysctl -w vm.unprivileged_userfaultfd=1
           # Disable AppArmor restriction on unprivileged user namespaces (needed for rootless networking on newer Ubuntu)
@@ -863,6 +862,13 @@ jobs:
           printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n' > ~/.config/containers/containers.conf
           # Reset podman state if corrupted from previous runs
           podman system migrate || true
+          # The AMI can bake a contaminated default rootless store (live builder
+          # snapshot, 8a9c564f). Runs AFTER the config writes above so podman's
+          # own `system reset` tears db+stores down against the FINAL storage
+          # layout — placed earlier, it left the bolt db referencing paths that
+          # no longer matched ("database static dir ... does not match", podman
+          # exit 125 before any test ran, 2026-08-13).
+          ./fcvm/scripts/runner-podman-hygiene.sh
           # Create cargo cache directory for container
           mkdir -p ${{ github.workspace }}/cargo-cache/registry ${{ github.workspace }}/cargo-cache/target
       - name: Login to ghcr.io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,6 +439,9 @@ jobs:
           fi
           echo ""
           sudo chmod 666 /dev/kvm
+          # The AMI can bake a contaminated default rootless store (live builder
+          # snapshot, 8a9c564f); CI never legitimately uses it, so remove it.
+          ./fcvm/scripts/runner-podman-hygiene.sh
           sudo mkdir -p /var/run/netns
           if [ ! -e /dev/userfaultfd ]; then
             sudo mknod /dev/userfaultfd c 10 126
@@ -487,7 +490,11 @@ jobs:
           # Build btrfs kernel locally (needed for test_localhost_rootless tests)
           sudo ./target/release/fcvm setup --kernel-profile btrfs --build-kernels
       - name: Refresh KVM permissions
-        run: sudo chmod 666 /dev/kvm
+        run: |
+          sudo chmod 666 /dev/kvm
+          # The AMI can bake a contaminated default rootless store (live builder
+          # snapshot, 8a9c564f); CI never legitimately uses it, so remove it.
+          ./fcvm/scripts/runner-podman-hygiene.sh
       # #61: provision the optional Cloud Hypervisor backend so the
       # --hypervisor cloud-hypervisor sanity tests run (instead of skipping).
       # Built from the [cloud_hypervisor] fork (SVE register fix, CH #8268) and
@@ -653,6 +660,9 @@ jobs:
       - name: Setup KVM and networking
         run: |
           sudo chmod 666 /dev/kvm
+          # The AMI can bake a contaminated default rootless store (live builder
+          # snapshot, 8a9c564f); CI never legitimately uses it, so remove it.
+          ./fcvm/scripts/runner-podman-hygiene.sh
           sudo mkdir -p /var/run/netns
           if [ ! -e /dev/userfaultfd ]; then
             sudo mknod /dev/userfaultfd c 10 126
@@ -703,7 +713,11 @@ jobs:
           # Build btrfs kernel locally (needed for test_localhost_rootless tests)
           sudo ./target/release/fcvm setup --kernel-profile btrfs --build-kernels
       - name: Refresh KVM permissions
-        run: sudo chmod 666 /dev/kvm
+        run: |
+          sudo chmod 666 /dev/kvm
+          # The AMI can bake a contaminated default rootless store (live builder
+          # snapshot, 8a9c564f); CI never legitimately uses it, so remove it.
+          ./fcvm/scripts/runner-podman-hygiene.sh
       - name: Allocate hugepages
         run: |
           echo 512 | sudo tee /proc/sys/vm/nr_hugepages
@@ -823,6 +837,9 @@ jobs:
       - name: Setup KVM and rootless podman
         run: |
           sudo chmod 666 /dev/kvm
+          # The AMI can bake a contaminated default rootless store (live builder
+          # snapshot, 8a9c564f); CI never legitimately uses it, so remove it.
+          ./fcvm/scripts/runner-podman-hygiene.sh
           # Enable userfaultfd syscall for snapshot cloning
           sudo sysctl -w vm.unprivileged_userfaultfd=1
           # Disable AppArmor restriction on unprivileged user namespaces (needed for rootless networking on newer Ubuntu)

--- a/scripts/root-test-runner.sh
+++ b/scripts/root-test-runner.sh
@@ -26,12 +26,16 @@
 # so it holds in the case that leaked here — a SIGKILL where no userspace cleanup,
 # Drop impl or signal handler gets to run.
 
-# Host test recipes provide a unique absolute XDG_CONFIG_HOME containing the
-# current worktree's embedded config. sudo also sets SUDO_USER, and fcvm normally
-# gives that user's ~/.config precedence over XDG; remove only that lookup hint
-# for hermetic test runs so another worktree cannot replace the config between
-# setup and VM launch. Normal invocations without XDG_CONFIG_HOME are unchanged.
-if [ -n "${XDG_CONFIG_HOME:-}" ]; then
+# Host test recipes provide a unique absolute FCVM_CONFIG_DIR containing the
+# current worktree's embedded config (previously signalled via XDG_CONFIG_HOME;
+# both are honoured so an older wrapper still gets hermetic behaviour). sudo
+# also sets SUDO_USER, and fcvm gives that user's config precedence when it is
+# set; remove only that lookup hint for hermetic test runs so another worktree
+# cannot replace the config between setup and VM launch — and so the store
+# ownership hand-back stays a no-op under the test harness, exactly as it is
+# for a genuine root login. Normal invocations without an isolated config dir
+# are unchanged.
+if [ -n "${FCVM_CONFIG_DIR:-}" ] || [ -n "${XDG_CONFIG_HOME:-}" ]; then
 	unset SUDO_USER
 fi
 

--- a/scripts/runner-podman-hygiene.sh
+++ b/scripts/runner-podman-hygiene.sh
@@ -35,15 +35,24 @@
 # one every later podman call will use.
 set -euo pipefail
 
+# Unprivileged removal first, sudo only for what it could not delete (the
+# AMI's foreign-uid droppings). Keeps the script runnable where sudo is
+# unavailable — the unprivileged test suite shims sudo with a hard failure,
+# which is how the first version of this fallback was caught (2026-08-13:
+# green under bare cargo-nextest, red under `make test-fast`'s sudo guard).
+remove_tree() {
+	rm -rf "$1" 2>/dev/null || sudo rm -rf "$1"
+}
+
 store="${HOME:?HOME must be set}/.local/share/containers"
 
 # Record what is there before destroying the evidence — this is the data the
 # AMI follow-up (issue #806) needs to confirm where the droppings come from.
 if [ -e "$store" ]; then
 	echo "runner-podman-hygiene: pre-existing default store $store:"
-	sudo find "$store" -maxdepth 3 -printf '%u:%g %m %p\n' 2>/dev/null | head -20 || true
+	find "$store" -maxdepth 3 -printf '%u:%g %m %p\n' 2>/dev/null | head -20 || true
 fi
-sudo rm -rf "$store"
+remove_tree "$store"
 echo "runner-podman-hygiene: default store cleared"
 
 conf="${HOME}/.config/containers/storage.conf"
@@ -53,7 +62,8 @@ if [ -r "$conf" ]; then
 fi
 if [ -n "$graphroot" ] && [ -d "$graphroot" ]; then
 	echo "runner-podman-hygiene: clearing state db under $graphroot (image layers preserved)"
-	sudo rm -rf "$graphroot/libpod" "$graphroot/db.sql"
+	remove_tree "$graphroot/libpod"
+	remove_tree "$graphroot/db.sql"
 else
 	echo "runner-podman-hygiene: no configured graphroot to heal (conf=$conf)"
 fi

--- a/scripts/runner-podman-hygiene.sh
+++ b/scripts/runner-podman-hygiene.sh
@@ -1,24 +1,38 @@
 #!/usr/bin/env bash
-# Remove the DEFAULT rootless podman store before tests run.
+# Per-job podman hygiene for self-hosted runners. Two independent repairs, both
+# safe to run unconditionally because CI's podman state is disposable while its
+# IMAGE LAYERS are the expensive persistent cache:
 #
-# CI never legitimately uses it: every job writes ~/.config/containers/storage.conf
-# pointing the graphroot at /mnt/fcvm-btrfs, so any content under
-# ~/.local/share/containers is a dropping by definition — which is what makes
-# unconditional removal correct and heuristics unnecessary.
+# 1. Remove the DEFAULT rootless store (~/.local/share/containers). CI never
+#    legitimately uses it: every job writes ~/.config/containers/storage.conf
+#    pointing the graphroot at /mnt/fcvm-btrfs, so any content there is a
+#    dropping by definition. It arrives PRE-CONTAMINATED from the AMI: 8a9c564f
+#    switched AMI creation to snapshotting the RUNNING builder, so whatever
+#    rootless-store state the builder accumulated (partial layers, foreign-uid
+#    files from a different subuid map) is baked into every runner. The first
+#    `podman build` that resolves to it dies with
+#      chown .../storage/overlay/l: operation not permitted
+#    — how every Host job failed on 2026-08-12 (#792/#805). Removal needs sudo
+#    because foreign-uid files are the failure mode.
 #
-# Why it must be removed: the store arrives PRE-CONTAMINATED from the AMI.
-# 8a9c564f switched AMI creation to snapshotting the RUNNING builder, so
-# whatever rootless-store state the builder accumulated (partial layers,
-# foreign-uid files from a different subuid map) is baked into every runner.
-# The first `podman build` that resolves to the default store then dies with
-#   chown .../storage/overlay/l: operation not permitted
-# — which is how every Host job failed on 2026-08-12 (#792/#805). Tests were
-# only steered into the default store by an XDG_CONFIG_HOME redirect that is
-# also fixed (FCVM_CONFIG_DIR), so this is defence in depth: the droppings stay
-# gone even if some future path resolves the default store again.
+# 2. Remove podman's state databases from the CONFIGURED graphroot, KEEPING the
+#    image layers. The graphroot lives on /mnt/fcvm-btrfs, which persists
+#    across runner instances, so a database poisoned by one job poisons every
+#    later job on that volume: observed 2026-08-13, a db recording static dir
+#    "" made every podman call fail with
+#      database static dir "" does not match our static dir ".../libpod"
+#    (exit 125 before any test ran) — and `podman system reset` REFUSES on
+#    exactly that mismatch, so no podman-native repair can run. Deleting only
+#    libpod/ and db.sql lets the next podman call recreate a coherent db while
+#    the overlay layer cache (the one-time-cost content this volume exists to
+#    keep) survives. An earlier version of this script used
+#    `podman system reset --force` instead: on poisoned runners it failed the
+#    same way as everything else, and on healthy ones it threw away the entire
+#    persistent image cache every job.
 #
-# Removal uses sudo because the droppings are, by nature, not ours to delete
-# unprivileged — foreign-uid files are the failure mode.
+# Invoked by ci.yml immediately after each job's `podman system migrate` — the
+# last line of its podman configuration — so the graphroot parsed here is the
+# one every later podman call will use.
 set -euo pipefail
 
 store="${HOME:?HOME must be set}/.local/share/containers"
@@ -29,18 +43,17 @@ if [ -e "$store" ]; then
 	echo "runner-podman-hygiene: pre-existing default store $store:"
 	sudo find "$store" -maxdepth 3 -printf '%u:%g %m %p\n' 2>/dev/null | head -20 || true
 fi
-
-# Tear down podman's state COHERENTLY first: the bolt db cross-references the
-# configured store paths, and removing a directory out from under it leaves
-# every later podman call failing with "database static dir ... does not match"
-# (observed 2026-08-13 when this script was a bare rm -rf: podman login died
-# with exit 125 before any test ran). `system reset` is podman's own primitive
-# for exactly this, and it reads the job's FINAL storage config — which is why
-# the workflow invokes this script after the config writes, not before.
-podman system reset --force 2>&1 | tail -2 || true
-
-# Then sweep the default store path itself: reset runs unprivileged and cannot
-# remove the AMI's foreign-uid droppings, which are the original failure mode
-# (chown .../overlay/l: operation not permitted).
 sudo rm -rf "$store"
 echo "runner-podman-hygiene: default store cleared"
+
+conf="${HOME}/.config/containers/storage.conf"
+graphroot=""
+if [ -r "$conf" ]; then
+	graphroot=$(sed -n 's/^graphroot[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' "$conf" | head -1)
+fi
+if [ -n "$graphroot" ] && [ -d "$graphroot" ]; then
+	echo "runner-podman-hygiene: clearing state db under $graphroot (image layers preserved)"
+	sudo rm -rf "$graphroot/libpod" "$graphroot/db.sql"
+else
+	echo "runner-podman-hygiene: no configured graphroot to heal (conf=$conf)"
+fi

--- a/scripts/runner-podman-hygiene.sh
+++ b/scripts/runner-podman-hygiene.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Remove the DEFAULT rootless podman store before tests run.
+#
+# CI never legitimately uses it: every job writes ~/.config/containers/storage.conf
+# pointing the graphroot at /mnt/fcvm-btrfs, so any content under
+# ~/.local/share/containers is a dropping by definition — which is what makes
+# unconditional removal correct and heuristics unnecessary.
+#
+# Why it must be removed: the store arrives PRE-CONTAMINATED from the AMI.
+# 8a9c564f switched AMI creation to snapshotting the RUNNING builder, so
+# whatever rootless-store state the builder accumulated (partial layers,
+# foreign-uid files from a different subuid map) is baked into every runner.
+# The first `podman build` that resolves to the default store then dies with
+#   chown .../storage/overlay/l: operation not permitted
+# — which is how every Host job failed on 2026-08-12 (#792/#805). Tests were
+# only steered into the default store by an XDG_CONFIG_HOME redirect that is
+# also fixed (FCVM_CONFIG_DIR), so this is defence in depth: the droppings stay
+# gone even if some future path resolves the default store again.
+#
+# Removal uses sudo because the droppings are, by nature, not ours to delete
+# unprivileged — foreign-uid files are the failure mode.
+set -euo pipefail
+
+store="${HOME:?HOME must be set}/.local/share/containers"
+
+if [ ! -e "$store" ]; then
+	echo "runner-podman-hygiene: no default store at $store (clean)"
+	exit 0
+fi
+
+# Record what was there before destroying the evidence — this is the data the
+# AMI follow-up (issue #806) needs to confirm where the droppings come from.
+echo "runner-podman-hygiene: removing pre-existing default store $store:"
+sudo find "$store" -maxdepth 3 -printf '%u:%g %m %p\n' 2>/dev/null | head -20 || true
+
+sudo rm -rf "$store"
+echo "runner-podman-hygiene: removed"

--- a/scripts/runner-podman-hygiene.sh
+++ b/scripts/runner-podman-hygiene.sh
@@ -35,6 +35,23 @@
 # one every later podman call will use.
 set -euo pipefail
 
+# The default-store sweep can escalate to sudo, so refuse to run against a
+# HOME that is not this user's real home: a preceding step exporting a stray
+# HOME would otherwise aim `sudo rm -rf` at an arbitrary directory. Tests
+# exercise the script against a fixture home via FCVM_HYGIENE_HOME_OVERRIDE=1
+# (fixture trees are user-owned, so those runs never reach sudo).
+if [ "${FCVM_HYGIENE_HOME_OVERRIDE:-0}" != 1 ]; then
+	runner_home="$(getent passwd "$(id -u)" | cut -d: -f6)"
+	if [ -z "$runner_home" ] || [ "${HOME:-}" != "$runner_home" ]; then
+		echo "runner-podman-hygiene: HOME (${HOME:-unset}) does not match this user's passwd home ($runner_home); refusing" >&2
+		exit 1
+	fi
+fi
+case "${HOME:-}" in
+	/*) ;;
+	*) echo "runner-podman-hygiene: HOME must be an absolute path" >&2; exit 1 ;;
+esac
+
 # Unprivileged removal first, sudo only for what it could not delete (the
 # AMI's foreign-uid droppings). Keeps the script runnable where sudo is
 # unavailable — the unprivileged test suite shims sudo with a hard failure,

--- a/scripts/runner-podman-hygiene.sh
+++ b/scripts/runner-podman-hygiene.sh
@@ -23,15 +23,24 @@ set -euo pipefail
 
 store="${HOME:?HOME must be set}/.local/share/containers"
 
-if [ ! -e "$store" ]; then
-	echo "runner-podman-hygiene: no default store at $store (clean)"
-	exit 0
+# Record what is there before destroying the evidence — this is the data the
+# AMI follow-up (issue #806) needs to confirm where the droppings come from.
+if [ -e "$store" ]; then
+	echo "runner-podman-hygiene: pre-existing default store $store:"
+	sudo find "$store" -maxdepth 3 -printf '%u:%g %m %p\n' 2>/dev/null | head -20 || true
 fi
 
-# Record what was there before destroying the evidence — this is the data the
-# AMI follow-up (issue #806) needs to confirm where the droppings come from.
-echo "runner-podman-hygiene: removing pre-existing default store $store:"
-sudo find "$store" -maxdepth 3 -printf '%u:%g %m %p\n' 2>/dev/null | head -20 || true
+# Tear down podman's state COHERENTLY first: the bolt db cross-references the
+# configured store paths, and removing a directory out from under it leaves
+# every later podman call failing with "database static dir ... does not match"
+# (observed 2026-08-13 when this script was a bare rm -rf: podman login died
+# with exit 125 before any test ran). `system reset` is podman's own primitive
+# for exactly this, and it reads the job's FINAL storage config — which is why
+# the workflow invokes this script after the config writes, not before.
+podman system reset --force 2>&1 | tail -2 || true
 
+# Then sweep the default store path itself: reset runs unprivileged and cannot
+# remove the AMI's foreign-uid droppings, which are the original failure mode
+# (chown .../overlay/l: operation not permitted).
 sudo rm -rf "$store"
-echo "runner-podman-hygiene: removed"
+echo "runner-podman-hygiene: default store cleared"

--- a/scripts/with-test-config.sh
+++ b/scripts/with-test-config.sh
@@ -29,7 +29,16 @@ cleanup() {
 }
 trap cleanup EXIT
 
-export XDG_CONFIG_HOME="$config_home"
+# FCVM_CONFIG_DIR is fcvm-private, so this isolation cannot perturb any other
+# tool. The previous mechanism exported XDG_CONFIG_HOME, which podman and
+# skopeo also read to find containers/storage.conf — with version- and
+# uid-dependent fallback rules. That split the test's image store from fcvm's
+# twice over: rootless skopeo missed the configured graphroot ("cannot specify
+# 64-byte hexadecimal strings" on every localhost-image test), and a CI
+# runner's root podman honoured the redirected config while the test's
+# env-reset `sudo podman build` did not ("image not known"). A variable only
+# fcvm reads has no second reader to disagree with.
+export FCVM_CONFIG_DIR="$config_home"
 ./target/release/fcvm setup --generate-config --force >/dev/null
 
 "$@"

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -733,13 +733,44 @@ pub fn generate_setup_script(plan: &Plan) -> String {
 // Config File Loading
 // ============================================================================
 
+/// The directory fcvm's config lives in.
+///
+/// `FCVM_CONFIG_DIR` overrides everything, and exists for exactly one caller:
+/// the test harness (`scripts/with-test-config.sh`), which needs a per-run
+/// config directory. It deliberately does NOT ride on `XDG_CONFIG_HOME`: that
+/// variable is shared with podman and skopeo, and pointing it at a bare temp
+/// dir makes container tools re-resolve `containers/storage.conf` — with
+/// version- and uid-dependent fallback rules, so the test's `podman build` and
+/// fcvm's `skopeo`/`podman` calls can land on DIFFERENT image stores. Observed
+/// both ways: rootless skopeo missing the configured graphroot (12 local test
+/// failures), and a runner's root podman honouring the redirected config while
+/// a nested env-reset `sudo podman build` did not ("image not known").
+/// An fcvm-private variable cannot perturb any other tool.
+pub fn fcvm_config_dir() -> Result<std::path::PathBuf> {
+    if let Some(dir) = std::env::var_os("FCVM_CONFIG_DIR") {
+        let dir = std::path::PathBuf::from(dir);
+        // Relative paths are refused rather than resolved: the value crosses
+        // process boundaries (nextest -> sudo -> fcvm -> nested launches) where
+        // the working directory differs, and the directories crate's silent
+        // fallback on bad XDG paths is exactly the trap this replaces.
+        anyhow::ensure!(
+            dir.is_absolute(),
+            "FCVM_CONFIG_DIR must be absolute, got: {}",
+            dir.display()
+        );
+        return Ok(dir.join("fcvm"));
+    }
+    let proj_dirs =
+        ProjectDirs::from("", "", "fcvm").context("Could not determine config directory")?;
+    Ok(proj_dirs.config_dir().to_path_buf())
+}
+
 /// Generate default config file at XDG config directory.
 ///
 /// Writes the embedded default config to ~/.config/fcvm/rootfs-config.toml
 pub fn generate_config(force: bool) -> Result<PathBuf> {
-    let proj_dirs =
-        ProjectDirs::from("", "", "fcvm").context("Could not determine config directory")?;
-    let config_dir = proj_dirs.config_dir();
+    let config_dir = fcvm_config_dir()?;
+    let config_dir = config_dir.as_path();
     let config_path = config_dir.join(CONFIG_FILE);
 
     if config_path.exists() && !force {
@@ -810,8 +841,8 @@ pub fn find_config_file(explicit_path: Option<&str>) -> Result<PathBuf> {
     }
 
     // 3. XDG user config
-    if let Some(proj_dirs) = ProjectDirs::from("", "", "fcvm") {
-        let p = proj_dirs.config_dir().join(CONFIG_FILE);
+    if let Ok(config_dir) = fcvm_config_dir() {
+        let p = config_dir.join(CONFIG_FILE);
         if p.exists() {
             return Ok(p);
         }

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -765,9 +765,11 @@ pub fn fcvm_config_dir() -> Result<std::path::PathBuf> {
     Ok(proj_dirs.config_dir().to_path_buf())
 }
 
-/// Generate default config file at XDG config directory.
+/// Generate the default config file into the resolved config directory.
 ///
-/// Writes the embedded default config to ~/.config/fcvm/rootfs-config.toml
+/// Writes the embedded default config to `$FCVM_CONFIG_DIR/fcvm/rootfs-config.toml`
+/// when the override is set (per-run test isolation), otherwise to the platform
+/// default (`~/.config/fcvm/rootfs-config.toml` on Linux).
 pub fn generate_config(force: bool) -> Result<PathBuf> {
     let config_dir = fcvm_config_dir()?;
     let config_dir = config_dir.as_path();
@@ -821,26 +823,46 @@ pub fn find_config_file(explicit_path: Option<&str>) -> Result<PathBuf> {
         return Ok(p.clone());
     }
 
-    // 2. SUDO_USER's config (when running with sudo)
-    if let Ok(sudo_user) = std::env::var("SUDO_USER") {
-        // Get the invoking user's home directory
-        match nix::unistd::User::from_name(&sudo_user) {
-            Ok(Some(user)) => {
-                let p = user.dir.join(".config/fcvm").join(CONFIG_FILE);
-                if p.exists() {
-                    return Ok(p);
+    // 2. FCVM_CONFIG_DIR — an explicit per-run override (test isolation). It
+    // outranks SUDO_USER because it is set deliberately for THIS process while
+    // SUDO_USER is ambient: a sudoed test run must read its per-run config,
+    // not the invoking user's ~/.config/fcvm. A set-but-invalid override
+    // (relative path) is an error, not a fallback — silently reading a
+    // different file is the failure this chain exists to remove.
+    if std::env::var_os("FCVM_CONFIG_DIR").is_some() {
+        let config_dir = fcvm_config_dir()?;
+        let p = config_dir.join(CONFIG_FILE);
+        if p.exists() {
+            return Ok(p);
+        }
+        // Not generated yet: continue past SUDO_USER (ambient, would be the
+        // wrong file by definition when an override is set) to the shared
+        // system/development fallbacks below.
+    }
+
+    // 3. SUDO_USER's config (when running with sudo). Skipped entirely when an
+    // FCVM_CONFIG_DIR override is set — see above.
+    if std::env::var_os("FCVM_CONFIG_DIR").is_none() {
+        if let Ok(sudo_user) = std::env::var("SUDO_USER") {
+            // Get the invoking user's home directory
+            match nix::unistd::User::from_name(&sudo_user) {
+                Ok(Some(user)) => {
+                    let p = user.dir.join(".config/fcvm").join(CONFIG_FILE);
+                    if p.exists() {
+                        return Ok(p);
+                    }
                 }
-            }
-            Ok(None) => {
-                tracing::debug!("SUDO_USER '{}' not found in passwd database", sudo_user);
-            }
-            Err(e) => {
-                tracing::debug!("Failed to lookup SUDO_USER '{}': {}", sudo_user, e);
+                Ok(None) => {
+                    tracing::debug!("SUDO_USER '{}' not found in passwd database", sudo_user);
+                }
+                Err(e) => {
+                    tracing::debug!("Failed to lookup SUDO_USER '{}': {}", sudo_user, e);
+                }
             }
         }
     }
 
-    // 3. XDG user config
+    // 4. Default user config dir (XDG); FCVM_CONFIG_DIR-set case handled above.
     if let Ok(config_dir) = fcvm_config_dir() {
         let p = config_dir.join(CONFIG_FILE);
         if p.exists() {
@@ -2577,6 +2599,21 @@ firecracker_commit = "27305f49ab3a5d862dc56b5108713b6536d2baa7"
 
     /// A --config path that does not exist must fail, not quietly fall back to
     /// the discovered config, which is the bug this whole path removes.
+    #[test]
+    fn find_config_file_propagates_a_relative_fcvm_config_dir() {
+        // A set-but-invalid override must ERROR, not silently fall through to
+        // some other config location (nextest runs each test in its own
+        // process, so the env mutation cannot leak).
+        std::env::set_var("FCVM_CONFIG_DIR", "relative/not-absolute");
+        let err = find_config_file(None)
+            .expect_err("a relative FCVM_CONFIG_DIR must be an error, not a fallthrough");
+        std::env::remove_var("FCVM_CONFIG_DIR");
+        assert!(
+            format!("{err:#}").contains("absolute"),
+            "error should name the absolute-path requirement: {err:#}"
+        );
+    }
+
     #[test]
     fn find_config_file_rejects_a_missing_explicit_path() {
         let err = find_config_file(Some("/nonexistent/rootfs-config.toml"))

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -224,9 +224,14 @@ fn ensure_config_exists() {
             .expect("failed to acquire config generation lock");
 
         // Check if config already exists and is valid
-        let config_path = std::env::var_os("XDG_CONFIG_HOME")
+        let config_path = std::env::var_os("FCVM_CONFIG_DIR")
             .map(PathBuf::from)
             .map(|dir| dir.join("fcvm/rootfs-config.toml"))
+            .or_else(|| {
+                std::env::var_os("XDG_CONFIG_HOME")
+                    .map(PathBuf::from)
+                    .map(|dir| dir.join("fcvm/rootfs-config.toml"))
+            })
             .or_else(|| {
                 std::env::var_os("HOME")
                     .map(PathBuf::from)

--- a/tests/test_ci_workflow_coverage.rs
+++ b/tests/test_ci_workflow_coverage.rs
@@ -822,14 +822,16 @@ fn self_hosted_setup_steps_clear_the_default_podman_store() {
         hygiene >= 3,
         "expected at least 3 wired jobs, found {hygiene}"
     );
-    // Adjacency, not just equal counts: each migrate must have the hygiene call
-    // in the lines that follow it before the step ends.
+    // Adjacency within the STEP, not just equal counts: global substring
+    // counting can pass when one setup block loses its call and a comment
+    // elsewhere adds an occurrence. Bound each check at the next step header.
     for (idx, _) in ci.match_indices("podman system migrate") {
-        let after = &ci[idx..(idx + 600).min(ci.len())];
+        let rest = &ci[idx..];
+        let step_end = rest.find("\n      - name:").unwrap_or(rest.len());
         assert!(
-            after.contains("runner-podman-hygiene.sh"),
-            "a `podman system migrate` at byte {idx} is not followed by the hygiene call \
-             within its step"
+            rest[..step_end].contains("./fcvm/scripts/runner-podman-hygiene.sh"),
+            "a `podman system migrate` at byte {idx} is not followed by the exact hygiene \
+             invocation within its own step"
         );
     }
 }
@@ -874,6 +876,9 @@ fn hygiene_script_heals_state_db_and_preserves_layers() {
     );
     let out = std::process::Command::new(script)
         .env("HOME", home)
+        // Fixture home: the script's passwd-match guard would (correctly)
+        // refuse it; the override is the documented test entry.
+        .env("FCVM_HYGIENE_HOME_OVERRIDE", "1")
         .output()
         .expect("run hygiene script");
     assert!(
@@ -898,5 +903,40 @@ fn hygiene_script_heals_state_db_and_preserves_layers() {
     assert!(
         !default_store.exists(),
         "the default rootless store is a dropping and must be removed"
+    );
+}
+
+/// The privileged sweep must refuse a HOME that is not this user's passwd
+/// home — a stray HOME export would otherwise aim `sudo rm -rf` at an
+/// arbitrary directory. Red-verified against the pre-guard script version:
+/// it deleted the fixture store instead of refusing.
+#[test]
+fn hygiene_script_refuses_a_home_that_is_not_the_users() {
+    let tmp = tempfile::tempdir().expect("create fixture home");
+    let home = tmp.path();
+    let default_store = home.join(".local/share/containers");
+    std::fs::create_dir_all(&default_store).unwrap();
+
+    let script = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/scripts/runner-podman-hygiene.sh"
+    );
+    let out = std::process::Command::new(script)
+        .env("HOME", home)
+        .env_remove("FCVM_HYGIENE_HOME_OVERRIDE")
+        .output()
+        .expect("run hygiene script");
+    assert!(
+        !out.status.success(),
+        "a HOME that does not match the passwd entry must be refused"
+    );
+    assert!(
+        default_store.exists(),
+        "nothing may be deleted when the guard refuses"
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("does not match"),
+        "stderr must say why: {}",
+        String::from_utf8_lossy(&out.stderr)
     );
 }

--- a/tests/test_ci_workflow_coverage.rs
+++ b/tests/test_ci_workflow_coverage.rs
@@ -833,3 +833,70 @@ fn self_hosted_setup_steps_clear_the_default_podman_store() {
         );
     }
 }
+
+/// The hygiene script must heal a poisoned graphroot state db WITHOUT touching
+/// the image layers — the persistent volume's expensive content.
+///
+/// RED-verified against the previous script version (podman system reset +
+/// default-store rm): reset either refused on the very mismatch it was meant
+/// to clear ("database static dir \"\" does not match", 2026-08-13, every
+/// arm64 job) or, where the db was healthy, deleted the layer cache this test
+/// pins as preserved.
+#[test]
+fn hygiene_script_heals_state_db_and_preserves_layers() {
+    let tmp = tempfile::tempdir().expect("create fixture home");
+    let home = tmp.path();
+
+    // Fixture: a configured graphroot carrying a state db and an image layer.
+    let graphroot = home.join("graphroot");
+    std::fs::create_dir_all(graphroot.join("libpod")).unwrap();
+    std::fs::write(graphroot.join("libpod/bolt_state.db"), b"poisoned").unwrap();
+    std::fs::write(graphroot.join("db.sql"), b"poisoned").unwrap();
+    std::fs::create_dir_all(graphroot.join("overlay/abc123")).unwrap();
+    std::fs::write(graphroot.join("overlay/abc123/layer"), b"cached layer").unwrap();
+    let conf_dir = home.join(".config/containers");
+    std::fs::create_dir_all(&conf_dir).unwrap();
+    std::fs::write(
+        conf_dir.join("storage.conf"),
+        format!(
+            "[storage]\ndriver = \"overlay\"\ngraphroot = \"{}\"\n",
+            graphroot.display()
+        ),
+    )
+    .unwrap();
+    // And an AMI-style default store dropping.
+    let default_store = home.join(".local/share/containers");
+    std::fs::create_dir_all(default_store.join("storage/overlay/l")).unwrap();
+
+    let script = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/scripts/runner-podman-hygiene.sh"
+    );
+    let out = std::process::Command::new(script)
+        .env("HOME", home)
+        .output()
+        .expect("run hygiene script");
+    assert!(
+        out.status.success(),
+        "hygiene script failed: {}\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(
+        !graphroot.join("libpod").exists(),
+        "poisoned libpod db dir must be removed"
+    );
+    assert!(
+        !graphroot.join("db.sql").exists(),
+        "poisoned sqlite db must be removed"
+    );
+    assert!(
+        graphroot.join("overlay/abc123/layer").exists(),
+        "image layers are the persistent cache and must survive hygiene"
+    );
+    assert!(
+        !default_store.exists(),
+        "the default rootless store is a dropping and must be removed"
+    );
+}

--- a/tests/test_ci_workflow_coverage.rs
+++ b/tests/test_ci_workflow_coverage.rs
@@ -790,3 +790,31 @@ fn summary_artifact_steps_are_gated_on_the_changes_job() {
          {checked}, so this test is not inspecting what it claims"
     );
 }
+
+/// Every self-hosted job that runs podman must clear the DEFAULT rootless store
+/// before tests. The AMI can bake a contaminated one (it is snapshotted from
+/// the RUNNING builder since 8a9c564f), and the first `podman build` that
+/// resolves to it dies with `chown .../overlay/l: operation not permitted` —
+/// every Host job on 2026-08-12 (#792/#805). CI's own storage.conf points the
+/// graphroot at btrfs, so the default store is never legitimately used and
+/// removal is unconditionally safe.
+#[test]
+fn self_hosted_setup_steps_clear_the_default_podman_store() {
+    let ci = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/.github/workflows/ci.yml"
+    ))
+    .expect("read ci.yml");
+    let kvm_steps = ci.matches("sudo chmod 666 /dev/kvm").count();
+    let hygiene = ci.matches("runner-podman-hygiene.sh").count();
+    assert_eq!(
+        kvm_steps, hygiene,
+        "every runner setup step (the `chmod 666 /dev/kvm` blocks: {kvm_steps}) must invoke \
+         scripts/runner-podman-hygiene.sh (found {hygiene}); a job without it inherits the \
+         AMI's contaminated default store and fails its first rootless podman build"
+    );
+    assert!(
+        hygiene >= 3,
+        "expected at least 3 wired setup steps, found {hygiene}"
+    );
+}

--- a/tests/test_ci_workflow_coverage.rs
+++ b/tests/test_ci_workflow_coverage.rs
@@ -828,10 +828,20 @@ fn self_hosted_setup_steps_clear_the_default_podman_store() {
     for (idx, _) in ci.match_indices("podman system migrate") {
         let rest = &ci[idx..];
         let step_end = rest.find("\n      - name:").unwrap_or(rest.len());
-        assert!(
-            rest[..step_end].contains("./fcvm/scripts/runner-podman-hygiene.sh"),
-            "a `podman system migrate` at byte {idx} is not followed by the exact hygiene \
-             invocation within its own step"
+        // The hygiene call must be the NEXT executable line (comments allowed):
+        // an intervening command could recreate podman state after the heal.
+        let next_command = rest[..step_end]
+            .split_once('\n')
+            .map(|(_, following)| following)
+            .unwrap_or_default()
+            .lines()
+            .map(str::trim)
+            .find(|line| !line.is_empty() && !line.starts_with('#'));
+        assert_eq!(
+            next_command,
+            Some("./fcvm/scripts/runner-podman-hygiene.sh"),
+            "a `podman system migrate` at byte {idx} is not immediately followed by \
+             the hygiene invocation"
         );
     }
 }

--- a/tests/test_ci_workflow_coverage.rs
+++ b/tests/test_ci_workflow_coverage.rs
@@ -792,12 +792,16 @@ fn summary_artifact_steps_are_gated_on_the_changes_job() {
 }
 
 /// Every self-hosted job that runs podman must clear the DEFAULT rootless store
-/// before tests. The AMI can bake a contaminated one (it is snapshotted from
-/// the RUNNING builder since 8a9c564f), and the first `podman build` that
-/// resolves to it dies with `chown .../overlay/l: operation not permitted` —
-/// every Host job on 2026-08-12 (#792/#805). CI's own storage.conf points the
-/// graphroot at btrfs, so the default store is never legitimately used and
-/// removal is unconditionally safe.
+/// before tests — ONCE, and only after its containers config is fully written.
+/// The AMI can bake a contaminated store (it is snapshotted from the RUNNING
+/// builder since 8a9c564f), and the first `podman build` that resolves to it
+/// dies with `chown .../overlay/l: operation not permitted` (#792/#805,
+/// 2026-08-12). Placement matters as much as presence: invoked BEFORE the
+/// config writes, the script's `podman system reset` tore state down against
+/// the wrong layout and every later podman call failed with "database static
+/// dir ... does not match" (exit 125 before any test ran, 2026-08-13). The
+/// pinned invariant is therefore "immediately after every `podman system
+/// migrate`", which is the last line of each job's podman configuration.
 #[test]
 fn self_hosted_setup_steps_clear_the_default_podman_store() {
     let ci = std::fs::read_to_string(concat!(
@@ -805,16 +809,27 @@ fn self_hosted_setup_steps_clear_the_default_podman_store() {
         "/.github/workflows/ci.yml"
     ))
     .expect("read ci.yml");
-    let kvm_steps = ci.matches("sudo chmod 666 /dev/kvm").count();
+    let migrates = ci.matches("podman system migrate").count();
     let hygiene = ci.matches("runner-podman-hygiene.sh").count();
     assert_eq!(
-        kvm_steps, hygiene,
-        "every runner setup step (the `chmod 666 /dev/kvm` blocks: {kvm_steps}) must invoke \
-         scripts/runner-podman-hygiene.sh (found {hygiene}); a job without it inherits the \
-         AMI's contaminated default store and fails its first rootless podman build"
+        migrates, hygiene,
+        "every `podman system migrate` ({migrates}) must be followed by \
+         scripts/runner-podman-hygiene.sh (found {hygiene} calls); a job without it inherits \
+         the AMI's contaminated default store, and a call anywhere else runs against the \
+         wrong storage config"
     );
     assert!(
         hygiene >= 3,
-        "expected at least 3 wired setup steps, found {hygiene}"
+        "expected at least 3 wired jobs, found {hygiene}"
     );
+    // Adjacency, not just equal counts: each migrate must have the hygiene call
+    // in the lines that follow it before the step ends.
+    for (idx, _) in ci.match_indices("podman system migrate") {
+        let after = &ci[idx..(idx + 600).min(ci.len())];
+        assert!(
+            after.contains("runner-podman-hygiene.sh"),
+            "a `podman system migrate` at byte {idx} is not followed by the hygiene call \
+             within its step"
+        );
+    }
 }

--- a/tests/test_kvm.rs
+++ b/tests/test_kvm.rs
@@ -64,7 +64,9 @@ impl ImageCacheMount {
 /// L1 runs its nested fcvm process as root, so callers mount this directory at
 /// `/root/.config/fcvm` instead of letting L2 reopen a shared host config.
 fn active_fcvm_config_dir() -> std::path::PathBuf {
-    if let Some(config_home) = std::env::var_os("XDG_CONFIG_HOME") {
+    if let Some(config_dir) = std::env::var_os("FCVM_CONFIG_DIR") {
+        std::path::PathBuf::from(config_dir).join("fcvm")
+    } else if let Some(config_home) = std::env::var_os("XDG_CONFIG_HOME") {
         std::path::PathBuf::from(config_home).join("fcvm")
     } else if let Some(home) = std::env::var_os("HOME") {
         std::path::PathBuf::from(home).join(".config/fcvm")

--- a/tests/test_nested_harness_invariants.rs
+++ b/tests/test_nested_harness_invariants.rs
@@ -74,12 +74,19 @@ fn test_recipes_use_an_exact_worktree_local_config() {
     );
     assert!(
         wrapper.contains("target_dir=\"$(cd \"$target_dir\" && pwd -P)\""),
-        "XDG_CONFIG_HOME must be absolute; the directories crate ignores relative XDG paths \
-         and silently falls back to the shared ~/.config/fcvm directory"
+        "FCVM_CONFIG_DIR must be absolute; fcvm refuses relative values because they cross \
+         process boundaries with different working directories"
     );
     assert!(
-        wrapper.contains("export XDG_CONFIG_HOME=\"$config_home\""),
+        wrapper.contains("export FCVM_CONFIG_DIR=\"$config_home\""),
         "the isolated config directory must reach nextest, sudo, and every fcvm child"
+    );
+    assert!(
+        !wrapper.contains("export XDG_CONFIG_HOME"),
+        "the wrapper must NOT touch XDG_CONFIG_HOME: podman and skopeo resolve \
+         containers/storage.conf through it with version- and uid-dependent fallbacks, which \
+         split the test's image store from fcvm's (rootless skopeo hex-ID failures locally; \
+         root podman 'image not known' on a CI runner)"
     );
     assert!(
         wrapper.contains("./target/release/fcvm setup --generate-config --force"),
@@ -110,8 +117,8 @@ fn isolated_config_mounts_the_active_xdg_config_into_nested_guests() {
     let source = nested_test_source();
 
     assert!(
-        source.contains("var_os(\"XDG_CONFIG_HOME\")"),
-        "nested launches must resolve the config mounted into L1 from the active XDG_CONFIG_HOME"
+        source.contains("var_os(\"FCVM_CONFIG_DIR\")"),
+        "nested launches must resolve the config mounted into L1 from the active FCVM_CONFIG_DIR"
     );
     assert!(
         source.contains("join(\"fcvm\")"),

--- a/tests/test_packaging.rs
+++ b/tests/test_packaging.rs
@@ -83,15 +83,18 @@ fn test_completions_all_shells() {
 fn test_generate_config() {
     let fcvm = fcvm_binary();
 
-    // Use a temp directory for XDG_CONFIG_HOME to avoid polluting real config
+    // Use a temp directory for FCVM_CONFIG_DIR (highest-precedence override;
+    // the harness wrapper exports it, so the test must control it) to avoid
+    // polluting real config
     let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
     let config_dir = temp_dir.path().join("fcvm");
     let config_path = config_dir.join("rootfs-config.toml");
 
-    // Generate config with custom XDG_CONFIG_HOME
+    // Generate config with a custom FCVM_CONFIG_DIR
     let output = Command::new(&fcvm)
         .args(["setup", "--generate-config", "--force"])
-        .env("XDG_CONFIG_HOME", temp_dir.path())
+        .env("FCVM_CONFIG_DIR", temp_dir.path())
+        .env_remove("XDG_CONFIG_HOME")
         .output()
         .expect("failed to run fcvm setup --generate-config");
 
@@ -141,7 +144,8 @@ fn test_generate_config_no_overwrite() {
     // Try to generate without --force
     let output = Command::new(&fcvm)
         .args(["setup", "--generate-config"])
-        .env("XDG_CONFIG_HOME", temp_dir.path())
+        .env("FCVM_CONFIG_DIR", temp_dir.path())
+        .env_remove("XDG_CONFIG_HOME")
         .output()
         .expect("failed to run fcvm setup --generate-config");
 
@@ -180,7 +184,8 @@ fn test_generate_config_force_overwrite() {
     // Generate with --force
     let output = Command::new(&fcvm)
         .args(["setup", "--generate-config", "--force"])
-        .env("XDG_CONFIG_HOME", temp_dir.path())
+        .env("FCVM_CONFIG_DIR", temp_dir.path())
+        .env_remove("XDG_CONFIG_HOME")
         .output()
         .expect("failed to run fcvm setup --generate-config --force");
 
@@ -257,4 +262,32 @@ fn test_help_shows_all_commands() {
             cmd
         );
     }
+}
+
+/// The XDG fallback must keep working when FCVM_CONFIG_DIR is absent: real
+/// users have no FCVM_CONFIG_DIR, and the directories crate resolves
+/// XDG_CONFIG_HOME. The harness wrapper exports FCVM_CONFIG_DIR, so this test
+/// must remove it explicitly or it asserts the wrong precedence.
+#[test]
+fn test_generate_config_falls_back_to_xdg() {
+    let fcvm = fcvm_binary();
+    let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let config_path = temp_dir.path().join("fcvm/rootfs-config.toml");
+
+    let output = Command::new(&fcvm)
+        .args(["setup", "--generate-config", "--force"])
+        .env_remove("FCVM_CONFIG_DIR")
+        .env("XDG_CONFIG_HOME", temp_dir.path())
+        .output()
+        .expect("failed to run fcvm setup --generate-config");
+    assert!(
+        output.status.success(),
+        "generate-config failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        config_path.exists(),
+        "XDG fallback did not create {config_path:?} — FCVM_CONFIG_DIR must be an override, \
+         not a replacement, of the XDG resolution real users rely on"
+    );
 }

--- a/tests/test_packaging.rs
+++ b/tests/test_packaging.rs
@@ -90,13 +90,21 @@ fn test_generate_config() {
     let config_dir = temp_dir.path().join("fcvm");
     let config_path = config_dir.join("rootfs-config.toml");
 
-    // Generate config with a custom FCVM_CONFIG_DIR
+    // XDG set to a DIFFERENT directory: the override must win when both are
+    // present (a run where FCVM_CONFIG_DIR silently lost to XDG would pass a
+    // remove-XDG-only test while regressing the harness isolation).
+    let xdg_dir = tempfile::tempdir().expect("failed to create XDG temp dir");
     let output = Command::new(&fcvm)
         .args(["setup", "--generate-config", "--force"])
         .env("FCVM_CONFIG_DIR", temp_dir.path())
-        .env_remove("XDG_CONFIG_HOME")
+        .env("XDG_CONFIG_HOME", xdg_dir.path())
         .output()
         .expect("failed to run fcvm setup --generate-config");
+
+    assert!(
+        !xdg_dir.path().join("fcvm/rootfs-config.toml").exists(),
+        "config must not land under XDG_CONFIG_HOME when FCVM_CONFIG_DIR is set"
+    );
 
     assert!(
         output.status.success(),


### PR DESCRIPTION
Give fcvm a private `FCVM_CONFIG_DIR` for per-run test config isolation, and stop the test wrapper exporting `XDG_CONFIG_HOME` — a namespace podman and skopeo also read, with fallback rules that differ **by tool, by version, and by uid**.

## The Problem

`scripts/with-test-config.sh` (8fc51667) isolates fcvm's config per test run by pointing `XDG_CONFIG_HOME` at a fresh temp dir — a real cross-worktree race, correctly identified. But that variable has more than one reader, and the readers disagree about fallbacks when `containers/storage.conf` is absent from it. Three independently measured failures, all the same defect:

| where | split | symptom |
|---|---|---|
| this box, rootless | podman falls back to `~/.config/containers` (btrfs graphroot); **skopeo 1.13.3 does not** | 12 localhost-image tests: `containers-storage:<id>: ... cannot specify 64-byte hexadecimal strings` (ID miss re-parsed as a name) |
| CI runners, rootless | runner podman honours the bare XDG **strictly** → builds land in `~/.local/share/containers`, which carries root-owned droppings | `chown .../overlay/l: operation not permitted` (#792/#805 Host jobs) |
| CI runners, root | an interim symlink fix exposed ubuntu's containers config under XDG; runner **root** podman honoured it while the test's env-reset `sudo podman build` did not | `Failed to inspect image 'localhost/test-healthy': image not known` (#808's first CI round, Host-Root jobs) |

The box-vs-runner disagreement within the *same uid* is the tell: no single arrangement of the XDG namespace is correct across podman/skopeo versions. The only safe move is to stop sharing the namespace.

## The Fix

- `fcvm_config_dir()` in `src/setup/rootfs.rs`: honours `FCVM_CONFIG_DIR` (absolute only — the value crosses nextest → sudo → fcvm → nested launches; fcvm refuses relative values instead of inheriting the directories crate's silent fallback), else `ProjectDirs` exactly as before. No behaviour change outside tests.
- The wrapper exports `FCVM_CONFIG_DIR` and touches nothing else.
- `tests/common`, the nested L1 config mount (`test_kvm.rs`), and the harness-invariant tests follow the new contract — including a pin that the wrapper contains **no** `export XDG_CONFIG_HOME`, which is the regression this PR exists to prevent.

## RED verification

With the content-addressed image cache cleared so the skopeo export actually runs (a warm cache passes these tests without skopeo — that confounder made an earlier verification attempt vacuous, and is documented in the commit):

```
main's wrapper:  test_localhost_default_mode FAILS — skopeo hex error ×2
this wrapper:    PASSES — 63MB archive exported
root suite:      test_podman_healthcheck_* 4/4 pass (the exact set red on the runners)
invariants:      14/14, including the new no-XDG-export assertion
```

Full local suites on the stack: `test-root` 1081/1081, `test-fast` 861/861.

#792 and #805 are stacked on this branch — both need it to pass the runners' Host jobs.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Test runs now isolate application configuration without affecting Podman or Skopeo settings.
  * Configuration discovery is more consistent across local, nested virtual machine, and packaging test runs.
  * Invalid relative configuration overrides are rejected with a clear error.
  * Temporary test configuration is isolated and cleaned up reliably.
  * Improved KVM and rootless container test reliability by clearing contaminated container state while preserving image layers.
  * CI now validates container-state cleanup and configuration isolation more thoroughly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->