### PR TITLE
Carry pasta's own error into network-setup failures

### DIFF
--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -64,6 +64,13 @@ const PASTA_STDERR_TAIL_LINES: usize = 20;
 /// case of an inherited, still-open pipe.
 const PASTA_STDERR_EOF_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 
+/// Bounded window for a dying pasta to become reapable when a network-setup
+/// step fails. pasta drops its TAP before it can be reaped, so the failing
+/// step routinely observes the vanished device a beat before `try_wait`
+/// reports the exit; sampling once would drop the diagnosis exactly when it
+/// is needed.
+const PASTA_EXIT_CONTEXT_WAIT: std::time::Duration = std::time::Duration::from_secs(2);
+
 /// Whether `ip neigh show` proves that the bridge resolved the guest's MAC.
 ///
 /// This is an L2 fact and nothing more. A resolved entry is necessary for
@@ -1326,11 +1333,16 @@ impl PastaNetwork {
         // can show what pasta actually printed. Without this, pasta's output is
         // silently discarded and a dead pasta only surfaces later as an
         // unrelated bridge setup failure.
+        //
+        // The target must live under `fcvm::` — every documented invocation
+        // filters with `RUST_LOG=fcvm=...`, and a bare `pasta` target is
+        // dropped by all of them, so a fatal line like "Listen failed for
+        // HOST TCP port ...: Address already in use" never reached any log.
         if let Some(stderr) = child.stderr.take() {
             self.stderr_reader = Some(tokio::spawn(async move {
                 let mut lines = BufReader::new(stderr).lines();
                 while let Ok(Some(line)) = lines.next_line().await {
-                    warn!(target: "pasta", "{}", line);
+                    warn!(target: "fcvm::pasta", "{}", line);
                     if let Ok(mut tail) = stderr_tail.lock() {
                         if tail.len() >= PASTA_STDERR_TAIL_LINES {
                             tail.pop_front();
@@ -1437,6 +1449,48 @@ impl PastaNetwork {
                 }
                 _ = tokio::time::sleep(std::time::Duration::from_millis(250)) => {
                     // Safety tick: re-check the condition even without events.
+                }
+            }
+        }
+    }
+
+    /// pasta's exit status and captured stderr, for appending to
+    /// network-setup errors.
+    ///
+    /// pasta creates its TAP and writes its PID file before binding forwarded
+    /// ports, so a port conflict kills it after both readiness signals. The
+    /// next setup step then fails with "Cannot find device pasta0" while the
+    /// real cause ("Listen failed ...: Address already in use") is only in
+    /// pasta's stderr. A dying pasta drops its TAP before it becomes
+    /// reapable, so a single `try_wait` sample can race the exit; wait a
+    /// bounded moment for it, and when pasta is genuinely still running,
+    /// still report any stderr it produced rather than nothing.
+    async fn pasta_exit_context(&mut self) -> String {
+        let deadline = tokio::time::Instant::now() + PASTA_EXIT_CONTEXT_WAIT;
+        loop {
+            let Some(child) = self.pasta_process.as_mut() else {
+                return String::new();
+            };
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    // pasta's exit closed the pipe; drain it so the tail is
+                    // complete.
+                    crate::utils::wait_for_stderr_eof(
+                        &mut self.stderr_reader,
+                        PASTA_STDERR_EOF_TIMEOUT,
+                    )
+                    .await;
+                    return format!(" (pasta exited: {}{})", status, self.stderr_tail_message());
+                }
+                Ok(None) if tokio::time::Instant::now() < deadline => {
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                }
+                _ => {
+                    let tail = self.stderr_tail_message();
+                    if tail.contains("no stderr output captured") {
+                        return String::new();
+                    }
+                    return format!(" (pasta still running{})", tail);
                 }
             }
         }
@@ -1746,8 +1800,9 @@ impl NetworkManager for PastaNetwork {
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             anyhow::bail!(
-                "bridge setup failed: {}",
-                bridge_script.describe_failure(&stderr)
+                "bridge setup failed: {}{}",
+                bridge_script.describe_failure(&stderr),
+                self.pasta_exit_context().await
             );
         }
 

--- a/tests/test_pasta_diagnostics.rs
+++ b/tests/test_pasta_diagnostics.rs
@@ -1,0 +1,97 @@
+//! A dead pasta must fail the VM with pasta's OWN error, not a downstream one.
+//!
+//! pasta creates its TAP device and writes its readiness PID file BEFORE it
+//! binds forwarded ports, so a port conflict kills it after every readiness
+//! signal fcvm watches. The next network-setup step then fails on the vanished
+//! TAP ("Cannot find device pasta0") and, before the fix, the only line naming
+//! the real cause ("Listen failed ... Address already in use") was dropped:
+//! logged under a bare `pasta` target that every documented RUST_LOG filter
+//! discards, and absent from the propagated error.
+//!
+//! The conflict here is a wildcard 0.0.0.0 listener, which collides with a
+//! pasta forward on ANY per-VM loopback IP: exactly how a host daemon squatting
+//! a port broke every `--publish <port>` VM on a shared dev box.
+
+// Boots a real (rootless) VM, so it runs only in the suites that guarantee
+// fcvm's assets exist -- the same gate every VM-booting test uses. Without it
+// the unprivileged container suite fails at "Custom firecracker not found"
+// before the port conflict under test is ever reached.
+#![cfg(feature = "privileged-tests")]
+
+mod common;
+
+use std::time::Duration;
+
+#[tokio::test]
+async fn port_conflict_failure_names_pastas_own_error() {
+    // Squat a wildcard port for the lifetime of the test. Binding port 0 lets
+    // the kernel pick a free one, so parallel tests cannot collide with each
+    // other or with real services.
+    let squatter = std::net::TcpListener::bind("0.0.0.0:0").expect("bind squatter port");
+    let port = squatter.local_addr().expect("squatter addr").port();
+
+    let (name, _, _, _) = common::unique_names("pasta-diag");
+
+    // Rootless run publishing the squatted port, through the common spawn
+    // helper (pdeathsig, config setup, log consumers). Network setup fails
+    // before the VM boots, so the image reference is never pulled; the run
+    // must exit nonzero and the captured log must carry pasta's stderr, not
+    // only the downstream bridge failure.
+    let (mut child, _pid, log_path) = common::spawn_fcvm_with_log_path(
+        &[
+            "podman",
+            "run",
+            "--name",
+            &name,
+            "--publish",
+            &format!("{port}:80"),
+            "alpine:latest",
+        ],
+        &name,
+    )
+    .await
+    .expect("spawning fcvm");
+
+    // The failure path is seconds (4 pasta start attempts); the bound exists
+    // so a regression that makes the run hang cannot eat the whole suite and
+    // cannot leave the VM tree behind.
+    let status = match tokio::time::timeout(Duration::from_secs(180), child.wait()).await {
+        Ok(waited) => waited.expect("waiting on fcvm"),
+        Err(_) => {
+            let _ = child.kill().await;
+            panic!("fcvm still running 180s after publishing a squatted port");
+        }
+    };
+    assert!(
+        !status.success(),
+        "a squatted published port must fail the run"
+    );
+
+    // The log consumers drain the child's pipes asynchronously; give the
+    // final lines a moment to land in the file.
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let mut log_text = String::new();
+    while std::time::Instant::now() < deadline {
+        log_text = tokio::fs::read_to_string(&log_path)
+            .await
+            .unwrap_or_default();
+        if log_text.contains("Address already in use") {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    assert!(
+        log_text.contains("Address already in use"),
+        "the failure must carry pasta's own stderr (the port conflict), not only \
+         a downstream symptom; log at {}:\n{}",
+        log_path.display(),
+        log_text
+            .chars()
+            .rev()
+            .take(4000)
+            .collect::<String>()
+            .chars()
+            .rev()
+            .collect::<String>()
+    );
+}


### PR DESCRIPTION
**Stacked on:** `skopeo-rootless-store` (PR #850)

pasta creates its TAP and writes its readiness PID file before binding forwarded ports, so a port conflict kills it after every readiness signal fcvm watches. The next setup step then failed with `bridge setup failed: ... Cannot find device "pasta0"` while the only line naming the cause (`Listen failed for HOST TCP port ...: Address already in use`) was dropped twice over: the propagated error never consulted the dead child, and the stderr stream was logged under a bare `pasta` target that every documented `RUST_LOG=fcvm=...` invocation filters out.

Two changes:
- bridge-setup failures append pasta's exit status and captured stderr tail when pasta has exited;
- the stderr stream logs under `fcvm::pasta`, so the standard filters keep it (in per-VM debug logs and CI artifacts too).

A wildcard `0.0.0.0` listener collides with a pasta forward on any per-VM loopback IP, which is how one host daemon squatting one port broke every `--publish` VM on a shared dev box, with three consecutive runs blaming the bridge.

## Test Results

`tests/test_pasta_diagnostics.rs` squats a wildcard port (kernel-assigned, so parallel-safe) and asserts the run fails with pasta's own error in the output. Watched fail without the fix and pass with it:

```
# fix reverted (git stash), rebuilt:
thread 'port_conflict_failure_names_pastas_own_error' panicked:
the failure must carry pasta's own stderr (the port conflict), not only a downstream symptom
test result: FAILED. 0 passed; 1 failed
# fix restored:
test result: ok. 1 passed; 0 failed (0.77s)
```