### PR TITLE
Classify a runner death whose log blob survives but stops growing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -962,6 +962,32 @@ jobs:
       #
       # `skipped` is deliberately not a failure: skip-check legitimately skips the
       # matrix when this tree SHA already passed on a PR branch.
+      # Runs BEFORE the gate below, which exits 1 and would skip anything after
+      # it. A dead runner agent produces a job failure indistinguishable from a
+      # test failure, so without this the operator re-reads a passing test suite
+      # hunting a bug that was never there. The classifier is narrow and
+      # fail-closed; this step is a diagnostic and must never turn a green run
+      # red, so every failure inside it degrades to silence.
+      - name: Diagnose runner loss
+        if: contains(needs.*.result, 'failure')
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          VERDICT=$(python3 fcvm/scripts/classify_ci_failure.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" 2>/dev/null)
+          [ -n "$VERDICT" ] || exit 0
+          [ "$(printf '%s' "$VERDICT" | jq -r '.classification' 2>/dev/null)" = infrastructure ] || exit 0
+          printf '%s' "$VERDICT" | jq -r '
+            .jobs[]
+            | select(.kind | startswith("infrastructure"))
+            | "::error::\(.name): the runner agent died mid-job (\(.reason)). This is NOT a test failure."
+          ' 2>/dev/null
+          exit 0
+
       - name: Fail if any gating job did not succeed
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -968,6 +968,14 @@ jobs:
       # hunting a bug that was never there. The classifier is narrow and
       # fail-closed; this step is a diagnostic and must never turn a green run
       # red, so every failure inside it degrades to silence.
+      # Summary does not check out until AFTER the gate below, and the gate
+      # exits 1, so the diagnosis needs its own checkout here. Without it the
+      # step invoked a path that does not exist, python exited ENOENT, the
+      # discarded stderr hid it, and the diagnosis silently never appeared on
+      # any run: a check that cannot fire, which is worse than no check.
+      - name: Check out for runner-loss diagnosis
+        if: contains(needs.*.result, 'failure')
+        uses: actions/checkout@v7
       - name: Diagnose runner loss
         if: contains(needs.*.result, 'failure')
         continue-on-error: true
@@ -975,12 +983,26 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set +e
-          VERDICT=$(python3 fcvm/scripts/classify_ci_failure.py \
+          # Every reason this cannot render a verdict is announced. A diagnostic
+          # that stays quiet is indistinguishable from one that found nothing.
+          if [ ! -f scripts/classify_ci_failure.py ]; then
+            echo "::notice::runner-loss diagnosis skipped: classifier not present"
+            exit 0
+          fi
+          VERDICT=$(python3 scripts/classify_ci_failure.py \
             --repository "$GITHUB_REPOSITORY" \
             --run-id "$GITHUB_RUN_ID" \
-            --run-attempt "$GITHUB_RUN_ATTEMPT" 2>/dev/null)
-          [ -n "$VERDICT" ] || exit 0
-          [ "$(printf '%s' "$VERDICT" | jq -r '.classification' 2>/dev/null)" = infrastructure ] || exit 0
+            --run-attempt "$GITHUB_RUN_ATTEMPT" 2>/tmp/classify.err)
+          if [ -z "$VERDICT" ]; then
+            echo "::notice::runner-loss diagnosis unavailable: $(head -c 300 /tmp/classify.err | tr '\n' ' ')"
+            exit 0
+          fi
+          CLASSIFICATION=$(printf '%s' "$VERDICT" | jq -r '.classification' 2>/dev/null)
+          if [ -z "$CLASSIFICATION" ] || [ "$CLASSIFICATION" = null ]; then
+            echo "::notice::runner-loss diagnosis unreadable: classifier emitted no classification"
+            exit 0
+          fi
+          [ "$CLASSIFICATION" = infrastructure ] || exit 0
           printf '%s' "$VERDICT" | jq -r '
             .jobs[]
             | select(.kind | startswith("infrastructure"))

--- a/scripts/classify_ci_failure.py
+++ b/scripts/classify_ci_failure.py
@@ -16,6 +16,8 @@ run into a mixed failure. Every unknown shape is non-infrastructure.
 from __future__ import annotations
 
 import argparse
+import datetime
+import email.utils
 import json
 import re
 import subprocess
@@ -75,6 +77,9 @@ def _validate_jobs(jobs: Any) -> list[dict[str, Any]]:
         conclusion = job.get("conclusion")
         if conclusion is not None and not isinstance(conclusion, str):
             raise InputError(f"job {job_id} has an invalid conclusion")
+        completed_at = job.get("completed_at")
+        if completed_at is not None and not isinstance(completed_at, str):
+            raise InputError(f"job {job_id} has an invalid completed_at")
         steps = job.get("steps")
         if not isinstance(steps, list):
             raise InputError(f"job {job_id} has no steps array")
@@ -106,6 +111,11 @@ def _validate_logs(logs: Any) -> dict[str, dict[str, Any]]:
             raise InputError(f"log evidence for job {job_id} has invalid status")
         if status == "available" and not isinstance(evidence.get("text"), str):
             raise InputError(f"available log evidence for job {job_id} needs text")
+        last_modified = evidence.get("last_modified")
+        if last_modified is not None and not isinstance(last_modified, str):
+            raise InputError(
+                f"log evidence for job {job_id} has an invalid last_modified"
+            )
         if status == "missing_blob" and (
             evidence.get("http_status") != 404
             or evidence.get("error_code") != "BlobNotFound"
@@ -170,6 +180,21 @@ def _fetch_jobs(repository: str, run_id: int, run_attempt: int) -> list[dict[str
     return _validate_jobs(jobs)
 
 
+def _last_modified_header(response: str) -> str | None:
+    """The Last-Modified value from a `gh api --include` response, if present.
+
+    Headers end at the first blank line; a log body can contain anything,
+    including a line that looks like a header, so parsing must stop there.
+    """
+    for line in response.splitlines():
+        if not line.strip():
+            return None
+        name, separator, value = line.partition(":")
+        if separator and name.strip().lower() == "last-modified":
+            return value.strip()
+    return None
+
+
 def _fetch_log(repository: str, job_id: int) -> dict[str, Any]:
     endpoint = f"repos/{repository}/actions/jobs/{job_id}/logs"
     # gh <= 2.96 has no --allow-escape-sequences option and emits captured API
@@ -185,7 +210,14 @@ def _fetch_log(repository: str, job_id: int) -> dict[str, Any]:
             ["api", "--include", "--allow-escape-sequences", endpoint]
         )
     if result.returncode == 0:
-        return {"status": "available", "text": result.stdout}
+        evidence: dict[str, Any] = {"status": "available", "text": result.stdout}
+        # `--include` already returns the response headers, so the blob's write
+        # time costs no extra request. Absent or malformed, the field is simply
+        # omitted and the stale-gap witness cannot fire.
+        last_modified = _last_modified_header(result.stdout)
+        if last_modified is not None:
+            evidence["last_modified"] = last_modified
+        return evidence
 
     response = f"{result.stdout}\n{result.stderr}"
     if "gh: HTTP 404" in response and "BlobNotFound" in response:
@@ -267,6 +299,41 @@ def _has_silent_loss_shape(job: dict[str, Any]) -> bool:
     )
 
 
+# A log blob that stopped growing this long before GitHub concluded the job is
+# a runner that died, not a job that ran. Measured on the live API the two
+# populations do not overlap: runner-concluded jobs write their blob within
+# 0-2s of completed_at (n=66), agent-death jobs show 569-1149s (n=6). 120s sits
+# 60x above the largest healthy gap and 4.7x below the smallest observed loss.
+STALE_LOG_SECONDS = 120
+
+
+def _blob_stale_seconds(
+    job: dict[str, Any], evidence: dict[str, Any]
+) -> float | None:
+    """Seconds between the log blob's last write and the job's conclusion.
+
+    Returns None whenever the answer is not knowable: a missing or unparseable
+    timestamp on either side, or a negative gap. Every such case falls through
+    to `unknown`, so an unreadable header can never manufacture an
+    infrastructure verdict.
+    """
+    completed_at = job.get("completed_at")
+    last_modified = evidence.get("last_modified")
+    if not isinstance(completed_at, str) or not isinstance(last_modified, str):
+        return None
+    try:
+        concluded = datetime.datetime.fromisoformat(
+            completed_at.replace("Z", "+00:00")
+        )
+        written = email.utils.parsedate_to_datetime(last_modified)
+    except (ValueError, TypeError):
+        return None
+    if concluded.tzinfo is None or written.tzinfo is None:
+        return None
+    gap = (concluded - written).total_seconds()
+    return gap if gap >= 0 else None
+
+
 def _classify_root_job(
     job: dict[str, Any], evidence: dict[str, Any] | None
 ) -> tuple[str, str]:
@@ -283,6 +350,17 @@ def _classify_root_job(
         return "infrastructure_explicit", "GitHub runner shutdown sentinel"
     if evidence.get("status") == "missing_blob" and _has_silent_loss_shape(job):
         return "infrastructure_silent", "null-step runner loss with missing log blob"
+    if evidence.get("status") == "available" and _has_silent_loss_shape(job):
+        # The blob survived but stopped mid-job. Same event as the missing-blob
+        # case; GitHub simply kept what the dying agent had already flushed.
+        # The null-step shape stays REQUIRED: the gap is a second witness, never
+        # the only one.
+        stale_by = _blob_stale_seconds(job, evidence)
+        if stale_by is not None and stale_by >= STALE_LOG_SECONDS:
+            return (
+                "infrastructure_silent",
+                f"null-step runner loss with log blob stale by {stale_by:.0f}s",
+            )
     return "unknown", "no exclusive runner-loss evidence"
 
 

--- a/tests/fixtures/ci-infrastructure/truncated-log-fresh-blob.json
+++ b/tests/fixtures/ci-infrastructure/truncated-log-fresh-blob.json
@@ -1,0 +1,69 @@
+{
+  "run_attempt": 1,
+  "jobs": [
+    {
+      "id": 2001,
+      "name": "Container-x64",
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success"
+        },
+        {
+          "name": "Run actions/checkout@v7",
+          "status": "completed",
+          "conclusion": "success"
+        },
+        {
+          "name": "Clean test data",
+          "status": "in_progress",
+          "conclusion": null
+        },
+        {
+          "name": "container-test-unit",
+          "status": "pending",
+          "conclusion": null
+        },
+        {
+          "name": "Post Run actions/checkout@v7",
+          "status": "pending",
+          "conclusion": null
+        }
+      ],
+      "completed_at": "2026-08-14T18:42:17Z"
+    },
+    {
+      "id": 2002,
+      "name": "Summary",
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success"
+        },
+        {
+          "name": "Fail if any gating job did not succeed",
+          "status": "completed",
+          "conclusion": "failure"
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success"
+        }
+      ]
+    }
+  ],
+  "logs": {
+    "2001": {
+      "status": "available",
+      "text": "HTTP/2.0 200\nlast-modified: Fri, 14 Aug 2026 18:42:16 GMT\n\nordinary test output\n",
+      "last_modified": "Fri, 14 Aug 2026 18:42:16 GMT"
+    }
+  }
+}

--- a/tests/fixtures/ci-infrastructure/truncated-log-runner-loss.json
+++ b/tests/fixtures/ci-infrastructure/truncated-log-runner-loss.json
@@ -1,0 +1,69 @@
+{
+  "run_attempt": 1,
+  "jobs": [
+    {
+      "id": 2001,
+      "name": "Container-x64",
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success"
+        },
+        {
+          "name": "Run actions/checkout@v7",
+          "status": "completed",
+          "conclusion": "success"
+        },
+        {
+          "name": "Clean test data",
+          "status": "in_progress",
+          "conclusion": null
+        },
+        {
+          "name": "container-test-unit",
+          "status": "pending",
+          "conclusion": null
+        },
+        {
+          "name": "Post Run actions/checkout@v7",
+          "status": "pending",
+          "conclusion": null
+        }
+      ],
+      "completed_at": "2026-08-14T18:42:17Z"
+    },
+    {
+      "id": 2002,
+      "name": "Summary",
+      "status": "completed",
+      "conclusion": "failure",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success"
+        },
+        {
+          "name": "Fail if any gating job did not succeed",
+          "status": "completed",
+          "conclusion": "failure"
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success"
+        }
+      ]
+    }
+  ],
+  "logs": {
+    "2001": {
+      "status": "available",
+      "text": "HTTP/2.0 200\nlast-modified: Fri, 14 Aug 2026 18:32:20 GMT\n\nordinary test output\n",
+      "last_modified": "Fri, 14 Aug 2026 18:32:20 GMT"
+    }
+  }
+}

--- a/tests/test_ci_infrastructure.py
+++ b/tests/test_ci_infrastructure.py
@@ -222,6 +222,40 @@ class CiInfrastructureClassificationTests(unittest.TestCase):
             ["api", "--include", "repos/owner/repo/actions/jobs/20/logs"]
         )
 
+    def test_log_fetch_records_the_blob_write_time(self) -> None:
+        """The stale-gap witness is useless if nothing populates its input.
+
+        `--include` already returns headers, so this costs no extra request.
+        A header-shaped line in the log BODY must not be mistaken for one.
+        """
+        available = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=(
+                "HTTP/2.0 200\n"
+                "Last-Modified: Fri, 14 Aug 2026 18:32:20 GMT\n"
+                "\n"
+                "2026-08-14T18:32:20Z Last-Modified: not a header, this is output\n"
+            ),
+            stderr="",
+        )
+
+        with mock.patch.object(CLASSIFIER, "_run_gh", return_value=available):
+            evidence = CLASSIFIER._fetch_log("owner/repo", 21)
+
+        self.assertEqual(evidence["status"], "available")
+        self.assertEqual(evidence["last_modified"], "Fri, 14 Aug 2026 18:32:20 GMT")
+
+    def test_log_fetch_omits_blob_write_time_when_absent(self) -> None:
+        available = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="HTTP/2.0 200\n\nlog body\n", stderr=""
+        )
+
+        with mock.patch.object(CLASSIFIER, "_run_gh", return_value=available):
+            evidence = CLASSIFIER._fetch_log("owner/repo", 22)
+
+        self.assertNotIn("last_modified", evidence)
+
     def test_explicit_runner_shutdown_is_rerun_once(self) -> None:
         result = classify_fixture("explicit-runner-shutdown.json")
 
@@ -238,6 +272,36 @@ class CiInfrastructureClassificationTests(unittest.TestCase):
         self.assertEqual(result["classification"], "infrastructure")
         self.assertTrue(result["rerun_failed_jobs"])
         self.assertEqual(result["jobs"][0]["kind"], "infrastructure_silent")
+
+    def test_silent_null_step_with_stale_log_blob_is_infrastructure(self) -> None:
+        """A runner that dies leaves a log blob that EXISTS but stopped growing.
+
+        The missing-blob branch only fires when the blob 404s, so the variant
+        where GitHub kept a truncated blob classified `unknown` and the run
+        read as a code failure. Measured on the live API, the two populations
+        do not overlap: runner-concluded jobs write their blob within 0-2s of
+        `completed_at` (n=66), while jobs whose agent died show 569-1149s
+        (n=6). Verified independently here: run 31823415675's dead job shows
+        597s while every other job in it shows 0-1s, and run 31906708922, a
+        genuine test failure, shows at most 1s across all 15 jobs.
+        """
+        result = classify_fixture("truncated-log-runner-loss.json")
+
+        self.assertEqual(result["classification"], "infrastructure")
+        self.assertTrue(result["rerun_failed_jobs"])
+        self.assertEqual(result["jobs"][0]["kind"], "infrastructure_silent")
+
+    def test_silent_null_step_with_fresh_log_blob_is_not_infrastructure(self) -> None:
+        """The gap is the witness, not the null-step shape on its own.
+
+        Without this the fix could classify any interrupted job as
+        infrastructure and rerun genuine failures forever.
+        """
+        result = classify_fixture("truncated-log-fresh-blob.json")
+
+        self.assertEqual(result["classification"], "not_infrastructure")
+        self.assertFalse(result["rerun_failed_jobs"])
+        self.assertEqual(result["jobs"][0]["kind"], "unknown")
 
     def test_genuine_failure_is_not_infrastructure(self) -> None:
         result = classify_fixture("genuine-failure.json")

--- a/tests/test_ci_workflow_coverage.rs
+++ b/tests/test_ci_workflow_coverage.rs
@@ -357,6 +357,79 @@ fn summary_fails_when_a_gating_job_fails() {
     }
 }
 
+/// A diagnostic that cannot run is worse than no diagnostic: it is silent in
+/// exactly the case it was written for, and its silence reads as "nothing to
+/// report". The runner-loss step shipped that way for one review round. It runs
+/// inside `summary`, whose own checkout happens AFTER the gate step that exits
+/// 1, so without a checkout of its own the script it invokes does not exist,
+/// python exits ENOENT, and the annotation never appears on any run.
+#[test]
+fn runner_loss_diagnosis_can_actually_run() {
+    let ci = parse_workflow("ci.yml");
+    let summary = workflow_job(&ci, "summary");
+    let steps = summary
+        .get("steps")
+        .and_then(Value::as_sequence)
+        .expect("`summary` job has no steps");
+
+    let diagnose_index = steps
+        .iter()
+        .position(|s| {
+            s.get("name")
+                .and_then(Value::as_str)
+                .is_some_and(|n| n.contains("Diagnose runner loss"))
+        })
+        .expect(
+            "ci.yml's `summary` job has no `Diagnose runner loss` step, so a dead runner agent \
+             stays indistinguishable from a test failure",
+        );
+
+    let checkout_before = steps[..diagnose_index].iter().any(|s| {
+        s.get("uses")
+            .and_then(Value::as_str)
+            .is_some_and(|u| u.starts_with("actions/checkout"))
+    });
+    assert!(
+        checkout_before,
+        "`Diagnose runner loss` runs before any checkout in the `summary` job, so the classifier \
+         it invokes is not on disk. The step then fails to ENOENT and prints nothing, on every \
+         run, forever."
+    );
+
+    let run = steps[diagnose_index]
+        .get("run")
+        .and_then(Value::as_str)
+        .expect("`Diagnose runner loss` has no `run` block");
+
+    // Every script path the step names must exist in the repo. A path typo
+    // (`fcvm/scripts/...` when the checkout lands at the workspace root) is the
+    // same unrunnable-check bug wearing different clothes.
+    let repo_root = workflow_path("ci.yml")
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.parent())
+        .expect("cannot locate repo root from workflow path")
+        .to_path_buf();
+    let mut checked = 0;
+    for token in run.split_whitespace() {
+        let candidate = token.trim_matches(|c| c == '"' || c == '\'');
+        if !candidate.ends_with(".py") {
+            continue;
+        }
+        checked += 1;
+        assert!(
+            repo_root.join(candidate).is_file(),
+            "`Diagnose runner loss` invokes `{candidate}`, which does not exist relative to the \
+             checkout root. The step would exit ENOENT and emit no diagnosis."
+        );
+    }
+    assert!(
+        checked > 0,
+        "`Diagnose runner loss` names no .py script, so this test verified nothing. If the step \
+         changed shape, update the check rather than letting it pass vacuously."
+    );
+}
+
 /// The infrastructure classifier decides whether a failed CI run is retried or
 /// handed to a secret-bearing code fixer. Its fixture suite must execute in the
 /// ordinary pull-request gate, not remain a manual-only Make target.


### PR DESCRIPTION
**Stacked on:** `readiness-attempt-budget` (PR #839)

Closes the tractable half of #834. Does not attempt the kill mechanism.

## The gap

`classify_ci_failure.py` calls a job infrastructure only when the silent-loss step shape coexists with a **missing** (404 BlobNotFound) log blob. When the agent dies and GitHub keeps what it had already flushed, the blob exists and is merely truncated, so neither branch fires: the job classifies `unknown`, the run classifies `not_infrastructure`, and a dead runner reads as a test failure.

## The witness was already in the bytes it fetches

`gh api --include` returns `Last-Modified`. Against the job's `completed_at`, the two populations do not overlap. Verified independently against the live API:

| run | dead job gap | other jobs |
|---|---|---|
| 31823415675 | **597 s** | 0–1 s |
| 31850139260 | **1101 s** | — |
| 31906708922 (genuine test failure) | — | ≤ 1 s across all 15 |

`STALE_LOG_SECONDS = 120` sits 60x above the largest healthy gap and 4.7x below the smallest observed loss. The null-step shape stays **required** — the gap is a second witness, never the only one. A missing, unparseable, or negative timestamp falls through to `unknown`, so an unreadable header cannot manufacture an infrastructure verdict.

## End to end, live

```
run 31823415675 -> infrastructure  | Host-Root-x64-SnapshotDisabled -> infrastructure_silent
                                     "null-step runner loss with log blob stale by 1101s"
run 31850139260 -> infrastructure
run 31906708922 -> not_infrastructure | both jobs -> genuine
```

That last line is the one that matters: today's genuine flake is not relabeled as infrastructure.

## The verdict now has a consumer

It had none. Its only caller is `claude.yml`, which is `disabled_manually` and did not fire for any occurrence. `ci.yml`'s Summary job gains a **Diagnose runner loss** step, placed before the gate step (that step `exit 1`s, so anything after it never runs), `continue-on-error`, degrading to silence on any internal failure. It annotates; it never gates.

## Tests, each watched failing first

- `test_silent_null_step_with_stale_log_blob_is_infrastructure`
- `test_silent_null_step_with_fresh_log_blob_is_not_infrastructure` — pins that the shape alone is not enough, so genuine failures are not rerun forever
- `test_log_fetch_records_the_blob_write_time` — a witness nothing populates can never fire; also pins that a header-shaped line in the log **body** is not read as a header
- `test_log_fetch_omits_blob_write_time_when_absent`

```
$ python3 -m unittest discover -s tests -p test_ci_infrastructure.py
Ran 25 tests — OK
$ cargo test --release --test test_ci_workflow_coverage
14 passed
```

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd