### PR TITLE
Document the direct-CDP request path in the bench README

### DIFF
--- a/bench/chromium/README.md
+++ b/bench/chromium/README.md
@@ -109,8 +109,10 @@ meant to be analyzed for stage attribution (serve/restore logs land in
 ## The request-optimized path (`reqbench.sh`)
 
 `bench.sh` measures the egress matrix with an in-guest driver started by `fcvm exec`
-per request — its `exec up` stage (~252 ms median, mostly Python startup inside the
-guest) is a harness artifact, not something a real service would pay. `reqbench.sh`
+per request — its `exec up` stage (252 ms median, 95% CI 245–259, n=12; the
+"exec up" row of `results/20260808-corrected/tables.md`, raw records in
+`corrected.json`) is mostly Python startup inside the guest: a harness
+artifact, not something a real service would pay. `reqbench.sh`
 is the request path a service would actually run:
 
 - **Direct CDP from the host.** Chromium binds CDP to guest loopback `127.0.0.1:9222`
@@ -121,19 +123,39 @@ is the request path a service would actually run:
   no exec, and no benchmark-owned process in the byte path. The former per-clone
   `socat` relay is deleted; the socat-era availability A/B was withdrawn as
   non-comparable and is not evidence about the relay.
-- **Goldens via `fcvm podman prepare`** snapshotted at the image health gate, and
+- **Goldens via `fcvm podman prepare`** snapshotted at the image health gate —
+  which requires BOTH the warm marker file and a live CDP round trip that finds
+  a page target (`entry.sh` + `cdp_health.py`; rootless guests must have
+  healthcheck scheduling active for the gate to fire), and
   clones inherit `port_mappings` from snapshot metadata — which is why
   `./reqbench.sh verify` proves every hop **on a restored clone** before `run`
   measures anything.
-- **Teardown is one SIGKILL** to fcvm; the kernel fans it out to Firecracker and the
-  namespace holder via `PR_SET_PDEATHSIG`.
+- **Each request's timing includes CDP setup.** `cdpdrive.py` records target
+  resolution (`resolve_ms`), TCP connect (`tcp_ms` — successor of the obsolete
+  `port_wait_ms`, whose old numbers measured a state-discovery boundary, not
+  the network), WebSocket upgrade (`upgrade_ms`), and `Page.enable`
+  (`enable_ms`), rolled up as `connect_total_ms`; the connect stage runs
+  serially within a request (no cross-request connection reuse — every request
+  proves the whole path).
+- **Teardown differs per arm, deliberately**: `cdp-fast` uses the one-SIGKILL
+  teardown (the kernel fans it out to Firecracker and the namespace holder via
+  `PR_SET_PDEATHSIG`); the `cdp`, `noop`, and `exec` control arms keep the
+  normal SIGTERM-and-wait path so the A/B isolates exactly that change.
 - **Sealed provenance.** Each run records content hashes of the harness, `fcvm`, and
   `fc-agent`, the snapshot generation UUID, and the exact config digest, so every
   number is bound to the code that produced it.
 
-Phases: `./reqbench.sh build` → `golden` → `verify` → `run` (or `all`). The box must
-be quiet — the harness refuses to measure under load (`ALLOW_BUSY=1` overrides, and
-says so in the record).
+Prerequisites: `make build && make setup-fcvm` from the repo root first — the
+script stages the `fcvm`/`fc-agent` binaries and `golden` needs the
+content-addressed fc-agent initrd that only `make setup-fcvm` creates (its own
+`build` subcommand builds just the Podman image; a fresh checkout that skips
+setup fails exactly there).
+
+Phases: `./reqbench.sh build` → `golden` → `verify` → `run` (or `all`). Preflight
+`uptime` and `pgrep -c firecracker` yourself; the harness refuses to measure on a
+busy box. `ALLOW_BUSY=1` overrides the refusal and is recorded in the run — an
+overridden run is contaminated and must be excluded from comparisons or rerun
+before publication.
 
 ## Results conventions
 
@@ -168,7 +190,10 @@ site-isolation-off saves 3.6% on PSS (not 23% - that number was an RSS artifact)
 before quoting anything from this directory.
 
 The corrected run measured the **exec-path** request flow; its `exec up` stage does not exist on
-the `reqbench.sh` direct-CDP path above, whose timing dataset is the open re-baseline.
+the `reqbench.sh` direct-CDP path above. Publication gate for that dataset: at least 200
+measured non-warmup CDP requests per backend at zero failures (the harness enforces this and
+exits 5 otherwise), quoted with exact per-arm denominators and two-sided Clopper–Pearson
+intervals for any reliability claim.
 
 ### Running it reproducibly
 

--- a/bench/chromium/README.md
+++ b/bench/chromium/README.md
@@ -34,6 +34,11 @@ Fan-out phases add burst latency and marginal memory per concurrent request.
 | `pageserver.py` | in-guest fixture server (`Cache-Control: no-store`, `/ready` gate for `--health-check` golden snapshots) |
 | `render.py` | per-request CDP driver (stdlib-only WebSocket client); prints one machine-parsable `RENDER_OK` line with per-phase timings |
 | `bench.sh` | host-side harness: golden snapshots, egress matrix, fan-out, baselines (see phases below) |
+| `reqbench.sh` | the request-optimized path: direct CDP over fcvm's published-port DNAT, `podman prepare` goldens, hop verification on a restored clone, three-arm A/B, one-SIGKILL teardown (see below) |
+| `cdpdrive.py` | host-side CDP driver for reqbench (stdlib WebSocket); nothing of ours is resident in the guest |
+| `reqbench.py` / `reqanalyze.py` / `reqstages.py` | per-request record schema, analysis, and stage decomposition for reqbench runs |
+| `reqscale.py` / `reqscale_analyze.py` | concurrency scaling arms over the request path |
+| `faultbench.py` / `faultanalyze.py` / `faulttrace.bt` | guest page-fault count/cost per request, per memory backend |
 | `hostserver.py` | host-side "simulated external site": dual-stack bind, optional self-signed TLS, same `pages/` bytes as the image |
 | `report.py` | `sample` (host memory + per-clone PSS one-liner) and `finalize` (requests/samples → `raw.json` + `report.md`) |
 | `gen_images.py` | regenerates the deterministic PNG fixtures in `pages/` (stdlib only) |
@@ -101,6 +106,35 @@ Run the harness with `RUST_LOG=fcvm=debug` in the environment when the run is
 meant to be analyzed for stage attribution (serve/restore logs land in
 `results/<stamp>/logs/`).
 
+## The request-optimized path (`reqbench.sh`)
+
+`bench.sh` measures the egress matrix with an in-guest driver started by `fcvm exec`
+per request — its `exec up` stage (~252 ms median, mostly Python startup inside the
+guest) is a harness artifact, not something a real service would pay. `reqbench.sh`
+is the request path a service would actually run:
+
+- **Direct CDP from the host.** Chromium binds CDP to guest loopback `127.0.0.1:9222`
+  only (it ignores `--remote-debugging-address`; evidence in `entry.sh`), and fcvm
+  DNATs each eligible published TCP port to guest loopback
+  (`fc-agent/src/network.rs::publish_to_loopback`, DESIGN.md "Eligible published TCP
+  ports reach guest loopback") — so `--publish 9222:9222` reaches it with no relay,
+  no exec, and no benchmark-owned process in the byte path. The former per-clone
+  `socat` relay is deleted; the socat-era availability A/B was withdrawn as
+  non-comparable and is not evidence about the relay.
+- **Goldens via `fcvm podman prepare`** snapshotted at the image health gate, and
+  clones inherit `port_mappings` from snapshot metadata — which is why
+  `./reqbench.sh verify` proves every hop **on a restored clone** before `run`
+  measures anything.
+- **Teardown is one SIGKILL** to fcvm; the kernel fans it out to Firecracker and the
+  namespace holder via `PR_SET_PDEATHSIG`.
+- **Sealed provenance.** Each run records content hashes of the harness, `fcvm`, and
+  `fc-agent`, the snapshot generation UUID, and the exact config digest, so every
+  number is bound to the code that produced it.
+
+Phases: `./reqbench.sh build` → `golden` → `verify` → `run` (or `all`). The box must
+be quiet — the harness refuses to measure under load (`ALLOW_BUSY=1` overrides, and
+says so in the record).
+
 ## Results conventions
 
 Raw run output goes to `results/<timestamp>/` — **git-ignored** (see
@@ -132,6 +166,9 @@ site-isolation-off saves 3.6% on PSS (not 23% - that number was an RSS artifact)
 
 `REVIEW.md` is the ledger of what holds, what was refuted, and what remains unmeasured. Read it
 before quoting anything from this directory.
+
+The corrected run measured the **exec-path** request flow; its `exec up` stage does not exist on
+the `reqbench.sh` direct-CDP path above, whose timing dataset is the open re-baseline.
 
 ### Running it reproducibly
 


### PR DESCRIPTION
bench/chromium/README.md still presented the exec-path `bench.sh` matrix as the whole story — no mention of `reqbench.sh`, `cdpdrive.py`, or the published-port DNAT — while AGENTS.md, REVIEW.md, `entry.sh`, and DESIGN.md all describe the direct path as current. The README is the front door of the bench directory, and its silence made the deleted socat-era design read as present (it cost a real detour today).

## Changes
- Files table: add the request-path entries (reqbench/cdpdrive/req* analysis/fault harness).
- New section **The request-optimized path (`reqbench.sh`)**: direct CDP over `publish_to_loopback` DNAT (no relay, no exec in the byte path), `podman prepare` goldens, hop verification on a restored clone before measuring, one-SIGKILL teardown, sealed provenance; records that the socat relay is deleted and the socat-era A/B withdrawn.
- **Current status**: scopes the 20260808-corrected record as exec-path and names the direct-CDP timing dataset as the open re-baseline.

Docs-only.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for the request-optimized Chromium benchmark workflow.
  * Documented snapshot preparation, verification, teardown, provenance tracking, and execution phases.
  * Expanded the benchmark file inventory to include request, scaling, fault-analysis, and CDP driver components.
  * Clarified measured results and identified direct-CDP timing as pending re-baselining.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->