### PR TITLE
Restore the nested reflink, delete the copy fallback, guard sun_path

### DIFF
--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -1353,6 +1353,13 @@ async fn prepare_vm_for_lifecycle(
     }
 
     // Setup paths
+    //
+    // Checked before anything is created: the VM's Unix sockets live in this
+    // directory, and a directory a few characters too deep pushes them past
+    // sun_path. bind() then fails with ENAMETOOLONG and surfaces far away from
+    // the cause (observed as "VolumeServer failed to signal ready: channel
+    // closed"), so refuse it here where the path can still be named.
+    paths::check_socket_path_budget(&vm_id)?;
     let data_dir = paths::vm_runtime_dir(&vm_id);
     tokio::fs::create_dir_all(&data_dir)
         .await

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -132,7 +132,118 @@ pub fn vm_runtime_dir(vm_id: &str) -> PathBuf {
     data_dir().join("vm-disks").join(vm_id)
 }
 
+/// `sockaddr_un.sun_path` is 108 bytes including the NUL, so a path of 107
+/// bytes is the most that can ever be bound.
+const SUN_PATH_MAX: usize = 107;
+
+/// The longest socket file placed in a VM's runtime directory.
+///
+/// Checked rather than assumed: if a longer name is added later, the budget
+/// below silently stops covering it, so this constant and the check move
+/// together.
+const LONGEST_SOCKET_NAME: &str = "firecracker.socket";
+
+/// Fail early when this VM's data directory leaves no room for its sockets.
+///
+/// A data directory only a few characters too deep pushes the VM's sockets past
+/// `sun_path`, `bind` returns ENAMETOOLONG, and what the operator sees is a
+/// downstream symptom with no mention of paths at all. Observed 2026-08-16: a
+/// nested data directory keyed by a full uuid produced a 128 byte socket path,
+/// and the failure surfaced as
+///   "VolumeServer 0 failed to signal ready: channel closed"
+/// which names neither the path nor the limit. Worse, the same class of failure
+/// appears to have been misdiagnosed in 55ef6350 as "FUSE doesn't support Unix
+/// sockets", and the workaround for that non-problem disabled reflinks for
+/// every nested VM for seven months (issue #810).
+pub fn check_socket_path_budget(vm_id: &str) -> anyhow::Result<()> {
+    check_socket_path_budget_under(&data_dir(), vm_id)
+}
+
+/// [`check_socket_path_budget`] against an explicit data directory.
+///
+/// Split out so the rule is testable: the real one reads a process-global
+/// `OnceLock`, and a check that cannot be tested is how the limit gets
+/// forgotten again.
+pub fn check_socket_path_budget_under(
+    data_dir: &std::path::Path,
+    vm_id: &str,
+) -> anyhow::Result<()> {
+    let longest = data_dir
+        .join("vm-disks")
+        .join(vm_id)
+        .join(LONGEST_SOCKET_NAME);
+    let length = longest.as_os_str().len();
+    anyhow::ensure!(
+        length <= SUN_PATH_MAX,
+        "the data directory is too deep for this VM's Unix sockets: {length} bytes, \
+         limit {SUN_PATH_MAX} (sockaddr_un.sun_path)\n  {}\n\
+         Shorten the data directory (FCVM_DATA_DIR or paths.data_dir). This fails \
+         here on purpose: bind() would otherwise return ENAMETOOLONG and surface \
+         as an unrelated-looking readiness or channel error.",
+        longest.display()
+    );
+    Ok(())
+}
+
 /// Directory for snapshot data
 pub fn snapshot_dir() -> PathBuf {
     data_dir().join("snapshots")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    /// A 32-hex vm_id, the real shape.
+    const VM_ID: &str = "vm-1036ea9415214256aff023d3e28646a9";
+
+    /// The exact directory that broke the nested L2 launch on 2026-08-16.
+    #[test]
+    fn a_data_dir_that_overflows_sun_path_is_rejected() {
+        let too_deep =
+            Path::new("/mnt/fcvm-btrfs/nested-data/9db69791-596f-4f92-9717-44208140b129");
+        let error = check_socket_path_budget_under(too_deep, VM_ID)
+            .expect_err("a 128 byte socket path must be refused, not bound");
+        let text = error.to_string();
+        assert!(
+            text.contains("sun_path") && text.contains("128"),
+            "the error must name the limit AND the measured length, or the operator \
+             is left with the same unattributable symptom this replaces: {text}"
+        );
+    }
+
+    /// The shortened form must pass, or the guard would block the fix.
+    #[test]
+    fn the_shortened_nested_data_dir_fits() {
+        let short = Path::new("/mnt/fcvm-btrfs/nd/9db69791");
+        check_socket_path_budget_under(short, VM_ID)
+            .expect("91 bytes must be accepted; if this fails the budget is miscomputed");
+    }
+
+    /// The default layout must have room, or every VM would fail to start.
+    #[test]
+    fn the_default_data_dir_fits() {
+        check_socket_path_budget_under(Path::new("/mnt/fcvm-btrfs"), VM_ID)
+            .expect("the default data dir must leave room for VM sockets");
+    }
+
+    /// Exactly at the limit is allowed; one byte over is not. Pins the
+    /// boundary, so an off-by-one cannot creep in unnoticed.
+    #[test]
+    fn the_boundary_is_exact() {
+        let suffix_len = format!("/vm-disks/{VM_ID}/{LONGEST_SOCKET_NAME}").len();
+        let at_limit = "/".repeat(SUN_PATH_MAX - suffix_len);
+        assert_eq!(
+            at_limit.len() + suffix_len,
+            SUN_PATH_MAX,
+            "test set-up is wrong"
+        );
+        check_socket_path_budget_under(Path::new(&at_limit), VM_ID)
+            .expect("a path of exactly SUN_PATH_MAX bytes must be accepted");
+
+        let over = format!("{at_limit}x");
+        check_socket_path_budget_under(Path::new(&over), VM_ID)
+            .expect_err("one byte over SUN_PATH_MAX must be refused");
+    }
 }

--- a/src/storage/disk.rs
+++ b/src/storage/disk.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Context, Result};
 use std::path::{Path, PathBuf};
 use tokio::fs;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 /// Configuration for a VM disk
 #[derive(Debug, Clone)]
@@ -66,35 +66,36 @@ impl DiskManager {
 
             if !reflink_output.status.success() {
                 let stderr = String::from_utf8_lossy(&reflink_output.stderr);
-
-                // Check if this is a cross-device error (common in nested VMs where
-                // source is on FUSE mount but destination is local filesystem)
-                if stderr.contains("cross-device") || stderr.contains("Invalid cross-device link") {
-                    warn!(
-                        base = %self.base_rootfs.display(),
-                        disk = %disk_path.display(),
-                        "reflink failed (cross-device), falling back to regular copy (slower)"
-                    );
-
-                    // Fall back to regular copy
-                    let copy_output = tokio::process::Command::new("cp")
-                        .arg(&self.base_rootfs)
-                        .arg(&disk_path)
-                        .output()
-                        .await
-                        .context("executing cp (fallback)")?;
-
-                    if !copy_output.status.success() {
-                        let copy_stderr = String::from_utf8_lossy(&copy_output.stderr);
-                        anyhow::bail!("Disk copy failed. Error: {}", copy_stderr);
+                // No copy fallback. A reflink that silently becomes a copy is
+                // not a slower success, it is a different operation: O(1)
+                // becomes O(image size), per VM, and the only trace is a WARN.
+                // Issue #810 lived seven months behind exactly that fallback
+                // (55ef6350), surfacing as nested tests timing out at 843s
+                // under load while passing on a quiet box. Fail loudly instead
+                // and name both causes, because the fix differs per cause.
+                let cross_device =
+                    stderr.contains("cross-device") || stderr.contains("Invalid cross-device link");
+                anyhow::bail!(
+                    "Reflink copy failed (required for CoW disk): {}\n\
+                     base: {}\n\
+                     disk: {}\n\
+                     {}",
+                    stderr.trim(),
+                    self.base_rootfs.display(),
+                    disk_path.display(),
+                    if cross_device {
+                        "Cause: the base image and the VM disk are on DIFFERENT filesystems, so \
+                         the kernel refuses FICLONE with EXDEV before the filesystem is ever \
+                         consulted. Put the data directory on the same filesystem as the base \
+                         image (for a nested VM, that is the mapped /mnt/fcvm-btrfs, not the \
+                         guest's local disk)."
+                    } else {
+                        "Cause: the filesystem holding these paths does not implement clone. \
+                         Ensure the kernel has FUSE_REMAP_FILE_RANGE support (a kernel profile \
+                         carrying kernel/patches/0001-fuse-add-remap_file_range-support.patch), \
+                         and that the backing store is btrfs."
                     }
-                } else {
-                    anyhow::bail!(
-                        "Reflink copy failed (required for CoW disk). Error: {}. \
-                        Ensure the kernel has FUSE_REMAP_FILE_RANGE support (requires a kernel profile with this patch).",
-                        stderr
-                    );
-                }
+                );
             }
         }
 

--- a/tests/test_kvm.rs
+++ b/tests/test_kvm.rs
@@ -1572,9 +1572,33 @@ podman load -i {image_cache}/{digest}.oci.tar
 podman tag sha256:{digest} localhost/nested-test 2>/dev/null || true
 
 echo "L{level}: Starting L{next_level} VM..."
-# Use local data_dir for nested VMs (FUSE doesn't support Unix sockets)
-mkdir -p /root/fcvm-data/state /root/fcvm-data/vm-disks
-FCVM_DATA_DIR=/root/fcvm-data FCVM_FUSE_TRACE_RATE=100 FCVM_FUSE_MAX_WRITE={fuse_max_write} fcvm podman run \
+# The data dir MUST live on the same filesystem as the base rootfs, or the
+# VM disk cannot be a reflink of it. FICLONE is refused across superblocks
+# (EXDEV) by the VFS before FUSE is ever consulted, so a data dir on the L1's
+# local disk silently turns an O(1) clone into a full ~10GB copy pulled
+# through fuse-pipe (src/storage/disk.rs falls back to cp). That is issue
+# #810: under the parallel suite the copy blows the `timeout 600` below and
+# the nested tests die at a near-constant 843s, passing on retry in 100-307s.
+#
+# This used to be a local dir because of "Unix socket issues on FUSE"
+# (55ef6350, 2026-01-04). Measured 2026-08-16 on a real guest: AF_UNIX bind
+# AND connect both succeed on the fuse-pipe mount, and fuse-pipe has had
+# mknod for special files including sockets since 26c75963 (2025-11-28), five
+# weeks BEFORE that workaround. The L1's own disk is ext4, which has no
+# reflink at all, so this mount is the only place CoW can happen.
+#
+# A uuid, not $$: concurrent L1s share this host directory through the map,
+# and separate PID namespaces reuse numbers (see AGENTS.md on the cross-VM
+# cache race).
+# Short on purpose. AF_UNIX sun_path is 108 bytes and the VM's sockets sit at
+# <data>/vm-disks/vm-<32 hex>/firecracker.socket, which is 63 bytes on its own.
+# A full uuid here produced a 128 byte path, bind() failed, and the L2's
+# VolumeServer died with "channel closed". That is almost certainly what was
+# misread in 55ef6350 as "FUSE doesn't support Unix sockets": the failure was
+# path length, not the filesystem.
+NESTED_DATA=/mnt/fcvm-btrfs/nd/$(cut -c1-8 /proc/sys/kernel/random/uuid)
+mkdir -p $NESTED_DATA/state $NESTED_DATA/vm-disks
+FCVM_DATA_DIR=$NESTED_DATA FCVM_FUSE_TRACE_RATE=100 FCVM_FUSE_MAX_WRITE={fuse_max_write} fcvm podman run \
     --no-snapshot \
     --name l{next_level} \
     --network bridged \
@@ -1611,9 +1635,33 @@ podman load -i {image_cache}/{digest}.oci.tar
 podman tag sha256:{digest} localhost/nested-test 2>/dev/null || true
 
 echo "L{level}: Starting L{next_level} VM..."
-# Use local data_dir for nested VMs (FUSE doesn't support Unix sockets)
-mkdir -p /root/fcvm-data/state /root/fcvm-data/vm-disks
-FCVM_DATA_DIR=/root/fcvm-data FCVM_FUSE_TRACE_RATE=100 FCVM_FUSE_MAX_WRITE={fuse_max_write} fcvm podman run \
+# The data dir MUST live on the same filesystem as the base rootfs, or the
+# VM disk cannot be a reflink of it. FICLONE is refused across superblocks
+# (EXDEV) by the VFS before FUSE is ever consulted, so a data dir on the L1's
+# local disk silently turns an O(1) clone into a full ~10GB copy pulled
+# through fuse-pipe (src/storage/disk.rs falls back to cp). That is issue
+# #810: under the parallel suite the copy blows the `timeout 600` below and
+# the nested tests die at a near-constant 843s, passing on retry in 100-307s.
+#
+# This used to be a local dir because of "Unix socket issues on FUSE"
+# (55ef6350, 2026-01-04). Measured 2026-08-16 on a real guest: AF_UNIX bind
+# AND connect both succeed on the fuse-pipe mount, and fuse-pipe has had
+# mknod for special files including sockets since 26c75963 (2025-11-28), five
+# weeks BEFORE that workaround. The L1's own disk is ext4, which has no
+# reflink at all, so this mount is the only place CoW can happen.
+#
+# A uuid, not $$: concurrent L1s share this host directory through the map,
+# and separate PID namespaces reuse numbers (see AGENTS.md on the cross-VM
+# cache race).
+# Short on purpose. AF_UNIX sun_path is 108 bytes and the VM's sockets sit at
+# <data>/vm-disks/vm-<32 hex>/firecracker.socket, which is 63 bytes on its own.
+# A full uuid here produced a 128 byte path, bind() failed, and the L2's
+# VolumeServer died with "channel closed". That is almost certainly what was
+# misread in 55ef6350 as "FUSE doesn't support Unix sockets": the failure was
+# path length, not the filesystem.
+NESTED_DATA=/mnt/fcvm-btrfs/nd/$(cut -c1-8 /proc/sys/kernel/random/uuid)
+mkdir -p $NESTED_DATA/state $NESTED_DATA/vm-disks
+FCVM_DATA_DIR=$NESTED_DATA FCVM_FUSE_TRACE_RATE=100 FCVM_FUSE_MAX_WRITE={fuse_max_write} fcvm podman run \
     --no-snapshot \
     --name l{next_level} \
     --network bridged \
@@ -1649,9 +1697,33 @@ podman load -i {image_cache}/{digest}.oci.tar
 podman tag sha256:{digest} localhost/nested-test 2>/dev/null || true
 
 echo "L{level}: Starting L{next_level} VM..."
-# Use local data_dir for nested VMs (FUSE doesn't support Unix sockets)
-mkdir -p /root/fcvm-data/state /root/fcvm-data/vm-disks
-FCVM_DATA_DIR=/root/fcvm-data FCVM_FUSE_TRACE_RATE=100 FCVM_FUSE_MAX_WRITE={fuse_max_write} fcvm podman run \
+# The data dir MUST live on the same filesystem as the base rootfs, or the
+# VM disk cannot be a reflink of it. FICLONE is refused across superblocks
+# (EXDEV) by the VFS before FUSE is ever consulted, so a data dir on the L1's
+# local disk silently turns an O(1) clone into a full ~10GB copy pulled
+# through fuse-pipe (src/storage/disk.rs falls back to cp). That is issue
+# #810: under the parallel suite the copy blows the `timeout 600` below and
+# the nested tests die at a near-constant 843s, passing on retry in 100-307s.
+#
+# This used to be a local dir because of "Unix socket issues on FUSE"
+# (55ef6350, 2026-01-04). Measured 2026-08-16 on a real guest: AF_UNIX bind
+# AND connect both succeed on the fuse-pipe mount, and fuse-pipe has had
+# mknod for special files including sockets since 26c75963 (2025-11-28), five
+# weeks BEFORE that workaround. The L1's own disk is ext4, which has no
+# reflink at all, so this mount is the only place CoW can happen.
+#
+# A uuid, not $$: concurrent L1s share this host directory through the map,
+# and separate PID namespaces reuse numbers (see AGENTS.md on the cross-VM
+# cache race).
+# Short on purpose. AF_UNIX sun_path is 108 bytes and the VM's sockets sit at
+# <data>/vm-disks/vm-<32 hex>/firecracker.socket, which is 63 bytes on its own.
+# A full uuid here produced a 128 byte path, bind() failed, and the L2's
+# VolumeServer died with "channel closed". That is almost certainly what was
+# misread in 55ef6350 as "FUSE doesn't support Unix sockets": the failure was
+# path length, not the filesystem.
+NESTED_DATA=/mnt/fcvm-btrfs/nd/$(cut -c1-8 /proc/sys/kernel/random/uuid)
+mkdir -p $NESTED_DATA/state $NESTED_DATA/vm-disks
+FCVM_DATA_DIR=$NESTED_DATA FCVM_FUSE_TRACE_RATE=100 FCVM_FUSE_MAX_WRITE={fuse_max_write} fcvm podman run \
     --no-snapshot \
     --name l{next_level} \
     --network bridged \
@@ -1756,6 +1828,21 @@ FCVM_DATA_DIR=/root/fcvm-data FCVM_FUSE_TRACE_RATE=100 FCVM_FUSE_MAX_WRITE={fuse
     let log_content = tokio::fs::read_to_string(&log_file)
         .await
         .unwrap_or_default();
+
+    // The nested VM's disk must be a reflink of the base image, never a copy.
+    // A cross-device fallback means the data dir drifted off the filesystem
+    // that holds the base rootfs, which converts an O(1) clone into a full
+    // ~10GB copy through fuse-pipe. That is invisible in a passing run on a
+    // quiet box (it merely takes 327s instead of 30s) and fatal under the
+    // parallel suite, where it blows the inner `timeout 600` and the test dies
+    // at a near-constant 843s. Issue #810 went unattributed for seven months
+    // because the degrade only warns. Assert on it instead.
+    assert!(
+        !log_content.contains("reflink failed (cross-device)"),
+        "the nested VM disk fell back to a full copy instead of a reflink. The data dir is \
+         not on the same filesystem as the base rootfs, so FICLONE was refused with EXDEV. \
+         Check FCVM_DATA_DIR in this test's script."
+    );
 
     // Verify all level markers present
     for level in 1..=n {


### PR DESCRIPTION
**Stacked on:** `guest-vitals` (PR #842) → `runner-loss-detection` (#840) → `readiness-attempt-budget` (#839)

Fixes #810. It is a regression from `55ef6350` (2026-01-04), not a load problem — reflinks did work before it.

## The chain, from that commit's own message

1. A prior commit set `FCVM_DATA_DIR=/root/fcvm-data` for nested VMs "to avoid Unix socket issues on FUSE filesystems".
2. That left the base image on the mapped mount and the VM disk on the L1's local disk, so `FICLONE` became cross-superblock. The VFS refuses that with `EXDEV` **before FUSE is ever consulted**.
3. The same commit added a `cp` fallback, "slower but works", measured at 327 s on a quiet box.

An O(1) clone had become a ~10 GB copy pulled through fuse-pipe, per nested VM, and the only trace was one `WARN`.

Under the parallel suite that copy exceeds the `timeout 600` bounding the L2 launch, so `MARKER_L2_OK` never appears. Four failures inside a **0.4 s band** across three tests is a deadline, not a stall:

```
842.664s  test_nested_l2_network_fuse  TRY 1 FAIL
842.696s  test_nested_l2_nfs           TRY 1 FAIL
842.936s  test_nested_l2_network_nfs   TRY 1 FAIL
843.033s  test_nested_l2_network_nfs   TRY 2 FAIL   <- failed both tries
```

## Measured before changing anything

- **AF_UNIX bind and connect both succeed on the fuse-pipe mount**, tested in a real guest with a local-disk control. The stated premise does not hold.
- fuse-pipe has had `mknod` for special files including sockets since `26c75963` (2025-11-28), **five weeks before** that workaround.
- The L1's local disk is **ext4**, which has no reflink at all — so there was never a local arrangement in which CoW could have worked.

## What January most likely hit: path length, not the filesystem

`sun_path` is 108 bytes. Reproduced here: a uuid-keyed data dir gives a **128-byte** socket path, `bind` fails, and it surfaces as `VolumeServer 0 failed to signal ready: channel closed` — naming neither the path nor the limit.

## The change

- Data dir moves back onto the mapped mount at a **short** path (`/mnt/fcvm-btrfs/nd/<8 hex>`, 91 bytes for the longest socket). A uuid rather than `$$`, because concurrent L1s share that directory and separate PID namespaces reuse numbers.
- **The cross-device `cp` fallback is deleted.** A reflink that silently becomes a copy is a different operation, not a slower success. Failure now names which of the two causes applies, since the fix differs per cause.
- `paths::check_socket_path_budget` refuses an over-deep data dir *before* the VM directory is created, naming the path and the limit.

## Verified end to end (aarch64)

| | before | after |
|---|---|---|
| `test_nested_l2_fuse` | `TRY 1 FAIL [901.890s]` | `PASS [173.927s]` |
| cross-device fallbacks | 1 | **0** |
| markers | — | `MARKER_L1_OK`, `MARKER_L2_OK` |

## Tests

4 for the `sun_path` budget, including the exact 128-byte path that broke it and an exact-boundary case (at the limit passes, one byte over fails), plus an assertion in the nested test that the L1 log carries no cross-device fallback. That assertion is red against tonight's captured log.

Note for review: the nested tests are excluded from CI by `Makefile` `CI_ROOT_BASE`, so this verification is local and CI will not exercise it.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd