### PR TITLE
Bound each readiness probe attempt so one stall cannot eat the budget

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -374,6 +374,39 @@ where nobody looks. Find the cheap equivalent:
 If after genuinely trying you cannot make it cheap, say so **in the test file**, with what it
 would take — never only in a commit message, where the next reader will not find it.
 
+## WHAT CI CAPTURES WHEN SOMETHING FAILS
+
+The rule behind all of it: **a failure must carry the evidence needed to attribute it.**
+Every unattributable failure this repo has chased ended the same way, with the state gone by
+the time anyone looked, and the argument settled by whoever sounded most confident.
+
+Host side, captured today:
+
+| What | Where | Why it is there |
+|---|---|---|
+| `sar -q` / `sar -u`, whole day | `host-load.log` artifact | sysstat already runs on every runner and nothing read it. 10-minute samples, so it answers "was the box busy", not "at this millisecond" |
+| `pidstat -u -h 30` during the suite | `pidstat.log` artifact | `sar` is system-wide and the post-step snapshot is taken after the suite ends, so neither can say WHICH process consumed the host at the moment of a timeout |
+| `/proc/loadavg` inline in the readiness error | the error text itself | so "the box was busy" is checkable in the message, without fetching anything |
+| filtered `dmesg` | `dmesg-filtered.log` artifact | host OOM, KVM, page-fault signatures |
+| D-state watchdog | live step log | prints nothing when healthy; an ephemeral runner dies with its artifacts, so the live log is the only channel that survives |
+
+Rules learned the hard way, each from a check that could not fire:
+
+- **Never conclude "no OOM" from a job log.** Guest console lines are DEBUG and filtered out of
+  it, and host `dmesg` only reaches an artifact. Measured: `grep -c "DEBUG firecracker"` on a
+  259,570-line job log returns 0. Render resource verdicts against `/tmp/fcvm-test-logs/*`, and
+  fail closed when the artifact is missing.
+- **Prefer `/proc/vmstat`'s `oom_kill` to dmesg.** It is monotonic and cannot wrap. The guest's
+  printk ring is 128 KiB (`CONFIG_LOG_BUF_SHIFT=17`) and a chatty boot does wrap it, so a
+  dmesg-only OOM check intermittently cannot fire.
+- **Never `statvfs` a path you have not proved is local.** On a wedged FUSE mount it parks in
+  uninterruptible sleep and no timeout can cancel it, turning a diagnostic into a second hang.
+  Read `/proc/self/mountinfo` first and skip anything that is not tmpfs/ext4/btrfs/xfs.
+- **Never read `/proc/<pid>/cmdline` in a wedge scan.** It faults the target's mm and hangs on
+  exactly the processes you are trying to inspect.
+- **A collector that cannot run must say so.** Silence from a diagnostic is indistinguishable
+  from a clean result, which is the same bug as a gate printing CLEAN because `jq` was missing.
+
 ## HOW TO INVESTIGATE A TIMEOUT
 
 A deadline miss says one thing only: the answer did not arrive in time. It does NOT say the

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -213,6 +213,45 @@ The gate has its own tests, each written against the unfixed script and observed
 live oversized-thread path that fixtures cannot reach. CI state cannot tell you whether a
 finding was answered.
 
+### "LOAD RELATED" IS NOT A DIAGNOSIS. NEITHER IS "FLAKY", "TIMING", OR "CONTENTION"
+
+**These words describe the absence of an explanation, not an explanation.** They
+are what an investigation says when it has stopped. Every one of them has a
+measurement attached, and the measurement is cheap, so take it before saying the
+word:
+
+| the claim | what must be shown |
+|---|---|
+| "it was load" | `/proc/loadavg` AND per-process CPU **at the moment of failure** - captured by the failing run, not inferred afterwards |
+| "it was slow" | the operation completing at all, with its duration; "it appeared moments later" is worthless if the diagnostic itself provoked the appearance |
+| "contention" | a latency distribution that DEGRADES CONTINUOUSLY. Contention produces a spread; a broken path produces two clusters |
+| "flaky" | a failure rate, and a mechanism for the failures |
+
+Load produces a spectrum. A broken path produces a step function. That single
+test settles most of these arguments for free, and it is one `awk` away from
+data you already have.
+
+Observed 2026-08-15, three times in one investigation, all three wrong:
+
+- Claimed the published-port flake was contention. The distribution refuted it:
+  **421 requests under 0.1s, ZERO between 0.1s and 4.5s, 8 at the 5s deadline.**
+  Perfectly bimodal. The real cause was a purged neighbour entry, a binary state.
+- Claimed a box was "quiet" because I had stopped my own work. I had not stopped
+  the other tenants (three `claude` sessions and two `codex` processes were
+  running), and had never measured. Separately quoted `loadavg 6.43` as evidence
+  of CPU load when the visible processes summed to well under one core of a
+  64-core box: loadavg counts uninterruptible I/O, so it was mostly btrfs.
+- Claimed a restored clone was "merely slow to announce", from a forensics dump
+  taken AFTER the failure - a dump whose own probing can create the very entry
+  it then reports. The actual error said `neighbour: ""` and `probe: (silence)`
+  for a full 5 seconds. Nothing was slow. Something was broken, and a timeout
+  increase built on that theory would have hidden it.
+
+**A timeout increase is the most dangerous form of this.** It converts a defect
+into latency and ships. Raise a timeout only when you can show the operation
+COMPLETING at a measured duration, and say the duration in the commit message.
+"It needs more time" without a number is a guess wearing a fix's clothes.
+
 ### A FUZZ CATCH IS A LEAD, NOT A REGRESSION TEST
 
 **When the chaos fuzz (or any stochastic harness) finds a defect, the fix is not
@@ -334,6 +373,44 @@ where nobody looks. Find the cheap equivalent:
 
 If after genuinely trying you cannot make it cheap, say so **in the test file**, with what it
 would take — never only in a commit message, where the next reader will not find it.
+
+## HOW TO INVESTIGATE A TIMEOUT
+
+A deadline miss says one thing only: the answer did not arrive in time. It does NOT say the
+peer was slow, and it never says the box was busy. Work the list in order; each step is a
+measurement, and any of them can end the investigation.
+
+1. **Get the load, do not assume it.** Every runner runs sysstat, so the record already
+   exists: `sar -q -f /var/log/sysstat/sa<DD> -s HH:MM:00 -e HH:MM:00` for load average and
+   run queue, `sar -u` for idle/steal. CI captures both (`Capture host load record`) and the
+   readiness error embeds `/proc/loadavg` inline. Run 31906708922 was **95.1% idle, run queue
+   1, 0% steal** at the failing sample -- every "the box was busy" sentence written about it
+   was false, and checkable in one command.
+2. **Compare against the healthy distribution, not against the deadline.** Pull the same
+   measurement from a passing run. Healthy readiness there was **84ms** against a 5s deadline.
+   Two orders of magnitude is a different state, not a slow tail, and it rules out "just raise
+   the timeout" without further argument. Log the duration on SUCCESS so this comparison is
+   always available (`readiness_ms`).
+3. **Prove the waiter actually ran.** Count its per-round log lines across the window. Zero
+   rounds in 5s means the loop never iterated, so every field in its error message is a
+   default, not an observation -- `neighbour: ""` meant "never queried", not "no entry".
+   A check that reports on work it never did is the same fail-open bug as a gate that passes
+   because `jq` was missing.
+4. **Look for evidence that contradicts the error text.** The same forensics that said the
+   guest never answered also held a TIME-WAIT socket to that guest and a REACHABLE neighbour
+   entry: the guest had answered. When the error and the artifacts disagree, the error is
+   wrong.
+5. **Bound every attempt, not just the total.** One subprocess that never returns will eat an
+   entire budget and produce a message blaming the peer. Wrap each attempt
+   (`GUEST_PROBE_ATTEMPT_BUDGET`) and count abandonments in the error. Do not trust a
+   subprocess to honour a budget you handed it -- the probe already ran `timeout(1) bash` and
+   still hung the caller.
+6. **Kill hypotheses with an experiment, cheaply.** "netns churn stalls nsenter" sounded
+   right; 16 churners moved nsenter from 9ms to 18ms max, so it was wrong and cost 60s to
+   find out. A two-arm measurement beats a paragraph of reasoning.
+
+Raising a timeout is a valid fix only after step 2 shows the healthy distribution genuinely
+crowds the deadline. Otherwise it hides the defect and buys a slower failure.
 
 ## STACKED PRs BY DEFAULT
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -767,6 +767,25 @@ jobs:
         if: always()
         run: |
           sudo dmesg | grep -iE 'userfault|uffd|kvm|firecracker|oom|killed|segfault|page.fault' > /tmp/fcvm-test-logs/dmesg-filtered.log || true
+      # The runners already run sysstat, and nothing was reading it. Without this,
+      # every deadline miss in a test invites "the box was busy" as an explanation
+      # that cannot be checked -- and on the run this was added for, the box was
+      # 95% idle with a run queue of 1. Capture the record so the question is
+      # answered from data instead of argued from intuition.
+      - name: Capture host load record
+        if: always()
+        run: |
+          {
+            echo "### /proc/loadavg at capture time"
+            cat /proc/loadavg
+            echo "### nproc"
+            nproc
+            echo "### sar -q (run queue and load average, whole day)"
+            LC_ALL=C sar -q 2>&1 || echo "sar -q unavailable"
+            echo "### sar -u (CPU utilisation, whole day)"
+            LC_ALL=C sar -u 2>&1 || echo "sar -u unavailable"
+          } > /tmp/fcvm-test-logs/host-load.log 2>&1 || true
+          echo "load at capture: $(cat /proc/loadavg) on $(nproc) CPUs"
       - name: Upload test logs
         if: always()
         uses: actions/upload-artifact@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -732,6 +732,14 @@ jobs:
           # instance is terminated with its artifacts — the live log pipe is
           # the only channel that survives, so the watchdog must share it.
           sudo ./scripts/ci-dstate-watchdog.sh & WD=$!
+          # Per-process CPU, sampled WHILE the tests run. `sar` is system-wide
+          # and the post-step snapshot is taken after the suite has finished, so
+          # neither can say WHICH process consumed the host at the moment a
+          # readiness probe timed out. pidstat can. One process, 30s samples,
+          # written to the artifact directory rather than the job log.
+          (pidstat -u -h 30 > /tmp/fcvm-test-logs/pidstat.log 2>&1 || \
+            echo "pidstat unavailable (sysstat not installed)" > /tmp/fcvm-test-logs/pidstat.log) &
+          PIDSTAT=$!
           SNAPSHOT_DIR="${FCVM_DATA_DIR:-/mnt/fcvm-btrfs/root}/snapshots"
           for i in $(seq 1 ${{ matrix.test_runs }}); do
             echo ""
@@ -751,6 +759,7 @@ jobs:
             fi
           done
           sudo kill $WD 2>/dev/null || true
+          kill $PIDSTAT 2>/dev/null || true
       - name: bench-vm
         if: matrix.mode == 'SnapshotEnabled'
         working-directory: fcvm

--- a/scripts/scan-test-log.sh
+++ b/scripts/scan-test-log.sh
@@ -38,14 +38,26 @@ pass=$(count '(^|[^A-Z])PASS \[')
 # A hard FAIL must exclude retry lines: "TRY 1 FAIL [" also ends in " FAIL [",
 # so counting it here would double-report every retry as a hard failure.
 fail=$(grep -aE '(^|[^A-Z])FAIL \[' "$clean" | grep -acvE 'TRY [0-9]+ FAIL'; true)
-try_fail=$(count 'TRY [0-9]+ FAIL \[')
+# A retry counts however its first attempt died. nextest reports a slow-timeout
+# kill as TMT and a terminating run as TRMNTG, so a pattern matching only FAIL is
+# blind to a 900s hang that passes in 7s on retry. Five of those occurred in one
+# 6-day window, every one inside a job that reported green.
+try_fail=$(count 'TRY [0-9]+ (FAIL|TMT|TRMNTG|SIGSEGV|SIGABRT|ABORT|LEAK) \[')
 timeout=$(count '(^|[^A-Z])TIMEOUT \[')
 leak=$(count '(^|[^A-Z])LEAK \[')
 # The per-test "FLAKY [" verdict and the summary's "(N flaky)" describe the SAME
 # retries; count only the per-test verdict so a flake is not reported twice.
+# Dead in practice: with retries configured, nextest prints "TRY n <status>"
+# lines and no per-test "FLAKY [" verdict, so this reads 0 in every real log.
+# Kept only because a differently-configured run can emit it; never rely on it
+# alone, which is why try_fail above carries the weight.
 flaky=$(count '(^|[^A-Z])FLAKY \[')
 
-summary=$(grep -aE 'Summary \[.*tests run:' "$clean" | tail -1 | sed 's/^[[:space:]]*//')
+# EVERY summary, not the last one. A SnapshotEnabled job runs the suite twice
+# and emits two; in 7 of 19 multi-summary jobs the flaky summary is the FIRST,
+# and `tail -1` silently discarded it.
+summaries=$(grep -aE 'Summary \[.*tests run:' "$clean" | sed 's/^[[:space:]]*//')
+summary=$(printf '%s\n' "$summaries" | tail -1)
 
 echo "summary: ${summary:-<none found>}"
 echo "pass: $pass"
@@ -62,8 +74,14 @@ echo "flaky: $flaky"
 # gone, and this then reported CLEAN on a run the summary itself called failed —
 #   "Summary [10.0s] 1 tests run: 0 passed, 1 failed"  ->  verdict: CLEAN, exit 0
 # which is the exact defect this scanner exists to catch.
