### PR TITLE
Hugepage goldens on the request path + make-driven bench phases

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -406,11 +406,11 @@ then on "Custom firecracker not found", because a hand-rolled runner called
 | Target | Deps | Knobs (command-line vars; make exports them) |
 |--------|------|----------------------------------------------|
 | `bench-chromium-request-build` | `build` | container image only |
-| `bench-chromium-request-golden` | `-build` + `setup-default` | `TAG=`, `HUGEPAGES=1`, `NETMODE=`, `CPU=`, `MEM=` |
+| `bench-chromium-request-golden` | `bench-chromium-request-build` + `setup-default` | `TAG=`, `HUGEPAGES=1`, `NETMODE=`, `CPU=`, `MEM=` |
 | `bench-chromium-request-verify` | none (sealed bundle) | `TAG=` |
 | `bench-chromium-request-run` | none (sealed bundle) | `TAG=`, `BACKEND=`, `UFFD_MODE=`, `UFFD_PREFETCH=`, `REPS=`, `WARMUP=`, `ARMS=`, `RESULTS=` |
 | `bench-chromium-request-all` | `build` + `setup-default` | all of the above, one seal |
-| `bench-chromium-hostcdp` | `-build` | host-container CDP baseline, no VM |
+| `bench-chromium-hostcdp` | `bench-chromium-request-build` | host-container CDP baseline, no VM |
 | `bench-chromium-fault` | `build` + `setup-default` | `FAULT_OUT=` (required), `FAULT_ARGS=` |
 
 - **verify/run must never gain a `build` dependency.** reqbench.sh seals

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -408,7 +408,7 @@ then on "Custom firecracker not found", because a hand-rolled runner called
 | `bench-chromium-request-build` | `build` | container image only |
 | `bench-chromium-request-golden` | `-build` + `setup-default` | `TAG=`, `HUGEPAGES=1`, `NETMODE=`, `CPU=`, `MEM=` |
 | `bench-chromium-request-verify` | none (sealed bundle) | `TAG=` |
-| `bench-chromium-request-run` | none (sealed bundle) | `BACKEND=`, `UFFD_MODE=`, `UFFD_PREFETCH=`, `REPS=`, `ARMS=`, `RESULTS=` |
+| `bench-chromium-request-run` | none (sealed bundle) | `TAG=`, `BACKEND=`, `UFFD_MODE=`, `UFFD_PREFETCH=`, `REPS=`, `WARMUP=`, `ARMS=`, `RESULTS=` |
 | `bench-chromium-request-all` | `build` + `setup-default` | all of the above, one seal |
 | `bench-chromium-hostcdp` | `-build` | host-container CDP baseline, no VM |
 | `bench-chromium-fault` | `build` + `setup-default` | `FAULT_OUT=` (required), `FAULT_ARGS=` |
@@ -424,9 +424,14 @@ then on "Custom firecracker not found", because a hand-rolled runner called
   `make bench-chromium-request-golden TAG=cb-req-golden-huge HUGEPAGES=1`
   (the golden grows the pool to 2048x2MB pages and fails closed if the
   kernel cannot deliver them).
-- Quiet-box gates: `run` refuses at 1-min load >= 2.0 or with stray
-  fcvm/firecracker processes (hostcdp and faultbench refuse at 1.0). Do not
-  start builds while a measured run is in flight.
+- Quiet-box gates: `run` refuses when 1-min load exceeds 2.0 or stray
+  fcvm/firecracker processes exist (hostcdp and faultbench refuse above 1.0).
+  Do not start builds — or ANY box-local work, including analysis scripts and
+  background agents — while a measured run is in flight; the noop drift gate
+  catches the contamination and voids the run (burned twice, 2026-08-13).
+- BACKEND=file is refused against a hugepage TAG (fcvm restores those via an
+  implicit UFFD server; the record would be mislabeled), and the pool is
+  ensured MEM-derived (4 x MEM/2 pages) at golden, verify, AND run time.
 - Structural pin: `MakefileBenchGraph` in bench/chromium/test_reqbench.py
   (`make test-chromium-request`) — it fails if the dependency graph or the
   no-rebuild property of the measured phases regresses.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -425,7 +425,7 @@ then on "Custom firecracker not found", because a hand-rolled runner called
   (the golden grows the pool to 2048x2MB pages and fails closed if the
   kernel cannot deliver them).
 - Quiet-box gates: `run` refuses when 1-min load exceeds 2.0 or stray
-  fcvm/firecracker processes exist (hostcdp and faultbench refuse above 1.0).
+  fcvm/firecracker processes exist (hostcdp refuses at >= 1.0, faultbench above 1.0).
   Do not start builds — or ANY box-local work, including analysis scripts and
   background agents — while a measured run is in flight; the noop drift gate
   catches the contamination and voids the run (burned twice, 2026-08-13).

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -395,6 +395,42 @@ may both be reports about code you are not editing. Use the appropriate Make tar
 believing a result, confirm `readlink -f target` resolves to this worktree's unique target
 directory and the `Running .../deps/<binary>` line points beneath it.
 
+### Chromium bench harness is make-driven (bench/chromium)
+
+Drive every bench phase through make — the dependency graph lives in the
+Makefile, so half-set-up boxes fail at `make` time instead of mid-golden
+(2026-08-13: two goldens died at runtime, first on a missing fcvm binary,
+then on "Custom firecracker not found", because a hand-rolled runner called
+`reqbench.sh` directly):
+
+| Target | Deps | Knobs (command-line vars; make exports them) |
+|--------|------|----------------------------------------------|
+| `bench-chromium-request-build` | `build` | container image only |
+| `bench-chromium-request-golden` | `-build` + `setup-default` | `TAG=`, `HUGEPAGES=1`, `NETMODE=`, `CPU=`, `MEM=` |
+| `bench-chromium-request-verify` | none (sealed bundle) | `TAG=` |
+| `bench-chromium-request-run` | none (sealed bundle) | `BACKEND=`, `UFFD_MODE=`, `UFFD_PREFETCH=`, `REPS=`, `ARMS=`, `RESULTS=` |
+| `bench-chromium-request-all` | `build` + `setup-default` | all of the above, one seal |
+| `bench-chromium-hostcdp` | `-build` | host-container CDP baseline, no VM |
+| `bench-chromium-fault` | `build` + `setup-default` | `FAULT_OUT=` (required), `FAULT_ARGS=` |
+
+- **verify/run must never gain a `build` dependency.** reqbench.sh seals
+  fcvm + fc-agent + its five sources into a hash-bound runtime bundle; the
+  run refuses a golden recorded under a different bundle hash. A rebuild (or
+  any edit to a sealed file) between golden and run invalidates the chain —
+  regolden, don't fight the seal. Sealed set: reqbench.{sh,py},
+  reqanalyze.py, cdpdrive.py, render.py, fcvm, fc-agent — the Makefile and
+  test files are NOT sealed and stay editable mid-run.
+- Hugepage goldens are part of the snapshot identity: distinct tag, e.g.
+  `make bench-chromium-request-golden TAG=cb-req-golden-huge HUGEPAGES=1`
+  (the golden grows the pool to 2048x2MB pages and fails closed if the
+  kernel cannot deliver them).
+- Quiet-box gates: `run` refuses at 1-min load >= 2.0 or with stray
+  fcvm/firecracker processes (hostcdp and faultbench refuse at 1.0). Do not
+  start builds while a measured run is in flight.
+- Structural pin: `MakefileBenchGraph` in bench/chromium/test_reqbench.py
+  (`make test-chromium-request`) — it fails if the dependency graph or the
+  no-rebuild property of the measured phases regresses.
+
 ## NEVER ROUTE AROUND BUILD PROCESSES
 
 **If a build fails, FIX THE BUILD. Never manually copy files.**

--- a/Makefile
+++ b/Makefile
@@ -587,7 +587,9 @@ setup-hugepages:
 		echo "==> Hugepages already allocated: $$current (need $(HUGEPAGE_POOL_TESTS))"; \
 	else \
 		echo "==> Allocating hugepage pool ($(HUGEPAGE_POOL_TESTS) pages = $$(( $(HUGEPAGE_POOL_TESTS) * 2 ))MB)..."; \
-		sudo sh -c 'echo $(HUGEPAGE_POOL_TESTS) > /proc/sys/vm/nr_hugepages'; \
+		sudo mkdir -p /mnt/fcvm-btrfs 2>/dev/null || true; \
+		flock -x -w 60 /mnt/fcvm-btrfs/hugepage-pool.lock \
+			sudo sh -c 'echo $(HUGEPAGE_POOL_TESTS) > /proc/sys/vm/nr_hugepages'; \
 	fi
 
 setup-btrfs:
@@ -772,16 +774,17 @@ FAULT_POOL ?= 4096
 bench-chromium-fault: build setup-default
 	@test -n "$(FAULT_OUT)" || (echo "ERROR: FAULT_OUT required (results directory)"; exit 1)
 	@if ls -d /mnt/fcvm-btrfs/snapshots/cb-golden-huge* >/dev/null 2>&1; then \
