### PR TITLE
Route bench-only changes to the bench suite instead of the VM matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.detect.outputs.code }}
+      bench: ${{ steps.detect.outputs.bench }}
     steps:
       - name: Detect whether any non-doc path changed
         id: detect
@@ -87,15 +88,41 @@ jobs:
             echo "no changed files reported: running the full matrix"
             exit 0
           fi
+          # bench/** is classified SEPARATELY, not lumped into code. The
+          # self-hosted matrix does not exercise the benchmark harness at all,
+          # so a bench-only PR was paying for the full matrix and getting no
+          # check of the thing it changed. It now runs bench-tests instead,
+          # which is the check that can actually fail for it. Skipping without
+          # routing would be the green-by-absence hole this file already
+          # documents twice.
           code=false
+          bench=false
           while IFS= read -r f; do
             case "$f" in
               scripts/claude-assistant/*|.github/workflows/claude*.yml|.claude/*|docs/*|*.md) ;;
+              bench/*) bench=true; echo "bench path: $f" ;;
               *) code=true; echo "code path: $f" ;;
             esac
           done <<< "$files"
           echo "code=$code" >> "$GITHUB_OUTPUT"
-          echo "code_changed=$code"
+          echo "bench=$bench" >> "$GITHUB_OUTPUT"
+          echo "code_changed=$code bench_changed=$bench"
+
+  # The benchmark harness has four test files and, until now, CI ran none of
+  # them: `grep -c bench/ ci.yml` was 0 while bench/chromium/test_reqbench.py,
+  # test_fixture_isolation.py, test_faultbench.py and test_reqscale.py sat
+  # unexecuted, including the MakefileBenchGraph structural pin that AGENTS.md
+  # says protects the bench dependency graph. Pure python, no KVM, no runner.
+  bench-tests:
+    name: Bench Harness Tests
+    needs: [changes]
+    if: ${{ needs.changes.outputs.bench == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run the bench harness test suite
+        run: |
+          python3 -m unittest discover -s bench/chromium -p 'test_*.py' -v
 
   # Lints every workflow file. Lives here, not in claude-lint.yml, so `Summary`
   # gates it: a PR that changes only `.github/workflows/claude*.yml` skips the
@@ -950,7 +977,7 @@ jobs:
   # Final summary job - runs after all test jobs
   summary:
     name: Summary
-    needs: [changes, actionlint, skip-check, lint, packaging, fc-mock, host, host-root, container]
+    needs: [changes, actionlint, skip-check, lint, packaging, fc-mock, bench-tests, host, host-root, container]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/tests/test_ci_workflow_coverage.rs
+++ b/tests/test_ci_workflow_coverage.rs
@@ -91,6 +91,109 @@ fn ci_runs_on_pull_requests_regardless_of_base_branch() {
 /// makes Summary *wait*, and with `if: always()` Summary then reports its own
 /// result regardless of theirs. `summary_fails_when_a_gating_job_fails` below
 /// covers the second half.
+/// Skipping draft PRs is only safe if marking one ready re-triggers CI.
+///
+/// `pull_request` defaults to opened, synchronize, reopened. `ready_for_review`
+/// is NOT in that set, so a workflow that skips drafts without adding it leaves
+/// a PR that was drafted and then marked ready sitting with no checks, forever,
+/// and GitHub renders that as nothing failing. It is the same green-by-absence
+/// hole this file already pins for `branches:` and `paths-ignore:`: a check set
+/// that cannot fail because it never ran.
+#[test]
+fn skipping_drafts_requires_ready_for_review() {
+    let ci = parse_workflow("ci.yml");
+    let text = std::fs::read_to_string(workflow_path("ci.yml")).expect("ci.yml must be readable");
+
+    // Does anything in this workflow branch on the draft flag?
+    let skips_drafts = text.contains("pull_request.draft");
+    if !skips_drafts {
+        return;
+    }
+
+    let pull_request = triggers(&ci)
+        .get("pull_request")
+        .expect("ci.yml has no `pull_request:` trigger");
+    let types = pull_request
+        .get("types")
+        .and_then(Value::as_sequence)
+        .map(|list| {
+            list.iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    assert!(
+        types.iter().any(|t| t == "ready_for_review"),
+        "ci.yml skips draft PRs but its `pull_request` types are {types:?}. Without \
+         `ready_for_review`, marking a draft ready fires no event, so the PR keeps \
+         zero checks and reads as green. Add it, or stop skipping drafts."
+    );
+
+    // The default types are implicit only when `types:` is absent. Once it is
+    // present, every needed event must be listed or it is silently dropped.
+    for needed in ["opened", "synchronize", "reopened"] {
+        assert!(
+            types.iter().any(|t| t == needed),
+            "ci.yml pins `pull_request` types to {types:?}, which drops `{needed}`. \
+             Listing types replaces the default set rather than extending it, so a \
+             {needed} event would now run nothing."
+        );
+    }
+}
+
+/// Excluding a path from the expensive matrix must ROUTE it, not silence it.
+///
+/// bench/** no longer sets `code`, because the self-hosted matrix does not
+/// exercise the benchmark harness. That is only safe while some job still runs
+/// for a bench-only PR. Otherwise such a PR gets Summary and actionlint alone,
+/// its four test files never execute, and the result reads as green because
+/// nothing that could fail was scheduled. That is the same hole this file pins
+/// for `branches:` and `paths-ignore:`.
+///
+/// Measured when this was written: `grep -c "bench/" ci.yml` was 0 while
+/// bench/chromium held 262 passing tests, including the MakefileBenchGraph
+/// structural pin AGENTS.md relies on.
+#[test]
+fn a_path_excluded_from_the_matrix_still_gets_a_check() {
+    let ci = parse_workflow("ci.yml");
+    let text = std::fs::read_to_string(workflow_path("ci.yml")).expect("ci.yml must be readable");
+
+    // Only binding once bench is classified separately from code.
+    if !text.contains("bench=true") {
+        return;
+    }
+
+    let jobs = ci.get("jobs").expect("ci.yml has no jobs");
+    let bench_job = jobs
+        .get("bench-tests")
+        .expect("ci.yml classifies bench/** out of `code` but has no `bench-tests` job, so a \
+                 bench-only PR would run nothing that can fail");
+
+    let condition = bench_job
+        .get("if")
+        .and_then(Value::as_str)
+        .expect("`bench-tests` has no `if:`; it must run exactly when bench changed");
+    assert!(
+        condition.contains("changes.outputs.bench"),
+        "`bench-tests` does not gate on `changes.outputs.bench` ({condition:?}), so it either \
+         never runs or always runs; neither routes a bench-only PR to the check that can fail"
+    );
+
+    let summary_needs = jobs
+        .get("summary")
+        .and_then(|s| s.get("needs"))
+        .and_then(Value::as_sequence)
+        .map(|l| l.iter().filter_map(Value::as_str).collect::<Vec<_>>())
+        .unwrap_or_default();
+    assert!(
+        summary_needs.contains(&"bench-tests"),
+        "`summary` does not depend on `bench-tests` (needs = {summary_needs:?}), so a failing \
+         bench suite would not fail the run's required check and would be advisory only"
+    );
+}
+
 #[test]
 fn gating_jobs_live_in_the_pull_request_workflow() {
     let ci = parse_workflow("ci.yml");

--- a/tests/test_ci_workflow_coverage.rs
+++ b/tests/test_ci_workflow_coverage.rs
@@ -166,10 +166,10 @@ fn a_path_excluded_from_the_matrix_still_gets_a_check() {
     }
 
     let jobs = ci.get("jobs").expect("ci.yml has no jobs");
-    let bench_job = jobs
-        .get("bench-tests")
-        .expect("ci.yml classifies bench/** out of `code` but has no `bench-tests` job, so a \
-                 bench-only PR would run nothing that can fail");
+    let bench_job = jobs.get("bench-tests").expect(
+        "ci.yml classifies bench/** out of `code` but has no `bench-tests` job, so a \
+                 bench-only PR would run nothing that can fail",
+    );
 
     let condition = bench_job
         .get("if")


### PR DESCRIPTION
Smart skip by content: a PR touching only `bench/**` no longer runs the self-hosted matrix, and instead runs the check that can actually fail for it.

## The gap

`grep -c "bench/" .github/workflows/ci.yml` was **0**. Meanwhile `bench/chromium` holds four test files and **262 passing tests** (43s, pure python), including the `MakefileBenchGraph` structural pin that AGENTS.md says protects the bench dependency graph. None had ever run in CI.

So a bench-only PR paid for two arches, four `Host-Root` jobs and both container jobs — and got no check of the code it changed.

## The change

`changes` now classifies `bench/**` separately from `code`:

| PR touches | matrix | bench-tests |
|---|---|---|
| src, tests, kernel | runs | skipped |
| bench only | **skipped** | **runs** |
| docs/md only | skipped | skipped |

`bench-tests` is `ubuntu-latest`, no KVM, no self-hosted runner, and `summary` depends on it so a failure is not advisory.

## Why skipping alone would have been wrong

This file already documents two incidents where a filter left a PR with no check runs and GitHub rendered it CLEAN: the `branches:` filter (which matches the PR's *base*, so it skipped every stacked PR) and `paths-ignore:` (PR #785 was mechanically mergeable that way). Excluding a path from the matrix without routing it somewhere is the same hole. Hence a job, not just a skip.

## Tests, both watched failing first

**`a_path_excluded_from_the_matrix_still_gets_a_check`** — removing the `bench-tests` job while keeping the classification is exactly the mistake it guards:

```
ci.yml classifies bench/** out of `code` but has no `bench-tests` job,
so a bench-only PR would run nothing that can fail
```

It also asserts `summary` depends on the job, so a failing bench suite fails the required check.

**`skipping_drafts_requires_ready_for_review`** — dormant unless someone skips draft PRs. If they do, it requires `ready_for_review` in the `pull_request` types: the default set is `opened, synchronize, reopened`, so without it a draft marked ready fires **no event** and the PR keeps zero checks forever. Listing `types:` replaces the default set rather than extending it, so it also pins the other three.

```
$ cargo test --test test_ci_workflow_coverage     17 passed
$ python3 -m unittest discover -s bench/chromium  262 passed
```

Follow-on: with this merged, #844 (benchmark records + gitignore, entirely under `bench/`) can come out of draft and will run `bench-tests` rather than the full matrix.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd