### PR TITLE
Repoint firecracker at the restacked agent/uffd-minor chain

### DIFF
--- a/rootfs-config.toml
+++ b/rootfs-config.toml
@@ -33,13 +33,16 @@ repo = "https://passt.top/passt"
 commit = "e1a6d9ef626aa6dbcfeef97dbbab3bd69c35b4b1"
 
 # Default Firecracker binary
-# Build from fork with diff snapshot fix for multi-slot VMs (>3GB RAM).
+# Build from the fork's restacked patch chain on current upstream main
+# (2c4604808, 2026-08): vsock muxer capacity + the bounded UFFD-minor memory
+# backend. The old bump-vsock-max-connections branch sat on a 2026-02 base and
+# carried serial (THRE) and dump_dirty patches that upstream has since fixed
+# itself (firecracker-microvm#5764; v1.14.2) — both dropped here as redundant.
 # `fcvm setup` builds this automatically; `find_firecracker()` uses it.
 # Kernel profiles can override with their own firecracker_repo/branch.
-# Upstream PR: https://github.com/firecracker-microvm/firecracker/pull/5696
 [firecracker]
 repo = "ejc3/firecracker"
-branch = "bump-vsock-max-connections"
+branch = "agent/uffd-minor"
 
 # Cloud Hypervisor backend (#632), optional VMM selected via --hypervisor cloud-hypervisor.
 # Built on demand with `fcvm setup --cloud-hypervisor` (content-addressed, like firecracker).

--- a/rootfs-config.toml
+++ b/rootfs-config.toml
@@ -37,7 +37,7 @@ commit = "e1a6d9ef626aa6dbcfeef97dbbab3bd69c35b4b1"
 # (2c4604808, 2026-08): vsock muxer capacity + the bounded UFFD-minor memory
 # backend. The old bump-vsock-max-connections branch sat on a 2026-02 base and
 # carried serial (THRE) and dump_dirty patches that upstream has since fixed
-# itself (firecracker-microvm#5764; v1.14.2) — both dropped here as redundant.
+# itself (firecracker-microvm#5764; v1.14.2), so both are dropped as redundant.
 # `fcvm setup` builds this automatically; `find_firecracker()` uses it.
 # Kernel profiles can override with their own firecracker_repo/branch.
 [firecracker]

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -2628,6 +2628,14 @@ firecracker_commit = "27305f49ab3a5d862dc56b5108713b6536d2baa7"
     #[test]
     fn explicit_default_profiles_inherit_global_firecracker_without_overriding_profile() {
         let mut plan: Plan = toml::from_str(EMBEDDED_CONFIG).unwrap();
+        // Read the global pin from the config under test rather than naming a
+        // branch here: this asserts the inheritance rule, and hardcoding the
+        // value made every repin of [firecracker] fail an unrelated test.
+        let global = plan
+            .firecracker
+            .as_ref()
+            .expect("embedded config declares a global [firecracker] pin")
+            .clone();
         let arm64 = plan
             .kernel_profiles
             .get_mut("default")
@@ -2648,10 +2656,13 @@ firecracker_commit = "27305f49ab3a5d862dc56b5108713b6536d2baa7"
         assert_eq!(arm64.firecracker_branch.as_deref(), Some("profile-branch"));
 
         let amd64 = defaults.get("amd64").unwrap();
-        assert_eq!(amd64.firecracker_repo.as_deref(), Some("ejc3/firecracker"));
+        assert_eq!(
+            amd64.firecracker_repo.as_deref(),
+            Some(global.repo.as_str())
+        );
         assert_eq!(
             amd64.firecracker_branch.as_deref(),
-            Some("bump-vsock-max-connections")
+            Some(global.branch.as_str())
         );
     }
 }


### PR DESCRIPTION
**Stacked on:** corpus-mix (PR #818)

One commit: the `[firecracker]` pin moves from `bump-vsock-max-connections` (upstream base 2026-02-17, 585 commits behind, carrying serial-THRE and dump_dirty patches upstream has since fixed itself — firecracker-microvm#5764 and v1.14.2, both crediting our reports) to `agent/uffd-minor`, the restacked chain on current upstream `2c4604808`: vsock muxer capacity + the bounded UFFD-minor memory backend, redundant patches dropped.

The binary is content-addressed by repo+branch+remote commit and `firecracker_bin` is a hashed snapshot-key field, so this forces a one-time regolden everywhere — which is the point: benchmark and CI runs move onto the current base. Staged half of #708 (upstream UART fix now in the base); its close waits on a snapshot-with-serial-TX-in-flight validation run. Fork chain under review: ejc3/firecracker #13 → #9 → #14 → #15.

Local validation before the benchmark regolden: `make setup-fcvm` builds the new binary content-addressed, then a sanity run on it (results to follow in a comment before merge).

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd