### PR TITLE
Record what a request cost in memory, on the record that has its latency

### DIFF
--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -136,6 +136,42 @@ CONTROL_WINDOW_S = 0.05
 # ---------------------------------------------------------------- procfs utils
 
 
+def proc_private_dirty_kb(pid: int) -> dict:
+    """What this process has PRIVATISED, from /proc/<pid>/smaps_rollup.
+
+    A clone starts as a view of the shared snapshot, so its Private_Dirty IS
+    the delta it cost: the pages it wrote rather than read. Read here, alive,
+    immediately before the kill, so the figure is the cost of the request that
+    just completed.
+
+    Not readable from a zombie. smaps_rollup disappears with the address space,
+    which is why this cannot be sampled alongside the CPU figures after exit.
+
+    Returns the reason rather than a zero when it cannot measure. A zero with no
+    uncertainty is a claim, and an unreadable file does not support one.
+    """
+    try:
+        with open(f"/proc/{pid}/smaps_rollup", "r", encoding="ascii") as handle:
+            rollup = handle.read()
+    except FileNotFoundError:
+        return {"private_dirty_kb": None, "unavailable": "no smaps_rollup (exited, or kernel lacks CONFIG_PROC_PAGE_MONITOR)"}
+    except PermissionError as error:
+        return {"private_dirty_kb": None, "unavailable": f"permission: {error}"}
+    except OSError as error:
+        return {"private_dirty_kb": None, "unavailable": f"{type(error).__name__}: {error}"}
+    fields = {}
+    for line in rollup.splitlines():
+        key, _, rest = line.partition(":")
+        if key in ("Private_Dirty", "Private_Clean", "Shared_Clean", "Shared_Dirty", "Pss", "Rss"):
+            try:
+                fields[key.lower() + "_kb"] = int(rest.strip().split()[0])
+            except (IndexError, ValueError):
+                pass
+    if "private_dirty_kb" not in fields:
+        return {"private_dirty_kb": None, "unavailable": "smaps_rollup carried no Private_Dirty"}
+    return fields
+
+
 def proc_stat_fields(pid: int):
     """(state, utime_ticks, stime_ticks, starttime) or None if the pid is gone.
 
@@ -1378,6 +1414,10 @@ def measure_fast_reap(
     all_fds = [parent_fd, *fds.values()]
     try:
         pre = {name: proc_stat_fields(pid) for name, pid in tracked.items()}
+        # Memory MUST be read here: alive, request complete, before the kill.
+        # It cannot be recovered afterwards the way CPU can, because
+        # smaps_rollup dies with the address space.
+        pre_memory = {name: proc_private_dirty_kb(pid) for name, pid in tracked.items()}
         missing_pre = [name for name, fields in pre.items() if fields is None]
         if missing_pre:
             raise RuntimeError(
@@ -1443,6 +1483,7 @@ def measure_fast_reap(
             "machine_window_ms": machine_window_ms,
             "parent_live": parent_live,
             "pre": pre,
+            "pre_memory": pre_memory,
             "reclaim_cpu": reclaim_cpu,
             "sample_period_s": sample_period_s,
             "self_ms": self_ms,
@@ -1548,6 +1589,7 @@ def teardown_fast(
     machine_cpu_ms = measured["machine_ms"]
     machine_window_ms = measured["machine_window_ms"]
     pre = measured["pre"]
+    pre_memory = measured.get("pre_memory", {})
     # Absolute CPU each pinned child had burned at the kill instant. The VM
     # lives exactly one request, so firecracker's figure IS the per-request
     # VMM+vCPU cost; subtracting the noop arm's (restore + idle) yields
@@ -1633,6 +1675,18 @@ def teardown_fast(
             # False -> reaper won the race, figure is a LOWER BOUND.
             "complete": s["zombie_seen"],
         }
+
+    # The delta this request cost, per pinned process. Reported next to the
+    # latency on the SAME record, so a memory/latency frontier is one
+    # measurement rather than a join across two experiments on two goldens.
+    out["per_child_memory"] = dict(pre_memory)
+    dirty = [m.get("private_dirty_kb") for m in pre_memory.values()]
+    out["private_dirty_total_kb"] = (
+        sum(v for v in dirty if v is not None) if any(v is not None for v in dirty) else None
+    )
+    out["private_dirty_unmeasured"] = [
+        name for name, m in pre_memory.items() if m.get("private_dirty_kb") is None
+    ]
 
     if not all_gone:
         survivors = dict(measured["live_exact"])

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -136,13 +136,50 @@ CONTROL_WINDOW_S = 0.05
 # ---------------------------------------------------------------- procfs utils
 
 
+def private_dirty_total_kb(per_child: dict) -> int | None:
+    """Total privatised memory, or None when the total would be a fiction.
+
+    None unless EVERY pinned process was sampled, and None for an empty set. A
+    partial sum is not a smaller measurement, it is a different one: if
+    firecracker exits between the pin and the read, the remaining processes
+    total a few MiB against its few hundred, and a number is what a reader
+    takes at face value.
+
+    A function rather than an inline expression so a test can call the rule the
+    record is actually built from. Inlining a copy into the test proved only
+    that Python sums the way Python sums.
+    """
+    if not per_child:
+        return None
+    values = [m.get("private_dirty_kb") for m in per_child.values()]
+    if any(v is None for v in values):
+        return None
+    return sum(values)
+
+
 def proc_private_dirty_kb(pid: int) -> dict:
     """What this process has PRIVATISED, from /proc/<pid>/smaps_rollup.
 
-    A clone starts as a view of the shared snapshot, so its Private_Dirty IS
-    the delta it cost: the pages it wrote rather than read. Read here, alive,
-    immediately before the kill, so the figure is the cost of the request that
-    just completed.
+    NOT "the pages it wrote". What Private_Dirty counts depends on the memory
+    backend, and the two the harness compares do not agree:
+
+      uffd copy   UFFDIO_COPY populates ANONYMOUS memory, so every page the
+                  server fills is private the moment it is filled, written or
+                  not. With --uffd-prefetch on (the default) the whole recorded
+                  working set, about 56k pages, is replayed BEFORE the guest
+                  runs and all of it counts here.
+      uffd minor  UFFDIO_CONTINUE installs a read-only PTE to the shared page,
+                  so a replayed page costs nothing until it is written. This is
+                  the arm where the field really does mean "pages written".
+      file        MAP_PRIVATE over the page cache: only real writes count.
+
+    So this number is comparable ACROSS CLONES of one configuration, and NOT
+    across backends or across prefetch settings, unless the reader also has
+    those settings. The caller records them beside the figure for that reason.
+
+    Read alive, immediately before the kill, so it describes the request that
+    just completed. It cannot be recovered afterwards the way CPU can, because
+    smaps_rollup dies with the address space.
 
     Not readable from a zombie. smaps_rollup disappears with the address space,
     which is why this cannot be sampled alongside the CPU figures after exit.
@@ -1413,11 +1450,18 @@ def measure_fast_reap(
     """Measure one fast reap while guaranteeing a stopped owner cannot escape."""
     all_fds = [parent_fd, *fds.values()]
     try:
-        pre = {name: proc_stat_fields(pid) for name, pid in tracked.items()}
-        # Memory MUST be read here: alive, request complete, before the kill.
-        # It cannot be recovered afterwards the way CPU can, because
-        # smaps_rollup dies with the address space.
+        # Memory FIRST, then the CPU baseline. Both must be read while the
+        # processes are alive (smaps_rollup dies with the address space), but
+        # the ORDER is load-bearing: only the fcvm parent is frozen here, so
+        # firecracker, holder and pasta keep burning CPU while this runs, and
+        # any CPU they burn between the baseline and the kill lands in
+        # reclaim_cpu_ms as if the reap had caused it. Walking smaps_rollup
+        # costs 3.9-6.6 ms on a 722 MB RSS process (about 6-9 ms per GiB),
+        # which is the order of the 10 ms CLK_TCK quantum this function is
+        # careful to bound. Sampling before the baseline removes the window
+        # entirely rather than making it small.
         pre_memory = {name: proc_private_dirty_kb(pid) for name, pid in tracked.items()}
+        pre = {name: proc_stat_fields(pid) for name, pid in tracked.items()}
         missing_pre = [name for name, fields in pre.items() if fields is None]
         if missing_pre:
             raise RuntimeError(
@@ -1680,13 +1724,15 @@ def teardown_fast(
     # latency on the SAME record, so a memory/latency frontier is one
     # measurement rather than a join across two experiments on two goldens.
     out["per_child_memory"] = dict(pre_memory)
-    dirty = [m.get("private_dirty_kb") for m in pre_memory.values()]
-    out["private_dirty_total_kb"] = (
-        sum(v for v in dirty if v is not None) if any(v is not None for v in dirty) else None
-    )
     out["private_dirty_unmeasured"] = [
         name for name, m in pre_memory.items() if m.get("private_dirty_kb") is None
     ]
+    # None unless EVERY pinned process was sampled. A partial sum is not a
+    # smaller measurement, it is a different one: if firecracker exits between
+    # the pin and the read, the remaining processes total a few MiB against its
+    # few hundred, and a reader who does not separately consult
+    # private_dirty_unmeasured would take that at face value.
+    out["private_dirty_total_kb"] = private_dirty_total_kb(pre_memory)
 
     if not all_gone:
         survivors = dict(measured["live_exact"])

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -6194,3 +6194,40 @@ class HtmlArmAndPrewire(unittest.TestCase):
                 any("prewire" in e for e in errors),
                 f"an unprewired MEASURED rep must be caught, got: {errors[:3]}",
             )
+
+
+class PerRequestPrivateDirty(unittest.TestCase):
+    """The delta a request costs, sampled where it can still be sampled.
+
+    A clone starts as a view of the shared snapshot, so Private_Dirty is what it
+    PRIVATISED: pages written, not read. It is read alive, immediately before
+    the kill, because smaps_rollup dies with the address space and cannot be
+    recovered from a zombie the way CPU can.
+
+    Reported on the same record as the latency, so a memory/latency frontier is
+    one measurement rather than a join across two harnesses on two goldens.
+    """
+
+    def test_a_live_process_reports_private_dirty(self) -> None:
+        got = reqbench.proc_private_dirty_kb(os.getpid())
+        self.assertIsNotNone(
+            got.get("private_dirty_kb"),
+            f"could not sample this process: {got.get('unavailable')}",
+        )
+        self.assertGreater(got["private_dirty_kb"], 0, got)
+
+    def test_an_unreadable_process_reports_a_reason_not_a_zero(self) -> None:
+        """A zero with no uncertainty is a claim. An unreadable file does not
+        support one, and reporting 0 KiB would silently understate every clone
+        whose sample failed."""
+        got = reqbench.proc_private_dirty_kb(999_999_999)
+        self.assertIsNone(got.get("private_dirty_kb"), got)
+        self.assertTrue(got.get("unavailable"), "no reason given for the missing sample")
+
+    def test_the_total_is_none_when_nothing_could_be_sampled(self) -> None:
+        """Summing Nones as zero would publish a confident 0 KiB for a run that
+        measured nothing at all."""
+        per_child = {"a": {"private_dirty_kb": None, "unavailable": "x"}}
+        dirty = [m.get("private_dirty_kb") for m in per_child.values()]
+        total = sum(v for v in dirty if v is not None) if any(v is not None for v in dirty) else None
+        self.assertIsNone(total)

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -6224,10 +6224,29 @@ class PerRequestPrivateDirty(unittest.TestCase):
         self.assertIsNone(got.get("private_dirty_kb"), got)
         self.assertTrue(got.get("unavailable"), "no reason given for the missing sample")
 
-    def test_the_total_is_none_when_nothing_could_be_sampled(self) -> None:
-        """Summing Nones as zero would publish a confident 0 KiB for a run that
-        measured nothing at all."""
-        per_child = {"a": {"private_dirty_kb": None, "unavailable": "x"}}
-        dirty = [m.get("private_dirty_kb") for m in per_child.values()]
-        total = sum(v for v in dirty if v is not None) if any(v is not None for v in dirty) else None
-        self.assertIsNone(total)
+    def test_a_partial_sample_totals_none_not_a_smaller_number(self) -> None:
+        """Calls the production rule, not a copy of it.
+
+        The previous version of this test inlined the expression and asserted on
+        its own arithmetic, so deleting every out[...] assignment in reqbench
+        left the suite green. It proved that Python sums the way Python sums.
+
+        The case that matters: firecracker exits between the pin and the read.
+        The survivors total a few MiB against its few hundred, and a number is
+        what a reader takes at face value.
+        """
+        self.assertIsNone(
+            reqbench.private_dirty_total_kb(
+                {"firecracker": {"private_dirty_kb": None, "unavailable": "exited"},
+                 "pasta": {"private_dirty_kb": 2048}}
+            ),
+            "a partial sum was published as an ordinary number",
+        )
+        self.assertIsNone(reqbench.private_dirty_total_kb({}), "an empty set has no total")
+        self.assertEqual(
+            reqbench.private_dirty_total_kb(
+                {"firecracker": {"private_dirty_kb": 300_000}, "pasta": {"private_dirty_kb": 2048}}
+            ),
+            302_048,
+            "a complete sample must still total",
+        )


### PR DESCRIPTION
The request path records **no memory at all**. The only memory-ish field in a run's `analysis.json` is `cell.memory_mib` — the guest's *configured* RAM, not a measurement. So nothing answers "how much did this clone dirty between restore and screenshot".

The only memory numbers in the project come from a separate concurrency ladder run by `bench.sh`. A latency-versus-memory frontier chart built from those would be a **join across two harnesses, two runs and two goldens**, where every point silently crosses a run boundary. The report already carries that defect in its cross-run subtractions; a new chart shouldn't add another.

## The change

`teardown_fast` already pins the exact child set and samples per-child CPU immediately before the kill. This samples `Private_Dirty` at the same point and publishes `per_child_memory` beside `per_child_cpu`.

**Why there and nowhere else:** a clone starts as a view of the shared snapshot, so `Private_Dirty` is what it *privatised* — pages written rather than read — which is precisely the delta the request cost. It must be read while the process is alive: `smaps_rollup` dies with the address space, so unlike CPU it cannot be recovered from a zombie. The sample also lands before `t_kill`, so it cannot perturb the reap timing the same function measures.

## It never reports a confident zero

The sampler returns a **reason** rather than a zero when it cannot measure (exited, no `CONFIG_PROC_PAGE_MONITOR`, permission), and the total is `None` rather than `0` when nothing could be sampled. A zero with no uncertainty is a claim, and a failed read does not support one.

```
self:          {'rss_kb': 22916, 'pss_kb': 15105, 'private_dirty_kb': 13416}
dead pid:      {'private_dirty_kb': None, 'unavailable': 'no smaps_rollup (exited, or kernel lacks CONFIG_PROC_PAGE_MONITOR)'}
```

## Tests

`PerRequestPrivateDirty`, 3 cases: a live process reports a positive figure; an unreadable one reports a reason and `None`; a run where nothing could be sampled totals `None` rather than a confident 0 KiB.

```
$ python3 -m unittest discover -s bench/chromium
272 passed
```

Enables the frontier chart to be one measurement: latency and delta-memory from the same golden, same seal, same record.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-process private memory usage sampling during benchmark teardown.
  * Reports total private dirty memory when measurements are available.
  * Identifies processes whose memory usage could not be measured and provides reasons.

* **Tests**
  * Added regression coverage for successful sampling, unavailable process data, and missing measurement totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->