### PR TITLE
uffd: wake waiters after an EEXIST'd UFFDIO_CONTINUE

### DIFF
--- a/src/uffd/server.rs
+++ b/src/uffd/server.rs
@@ -986,6 +986,28 @@ fn continue_hit_present_page(e: &userfaultfd::Error) -> bool {
     )
 }
 
+/// Wake any faulter stranded on an EEXIST'd granule.
+///
+/// EEXIST from UFFDIO_CONTINUE or UFFDIO_COPY proves the PTE/page is present — NOT that
+/// the faulter was woken. The kernel's check-then-sleep window lets a faulter enqueue
+/// AFTER the racing winner's wake scan, and userfaultfd(2) requires an explicit
+/// UFFDIO_WAKE after EEXIST for exactly that case (Linux's own uffd selftests wake after
+/// COPY EEXIST). Without it the faulter sleeps forever: the 4K-minor clone wedge — VMM
+/// device thread parked in `handle_userfault`, victim uffd fdinfo `pending:0 total:1`,
+/// whole virtio plane dead. A failed wake is the hang this call exists to prevent, so it
+/// propagates into the fail-closed kill path rather than being logged and limped past.
+fn wake_eexist_waiters(uffd: &Uffd, addr: usize, len: usize) -> Result<()> {
+    uffd.wake(addr as *mut std::ffi::c_void, len).map_err(|wake_error| {
+        anyhow!(
+            "UFFDIO_WAKE after EEXIST failed at 0x{:x}+{}: {:?} — a stranded faulter \
+             would hang its thread permanently",
+            addr,
+            len,
+            wake_error
+        )
+    })
+}
+
 /// Whether a UFFDIO_CONTINUE error is the kernel saying "not now, try again".
 ///
 /// The ioctl fails with `EAGAIN` (and zero progress) while the context's `mmap_changing`
@@ -1076,23 +1098,9 @@ fn continue_page(
                     fault_addr = format!("0x{:x}", page + done),
                     "UFFDIO_CONTINUE skipped - page already mapped (EEXIST), waking waiters"
                 );
-                // EEXIST proves the PTE is present — NOT that the faulter was woken. The
-                // kernel's check-then-sleep window lets a faulter enqueue AFTER the racing
-                // winner's wake scan, and userfaultfd(2) requires an explicit UFFDIO_WAKE
-                // here for exactly that case. Without it the faulter sleeps forever: the
-                // 4K-minor clone wedge (VMM device thread parked in handle_userfault,
-                // victim uffd fdinfo `pending:0 total:1`, whole virtio plane dead).
-                // A failed wake is the hang this arm exists to prevent — propagate it
-                // into the fail-closed kill path rather than logging and limping on.
-                uffd.wake(addr, remaining).map_err(|wake_error| {
-                    anyhow!(
-                        "UFFDIO_WAKE after EEXIST failed at 0x{:x}+{}: {:?} — a stranded \
-                         faulter would hang its thread permanently",
-                        page + done,
-                        remaining,
-                        wake_error
-                    )
-                })?;
+                // See wake_eexist_waiters: EEXIST != woken; the explicit wake is the
+                // userfaultfd(2) contract and the fix for the 4K-minor clone wedge.
+                wake_eexist_waiters(uffd, page + done, remaining)?;
                 // EEXIST refers to the granule at the current position; with per-granule
                 // requests that is the whole remaining range.
                 done += remaining;
@@ -1842,8 +1850,13 @@ fn drain_events(uffd: &Uffd, ctx: &VmContext<'_>, state: &mut VmState) -> Result
                                     target: "uffd",
                                     vm_id = %vm_id,
                                     fault_addr = format!("0x{:x}", fault_page),
-                                    "UFFD copy skipped - page already filled (EEXIST)"
+                                    "UFFD copy skipped - page already filled (EEXIST), waking waiters"
                                 );
+                                // See wake_eexist_waiters: the COPY backend has the same
+                                // check-then-sleep window as CONTINUE, this fault event is
+                                // already consumed, and Linux's uffd selftests wake after
+                                // COPY EEXIST for exactly this reason.
+                                wake_eexist_waiters(uffd, fault_page, page_size)?;
                                 if let Some(t) = state.trace.as_mut() {
                                     let t1 = t.now_ns();
                                     t.record(offset_in_file as u64, trace_t0, t1);
@@ -3592,6 +3605,23 @@ mod tests {
         assert_eq!(a, Path::new("/data/uffd-snap-42-1000.sock"));
     }
 
+    /// Poll the kernel until `tid` is parked in `handle_userfault`, or panic. This is
+    /// the oracle that makes the stranded-faulter tests deterministic: a queued fault
+    /// event does NOT imply the faulter finished its final PTE recheck and slept, and a
+    /// PTE installed inside that window lets the faulter skip sleeping entirely —
+    /// turning the test into a false green on an unfixed tree.
+    fn wait_parked_in_handle_userfault(tid: libc::pid_t) {
+        for _ in 0..5000 {
+            let wchan =
+                std::fs::read_to_string(format!("/proc/self/task/{tid}/wchan")).unwrap_or_default();
+            if wchan.trim() == "handle_userfault" {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+        panic!("faulter (tid {tid}) never parked in handle_userfault within 5s");
+    }
+
     /// EEXIST from UFFDIO_CONTINUE proves the PTE is present — NOT that the faulter was
     /// woken. The kernel's check-then-sleep window lets a faulter enqueue AFTER a racing
     /// winner's wake scan, which is why userfaultfd(2) requires an explicit UFFDIO_WAKE
@@ -3726,13 +3756,19 @@ mod tests {
         let uffd = unsafe { Uffd::from_raw_fd(raw) };
 
         let addr = base as usize;
+        let (tid_tx, tid_rx) = mpsc::channel();
         let (tx, rx) = mpsc::channel();
         let reader = std::thread::spawn(move || {
+            // SAFETY: gettid on the current thread.
+            tid_tx.send(unsafe { libc::gettid() }).ok();
             // Minor-faults (page resident, PTE absent) and sleeps until woken.
             // SAFETY: addr is a live registered mapping for the test's lifetime.
             let got = unsafe { std::ptr::read_volatile(addr as *const u8) };
             tx.send(got).ok();
         });
+        let reader_tid = tid_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("reader tid");
 
         let mut pfd = libc::pollfd {
             fd: uffd.as_raw_fd(),
@@ -3749,8 +3785,15 @@ mod tests {
             other => panic!("expected the reader's pagefault event, got {other:?}"),
         }
 
+        // ORACLE: the event proves the reader QUEUED, not that it finished its final
+        // PTE recheck and slept. If the winner's PTE lands inside that window the
+        // reader never sleeps and the test would pass without any fix. Proceed only
+        // once the kernel reports the reader parked in handle_userfault.
+        wait_parked_in_handle_userfault(reader_tid);
+
         // The racing winner: installs the PTE with NO wake. The fault event is already
-        // consumed above, so nothing else will ever wake the reader.
+        // consumed above and the reader is PROVEN asleep, so nothing else will ever
+        // wake it.
         uffd.r#continue(base, PAGE, false)
             .expect("winner's CONTINUE must succeed");
 
@@ -3769,6 +3812,118 @@ mod tests {
         unsafe {
             libc::munmap(base, PAGE);
             libc::close(memfd);
+        }
+    }
+
+    /// The COPY twin of the stranded-faulter test: the default (file-backed) serve mode
+    /// resolves MISSING faults with UFFDIO_COPY, whose EEXIST has the same
+    /// check-then-sleep window — Linux's own uffd selftests wake after COPY EEXIST.
+    /// Constructs the stranded state with the parked-oracle, then runs the exact
+    /// sequence the demand COPY arm runs: attempt the copy, observe EEXIST, wake.
+    #[test]
+    fn eexist_copy_resolution_wakes_the_stranded_faulter() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        const PAGE: usize = 4096;
+        // SAFETY: fresh anonymous mapping.
+        let base = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                PAGE,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        };
+        assert_ne!(base, libc::MAP_FAILED);
+        let uffd = userfaultfd::UffdBuilder::new()
+            .close_on_exec(true)
+            .non_blocking(true)
+            .user_mode_only(true)
+            .create()
+            .expect("creating userfaultfd");
+        uffd.register(base, PAGE).expect("MISSING registration");
+
+        let addr = base as usize;
+        let (tid_tx, tid_rx) = mpsc::channel();
+        let (tx, rx) = mpsc::channel();
+        let reader = std::thread::spawn(move || {
+            // SAFETY: gettid on the current thread.
+            tid_tx.send(unsafe { libc::gettid() }).ok();
+            // MISSING-faults and sleeps until woken.
+            // SAFETY: addr is a live registered mapping for the test's lifetime.
+            let got = unsafe { std::ptr::read_volatile(addr as *const u8) };
+            tx.send(got).ok();
+        });
+        let reader_tid = tid_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("reader tid");
+
+        let mut pfd = libc::pollfd {
+            fd: uffd.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: one initialised pollfd, owned fd.
+        assert!(
+            unsafe { libc::poll(&mut pfd, 1, 5000) } > 0,
+            "no fault event within 5s"
+        );
+        match uffd.read_event() {
+            Ok(Some(userfaultfd::Event::Pagefault { .. })) => {}
+            other => panic!("expected the reader's pagefault event, got {other:?}"),
+        }
+        wait_parked_in_handle_userfault(reader_tid);
+
+        // The racing winner: fills the page with NO wake; the event is consumed and
+        // the reader is proven asleep.
+        let src = vec![0xA5u8; PAGE];
+        // SAFETY: src outlives the ioctl; base is the registered page.
+        unsafe { uffd.copy(src.as_ptr().cast(), base, PAGE, false) }
+            .expect("winner's COPY must succeed");
+
+        // The demand COPY arm's exact sequence: attempt, observe EEXIST, wake.
+        // SAFETY: same as above.
+        let err = unsafe { uffd.copy(src.as_ptr().cast(), base, PAGE, true) }
+            .expect_err("second COPY must report EEXIST");
+        assert!(
+            matches!(&err, userfaultfd::Error::CopyFailed(errno) if (*errno as i32) == libc::EEXIST),
+            "expected CopyFailed(EEXIST), got {err:?}"
+        );
+        wake_eexist_waiters(&uffd, addr, PAGE).expect("wake after COPY EEXIST");
+
+        let got = rx.recv_timeout(Duration::from_secs(5)).expect(
+            "faulter still asleep after COPY EEXIST — the demand COPY arm must wake \
+             (userfaultfd(2) contract; COPY-mode half of the clone wedge)",
+        );
+        assert_eq!(got, 0xA5, "reader must observe the winner's bytes");
+        reader.join().expect("reader thread");
+        // SAFETY: unmapping our own mapping.
+        unsafe { libc::munmap(base, PAGE) };
+    }
+
+    /// The behavioral tests above bind wake_eexist_waiters' SEMANTICS; this binds the
+    /// CALL SITES. The demand COPY arm lives inline in drain_events and cannot be
+    /// driven directly by a unit test, so removing its wake would leave every
+    /// behavioral test green — this assertion goes red instead.
+    #[test]
+    fn both_eexist_arms_wake_their_waiters() {
+        let source = include_str!("server.rs");
+        for anchor in [
+            "UFFDIO_CONTINUE skipped - page already mapped (EEXIST), waking waiters",
+            "UFFD copy skipped - page already filled (EEXIST), waking waiters",
+        ] {
+            let at = source.find(anchor).unwrap_or_else(|| {
+                panic!("EEXIST arm anchor missing (renamed without updating this test): {anchor}")
+            });
+            let window = &source[at..source.len().min(at + 800)];
+            assert!(
+                window.contains("wake_eexist_waiters("),
+                "the EEXIST arm at {anchor:?} no longer wakes its waiters — \
+                 that is the stranded-faulter hang, do not remove the wake"
+            );
         }
     }
 }

--- a/src/uffd/server.rs
+++ b/src/uffd/server.rs
@@ -1074,8 +1074,25 @@ fn continue_page(
                     target: "uffd",
                     vm_id = %vm_id,
                     fault_addr = format!("0x{:x}", page + done),
-                    "UFFDIO_CONTINUE skipped - page already mapped (EEXIST)"
+                    "UFFDIO_CONTINUE skipped - page already mapped (EEXIST), waking waiters"
                 );
+                // EEXIST proves the PTE is present — NOT that the faulter was woken. The
+                // kernel's check-then-sleep window lets a faulter enqueue AFTER the racing
+                // winner's wake scan, and userfaultfd(2) requires an explicit UFFDIO_WAKE
+                // here for exactly that case. Without it the faulter sleeps forever: the
+                // 4K-minor clone wedge (VMM device thread parked in handle_userfault,
+                // victim uffd fdinfo `pending:0 total:1`, whole virtio plane dead).
+                // A failed wake is the hang this arm exists to prevent — propagate it
+                // into the fail-closed kill path rather than logging and limping on.
+                uffd.wake(addr, remaining).map_err(|wake_error| {
+                    anyhow!(
+                        "UFFDIO_WAKE after EEXIST failed at 0x{:x}+{}: {:?} — a stranded \
+                         faulter would hang its thread permanently",
+                        page + done,
+                        remaining,
+                        wake_error
+                    )
+                })?;
                 // EEXIST refers to the granule at the current position; with per-granule
                 // requests that is the whole remaining range.
                 done += remaining;
@@ -3573,5 +3590,185 @@ mod tests {
             "the name must be reconstructible: clones derive it from the serve state file"
         );
         assert_eq!(a, Path::new("/data/uffd-snap-42-1000.sock"));
+    }
+
+    /// EEXIST from UFFDIO_CONTINUE proves the PTE is present — NOT that the faulter was
+    /// woken. The kernel's check-then-sleep window lets a faulter enqueue AFTER a racing
+    /// winner's wake scan, which is why userfaultfd(2) requires an explicit UFFDIO_WAKE
+    /// after EEXIST. This is the userspace half of the 4K-minor clone wedge: the VMM's
+    /// device thread parked forever in `handle_userfault`, the victim uffd's fdinfo
+    /// reading `pending:0 total:1` (one read-but-never-woken fault), the serve idle.
+    ///
+    /// Deterministic — no race roulette: the "winner" installs the PTE with wake=false
+    /// (a legal stand-in for a wake scan the sleeper missed), so the sleeping reader can
+    /// be released ONLY by `continue_page`'s EEXIST arm issuing the mandated wake.
+    #[test]
+    fn eexist_resolution_wakes_the_stranded_faulter() {
+        use std::os::unix::io::FromRawFd;
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        const PAGE: usize = 4096;
+        // Pinned from uapi/linux/userfaultfd.h: _IOWR(0xAA, 0x3F, uffdio_api) and
+        // _IOWR(0xAA, 0x00, uffdio_register); identical on x86_64 and aarch64.
+        const UFFDIO_API: libc::c_ulong = 0xc018_aa3f;
+        const UFFDIO_REGISTER: libc::c_ulong = 0xc020_aa00;
+        const UFFD_FEATURE_MINOR_SHMEM: u64 = 1 << 10;
+        const UFFDIO_REGISTER_MODE_MINOR: u64 = 1 << 2;
+
+        #[repr(C)]
+        struct UffdioApi {
+            api: u64,
+            features: u64,
+            ioctls: u64,
+        }
+        #[repr(C)]
+        struct UffdioRange {
+            start: u64,
+            len: u64,
+        }
+        #[repr(C)]
+        struct UffdioRegister {
+            range: UffdioRange,
+            mode: u64,
+            ioctls: u64,
+        }
+
+        // The crate's builder cannot negotiate MINOR_SHMEM (no such FeatureFlag in 0.9),
+        // so the api/register handshake is raw; the fd then becomes an ordinary `Uffd`
+        // and `continue_page` runs exactly as production runs it. /dev/userfaultfd is a
+        // CONTROL device: the real uffd comes from its USERFAULTFD_IOC_NEW ioctl
+        // (_IO(0xAA, 0x00)), with the O_* flags as the ioctl argument.
+        const USERFAULTFD_IOC_NEW: libc::c_ulong = 0xAA00;
+        let dev = unsafe { libc::open(c"/dev/userfaultfd".as_ptr(), libc::O_RDWR | libc::O_CLOEXEC) };
+        assert!(
+            dev >= 0,
+            "open /dev/userfaultfd: {}",
+            std::io::Error::last_os_error()
+        );
+        // SAFETY: valid control fd; IOC_NEW returns a fresh uffd fd.
+        let raw = unsafe {
+            libc::ioctl(
+                dev,
+                USERFAULTFD_IOC_NEW,
+                libc::O_CLOEXEC | libc::O_NONBLOCK,
+            )
+        };
+        assert!(
+            raw >= 0,
+            "USERFAULTFD_IOC_NEW: {}",
+            std::io::Error::last_os_error()
+        );
+        // SAFETY: closing the control fd; the created uffd is independent of it.
+        unsafe { libc::close(dev) };
+        let mut api = UffdioApi {
+            api: 0xAA,
+            features: UFFD_FEATURE_MINOR_SHMEM,
+            ioctls: 0,
+        };
+        // SAFETY: valid fd, matching pinned request/struct pair.
+        let rc = unsafe { libc::ioctl(raw, UFFDIO_API, &mut api) };
+        assert_eq!(
+            rc,
+            0,
+            "UFFDIO_API(MINOR_SHMEM): {}",
+            std::io::Error::last_os_error()
+        );
+
+        // One-page memfd whose page is RESIDENT: minor faults require page-in-cache.
+        let memfd = unsafe { libc::memfd_create(c"eexist-wake".as_ptr(), 0) };
+        assert!(memfd >= 0);
+        assert_eq!(unsafe { libc::ftruncate(memfd, PAGE as libc::off_t) }, 0);
+        // SAFETY: fresh shared mapping of the memfd, written then unmapped.
+        unsafe {
+            let shared = libc::mmap(
+                std::ptr::null_mut(),
+                PAGE,
+                libc::PROT_WRITE,
+                libc::MAP_SHARED,
+                memfd,
+                0,
+            );
+            assert_ne!(shared, libc::MAP_FAILED);
+            std::ptr::write_volatile(shared as *mut u8, 0x5A);
+            libc::munmap(shared, PAGE);
+        }
+
+        // SAFETY: fresh private mapping of the same memfd.
+        let base = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                PAGE,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE,
+                memfd,
+                0,
+            )
+        };
+        assert_ne!(base, libc::MAP_FAILED);
+        let mut reg = UffdioRegister {
+            range: UffdioRange {
+                start: base as u64,
+                len: PAGE as u64,
+            },
+            mode: UFFDIO_REGISTER_MODE_MINOR,
+            ioctls: 0,
+        };
+        // SAFETY: valid fd, matching pinned request/struct pair.
+        let rc = unsafe { libc::ioctl(raw, UFFDIO_REGISTER, &mut reg) };
+        assert_eq!(
+            rc,
+            0,
+            "UFFDIO_REGISTER(MINOR): {}",
+            std::io::Error::last_os_error()
+        );
+        // SAFETY: `raw` is a live uffd whose API handshake just succeeded.
+        let uffd = unsafe { Uffd::from_raw_fd(raw) };
+
+        let addr = base as usize;
+        let (tx, rx) = mpsc::channel();
+        let reader = std::thread::spawn(move || {
+            // Minor-faults (page resident, PTE absent) and sleeps until woken.
+            // SAFETY: addr is a live registered mapping for the test's lifetime.
+            let got = unsafe { std::ptr::read_volatile(addr as *const u8) };
+            tx.send(got).ok();
+        });
+
+        let mut pfd = libc::pollfd {
+            fd: uffd.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: one initialised pollfd, owned fd.
+        assert!(
+            unsafe { libc::poll(&mut pfd, 1, 5000) } > 0,
+            "no fault event within 5s"
+        );
+        match uffd.read_event() {
+            Ok(Some(userfaultfd::Event::Pagefault { .. })) => {}
+            other => panic!("expected the reader's pagefault event, got {other:?}"),
+        }
+
+        // The racing winner: installs the PTE with NO wake. The fault event is already
+        // consumed above, so nothing else will ever wake the reader.
+        uffd.r#continue(base, PAGE, false)
+            .expect("winner's CONTINUE must succeed");
+
+        // The handler under test answers the consumed fault: it must see EEXIST and wake.
+        let outcome =
+            continue_page(&uffd, "eexist-wake-test", addr, PAGE).expect("continue_page");
+        assert!(matches!(outcome, ContinueOutcome::Resolved));
+
+        let got = rx.recv_timeout(Duration::from_secs(5)).expect(
+            "faulter still asleep after EEXIST resolution — continue_page must UFFDIO_WAKE \
+             the granule (userfaultfd(2) EEXIST contract); this is the 4K clone wedge",
+        );
+        assert_eq!(got, 0x5A, "reader must observe the resident page's bytes");
+        reader.join().expect("reader thread");
+        // SAFETY: unmapping our own mapping; memfd close releases the file.
+        unsafe {
+            libc::munmap(base, PAGE);
+            libc::close(memfd);
+        }
     }
 }

--- a/src/uffd/server.rs
+++ b/src/uffd/server.rs
@@ -997,15 +997,16 @@ fn continue_hit_present_page(e: &userfaultfd::Error) -> bool {
 /// whole virtio plane dead. A failed wake is the hang this call exists to prevent, so it
 /// propagates into the fail-closed kill path rather than being logged and limped past.
 fn wake_eexist_waiters(uffd: &Uffd, addr: usize, len: usize) -> Result<()> {
-    uffd.wake(addr as *mut std::ffi::c_void, len).map_err(|wake_error| {
-        anyhow!(
-            "UFFDIO_WAKE after EEXIST failed at 0x{:x}+{}: {:?} — a stranded faulter \
+    uffd.wake(addr as *mut std::ffi::c_void, len)
+        .map_err(|wake_error| {
+            anyhow!(
+                "UFFDIO_WAKE after EEXIST failed at 0x{:x}+{}: {:?} — a stranded faulter \
              would hang its thread permanently",
-            addr,
-            len,
-            wake_error
-        )
-    })
+                addr,
+                len,
+                wake_error
+            )
+        })
 }
 
 /// Whether a UFFDIO_CONTINUE error is the kernel saying "not now, try again".
@@ -3670,20 +3671,16 @@ mod tests {
         // CONTROL device: the real uffd comes from its USERFAULTFD_IOC_NEW ioctl
         // (_IO(0xAA, 0x00)), with the O_* flags as the ioctl argument.
         const USERFAULTFD_IOC_NEW: libc::c_ulong = 0xAA00;
-        let dev = unsafe { libc::open(c"/dev/userfaultfd".as_ptr(), libc::O_RDWR | libc::O_CLOEXEC) };
+        let dev =
+            unsafe { libc::open(c"/dev/userfaultfd".as_ptr(), libc::O_RDWR | libc::O_CLOEXEC) };
         assert!(
             dev >= 0,
             "open /dev/userfaultfd: {}",
             std::io::Error::last_os_error()
         );
         // SAFETY: valid control fd; IOC_NEW returns a fresh uffd fd.
-        let raw = unsafe {
-            libc::ioctl(
-                dev,
-                USERFAULTFD_IOC_NEW,
-                libc::O_CLOEXEC | libc::O_NONBLOCK,
-            )
-        };
+        let raw =
+            unsafe { libc::ioctl(dev, USERFAULTFD_IOC_NEW, libc::O_CLOEXEC | libc::O_NONBLOCK) };
         assert!(
             raw >= 0,
             "USERFAULTFD_IOC_NEW: {}",
@@ -3798,8 +3795,7 @@ mod tests {
             .expect("winner's CONTINUE must succeed");
 
         // The handler under test answers the consumed fault: it must see EEXIST and wake.
-        let outcome =
-            continue_page(&uffd, "eexist-wake-test", addr, PAGE).expect("continue_page");
+        let outcome = continue_page(&uffd, "eexist-wake-test", addr, PAGE).expect("continue_page");
         assert!(matches!(outcome, ContinueOutcome::Resolved));
 
         let got = rx.recv_timeout(Duration::from_secs(5)).expect(


### PR DESCRIPTION
## The bug

At 4K-minor concurrency, ~10% of clones per N=32 rung wedged permanently: the published CDP port accepted TCP but never answered HTTP, for the full 120 s deadline and beyond. Frozen-victim inspection showed the exact shape:

- Firecracker's device event-loop thread parked forever in `handle_userfault` (virtio plane dead — hence port-open-but-silent)
- both vCPUs innocently idle in `kvm_vcpu_block`
- the victim uffd's fdinfo reading `pending:0 total:1` — one fault **read by the serve and never woken**
- the serve idle in `futex_wait`, believing all faults handled

## Root cause

EEXIST from `UFFDIO_CONTINUE` — or `UFFDIO_COPY` — proves the page is present, **not** that the faulter was woken. The kernel's check-then-sleep window lets a faulter enqueue after the racing winner's wake scan; userfaultfd(2) requires an explicit `UFFDIO_WAKE` after EEXIST for exactly this case (Linux's own uffd selftests do it after COPY EEXIST). Both demand arms skipped silently, stranding the waiter forever. A debug-logged reproduction showed exactly one EEXIST-skip per wedged VM, timestamped at first CDP contact. Hugepage mode never wedged (427/427 clones): ~500 faults/clone vs ~250k at 4K puts the race at ~1 per 2–3 million faults.

## The fix (2 commits)

1. `bfb2b637` — wake the EEXIST'd granule in `continue_page` (MINOR path); a failed wake propagates into the fail-closed kill path.
2. `4a403347` — adversarial-review round: the default **COPY backend had the identical bug** in its demand EEXIST arm; both arms now share a `wake_eexist_waiters` helper. The regression test also had a false-green interleaving (a queued event ≠ a parked faulter), closed with a parked-oracle: `/proc/self/task/<tid>/wchan` must read `handle_userfault` before the winner installs the page.

## Tests

- `eexist_resolution_wakes_the_stranded_faulter` — CONTINUE path, end to end through `continue_page`, parked-oracle gated.
- `eexist_copy_resolution_wakes_the_stranded_faulter` — COPY twin (MISSING registration, the demand arm's exact attempt/EEXIST/wake sequence).
- `both_eexist_arms_wake_their_waiters` — source contract binding the inline COPY arm (not unit-drivable) to the helper call.

RED-VERIFIED: with the wake disabled, both behavioral tests fail deterministically (reader parked in `handle_userfault`, recv_timeout expires); green restored. Full cycle watched red → green → red → green.

## Validation on hardware

5 rounds × N=32 clones against the fixed serve: **0 userfault wedges in 160 clones** (vs 12/114 unfixed; p ≈ 2×10⁻⁸ under the unfixed rate). The single unrelated failure was a post-restore container exit with a different fingerprint (no parked threads, clean teardown).

## Test results

```
make lint       # clean
make test-unit  # 787 passed, 0 skipped
```

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd