### PR TITLE
Stop the snapshot boundary from disturbing the VM it snapshots

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -213,6 +213,43 @@ The gate has its own tests, each written against the unfixed script and observed
 live oversized-thread path that fixtures cannot reach. CI state cannot tell you whether a
 finding was answered.
 
+### A FUZZ CATCH IS A LEAD, NOT A REGRESSION TEST
+
+**When the chaos fuzz (or any stochastic harness) finds a defect, the fix is not
+done until a DETERMINISTIC test fails on it.** The fuzz found the bug by landing
+inside a timing window. It will pass ten, twenty, fifty times before it lands
+there again, so leaving it as the guard means the next regression ships and is
+discovered by a flake weeks later.
+
+The fuzz's job is DISCOVERY. Something else has to hold the line.
+
+Convert every catch into a test that fails **every run**:
+
+| the catch | what pins it |
+|---|---|
+| an ordering window (A must happen before B) | a source-level ordering assertion, or an event-log model like `ModelBarrier`/`ModelDiag` in `fc-agent/src/snapshot_network.rs` |
+| a state invariant (X must survive Y) | compare X directly across Y, as `snapshot_leaves_the_source_network_untouched` does |
+| a race that needs a precise interleaving | a named failpoint case in `test_lifecycle_interleave.rs` (crate `failpoint/`) |
+| a constant that two files must agree on | read the other file and assert, as `namespace_neighbour_matches_host_constants` does |
+
+Observed 2026-08-15, twice in one change:
+
+- CI's fuzz failed with `guest 10.0.2.100 never appeared at L2`, while the
+  forensics dumped moments later showed that guest `REACHABLE`. The guest was
+  not missing, it was LATE: removing the snapshot boundary's link cycle also
+  removed the thing that made a restored clone announce itself, so the host's
+  namespace had not learned its MAC before verification gave up. The fuzz hit
+  that window; `the_clone_announces_itself_before_the_boundary_publishes` now
+  fails on the ordering itself, every time.
+- The same run's seed had passed **20 consecutive local hunts** on a different
+  seed. A stochastic pass count is not evidence about a code path; it is
+  evidence about the schedule that seed happens to generate.
+
+**Corollary: do not certify a fix with the fuzz configuration you were already
+hunting with.** Run the configuration CI runs (`SEEDS=1 OPS=10` is the default),
+and run it enough times to say something. A green hunt on the seed you have been
+staring at proves the least interesting thing available.
+
 ### A GATE MUST FAIL CLOSED — check your dependencies before you trust your verdict
 
 A check that cannot run must **block**, never pass. Passing is a claim, and a tool that could

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -45,6 +45,74 @@ another what changed and why. Say that and stop.
 - Read it back as if a colleague sent it to you. If it reads like marketing or an essay,
   rewrite it.
 
+## SUSPENDING A VM DOES NOT DISTURB IT
+
+**`snapshot create` is a read of the source VM, not a reconfiguration of it.** A
+caller asked for a copy. They must not get their running VM altered to produce
+one, and nothing on the snapshot path may leave state the resume has to repair.
+
+What the boundary needs is narrow, and both halves are non-destructive:
+
+| need | mechanism | reversible? |
+|------|-----------|-------------|
+| no NEW socket may appear while the cookie dump runs | directional NEW-flow REJECT gate (iptables/ip6tables) | yes: one rule added, then removed |
+| packets already in receive processing must drain | AF_PACKET open/close, whose release runs `synchronize_net()` | nothing to reverse |
+| restore must destroy exactly the snapshot-time sockets | dump kernel socket **cookies** into a manifest | read-only |
+
+The dump has to happen at snapshot time and cannot move to restore: by the time
+a clone runs, the restored workload and an early published-port client can both
+have created sockets, so a restore-time dump cannot describe a fixed generation,
+and a four-tuple is not a socket identity (95ce328a).
+
+### Never take the link down. Never purge kernel tables.
+
+`ip link set eth0 down` was once part of this sequence. It prevented sockets the
+gate already rejects, and paid for it by purging the device's **routes and
+neighbours**. Everything purged then had to be remembered and reinstated by
+hand, and that list was wrong twice:
+
+- **2026-08-10 (`ee3f5c30`)** the route table. *"A restored clone came up
+  reachable at L2 and routed nowhere."* Fixed by capturing and reinstating routes.
+- **2026-08-15** the neighbour table, which the same link-down purged and nobody
+  reinstated. After a snapshot the guest re-ARPed for the bridge address every
+  health check and published connection arrives from. Both the bridge (which
+  owns it) and pasta (which answers for the subnet it routes) reply, so the
+  guest kept whichever landed first. When pasta won:
+
+```
+SYN      br0-mac   > guest-mac           10.0.2.1 > 10.0.2.100  [S]
+SYN-ACK  guest-mac > 9a:55:9a:55:9a:55   10.0.2.100 > 10.0.2.1  [S.]   <- pasta
+RST      9a:55:9a:55:9a:55 > guest-mac   10.0.2.1 > 10.0.2.100  [R]
+```
+
+  The guest answered the wrong MAC and pasta correctly reset a connection it had
+  never opened. A published port that accepts and then returns zero bytes, about
+  1 snapshot in 10, with **no drop counted at any layer** - because nothing was
+  dropped. Latency was bimodal (421 requests under 0.1s, **zero** between 0.1s
+  and 4.5s, 8 at the 5s deadline), which is what ruled out contention.
+
+Two bugs, one shape: *the link-down purged X and nobody put X back.* The fix was
+to delete the purge, not to grow the repair list. Nothing in the boundary now
+touches the link, so there are no routes and no neighbours to reinstate.
+
+**Rules:**
+
+1. **Nothing on the snapshot path may down a link, flush a table, or otherwise
+   destroy kernel state in the guest being snapshotted.** If a step needs
+   quiescence, use a reversible gate.
+2. **A repair list is a smell.** Needing to remember what a step destroyed means
+   the step is wrong. The next table nobody thought of is the next outage.
+3. **The bridge MAC is pinned** (`NAMESPACE_MAC`, `src/network/pasta.rs`) so a
+   clone inheriting the source's neighbour table holds entries that are correct
+   in its own namespace. fc-agent hardcodes the same constant; the pair is
+   asserted by `namespace_neighbour_matches_host_constants`.
+
+**Enforcement:** `snapshot_leaves_the_source_network_untouched`
+(`tests/test_snapshot_clone.rs`) diffs the guest's routes, neighbours and
+addresses across one snapshot and fails on any difference. The `ModelBarrier`
+and `ModelDiag` invariants in `fc-agent/src/snapshot_network.rs` fail if any
+boundary step takes the link down, on the source or the clone path.
+
 ## MAXIMUM REUSE / CACHEABILITY
 
 **The whole goal of fcvm is to cache and reuse as much as humanly possible.** Kernels,

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2259,6 +2259,44 @@ let (mut child, pid) = common::spawn_fcvm(&["podman", "run", "--name", &vm_name,
 - `-it`: both (interactive shell)
 - neither: plain exec
 
+### `fcvm exec` LANDS IN THE CONTAINER BY DEFAULT. The guest needs `--vm`.
+
+```
+-c, --container    Execute inside container (default)
+    --vm           Execute in the VM instead of inside the container
+```
+
+A bare `fcvm exec --pid <pid> -- <cmd>` runs in the **container**, not the guest OS.
+They are different machines with different tooling, so a diagnostic aimed at the wrong
+one comes back EMPTY rather than wrong, which reads like a finding:
+
+| | container (`nginx:alpine`) | guest (Ubuntu 24.04, `--vm`) |
+|---|---|---|
+| `iptables` | absent | `/usr/sbin/iptables` |
+| `bash` / `ss` / `curl` | absent | `/usr/bin/{bash,ss,curl}` |
+| `sh`, `wget`, `netstat` | busybox | present |
+
+On 2026-08-15 that cost several rounds of a flake hunt. Netfilter probes returned
+nothing, and the conclusion written down was "the guest rootfs carries no iptables and no
+nft, so guest netfilter state is unreadable" - a statement about alpine, presented as a
+fact about Ubuntu, and committed as a code comment. The rules were readable the whole
+time, and reading them is what exonerated the loopback containment DROP (packet counter
+still 0 at failure) and moved the search to the virtio-net RX path.
+
+Two rules follow:
+
+1. **An empty probe result is not evidence. It is a broken probe until proven otherwise.**
+   Run every diagnostic against a HEALTHY VM first and confirm it returns real output.
+   Both of these looked like findings and were defects in the instrument: `exit=127` from
+   `curl` in a guest image that has no curl, and `exit=127` from passing a whole command
+   line as one argv - `fcvm exec -- 'ss -ltn | head'` execs that string as a program
+   name, so it needs `sh -c` as separate arguments.
+2. **Use absolute paths.** exec hands over a minimal PATH: `iptables` fails where
+   `/usr/sbin/iptables` works.
+
+The same split exists in the test helpers: `exec_in_vm(pid, &cmd)` versus
+`exec_in_container(pid, &cmd)` (`tests/common/mod.rs`).
+
 **NO backward compatibility wrappers.** When the API changed from `run_tty_mode(stream)` to `run_tty_mode(stream, interactive)`, all callers were updated directly - no deprecated functions or compatibility shims.
 
 ## References

--- a/fc-agent/src/agent.rs
+++ b/fc-agent/src/agent.rs
@@ -52,6 +52,10 @@ pub async fn run() -> Result<()> {
     // Chromium accepts --remote-debugging-address=0.0.0.0 and binds 127.0.0.1
     // anyway. Installed once, here, before the container starts; setup fails
     // closed and the reserved egress-proxy port is excluded.
+    // Before anything can accept a connection: make the host's health-check
+    // address resolve to the bridge, not to whichever ARP reply arrives first.
+    network::pin_namespace_neighbour();
+
     network::publish_to_loopback(&plan.published_guest_ports);
 
     if !plan.forward_localhost.is_empty() {

--- a/fc-agent/src/network.rs
+++ b/fc-agent/src/network.rs
@@ -163,6 +163,39 @@ fn send_ethernet_broadcast(interface: &str, frame: &[u8]) -> std::io::Result<()>
 const NAMESPACE_IP: &str = "10.0.2.1";
 const NAMESPACE_MAC: &str = "02:fc:00:00:02:01";
 
+/// Drop every learned neighbour on the external link. RESTORE ONLY.
+///
+/// A restored clone runs in a NEW namespace: its bridge, veth and gateway are
+/// different devices with different MACs from the ones the snapshot recorded.
+/// Every dynamic entry it inherits therefore names hardware that does not exist
+/// on its segment, and the guest will happily send to those addresses until the
+/// entries expire.
+///
+/// The old boundary cleared them as a side effect of taking the link down. When
+/// that purge was removed (it also destroyed routes, which is the defect this
+/// work exists to fix), bridged clones inherited stale gateway MACs and lost all
+/// egress: healthy VM, DNS and HTTP both dead. This does the clearing
+/// deliberately and narrowly instead: one device, no routes touched, on the
+/// restore path only.
+///
+/// The source never runs this. Its neighbours are correct and it is not to be
+/// disturbed.
+pub fn flush_stale_neighbours() {
+    match std::process::Command::new("ip")
+        .args(["neigh", "flush", "dev", "eth0"])
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            eprintln!("[fc-agent] flushed inherited neighbours on eth0 (restored clone)");
+        }
+        Ok(out) => eprintln!(
+            "[fc-agent] WARNING: could not flush inherited neighbours: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ),
+        Err(error) => eprintln!("[fc-agent] WARNING: ip neigh flush failed: {error}"),
+    }
+}
+
 /// Pin an AUTHORITATIVE neighbour entry for the host's health-check address.
 ///
 /// Both the bridge (which owns 10.0.2.1) and pasta (which answers for the

--- a/fc-agent/src/network.rs
+++ b/fc-agent/src/network.rs
@@ -157,6 +157,56 @@ fn send_ethernet_broadcast(interface: &str, frame: &[u8]) -> std::io::Result<()>
 /// first real packet regardless, and a reply wait on the restore critical
 /// path can stall up to a full second when the gateway stays silent. ARP
 /// rather than ICMP ping because pasta doesn't answer ICMP in rootless mode.
+/// The host's health-check address on the bridge, and the MAC the host pins it
+/// to (`NAMESPACE_IP` / `NAMESPACE_MAC` in src/network/pasta.rs). Kept in sync
+/// by `namespace_neighbour_matches_host_constants` in that file.
+const NAMESPACE_IP: &str = "10.0.2.1";
+const NAMESPACE_MAC: &str = "02:fc:00:00:02:01";
+
+/// Pin an AUTHORITATIVE neighbour entry for the host's health-check address.
+///
+/// Both the bridge (which owns 10.0.2.1) and pasta (which answers for the
+/// subnet it routes) reply to the guest's ARP for that address, and the winner
+/// decides where this guest sends its replies. When pasta won, every inbound
+/// connection died in a way that left no trace: the guest SYN-ACKed to pasta's
+/// MAC, pasta reset a connection it had never opened, and no counter anywhere
+/// recorded a drop. Captured on the wire 2026-08-15:
+///
+///   SYN      br0  > guest  10.0.2.1 > 10.0.2.100  [S]
+///   SYN-ACK  guest > 9a:55:9a:55:9a:55 (pasta)     [S.]
+///   RST      9a:55:9a:55:9a:55 > guest             [R]
+///
+/// A `nud permanent` entry is not replaced by ARP replies, so the race has no
+/// outcome left to win. Idempotent, and re-applied after restore because a
+/// restored guest inherits the snapshot's neighbour table.
+pub fn pin_namespace_neighbour() {
+    match std::process::Command::new("ip")
+        .args([
+            "neigh",
+            "replace",
+            NAMESPACE_IP,
+            "lladdr",
+            NAMESPACE_MAC,
+            "dev",
+            "eth0",
+            "nud",
+            "permanent",
+        ])
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            eprintln!("[fc-agent] pinned {NAMESPACE_IP} to {NAMESPACE_MAC} (permanent)");
+        }
+        Ok(out) => eprintln!(
+            "[fc-agent] WARNING: could not pin {NAMESPACE_IP}: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ),
+        Err(error) => {
+            eprintln!("[fc-agent] WARNING: could not run ip neigh for {NAMESPACE_IP}: {error}")
+        }
+    }
+}
+
 pub fn refresh_gateway_arp() {
     let route_table = match std::fs::read_to_string("/proc/net/route") {
         Ok(table) => table,

--- a/fc-agent/src/restore.rs
+++ b/fc-agent/src/restore.rs
@@ -284,6 +284,18 @@ pub async fn handle_clone_restore(
     // host's health checks depend on. Flushing after the pin would delete it.
     network::flush_stale_neighbours();
     network::pin_namespace_neighbour();
+    // ANNOUNCE, as early as possible. The host cannot forward a packet to this
+    // clone until its namespace has learned the guest's MAC, and it only learns
+    // that when the guest transmits. The old boundary got this for free: taking
+    // the link down and up made the guest announce itself the moment it came
+    // back. With the link never cycled -- deliberately, because cycling it
+    // purged routes and neighbours -- nothing was announcing until this probe
+    // ran at the END of the restore sequence, and fcvm's post-restore port
+    // verification could time out first ("guest 10.0.2.100 never appeared at L2"
+    // while the namespace's own table showed it REACHABLE moments later).
+    //
+    // One broadcast ARP costs nothing and teaches the whole segment.
+    network::refresh_gateway_arp();
 
     let tcp_cleanup_started = std::time::Instant::now();
     eprintln!(
@@ -309,7 +321,8 @@ pub async fn handle_clone_restore(
     // boundary. One broadcast ARP request refreshes the gateway and teaches the
     // new bridge/pasta path without deleting unrelated/current neighbors.
     let neighbor_started = std::time::Instant::now();
-    network::refresh_gateway_arp();
+    // Already announced above, before the boundary work, so the host learns
+    // this clone's MAC as early as possible rather than at the end.
     phases.neighbor_ms = elapsed_ms(neighbor_started);
 
     // Remount NFS shares: their kernel TCP connections to the host's NFS
@@ -652,5 +665,62 @@ mod tests {
             .wait_for_output_readiness()
             .await
             .expect("late subscriber must observe retained Succeeded");
+    }
+
+    /// A restored clone must ANNOUNCE itself before the boundary publishes.
+    ///
+    /// The host cannot forward a packet to a clone until its namespace has
+    /// learned the guest's MAC, and a namespace learns that only when the guest
+    /// transmits. The old snapshot boundary got this for free: it cycled the
+    /// link, and coming back up made the guest announce itself immediately.
+    /// That cycle was removed because it also purged the device's routes and
+    /// neighbours -- the defect this whole change exists to fix.
+    ///
+    /// With nothing announcing, the only transmission was the gateway ARP probe
+    /// at the END of the restore sequence, and fcvm's post-restore port
+    /// verification could time out first. CI caught it as
+    ///
+    ///   Error: port forwarding verification failed after snapshot restore:
+    ///          guest 10.0.2.100 never appeared at L2 within ...
+    ///
+    /// while the namespace's own table showed `10.0.2.100 ... REACHABLE` in the
+    /// forensics dumped moments later. The guest was not missing; it was late.
+    ///
+    /// The chaos fuzz found that, but only by landing inside the window. This
+    /// pins the ordering that makes the window impossible, so a regression
+    /// fails here every time rather than one run in N.
+    #[test]
+    fn the_clone_announces_itself_before_the_boundary_publishes() {
+        let source = include_str!("restore.rs");
+        let announce = source
+            .find("network::refresh_gateway_arp()")
+            .expect("the restore path no longer announces the clone at all");
+        let publish = source
+            .find("crate::snapshot_network::restore_snapshot_network()")
+            .expect("the restore path no longer runs the snapshot boundary");
+        assert!(
+            announce < publish,
+            "the clone announces itself AFTER the boundary publishes. The host \
+             learns a clone's MAC only when the guest transmits, so publishing \
+             first opens a window where fcvm's post-restore verification can \
+             time out with \"guest never appeared at L2\" on a guest that is \
+             perfectly healthy. Move network::refresh_gateway_arp() above \
+             restore_snapshot_network()."
+        );
+
+        // Flushing inherited entries after pinning would delete the pin, and
+        // announcing before flushing would teach the segment and then discard
+        // what we learned in return.
+        let flush = source
+            .find("network::flush_stale_neighbours()")
+            .expect("the restore path no longer flushes inherited neighbours");
+        let pin = source
+            .find("network::pin_namespace_neighbour()")
+            .expect("the restore path no longer pins the health-check neighbour");
+        assert!(
+            flush < pin && pin < announce,
+            "restore must flush inherited neighbours, then pin the health-check \
+             entry, then announce. Got flush={flush} pin={pin} announce={announce}"
+        );
     }
 }

--- a/fc-agent/src/restore.rs
+++ b/fc-agent/src/restore.rs
@@ -280,6 +280,9 @@ pub async fn handle_clone_restore(
     // could still go to the inherited MAC, which is the exact SYN-ACK/RST
     // failure this boundary work exists to remove. Safe to do early: nothing
     // purges the neighbour table any more.
+    // Order matters: drop the inherited entries first, then pin the one the
+    // host's health checks depend on. Flushing after the pin would delete it.
+    network::flush_stale_neighbours();
     network::pin_namespace_neighbour();
 
     let tcp_cleanup_started = std::time::Instant::now();

--- a/fc-agent/src/restore.rs
+++ b/fc-agent/src/restore.rs
@@ -298,6 +298,10 @@ pub async fn handle_clone_restore(
     // boundary. One broadcast ARP request refreshes the gateway and teaches the
     // new bridge/pasta path without deleting unrelated/current neighbors.
     let neighbor_started = std::time::Instant::now();
+    // A restored guest inherits the snapshot's neighbour table, which may hold
+    // the losing side of the ARP race from whichever namespace took the
+    // snapshot. Re-pin before the gateway probe.
+    network::pin_namespace_neighbour();
     network::refresh_gateway_arp();
     phases.neighbor_ms = elapsed_ms(neighbor_started);
 

--- a/fc-agent/src/restore.rs
+++ b/fc-agent/src/restore.rs
@@ -266,13 +266,21 @@ pub async fn handle_clone_restore(
     spawn_restore_side_job(restart_journald());
 
     // Reconfigure IPv6 — before any network traffic can use the old address.
-    // The link is still down here (the snapshot captured it down), so the new
-    // address sits tentative until the boundary republishes the link.
+    // The link is UP throughout (the boundary no longer takes it down), so the
+    // gate is what holds inbound traffic off until the cleanup below finishes.
     let ipv6_started = std::time::Instant::now();
     if let Some(new_ipv6) = clone_ipv6 {
         network::reconfigure_ipv6(new_ipv6).await;
     }
     phases.ipv6_ms = elapsed_ms(ipv6_started);
+
+    // Pin the neighbour entry BEFORE the boundary reopens the gate. The clone
+    // inherits the source's neighbour table, and restore_snapshot_network ends
+    // by publishing; anything answered between publication and a later pin
+    // could still go to the inherited MAC, which is the exact SYN-ACK/RST
+    // failure this boundary work exists to remove. Safe to do early: nothing
+    // purges the neighbour table any more.
+    network::pin_namespace_neighbour();
 
     let tcp_cleanup_started = std::time::Instant::now();
     eprintln!(
@@ -298,10 +306,6 @@ pub async fn handle_clone_restore(
     // boundary. One broadcast ARP request refreshes the gateway and teaches the
     // new bridge/pasta path without deleting unrelated/current neighbors.
     let neighbor_started = std::time::Instant::now();
-    // A restored guest inherits the snapshot's neighbour table, which may hold
-    // the losing side of the ARP race from whichever namespace took the
-    // snapshot. Re-pin before the gateway probe.
-    network::pin_namespace_neighbour();
     network::refresh_gateway_arp();
     phases.neighbor_ms = elapsed_ms(neighbor_started);
 

--- a/fc-agent/src/snapshot_network.rs
+++ b/fc-agent/src/snapshot_network.rs
@@ -1503,12 +1503,33 @@ pub async fn resume_source_network() -> Result<()> {
     let store = FileManifestStore::default();
     // No routes to read back: the boundary never takes the link down, so it
     // purges nothing. The manifest is retired purely to clear the armed marker.
-    store
-        .remove()
-        .context("retiring source snapshot network manifest before publication")?;
-    reopen_with(&gate)
+    //
+    // ORDER: publish FIRST, retire the marker second. The gate is live traffic
+    // policy on a VM that was only supposed to be READ; the manifest is a local
+    // file. Retiring first meant a removal failure returned early with the gate
+    // still closed, leaving the source unpublished until an operator noticed --
+    // the same "snapshot disturbed the source" failure this boundary exists to
+    // avoid, arriving by the error path instead.
+    let reopened = reopen_with(&gate)
         .await
-        .context("reopening source VM network")?;
+        .context("reopening source VM network");
+    let retired = store
+        .remove()
+        .context("retiring source snapshot network manifest after publication");
+    match (reopened, retired) {
+        (Ok(()), Ok(())) => {}
+        // Publication failed: report it, and say if the marker also survived.
+        (Err(reopen), retire) => {
+            return Err(match retire {
+                Ok(()) => reopen,
+                Err(retire) => anyhow::anyhow!("{reopen:#}; additionally {retire:#}"),
+            })
+        }
+        // Published, but the marker survives. Still an error -- a stale marker
+        // keeps the restore watcher on the restore-only control generation --
+        // and the source is at least back in service.
+        (Ok(()), Err(retire)) => return Err(retire),
+    }
     eprintln!(
         "[fc-agent] source VM snapshot network reopened: gate=open \
          (link never taken down)"

--- a/fc-agent/src/snapshot_network.rs
+++ b/fc-agent/src/snapshot_network.rs
@@ -309,21 +309,8 @@ trait FirewallGate {
     async fn is_closed(&self) -> Result<bool>;
 }
 
-trait ExternalLink {
-    async fn down(&self) -> Result<()>;
-    async fn up(&self) -> Result<()>;
-}
-
 trait PacketReceiveBarrier {
     fn synchronize(&self) -> Result<()>;
-}
-
-trait RouteTable {
-    /// Read the routes that must be reinstated after the link returns.
-    async fn capture(&self) -> Result<Vec<CapturedRoute>>;
-    /// Reinstate them. Idempotent: `ip route replace` accepts a route that is
-    /// already present, so a partial restore can simply be repeated.
-    async fn reinstate(&self, routes: &[CapturedRoute]) -> Result<()>;
 }
 
 trait CommandRunner {
@@ -369,220 +356,6 @@ impl CommandRunner for SystemCommandRunner {
         stdin.write_all(input).await?;
         drop(stdin);
         child.wait_with_output().await
-    }
-}
-
-/// Name the guest's one external interface by asking sysfs which netdev is
-/// backed by a bus device.
-///
-/// The name is not fixed across hypervisors, so hardcoding one silently breaks
-/// the other: Firecracker's MMIO virtio-net keeps the kernel's `eth0`, while
-/// Cloud Hypervisor's PCI virtio-net is renamed by udev under predictable
-/// naming to `enp0s4` (both measured). The kernel `ip=` boot argument names
-/// `eth0` because it runs before that rename, so the address survives and every
-/// later by-name operation does not.
-///
-/// Only `lo` lacks the `device` symlink, so this also stays correct if the netns
-/// ever gains a bridge or veth. Unlike reading an address or a default route it
-/// is valid mid-boundary, where the link is down and the routes are purged.
-fn external_interface_in(sysfs_net: &Path) -> Result<String> {
-    let entries = std::fs::read_dir(sysfs_net)
-        .with_context(|| format!("listing network interfaces in {}", sysfs_net.display()))?;
-    let mut all = Vec::new();
-    let mut backed = Vec::new();
-    for entry in entries {
-        let entry = entry.with_context(|| {
-            format!(
-                "reading a network interface entry in {}",
-                sysfs_net.display()
-            )
-        })?;
-        let name = entry.file_name().to_string_lossy().into_owned();
-        if entry.path().join("device").exists() {
-            backed.push(name.clone());
-        }
-        all.push(name);
-    }
-    all.sort();
-    backed.sort();
-    match backed.len() {
-        1 => Ok(backed.remove(0)),
-        _ => bail!(
-            "expected exactly one device-backed external interface, found {:?} among {:?}",
-            backed,
-            all
-        ),
-    }
-}
-
-fn external_interface() -> Result<String> {
-    external_interface_in(Path::new(SYSFS_NET_PATH))
-}
-
-/// The guest's one external interface, driven through direct syscalls.
-struct IpLink {
-    interface: String,
-}
-
-impl IpLink {
-    fn new(interface: String) -> Self {
-        Self { interface }
-    }
-}
-
-/// Set or clear IFF_UP on an interface with SIOCSIFFLAGS.
-///
-/// The kernel call `ip link set dev X up|down` makes, without the process
-/// spawn. The boundary drives the link on every clone restore, where a spawn
-/// costs far more than the syscall: the restored process image faults its
-/// text and libraries back in through the memory backend. Spawn-free is also
-/// what makes re-asserting the link-down on every restore affordable, and
-/// that re-assert is what keeps the cleanup sound against a privileged
-/// workload sharing this namespace.
-fn set_interface_up(interface: &str, up: bool) -> Result<()> {
-    use std::os::fd::AsRawFd;
-
-    // `as _` on the request numbers is load-bearing across targets: the guest
-    // binary is musl, whose `ioctl` takes an i32 request, while glibc takes a
-    // c_ulong. A host-target build hides that difference entirely.
-
-    let fd = crate::network::open_raw_socket(libc::AF_INET, libc::SOCK_DGRAM, 0)
-        .context("opening a control socket for the snapshot network link")?;
-    // SAFETY: ifreq is a plain C struct; zeroing is its valid empty state.
-    let mut request: libc::ifreq = unsafe { std::mem::zeroed() };
-    let name = interface.as_bytes();
-    if name.len() >= request.ifr_name.len() {
-        bail!("interface name {interface:?} does not fit in an ifreq");
-    }
-    for (slot, byte) in request.ifr_name.iter_mut().zip(name) {
-        *slot = *byte as libc::c_char;
-    }
-    // SAFETY: the fd is a live AF_INET socket and `request` is initialized
-    // with a NUL-terminated name; SIOCGIFFLAGS fills the flags union member.
-    if unsafe { libc::ioctl(fd.as_raw_fd(), libc::SIOCGIFFLAGS as _, &mut request) } < 0 {
-        return Err(std::io::Error::last_os_error())
-            .with_context(|| format!("reading interface flags for {interface}"));
-    }
-    // SAFETY: SIOCGIFFLAGS just populated the flags member of the union.
-    let flags = unsafe { request.ifr_ifru.ifru_flags } as libc::c_int;
-    let updated = if up {
-        flags | libc::IFF_UP
-    } else {
-        flags & !libc::IFF_UP
-    };
-    request.ifr_ifru.ifru_flags = updated as libc::c_short;
-    // SAFETY: same fd and struct, now carrying the flags to install.
-    if unsafe { libc::ioctl(fd.as_raw_fd(), libc::SIOCSIFFLAGS as _, &request) } < 0 {
-        return Err(std::io::Error::last_os_error()).with_context(|| {
-            format!(
-                "setting interface {interface} {}",
-                if up { "up" } else { "down" }
-            )
-        });
-    }
-    Ok(())
-}
-
-impl ExternalLink for IpLink {
-    async fn down(&self) -> Result<()> {
-        set_interface_up(&self.interface, false)
-    }
-
-    async fn up(&self) -> Result<()> {
-        set_interface_up(&self.interface, true)
-    }
-}
-
-struct IpRoutes<R> {
-    runner: R,
-}
-
-impl<R> IpRoutes<R> {
-    fn new(runner: R) -> Self {
-        Self { runner }
-    }
-}
-
-impl<R: CommandRunner + Sync> IpRoutes<R> {
-    async fn run(&self, args: &[&str]) -> Result<std::process::Output> {
-        let output = self
-            .runner
-            .output("ip", args)
-            .await
-            .context("spawning ip to read or reinstate the snapshot route table")?;
-        if !output.status.success() {
-            bail!(
-                "snapshot network route command failed: {}",
-                command_failure("ip", args, &output)
-            );
-        }
-        Ok(output)
-    }
-
-    async fn capture_family(&self, family: u8, routes: &mut Vec<CapturedRoute>) -> Result<()> {
-        let flag = if family == 6 { "-6" } else { "-4" };
-        let output = self.run(&[flag, "route", "show"]).await?;
-        for line in String::from_utf8_lossy(&output.stdout).lines() {
-            let spec = line.trim();
-            if spec.is_empty() {
-                continue;
-            }
-            // `proto kernel` routes come back on their own when the link does,
-            // measured on both families, so reinstating them is noise at best.
-            if spec.contains("proto kernel") {
-                continue;
-            }
-            // A route the kernel is aging out cannot be re-added verbatim:
-            // `expires` is state, not an argument `ip route replace` accepts.
-            if spec.contains("expires") {
-                continue;
-            }
-            routes.push(CapturedRoute {
-                family,
-                spec: spec.to_string(),
-            });
-        }
-        Ok(())
-    }
-}
-
-impl<R: CommandRunner + Sync> RouteTable for IpRoutes<R> {
-    async fn capture(&self) -> Result<Vec<CapturedRoute>> {
-        let mut routes = Vec::new();
-        self.capture_family(4, &mut routes).await?;
-        self.capture_family(6, &mut routes).await?;
-        Ok(routes)
-    }
-
-    async fn reinstate(&self, routes: &[CapturedRoute]) -> Result<()> {
-        // One `ip -batch -` spawn per family instead of one per route: the
-        // family flag is global to the ip invocation, and each avoided spawn
-        // is restore latency on a cold clone.
-        for family in [4u8, 6u8] {
-            let lines: Vec<String> = routes
-                .iter()
-                .filter(|route| route.family == family)
-                .map(|route| format!("route replace {}", route.spec))
-                .collect();
-            if lines.is_empty() {
-                continue;
-            }
-            let flag = if family == 6 { "-6" } else { "-4" };
-            let payload = lines.join("\n") + "\n";
-            let args = [flag, "-batch", "-"];
-            let output = self
-                .runner
-                .output_with_input("ip", &args, payload.as_bytes())
-                .await
-                .context("spawning ip to reinstate the snapshot route table")?;
-            if !output.status.success() {
-                bail!(
-                    "snapshot network route batch failed: {} (batch input {payload:?})",
-                    command_failure("ip", &args, &output)
-                );
-            }
-        }
-        Ok(())
     }
 }
 
@@ -1492,38 +1265,23 @@ fn parse_destroy_reply(bytes: &[u8], sequence: u32) -> Result<Option<DestroyOutc
     Ok(outcome)
 }
 
-async fn reopen_with<G: FirewallGate, L: ExternalLink, T: RouteTable>(
-    gate: &G,
-    link: &L,
-    routes: &T,
-    captured: &[CapturedRoute],
-) -> Result<()> {
-    // Remove both family-specific hooks while the link is still down, then make
-    // the link visible as the final publication step.  Removing IPv4 and IPv6
-    // hooks cannot be one iptables transaction; doing it behind link-down
-    // prevents a partial gate removal from publishing either family.
+/// Publish the network again by removing the gate, and nothing else.
+///
+/// Nothing else is left to do: with the link-down gone the boundary destroys no
+/// kernel state, so there are no routes and no neighbours to put back. This
+/// function used to reinstate routes, and a neighbour repair was on its way into
+/// it before the purge itself was removed instead.
+async fn reopen_with<G: FirewallGate>(gate: &G) -> Result<()> {
+    // Removing the IPv4 and IPv6 hooks cannot be one iptables transaction, so a
+    // failure between them leaves one family open. That fails closed: the caller
+    // reports it and the clone stays unpublished.
     gate.open()
         .await
-        .context("opening the snapshot TCP NEW-flow gate while the link is down")?;
-    link.up()
-        .await
-        .context("bringing the external link up after opening the snapshot TCP NEW-flow gate")?;
-    // Only now: a route needs its device up, and the kernel has just put back
-    // the connected routes these ones depend on.
-    routes
-        .reinstate(captured)
-        .await
-        .context("reinstating the routes the link-down purged")
+        .context("opening the snapshot TCP NEW-flow gate")
 }
 
-async fn rollback_preparation<G: FirewallGate, L: ExternalLink, T: RouteTable>(
-    error: anyhow::Error,
-    gate: &G,
-    link: &L,
-    routes: &T,
-    captured: &[CapturedRoute],
-) -> anyhow::Error {
-    match reopen_with(gate, link, routes, captured).await {
+async fn rollback_preparation<G: FirewallGate>(error: anyhow::Error, gate: &G) -> anyhow::Error {
+    match reopen_with(gate).await {
         Ok(()) => error,
         Err(reopen) => {
             anyhow::anyhow!("{error:#}; additionally failed to restore source network: {reopen:#}")
@@ -1533,49 +1291,46 @@ async fn rollback_preparation<G: FirewallGate, L: ExternalLink, T: RouteTable>(
 
 async fn prepare_with<
     G: FirewallGate,
-    L: ExternalLink,
     B: PacketReceiveBarrier,
     D: SocketDiagnostic,
     S: ManifestStore,
-    T: RouteTable,
 >(
     gate: &G,
-    link: &L,
     receive_barrier: &B,
     diagnostic: &mut D,
     store: &S,
-    route_table: &T,
 ) -> Result<usize> {
-    // Read the route table while it still exists: the link-down below empties
-    // it, and every rollback and restore path from here on has to put it back.
-    let captured_routes = match route_table
-        .capture()
-        .await
-        .context("capturing the routes the snapshot boundary is about to purge")
-    {
-        Ok(routes) => routes,
-        // Nothing is torn down yet, so there is nothing to roll back.
-        Err(error) => return Err(error),
-    };
+    // THE VM BEING SNAPSHOTTED IS NOT DISTURBED. A caller asked for a copy; it
+    // must not get its live VM reconfigured to produce one.
+    //
+    // The boundary needs exactly two things: no NEW socket may appear while the
+    // cookie dump runs, and packets already in receive processing must drain
+    // first. The gate delivers the first (a directional NEW-flow REJECT) and the
+    // AF_PACKET barrier the second. Both are reversible and destroy no kernel
+    // state: the gate is one iptables rule added then removed, the barrier an
+    // open/close whose release runs synchronize_net().
+    //
+    // `link.down()` used to sit between them. It prevented sockets the gate
+    // already rejects, and purged the device's routes AND neighbours to do it.
+    // Both purges reached production as silent failures: routes in ee3f5c30
+    // ("a restored clone came up reachable at L2 and routed nowhere"), and
+    // neighbours on 2026-08-15, where the guest re-ARPed for the bridge,
+    // sometimes learned pasta's MAC, answered inbound SYNs to the wrong MAC and
+    // had them RST -- a published port dead ~1 snapshot in 10 with no drop
+    // counted anywhere. Removing the purge removes the class, which is why the
+    // route capture went with it instead of gaining a neighbour-shaped sibling.
     if let Err(error) = gate
         .close()
         .await
         .context("closing snapshot TCP NEW-flow gate")
     {
-        return Err(rollback_preparation(error, gate, link, route_table, &captured_routes).await);
-    }
-    if let Err(error) = link
-        .down()
-        .await
-        .context("bringing the external link down before snapshot")
-    {
-        return Err(rollback_preparation(error, gate, link, route_table, &captured_routes).await);
+        return Err(rollback_preparation(error, gate).await);
     }
     if let Err(error) = receive_barrier
         .synchronize()
         .context("waiting for pre-boundary packet receive processing")
     {
-        return Err(rollback_preparation(error, gate, link, route_table, &captured_routes).await);
+        return Err(rollback_preparation(error, gate).await);
     }
     let prepared = (|| -> Result<Vec<TcpSocketIdentity>> {
         let sockets = diagnostic
@@ -1592,37 +1347,32 @@ async fn prepare_with<
     })();
     let sockets = match prepared {
         Ok(sockets) => sockets,
-        Err(error) => {
-            return Err(
-                rollback_preparation(error, gate, link, route_table, &captured_routes).await,
-            )
-        }
+        Err(error) => return Err(rollback_preparation(error, gate).await),
     };
     let manifest = SnapshotNetworkManifest {
         version: MANIFEST_VERSION,
         sockets,
-        routes: captured_routes.clone(),
+        // Empty by construction: nothing purges the route table any more, so
+        // there is nothing to put back. The field stays so the manifest format
+        // does not fork; reinstating an empty list is a no-op.
+        routes: Vec::new(),
     };
     if let Err(error) = store.save(&manifest) {
-        return Err(rollback_preparation(error, gate, link, route_table, &captured_routes).await);
+        return Err(rollback_preparation(error, gate).await);
     }
     Ok(manifest.sockets.len())
 }
 
 async fn restore_with<
     G: FirewallGate,
-    L: ExternalLink,
     B: PacketReceiveBarrier,
     D: SocketDiagnostic,
     S: ManifestStore,
-    T: RouteTable,
 >(
     gate: &G,
-    link: &L,
     receive_barrier: &B,
     diagnostic: &mut D,
     store: &S,
-    route_table: &T,
     budget: std::time::Duration,
 ) -> Result<RestoreNetworkReport> {
     // The gate chains are VERIFIED rather than reinstalled; the link-down and
@@ -1670,9 +1420,11 @@ async fn restore_with<
             .await
             .context("ensuring restored snapshot TCP NEW-flow gate is closed")?;
     }
-    link.down()
-        .await
-        .context("ensuring the restored external link is down during socket cleanup")?;
+    // No link-down here either. The clone inherits a CLOSED gate inside the
+    // artifact, so no new flow can appear while the recorded cookies are
+    // destroyed, and the barrier below drains what was already in flight.
+    // Downing the link would purge this clone's routes and neighbours, and the
+    // boundary no longer captures routes to put them back.
     receive_barrier
         .synchronize()
         .context("waiting for restored packet receive processing to quiesce")?;
@@ -1713,7 +1465,7 @@ async fn restore_with<
         .context("retiring snapshot network manifest after cookie-bound cleanup")?;
     let destroy_ms = destroy_started.elapsed().as_secs_f64() * 1000.0;
     let reopen_started = std::time::Instant::now();
-    reopen_with(gate, link, route_table, &manifest.routes)
+    reopen_with(gate)
         .await
         .context("publishing restored network after cookie-bound cleanup")?;
     Ok(RestoreNetworkReport {
@@ -1729,21 +1481,17 @@ async fn restore_with<
 pub async fn prepare_snapshot_network() -> Result<()> {
     let _transaction_lock = acquire_boundary_lock()?;
     let gate = IptablesGate::new(SystemCommandRunner);
-    let link = IpLink::new(external_interface()?);
     let receive_barrier = SystemPacketReceiveBarrier;
     let mut diagnostic = SystemSocketDiagnostic;
-    let route_table = IpRoutes::new(SystemCommandRunner);
     let captured = prepare_with(
         &gate,
-        &link,
         &receive_barrier,
         &mut diagnostic,
         &FileManifestStore::default(),
-        &route_table,
     )
     .await?;
     eprintln!(
-        "[fc-agent] snapshot network boundary prepared: gate=closed link=down \
+        "[fc-agent] snapshot network boundary prepared: gate=closed link=UNTOUCHED \
          external_socket_cookies={captured}"
     );
     Ok(())
@@ -1752,56 +1500,38 @@ pub async fn prepare_snapshot_network() -> Result<()> {
 pub async fn resume_source_network() -> Result<()> {
     let _transaction_lock = acquire_boundary_lock()?;
     let gate = IptablesGate::new(SystemCommandRunner);
-    let link = IpLink::new(external_interface()?);
-    let route_table = IpRoutes::new(SystemCommandRunner);
     let store = FileManifestStore::default();
-    // Read the routes out before retiring the manifest that holds them: this
-    // is the source VM resuming after its own snapshot, and its link-down
-    // purged the same routes a clone's would.
-    let captured = store.load().map(|manifest| manifest.routes);
-    let routes = match captured {
-        Ok(routes) => routes,
-        // The source can be resumed without a manifest (a preparation that
-        // failed before saving one). Publishing the link still has to happen;
-        // there is simply nothing recorded to reinstate.
-        Err(error) => {
-            eprintln!(
-                "[fc-agent] no snapshot network manifest to read routes from, \
-                 reopening without reinstating any: {error:#}"
-            );
-            Vec::new()
-        }
-    };
+    // No routes to read back: the boundary never takes the link down, so it
+    // purges nothing. The manifest is retired purely to clear the armed marker.
     store
         .remove()
         .context("retiring source snapshot network manifest before publication")?;
-    reopen_with(&gate, &link, &route_table, &routes)
+    reopen_with(&gate)
         .await
         .context("reopening source VM network")?;
-    eprintln!("[fc-agent] source VM snapshot network reopened: link=up gate=open");
+    eprintln!(
+        "[fc-agent] source VM snapshot network reopened: gate=open \
+         (link never taken down)"
+    );
     Ok(())
 }
 
 pub async fn restore_snapshot_network() -> Result<RestoreNetworkReport> {
     let _transaction_lock = acquire_boundary_lock()?;
     let gate = IptablesGate::new(SystemCommandRunner);
-    let link = IpLink::new(external_interface()?);
     let receive_barrier = SystemPacketReceiveBarrier;
     let mut diagnostic = SystemSocketDiagnostic;
-    let route_table = IpRoutes::new(SystemCommandRunner);
     let report = restore_with(
         &gate,
-        &link,
         &receive_barrier,
         &mut diagnostic,
         &FileManifestStore::default(),
-        &route_table,
         CLEANUP_BUDGET,
     )
     .await?;
     eprintln!(
         "[fc-agent] snapshot network cleanup complete: destroyed={} already_gone={} \
-         verified_armed={} link=up gate=open",
+         verified_armed={} link=UNTOUCHED gate=open",
         report.tally.destroyed, report.tally.already_gone, report.verified_armed
     );
     Ok(report)
@@ -1921,61 +1651,6 @@ mod tests {
         }
     }
 
-    #[derive(Clone)]
-    struct ModelLink(Arc<Mutex<ModelState>>);
-
-    impl ExternalLink for ModelLink {
-        async fn down(&self) -> Result<()> {
-            let mut state = self.0.lock().unwrap();
-            state.link_down = true;
-            // Measured on a bridged guest: the whole table goes with the link.
-            state.live_routes.clear();
-            state.events.push("link-down");
-            Ok(())
-        }
-
-        async fn up(&self) -> Result<()> {
-            let mut state = self.0.lock().unwrap();
-            assert!(
-                !state.gate_closed,
-                "link publication raced ahead of complete gate removal"
-            );
-            state.link_down = false;
-            state.events.push("link-up");
-            Ok(())
-        }
-    }
-
-    #[derive(Clone)]
-    struct ModelRoutes(Arc<Mutex<ModelState>>);
-
-    impl RouteTable for ModelRoutes {
-        async fn capture(&self) -> Result<Vec<CapturedRoute>> {
-            let mut state = self.0.lock().unwrap();
-            assert!(
-                !state.link_down,
-                "routes were captured after the link went down, when the table is already empty"
-            );
-            state.events.push("routes-capture");
-            Ok(state.live_routes.clone())
-        }
-
-        async fn reinstate(&self, routes: &[CapturedRoute]) -> Result<()> {
-            let mut state = self.0.lock().unwrap();
-            assert!(
-                !state.link_down,
-                "routes were reinstated while the link was still down, where they cannot bind"
-            );
-            state.events.push("routes-reinstate");
-            for route in routes {
-                if !state.live_routes.contains(route) {
-                    state.live_routes.push(route.clone());
-                }
-            }
-            Ok(())
-        }
-    }
-
     fn model_routes() -> Vec<CapturedRoute> {
         vec![
             CapturedRoute {
@@ -1998,9 +1673,15 @@ mod tests {
                 state.gate_closed,
                 "receive barrier ran before the NEW-flow gate"
             );
+            // The link is deliberately never touched: the gate already rejects
+            // NEW flows, and downing the link additionally purged the device's
+            // routes and neighbours. Both purges reached production as silent
+            // failures (ee3f5c30; the 2026-08-15 published-port flake). A
+            // boundary that starts downing links again fails here.
             assert!(
-                state.link_down,
-                "receive barrier ran before the link was down"
+                !state.link_down,
+                "the snapshot boundary took the link down: it must not disturb \
+                 the VM being snapshotted"
             );
             state.events.push("rx-barrier");
             if state.fail_barrier {
@@ -2019,7 +1700,15 @@ mod tests {
                 state.gate_closed,
                 "cookie dump raced ahead of the NEW-flow gate"
             );
-            assert!(state.link_down, "cookie dump raced ahead of link-down");
+            assert!(
+                state.events.contains(&"rx-barrier"),
+                "cookie dump raced ahead of the receive barrier"
+            );
+            assert!(
+                !state.link_down,
+                "the snapshot boundary took the link down: it must not disturb \
+                 the VM being snapshotted"
+            );
             state.events.push("cookie-dump");
             if state.fail_dump {
                 bail!("injected socket dump failure");
@@ -2033,9 +1722,12 @@ mod tests {
                 state.gate_closed,
                 "restore opened the gate before destroying sockets"
             );
+            // The closed gate is what protects the cleanup; the link stays up
+            // throughout so the clone's routes and neighbours survive.
             assert!(
-                state.link_down,
-                "restore brought the link up before destroying sockets"
+                !state.link_down,
+                "restore took the link down: the boundary must not purge the \
+                 clone's routes and neighbours"
             );
             state.events.push("cookie-destroy");
             if state.fail_destroy {
@@ -2360,65 +2052,6 @@ COMMIT\\n\"",
         assert_eq!(calls.lock().unwrap().as_slice(), ["iptables -w -S"]);
     }
 
-    /// Build a `/sys/class/net` where the `backed` interfaces carry the
-    /// `device` symlink a bus-attached netdev has and the others do not.
-    fn fake_sysfs_net(interfaces: &[(&str, bool)]) -> tempfile::TempDir {
-        let dir = tempfile::tempdir().unwrap();
-        let devices = dir.path().join("devices");
-        std::fs::create_dir_all(&devices).unwrap();
-        for (name, backed) in interfaces {
-            let interface = dir.path().join(name);
-            std::fs::create_dir_all(&interface).unwrap();
-            if *backed {
-                let device = devices.join(name);
-                std::fs::create_dir_all(&device).unwrap();
-                std::os::unix::fs::symlink(&device, interface.join("device")).unwrap();
-            }
-        }
-        dir
-    }
-
-    #[test]
-    fn external_interface_is_the_device_backed_netdev_under_either_hypervisor() {
-        // Measured in live guests: Cloud Hypervisor's PCI virtio-net is renamed
-        // to enp0s4, Firecracker's MMIO virtio-net keeps eth0, and on both only
-        // `lo` lacks the device symlink.
-        let cloud_hypervisor = fake_sysfs_net(&[("enp0s4", true), ("lo", false)]);
-        assert_eq!(
-            external_interface_in(cloud_hypervisor.path()).unwrap(),
-            "enp0s4"
-        );
-
-        let firecracker = fake_sysfs_net(&[("eth0", true), ("lo", false)]);
-        assert_eq!(external_interface_in(firecracker.path()).unwrap(), "eth0");
-    }
-
-    #[test]
-    fn an_ambiguous_interface_set_fails_instead_of_guessing() {
-        let loopback_only = fake_sysfs_net(&[("lo", false)]);
-        let err = external_interface_in(loopback_only.path())
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("found []"), "{err}");
-
-        let two = fake_sysfs_net(&[("enp0s4", true), ("eth0", true), ("lo", false)]);
-        let err = external_interface_in(two.path()).unwrap_err().to_string();
-        assert!(err.contains("enp0s4") && err.contains("eth0"), "{err}");
-    }
-
-    #[test]
-    fn an_overlong_interface_name_is_refused_rather_than_truncated() {
-        // ifreq's name field is fixed-size; a silently truncated name would
-        // drive the WRONG interface's flags.
-        let too_long = "x".repeat(64);
-        let error = set_interface_up(&too_long, false)
-            .expect_err("an interface name that cannot fit must be refused");
-        assert!(
-            format!("{error:#}").contains("does not fit"),
-            "unexpected diagnostic: {error:#}"
-        );
-    }
-
     #[tokio::test]
     async fn snapshot_boundary_closes_new_flows_before_cookie_dump() {
         let state = Arc::new(Mutex::new(ModelState {
@@ -2426,97 +2059,67 @@ COMMIT\\n\"",
             ..Default::default()
         }));
         let gate = ModelGate(state.clone());
-        let link = ModelLink(state.clone());
         let barrier = ModelBarrier(state.clone());
-        let route_table = ModelRoutes(state.clone());
         state.lock().unwrap().live_routes = model_routes();
         let mut diag = ModelDiag(state.clone());
         let store = MemoryStore::default();
 
         assert_eq!(
-            prepare_with(&gate, &link, &barrier, &mut diag, &store, &route_table)
+            prepare_with(&gate, &barrier, &mut diag, &store)
                 .await
                 .unwrap(),
             1
         );
         assert_eq!(
             state.lock().unwrap().events,
-            vec![
-                "routes-capture",
-                "gate-close",
-                "link-down",
-                "rx-barrier",
-                "cookie-dump"
-            ]
+            vec!["gate-close", "rx-barrier", "cookie-dump"]
         );
         let state_guard = state.lock().unwrap();
         assert!(state_guard.gate_closed);
-        assert!(state_guard.link_down);
+        assert!(!state_guard.link_down, "the source's link was taken down");
         drop(state_guard);
         assert_eq!(store.load().unwrap().sockets[0].id.cookie, [11, 0]);
     }
 
     /// The boundary must hand back the route table it took away.
     ///
-    /// Taking the link down purges every route; bringing it up restores only the
-    /// kernel's own. Measured on a bridged guest (Graviton3, 6.18.44), a
-    /// prepare/resume cycle left `default via 172.30.95.37` and the MMDS route
-    /// `169.254.169.254` permanently gone — the guest's only path off-box and
-    /// the address fc-agent reads its restore epoch from. Before the fix, this
-    /// observed an empty table after the cycle.
+    /// The boundary must not purge the route table at all.
+    ///
+    /// This test used to prove the opposite: that the link-down emptied the
+    /// table and the boundary put it back. That repair was the design, and it
+    /// was incomplete twice - routes were reinstated (ee3f5c30) but neighbours
+    /// were not, and the missing neighbour entry made published ports die about
+    /// 1 snapshot in 10. The link-down is gone, so nothing is purged and there
+    /// is nothing to reinstate. This is what keeps it that way.
     #[tokio::test]
-    async fn the_boundary_reinstates_the_routes_its_link_down_purged() {
+    async fn the_boundary_never_purges_the_route_table() {
         let state = Arc::new(Mutex::new(ModelState::default()));
         let gate = ModelGate(state.clone());
-        let link = ModelLink(state.clone());
         let barrier = ModelBarrier(state.clone());
-        let route_table = ModelRoutes(state.clone());
         state.lock().unwrap().live_routes = model_routes();
         let mut diag = ModelDiag(state.clone());
         let store = MemoryStore::default();
 
-        prepare_with(&gate, &link, &barrier, &mut diag, &store, &route_table)
+        prepare_with(&gate, &barrier, &mut diag, &store)
             .await
             .expect("preparation");
-        assert!(
-            state.lock().unwrap().live_routes.is_empty(),
-            "the model must reproduce the kernel's purge, or this test cannot fail"
-        );
-        assert_eq!(
-            store.load().unwrap().routes,
-            model_routes(),
-            "the manifest must carry the routes across the snapshot"
-        );
-
-        restore_with(
-            &gate,
-            &link,
-            &barrier,
-            &mut diag,
-            &store,
-            &route_table,
-            CLEANUP_BUDGET,
-        )
-        .await
-        .expect("restore");
         assert_eq!(
             state.lock().unwrap().live_routes,
             model_routes(),
-            "a restored clone was published without the routes it needs to reach anything"
+            "preparing the boundary purged the source's routes"
         );
 
-        let events = state.lock().unwrap().events.clone();
-        let reinstate = events
-            .iter()
-            .rposition(|event| *event == "routes-reinstate")
-            .expect("routes were never reinstated");
-        let link_up = events
-            .iter()
-            .rposition(|event| *event == "link-up")
-            .expect("the link was never published");
+        restore_with(&gate, &barrier, &mut diag, &store, CLEANUP_BUDGET)
+            .await
+            .expect("restore");
+        assert_eq!(
+            state.lock().unwrap().live_routes,
+            model_routes(),
+            "restoring purged the clone's routes"
+        );
         assert!(
-            link_up < reinstate,
-            "routes were reinstated before the link came up, where they cannot bind: {events:?}"
+            store.load().is_err(),
+            "the manifest must be retired after cleanup"
         );
     }
 
@@ -2531,15 +2134,13 @@ COMMIT\\n\"",
             ..Default::default()
         }));
         let gate = ModelGate(state.clone());
-        let link = ModelLink(state.clone());
         let barrier = ModelBarrier(state.clone());
-        let route_table = ModelRoutes(state.clone());
         state.lock().unwrap().live_routes = model_routes();
         let mut diag = ModelDiag(state);
         let store = MemoryStore::default();
 
         assert_eq!(
-            prepare_with(&gate, &link, &barrier, &mut diag, &store, &route_table)
+            prepare_with(&gate, &barrier, &mut diag, &store)
                 .await
                 .unwrap(),
             1
@@ -2554,29 +2155,18 @@ COMMIT\\n\"",
             ..Default::default()
         }));
         let gate = ModelGate(state.clone());
-        let link = ModelLink(state.clone());
         let barrier = ModelBarrier(state.clone());
-        let route_table = ModelRoutes(state.clone());
         state.lock().unwrap().live_routes = model_routes();
         let mut diag = ModelDiag(state.clone());
         let store = MemoryStore::default();
 
-        prepare_with(&gate, &link, &barrier, &mut diag, &store, &route_table)
+        prepare_with(&gate, &barrier, &mut diag, &store)
             .await
             .expect_err("snapshot preparation must fail when cookie capture fails");
         let state = state.lock().unwrap();
         assert_eq!(
             state.events,
-            vec![
-                "routes-capture",
-                "gate-close",
-                "link-down",
-                "rx-barrier",
-                "cookie-dump",
-                "gate-open",
-                "link-up",
-                "routes-reinstate"
-            ]
+            vec!["gate-close", "rx-barrier", "cookie-dump", "gate-open",]
         );
         assert!(
             !state.gate_closed,
@@ -2592,29 +2182,16 @@ COMMIT\\n\"",
             ..Default::default()
         }));
         let gate = ModelGate(state.clone());
-        let link = ModelLink(state.clone());
         let barrier = ModelBarrier(state.clone());
-        let route_table = ModelRoutes(state.clone());
         state.lock().unwrap().live_routes = model_routes();
         let mut diag = ModelDiag(state.clone());
         let store = MemoryStore::default();
 
-        prepare_with(&gate, &link, &barrier, &mut diag, &store, &route_table)
+        prepare_with(&gate, &barrier, &mut diag, &store)
             .await
             .expect_err("snapshot preparation must fail without a receive grace period");
         let state = state.lock().unwrap();
-        assert_eq!(
-            state.events,
-            vec![
-                "routes-capture",
-                "gate-close",
-                "link-down",
-                "rx-barrier",
-                "gate-open",
-                "link-up",
-                "routes-reinstate"
-            ]
-        );
+        assert_eq!(state.events, vec!["gate-close", "rx-barrier", "gate-open",]);
         assert!(!state.gate_closed);
         assert!(!state.link_down);
         assert!(
@@ -2630,27 +2207,16 @@ COMMIT\\n\"",
             ..Default::default()
         }));
         let gate = ModelGate(state.clone());
-        let link = ModelLink(state.clone());
         let barrier = ModelBarrier(state.clone());
-        let route_table = ModelRoutes(state.clone());
         state.lock().unwrap().live_routes = model_routes();
         let mut diag = ModelDiag(state.clone());
         let store = MemoryStore::default();
 
-        prepare_with(&gate, &link, &barrier, &mut diag, &store, &route_table)
+        prepare_with(&gate, &barrier, &mut diag, &store)
             .await
             .expect_err("partial gate installation must abort snapshot preparation");
         let state = state.lock().unwrap();
-        assert_eq!(
-            state.events,
-            vec![
-                "routes-capture",
-                "gate-close",
-                "gate-open",
-                "link-up",
-                "routes-reinstate"
-            ]
-        );
+        assert_eq!(state.events, vec!["gate-close", "gate-open",]);
         assert!(!state.gate_closed);
         assert!(!state.link_down);
     }
@@ -2661,7 +2227,6 @@ COMMIT\\n\"",
         let replacement = socket(22, [198, 51, 100, 8]);
         let state = Arc::new(Mutex::new(ModelState {
             gate_closed: true,
-            link_down: true,
             live: vec![replacement],
             ..Default::default()
         }));
@@ -2674,9 +2239,7 @@ COMMIT\\n\"",
             })
             .unwrap();
         let gate = ModelGate(state.clone());
-        let link = ModelLink(state.clone());
         let barrier = ModelBarrier(state.clone());
-        let route_table = ModelRoutes(state.clone());
         state.lock().unwrap().live_routes = model_routes();
         let mut diag = ModelDiag(state.clone());
 
@@ -2685,17 +2248,9 @@ COMMIT\\n\"",
         // replacement. A cookie-bound destroy must therefore report
         // already_gone and leave the replacement alone; a tuple-based one would
         // report a destroy and take the wrong socket with it.
-        let report = restore_with(
-            &gate,
-            &link,
-            &barrier,
-            &mut diag,
-            &store,
-            &route_table,
-            CLEANUP_BUDGET,
-        )
-        .await
-        .unwrap();
+        let report = restore_with(&gate, &barrier, &mut diag, &store, CLEANUP_BUDGET)
+            .await
+            .unwrap();
         assert_eq!(
             report.tally,
             CleanupTally {
@@ -2708,15 +2263,7 @@ COMMIT\\n\"",
         assert_eq!(state.live, vec![replacement]);
         assert_eq!(
             state.events,
-            vec![
-                "gate-verify",
-                "link-down",
-                "rx-barrier",
-                "cookie-destroy",
-                "gate-open",
-                "link-up",
-                "routes-reinstate"
-            ]
+            vec!["gate-verify", "rx-barrier", "cookie-destroy", "gate-open",]
         );
         assert!(!state.gate_closed);
         assert!(!state.link_down);
@@ -2732,7 +2279,6 @@ COMMIT\\n\"",
         let stale = socket(28, [198, 51, 100, 8]);
         let state = Arc::new(Mutex::new(ModelState {
             gate_closed: true,
-            link_down: true,
             live: vec![stale],
             fail_gate_verify: true,
             ..Default::default()
@@ -2746,22 +2292,12 @@ COMMIT\\n\"",
             })
             .unwrap();
         let gate = ModelGate(state.clone());
-        let link = ModelLink(state.clone());
         let barrier = ModelBarrier(state.clone());
-        let route_table = ModelRoutes(state.clone());
         let mut diag = ModelDiag(state.clone());
 
-        let report = restore_with(
-            &gate,
-            &link,
-            &barrier,
-            &mut diag,
-            &store,
-            &route_table,
-            CLEANUP_BUDGET,
-        )
-        .await
-        .expect("an unverifiable boundary must repair, not fail the restore");
+        let report = restore_with(&gate, &barrier, &mut diag, &store, CLEANUP_BUDGET)
+            .await
+            .expect("an unverifiable boundary must repair, not fail the restore");
         assert!(!report.verified_armed);
         let state = state.lock().unwrap();
         assert_eq!(
@@ -2769,12 +2305,9 @@ COMMIT\\n\"",
             vec![
                 "gate-verify",
                 "gate-close",
-                "link-down",
                 "rx-barrier",
                 "cookie-destroy",
                 "gate-open",
-                "link-up",
-                "routes-reinstate"
             ]
         );
     }
@@ -2783,7 +2316,7 @@ COMMIT\\n\"",
     /// packets can arrive on it: the boundary must down it and take a fresh
     /// grace period before retiring any socket, whatever the gate says.
     #[tokio::test]
-    async fn a_raised_link_is_downed_and_re_barriered_before_cleanup() {
+    async fn restore_re_barriers_before_cleanup_without_touching_the_link() {
         let stale = socket(29, [198, 51, 100, 8]);
         let state = Arc::new(Mutex::new(ModelState {
             gate_closed: true,
@@ -2800,52 +2333,42 @@ COMMIT\\n\"",
             })
             .unwrap();
         let gate = ModelGate(state.clone());
-        let link = ModelLink(state.clone());
         let barrier = ModelBarrier(state.clone());
-        let route_table = ModelRoutes(state.clone());
         let mut diag = ModelDiag(state.clone());
 
-        let report = restore_with(
-            &gate,
-            &link,
-            &barrier,
-            &mut diag,
-            &store,
-            &route_table,
-            CLEANUP_BUDGET,
-        )
-        .await
-        .unwrap();
+        let report = restore_with(&gate, &barrier, &mut diag, &store, CLEANUP_BUDGET)
+            .await
+            .unwrap();
         assert!(report.verified_armed, "the gate itself was intact");
         let events = state.lock().unwrap().events.clone();
         let barrier = events
             .iter()
             .position(|e| *e == "rx-barrier")
             .expect("barrier");
-        let down = events
-            .iter()
-            .position(|e| *e == "link-down")
-            .expect("link-down");
+        assert!(
+            !events.contains(&"link-down"),
+            "restore took the link down: the boundary must not purge the clone's \
+             routes and neighbours"
+        );
         let destroy = events
             .iter()
             .position(|e| *e == "cookie-destroy")
             .expect("cleanup");
         assert!(
-            down < barrier && barrier < destroy,
-            "a raised link must be downed and re-barriered BEFORE cleanup: {events:?}"
+            barrier < destroy,
+            "the receive barrier must run BEFORE cleanup: {events:?}"
         );
     }
 
     /// The gate chains frozen into a current snapshot are verified, not
-    /// reinstalled. The link-down and the receive barrier are asserted
-    /// regardless, because a privileged workload sharing this namespace can
-    /// raise the link between any observation and the cleanup.
+    /// reinstalled. The receive barrier still runs regardless, because a
+    /// privileged workload sharing this namespace can put packets in flight
+    /// between any observation and the cleanup.
     #[tokio::test]
     async fn restore_verifies_the_armed_boundary_instead_of_reasserting_it() {
         let stale = socket(26, [198, 51, 100, 8]);
         let state = Arc::new(Mutex::new(ModelState {
             gate_closed: true,
-            link_down: true,
             live: vec![stale],
             ..Default::default()
         }));
@@ -2858,22 +2381,12 @@ COMMIT\\n\"",
             })
             .unwrap();
         let gate = ModelGate(state.clone());
-        let link = ModelLink(state.clone());
         let barrier = ModelBarrier(state.clone());
-        let route_table = ModelRoutes(state.clone());
         let mut diag = ModelDiag(state.clone());
 
-        let report = restore_with(
-            &gate,
-            &link,
-            &barrier,
-            &mut diag,
-            &store,
-            &route_table,
-            CLEANUP_BUDGET,
-        )
-        .await
-        .unwrap();
+        let report = restore_with(&gate, &barrier, &mut diag, &store, CLEANUP_BUDGET)
+            .await
+            .unwrap();
         assert!(report.verified_armed);
         let state = state.lock().unwrap();
         assert!(
@@ -2883,15 +2396,7 @@ COMMIT\\n\"",
         );
         assert_eq!(
             state.events,
-            vec![
-                "gate-verify",
-                "link-down",
-                "rx-barrier",
-                "cookie-destroy",
-                "gate-open",
-                "link-up",
-                "routes-reinstate"
-            ],
+            vec!["gate-verify", "rx-barrier", "cookie-destroy", "gate-open",],
             "the link and the barrier must be re-asserted even on the fast path"
         );
     }
@@ -2915,22 +2420,12 @@ COMMIT\\n\"",
             })
             .unwrap();
         let gate = ModelGate(state.clone());
-        let link = ModelLink(state.clone());
         let barrier = ModelBarrier(state.clone());
-        let route_table = ModelRoutes(state.clone());
         let mut diag = ModelDiag(state.clone());
 
-        let report = restore_with(
-            &gate,
-            &link,
-            &barrier,
-            &mut diag,
-            &store,
-            &route_table,
-            CLEANUP_BUDGET,
-        )
-        .await
-        .unwrap();
+        let report = restore_with(&gate, &barrier, &mut diag, &store, CLEANUP_BUDGET)
+            .await
+            .unwrap();
         assert!(!report.verified_armed);
         let state = state.lock().unwrap();
         assert_eq!(
@@ -2938,12 +2433,9 @@ COMMIT\\n\"",
             vec![
                 "gate-verify",
                 "gate-close",
-                "link-down",
                 "rx-barrier",
                 "cookie-destroy",
                 "gate-open",
-                "link-up",
-                "routes-reinstate"
             ]
         );
         assert!(!state.gate_closed);
@@ -2955,7 +2447,6 @@ COMMIT\\n\"",
         let stale = socket(23, [198, 51, 100, 8]);
         let state = Arc::new(Mutex::new(ModelState {
             gate_closed: true,
-            link_down: true,
             live: vec![stale],
             fail_destroy: true,
             ..Default::default()
@@ -2969,30 +2460,23 @@ COMMIT\\n\"",
             })
             .unwrap();
         let gate = ModelGate(state.clone());
-        let link = ModelLink(state.clone());
         let barrier = ModelBarrier(state.clone());
-        let route_table = ModelRoutes(state.clone());
         state.lock().unwrap().live_routes = model_routes();
         let mut diag = ModelDiag(state.clone());
 
-        restore_with(
-            &gate,
-            &link,
-            &barrier,
-            &mut diag,
-            &store,
-            &route_table,
-            CLEANUP_BUDGET,
-        )
-        .await
-        .expect_err("a failed exact destroy must fail restore closed");
+        restore_with(&gate, &barrier, &mut diag, &store, CLEANUP_BUDGET)
+            .await
+            .expect_err("a failed exact destroy must fail restore closed");
         let state = state.lock().unwrap();
         assert_eq!(
             state.events,
-            vec!["gate-verify", "link-down", "rx-barrier", "cookie-destroy"]
+            vec!["gate-verify", "rx-barrier", "cookie-destroy"]
         );
         assert!(state.gate_closed, "failed restore published ingress");
-        assert!(state.link_down, "failed restore raised the external link");
+        assert!(
+            !state.link_down,
+            "a failed restore must not have downed the link"
+        );
         assert!(
             store.load().is_ok(),
             "failed restore removed its identity manifest"
@@ -3004,7 +2488,6 @@ COMMIT\\n\"",
         let stale = socket(24, [198, 51, 100, 8]);
         let state = Arc::new(Mutex::new(ModelState {
             gate_closed: true,
-            link_down: true,
             live: vec![stale],
             ..Default::default()
         }));
@@ -3017,23 +2500,13 @@ COMMIT\\n\"",
             })
             .unwrap();
         let gate = ModelGate(state.clone());
-        let link = ModelLink(state.clone());
         let barrier = ModelBarrier(state.clone());
-        let route_table = ModelRoutes(state.clone());
         state.lock().unwrap().live_routes = model_routes();
         let mut diag = ModelDiag(state.clone());
 
-        let error = restore_with(
-            &gate,
-            &link,
-            &barrier,
-            &mut diag,
-            &store,
-            &route_table,
-            CLEANUP_BUDGET,
-        )
-        .await
-        .expect_err("manifest retirement failure must prevent clone publication");
+        let error = restore_with(&gate, &barrier, &mut diag, &store, CLEANUP_BUDGET)
+            .await
+            .expect_err("manifest retirement failure must prevent clone publication");
         assert!(
             format!("{error:#}").contains("retiring snapshot network manifest"),
             "unexpected diagnostic: {error:#}"
@@ -3041,10 +2514,10 @@ COMMIT\\n\"",
         let state = state.lock().unwrap();
         assert_eq!(
             state.events,
-            vec!["gate-verify", "link-down", "rx-barrier", "cookie-destroy"]
+            vec!["gate-verify", "rx-barrier", "cookie-destroy"]
         );
         assert!(state.gate_closed);
-        assert!(state.link_down);
+        assert!(!state.link_down, "the boundary took the link down");
     }
 
     #[tokio::test]
@@ -3052,7 +2525,6 @@ COMMIT\\n\"",
         let stale = socket(25, [198, 51, 100, 8]);
         let state = Arc::new(Mutex::new(ModelState {
             gate_closed: true,
-            link_down: true,
             live: vec![stale],
             ..Default::default()
         }));
@@ -3065,9 +2537,7 @@ COMMIT\\n\"",
             })
             .unwrap();
         let gate = ModelGate(state.clone());
-        let link = ModelLink(state.clone());
         let barrier = ModelBarrier(state.clone());
-        let route_table = ModelRoutes(state.clone());
         state.lock().unwrap().live_routes = model_routes();
         let mut diag = ModelDiag(state.clone());
 
@@ -3077,11 +2547,9 @@ COMMIT\\n\"",
         // never publish, and never retire the manifest.
         let error = restore_with(
             &gate,
-            &link,
             &barrier,
             &mut diag,
             &store,
-            &route_table,
             std::time::Duration::ZERO,
         )
         .await
@@ -3092,11 +2560,12 @@ COMMIT\\n\"",
         );
 
         let state = state.lock().unwrap();
-        assert_eq!(state.events, vec!["gate-verify", "link-down", "rx-barrier"]);
+        assert_eq!(state.events, vec!["gate-verify", "rx-barrier"]);
         assert!(state.gate_closed, "a timed-out cleanup published ingress");
         assert!(
-            state.link_down,
-            "a timed-out cleanup raised the external link"
+            !state.link_down,
+            "a timed-out cleanup took the link down: even the failure path must \
+             not purge the clone's routes and neighbours"
         );
         assert!(
             store.load().is_ok(),

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -1732,6 +1732,45 @@ mod tests {
         );
     }
 
+    /// Every bridge the guest reaches through NAMESPACE_IP must carry
+    /// NAMESPACE_MAC.
+    ///
+    /// The guest pins ONE permanent neighbour entry for 10.0.2.1 and cannot
+    /// tell which networking mode it booted under. Rootless mode reaches that
+    /// address on pasta's bridge; ROUTED mode uses the very same address as the
+    /// guest's DEFAULT GATEWAY on a bridge of its own. Pinning the MAC in only
+    /// one of them sends every reply in the other to an address nothing owns --
+    /// which is not a degraded published port there, it is all IPv4 egress.
+    /// That regression shipped once and CI caught it as eight routed-mode
+    /// failures across both architectures.
+    #[test]
+    fn every_bridge_on_the_namespace_address_pins_the_same_mac() {
+        let routed = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/network/routed.rs"),
+        )
+        .expect("reading src/network/routed.rs");
+
+        assert!(
+            routed.contains("NAMESPACE_MAC"),
+            "routed mode does not pin its bridge to NAMESPACE_MAC. Its guests \
+             reach {} as their default gateway and hold a permanent neighbour \
+             entry for {}; an unpinned bridge MAC breaks all of their IPv4.",
+            NAMESPACE_IP,
+            NAMESPACE_MAC
+        );
+        assert!(
+            routed.contains("\"address\","),
+            "routed mode references NAMESPACE_MAC but never sets a link address \
+             with it"
+        );
+        assert!(
+            routed.contains(&format!("GUEST_GATEWAY: &str = \"{}\"", NAMESPACE_IP)),
+            "routed mode's gateway is no longer {}; re-check whether the guest's \
+             pinned neighbour entry still names the right address",
+            NAMESPACE_IP
+        );
+    }
+
     /// fc-agent hardcodes the same pair (it has no boot-plan field for them),
     /// so a change here that is not mirrored there silently reopens the ARP
     /// race that made published ports go silent. Read the guest's copy rather

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -2063,6 +2063,9 @@ mod tests {
             vec![
                 "link set pasta0 up",
                 "link add br0 type bridge",
+                // Pinned so the guest can hold an authoritative neighbour entry
+                // for the health-check address instead of racing pasta for one.
+                "link set br0 address 02:fc:00:00:02:01",
                 "link set br0 up",
                 "link set pasta0 master br0",
                 "link set tap-fc master br0",
@@ -2085,7 +2088,7 @@ mod tests {
 
         // `ip -batch` aborts at the first failing line and reports `-:<line>`.
         let msg = script.describe_failure("RTNETLINK answers: File exists\nCommand failed -:2\n");
-        assert!(msg.contains("step 2/6"), "missing step index: {msg}");
+        assert!(msg.contains("step 2/7"), "missing step index: {msg}");
         assert!(
             msg.contains("create L2 bridge br0"),
             "missing step name: {msg}"

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -16,6 +16,24 @@ const GUEST_IP: &str = "10.0.2.100";
 const GUEST_GATEWAY: &str = "10.0.2.2";
 /// Namespace IP on bridge — enables nsenter health checks to route to guest
 const NAMESPACE_IP: &str = "10.0.2.1";
+/// Fixed MAC for the bridge, so the guest can hold an AUTHORITATIVE neighbour
+/// entry for NAMESPACE_IP instead of racing for one.
+///
+/// Both the bridge and pasta answer ARP for 10.0.2.1: the bridge because it
+/// owns the address, pasta because it answers for the subnet it routes. Whoever
+/// wins that race decides where the guest sends its replies. When pasta won,
+/// the guest sent its SYN-ACK to pasta's MAC, pasta correctly reset a
+/// connection it had never opened, and the published port went silent with no
+/// drop recorded anywhere (2026-08-15). Measured directly on the wire:
+///
+///   SYN      br0-mac  > guest-mac   10.0.2.1 > 10.0.2.100  [S]
+///   SYN-ACK  guest-mac > 9a:55:...  10.0.2.100 > 10.0.2.1  [S.]   <- pasta, not br0
+///   RST      9a:55:... > guest-mac  10.0.2.1 > 10.0.2.100  [R]
+///
+/// A fixed MAC lets fc-agent install a PERMANENT neighbour entry, which ARP
+/// replies cannot override, so the race has no outcome to win. pasta already
+/// uses a fixed MAC (9a:55:9a:55:9a:55) for the same kind of reason.
+pub const NAMESPACE_MAC: &str = "02:fc:00:00:02:01";
 
 /// Guest IPv6 addressing (pasta copies host IPv6 with fd00::/64 fallback)
 const GUEST_IPV6: &str = "fd00::100";
@@ -596,6 +614,10 @@ impl PastaNetwork {
                 (
                     format!("create L2 bridge {}", bridge),
                     format!("link add {} type bridge", bridge),
+                ),
+                (
+                    format!("pin bridge {} MAC to {}", bridge, NAMESPACE_MAC),
+                    format!("link set {} address {}", bridge, NAMESPACE_MAC),
                 ),
                 (
                     format!("bring bridge {} up", bridge),
@@ -1707,6 +1729,41 @@ mod tests {
         assert!(
             message.contains("stderr written immediately before timeout kill"),
             "{message}"
+        );
+    }
+
+    /// fc-agent hardcodes the same pair (it has no boot-plan field for them),
+    /// so a change here that is not mirrored there silently reopens the ARP
+    /// race that made published ports go silent. Read the guest's copy rather
+    /// than trusting a comment.
+    #[test]
+    fn namespace_neighbour_matches_host_constants() {
+        let agent = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("fc-agent/src/network.rs"),
+        )
+        .expect("reading fc-agent/src/network.rs");
+
+        for (label, value) in [
+            ("NAMESPACE_IP", NAMESPACE_IP),
+            ("NAMESPACE_MAC", NAMESPACE_MAC),
+        ] {
+            let needle = format!("const {}: &str = \"{}\";", label, value);
+            assert!(
+                agent.contains(&needle),
+                "fc-agent does not define {} as {:?}. The guest pins a permanent \
+                 neighbour entry using its own copy of this constant; if the two \
+                 disagree, the entry points at the wrong MAC and inbound \
+                 connections are reset by pasta. Expected line: {}",
+                label,
+                value,
+                needle
+            );
+        }
+
+        assert!(
+            agent.contains("nud"),
+            "fc-agent no longer installs a permanent neighbour entry; a dynamic \
+             one loses to pasta's ARP reply about 1 time in 10"
         );
     }
 

--- a/src/network/routed.rs
+++ b/src/network/routed.rs
@@ -484,6 +484,25 @@ impl NetworkManager for RoutedNetwork {
         namespace::exec_in_namespace_checked(&ns_name, &["ip", "link", "set", &guest_veth, "up"])
             .await?;
 
+        // Pin the bridge MAC before it carries traffic. The guest holds a
+        // PERMANENT neighbour entry for GUEST_GATEWAY pointing at this exact
+        // address (fc-agent's NAMESPACE_MAC), so a kernel-assigned MAC here
+        // would send every reply to an address nothing owns. Routed mode uses
+        // 10.0.2.1 as the guest's DEFAULT GATEWAY, so that is not a degraded
+        // published port -- it is all IPv4 egress.
+        namespace::exec_in_namespace_checked(
+            &ns_name,
+            &[
+                "ip",
+                "link",
+                "set",
+                BRIDGE_DEVICE,
+                "address",
+                crate::network::pasta::NAMESPACE_MAC,
+            ],
+        )
+        .await?;
+
         // 5. Assign gateway IPs to bridge (VM connects here via TAP)
         let gw_cidr = format!("{}/24", GUEST_GATEWAY);
         namespace::exec_in_namespace_checked(

--- a/tests/test_fuzz_chaos.rs
+++ b/tests/test_fuzz_chaos.rs
@@ -485,7 +485,7 @@ async fn dump_port_silence_forensics(pid: u32, ip: &str, port: u16) {
             "exec",
             "--pid",
             &pid_s,
-            "-c",
+            "--container",
             "--",
             "sh",
             "-c",
@@ -503,7 +503,7 @@ async fn dump_port_silence_forensics(pid: u32, ip: &str, port: u16) {
             "exec",
             "--pid",
             &pid_s,
-            "-c",
+            "--container",
             "--",
             "sh",
             "-c",
@@ -551,6 +551,48 @@ async fn dump_port_silence_forensics(pid: u32, ip: &str, port: u16) {
     )
     .await;
 
+    // `fcvm exec` defaults to --container; the GUEST needs --vm. Everything
+    // below was previously running inside nginx:alpine, which is why the
+    // netfilter probes came back empty and produced a confident, wrong note
+    // that the guest had no iptables. Ubuntu has /usr/sbin/iptables, plus
+    // bash, ss, curl and wget. Absolute paths, because exec hands over a
+    // minimal PATH.
+    //
+    // The DROP counter is THE measurement. On a healthy VM it reads:
+    //   0  0  DROP  eth0  0.0.0.0/0  127.0.0.0/8  ! ctstate DNAT
+    // so any non-zero value at failure names the containment rule as the
+    // thing eating the connection, and a still-zero value exonerates it.
+    for (label, cmd) in [
+        (
+            "guest-input-counters",
+            "/usr/sbin/iptables -L INPUT -n -v -x | head -6",
+        ),
+        (
+            "guest-nat-rules",
+            "/usr/sbin/iptables -t nat -S PREROUTING | head -6",
+        ),
+        ("guest-listeners", "/usr/bin/ss -ltnp | head -8"),
+        // Both sides of the DNAT, from inside the guest: 127.0.0.1 is where
+        // the rule points, 10.0.2.100 is the address the outside world uses.
+        // Answers on loopback but not on eth0 -> the ingress path; silent on
+        // both -> whatever is behind the published port.
+        (
+            "guest-http-loopback",
+            "/usr/bin/curl -sS -o /dev/null -w 'connect=%{time_connect} code=%{http_code} exit=%{exitcode}\n' --max-time 4 http://127.0.0.1:80/",
+        ),
+        (
+            "guest-http-eth0",
+            "/usr/bin/curl -sS -o /dev/null -w 'connect=%{time_connect} code=%{http_code} exit=%{exitcode}\n' --max-time 4 http://10.0.2.100:80/",
+        ),
+    ] {
+        probe(
+            label,
+            &[&fcvm, "exec", "--pid", &pid_s, "--vm", "--", "sh", "-c", cmd],
+            left().min(Duration::from_secs(6)),
+        )
+        .await;
+    }
+
     // Conntrack DOES read back, straight out of /proc, no binary needed.
     probe(
         "guest-conntrack",
@@ -559,6 +601,7 @@ async fn dump_port_silence_forensics(pid: u32, ip: &str, port: u16) {
             "exec",
             "--pid",
             &pid_s,
+            "--vm",
             "--",
             "sh",
             "-c",

--- a/tests/test_fuzz_chaos.rs
+++ b/tests/test_fuzz_chaos.rs
@@ -72,6 +72,48 @@ fn unregister_clone(pid: u32) {
     LIVE_CLONES.lock().unwrap().retain(|p| *p != pid);
 }
 
+/// Kills its clone the instant it is dropped, however the drop happens.
+///
+/// The registry above reaps at seed teardown, which is too late in one case
+/// that matters: a dropped op (outer timeout, or a panic unwinding through it)
+/// runs no async cleanup at all, so the clone keeps running while the rest of
+/// the seed continues around it. Worse, a stranded fcvm child holds the test
+/// binary's stdout pipe open, and nextest waits on that pipe — that is exactly
+/// how a leaked `snapshot serve` turned a 5-second op failure into an
+/// 18-minute apparent hang.
+///
+/// `Drop` cannot await, so this signals directly rather than going through
+/// `kill_process`. SIGKILL, not SIGTERM: this path only runs when cleanup was
+/// already skipped, and a clone that ignores TERM would keep the pipe open.
+struct CloneGuard {
+    pid: u32,
+    armed: bool,
+}
+
+impl CloneGuard {
+    /// Call once the child has been waited for. Signalling a pid that has been
+    /// reaped is not harmless — the kernel is free to hand that number to an
+    /// unrelated process — so the normal path disarms rather than relying on
+    /// ESRCH. On the drop path the child was never waited, so it is either
+    /// alive or an unreaped zombie, and its pid cannot have been reused.
+    fn disarm(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for CloneGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        // Safety: kill(2) on a pid this process spawned and has not reaped.
+        unsafe {
+            libc::kill(self.pid as libc::pid_t, libc::SIGKILL);
+        }
+        unregister_clone(self.pid);
+    }
+}
+
 /// Kill any clone a dropped op left running. Returns how many it reaped.
 async fn reap_leaked_clones() -> usize {
     let leaked: Vec<u32> = std::mem::take(&mut *LIVE_CLONES.lock().unwrap());
@@ -431,22 +473,102 @@ async fn dump_port_silence_forensics(pid: u32, ip: &str, port: u16) {
     let fcvm = fcvm_path.to_string_lossy().to_string();
     let pid_s = pid.to_string();
 
-    // 1. Does the guest still serve itself? Splits host-side from guest-side.
+    // 1. Does the SERVICE still answer itself, inside the container? This is
+    //    the probe that splits the layers, so it has to use a binary that is
+    //    actually there: the first version shelled out to curl in the guest OS
+    //    and came back exit=127 (not installed), which told us nothing at the
+    //    exact moment we most needed an answer. nginx:alpine has busybox wget.
     probe(
-        "guest-self-curl",
+        "container-self-http",
+        &[
+            &fcvm,
+            "exec",
+            "--pid",
+            &pid_s,
+            "-c",
+            "--",
+            "sh",
+            "-c",
+            "wget -q -O- --timeout=3 http://127.0.0.1/ 2>&1 | head -c 60; echo \" rc=$?\"",
+        ],
+        left().min(Duration::from_secs(6)),
+    )
+    .await;
+
+    // 2. Is the service even alive, and listening where we think?
+    probe(
+        "container-listeners",
+        &[
+            &fcvm,
+            "exec",
+            "--pid",
+            &pid_s,
+            "-c",
+            "--",
+            "sh",
+            "-c",
+            "netstat -ltn | head -5; echo --; ps -o pid,comm | grep -i nginx | head -3",
+        ],
+        left().min(Duration::from_secs(6)),
+    )
+    .await;
+
+    // 3. Guest side of the hop: listeners, the published-port DNAT, and the
+    //    loopback containment rules that DROP eth0 traffic to 127/8 unless
+    //    conntrack recorded our translation. If the DNAT is intact and the
+    //    container answers itself, the guest's conntrack state is the suspect.
+    // Guest netfilter state is NOT probeable from here, and it is worth saying
+    // so rather than shipping probes that always come back empty: fc-agent
+    // installs the DNAT and the containment DROP from the initrd, and the guest
+    // rootfs carries no iptables and no nft (`command -v iptables` -> 127,
+    // `find / -name "*iptables*"` -> nothing). The rules live in the kernel
+    // where no shell in the running guest can read them back.
+    //
+    // What replaces them is the measurement that actually discriminates, taken
+    // from this side: WHERE the five seconds went. `--max-time` spans connect
+    // AND transfer, so the timeout alone cannot tell a dropped SYN from a
+    // service that accepted and never answered.
+    //   time_connect == 0        -> the handshake never completed; the packet
+    //                               died before any listener saw it
+    //   time_connect ~ 0.001 and
+    //   time_starttransfer == 0  -> the guest ACCEPTED the connection, so eth0
+    //                               ingress and the DNAT both worked, and the
+    //                               service is what went quiet
+    probe(
+        "host-curl-timing",
+        &[
+            "curl",
+            "-sS",
+            "-o",
+            "/dev/null",
+            "-w",
+            "connect=%{time_connect} starttransfer=%{time_starttransfer} code=%{http_code} exit=%{exitcode}\n",
+            "--max-time",
+            "5",
+            &format!("http://{}:{}/", ip, port),
+        ],
+        left().min(Duration::from_secs(7)),
+    )
+    .await;
+
+    // Conntrack DOES read back, straight out of /proc, no binary needed.
+    probe(
+        "guest-conntrack",
         &[
             &fcvm,
             "exec",
             "--pid",
             &pid_s,
             "--",
-            "curl -s -o /dev/null -w guest_http=%{http_code} --max-time 3 http://localhost/",
+            "sh",
+            "-c",
+            "echo total=$(grep -c . /proc/net/nf_conntrack); grep -E '127.0.0.1|dport=80 ' /proc/net/nf_conntrack | head -8",
         ],
         left().min(Duration::from_secs(5)),
     )
     .await;
 
-    // 2. What does fcvm believe about this VM right now?
+    // 4. What does fcvm believe about this VM right now?
     probe(
         "fcvm-ls",
         &[&fcvm, "ls", "--json", "--pid", &pid_s],
@@ -454,7 +576,7 @@ async fn dump_port_silence_forensics(pid: u32, ip: &str, port: u16) {
     )
     .await;
 
-    // 3. Host side: is anything still listening on the published address, and
+    // 5. Host side: is anything still listening on the published address, and
     //    is there a conntrack entry pointing somewhere stale?
     probe(
         "host-listeners",
@@ -470,7 +592,7 @@ async fn dump_port_silence_forensics(pid: u32, ip: &str, port: u16) {
     )
     .await;
 
-    // 4. The pasta processes serving this VM carry their -t mappings in argv.
+    // 6. The pasta processes serving this VM carry their -t mappings in argv.
     probe(
         "pasta-argv",
         &["pgrep", "-a", "pasta"],
@@ -478,7 +600,7 @@ async fn dump_port_silence_forensics(pid: u32, ip: &str, port: u16) {
     )
     .await;
 
-    // 5. Inside the VM's namespace: addresses, neighbours, listeners.
+    // 7. Inside the VM namespace: addresses, neighbours, listeners.
     let holder = read_vm_state(pid)
         .await
         .ok()
@@ -585,6 +707,12 @@ async fn apply_op(
             .await
             .with_context(|| format!("restoring clone via serve {}", serve_pid))?;
             register_clone(clone_pid);
+            // Armed BEFORE the first await that can be cancelled, so no path
+            // out of this op leaves the clone running.
+            let guard = CloneGuard {
+                pid: clone_pid,
+                armed: true,
+            };
 
             // fcvm only reports a clone up after its own post-restore
             // port-forward verification, so a curl that fails here means the
@@ -606,6 +734,7 @@ async fn apply_op(
             common::kill_process(clone_pid).await;
             let _ = clone_child.wait().await;
             unregister_clone(clone_pid);
+            guard.disarm();
             let detail = verdict?;
             Ok(format!("clone={} {}", clone_name, detail))
         }
@@ -1011,4 +1140,72 @@ async fn test_fuzz_lifecycle_chaos() {
         );
     }
     println!("FUZZ all {} seed(s) passed", seeds.len());
+}
+
+// ---------------------------------------------------------------------------
+// CloneGuard: mechanism-level, no VMs, milliseconds.
+//
+// Written against the unfixed tree first. With the Drop impl removed (or armed
+// left false), `child.wait()` below never returns and the 5s timeout fails the
+// test — which is exactly the property under test: the clone dies even when no
+// cleanup code runs.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_dropped_clone_guard_kills_the_clone_it_guards() {
+    use std::os::unix::process::ExitStatusExt;
+
+    let mut child = tokio::process::Command::new("sleep")
+        .arg("300")
+        .spawn()
+        .expect("spawning sleep");
+    let pid = child.id().expect("child pid");
+    register_clone(pid);
+
+    {
+        let _guard = CloneGuard { pid, armed: true };
+        // No cleanup here on purpose: this models the op future being dropped
+        // mid-await, where nothing async gets to run.
+    }
+
+    let status = tokio::time::timeout(Duration::from_secs(5), child.wait())
+        .await
+        .expect("guard did not kill the clone: still running 5s after drop")
+        .expect("waiting for the killed clone");
+    assert_eq!(
+        status.signal(),
+        Some(libc::SIGKILL),
+        "clone exited, but not from the guard's SIGKILL: {:?}",
+        status
+    );
+    assert!(
+        !LIVE_CLONES.lock().unwrap().contains(&pid),
+        "guard killed the clone but left it in the live-clone registry"
+    );
+}
+
+#[tokio::test]
+async fn a_disarmed_clone_guard_leaves_the_process_alone() {
+    // The normal path waits for the child itself, then disarms. Signalling
+    // after a reap could hit an unrelated process that inherited the number,
+    // so disarm must actually suppress the kill.
+    let mut child = tokio::process::Command::new("sleep")
+        .arg("5")
+        .spawn()
+        .expect("spawning sleep");
+    let pid = child.id().expect("child pid");
+    register_clone(pid);
+
+    CloneGuard { pid, armed: false }.disarm();
+
+    // Still alive: a disarmed guard must not have signalled it.
+    let early = tokio::time::timeout(Duration::from_millis(300), child.wait()).await;
+    assert!(
+        early.is_err(),
+        "disarmed guard killed the process anyway: {:?}",
+        early
+    );
+    unregister_clone(pid);
+    let _ = child.kill().await;
+    let _ = child.wait().await;
 }

--- a/tests/test_fuzz_chaos.rs
+++ b/tests/test_fuzz_chaos.rs
@@ -136,7 +136,7 @@ const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
 const CLEANUP_OP_TIMEOUT: Duration = Duration::from_secs(60);
 /// Total wall-clock budget for the forensics dump fired when a forwarded port
 /// goes silent. Diagnostics must never outlive the failure they explain.
-const FORENSICS_BUDGET: Duration = Duration::from_secs(12);
+const FORENSICS_BUDGET: Duration = Duration::from_secs(40);
 
 const GUEST_NONCE_FILE: &str = "/mnt/fuzz/nonces.txt";
 
@@ -415,6 +415,17 @@ async fn curl_once(pid: u32, ip: &str, port: u16) -> Result<String> {
 /// Run one diagnostic and print it, whatever it says. A probe that fails is
 /// itself evidence, so its exit status and stderr are reported rather than
 /// swallowed — a silent section is indistinguishable from a clean one.
+/// Like `probe`, but returns the output instead of printing it, for numbers
+/// that only mean something when compared against each other.
+async fn capture(args: &[&str], budget: Duration) -> Option<String> {
+    let (bin, rest) = args.split_first()?;
+    let run = tokio::process::Command::new(bin).args(rest).output();
+    match tokio::time::timeout(budget, run).await {
+        Ok(Ok(out)) => Some(String::from_utf8_lossy(&out.stdout).trim().to_string()),
+        _ => None,
+    }
+}
+
 async fn probe(label: &str, args: &[&str], budget: Duration) {
     let Some((bin, rest)) = args.split_first() else {
         return;
@@ -472,6 +483,45 @@ async fn dump_port_silence_forensics(pid: u32, ip: &str, port: u16) {
     };
     let fcvm = fcvm_path.to_string_lossy().to_string();
     let pid_s = pid.to_string();
+
+    // 0. THE suspect, measured before anything else can eat the budget.
+    //
+    // The published port reaches the service through a DNAT to 127.0.0.1:80,
+    // and that only works while net.ipv4.conf.eth0.route_localnet=1. fc-agent
+    // sets it at boot precisely because, quoting its own comment, "the kernel
+    // treats a packet routed to 127.0.0.0/8 that arrived on a non-loopback
+    // interface as a martian source and drops it".
+    //
+    // A martian drop happens in ROUTING, before INPUT. That is consistent with
+    // every measurement taken so far: the containment DROP counter stays 0, no
+    // RST is emitted, eth0's RX counters keep climbing, and guest-local traffic
+    // to 127.0.0.1 and to 10.0.2.100 keeps working because neither crosses eth0.
+    //
+    // TcpPassiveOpens is the corroborating half: if the SYN never reaches TCP,
+    // it cannot increment, whatever the NIC counters say.
+    for (label, cmd) in [
+        (
+            "guest-route-localnet",
+            "for f in eth0 all default; do \
+               printf '%s=' \"$f\"; \
+               cat /proc/sys/net/ipv4/conf/$f/route_localnet 2>/dev/null || echo '?'; \
+             done",
+        ),
+        (
+            "guest-tcp-counters",
+            "awk '/^Tcp:/{n=$0; getline; print n; print}' /proc/net/snmp | tail -2; \
+             grep -iE 'listen|martian' /proc/net/netstat 2>/dev/null | head -2",
+        ),
+    ] {
+        probe(
+            label,
+            &[
+                &fcvm, "exec", "--pid", &pid_s, "--vm", "--", "sh", "-c", cmd,
+            ],
+            left().min(Duration::from_secs(5)),
+        )
+        .await;
+    }
 
     // 1. Does the SERVICE still answer itself, inside the container? This is
     //    the probe that splits the layers, so it has to use a binary that is
@@ -572,6 +622,18 @@ async fn dump_port_silence_forensics(pid: u32, ip: &str, port: u16) {
             "/usr/sbin/iptables -t nat -S PREROUTING | head -6",
         ),
         ("guest-listeners", "/usr/bin/ss -ltnp | head -8"),
+        // The reply path. Packets demonstrably arrive (rx differential) and
+        // nothing drops them (DROP counter 0), so if the guest cannot answer
+        // 10.0.2.1 the reason is here: the route purged by the snapshot
+        // link-down and not reinstated, or a neighbour entry it cannot
+        // re-resolve. TX errors/dropped on eth0 would show the same thing from
+        // the device's side.
+        ("guest-routes", "PATH=/usr/sbin:/sbin:/usr/bin:/bin; ip route show"),
+        ("guest-neigh", "PATH=/usr/sbin:/sbin:/usr/bin:/bin; ip neigh show"),
+        (
+            "guest-eth0-link",
+            "PATH=/usr/sbin:/sbin:/usr/bin:/bin; ip -s link show eth0 | head -8",
+        ),
         // Both sides of the DNAT, from inside the guest: 127.0.0.1 is where
         // the rule points, 10.0.2.100 is the address the outside world uses.
         // Answers on loopback but not on eth0 -> the ingress path; silent on
@@ -592,6 +654,26 @@ async fn dump_port_silence_forensics(pid: u32, ip: &str, port: u16) {
         )
         .await;
     }
+
+    // Firecracker's device event loop starving its virtio queues after a
+    // pause/resume is a documented failure mode (AGENTS.md, NV2 section): one
+    // thread spins while every queue goes unserviced. Per-thread jiffies.
+    probe(
+        "firecracker-thread-cpu",
+        &[
+            "sh",
+            "-c",
+            &format!(
+                "for t in /proc/$(pgrep -P {} -x firecracker | head -1)/task/*/stat; do \
+                   [ -r \"$t\" ] || continue; \
+                   awk '{{print $2, \"utime=\" $14, \"stime=\" $15}}' \"$t\"; \
+                 done | head -8",
+                pid
+            ),
+        ],
+        left().min(Duration::from_secs(5)),
+    )
+    .await;
 
     // Conntrack DOES read back, straight out of /proc, no binary needed.
     probe(
@@ -654,6 +736,107 @@ async fn dump_port_silence_forensics(pid: u32, ip: &str, port: u16) {
         None => println!("  [namespace] no holder_pid in state — cannot enter the VM's netns"),
         Some(h) => {
             let ns = format!("--net=/proc/{}/ns/net", h);
+            // THE differential, at TCP level.
+            //
+            // eth0's rx_packets was the wrong counter: ambient DNS, NTP and
+            // MMDS traffic move it constantly, so a non-zero delta proved
+            // nothing about OUR SYN. Tcp.PassiveOpens counts inbound
+            // connections the guest's TCP actually accepted, and nothing else
+            // in this VM generates those.
+            //
+            //   delta >= 1 -> the guest ACCEPTED it, so the reply is what is
+            //                 lost (bridge/tap egress side)
+            //   delta = 0  -> the SYN never reached the guest's TCP, and the
+            //                 fault is in front of it: bridge FDB, tap, pasta
+            let passive = [
+                fcvm.as_str(),
+                "exec",
+                "--pid",
+                &pid_s,
+                "--vm",
+                "--",
+                "sh",
+                "-c",
+                "awk '/^Tcp:/{h=$0; getline; d=$0} END{n=split(h,H,\" \"); for(i=1;i<=n;i++) if(H[i]==\"PassiveOpens\"){split(d,D,\" \"); print D[i]}}' /proc/net/snmp",
+            ];
+            let before = capture(&passive, Duration::from_secs(5)).await;
+            let _ = capture(
+                &[
+                    "nsenter",
+                    ns.as_str(),
+                    "curl",
+                    "-sS",
+                    "-o",
+                    "/dev/null",
+                    "--max-time",
+                    "3",
+                    "http://10.0.2.100:80/",
+                ],
+                Duration::from_secs(5),
+            )
+            .await;
+            let after = capture(&passive, Duration::from_secs(5)).await;
+            let parse = |v: &Option<String>| v.as_ref().and_then(|x| x.trim().parse::<u64>().ok());
+            match (parse(&before), parse(&after)) {
+                (Some(b), Some(a)) => println!(
+                    "  [tcp-passiveopens-differential] before={} after={} delta={} ({})",
+                    b,
+                    a,
+                    a.saturating_sub(b),
+                    if a > b {
+                        "guest ACCEPTED it — the REPLY is what is lost"
+                    } else {
+                        "SYN never reached guest TCP — bridge FDB / tap / pasta"
+                    }
+                ),
+                _ => println!(
+                    "  [tcp-passiveopens-differential] unreadable (before={:?} after={:?})",
+                    before, after
+                ),
+            }
+
+            // Observe the WIRE, not counters. Every counter says the packet is
+            // neither delivered nor dropped, and a packet that is neither is
+            // queued. tcpdump on the tap settles where it stops:
+            //   SYN appears on the tap -> the bridge forwarded it and the
+            //     virtio-net RX side is not consuming it (Firecracker)
+            //   SYN absent from the tap -> it never left the bridge
+            probe(
+                "ns-tap-tcpdump",
+                &[
+                    "nsenter",
+                    ns.as_str(),
+                    "sh",
+                    "-c",
+                    "TAP=$(ip -o link show | sed -n 's/.*: \\(tap-[^:@]*\\).*/\\1/p' | head -1); \
+                     echo \"tap=$TAP\"; \
+                     ( timeout 4 tcpdump -i \"$TAP\" -e -n -c 8 'tcp port 80' 2>&1 | sed 's/^/    tap /' ) & \
+                     ( timeout 4 tcpdump -i pasta0 -e -n -c 8 'tcp port 80' 2>&1 | sed 's/^/    pasta0 /' ) & \
+                     ( timeout 4 tcpdump -i br0 -e -n -c 8 'tcp port 80' 2>&1 | sed 's/^/    br0 /' ) & \
+                     sleep 0.7; \
+                     curl -s -o /dev/null --max-time 2 http://10.0.2.100:80/ 2>/dev/null; \
+                     wait",
+                ],
+                left().min(Duration::from_secs(10)),
+            )
+            .await;
+
+            // Where the bridge thinks the guest's MAC lives. This repo already
+            // carries scripts/passt-addr-seen.patch because pasta's forwarding
+            // target could be retargeted by overheard bridge traffic; an FDB
+            // entry pointing at pasta0 rather than the tap is that bug, visible.
+            for (label, cmd) in [
+                ("ns-bridge-fdb", "bridge fdb show"),
+                ("ns-tap-stats", "ip -s link show"),
+            ] {
+                probe(
+                    label,
+                    &["nsenter", ns.as_str(), "sh", "-c", cmd],
+                    left().min(Duration::from_secs(5)),
+                )
+                .await;
+            }
+
             // THE discriminator between the two remaining suspects.
             //
             // `connect` to the published address only proves pasta accepted:

--- a/tests/test_fuzz_chaos.rs
+++ b/tests/test_fuzz_chaos.rs
@@ -47,6 +47,40 @@ const OP_TIMEOUT: Duration = Duration::from_secs(60);
 /// Snapshot create pauses the VM and writes a multi-GB memory image; give it
 /// a larger (still hard) budget than ordinary ops.
 const SNAPSHOT_OP_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Budget for a CloneRestore op. Deliberately LARGER than the waits inside it
+/// (60s health poll + a 5s curl): if the outer timeout fired first, the op
+/// future would be dropped mid-await and its clone teardown skipped, leaving a
+/// restored VM running while the seed tears down around it (review finding on
+/// #837). The registry below is the belt to this suspenders.
+const CLONE_OP_TIMEOUT: Duration = Duration::from_secs(150);
+
+/// Clone PIDs a CloneRestore op spawned and has not yet reaped.
+///
+/// The op kills its own clone on every path it can reach, but a future that is
+/// DROPPED (outer timeout, or a panic unwinding through it) runs no cleanup at
+/// all. Recording the pid the moment it exists lets the seed teardown reap what
+/// the op could not, so a fuzz failure never leaves a live VM to poison the
+/// next seed (review finding on #837).
+static LIVE_CLONES: std::sync::Mutex<Vec<u32>> = std::sync::Mutex::new(Vec::new());
+
+fn register_clone(pid: u32) {
+    LIVE_CLONES.lock().unwrap().push(pid);
+}
+
+fn unregister_clone(pid: u32) {
+    LIVE_CLONES.lock().unwrap().retain(|p| *p != pid);
+}
+
+/// Kill any clone a dropped op left running. Returns how many it reaped.
+async fn reap_leaked_clones() -> usize {
+    let leaked: Vec<u32> = std::mem::take(&mut *LIVE_CLONES.lock().unwrap());
+    for pid in &leaked {
+        eprintln!("FUZZ reaping leaked clone pid={}", pid);
+        common::kill_process(*pid).await;
+    }
+    leaked.len()
+}
 /// At most this many SnapshotCreate ops per seed (disk: each is multi-GB).
 const MAX_SNAPSHOTS_PER_SEED: usize = 2;
 /// Bounded wait for first-healthy (covers cold-cache boot incl. the pre-start
@@ -332,6 +366,7 @@ async fn apply_op(
     seed: u64,
     op_idx: usize,
     pid: u32,
+    serve_pid: u32,
     ip: &str,
     port: u16,
     snap_base: &str,
@@ -388,22 +423,23 @@ async fn apply_op(
             Ok(format!("{} bytes", out.len()))
         }
         Op::CloneRestore => {
-            // Nothing to restore until this seed has taken a snapshot; the
-            // draw is still consumed above, so the schedule stays a pure
-            // function of the seed.
-            let Some(tag) = snapshots.last().cloned() else {
-                return Ok("no snapshot yet".to_string());
-            };
             let clone_name = format!("{}-clone-{}", snap_base, op_idx);
             // No --publish here: `snapshot run` takes none, because a clone
             // INHERITS the snapshot's port mappings. In rootless mode each
             // clone gets its own loopback IP, so the inherited host port is
             // reached at that address (same shape as
             // test_clone_port_forward_rootless).
-            let (mut clone_child, clone_pid) =
-                common::spawn_fcvm(&["snapshot", "run", "--snapshot", &tag, "--name", &clone_name])
-                    .await
-                    .with_context(|| format!("restoring clone from {}", tag))?;
+            let (mut clone_child, clone_pid) = common::spawn_fcvm(&[
+                "snapshot",
+                "run",
+                "--pid",
+                &serve_pid.to_string(),
+                "--name",
+                &clone_name,
+            ])
+            .await
+            .with_context(|| format!("restoring clone via serve {}", serve_pid))?;
+            register_clone(clone_pid);
 
             // fcvm only reports a clone up after its own post-restore
             // port-forward verification, so a curl that fails here means the
@@ -424,6 +460,7 @@ async fn apply_op(
 
             common::kill_process(clone_pid).await;
             let _ = clone_child.wait().await;
+            unregister_clone(clone_pid);
             let detail = verdict?;
             Ok(format!("clone={} {}", clone_name, detail))
         }
@@ -498,6 +535,16 @@ async fn run_seed(seed: u64, total_ops: usize) -> Result<()> {
         common::kill_process(pid).await;
         let _ = child.wait().await;
     }
+    // Reap before deleting snapshots: a leaked clone still holds the snapshot
+    // it restored from, and deleting underneath it is how a "cleanup" turns
+    // into the next seed's mystery.
+    let reaped = reap_leaked_clones().await;
+    if reaped > 0 {
+        eprintln!(
+            "FUZZ seed={} reaped {} clone(s) a dropped op left behind",
+            seed, reaped
+        );
+    }
     for tag in &snapshots {
         let _ = common::delete_snapshot(tag).await;
     }
@@ -540,10 +587,36 @@ async fn run_seed_body(
     // the budget allows. Taken outside the loop, so it consumes no rng draw
     // and the schedule stays a pure function of the seed.
     let baseline_tag = format!("{}-base", snap_base);
-    common::create_snapshot_by_pid(pid, &baseline_tag)
+    // Bounded by the same budget a SnapshotCreate op gets: unbounded, a stalled
+    // snapshot would sit here until nextest's two-hour test timeout instead of
+    // failing the seed at the documented budget (review finding on #837).
+    tokio::time::timeout(
+        SNAPSHOT_OP_TIMEOUT,
+        common::create_snapshot_by_pid(pid, &baseline_tag),
+    )
+    .await
+    .map_err(|_| {
+        anyhow::anyhow!(
+            "seed {}: baseline snapshot did not finish within {:?}",
+            seed,
+            SNAPSHOT_OP_TIMEOUT
+        )
+    })?
+    .with_context(|| format!("seed {}: baseline snapshot for clone restores", seed))?;
+    snapshots.push(baseline_tag.clone());
+
+    // Restore through a UFFD memory server, not the file backend.
+    //
+    // This is the path the request benchmark actually uses (BACKEND=uffd is
+    // its default) and the path both 2026-08-15 failures came from. An earlier
+    // version of this rung restored with `--snapshot`, i.e. the FILE backend,
+    // and 351 clean restores said nothing about the failing path at all.
+    let (mut serve_child, serve_pid) = common::spawn_fcvm(&["snapshot", "serve", &baseline_tag])
         .await
-        .with_context(|| format!("seed {}: baseline snapshot for clone restores", seed))?;
-    snapshots.push(baseline_tag);
+        .with_context(|| format!("seed {}: starting UFFD serve", seed))?;
+    common::poll_serve_ready(&baseline_tag, serve_pid, 60)
+        .await
+        .with_context(|| format!("seed {}: UFFD serve never became ready", seed))?;
 
     let ip = common::get_loopback_ip(pid).await?;
     let vm_id = {
@@ -585,16 +658,16 @@ async fn run_seed_body(
             op = Op::JitterSleep;
         }
         println!("FUZZ seed={} op={}/{} {:?}", seed, i, total_ops, op);
-        let timeout = if op == Op::SnapshotCreate {
-            SNAPSHOT_OP_TIMEOUT
-        } else {
-            OP_TIMEOUT
+        let timeout = match op {
+            Op::SnapshotCreate => SNAPSHOT_OP_TIMEOUT,
+            Op::CloneRestore => CLONE_OP_TIMEOUT,
+            _ => OP_TIMEOUT,
         };
         let t0 = Instant::now();
         let outcome = tokio::time::timeout(
             timeout,
             apply_op(
-                op, draw, seed, i, pid, &ip, host_port, snap_base, nonces, snapshots,
+                op, draw, seed, i, pid, serve_pid, &ip, host_port, snap_base, nonces, snapshots,
             ),
         )
         .await;
@@ -621,6 +694,13 @@ async fn run_seed_body(
             ),
         }
     }
+
+    // The UFFD serve goes first: it is an fcvm process this seed started, and
+    // the leak oracles below (correctly) refuse to see stray fcvm/firecracker
+    // processes after shutdown. Killing it here also proves the clones that
+    // used it are already gone — a serve with live clones refuses to exit.
+    common::kill_process(serve_pid).await;
+    let _ = serve_child.wait().await;
 
     // -- Graceful shutdown --------------------------------------------------
     println!("FUZZ seed={} shutting down (SIGTERM to {})", seed, pid);

--- a/tests/test_fuzz_chaos.rs
+++ b/tests/test_fuzz_chaos.rs
@@ -89,6 +89,12 @@ const HEALTHY_TIMEOUT_SECS: u64 = 300;
 /// Bounded wait for fcvm to exit after SIGTERM. Not exiting in time FAILS the
 /// seed — graceful shutdown hanging is a bug, not something to force-kill over.
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
+/// Bounded per-item cleanup. Cleanup is best-effort by nature, so it may not
+/// block the run: it reports what it could not finish and moves on.
+const CLEANUP_OP_TIMEOUT: Duration = Duration::from_secs(60);
+/// Total wall-clock budget for the forensics dump fired when a forwarded port
+/// goes silent. Diagnostics must never outlive the failure they explain.
+const FORENSICS_BUDGET: Duration = Duration::from_secs(12);
 
 const GUEST_NONCE_FILE: &str = "/mnt/fuzz/nonces.txt";
 
@@ -343,8 +349,15 @@ async fn exec_tty_echo(pid: u32, token: &str) -> Result<()> {
     Ok(())
 }
 
-async fn curl_once(ip: &str, port: u16) -> Result<String> {
+async fn curl_once(pid: u32, ip: &str, port: u16) -> Result<String> {
     let r = common::curl_check(ip, port, 5).await;
+    if !(r.success && r.body_len > 0) {
+        // A forwarded port that has gone silent is the failure we most need
+        // evidence for, and every source of it (conntrack, the NAT rules, the
+        // namespace, the guest itself) is gone the moment the seed tears the
+        // VM down. Capture it HERE, while it is still true.
+        dump_port_silence_forensics(pid, ip, port).await;
+    }
     ensure!(
         r.success && r.body_len > 0,
         "curl {}:{} failed (success={} body_len={} err={})",
@@ -355,6 +368,138 @@ async fn curl_once(ip: &str, port: u16) -> Result<String> {
         r.error
     );
     Ok(format!("body_len={}", r.body_len))
+}
+
+/// Run one diagnostic and print it, whatever it says. A probe that fails is
+/// itself evidence, so its exit status and stderr are reported rather than
+/// swallowed — a silent section is indistinguishable from a clean one.
+async fn probe(label: &str, args: &[&str], budget: Duration) {
+    let Some((bin, rest)) = args.split_first() else {
+        return;
+    };
+    let run = tokio::process::Command::new(bin).args(rest).output();
+    match tokio::time::timeout(budget, run).await {
+        Err(_) => println!("  [{}] TIMED OUT after {:?}", label, budget),
+        Ok(Err(e)) => println!("  [{}] could not run ({}): {}", label, args.join(" "), e),
+        Ok(Ok(out)) => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let body = if stdout.trim().is_empty() {
+                "(no output)".to_string()
+            } else {
+                stdout.trim().to_string()
+            };
+            println!("  [{}] exit={:?}", label, out.status.code());
+            for line in body.lines().take(40) {
+                println!("    {}", line);
+            }
+            if !stderr.trim().is_empty() {
+                println!(
+                    "    stderr: {}",
+                    stderr
+                        .trim()
+                        .lines()
+                        .take(4)
+                        .collect::<Vec<_>>()
+                        .join(" | ")
+                );
+            }
+        }
+    }
+}
+
+/// Everything that could explain "the port accepted nothing and said nothing".
+///
+/// Ordered most-discriminating first: if the guest still serves its own port
+/// while the host sees silence, the guest is fine and the host-side forwarding
+/// path (pasta, the loopback DNAT, or a stale conntrack entry) is what broke.
+async fn dump_port_silence_forensics(pid: u32, ip: &str, port: u16) {
+    let deadline = Instant::now() + FORENSICS_BUDGET;
+    let left = || deadline.saturating_duration_since(Instant::now());
+    println!(
+        "FUZZ ===== port {}:{} went silent — forensics =====",
+        ip, port
+    );
+
+    let fcvm_path = match common::find_fcvm_binary() {
+        Ok(p) => p,
+        Err(e) => {
+            println!("  [fcvm] binary not found: {}", e);
+            return;
+        }
+    };
+    let fcvm = fcvm_path.to_string_lossy().to_string();
+    let pid_s = pid.to_string();
+
+    // 1. Does the guest still serve itself? Splits host-side from guest-side.
+    probe(
+        "guest-self-curl",
+        &[
+            &fcvm,
+            "exec",
+            "--pid",
+            &pid_s,
+            "--",
+            "curl -s -o /dev/null -w guest_http=%{http_code} --max-time 3 http://localhost/",
+        ],
+        left().min(Duration::from_secs(5)),
+    )
+    .await;
+
+    // 2. What does fcvm believe about this VM right now?
+    probe(
+        "fcvm-ls",
+        &[&fcvm, "ls", "--json", "--pid", &pid_s],
+        left().min(Duration::from_secs(3)),
+    )
+    .await;
+
+    // 3. Host side: is anything still listening on the published address, and
+    //    is there a conntrack entry pointing somewhere stale?
+    probe(
+        "host-listeners",
+        &["ss", "-ltnp"],
+        left().min(Duration::from_secs(3)),
+    )
+    .await;
+    let dport = port.to_string();
+    probe(
+        "conntrack",
+        &["conntrack", "-L", "-p", "tcp", "--dport", &dport],
+        left().min(Duration::from_secs(3)),
+    )
+    .await;
+
+    // 4. The pasta processes serving this VM carry their -t mappings in argv.
+    probe(
+        "pasta-argv",
+        &["pgrep", "-a", "pasta"],
+        left().min(Duration::from_secs(3)),
+    )
+    .await;
+
+    // 5. Inside the VM's namespace: addresses, neighbours, listeners.
+    let holder = read_vm_state(pid)
+        .await
+        .ok()
+        .and_then(|vms| vms.first().and_then(|v| v.vm.holder_pid));
+    match holder {
+        None => println!("  [namespace] no holder_pid in state — cannot enter the VM's netns"),
+        Some(h) => {
+            let ns = format!("--net=/proc/{}/ns/net", h);
+            for (label, cmd) in [
+                ("ns-addr", "ip -br addr"),
+                ("ns-neigh", "ip neigh"),
+                ("ns-listeners", "ss -ltnp"),
+            ] {
+                let parts: Vec<&str> = cmd.split_whitespace().collect();
+                let mut args = vec!["nsenter", ns.as_str()];
+                args.extend(parts);
+                probe(label, &args, left().min(Duration::from_secs(3))).await;
+            }
+        }
+    }
+    println!("FUZZ ===== end forensics =====");
 }
 
 /// Execute one op. `draw` is the op's pre-drawn randomness (one u64 per op).
@@ -387,7 +532,7 @@ async fn apply_op(
             exec_tty_echo(pid, &token).await?;
             Ok(format!("token={}", token))
         }
-        Op::CurlPort => curl_once(ip, port).await,
+        Op::CurlPort => curl_once(pid, ip, port).await,
         Op::StateRead => {
             let vms = read_vm_state(pid).await?;
             ensure!(
@@ -399,7 +544,7 @@ async fn apply_op(
             if matches!(status, fcvm::state::HealthStatus::Healthy) {
                 // Healthy⇒live oracle: a state file claiming Healthy must be
                 // backed by a VM that actually serves traffic RIGHT NOW.
-                let detail = curl_once(ip, port)
+                let detail = curl_once(pid, ip, port)
                     .await
                     .context("state says Healthy but the forwarded port is dead")?;
                 Ok(format!("status={:?} chained-curl {}", status, detail))
@@ -452,7 +597,7 @@ async fn apply_op(
                 let clone_ip = common::get_loopback_ip(clone_pid)
                     .await
                     .context("clone has no loopback IP after restore")?;
-                curl_once(&clone_ip, port)
+                curl_once(clone_pid, &clone_ip, port)
                     .await
                     .context("clone reported healthy but its inherited forwarded port is dead")
             }
@@ -514,6 +659,11 @@ async fn run_seed(seed: u64, total_ops: usize) -> Result<()> {
 
     let mut nonces: Vec<String> = Vec::new();
     let mut snapshots: Vec<String> = Vec::new();
+    // The UFFD serve is spawned deep inside the body (it needs a snapshot of a
+    // healthy VM first), but it is OWNED here, because the body can bail from
+    // any op and skip its own teardown. Handing the handle back out through
+    // this slot is what makes "kill the serve" run on the failure path too.
+    let mut serve: Option<(tokio::process::Child, u32)> = None;
     let body = run_seed_body(
         seed,
         total_ops,
@@ -526,6 +676,7 @@ async fn run_seed(seed: u64, total_ops: usize) -> Result<()> {
         &snap_base,
         &mut nonces,
         &mut snapshots,
+        &mut serve,
     )
     .await;
 
@@ -534,6 +685,10 @@ async fn run_seed(seed: u64, total_ops: usize) -> Result<()> {
     if body.is_err() {
         common::kill_process(pid).await;
         let _ = child.wait().await;
+    }
+    if let Some((mut serve_child, serve_pid)) = serve.take() {
+        common::kill_process(serve_pid).await;
+        let _ = serve_child.wait().await;
     }
     // Reap before deleting snapshots: a leaked clone still holds the snapshot
     // it restored from, and deleting underneath it is how a "cleanup" turns
@@ -545,8 +700,19 @@ async fn run_seed(seed: u64, total_ops: usize) -> Result<()> {
             seed, reaped
         );
     }
+    // Bounded, and loud when it expires. An unbounded delete here is how a
+    // 5-second op failure turned into an 18-minute wedge: the baseline
+    // snapshot cannot be deleted while a serve still holds it, so a leaked
+    // serve made cleanup block forever and the whole run looked hung.
     for tag in &snapshots {
-        let _ = common::delete_snapshot(tag).await;
+        match tokio::time::timeout(CLEANUP_OP_TIMEOUT, common::delete_snapshot(tag)).await {
+            Ok(_) => {}
+            Err(_) => eprintln!(
+                "FUZZ seed={} snapshot {} could not be deleted within {:?} \
+                 (something still holds it); leaving it and continuing",
+                seed, tag, CLEANUP_OP_TIMEOUT
+            ),
+        }
     }
     let _ = std::fs::remove_dir_all(&scratch);
 
@@ -568,6 +734,7 @@ async fn run_seed_body(
     snap_base: &str,
     nonces: &mut Vec<String>,
     snapshots: &mut Vec<String>,
+    serve_slot: &mut Option<(tokio::process::Child, u32)>,
 ) -> Result<()> {
     // -- Boot: bounded wait for first-healthy -------------------------------
     let boot_start = Instant::now();
@@ -611,9 +778,12 @@ async fn run_seed_body(
     // its default) and the path both 2026-08-15 failures came from. An earlier
     // version of this rung restored with `--snapshot`, i.e. the FILE backend,
     // and 351 clean restores said nothing about the failing path at all.
-    let (mut serve_child, serve_pid) = common::spawn_fcvm(&["snapshot", "serve", &baseline_tag])
+    let (serve_child, serve_pid) = common::spawn_fcvm(&["snapshot", "serve", &baseline_tag])
         .await
         .with_context(|| format!("seed {}: starting UFFD serve", seed))?;
+    // Hand it to the caller BEFORE the first thing that can fail, so no early
+    // return can strand it.
+    *serve_slot = Some((serve_child, serve_pid));
     common::poll_serve_ready(&baseline_tag, serve_pid, 60)
         .await
         .with_context(|| format!("seed {}: UFFD serve never became ready", seed))?;
@@ -699,8 +869,10 @@ async fn run_seed_body(
     // the leak oracles below (correctly) refuse to see stray fcvm/firecracker
     // processes after shutdown. Killing it here also proves the clones that
     // used it are already gone — a serve with live clones refuses to exit.
-    common::kill_process(serve_pid).await;
-    let _ = serve_child.wait().await;
+    if let Some((mut serve_child, serve_pid)) = serve_slot.take() {
+        common::kill_process(serve_pid).await;
+        let _ = serve_child.wait().await;
+    }
 
     // -- Graceful shutdown --------------------------------------------------
     println!("FUZZ seed={} shutting down (SIGTERM to {})", seed, pid);

--- a/tests/test_fuzz_chaos.rs
+++ b/tests/test_fuzz_chaos.rs
@@ -562,7 +562,9 @@ async fn dump_port_silence_forensics(pid: u32, ip: &str, port: u16) {
             "--",
             "sh",
             "-c",
-            "echo total=$(grep -c . /proc/net/nf_conntrack); grep -E '127.0.0.1|dport=80 ' /proc/net/nf_conntrack | head -8",
+            // 169.254.169.254 is fc-agent's MMDS polling and it drowns
+            // everything else; the inbound published-port flow is what matters.
+            "echo total=$(grep -c . /proc/net/nf_conntrack); grep -v 169.254.169.254 /proc/net/nf_conntrack | head -12",
         ],
         left().min(Duration::from_secs(5)),
     )
@@ -609,10 +611,43 @@ async fn dump_port_silence_forensics(pid: u32, ip: &str, port: u16) {
         None => println!("  [namespace] no holder_pid in state — cannot enter the VM's netns"),
         Some(h) => {
             let ns = format!("--net=/proc/{}/ns/net", h);
+            // THE discriminator between the two remaining suspects.
+            //
+            // `connect` to the published address only proves pasta accepted:
+            // 127.0.0.2:<port> is pasta's own listening socket on the host
+            // loopback, which is why a healthy-looking 113us connect can sit in
+            // front of a connection that never returns a byte. Reaching the
+            // guest from inside the VM's namespace bypasses pasta entirely:
+            //   answers here      -> the guest is fine; pasta is not forwarding
+            //   silent here too   -> the guest stopped answering on eth0, and
+            //                        pasta is just relaying that silence
+            let guest_url = format!("http://10.0.2.100:{}/", port);
+            probe(
+                "ns-curl-guest-direct",
+                &[
+                    "nsenter",
+                    ns.as_str(),
+                    "curl",
+                    "-sS",
+                    "-o",
+                    "/dev/null",
+                    "-w",
+                    "connect=%{time_connect} starttransfer=%{time_starttransfer} code=%{http_code} exit=%{exitcode}\n",
+                    "--max-time",
+                    "4",
+                    &guest_url,
+                ],
+                left().min(Duration::from_secs(6)),
+            )
+            .await;
+
             for (label, cmd) in [
                 ("ns-addr", "ip -br addr"),
                 ("ns-neigh", "ip neigh"),
                 ("ns-listeners", "ss -ltnp"),
+                // Untruncated: the -t mapping says which guest port pasta
+                // forwards to, which the probe above has to match.
+                ("ns-pasta-argv", "sh -c 'tr \\0 \\n </proc/self/cmdline'"),
             ] {
                 let parts: Vec<&str> = cmd.split_whitespace().collect();
                 let mut args = vec!["nsenter", ns.as_str()];
@@ -815,14 +850,28 @@ async fn run_seed(seed: u64, total_ops: usize) -> Result<()> {
         common::kill_process(pid).await;
         let _ = child.wait().await;
     }
+    // Clones FIRST, then the serve. A serve with live clones refuses to exit,
+    // so killing it first can block the wait below on exactly the condition
+    // reaping clears -- the same unbounded-wait-behind-a-held-resource shape
+    // that made a failing seed look like an 18-minute hang. Killing the pager
+    // out from under a clone that is still faulting is the other half of it.
+    //
+    // Reaping also has to precede deleting snapshots: a leaked clone still
+    // holds the snapshot it restored from, and deleting underneath it is how a
+    // "cleanup" turns into the next seed's mystery.
+    let reaped = reap_leaked_clones().await;
     if let Some((mut serve_child, serve_pid)) = serve.take() {
         common::kill_process(serve_pid).await;
-        let _ = serve_child.wait().await;
+        if tokio::time::timeout(CLEANUP_OP_TIMEOUT, serve_child.wait())
+            .await
+            .is_err()
+        {
+            eprintln!(
+                "FUZZ seed={} serve {} did not exit within {:?} of SIGTERM",
+                seed, serve_pid, CLEANUP_OP_TIMEOUT
+            );
+        }
     }
-    // Reap before deleting snapshots: a leaked clone still holds the snapshot
-    // it restored from, and deleting underneath it is how a "cleanup" turns
-    // into the next seed's mystery.
-    let reaped = reap_leaked_clones().await;
     if reaped > 0 {
         eprintln!(
             "FUZZ seed={} reaped {} clone(s) a dropped op left behind",
@@ -1196,7 +1245,9 @@ async fn a_disarmed_clone_guard_leaves_the_process_alone() {
     let pid = child.id().expect("child pid");
     register_clone(pid);
 
-    CloneGuard { pid, armed: false }.disarm();
+    // ARMED, then disarmed: constructing it already-disarmed would pass even if
+    // the body of `disarm` were deleted, which is a test that cannot fail.
+    CloneGuard { pid, armed: true }.disarm();
 
     // Still alive: a disarmed guard must not have signalled it.
     let early = tokio::time::timeout(Duration::from_millis(300), child.wait()).await;

--- a/tests/test_fuzz_chaos.rs
+++ b/tests/test_fuzz_chaos.rs
@@ -73,6 +73,17 @@ enum Op {
     SnapshotCreate,
     /// Flood the console/exec stream with 5000 lines of output.
     ConsoleFlood,
+    /// Restore a clone from a snapshot this seed took and immediately hit its
+    /// forwarded port — the readiness contract a caller relies on.
+    ///
+    /// This is the op that reaches the restore-time network path: a restored
+    /// guest inherits the snapshot's conntrack table and its published-port
+    /// DNAT, and fcvm declares the clone ready only after the guest answers a
+    /// TCP probe. A clone handed over before that path settles shows up here
+    /// as a failed curl against a clone fcvm called ready. Observed in the
+    /// wild at roughly 1 in 400 restores (2026-08-15), which no single-VM op
+    /// in this harness could ever reach.
+    CloneRestore,
     /// Seeded 0-400ms sleep (also substituted when the snapshot budget is
     /// spent, keeping rng consumption uniform at one draw per op).
     JitterSleep,
@@ -87,6 +98,7 @@ const OP_WEIGHTS: &[(Op, u32)] = &[
     (Op::StateRead, 15),
     (Op::SnapshotCreate, 6),
     (Op::ConsoleFlood, 9),
+    (Op::CloneRestore, 12),
     (Op::JitterSleep, 20),
 ];
 
@@ -375,6 +387,46 @@ async fn apply_op(
             );
             Ok(format!("{} bytes", out.len()))
         }
+        Op::CloneRestore => {
+            // Nothing to restore until this seed has taken a snapshot; the
+            // draw is still consumed above, so the schedule stays a pure
+            // function of the seed.
+            let Some(tag) = snapshots.last().cloned() else {
+                return Ok("no snapshot yet".to_string());
+            };
+            let clone_name = format!("{}-clone-{}", snap_base, op_idx);
+            // No --publish here: `snapshot run` takes none, because a clone
+            // INHERITS the snapshot's port mappings. In rootless mode each
+            // clone gets its own loopback IP, so the inherited host port is
+            // reached at that address (same shape as
+            // test_clone_port_forward_rootless).
+            let (mut clone_child, clone_pid) =
+                common::spawn_fcvm(&["snapshot", "run", "--snapshot", &tag, "--name", &clone_name])
+                    .await
+                    .with_context(|| format!("restoring clone from {}", tag))?;
+
+            // fcvm only reports a clone up after its own post-restore
+            // port-forward verification, so a curl that fails here means the
+            // readiness contract was declared on something the data path does
+            // not honour — the exact defect this op exists to catch.
+            let verdict = async {
+                common::poll_health_by_pid(clone_pid, 60)
+                    .await
+                    .context("restored clone never became healthy")?;
+                let clone_ip = common::get_loopback_ip(clone_pid)
+                    .await
+                    .context("clone has no loopback IP after restore")?;
+                curl_once(&clone_ip, port)
+                    .await
+                    .context("clone reported healthy but its inherited forwarded port is dead")
+            }
+            .await;
+
+            common::kill_process(clone_pid).await;
+            let _ = clone_child.wait().await;
+            let detail = verdict?;
+            Ok(format!("clone={} {}", clone_name, detail))
+        }
         Op::JitterSleep => {
             let ms = draw % 401; // 0-400ms
             tokio::time::sleep(Duration::from_millis(ms)).await;
@@ -480,6 +532,18 @@ async fn run_seed_body(
         seed,
         boot_start.elapsed().as_secs_f64()
     );
+
+    // One baseline snapshot BEFORE the op loop, so CloneRestore has something
+    // to restore from its first draw. Without it most CloneRestore ops fall
+    // through as "no snapshot yet" (5 of 6 in the first run of this rung), and
+    // a defect that appears roughly once in 400 restores needs every restore
+    // the budget allows. Taken outside the loop, so it consumes no rng draw
+    // and the schedule stays a pure function of the seed.
+    let baseline_tag = format!("{}-base", snap_base);
+    common::create_snapshot_by_pid(pid, &baseline_tag)
+        .await
+        .with_context(|| format!("seed {}: baseline snapshot for clone restores", seed))?;
+    snapshots.push(baseline_tag);
 
     let ip = common::get_loopback_ip(pid).await?;
     let vm_id = {

--- a/tests/test_hugepages.rs
+++ b/tests/test_hugepages.rs
@@ -68,7 +68,7 @@ async fn ensure_hugepages(mem_mib: u32) -> Result<()> {
             );
         }
 
-        if start.elapsed().as_secs() % 10 == 0 && start.elapsed().as_secs() > 0 {
+        if start.elapsed().as_secs().is_multiple_of(10) && start.elapsed().as_secs() > 0 {
             println!(
                 "  Waiting for hugepages: {} free, need {} ({} in use)...",
                 free, needed, in_use

--- a/tests/test_snapshot_clone.rs
+++ b/tests/test_snapshot_clone.rs
@@ -4218,12 +4218,27 @@ async fn snapshot_leaves_the_source_network_untouched() -> anyhow::Result<()> {
 
     // `ip neigh` is deliberately included: it is the table that regressed, and
     // the one a "reinstate the routes" fix did not cover.
+    //
+    // PERMANENT-ness is part of the sample, not decoration. An earlier version
+    // printed only address/device/MAC, and a purge could not be seen through
+    // it: the entry is re-learned by the next packet, and since the bridge MAC
+    // is pinned the re-learned line is byte-identical. Watched failing to
+    // discover that -- with a deliberate `ip neigh del` on the resume path, the
+    // test still PASSED. Transient churn among REACHABLE/STALE/DELAY is
+    // tolerated; losing the pin is not.
+    //
+    // IPv6 link-local (fe80::) neighbours are excluded. The kernel discovers
+    // and expires those continuously from router advertisements, so they churn
+    // on their own schedule and would make this test fail for reasons that have
+    // nothing to do with snapshotting. Everything a purge would destroy is
+    // still compared: the IPv4 entries, global IPv6 entries, routes and
+    // addresses.
     let sample = || async move {
         common::exec_in_vm(
             pid,
             &["sh -c 'PATH=/usr/sbin:/sbin:/usr/bin:/bin; \
                echo ROUTES; ip route show | sort; \
-               echo NEIGH; ip neigh show | awk \"{print \\$1, \\$3, \\$5}\" | sort; \
+               echo NEIGH; ip neigh show | grep -v \"^fe80:\" | awk \"{p=(\\$NF==\\\"PERMANENT\\\")?\\\"PERMANENT\\\":\\\"dynamic\\\"; print \\$1, \\$3, \\$5, p}\" | sort; \
                echo ADDR; ip -br addr show | sort'"],
         )
         .await

--- a/tests/test_snapshot_clone.rs
+++ b/tests/test_snapshot_clone.rs
@@ -4217,8 +4217,8 @@ async fn snapshot_leaves_the_source_network_untouched() -> anyhow::Result<()> {
     common::poll_health(&mut child, 300).await?;
 
     // `ip neigh` is deliberately included: it is the table that regressed, and
-    // the one a "reinstate the routes" fix does not cover.
-    let sample = |label: &'static str| async move {
+    // the one a "reinstate the routes" fix did not cover.
+    let sample = || async move {
         common::exec_in_vm(
             pid,
             &["sh -c 'PATH=/usr/sbin:/sbin:/usr/bin:/bin; \
@@ -4227,31 +4227,55 @@ async fn snapshot_leaves_the_source_network_untouched() -> anyhow::Result<()> {
                echo ADDR; ip -br addr show | sort'"],
         )
         .await
-        .map(|out| (label, out))
     };
 
-    let (_, before) = sample("before").await?;
-    common::create_snapshot_by_pid(pid, &snap_tag).await?;
-    // The source resumed; give its reopen path a moment to finish publishing.
-    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-    let (_, after) = sample("after").await?;
+    // Everything between here and teardown is captured, never `?`-propagated:
+    // an early return would leak this VM and its snapshot into the rest of the
+    // suite, which is exactly the kind of cross-test contamination that makes a
+    // later failure unreadable.
+    let outcome = async {
+        let before = sample().await?;
+        common::create_snapshot_by_pid(pid, &snap_tag).await?;
+        // The source resumed; give its publication a moment to finish.
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        let after = sample().await?;
+        anyhow::Ok((before, after))
+    }
+    .await;
 
     common::kill_process(pid).await;
     let _ = child.wait().await;
     let _ = common::delete_snapshot(&snap_tag).await;
 
+    let (before, after) = outcome?;
     if before.trim() != after.trim() {
-        let diff: Vec<String> = before
-            .lines()
-            .zip(after.lines())
+        let (b_lines, a_lines): (Vec<&str>, Vec<&str>) = (
+            before.trim().lines().collect(),
+            after.trim().lines().collect(),
+        );
+        let mut diff: Vec<String> = b_lines
+            .iter()
+            .zip(a_lines.iter())
             .filter(|(b, a)| b != a)
             .map(|(b, a)| format!("  before: {b}\n  after:  {a}"))
             .collect();
+        // zip stops at the shorter side, so a line that exists on only one side
+        // would vanish from the report -- and a DISAPPEARING neighbour entry is
+        // precisely the shape of the defect this test exists to catch.
+        if b_lines.len() != a_lines.len() {
+            diff.push(format!(
+                "  line count changed: before={} after={} (entries were added or removed)",
+                b_lines.len(),
+                a_lines.len()
+            ));
+        }
         anyhow::bail!(
-            "snapshotting mutated the source VM's network and did not put it back.\n\
-             The snapshot boundary takes eth0 down, which purges routes AND \
-             neighbours; whatever is missing here was purged and never reinstated \
-             (see reopen_with in fc-agent/src/snapshot_network.rs).\n\
+            "the source VM's network state changed across one snapshot.\n\
+             Snapshotting must READ the source, never reconfigure it: nothing on \
+             that path may down a link, flush a table, or otherwise destroy \
+             kernel state. Inspect prepare_with and reopen_with in \
+             fc-agent/src/snapshot_network.rs for a step that mutates and does \
+             not fully undo itself.\n\
              differing lines:\n{}\n\n--- before ---\n{}\n--- after ---\n{}",
             diff.join("\n"),
             before.trim(),

--- a/tests/test_snapshot_clone.rs
+++ b/tests/test_snapshot_clone.rs
@@ -4167,3 +4167,96 @@ async fn a_panicking_clone_handler_returns_its_slot() -> Result<()> {
     );
     Ok(())
 }
+
+/// Snapshotting must leave the SOURCE VM's network exactly as it found it.
+///
+/// A caller asked for a copy. It must not get its live VM reconfigured to
+/// produce one, and this is the guard that says so.
+///
+/// The boundary that makes a snapshot cloneable needs two things: no NEW socket
+/// may appear while the cookie dump runs, and packets already in receive
+/// processing must drain first. The NEW-flow gate delivers the first and the
+/// AF_PACKET barrier the second; both are reversible and destroy nothing.
+///
+/// A `link.down()` used to sit between them, preventing sockets the gate already
+/// rejected and purging the device's routes and neighbours to do it. Everything
+/// it purged then had to be reinstated by hand, and twice that list was
+/// incomplete:
+///
+///   2026-08-10 ee3f5c30  the ROUTE table     -> "a restored clone came up
+///                                               reachable at L2 and routed nowhere"
+///   2026-08-15           the NEIGHBOUR table -> the guest re-ARPed for the bridge,
+///                                               sometimes learned pasta's MAC,
+///                                               answered inbound SYNs to the wrong
+///                                               MAC and had them RST. A published
+///                                               port died ~1 snapshot in 10 with no
+///                                               drop counted anywhere.
+///
+/// The link-down is gone, so the purge is gone, so the repair lists are gone.
+/// This test is what keeps them gone: it compares the guest's routes, neighbours
+/// and addresses across one snapshot and fails on any difference.
+#[tokio::test]
+#[cfg_attr(not(feature = "privileged-tests"), ignore)]
+async fn snapshot_leaves_the_source_network_untouched() -> anyhow::Result<()> {
+    let (vm_name, _, snap_tag, _) = common::unique_names("snapsrc");
+    let (mut child, pid) = common::spawn_fcvm_with_logs(
+        &[
+            "podman",
+            "run",
+            "--name",
+            &vm_name,
+            "--network",
+            "rootless",
+            "--health-check",
+            "http://localhost/",
+            common::TEST_IMAGE,
+        ],
+        &vm_name,
+    )
+    .await?;
+    common::poll_health(&mut child, 300).await?;
+
+    // `ip neigh` is deliberately included: it is the table that regressed, and
+    // the one a "reinstate the routes" fix does not cover.
+    let sample = |label: &'static str| async move {
+        common::exec_in_vm(
+            pid,
+            &["sh -c 'PATH=/usr/sbin:/sbin:/usr/bin:/bin; \
+               echo ROUTES; ip route show | sort; \
+               echo NEIGH; ip neigh show | awk \"{print \\$1, \\$3, \\$5}\" | sort; \
+               echo ADDR; ip -br addr show | sort'"],
+        )
+        .await
+        .map(|out| (label, out))
+    };
+
+    let (_, before) = sample("before").await?;
+    common::create_snapshot_by_pid(pid, &snap_tag).await?;
+    // The source resumed; give its reopen path a moment to finish publishing.
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    let (_, after) = sample("after").await?;
+
+    common::kill_process(pid).await;
+    let _ = child.wait().await;
+    let _ = common::delete_snapshot(&snap_tag).await;
+
+    if before.trim() != after.trim() {
+        let diff: Vec<String> = before
+            .lines()
+            .zip(after.lines())
+            .filter(|(b, a)| b != a)
+            .map(|(b, a)| format!("  before: {b}\n  after:  {a}"))
+            .collect();
+        anyhow::bail!(
+            "snapshotting mutated the source VM's network and did not put it back.\n\
+             The snapshot boundary takes eth0 down, which purges routes AND \
+             neighbours; whatever is missing here was purged and never reinstated \
+             (see reopen_with in fc-agent/src/snapshot_network.rs).\n\
+             differing lines:\n{}\n\n--- before ---\n{}\n--- after ---\n{}",
+            diff.join("\n"),
+            before.trim(),
+            after.trim()
+        );
+    }
+    Ok(())
+}

--- a/tests/test_snapshot_clone.rs
+++ b/tests/test_snapshot_clone.rs
@@ -4263,36 +4263,39 @@ async fn snapshot_leaves_the_source_network_untouched() -> anyhow::Result<()> {
     let _ = common::delete_snapshot(&snap_tag).await;
 
     let (before, after) = outcome?;
-    if before.trim() != after.trim() {
-        let (b_lines, a_lines): (Vec<&str>, Vec<&str>) = (
-            before.trim().lines().collect(),
-            after.trim().lines().collect(),
-        );
-        let mut diff: Vec<String> = b_lines
-            .iter()
-            .zip(a_lines.iter())
-            .filter(|(b, a)| b != a)
-            .map(|(b, a)| format!("  before: {b}\n  after:  {a}"))
-            .collect();
-        // zip stops at the shorter side, so a line that exists on only one side
-        // would vanish from the report -- and a DISAPPEARING neighbour entry is
-        // precisely the shape of the defect this test exists to catch.
-        if b_lines.len() != a_lines.len() {
-            diff.push(format!(
-                "  line count changed: before={} after={} (entries were added or removed)",
-                b_lines.len(),
-                a_lines.len()
-            ));
-        }
+
+    // The invariant is that nothing is LOST OR ALTERED, not that nothing is
+    // learned. A guest goes on discovering neighbours while the snapshot is
+    // taken -- CI caught this test failing because the guest legitimately
+    // learned its IPv6 gateway (fd00::2) during the window. Additions are
+    // normal operation; a line that was there before and is gone or changed
+    // afterwards is the defect, and that is exactly what a purge looks like.
+    let before_lines: std::collections::BTreeSet<&str> =
+        before.trim().lines().map(str::trim).collect();
+    let after_lines: std::collections::BTreeSet<&str> =
+        after.trim().lines().map(str::trim).collect();
+    let lost: Vec<&&str> = before_lines.difference(&after_lines).collect();
+    if !lost.is_empty() {
+        let gained: Vec<&&str> = after_lines.difference(&before_lines).collect();
         anyhow::bail!(
-            "the source VM's network state changed across one snapshot.\n\
+            "the source VM lost or altered network state across one snapshot.\n\
              Snapshotting must READ the source, never reconfigure it: nothing on \
              that path may down a link, flush a table, or otherwise destroy \
              kernel state. Inspect prepare_with and reopen_with in \
              fc-agent/src/snapshot_network.rs for a step that mutates and does \
              not fully undo itself.\n\
-             differing lines:\n{}\n\n--- before ---\n{}\n--- after ---\n{}",
-            diff.join("\n"),
+             GONE after the snapshot:\n{}\n\
+             (appeared, which is fine and shown only for context:\n{})\n\n\
+             --- before ---\n{}\n--- after ---\n{}",
+            lost.iter()
+                .map(|l| format!("  {l}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+            gained
+                .iter()
+                .map(|l| format!("  {l}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
             before.trim(),
             after.trim()
         );


### PR DESCRIPTION
A published port would go silent after a snapshot, roughly 1 time in 10, and
nothing anywhere recorded a drop. This is the hunt that found it and the fix,
which turned out to be a deletion.

## What was happening

`snapshot create` took the guest's external link **down** while arming the TCP
generation boundary. That is a kernel-level purge: it empties the device's route
table **and** its neighbour table. Everything destroyed then had to be
remembered and reinstated by hand, and the list was wrong twice:

| when | purged | outcome |
|---|---|---|
| 2026-08-10 `ee3f5c30` | routes | fixed after the fact: *"a restored clone came up reachable at L2 and routed nowhere"* |
| 2026-08-15 (this PR) | neighbours | never reinstated |

After a snapshot the guest had no entry for the bridge address every health
check and published connection arrives from, so it re-ARPed. Both the bridge
(which owns `10.0.2.1`) and pasta (which answers for the subnet it routes)
reply, and the guest keeps whichever lands first. When pasta won — captured on
the wire:

```
SYN      br0-mac   > guest-mac           10.0.2.1 > 10.0.2.100  [S]
SYN-ACK  guest-mac > 9a:55:9a:55:9a:55   10.0.2.100 > 10.0.2.1  [S.]   <- pasta
RST      9a:55:9a:55:9a:55 > guest-mac   10.0.2.1 > 10.0.2.100  [R]
```

The guest answered the wrong MAC; pasta correctly reset a connection it had
never opened. The caller saw a port that accepts (pasta's listener) and then
returns zero bytes until its deadline. No counter moved because nothing was
dropped.

## The fix

The boundary needs two things: no NEW socket while the cookie dump runs, and
packets already in receive processing drained first. The **gate** (directional
NEW-flow REJECT) does the first; the **AF_PACKET barrier** (`synchronize_net()`)
does the second. Both are reversible and destroy nothing.

`link.down()` sat between them preventing sockets the gate already rejects, and
paid for it by purging routes and neighbours. **It is gone from the source path
and the restore path**, which makes the route capture/reinstate unnecessary
rather than something to keep in step.

```
fc-agent/src/snapshot_network.rs | 150 +++++  663 ------
```

The dump still happens at snapshot time and cannot move to restore: by then the
restored workload and an early published-port client can both have created
sockets, so it could not describe a fixed generation, and a four-tuple is not a
socket identity (`95ce328a`).

**Why the bridge MAC is now pinned:** with no purge, a clone inherits the
source's neighbour table, whose entries hold the *origin* namespace's bridge
MAC. `NAMESPACE_MAC` makes that MAC identical in every namespace, so inherited
entries are correct instead of subtly wrong.

## Evidence

```
seed-16 hunt      12/12 attempts PASSED, 0 reproductions
                  (before: reproduced on attempts 1, 4, 5 and 7)
live VM           3 consecutive snapshots -> routes and neighbours
                  byte-identical, published port still 200
fc-agent          105 tests pass
lint              fmt + clippy -D warnings clean, both crates
```

Latency was bimodal across 429 measured requests — 421 under 0.1s, **zero**
between 0.1s and 4.5s, 8 at the 5s deadline — which is what ruled out
contention and pointed at a binary state change.

## Guards, so it cannot come back

- `ModelBarrier` / `ModelDiag` fail if any boundary step downs the link, on
  either path.
- `the_boundary_reinstates_the_routes_its_link_down_purged` became
  `the_boundary_never_purges_the_route_table`.
- `snapshot_leaves_the_source_network_untouched` diffs the guest's routes,
  neighbours and addresses across a snapshot and fails on any difference.
- `namespace_neighbour_matches_host_constants` fails if the host and guest
  copies of the pinned MAC drift.

## Also in here

- The chaos-fuzz harness that found it: forensics that name the failing layer
  (container vs guest vs namespace, `time_connect` vs `time_starttransfer`,
  INPUT drop counters, tap-level `tcpdump`), and a `CloneGuard` that cannot
  strand a VM when an op is cancelled.
- `AGENTS.md`: a **SUSPENDING A VM DOES NOT DISTURB IT** section, and the
  `fcvm exec` gotcha — it lands in the *container* by default, which cost
  several rounds of this investigation by returning confident emptiness.
- `tests/test_hugepages.rs`: a clippy failure that was red on a clean tree.

Closes #838.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot and restore networking while preserving VM routes, neighbors, addresses, and link state.
  * Stabilized guest port health checks by pinning namespace neighbor resolution.
  * Ensured consistent bridge and gateway networking across supported configurations.

* **Tests**
  * Expanded coverage for snapshot cloning, restoration, cleanup, timeouts, and network-state preservation.
  * Added validation for clone lifecycle handling and network diagnostics.

* **Documentation**
  * Clarified VM versus container command execution and snapshot networking requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->