-summary_failed=$(sed -nE 's/.*tests? run:.*[^0-9]([0-9]+) failed.*/\1/p' <<<"$summary" | head -1)
-summary_flaky=$(sed -nE 's/.*\(([0-9]+) flaky\).*/\1/p' <<<"$summary" | head -1)
+# Summed across ALL summaries. `flaky` is never alone in the parens: nextest
+# writes "(1 slow, 1 flaky)", so a pattern anchored on `\(N flaky\)` matched
+# nothing in production and this gate never once fired.
+sum_field() {
+  printf '%s\n' "$summaries" | sed -nE "$1" | awk '{t+=$1} END {print t+0}'
+}
+summary_failed=$(sum_field 's/.*tests? run:.*[^0-9]([0-9]+) failed.*/\1/p')
+summary_flaky=$(sum_field 's/.*[( ]([0-9]+) flaky[,)].*/\1/p')
 summary_passed=$(sed -nE 's/.*tests? run:[^0-9]*([0-9]+) passed.*/\1/p' <<<"$summary" | head -1)
 summary_total=$(sed -nE 's/.*\] ([0-9]+) tests? run:.*/\1/p' <<<"$summary" | head -1)
 

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -300,18 +300,29 @@ async fn wait_for_guest_to_answer<P: GuestProbe>(
     // the deadline error: it is the difference between "the guest said nothing"
     // and "this check never got an answer out of its own subprocess".
     let mut stalled_attempts: u32 = 0;
+    // Whether the guest's TCP probe answered on the LAST completed attempt. An
+    // answered probe leaves `detail` empty, and rendering "empty" as silence is
+    // what made run 31906708922 read as a dead guest when the guest had in fact
+    // answered (its own TIME-WAIT socket was in the namespace dump). Carry the
+    // state rather than inferring it from an absence.
+    let mut last_answered = false;
 
     loop {
-        rounds += 1;
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         if remaining.is_zero() {
             return Err(guest_unanswered_error(
                 &last_neighbor,
                 &last_detail,
+                last_answered,
                 rounds,
                 stalled_attempts,
             ));
         }
+        // Counted here, not at the top of the loop: a round that finds the
+        // deadline already spent probed nothing, and a reported count that
+        // includes it overstates the work by one. The number is a diagnostic,
+        // so it has to be the number of attempts actually made.
+        rounds += 1;
         // Each attempt is bounded separately from the deadline, so one stuck
         // attempt costs a round instead of the whole budget.
         let attempt = remaining.min(GUEST_PROBE_ATTEMPT_BUDGET);
@@ -338,6 +349,7 @@ async fn wait_for_guest_to_answer<P: GuestProbe>(
                     }
                 }
             };
+        last_answered = answer.answered;
         last_detail = answer.detail;
         if !answer.answered {
             debug!(
@@ -353,6 +365,7 @@ async fn wait_for_guest_to_answer<P: GuestProbe>(
             return Err(guest_unanswered_error(
                 &last_neighbor,
                 &last_detail,
+                last_answered,
                 rounds,
                 stalled_attempts,
             ));
@@ -406,6 +419,7 @@ async fn wait_for_guest_to_answer<P: GuestProbe>(
             return Err(guest_unanswered_error(
                 &last_neighbor,
                 &last_detail,
+                last_answered,
                 rounds,
                 stalled_attempts,
             ));
@@ -447,14 +461,19 @@ fn host_load_snapshot() -> String {
 fn guest_unanswered_error(
     neighbor: &str,
     detail: &str,
+    answered: bool,
     rounds: u32,
     stalled_attempts: u32,
 ) -> anyhow::Error {
     let neighbor = neighbor.trim();
-    let detail = if detail.is_empty() {
-        "(silence)"
-    } else {
-        detail
+    // An answered probe leaves `detail` empty, so empty means two opposite
+    // things and must never be rendered as one. Reporting "(silence)" for a
+    // guest that answered is what made run 31906708922 read as a dead guest
+    // while its own TIME-WAIT socket to the prober sat in the namespace dump.
+    let detail = match (answered, detail.is_empty()) {
+        (true, _) => "answered (SYN-ACK or RST)",
+        (false, true) => "(silence)",
+        (false, false) => detail,
     };
     if neighbor_is_resolved(neighbor) {
         // The failure this whole path exists to catch: pasta can reach the
@@ -474,11 +493,18 @@ fn guest_unanswered_error(
         )
     } else {
         anyhow::anyhow!(
-            "guest {} never appeared at L2 within {:?}: no resolved neighbour entry \
-             and no TCP answer; neighbour: {:?}; probe: {}; rounds {} ({} stalled); \
-             host {}",
+            "guest {} never appeared at L2 within {:?}: {}; neighbour: {:?}; \
+             probe: {}; rounds {} ({} stalled); host {}",
             GUEST_IP,
             GUEST_ANSWER_DEADLINE,
+            if answered {
+                // The guest is alive and talking; only its neighbour entry is
+                // missing. Naming that separately points at ARP or the bridge
+                // rather than at a dead guest.
+                "the guest ANSWERED TCP but its neighbour entry never resolved"
+            } else {
+                "no resolved neighbour entry and no TCP answer"
+            },
             neighbor,
             detail,
             rounds,
@@ -2361,6 +2387,45 @@ mod tests {
             result.is_err(),
             "readiness must not be declared from a neighbour reading taken in an \
              earlier round when this round's query never returned"
+        );
+    }
+
+    /// The deadline error must never call an answering guest silent.
+    ///
+    /// A probe that answered leaves `detail` empty, so "empty" carries two
+    /// opposite meanings and cannot be rendered as one. Run 31906708922 reported
+    /// `no TCP answer` and `probe: (silence)` for a guest that had demonstrably
+    /// answered: its own TIME-WAIT socket to the prober was in the namespace
+    /// dump and its neighbour entry was REACHABLE. Hours went into looking for a
+    /// dead guest that was never dead.
+    #[tokio::test(start_paused = true)]
+    async fn an_answering_guest_is_never_reported_as_silent() {
+        // Answers TCP every time; its neighbour entry never resolves.
+        let mut probe = ScriptedGuest {
+            answers: [true].into_iter().collect(),
+            last_answer: true,
+            neighbor: "10.0.2.100 dev br0 INCOMPLETE".to_string(),
+            probes: 0,
+        };
+
+        let error = wait_for_guest_to_answer(&mut probe, PROBE_PORT, paused_deadline())
+            .await
+            .expect_err("an unresolved neighbour must still fail readiness");
+        let text = error.to_string();
+
+        assert!(
+            !text.contains("no TCP answer"),
+            "the guest answered TCP, so the error must not claim otherwise: {text}"
+        );
+        assert!(
+            !text.contains("(silence)"),
+            "an answered probe leaves `detail` empty; rendering that as silence \
+             inverts the meaning: {text}"
+        );
+        assert!(
+            text.contains("ANSWERED TCP"),
+            "the error must say which half actually failed, so the reader looks at \
+             ARP and the bridge rather than at the guest: {text}"
         );
     }
 

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -2548,6 +2548,98 @@ mod tests {
         );
     }
 
+    /// `rounds` must equal the number of attempts actually made.
+    ///
+    /// It is reported in the deadline error as evidence of how much work the
+    /// check did. Incrementing at the top of the loop counted a round that
+    /// found the budget already spent and probed nothing, overstating it by
+    /// one. A diagnostic that is off by one is a diagnostic nobody can reason
+    /// from, which is the whole failure this PR is about.
+    #[tokio::test(start_paused = true)]
+    async fn the_reported_round_count_matches_the_probes_actually_made() {
+        let mut probe = ScriptedGuest::silent_behind_resolved_neighbor();
+
+        let error = wait_for_guest_to_answer(&mut probe, PROBE_PORT, paused_deadline())
+            .await
+            .expect_err("a silent guest must fail readiness");
+
+        let text = error.to_string();
+        let reported: usize = text
+            .split("rounds ")
+            .nth(1)
+            .and_then(|rest| rest.split_whitespace().next())
+            .and_then(|n| n.parse().ok())
+            .unwrap_or_else(|| panic!("no `rounds N` field in the error: {text}"));
+
+        assert_eq!(
+            reported, probe.probes,
+            "the error reports {reported} rounds but the probe was called {} times. \
+             The count must describe attempts made, not loop iterations entered.\n{text}",
+            probe.probes
+        );
+    }
+
+    /// An abandoned attempt must leave no descendant behind.
+    ///
+    /// `kill_on_drop` reaps only the immediate child. The production probe is
+    /// nsenter -> env -> timeout -> bash, so killing the leader can leave bash
+    /// alive holding a reference to the VM's network namespace, once per retry.
+    /// Each attempt therefore leads its own process group and the group is
+    /// killed on expiry. This drives that with a child that IGNORES SIGTERM, so
+    /// only a group KILL can end it.
+    #[tokio::test]
+    async fn an_abandoned_probe_kills_its_whole_process_group() {
+        let marker = std::env::temp_dir().join(format!("fcvm-probe-pg-{}", std::process::id()));
+        let _ = std::fs::remove_file(&marker);
+
+        let mut command = Command::new("bash");
+        command.args([
+            "-c",
+            &format!(
+                "trap '' TERM; sleep 300 & echo $! > {}; wait",
+                marker.display()
+            ),
+        ]);
+
+        let result = run_probe_bounded(
+            command,
+            std::time::Duration::from_millis(400),
+            "a group-kill probe",
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "the probe must time out to exercise the kill"
+        );
+
+        // The grandchild wrote its pid before sleeping; it must now be gone.
+        let pid: i32 = std::fs::read_to_string(&marker)
+            .expect("the probe child must have recorded its grandchild's pid")
+            .trim()
+            .parse()
+            .expect("pid file must hold a number");
+        let _ = std::fs::remove_file(&marker);
+
+        let mut alive = true;
+        for _ in 0..50 {
+            // SAFETY: signal 0 only tests for existence.
+            if unsafe { libc::kill(pid, 0) } != 0 {
+                alive = false;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        if alive {
+            unsafe { libc::kill(pid, libc::SIGKILL) };
+        }
+        assert!(
+            !alive,
+            "grandchild {pid} survived the abandoned attempt. It ignores SIGTERM, so \
+             only a process-group kill ends it; without one, every retry strands a \
+             process holding the VM's network namespace."
+        );
+    }
+
     /// Any port; the scripted guest ignores it.
     const PROBE_PORT: u16 = 80;
 

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -242,6 +242,24 @@ impl GuestProbe for NsenterGuestProbe {
 /// How long the readiness loop waits between probe rounds.
 const GUEST_ANSWER_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(10);
 
+/// Cap on ONE probe attempt, so a single stuck attempt cannot consume the whole
+/// readiness budget.
+///
+/// Run 31906708922 failed with `neighbour: ""; probe: (silence)` after the full
+/// 5s, and the artifacts show that reading as a lie: fc-agent had finished the
+/// restore 5s earlier with `gate=open`, the namespace held a TIME-WAIT socket
+/// from `10.0.2.1 -> 10.0.2.100:80` (the probe's own connect, so the guest DID
+/// answer), the neighbour entry was REACHABLE, and the host was 95% idle with a
+/// run queue of 1. What actually happened is that the loop emitted ZERO
+/// per-round debug lines in those 5s: one attempt was handed `remaining` and
+/// never came back, so no round ever finished, `last_neighbor` was never
+/// assigned, and the empty strings got reported as guest silence.
+///
+/// An attempt that outlives this is abandoned and RETRIED. The loop must not
+/// depend on a subprocess honouring its own budget -- the probe already asks
+/// `timeout` to bound `bash`, and that still did not bound the call.
+const GUEST_PROBE_ATTEMPT_BUDGET: std::time::Duration = std::time::Duration::from_secs(1);
+
 /// Wait until the guest itself answers, or the deadline expires.
 ///
 /// Readiness requires BOTH a TCP answer from the guest and a resolved neighbour
@@ -270,23 +288,50 @@ async fn wait_for_guest_to_answer<P: GuestProbe>(
     // never appeared at L2" from "the guest is at L2 but never answered".
     let mut last_neighbor = String::new();
     let mut last_detail = String::new();
+    let started = std::time::Instant::now();
+    let mut rounds: u32 = 0;
+    // Attempts abandoned for exceeding GUEST_PROBE_ATTEMPT_BUDGET. Reported in
+    // the deadline error: it is the difference between "the guest said nothing"
+    // and "this check never got an answer out of its own subprocess".
+    let mut stalled_attempts: u32 = 0;
 
     loop {
+        rounds += 1;
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         if remaining.is_zero() {
-            return Err(guest_unanswered_error(&last_neighbor, &last_detail));
+            return Err(guest_unanswered_error(
+                &last_neighbor,
+                &last_detail,
+                rounds,
+                stalled_attempts,
+            ));
         }
-        // A probe that outlives the whole deadline is reported as the guest
-        // never answering — with the neighbour context — not as a bare probe
-        // timeout: the informative error must not depend on where inside the
-        // loop the budget happened to run out.
-        let answer = match probe.answers_tcp(probe_port, remaining).await {
-            Ok(answer) => answer,
-            Err(error) if error.to_string().contains("readiness deadline") => {
-                return Err(guest_unanswered_error(&last_neighbor, &last_detail));
-            }
-            Err(error) => return Err(error),
-        };
+        // Each attempt is bounded separately from the deadline, so one stuck
+        // attempt costs a round instead of the whole budget.
+        let attempt = remaining.min(GUEST_PROBE_ATTEMPT_BUDGET);
+        let answer =
+            match tokio::time::timeout(attempt, probe.answers_tcp(probe_port, attempt)).await {
+                Ok(Ok(answer)) => answer,
+                // The probe ran out of ITS budget, or never returned within ours.
+                // Both mean this round failed, not that the guest is silent, so
+                // retry and carry the distinction into the deadline error. A
+                // stalled check is never again reported as an unreachable guest.
+                Ok(Err(error)) if error.to_string().contains("readiness deadline") => {
+                    stalled_attempts += 1;
+                    TcpAnswer {
+                        answered: false,
+                        detail: format!("TCP probe attempt exceeded its {attempt:?} budget"),
+                    }
+                }
+                Ok(Err(error)) => return Err(error),
+                Err(_elapsed) => {
+                    stalled_attempts += 1;
+                    TcpAnswer {
+                        answered: false,
+                        detail: format!("TCP probe attempt did not return within {attempt:?}"),
+                    }
+                }
+            };
         last_detail = answer.detail;
         if !answer.answered {
             debug!(
@@ -299,21 +344,38 @@ async fn wait_for_guest_to_answer<P: GuestProbe>(
 
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         if remaining.is_zero() {
-            return Err(guest_unanswered_error(&last_neighbor, &last_detail));
+            return Err(guest_unanswered_error(
+                &last_neighbor,
+                &last_detail,
+                rounds,
+                stalled_attempts,
+            ));
         }
-        last_neighbor = match probe.neighbor(remaining).await {
-            Ok(neighbor) => neighbor,
-            Err(error) if error.to_string().contains("readiness deadline") => {
-                return Err(guest_unanswered_error(&last_neighbor, &last_detail));
+        let attempt = remaining.min(GUEST_PROBE_ATTEMPT_BUDGET);
+        match tokio::time::timeout(attempt, probe.neighbor(attempt)).await {
+            Ok(Ok(neighbor)) => last_neighbor = neighbor,
+            // Keep the previous reading rather than blanking it: an empty string
+            // means "no entry", and a stalled query has not learned that.
+            Ok(Err(error)) if error.to_string().contains("readiness deadline") => {
+                stalled_attempts += 1;
             }
-            Err(error) => return Err(error),
-        };
+            Ok(Err(error)) => return Err(error),
+            Err(_elapsed) => stalled_attempts += 1,
+        }
         let resolved = neighbor_is_resolved(&last_neighbor);
 
         if answer.answered && resolved {
+            // Report HOW LONG readiness took, on success as well as failure.
+            // Without this number a deadline miss is unattributable: "slow" and
+            // "broken" look identical from one timed-out run, and the difference
+            // is whether the successful runs crowd the deadline or sit two
+            // orders of magnitude below it (they sit at ~84ms).
             info!(
                 guest_ip = GUEST_IP,
                 probe_port,
+                readiness_ms = started.elapsed().as_secs_f64() * 1000.0,
+                rounds,
+                stalled_attempts,
                 neighbor = %last_neighbor.trim(),
                 "guest answered and its MAC is resolved"
             );
@@ -322,7 +384,12 @@ async fn wait_for_guest_to_answer<P: GuestProbe>(
 
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         if remaining.is_zero() {
-            return Err(guest_unanswered_error(&last_neighbor, &last_detail));
+            return Err(guest_unanswered_error(
+                &last_neighbor,
+                &last_detail,
+                rounds,
+                stalled_attempts,
+            ));
         }
         debug!(
             guest_ip = GUEST_IP,
@@ -336,7 +403,34 @@ async fn wait_for_guest_to_answer<P: GuestProbe>(
 }
 
 /// Deadline error for [`wait_for_guest_to_answer`], naming which half was missing.
-fn guest_unanswered_error(neighbor: &str, detail: &str) -> anyhow::Error {
+/// The host's load at the instant a readiness probe gave up.
+///
+/// A readiness timeout is unattributable without this. "The box was busy" is the
+/// reflex explanation for any deadline miss, and it is worth nothing unless the
+/// number sits beside the failure. On the run this was added for, the host was
+/// 95% idle with a run queue of 1. `/proc/loadavg`'s fourth field is
+/// `runnable/total`, which separates "many tasks exist" from "many want CPU".
+fn host_load_snapshot() -> String {
+    match std::fs::read_to_string("/proc/loadavg") {
+        Ok(raw) => {
+            let fields: Vec<&str> = raw.split_whitespace().collect();
+            match fields.as_slice() {
+                [one, five, fifteen, runnable, ..] => {
+                    format!("load {one}/{five}/{fifteen}, runnable {runnable}")
+                }
+                _ => format!("load (unparsable: {})", raw.trim()),
+            }
+        }
+        Err(error) => format!("load (unavailable: {error})"),
+    }
+}
+
+fn guest_unanswered_error(
+    neighbor: &str,
+    detail: &str,
+    rounds: u32,
+    stalled_attempts: u32,
+) -> anyhow::Error {
     let neighbor = neighbor.trim();
     let detail = if detail.is_empty() {
         "(silence)"
@@ -350,20 +444,27 @@ fn guest_unanswered_error(neighbor: &str, detail: &str) -> anyhow::Error {
         anyhow::anyhow!(
             "guest {} resolved to a MAC but never answered a TCP probe within {:?}: \
              the guest is not reachable even though its neighbour entry is present; \
-             neighbour: {}; probe: {}",
+             neighbour: {}; probe: {}; rounds {} ({} stalled); host {}",
             GUEST_IP,
             GUEST_ANSWER_DEADLINE,
             neighbor,
-            detail
+            detail,
+            rounds,
+            stalled_attempts,
+            host_load_snapshot()
         )
     } else {
         anyhow::anyhow!(
             "guest {} never appeared at L2 within {:?}: no resolved neighbour entry \
-             and no TCP answer; neighbour: {:?}; probe: {}",
+             and no TCP answer; neighbour: {:?}; probe: {}; rounds {} ({} stalled); \
+             host {}",
             GUEST_IP,
             GUEST_ANSWER_DEADLINE,
             neighbor,
-            detail
+            detail,
+            rounds,
+            stalled_attempts,
+            host_load_snapshot()
         )
     }
 }
@@ -2126,6 +2227,69 @@ mod tests {
         async fn neighbor(&mut self, _budget: std::time::Duration) -> Result<String> {
             Ok(self.neighbor.clone())
         }
+    }
+
+    /// A probe whose FIRST attempt never returns, and which ignores the budget
+    /// it is handed. That is what the production probe did in run 31906708922,
+    /// where an inner `timeout` failed to bound the call.
+    struct StallingGuest {
+        attempts: u32,
+        stall: std::time::Duration,
+    }
+
+    impl GuestProbe for StallingGuest {
+        async fn answers_tcp(
+            &mut self,
+            _port: u16,
+            _budget: std::time::Duration,
+        ) -> Result<TcpAnswer> {
+            self.attempts += 1;
+            if self.attempts == 1 {
+                tokio::time::sleep(self.stall).await;
+            }
+            Ok(TcpAnswer {
+                answered: true,
+                detail: String::new(),
+            })
+        }
+
+        async fn neighbor(&mut self, _budget: std::time::Duration) -> Result<String> {
+            Ok("10.0.2.100 dev br0 lladdr 02:2c:77:3e:ae:5a REACHABLE".to_string())
+        }
+    }
+
+    /// One stuck attempt must not consume the whole readiness budget.
+    ///
+    /// Without the per-attempt bound the loop awaits the first attempt for the
+    /// entire deadline, so it completes ZERO rounds, never queries the
+    /// neighbour, and returns the deadline error, while the guest was ready the
+    /// whole time. That is the observed failure exactly: empty neighbour,
+    /// "(silence)", and a namespace that simultaneously held a TIME-WAIT socket
+    /// to the guest and a REACHABLE neighbour entry for it.
+    #[tokio::test(start_paused = true)]
+    async fn a_stalled_probe_attempt_is_abandoned_and_retried() {
+        let mut probe = StallingGuest {
+            attempts: 0,
+            // Outlives the deadline several times over: the loop cannot pass
+            // this test by waiting the attempt out.
+            stall: GUEST_ANSWER_DEADLINE * 6,
+        };
+        let deadline = tokio::time::Instant::now() + GUEST_ANSWER_DEADLINE;
+
+        let result = wait_for_guest_to_answer(&mut probe, PROBE_PORT, deadline).await;
+
+        assert!(
+            result.is_ok(),
+            "a single stalled attempt must be abandoned and retried, not reported \
+             as the guest never answering: {:?}",
+            result.err()
+        );
+        assert!(
+            probe.attempts >= 2,
+            "the loop must retry after abandoning the stalled attempt, but made \
+             only {} attempt(s)",
+            probe.attempts
+        );
     }
 
     /// Any port; the scripted guest ignores it.

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -166,6 +166,13 @@ async fn run_probe_bounded(
     what: &str,
 ) -> Result<std::process::Output> {
     command.process_group(0);
+    // Both streams MUST be piped here, exactly as `Command::output()` does it.
+    // Spawning directly does not imply it: tokio's default is INHERIT, so a
+    // caller that piped only stderr (the neighbour query does) would have its
+    // stdout go to the parent's and be captured as empty. That reads as "no
+    // neighbour entry" for every probe, which is indistinguishable from the
+    // failure this whole path is diagnosing.
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
     let mut child = command
         .spawn()
         .with_context(|| format!("spawning {what}"))?;
@@ -2511,6 +2518,33 @@ mod tests {
             text.contains("ANSWERED TCP"),
             "the error must say which half actually failed, so the reader looks at \
              ARP and the bridge rather than at the guest: {text}"
+        );
+    }
+
+    /// A bounded probe must capture stdout, not inherit it.
+    ///
+    /// `Command::output()` forces both streams to piped; spawning directly does
+    /// not. The neighbour query pipes only stderr, so when this function
+    /// replaced `output()` its stdout went to the parent and every reading came
+    /// back empty. Four clone and port-forward tests failed in CI within 15s,
+    /// all reporting a neighbour entry that never resolved, because the reading
+    /// was being thrown away rather than missing.
+    #[tokio::test]
+    async fn a_bounded_probe_captures_stdout_even_when_the_caller_piped_only_stderr() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "echo neighbour-line"]);
+        // Exactly what neighbor() does, and what broke it.
+        command.stderr(Stdio::piped());
+
+        let output = run_probe_bounded(command, std::time::Duration::from_secs(5), "a test probe")
+            .await
+            .expect("the probe must run");
+
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "neighbour-line",
+            "stdout was not captured. An inherited stdout reads as an empty result, \
+             which is indistinguishable from the guest having no neighbour entry."
         );
     }
 

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -185,6 +185,12 @@ impl GuestProbe for NsenterGuestProbe {
             "env",
             "LC_ALL=C",
             "timeout",
+            // SIGKILL shortly after the TERM. `kill_on_drop` reaps only the
+            // direct child, so an abandoned attempt's `bash` is reachable only
+            // through this timeout; if TERM alone did not land, one process per
+            // retry would sit in the namespace holding a socket.
+            "-k",
+            "0.1",
             &format!("{probe_timeout:.2}"),
             "bash",
             "-c",
@@ -352,17 +358,30 @@ async fn wait_for_guest_to_answer<P: GuestProbe>(
             ));
         }
         let attempt = remaining.min(GUEST_PROBE_ATTEMPT_BUDGET);
+        // A stalled query keeps the previous reading for the ERROR MESSAGE only:
+        // an empty string means "no entry", and a query that never returned has
+        // not learned that. It must not count as evidence of readiness. Both
+        // halves have to hold in the SAME round, or a neighbour seen REACHABLE
+        // in round 1 could pair with round 2's TCP answer and declare a guest
+        // ready whose entry has since gone FAILED, which is precisely the
+        // stale-evidence failure this function exists to prevent.
+        let neighbor_is_fresh;
         match tokio::time::timeout(attempt, probe.neighbor(attempt)).await {
-            Ok(Ok(neighbor)) => last_neighbor = neighbor,
-            // Keep the previous reading rather than blanking it: an empty string
-            // means "no entry", and a stalled query has not learned that.
+            Ok(Ok(neighbor)) => {
+                last_neighbor = neighbor;
+                neighbor_is_fresh = true;
+            }
             Ok(Err(error)) if error.to_string().contains("readiness deadline") => {
                 stalled_attempts += 1;
+                neighbor_is_fresh = false;
             }
             Ok(Err(error)) => return Err(error),
-            Err(_elapsed) => stalled_attempts += 1,
+            Err(_elapsed) => {
+                stalled_attempts += 1;
+                neighbor_is_fresh = false;
+            }
         }
-        let resolved = neighbor_is_resolved(&last_neighbor);
+        let resolved = neighbor_is_fresh && neighbor_is_resolved(&last_neighbor);
 
         if answer.answered && resolved {
             // Report HOW LONG readiness took, on success as well as failure.
@@ -2289,6 +2308,59 @@ mod tests {
             "the loop must retry after abandoning the stalled attempt, but made \
              only {} attempt(s)",
             probe.attempts
+        );
+    }
+
+    /// A guest whose neighbour query answers once and then stalls forever,
+    /// while its TCP probe answers from the second round on.
+    struct StaleNeighborGuest {
+        rounds: u32,
+    }
+
+    impl GuestProbe for StaleNeighborGuest {
+        async fn answers_tcp(
+            &mut self,
+            _port: u16,
+            _budget: std::time::Duration,
+        ) -> Result<TcpAnswer> {
+            self.rounds += 1;
+            // Silent on round 1, answering afterwards: this is what makes the
+            // stale reading the only "resolved" evidence available.
+            Ok(TcpAnswer {
+                answered: self.rounds > 1,
+                detail: String::new(),
+            })
+        }
+
+        async fn neighbor(&mut self, budget: std::time::Duration) -> Result<String> {
+            if self.rounds <= 1 {
+                return Ok("10.0.2.100 dev br0 lladdr 02:2c:77:3e:ae:5a REACHABLE".to_string());
+            }
+            // Never returns within the attempt budget again.
+            tokio::time::sleep(budget * 4).await;
+            Ok(String::new())
+        }
+    }
+
+    /// Both halves must hold in the SAME round.
+    ///
+    /// Keeping the last neighbour reading across a stalled query is right for
+    /// the error message and wrong for the verdict: pairing round 1's REACHABLE
+    /// with round 2's TCP answer would declare ready a guest whose entry may
+    /// since have gone FAILED. That is the stale-evidence failure this function
+    /// was written to prevent, so a stalled query must not satisfy the
+    /// neighbour half.
+    #[tokio::test(start_paused = true)]
+    async fn a_stalled_neighbor_query_cannot_satisfy_readiness() {
+        let mut probe = StaleNeighborGuest { rounds: 0 };
+        let deadline = tokio::time::Instant::now() + GUEST_ANSWER_DEADLINE;
+
+        let result = wait_for_guest_to_answer(&mut probe, PROBE_PORT, deadline).await;
+
+        assert!(
+            result.is_err(),
+            "readiness must not be declared from a neighbour reading taken in an \
+             earlier round when this round's query never returned"
         );
     }
 

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -150,6 +150,58 @@ fn describe_silent_probe(code: Option<i32>, stderr: &str) -> String {
     }
 }
 
+/// Run a bounded probe command, killing its whole process GROUP on expiry.
+///
+/// `kill_on_drop` reaps only the immediate child. The probe is
+/// `nsenter -> env -> timeout -> bash`, so dropping the future kills the
+/// leader and leaves `bash` with nobody to deliver the KILL that `timeout -k`
+/// promised. Each expiry could then strand a process holding a reference to
+/// the VM's network namespace, once per retry.
+///
+/// The child leads its own process group (`process_group(0)`, so pgid == pid),
+/// which makes the whole subtree addressable with one `killpg`.
+async fn run_probe_bounded(
+    mut command: Command,
+    budget: std::time::Duration,
+    what: &str,
+) -> Result<std::process::Output> {
+    command.process_group(0);
+    let mut child = command
+        .spawn()
+        .with_context(|| format!("spawning {what}"))?;
+    let pgid = child.id().map(|id| id as i32);
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+    let wait = async {
+        let status = child.wait().await?;
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        if let Some(mut handle) = stdout {
+            let _ = tokio::io::AsyncReadExt::read_to_end(&mut handle, &mut out).await;
+        }
+        if let Some(mut handle) = stderr {
+            let _ = tokio::io::AsyncReadExt::read_to_end(&mut handle, &mut err).await;
+        }
+        Ok::<_, std::io::Error>(std::process::Output {
+            status,
+            stdout: out,
+            stderr: err,
+        })
+    };
+    match tokio::time::timeout(budget, wait).await {
+        Ok(result) => result.with_context(|| format!("running {what}")),
+        Err(_elapsed) => {
+            // SAFETY: pgid came from this child, which leads its own group.
+            // Killing a group we created cannot reach an unrelated process:
+            // the pid is not reused while we hold the un-reaped child.
+            if let Some(pgid) = pgid {
+                unsafe { libc::killpg(pgid, libc::SIGKILL) };
+            }
+            anyhow::bail!("{what} exceeded pasta's readiness deadline")
+        }
+    }
+}
+
 /// Production [`GuestProbe`]: runs the probes inside the VM's network namespace
 /// via the holder PID.
 struct NsenterGuestProbe {
@@ -197,10 +249,7 @@ impl GuestProbe for NsenterGuestProbe {
             &script,
         ]);
         command.stdout(Stdio::null()).stderr(Stdio::piped());
-        let output = tokio::time::timeout(budget, command.output())
-            .await
-            .context("TCP probe exceeded pasta's readiness deadline")?
-            .context("running the TCP probe via nsenter in namespace")?;
+        let output = run_probe_bounded(command, budget, "the TCP probe").await?;
 
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         // Exit 0: connected (SYN-ACK). "Connection refused": the guest's kernel
@@ -229,10 +278,7 @@ impl GuestProbe for NsenterGuestProbe {
         let mut command =
             self.command(&["ip", "neigh", "show", "to", GUEST_IP, "dev", BRIDGE_DEVICE]);
         command.stderr(Stdio::piped());
-        let output = tokio::time::timeout(budget, command.output())
-            .await
-            .context("neighbor query exceeded pasta's readiness deadline")?
-            .context("reading guest neighbour entry via nsenter in namespace")?;
+        let output = run_probe_bounded(command, budget, "the neighbour query").await?;
         if !output.status.success() {
             anyhow::bail!(
                 "failed to inspect ARP entry for guest {} on {}: {}",

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -352,12 +352,19 @@ async fn wait_for_guest_to_answer<P: GuestProbe>(
     // answered (its own TIME-WAIT socket was in the namespace dump). Carry the
     // state rather than inferring it from an absence.
     let mut last_answered = false;
+    // Whether `last_neighbor` came from a query that COMPLETED this round. A
+    // reading kept across a stalled query is useful context and must not be
+    // presented as current state: a resolved entry from an earlier round would
+    // otherwise steer the error into the "resolved to a MAC but never answered"
+    // arm while TCP had in fact answered, making one message contradict itself.
+    let mut last_neighbor_fresh = false;
 
     loop {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         if remaining.is_zero() {
             return Err(guest_unanswered_error(
                 &last_neighbor,
+                last_neighbor_fresh,
                 &last_detail,
                 last_answered,
                 rounds,
@@ -410,6 +417,7 @@ async fn wait_for_guest_to_answer<P: GuestProbe>(
         if remaining.is_zero() {
             return Err(guest_unanswered_error(
                 &last_neighbor,
+                last_neighbor_fresh,
                 &last_detail,
                 last_answered,
                 rounds,
@@ -429,15 +437,18 @@ async fn wait_for_guest_to_answer<P: GuestProbe>(
             Ok(Ok(neighbor)) => {
                 last_neighbor = neighbor;
                 neighbor_is_fresh = true;
+                last_neighbor_fresh = true;
             }
             Ok(Err(error)) if error.to_string().contains("readiness deadline") => {
                 stalled_attempts += 1;
                 neighbor_is_fresh = false;
+                last_neighbor_fresh = false;
             }
             Ok(Err(error)) => return Err(error),
             Err(_elapsed) => {
                 stalled_attempts += 1;
                 neighbor_is_fresh = false;
+                last_neighbor_fresh = false;
             }
         }
         let resolved = neighbor_is_fresh && neighbor_is_resolved(&last_neighbor);
@@ -464,6 +475,7 @@ async fn wait_for_guest_to_answer<P: GuestProbe>(
         if remaining.is_zero() {
             return Err(guest_unanswered_error(
                 &last_neighbor,
+                last_neighbor_fresh,
                 &last_detail,
                 last_answered,
                 rounds,
@@ -506,6 +518,7 @@ fn host_load_snapshot() -> String {
 
 fn guest_unanswered_error(
     neighbor: &str,
+    neighbor_fresh: bool,
     detail: &str,
     answered: bool,
     rounds: u32,
@@ -521,17 +534,27 @@ fn guest_unanswered_error(
         (false, true) => "(silence)",
         (false, false) => detail,
     };
-    if neighbor_is_resolved(neighbor) {
+    // Only a reading from THIS round describes the current state. A stale one
+    // is labelled as such rather than silently standing in for a fresh answer.
+    let neighbor_note = if neighbor_fresh {
+        ""
+    } else if neighbor.is_empty() {
+        " (never read: every neighbour query stalled)"
+    } else {
+        " (STALE: this round's query stalled; reading is from an earlier round)"
+    };
+    if neighbor_fresh && neighbor_is_resolved(neighbor) && !answered {
         // The failure this whole path exists to catch: pasta can reach the
         // guest's MAC, so every host-side check passes, but nothing is answering
         // behind it. Report it here rather than letting a client discover it.
         anyhow::anyhow!(
             "guest {} resolved to a MAC but never answered a TCP probe within {:?}: \
              the guest is not reachable even though its neighbour entry is present; \
-             neighbour: {}; probe: {}; rounds {} ({} stalled); host {}",
+             neighbour: {}{}; probe: {}; rounds {} ({} stalled); host {}",
             GUEST_IP,
             GUEST_ANSWER_DEADLINE,
             neighbor,
+            neighbor_note,
             detail,
             rounds,
             stalled_attempts,
@@ -539,7 +562,7 @@ fn guest_unanswered_error(
         )
     } else {
         anyhow::anyhow!(
-            "guest {} never appeared at L2 within {:?}: {}; neighbour: {:?}; \
+            "guest {} never appeared at L2 within {:?}: {}; neighbour: {:?}{}; \
              probe: {}; rounds {} ({} stalled); host {}",
             GUEST_IP,
             GUEST_ANSWER_DEADLINE,
@@ -552,6 +575,7 @@ fn guest_unanswered_error(
                 "no resolved neighbour entry and no TCP answer"
             },
             neighbor,
+            neighbor_note,
             detail,
             rounds,
             stalled_attempts,
@@ -2429,10 +2453,25 @@ mod tests {
 
         let result = wait_for_guest_to_answer(&mut probe, PROBE_PORT, deadline).await;
 
-        assert!(
-            result.is_err(),
+        let error = result.expect_err(
             "readiness must not be declared from a neighbour reading taken in an \
-             earlier round when this round's query never returned"
+             earlier round when this round's query never returned",
+        );
+        let text = error.to_string();
+
+        // The verdict was right; the DIAGNOSTIC must be too. A stale resolved
+        // entry must not steer the message into "resolved to a MAC but never
+        // answered" while TCP did answer, which would make one error contradict
+        // itself, and must never be presented as the current reading.
+        assert!(
+            text.contains("STALE") || text.contains("never read"),
+            "a neighbour reading kept across a stalled query must be labelled, not \
+             presented as this round's state: {text}"
+        );
+        assert!(
+            !text.contains("never answered a TCP probe"),
+            "TCP answered, so the error must not select the never-answered arm on \
+             the strength of a stale neighbour entry: {text}"
         );
     }
 

--- a/tests/fixtures/nextest-flaky-with-slow.log
+++ b/tests/fixtures/nextest-flaky-with-slow.log
@@ -1,0 +1,3 @@
+    Starting 1020 tests across 24 binaries (10 skipped)
+        PASS [   0.012s] (1/1020) fcvm::test_state_manager test_save_and_load
+     Summary [ 808.819s] 1020 tests run: 1020 passed (1 slow, 1 flaky), 10 skipped

--- a/tests/fixtures/nextest-retry-timeout.log
+++ b/tests/fixtures/nextest-retry-timeout.log
@@ -1,0 +1,4 @@
+        PASS [   0.012s] (1/1022) fcvm::test_state_manager test_save_and_load
+  TRY 1 TMT [ 900.002s] (───────) fcvm::test_pjdfstest_vm test_pjdfstest_vm_ftruncate
+  TRY 2 PASS [   6.991s] (999/1022) fcvm::test_pjdfstest_vm test_pjdfstest_vm_ftruncate
+     Summary [ 612.810s] 1022 tests run: 1022 passed (1 slow), 20 skipped

--- a/tests/fixtures/nextest-two-summaries-flaky-first.log
+++ b/tests/fixtures/nextest-two-summaries-flaky-first.log
@@ -1,0 +1,4 @@
+        PASS [   0.012s] (1/1022) fcvm::test_state_manager test_save_and_load
+     Summary [ 612.810s] 1022 tests run: 1022 passed (1 slow, 2 flaky), 20 skipped
+        PASS [   0.011s] (1/1022) fcvm::test_state_manager test_save_and_load
+     Summary [ 590.100s] 1022 tests run: 1022 passed (1 slow), 20 skipped

--- a/tests/test_log_scan.rs
+++ b/tests/test_log_scan.rs
@@ -34,6 +34,69 @@ fn field(out: &str, key: &str) -> i64 {
         .unwrap_or_else(|e| panic!("`{key}` is not a number ({e}):\n{out}"))
 }
 
+/// The summary's flaky count must be read from the form nextest actually emits.
+///
+/// Measured against 59 cached CI job logs: the parenthetical is never `(N flaky)`
+/// alone, it is `(1 slow, 1 flaky)`. A pattern anchored on `\(([0-9]+) flaky\)`
+/// therefore matched nothing in production and the flaky gate never once fired,
+/// while reporting `verdict: CLEAN`, exit 0, on a log whose own summary said
+/// otherwise. Job 93992054596 is exactly that log.
+#[test]
+fn the_summary_flaky_count_is_read_when_other_items_share_the_parens() {
+    let log = repo_root().join("tests/fixtures/nextest-flaky-with-slow.log");
+    let (out, code) = run_scan(&log);
+
+    assert!(
+        out.contains("verdict: FLAKY"),
+        "a summary reading `(1 slow, 1 flaky)` must be reported FLAKY. If this says \
+         CLEAN, the flaky pattern requires `flaky` to be the only item in the parens \
+         and cannot match a real nextest summary.\n{out}"
+    );
+    assert_eq!(code, 1, "a flaky run must exit non-zero.\n{out}");
+}
+
+/// Every summary in the log must be judged, not only the last one.
+///
+/// The SnapshotEnabled matrix runs the suite twice in one job, so a job log
+/// carries two summary lines. In 7 of the 19 cached multi-summary jobs the flaky
+/// summary is the FIRST one, and `tail -1` discards it.
+#[test]
+fn a_flaky_summary_is_not_discarded_by_a_later_clean_one() {
+    let log = repo_root().join("tests/fixtures/nextest-two-summaries-flaky-first.log");
+    let (out, code) = run_scan(&log);
+
+    assert!(
+        out.contains("verdict: FLAKY"),
+        "the FIRST summary reports 2 flaky and must not be dropped in favour of the \
+         last. A scanner that only reads the final summary is blind to the first \
+         suite run in every SnapshotEnabled job.\n{out}"
+    );
+    assert_eq!(code, 1, "a flaky run must exit non-zero.\n{out}");
+}
+
+/// A retry counts however its first attempt died, not only when it said FAIL.
+///
+/// nextest reports a slow-timeout kill as `TRY 1 TMT`. Five such retries occurred
+/// in the last 6 days of CI (900s hang, then a 7s pass), every one inside a job
+/// that reported green. A pattern matching only `TRY n FAIL` cannot see them.
+#[test]
+fn a_retry_after_a_timeout_kill_is_counted() {
+    let log = repo_root().join("tests/fixtures/nextest-retry-timeout.log");
+    let (out, code) = run_scan(&log);
+
+    assert_eq!(
+        field(&out, "try_fail"),
+        1,
+        "`TRY 1 TMT` is a retried failure and must be counted. A 900s hang that \
+         passes on retry is a hang bug, not contention, and this is the only place \
+         it is visible.\n{out}"
+    );
+    assert_eq!(
+        code, 1,
+        "a run containing a retried timeout must not be reported clean.\n{out}"
+    );
+}
+
 /// THE trap: nextest writes a retry as `TRY 1 FAIL`, so `grep '^ *FAIL'` matches
 /// none of them. A test that failed and then passed on retry disappears into a
 /// green total — which is precisely how a flake survives review.


### PR DESCRIPTION
Fixes the red main: both `Host-Root-x64` jobs in run 31906708922 failed with

```
guest 10.0.2.100 never appeared at L2 within 5s: no resolved neighbour entry
and no TCP answer; neighbour: ""; probe: (silence)
```

## The message was wrong in every clause

From the failing clone's own log and forensics (artifact `test-logs-host-root-x64-SnapshotEnabled`, `fuzz1-snap-1373736-0-clone-5`):

| Claim in the error | What the artifacts show |
|---|---|
| guest never appeared at L2 | neighbour entry `10.0.2.100 dev br0 lladdr 02:2c:77:3e:ae:5a REACHABLE` |
| no TCP answer | `TIME-WAIT 10.0.2.1:59568 -> 10.0.2.100:80`, the probe's own completed connect |
| guest not ready | fc-agent finished restore 5s earlier: `gate=open link=UNTOUCHED`, tcp-cleanup complete in 48.1ms |
| (implied) host was busy | `sar`: 95.10% idle, ldavg-1 1.75 on 96 CPUs, run queue 1, 0.00% steal |

The loop emitted **zero** per-round debug lines across those 5s. One attempt was handed `remaining` and never returned, so no round completed, `last_neighbor` was never assigned, and its empty default was printed as guest silence.

## Fix

Each attempt is bounded by `GUEST_PROBE_ATTEMPT_BUDGET` (1s) independently of the deadline, for the TCP probe and the neighbour query alike; an attempt that outlives it is abandoned and retried. The loop no longer trusts a subprocess to honour a budget handed to it, since the probe already wrapped bash in `timeout` and that did not bound the caller.

## Reporting, so this class is not misattributed again

- deadline error carries `rounds N (M stalled)` and `/proc/loadavg`
- success logs `readiness_ms`; healthy restores measure **~84ms** against a 5s deadline, which is what rules out raising the timeout
- CI captures `sar -q`/`sar -u` into the test-log artifacts. sysstat was already running on every runner and nothing read it
- AGENTS.md gains a short "HOW TO INVESTIGATE A TIMEOUT" procedure

## Test

`a_stalled_probe_attempt_is_abandoned_and_retried`, watched failing without the per-attempt bound and reproducing the CI message exactly:

```
never appeared at L2 within 5s: ... neighbour: ""; probe: TCP probe attempt
did not return within 5s; rounds 1 (1 stalled)
```

```
$ cargo test --release -p fcvm --lib
test result: ok. 450 passed; 0 failed
```

## Hypotheses killed by measurement, not argument

- "merely slow, raise the timeout": healthy is ~84ms, two orders of magnitude below the deadline
- "load related": 95.1% idle, run queue 1
- "netns churn stalls nsenter": measured on the runner, 16 churners moved nsenter from 9.0ms p50 / 9.8ms max to 9.1ms p50 / 18.6ms max

Not claimed: the reason that one attempt stalled is still unknown. This change bounds its blast radius and makes the next occurrence self-describing.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network readiness checks by limiting stalled probes, retrying when needed, and validating fresh connectivity evidence.
  * Reduced the chance of readiness checks hanging indefinitely.
  * Enhanced timeout and success messages with clearer diagnostics, retry information, timing data, and host-load context.
  * Improved cleanup after stalled network checks.

* **Chores**
  * Added automated host-performance records to help investigate intermittent or slow test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->