### PR TITLE
Let an html arm back a publication run

### DIFF
--- a/bench/chromium/reqanalyze.py
+++ b/bench/chromium/reqanalyze.py
@@ -421,7 +421,7 @@ def _validate_arms(arms, label, errors):
         errors.append(f"{label} metadata has no valid duplicate-free arms list")
     elif any(arm not in {"exec", "cdp", "cdp-fast", "html", "noop"} for arm in arms):
         errors.append(f"{label} metadata declares an unsupported arm")
-    elif "noop" not in arms or not ({"cdp", "cdp-fast"} & set(arms)):
+    elif "noop" not in arms or not any(is_cdp_class(arm) for arm in arms):
         errors.append(
             f"{label} publication schedule requires noop and a CDP arm"
         )

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -3501,6 +3501,26 @@ def dispatch_request(args, rep: int, arm: str, is_warmup: bool, probe=None) -> d
 
 
 
+# Arms that drive Chromium over CDP and therefore pay the per-request
+# handshake. html belongs here: it navigates and extracts the DOM over the
+# same connection, differing from cdp only in the terminal stage. Keeping this
+# set in one place is the point — it was spelled inline as {"cdp","cdp-fast"}
+# while the analyzer already classified html as CDP-class, so a legitimate
+# `--arms noop,html` publication run was refused with "requires at least one
+# CDP arm" (observed 2026-08-15, corpus campaign).
+CDP_CLASS_ARMS = frozenset({"cdp", "cdp-fast", "html"})
+
+
+def publication_arms_ok(arms) -> bool:
+    """Whether an arm set can back a publication run.
+
+    noop is the drift canary every published cell is judged against, and at
+    least one CDP-class arm has to actually render something.
+    """
+    arms = set(arms)
+    return "noop" in arms and bool(CDP_CLASS_ARMS & arms)
+
+
 def parse_urls(spec):
     """Split a comma-separated --url value; single URLs pass through as [url]."""
     return [u.strip() for u in spec.split(",") if u.strip()]
@@ -3671,8 +3691,11 @@ def main_with_resources(resources: ExitStack) -> int:
     # faults a large run-varying page set that pollutes the shared prefetch
     # working set and destabilizes the noop drift canary. Requiring it forced
     # the arm that corrupts the baseline into every publication run.
-    if "noop" not in arms or not ({"cdp", "cdp-fast"} & set(arms)):
-        p.error("publication runs require noop and at least one CDP arm")
+    if not publication_arms_ok(arms):
+        p.error(
+            "publication runs require noop and at least one CDP arm "
+            "(cdp, cdp-fast, or html)"
+        )
 
     urls = parse_urls(args.url)
     if not urls:

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -5891,6 +5891,37 @@ class GuestDnsKnob(unittest.TestCase):
         self.assertIn('--dns "$GUEST_DNS"', src)
 
 
+class PublicationArmSets(unittest.TestCase):
+    """html is a CDP-class arm on BOTH sides of the harness.
+
+    The analyzer classified html as CDP-class (is_cdp_class) while the
+    producer still spelled the requirement inline as {"cdp","cdp-fast"}, so a
+    legitimate `--arms noop,html` publication run was refused with "requires
+    at least one CDP arm". Found by running exactly that during the corpus
+    campaign, 2026-08-15.
+    """
+
+    def test_noop_plus_html_is_a_publication_set(self):
+        self.assertTrue(reqbench.publication_arms_ok(["noop", "html"]))
+
+    def test_the_other_cdp_class_arms_still_qualify(self):
+        self.assertTrue(reqbench.publication_arms_ok(["noop", "cdp"]))
+        self.assertTrue(reqbench.publication_arms_ok(["noop", "cdp-fast"]))
+        self.assertTrue(
+            reqbench.publication_arms_ok(["noop", "cdp", "cdp-fast", "html"])
+        )
+
+    def test_a_rendering_arm_is_required(self):
+        """noop alone measures no render, so it cannot back a published cell."""
+        self.assertFalse(reqbench.publication_arms_ok(["noop"]))
+        self.assertFalse(reqbench.publication_arms_ok(["noop", "exec"]))
+
+    def test_the_drift_canary_is_required(self):
+        """Without noop there is no baseline to judge drift against."""
+        self.assertFalse(reqbench.publication_arms_ok(["cdp"]))
+        self.assertFalse(reqbench.publication_arms_ok(["html", "cdp-fast"]))
+
+
 class CorpusServeAnswerIp(unittest.TestCase):
     """--answer-ip must fail at startup, not by silently dropping A queries.
 

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -5786,6 +5786,37 @@ class ExecArmIsOptional(unittest.TestCase):
             control, "a noop-less schedule must be rejected by the same rule"
         )
 
+    def test_the_analyzer_accepts_an_html_publication_schedule(self):
+        """Both sides of the harness must agree on what a CDP arm is.
+
+        The producer's publication_arms_ok learned that html is CDP-class,
+        but this validator still spelled the rule as {"cdp","cdp-fast"} —
+        so `--arms noop,html` would run its full 200+ reps and then be
+        rejected here as an invalid schedule, paying for a campaign that
+        could never publish (codex finding on #836).
+        """
+        import reqanalyze
+
+        errors = []
+        reqanalyze._validate_arms(["noop", "html"], "run", errors)
+        self.assertEqual(
+            errors, [],
+            "noop+html is a publication schedule: html pays the CDP handshake",
+        )
+
+        # The producer and the analyzer must not drift apart again.
+        import reqbench
+
+        self.assertTrue(reqbench.publication_arms_ok(["noop", "html"]))
+        for arm in sorted(reqbench.CDP_CLASS_ARMS):
+            with self.subTest(arm=arm):
+                side = []
+                reqanalyze._validate_arms(["noop", arm], "run", side)
+                self.assertEqual(
+                    side, [],
+                    f"producer calls {arm} CDP-class; the analyzer must agree",
+                )
+
 
 class CorpusMixUrls(unittest.TestCase):
     """Multi-URL runs for the corpus arm (Cloudflare 14-URL mix).


### PR DESCRIPTION
Found by running it: the corpus campaign's html phase exited 2 in one second.

The analyzer already treats `html` as CDP-class (`is_cdp_class`), but the producer still spelled the publication requirement inline as `{"cdp","cdp-fast"}` — so `--arms noop,html`, the run that measures the operation Kitesurf prices second (HTML extraction), was refused with *"publication runs require noop and at least one CDP arm"*.

The rule is now one named set (`CDP_CLASS_ARMS`) behind `publication_arms_ok`, so the producer and the analyzer cannot drift apart again.

**RED-VERIFIED:** `PublicationArmSets` — watched failing with `CDP_CLASS_ARMS` reverted to `{"cdp","cdp-fast"}` (noop,html rejected), green with html included. The negative cases still hold: `noop` alone and `noop,exec` are refused (no rendering arm), and `cdp` without `noop` is refused (no drift canary).

```
python3 -m unittest test_reqbench  ->  OK
```

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated publication validation to recognize HTML as a supported rendering option.
  * Publication runs now require both a rendering option and the `noop` verification check.

* **Tests**
  * Added regression coverage for HTML, CDP, and fast CDP publication configurations.
  * Added checks to ensure incomplete publication configurations remain invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->