-		current=$$(cat /proc/sys/vm/nr_hugepages 2>/dev/null || echo 0); \
-		if [ "$$current" -lt "$(FAULT_POOL)" ]; then \
-			echo "==> Growing hugepage pool $$current -> $(FAULT_POOL) for the huge cells..."; \
-			sudo sh -c 'echo $(FAULT_POOL) > /proc/sys/vm/nr_hugepages'; \
-			after=$$(cat /proc/sys/vm/nr_hugepages 2>/dev/null || echo 0); \
-			if [ "$$after" -lt "$(FAULT_POOL)" ]; then \
-				echo "ERROR: hugepage pool only $$after/$(FAULT_POOL) pages (fragmentation)"; \
-				exit 1; \
-			fi; \
-		fi; \
+		flock -x -w 60 /mnt/fcvm-btrfs/hugepage-pool.lock sh -c ' \
+			current=$$(cat /proc/sys/vm/nr_hugepages 2>/dev/null || echo 0); \
+			if [ "$$current" -lt "$(FAULT_POOL)" ]; then \
+				echo "==> Growing hugepage pool $$current -> $(FAULT_POOL) for the huge cells..."; \
+				sudo sh -c "echo $(FAULT_POOL) > /proc/sys/vm/nr_hugepages"; \
+				after=$$(cat /proc/sys/vm/nr_hugepages 2>/dev/null || echo 0); \
+				if [ "$$after" -lt "$(FAULT_POOL)" ]; then \
+					echo "ERROR: hugepage pool only $$after/$(FAULT_POOL) pages (fragmentation)"; \
+					exit 1; \
+				fi; \
+			fi'; \
 	fi
 	@echo "==> Running per-request page-fault benchmark..."
 	@python3 bench/chromium/faultbench.py --out "$(FAULT_OUT)" $(FAULT_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,9 @@ CONTAINER_RUN := $(CONTAINER_RUN_BASE) --ulimit nproc=65536:65536 --pids-limit=6
 	container-build container-test container-test-unit container-test-fast container-test-all container-test-fc-mock \
 	container-setup-fcvm container-shell container-clean container-bench \
 	cargo-target-link build-host-tools setup-btrfs setup-default release-default-kernel setup-fcvm setup-pjdfstest setup-hugepages bench bench-vm bench-hugepages bench-hugepages-test \
-	bench-container-import bench-chromium bench-chromium-request analyze-chromium-request bench-clone-latency test-chromium-request \
+	bench-container-import bench-chromium analyze-chromium-request bench-clone-latency test-chromium-request \
+	bench-chromium-request-build bench-chromium-request-golden bench-chromium-request-verify \
+	bench-chromium-request-run bench-chromium-request-all bench-chromium-hostcdp bench-chromium-fault \
 	bench-chromium-scale analyze-chromium-scale report-chromium-scale test-chromium-scale \
 	test-chromium-fault \
 	bench-quick bench-throughput bench-operations bench-protocol \
@@ -290,7 +292,13 @@ help:
 	@echo "  bench-hugepages-test  Run hugepages benchmark (2GB VM, 256MB dirty)"
 	@echo "  bench-container-import  Compare podman load vs direct image mount"
 	@echo "  bench-chromium     Chromium shared-nothing clone bench (egress x memory matrix)"
-	@echo "  bench-chromium-request  Run the gated request benchmark (PHASE=, BACKEND=, REPS=, WARMUP=, RESULTS=)"
+	@echo "  bench-chromium-request-build   Build the request-bench container image"
+	@echo "  bench-chromium-request-golden  Create golden snapshot (TAG=, HUGEPAGES=1, NETMODE=)"
+	@echo "  bench-chromium-request-verify  Prove CDP hops on a restored clone (TAG=)"
+	@echo "  bench-chromium-request-run     Measured run (BACKEND=, UFFD_MODE=, UFFD_PREFETCH=, REPS=, ARMS=, RESULTS=)"
+	@echo "  bench-chromium-request-all     Full chain: image, golden, verify, run"
+	@echo "  bench-chromium-hostcdp         Host-container direct-CDP baseline (no VM)"
+	@echo "  bench-chromium-fault           Page-fault bench (FAULT_OUT= required; needs bench.sh goldens)"
 	@echo "  analyze-chromium-request  Re-run publication gates for RESULTS=/path/to/run"
 	@echo "  test-chromium-request  Run the request benchmark's deterministic unit tests"
 	@echo "  bench-chromium-scale  Open-loop FILE/UFFD Chromium request scalability run"
@@ -697,10 +705,27 @@ bench-chromium: build
 	@echo "==> Running Chromium shared-nothing benchmark..."
 	@bash bench/chromium/bench.sh run
 
-# Request-optimized Chromium benchmark. The driver invokes reqanalyze.py after
-# every run and propagates its publication-gate status, so a Make success means
-# both the producer and analyzer accepted the result.
-PHASE ?= run
+# Request-optimized Chromium benchmark: one make target per reqbench.sh phase,
+# so the dependency chain is explicit instead of discovered at runtime. The
+# golden needs the fcvm binary AND the default-profile assets (kernel, rootfs,
+# initrd, firecracker — that is `setup-default`, whose absence is the
+# "Custom firecracker not found" golden failure of 2026-08-13). The measured
+# phases (verify/run) deliberately do NOT depend on `build`: reqbench.sh
+# stages fcvm+fc-agent+its own sources into a hash-sealed runtime bundle, and
+# the run refuses a golden whose provenance records a different bundle hash —
+# a rebuild between golden and run would swap the binary under test, so the
+# binary must come from the golden-time build and a missing/stale one fails
+# closed with a clear error. Structural pin: MakefileBenchGraph in
+# bench/chromium/test_reqbench.py (make test-chromium-request).
+#
+# Knobs reach reqbench.sh through the environment — make exports command-line
+# variables — so e.g.:
+#   make bench-chromium-request-golden TAG=cb-req-golden-huge HUGEPAGES=1
+#   make bench-chromium-request-run TAG=cb-req-golden-huge UFFD_MODE=minor \
+#        UFFD_PREFETCH=on REPS=202 ARMS=exec,noop,cdp-fast,cdp
+# The run driver invokes reqanalyze.py afterwards and propagates its
+# publication-gate status, so a Make success means both the producer and the
+# analyzer accepted the result.
 BACKEND ?= uffd
 REPS ?= 200
 WARMUP ?= 2
@@ -708,10 +733,40 @@ ifndef RESULTS
 RESULTS := $(CURDIR)/bench/chromium/results/reqbench-$(shell date +%Y%m%d-%H%M%S)-$(BACKEND)
 endif
 
-bench-chromium-request: build
+bench-chromium-request-build: build
+	@echo "==> Building Chromium request-bench container image..."
+	@bash bench/chromium/reqbench.sh build
+
+bench-chromium-request-golden: bench-chromium-request-build setup-default
+	@echo "==> Creating golden snapshot (TAG=$(if $(TAG),$(TAG),cb-req-golden), HUGEPAGES=$(if $(HUGEPAGES),$(HUGEPAGES),0))..."
+	@bash bench/chromium/reqbench.sh golden
+
+bench-chromium-request-verify:
+	@echo "==> Verifying CDP hops on a restored clone..."
+	@bash bench/chromium/reqbench.sh verify
+
+bench-chromium-request-run:
 	@echo "==> Running gated Chromium request benchmark ($(BACKEND), $(REPS) measured attempts per arm)..."
 	@BACKEND="$(BACKEND)" REPS="$(REPS)" WARMUP="$(WARMUP)" RESULTS="$(RESULTS)" \
-		bash bench/chromium/reqbench.sh "$(PHASE)"
+		bash bench/chromium/reqbench.sh run
+
+bench-chromium-request-all: build setup-default
+	@echo "==> Full request-bench chain (image, golden, verify, measured run) under one seal..."
+	@BACKEND="$(BACKEND)" REPS="$(REPS)" WARMUP="$(WARMUP)" RESULTS="$(RESULTS)" \
+		bash bench/chromium/reqbench.sh all
+
+# Host-container direct-CDP baseline (no VM): same image, same driver, warm
+# pool on the host. Needs only the container image, not VM assets.
+bench-chromium-hostcdp: bench-chromium-request-build
+	@echo "==> Running host-container direct-CDP baseline..."
+	@bash bench/chromium/hostcdp.sh
+
+# Per-request guest page-fault count/cost per memory backend. Requires the
+# bench.sh goldens (cb-golden-*) to exist; cells without one are skipped.
+bench-chromium-fault: build setup-default
+	@test -n "$(FAULT_OUT)" || (echo "ERROR: FAULT_OUT required (results directory)"; exit 1)
+	@echo "==> Running per-request page-fault benchmark..."
+	@python3 bench/chromium/faultbench.py --out "$(FAULT_OUT)" $(FAULT_ARGS)
 
 analyze-chromium-request:
 	@test -f "$(RESULTS)/reqbench.jsonl" || { echo "ERROR: no $(RESULTS)/reqbench.jsonl" >&2; exit 2; }

--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,7 @@ help:
 	@echo "  bench-chromium-request-build   Build the request-bench container image"
 	@echo "  bench-chromium-request-golden  Create golden snapshot (TAG=, HUGEPAGES=1, NETMODE=)"
 	@echo "  bench-chromium-request-verify  Prove CDP hops on a restored clone (TAG=)"
-	@echo "  bench-chromium-request-run     Measured run (BACKEND=, UFFD_MODE=, UFFD_PREFETCH=, REPS=, ARMS=, RESULTS=)"
+	@echo "  bench-chromium-request-run     Measured run (TAG=, BACKEND=, UFFD_MODE=, UFFD_PREFETCH=, REPS=, WARMUP=, ARMS=, RESULTS=)"
 	@echo "  bench-chromium-request-all     Full chain: image, golden, verify, run"
 	@echo "  bench-chromium-hostcdp         Host-container direct-CDP baseline (no VM)"
 	@echo "  bench-chromium-fault           Page-fault bench (FAULT_OUT= required; needs bench.sh goldens)"
@@ -763,8 +763,19 @@ bench-chromium-hostcdp: bench-chromium-request-build
 
 # Per-request guest page-fault count/cost per memory backend. Requires the
 # bench.sh goldens (cb-golden-*) to exist; cells without one are skipped.
+# faultbench selects uffd-huge-minor whenever the huge golden exists, and
+# bench.sh restores the pool (commonly to zero) after creating that golden —
+# so the pool must be provisioned HERE or the entry point fails immediately
+# after the workflow that created its own prerequisite. Default sized for
+# --guest-mib 2048: backing memfd (1024 pages) + concurrent clones.
+FAULT_POOL ?= 4096
 bench-chromium-fault: build setup-default
 	@test -n "$(FAULT_OUT)" || (echo "ERROR: FAULT_OUT required (results directory)"; exit 1)
+	@current=$$(cat /proc/sys/vm/nr_hugepages 2>/dev/null || echo 0); \
+	if [ "$$current" -lt "$(FAULT_POOL)" ]; then \
+		echo "==> Growing hugepage pool $$current -> $(FAULT_POOL) for the huge cells..."; \
+		sudo sh -c 'echo $(FAULT_POOL) > /proc/sys/vm/nr_hugepages'; \
+	fi
 	@echo "==> Running per-request page-fault benchmark..."
 	@python3 bench/chromium/faultbench.py --out "$(FAULT_OUT)" $(FAULT_ARGS)
 

--- a/Makefile
+++ b/Makefile
@@ -588,6 +588,7 @@ setup-hugepages:
 	else \
 		echo "==> Allocating hugepage pool ($(HUGEPAGE_POOL_TESTS) pages = $$(( $(HUGEPAGE_POOL_TESTS) * 2 ))MB)..."; \
 		sudo mkdir -p /mnt/fcvm-btrfs 2>/dev/null || true; \
+		sudo sh -c 'touch /mnt/fcvm-btrfs/hugepage-pool.lock && chmod 666 /mnt/fcvm-btrfs/hugepage-pool.lock'; \
 		flock -x -w 60 /mnt/fcvm-btrfs/hugepage-pool.lock \
 			sudo sh -c 'echo $(HUGEPAGE_POOL_TESTS) > /proc/sys/vm/nr_hugepages'; \
 	fi
@@ -774,6 +775,7 @@ FAULT_POOL ?= 4096
 bench-chromium-fault: build setup-default
 	@test -n "$(FAULT_OUT)" || (echo "ERROR: FAULT_OUT required (results directory)"; exit 1)
 	@if ls -d /mnt/fcvm-btrfs/snapshots/cb-golden-huge* >/dev/null 2>&1; then \
+		sudo sh -c 'touch /mnt/fcvm-btrfs/hugepage-pool.lock && chmod 666 /mnt/fcvm-btrfs/hugepage-pool.lock'; \
 		flock -x -w 60 /mnt/fcvm-btrfs/hugepage-pool.lock sh -c ' \
 			current=$$(cat /proc/sys/vm/nr_hugepages 2>/dev/null || echo 0); \
 			if [ "$$current" -lt "$(FAULT_POOL)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -771,10 +771,17 @@ bench-chromium-hostcdp: bench-chromium-request-build
 FAULT_POOL ?= 4096
 bench-chromium-fault: build setup-default
 	@test -n "$(FAULT_OUT)" || (echo "ERROR: FAULT_OUT required (results directory)"; exit 1)
-	@current=$$(cat /proc/sys/vm/nr_hugepages 2>/dev/null || echo 0); \
-	if [ "$$current" -lt "$(FAULT_POOL)" ]; then \
-		echo "==> Growing hugepage pool $$current -> $(FAULT_POOL) for the huge cells..."; \
-		sudo sh -c 'echo $(FAULT_POOL) > /proc/sys/vm/nr_hugepages'; \
+	@if ls -d /mnt/fcvm-btrfs/snapshots/cb-golden-huge* >/dev/null 2>&1; then \
+		current=$$(cat /proc/sys/vm/nr_hugepages 2>/dev/null || echo 0); \
+		if [ "$$current" -lt "$(FAULT_POOL)" ]; then \
+			echo "==> Growing hugepage pool $$current -> $(FAULT_POOL) for the huge cells..."; \
+			sudo sh -c 'echo $(FAULT_POOL) > /proc/sys/vm/nr_hugepages'; \
+			after=$$(cat /proc/sys/vm/nr_hugepages 2>/dev/null || echo 0); \
+			if [ "$$after" -lt "$(FAULT_POOL)" ]; then \
+				echo "ERROR: hugepage pool only $$after/$(FAULT_POOL) pages (fragmentation)"; \
+				exit 1; \
+			fi; \
+		fi; \
 	fi
 	@echo "==> Running per-request page-fault benchmark..."
 	@python3 bench/chromium/faultbench.py --out "$(FAULT_OUT)" $(FAULT_ARGS)

--- a/bench/chromium/AGENTS.md
+++ b/bench/chromium/AGENTS.md
@@ -34,7 +34,9 @@ Knobs pass as make command-line variables (make exports them to the recipe
 environment): `TAG=`, `HUGEPAGES=1`, `NETMODE=`, `UFFD_MODE=`,
 `UFFD_PREFETCH=`, `REPS=`, `WARMUP=`, `ARMS=`, `RESULTS=`. Hugepage goldens
 are part of the snapshot identity — give them their own tag
-(`make bench-chromium-request-golden TAG=cb-req-golden-huge HUGEPAGES=1`).
+(`make bench-chromium-request-golden TAG=cb-req-golden-huge HUGEPAGES=1`;
+the same `TAG=` must then be passed to `-verify` and `-run`, or they select
+the default snapshot).
 
 `verify` and `run` deliberately have NO build dependency: reqbench.sh seals
 fcvm + fc-agent + its five sources into a hash-bound runtime bundle, and the

--- a/bench/chromium/AGENTS.md
+++ b/bench/chromium/AGENTS.md
@@ -13,23 +13,36 @@ nothing. Every rule below exists because one of them broke.
 
 ## Running the gated request benchmark end to end
 
-The phases are separate subcommands and the order is not optional. `golden`
-does NOT build the image — on a box that has never built it, `golden` dies
-with `localhost/chromium-bench-req: image not known`, so `build` comes first.
-After rebuilding fcvm or fc-agent, `make setup-fcvm` must run before `golden`:
-the initrd is content-addressed by the fc-agent binary's SHA, `make build`
-does not create it, and `podman prepare` refuses rather than auto-creating
-("fc-agent initrd not found. Run 'fcvm setup' first"):
+The phases are separate make targets and the order is not optional. The
+dependency graph is IN the Makefile now, so make — not the operator — walks
+it: the golden depends on the container image build and on `setup-default`
+(kernel, rootfs, initrd, firecracker; their absence is the runtime failure
+"Custom firecracker not found ... Run: fcvm setup"), and the image build
+depends on the fcvm binary build. Drive the phases through make; the raw
+`bash bench/chromium/reqbench.sh <phase>` route skips the dependency graph
+and is how goldens died on half-set-up boxes (2026-08-13, twice in one day):
 
 ```bash
-cd ~/src/fcvm            # phases resolve the repo root from the script path
-make build && make setup-fcvm            # setup-fcvm creates the initrd for the NEW fc-agent SHA
-bash bench/chromium/reqbench.sh build    # podman build --format docker (HEALTHCHECK is load-bearing)
-bash bench/chromium/reqbench.sh golden   # podman prepare: cold build, snapshot at the health gate
-bash bench/chromium/reqbench.sh verify   # prove all three hops on a RESTORED clone before measuring
-BACKEND=uffd REPS=200 RESULTS=/mnt/fcvm-btrfs/reqbench-uffd-200 bash bench/chromium/reqbench.sh run
-BACKEND=file REPS=200 RESULTS=/mnt/fcvm-btrfs/reqbench-file-200 bash bench/chromium/reqbench.sh run
+cd ~/src/fcvm
+make bench-chromium-request-golden       # deps: fcvm build -> image build -> setup-default -> golden
+make bench-chromium-request-verify       # prove all three hops on a RESTORED clone before measuring
+make bench-chromium-request-run BACKEND=uffd REPS=200 RESULTS=/mnt/fcvm-btrfs/reqbench-uffd-200
+make bench-chromium-request-run BACKEND=file REPS=200 RESULTS=/mnt/fcvm-btrfs/reqbench-file-200
 ```
+
+Knobs pass as make command-line variables (make exports them to the recipe
+environment): `TAG=`, `HUGEPAGES=1`, `NETMODE=`, `UFFD_MODE=`,
+`UFFD_PREFETCH=`, `REPS=`, `WARMUP=`, `ARMS=`, `RESULTS=`. Hugepage goldens
+are part of the snapshot identity — give them their own tag
+(`make bench-chromium-request-golden TAG=cb-req-golden-huge HUGEPAGES=1`).
+
+`verify` and `run` deliberately have NO build dependency: reqbench.sh seals
+fcvm + fc-agent + its five sources into a hash-bound runtime bundle, and the
+run refuses a golden whose provenance records a different bundle hash.
+Rebuilding — or editing any sealed file — between golden and run therefore
+invalidates the chain; regolden instead of fighting the seal. The structural
+pin for all of this is `MakefileBenchGraph` in `test_reqbench.py`
+(`make test-chromium-request`).
 
 The acceptance gate is >=200 measured requests PER BACKEND (`uffd` and `file`)
 at zero failures. For anything long-running on a remote box, write the chain

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -665,8 +665,16 @@ cmd_verify() {
     local fail=0
     # A rebooted or pool-shrunk box re-runs verify against a persisted huge
     # golden with an empty pool; grow it here, not only at golden time.
-    if [ "$(hugepage_snapshot_state)" = huge ]; then
-        ensure_hugepage_pool || return 1
+    # unknown refuses: jq missing or an unreadable config would otherwise
+    # skip provisioning fail-OPEN and die mid-serve instead.
+    local huge_state
+    huge_state=$(hugepage_snapshot_state)
+    if [ "$huge_state" = unknown ]; then
+        log "verify: cannot determine hugepage state for '$TAG' (config.json unreadable or jq missing)"
+        return 1
+    fi
+    if [ "$huge_state" = huge ]; then
+        ensure_hugepage_pool "$(snapshot_memory_mib)" || return 1
     fi
     log "verify: starting serve for $TAG"
     local sf="$RESULTS/logs/verify-serve.log"
@@ -803,18 +811,36 @@ hugepage_snapshot_state() {
 # quietly starting on a starved pool would die mid-measurement, or worse,
 # measure a mixed-page configuration.
 ensure_hugepage_pool() {
-    local per_vm=$((MEM / 2)) need cur
-    need=$((per_vm * 4))
+    # $1: guest MiB to size for (defaults to $MEM). Measured phases pass the
+    # SNAPSHOT's recorded memory_mib — sizing from the caller's ambient MEM
+    # under-provisions when a big golden is verified with default knobs.
+    local mem="${1:-$MEM}" need cur
+    if [ $((mem % 2)) -ne 0 ]; then
+        # fcvm rejects odd MEM too, but only AFTER we would have reserved
+        # gigabytes of pool for an invocation that can never boot.
+        log "hugepages: MEM=${mem} is not divisible by 2 (2MB pages)"
+        return 1
+    fi
+    need=$(( (mem / 2) * 4 ))
     cur=$(cat "$HUGEPAGE_POOL_FILE" 2>/dev/null || echo 0)
     if [ "$cur" -lt "$need" ]; then
-        log "hugepages: growing pool $cur -> $need (MEM=${MEM}MiB x4)"
-        sudo sh -c "echo $need > '$HUGEPAGE_POOL_FILE'"
+        log "hugepages: growing pool $cur -> $need (${mem}MiB guest x4)"
+        sudo sh -c 'echo "$1" > "$2"' _ "$need" "$HUGEPAGE_POOL_FILE"
         cur=$(cat "$HUGEPAGE_POOL_FILE" 2>/dev/null || echo 0)
         if [ "$cur" -lt "$need" ]; then
             log "hugepages: pool only $cur/$need pages (fragmentation?)"
             return 1
         fi
     fi
+}
+
+# The installed snapshot's guest size; falls back to ambient MEM when the
+# config predates the field.
+snapshot_memory_mib() {
+    local v
+    v=$($SUDO jq -er '.metadata.memory_mib' \
+        "$DATA_ROOT/snapshots/$TAG/config.json" 2>/dev/null) || v="$MEM"
+    echo "$v"
 }
 
 cmd_run() {
@@ -830,7 +856,7 @@ cmd_run() {
         return 2
     fi
     if [ "$huge_state" = huge ]; then
-        ensure_hugepage_pool || return 1
+        ensure_hugepage_pool "$(snapshot_memory_mib)" || return 1
     fi
     local guard_rc=0
     guard_quiet || guard_rc=$?

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -442,7 +442,7 @@ cmd_build() {
 }
 
 cmd_golden() {
-    log "golden: podman prepare --tag $TAG (cold build, snapshot at the image health gate)"
+    log "golden: podman prepare --tag $TAG (cold build, snapshot at the image health gate, hugepages=$HUGEPAGES)"
     local name="cb-req-g-$RUNID" lf="$RESULTS/logs/golden.log"
     local image_record image_digest image_id image_cache_key
     # One inspect binds the mutable tag's manifest digest and immutable image ID
@@ -485,7 +485,26 @@ cmd_golden() {
     # captured separately from the log so the provenance below can be bound to
     # THAT generation rather than to whatever currently sits under the tag.
     local prepared_json="$RESULTS/logs/golden-prepared.json"
-    $SUDO env RUST_LOG="$FCVM_LOG" "$FCVM" podman prepare --tag "$TAG" --force \
+    local huge_flag=""
+    if [ "$HUGEPAGES" = 1 ]; then
+        huge_flag="--hugepages"
+        # One 1024MiB guest = 512 2MB pages; golden build + serve + clones in
+        # flight need headroom. Grow the pool if short and fail closed if the
+        # kernel could not deliver (fragmentation) — a golden quietly built
+        # on 4K pages would poison every later A/B against this tag.
+        local huge_need=2048 huge_cur
+        huge_cur=$(cat /proc/sys/vm/nr_hugepages)
+        if [ "$huge_cur" -lt "$huge_need" ]; then
+            log "golden: growing hugepage pool $huge_cur -> $huge_need"
+            sudo sh -c "echo $huge_need > /proc/sys/vm/nr_hugepages"
+            huge_cur=$(cat /proc/sys/vm/nr_hugepages)
+            if [ "$huge_cur" -lt "$huge_need" ]; then
+                log "golden: hugepage pool only $huge_cur/$huge_need pages"
+                return 1
+            fi
+        fi
+    fi
+    $SUDO env RUST_LOG="$FCVM_LOG" "$FCVM" podman prepare --tag "$TAG" --force $huge_flag \
         --name "$name" --cpu "$CPU" --mem "$MEM" --network "$NETMODE" \
         --publish "$CDP_PORT:$CDP_PORT" "$IMAGE" 2>"$lf" >"$prepared_json" \
         || { log "golden: PREPARE FAILED"; tail -20 "$lf" >&2; return 1; }
@@ -763,6 +782,12 @@ UFFD_MODE="${UFFD_MODE:-copy}"
 # binary default and an env override could not be excluded, making replay's
 # contribution unattributable.
 UFFD_PREFETCH="${UFFD_PREFETCH:-on}"
+# Hugepage-backed guest memory (2MB pages). Part of the snapshot identity, so
+# the golden must be CREATED with it; serve/restore inherit it from snapshot
+# metadata. Use a distinct TAG (e.g. cb-req-golden-huge) so plain and huge
+# goldens coexist. faultbench measured huge+minor at zero userspace faults
+# per render — this knob puts that configuration on the request path.
+HUGEPAGES="${HUGEPAGES:-0}"
 
 cmd_run() {
     local guard_rc=0

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -83,6 +83,11 @@ URL="${URL:-http://127.0.0.1:8000/medium.html}"
 
 STATE_DIR="${STATE_DIR:-/mnt/fcvm-btrfs/state}"
 DATA_ROOT="${DATA_ROOT:-$(dirname "$STATE_DIR")}"
+# fcvm resolves snapshots/ (and the generation lock this harness shares with
+# it) from FCVM_DATA_DIR. reqbench derives DATA_ROOT independently; export
+# the alignment so both processes always lock the SAME files even when the
+# caller overrides the paths.
+export FCVM_DATA_DIR="$DATA_ROOT"
 LOADAVG_FILE="${LOADAVG_FILE:-/proc/loadavg}"
 QUIET_LOADAVG1_LIMIT="2.0"
 QUIET_GUARD_LOADAVG1=""

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -488,21 +488,7 @@ cmd_golden() {
     local huge_flag=""
     if [ "$HUGEPAGES" = 1 ]; then
         huge_flag="--hugepages"
-        # One 1024MiB guest = 512 2MB pages; golden build + serve + clones in
-        # flight need headroom. Grow the pool if short and fail closed if the
-        # kernel could not deliver (fragmentation) — a golden quietly built
-        # on 4K pages would poison every later A/B against this tag.
-        local huge_need=2048 huge_cur
-        huge_cur=$(cat /proc/sys/vm/nr_hugepages)
-        if [ "$huge_cur" -lt "$huge_need" ]; then
-            log "golden: growing hugepage pool $huge_cur -> $huge_need"
-            sudo sh -c "echo $huge_need > /proc/sys/vm/nr_hugepages"
-            huge_cur=$(cat /proc/sys/vm/nr_hugepages)
-            if [ "$huge_cur" -lt "$huge_need" ]; then
-                log "golden: hugepage pool only $huge_cur/$huge_need pages"
-                return 1
-            fi
-        fi
+        ensure_hugepage_pool || return 1
     fi
     $SUDO env RUST_LOG="$FCVM_LOG" "$FCVM" podman prepare --tag "$TAG" --force $huge_flag \
         --name "$name" --cpu "$CPU" --mem "$MEM" --network "$NETMODE" \
@@ -677,6 +663,11 @@ cmd_verify() {
     # after printing three FAILED lines. verify is documented as the gate; a gate
     # that cannot fail is not a gate.
     local fail=0
+    # A rebooted or pool-shrunk box re-runs verify against a persisted huge
+    # golden with an empty pool; grow it here, not only at golden time.
+    if [ "$(hugepage_snapshot_state)" = huge ]; then
+        ensure_hugepage_pool || return 1
+    fi
     log "verify: starting serve for $TAG"
     local sf="$RESULTS/logs/verify-serve.log"
     $SUDO "$FCVM" snapshot serve "$TAG" >"$sf" 2>&1 &
@@ -788,8 +779,59 @@ UFFD_PREFETCH="${UFFD_PREFETCH:-on}"
 # goldens coexist. faultbench measured huge+minor at zero userspace faults
 # per render — this knob puts that configuration on the request path.
 HUGEPAGES="${HUGEPAGES:-0}"
+# Overridable for unit tests only; production is the real kernel knob.
+HUGEPAGE_POOL_FILE="${HUGEPAGE_POOL_FILE:-/proc/sys/vm/nr_hugepages}"
+
+# "huge", "normal", or "unknown" for the INSTALLED snapshot under $TAG.
+# unknown (unreadable/missing config.json) must be treated fail-closed by
+# callers that would mislabel data on a wrong guess.
+hugepage_snapshot_state() {
+    local v
+    v=$($SUDO jq -r '.metadata.hugepages' \
+        "$DATA_ROOT/snapshots/$TAG/config.json" 2>/dev/null) || { echo unknown; return; }
+    case "$v" in
+        true) echo huge ;;
+        false|null) echo normal ;;
+        *) echo unknown ;;
+    esac
+}
+
+# 2MB pages: a MEM-MiB guest needs MEM/2 pages. Sized for the worst
+# concurrent set — serve backing memfd + the prepare/verify VM + two clones
+# overlapping across a teardown boundary => 4x. Grow-only, and fails closed
+# when the kernel cannot deliver the pages (fragmentation): a hugepage phase
+# quietly starting on a starved pool would die mid-measurement, or worse,
+# measure a mixed-page configuration.
+ensure_hugepage_pool() {
+    local per_vm=$((MEM / 2)) need cur
+    need=$((per_vm * 4))
+    cur=$(cat "$HUGEPAGE_POOL_FILE" 2>/dev/null || echo 0)
+    if [ "$cur" -lt "$need" ]; then
+        log "hugepages: growing pool $cur -> $need (MEM=${MEM}MiB x4)"
+        sudo sh -c "echo $need > '$HUGEPAGE_POOL_FILE'"
+        cur=$(cat "$HUGEPAGE_POOL_FILE" 2>/dev/null || echo 0)
+        if [ "$cur" -lt "$need" ]; then
+            log "hugepages: pool only $cur/$need pages (fragmentation?)"
+            return 1
+        fi
+    fi
+}
 
 cmd_run() {
+    # Backend/pool sanity BEFORE the quiet gate: these are configuration
+    # errors, not load conditions. A hugepage snapshot cannot be restored
+    # file-backed — fcvm silently starts a UFFD server and the record would
+    # say backend=file, so the analyzer would gate MISLABELED data. unknown
+    # (unreadable config.json) refuses too: fail closed, never guess.
+    local huge_state
+    huge_state=$(hugepage_snapshot_state)
+    if [ "$BACKEND" = file ] && [ "$huge_state" != normal ]; then
+        log "run: BACKEND=file refused: snapshot '$TAG' hugepage state is '$huge_state' (a hugepage snapshot restores via an implicit UFFD server and the record would be mislabeled); use BACKEND=uffd or a non-hugepage TAG"
+        return 2
+    fi
+    if [ "$huge_state" = huge ]; then
+        ensure_hugepage_pool || return 1
+    fi
     local guard_rc=0
     guard_quiet || guard_rc=$?
     if [ "$guard_rc" -ne 0 ]; then

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -831,9 +831,14 @@ ensure_hugepage_pool() {
     # than hanging behind a stuck owner.
     local wait_s="${HUGEPAGE_POOL_LOCK_WAIT:-60}"
     local pool_lock="$DATA_ROOT/hugepage-pool.lock"
+    mkdir -p "$DATA_ROOT" 2>/dev/null || true
     touch "$pool_lock" 2>/dev/null || true
     if [ -z "${REQBENCH_POOL_LOCK_FD:-}" ]; then
-        exec {REQBENCH_POOL_LOCK_FD}<>"$pool_lock"
+        exec {REQBENCH_POOL_LOCK_FD}<>"$pool_lock" || true
+    fi
+    if [ -z "${REQBENCH_POOL_LOCK_FD:-}" ]; then
+        log "hugepages: pool lock unavailable at $pool_lock"
+        return 1
     fi
     if ! flock -s -w "$wait_s" "$REQBENCH_POOL_LOCK_FD"; then
         log "hugepages: pool lock busy for ${wait_s}s; refusing to race the owner"
@@ -870,9 +875,14 @@ ensure_hugepage_pool() {
 # PR #815): fcvm snapshot create/delete take this lock exclusive.
 acquire_generation_lock() {
     local gen_lock="$DATA_ROOT/snapshots/$TAG.lock"
+    mkdir -p "$(dirname "$gen_lock")" 2>/dev/null || true
     touch "$gen_lock" 2>/dev/null || true
     if [ -z "${REQBENCH_GEN_LOCK_FD:-}" ]; then
-        exec {REQBENCH_GEN_LOCK_FD}<>"$gen_lock"
+        exec {REQBENCH_GEN_LOCK_FD}<>"$gen_lock" || true
+    fi
+    if [ -z "${REQBENCH_GEN_LOCK_FD:-}" ]; then
+        log "generation lock unavailable at $gen_lock"
+        return 1
     fi
     if ! flock -s -w "${HUGEPAGE_POOL_LOCK_WAIT:-60}" "$REQBENCH_GEN_LOCK_FD"; then
         log "generation lock busy for '$TAG'; refusing to classify a moving target"

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -667,6 +667,7 @@ cmd_verify() {
     # golden with an empty pool; grow it here, not only at golden time.
     # unknown refuses: jq missing or an unreadable config would otherwise
     # skip provisioning fail-OPEN and die mid-serve instead.
+    acquire_generation_lock || return 1
     local huge_state
     huge_state=$(hugepage_snapshot_state)
     if [ "$huge_state" = unknown ]; then
@@ -822,15 +823,60 @@ ensure_hugepage_pool() {
         return 1
     fi
     need=$(( (mem / 2) * 4 ))
+    # The pool is host-global state shared by every harness (reqbench,
+    # faultbench, bench.sh, make setup-hugepages). One flock serializes all
+    # of them (codex P1, PR #815): a phase that DEPENDS on the pool keeps the
+    # fd open holding it SHARED for the phase lifetime; a grow upgrades to
+    # EXCLUSIVE and atomically downgrades. Bounded waits fail closed rather
+    # than hanging behind a stuck owner.
+    local wait_s="${HUGEPAGE_POOL_LOCK_WAIT:-60}"
+    local pool_lock="$DATA_ROOT/hugepage-pool.lock"
+    touch "$pool_lock" 2>/dev/null || true
+    if [ -z "${REQBENCH_POOL_LOCK_FD:-}" ]; then
+        exec {REQBENCH_POOL_LOCK_FD}<>"$pool_lock"
+    fi
+    if ! flock -s -w "$wait_s" "$REQBENCH_POOL_LOCK_FD"; then
+        log "hugepages: pool lock busy for ${wait_s}s; refusing to race the owner"
+        return 1
+    fi
     cur=$(cat "$HUGEPAGE_POOL_FILE" 2>/dev/null || echo 0)
     if [ "$cur" -lt "$need" ]; then
-        log "hugepages: growing pool $cur -> $need (${mem}MiB guest x4)"
-        sudo sh -c 'echo "$1" > "$2"' _ "$need" "$HUGEPAGE_POOL_FILE"
+        if ! flock -x -w "$wait_s" "$REQBENCH_POOL_LOCK_FD"; then
+            log "hugepages: pool lock busy for ${wait_s}s; refusing to race the owner"
+            return 1
+        fi
+        # Re-read under the exclusive lock: another grower may have won.
         cur=$(cat "$HUGEPAGE_POOL_FILE" 2>/dev/null || echo 0)
+        if [ "$cur" -lt "$need" ]; then
+            log "hugepages: growing pool $cur -> $need (${mem}MiB guest x4)"
+            # Literal sudo, NOT $SUDO: $SUDO is empty by default (rootless
+            # needs no privilege), but writing the kernel pool knob requires
+            # root in every mode. $SUDO here would break the rootless path.
+            sudo sh -c 'echo "$1" > "$2"' _ "$need" "$HUGEPAGE_POOL_FILE"
+            cur=$(cat "$HUGEPAGE_POOL_FILE" 2>/dev/null || echo 0)
+        fi
+        flock -s "$REQBENCH_POOL_LOCK_FD"
         if [ "$cur" -lt "$need" ]; then
             log "hugepages: pool only $cur/$need pages (fragmentation?)"
             return 1
         fi
+    fi
+    # fd stays open: the SHARED lease lives until the phase shell exits.
+}
+
+# Shared generation lock, held (via fd inheritance) from backend
+# classification through the driver handoff, so another fcvm command cannot
+# replace $TAG between the hugepage check and the measured run (codex P1,
+# PR #815): fcvm snapshot create/delete take this lock exclusive.
+acquire_generation_lock() {
+    local gen_lock="$DATA_ROOT/snapshots/$TAG.lock"
+    touch "$gen_lock" 2>/dev/null || true
+    if [ -z "${REQBENCH_GEN_LOCK_FD:-}" ]; then
+        exec {REQBENCH_GEN_LOCK_FD}<>"$gen_lock"
+    fi
+    if ! flock -s -w "${HUGEPAGE_POOL_LOCK_WAIT:-60}" "$REQBENCH_GEN_LOCK_FD"; then
+        log "generation lock busy for '$TAG'; refusing to classify a moving target"
+        return 1
     fi
 }
 
@@ -849,6 +895,7 @@ cmd_run() {
     # file-backed — fcvm silently starts a UFFD server and the record would
     # say backend=file, so the analyzer would gate MISLABELED data. unknown
     # (unreadable config.json) refuses too: fail closed, never guess.
+    acquire_generation_lock || return 1
     local huge_state
     huge_state=$(hugepage_snapshot_state)
     if [ "$BACKEND" = file ] && [ "$huge_state" != normal ]; then
@@ -857,6 +904,12 @@ cmd_run() {
     fi
     if [ "$huge_state" = huge ]; then
         ensure_hugepage_pool "$(snapshot_memory_mib)" || return 1
+    fi
+    if [ -n "${REQBENCH_DRIVER_HOOK:-}" ]; then
+        # Test seam: runs inside the held generation + pool locks, exactly
+        # where the driver handoff happens.
+        "$REQBENCH_DRIVER_HOOK"
+        return $?
     fi
     local guard_rc=0
     guard_quiet || guard_rc=$?

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -5380,6 +5380,11 @@ class MakefileBenchGraph(unittest.TestCase):
         # run must not reserve gigabytes it will never touch.
         self.assertIn("cb-golden-huge", recipe,
                       "pool growth must be gated on the huge golden")
+        # And the grow must hold the cross-harness pool lock (codex P1,
+        # PR #815): the pool is host-global and reqbench/faultbench/bench.sh
+        # all write it.
+        self.assertIn("hugepage-pool.lock", recipe,
+                      "fault recipe must serialize on the shared pool lock")
 
     def test_run_help_documents_tag(self):
         # Following the documented huge flow without TAG= on the run line
@@ -5406,6 +5411,7 @@ class MakefileBenchGraph(unittest.TestCase):
         # with no firecracker asset. Its survival (including as a stray
         # .PHONY entry) means the clean break did not happen.
         self.assertNotIn("bench-chromium-request", self.rules)
+        self.assertNotIn("bench-chromium-request", self.phony)
 
 
 class HugepageGuards(unittest.TestCase):
@@ -5426,7 +5432,12 @@ class HugepageGuards(unittest.TestCase):
 
     def _bash(self, snippet, env_extra=None, hugepages="true"):
         d = tempfile.mkdtemp(prefix="hugeguard-")
-        self.addCleanup(shutil.rmtree, d, ignore_errors=True)
+
+        def _cleanup(path=d):
+            shutil.rmtree(path)
+            assert not os.path.exists(path), f"cleanup left {path}"
+
+        self.addCleanup(_cleanup)
         snapdir = os.path.join(d, "data", "snapshots", "tag-under-test")
         os.makedirs(snapdir)
         with open(os.path.join(snapdir, "config.json"), "w") as f:
@@ -5528,3 +5539,52 @@ class HugepageGuardsRound2(unittest.TestCase):
         r, _ = self._bash( "TAG=missing-tag cmd_verify")
         self.assertNotEqual(r.returncode, 0)
         self.assertIn("hugepage state", r.stdout + r.stderr)
+
+
+class SnapshotLockHeldAcrossRun(unittest.TestCase):
+    """Codex P1 (PR #815): the backend classification must happen under the
+    snapshot generation lock and the lock must stay held through the driver
+    handoff — otherwise another fcvm command can replace $TAG between the
+    hugepage_snapshot_state read and the run, and a same-shaped hugepage
+    generation slips past the BACKEND=file refusal (mislabeled data).
+
+    Watched red 2026-08-14: the exclusive-flock probe inside the stub driver
+    SUCCEEDED (no lock held during the run) and the pool-lease probe likewise.
+    """
+
+    SH = HugepageGuards.SH
+    _bash = HugepageGuards._bash
+
+    def test_generation_lock_held_shared_through_driver(self):
+        # The stub driver tries to take the generation lock EXCLUSIVE; if
+        # cmd_run holds it SHARED across the handoff, that must fail.
+        r, _ = self._bash(
+            'mkdir -p "$RESULTS/logs"; '
+            'probe() { flock -x -n "$DATA_ROOT/snapshots/$TAG.lock" true '
+            '  && echo LOCK-FREE || echo LOCK-HELD; }; '
+            'export -f probe; '
+            'REQBENCH_DRIVER_HOOK="probe" cmd_run',
+            {"BACKEND": "uffd", "UFFD_MODE": "minor"})
+        self.assertIn("LOCK-HELD", r.stdout + r.stderr)
+
+    def test_pool_lease_held_shared_through_phase(self):
+        r, _ = self._bash(
+            'mkdir -p "$RESULTS/logs"; '
+            'probe() { flock -x -n "$DATA_ROOT/hugepage-pool.lock" true '
+            '  && echo POOL-FREE || echo POOL-HELD; }; '
+            'export -f probe; '
+            'REQBENCH_DRIVER_HOOK="probe" cmd_run',
+            {"BACKEND": "uffd", "UFFD_MODE": "minor"})
+        self.assertIn("POOL-HELD", r.stdout + r.stderr)
+
+    def test_pool_grow_respects_exclusive_holder(self):
+        # While another process holds the pool lock exclusive, a grow must
+        # not proceed concurrently: bounded wait, then fail closed.
+        r, pool = self._bash(
+            'touch "$DATA_ROOT/hugepage-pool.lock"; '
+            'exec 9<>"$DATA_ROOT/hugepage-pool.lock"; flock -x 9; '
+            'HUGEPAGE_POOL_LOCK_WAIT=1 ensure_hugepage_pool')
+        self.assertNotEqual(r.returncode, 0,
+                            "grow must not race a concurrent pool owner")
+        self.assertEqual(open(pool).read().strip(), "100",
+                         "pool must be untouched while another owner holds it")

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -5250,3 +5250,73 @@ class TimedWsUpgradeDiagnostics(unittest.TestCase):
         self.assertEqual(diagnostics["socket_local"][0], "127.0.0.1")
         self.assertEqual(diagnostics["socket_peer"][1], port)
         self.assertIsInstance(diagnostics["socket_so_error"], int)
+
+
+class MakefileBenchGraph(unittest.TestCase):
+    """The Chromium bench make targets must encode their real dependencies.
+
+    Watched red 2026-08-13 against the PHASE?=run single-target Makefile:
+    every assertion failed with "bench-chromium-request-golden not found in
+    make database" (and the PHASE target still present). That day's golden had
+    failed at RUNTIME instead — "Custom firecracker not found ... Run: fcvm
+    setup --kernel-profile default" — because the only make entry point
+    depended on `build` alone and nothing expressed the asset dependency.
+    """
+
+    REPO = os.path.dirname(os.path.dirname(HERE))
+
+    @classmethod
+    def setUpClass(cls):
+        out = subprocess.run(
+            ["make", "-C", cls.REPO, "-pq", "help"],
+            capture_output=True, text=True, timeout=120)
+        cls.rules = {}
+        for line in out.stdout.splitlines():
+            # Rule lines sit at column 0 as "target: prereqs". Skip recipes,
+            # comments, special targets, and target-specific variable lines
+            # ("bench-quick: BENCH_ARGS := ..."), which contain "=".
+            if not line or line[0] in "\t# ." or "=" in line or ":" not in line:
+                continue
+            tgt, _, prereqs = line.partition(":")
+            cls.rules.setdefault(tgt.strip(), set()).update(prereqs.split())
+
+    def prereqs(self, target):
+        self.assertIn(target, self.rules,
+                      f"{target} not found in make database")
+        return self.rules[target]
+
+    def test_golden_depends_on_binary_and_assets(self):
+        p = self.prereqs("bench-chromium-request-golden")
+        self.assertIn("bench-chromium-request-build", p)
+        self.assertIn("setup-default", p)
+
+    def test_image_build_depends_on_fcvm_build(self):
+        self.assertIn("build", self.prereqs("bench-chromium-request-build"))
+
+    def test_measured_phases_never_rebuild(self):
+        # verify/run stage the CURRENT binary into the runtime bundle, and the
+        # run refuses a golden whose provenance records a different bundle
+        # hash. A `build` prerequisite here could swap the binary between
+        # golden and run: the seal would fail closed, but the chain would be
+        # self-breaking. The binary under test comes from the golden-time
+        # build, so these targets must not rebuild anything.
+        for t in ("bench-chromium-request-run", "bench-chromium-request-verify"):
+            self.assertNotIn("build", self.prereqs(t), t)
+            self.assertNotIn("setup-default", self.prereqs(t), t)
+
+    def test_full_chain_and_companion_benches(self):
+        p = self.prereqs("bench-chromium-request-all")
+        self.assertIn("build", p)
+        self.assertIn("setup-default", p)
+        self.assertIn("bench-chromium-request-build",
+                      self.prereqs("bench-chromium-hostcdp"))
+        fp = self.prereqs("bench-chromium-fault")
+        self.assertIn("build", fp)
+        self.assertIn("setup-default", fp)
+
+    def test_phase_indirection_is_gone(self):
+        # NO LEGACY: the PHASE?=run single target could not express
+        # inter-phase dependencies and is exactly how a golden ran on a box
+        # with no firecracker asset. Its survival (including as a stray
+        # .PHONY entry) means the clean break did not happen.
+        self.assertNotIn("bench-chromium-request", self.rules)

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -3862,6 +3862,11 @@ exit 1
         os.makedirs(provenance_dir, exist_ok=True)
         with open(os.path.join(provenance_dir, "reqbench-provenance.json"), "w") as f:
             json.dump({"image_id": "sha256:" + "1" * 64}, f)
+        # Every real installed snapshot carries config.json; without it the
+        # hugepage guard reads state "unknown" and (correctly) refuses
+        # BACKEND=file fail-closed rather than risking a mislabeled record.
+        with open(os.path.join(provenance_dir, "config.json"), "w") as f:
+            json.dump({"metadata": {"hugepages": False}}, f)
         argv = os.path.join(d, "argv.log")
         pyargv = os.path.join(d, "pyargv.log")
         driver_env = os.path.join(d, "driver-env.log")
@@ -5270,20 +5275,58 @@ class MakefileBenchGraph(unittest.TestCase):
         out = subprocess.run(
             ["make", "-C", cls.REPO, "-pq", "help"],
             capture_output=True, text=True, timeout=120)
+        # -q exits 0/1 for up-to-date/rebuild-needed; 2 means make itself
+        # FAILED to parse — and it still prints a partial database, so
+        # trusting stdout alone lets a broken Makefile pass every structural
+        # assertion below (codex P2, 2026-08-14).
+        cls.make_rc = out.returncode
+        cls.make_stderr = out.stderr[-2000:]
         cls.rules = {}
+        cls.recipes = {}
+        cls.phony = set()
+        cur = None
         for line in out.stdout.splitlines():
+            if line.startswith("\t") and cur:
+                cls.recipes.setdefault(cur, []).append(line)
+                continue
+            if line.startswith(".PHONY:"):
+                cls.phony.update(line.partition(":")[2].split())
+                continue
+            if line.startswith("#"):
+                # -p interleaves "# recipe to execute (from ...)" comments
+                # between a rule and its recipe: keep cur so the recipe
+                # lines that follow still attach to their target.
+                continue
             # Rule lines sit at column 0 as "target: prereqs". Skip recipes,
-            # comments, special targets, and target-specific variable lines
+            # special targets, and target-specific variable lines
             # ("bench-quick: BENCH_ARGS := ..."), which contain "=".
-            if not line or line[0] in "\t# ." or "=" in line or ":" not in line:
+            if not line or line[0] in "\t." or "=" in line or ":" not in line:
+                cur = None
                 continue
             tgt, _, prereqs = line.partition(":")
-            cls.rules.setdefault(tgt.strip(), set()).update(prereqs.split())
+            cur = tgt.strip()
+            cls.rules.setdefault(cur, set()).update(prereqs.split())
 
     def prereqs(self, target):
         self.assertIn(target, self.rules,
                       f"{target} not found in make database")
         return self.rules[target]
+
+    def closure(self, target):
+        seen, stack = set(), [target]
+        while stack:
+            for p in self.rules.get(stack.pop(), ()):
+                if p not in seen:
+                    seen.add(p)
+                    stack.append(p)
+        return seen
+
+    def test_make_database_is_from_a_parsable_makefile(self):
+        self.assertIn(self.make_rc, (0, 1),
+                      f"make -pq exited {self.make_rc} (fatal parse error) — "
+                      f"the database below it is partial and every other "
+                      f"assertion in this class is vacuous. stderr: "
+                      f"{self.make_stderr}")
 
     def test_golden_depends_on_binary_and_assets(self):
         p = self.prereqs("bench-chromium-request-golden")
@@ -5299,10 +5342,43 @@ class MakefileBenchGraph(unittest.TestCase):
         # hash. A `build` prerequisite here could swap the binary between
         # golden and run: the seal would fail closed, but the chain would be
         # self-breaking. The binary under test comes from the golden-time
-        # build, so these targets must not rebuild anything.
+        # build, so these targets must not rebuild anything — TRANSITIVELY:
+        # a direct-only check passes `run: bench-chromium-request-build`,
+        # which rebuilds through its own deps (codex P2, 2026-08-14).
         for t in ("bench-chromium-request-run", "bench-chromium-request-verify"):
-            self.assertNotIn("build", self.prereqs(t), t)
-            self.assertNotIn("setup-default", self.prereqs(t), t)
+            c = self.closure(t)
+            for forbidden in ("build", "setup-default", "cargo-target-link"):
+                self.assertNotIn(forbidden, c,
+                                 f"{t} transitively reaches {forbidden}")
+
+    def test_bench_targets_are_phony(self):
+        # A stray file named like a target silently suppresses its recipe;
+        # make then reports "up to date" and nothing runs.
+        for t in ("bench-chromium-request-build", "bench-chromium-request-golden",
+               "bench-chromium-request-verify", "bench-chromium-request-run",
+               "bench-chromium-request-all", "bench-chromium-hostcdp",
+               "bench-chromium-fault"):
+            self.assertIn(t, self.phony, f"{t} missing from .PHONY")
+
+    def test_fault_target_provisions_its_hugepage_pool(self):
+        # faultbench selects uffd-huge-minor whenever the huge golden exists,
+        # and bench.sh restores the pool (commonly to zero) after creating
+        # that golden — so without provisioning here the new entry point
+        # fails immediately after the workflow that creates its own
+        # prerequisite (codex P1, 2026-08-14).
+        recipe = "\n".join(self.recipes.get("bench-chromium-fault", []))
+        self.assertIn("nr_hugepages", recipe,
+                      "bench-chromium-fault recipe does not provision the "
+                      "hugepage pool its default cell matrix needs")
+
+    def test_run_help_documents_tag(self):
+        # Following the documented huge flow without TAG= on the run line
+        # measures the DEFAULT 4K tag while the huge golden sits unused
+        # (codex P2, 2026-08-14).
+        help_lines = [ln for ln in self.recipes.get("help", [])
+                      if "bench-chromium-request-run" in ln]
+        self.assertTrue(help_lines, "run target missing from help")
+        self.assertIn("TAG=", help_lines[0])
 
     def test_full_chain_and_companion_benches(self):
         p = self.prereqs("bench-chromium-request-all")
@@ -5320,3 +5396,83 @@ class MakefileBenchGraph(unittest.TestCase):
         # with no firecracker asset. Its survival (including as a stray
         # .PHONY entry) means the clean break did not happen.
         self.assertNotIn("bench-chromium-request", self.rules)
+
+
+class HugepageGuards(unittest.TestCase):
+    """reqbench.sh must fail closed around hugepage goldens.
+
+    Watched red 2026-08-14 before the fix: `ensure_hugepage_pool` and
+    `hugepage_snapshot_state` did not exist (bash: command not found), and
+    `cmd_run BACKEND=file` against a hugepage-snapshot fixture sailed past
+    the missing check into guard_quiet. Codex P1s: (a) a hugepage golden
+    restored with BACKEND=file silently starts a UFFD server while the
+    record says backend=file — the analyzer then gates MISLABELED data;
+    (b) the pool grow was golden-only and fixed at 2048 pages, ignoring
+    MEM and later phases (a 2050 MiB guest needs 4100 pages; a rebooted
+    box re-runs verify/run with an empty pool).
+    """
+
+    SH = os.path.join(HERE, "reqbench.sh")
+
+    def _bash(self, snippet, env_extra=None, hugepages="true"):
+        d = tempfile.mkdtemp(prefix="hugeguard-")
+        self.addCleanup(shutil.rmtree, d, ignore_errors=True)
+        snapdir = os.path.join(d, "data", "snapshots", "tag-under-test")
+        os.makedirs(snapdir)
+        with open(os.path.join(snapdir, "config.json"), "w") as f:
+            f.write('{"metadata": {"hugepages": %s}}' % hugepages)
+        pool = os.path.join(d, "nr_hugepages")
+        with open(pool, "w") as f:
+            f.write("100\n")
+        binx = os.path.join(d, "bin")
+        os.makedirs(binx)
+        with open(os.path.join(binx, "sudo"), "w") as f:
+            f.write('#!/bin/bash\nexec "$@"\n')
+        os.chmod(os.path.join(binx, "sudo"), 0o755)
+        env = dict(os.environ)
+        env.update(
+            PATH=binx + os.pathsep + env["PATH"],
+            TAG="tag-under-test",
+            STATE_DIR=os.path.join(d, "data", "state"),
+            HUGEPAGE_POOL_FILE=pool,
+            MEM="1024",
+            RESULTS=os.path.join(d, "results"),
+        )
+        env.update(env_extra or {})
+        r = subprocess.run(
+            ["bash", "-c", f'source "{self.SH}" && {snippet}'],
+            capture_output=True, text=True, env=env, timeout=60)
+        return r, pool
+
+    def test_pool_grows_to_mem_derived_need(self):
+        r, pool = self._bash("ensure_hugepage_pool")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        # 1024 MiB / 2 MiB per page = 512 per VM; x4 for backing + prepare
+        # VM + two teardown-overlapping clones.
+        self.assertEqual(open(pool).read().strip(), "2048")
+
+    def test_pool_need_scales_with_mem(self):
+        r, pool = self._bash("ensure_hugepage_pool", {"MEM": "2050"})
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(open(pool).read().strip(), "4100")
+
+    def test_pool_grow_failure_is_fatal(self):
+        # sudo "succeeds" but the write never lands (the kernel could not
+        # deliver contiguous pages): the phase must stop, not measure a
+        # hugepage cell on a starved pool.
+        r, _ = self._bash(
+            'cp "$HUGEPAGE_POOL_FILE" /tmp/keep-$$; '
+            'sudo() { :; }; ensure_hugepage_pool')
+        self.assertNotEqual(r.returncode, 0)
+
+    def test_snapshot_state_reads_metadata(self):
+        for js, want in (("true", "huge"), ("false", "normal")):
+            r, _ = self._bash("hugepage_snapshot_state", hugepages=js)
+            self.assertEqual(r.stdout.strip(), want, r.stderr)
+        r, _ = self._bash('TAG=missing-tag hugepage_snapshot_state')
+        self.assertEqual(r.stdout.strip(), "unknown")
+
+    def test_cmd_run_refuses_file_backend_on_hugepage_snapshot(self):
+        r, _ = self._bash("BACKEND=file cmd_run")
+        self.assertEqual(r.returncode, 2, f"stdout={r.stdout} stderr={r.stderr}")
+        self.assertIn("BACKEND=uffd", r.stdout + r.stderr)

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -5367,9 +5367,19 @@ class MakefileBenchGraph(unittest.TestCase):
         # fails immediately after the workflow that creates its own
         # prerequisite (codex P1, 2026-08-14).
         recipe = "\n".join(self.recipes.get("bench-chromium-fault", []))
-        self.assertIn("nr_hugepages", recipe,
-                      "bench-chromium-fault recipe does not provision the "
-                      "hugepage pool its default cell matrix needs")
+        # Three reads of the knob: current-value cat, the grow write, and
+        # the POST-WRITE reread. Linux accepts the write even when
+        # fragmentation delivers fewer pages, so a recipe that never
+        # rereads reports a pool it does not have (codex round 2).
+        self.assertGreaterEqual(recipe.count("nr_hugepages"), 3,
+                                "fault recipe must reread the pool "
+                                "after growing it")
+        self.assertIn("ERROR", recipe,
+                      "short delivery must fail the target")
+        # Growth is gated on the huge golden existing: a file-4k-only
+        # run must not reserve gigabytes it will never touch.
+        self.assertIn("cb-golden-huge", recipe,
+                      "pool growth must be gated on the huge golden")
 
     def test_run_help_documents_tag(self):
         # Following the documented huge flow without TAG= on the run line
@@ -5420,7 +5430,8 @@ class HugepageGuards(unittest.TestCase):
         snapdir = os.path.join(d, "data", "snapshots", "tag-under-test")
         os.makedirs(snapdir)
         with open(os.path.join(snapdir, "config.json"), "w") as f:
-            f.write('{"metadata": {"hugepages": %s}}' % hugepages)
+            f.write('{"metadata": {"hugepages": %s, "memory_mib": 4096}}'
+                    % hugepages)
         pool = os.path.join(d, "nr_hugepages")
         with open(pool, "w") as f:
             f.write("100\n")
@@ -5460,10 +5471,10 @@ class HugepageGuards(unittest.TestCase):
         # sudo "succeeds" but the write never lands (the kernel could not
         # deliver contiguous pages): the phase must stop, not measure a
         # hugepage cell on a starved pool.
-        r, _ = self._bash(
-            'cp "$HUGEPAGE_POOL_FILE" /tmp/keep-$$; '
-            'sudo() { :; }; ensure_hugepage_pool')
+        r, _ = self._bash('sudo() { :; }; ensure_hugepage_pool')
         self.assertNotEqual(r.returncode, 0)
+        self.assertIn("pool only", r.stdout + r.stderr,
+                      "must fail via the reread check, not incidentally")
 
     def test_snapshot_state_reads_metadata(self):
         for js, want in (("true", "huge"), ("false", "normal")):
@@ -5476,3 +5487,44 @@ class HugepageGuards(unittest.TestCase):
         r, _ = self._bash("BACKEND=file cmd_run")
         self.assertEqual(r.returncode, 2, f"stdout={r.stdout} stderr={r.stderr}")
         self.assertIn("BACKEND=uffd", r.stdout + r.stderr)
+
+
+class HugepageGuardsRound2(unittest.TestCase):
+    """Second codex round on the hugepage guards.
+
+    Watched red 2026-08-14 before the fix: `snapshot_memory_mib` did not
+    exist; `ensure_hugepage_pool` accepted odd MEM (2051 -> grew the pool,
+    exit 0) and sized from ambient MEM rather than the snapshot's recorded
+    memory_mib; `cmd_verify` treated unknown hugepage state as non-huge and
+    sailed on toward serve (fail-open when jq or the config is missing).
+    """
+
+    SH = HugepageGuards.SH
+    _bash = HugepageGuards._bash
+
+    def test_pool_sizes_from_snapshot_memory(self):
+        # The fixture snapshot records memory_mib=4096: verify/run must size
+        # from THAT, not from the caller's ambient MEM (default 1024) — an
+        # 8 GiB golden verified after a reboot would otherwise provision a
+        # quarter of what the first clone needs.
+        r, pool = self._bash(
+            'ensure_hugepage_pool "$(snapshot_memory_mib)"')
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(open(pool).read().strip(), "8192")
+
+    def test_pool_rejects_odd_mem(self):
+        r, pool = self._bash( "ensure_hugepage_pool",
+                                   {"MEM": "2051"})
+        self.assertNotEqual(r.returncode, 0,
+                            "odd MEM must fail before touching the pool "
+                            "(fcvm rejects it AFTER we would have reserved "
+                            "gigabytes)")
+        self.assertEqual(open(pool).read().strip(), "100",
+                         "pool must be untouched on rejection")
+
+    def test_verify_fails_closed_on_unknown_state(self):
+        # jq missing / config unreadable => unknown. Proceeding as if
+        # non-huge is exactly the fail-open shape this repo bans.
+        r, _ = self._bash( "TAG=missing-tag cmd_verify")
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("hugepage state", r.stdout + r.stderr)

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -5385,6 +5385,11 @@ class MakefileBenchGraph(unittest.TestCase):
         # all write it.
         self.assertIn("hugepage-pool.lock", recipe,
                       "fault recipe must serialize on the shared pool lock")
+        # The lock file must be creatable by unprivileged callers even when
+        # the data root is root-owned (fresh boxes): the recipe pre-creates
+        # it with sudo before flock (CodeRabbit round 2, PR #815).
+        self.assertRegex(recipe, r"sudo[^\n]*touch[^\n]*hugepage-pool\.lock",
+                         "fault recipe must sudo-pre-create the pool lock")
 
     def test_run_help_documents_tag(self):
         # Following the documented huge flow without TAG= on the run line
@@ -5554,6 +5559,17 @@ class SnapshotLockHeldAcrossRun(unittest.TestCase):
 
     SH = HugepageGuards.SH
     _bash = HugepageGuards._bash
+
+    def test_fcvm_data_dir_is_aligned_with_data_root(self):
+        # fcvm resolves its snapshot paths (and therefore the generation
+        # lock file) from FCVM_DATA_DIR; reqbench derives DATA_ROOT
+        # independently. Without exporting the alignment, the two processes
+        # can lock DIFFERENT files and the generation lock is theater
+        # (CodeRabbit round 2, PR #815).
+        r, _ = self._bash('echo "FCVM_DATA_DIR=[$FCVM_DATA_DIR]"')
+        self.assertIn("FCVM_DATA_DIR=[", r.stdout)
+        self.assertNotIn("FCVM_DATA_DIR=[]", r.stdout,
+                         "reqbench.sh must export FCVM_DATA_DIR=$DATA_ROOT")
 
     def test_generation_lock_held_shared_through_driver(self):
         # The stub driver tries to take the generation lock EXCLUSIVE; if


### PR DESCRIPTION
Puts the hugepage-backed UFFD-minor configuration on the request benchmark path and makes every bench phase a first-class make target with a real dependency graph.

## What's here (4 commits)

**1. `HUGEPAGES` knob (38eafc13)** — `reqbench.sh golden` can create hugepage-backed goldens (`--hugepages` on `podman prepare`, distinct TAG since hugepages are part of the snapshot identity), growing the host pool fail-closed.

**2. Make-driven phases (2faad439)** — replaces the `PHASE?=run` indirection with one target per phase so the dependency chain is explicit: `-golden` depends on the image build, the fcvm build, and `setup-default` (the missing-assets case is the "Custom firecracker not found" failure that motivated this); `-verify`/`-run` deliberately do NOT rebuild — the runtime-bundle seal pins the binary under test. First make entry points for `bench-chromium-hostcdp` and `bench-chromium-fault`. New `MakefileBenchGraph` tests parse the `make -pq` database and pin the graph. AGENTS.md (root + bench) rewritten make-first.

**3+4. Two local-codex review rounds closed (b72e516a, 1860185f)** — all fixes red-tested first:
- `BACKEND=file` against a hugepage snapshot refused (fcvm restores those via an implicit UFFD server; the record would be mislabeled and the analyzer would gate wrong data). Unknown state refuses too.
- Pool sizing is snapshot-derived (`metadata.memory_mib`, 4×MEM/2 pages) and ensured at golden, verify, and run; odd MEM fails before reserving; sudo write un-injectable.
- `cmd_verify` fails closed on unknown hugepage state (was fail-open into a 60 s serve timeout).
- `bench-chromium-fault` provisions its pool only when the huge golden exists and rereads after the write (fragmentation can short-deliver).
- Graph tests fail closed on `make -pq` exit 2, check no-rebuild transitively, pin `.PHONY`.

Deferred with issues: #813 (image-tag binding across phases), #814 (pool cross-harness race, one-shot targets tripping their own quiet gates).

## Measured result (why the knob exists)

Same-golden A/B on the hugepage golden, 202 reps/arm, all publication gates passed: **minor beats copy by a CI-disjoint 5–8% in every arm** (cdp 374.9 vs 401.9 ms) — the sign flip vs 4K pages (where copy wins by 14%) lives entirely in restored-browser wake-up (resolve 130.7 vs 156.7 ms; navigate identical). Both huge runs read a 39.8 ms restore floor vs ~59 ms on all 4K goldens (cross-golden, indicative). Two earlier passes were refused by the noop drift gate (box contamination) and discarded. Runs: `results/reqbench-20260814-001144-uffd` (minor), `results/reqbench-20260814-002056-uffd` (copy).

## Test results

```
$ make test-chromium-request
Ran 148 tests ... OK
```
Revert/restore cycles on reqbench.sh + Makefile watched red (4–5 failures) then green. Full end-to-end exercised live: the published hugepage A/B ran through `make bench-chromium-request-{golden,verify,run}`.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate benchmark steps for image building, golden snapshot creation, verification, measured runs, and complete execution.
  * Added host CDP and page-fault benchmark targets.
  * Added hugepage-aware snapshot preparation, validation, and runtime setup.

* **Bug Fixes**
  * Prevented incompatible backends and file-backed execution for hugepage snapshots.
  * Added fail-closed handling for missing or unknown snapshot metadata.
  * Serialized hugepage pool allocation to prevent concurrent setup conflicts.

* **Documentation**
  * Documented benchmark workflows, configuration variables, runtime requirements, and validation rules.

* **Tests**
  * Expanded coverage for benchmark dependencies, hugepage provisioning, metadata validation, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->