### PR TITLE
reqbench: corpus-mix replay, html arm, CDP prewiring, 2ms probe grid

### DIFF
--- a/bench/chromium/cdpdrive.py
+++ b/bench/chromium/cdpdrive.py
@@ -387,34 +387,65 @@ def drive(args) -> dict:
                 out["idle_timeout"] = 1
         stages["idle_ms"] = (time.monotonic() - t) * 1000
 
-        stage = "screenshot"
-        stage_started = time.monotonic()
-        t = time.monotonic()
-        params = {"format": args.format}
-        if args.format == "jpeg":
-            params["quality"] = args.quality
-        shot = cdp.cmd("Page.captureScreenshot", params, deadline=deadline)
-        stages["screenshot_ms"] = (time.monotonic() - t) * 1000
+        if getattr(args, "op", "screenshot") == "html":
+            # HTML-extraction op: the page's serialized DOM instead of pixels —
+            # the second operation Kitesurf's table prices. Same connect and
+            # navigate path; the terminal stage swaps.
+            stage = "extract"
+            stage_started = time.monotonic()
+            t = time.monotonic()
+            result = cdp.cmd(
+                "Runtime.evaluate",
+                {
+                    "expression": "document.documentElement.outerHTML",
+                    "returnByValue": True,
+                },
+                deadline=deadline,
+            )
+            html = result.get("result", {}).get("value")
+            if not isinstance(html, str) or "</html>" not in html.lower():
+                raise RuntimeError(
+                    "outerHTML extraction returned no closed document "
+                    f"({type(html).__name__}, {len(html) if isinstance(html, str) else 0} chars)"
+                )
+            encoded = html.encode()
+            out.update(
+                html_bytes=len(encoded),
+                html_sha256=hashlib.sha256(encoded).hexdigest(),
+            )
+            stages["extract_ms"] = (time.monotonic() - t) * 1000
+            if args.out_prefix:
+                with open(f"{args.out_prefix}.html", "w") as f:
+                    f.write(html)
+        else:
+            stage = "screenshot"
+            stage_started = time.monotonic()
+            t = time.monotonic()
+            params = {"format": args.format}
+            if args.format == "jpeg":
+                params["quality"] = args.quality
+            shot = cdp.cmd("Page.captureScreenshot", params, deadline=deadline)
+            stages["screenshot_ms"] = (time.monotonic() - t) * 1000
 
-        stage = "decode"
-        stage_started = time.monotonic()
-        t = time.monotonic()
-        raw = base64.b64decode(shot["data"])
-        magic = b"\x89PNG" if args.format == "png" else b"\xff\xd8\xff"
-        if not raw.startswith(magic):
-            raise RuntimeError(f"captureScreenshot returned non-{args.format.upper()} data")
-        w, h = image_dimensions(raw)
-        out.update(
-            image_bytes=len(raw),
-            image_sha256=hashlib.sha256(raw).hexdigest(),
-            width=w,
-            height=h,
-            quality=args.quality if args.format == "jpeg" else 0,
-        )
-        stages["decode_ms"] = (time.monotonic() - t) * 1000
-        if args.out_prefix:
-            with open(f"{args.out_prefix}.{args.format}", "wb") as f:
-                f.write(raw)
+            stage = "decode"
+            stage_started = time.monotonic()
+            t = time.monotonic()
+            raw = base64.b64decode(shot["data"])
+            magic = b"\x89PNG" if args.format == "png" else b"\xff\xd8\xff"
+            if not raw.startswith(magic):
+                raise RuntimeError(f"captureScreenshot returned non-{args.format.upper()} data")
+            w, h = image_dimensions(raw)
+            out.update(
+                image_bytes=len(raw),
+                image_sha256=hashlib.sha256(raw).hexdigest(),
+                width=w,
+                height=h,
+                quality=args.quality if args.format == "jpeg" else 0,
+            )
+            stages["decode_ms"] = (time.monotonic() - t) * 1000
+            if args.out_prefix:
+                with open(f"{args.out_prefix}.{args.format}", "wb") as f:
+                    f.write(raw)
 
         if args.nav_timing:
             stage = "nav-timing"

--- a/bench/chromium/corpus_serve.py
+++ b/bench/chromium/corpus_serve.py
@@ -153,7 +153,7 @@ def selfsigned(tmpdir: Path):
     return crt, key
 
 
-def dns_responder(addr: str, port: int):
+def dns_responder(addr: str, port: int, answer_ip: str = "127.0.0.1"):
     """Answer every A query with 127.0.0.1 (AAAA answered empty, forcing v4).
 
     Browser-agnostic host mapping for the replay arm: the replay container
@@ -181,7 +181,7 @@ def dns_responder(addr: str, port: int):
             qtype = struct.unpack(">H", qd[i + 1:i + 3])[0]
             if qtype == 1:  # A
                 answer = (b"\xc0\x0c" + struct.pack(">HHIH", 1, 1, 5, 4)
-                          + socket.inet_aton("127.0.0.1"))
+                          + socket.inet_aton(answer_ip))
                 resp = txid + flags + struct.pack(">HHHH", 1, 1, 0, 0) + question + answer
             else:  # empty NOERROR (esp. AAAA -> fall back to A)
                 resp = txid + flags + struct.pack(">HHHH", 1, 0, 0, 0) + question
@@ -197,14 +197,19 @@ def main():
     ap.add_argument("--tls-port", type=int, default=443)
     ap.add_argument("--dns-addr", default="127.0.0.2")
     ap.add_argument("--dns-port", type=int, default=53)
+    # The address DNS answers point at. Host-side replay: 127.0.0.1. In-guest
+    # replay: 10.0.2.2, the pasta gateway, which maps guest connections onto
+    # the host's loopback where this server listens.
+    ap.add_argument("--answer-ip", default="127.0.0.1")
     args = ap.parse_args()
 
     Handler.exact, Handler.noquery, Handler.redirects = load_indexes(Path(args.root))
     print(f"loaded {len(Handler.exact)} urls", flush=True)
 
-    threading.Thread(target=dns_responder, args=(args.dns_addr, args.dns_port),
+    threading.Thread(target=dns_responder,
+                     args=(args.dns_addr, args.dns_port, args.answer_ip),
                      daemon=True).start()
-    print(f"wildcard DNS on {args.dns_addr}:{args.dns_port} -> 127.0.0.1", flush=True)
+    print(f"wildcard DNS on {args.dns_addr}:{args.dns_port} -> {args.answer_ip}", flush=True)
 
     plain = http.server.ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
     threading.Thread(target=plain.serve_forever, daemon=True).start()

--- a/bench/chromium/corpus_serve.py
+++ b/bench/chromium/corpus_serve.py
@@ -202,6 +202,14 @@ def main():
     # the host's loopback where this server listens.
     ap.add_argument("--answer-ip", default="127.0.0.1")
     args = ap.parse_args()
+    # Validate up front: inet_aton runs inside the responder's broad exception
+    # handler, so a malformed address would silently drop every A query while
+    # the servers keep running — the failure has to happen before any thread
+    # starts.
+    try:
+        socket.inet_aton(args.answer_ip)
+    except OSError:
+        ap.error(f"--answer-ip is not a valid IPv4 address: {args.answer_ip!r}")
 
     Handler.exact, Handler.noquery, Handler.redirects = load_indexes(Path(args.root))
     print(f"loaded {len(Handler.exact)} urls", flush=True)

--- a/bench/chromium/reqanalyze.py
+++ b/bench/chromium/reqanalyze.py
@@ -407,7 +407,7 @@ def _validate_arms(arms, label, errors):
         or len(arms) != len(set(arms))
     ):
         errors.append(f"{label} metadata has no valid duplicate-free arms list")
-    elif any(arm not in {"exec", "cdp", "cdp-fast", "noop"} for arm in arms):
+    elif any(arm not in {"exec", "cdp", "cdp-fast", "html", "noop"} for arm in arms):
         errors.append(f"{label} metadata declares an unsupported arm")
     elif "noop" not in arms or not ({"cdp", "cdp-fast"} & set(arms)):
         errors.append(
@@ -677,7 +677,7 @@ def _validate_schedule(dataset):
                     errors.append(f"{rlabel} successful exec did not exit cleanly")
                 if not finite_nonnegative(record.get("render_total_ms")):
                     errors.append(f"{rlabel} successful exec has no render_total_ms")
-            elif arm in ("cdp", "cdp-fast"):
+            elif arm in ("cdp", "cdp-fast", "html"):
                 for metric in ("state_to_port_ms", "spawn_to_port_ms"):
                     if not finite_nonnegative(record.get(metric)):
                         errors.append(f"{rlabel} successful CDP record has no {metric}")
@@ -710,14 +710,34 @@ def _validate_schedule(dataset):
                         errors.append(
                             f"{rlabel} CDP render did not complete its declared idle policy"
                         )
-                    if render.get("target_prewired") is not meta.get("ws_url_prewired"):
+                    prewired_expected = meta.get("ws_url_prewired")
+                    discovery_warmup = (
+                        is_warmup
+                        and prewired_expected is True
+                        and render.get("target_prewired") is False
+                    )
+                    # --prewire pins the URL on the first successful warmup rep,
+                    # which itself necessarily runs unprewired; measured reps are
+                    # held strictly to the metadata.
+                    if not discovery_warmup and (
+                        render.get("target_prewired") is not prewired_expected
+                    ):
                         errors.append(f"{rlabel} CDP target prewire mode mismatches metadata")
                     stages = render.get("stages")
-                    required_stages = (
-                        "resolve_ms", "tcp_ms", "upgrade_ms", "enable_ms",
-                        "connect_total_ms", "navigate_ms", "idle_ms",
-                        "screenshot_ms", "decode_ms", "nav_timing_ms", "total_ms",
-                    )
+                    if arm == "html":
+                        # The html op swaps the terminal screenshot+decode stages
+                        # for a single DOM-extraction stage.
+                        required_stages = (
+                            "resolve_ms", "tcp_ms", "upgrade_ms", "enable_ms",
+                            "connect_total_ms", "navigate_ms", "idle_ms",
+                            "extract_ms", "nav_timing_ms", "total_ms",
+                        )
+                    else:
+                        required_stages = (
+                            "resolve_ms", "tcp_ms", "upgrade_ms", "enable_ms",
+                            "connect_total_ms", "navigate_ms", "idle_ms",
+                            "screenshot_ms", "decode_ms", "nav_timing_ms", "total_ms",
+                        )
                     if not isinstance(stages, dict):
                         errors.append(f"{rlabel} successful CDP render has no stages")
                     else:
@@ -726,15 +746,30 @@ def _validate_schedule(dataset):
                                 errors.append(
                                     f"{rlabel} successful CDP render has invalid {stage}"
                                 )
+                    if arm == "html":
+                        html_bytes = render.get("html_bytes")
+                        html_sha256 = render.get("html_sha256")
+                        if (
+                            not isinstance(html_bytes, int)
+                            or isinstance(html_bytes, bool)
+                            or html_bytes <= 0
+                        ):
+                            errors.append(f"{rlabel} html render has no positive html_bytes")
+                        if (
+                            not isinstance(html_sha256, str)
+                            or len(html_sha256) != 64
+                            or any(c not in "0123456789abcdef" for c in html_sha256)
+                        ):
+                            errors.append(f"{rlabel} html render has invalid html_sha256")
                     image_bytes = render.get("image_bytes")
                     image_sha256 = render.get("image_sha256")
-                    if (
+                    if arm != "html" and (
                         not isinstance(image_bytes, int)
                         or isinstance(image_bytes, bool)
                         or image_bytes <= 0
                     ):
                         errors.append(f"{rlabel} CDP render has no positive image_bytes")
-                    if (
+                    if arm != "html" and (
                         not isinstance(image_sha256, str)
                         or len(image_sha256) != 64
                         or any(
@@ -743,7 +778,7 @@ def _validate_schedule(dataset):
                         )
                     ):
                         errors.append(f"{rlabel} CDP render has invalid image_sha256")
-                    for dimension in ("width", "height"):
+                    for dimension in (() if arm == "html" else ("width", "height")):
                         value = render.get(dimension)
                         if (
                             not isinstance(value, int)
@@ -752,7 +787,7 @@ def _validate_schedule(dataset):
                         ):
                             errors.append(f"{rlabel} CDP render has invalid {dimension}")
                     expected_quality = meta["quality"] if meta["format"] == "jpeg" else 0
-                    if render.get("quality") != expected_quality:
+                    if arm != "html" and render.get("quality") != expected_quality:
                         errors.append(f"{rlabel} CDP render quality mismatches metadata")
                     nav = render.get("nav")
                     nav_fields = (

--- a/bench/chromium/reqanalyze.py
+++ b/bench/chromium/reqanalyze.py
@@ -685,8 +685,18 @@ def _validate_schedule(dataset):
                 if not isinstance(render, dict) or render.get("ok") is not True:
                     errors.append(f"{rlabel} successful CDP record has no successful render")
                 else:
+                    # Multi-URL runs declare meta.urls and cycle rep-modulo;
+                    # the expected URL for THIS record is re-derived from the
+                    # schedule, which is stricter than set membership: a
+                    # record rendering the right URL at the wrong rep is a
+                    # schedule violation.
+                    urls = meta.get("urls")
+                    if isinstance(urls, list) and urls:
+                        expected_url = urls[record.get("rep", 0) % len(urls)]
+                    else:
+                        expected_url = meta.get("url")
                     expected_fields = {
-                        "url": meta.get("url"),
+                        "url": expected_url,
                         "format": meta.get("format"),
                         "cdp_host": record.get("endpoint"),
                     }

--- a/bench/chromium/reqanalyze.py
+++ b/bench/chromium/reqanalyze.py
@@ -49,6 +49,18 @@ import uuid
 
 
 MIN_CDP_ATTEMPTS_PER_BACKEND = 200
+
+
+def is_cdp_class(arm):
+    """Arms that pay the per-request CDP handshake: cdp, cdp-fast, and html.
+
+    Both the sample-size gate and the stage decomposition key off this
+    predicate. A name test scattered as startswith("cdp") let the html arm
+    fall out of both: a mixed run could publish an html latency from fewer
+    than 200 measured attempts, and analysis.json dropped every
+    connection/extraction stage for it.
+    """
+    return isinstance(arm, str) and (arm.startswith("cdp") or arm == "html")
 MIN_NOOP_ATTEMPTS = 6
 DRIFT_EQUIVALENCE_MARGIN_MS = 10.0
 QUIET_LOADAVG1_LIMIT = 2.0
@@ -1524,10 +1536,10 @@ def analyze_backend(
     expected_cdp_arms = set()
     for meta in metas:
         for arm in meta.get("arms") or []:
-            if isinstance(arm, str) and arm.startswith("cdp"):
+            if is_cdp_class(arm):
                 expected_cdp_arms.add(arm)
     if not expected_cdp_arms:
-        expected_cdp_arms.update(a for a in arms if a.startswith("cdp"))
+        expected_cdp_arms.update(a for a in arms if is_cdp_class(a))
     expected_cdp_arms = sorted(expected_cdp_arms)
     cdp_counts = {
         a: len(measured_attempted.get(a, [])) for a in expected_cdp_arms
@@ -1668,7 +1680,13 @@ def analyze_backend(
     print("-" * 78)
     stage_keys = ["resolve_ms", "tcp_ms", "upgrade_ms", "enable_ms", "connect_total_ms",
                   "navigate_ms", "screenshot_ms", "total_ms"]
-    for a in [x for x in arms if x.startswith("cdp")]:
+    for a in [x for x in arms if is_cdp_class(x)]:
+        # html swaps the terminal screenshot stage for extract (no image);
+        # every other stage is the same CDP handshake all cdp-class arms pay.
+        arm_stage_keys = [
+            ("extract_ms" if (k == "screenshot_ms" and a == "html") else k)
+            for k in stage_keys
+        ]
         print(f"  [{a}]")
         for metric, explanation in (
             ("spawn_to_port_ms", "process spawn -> first TCP accept; stable readiness boundary"),
@@ -1689,7 +1707,7 @@ def analyze_backend(
             print("    resolve_ms       SKIPPED (--ws-url prewired; NOT measured)")
         elif len(prewired) > 1:
             print("    resolve_ms       MIXED prewired/measured records -- refusing to pool")
-        for k in stage_keys:
+        for k in arm_stage_keys:
             if k == "resolve_ms" and (prewired == {True} or len(prewired) > 1):
                 continue
             # cdpdrive nests its timings under render.stages; reading render[k]

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -2790,7 +2790,7 @@ def run_cdp_request(args, rep: int, fast: bool, probe=None) -> dict:
             rec["ws_url_prewired"] = bool(ws_url)
             drive_args = argparse.Namespace(
                 cdp_host=endpoint,
-                url=args.url,
+                url=url_for_rep(getattr(args, "urls", None) or [args.url], rep),
                 format=args.format,
                 quality=args.quality,
                 timeout=max(1.0, deadline - time.monotonic()),
@@ -3099,7 +3099,8 @@ def run_exec_request(args, rep: int) -> dict:
     name = f"rb-{args.run_id}-{rep}-exec"
     log = os.path.join(args.out_dir, f"{name}.log")
     driver = shlex.join([
-        "python3", "/opt/bench/render.py", args.url,
+        "python3", "/opt/bench/render.py",
+        url_for_rep(getattr(args, "urls", None) or [args.url], rep),
         "--out-prefix", "/tmp/rb",
         "--format", args.format,
         "--quality", str(args.quality),
@@ -3469,6 +3470,16 @@ def dispatch_request(args, rep: int, arm: str, is_warmup: bool, probe=None) -> d
     return run_cdp_request(args, rep, fast=(arm == "cdp-fast"), probe=probe)
 
 
+def parse_urls(spec):
+    """Split a comma-separated --url value; single URLs pass through as [url]."""
+    return [u.strip() for u in spec.split(",") if u.strip()]
+
+
+def url_for_rep(urls, rep):
+    """Deterministic uniform cycle: rep r renders urls[r % len(urls)]."""
+    return urls[rep % len(urls)]
+
+
 def main() -> int:
     """Run one schedule and release every whole-run resource on every exit."""
     with ExitStack() as resources:
@@ -3481,7 +3492,9 @@ def main_with_resources(resources: ExitStack) -> int:
                    help="UFFD serve pid (omit when using --snapshot-tag)")
     p.add_argument("--snapshot-tag", default="",
                    help="FILE-backed restore from this tag instead of a UFFD serve")
-    p.add_argument("--url", required=True)
+    p.add_argument("--url", required=True,
+                   help="page URL, or a comma-separated list cycled across "
+                        "reps (the corpus-mix arm)")
     p.add_argument("--arms", default="exec,cdp,cdp-fast,noop")
     p.add_argument("--reps", type=int, default=10)
     p.add_argument("--warmup", type=int, default=2, help="discarded EXPLICITLY, and reported")
@@ -3624,6 +3637,21 @@ def main_with_resources(resources: ExitStack) -> int:
     if "noop" not in arms or not ({"cdp", "cdp-fast"} & set(arms)):
         p.error("publication runs require noop and at least one CDP arm")
 
+    urls = parse_urls(args.url)
+    if not urls:
+        p.error("--url must name at least one URL")
+    if len(urls) > 1 and args.warmup < 2 * len(urls):
+        # A mix trains the prefetch working set during its first cycle; the
+        # noop baseline is not stationary until every URL has faulted its
+        # pages in (measured 2026-08-14: the drift gate rejects runs whose
+        # working set converges inside the measured window). Two full cycles
+        # of warmup cover convergence.
+        p.error(
+            f"multi-URL runs need --warmup >= {2 * len(urls)} "
+            f"(2x the URL count, working-set convergence); got {args.warmup}"
+        )
+    args.urls = urls
+
     args.run_id = args.run_id or uuid.uuid4().hex
     if (
         len(args.run_id) != 32
@@ -3669,7 +3697,7 @@ def main_with_resources(resources: ExitStack) -> int:
             "kind": "meta", "run_id": run_id, "seed": args.seed,
             "backend": "file" if args.snapshot_tag else "uffd", "arms": arms, "reps": args.reps,
             "uffd_mode": uffd_mode,
-            "warmup": args.warmup, "url": args.url, "format": args.format,
+            "warmup": args.warmup, "url": args.url, "urls": args.urls, "format": args.format,
             "quality": args.quality,
             "source_revision": current_source_revision,
             "fcvm_path": args.fcvm,
@@ -3741,6 +3769,7 @@ def main_with_resources(resources: ExitStack) -> int:
                 }
                 fatal = e
             rec["warmup"] = is_warmup  # discarded explicitly at analysis, never silently
+            rec["url"] = url_for_rep(getattr(args, "urls", None) or [args.url], rep)
             rec["run_id"] = run_id
             rec["record_id"] = f"{run_id}:{arm}:{rep}:{int(is_warmup)}"
             rec["loadavg1"] = float(read_trimmed("/proc/loadavg").split()[0])

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -911,7 +911,13 @@ def wait_port(
             remaining = deadline - time.monotonic()
             if remaining > 0:
                 time.sleep(min(delay, remaining))
-            delay = min(delay * 1.5, 0.02)
+            # Cap at 2 ms, not 20: with a 20 ms cap the attempts past the
+            # ramp land ~17-20 ms apart (cumulative ~39.8/56.9/76.9 ms), and
+            # every restore-readiness figure snapped to those grid points —
+            # a ~1-2 ms real effect near an attempt boundary read as a clean
+            # "17 ms bimodal restore floor" (2026-08-14). ~20 extra connect
+            # attempts per 40 ms wait is noise; measurement resolution is not.
+            delay = min(delay * 1.5, 0.002)
 
 
 def sha256_file(path: str) -> str:

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -912,11 +912,12 @@ def wait_port(
             if remaining > 0:
                 time.sleep(min(delay, remaining))
             # Cap at 2 ms, not 20: with a 20 ms cap the attempts past the
-            # ramp land ~17-20 ms apart (cumulative ~39.8/56.9/76.9 ms), and
-            # every restore-readiness figure snapped to those grid points —
-            # a ~1-2 ms real effect near an attempt boundary read as a clean
-            # "17 ms bimodal restore floor" (2026-08-14). ~20 extra connect
-            # attempts per 40 ms wait is noise; measurement resolution is not.
+            # ramp land ~17-20 ms apart, so restore-readiness figures snapped
+            # to the probe grid — a small real effect near an attempt boundary
+            # read as a clean bimodal restore floor until the fine-grid gated
+            # run (reqbench-20260814-035757) showed readiness is unimodal.
+            # ~20 extra connect attempts per 40 ms wait is noise; measurement
+            # resolution is not.
             delay = min(delay * 1.5, 0.002)
 
 
@@ -2822,7 +2823,16 @@ def run_cdp_request(args, rep: int, fast: bool, probe=None, op: str = "screensho
             raise_if_harness_interrupted()
             rec["render"] = result
             rec["ok"] = bool(result.get("ok"))
-            if args.prewire and not args.ws_url and rec["ok"] and result.get("target_id"):
+            # getattr, not args.prewire: failure-path fixtures drive this
+            # function with bare Namespaces, and the attribute lookup runs
+            # before the rec["ok"] guard — an AttributeError here replaced
+            # every failure label with its own traceback.
+            if (
+                getattr(args, "prewire", False)
+                and not args.ws_url
+                and rec["ok"]
+                and result.get("target_id")
+            ):
                 # Discovery-once: pin the page target's WS URL for every later
                 # rep. clone_ws_url() re-hosts it onto each clone's endpoint, so
                 # only the path — the guest-side target id, identical across
@@ -3652,7 +3662,7 @@ def main_with_resources(resources: ExitStack) -> int:
     if not arms or len(set(arms)) != len(arms) or any(a not in allowed_arms for a in arms):
         p.error(
             "--arms must be a non-empty, duplicate-free subset of "
-            "exec,cdp,cdp-fast,noop"
+            "exec,cdp,cdp-fast,html,noop"
         )
     # exec is ALLOWED but no longer REQUIRED: it is retired from measurement
     # (no published claim rests on it), and run reqbench-20260814-022254-uffd

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -2741,12 +2741,15 @@ def spawn_clone_process(cmd: list[str], log: str, env: dict) -> subprocess.Popen
         signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
 
 
-def run_cdp_request(args, rep: int, fast: bool, probe=None) -> dict:
+def run_cdp_request(args, rep: int, fast: bool, probe=None, op: str = "screenshot") -> dict:
     import cdpdrive
 
-    name = f"rb-{args.run_id}-{rep}-{'fast' if fast else 'norm'}"
+    arm_name = "html" if op == "html" else ("cdp-fast" if fast else "cdp")
+    # The clone name carries the arm: cdp and html arms share rep indices, and a
+    # shared name would collide two live clones.
+    name = f"rb-{args.run_id}-{rep}-{'html' if op == 'html' else ('fast' if fast else 'norm')}"
     log = os.path.join(args.out_dir, f"{name}.log")
-    rec: dict = {"arm": "cdp-fast" if fast else "cdp", "rep": rep, "name": name}
+    rec: dict = {"arm": arm_name, "rep": rep, "name": name}
 
     cmd = [args.fcvm, "snapshot", "run"] + clone_backend_args(args) + [
         "--name", name, "--no-dirty-tracking", "--no-swap",
@@ -2812,12 +2815,21 @@ def run_cdp_request(args, rep: int, fast: bool, probe=None) -> dict:
                 # and is swallowed by the `except Exception` below, failing every
                 # cdp rep. cdpdrive also reads it with getattr; both halves.
                 host_header="",
+                op=op,
                 render_module=os.path.join(HERE, "render.py"),
             )
             result = cdpdrive.drive(drive_args)
             raise_if_harness_interrupted()
             rec["render"] = result
             rec["ok"] = bool(result.get("ok"))
+            if args.prewire and not args.ws_url and rec["ok"] and result.get("target_id"):
+                # Discovery-once: pin the page target's WS URL for every later
+                # rep. clone_ws_url() re-hosts it onto each clone's endpoint, so
+                # only the path — the guest-side target id, identical across
+                # clones because it is snapshot state — is load-bearing. This
+                # lands on a warmup rep by schedule construction (warmups run
+                # first); the analyzer holds measured reps to meta.ws_url_prewired.
+                args.ws_url = f"ws://{endpoint}/devtools/page/{result['target_id']}"
             if not rec["ok"]:
                 # LIFT THE DIAGNOSTIC TO THE TOP LEVEL. cdpdrive can return
                 # ok=false WITHOUT raising, in which case the `except` below never
@@ -3473,7 +3485,10 @@ def dispatch_request(args, rep: int, arm: str, is_warmup: bool, probe=None) -> d
         return run_exec_request(args, rep)
     if arm == "noop":
         return run_noop_request(args, rep)
+    if arm == "html":
+        return run_cdp_request(args, rep, fast=False, probe=probe, op="html")
     return run_cdp_request(args, rep, fast=(arm == "cdp-fast"), probe=probe)
+
 
 
 def parse_urls(spec):
@@ -3504,6 +3519,12 @@ def main_with_resources(resources: ExitStack) -> int:
     p.add_argument("--arms", default="exec,cdp,cdp-fast,noop")
     p.add_argument("--reps", type=int, default=10)
     p.add_argument("--warmup", type=int, default=2, help="discarded EXPLICITLY, and reported")
+    p.add_argument("--prewire", action="store_true",
+                   help="discover the CDP page target once (on the first successful cdp "
+                        "rep, a warmup by schedule construction) and pin its re-hosted "
+                        "WebSocket URL for every later rep, skipping per-request "
+                        "/json/list discovery; the target id is guest-side snapshot "
+                        "state, identical across clones like a WebDriver session id")
     p.add_argument("--seed", type=int, default=20260808)
     p.add_argument("--format", choices=("png", "jpeg"), default="jpeg")
     p.add_argument("--quality", type=int, default=80)
@@ -3627,7 +3648,7 @@ def main_with_resources(resources: ExitStack) -> int:
             )
     os.makedirs(args.out_dir, exist_ok=True)
     arms = [a.strip() for a in args.arms.split(",") if a.strip()]
-    allowed_arms = {"exec", "cdp", "cdp-fast", "noop"}
+    allowed_arms = {"exec", "cdp", "cdp-fast", "html", "noop"}
     if not arms or len(set(arms)) != len(arms) or any(a not in allowed_arms for a in arms):
         p.error(
             "--arms must be a non-empty, duplicate-free subset of "
@@ -3724,7 +3745,7 @@ def main_with_resources(resources: ExitStack) -> int:
             "cpu": snapshot["vcpu"],
             "memory_mib": snapshot["memory_mib"],
             "rust_log": args.rust_log,
-            "ws_url_prewired": bool(args.ws_url),
+            "ws_url_prewired": bool(args.ws_url) or bool(args.prewire),
             "allow_busy": os.environ.get("ALLOW_BUSY", "0") == "1",
             "quiet_guard_passed": os.environ.get("REQBENCH_QUIET_GUARD") == "1",
             "quiet_guard_loadavg1": quiet_guard_loadavg1,

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -940,6 +940,10 @@ cmd_run() {
     fi
     local rc=0 spid="" serve_bg=""
     local backend_args=()
+    # --prewire only for PREWIRE=1: ${PREWIRE:+--prewire} treats the ordinary
+    # false-like PREWIRE=0 as ON, silently changing the measured operation.
+    local prewire_args=()
+    [ "${PREWIRE:-0}" = "1" ] && prewire_args=(--prewire)
     local image_id provenance="$DATA_ROOT/snapshots/$TAG/reqbench-provenance.json"
     image_id=$($SUDO jq -er '.image_id | select(type == "string")' "$provenance") \
         || { log "run: cannot read immutable image identity from $provenance"; return 1; }
@@ -989,7 +993,7 @@ cmd_run() {
         --data-root "$DATA_ROOT" --state-dir "$STATE_DIR" \
         --network-mode "$NETMODE" --cpu "$CPU" --memory-mib "$MEM" \
         --run-id "$RUNID" --arms "${ARMS:-exec,cdp,cdp-fast,noop}" \
-        ${PREWIRE:+--prewire} &
+        "${prewire_args[@]}" &
     local driver_bg=$!
     track "$driver_bg"
     ACTIVE_DRIVER_BG="$driver_bg"

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -495,7 +495,9 @@ cmd_golden() {
         huge_flag="--hugepages"
         ensure_hugepage_pool || return 1
     fi
-    $SUDO env RUST_LOG="$FCVM_LOG" "$FCVM" podman prepare --tag "$TAG" --force $huge_flag \
+    local dns_flag=()
+    [ -n "$GUEST_DNS" ] && dns_flag=(--dns "$GUEST_DNS")
+    $SUDO env RUST_LOG="$FCVM_LOG" "$FCVM" podman prepare --tag "$TAG" --force $huge_flag "${dns_flag[@]}" \
         --name "$name" --cpu "$CPU" --mem "$MEM" --network "$NETMODE" \
         --publish "$CDP_PORT:$CDP_PORT" "$IMAGE" 2>"$lf" >"$prepared_json" \
         || { log "golden: PREPARE FAILED"; tail -20 "$lf" >&2; return 1; }
@@ -793,6 +795,10 @@ UFFD_PREFETCH="${UFFD_PREFETCH:-on}"
 # goldens coexist. faultbench measured huge+minor at zero userspace faults
 # per render — this knob puts that configuration on the request path.
 HUGEPAGES="${HUGEPAGES:-0}"
+# Guest DNS override for the golden (baked into resolv.conf at boot). The
+# corpus replay arm sets GUEST_DNS=10.0.2.2 so every corpus hostname
+# resolves through the host-loopback replay server via the pasta gateway.
+GUEST_DNS="${GUEST_DNS:-}"
 # Overridable for unit tests only; production is the real kernel knob.
 HUGEPAGE_POOL_FILE="${HUGEPAGE_POOL_FILE:-/proc/sys/vm/nr_hugepages}"
 

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -988,7 +988,8 @@ cmd_run() {
         --image "$IMAGE" --image-id "$image_id" --snapshot-name "$TAG" \
         --data-root "$DATA_ROOT" --state-dir "$STATE_DIR" \
         --network-mode "$NETMODE" --cpu "$CPU" --memory-mib "$MEM" \
-        --run-id "$RUNID" --arms "${ARMS:-exec,cdp,cdp-fast,noop}" &
+        --run-id "$RUNID" --arms "${ARMS:-exec,cdp,cdp-fast,noop}" \
+        ${PREWIRE:+--prewire} &
     local driver_bg=$!
     track "$driver_bg"
     ACTIVE_DRIVER_BG="$driver_bg"

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -5888,3 +5888,136 @@ class GuestDnsKnob(unittest.TestCase):
         src = open(self.SH).read()
         self.assertIn('GUEST_DNS="${GUEST_DNS:-}"', src)
         self.assertIn('--dns "$GUEST_DNS"', src)
+
+
+class HtmlArmAndPrewire(unittest.TestCase):
+    """The html op and target-prewiring, validated through the FULL analyzer.
+
+    Both features change what a valid record looks like, so the tests build a
+    complete clean dataset, transform it, and hold the analyzer to zero
+    metadata errors — then break one field and demand the specific error, so
+    the validation under test is proven live rather than skipped.
+    """
+
+    @staticmethod
+    def _load_errors(path):
+        return [
+            error
+            for dataset in reqanalyze.load([path])
+            for error in dataset["metadata_errors"]
+        ]
+
+    @staticmethod
+    def _rows(path):
+        with open(path) as source:
+            return [json.loads(line) for line in source]
+
+    @staticmethod
+    def _write(path, rows):
+        with open(path, "w") as target:
+            target.write("\n".join(json.dumps(row) for row in rows) + "\n")
+
+    def _dataset_with_html_arm(self, path):
+        """Clean dataset whose exec arm is rewritten as an html arm."""
+        AnalyzerAvailability._write_clean_backend(path, "file", 6, 384.0)
+        rows = self._rows(path)
+        cdp_by_key = {
+            (row["rep"], row["warmup"]): row
+            for row in rows
+            if row.get("arm") == "cdp"
+        }
+        for row in rows:
+            if row.get("kind") == "meta":
+                row["arms"] = ["html" if a == "exec" else a for a in row["arms"]]
+                continue
+            if row.get("arm") != "exec":
+                continue
+            template = cdp_by_key[(row["rep"], row["warmup"])]
+            row["arm"] = "html"
+            row["record_id"] = row["record_id"].replace(":exec:", ":html:")
+            row["teardown"] = dict(template["teardown"])
+            row["endpoint"] = template["endpoint"]
+            render = json.loads(json.dumps(template["render"]))
+            stages = render["stages"]
+            for gone in ("screenshot_ms", "decode_ms"):
+                stages.pop(gone, None)
+            stages["extract_ms"] = 1.0
+            for gone in ("image_bytes", "image_sha256", "width", "height"):
+                render.pop(gone, None)
+            render["html_bytes"] = 2048
+            render["html_sha256"] = "a" * 64
+            row["render"] = render
+            # The html record carries every per-record metric a cdp record
+            # does; identity fields stay the (renamed) exec record's own.
+            identity = {"arm", "rep", "warmup", "record_id", "name", "run_id",
+                        "render", "teardown", "endpoint"}
+            for metric, value in template.items():
+                if metric not in identity and metric not in row:
+                    row[metric] = value
+        self._write(path, rows)
+
+    def test_html_arm_dataset_validates_cleanly(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "html.jsonl")
+            self._dataset_with_html_arm(path)
+            self.assertEqual(self._load_errors(path), [])
+
+    def test_html_record_without_payload_is_rejected(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "html.jsonl")
+            self._dataset_with_html_arm(path)
+            rows = self._rows(path)
+            victim = next(
+                r for r in rows
+                if r.get("arm") == "html" and r.get("warmup") is False
+            )
+            del victim["render"]["html_bytes"]
+            self._write(path, rows)
+            errors = self._load_errors(path)
+            self.assertTrue(
+                any("html_bytes" in e for e in errors),
+                f"dropping html_bytes must be caught, got: {errors[:3]}",
+            )
+
+    def _dataset_with_prewire(self, path):
+        """Clean dataset in prewire mode: discovery on one warmup, pinned after."""
+        AnalyzerAvailability._write_clean_backend(path, "file", 6, 384.0)
+        rows = self._rows(path)
+        first_warmup_seen = False
+        for row in rows:
+            if row.get("kind") == "meta":
+                row["ws_url_prewired"] = True
+                continue
+            render = row.get("render")
+            if not isinstance(render, dict):
+                continue
+            if row.get("warmup") and not first_warmup_seen:
+                first_warmup_seen = True
+                render["target_prewired"] = False  # the discovery rep
+            else:
+                render["target_prewired"] = True
+                render["stages"]["resolve_ms"] = 0.0
+        self._write(path, rows)
+
+    def test_prewire_discovery_warmup_is_tolerated(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "prewire.jsonl")
+            self._dataset_with_prewire(path)
+            self.assertEqual(self._load_errors(path), [])
+
+    def test_prewire_mismatch_on_measured_rep_is_rejected(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "prewire.jsonl")
+            self._dataset_with_prewire(path)
+            rows = self._rows(path)
+            victim = next(
+                r for r in rows
+                if isinstance(r.get("render"), dict) and r.get("warmup") is False
+            )
+            victim["render"]["target_prewired"] = False
+            self._write(path, rows)
+            errors = self._load_errors(path)
+            self.assertTrue(
+                any("prewire" in e for e in errors),
+                f"an unprewired MEASURED rep must be caught, got: {errors[:3]}",
+            )

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -5840,11 +5840,12 @@ class PortProbeResolution(unittest.TestCase):
     """wait_port must measure readiness on a fine grid.
 
     Watched red 2026-08-14: with the 1ms x1.5 backoff capped at 20 ms, probe
-    attempts land ~17-20 ms apart past the ramp (cumulative sleeps ~39.8,
-    56.9, 76.9 ms), so a port that opens at 45 ms was reported as ~57 ms.
-    That grid quantized a ~1-2 ms real teardown-adjacency effect into the
-    "17 ms bimodal restore floor" that consumed 2026-08-14; every published
-    restore figure sat on these grid points rather than on true readiness.
+    attempts land ~17-20 ms apart past the ramp, so a port that opens at
+    45 ms was reported as ~57 ms — readiness figures sat on the probe grid
+    rather than on true readiness, and a small real teardown-adjacency
+    effect near an attempt boundary read as a clean bimodal restore floor
+    until the fine-grid gated run (reqbench-20260814-035757) showed
+    readiness is unimodal.
     """
 
     def test_readiness_is_resolved_within_3ms(self):
@@ -5890,6 +5891,34 @@ class GuestDnsKnob(unittest.TestCase):
         self.assertIn('--dns "$GUEST_DNS"', src)
 
 
+class CorpusServeAnswerIp(unittest.TestCase):
+    """--answer-ip must fail at startup, not by silently dropping A queries.
+
+    inet_aton runs inside the DNS responder's broad exception handler, so a
+    malformed address left every server running while every A query vanished
+    without a trace.
+    """
+
+    def test_malformed_answer_ip_exits_before_serving(self):
+        proc = subprocess.run(
+            [
+                sys.executable,
+                os.path.join(os.path.dirname(os.path.abspath(__file__)), "corpus_serve.py"),
+                "--answer-ip",
+                "not-an-ip",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(proc.returncode, 2, proc.stderr)
+        self.assertIn("answer-ip", proc.stderr)
+        self.assertNotIn(
+            "wildcard DNS", proc.stdout,
+            "the DNS responder must never start under an unusable answer address",
+        )
+
+
 class HtmlArmAndPrewire(unittest.TestCase):
     """The html op and target-prewiring, validated through the FULL analyzer.
 
@@ -5917,9 +5946,9 @@ class HtmlArmAndPrewire(unittest.TestCase):
         with open(path, "w") as target:
             target.write("\n".join(json.dumps(row) for row in rows) + "\n")
 
-    def _dataset_with_html_arm(self, path):
+    def _dataset_with_html_arm(self, path, reps=6):
         """Clean dataset whose exec arm is rewritten as an html arm."""
-        AnalyzerAvailability._write_clean_backend(path, "file", 6, 384.0)
+        AnalyzerAvailability._write_clean_backend(path, "file", reps, 384.0)
         rows = self._rows(path)
         cdp_by_key = {
             (row["rep"], row["warmup"]): row
@@ -5955,6 +5984,88 @@ class HtmlArmAndPrewire(unittest.TestCase):
                 if metric not in identity and metric not in row:
                     row[metric] = value
         self._write(path, rows)
+
+    def test_short_html_arm_fails_the_sample_size_gate(self):
+        """A mixed run must not publish while its html arm is short.
+
+        expected_cdp_arms matched only names starting with "cdp", so a run
+        whose cdp arms reached 200 passed publication with the html arm at
+        any count — an html latency published from a sample the gate never
+        examined.
+        """
+        from unittest import mock
+
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(d, "r.jsonl")
+            dst = os.path.join(d, "r.json")
+            self._dataset_with_html_arm(src, reps=200)
+            rows = self._rows(src)
+            victim = next(
+                r for r in rows
+                if r.get("arm") == "html" and r.get("warmup") is False
+            )
+            rows.remove(victim)
+            self._write(src, rows)
+            buf = io.StringIO()
+            with (
+                mock.patch.object(
+                    reqanalyze, "median_ci", AnalyzerAvailability._fast_median_ci
+                ),
+                mock.patch.object(
+                    reqanalyze,
+                    "hodges_lehmann_shift",
+                    AnalyzerAvailability._fast_shift,
+                ),
+                redirect_stdout(buf),
+            ):
+                rc = reqanalyze.main_with(["--json-out", dst, src])
+            with open(dst) as f:
+                out = json.load(f)
+            sample = out["gate"]["cdp_sample_size"]
+            self.assertEqual(
+                sample["measured_non_warmup_attempts_per_arm"].get("html"), 199
+            )
+            self.assertIs(sample["passed"], False)
+            self.assertIs(out["publishable"], False)
+            self.assertEqual(rc, 5, buf.getvalue())
+
+    def test_html_arm_gets_stage_decomposition(self):
+        """analysis.json must carry the html arm's per-stage metrics.
+
+        The stage loop keyed on startswith("cdp") dropped every connection
+        and extraction stage for html even though the arm pays the same
+        per-request CDP handshake; only aggregate blocking and wall time
+        survived into analysis.json.
+        """
+        from unittest import mock
+
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(d, "r.jsonl")
+            dst = os.path.join(d, "r.json")
+            self._dataset_with_html_arm(src)
+            buf = io.StringIO()
+            with (
+                mock.patch.object(
+                    reqanalyze, "median_ci", AnalyzerAvailability._fast_median_ci
+                ),
+                mock.patch.object(
+                    reqanalyze,
+                    "hodges_lehmann_shift",
+                    AnalyzerAvailability._fast_shift,
+                ),
+                redirect_stdout(buf),
+            ):
+                reqanalyze.main_with(["--json-out", dst, src, "--no-gate"])
+            with open(dst) as f:
+                out = json.load(f)
+            html_arm = out["arms"]["html"]
+            for metric in ("connect_total_ms", "navigate_ms", "extract_ms", "total_ms"):
+                self.assertIn(metric, html_arm, f"html arm must publish {metric}")
+            self.assertNotIn(
+                "screenshot_ms", html_arm,
+                "html renders no screenshot; a summary here means the arm was "
+                "pooled with the wrong stage list",
+            )
 
     def test_html_arm_dataset_validates_cleanly(self):
         with tempfile.TemporaryDirectory() as d:

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -5873,3 +5873,18 @@ class PortProbeResolution(unittest.TestCase):
             measured, ready_at_s * 1000 + 3.5,
             f"wait_port reported {measured:.1f} ms for a port ready at "
             f"{ready_at_s * 1000:.0f} ms: the probe grid is too coarse")
+
+
+class GuestDnsKnob(unittest.TestCase):
+    """GUEST_DNS must reach the golden's podman prepare as --dns.
+
+    Watched red 2026-08-14: the knob did not exist and the prepare argv
+    carried no --dns.
+    """
+
+    SH = HugepageGuards.SH
+
+    def test_guest_dns_reaches_prepare_argv(self):
+        src = open(self.SH).read()
+        self.assertIn('GUEST_DNS="${GUEST_DNS:-}"', src)
+        self.assertIn('--dns "$GUEST_DNS"', src)

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -5785,3 +5785,52 @@ class ExecArmIsOptional(unittest.TestCase):
         self.assertTrue(
             control, "a noop-less schedule must be rejected by the same rule"
         )
+
+
+class CorpusMixUrls(unittest.TestCase):
+    """Multi-URL runs for the corpus arm (Cloudflare 14-URL mix).
+
+    Watched red 2026-08-14: --url with a comma list was passed through as one
+    junk URL (no cycling, no per-record url, no warmup floor), and the
+    analyzer's schedule validation rejected any record whose render.url
+    differed from the single meta.url.
+    """
+
+    def _parse(self, extra):
+        argv = sys.argv
+        sys.argv = ["reqbench.py", "--out-dir", "/tmp"] + extra
+        import io as _io
+        from contextlib import redirect_stderr
+        err = _io.StringIO()
+        try:
+            with self.assertRaises(SystemExit) as cm:
+                with redirect_stderr(err), redirect_stdout(io.StringIO()):
+                    reqbench.main()
+            return cm.exception.code, err.getvalue()
+        finally:
+            sys.argv = argv
+
+    def test_urls_helper_cycles_deterministically(self):
+        urls = reqbench.parse_urls("http://a/,http://b/,http://c/")
+        self.assertEqual(urls, ["http://a/", "http://b/", "http://c/"])
+        self.assertEqual([reqbench.url_for_rep(urls, r) for r in range(5)],
+                         ["http://a/", "http://b/", "http://c/",
+                          "http://a/", "http://b/"])
+
+    def test_mix_requires_warmup_of_two_cycles(self):
+        # A mix trains the prefetch working set during its first cycle; the
+        # baseline is not stationary until every URL has run. Fail closed
+        # when warmup cannot cover two full cycles.
+        rc, err = self._parse(["--url", "http://a/,http://b/,http://c/",
+                               "--arms", "noop,cdp", "--warmup", "2",
+                               "--serve-pid", "7"])
+        self.assertEqual(rc, 2)
+        self.assertIn("warmup", err.lower())
+
+    def test_analyzer_accepts_declared_url_set(self):
+        import reqanalyze
+        src = open(os.path.join(HERE, "reqanalyze.py")).read()
+        body = src.split("def _validate_schedule")[1]
+        self.assertIn('meta.get("urls")', body,
+                      "schedule validation must accept a declared URL set, "
+                      "not only a single meta.url")

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -5834,3 +5834,42 @@ class CorpusMixUrls(unittest.TestCase):
         self.assertIn('meta.get("urls")', body,
                       "schedule validation must accept a declared URL set, "
                       "not only a single meta.url")
+
+
+class PortProbeResolution(unittest.TestCase):
+    """wait_port must measure readiness on a fine grid.
+
+    Watched red 2026-08-14: with the 1ms x1.5 backoff capped at 20 ms, probe
+    attempts land ~17-20 ms apart past the ramp (cumulative sleeps ~39.8,
+    56.9, 76.9 ms), so a port that opens at 45 ms was reported as ~57 ms.
+    That grid quantized a ~1-2 ms real teardown-adjacency effect into the
+    "17 ms bimodal restore floor" that consumed 2026-08-14; every published
+    restore figure sat on these grid points rather than on true readiness.
+    """
+
+    def test_readiness_is_resolved_within_3ms(self):
+        import socket as _socket
+        import threading
+
+        srv = _socket.socket()
+        srv.bind(("127.0.0.1", 0))
+        port = srv.getsockname()[1]
+        ready_at_s = 0.045
+
+        def open_late():
+            time.sleep(ready_at_s)
+            srv.listen(1)
+
+        t = threading.Thread(target=open_late)
+        t.start()
+        try:
+            measured = reqbench.wait_port(
+                f"127.0.0.1:{port}", time.monotonic() + 10.0)
+        finally:
+            t.join()
+            srv.close()
+        self.assertGreaterEqual(measured, ready_at_s * 1000 - 1)
+        self.assertLessEqual(
+            measured, ready_at_s * 1000 + 3.5,
+            f"wait_port reported {measured:.1f} ms for a port ready at "
+            f"{ready_at_s * 1000:.0f} ms: the probe grid is too coarse")

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -190,6 +190,14 @@ pub struct RunArgs {
     #[arg(long, default_value = "10G")]
     pub rootfs_size: String,
 
+    /// Override the guest DNS server. Written to the guest's resolv.conf at
+    /// boot, so it is baked into any snapshot taken from this VM. Rootless
+    /// guests reach host loopback services via the pasta gateway 10.0.2.2,
+    /// so `--dns 10.0.2.2` points the guest at a DNS server bound on host
+    /// 127.0.0.1 (the corpus replay benchmark arm).
+    #[arg(long)]
+    pub dns: Option<String>,
+
     /// Volume mapping(s): HOST:GUEST[:ro] (repeat for multiple)
     #[arg(long, action = clap::ArgAction::Append)]
     pub map: Vec<String>,
@@ -860,5 +868,17 @@ mod tests {
         ]);
         assert_eq!(run.publish, vec!["8080:80", "8443:443"]);
         assert_eq!(run.forward_localhost, vec![1421u16, 9099]);
+    }
+
+    #[test]
+    fn dns_override_parses_on_run_and_prepare() {
+        // The corpus replay arm points guests at a host-loopback DNS server
+        // through the pasta gateway; the flag must reach both run and
+        // prepare (goldens bake resolv.conf at boot).
+        let run = parse_run(&["--dns", "10.0.2.2", "nginx:alpine"]);
+        assert_eq!(run.dns.as_deref(), Some("10.0.2.2"));
+        let prep = parse_prepare(&["--name", "t", "--dns", "10.0.2.2", "nginx:alpine"]);
+        assert_eq!(prep.run.dns.as_deref(), Some("10.0.2.2"));
+        assert_eq!(parse_run(&["nginx:alpine"]).dns, None);
     }
 }

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -1475,7 +1475,7 @@ async fn prepare_vm_for_lifecycle(
     // network.setup() may fail partway through (it tears nothing down itself),
     // so any error from here until the run_vm_setup error handler below must
     // run network.cleanup() to remove partially-created host network state.
-    let network_config = match network.setup().await.context("setting up network") {
+    let mut network_config = match network.setup().await.context("setting up network") {
         Ok(config) => config,
         Err(e) => {
             if let Err(cleanup_err) = network.cleanup().await {
@@ -1488,6 +1488,13 @@ async fn prepare_vm_for_lifecycle(
             return Err(e);
         }
     };
+
+    // --dns overrides the mode's DNS choice. fc-agent writes it to the
+    // guest's resolv.conf at boot, so a snapshot taken from this VM bakes it
+    // in; restored clones resolve through it with no further configuration.
+    if let Some(ref dns) = args.dns {
+        network_config.dns_server = Some(dns.clone());
+    }
 
     info!(tap = %network_config.tap_device, mac = %network_config.guest_mac, "network configured");
 

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -1191,6 +1191,7 @@ async fn prepare_vm_for_lifecycle(
             resolved_mode,
             runtime_config.firecracker_bin.as_deref(),
             image_disk_identity.clone(),
+            vm_config::effective_extra_boot_args(&runtime_config),
         );
         let key = config.snapshot_key();
 
@@ -2695,11 +2696,60 @@ mod tests {
             non_blocking_output: false,
             label: vec![],
             ipv6_prefix: None,
+            dns: None,
             image: "alpine:latest".to_string(),
             command_args: vec![],
             rootfs_override: None,
             image_disk_override: None,
         }
+    }
+
+    /// Guest-visible launch inputs must change the snapshot key. --dns is
+    /// baked into the guest's resolv.conf, so two runs differing only in --dns
+    /// must never share a snapshot; before FirecrackerConfig carried these
+    /// fields the keys came out equal and a cache hit silently kept the old
+    /// resolver. Same guarantee for --strace-agent and extra boot args.
+    #[test]
+    fn guest_visible_inputs_change_snapshot_key() {
+        use std::path::Path;
+        let key = |args: &RunArgs, extra: Option<String>| {
+            build_firecracker_config(
+                args,
+                "sha256:test",
+                Path::new("/kernel"),
+                Path::new("/rootfs"),
+                Path::new("/initrd"),
+                None,
+                ImageMode::Overlay,
+                None,
+                None,
+                extra,
+            )
+            .snapshot_key()
+        };
+        let base = test_args();
+
+        let mut with_dns = test_args();
+        with_dns.dns = Some("10.0.2.2".to_string());
+        assert_ne!(
+            key(&base, None),
+            key(&with_dns, None),
+            "--dns must change the key"
+        );
+
+        let mut with_strace = test_args();
+        with_strace.strace_agent = true;
+        assert_ne!(
+            key(&base, None),
+            key(&with_strace, None),
+            "--strace-agent must change the key"
+        );
+
+        assert_ne!(
+            key(&base, None),
+            key(&base, Some("arm64.nv2".to_string())),
+            "extra boot args must change the key"
+        );
     }
 
     #[test]

--- a/src/commands/podman/snapshot.rs
+++ b/src/commands/podman/snapshot.rs
@@ -308,6 +308,7 @@ pub(super) fn build_firecracker_config(
     image_mode: crate::firecracker::ImageMode,
     firecracker_bin: Option<&Path>,
     image_disk_identity: Option<String>,
+    extra_boot_args: Option<String>,
 ) -> crate::firecracker::FirecrackerConfig {
     // image_identifier is the digest for localhost images (content-addressed cache key).
     // args.image is the original name (what the guest uses to find the image).
@@ -372,6 +373,9 @@ pub(super) fn build_firecracker_config(
         // Cache-key isolation for guest failpoints (see field docs): the spec is
         // forwarded to the guest by build_runtime_boot_args from the same env var.
         guest_failpoint: std::env::var("FCVM_GUEST_FAILPOINT").ok(),
+        dns_server: args.dns.clone(),
+        agent_strace: args.strace_agent,
+        extra_boot_args,
         image_disk_identity,
     }
 }

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -272,10 +272,7 @@ pub(crate) fn build_runtime_boot_args(
     }
 
     // Additional boot args from RuntimeConfig (kernel profile) or FCVM_BOOT_ARGS env var
-    let extra_boot_args = runtime_config
-        .boot_args
-        .clone()
-        .or_else(|| std::env::var("FCVM_BOOT_ARGS").ok());
+    let extra_boot_args = effective_extra_boot_args(runtime_config);
     if let Some(ref extra) = extra_boot_args {
         if !boot_args.is_empty() {
             boot_args.push(' ');
@@ -974,6 +971,19 @@ pub(super) async fn run_vm_setup(
 ///   * initial `fcvm podman run` (run_vm_setup_inner, cache miss)
 ///   * the snapshot-restore path's up-front reboot plan (a rebooted restored clone
 ///     cold-boots from its current provisioned disk — disk-only-clone semantics)
+/// The extra kernel boot args a launch will actually append: the kernel
+/// profile's `boot_args`, or the FCVM_BOOT_ARGS env fallback. One derivation,
+/// used both by the snapshot-key config (hashed) and by the runtime cmdline
+/// assembly (applied), so the hashed value and the applied value cannot drift.
+pub(crate) fn effective_extra_boot_args(
+    runtime_config: &crate::commands::common::RuntimeConfig,
+) -> Option<String> {
+    runtime_config
+        .boot_args
+        .clone()
+        .or_else(|| std::env::var("FCVM_BOOT_ARGS").ok())
+}
+
 pub(crate) fn build_launch_config(
     args: &RunArgs,
     rootfs_path: &std::path::Path,
@@ -1038,6 +1048,9 @@ pub(crate) fn build_launch_config(
         // Cache-key isolation for guest failpoints (see field docs): the spec is
         // forwarded to the guest by build_runtime_boot_args from the same env var.
         guest_failpoint: std::env::var("FCVM_GUEST_FAILPOINT").ok(),
+        dns_server: args.dns.clone(),
+        agent_strace: args.strace_agent,
+        extra_boot_args: effective_extra_boot_args(runtime_config),
         // Launch-only config: never hashed into a snapshot key, so the image
         // disk's build identity is not resolved here.
         image_disk_identity: None,
@@ -1523,6 +1536,106 @@ mod tests {
     }
 
     use super::*;
+
+    /// Fail-closed inventory of the runtime kernel-cmdline tokens. Everything
+    /// build_runtime_boot_args emits is guest-visible, so each token must be
+    /// either derived from a hashed FirecrackerConfig field or consciously
+    /// listed here as per-instance (excluded from the snapshot key by design)
+    /// or as tracked unhashed state (#821). A new push_str token fails this
+    /// test until its author hashes it into the key or adds it below with a
+    /// disposition — the fail-open alternative is a --dns-style silent
+    /// cache-hit bug.
+    #[test]
+    fn runtime_boot_arg_tokens_are_hashed_or_allowlisted() {
+        const EXPECTED: &[(&str, &str)] = &[
+            (
+                "ip",
+                "per-instance addresses; excluded from the key by design",
+            ),
+            (
+                "ipv6",
+                "per-instance addresses; excluded from the key by design",
+            ),
+            (
+                "fcvm_dns",
+                "--dns override hashed via FirecrackerConfig.dns_server; the \
+                 no-override host fallback is tracked in #821",
+            ),
+            (
+                "fcvm_dns_search",
+                "host-derived at launch; unhashed, tracked in #821",
+            ),
+            (
+                "fc_agent_strace",
+                "hashed via FirecrackerConfig.agent_strace",
+            ),
+            (
+                "fuse_readers",
+                "guest-visible knob; unhashed, tracked in #821",
+            ),
+            (
+                "fuse_trace_rate",
+                "guest-visible knob; unhashed, tracked in #821",
+            ),
+            (
+                "fcvm_failpoint",
+                "hashed via FirecrackerConfig.guest_failpoint",
+            ),
+            (
+                "fuse_max_write",
+                "guest-visible knob; unhashed, tracked in #821",
+            ),
+            (
+                "no_writeback_cache",
+                "guest-visible knob; unhashed, tracked in #821",
+            ),
+        ];
+        let src = include_str!("vm_config.rs");
+        let start = src
+            .find("fn build_runtime_boot_args")
+            .expect("build_runtime_boot_args present in vm_config.rs");
+        let end = src[start..]
+            .find("\npub(super) async fn attach_extra_disks")
+            .expect("attach_extra_disks still follows build_runtime_boot_args")
+            + start;
+        let body = &src[start..end];
+        // Extract the token name from every push_str carrying a string
+        // literal, including multi-line format! calls (the ip= literal sits
+        // on the line after its push_str). A ')' before the next '"' means
+        // the call carries no literal at all — push_str(extra), which is
+        // hashed whole via FirecrackerConfig.extra_boot_args.
+        let mut found: Vec<String> = Vec::new();
+        let mut rest = body;
+        while let Some(i) = rest.find("push_str") {
+            rest = &rest[i + "push_str".len()..];
+            let (Some(q), Some(c)) = (rest.find('"'), rest.find(')')) else {
+                continue;
+            };
+            if c < q {
+                continue;
+            }
+            let lit = &rest[q + 1..];
+            let token: String = lit
+                .chars()
+                .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '_')
+                .collect();
+            if token.is_empty() {
+                continue;
+            }
+            assert!(
+                lit[token.len()..].starts_with('='),
+                "cmdline literal starting {token:?} must have the shape token=value"
+            );
+            found.push(token);
+        }
+        let expected: Vec<&str> = EXPECTED.iter().map(|(t, _)| *t).collect();
+        assert_eq!(
+            found, expected,
+            "runtime boot-arg token inventory changed: hash the new token into \
+             FirecrackerConfig (see the guest_failpoint field for the pattern) \
+             or add it to EXPECTED with a disposition"
+        );
+    }
 
     #[test]
     fn test_rebuild_proxy_url_preserves_auth_and_query() {

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -965,12 +965,6 @@ pub(super) async fn run_vm_setup(
     Ok((vm_manager, holder_slot, reboot_spec, bootplan_handle_slot))
 }
 
-/// Build the FirecrackerConfig used to cold-boot a VM from a disk.
-///
-/// Single source of truth for launch-config construction, shared by:
-///   * initial `fcvm podman run` (run_vm_setup_inner, cache miss)
-///   * the snapshot-restore path's up-front reboot plan (a rebooted restored clone
-///     cold-boots from its current provisioned disk — disk-only-clone semantics)
 /// The extra kernel boot args a launch will actually append.
 ///
 /// Resolves the kernel profile's `boot_args`, falling back to FCVM_BOOT_ARGS.
@@ -986,6 +980,12 @@ pub(crate) fn effective_extra_boot_args(
         .or_else(|| std::env::var("FCVM_BOOT_ARGS").ok())
 }
 
+/// Build the FirecrackerConfig used to cold-boot a VM from a disk.
+///
+/// Single source of truth for launch-config construction, shared by:
+///   * initial `fcvm podman run` (run_vm_setup_inner, cache miss)
+///   * the snapshot-restore path's up-front reboot plan (a rebooted restored clone
+///     cold-boots from its current provisioned disk — disk-only-clone semantics)
 pub(crate) fn build_launch_config(
     args: &RunArgs,
     rootfs_path: &std::path::Path,

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -971,10 +971,12 @@ pub(super) async fn run_vm_setup(
 ///   * initial `fcvm podman run` (run_vm_setup_inner, cache miss)
 ///   * the snapshot-restore path's up-front reboot plan (a rebooted restored clone
 ///     cold-boots from its current provisioned disk — disk-only-clone semantics)
-/// The extra kernel boot args a launch will actually append: the kernel
-/// profile's `boot_args`, or the FCVM_BOOT_ARGS env fallback. One derivation,
-/// used both by the snapshot-key config (hashed) and by the runtime cmdline
-/// assembly (applied), so the hashed value and the applied value cannot drift.
+/// The extra kernel boot args a launch will actually append.
+///
+/// Resolves the kernel profile's `boot_args`, falling back to FCVM_BOOT_ARGS.
+/// One derivation, used both by the snapshot-key config (hashed) and by the
+/// runtime cmdline assembly (applied), so the hashed value and the applied
+/// value cannot drift.
 pub(crate) fn effective_extra_boot_args(
     runtime_config: &crate::commands::common::RuntimeConfig,
 ) -> Option<String> {

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -275,6 +275,7 @@ async fn create_sandbox(
 
     // Build RunArgs for start_vm
     let args = crate::cli::RunArgs {
+        dns: None,
         name: name.clone(),
         cpu: req.cpu.unwrap_or(2),
         mem: req.memory_mib.unwrap_or(2048),

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -3069,7 +3069,10 @@ fn run_args_from_snapshot_metadata(
         .collect();
 
     RunArgs {
-        dns: None,
+        // The captured resolver, not None: fc-agent rewrites resolv.conf on a
+        // cold boot from this synthesized config, and falling back to the
+        // current host DNS would silently replace what the snapshot baked in.
+        dns: meta.network_config.dns_server.clone(),
         name,
         cpu,
         mem,
@@ -3360,6 +3363,16 @@ mod tests {
         meta2.username = None;
         let args2 = run_args_from_snapshot_metadata(&meta2, "c".to_string(), 1, 512, false, None);
         assert!(args2.env.is_empty());
+
+        // The captured resolver must survive into a cold boot: fc-agent
+        // rewrites resolv.conf from these synthesized args, and dns: None
+        // means "current host DNS", silently replacing what the snapshot
+        // baked in.
+        let mut meta_dns = meta.clone();
+        meta_dns.network_config.dns_server = Some("192.0.2.53".to_string());
+        let args_dns =
+            run_args_from_snapshot_metadata(&meta_dns, "c".to_string(), 1, 512, false, None);
+        assert_eq!(args_dns.dns.as_deref(), Some("192.0.2.53"));
 
         // Recorded NFS shares must survive into the cold-boot RunArgs (a
         // disk-only clone of an NFS VM used to silently lose its shares).

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -3069,6 +3069,7 @@ fn run_args_from_snapshot_metadata(
         .collect();
 
     RunArgs {
+        dns: None,
         name,
         cpu,
         mem,

--- a/src/firecracker/config.rs
+++ b/src/firecracker/config.rs
@@ -124,6 +124,26 @@ pub struct FirecrackerConfig {
     /// entries. None (the default) is skip-serialized so existing keys are unchanged.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub guest_failpoint: Option<String>,
+    /// DNS override from --dns. fc-agent writes it into the guest's resolv.conf
+    /// at boot, so it is baked into any snapshot taken from the VM; without this
+    /// field a run with a different --dns cache-hits a snapshot answering with
+    /// the old resolver and the flag is silently ignored. None (the default,
+    /// mode-derived DNS) is skip-serialized so existing keys are unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dns_server: Option<String>,
+    /// Whether fc-agent straces the container (fc_agent_strace=1 on the kernel
+    /// cmdline, from --strace-agent). Guest-visible boot behavior baked into
+    /// snapshots, so part of the cache key. false is skip-serialized so
+    /// existing keys are unchanged.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub agent_strace: bool,
+    /// Effective extra kernel boot args (RuntimeConfig.boot_args or
+    /// FCVM_BOOT_ARGS). Appended to the runtime cmdline at launch and therefore
+    /// baked into the guest, so part of the cache key — a profile with
+    /// different boot args must never share a snapshot with one without them.
+    /// None (the default) is skip-serialized so existing keys are unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra_boot_args: Option<String>,
     /// Build identity (inode:size:mtime) of the attached image-delivery disk
     /// (overlay storage image or Docker archive). The disk's PATH is
     /// content-addressed by image digest and so survives rebuilds — but
@@ -166,6 +186,9 @@ impl Default for FirecrackerConfig {
             portable_volumes: false,
             firecracker_bin: None,
             guest_failpoint: None,
+            dns_server: None,
+            agent_strace: false,
+            extra_boot_args: None,
             image_disk_identity: None,
         }
     }

--- a/tests/test_library_api.rs
+++ b/tests/test_library_api.rs
@@ -52,6 +52,7 @@ fn test_run_args(name: &str) -> RunArgs {
         non_blocking_output: false,
         health_check_timeout: 5,
         ipv6_prefix: None,
+        dns: None,
         image: common::TEST_IMAGE.to_string(),
         command_args: vec![],
         rootfs_override: None,


### PR DESCRIPTION
Five commits extending the request benchmark toward Kitesurf-comparable coverage, plus the review-round close.

## 1. Corpus-mix plumbing (2c27f08c)
Renders Cloudflare's 14-URL corpus inside the guest, per-URL-cycled like their methodology:
- fcvm gains `--dns` (run + prepare): overrides the network mode's guest DNS, baked into goldens. `--dns 10.0.2.2` points corpus hostnames at a host-loopback DNS via the pasta gateway.
- `corpus_serve.py --answer-ip`: wildcard DNS responder can answer A queries with 10.0.2.2 instead of hardcoded 127.0.0.1.
- `reqbench --url` accepts a comma-separated list, cycled rep-modulo (deterministic `url_for_rep`); every record carries its url; multi-URL runs fail closed unless warmup covers two full cycles. Analyzer re-derives the expected URL per record from the declared schedule.

## 2. 2 ms port-probe grid (cdb21f09)
The wait_port backoff (1 ms ×1.5 capped 20 ms) aliased restore readiness onto a ~17–20 ms probe grid. True readiness is unimodal at 40.9 ms (fine-grid gated run, 202 reps). Backoff now caps at 2 ms.

## 3. GUEST_DNS golden knob (af3cb386)
`GUEST_DNS=10.0.2.2` appends `--dns` to the golden's `podman prepare`, so corpus hostnames resolve through the replay server from inside clones.

## 4. HTML arm + CDP target prewiring (6065585c)
- `html` arm: navigate + `Runtime.evaluate` outerHTML with no screenshot — the second operation Kitesurf prices. Per-op stage lists and payload validation in the analyzer; fails closed on an unclosed document.
- `--prewire` (`PREWIRE=1`): discover the CDP page target once on the first successful warmup rep and pin its re-hosted WebSocket URL for every later rep — the target id is guest-side snapshot state, identical across clones (same principle as WebKit's inherited session id).

## 5. Review-round close (de5fb5c4)
The CI break and both reviewers' P1 finding shared one structure: `--dns` rode the runtime boot-args tail — the unhashed side-channel into the guest — so a different `--dns` could cache-hit a snapshot baked with the old resolver.
- `FirecrackerConfig` gains **dns_server / agent_strace / extra_boot_args** as hashed, skip-serialized fields (existing keys unchanged when unset), following the `guest_failpoint` pattern; `effective_extra_boot_args()` is the single derivation shared by the hashed config and the cmdline assembly so they cannot drift. **Behavior note:** kernel profiles that set `boot_args` (e.g. nested) get new snapshot keys and will regolden once.
- Snapshot cold-boot `RunArgs` restores the captured resolver from metadata instead of `None`.
- `runtime_boot_arg_tokens_are_hashed_or_allowlisted` pins the full cmdline token inventory — a new token fails the suite until hashed or consciously allowlisted (remaining host-derived + FUSE-knob tokens tracked in #821).
- Analyzer: `is_cdp_class()` puts the html arm into the sample-size gate (a mixed run could publish a short html arm the gate never saw) and stage decomposition.
- `getattr(args, "prewire", False)`: the unguarded attribute ran before the `rec["ok"]` check, so bare-Namespace failure fixtures replaced every failure label with an AttributeError — this also broke 3 existing suite tests at commit 4, whose "163 OK" was stamped from a stale run.
- `PREWIRE=1` exact check; `--answer-ip` validated before any thread starts; compile fix for the test-only `RunArgs` initializer that failed every CI job; allowed-arms message and ledger-comment rewording.

## Test evidence
Every behavioral claim is pinned by a watched-red test (red observed with the fix toggled off, green restored): CorpusMixUrls, PortProbeResolution, GuestDnsKnob, HtmlArmAndPrewire, guest_visible_inputs_change_snapshot_key, run_args_from_metadata (dns), runtime_boot_arg_tokens (fired on its own scanner gap during development), test_short_html_arm_fails_the_sample_size_gate, test_html_arm_gets_stage_decomposition, CorpusServeAnswerIp, and the three failure-path tests guarding the prewire fix.

```
python3 -m unittest test_reqbench  ->  166 tests OK
make test-unit (new key/metadata/token tests) -> 3/3
make lint -> clean
```

All 11 inline review threads answered with the red-verified test by name (or a reasoned rejection for the two inapplicable findings).

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added HTML capture for Chromium benchmarks with document size and integrity reporting.
  - Added configurable guest DNS settings through the command line.
  - Added multi-URL benchmark runs with deterministic URL selection and warmup validation.
  - Added optional WebSocket target prewiring for benchmark environments.
  - Included DNS, tracing, and boot-argument settings in VM and snapshot configuration.
- **Bug Fixes**
  - Improved CDP readiness responsiveness with faster retry timing.
- **Tests**
  - Added coverage for HTML results, URL rotation, DNS configuration, readiness timing, and prewiring validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->