### PR TITLE
Update review-gate fixtures and assertions to the disposition-reply rule

### DIFF
--- a/tests/fixtures/review-threads-clear.json
+++ b/tests/fixtures/review-threads-clear.json
@@ -1,3 +1,3 @@
 {"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
- {"isResolved":true,"isOutdated":true,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"path":"src/uffd/server.rs","line":216,"originalLine":210,"body":"Fixed."}]}}
+ {"isResolved":true,"isOutdated":true,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"path":"src/uffd/server.rs","line":216,"originalLine":210,"body":"Nit: `srv` reads as an abbreviation of server here."},{"author":{"login":"ejc3"},"path":"src/uffd/server.rs","line":216,"originalLine":210,"body":"NOT-A-DEFECT: naming only, no behavior claimed."}]}}
 ]}}}}}

--- a/tests/fixtures/review-threads-resolved-proven.json
+++ b/tests/fixtures/review-threads-resolved-proven.json
@@ -1,6 +1,6 @@
 {"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
  {"isResolved":true,"isOutdated":false,"comments":{"nodes":[
    {"author":{"login":"chatgpt-codex-connector"},"path":"src/uffd/prefetch.rs","line":196,"originalLine":196,"body":"P1: indexing the snapshot mapping can panic inside the fault-handler task and hang the guest."},
-   {"author":{"login":"ejc3"},"path":"src/uffd/prefetch.rs","line":196,"originalLine":196,"body":"Fixed in 7672df92. RED-VERIFIED: a_corrupt_working_set_falls_back_to_on_demand_faulting — confirmed failing with the checked get() reverted."}
+   {"author":{"login":"ejc3"},"path":"src/uffd/prefetch.rs","line":196,"originalLine":196,"body":"RED-VERIFIED: a_corrupt_working_set_falls_back_to_on_demand_faulting — confirmed failing with the checked get() reverted. Fixed in 7672df92."}
  ]}}
 ]}}}}}

--- a/tests/test_log_scan.rs
+++ b/tests/test_log_scan.rs
@@ -204,10 +204,16 @@ fn unresolved_review_threads_block_the_merge() {
 }
 
 /// The counterpart: the gate must be able to pass, or it is just a wall.
+/// "Fully resolved" now means resolved AND dispositioned — the fixture's
+/// thread carries a NOT-A-DEFECT reply, since resolution alone stopped
+/// being sufficient when every resolved thread began requiring an answer.
 #[test]
 fn a_fully_resolved_pr_passes_the_gate() {
     let (out, code) = run_threads("review-threads-clear.json");
-    assert_eq!(code, 0, "an all-resolved PR must pass:\n{out}");
+    assert_eq!(
+        code, 0,
+        "an all-resolved, dispositioned PR must pass:\n{out}"
+    );
     assert!(out.contains("CLEAR"), "{out}");
 }
 
@@ -221,7 +227,11 @@ fn a_resolved_defect_claim_without_a_red_test_blocks_the_merge() {
         "a resolved thread describing a panic, with no RED-VERIFIED reply, must \
          block — otherwise a defect is closed by assertion.\n{out}"
     );
-    assert!(out.contains("UNPROVEN"), "{out}");
+    // The gate names the missing thing rather than guessing whether the
+    // finding was defect-shaped: the regex that used to decide that failed
+    // both ways (AGENTS.md), so an undispositioned resolved thread blocks
+    // whatever it says.
+    assert!(out.contains("carry no disposition reply"), "{out}");
 }
 
 /// ...and citing the test clears it, so the rule is satisfiable.
@@ -356,7 +366,7 @@ fn a_defect_report_cannot_serve_as_its_own_red_verification() {
         "a lone defect comment containing the marker must NOT count as proof — the \
          evidence has to come from a reply.\n{out}"
     );
-    assert!(out.contains("UNPROVEN"), "{out}");
+    assert!(out.contains("carry no disposition reply"), "{out}");
 }
 
 /// The run's OWN summary is authoritative — counting per-test lines is not enough.


### PR DESCRIPTION
**Main is red and has been since f5406797** — four `test_log_scan` failures at head 3ce63792, and every open PR inherits them (#818, #822, #825 all show the same set). This unblocks them. Rebased onto current main.

The gate script is correct in every case; its fixtures and two assertions still encode earlier contracts:

- `review-threads-clear.json`'s resolved thread carried only `"Fixed."` — no disposition reply — so the gate correctly blocked the fixture that names itself *clear*. It now carries a NOT-A-DEFECT reply: "fully resolved" means resolved **and** dispositioned once every resolved thread requires an answer.
- `review-threads-resolved-proven.json` buried its marker mid-sentence (`"Fixed in 7672df92. RED-VERIFIED: ..."`). 3ce63792 anchored the disposition regex with `\A`, so the marker must lead the comment; the reply now does — the same shape the gate's own help text asks for. This is the newest of the four failures.
- Two tests asserted the output contains `UNPROVEN`. The gate no longer emits that word; it names the missing disposition instead, precisely because inferring defect-shapedness from the text failed both ways (AGENTS.md). They now assert the message the gate actually prints. The blocking behavior they check is unchanged.

No change to `scripts/check-review-threads.sh` — the stricter behavior is the doctrine, and these are its tests catching up.

## Evidence
Every thread fixture, run against the gate on this branch:

```
clear             rc=0 CLEAR
resolved-proven   rc=0 CLEAR
resolved-unproven rc=1 BLOCKED
selfproof         rc=1 BLOCKED
unresolved        rc=1 BLOCKED
live-748          rc=1 BLOCKED
```

Through the test binary: `17 tests run, 17 passed` (rc=0). With the fixture change reverted, `clear` returns to rc=1 BLOCKED — the failure CI reports.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated review-thread validation tests to require a disposition reply for fully resolved threads.
  * Added clearer diagnostics for unresolved or self-proving defect threads without a disposition reply.
  * Refined test fixtures to cover multiple review comments and updated verification statement ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->