### PR TITLE
WebKit engine arm: recover it, upgrade to current upstream, and fix the navigate stall

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,11 @@
+# cargo-audit configuration. Keep in sync with deny.toml [advisories].
+[advisories]
+ignore = [
+    # h2 0.3 queues empty DATA frames without limit (low-severity DoS). The
+    # patch exists only in h2 >= 0.4.16, which requires the hyper 1.x line;
+    # fcvm/fc-mock sit on hyper 0.14 + hyperlocal and fc-agent on reqwest
+    # 0.11. h2 here runs only in client mode over trusted local transports
+    # (Unix socket to firecracker, guest-local HTTP), so the condition is not
+    # reachable from an untrusted peer. Remove with the migration: issue #859.
+    "RUSTSEC-2026-0258",
+]

--- a/Containerfile.chromium-bench
+++ b/Containerfile.chromium-bench
@@ -71,7 +71,8 @@ ENV VK_ICD_FILENAMES=/usr/lib/chromium/./vk_swiftshader_icd.json
 
 COPY bench/chromium/pages/ /opt/bench/pages/
 COPY bench/chromium/pageserver.py bench/chromium/render.py bench/chromium/entry.sh \
-     bench/chromium/cdp_health.py bench/chromium/health_state.sh /opt/bench/
+     bench/chromium/cdp_health.py bench/chromium/health_loop.py \
+     bench/chromium/health_state.sh /opt/bench/
 RUN chmod +x /opt/bench/entry.sh /opt/bench/render.py /opt/bench/pageserver.py \
      /opt/bench/cdp_health.py /opt/bench/health_state.sh
 

--- a/Containerfile.webkit-bench
+++ b/Containerfile.webkit-bench
@@ -75,9 +75,10 @@ RUN set -e; \
 
 COPY bench/chromium/pages/ /opt/bench/pages/
 COPY bench/chromium/pageserver.py bench/chromium/entry-webkit.sh \
-     bench/chromium/wddrive.py bench/chromium/wd_health.py /opt/bench/
+     bench/chromium/wddrive.py bench/chromium/wd_health.py \
+     bench/chromium/health_loop.py bench/chromium/health_state.sh /opt/bench/
 RUN chmod +x /opt/bench/entry-webkit.sh /opt/bench/pageserver.py \
-     /opt/bench/wddrive.py /opt/bench/wd_health.py
+     /opt/bench/wddrive.py /opt/bench/wd_health.py /opt/bench/health_state.sh
 
 # WebKitWebDriver's HTTP endpoint. fcvm DNATs eligible published TCP ports to
 # guest loopback, so `--publish 9515:9515` reaches the driver directly.
@@ -89,7 +90,14 @@ EXPOSE 9515
 # WebDriver's /status reports "ready" even when no browser is running, so the
 # probe is GET /session/<id>/url, which fails once the session or browser dies.
 # start-period covers Xvfb + MiniBrowser cold launch + the warm render.
+# The reader, not the probe. A per-second `python3 wd_health.py` spends a
+# fresh interpreter in every clone forever -- 9.1ms startup, 43.6ms per check
+# measured in this image -- and dirties those pages INSIDE the clone, against
+# the per-clone memory figure this bench exists to measure. wd_health.py --loop
+# runs resident from entry-webkit.sh BEFORE the warm marker, so its pages join
+# the golden and are shared. reqbench.sh also asserts the HEALTHCHECK names
+# health_state.sh, so the image could not pass the golden gate as it was.
 HEALTHCHECK --interval=1s --timeout=5s --start-period=90s --retries=3 \
-    CMD ["python3", "/opt/bench/wd_health.py"]
+    CMD ["/opt/bench/health_state.sh"]
 
 CMD ["/opt/bench/entry-webkit.sh"]

--- a/Containerfile.webkit-bench
+++ b/Containerfile.webkit-bench
@@ -37,7 +37,7 @@
 #
 # Host smoke test (fast loop, no VM):
 #   podman run -d --name wb localhost/webkit-bench
-#   podman logs -f wb          # wait for WEBKIT_BENCH_READY
+#   podman logs -f wb          # wait for BENCH_READY
 #   podman exec wb python3 /opt/bench/wddrive.py http://127.0.0.1:8000/medium.html \
 #       --host 127.0.0.1:9515 --session-file /run/bench-session-id --out-prefix /tmp/medium
 
@@ -88,7 +88,7 @@ EXPOSE 9515
 # `Healthy` = container running AND this HEALTHCHECK). wd_health.py requires the
 # warm marker AND a live WebDriver round trip on the WARM SESSION — classic
 # WebDriver's /status reports "ready" even when no browser is running, so the
-# probe is GET /session/<id>/url, which fails once the session or browser dies.
+# probe is POST execute/sync, which fails once the session or browser dies.
 # start-period covers Xvfb + MiniBrowser cold launch + the warm render.
 # The reader, not the probe. A per-second `python3 wd_health.py` spends a
 # fresh interpreter in every clone forever -- 9.1ms startup, 43.6ms per check

--- a/Containerfile.webkit-bench
+++ b/Containerfile.webkit-bench
@@ -1,0 +1,88 @@
+# WebKit WebDriver benchmark container: warm WebKitGTK + in-guest fixture server.
+#
+# The WebKit twin of Containerfile.chromium-bench: same shared-nothing design
+# (snapshot AFTER warmup, fan out clones, one render per clone), same fixture
+# pageserver, same warm-marker + HEALTHCHECK golden-snapshot gate — but the
+# engine is WebKitGTK driven over the W3C WebDriver classic protocol instead of
+# CDP, because WebKitGTK has no CDP endpoint.
+#
+# Engine stack (Debian bookworm arm64, probed 2026-08-14):
+#   webkit2gtk-driver  — /usr/bin/WebKitWebDriver (WebDriver HTTP on :9515) and
+#                        the MiniBrowser binary it launches with --automation.
+#                        WPE (the headless-native flavor) has no current arm64
+#                        Debian packages, and headless GTK rendering needs an X
+#                        server, so MiniBrowser runs under Xvfb.
+#   xvfb               — virtual display; WebKitGTK cannot render truly headless.
+#   fonts-dejavu-core  — deterministic text (same as the Chromium image).
+#
+# Request path: host -> fcvm published TCP 9515 -> WebKitWebDriver -> MiniBrowser.
+# WebDriver classic has NO session-discovery API, so the warm session is created
+# in entry-webkit.sh BEFORE the golden snapshot and its id is persisted to
+# /run/bench-session-id (health check) and pages/webdriver-session.txt (host
+# driver, served by the pageserver). Every clone inherits the same id.
+#
+# Build (repo root context; .dockerignore excludes target/):
+#   podman build --format docker -t localhost/webkit-bench -f Containerfile.webkit-bench .
+#
+# --format docker is LOAD-BEARING for the same reason as the Chromium image:
+# podman's OCI default silently DROPS the HEALTHCHECK, fcvm treats a missing
+# healthcheck as PASS, and the golden snapshot fires on a COLD browser.
+#
+# Host smoke test (fast loop, no VM):
+#   podman run -d --name wb localhost/webkit-bench
+#   podman logs -f wb          # wait for WEBKIT_BENCH_READY
+#   podman exec wb python3 /opt/bench/wddrive.py http://127.0.0.1:8000/medium.html \
+#       --host 127.0.0.1:9515 --session-file /run/bench-session-id --out-prefix /tmp/medium
+
+FROM docker.io/library/debian:bookworm-slim
+
+# The trailing rm also drops /var/cache/apt/archives/partial (_apt-owned, mode
+# 0700): rootless fcvm packs the image store with an unprivileged mkfs.ext4 -d
+# outside the user namespace, and any non-root-owned dir without world rx makes
+# that fail with "__populate_fs: Permission denied".
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    webkit2gtk-driver \
+    xvfb \
+    python3 \
+    fonts-dejavu-core \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/partial
+
+# Fail the BUILD, not the first boot, if the engine binaries moved. MiniBrowser
+# lives under the versioned libexec dir (/usr/lib/*/webkit2gtk-4.1/MiniBrowser
+# on bookworm); resolve it once into a stable path the entry script and the
+# WebDriver capabilities can name. GTK opens the display before parsing argv,
+# so even --version needs a display — a raw Xvfb (exactly how entry-webkit.sh
+# runs it; xvfb-run would drag in xauth) makes this a real "MiniBrowser can
+# start under a virtual display" check rather than a file-exists check.
+RUN set -e; \
+    test -x /usr/bin/WebKitWebDriver; \
+    MB=$(find /usr -name MiniBrowser -type f -perm -111 | head -1); \
+    test -n "$MB"; \
+    ln -s "$MB" /usr/local/bin/MiniBrowser; \
+    Xvfb :91 -screen 0 640x480x24 -nolisten tcp & \
+    XVFB_PID=$!; \
+    sleep 1; \
+    DISPLAY=:91 WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1 \
+        /usr/local/bin/MiniBrowser --version; \
+    kill "$XVFB_PID"
+
+COPY bench/chromium/pages/ /opt/bench/pages/
+COPY bench/chromium/pageserver.py bench/chromium/entry-webkit.sh \
+     bench/chromium/wddrive.py bench/chromium/wd_health.py /opt/bench/
+RUN chmod +x /opt/bench/entry-webkit.sh /opt/bench/pageserver.py \
+     /opt/bench/wddrive.py /opt/bench/wd_health.py
+
+# WebKitWebDriver's HTTP endpoint. fcvm DNATs eligible published TCP ports to
+# guest loopback, so `--publish 9515:9515` reaches the driver directly.
+EXPOSE 9515
+
+# fcvm's health gate is the golden-snapshot trigger (no --health-check URL, so
+# `Healthy` = container running AND this HEALTHCHECK). wd_health.py requires the
+# warm marker AND a live WebDriver round trip on the WARM SESSION — classic
+# WebDriver's /status reports "ready" even when no browser is running, so the
+# probe is GET /session/<id>/url, which fails once the session or browser dies.
+# start-period covers Xvfb + MiniBrowser cold launch + the warm render.
+HEALTHCHECK --interval=1s --timeout=5s --start-period=90s --retries=3 \
+    CMD ["python3", "/opt/bench/wd_health.py"]
+
+CMD ["/opt/bench/entry-webkit.sh"]

--- a/Containerfile.webkit-bench
+++ b/Containerfile.webkit-bench
@@ -6,7 +6,14 @@
 # engine is WebKitGTK driven over the W3C WebDriver classic protocol instead of
 # CDP, because WebKitGTK has no CDP endpoint.
 #
-# Engine stack (Debian bookworm arm64, probed 2026-08-14):
+# Engine stack (Debian TRIXIE arm64, moved from bookworm 2026-08-16):
+#
+# bookworm pins webkit2gtk-driver at 2.50.6, one full stable series behind
+# upstream: WebKitGTK's current stable is 2.52.5 (2026-07-09), and the 2.52
+# series opened 2026-03-18. trixie carries 2.52.5-1~deb13u1, so the base moved
+# rather than the package being pinned. Chromium is 151.0.7922.137 in BOTH
+# suites, so the Chromium image stays on bookworm and the engine comparison
+# now spans two base images -- state that caveat wherever the two are compared.
 #   webkit2gtk-driver  — /usr/bin/WebKitWebDriver (WebDriver HTTP on :9515) and
 #                        the MiniBrowser binary it launches with --automation.
 #                        WPE (the headless-native flavor) has no current arm64
@@ -34,7 +41,7 @@
 #   podman exec wb python3 /opt/bench/wddrive.py http://127.0.0.1:8000/medium.html \
 #       --host 127.0.0.1:9515 --session-file /run/bench-session-id --out-prefix /tmp/medium
 
-FROM docker.io/library/debian:bookworm-slim
+FROM docker.io/library/debian:trixie-slim
 
 # The trailing rm also drops /var/cache/apt/archives/partial (_apt-owned, mode
 # 0700): rootless fcvm packs the image store with an unprivileged mkfs.ext4 -d
@@ -49,7 +56,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Fail the BUILD, not the first boot, if the engine binaries moved. MiniBrowser
 # lives under the versioned libexec dir (/usr/lib/*/webkit2gtk-4.1/MiniBrowser
-# on bookworm); resolve it once into a stable path the entry script and the
+# on bookworm and trixie alike); resolve it once into a stable path the entry script and the
 # WebDriver capabilities can name. GTK opens the display before parsing argv,
 # so even --version needs a display — a raw Xvfb (exactly how entry-webkit.sh
 # runs it; xvfb-run would drag in xauth) makes this a real "MiniBrowser can

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ CONTAINER_RUN := $(CONTAINER_RUN_BASE) --ulimit nproc=65536:65536 --pids-limit=6
 	container-setup-fcvm container-shell container-clean container-bench \
 	cargo-target-link build-host-tools setup-btrfs setup-default release-default-kernel setup-fcvm setup-pjdfstest setup-hugepages bench bench-vm bench-hugepages bench-hugepages-test \
 	bench-container-import bench-chromium analyze-chromium-request bench-clone-latency test-chromium-request \
-	bench-chromium-request-build bench-chromium-request-golden bench-chromium-request-verify \
+	bench-chromium-request-build bench-webkit-request-build test-chromium bench-chromium-request-golden bench-chromium-request-verify \
 	bench-chromium-corpus bench-stop \
 	bench-chromium-request-run bench-chromium-request-all bench-chromium-hostcdp bench-chromium-fault \
 	bench-chromium-scale analyze-chromium-scale report-chromium-scale test-chromium-scale \
@@ -294,6 +294,7 @@ help:
 	@echo "  bench-container-import  Compare podman load vs direct image mount"
 	@echo "  bench-chromium     Chromium shared-nothing clone bench (egress x memory matrix)"
 	@echo "  bench-chromium-request-build   Build the request-bench container image"
+	@echo "  bench-webkit-request-build     Build the WebKit request-bench container image"
 	@echo "  bench-chromium-request-golden  Create golden snapshot (TAG=, HUGEPAGES=1, NETMODE=)"
 	@echo "  bench-chromium-request-verify  Prove CDP hops on a restored clone (TAG=)"
 	@echo "  bench-chromium-request-run     Measured run (TAG=, BACKEND=, UFFD_MODE=, UFFD_PREFETCH=, REPS=, WARMUP=, ARMS=, RESULTS=)"
@@ -303,6 +304,7 @@ help:
 	@echo "  bench-chromium-hostcdp         Host-container direct-CDP baseline (no VM)"
 	@echo "  bench-chromium-fault           Page-fault bench (FAULT_OUT= required; needs bench.sh goldens)"
 	@echo "  analyze-chromium-request  Re-run publication gates for RESULTS=/path/to/run"
+	@echo "  test-chromium          Run ALL bench unit tests (what CI runs)"
 	@echo "  test-chromium-request  Run the request benchmark's deterministic unit tests"
 	@echo "  bench-chromium-scale  Open-loop FILE/UFFD Chromium request scalability run"
 	@echo "  analyze-chromium-scale  Validate a scale run and write deterministic JSON"
@@ -743,6 +745,15 @@ bench-chromium-request-build: build
 	@echo "==> Building Chromium request-bench container image..."
 	@bash bench/chromium/reqbench.sh build
 
+# The WebKit arm's image. Separate from the Chromium one on purpose: they are
+# different engines behind the same BENCH_READY contract, and rebuilding the
+# Chromium image changes its digest, which invalidates goldens already recorded
+# against it.
+bench-webkit-request-build: build
+	@echo "==> Building WebKit request-bench container image..."
+	@podman build --format docker -t localhost/webkit-bench-req:latest \
+		-f Containerfile.webkit-bench .
+
 bench-chromium-request-golden: bench-chromium-request-build setup-default
 	@echo "==> Creating golden snapshot (TAG=$(if $(TAG),$(TAG),cb-req-golden), HUGEPAGES=$(if $(HUGEPAGES),$(HUGEPAGES),0))..."
 	@bash bench/chromium/reqbench.sh golden
@@ -946,6 +957,14 @@ analyze-chromium-request:
 	@test -f "$(RESULTS)/reqbench.jsonl" || { echo "ERROR: no $(RESULTS)/reqbench.jsonl" >&2; exit 2; }
 	@python3 bench/chromium/reqanalyze.py --json-out "$(RESULTS)/analysis.json" \
 		"$(RESULTS)/reqbench.jsonl"
+
+# What CI runs (ci.yml globs test_*.py). The per-harness targets below are
+# narrower dev conveniences; run THIS before pushing, because a new test file is
+# invisible to every one of them until somebody remembers to add a target, and
+# the failure mode of forgetting is a green local run.
+test-chromium:
+	@python3 -m unittest discover -s bench/chromium -p 'test_*.py' \
+		$(if $(FILTER),-k '$(FILTER)',)
 
 test-chromium-request:
 	@python3 -m unittest discover -s bench/chromium -p 'test_reqbench.py' \

--- a/Makefile
+++ b/Makefile
@@ -751,8 +751,7 @@ bench-chromium-request-build: build
 # against it.
 bench-webkit-request-build: build
 	@echo "==> Building WebKit request-bench container image..."
-	@podman build --format docker -t localhost/webkit-bench-req:latest \
-		-f Containerfile.webkit-bench .
+	@ENGINE=webkit bash bench/chromium/reqbench.sh build
 
 # The WebKit twins of the chromium request targets: same reqbench.sh, same
 # seal, same gates -- ENGINE=webkit swaps the render driver (wddrive over W3C
@@ -767,8 +766,10 @@ bench-webkit-request-verify:
 	@ENGINE=webkit TAG=$(if $(TAG),$(TAG),cb-req-webkit) bash bench/chromium/reqbench.sh verify
 
 bench-webkit-request-run:
-	@echo "==> Running WebKit request benchmark (sealed bundle)..."
-	@ENGINE=webkit TAG=$(if $(TAG),$(TAG),cb-req-webkit) bash bench/chromium/reqbench.sh run
+	@echo "==> Running WebKit request benchmark ($(BACKEND), $(REPS) measured attempts per arm)..."
+	@ENGINE=webkit TAG=$(if $(TAG),$(TAG),cb-req-webkit) \
+		BACKEND="$(BACKEND)" REPS="$(REPS)" WARMUP="$(WARMUP)" RESULTS="$(RESULTS)" \
+		bash bench/chromium/reqbench.sh run
 
 bench-chromium-request-golden: bench-chromium-request-build setup-default
 	@echo "==> Creating golden snapshot (TAG=$(if $(TAG),$(TAG),cb-req-golden), HUGEPAGES=$(if $(HUGEPAGES),$(HUGEPAGES),0))..."

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ CONTAINER_RUN := $(CONTAINER_RUN_BASE) --ulimit nproc=65536:65536 --pids-limit=6
 	container-setup-fcvm container-shell container-clean container-bench \
 	cargo-target-link build-host-tools setup-btrfs setup-default release-default-kernel setup-fcvm setup-pjdfstest setup-hugepages bench bench-vm bench-hugepages bench-hugepages-test \
 	bench-container-import bench-chromium analyze-chromium-request bench-clone-latency test-chromium-request \
-	bench-chromium-request-build bench-webkit-request-build test-chromium bench-chromium-request-golden bench-chromium-request-verify \
+	bench-chromium-request-build bench-webkit-request-build bench-webkit-request-golden bench-webkit-request-verify bench-webkit-request-run test-chromium bench-chromium-request-golden bench-chromium-request-verify \
 	bench-chromium-corpus bench-stop \
 	bench-chromium-request-run bench-chromium-request-all bench-chromium-hostcdp bench-chromium-fault \
 	bench-chromium-scale analyze-chromium-scale report-chromium-scale test-chromium-scale \
@@ -753,6 +753,22 @@ bench-webkit-request-build: build
 	@echo "==> Building WebKit request-bench container image..."
 	@podman build --format docker -t localhost/webkit-bench-req:latest \
 		-f Containerfile.webkit-bench .
+
+# The WebKit twins of the chromium request targets: same reqbench.sh, same
+# seal, same gates -- ENGINE=webkit swaps the render driver (wddrive over W3C
+# WebDriver classic on 9515), the image default, and the arm list (cdp,noop:
+# cdp-fast is CDP WebSocket prewiring and exec's guest driver is CDP-only).
+bench-webkit-request-golden: bench-webkit-request-build setup-default
+	@echo "==> Creating WebKit golden snapshot (TAG=$(if $(TAG),$(TAG),cb-req-webkit))..."
+	@ENGINE=webkit TAG=$(if $(TAG),$(TAG),cb-req-webkit) bash bench/chromium/reqbench.sh golden
+
+bench-webkit-request-verify:
+	@echo "==> Verifying WD hops on a restored WebKit clone..."
+	@ENGINE=webkit TAG=$(if $(TAG),$(TAG),cb-req-webkit) bash bench/chromium/reqbench.sh verify
+
+bench-webkit-request-run:
+	@echo "==> Running WebKit request benchmark (sealed bundle)..."
+	@ENGINE=webkit TAG=$(if $(TAG),$(TAG),cb-req-webkit) bash bench/chromium/reqbench.sh run
 
 bench-chromium-request-golden: bench-chromium-request-build setup-default
 	@echo "==> Creating golden snapshot (TAG=$(if $(TAG),$(TAG),cb-req-golden), HUGEPAGES=$(if $(HUGEPAGES),$(HUGEPAGES),0))..."

--- a/bench/chromium/.gitignore
+++ b/bench/chromium/.gitignore
@@ -16,4 +16,5 @@ results/**
 !results/**/summary.md
 !results/campaign-*-summary.json
 !results/**/cpuprobe-*-curated.json
+!results/**/webkit-host-probe.json
 __pycache__/

--- a/bench/chromium/cdp_health.py
+++ b/bench/chromium/cdp_health.py
@@ -34,7 +34,6 @@ import sys
 
 import health_loop
 from health_loop import monotonic_seconds, publish, state_file  # re-exported for callers/tests
-import time
 import urllib.request
 
 # Chromium's own DevTools port. There is no relay any more: fcvm DNATs this
@@ -87,12 +86,6 @@ def main() -> int:
     print(("healthy " if code == 0 else "unhealthy: ") + reason,
           file=sys.stdout if code == 0 else sys.stderr)
     return code
-
-
-# Where the resident loop publishes its verdict, and how stale a verdict may be
-# before the reader must refuse it.
-STATE_FILE = os.environ.get("BENCH_HEALTH_STATE", "/run/bench-health")
-LOOP_INTERVAL = float(os.environ.get("BENCH_HEALTH_INTERVAL", "1"))
 
 
 if __name__ == "__main__":

--- a/bench/chromium/cdp_health.py
+++ b/bench/chromium/cdp_health.py
@@ -31,6 +31,9 @@ have half-done in the snapshot.
 import json
 import os
 import sys
+
+import health_loop
+from health_loop import monotonic_seconds, publish, state_file  # re-exported for callers/tests
 import time
 import urllib.request
 
@@ -92,71 +95,7 @@ STATE_FILE = os.environ.get("BENCH_HEALTH_STATE", "/run/bench-health")
 LOOP_INTERVAL = float(os.environ.get("BENCH_HEALTH_INTERVAL", "1"))
 
 
-def monotonic_seconds() -> float:
-    """Seconds from /proc/uptime, so a clock step cannot age a verdict.
-
-    NOT time.time(). fc-agent steps CLOCK_REALTIME on every restore
-    (set_system_clock), which would make every clone's freshly written verdict
-    look hours old to a wall-clock reader and fail the gate on every clone.
-
-    /proc/uptime is CLOCK_BOOTTIME (ktime_get_boottime_ts64), not
-    CLOCK_MONOTONIC. The reader uses the same file, so both sides measure the
-    same clock either way, but the freshness scheme rests on guest boottime
-    being CONTINUOUS across snapshot and restore. That holds where the
-    firecracker fork owns the VM-wide counter offset and advances it by the
-    pause duration (AGENTS.md, NV2 snapshot lifecycle). It is NOT established
-    for the cloud-hypervisor backend. If boottime jumps on restore, every
-    clone reports "verdict is Ns old" forever, which is the same total failure
-    this design moved away from, relocated from realtime to boottime.
-    """
-    with open("/proc/uptime", "r", encoding="ascii") as handle:
-        return float(handle.read().split()[0])
-
-
-def publish(verdict: str, detail: str) -> None:
-    """Write the verdict atomically, so a reader never sees a half-written line."""
-    tmp = f"{STATE_FILE}.tmp"
-    with open(tmp, "w", encoding="utf-8") as handle:
-        handle.write(f"{verdict} {monotonic_seconds():.3f} {detail}\n")
-    os.replace(tmp, STATE_FILE)
-
-
-def loop() -> int:
-    """Run the check forever, publishing each verdict.
-
-    Why resident: as a HEALTHCHECK command this cost a fresh CPython per second
-    in EVERY clone, forever. Measured in this image: 9.1ms of interpreter
-    startup, 43.6ms for the whole check even when it fails fast. Paid once at
-    the golden instead, the interpreter's pages are dirtied before the snapshot
-    and are therefore SHARED by every clone rather than privately re-dirtied.
-    Each iteration then writes one small file on tmpfs.
-    """
-    while True:
-        started = monotonic_seconds()
-        try:
-            code, reason = main_with_reason()
-            publish("healthy" if code == 0 else "unhealthy", reason)
-        except Exception as error:  # a crash here must not look healthy
-            # Guarded. The unguarded version raised the SAME error the handler
-            # was catching (a full /run tmpfs, EROFS, a missing directory), let
-            # it escape loop(), and the process exited. Nothing supervises this
-            # loop, so the container would then be unhealthy forever with no
-            # verdict file at all, and the golden would wait out its full 300s
-            # timeout with nothing to say why.
-            try:
-                publish("unhealthy", f"loop error: {type(error).__name__}: {error}")
-            except Exception as publish_error:
-                print(
-                    f"cdp_health loop: cannot publish ({type(publish_error).__name__}: "
-                    f"{publish_error}) after {type(error).__name__}: {error}",
-                    file=sys.stderr,
-                    flush=True,
-                )
-        elapsed = monotonic_seconds() - started
-        time.sleep(max(0.0, LOOP_INTERVAL - elapsed))
-
-
 if __name__ == "__main__":
     if "--loop" in sys.argv:
-        sys.exit(loop())
+        sys.exit(health_loop.loop(main_with_reason, "cdp_health"))
     sys.exit(main())

--- a/bench/chromium/corpus_campaign.sh
+++ b/bench/chromium/corpus_campaign.sh
@@ -23,10 +23,22 @@ set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="${REPO:-$(cd "$HERE/../.." && pwd)}"
-TAG="${TAG:-cb-req-corpus}"
+ENGINE="${ENGINE:-chromium}"
+case "$ENGINE" in chromium|webkit) ;; *) echo "unknown ENGINE '$ENGINE'" >&2; exit 2 ;; esac
+# Engine-scoped default tag: a webkit golden under the chromium tag would be
+# refused by the seal anyway (different image digest), but the failure would
+# come minutes in rather than at naming time.
+if [ "$ENGINE" = webkit ]; then TAG="${TAG:-cb-req-corpus-webkit}"; else TAG="${TAG:-cb-req-corpus}"; fi
+# cdp-fast is CDP WebSocket prewiring; WebKit's driver has no WebSocket, so its
+# default drops that arm rather than recording 202 guaranteed failures.
+if [ "${ENGINE:-chromium}" = webkit ]; then
+    ARMS="${ARMS:-cdp,noop}"
+else
+    ARMS="${ARMS:-cdp,cdp-fast,noop}"
+fi
 REPS="${REPS:-202}"
 WARMUP="${WARMUP:-28}"          # two full 14-URL cycles; the harness fails closed below this
-ARMS="${ARMS:-cdp,cdp-fast,noop}"
+
 UFFD_MODE="${UFFD_MODE:-minor}"
 UFFD_PREFETCH="${UFFD_PREFETCH:-on}"
 BACKEND="${BACKEND:-uffd}"
@@ -223,11 +235,11 @@ say "fcvm binary $FCVM_BIN sha256=$FCVM_SHA (recorded per run in cell.fcvm_sha25
 PHASE="${PHASE:-all}"
 if [ "$PHASE" = all ]; then
     say "golden $TAG (GUEST_DNS=10.0.2.2 baked into resolv.conf at boot)"
-    GUEST_DNS=10.0.2.2 TAG="$TAG" \
-        make -C "$REPO" bench-chromium-request-golden 2>&1 | tee "$LOGDIR/golden.log"
+    GUEST_DNS=10.0.2.2 TAG="$TAG" ENGINE="$ENGINE" \
+        make -C "$REPO" "bench-$([ "$ENGINE" = webkit ] && echo webkit || echo chromium)-request-golden" 2>&1 | tee "$LOGDIR/golden.log"
 
     say "verify: CDP hops on a restored clone"
-    TAG="$TAG" make -C "$REPO" bench-chromium-request-verify 2>&1 | tee "$LOGDIR/verify.log"
+    TAG="$TAG" ENGINE="$ENGINE" make -C "$REPO" "bench-$([ "$ENGINE" = webkit ] && echo webkit || echo chromium)-request-verify" 2>&1 | tee "$LOGDIR/verify.log"
 else
     snap="${DATA_ROOT:-/mnt/fcvm-btrfs}/snapshots/$TAG"
     [ -f "$snap/config.json" ] || { echo "BLOCKED: PHASE=$PHASE but no golden at $snap" >&2; exit 2; }
@@ -264,8 +276,8 @@ say "box quiet (1-min load $load1)"
 say "measured run: $REPS reps/arm, warmup $WARMUP, arms $ARMS, $BACKEND/$UFFD_MODE prefetch=$UFFD_PREFETCH"
 TAG="$TAG" URL="$URLS" BACKEND="$BACKEND" UFFD_MODE="$UFFD_MODE" \
     UFFD_PREFETCH="$UFFD_PREFETCH" ARMS="$ARMS" REPS="$REPS" WARMUP="$WARMUP" \
-    RESULTS="$RESULTS" \
-    make -C "$REPO" bench-chromium-request-run 2>&1 | tee "$LOGDIR/run.log"
+    RESULTS="$RESULTS" ENGINE="$ENGINE" \
+    make -C "$REPO" "bench-$([ "$ENGINE" = webkit ] && echo webkit || echo chromium)-request-run" 2>&1 | tee "$LOGDIR/run.log"
 
 say "records: $RESULTS"
 say "logs:    $LOGDIR"

--- a/bench/chromium/corpus_campaign.sh
+++ b/bench/chromium/corpus_campaign.sh
@@ -238,7 +238,7 @@ if [ "$PHASE" = all ]; then
     GUEST_DNS=10.0.2.2 TAG="$TAG" ENGINE="$ENGINE" \
         make -C "$REPO" "bench-$([ "$ENGINE" = webkit ] && echo webkit || echo chromium)-request-golden" 2>&1 | tee "$LOGDIR/golden.log"
 
-    say "verify: CDP hops on a restored clone"
+    say "verify: $([ "$ENGINE" = webkit ] && echo WebDriver || echo CDP) hops on a restored clone"
     TAG="$TAG" ENGINE="$ENGINE" make -C "$REPO" "bench-$([ "$ENGINE" = webkit ] && echo webkit || echo chromium)-request-verify" 2>&1 | tee "$LOGDIR/verify.log"
 else
     snap="${DATA_ROOT:-/mnt/fcvm-btrfs}/snapshots/$TAG"

--- a/bench/chromium/entry-webkit.sh
+++ b/bench/chromium/entry-webkit.sh
@@ -103,12 +103,19 @@ python3 /opt/bench/wddrive.py "http://127.0.0.1:$HTTP_PORT/warmup.html" \
 # port; the health probe reads the /run copy.
 cp "$SESSION_FILE" "$PAGES_DIR/webdriver-session.txt"
 
+# Resident health checker, started BEFORE the warm marker so the interpreter's
+# pages are dirtied pre-snapshot and shared by every clone. stdout to /dev/null:
+# a per-second writer would otherwise grow podman's container log on the clone's
+# CoW disk forever.
+python3 /opt/bench/wd_health.py --loop >/dev/null 2>&1 &
+echo "webkit-bench: resident health checker started"
+
 # Warm marker. wddrive.py --then-blank returns zero only after the navigate,
 # the PNG screenshot, and a verified about:blank transition, and `set -e`
 # means any failure exits before this touch — same golden-snapshot contract as
 # the Chromium entry.
 touch "$READY_FILE"
-echo "WEBKIT_BENCH_READY wd=127.0.0.1:$WD_PORT pages=http://127.0.0.1:$HTTP_PORT session=$(cat "$SESSION_FILE")"
+echo "BENCH_READY engine=webkit wd=127.0.0.1:$WD_PORT pages=http://127.0.0.1:$HTTP_PORT session=$(cat "$SESSION_FILE")"
 
 # Hold the warm driver. wait exits with WebKitWebDriver's status if it dies so
 # the container stops instead of hiding a dead driver; the trap keeps `podman

--- a/bench/chromium/entry-webkit.sh
+++ b/bench/chromium/entry-webkit.sh
@@ -116,8 +116,9 @@ cp "$SESSION_FILE" "$PAGES_DIR/webdriver-session.txt"
 # Resident health checker, started BEFORE the warm marker so the interpreter's
 # pages are dirtied pre-snapshot and shared by every clone. stdout to /dev/null:
 # a per-second writer would otherwise grow podman's container log on the clone's
-# CoW disk forever.
-python3 /opt/bench/wd_health.py --loop >/dev/null 2>&1 &
+# CoW disk forever. stderr kept: the loop writes there only when it is dying,
+# and that crash is otherwise invisible (see entry.sh's cdp_health.py twin).
+python3 /opt/bench/wd_health.py --loop >/dev/null &
 echo "webkit-bench: resident health checker started"
 
 # Warm marker. wddrive.py --then-blank returns zero only after the navigate,

--- a/bench/chromium/entry-webkit.sh
+++ b/bench/chromium/entry-webkit.sh
@@ -52,6 +52,20 @@ echo "webkit-bench: starting Xvfb on $DISPLAY_NUM"
 Xvfb "$DISPLAY_NUM" -screen 0 1280x800x24 -nolisten tcp -noreset &
 export DISPLAY="$DISPLAY_NUM"
 
+# WAIT for the X socket. Nothing else here does: the two wait_http loops below
+# can each return on their first probe, and GTK opens the display before it
+# parses argv, so on a loaded box MiniBrowser reached the display before Xvfb
+# was listening, create_session failed, `set -e` killed PID 1, and the container
+# never became healthy. The Containerfile's own build-time probe sleeps 1 s for
+# exactly this reason; poll the socket instead of guessing a duration.
+x_socket="/tmp/.X11-unix/X${DISPLAY_NUM#:}"
+for _ in $(seq 1 200); do
+    [ -S "$x_socket" ] && break
+    sleep 0.05
+done
+[ -S "$x_socket" ] || { echo "FATAL: Xvfb never created $x_socket" >&2; exit 1; }
+echo "webkit-bench: Xvfb listening ($x_socket)"
+
 echo "webkit-bench: starting pageserver on $HTTP_ADDR:$HTTP_PORT"
 python3 /opt/bench/pageserver.py --root "$PAGES_DIR" --addr "$HTTP_ADDR" \
     --port "$HTTP_PORT" --ready-file "$READY_FILE" &

--- a/bench/chromium/entry-webkit.sh
+++ b/bench/chromium/entry-webkit.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+# webkit-bench container entry: Xvfb + fixture pageserver + WARM WebKitGTK
+# session behind WebKitWebDriver.
+#
+# Sequence: Xvfb -> pageserver -> WebKitWebDriver -> CREATE the warm session
+# (wddrive.py --create: launches MiniBrowser --automation, navigates a fixture,
+# screenshots once to heat the raster/encode path, proves the blank transition)
+# -> touch the ready file (HEALTHCHECK gates on it) -> print READY -> hold.
+#
+# REQUEST PATH: WebKitWebDriver's HTTP endpoint is the request server — the
+# host reaches published TCP 9515 through fcvm's DNAT-to-loopback and speaks
+# classic WebDriver straight to it. Nothing of ours is in the byte path.
+#
+# THE SESSION IS PART OF THE SNAPSHOT. Classic WebDriver has no session
+# discovery: a session created after restore would launch a cold browser, so
+# the warm session id minted here is what every clone inherits. It is persisted
+# twice: /run/bench-session-id for the in-guest health probe, and
+# pages/webdriver-session.txt so the HOST driver can fetch it over the
+# published pageserver port without an exec round trip.
+set -eu
+
+PAGES_DIR="${BENCH_PAGES_DIR:-/opt/bench/pages}"
+HTTP_ADDR="${BENCH_HTTP_ADDR:-0.0.0.0}"
+HTTP_PORT="${BENCH_HTTP_PORT:-8000}"
+WD_PORT="${BENCH_WD_PORT:-9515}"
+READY_FILE="${BENCH_READY_FILE:-/run/bench-ready}"
+SESSION_FILE="${BENCH_SESSION_FILE:-/run/bench-session-id}"
+DISPLAY_NUM="${BENCH_DISPLAY:-:99}"
+
+rm -f "$READY_FILE" "$SESSION_FILE"
+
+probe() {
+    python3 -c 'import sys,urllib.request; urllib.request.urlopen(sys.argv[1], timeout=1)' "$1" 2>/dev/null
+}
+
+wait_http() { # url tries label — poll every 100ms
+    _i=0
+    while ! probe "$1"; do
+        _i=$((_i + 1))
+        if [ "$_i" -ge "$2" ]; then
+            echo "ERROR: $3 not answering at $1 after $2 tries" >&2
+            return 1
+        fi
+        sleep 0.1
+    done
+}
+
+# WebKitGTK cannot render without a display server; Xvfb is the cheapest one.
+# -noreset keeps the server alive when the last client disconnects (MiniBrowser
+# restarts during session churn would otherwise kill it).
+echo "webkit-bench: starting Xvfb on $DISPLAY_NUM"
+Xvfb "$DISPLAY_NUM" -screen 0 1280x800x24 -nolisten tcp -noreset &
+export DISPLAY="$DISPLAY_NUM"
+
+echo "webkit-bench: starting pageserver on $HTTP_ADDR:$HTTP_PORT"
+python3 /opt/bench/pageserver.py --root "$PAGES_DIR" --addr "$HTTP_ADDR" \
+    --port "$HTTP_PORT" --ready-file "$READY_FILE" &
+wait_http "http://127.0.0.1:$HTTP_PORT/minimal.html" 50 pageserver
+
+# WebKit's bubblewrap sandbox needs user namespaces the guest container does
+# not grant — same trust argument as Chromium's --no-sandbox: the microVM is
+# the isolation boundary, each clone is single-tenant and destroyed after one
+# request. LIBGL_ALWAYS_SOFTWARE pins Mesa to llvmpipe (no GPU on this
+# platform) under the DEFAULT renderer. Do NOT add
+# WEBKIT_DISABLE_COMPOSITING_MODE or WEBKIT_DISABLE_DMABUF_RENDERER "for
+# headless": measured 2026-08-14 on webkit2gtk 2.50.6 under Xvfb, either one
+# makes GET /session/<id>/screenshot hang forever (page still alive — JS
+# executes) while the untouched default renders a PNG in 0.1s. The snapshot
+# path requires the compositing/DMA-BUF renderer these flags remove.
+export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
+export LIBGL_ALWAYS_SOFTWARE=1
+
+# --host=all: WebKitWebDriver binds wildcard so fcvm's health probe path and
+# any future non-loopback ingress work; the published-port DNAT lands on guest
+# loopback either way. Session creation is the only mutating surface and the
+# port is reachable only through fcvm's per-clone forwarding (see the security
+# rationale in entry.sh — identical trust model).
+echo "webkit-bench: starting WebKitWebDriver on :$WD_PORT"
+WebKitWebDriver --port="$WD_PORT" --host=all &
+WD_PID=$!
+wait_http "http://127.0.0.1:$WD_PORT/status" 300 webkit-webdriver
+
+echo "webkit-bench: creating warm session + warming renderer"
+python3 /opt/bench/wddrive.py "http://127.0.0.1:$HTTP_PORT/warmup.html" \
+    --host "127.0.0.1:$WD_PORT" --create --session-file "$SESSION_FILE" \
+    --out-prefix /tmp/warmup --then-blank
+
+# The host driver reads the inherited session id over the published pageserver
+# port; the health probe reads the /run copy.
+cp "$SESSION_FILE" "$PAGES_DIR/webdriver-session.txt"
+
+# Warm marker. wddrive.py --then-blank returns zero only after the navigate,
+# the PNG screenshot, and a verified about:blank transition, and `set -e`
+# means any failure exits before this touch — same golden-snapshot contract as
+# the Chromium entry.
+touch "$READY_FILE"
+echo "WEBKIT_BENCH_READY wd=127.0.0.1:$WD_PORT pages=http://127.0.0.1:$HTTP_PORT session=$(cat "$SESSION_FILE")"
+
+# Hold the warm driver. wait exits with WebKitWebDriver's status if it dies so
+# the container stops instead of hiding a dead driver; the trap keeps `podman
+# stop` from eating the 10s SIGKILL fallback (this shell is PID 1).
+cleanup_webkit() {
+    trap - TERM INT
+    kill "$WD_PID" 2>/dev/null || true
+    (
+        sleep 5
+        if kill -0 "$WD_PID" 2>/dev/null; then
+            echo "webkit-bench: WebKitWebDriver ignored TERM for 5s; sending KILL" >&2
+            kill -KILL "$WD_PID" 2>/dev/null || true
+        fi
+    ) &
+    killer_pid=$!
+    wait "$WD_PID" 2>/dev/null || true
+    kill "$killer_pid" 2>/dev/null || true
+    wait "$killer_pid" 2>/dev/null || true
+    exit 0
+}
+trap cleanup_webkit TERM INT
+wait "$WD_PID"

--- a/bench/chromium/entry-webkit.sh
+++ b/bench/chromium/entry-webkit.sh
@@ -95,9 +95,19 @@ WD_PID=$!
 wait_http "http://127.0.0.1:$WD_PORT/status" 300 webkit-webdriver
 
 echo "webkit-bench: creating warm session + warming renderer"
+# TWO screenshot passes, both timed in this log. The first heats
+# raster/encode/GTK init; the second PROVES the heat took (its screenshot_ms
+# should collapse, the way 1,429 ms -> 87 ms was measured post-restore). If a
+# later gated run still shows a cold first screenshot per clone, this log line
+# is the evidence that the cost does not survive the snapshot -- a finding, not
+# a config error. The quiescing --then-blank stays on the LAST pass so the
+# golden still snapshots an idle about:blank.
 python3 /opt/bench/wddrive.py "http://127.0.0.1:$HTTP_PORT/warmup.html" \
     --host "127.0.0.1:$WD_PORT" --create --session-file "$SESSION_FILE" \
-    --out-prefix /tmp/warmup --then-blank
+    --out-prefix /tmp/warmup
+python3 /opt/bench/wddrive.py "http://127.0.0.1:$HTTP_PORT/warmup.html" \
+    --host "127.0.0.1:$WD_PORT" --session-file "$SESSION_FILE" \
+    --out-prefix /tmp/warmup2 --then-blank
 
 # The host driver reads the inherited session id over the published pageserver
 # port; the health probe reads the /run copy.

--- a/bench/chromium/entry-webkit.sh
+++ b/bench/chromium/entry-webkit.sh
@@ -13,10 +13,9 @@
 #
 # THE SESSION IS PART OF THE SNAPSHOT. Classic WebDriver has no session
 # discovery: a session created after restore would launch a cold browser, so
-# the warm session id minted here is what every clone inherits. It is persisted
-# twice: /run/bench-session-id for the in-guest health probe, and
-# pages/webdriver-session.txt so the HOST driver can fetch it over the
-# published pageserver port without an exec round trip.
+# the warm session id minted here is what every clone inherits, persisted at
+# /run/bench-session-id. The in-guest health probe reads it there and the host
+# harness captures it once per run over fcvm exec (discover_wd_session).
 set -eu
 
 PAGES_DIR="${BENCH_PAGES_DIR:-/opt/bench/pages}"
@@ -109,9 +108,6 @@ python3 /opt/bench/wddrive.py "http://127.0.0.1:$HTTP_PORT/warmup.html" \
     --host "127.0.0.1:$WD_PORT" --session-file "$SESSION_FILE" \
     --out-prefix /tmp/warmup2 --then-blank
 
-# The host driver reads the inherited session id over the published pageserver
-# port; the health probe reads the /run copy.
-cp "$SESSION_FILE" "$PAGES_DIR/webdriver-session.txt"
 
 # Resident health checker, started BEFORE the warm marker so the interpreter's
 # pages are dirtied pre-snapshot and shared by every clone. stdout to /dev/null:

--- a/bench/chromium/health_loop.py
+++ b/bench/chromium/health_loop.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Resident health loop shared by every engine's probe.
+
+Extracted from cdp_health.py when the WebKit arm arrived and copied the
+PRE-resident shape: a per-second `python3 <probe>` HEALTHCHECK. That is the
+design this file exists to prevent. Measured in this image, per clone, per
+second, forever: 9.1ms of interpreter startup and 43.6ms for the whole check
+even when it fails fast. Run resident and paid once at the golden instead, the
+interpreter's pages are dirtied BEFORE the snapshot and are therefore shared by
+every clone rather than privately re-dirtied -- which is the per-clone memory
+figure this benchmark exists to produce.
+
+Everything here is engine-agnostic. A probe supplies only
+`main_with_reason() -> (exit_code, reason)`; the verdict file, its boottime
+stamp, the atomic publish and the crash guard are identical for all of them,
+so reqbench.sh's `grep -q health_state` gate stays engine-independent too.
+"""
+
+import os
+import sys
+import time
+
+# MUST match health_state.sh:31 -- writer and reader resolve the same path.
+DEFAULT_STATE_FILE = "/run/bench-health"
+LOOP_INTERVAL = float(os.environ.get("BENCH_HEALTH_INTERVAL", "1.0"))
+
+
+def state_file() -> str:
+    """Resolved per call, not bound at import.
+
+    Binding it at import makes the value depend on WHEN this module is first
+    imported relative to the environment being set, which is an ordering the
+    caller cannot see. test_health_state loads a cache-free COPY of a probe to
+    prove the writer and reader agree, and with an import-time constant that
+    copy silently wrote to the real /run path instead of the test's temp file.
+    """
+    return os.environ.get("BENCH_HEALTH_STATE", DEFAULT_STATE_FILE)
+
+
+def monotonic_seconds() -> float:
+    """Seconds from /proc/uptime, so a clock step cannot age a verdict.
+
+    NOT time.time(). fc-agent steps CLOCK_REALTIME on every restore
+    (set_system_clock), which would make every clone's freshly written verdict
+    look hours old to a wall-clock reader and fail the gate on every clone.
+
+    /proc/uptime is CLOCK_BOOTTIME (ktime_get_boottime_ts64), not
+    CLOCK_MONOTONIC. The reader uses the same file, so both sides measure the
+    same clock either way, but the freshness scheme rests on guest boottime
+    being CONTINUOUS across snapshot and restore. That holds where the
+    firecracker fork owns the VM-wide counter offset and advances it by the
+    pause duration (AGENTS.md, NV2 snapshot lifecycle). It is NOT established
+    for the cloud-hypervisor backend. If boottime jumps on restore, every
+    clone reports "verdict is Ns old" forever, which is the same total failure
+    this design moved away from, relocated from realtime to boottime.
+    """
+    with open("/proc/uptime", "r", encoding="ascii") as handle:
+        return float(handle.read().split()[0])
+
+
+def publish(verdict: str, detail: str) -> None:
+    """Write the verdict atomically, so a reader never sees a half-written line."""
+    target = state_file()
+    tmp = f"{target}.tmp"
+    with open(tmp, "w", encoding="utf-8") as handle:
+        handle.write(f"{verdict} {monotonic_seconds():.3f} {detail}\n")
+    os.replace(tmp, target)
+
+
+def loop(main_with_reason, label: str) -> int:
+    """Run the check forever, publishing each verdict.
+
+    Why resident: as a HEALTHCHECK command this cost a fresh CPython per second
+    in EVERY clone, forever. Measured in this image: 9.1ms of interpreter
+    startup, 43.6ms for the whole check even when it fails fast. Paid once at
+    the golden instead, the interpreter's pages are dirtied before the snapshot
+    and are therefore SHARED by every clone rather than privately re-dirtied.
+    Each iteration then writes one small file on tmpfs.
+    """
+    while True:
+        started = monotonic_seconds()
+        try:
+            code, reason = main_with_reason()
+            publish("healthy" if code == 0 else "unhealthy", reason)
+        except Exception as error:  # a crash here must not look healthy
+            # Guarded. The unguarded version raised the SAME error the handler
+            # was catching (a full /run tmpfs, EROFS, a missing directory), let
+            # it escape loop(), and the process exited. Nothing supervises this
+            # loop, so the container would then be unhealthy forever with no
+            # verdict file at all, and the golden would wait out its full 300s
+            # timeout with nothing to say why.
+            try:
+                publish("unhealthy", f"loop error: {type(error).__name__}: {error}")
+            except Exception as publish_error:
+                print(
+                    f"{label} loop: cannot publish ({type(publish_error).__name__}: "
+                    f"{publish_error}) after {type(error).__name__}: {error}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+        elapsed = monotonic_seconds() - started
+        time.sleep(max(0.0, LOOP_INTERVAL - elapsed))
+
+

--- a/bench/chromium/health_loop.py
+++ b/bench/chromium/health_loop.py
@@ -20,7 +20,9 @@ import os
 import sys
 import time
 
-# MUST match health_state.sh:31 -- writer and reader resolve the same path.
+# MUST equal the default in health_state.sh (its STATE_FILE fallback) --
+# writer and reader resolve the same path or every verdict is invisible.
+# Enforced end to end by test_the_default_paths_agree_without_the_env.
 DEFAULT_STATE_FILE = "/run/bench-health"
 LOOP_INTERVAL = float(os.environ.get("BENCH_HEALTH_INTERVAL", "1.0"))
 

--- a/bench/chromium/health_state.sh
+++ b/bench/chromium/health_state.sh
@@ -26,7 +26,7 @@
 # (set_system_clock), so a wall-clock reader would judge every clone's freshly
 # written verdict to be hours old and fail the gate on every single clone.
 # /proc/uptime is CLOCK_BOOTTIME (ktime_get_boottime_ts64), not CLOCK_MONOTONIC,
-# and is exactly what the writer records -- see cdp_health.monotonic_seconds,
+# and is exactly what the writer records -- see health_loop.monotonic_seconds,
 # which explains why boottime continuity across restore is what makes this work.
 set -uo pipefail
 

--- a/bench/chromium/reqanalyze.py
+++ b/bench/chromium/reqanalyze.py
@@ -720,7 +720,10 @@ def _validate_schedule(dataset):
                     # no idle policy, no prewire, no tcp/upgrade/enable
                     # stages), which gated every webkit run into failure.
                     engine = meta_engine
-                    if (render.get("engine") or meta_engine) != meta_engine:
+                    # cdpdrive stamps no engine field, so a missing stamp means
+                    # chromium, never "whatever the meta says": a webkit run
+                    # whose renders carry no stamp must fail, not inherit.
+                    if (render.get("engine") or "chromium") != meta_engine:
                         errors.append(
                             f"{rlabel} render engine {render.get('engine')!r} "
                             f"mismatches metadata {meta.get('engine')!r}"

--- a/bench/chromium/reqanalyze.py
+++ b/bench/chromium/reqanalyze.py
@@ -522,6 +522,12 @@ def _validate_schedule(dataset):
     expected = set(expected_order)
     observed = {}
     observed_order = []
+    # Per-run constants, hoisted out of the record loop. The meta owns the
+    # engine: the harness stamps it once per run, so a record's own stamp is
+    # asserted against it below rather than allowed to pick the schema that
+    # judges it.
+    meta_engine = meta.get("engine") or "chromium"
+    expected_quality = meta["quality"] if meta["format"] == "jpeg" else 0
     for record in dataset["records"]:
         rsource = record.get("_source") or {}
         rlabel = f"{rsource.get('path')}:{rsource.get('line')}"
@@ -713,24 +719,18 @@ def _validate_schedule(dataset):
                     # healthy render: wd_host is not cdp_host, WebDriver has
                     # no idle policy, no prewire, no tcp/upgrade/enable
                     # stages), which gated every webkit run into failure.
-                    engine = render.get("engine") or meta.get("engine") or "chromium"
-                    if engine != (meta.get("engine") or "chromium"):
+                    engine = meta_engine
+                    if (render.get("engine") or meta_engine) != meta_engine:
                         errors.append(
-                            f"{rlabel} render engine {engine!r} mismatches "
-                            f"metadata {meta.get('engine')!r}"
+                            f"{rlabel} render engine {render.get('engine')!r} "
+                            f"mismatches metadata {meta.get('engine')!r}"
                         )
-                    if engine == "webkit":
-                        expected_fields = {
-                            "url": expected_url,
-                            "format": meta.get("format"),
-                            "wd_host": record.get("endpoint"),
-                        }
-                    else:
-                        expected_fields = {
-                            "url": expected_url,
-                            "format": meta.get("format"),
-                            "cdp_host": record.get("endpoint"),
-                        }
+                    host_key = "wd_host" if engine == "webkit" else "cdp_host"
+                    expected_fields = {
+                        "url": expected_url,
+                        "format": meta.get("format"),
+                        host_key: record.get("endpoint"),
+                    }
                     for field, expected_value in expected_fields.items():
                         if render.get(field) != expected_value:
                             errors.append(
@@ -842,28 +842,27 @@ def _validate_schedule(dataset):
                             or value <= 0
                         ):
                             errors.append(f"{rlabel} CDP render has invalid {dimension}")
-                    expected_quality = meta["quality"] if meta["format"] == "jpeg" else 0
                     if (
                         arm != "html"
                         and engine != "webkit"
                         and render.get("quality") != expected_quality
                     ):
                         errors.append(f"{rlabel} CDP render quality mismatches metadata")
-                    nav = render.get("nav") if engine != "webkit" else None
                     nav_fields = (
                         "dns_ms", "connect_ms", "tls_ms", "ttfb_ms",
                         "resp_ms", "load_ms",
                     )
-                    if engine == "webkit":
-                        pass  # WebDriver classic exposes no navigation timing.
-                    elif not isinstance(nav, dict):
-                        errors.append(f"{rlabel} CDP render has no navigation timing")
-                    else:
-                        for field in nav_fields:
-                            if not finite_nonnegative(nav.get(field)):
-                                errors.append(
-                                    f"{rlabel} CDP render has invalid nav.{field}"
-                                )
+                    # WebDriver classic exposes no navigation timing.
+                    if engine != "webkit":
+                        nav = render.get("nav")
+                        if not isinstance(nav, dict):
+                            errors.append(f"{rlabel} CDP render has no navigation timing")
+                        else:
+                            for field in nav_fields:
+                                if not finite_nonnegative(nav.get(field)):
+                                    errors.append(
+                                        f"{rlabel} CDP render has invalid nav.{field}"
+                                    )
                 if arm == "cdp-fast" and isinstance(teardown, dict):
                     if teardown.get("accounting_version") != "post-terminal-ambient-v2":
                         errors.append(f"{rlabel} fast teardown has stale accounting semantics")

--- a/bench/chromium/reqanalyze.py
+++ b/bench/chromium/reqanalyze.py
@@ -707,36 +707,78 @@ def _validate_schedule(dataset):
                         expected_url = urls[record.get("rep", 0) % len(urls)]
                     else:
                         expected_url = meta.get("url")
-                    expected_fields = {
-                        "url": expected_url,
-                        "format": meta.get("format"),
-                        "cdp_host": record.get("endpoint"),
-                    }
+                    # The two engines emit different render schemas and each
+                    # is held to its own: a webkit record judged by the
+                    # chromium schema fails structurally (~13 errors per
+                    # healthy render: wd_host is not cdp_host, WebDriver has
+                    # no idle policy, no prewire, no tcp/upgrade/enable
+                    # stages), which gated every webkit run into failure.
+                    engine = render.get("engine") or meta.get("engine") or "chromium"
+                    if engine != (meta.get("engine") or "chromium"):
+                        errors.append(
+                            f"{rlabel} render engine {engine!r} mismatches "
+                            f"metadata {meta.get('engine')!r}"
+                        )
+                    if engine == "webkit":
+                        expected_fields = {
+                            "url": expected_url,
+                            "format": meta.get("format"),
+                            "wd_host": record.get("endpoint"),
+                        }
+                    else:
+                        expected_fields = {
+                            "url": expected_url,
+                            "format": meta.get("format"),
+                            "cdp_host": record.get("endpoint"),
+                        }
                     for field, expected_value in expected_fields.items():
                         if render.get(field) != expected_value:
                             errors.append(
                                 f"{rlabel} CDP render {field}={render.get(field)!r} "
                                 f"does not match {expected_value!r}"
                             )
-                    if render.get("idle_timeout") != 0:
+                    if engine != "webkit" and render.get("idle_timeout") != 0:
                         errors.append(
                             f"{rlabel} CDP render did not complete its declared idle policy"
                         )
-                    prewired_expected = meta.get("ws_url_prewired")
-                    discovery_warmup = (
-                        is_warmup
-                        and prewired_expected is True
-                        and render.get("target_prewired") is False
-                    )
-                    # --prewire pins the URL on the first successful warmup rep,
-                    # which itself necessarily runs unprewired; measured reps are
-                    # held strictly to the metadata.
-                    if not discovery_warmup and (
-                        render.get("target_prewired") is not prewired_expected
-                    ):
-                        errors.append(f"{rlabel} CDP target prewire mode mismatches metadata")
+                    if engine == "webkit":
+                        # Classic WebDriver has no target discovery: the warm
+                        # session id is snapshot state, so every rep must run
+                        # prewired.
+                        if render.get("session_prewired") is not True:
+                            errors.append(
+                                f"{rlabel} webkit render ran without its "
+                                "prewired session"
+                            )
+                    else:
+                        prewired_expected = meta.get("ws_url_prewired")
+                        discovery_warmup = (
+                            is_warmup
+                            and prewired_expected is True
+                            and render.get("target_prewired") is False
+                        )
+                        # --prewire pins the URL on the first successful warmup rep,
+                        # which itself necessarily runs unprewired; measured reps are
+                        # held strictly to the metadata.
+                        if not discovery_warmup and (
+                            render.get("target_prewired") is not prewired_expected
+                        ):
+                            errors.append(f"{rlabel} CDP target prewire mode mismatches metadata")
                     stages = render.get("stages")
-                    if arm == "html":
+                    if engine == "webkit":
+                        # WebDriver classic is plain HTTP: no WebSocket
+                        # (tcp/upgrade/enable), no idle policy, no separate
+                        # decode, and no navigation-timing extraction. The html
+                        # arm is refused upfront for this engine.
+                        if arm == "html":
+                            errors.append(
+                                f"{rlabel} html arm is not valid for webkit records"
+                            )
+                        required_stages = (
+                            "resolve_ms", "connect_total_ms", "navigate_ms",
+                            "screenshot_ms", "total_ms",
+                        )
+                    elif arm == "html":
                         # The html op swaps the terminal screenshot+decode stages
                         # for a single DOM-extraction stage.
                         required_stages = (
@@ -790,7 +832,9 @@ def _validate_schedule(dataset):
                         )
                     ):
                         errors.append(f"{rlabel} CDP render has invalid image_sha256")
-                    for dimension in (() if arm == "html" else ("width", "height")):
+                    for dimension in (
+                        () if (arm == "html" or engine == "webkit") else ("width", "height")
+                    ):
                         value = render.get(dimension)
                         if (
                             not isinstance(value, int)
@@ -799,14 +843,20 @@ def _validate_schedule(dataset):
                         ):
                             errors.append(f"{rlabel} CDP render has invalid {dimension}")
                     expected_quality = meta["quality"] if meta["format"] == "jpeg" else 0
-                    if arm != "html" and render.get("quality") != expected_quality:
+                    if (
+                        arm != "html"
+                        and engine != "webkit"
+                        and render.get("quality") != expected_quality
+                    ):
                         errors.append(f"{rlabel} CDP render quality mismatches metadata")
-                    nav = render.get("nav")
+                    nav = render.get("nav") if engine != "webkit" else None
                     nav_fields = (
                         "dns_ms", "connect_ms", "tls_ms", "ttfb_ms",
                         "resp_ms", "load_ms",
                     )
-                    if not isinstance(nav, dict):
+                    if engine == "webkit":
+                        pass  # WebDriver classic exposes no navigation timing.
+                    elif not isinstance(nav, dict):
                         errors.append(f"{rlabel} CDP render has no navigation timing")
                     else:
                         for field in nav_fields:

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -360,8 +360,27 @@ def machine_counter_tracks_this_process(burn_ms: float = None) -> bool:
         # excusing it. NOT memoized: this is a statement about the probe, not
         # about the host, so a later attempt may still answer the question.
         return True
-    _MACHINE_COUNTER_TRACKS = excess >= spent - CPU_RESIDUAL_UNCERTAINTY_MS
-    return _MACHINE_COUNTER_TRACKS
+    if excess >= spent - CPU_RESIDUAL_UNCERTAINTY_MS:
+        _MACHINE_COUNTER_TRACKS = True
+        return True
+    # The median says "not tracking" -- but that verdict is only trustworthy if
+    # the pairs AGREE. Pairing cancels STEADY ambient; it amplifies FLUCTUATING
+    # ambient, because a load that starts or stops between the idle window and
+    # the burn window lands in the difference at full weight. Observed: two
+    # test suites running concurrently made this probe condemn a host that
+    # tracks perfectly (excess spread far beyond tolerance, median dragged
+    # low). When the spread of excesses exceeds the tolerance the probe cannot
+    # distinguish "counter excludes us" from "ambient was choppy", so it fails
+    # toward "tracks" -- keeping the strict violation path (RuntimeError) live
+    # rather than excusing the host -- and does NOT memoize, since choppiness
+    # is a statement about the moment, not the host. A genuinely untracked
+    # counter yields excesses that agree near zero (spread within tolerance)
+    # and is still condemned.
+    spread = excesses[-1] - excesses[0]
+    if spread > CPU_RESIDUAL_UNCERTAINTY_MS:
+        return True
+    _MACHINE_COUNTER_TRACKS = False
+    return False
 
 
 def bounded_cpu_residual(machine_ms: float, harness_ms: float, tracks=None) -> dict:

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -3422,7 +3422,7 @@ def run_noop_request(args, rep: int) -> dict:
             rec["ok"] = False
             rec["request_error"] = f"{type(e).__name__}: {e}"
             rec["error"] = rec["request_error"]
-            if not isinstance(e, Exception):
+            if rep_error_escalates(e):
                 interrupted = e
             if state_path is None and fcvm_start_time is not None:
                 state_path, state = scan_state(
@@ -3622,7 +3622,7 @@ def run_exec_request(args, rep: int) -> dict:
             rec["log"] = log
             teardown_error.record = rec
             raise teardown_error from request_error
-        if not isinstance(request_error, Exception):
+        if rep_error_escalates(request_error):
             raise
         rec["blocking_ms"] = rec["wall_ms"] = (time.monotonic() - t0) * 1000
         rec["log"] = log
@@ -4046,13 +4046,18 @@ def main_with_resources(resources: ExitStack) -> int:
             )
     os.makedirs(args.out_dir, exist_ok=True)
     arms = [a.strip() for a in args.arms.split(",") if a.strip()]
-    allowed_arms = allowed_arms_for_engine(getattr(args, "engine", "chromium"))
+    allowed_arms = allowed_arms_for_engine(args.engine)
     if not arms or len(set(arms)) != len(arms) or any(a not in allowed_arms for a in arms):
         p.error(
             "--arms must be a non-empty, duplicate-free subset of "
             + ",".join(sorted(allowed_arms))
-            + f" for --engine {getattr(args, 'engine', 'chromium')}"
+            + f" for --engine {args.engine}"
         )
+    if args.engine == "webkit":
+        # WebDriver's screenshot is always PNG (wddrive stamps format=png), so
+        # the jpeg default in --format would put a declaration in meta the
+        # renders can never satisfy.
+        args.format = "png"
     # exec is ALLOWED but no longer REQUIRED: it is retired from measurement
     # (no published claim rests on it), and run reqbench-20260814-022254-uffd
     # measured that 95% of noop reps following an exec rep land in a +17 ms
@@ -4126,10 +4131,7 @@ def main_with_resources(resources: ExitStack) -> int:
             "kind": "meta", "run_id": run_id, "seed": args.seed,
             "backend": "file" if args.snapshot_tag else "uffd", "arms": arms, "reps": args.reps,
             "uffd_mode": uffd_mode,
-            "warmup": args.warmup, "url": args.url, "urls": args.urls,
-            # webkit's WebDriver screenshot is always PNG; recording args.format
-            # here made the analyzer hold png renders to a jpeg declaration.
-            "format": "png" if args.engine == "webkit" else args.format,
+            "warmup": args.warmup, "url": args.url, "urls": args.urls, "format": args.format,
             "engine": args.engine,
             "quality": args.quality,
             "source_revision": current_source_revision,

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -3028,6 +3028,29 @@ def spawn_clone_process(cmd: list[str], log: str, env: dict) -> subprocess.Popen
         signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
 
 
+def discover_wd_session(args, fcvm_pid: int) -> str:
+    """Read the golden's warm WebDriver session id out of a live clone, once.
+
+    entry-webkit.sh writes it to /run/bench-session-id in the CONTAINER before
+    the warm marker, so it precedes every golden snapshot and restores
+    identically into every clone. One `fcvm exec` (vsock, no network stack in
+    the path) on the first clone; the caller pins the result for the run.
+    Raises rather than returning empty: a run without a session id cannot
+    render anything, and a silent "" would surface 202 reps later as uniform
+    navigate failures with the real cause off-screen.
+    """
+    argv = [args.fcvm, "exec", "--pid", str(fcvm_pid), "-c",
+            "--", "cat", "/run/bench-session-id"]
+    proc = subprocess.run(argv, capture_output=True, text=True, timeout=60)
+    session = (proc.stdout or "").strip()
+    if proc.returncode != 0 or not session:
+        raise RuntimeError(
+            "webkit session discovery failed: "
+            f"rc={proc.returncode} stdout={proc.stdout!r} stderr={proc.stderr[-300:]!r}"
+        )
+    return session
+
+
 def run_cdp_request(args, rep: int, fast: bool, probe=None, op: str = "screenshot") -> dict:
     import cdpdrive
 
@@ -3082,30 +3105,52 @@ def run_cdp_request(args, rep: int, fast: bool, probe=None, op: str = "screensho
             rec["state_to_port_ms"] = wait_port(endpoint, deadline, proc, log)
             rec["spawn_to_port_ms"] = (time.monotonic() - t_spawn) * 1000
 
-            ws_url = clone_ws_url(args.ws_url, endpoint) if args.ws_url else ""
-            rec["ws_url_prewired"] = bool(ws_url)
-            drive_args = argparse.Namespace(
-                cdp_host=endpoint,
-                url=url_for_rep(getattr(args, "urls", None) or [args.url], rep),
-                format=args.format,
-                quality=args.quality,
-                timeout=max(1.0, deadline - time.monotonic()),
-                idle_wait_ms=0.0,
-                out_prefix="",
-                ws_url=ws_url,
-                connect_retries=200,
-                nav_timing=True,
-                print_target=False,
-                # This Namespace is an explicit, CLOSED field list, so every flag
-                # cdpdrive grows has to be added here too or `drive()` raises
-                # AttributeError — which is not in its except tuple, escapes it,
-                # and is swallowed by the `except Exception` below, failing every
-                # cdp rep. cdpdrive also reads it with getattr; both halves.
-                host_header="",
-                op=op,
-                render_module=os.path.join(HERE, "render.py"),
-            )
-            result = cdpdrive.drive(drive_args)
+            if getattr(args, "engine", "chromium") == "webkit":
+                # Classic WebDriver has NO session discovery: the warm session
+                # id is written by entry-webkit.sh to /run/bench-session-id
+                # BEFORE the golden snapshot, so it is snapshot state --
+                # identical across clones for exactly the reason cdpdrive's
+                # target id is. Captured ONCE via fcvm exec on the first clone
+                # and pinned for every later rep (discovery-once, same pattern
+                # as --prewire; warmups run first, so the exec cost lands on a
+                # discarded rep).
+                if not getattr(args, "wd_session_id", ""):
+                    args.wd_session_id = discover_wd_session(args, fcvm_pid)
+                rec["session_prewired"] = True
+                import wddrive
+
+                result = wddrive.drive(argparse.Namespace(
+                    cdp_host=endpoint,
+                    url=url_for_rep(getattr(args, "urls", None) or [args.url], rep),
+                    timeout=max(1.0, deadline - time.monotonic()),
+                    session_id=args.wd_session_id,
+                    out_prefix="",
+                ))
+            else:
+                ws_url = clone_ws_url(args.ws_url, endpoint) if args.ws_url else ""
+                rec["ws_url_prewired"] = bool(ws_url)
+                drive_args = argparse.Namespace(
+                    cdp_host=endpoint,
+                    url=url_for_rep(getattr(args, "urls", None) or [args.url], rep),
+                    format=args.format,
+                    quality=args.quality,
+                    timeout=max(1.0, deadline - time.monotonic()),
+                    idle_wait_ms=0.0,
+                    out_prefix="",
+                    ws_url=ws_url,
+                    connect_retries=200,
+                    nav_timing=True,
+                    print_target=False,
+                    # This Namespace is an explicit, CLOSED field list, so every flag
+                    # cdpdrive grows has to be added here too or `drive()` raises
+                    # AttributeError — which is not in its except tuple, escapes it,
+                    # and is swallowed by the `except Exception` below, failing every
+                    # cdp rep. cdpdrive also reads it with getattr; both halves.
+                    host_header="",
+                    op=op,
+                    render_module=os.path.join(HERE, "render.py"),
+                )
+                result = cdpdrive.drive(drive_args)
             raise_if_harness_interrupted()
             rec["render"] = result
             rec["ok"] = bool(result.get("ok"))
@@ -3845,6 +3890,10 @@ def main_with_resources(resources: ExitStack) -> int:
     p.add_argument("--format", choices=("png", "jpeg"), default="jpeg")
     p.add_argument("--quality", type=int, default=80)
     p.add_argument("--cdp-port", type=int, default=9222)
+    p.add_argument("--engine", choices=("chromium", "webkit"), default="chromium",
+                   help="render driver: chromium drives CDP via cdpdrive; webkit "
+                        "drives W3C WebDriver classic via wddrive (the port in "
+                        "--cdp-port is then the WD port, 9515)")
     p.add_argument("--image", default="")
     p.add_argument("--image-id", default="")
     p.add_argument("--snapshot-name", default="")
@@ -4044,6 +4093,7 @@ def main_with_resources(resources: ExitStack) -> int:
             "backend": "file" if args.snapshot_tag else "uffd", "arms": arms, "reps": args.reps,
             "uffd_mode": uffd_mode,
             "warmup": args.warmup, "url": args.url, "urls": args.urls, "format": args.format,
+            "engine": args.engine,
             "quality": args.quality,
             "source_revision": current_source_revision,
             "fcvm_path": args.fcvm,

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -1383,6 +1383,26 @@ class SurvivedTeardown(RuntimeError):
         self.record: dict = {}
 
 
+class SessionDiscoveryFailed(RuntimeError):
+    """The golden holds no usable WebDriver session id; no rep can ever render.
+
+    Escalates out of the per-rep handler (after that rep's teardown) instead of
+    being recorded and retried: every retry re-spawns a clone, re-execs, and
+    fails the same way, so a swallowed discovery failure burns the entire
+    schedule and surfaces 202 reps later as uniform navigate failures with the
+    real cause off-screen."""
+
+
+def rep_error_escalates(error: BaseException) -> bool:
+    """Whether a per-rep exception must abort the schedule after teardown.
+
+    Non-Exception BaseExceptions (KeyboardInterrupt, HarnessInterrupted) always
+    do; SessionDiscoveryFailed does because retrying it is structurally
+    pointless (the missing session id is snapshot state, identical for every
+    clone)."""
+    return not isinstance(error, Exception) or isinstance(error, SessionDiscoveryFailed)
+
+
 class HarnessInterrupted(BaseException):
     """A host signal that must unwind only after the active clone is reaped."""
 
@@ -3044,7 +3064,7 @@ def discover_wd_session(args, fcvm_pid: int) -> str:
     proc = subprocess.run(argv, capture_output=True, text=True, timeout=60)
     session = (proc.stdout or "").strip()
     if proc.returncode != 0 or not session:
-        raise RuntimeError(
+        raise SessionDiscoveryFailed(
             "webkit session discovery failed: "
             f"rc={proc.returncode} stdout={proc.stdout!r} stderr={proc.stderr[-300:]!r}"
         )
@@ -3203,7 +3223,7 @@ def run_cdp_request(args, rep: int, fast: bool, probe=None, op: str = "screensho
             rec["ok"] = False
             rec["request_error"] = f"{type(e).__name__}: {e}"
             rec["error"] = rec["request_error"]
-            if not isinstance(e, Exception):
+            if rep_error_escalates(e):
                 interrupted = e
             rec.setdefault("blocking_ms", (time.monotonic() - t_spawn) * 1000)
             if state_path is None and fcvm_start_time is not None:
@@ -3842,6 +3862,19 @@ def dispatch_request(args, rep: int, arm: str, is_warmup: bool, probe=None) -> d
 CDP_CLASS_ARMS = frozenset({"cdp", "cdp-fast", "html"})
 
 
+def allowed_arms_for_engine(engine: str) -> frozenset:
+    """The arms an engine can actually execute; refused upfront, not per-rep.
+
+    webkit excludes exec (its in-guest driver is render.py, which
+    Containerfile.webkit-bench does not ship, so every exec rep burns a full
+    clone lifecycle on a guaranteed in-guest failure) and html (wddrive has no
+    DOM-extraction op; the request would silently return screenshot records the
+    analyzer then rejects for missing extract_ms/html_bytes/html_sha256)."""
+    if engine == "webkit":
+        return frozenset({"cdp", "cdp-fast", "noop"})
+    return frozenset({"exec", "cdp", "cdp-fast", "html", "noop"})
+
+
 def publication_arms_ok(arms) -> bool:
     """Whether an arm set can back a publication run.
 
@@ -4013,11 +4046,12 @@ def main_with_resources(resources: ExitStack) -> int:
             )
     os.makedirs(args.out_dir, exist_ok=True)
     arms = [a.strip() for a in args.arms.split(",") if a.strip()]
-    allowed_arms = {"exec", "cdp", "cdp-fast", "html", "noop"}
+    allowed_arms = allowed_arms_for_engine(getattr(args, "engine", "chromium"))
     if not arms or len(set(arms)) != len(arms) or any(a not in allowed_arms for a in arms):
         p.error(
             "--arms must be a non-empty, duplicate-free subset of "
-            "exec,cdp,cdp-fast,html,noop"
+            + ",".join(sorted(allowed_arms))
+            + f" for --engine {getattr(args, 'engine', 'chromium')}"
         )
     # exec is ALLOWED but no longer REQUIRED: it is retired from measurement
     # (no published claim rests on it), and run reqbench-20260814-022254-uffd
@@ -4092,7 +4126,10 @@ def main_with_resources(resources: ExitStack) -> int:
             "kind": "meta", "run_id": run_id, "seed": args.seed,
             "backend": "file" if args.snapshot_tag else "uffd", "arms": arms, "reps": args.reps,
             "uffd_mode": uffd_mode,
-            "warmup": args.warmup, "url": args.url, "urls": args.urls, "format": args.format,
+            "warmup": args.warmup, "url": args.url, "urls": args.urls,
+            # webkit's WebDriver screenshot is always PNG; recording args.format
+            # here made the analyzer hold png renders to a jpeg declaration.
+            "format": "png" if args.engine == "webkit" else args.format,
             "engine": args.engine,
             "quality": args.quality,
             "source_revision": current_source_revision,

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -1152,11 +1152,19 @@ def sha256_file(path: str) -> str:
     return h.hexdigest()
 
 
+# Every script that defines one request sample, for either engine. Must stay
+# equal to reqbench.sh's staged runtime sources minus the binaries and the
+# analyzer (which reads samples but defines none); asserted by
+# harness_hash_covers_every_staged_request_script in test_reqbench.py.
+HARNESS_SOURCES = ("reqbench.py", "cdpdrive.py", "render.py", "wddrive.py",
+                   "reqbench.sh")
+
+
 def harness_sha256() -> str:
     """Content identity for every script that defines one request sample."""
     h = hashlib.sha256()
     h.update(b"fcvm-chromium-request-harness-v1\0")
-    for name in ("reqbench.py", "cdpdrive.py", "render.py", "reqbench.sh"):
+    for name in HARNESS_SOURCES:
         encoded = name.encode()
         h.update(len(encoded).to_bytes(4, "big"))
         h.update(encoded)
@@ -4058,6 +4066,14 @@ def main_with_resources(resources: ExitStack) -> int:
         # the jpeg default in --format would put a declaration in meta the
         # renders can never satisfy.
         args.format = "png"
+        if args.ws_url:
+            p.error("--ws-url is CDP WebSocket prewiring; --engine webkit "
+                    "drives WebDriver classic and cannot use it")
+        # --prewire likewise names CDP prewiring. Leaving it set would stamp
+        # ws_url_prewired=true in meta for a WebSocket that never exists; the
+        # webkit analogue (the inherited WebDriver session) is recorded per
+        # rep as session_prewired.
+        args.prewire = False
     # exec is ALLOWED but no longer REQUIRED: it is retired from measurement
     # (no published claim rests on it), and run reqbench-20260814-022254-uffd
     # measured that 95% of noop reps following an exec rep land in a +17 ms

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -3056,7 +3056,7 @@ def spawn_clone_process(cmd: list[str], log: str, env: dict) -> subprocess.Popen
         signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
 
 
-def discover_wd_session(args, fcvm_pid: int) -> str:
+def discover_wd_session(args, fcvm_pid: int, deadline: float) -> str:
     """Read the golden's warm WebDriver session id out of a live clone, once.
 
     entry-webkit.sh writes it to /run/bench-session-id in the CONTAINER before
@@ -3069,7 +3069,18 @@ def discover_wd_session(args, fcvm_pid: int) -> str:
     """
     argv = [args.fcvm, "exec", "--pid", str(fcvm_pid), "-c",
             "--", "cat", "/run/bench-session-id"]
-    proc = subprocess.run(argv, capture_output=True, text=True, timeout=60)
+    # Bounded by the CLONE's remaining deadline, and every failure mode is
+    # SessionDiscoveryFailed: a timeout or an unlaunchable fcvm left as its
+    # own type is an ordinary Exception the per-rep handler records and
+    # RETRIES, so each later webkit rep would repeat the whole discovery wait
+    # against a value that is snapshot state and will not change.
+    timeout = max(1.0, min(60.0, deadline - time.monotonic()))
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+    except (subprocess.TimeoutExpired, OSError) as error:
+        raise SessionDiscoveryFailed(
+            f"webkit session discovery failed: {type(error).__name__}: {error}"
+        ) from error
     session = (proc.stdout or "").strip()
     if proc.returncode != 0 or not session:
         raise SessionDiscoveryFailed(
@@ -3143,7 +3154,7 @@ def run_cdp_request(args, rep: int, fast: bool, probe=None, op: str = "screensho
                 # as --prewire; warmups run first, so the exec cost lands on a
                 # discarded rep).
                 if not getattr(args, "wd_session_id", ""):
-                    args.wd_session_id = discover_wd_session(args, fcvm_pid)
+                    args.wd_session_id = discover_wd_session(args, fcvm_pid, deadline)
                 rec["session_prewired"] = True
                 import wddrive
 

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -812,7 +812,9 @@ PYWD3
     echo "--- target id stability ACROSS CLONES (-> can /json/list be skipped?) ---"
     local id1 id2 cname2="cb-req-verify2-$RUNID" cpid2 ip2 clone2_bg vmid2
     if [ "$ENGINE" = webkit ]; then
-        id1=$(wd_session_id "$cpid")
+        # The id is a baked, immutable file; HOP C already read it from this
+        # clone, so reuse that instead of another exec round trip.
+        id1="$wd_session"
     else
     id1=$(target_id "$ip:$CDP_PORT")
     fi

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -30,7 +30,25 @@ fi
 # rootless needs no sudo. SUDO is kept as a hook only so the same script can be
 # pointed at a root-only mode later without rewriting every call site.
 SUDO="${SUDO:-}"
-IMAGE="${IMAGE:-localhost/chromium-bench-req}"
+# ENGINE picks the render driver and, with it, the image and port defaults.
+# webkit: W3C WebDriver classic on 9515 via wddrive.py; the session id is baked
+# into the golden (entry-webkit.sh), captured once per run over fcvm exec.
+ENGINE="${ENGINE:-chromium}"
+case "$ENGINE" in
+chromium)
+    IMAGE="${IMAGE:-localhost/chromium-bench-req}"
+    ;;
+webkit)
+    IMAGE="${IMAGE:-localhost/webkit-bench-req}"
+    CDP_PORT="${CDP_PORT:-9515}"
+    # cdp-fast is CDP WebSocket prewiring; exec's guest driver is CDP-only.
+    ARMS="${ARMS:-cdp,noop}"
+    ;;
+*)
+    echo "unknown ENGINE '$ENGINE' (chromium|webkit)" >&2
+    exit 2
+    ;;
+esac
 # 9222 is Chromium's own CDP port. It binds guest loopback ONLY (it ignores
 # --remote-debugging-address; measured evidence in entry.sh), but fcvm DNATs each
 # eligible published TCP port to guest 127.0.0.1 when setup succeeds, so
@@ -103,17 +121,17 @@ if [ "${BASH_SOURCE[0]}" = "$0" ] && [ "${REQBENCH_STAGED:-0}" != 1 ]; then
     source_revision_before=$(git -C "$REPO" rev-parse HEAD)
     mkdir -p "$RESULTS/runtime"
     stage_dir=$(mktemp -d "$RESULTS/runtime/.stage.XXXXXX")
-    for source in reqbench.sh reqbench.py reqanalyze.py cdpdrive.py render.py; do
+    for source in reqbench.sh reqbench.py reqanalyze.py cdpdrive.py render.py wddrive.py; do
         cp --reflink=auto "$HERE/$source" "$stage_dir/$source"
     done
     cp --reflink=auto "$FC_AGENT" "$stage_dir/fc-agent"
     cp --reflink=auto "$FCVM" "$stage_dir/fcvm"
     chmod 0555 "$stage_dir/fcvm" "$stage_dir/fc-agent" "$stage_dir/reqbench.sh" \
         "$stage_dir/reqbench.py" "$stage_dir/reqanalyze.py" \
-        "$stage_dir/cdpdrive.py" "$stage_dir/render.py"
+        "$stage_dir/cdpdrive.py" "$stage_dir/render.py" "$stage_dir/wddrive.py"
     (
         cd "$stage_dir"
-        sha256sum fcvm fc-agent reqbench.sh reqbench.py reqanalyze.py cdpdrive.py render.py \
+        sha256sum fcvm fc-agent reqbench.sh reqbench.py reqanalyze.py cdpdrive.py render.py wddrive.py \
             > MANIFEST.sha256
     )
     bundle_hash=$(sha256sum "$stage_dir/MANIFEST.sha256" | cut -d' ' -f1)
@@ -147,6 +165,7 @@ if [ "${BASH_SOURCE[0]}" = "$0" ] && [ "${REQBENCH_STAGED:-0}" != 1 ]; then
         FC_AGENT="$bundle_dir/fc-agent" \
         SUDO="$SUDO" \
         IMAGE="$IMAGE" \
+        ENGINE="$ENGINE" \
         CDP_PORT="$CDP_PORT" \
         NETMODE="$NETMODE" \
         CPU="$CPU" \
@@ -714,9 +733,21 @@ cmd_verify() {
     log "verify: clone pid=$cpid host-side ip=$ip"
 
     echo "--- HOP A: healthcheck path, 127.0.0.1:$CDP_PORT INSIDE the container ---"
-    $SUDO "$FCVM" exec --pid "$cpid" -c -- python3 /opt/bench/cdp_health.py \
-        || { echo "HOP A FAILED (in-container CDP round trip)"; fail=1; }
+    local health_probe=cdp_health.py
+    [ "$ENGINE" = webkit ] && health_probe=wd_health.py
+    $SUDO "$FCVM" exec --pid "$cpid" -c -- python3 "/opt/bench/$health_probe" \
+        || { echo "HOP A FAILED (in-container $ENGINE health round trip)"; fail=1; }
 
+    if [ "$ENGINE" = webkit ]; then
+        echo "--- HOP B: GET /status from the HOST against $ip:$CDP_PORT ---"
+        python3 - "$ip:$CDP_PORT" <<'PYWD' || { echo "HOP B FAILED (host -> clone WD HTTP)"; fail=1; }
+import json, sys, urllib.request
+host = sys.argv[1]
+with urllib.request.urlopen(f"http://{host}/status", timeout=10) as r:
+    v = json.load(r)["value"]
+print("  OK ready=", v.get("ready"), "|", v.get("message", ""))
+PYWD
+    else
     echo "--- HOP B: GET /json/version from the HOST against $ip:$CDP_PORT ---"
     python3 - "$ip:$CDP_PORT" <<'PY' || { echo "HOP B FAILED (host -> clone CDP HTTP)"; fail=1; }
 import json, sys, urllib.request
@@ -735,9 +766,32 @@ except Exception as e:
     print(f"  note: non-IP Host header REJECTED ({e}) — expected; connect by IP")
 PY
 
+    fi
+
+    if [ "$ENGINE" = webkit ]; then
+        echo "--- HOP C: WD render (navigate + screenshot) from the HOST ---"
+        local wd_session
+        wd_session=$($SUDO "$FCVM" exec --pid "$cpid" -c -- cat /run/bench-session-id | tr -d '[:space:]')
+        if [ -z "$wd_session" ]; then
+            echo "HOP C FAILED (no baked session id in the clone)"; fail=1
+        else
+            REQBENCH_HERE="$HERE" python3 - "$ip:$CDP_PORT" "$URL" "$wd_session" "$RESULTS/verify" <<'PYWD3' \
+                || { echo "HOP C FAILED (host WD render)"; fail=1; }
+import argparse, json, sys
+import os; sys.path.insert(0, os.environ["REQBENCH_HERE"])
+import wddrive
+host, url, session, prefix = sys.argv[1:5]
+r = wddrive.drive(argparse.Namespace(cdp_host=host, url=url, timeout=120.0,
+                                     session_id=session, out_prefix=prefix))
+print(json.dumps({k: r[k] for k in ("ok", "image_bytes", "stages") if k in r}))
+sys.exit(0 if r.get("ok") else 1)
+PYWD3
+        fi
+    else
     echo "--- HOP C: WebSocket upgrade + one CDP command from the HOST ---"
     python3 "$HERE/cdpdrive.py" "$ip:$CDP_PORT" "$URL" --format jpeg --nav-timing \
         --out-prefix "$RESULTS/verify" || { echo "HOP C FAILED (host WS + CDP)"; fail=1; }
+    fi
 
     # --- target id stability, ACROSS CLONES, asserted.
     # This block used to print one clone's id and compare it with nothing, under
@@ -745,10 +799,18 @@ PY
     # serve is already up, so a second clone is cheap.
     echo "--- target id stability ACROSS CLONES (-> can /json/list be skipped?) ---"
     local id1 id2 cname2="cb-req-verify2-$RUNID" cpid2 ip2 clone2_bg vmid2
+    if [ "$ENGINE" = webkit ]; then
+        id1=$($SUDO "$FCVM" exec --pid "$cpid" -c -- cat /run/bench-session-id | tr -d '[:space:]')
+    else
     id1=$(target_id "$ip:$CDP_PORT")
+    fi
     start_clone "$spid" "$cname2" "$RESULTS/logs/verify-clone2.log" || return 1
     cpid2="$CLONE_PID"; ip2="$CLONE_IP"; clone2_bg="$CLONE_BG"; vmid2="$CLONE_VM_ID"
+    if [ "$ENGINE" = webkit ]; then
+        id2=$($SUDO "$FCVM" exec --pid "$cpid2" -c -- cat /run/bench-session-id | tr -d '[:space:]')
+    else
     id2=$(target_id "$ip2:$CDP_PORT")
+    fi
     echo "  clone1 ($ip) id=${id1:-<none>}"
     echo "  clone2 ($ip2) id=${id2:-<none>}"
     if [ -z "$id1" ] || [ -z "$id2" ]; then
@@ -999,6 +1061,7 @@ cmd_run() {
         --data-root "$DATA_ROOT" --state-dir "$STATE_DIR" \
         --network-mode "$NETMODE" --cpu "$CPU" --memory-mib "$MEM" \
         --run-id "$RUNID" --arms "${ARMS:-exec,cdp,cdp-fast,noop}" \
+        --engine "$ENGINE" \
         "${prewire_args[@]}" &
     local driver_bg=$!
     track "$driver_bg"

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -37,9 +37,11 @@ ENGINE="${ENGINE:-chromium}"
 case "$ENGINE" in
 chromium)
     IMAGE="${IMAGE:-localhost/chromium-bench-req}"
+    CONTAINERFILE="Containerfile.chromium-bench"
     ;;
 webkit)
     IMAGE="${IMAGE:-localhost/webkit-bench-req}"
+    CONTAINERFILE="Containerfile.webkit-bench"
     CDP_PORT="${CDP_PORT:-9515}"
     # cdp-fast is CDP WebSocket prewiring; exec's guest driver is CDP-only.
     ARMS="${ARMS:-cdp,noop}"
@@ -460,7 +462,7 @@ cmd_build() {
     # --format docker is LOAD-BEARING: podman's default OCI format DROPS
     # HEALTHCHECK with only a warning, and fcvm's health gate is what
     # triggers the golden snapshot (src/health.rs AND-logic).
-    podman build --format docker -t "$IMAGE" -f "$REPO/Containerfile.chromium-bench" "$REPO"
+    podman build --format docker -t "$IMAGE" -f "$REPO/$CONTAINERFILE" "$REPO"
     # The warm gate lives or dies here. fcvm treats a MISSING healthcheck as a
     # PASS, so an image that lost it snapshots a COLD browser and every clone's
     # "warm" latency is really a first-paint number. Assert the healthcheck
@@ -687,6 +689,16 @@ target_id() {
         --timeout "$TARGET_ID_TIMEOUT" 2>/dev/null || true
 }
 
+# The webkit twin of target_id(): read the baked session id out of a clone.
+# `|| true` for the same reason: under `set -euo pipefail` an exec/cat failure
+# inside $() would abort cmd_verify BEFORE its own "HOP C FAILED (no baked
+# session id)" / "TARGET ID UNREADABLE" diagnostics and the ordered teardown
+# that follows them, the exact failures those branches exist to name.
+wd_session_id() {
+    $SUDO "$FCVM" exec --pid "$1" -c -- cat /run/bench-session-id 2>/dev/null \
+        | tr -d '[:space:]' || true
+}
+
 cmd_verify() {
     # Every hop feeds this counter and the function RETURNS it. Each hop used to
     # be `... || echo "HOP X FAILED"`, which makes the compound command SUCCEED —
@@ -771,7 +783,7 @@ PY
     if [ "$ENGINE" = webkit ]; then
         echo "--- HOP C: WD render (navigate + screenshot) from the HOST ---"
         local wd_session
-        wd_session=$($SUDO "$FCVM" exec --pid "$cpid" -c -- cat /run/bench-session-id | tr -d '[:space:]')
+        wd_session=$(wd_session_id "$cpid")
         if [ -z "$wd_session" ]; then
             echo "HOP C FAILED (no baked session id in the clone)"; fail=1
         else
@@ -800,14 +812,14 @@ PYWD3
     echo "--- target id stability ACROSS CLONES (-> can /json/list be skipped?) ---"
     local id1 id2 cname2="cb-req-verify2-$RUNID" cpid2 ip2 clone2_bg vmid2
     if [ "$ENGINE" = webkit ]; then
-        id1=$($SUDO "$FCVM" exec --pid "$cpid" -c -- cat /run/bench-session-id | tr -d '[:space:]')
+        id1=$(wd_session_id "$cpid")
     else
     id1=$(target_id "$ip:$CDP_PORT")
     fi
     start_clone "$spid" "$cname2" "$RESULTS/logs/verify-clone2.log" || return 1
     cpid2="$CLONE_PID"; ip2="$CLONE_IP"; clone2_bg="$CLONE_BG"; vmid2="$CLONE_VM_ID"
     if [ "$ENGINE" = webkit ]; then
-        id2=$($SUDO "$FCVM" exec --pid "$cpid2" -c -- cat /run/bench-session-id | tr -d '[:space:]')
+        id2=$(wd_session_id "$cpid2")
     else
     id2=$(target_id "$ip2:$CDP_PORT")
     fi

--- a/bench/chromium/results/webkit-20260816/webkit-host-probe.json
+++ b/bench/chromium/results/webkit-20260816/webkit-host-probe.json
@@ -69,6 +69,12 @@
    "fisher_exact_two_sided_p": 0.395,
    "reading": "Indistinguishable at this sample size: the upgrade did NOT fix the stall, and the apparent worsening is not significant. Pooled across both versions the stall rate is 10/21 = 48%. So this is a live defect in the CURRENT upstream stable WebKitGTK (2.52.5), not an artifact of Debian bookworm shipping an old series.",
    "completion_time_when_ok_s": 1.6
+  },
+  "pooled_across_all_arms": {
+   "stalled": 13,
+   "attempts": 31,
+   "rate": "42%",
+   "wilson95": "[26%, 59%]"
   }
  },
  "chromium_host_reference": {
@@ -91,5 +97,28 @@
    "verdict": "bookworm pinned one full stable series behind; base image moved to trixie"
   },
   "caveat": "The Chromium image stays on bookworm because its Chromium version is identical and moving it would invalidate every golden and seal measured on 2026-08-16. Engine comparisons therefore span two base images (different libc and fonts). State that wherever the two engines are compared."
+ },
+ "mechanism_investigation": {
+  "two_of_my_inferences_were_wrong": [
+   "'the session stays responsive' does NOT prove the WebProcess is alive. GET /session/<id>/url maps to Automation.getBrowsingContext, which builds its reply from page.pageLoadState().activeURL() -- pure UI-process state, no IPC to the WebProcess. A 200 proves only that the UI-process run loop is alive.",
+   "'a lighter page navigates instantly' is ambiguous. waitForNavigationToCompleteOnPage returns IMMEDIATELY when !isLoading && !hasUncommittedLoad, so 0.0-0.1 s is the signature of that early-return branch -- which also fires when the WebProcess never acknowledged the load."
+  ],
+  "sharpest_discriminator": "A stalling run burns ~8 CPU-seconds; a successful run of the SAME page returns in 1.4 s. A 5-6x work difference on identical input means a different code path was taken, which rules out every 'UI process dropped the completion' candidate -- those predict identical work in both cases.",
+  "leading_candidate_NOT_confirmed": {
+   "hypothesis": "Accelerated 2D canvas under Xvfb/llvmpipe: getImageData does a synchronous readPixels on the main thread and flushContext waits on a GL fence with NO timeout (GLFenceEGL passes EGL_FOREVER_KHR, GLFenceGL passes GL_TIMEOUT_IGNORED). A stuck fence would mean the script never returns, Document::parsing() stays true, checkCompleted() early-returns forever and the load event never fires.",
+   "test": "WEBKIT_DISABLE_COMPOSITING_MODE=1, same 10-trial protocol",
+   "result": {
+    "compositing_on": "6/10 stalled",
+    "compositing_off": "3/10 stalled",
+    "fisher_p": 0.37
+   },
+   "verdict": "NOT CONFIRMED. Stalls persist with compositing disabled and the reduction is not significant. Caveat on this negative: I did not verify that the env var actually disabled the accelerated canvas path, so the intervention itself is unproven and the negative is only as strong as the intervention."
+  },
+  "second_independent_defect": {
+   "observed": "a navigate ran 390 s with no response at all (client timeout, not a return)",
+   "expected": "session timeouts report pageLoad=300000, and WebAutomationSession defaultPageLoadTimeout is 300 s",
+   "reading": "A registered wait MUST be answered by 300 s with a WebDriver `timeout` error. It was not. So either the callback was never registered with a deadline, or its deadline was stripped -- WebAutomationSession has a single shared m_loadTimer that any resolving wait calls stop() on. This is a separate defect from the stall itself."
+  },
+  "status": "mechanism NOT established; the two facts above are established"
  }
 }

--- a/bench/chromium/results/webkit-20260816/webkit-host-probe.json
+++ b/bench/chromium/results/webkit-20260816/webkit-host-probe.json
@@ -30,15 +30,29 @@
   "caveat": "warmup.html is self-contained BY DESIGN so the warm point shares zero byte-resources with measured fixtures, and Chromium's entry.sh warms with the same page. Any fix must trigger the init without sharing bytes with what is measured."
  },
  "heavy_html_hang": {
-  "webkit": "navigate POST times out after 120.0 s, deterministic, N=1, 2/2 fresh containers",
-  "chromium": {
+  "corrected": "An earlier version of this record called the stall DETERMINISTIC on the strength of 2 observations that both stalled. That was wrong. It is INTERMITTENT.",
+  "measurement": {
+   "clean_fresh_container_attempts": 11,
+   "stalled": 4,
+   "completed": 7,
+   "stall_rate": "36%",
+   "completion_time_when_ok_s": 1.4,
+   "longest_observed_stall_s": 390,
+   "note": "390 s was curl's own timeout, not a return; the navigate had not completed."
+  },
+  "during_the_stall": {
+   "webkit_web_process_instantaneous_cpu": "0.3% of one core",
+   "cpu_consumed_total": "~8 CPU-seconds, all in the first ~6 s",
+   "session_responsive": "yes - GET /session/<id>/url returns the correct URL throughout",
+   "reading": "Not slow computation and not a crash. The page's work completes, the browser goes idle and stays responsive, and the navigate command simply never reports completion."
+  },
+  "chromium_same_page": {
    "total_ms": 1387.6,
    "navigate_load_event_ms": 1312.8,
-   "screenshot_ms": 40.9,
-   "image_bytes": 139227
+   "stalls_observed": 0
   },
-  "page": "3302 bytes, one <canvas 800x600> with getContext(\"2d\")",
-  "finding": "The report attributes a '120-second navigate-stall class Chromium does not show' to CONCURRENCY (N>=8, success 19/32 at N=32). It reproduces at N=1 and is triggered by page content. Chromium renders the same page in 1.39 s. Which page the N>=8 runs used is not recorded, so this does not prove the concurrency attribution wrong -- but 'at N>=8' is not a sufficient characterisation of a stall that occurs at N=1."
+  "page": "3302 bytes: a synchronous script building a 1200x6 table with a forced layout every 100 rows, then canvas gradients/arcs/text and a pixel readback, all before the load event",
+  "bearing_on_the_report": "The report attributes a '120-second navigate-stall class Chromium does not show' to CONCURRENCY (N>=8; 'success 19/32 at N=32' = 41% failure). This measures a 36% stall rate at N=1. Those rates are close enough to be the same underlying intermittent bug rather than a load effect. It does not PROVE the concurrency attribution wrong -- which page those runs rendered is not recorded -- but a stall that occurs 36% of the time at N=1 is not explained by concurrency."
  },
  "chromium_host_reference": {
   "p50_ms": 145.6,

--- a/bench/chromium/results/webkit-20260816/webkit-host-probe.json
+++ b/bench/chromium/results/webkit-20260816/webkit-host-probe.json
@@ -121,8 +121,9 @@
   },
   "status": "mechanism NOT established; the two facts above are established"
  },
- "ROOT_CAUSE_AND_FIX": {
-  "diagnosis": "NOT a hang, not slow layout, not a GL fence. WebKit loses the navigation-completion notification. Probed during a CONFIRMED stall with the navigate still outstanding at t=25s: document.readyState='complete'; the page's own marker read 'done layout_ms=1145.0 canvas_ms=160.0 checksum=65030'; 1200 table rows present; GET /status, /url and /title all answered 200 in under 3 ms. The page finished in ~1.3 s and JavaScript still executes. Only the COMMAND never completes.",
+ "leading_hypothesis_and_workaround": {
+  "observed_during_confirmed_stall": "Probed with the navigate still outstanding at t=25s: document.readyState='complete'; the page's own marker read 'done layout_ms=1145.0 canvas_ms=160.0 checksum=65030'; 1200 table rows present; GET /status, /url and /title all answered 200 in under 3 ms. The page finished in ~1.3 s and JavaScript still executes. Only the COMMAND never completes.",
+  "hypothesis": "WebKit drops the navigation-completion notification. Consistent with everything observed, but the mechanism is not established (see mechanism_investigation.status) and the gate patch in upstream/ is not built or tested, so this stays a hypothesis rather than a root cause.",
   "why_nothing_rescues_it": "Source/WebDriver/Session.cpp Session::go arms NO timer: it sends navigateBrowsingContext and waits for the backend indefinitely. The only deadline is the browser-side WebAutomationSession::m_loadTimer (defaultPageLoadTimeout = 300_s, WebAutomationSession.cpp:92). One observed navigate ran 390 s with no response, so that deadline did not fire either. There is a SINGLE shared m_loadTimer for four separate pending-callback maps and every resolving wait calls stop() on it (lines 962, 968, 993, 1002), so a second wait can strip the first one's deadline.",
   "workaround": "pageLoadStrategy 'none' plus polling document.readyState over execute/sync. WebAutomationSession::waitForNavigationToCompleteOnPage returns immediately on its first branch when the strategy is None, so the broken completion path is never entered; readiness comes from a different command path that is demonstrably alive during the stall. It also makes navigate_ms mean navigate-to-readyState-complete, i.e. the same quantity as Chromium's navigate-to-load-event, instead of 'whenever WebKit felt like replying'.",
   "validation": {
@@ -135,11 +136,6 @@
     "screenshot_ms": "~95",
     "total_ms": "1678-1729, a 51 ms spread"
    }
-  },
-  "engine_comparison_on_this_page": {
-   "webkit_total_ms": 1700,
-   "chromium_total_ms": 1387.6,
-   "reading": "WebKit ~22% slower on this page once it is reliable, versus unusable 42% of the time before."
   },
   "still_upstream_bugs": [
    "the lost navigation-completion notification itself",

--- a/bench/chromium/results/webkit-20260816/webkit-host-probe.json
+++ b/bench/chromium/results/webkit-20260816/webkit-host-probe.json
@@ -52,12 +52,44 @@
    "stalls_observed": 0
   },
   "page": "3302 bytes: a synchronous script building a 1200x6 table with a forced layout every 100 rows, then canvas gradients/arcs/text and a pixel readback, all before the load event",
-  "bearing_on_the_report": "The report attributes a '120-second navigate-stall class Chromium does not show' to CONCURRENCY (N>=8; 'success 19/32 at N=32' = 41% failure). This measures a 36% stall rate at N=1. Those rates are close enough to be the same underlying intermittent bug rather than a load effect. It does not PROVE the concurrency attribution wrong -- which page those runs rendered is not recorded -- but a stall that occurs 36% of the time at N=1 is not explained by concurrency."
+  "bearing_on_the_report": "The report attributes a '120-second navigate-stall class Chromium does not show' to CONCURRENCY (N>=8; 'success 19/32 at N=32' = 41% failure). This measures a 36% stall rate at N=1. Those rates are close enough to be the same underlying intermittent bug rather than a load effect. It does not PROVE the concurrency attribution wrong -- which page those runs rendered is not recorded -- but a stall that occurs 36% of the time at N=1 is not explained by concurrency.",
+  "upgrade_did_not_fix_it": {
+   "2.50.6": {
+    "stalled": 4,
+    "attempts": 11,
+    "rate": "36%",
+    "wilson95": "[15%, 65%]"
+   },
+   "2.52.5": {
+    "stalled": 6,
+    "attempts": 10,
+    "rate": "60%",
+    "wilson95": "[31%, 83%]"
+   },
+   "fisher_exact_two_sided_p": 0.395,
+   "reading": "Indistinguishable at this sample size: the upgrade did NOT fix the stall, and the apparent worsening is not significant. Pooled across both versions the stall rate is 10/21 = 48%. So this is a live defect in the CURRENT upstream stable WebKitGTK (2.52.5), not an artifact of Debian bookworm shipping an old series.",
+   "completion_time_when_ok_s": 1.6
+  }
  },
  "chromium_host_reference": {
   "p50_ms": 145.6,
   "n": 200,
   "source": "results/hostcdp-509059c1700d47bb89e9854ddd54bb73/hostcdp.jsonl",
   "format": "jpeg q80"
+ },
+ "version_audit": {
+  "chromium": {
+   "installed": "151.0.7922.137",
+   "bookworm_candidate": "151.0.7922.137-1~deb12u1",
+   "trixie_candidate": "151.0.7922.137-1~deb13u1",
+   "verdict": "already the latest packaged build; identical in both suites, so no upgrade available or needed"
+  },
+  "webkitgtk": {
+   "was": "2.50.6-1~deb12u2 (Debian bookworm)",
+   "now": "2.52.5-1~deb13u1 (Debian trixie)",
+   "upstream_stable": "2.52.5, released 2026-07-09; the 2.52 series opened 2026-03-18",
+   "verdict": "bookworm pinned one full stable series behind; base image moved to trixie"
+  },
+  "caveat": "The Chromium image stays on bookworm because its Chromium version is identical and moving it would invalidate every golden and seal measured on 2026-08-16. Engine comparisons therefore span two base images (different libc and fonts). State that wherever the two engines are compared."
  }
 }

--- a/bench/chromium/results/webkit-20260816/webkit-host-probe.json
+++ b/bench/chromium/results/webkit-20260816/webkit-host-probe.json
@@ -120,5 +120,30 @@
    "reading": "A registered wait MUST be answered by 300 s with a WebDriver `timeout` error. It was not. So either the callback was never registered with a deadline, or its deadline was stripped -- WebAutomationSession has a single shared m_loadTimer that any resolving wait calls stop() on. This is a separate defect from the stall itself."
   },
   "status": "mechanism NOT established; the two facts above are established"
+ },
+ "ROOT_CAUSE_AND_FIX": {
+  "diagnosis": "NOT a hang, not slow layout, not a GL fence. WebKit loses the navigation-completion notification. Probed during a CONFIRMED stall with the navigate still outstanding at t=25s: document.readyState='complete'; the page's own marker read 'done layout_ms=1145.0 canvas_ms=160.0 checksum=65030'; 1200 table rows present; GET /status, /url and /title all answered 200 in under 3 ms. The page finished in ~1.3 s and JavaScript still executes. Only the COMMAND never completes.",
+  "why_nothing_rescues_it": "Source/WebDriver/Session.cpp Session::go arms NO timer: it sends navigateBrowsingContext and waits for the backend indefinitely. The only deadline is the browser-side WebAutomationSession::m_loadTimer (defaultPageLoadTimeout = 300_s, WebAutomationSession.cpp:92). One observed navigate ran 390 s with no response, so that deadline did not fire either. There is a SINGLE shared m_loadTimer for four separate pending-callback maps and every resolving wait calls stop() on it (lines 962, 968, 993, 1002), so a second wait can strip the first one's deadline.",
+  "workaround": "pageLoadStrategy 'none' plus polling document.readyState over execute/sync. WebAutomationSession::waitForNavigationToCompleteOnPage returns immediately on its first branch when the strategy is None, so the broken completion path is never entered; readiness comes from a different command path that is demonstrably alive during the stall. It also makes navigate_ms mean navigate-to-readyState-complete, i.e. the same quantity as Chromium's navigate-to-load-event, instead of 'whenever WebKit felt like replying'.",
+  "validation": {
+   "baseline_failed": "13/31 (42%)",
+   "with_workaround_failed": "1/24 (4%)",
+   "fisher_exact_two_sided_p": 0.0015,
+   "note": "The single failure was a container that never became healthy because my test loop reused host ports before release; a second batch with port hygiene was 12/12.",
+   "timings_now_deterministic": {
+    "navigate_ms": "~1570",
+    "screenshot_ms": "~95",
+    "total_ms": "1678-1729, a 51 ms spread"
+   }
+  },
+  "engine_comparison_on_this_page": {
+   "webkit_total_ms": 1700,
+   "chromium_total_ms": 1387.6,
+   "reading": "WebKit ~22% slower on this page once it is reliable, versus unusable 42% of the time before."
+  },
+  "still_upstream_bugs": [
+   "the lost navigation-completion notification itself",
+   "the 300 s pageLoad deadline failing to fire, which makes the hang unrecoverable by any client"
+  ]
  }
 }

--- a/bench/chromium/results/webkit-20260816/webkit-host-probe.json
+++ b/bench/chromium/results/webkit-20260816/webkit-host-probe.json
@@ -1,0 +1,49 @@
+{
+ "_note": "WebKitGTK engine probe, HOST-side (podman --network host, no VM), same fixture pageserver the guest uses. Not a corpus number and not VM-isolated: under the publication rule this is optimisation evidence, not a headline. The ENGINE arm is NOT wired into reqbench.sh/py -- WebDriver classic and CDP are different protocols -- so no gated in-guest WebKit number exists on any committed path.",
+ "image": "localhost/webkit-bench-req",
+ "driver": "wddrive.py (W3C WebDriver classic, port 9515)",
+ "fixture": "medium.html",
+ "screenshot_format": "png (WebKitGTK is PNG-only; Chromium arm used JPEG q80)",
+ "warm_renders": {
+  "n": 54,
+  "total_ms": {
+   "p50": 122.0,
+   "p95": 129.44
+  },
+  "connect_ms": {
+   "p50": 26.0
+  },
+  "navigate_ms": {
+   "p50": 45.9
+  },
+  "screenshot_ms": {
+   "p50": 50.4
+  }
+ },
+ "first_render_penalty": {
+  "observed_ms": {
+   "first_medium_screenshot": 997.4,
+   "steady_state_screenshot": 50.4
+  },
+  "finding": "A one-time, process-global initialisation costs ~950 ms and is triggered by the first render of a page that needs it. Once paid, EVERY page is fast (~46 ms). Verified on three fresh containers, including one where medium.html was rendered FIRST: 999.6 ms, then warmup.html 47.2, minimal.html 30.4, medium.html 47.5.",
+  "consequence": "entry-webkit.sh warms with warmup.html, which does NOT trigger it, so the golden snapshot freezes the browser with the init UNPAID and every clone pays it on its first real render. That is the mechanism behind the report's 'full first render ~1.9 s' for WebKit clones.",
+  "caveat": "warmup.html is self-contained BY DESIGN so the warm point shares zero byte-resources with measured fixtures, and Chromium's entry.sh warms with the same page. Any fix must trigger the init without sharing bytes with what is measured."
+ },
+ "heavy_html_hang": {
+  "webkit": "navigate POST times out after 120.0 s, deterministic, N=1, 2/2 fresh containers",
+  "chromium": {
+   "total_ms": 1387.6,
+   "navigate_load_event_ms": 1312.8,
+   "screenshot_ms": 40.9,
+   "image_bytes": 139227
+  },
+  "page": "3302 bytes, one <canvas 800x600> with getContext(\"2d\")",
+  "finding": "The report attributes a '120-second navigate-stall class Chromium does not show' to CONCURRENCY (N>=8, success 19/32 at N=32). It reproduces at N=1 and is triggered by page content. Chromium renders the same page in 1.39 s. Which page the N>=8 runs used is not recorded, so this does not prove the concurrency attribution wrong -- but 'at N>=8' is not a sufficient characterisation of a stall that occurs at N=1."
+ },
+ "chromium_host_reference": {
+  "p50_ms": 145.6,
+  "n": 200,
+  "source": "results/hostcdp-509059c1700d47bb89e9854ddd54bb73/hostcdp.jsonl",
+  "format": "jpeg q80"
+ }
+}

--- a/bench/chromium/test_campaign.py
+++ b/bench/chromium/test_campaign.py
@@ -68,10 +68,29 @@ class RunPackaging(unittest.TestCase):
         The reservation must FAIL on collision.
         """
         body = makefile()
-        self.assertRegex(
-            body, r'@mkdir "\$\(CORPUS_RUN_DIR\)" \|\|',
-            "the run directory is not reserved with a failing plain mkdir",
-        )
+        # Behavioural, not structural: run the reservation recipe against a
+        # pre-created directory and require make itself to fail. The structural
+        # version regexed for `@mkdir ... ||` and never looked past the `||`,
+        # so `exit 1` -> `exit 0` survived it -- the recipe still PRINTED
+        # "REFUSING" and then proceeded into the existing directory, which is
+        # the exact contamination the reservation exists to prevent.
+        block = re.search(
+            r'(@mkdir "\$\(CORPUS_RUN_DIR\)" \|\| \{ \\\n.*?\})', body, re.S)
+        self.assertIsNotNone(block, "the reservation block is gone")
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = os.path.join(tmp, "corpus-x")
+            os.mkdir(run_dir)  # the collision
+            recipe = block.group(1).replace("$(CORPUS_RUN_DIR)", run_dir)
+            mk = os.path.join(tmp, "mk")
+            with open(mk, "w") as handle:
+                handle.write("reserve:\n\t" + recipe + "\n")
+            result = subprocess.run(["make", "-f", mk, "reserve"],
+                                    capture_output=True, text=True, timeout=60)
+            self.assertNotEqual(
+                result.returncode, 0,
+                "the reservation printed its refusal and PROCEEDED into an "
+                "existing campaign directory\n" + result.stdout + result.stderr)
+            self.assertIn("REFUSING", result.stdout + result.stderr)
         self.assertNotRegex(
             body, r'@mkdir -p "\$\(CORPUS_RUN_DIR\)"\s*$',
             "mkdir -p on the run directory silently reuses an existing campaign",
@@ -115,6 +134,14 @@ class Teardown(unittest.TestCase):
         )
         self.assertIn("exit 1", block,
                       "teardown cannot fail when it leaves the host broken")
+        # And the recipe line carrying that exit must not be prefixed `-`:
+        # make then ignores the failure and the target exits 0 over a box with
+        # no DNS, which is the same fail-open with one more character.
+        retry = re.search(r"^\t(@?-?)for i in", block, re.M)
+        self.assertIsNotNone(retry, "the dnsmasq retry loop is gone")
+        self.assertNotIn("-", retry.group(1),
+                         "the dnsmasq retry recipe is `-` prefixed, so make "
+                         "ignores its exit 1 and teardown reports clean anyway")
 
 
 class LogFilter(unittest.TestCase):

--- a/bench/chromium/test_campaign.py
+++ b/bench/chromium/test_campaign.py
@@ -52,13 +52,15 @@ class RunPackaging(unittest.TestCase):
         of packaging a run: the contamination it prevents is the contamination
         it would introduce.
         """
-        match = re.search(r"^CORPUS_STAMP\s*(\??:?=)", makefile(), re.M)
-        self.assertIsNotNone(match, "CORPUS_STAMP is gone from the Makefile")
-        self.assertEqual(
-            match.group(1), ":=",
-            "CORPUS_STAMP is recursively expanded, so $(shell date) re-runs on "
-            "every reference and one run can straddle two stamps",
-        )
+        for var in ("CORPUS_STAMP", "CORPUS_RUN_DIR"):
+            match = re.search(rf"^{var}\s*(\??:?=)", makefile(), re.M)
+            self.assertIsNotNone(match, f"{var} is gone from the Makefile")
+            self.assertEqual(
+                match.group(1), ":=",
+                f"{var} is recursively expanded; moving $(shell date) into any "
+                "recursively expanded variable re-runs it per reference, and one "
+                "run can straddle two stamps",
+            )
 
     def test_the_run_directory_is_reserved_and_not_reused(self):
         """`mkdir -p` accepts an existing directory.
@@ -109,7 +111,11 @@ class Provenance(unittest.TestCase):
         commit nobody can recover, which is the one thing writing SOURCE_REF
         exists to prevent.
         """
-        pin = re.search(r"git -C \"\$\(CURDIR\)\" branch[^\n]*", makefile())
+        # Join continuations FIRST: make folds backslash-newline into one shell
+        # command, so `|| true` on the next physical line is semantically on
+        # this one -- and a single-line regex cannot see it.
+        joined = re.sub(r"\\\n", " ", makefile())
+        pin = re.search(r"git -C \"\$\(CURDIR\)\" branch[^\n]*", joined)
         self.assertIsNotNone(pin, "the revision pin is gone")
         self.assertNotIn("branch -f", pin.group(0),
                          "the pin can move a ref an earlier record cites")

--- a/bench/chromium/test_containerfiles.py
+++ b/bench/chromium/test_containerfiles.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Every bench module a Containerfile ships must bring what it imports.
+
+The bench images COPY an explicit list of files. A module added to that list
+that imports a SIBLING module not on the list dies at import time inside the
+container -- and dies quietly, because entry.sh backgrounds the health checker,
+so `set -eu` never fires. The container comes up, touches its ready marker, and
+looks healthy while the thing that reports health is not running.
+
+That is not hypothetical. Splitting cdp_health.py into a probe plus a shared
+health_loop.py added `import health_loop` at module scope and updated only
+Containerfile.webkit-bench's COPY list. Reproduced by staging exactly the set
+Containerfile.chromium-bench copies:
+
+    ModuleNotFoundError: No module named 'health_loop'
+
+Nothing caught it. No test in bench/chromium reads a Containerfile, and CI runs
+only `unittest discover` over this directory, so the image was verified by
+nobody until it was built and run.
+
+Run: python3 -m unittest test_containerfiles -v
+"""
+
+import ast
+import os
+import re
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(os.path.dirname(HERE))
+CONTAINERFILES = ("Containerfile.chromium-bench", "Containerfile.webkit-bench")
+
+
+def copied_bench_files(containerfile: str) -> set[str]:
+    """Basenames of bench/chromium/* files the image COPYs.
+
+    Line continuations matter: the COPY lists span several lines with trailing
+    backslashes, and reading them line-by-line finds only the first entry.
+    """
+    with open(os.path.join(REPO, containerfile)) as handle:
+        text = handle.read()
+    text = re.sub(r"\\\s*\n", " ", text)  # join continuations
+    copied = set()
+    for line in text.splitlines():
+        if not line.strip().upper().startswith("COPY"):
+            continue
+        for token in re.findall(r"bench/chromium/([\w.]+)", line):
+            copied.add(token)
+    return copied
+
+
+def local_imports(module_basename: str) -> set[str]:
+    """Top-level imports of this module that resolve to a sibling .py here.
+
+    Only module-scope imports: an import inside a function fails at call time,
+    which is a different (and louder) failure than one at import time.
+    """
+    path = os.path.join(HERE, module_basename)
+    with open(path) as handle:
+        tree = ast.parse(handle.read(), filename=path)
+    names = set()
+    for node in tree.body:  # body only -- module scope
+        if isinstance(node, ast.Import):
+            names.update(a.name.split(".")[0] for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            names.add(node.module.split(".")[0])
+    return {n for n in names if os.path.exists(os.path.join(HERE, n + ".py"))}
+
+
+class ContainerfileImports(unittest.TestCase):
+    def test_every_copied_module_brings_what_it_imports(self):
+        """A shipped module whose sibling import is missing dies at import.
+
+        Checked for each Containerfile independently, because the two images
+        ship different sets and the failure is per-image.
+        """
+        for containerfile in CONTAINERFILES:
+            with self.subTest(containerfile=containerfile):
+                copied = copied_bench_files(containerfile)
+                self.assertTrue(
+                    copied,
+                    f"{containerfile} COPYs no bench/chromium files; either the parser "
+                    "broke or the image no longer ships the harness",
+                )
+                for module in sorted(m for m in copied if m.endswith(".py")):
+                    for needed in sorted(local_imports(module)):
+                        self.assertIn(
+                            needed + ".py",
+                            copied,
+                            f"{containerfile} copies {module}, which imports {needed} at "
+                            f"module scope, but does not copy {needed}.py. The container "
+                            f"fails with ModuleNotFoundError on first import -- and "
+                            f"quietly, because entry.sh backgrounds it.",
+                        )
+
+    def test_the_copy_parser_reads_continuations(self):
+        """Guard the guard.
+
+        The COPY lists wrap across lines with trailing backslashes. A parser
+        that reads line-by-line sees only the first path on each COPY and
+        reports a nearly empty set -- which would make the test above pass by
+        finding nothing to check. This pins that the parser sees a realistic
+        number of files.
+        """
+        for containerfile in CONTAINERFILES:
+            with self.subTest(containerfile=containerfile):
+                copied = copied_bench_files(containerfile)
+                self.assertGreaterEqual(
+                    len(copied),
+                    3,
+                    f"only {sorted(copied)} parsed out of {containerfile}; the COPY "
+                    "parser is not following line continuations, so the import check "
+                    "above is inspecting almost nothing",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/chromium/test_engine_seam.py
+++ b/bench/chromium/test_engine_seam.py
@@ -18,6 +18,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import time
 import unittest
 from unittest import mock
 
@@ -121,7 +122,7 @@ class SessionDiscovery(unittest.TestCase):
             run.return_value = subprocess.CompletedProcess(
                 args=[], returncode=0, stdout="", stderr="")
             with self.assertRaises(reqbench.SessionDiscoveryFailed) as caught:
-                reqbench.discover_wd_session(args, 1234)
+                reqbench.discover_wd_session(args, 1234, time.monotonic() + 5.0)
         self.assertIn("session discovery failed", str(caught.exception))
 
     def test_discovery_failure_escalates_out_of_the_rep_handler(self):
@@ -144,7 +145,7 @@ class SessionDiscovery(unittest.TestCase):
         with mock.patch.object(subprocess, "run") as run:
             run.return_value = subprocess.CompletedProcess(
                 args=[], returncode=0, stdout="  abc-123\n", stderr="")
-            self.assertEqual(reqbench.discover_wd_session(args, 1), "abc-123")
+            self.assertEqual(reqbench.discover_wd_session(args, 1, time.monotonic() + 5.0), "abc-123")
 
 
 class EngineDispatch(unittest.TestCase):
@@ -179,6 +180,34 @@ class EngineDispatch(unittest.TestCase):
         self.assertIn("discover_wd_session", src)
         self.assertIn("cdpdrive.drive", src,
                       "the chromium path was lost while adding webkit")
+
+
+class DiscoveryFailureClassification(unittest.TestCase):
+    """Every discovery failure mode is SessionDiscoveryFailed, so it escalates.
+
+    A subprocess.TimeoutExpired or OSError left as itself is an ordinary
+    Exception the per-rep handler records and retries; the session id is
+    snapshot state, so each retry repeats the full wait for the same answer.
+    """
+
+    def discover(self):
+        args = argparse.Namespace(fcvm="/bin/true", wd_session_id="")
+        return reqbench.discover_wd_session(args, 1234, time.monotonic() + 5.0)
+
+    def test_a_discovery_timeout_escalates(self):
+        with mock.patch.object(
+            reqbench.subprocess, "run",
+            side_effect=reqbench.subprocess.TimeoutExpired(cmd="x", timeout=1),
+        ):
+            with self.assertRaises(reqbench.SessionDiscoveryFailed):
+                self.discover()
+
+    def test_an_unlaunchable_fcvm_escalates(self):
+        with mock.patch.object(
+            reqbench.subprocess, "run", side_effect=OSError("no such file"),
+        ):
+            with self.assertRaises(reqbench.SessionDiscoveryFailed):
+                self.discover()
 
 
 class WebkitAnalyzerSchema(unittest.TestCase):
@@ -301,6 +330,22 @@ class WebkitAnalyzerSchema(unittest.TestCase):
         self.assertEqual(
             schema_noise, [],
             "a healthy webkit render must not fail chromium-schema checks",
+        )
+
+    def test_a_webkit_render_with_no_engine_stamp_fails(self):
+        """A missing render engine stamp means chromium (cdpdrive writes no
+        stamp), so on a webkit run it must be flagged as a mismatch, not
+        inherited from the meta.
+        """
+        def drop_engine_stamp(records):
+            for record in records:
+                if record["arm"] == "cdp":
+                    del record["render"]["engine"]
+
+        dataset = self.load_dataset(mutate=drop_engine_stamp)
+        self.assertTrue(
+            any("mismatches metadata" in error for error in dataset["metadata_errors"]),
+            f"unstamped renders must not pass a webkit run: {dataset['metadata_errors']}",
         )
 
     def test_a_webkit_render_missing_its_own_stages_still_fails(self):

--- a/bench/chromium/test_engine_seam.py
+++ b/bench/chromium/test_engine_seam.py
@@ -16,10 +16,14 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import threading
 import unittest
 from unittest import mock
 
+import random
+
+import reqanalyze
 import reqbench
 import wddrive
 
@@ -177,10 +181,6 @@ class EngineDispatch(unittest.TestCase):
                       "the chromium path was lost while adding webkit")
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class WebkitAnalyzerSchema(unittest.TestCase):
     """The publication gate judges each engine's renders by that engine's schema.
 
@@ -208,20 +208,41 @@ class WebkitAnalyzerSchema(unittest.TestCase):
     )
 
     @staticmethod
-    def healthy_webkit_dataset():
-        import random
+    def webkit_run_lines():
+        """One healthy ENGINE=webkit run as (meta, records) JSONL lines.
 
+        The records realise the seeded schedule exactly, in order, so the only
+        errors a test can observe are the schema checks under test.
+        """
         meta = {
             "kind": "meta", "run_id": "wk", "engine": "webkit",
+            "backend": "uffd", "uffd_mode": "copy",
             "format": "png", "quality": 85, "url": "http://c/p",
             "urls": None, "arms": ["cdp", "noop"], "reps": 1, "warmup": 1,
-            "seed": 7, "started": 1.0, "ws_url_prewired": None,
+            "seed": 7, "started": 1.0,
+            "image": "localhost/webkit-bench-req",
+            "image_id": "sha256:" + "d" * 64, "snapshot": "snapshot-wk",
+            "snapshot_generation_id": "22222222-2222-4222-8222-222222222222",
+            "snapshot_config_sha256": "7" * 64,
+            "snapshot_created_at": "2026-08-09T00:00:00Z",
+            "snapshot_vm_id": "vm-" + "f" * 32,
+            "fcvm_sha256": "a" * 64, "harness_sha256": "c" * 64,
+            "runtime_bundle_sha256": "8" * 64,
+            "source_revision": "b" * 40,
+            "cdp_port": 9515, "network_mode": "rootless", "cpu": 2,
+            "port_mappings": [{
+                "host_ip": None, "host_port": 9515, "guest_port": 9515,
+                "proto": "tcp",
+            }],
+            "memory_mib": 1024,
+            "rust_log": "fcvm=debug", "ws_url_prewired": False,
+            "allow_busy": False,
+            "host_boot_id": "00000000-0000-0000-0000-000000000001",
+            "host_kernel_release": "6.18.0-fixture", "host_machine": "aarch64",
             "loadavg": [0.5, 0.5, 0.5], "quiet_loadavg1_limit": 2.0,
             "quiet_vm_processes": 0, "quiet_guard_loadavg1": 0.5,
             "quiet_guard_passed": True,
-            "_source": {"path": "t.jsonl", "line": 1},
         }
-        # Records must realise the seeded schedule exactly, in order.
         rng = random.Random(meta["seed"])
         schedule = []
         for rep in range(meta["warmup"] + meta["reps"]):
@@ -229,13 +250,12 @@ class WebkitAnalyzerSchema(unittest.TestCase):
             rng.shuffle(order)
             schedule.extend((arm, rep, rep < meta["warmup"]) for arm in order)
         records = []
-        for line, (arm, rep, is_warmup) in enumerate(schedule, start=2):
+        for arm, rep, is_warmup in schedule:
             record = {
                 "kind": "request", "arm": arm, "rep": rep, "warmup": is_warmup,
                 "ok": True, "blocking_ms": 12.0, "wall_ms": 20.0,
                 "record_id": f"wk:{arm}:{rep}:{int(is_warmup)}", "run_id": "wk",
                 "url": meta["url"],
-                "_source": {"path": "t.jsonl", "line": line},
             }
             if arm == "cdp":
                 record.update({
@@ -255,17 +275,25 @@ class WebkitAnalyzerSchema(unittest.TestCase):
                     },
                 })
             records.append(record)
-        return {
-            "backend": "uffd", "cell": None, "cell_id": None, "run_id": "wk",
-            "records": records, "metas": [meta], "sources": ["t.jsonl"],
-            "source_artifacts": [], "metadata_errors": [],
-        }
+        return meta, records
+
+    def load_dataset(self, mutate=None):
+        """Round-trip the fixture run through reqanalyze.load(), as real
+        datasets arrive: the loader builds the envelope, stamps provenance,
+        and runs the schedule validation whose errors the tests read."""
+        meta, records = self.webkit_run_lines()
+        if mutate is not None:
+            mutate(records)
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "wk.jsonl")
+            with open(path, "w") as f:
+                for line in [meta, *records]:
+                    f.write(json.dumps(line) + "\n")
+            (dataset,) = reqanalyze.load([path])
+        return dataset
 
     def test_a_healthy_webkit_render_raises_no_chromium_schema_errors(self):
-        import reqanalyze
-
-        dataset = self.healthy_webkit_dataset()
-        reqanalyze._validate_schedule(dataset)
+        dataset = self.load_dataset()
         schema_noise = [
             error for error in dataset["metadata_errors"]
             if any(complaint in error for complaint in self.CHROMIUM_ONLY_COMPLAINTS)
@@ -276,16 +304,19 @@ class WebkitAnalyzerSchema(unittest.TestCase):
         )
 
     def test_a_webkit_render_missing_its_own_stages_still_fails(self):
-        import reqanalyze
+        def drop_screenshot_stage(records):
+            measured_cdp = next(
+                record for record in records
+                if record["arm"] == "cdp" and not record["warmup"]
+            )
+            del measured_cdp["render"]["stages"]["screenshot_ms"]
 
-        dataset = self.healthy_webkit_dataset()
-        measured_cdp = next(
-            record for record in dataset["records"]
-            if record["arm"] == "cdp" and not record["warmup"]
-        )
-        del measured_cdp["render"]["stages"]["screenshot_ms"]
-        reqanalyze._validate_schedule(dataset)
+        dataset = self.load_dataset(mutate=drop_screenshot_stage)
         self.assertTrue(
             any("invalid screenshot_ms" in error for error in dataset["metadata_errors"]),
             f"webkit schema must still gate its own stages: {dataset['metadata_errors']}",
         )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/chromium/test_engine_seam.py
+++ b/bench/chromium/test_engine_seam.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""The webkit engine seam: dispatch, discovery, and the driver contract.
+
+The seam exists so ONE harness (reqbench) produces records for two engines with
+identical accounting. The failure modes it must not have: silently rendering
+with the wrong driver (a chromium record labelled webkit), a lost session id
+surfacing 202 reps later as uniform navigate failures, and a webkit result
+whose field names the analyzer cannot read.
+
+Run: python3 -m unittest test_engine_seam -v
+"""
+
+import argparse
+import http.server
+import json
+import os
+import subprocess
+import sys
+import threading
+import unittest
+from unittest import mock
+
+import reqbench
+import wddrive
+
+
+class DriveContract(unittest.TestCase):
+    """wddrive.drive() must honour cdpdrive.drive()'s record contract."""
+
+    def drive_against(self, handler_cls, session="warm-sess", timeout=15.0):
+        server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        self.addCleanup(server.server_close)
+        self.addCleanup(server.shutdown)
+        return wddrive.drive(argparse.Namespace(
+            cdp_host=f"127.0.0.1:{server.server_port}",
+            url="http://page/x", timeout=timeout,
+            session_id=session, out_prefix="",
+        ))
+
+    def test_a_successful_render_carries_the_analyzer_fields(self):
+        """ok, stages{navigate_ms, screenshot_ms, total_ms}, image_bytes,
+        image_sha256 -- the names reqanalyze aggregates. A webkit record with
+        different names is not wrong, it is INVISIBLE: the analyzer's medians
+        simply omit it and the run publishes with silently thinner stages.
+        """
+        png = b"\x89PNG\r\n\x1a\n" + b"x" * 64
+        import base64
+        b64 = base64.b64encode(png).decode()
+
+        class Driver(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *_): pass
+            def _send(self, value):
+                body = json.dumps({"value": value}).encode()
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            def do_GET(self):
+                if self.path.endswith("/screenshot"):
+                    self._send(b64)
+                elif self.path.endswith("/url"):
+                    self._send("http://page/x")
+                else:
+                    self._send({"ready": True})
+            def do_POST(self):
+                self.rfile.read(int(self.headers.get("Content-Length", 0)))
+                if self.path.endswith("/execute/sync"):
+                    self._send(["complete", True])
+                else:
+                    self._send(None)
+
+        result = self.drive_against(Driver)
+        self.assertTrue(result["ok"], result.get("error"))
+        self.assertEqual(result["engine"], "webkit")
+        for key in ("navigate_ms", "screenshot_ms", "total_ms", "resolve_ms"):
+            self.assertIn(key, result["stages"], f"stage {key} missing")
+        self.assertEqual(result["image_bytes"], len(png))
+        self.assertEqual(len(result["image_sha256"]), 64)
+
+    def test_a_failure_is_a_labelled_record_not_a_traceback(self):
+        """cdpdrive's rule, inherited: drive() NEVER raises for a driver-side
+        failure. reqbench stores whatever comes back; an exception would be
+        swallowed by its broad except and every rep would fail with the cause
+        off-screen.
+        """
+        result = wddrive.drive(argparse.Namespace(
+            cdp_host="127.0.0.1:1", url="http://x/", timeout=0.3,
+            session_id="s", out_prefix=""))
+        self.assertFalse(result["ok"])
+        self.assertIn("error", result)
+        self.assertEqual(result["failed_stage"], "status")
+        self.assertIn("total_ms", result["stages"])
+
+    def test_a_missing_session_id_fails_before_any_network(self):
+        result = wddrive.drive(argparse.Namespace(
+            cdp_host="127.0.0.1:1", url="http://x/", timeout=5.0,
+            session_id="", out_prefix=""))
+        self.assertFalse(result["ok"])
+        self.assertIn("no session id", result["error"])
+
+
+class SessionDiscovery(unittest.TestCase):
+    def test_discovery_raises_loudly_when_exec_yields_nothing(self):
+        """An empty session id must stop the run AT DISCOVERY.
+
+        Returned silently, it becomes 202 navigate failures with the real cause
+        (the golden never baked a session file) nowhere in the record.
+        """
+        args = argparse.Namespace(fcvm="/bin/false")
+        with mock.patch.object(subprocess, "run") as run:
+            run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr="")
+            with self.assertRaises(RuntimeError) as caught:
+                reqbench.discover_wd_session(args, 1234)
+        self.assertIn("session discovery failed", str(caught.exception))
+
+    def test_discovery_strips_and_returns_the_id(self):
+        args = argparse.Namespace(fcvm="/bin/true")
+        with mock.patch.object(subprocess, "run") as run:
+            run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="  abc-123\n", stderr="")
+            self.assertEqual(reqbench.discover_wd_session(args, 1), "abc-123")
+
+
+class EngineDispatch(unittest.TestCase):
+    def test_reqbench_exposes_the_engine_flag_with_chromium_default(self):
+        """The flag is the seam. Its default must stay chromium: every existing
+        record and every chromium invocation predates the flag, and a changed
+        default silently relabels them.
+        """
+        import io
+        import contextlib
+        buf = io.StringIO()
+        with self.assertRaises(SystemExit), contextlib.redirect_stdout(buf):
+            saved = sys.argv
+            try:
+                sys.argv = ["reqbench.py", "--help"]
+                reqbench.main()
+            finally:
+                sys.argv = saved
+        text = buf.getvalue()
+        self.assertIn("--engine", text)
+        self.assertIn("webkit", text)
+
+    def test_the_webkit_branch_exists_and_is_reached_by_engine(self):
+        """Structural pin on the dispatch itself: run_cdp_request must consult
+        args.engine and route webkit to wddrive. The behavioural half (a full
+        fake clone) needs a VM; the routing decision does not.
+        """
+        import inspect
+        src = inspect.getsource(reqbench.run_cdp_request)
+        self.assertIn('== "webkit"', src)
+        self.assertIn("wddrive.drive", src)
+        self.assertIn("discover_wd_session", src)
+        self.assertIn("cdpdrive.drive", src,
+                      "the chromium path was lost while adding webkit")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/chromium/test_engine_seam.py
+++ b/bench/chromium/test_engine_seam.py
@@ -89,7 +89,12 @@ class DriveContract(unittest.TestCase):
             session_id="s", out_prefix=""))
         self.assertFalse(result["ok"])
         self.assertIn("error", result)
-        self.assertEqual(result["failed_stage"], "status")
+        # The seam contract key is "stage" (cdpdrive.py writes out["stage"];
+        # reqbench.py lifts result.get("stage") into rec["failure_stage"]).
+        # This test once pinned wddrive's deviant "failed_stage", so the suite
+        # passed while the harness recorded failure_stage="" for every
+        # webkit failure.
+        self.assertEqual(result["stage"], "status")
         self.assertIn("total_ms", result["stages"])
 
     def test_a_missing_session_id_fails_before_any_network(self):
@@ -111,9 +116,24 @@ class SessionDiscovery(unittest.TestCase):
         with mock.patch.object(subprocess, "run") as run:
             run.return_value = subprocess.CompletedProcess(
                 args=[], returncode=0, stdout="", stderr="")
-            with self.assertRaises(RuntimeError) as caught:
+            with self.assertRaises(reqbench.SessionDiscoveryFailed) as caught:
                 reqbench.discover_wd_session(args, 1234)
         self.assertIn("session discovery failed", str(caught.exception))
+
+    def test_discovery_failure_escalates_out_of_the_rep_handler(self):
+        """The raise alone is not the abort: the per-rep handler catches
+        BaseException and, before this predicate existed, recorded the failure
+        and let the schedule continue -- every later rep re-spawned a clone,
+        re-ran discovery, and failed the same way, exactly the 202-doomed-reps
+        outcome the discovery docstring promises to prevent. The handler must
+        escalate SessionDiscoveryFailed (after that rep's teardown) the same
+        way it escalates a host interrupt, and must NOT escalate an ordinary
+        per-rep failure."""
+        self.assertTrue(reqbench.rep_error_escalates(
+            reqbench.SessionDiscoveryFailed("no session")))
+        self.assertTrue(reqbench.rep_error_escalates(KeyboardInterrupt()))
+        self.assertFalse(reqbench.rep_error_escalates(RuntimeError("one bad rep")))
+        self.assertFalse(reqbench.rep_error_escalates(OSError("transient")))
 
     def test_discovery_strips_and_returns_the_id(self):
         args = argparse.Namespace(fcvm="/bin/true")
@@ -159,3 +179,113 @@ class EngineDispatch(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class WebkitAnalyzerSchema(unittest.TestCase):
+    """The publication gate judges each engine's renders by that engine's schema.
+
+    Before the analyzer learned the webkit schema, a healthy webkit render
+    failed ~13 structural checks written for cdpdrive records (cdp_host,
+    idle policy, prewire, the six WebSocket/idle/decode stages, width/height,
+    quality, navigation timing), so an ENGINE=webkit run could never gate
+    clean even with every render healthy.
+    """
+
+    CHROMIUM_ONLY_COMPLAINTS = (
+        "does not match",           # cdp_host / format held to the wrong keys
+        "idle policy",
+        "prewire",
+        "invalid tcp_ms",
+        "invalid upgrade_ms",
+        "invalid enable_ms",
+        "invalid idle_ms",
+        "invalid decode_ms",
+        "invalid nav_timing_ms",
+        "invalid width",
+        "invalid height",
+        "quality mismatches",
+        "no navigation timing",
+    )
+
+    @staticmethod
+    def healthy_webkit_dataset():
+        import random
+
+        meta = {
+            "kind": "meta", "run_id": "wk", "engine": "webkit",
+            "format": "png", "quality": 85, "url": "http://c/p",
+            "urls": None, "arms": ["cdp", "noop"], "reps": 1, "warmup": 1,
+            "seed": 7, "started": 1.0, "ws_url_prewired": None,
+            "loadavg": [0.5, 0.5, 0.5], "quiet_loadavg1_limit": 2.0,
+            "quiet_vm_processes": 0, "quiet_guard_loadavg1": 0.5,
+            "quiet_guard_passed": True,
+            "_source": {"path": "t.jsonl", "line": 1},
+        }
+        # Records must realise the seeded schedule exactly, in order.
+        rng = random.Random(meta["seed"])
+        schedule = []
+        for rep in range(meta["warmup"] + meta["reps"]):
+            order = list(meta["arms"])
+            rng.shuffle(order)
+            schedule.extend((arm, rep, rep < meta["warmup"]) for arm in order)
+        records = []
+        for line, (arm, rep, is_warmup) in enumerate(schedule, start=2):
+            record = {
+                "kind": "request", "arm": arm, "rep": rep, "warmup": is_warmup,
+                "ok": True, "blocking_ms": 12.0, "wall_ms": 20.0,
+                "record_id": f"wk:{arm}:{rep}:{int(is_warmup)}", "run_id": "wk",
+                "url": meta["url"],
+                "_source": {"path": "t.jsonl", "line": line},
+            }
+            if arm == "cdp":
+                record.update({
+                    "endpoint": "127.0.0.1:9515",
+                    "state_to_port_ms": 1.0, "spawn_to_port_ms": 2.0,
+                    "render": {
+                        "ok": True, "engine": "webkit",
+                        "wd_host": "127.0.0.1:9515", "url": meta["url"],
+                        "format": "png", "session_prewired": True,
+                        "session_id": "s", "image_bytes": 10,
+                        "image_sha256": "a" * 64,
+                        "stages": {
+                            "resolve_ms": 1.0, "connect_total_ms": 2.0,
+                            "navigate_ms": 3.0, "screenshot_ms": 4.0,
+                            "total_ms": 10.0,
+                        },
+                    },
+                })
+            records.append(record)
+        return {
+            "backend": "uffd", "cell": None, "cell_id": None, "run_id": "wk",
+            "records": records, "metas": [meta], "sources": ["t.jsonl"],
+            "source_artifacts": [], "metadata_errors": [],
+        }
+
+    def test_a_healthy_webkit_render_raises_no_chromium_schema_errors(self):
+        import reqanalyze
+
+        dataset = self.healthy_webkit_dataset()
+        reqanalyze._validate_schedule(dataset)
+        schema_noise = [
+            error for error in dataset["metadata_errors"]
+            if any(complaint in error for complaint in self.CHROMIUM_ONLY_COMPLAINTS)
+        ]
+        self.assertEqual(
+            schema_noise, [],
+            "a healthy webkit render must not fail chromium-schema checks",
+        )
+
+    def test_a_webkit_render_missing_its_own_stages_still_fails(self):
+        import reqanalyze
+
+        dataset = self.healthy_webkit_dataset()
+        measured_cdp = next(
+            record for record in dataset["records"]
+            if record["arm"] == "cdp" and not record["warmup"]
+        )
+        del measured_cdp["render"]["stages"]["screenshot_ms"]
+        reqanalyze._validate_schedule(dataset)
+        self.assertTrue(
+            any("invalid screenshot_ms" in error for error in dataset["metadata_errors"]),
+            f"webkit schema must still gate its own stages: {dataset['metadata_errors']}",
+        )

--- a/bench/chromium/test_health_state.py
+++ b/bench/chromium/test_health_state.py
@@ -146,6 +146,12 @@ class HealthStateReader(unittest.TestCase):
             spec.loader.exec_module(cdp_health)
 
             state = os.path.join(directory, "bench-health")
+            # Set the ENV, which is what health_state.sh reads too, rather than
+            # patching a module attribute. publish() resolves the path per call
+            # via the same variable, so this exercises the one resolution both
+            # sides actually use instead of a test-only back door.
+            os.environ["BENCH_HEALTH_STATE"] = state
+            self.addCleanup(os.environ.pop, "BENCH_HEALTH_STATE", None)
             cdp_health.STATE_FILE = state
             cdp_health.publish("healthy", "pages=1 id=ABC")
 

--- a/bench/chromium/test_health_state.py
+++ b/bench/chromium/test_health_state.py
@@ -19,6 +19,7 @@ import unittest
 from pathlib import Path
 
 READER = Path(__file__).resolve().parent / "health_state.sh"
+SH_DIR = Path(__file__).resolve().parent
 
 
 def monotonic_now() -> int:
@@ -38,6 +39,43 @@ def run_reader(state: str | None, max_age: str | None = None) -> subprocess.Comp
         return subprocess.run(
             ["bash", str(READER)], env=env, capture_output=True, text=True, check=False
         )
+
+
+class DefaultPathAgreement(unittest.TestCase):
+    def test_the_default_paths_agree_without_the_env(self):
+        """Writer and reader must meet at the same DEFAULT path.
+
+        Every other test here sets BENCH_HEALTH_STATE on both halves, so a
+        writer default of /run/WRONG-PATH passes the whole file -- verified by
+        mutation: 9/9 green with the default broken. Production sets the env
+        nowhere (neither entry script, neither Containerfile, not reqbench.sh),
+        so the DEFAULTS are the only contract that matters, and they were
+        enforced by nothing. A divergence reports every clone unhealthy -- or
+        worse, healthy off a stale file at the old path.
+
+        unshare gives this test a private /run without root: a user+mount
+        namespace with a tmpfs over /run, the writer publishing through its
+        default, the reader reading through its own. 23 ms, no container.
+        """
+        script = (
+            "mount -t tmpfs tmpfs /run && "
+            f"cd {SH_DIR} && "
+            "python3 -c \"import health_loop; health_loop.publish('healthy', 'pages=1 id=E2E')\" && "
+            "exec bash health_state.sh"
+        )
+        result = subprocess.run(
+            ["unshare", "-rm", "bash", "-c", script],
+            capture_output=True, text=True, timeout=60,
+            env={k: v for k, v in os.environ.items() if k != "BENCH_HEALTH_STATE"},
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            "the reader did not accept a verdict the writer just published "
+            "through both DEFAULT paths; they have diverged\n"
+            + result.stdout + result.stderr,
+        )
+        self.assertIn("id=E2E", result.stdout,
+                      "the reader passed but not on the verdict this test wrote")
 
 
 class HealthStateReader(unittest.TestCase):
@@ -87,7 +125,15 @@ class HealthStateReader(unittest.TestCase):
         # 64-bit integers, so a value that does not fit returns status 2 exactly
         # like a non-numeric one. A digits-only check passes them and the gate
         # falls open, which is the same defect wearing a disguise.
+        # 19 digits is the INT64 boundary case, and the only exploitable one:
+        # `[ -gt ]` accepts up to 9223372036854775807 (19 digits), so a length
+        # bound loosened to 19 admits budgets the comparison then chokes on.
+        # The 20- and 48-digit probes below are past the boundary and even a
+        # bound of 19 refuses them -- mutation testing showed the pair passing
+        # with the bound at 19 while a 19-digit budget waved a stale verdict
+        # through (`healthy (age 237s)`, exit 0).
         for budget in ("notanumber", "", "7s", "-1", "7.5",
+                       "9999999999999999999",
                        "99999999999999999999",
                        "999999999999999999999999999999999999999999999999"):
             with self.subTest(budget=budget):

--- a/bench/chromium/test_health_state.py
+++ b/bench/chromium/test_health_state.py
@@ -14,6 +14,7 @@ died. That is the green-by-absence shape this repo keeps finding in gates.
 """
 import os
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -76,6 +77,51 @@ class DefaultPathAgreement(unittest.TestCase):
         )
         self.assertIn("id=E2E", result.stdout,
                       "the reader passed but not on the verdict this test wrote")
+
+
+class ProbeContract(unittest.TestCase):
+    def test_every_probe_branch_returns_a_reason_tuple(self) -> None:
+        """main_with_reason() promises (int, str); every branch must keep it.
+
+        health_loop.loop() unpacks the pair, so a branch that returns a bare
+        int crashes the resident checker with `TypeError: cannot unpack
+        non-iterable int object`. The loop's crash guard fails closed, so the
+        symptom is not a wrong verdict but a checker that dies and a container
+        that goes unhealthy with a traceback for a reason as mundane as "the
+        warm marker is not there yet". wd_health's absent-marker branch shipped
+        exactly that: every other branch returned the tuple and it returned 1.
+
+        Driven for real: absent marker (the shipped bug's branch), then a
+        marker with an unreadable session file (the next branch down).
+        """
+        import importlib
+        with tempfile.TemporaryDirectory() as tmp:
+            for env, why in (
+                ({"BENCH_READY_FILE": os.path.join(tmp, "absent")},
+                 "warm marker absent"),
+                ({"BENCH_READY_FILE": __file__,
+                  "BENCH_SESSION_FILE": os.path.join(tmp, "no-session")},
+                 "session file unreadable"),
+            ):
+                with self.subTest(why=why):
+                    old = {k: os.environ.get(k) for k in env}
+                    os.environ.update(env)
+                    try:
+                        import wd_health
+                        importlib.reload(wd_health)
+                        result = wd_health.main_with_reason()
+                    finally:
+                        for k, v in old.items():
+                            if v is None:
+                                os.environ.pop(k, None)
+                            else:
+                                os.environ[k] = v
+                    self.assertIsInstance(result, tuple,
+                                          f"{why}: returned {result!r}, which "
+                                          "health_loop.loop() cannot unpack")
+                    self.assertEqual(len(result), 2)
+                    self.assertIsInstance(result[0], int)
+                    self.assertIsInstance(result[1], str)
 
 
 class HealthStateReader(unittest.TestCase):
@@ -160,9 +206,22 @@ class HealthStateReader(unittest.TestCase):
         self.assertEqual(result.returncode, 1, result.stdout)
 
     def test_garbage_is_not_healthy(self) -> None:
-        for junk in ("\n", "healthy\n", "healthy notanumber exit=0\n"):
+        # (input, the diagnostic its OWN guard prints). Exit code alone is not
+        # enough: with the validation deleted, `set -u` still aborts with 1 on
+        # the arithmetic error -- the right exit for the wrong reason, which is
+        # the accident the guard's comment says it exists to replace. The
+        # message pins WHICH check refused.
+        for junk, diagnostic in (
+            ("\n", "unrecognised verdict"),
+            ("healthy\n", "unparsable stamp"),
+            ("healthy notanumber exit=0\n", "unparsable stamp"),
+        ):
             with self.subTest(junk=junk):
-                self.assertEqual(run_reader(junk).returncode, 1, f"accepted {junk!r}")
+                result = run_reader(junk)
+                self.assertEqual(result.returncode, 1, f"accepted {junk!r}")
+                self.assertIn(diagnostic, result.stderr,
+                              f"refused {junk!r} but not by its own guard: "
+                              f"stderr was {result.stderr!r}")
 
     def test_the_writer_and_reader_agree_on_the_format(self) -> None:
         """The contract that actually matters: publish() -> health_state.sh.
@@ -183,10 +242,19 @@ class HealthStateReader(unittest.TestCase):
             # correct: the test reported drift that did not exist, and would
             # equally have hidden drift that did. A directory with no cache
             # cannot lie about which source ran.
+            # health_loop.py must come along: publish() lives there now, and
+            # importing it from the real tree reads bench/chromium/__pycache__
+            # -- the exact stale-bytecode hazard this copy exists to avoid.
+            shutil.copy(
+                Path(__file__).resolve().parent / "health_loop.py",
+                os.path.join(directory, "health_loop.py"),
+            )
             source = shutil.copy(
                 Path(__file__).resolve().parent / "cdp_health.py",
                 os.path.join(directory, "cdp_health_under_test.py"),
             )
+            sys.path.insert(0, directory)
+            self.addCleanup(sys.path.remove, directory)
             spec = importlib.util.spec_from_file_location("cdp_health_under_test", source)
             cdp_health = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(cdp_health)

--- a/bench/chromium/test_health_state.py
+++ b/bench/chromium/test_health_state.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 READER = Path(__file__).resolve().parent / "health_state.sh"
@@ -280,14 +281,10 @@ class HealthStateReader(unittest.TestCase):
             # so a previously imported bench/chromium copy would satisfy it and
             # the temp copy above would never run -- the exact stale-bytecode
             # hazard this directory exists to avoid. Evict it so the import
-            # resolves through sys.path to the copy.
-            cached_health_loop = sys.modules.pop("health_loop", None)
-            if cached_health_loop is not None:
-                self.addCleanup(
-                    sys.modules.__setitem__, "health_loop", cached_health_loop
-                )
-            else:
-                self.addCleanup(sys.modules.pop, "health_loop", None)
+            # resolves through sys.path to the copy; patch.dict restores the
+            # whole mapping on cleanup.
+            self.enterContext(mock.patch.dict(sys.modules))
+            sys.modules.pop("health_loop", None)
             spec = importlib.util.spec_from_file_location("cdp_health_under_test", source)
             cdp_health = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(cdp_health)

--- a/bench/chromium/test_health_state.py
+++ b/bench/chromium/test_health_state.py
@@ -43,40 +43,61 @@ def run_reader(state: str | None, max_age: str | None = None) -> subprocess.Comp
 
 
 class DefaultPathAgreement(unittest.TestCase):
-    def test_the_default_paths_agree_without_the_env(self):
-        """Writer and reader must meet at the same DEFAULT path.
+    def test_the_default_paths_agree_without_the_env(self) -> None:
+        """Writer and reader must resolve the same DEFAULT state-file path.
 
         Every other test here sets BENCH_HEALTH_STATE on both halves, so a
         writer default of /run/WRONG-PATH passes the whole file -- verified by
         mutation: 9/9 green with the default broken. Production sets the env
         nowhere (neither entry script, neither Containerfile, not reqbench.sh),
-        so the DEFAULTS are the only contract that matters, and they were
-        enforced by nothing. A divergence reports every clone unhealthy -- or
-        worse, healthy off a stale file at the old path.
+        so the DEFAULTS are the only contract in use, and nothing enforced
+        them. A divergence reports every clone unhealthy -- or worse, healthy
+        off a stale file at the old path.
 
-        unshare gives this test a private /run without root: a user+mount
-        namespace with a tmpfs over /run, the writer publishing through its
-        default, the reader reading through its own. 23 ms, no container.
+        Both sides are asked, not read: the writer's answer is the real
+        health_loop.state_file() with the env absent; the reader's is the real
+        STATE_FILE assignment lifted from health_state.sh and EXECUTED under
+        bash with the env absent -- the shipped bytes, not a paraphrase of
+        them. A first version of this test proved the same thing end to end
+        under `unshare -rm` with a private tmpfs /run; GitHub-hosted runners
+        refuse unprivileged user namespaces (`unshare: write failed
+        /proc/self/uid_map: Operation not permitted`), and AGENTS.md is
+        explicit that a test must run where CI runs it. The write-then-read
+        mechanics this drops are covered by the format round-trip test below.
         """
-        script = (
-            "mount -t tmpfs tmpfs /run && "
-            f"cd {SH_DIR} && "
-            "python3 -c \"import health_loop; health_loop.publish('healthy', 'pages=1 id=E2E')\" && "
-            "exec bash health_state.sh"
+        import importlib
+
+        env = {k: v for k, v in os.environ.items() if k != "BENCH_HEALTH_STATE"}
+
+        old = os.environ.pop("BENCH_HEALTH_STATE", None)
+        try:
+            import health_loop
+            importlib.reload(health_loop)
+            writer_default = health_loop.state_file()
+        finally:
+            if old is not None:
+                os.environ["BENCH_HEALTH_STATE"] = old
+
+        reader_line = next(
+            (line for line in READER.read_text().splitlines()
+             if line.startswith("STATE_FILE=")),
+            None,
         )
-        result = subprocess.run(
-            ["unshare", "-rm", "bash", "-c", script],
-            capture_output=True, text=True, timeout=60,
-            env={k: v for k, v in os.environ.items() if k != "BENCH_HEALTH_STATE"},
+        self.assertIsNotNone(reader_line, "health_state.sh no longer assigns STATE_FILE")
+        resolved = subprocess.run(
+            ["bash", "-c", reader_line + '\nprintf "%s" "$STATE_FILE"'],
+            capture_output=True, text=True, timeout=30, env=env,
         )
+        self.assertEqual(resolved.returncode, 0, resolved.stderr)
+        reader_default = resolved.stdout
+
         self.assertEqual(
-            result.returncode, 0,
-            "the reader did not accept a verdict the writer just published "
-            "through both DEFAULT paths; they have diverged\n"
-            + result.stdout + result.stderr,
+            writer_default, reader_default,
+            "writer and reader resolve DIFFERENT default paths; every verdict "
+            "the loop publishes is invisible to the gate",
         )
-        self.assertIn("id=E2E", result.stdout,
-                      "the reader passed but not on the verdict this test wrote")
+        self.assertTrue(writer_default.startswith("/"),
+                        f"the shared default {writer_default!r} is not absolute")
 
 
 class ProbeContract(unittest.TestCase):

--- a/bench/chromium/test_health_state.py
+++ b/bench/chromium/test_health_state.py
@@ -276,6 +276,18 @@ class HealthStateReader(unittest.TestCase):
             )
             sys.path.insert(0, directory)
             self.addCleanup(sys.path.remove, directory)
+            # `import health_loop` inside exec_module hits sys.modules first,
+            # so a previously imported bench/chromium copy would satisfy it and
+            # the temp copy above would never run -- the exact stale-bytecode
+            # hazard this directory exists to avoid. Evict it so the import
+            # resolves through sys.path to the copy.
+            cached_health_loop = sys.modules.pop("health_loop", None)
+            if cached_health_loop is not None:
+                self.addCleanup(
+                    sys.modules.__setitem__, "health_loop", cached_health_loop
+                )
+            else:
+                self.addCleanup(sys.modules.pop, "health_loop", None)
             spec = importlib.util.spec_from_file_location("cdp_health_under_test", source)
             cdp_health = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(cdp_health)
@@ -287,7 +299,6 @@ class HealthStateReader(unittest.TestCase):
             # sides actually use instead of a test-only back door.
             os.environ["BENCH_HEALTH_STATE"] = state
             self.addCleanup(os.environ.pop, "BENCH_HEALTH_STATE", None)
-            cdp_health.STATE_FILE = state
             cdp_health.publish("healthy", "pages=1 id=ABC")
 
             env = dict(os.environ, BENCH_HEALTH_STATE=state)

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -1238,6 +1238,65 @@ class TeardownFastCpuAccounting(unittest.TestCase):
                 "into a no-op",
             )
 
+    def test_choppy_ambient_does_not_condemn_the_host(self):
+        """Fluctuating load must read as "cannot tell", not as "not tracking".
+
+        Pairing cancels STEADY ambient but amplifies FLUCTUATING ambient: a
+        load that starts or stops between the idle and burn windows lands in
+        the difference at full weight. Observed live -- two test suites running
+        concurrently made the probe condemn this host (median excess dragged
+        below tolerance), failing the positive-control test above once per
+        ~six runs.
+
+        The stub alternates ambient between 0 and 8 cores per WINDOW, the
+        worst case: every idle window quiet, every burn window loud, then the
+        reverse -- excesses scatter far beyond tolerance. A probe that trusts
+        its median here condemns the host; one that notices the pairs disagree
+        must fail toward "tracks" (keeping the strict violation path live) and
+        must NOT memoize, because choppiness describes the moment, not the
+        host.
+
+        RED WITHOUT THE FIX: the median-only version returns False.
+        """
+        from unittest import mock
+
+        # Four calls bracket each pair: idle start, idle end, burn start, burn
+        # end. The deltas between consecutive calls are therefore
+        # [idle-window, gap, burn-window, gap] per pair. Ambient of 8 cores
+        # lands in pair 0's IDLE window (excess strongly negative), pair 1's
+        # BURN window (strongly positive), nowhere in pair 2 (zero), and so on
+        # -- the pairs DISAGREE, which is what distinguishes chop from a
+        # counter that genuinely excludes this process (whose excesses agree
+        # near zero; that case is the frozen/ambient tests above and must
+        # still be condemned). The first stub of this test alternated ambient
+        # IDENTICALLY in every pair, so all five excesses were equal, the
+        # spread was zero, and the probe rightly condemned it -- a stub of
+        # consistent chop is a stub of a broken counter.
+        w = 8.0 * 320.0  # 8 cores for one ~320 ms window, in ms of CPU
+        deltas = iter([0.0,  # first read
+                       w, 0.0, 0.0, 0.0,    # pair 0: loud idle  -> excess -w
+                       0.0, 0.0, w, 0.0,    # pair 1: loud burn  -> excess +w
+                       0.0, 0.0, 0.0, 0.0,  # pair 2: quiet      -> excess 0
+                       w, 0.0, 0.0, 0.0,    # pair 3: loud idle  -> excess -w
+                       0.0, 0.0, w, 0.0])   # pair 4: loud burn  -> excess +w
+        state = {"clock": 0.0}
+
+        def choppy():
+            state["clock"] += next(deltas, 0.0)
+            return state["clock"]
+
+        with mock.patch.object(reqbench, "machine_cpu_ms", side_effect=choppy):
+            self.assertTrue(
+                reqbench.machine_counter_tracks_this_process(),
+                "a choppy ambient made the probe condemn the host; 'the pairs "
+                "disagree' must read as 'cannot tell', not as 'not tracking'",
+            )
+        self.assertIsNone(
+            reqbench._MACHINE_COUNTER_TRACKS,
+            "a cannot-tell verdict was memoized; the next campaign inherits a "
+            "guess about a moment, not a fact about the host",
+        )
+
     def test_reclaim_sampler_does_not_burn_a_core(self):
         """The RECLAIM window must not spin either — the control window is only half.
 

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -19,6 +19,7 @@ import io
 import json
 import os
 import random
+import re
 import signal
 import shlex
 import shutil
@@ -5606,6 +5607,26 @@ class TimedWsUpgradeDiagnostics(unittest.TestCase):
         self.assertIsInstance(diagnostics["socket_so_error"], int)
 
 
+class HarnessIdentity(unittest.TestCase):
+    """harness_sha256 must cover every staged script that defines a sample.
+
+    The staged runtime bundle (reqbench.sh's `for source in ...` list) is what
+    actually runs; a script in the bundle but not in the hash means two runs
+    with different driver code can carry the same harness identity. That was
+    real: wddrive.py defined every webkit sample while harness_sha256 omitted
+    it.
+    """
+
+    def test_harness_hash_covers_every_staged_request_script(self):
+        sh = open(os.path.join(HERE, "reqbench.sh")).read()
+        m = re.search(r"for source in ([^;]+); do", sh)
+        self.assertIsNotNone(m, "staged source list not found in reqbench.sh")
+        staged = set(m.group(1).split())
+        # reqanalyze.py is staged (the analysis step runs from the bundle) but
+        # defines no request sample.
+        self.assertEqual(set(reqbench.HARNESS_SOURCES), staged - {"reqanalyze.py"})
+
+
 class MakefileBenchGraph(unittest.TestCase):
     """The Chromium bench make targets must encode their real dependencies.
 
@@ -5708,6 +5729,24 @@ class MakefileBenchGraph(unittest.TestCase):
                "bench-chromium-request-all", "bench-chromium-hostcdp",
                "bench-chromium-fault"):
             self.assertIn(t, self.phony, f"{t} missing from .PHONY")
+
+    def test_webkit_run_forwards_the_measurement_knobs(self):
+        # Without the forwarding, `make bench-webkit-request-run REPS=202`
+        # silently ran reqbench.sh's default rep count and wrote to a
+        # RUNID-derived directory while analyze-chromium-request read the
+        # empty $(RESULTS).
+        recipe = "\n".join(self.recipes.get("bench-webkit-request-run", []))
+        for knob in ("BACKEND", "REPS", "WARMUP", "RESULTS"):
+            self.assertIn(f'{knob}="$({knob})"', recipe,
+                          f"bench-webkit-request-run does not forward {knob}")
+
+    def test_webkit_build_routes_through_the_healthcheck_assert(self):
+        # A raw `podman build` here skips cmd_build's HEALTHCHECK assertion,
+        # so an image that lost its healthcheck (OCI format drop) snapshots a
+        # cold browser and the golden gate cannot notice.
+        recipe = "\n".join(self.recipes.get("bench-webkit-request-build", []))
+        self.assertIn("reqbench.sh build", recipe)
+        self.assertNotIn("podman build", recipe)
 
     def test_fault_target_provisions_its_hugepage_pool(self):
         # faultbench selects uffd-huge-minor whenever the huge golden exists,

--- a/bench/chromium/test_wddrive.py
+++ b/bench/chromium/test_wddrive.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""navigate() must not report a render that has not happened yet.
+
+The WebKit arm exists because WebDriver's own navigate command is unreliable
+(the lost-completion defect documented in navigate's docstring), so navigate()
+establishes readiness itself. That makes navigate() the arm's only definition of
+"the page is up", and a false ready there does not fail -- it silently moves
+layout time out of navigate_ms and into screenshot_ms, or freezes a golden whose
+browser never rendered the fixture.
+
+Both guards against that were added in response to measurements, and a
+measurement is not a test: a number can be explained away, and it cannot be
+re-run against a later regression. These drive the two guards through a real
+HTTP server speaking the same protocol WebKit's driver does, so each one fails
+if its guard is removed.
+
+Run: python3 -m unittest test_wddrive -v
+"""
+
+import http.server
+import json
+import threading
+import unittest
+
+import wddrive
+
+
+class FakeDriver(http.server.BaseHTTPRequestHandler):
+    """A WebDriver endpoint whose script results are scripted by the test."""
+
+    def log_message(self, *_args):
+        pass  # keep the test output clean
+
+    def _reply(self, value):
+        body = json.dumps({"value": value}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)
+        script = self.server.plan
+        if self.path.endswith("/url"):
+            script["navigated"] = True
+            self._reply(None)
+        else:  # execute/sync
+            self._reply(script["results"].pop(0) if script["results"] else None)
+
+    def do_GET(self):
+        self._reply(self.server.plan["landed"])
+
+
+class NavigateReadiness(unittest.TestCase):
+    def drive(self, results, landed="http://page/x"):
+        """Serve one navigate() against a scripted sequence of script results."""
+        server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), FakeDriver)
+        # results[0] answers the sentinel plant; the rest answer the poll.
+        server.plan = {"results": list(results), "landed": landed,
+                       "navigated": False}
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        self.addCleanup(server.server_close)
+        self.addCleanup(server.shutdown)
+        host = f"127.0.0.1:{server.server_port}"
+        try:
+            wddrive.navigate(host, "sess", "http://page/x", timeout=10.0,
+                             poll_s=0.001)
+        finally:
+            self.remaining = len(server.plan["results"])
+            self.navigated = server.plan["navigated"]
+
+    def test_a_stale_complete_from_the_previous_document_is_not_ready(self):
+        """readyState is "complete" from the OLD document when navigate lands.
+
+        This is the false-ready that was caught in the field as navigate_ms=3.4
+        beside screenshot_ms=1120 -- the 985 ms of layout had not started, let
+        alone finished. The only thing separating the old document from the new
+        one is the sentinel: a real document swap wipes the global, so
+        `swapped` false means this "complete" belongs to the page we are
+        navigating AWAY from.
+
+        Remove the `swapped` term from navigate()'s readiness condition and this
+        returns on the first poll with two results unconsumed.
+        """
+        self.drive([
+            1,                    # sentinel planted on the old document
+            ["complete", False],  # old document, still "complete" -- NOT ready
+            ["loading", True],    # new document has begun
+            ["complete", True],   # new document finished: ready
+        ])
+        self.assertEqual(self.remaining, 0,
+                         "navigate() returned before the document swapped, "
+                         "which is the false-ready the sentinel exists to catch")
+
+    def test_an_error_page_is_a_failed_load_and_not_a_render(self):
+        """WebKit's network-error page is a real document that reaches complete.
+
+        It wipes the sentinel and satisfies every readiness term, so without
+        comparing the landed URL a dead pageserver yields a successful render
+        over a screenshot of "Unable to load page". Chromium's twin is guarded
+        by render.py raising on nav["errorText"]; WebDriver classic exposes no
+        such field, which is why this compares document.URL instead.
+        """
+        with self.assertRaises(wddrive.WdError) as caught:
+            self.drive([1, ["complete", True]], landed="about:blank")
+        self.assertIn("landed elsewhere", str(caught.exception))
+
+    def test_a_fresh_session_navigates_without_a_previous_document(self):
+        """No previous document means no stale "complete" to guard against.
+
+        The sentinel plant is allowed to fail ONLY here, and navigate() must
+        still proceed -- a fresh session is the first thing the warm gate does.
+        """
+        self.drive([
+            wddrive.WdError("no such window (POST /session/sess/execute/sync)"),
+            ["complete", True],
+        ])
+        self.assertTrue(self.navigated)
+
+    def test_any_other_sentinel_failure_propagates(self):
+        """Anything but the fresh-session case must NOT fall back silently.
+
+        Treating a transient error as "no sentinel available" re-enables the
+        stale-complete path for a session that does have a previous document,
+        which is the same false-ready measured above wearing a different hat.
+        """
+        with self.assertRaises(wddrive.WdError):
+            self.drive([wddrive.WdError("unknown error: driver went away")])
+        self.assertFalse(self.navigated,
+                         "a failed sentinel must stop before navigating")
+
+
+def _install_error_replies():
+    """Let a scripted result be an exception the fake driver raises as HTTP 500.
+
+    Keeps the plan a flat list: a WdError in the sequence stands for "this round
+    trip fails", which is how the two sentinel-failure cases above are written.
+    """
+    original = FakeDriver._reply
+
+    def reply(self, value):
+        if isinstance(value, wddrive.WdError):
+            body = json.dumps({"value": {"error": "no such window",
+                                         "message": str(value)}}).encode()
+            if "unknown error" in str(value):
+                body = json.dumps({"value": {"error": "unknown error",
+                                             "message": str(value)}}).encode()
+            self.send_response(404)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        original(self, value)
+
+    FakeDriver._reply = reply
+
+
+_install_error_replies()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/chromium/test_wddrive.py
+++ b/bench/chromium/test_wddrive.py
@@ -106,7 +106,18 @@ class NavigateReadiness(unittest.TestCase):
         """
         with self.assertRaises(wddrive.WdError) as caught:
             self.drive([1, ["complete", True]], landed="about:blank")
-        self.assertIn("landed elsewhere", str(caught.exception))
+        self.assertIn("landed off-origin", str(caught.exception))
+
+    def test_a_same_origin_redirect_is_a_render_not_a_failure(self):
+        """The landed-URL guard compares origins, not full URLs.
+
+        The corpus preflight admits redirecting URLs and replayed real-site JS
+        rewrites document.URL via history.replaceState, so a same-origin
+        path/query difference is a legitimate render. Full-URL equality here
+        failed loads the Chromium arm passes.
+        """
+        self.drive([1, ["complete", True]], landed="http://page/x?session=abc")
+        self.assertTrue(self.navigated)
 
     def test_a_fresh_session_navigates_without_a_previous_document(self):
         """No previous document means no stale "complete" to guard against.

--- a/bench/chromium/test_wddrive.py
+++ b/bench/chromium/test_wddrive.py
@@ -54,7 +54,8 @@ class FakeDriver(http.server.BaseHTTPRequestHandler):
 
 
 class NavigateReadiness(unittest.TestCase):
-    def drive(self, results, landed="http://page/x"):
+    def drive(self, results, landed="http://page/x", url="http://page/x",
+              timeout=10.0):
         """Serve one navigate() against a scripted sequence of script results."""
         server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), FakeDriver)
         # results[0] answers the sentinel plant; the rest answer the poll.
@@ -66,8 +67,7 @@ class NavigateReadiness(unittest.TestCase):
         self.addCleanup(server.shutdown)
         host = f"127.0.0.1:{server.server_port}"
         try:
-            wddrive.navigate(host, "sess", "http://page/x", timeout=10.0,
-                             poll_s=0.001)
+            wddrive.navigate(host, "sess", url, timeout=timeout, poll_s=0.001)
         finally:
             self.remaining = len(server.plan["results"])
             self.navigated = server.plan["navigated"]
@@ -107,6 +107,38 @@ class NavigateReadiness(unittest.TestCase):
         with self.assertRaises(wddrive.WdError) as caught:
             self.drive([1, ["complete", True]], landed="about:blank")
         self.assertIn("landed off-origin", str(caught.exception))
+
+    def test_a_fragment_only_navigation_is_ready_without_a_document_swap(self):
+        """A fragment navigation keeps the SAME document, so the sentinel
+        survives and `swapped` can never come true. Requiring the swap polls a
+        finished page until the deadline and reports TimeoutError for a URL
+        that loaded. The plant's own round trip returns document.URL, which is
+        what identifies the case.
+        """
+        self.drive(["http://page/x", ["complete", False]],
+                   url="http://page/x#section", timeout=2.0)
+        self.assertTrue(self.navigated)
+
+    def test_a_same_url_reload_still_requires_the_document_swap(self):
+        """Repeating the same fragmentless URL is a RELOAD: the document is
+        replaced and readiness must wait for the swap. This is the exact
+        measured false-ready in navigate()'s docstring (navigate_ms=3.4 with
+        985 ms of layout pending), so the same-document shortcut must not
+        cover it -- only a requested fragment qualifies.
+        """
+        self.drive(["http://page/x", ["complete", False], ["complete", True]],
+                   url="http://page/x")
+        self.assertEqual(self.remaining, 0,
+                         "reload returned before the document swapped")
+
+    def test_origin_comparison_ignores_host_case_and_default_port(self):
+        """The driver serializes the active document's URL, which can differ
+        from the requested string in host case and an explicit default port
+        while naming the same origin.
+        """
+        self.drive([1, ["complete", True]],
+                   url="http://PAGE:80/x", landed="http://page/x")
+        self.assertTrue(self.navigated)
 
     def test_a_same_origin_redirect_is_a_render_not_a_failure(self):
         """The landed-URL guard compares origins, not full URLs.

--- a/bench/chromium/upstream/webkit-didFinishLoadForFrame-automation.patch
+++ b/bench/chromium/upstream/webkit-didFinishLoadForFrame-automation.patch
@@ -1,0 +1,39 @@
+diff --git a/Source/WebKit/UIProcess/WebPageProxy.cpp b/Source/WebKit/UIProcess/WebPageProxy.cpp
+index 5ab611d889..e740a81132 100644
+--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
++++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
+@@ -7985,11 +7985,6 @@ void WebPageProxy::didFinishLoadForFrame(IPC::Connection& connection, FrameIdent
+         if (isMainFrame)
+             protectedPageLoadState->didFinishLoad(transaction);
+ 
+-        if (RefPtr automationSession = activeAutomationSession()) {
+-            automationSession->navigationOccurredForFrame(*frame);
+-            automationSession->loadCompletedForFrame(*frame, navigationID, WallTime::now());
+-        }
+-
+         frame->didFinishLoad();
+ 
+         frame->notifyParentOfLoadCompletion(frame->protectedProcess());
+@@ -7997,6 +7992,22 @@ void WebPageProxy::didFinishLoadForFrame(IPC::Connection& connection, FrameIdent
+         protectedPageLoadState->commitChanges();
+     }
+ 
++    // Notify automation UNCONDITIONALLY, as didFinishDocumentLoadForFrame already
++    // does. Gating this on `navigation` being still registered loses the
++    // completion whenever DidDestroyNavigation (sent from
++    // WebLocalFrameLoaderClient::documentLoaderDetached) is processed before
++    // DidFinishLoadForFrame: the API::Navigation is already retired, so the
++    // enclosing branch above is skipped and a WebDriver `normal` page load wait
++    // never resolves. The wait then never times out either, because
++    // WebAutomationSession's single shared m_loadTimer is the only deadline and
++    // Session::go arms none of its own -- so the client hangs indefinitely.
++    // Measured on 2.52.5: 13 of 31 fresh sessions. `eager`, which resolves via
++    // the ungated documentLoadedForFrame path, never stalls (8/8).
++    if (RefPtr automationSession = activeAutomationSession()) {
++        automationSession->navigationOccurredForFrame(*frame);
++        automationSession->loadCompletedForFrame(*frame, navigationID, WallTime::now());
++    }
++
+     if (protectedPreferences()->siteIsolationEnabled())
+         frame->broadcastFrameTreeSyncData(frame->calculateFrameTreeSyncData());
+ 

--- a/bench/chromium/upstream/webkit-navigate-completion-lost.md
+++ b/bench/chromium/upstream/webkit-navigate-completion-lost.md
@@ -1,5 +1,54 @@
 # WebKitGTK: navigate never completes, and its 300 s timeout never fires
 
+## ROOT CAUSE (traced in Source/, confirmed by a prediction)
+
+`WebPageProxy::didFinishLoadForFrame` (WebPageProxy.cpp:7996) gates the
+automation notification on the navigation still being registered:
+
+```cpp
+RefPtr<API::Navigation> navigation;
+if (frame->isMainFrame() && navigationID && m_navigationState->hasNavigation(*navigationID))
+    navigation = m_navigationState->navigation(*navigationID);
+
+bool isMainFrame = frame->isMainFrame();
+if (!isMainFrame || !navigationID || navigation) {          // <-- gate
+    ...
+    automationSession->navigationOccurredForFrame(*frame);
+    automationSession->loadCompletedForFrame(*frame, navigationID, WallTime::now());
+}
+```
+
+The sibling path does NOT gate it. `didFinishDocumentLoadForFrame`
+(WebPageProxy.cpp:7832) notifies automation unconditionally, before it even
+looks the navigation up. That asymmetry is the defect.
+
+Two IPC messages from the WebProcess race:
+
+* `DidDestroyNavigation`, sent by
+  `WebLocalFrameLoaderClient::documentLoaderDetached`
+  (WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:218)
+* `DidFinishLoadForFrame`
+
+If the former is processed first the `API::Navigation` is already retired,
+`hasNavigation()` is false, the gate skips the whole block, and the WebDriver
+callback is left in `m_pendingNormalNavigationInBrowsingContextCallbacksPerPage`
+forever.
+
+**Confirming prediction.** WebDriver's `normal` strategy resolves via the GATED
+`navigationOccurredForFrame`; `eager` resolves via the UNGATED
+`documentLoadedForFrame`. So `eager` should never stall. Measured on 2.52.5,
+same page, same protocol, fresh container per trial:
+
+| pageLoadStrategy | stalled |
+|---|---|
+| normal | 13/31 (42%) |
+| **eager** | **0/8** |
+
+Proposed patch: `webkit-didFinishLoadForFrame-automation.patch` in this
+directory moves the automation notification out of the gate, matching
+`didFinishDocumentLoadForFrame`. NOT YET BUILT OR TESTED against a WebKit build.
+
+
 Two defects, filed together because the second is what makes the first fatal.
 Reproduced on **WebKitGTK 2.52.5** (current upstream stable) and **2.50.6**,
 aarch64, Debian trixie/bookworm, `WebKitWebDriver --port=9515 --host=all`,

--- a/bench/chromium/upstream/webkit-navigate-completion-lost.md
+++ b/bench/chromium/upstream/webkit-navigate-completion-lost.md
@@ -1,0 +1,90 @@
+# WebKitGTK: navigate never completes, and its 300 s timeout never fires
+
+Two defects, filed together because the second is what makes the first fatal.
+Reproduced on **WebKitGTK 2.52.5** (current upstream stable) and **2.50.6**,
+aarch64, Debian trixie/bookworm, `WebKitWebDriver --port=9515 --host=all`,
+MiniBrowser `--automation` under Xvfb.
+
+## 1. POST /session/<id>/url never returns, though the page has finished
+
+**Rate: 13 of 31 fresh sessions (42%, 95% CI [26%, 59%]).** When it does not
+stall it returns in 1.4 s.
+
+It is not a hang. Probed during a confirmed stall, navigate still outstanding
+at t=25 s:
+
+```
+document.readyState                     -> "complete"
+page's own marker element               -> "done layout_ms=1145.0 canvas_ms=160.0 checksum=65030"
+document.querySelectorAll("tr").length  -> 1200
+GET /status, /url, /title               -> 200, all under 3 ms
+```
+
+The page loaded and its script completed in ~1.3 s. JavaScript still executes.
+`WebKitWebProcess` instantaneous CPU during the stall is 0.3% of one core,
+having consumed ~8 CPU-seconds all within the first ~6 s. Only the WebDriver
+command fails to complete.
+
+Chromium 151.0.7922.137 renders the identical page in 1387.6 ms with no stalls.
+
+## 2. The pageLoad timeout does not fire, so the stall is unrecoverable
+
+`GET /session/<id>/timeouts` reports `pageLoad: 300000`, and
+`WebAutomationSession.cpp:92` has `defaultPageLoadTimeout = 300_s`. One
+observed navigate ran **390 s with no response at all** — the client's own
+timeout, not a WebDriver `timeout` error.
+
+Nothing else can rescue it: `Source/WebDriver/Session.cpp` `Session::go` arms no
+timer of its own, it sends `navigateBrowsingContext` and waits on the backend
+indefinitely. So a client that waits on this command waits forever.
+
+Structural note offered without a claim to have proven it fires here:
+`WebAutomationSession` keeps a **single shared `m_loadTimer`** for four separate
+pending-callback maps (per-page normal/eager, per-frame normal/eager), and every
+resolving wait calls `m_loadTimer.stop()` (lines 962, 968, 993, 1002).
+`loadTimerFired()` then responds to all four maps. One wait resolving therefore
+cancels every other pending wait's deadline.
+
+## Reproducer
+
+Self-contained, 3302 bytes, no network subresources beyond a `data:` favicon,
+no rAF/setInterval/Worker/fetch/WebGL. One synchronous script before the load
+event:
+
+- build a 1200-row x 6-column table (7200 cells), calling `appendChild` and
+  reading `table.offsetHeight` every 100 rows — ~12 forced layouts of a growing
+  table
+- then canvas 800x600: `createLinearGradient`, `fillRect`, arcs, text
+- then `getImageData` to force raster
+
+Full fixture: `bench/chromium/pages/heavy.html` in this repository.
+
+```
+POST /session/<id>/url  {"url": "http://127.0.0.1:8000/heavy.html"}
+```
+
+Repeat on fresh sessions; roughly 2 in 5 never return.
+
+## What we ruled out, with the measurement
+
+| hypothesis | ruled out by |
+|---|---|
+| slow layout / still computing | CPU idle at 0.3% during the stall; page marker shows it finished |
+| crash | session answers /status, /url, /title in under 3 ms |
+| old version | reproduces on 2.52.5, current upstream stable |
+| accelerated-canvas GL fence with no timeout | `WEBKIT_DISABLE_COMPOSITING_MODE=1` gave 3/10 vs 6/10, Fisher p = 0.370 — not significant. NOTE: we did not verify the env var actually disabled the accelerated path, so this negative is only as strong as the intervention. |
+| concurrency | reproduces at N=1 |
+
+## Client-side workaround (what we shipped)
+
+`pageLoadStrategy: "none"` plus polling `document.readyState` over
+`execute/sync`, with a sentinel global planted on the previous document so a
+stale `"complete"` cannot be mistaken for the new one.
+`waitForNavigationToCompleteOnPage` returns on its first branch when the
+strategy is None, so the broken completion path is never entered.
+
+Result: **0 failures in 30 fresh sessions**, against 13/31 before.
+
+This is a workaround, not a fix: any WebDriver client using the default
+`normal` page load strategy is exposed, and defect 2 means it has no timeout to
+fall back on.

--- a/bench/chromium/upstream/webkit-navigate-completion-lost.md
+++ b/bench/chromium/upstream/webkit-navigate-completion-lost.md
@@ -1,6 +1,6 @@
 # WebKitGTK: navigate never completes, and its 300 s timeout never fires
 
-## ROOT CAUSE (traced in Source/, confirmed by a prediction)
+## LEADING HYPOTHESIS (traced in Source/, supported by a prediction; the patch is not built or tested)
 
 `WebPageProxy::didFinishLoadForFrame` (WebPageProxy.cpp:7996) gates the
 automation notification on the navigation still being registered:
@@ -20,7 +20,7 @@ if (!isMainFrame || !navigationID || navigation) {          // <-- gate
 
 The sibling path does NOT gate it. `didFinishDocumentLoadForFrame`
 (WebPageProxy.cpp:7832) notifies automation unconditionally, before it even
-looks the navigation up. That asymmetry is the defect.
+looks the navigation up. That asymmetry is the candidate defect.
 
 Two IPC messages from the WebProcess race:
 
@@ -34,7 +34,7 @@ If the former is processed first the `API::Navigation` is already retired,
 callback is left in `m_pendingNormalNavigationInBrowsingContextCallbacksPerPage`
 forever.
 
-**Confirming prediction.** WebDriver's `normal` strategy resolves via the GATED
+**Supporting prediction.** WebDriver's `normal` strategy resolves via the GATED
 `navigationOccurredForFrame`; `eager` resolves via the UNGATED
 `documentLoadedForFrame`. So `eager` should never stall. Measured on 2.52.5,
 same page, same protocol, fresh container per trial:
@@ -46,7 +46,10 @@ same page, same protocol, fresh container per trial:
 
 Proposed patch: `webkit-didFinishLoadForFrame-automation.patch` in this
 directory moves the automation notification out of the gate, matching
-`didFinishDocumentLoadForFrame`. NOT YET BUILT OR TESTED against a WebKit build.
+`didFinishDocumentLoadForFrame`. NOT YET BUILT OR TESTED against a WebKit build;
+the eager/normal split is consistent with the gate being the cause but does not
+isolate it (eager also changes when the wait resolves), so the asymmetry stays
+a hypothesis until the patched `normal` path is measured to recover.
 
 
 Two defects, filed together because the second is what makes the first fatal.

--- a/bench/chromium/wd_health.py
+++ b/bench/chromium/wd_health.py
@@ -45,10 +45,25 @@ def main() -> int:
         print(f"unhealthy: session file {SESSION_FILE} is empty", file=sys.stderr)
         return 1
 
-    url = f"http://{WD_HOST}/session/{session}/url"
+    # execute/sync, NOT GET /url. Automation.getBrowsingContext -- which backs
+    # GET /url -- builds its reply from page.pageLoadState().activeURL(), pure
+    # UI-process state with no IPC to the web process. A wedged or dead web
+    # content process still answers it 200, so using it as the liveness probe
+    # would let the golden snapshot fire on a browser that cannot render: the
+    # green-by-absence class AGENTS.md names. Evaluating a script proves the web
+    # process executes. `return 1` mutates nothing, so the warm point stays the
+    # quiescent about:blank the golden requires.
+    url = f"http://{WD_HOST}/session/{session}/execute/sync"
+    body = json.dumps({"script": "return 1", "args": []}).encode()
     try:
-        with urllib.request.urlopen(url, timeout=TIMEOUT) as resp:
+        req = urllib.request.Request(url, data=body, method="POST",
+                                     headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
             value = json.load(resp)["value"]
+        if value != 1:
+            print(f"unhealthy: web process returned {value!r}, expected 1",
+                  file=sys.stderr)
+            return 1
     except Exception as error:  # noqa: BLE001 - any transport/protocol failure = unhealthy
         print(f"unhealthy: warm-session probe failed: "
               f"{type(error).__name__}: {error}", file=sys.stderr)

--- a/bench/chromium/wd_health.py
+++ b/bench/chromium/wd_health.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Container HEALTHCHECK: prove the WARM WebKit session can serve a request.
+
+The WebKit twin of cdp_health.py, with one protocol-forced difference: classic
+WebDriver's GET /status reports "ready" whether or not any browser is running —
+it describes the DRIVER's readiness to mint sessions, not the health of ours.
+The probe that actually covers the request path is GET /session/<id>/url on the
+warm session entry-webkit.sh created: it fails once the session or MiniBrowser
+dies, and succeeds only if the exact session every clone will inherit can still
+answer.
+
+Two conditions, both required (same golden-snapshot contract as the Chromium
+gate): the warm marker exists (entry-webkit.sh touches it only after a proven
+navigate + screenshot + blank transition), and the warm session answers a real
+WebDriver round trip.
+
+Deliberately does NOT navigate or screenshot: the health probe runs every
+second, and a mutation would thrash the quiescent about:blank state the
+snapshot is meant to freeze.
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+WD_HOST = os.environ.get("BENCH_WD_HEALTH_HOST", "127.0.0.1:9515")
+READY_FILE = os.environ.get("BENCH_READY_FILE", "/run/bench-ready")
+SESSION_FILE = os.environ.get("BENCH_SESSION_FILE", "/run/bench-session-id")
+TIMEOUT = float(os.environ.get("BENCH_WD_HEALTH_TIMEOUT", "3"))
+
+
+def main() -> int:
+    if not os.path.exists(READY_FILE):
+        print(f"unhealthy: warm marker {READY_FILE} absent", file=sys.stderr)
+        return 1
+    try:
+        with open(SESSION_FILE) as source:
+            session = source.read().strip()
+    except OSError as error:
+        print(f"unhealthy: session file: {error}", file=sys.stderr)
+        return 1
+    if not session:
+        print(f"unhealthy: session file {SESSION_FILE} is empty", file=sys.stderr)
+        return 1
+
+    url = f"http://{WD_HOST}/session/{session}/url"
+    try:
+        with urllib.request.urlopen(url, timeout=TIMEOUT) as resp:
+            value = json.load(resp)["value"]
+    except Exception as error:  # noqa: BLE001 - any transport/protocol failure = unhealthy
+        print(f"unhealthy: warm-session probe failed: "
+              f"{type(error).__name__}: {error}", file=sys.stderr)
+        return 1
+
+    print(f"healthy session={session} url={value}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/chromium/wd_health.py
+++ b/bench/chromium/wd_health.py
@@ -4,7 +4,7 @@
 The WebKit twin of cdp_health.py, with one protocol-forced difference: classic
 WebDriver's GET /status reports "ready" whether or not any browser is running —
 it describes the DRIVER's readiness to mint sessions, not the health of ours.
-The probe that actually covers the request path is GET /session/<id>/url on the
+The probe that actually covers the request path is POST execute/sync on the
 warm session entry-webkit.sh created: it fails once the session or MiniBrowser
 dies, and succeeds only if the exact session every clone will inherit can still
 answer.
@@ -35,8 +35,7 @@ TIMEOUT = float(os.environ.get("BENCH_WD_HEALTH_TIMEOUT", "3"))
 
 def main_with_reason() -> tuple[int, str]:
     if not os.path.exists(READY_FILE):
-        print(f"unhealthy: warm marker {READY_FILE} absent", file=sys.stderr)
-        return 1
+        return 1, f"warm marker {READY_FILE} absent"
     try:
         with open(SESSION_FILE) as source:
             session = source.read().strip()

--- a/bench/chromium/wd_health.py
+++ b/bench/chromium/wd_health.py
@@ -22,6 +22,8 @@ snapshot is meant to freeze.
 import json
 import os
 import sys
+
+import health_loop
 import urllib.error
 import urllib.request
 
@@ -31,7 +33,7 @@ SESSION_FILE = os.environ.get("BENCH_SESSION_FILE", "/run/bench-session-id")
 TIMEOUT = float(os.environ.get("BENCH_WD_HEALTH_TIMEOUT", "3"))
 
 
-def main() -> int:
+def main_with_reason() -> tuple[int, str]:
     if not os.path.exists(READY_FILE):
         print(f"unhealthy: warm marker {READY_FILE} absent", file=sys.stderr)
         return 1
@@ -39,11 +41,9 @@ def main() -> int:
         with open(SESSION_FILE) as source:
             session = source.read().strip()
     except OSError as error:
-        print(f"unhealthy: session file: {error}", file=sys.stderr)
-        return 1
+        return 1, f"session file: {error}"
     if not session:
-        print(f"unhealthy: session file {SESSION_FILE} is empty", file=sys.stderr)
-        return 1
+        return 1, f"session file {SESSION_FILE} is empty"
 
     # execute/sync, NOT GET /url. Automation.getBrowsingContext -- which backs
     # GET /url -- builds its reply from page.pageLoadState().activeURL(), pure
@@ -61,17 +61,23 @@ def main() -> int:
         with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
             value = json.load(resp)["value"]
         if value != 1:
-            print(f"unhealthy: web process returned {value!r}, expected 1",
-                  file=sys.stderr)
-            return 1
+            return 1, f"web process returned {value!r}, expected 1"
     except Exception as error:  # noqa: BLE001 - any transport/protocol failure = unhealthy
-        print(f"unhealthy: warm-session probe failed: "
-              f"{type(error).__name__}: {error}", file=sys.stderr)
-        return 1
+        return 1, f"warm-session probe failed: {type(error).__name__}: {error}"
 
-    print(f"healthy session={session} url={value}")
-    return 0
+    return 0, f"session={session}"
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    # Resident by default, exactly as cdp_health.py is: the per-second
+    # `python3 wd_health.py` HEALTHCHECK this file originally carried spends a
+    # fresh interpreter per clone per second forever, dirtying ~9 MB of private
+    # pages INSIDE the clone -- against the per-clone memory figure this bench
+    # exists to measure. health_state.sh is the cheap reader, and reqbench.sh
+    # asserts the image's HEALTHCHECK names it.
+    if "--loop" in sys.argv:
+        sys.exit(health_loop.loop(main_with_reason, "wd_health"))
+    code, reason = main_with_reason()
+    print(("healthy " if code == 0 else "unhealthy ") + reason,
+          file=sys.stdout if code == 0 else sys.stderr)
+    sys.exit(code)

--- a/bench/chromium/wddrive.py
+++ b/bench/chromium/wddrive.py
@@ -32,10 +32,6 @@ import urllib.request
 MINIBROWSER = "/usr/local/bin/MiniBrowser"
 
 
-def mono():
-    return time.clock_gettime(time.CLOCK_MONOTONIC)
-
-
 class WdError(RuntimeError):
     pass
 
@@ -155,7 +151,8 @@ def navigate(host, session, url, timeout=120.0, poll_s=0.01):
                    ("no such window", "no such execution context", "no such frame")):
             raise
         sentinel = False
-    wd(host, "POST", f"/session/{session}/url", {"url": url}, timeout=timeout)
+    wd(host, "POST", f"/session/{session}/url", {"url": url},
+       timeout=max(1.0, deadline - time.monotonic()))
     while True:
         state = wd(host, "POST", f"/session/{session}/execute/sync",
                    {"script": ("return [document.readyState, "
@@ -205,7 +202,6 @@ def main():
     p.add_argument("--host", default="127.0.0.1:9515")
     p.add_argument("--session-file",
                    help="read the warm session id from this file")
-    p.add_argument("--session-id", help="explicit session id (overrides file)")
     p.add_argument("--create", action="store_true",
                    help="create a NEW session (warm point only) and write its id "
                         "to --session-file")
@@ -215,7 +211,7 @@ def main():
                         "verify the session reports it (warm-point quiescence)")
     args = p.parse_args()
 
-    t0 = mono()
+    t0 = time.monotonic()
     try:
         if args.create:
             if not args.session_file:
@@ -224,24 +220,22 @@ def main():
             with open(args.session_file, "w") as target:
                 target.write(session + "\n")
         else:
-            session = args.session_id
-            if not session:
-                if not args.session_file:
-                    p.error("give --session-id or --session-file")
-                with open(args.session_file) as source:
-                    session = source.read().strip()
+            if not args.session_file:
+                p.error("give --session-file")
+            with open(args.session_file) as source:
+                session = source.read().strip()
 
-        t_connect = mono()
+        t_connect = time.monotonic()
         current_url(args.host, session)
-        connect_ms = (mono() - t_connect) * 1000
+        connect_ms = (time.monotonic() - t_connect) * 1000
 
-        t_nav = mono()
+        t_nav = time.monotonic()
         navigate(args.host, session, args.url)
-        navigate_ms = (mono() - t_nav) * 1000
+        navigate_ms = (time.monotonic() - t_nav) * 1000
 
-        t_shot = mono()
+        t_shot = time.monotonic()
         png = screenshot(args.host, session)
-        screenshot_ms = (mono() - t_shot) * 1000
+        screenshot_ms = (time.monotonic() - t_shot) * 1000
         if not png.startswith(b"\x89PNG"):
             raise WdError(f"screenshot is not a PNG ({png[:8]!r})")
         with open(f"{args.out_prefix}.png", "wb") as target:
@@ -259,12 +253,12 @@ def main():
         # b64decode raises ValueError. Each of those escaped as a traceback and
         # took the parseable one-line contract with it -- losing RENDER_FAIL
         # exactly in the failure case any harness keys on.
-        total_ms = (mono() - t0) * 1000
+        total_ms = (time.monotonic() - t0) * 1000
         print(f"RENDER_FAIL url={args.url} error={type(error).__name__}: {error} "
               f"total_ms={total_ms:.1f}")
         return 1
 
-    total_ms = (mono() - t0) * 1000
+    total_ms = (time.monotonic() - t0) * 1000
     print(
         f"RENDER_OK url={args.url} connect_ms={connect_ms:.1f} "
         f"navigate_ms={navigate_ms:.1f} screenshot_ms={screenshot_ms:.1f} "

--- a/bench/chromium/wddrive.py
+++ b/bench/chromium/wddrive.py
@@ -10,7 +10,7 @@ JSON bodies, no WebSocket). Used in three places:
     classic has no session-discovery API, so a session created after restore
     would launch a COLD browser — the id must be minted at the warm point and
     inherited by every clone.
-  * wd_health.py (in guest): GET /session/<id>/url as the liveness probe.
+  * wd_health.py (in guest): POST execute/sync as the liveness probe.
   * the host bench arms (default mode): reuse the inherited session id for
     navigate + screenshot against a restored clone.
 

--- a/bench/chromium/wddrive.py
+++ b/bench/chromium/wddrive.py
@@ -23,6 +23,7 @@ Timing fields mirror render.py where the protocols correspond:
 
 import argparse
 import base64
+import hashlib
 import json
 import sys
 import time
@@ -194,6 +195,87 @@ def screenshot(host, session, timeout=60.0):
 
 def current_url(host, session, timeout=10.0):
     return wd(host, "GET", f"/session/{session}/url", timeout=timeout)
+
+
+def drive(args) -> dict:
+    """One clone render, harness entry point -- cdpdrive.drive's contract.
+
+    reqbench dispatches every render through a module-level drive(args) and
+    stores the returned dict as rec["render"], so the field names here are the
+    analyzer's schema. Keys shared with cdpdrive keep its meaning (ok, url,
+    stages, image_bytes, image_sha256); WebDriver-specific facts get their own
+    keys rather than overloading CDP ones -- there is no WebSocket here, so no
+    tcp_ms/upgrade_ms, and resolve_ms is the WD status round trip that proves
+    the port is a driver rather than a socket.
+
+    The session id arrives pinned (args.session_id). Classic WebDriver has no
+    session discovery, so the id is captured ONCE per golden by the harness
+    (fcvm exec cat /run/bench-session-id on the first clone) and reused: it is
+    snapshot state, identical across clones for the same reason cdpdrive's
+    target id is.
+    """
+    t0 = time.monotonic()
+    deadline = t0 + args.timeout
+    out: dict = {"ok": False, "engine": "webkit", "wd_host": args.cdp_host,
+                 "url": args.url, "format": "png", "session_prewired": True}
+    stages: dict[str, float] = {}
+    stage = "status"
+    try:
+        session = args.session_id
+        if not session:
+            raise WdError("no session id was provided (harness discovery failed)")
+        out["session_id"] = session
+
+        # Like cdpdrive's resolve: retry the first round trip against the
+        # deadline, because the clone's forward may be seconds behind the state
+        # file. /status is the WD liveness probe; a socket that accepts but is
+        # not the driver fails here rather than mid-navigate.
+        t = time.monotonic()
+        last = None
+        while True:
+            try:
+                wd(args.cdp_host, "GET", "/status",
+                   timeout=max(0.2, min(5.0, deadline - time.monotonic())))
+                break
+            except WdError as error:
+                last = error
+                if time.monotonic() >= deadline:
+                    raise WdError(f"driver never answered /status: {last}") from error
+                time.sleep(0.05)
+        stages["resolve_ms"] = (time.monotonic() - t) * 1000
+        stages["connect_total_ms"] = (time.monotonic() - t0) * 1000
+
+        stage = "navigate"
+        t = time.monotonic()
+        navigate(args.cdp_host, session, args.url,
+                 timeout=max(1.0, deadline - time.monotonic()))
+        stages["navigate_ms"] = (time.monotonic() - t) * 1000
+
+        stage = "screenshot"
+        t = time.monotonic()
+        png = screenshot(args.cdp_host, session,
+                         timeout=max(1.0, deadline - time.monotonic()))
+        stages["screenshot_ms"] = (time.monotonic() - t) * 1000
+        if not png.startswith(b"\x89PNG"):
+            raise WdError(f"screenshot is not a PNG ({png[:8]!r})")
+        out["image_bytes"] = len(png)
+        out["image_sha256"] = hashlib.sha256(png).hexdigest()
+        if getattr(args, "out_prefix", ""):
+            with open(f"{args.out_prefix}.png", "wb") as target:
+                target.write(png)
+        stages["total_ms"] = (time.monotonic() - t0) * 1000
+        out["stages"] = stages
+        out["ok"] = True
+        return out
+    except (WdError, OSError, KeyError, TypeError, ValueError) as error:
+        # Same closed tuple as main(), same reason: TimeoutError is an OSError,
+        # session plumbing raises KeyError/TypeError, b64decode ValueError. A
+        # failure must come back as a labelled record, not a traceback.
+        stages["total_ms"] = (time.monotonic() - t0) * 1000
+        out["stages"] = stages
+        out["error"] = f"{type(error).__name__}: {error}"
+        out["failed_stage"] = stage
+        return out
 
 
 def main():

--- a/bench/chromium/wddrive.py
+++ b/bench/chromium/wddrive.py
@@ -56,7 +56,11 @@ def wd(host, method, path, body=None, timeout=30.0):
             detail = json.load(error)["value"]
             raise WdError(f"{detail.get('error')}: {detail.get('message')} "
                           f"({method} {path})") from error
-        except (ValueError, KeyError):
+        except (ValueError, KeyError, AttributeError, TypeError):
+            # `value` is not required to be an object. A proxy or error page can
+            # return {"value": "..."} , and .get() on a str raised AttributeError
+            # OUT of this handler -- past main()'s except, so the parseable
+            # RENDER_FAIL line was lost exactly when it was needed.
             raise WdError(f"HTTP {error.code} on {method} {path}") from error
     except (urllib.error.URLError, TimeoutError, OSError) as error:
         raise WdError(
@@ -138,9 +142,18 @@ def navigate(host, session, url, timeout=120.0, poll_s=0.01):
            {"script": "window.__fcvmNavSentinel = 1; return 1", "args": []},
            timeout=max(1.0, deadline - time.monotonic()))
         sentinel = True
-    except Exception:
-        # No current document to plant on (fresh session): readyState alone is
-        # unambiguous there, because there is no previous document to confuse it.
+    except WdError as error:
+        # ONLY the fresh-session case may skip the sentinel: with no previous
+        # document there is nothing for a stale "complete" to come from. Any
+        # other failure must propagate, because falling back silently turns a
+        # transient error into the exact false-ready measurement this sentinel
+        # exists to prevent (navigate_ms=3.4 while 985 ms of layout was still
+        # pending, which then landed in screenshot_ms).
+        # WdError carries only a formatted message, so match on it. Narrow by
+        # design: anything else propagates.
+        if not any(k in str(error) for k in
+                   ("no such window", "no such execution context", "no such frame")):
+            raise
         sentinel = False
     wd(host, "POST", f"/session/{session}/url", {"url": url}, timeout=timeout)
     while True:
@@ -151,6 +164,22 @@ def navigate(host, session, url, timeout=120.0, poll_s=0.01):
                    timeout=max(1.0, deadline - time.monotonic()))
         ready, swapped = (state[0], state[1]) if isinstance(state, list) else (state, True)
         if ready == "complete" and (swapped or not sentinel):
+            # readyState "complete" is NOT proof the requested page loaded.
+            # WebKit's network-error page is a fresh document (sentinel wiped)
+            # that reaches complete, so without this check a dead pageserver
+            # yields RENDER_OK over a screenshot of "Unable to load page" -- and
+            # at the warm point it would freeze a golden whose browser never
+            # rendered the fixture, making every clone's "warm" number a
+            # first-paint number. render.py guards the Chromium twin by raising
+            # on nav["errorText"]; WebDriver classic exposes no such field, so
+            # compare the document we actually landed on.
+            landed = wd(host, "GET", f"/session/{session}/url",
+                        timeout=max(1.0, deadline - time.monotonic()))
+            if landed != url:
+                raise WdError(
+                    f"navigation landed elsewhere: requested {url!r} but "
+                    f"document.URL is {landed!r}; this is a failed load (error "
+                    "page, redirect, or a dead origin), not a render")
             return
         state = ready
         if time.monotonic() >= deadline:
@@ -223,9 +252,16 @@ def main():
             landed = current_url(args.host, session)
             if landed != "about:blank":
                 raise WdError(f"blank transition landed on {landed!r}")
-    except WdError as error:
+    except (WdError, OSError, KeyError, TypeError, ValueError) as error:
+        # NOT just WdError. navigate() raises TimeoutError, which is an OSError
+        # subclass, not a RuntimeError; open(session_file) raises OSError;
+        # create_session's value["sessionId"] raises KeyError/TypeError;
+        # b64decode raises ValueError. Each of those escaped as a traceback and
+        # took the parseable one-line contract with it -- losing RENDER_FAIL
+        # exactly in the failure case any harness keys on.
         total_ms = (mono() - t0) * 1000
-        print(f"RENDER_FAIL url={args.url} error={error} total_ms={total_ms:.1f}")
+        print(f"RENDER_FAIL url={args.url} error={type(error).__name__}: {error} "
+              f"total_ms={total_ms:.1f}")
         return 1
 
     total_ms = (mono() - t0) * 1000

--- a/bench/chromium/wddrive.py
+++ b/bench/chromium/wddrive.py
@@ -29,6 +29,7 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from urllib.parse import urlsplit
 
 MINIBROWSER = "/usr/local/bin/MiniBrowser"
 
@@ -173,11 +174,20 @@ def navigate(host, session, url, timeout=120.0, poll_s=0.01):
             # compare the document we actually landed on.
             landed = wd(host, "GET", f"/session/{session}/url",
                         timeout=max(1.0, deadline - time.monotonic()))
-            if landed != url:
+            # Compare ORIGINS, not full URLs. The corpus preflight admits
+            # redirecting URLs (30x from the corpus server), and replayed
+            # real-site JS rewrites document.URL via history.replaceState, so
+            # full-URL equality fails legitimate renders that the Chromium arm
+            # passes. A dead origin or an internal error page still lands off
+            # the requested origin (about:, applewebdata:, blank), which is
+            # what this check exists to catch.
+            requested = urlsplit(url)
+            got = urlsplit(landed if isinstance(landed, str) else "")
+            if (got.scheme, got.netloc) != (requested.scheme, requested.netloc):
                 raise WdError(
-                    f"navigation landed elsewhere: requested {url!r} but "
+                    f"navigation landed off-origin: requested {url!r} but "
                     f"document.URL is {landed!r}; this is a failed load (error "
-                    "page, redirect, or a dead origin), not a render")
+                    "page or a dead origin), not a render")
             return
         state = ready
         if time.monotonic() >= deadline:
@@ -274,7 +284,7 @@ def drive(args) -> dict:
         stages["total_ms"] = (time.monotonic() - t0) * 1000
         out["stages"] = stages
         out["error"] = f"{type(error).__name__}: {error}"
-        out["failed_stage"] = stage
+        out["stage"] = stage  # seam key: cdpdrive writes "stage", reqbench reads "stage"
         return out
 
 

--- a/bench/chromium/wddrive.py
+++ b/bench/chromium/wddrive.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""W3C WebDriver classic driver for the WebKit bench — stdlib only.
+
+The WebKit twin of render.py/cdpdrive.py. WebKitGTK has no CDP endpoint, so
+navigate + screenshot go over WebDriver's HTTP protocol (one POST per command,
+JSON bodies, no WebSocket). Used in three places:
+
+  * entry-webkit.sh (in guest, --create): create the WARM session before the
+    golden snapshot, warm-render a fixture, persist the session id. WebDriver
+    classic has no session-discovery API, so a session created after restore
+    would launch a COLD browser — the id must be minted at the warm point and
+    inherited by every clone.
+  * wd_health.py (in guest): GET /session/<id>/url as the liveness probe.
+  * the host bench arms (default mode): reuse the inherited session id for
+    navigate + screenshot against a restored clone.
+
+Timing fields mirror render.py where the protocols correspond:
+  connect_ms   first HTTP round trip on this connection (session status read)
+  navigate_ms  POST /session/<id>/url (returns after the classic load event)
+  screenshot_ms POST returns base64 PNG (WebKitGTK is PNG-only; no quality knob)
+  total_ms     whole request from process start
+"""
+
+import argparse
+import base64
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+MINIBROWSER = "/usr/local/bin/MiniBrowser"
+
+
+def mono():
+    return time.clock_gettime(time.CLOCK_MONOTONIC)
+
+
+class WdError(RuntimeError):
+    pass
+
+
+def wd(host, method, path, body=None, timeout=30.0):
+    """One WebDriver HTTP round trip; raises WdError for protocol AND transport
+    failures (socket timeout, refused, reset), tagged with the command so a
+    failure names its stage instead of crashing the entry script's warm gate."""
+    url = f"http://{host}{path}"
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method,
+                                 headers={"Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            payload = json.load(resp)
+    except urllib.error.HTTPError as error:
+        try:
+            detail = json.load(error)["value"]
+            raise WdError(f"{detail.get('error')}: {detail.get('message')} "
+                          f"({method} {path})") from error
+        except (ValueError, KeyError):
+            raise WdError(f"HTTP {error.code} on {method} {path}") from error
+    except (urllib.error.URLError, TimeoutError, OSError) as error:
+        raise WdError(
+            f"transport failure on {method} {path} after {timeout}s: "
+            f"{type(error).__name__}: {error}"
+        ) from error
+    return payload["value"]
+
+
+def create_session(host, timeout=120.0):
+    """Mint the warm session: MiniBrowser under --automation, insecure certs OK.
+
+    The generous timeout is for the WARM POINT only (cold MiniBrowser launch
+    builds the fontconfig cache on first run); request-path arms never create
+    sessions — they inherit the snapshot's."""
+    caps = {
+        "capabilities": {
+            "alwaysMatch": {
+                "browserName": "MiniBrowser",
+                "acceptInsecureCerts": True,
+                "webkitgtk:browserOptions": {
+                    "binary": MINIBROWSER,
+                    "args": ["--automation"],
+                },
+            }
+        }
+    }
+    value = wd(host, "POST", "/session", caps, timeout=timeout)
+    return value["sessionId"]
+
+
+def navigate(host, session, url, timeout=120.0):
+    wd(host, "POST", f"/session/{session}/url", {"url": url}, timeout=timeout)
+
+
+def screenshot(host, session, timeout=60.0):
+    b64 = wd(host, "GET", f"/session/{session}/screenshot", timeout=timeout)
+    return base64.b64decode(b64)
+
+
+def current_url(host, session, timeout=10.0):
+    return wd(host, "GET", f"/session/{session}/url", timeout=timeout)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("url")
+    p.add_argument("--host", default="127.0.0.1:9515")
+    p.add_argument("--session-file",
+                   help="read the warm session id from this file")
+    p.add_argument("--session-id", help="explicit session id (overrides file)")
+    p.add_argument("--create", action="store_true",
+                   help="create a NEW session (warm point only) and write its id "
+                        "to --session-file")
+    p.add_argument("--out-prefix", required=True)
+    p.add_argument("--then-blank", action="store_true",
+                   help="after the screenshot, navigate to about:blank and "
+                        "verify the session reports it (warm-point quiescence)")
+    args = p.parse_args()
+
+    t0 = mono()
+    try:
+        if args.create:
+            if not args.session_file:
+                p.error("--create requires --session-file")
+            session = create_session(args.host)
+            with open(args.session_file, "w") as target:
+                target.write(session + "\n")
+        else:
+            session = args.session_id
+            if not session:
+                if not args.session_file:
+                    p.error("give --session-id or --session-file")
+                with open(args.session_file) as source:
+                    session = source.read().strip()
+
+        t_connect = mono()
+        current_url(args.host, session)
+        connect_ms = (mono() - t_connect) * 1000
+
+        t_nav = mono()
+        navigate(args.host, session, args.url)
+        navigate_ms = (mono() - t_nav) * 1000
+
+        t_shot = mono()
+        png = screenshot(args.host, session)
+        screenshot_ms = (mono() - t_shot) * 1000
+        if not png.startswith(b"\x89PNG"):
+            raise WdError(f"screenshot is not a PNG ({png[:8]!r})")
+        with open(f"{args.out_prefix}.png", "wb") as target:
+            target.write(png)
+
+        if args.then_blank:
+            navigate(args.host, session, "about:blank")
+            landed = current_url(args.host, session)
+            if landed != "about:blank":
+                raise WdError(f"blank transition landed on {landed!r}")
+    except WdError as error:
+        total_ms = (mono() - t0) * 1000
+        print(f"RENDER_FAIL url={args.url} error={error} total_ms={total_ms:.1f}")
+        return 1
+
+    total_ms = (mono() - t0) * 1000
+    print(
+        f"RENDER_OK url={args.url} connect_ms={connect_ms:.1f} "
+        f"navigate_ms={navigate_ms:.1f} screenshot_ms={screenshot_ms:.1f} "
+        f"total_ms={total_ms:.1f} shot_fmt=png png_bytes={len(png)} "
+        f"png={args.out_prefix}.png session={session}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/chromium/wddrive.py
+++ b/bench/chromium/wddrive.py
@@ -155,6 +155,7 @@ def navigate(host, session, url, timeout=120.0, poll_s=0.01):
         sentinel = False
     wd(host, "POST", f"/session/{session}/url", {"url": url},
        timeout=max(1.0, deadline - time.monotonic()))
+    requested = urlsplit(url)
     while True:
         state = wd(host, "POST", f"/session/{session}/execute/sync",
                    {"script": ("return [document.readyState, "
@@ -181,7 +182,6 @@ def navigate(host, session, url, timeout=120.0, poll_s=0.01):
             # passes. A dead origin or an internal error page still lands off
             # the requested origin (about:, applewebdata:, blank), which is
             # what this check exists to catch.
-            requested = urlsplit(url)
             got = urlsplit(landed if isinstance(landed, str) else "")
             if (got.scheme, got.netloc) != (requested.scheme, requested.netloc):
                 raise WdError(

--- a/bench/chromium/wddrive.py
+++ b/bench/chromium/wddrive.py
@@ -77,6 +77,9 @@ def create_session(host, timeout=120.0):
             "alwaysMatch": {
                 "browserName": "MiniBrowser",
                 "acceptInsecureCerts": True,
+                # pageLoadStrategy "none" is a WORKAROUND for a WebKit defect,
+                # not a shortcut. See navigate() below for the evidence.
+                "pageLoadStrategy": "none",
                 "webkitgtk:browserOptions": {
                     "binary": MINIBROWSER,
                     "args": ["--automation"],
@@ -88,8 +91,53 @@ def create_session(host, timeout=120.0):
     return value["sessionId"]
 
 
-def navigate(host, session, url, timeout=120.0):
+def navigate(host, session, url, timeout=120.0, poll_s=0.01):
+    """Navigate, then wait for readyState ourselves rather than trusting WebDriver.
+
+    WebKitGTK loses the navigation-completion notification. Measured on
+    2.52.5 (current upstream stable) AND 2.50.6: POST /session/<id>/url never
+    returns on 13 of 31 fresh sessions (42%, 95% CI [26%, 59%]) for a page that
+    does a large synchronous layout plus a canvas readback. It is not a hang.
+    Probed during a CONFIRMED stall, 25 s in, with the navigate still
+    outstanding:
+
+        document.readyState  -> "complete"
+        page's own marker    -> "done layout_ms=1145.0 canvas_ms=160.0 checksum=65030"
+        document.querySelectorAll("tr").length -> 1200
+        GET /status, /url, /title -> 200 in under 3 ms
+
+    So the page finished in ~1.3 s, JavaScript still executes, and only the
+    COMMAND fails to complete. Nor does anything rescue it: the driver arms no
+    timer of its own (Session::go just sends navigateBrowsingContext and waits),
+    and the browser-side deadline never fired -- one navigate ran 390 s against
+    a 300 s pageLoad timeout. A client that waits on this command waits forever.
+
+    So do not wait on it. With pageLoadStrategy "none",
+    WebAutomationSession::waitForNavigationToCompleteOnPage returns immediately
+    by its own first branch:
+
+        if (loadStrategy == PageLoadStrategy::None || (!pageLoadState->isLoading()
+            && !pageLoadState->hasUncommittedLoad())) { callback({ }); return; }
+
+    and readiness is then established by polling document.readyState over
+    execute/sync -- a different command path, demonstrably alive throughout the
+    stall. That also makes navigate_ms mean the same thing as Chromium's
+    navigate-to-load-event rather than "whenever WebKit felt like replying".
+    """
+    deadline = time.monotonic() + timeout
     wd(host, "POST", f"/session/{session}/url", {"url": url}, timeout=timeout)
+    while True:
+        state = wd(host, "POST", f"/session/{session}/execute/sync",
+                   {"script": "return document.readyState", "args": []},
+                   timeout=max(1.0, deadline - time.monotonic()))
+        if state == "complete":
+            return
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"document.readyState={state!r} after {timeout:.0f}s; the page "
+                "never reached complete (this is a REAL load failure, unlike the "
+                "lost-notification defect this poll works around)")
+        time.sleep(poll_s)
 
 
 def screenshot(host, session, timeout=60.0):

--- a/bench/chromium/wddrive.py
+++ b/bench/chromium/wddrive.py
@@ -125,13 +125,34 @@ def navigate(host, session, url, timeout=120.0, poll_s=0.01):
     navigate-to-load-event rather than "whenever WebKit felt like replying".
     """
     deadline = time.monotonic() + timeout
+    # Plant a sentinel on the CURRENT document first. readyState alone is not a
+    # navigation signal: it is still "complete" from the PREVIOUS document at the
+    # instant the navigate is issued, so polling it races and can return before
+    # the new document has even started. Measured with the naive version -- a
+    # repeat navigation to the same URL reported navigate_ms=3.4 while the page
+    # was still doing 985 ms of layout, which then landed in screenshot_ms.
+    # A real document swap wipes the global, so its ABSENCE is the proof that
+    # this readyState belongs to the new document and not the old one.
+    try:
+        wd(host, "POST", f"/session/{session}/execute/sync",
+           {"script": "window.__fcvmNavSentinel = 1; return 1", "args": []},
+           timeout=max(1.0, deadline - time.monotonic()))
+        sentinel = True
+    except Exception:
+        # No current document to plant on (fresh session): readyState alone is
+        # unambiguous there, because there is no previous document to confuse it.
+        sentinel = False
     wd(host, "POST", f"/session/{session}/url", {"url": url}, timeout=timeout)
     while True:
         state = wd(host, "POST", f"/session/{session}/execute/sync",
-                   {"script": "return document.readyState", "args": []},
+                   {"script": ("return [document.readyState, "
+                               "typeof window.__fcvmNavSentinel === 'undefined']"),
+                    "args": []},
                    timeout=max(1.0, deadline - time.monotonic()))
-        if state == "complete":
+        ready, swapped = (state[0], state[1]) if isinstance(state, list) else (state, True)
+        if ready == "complete" and (swapped or not sentinel):
             return
+        state = ready
         if time.monotonic() >= deadline:
             raise TimeoutError(
                 f"document.readyState={state!r} after {timeout:.0f}s; the page "

--- a/bench/chromium/wddrive.py
+++ b/bench/chromium/wddrive.py
@@ -135,11 +135,23 @@ def navigate(host, session, url, timeout=120.0, poll_s=0.01):
     # was still doing 985 ms of layout, which then landed in screenshot_ms.
     # A real document swap wipes the global, so its ABSENCE is the proof that
     # this readyState belongs to the new document and not the old one.
+    requested = urlsplit(url)
+    same_document = False
     try:
-        wd(host, "POST", f"/session/{session}/execute/sync",
-           {"script": "window.__fcvmNavSentinel = 1; return 1", "args": []},
+        planted = wd(host, "POST", f"/session/{session}/execute/sync",
+           {"script": "window.__fcvmNavSentinel = 1; return document.URL", "args": []},
            timeout=max(1.0, deadline - time.monotonic()))
         sentinel = True
+        # A navigation that differs from the CURRENT document only by fragment
+        # is a same-document navigation: nothing is loaded, the sentinel is
+        # never wiped, and requiring the swap would poll a finished page until
+        # the deadline. The requested fragment must be non-empty: repeating the
+        # SAME fragmentless URL is a reload, which replaces the document and is
+        # exactly the measured false-ready the sentinel exists to catch.
+        # document.URL rides the plant's round trip, so this costs nothing.
+        current = urlsplit(planted) if isinstance(planted, str) else urlsplit("")
+        same_document = bool(requested.fragment) and (
+            requested._replace(fragment="") == current._replace(fragment=""))
     except WdError as error:
         # ONLY the fresh-session case may skip the sentinel: with no previous
         # document there is nothing for a stale "complete" to come from. Any
@@ -155,7 +167,6 @@ def navigate(host, session, url, timeout=120.0, poll_s=0.01):
         sentinel = False
     wd(host, "POST", f"/session/{session}/url", {"url": url},
        timeout=max(1.0, deadline - time.monotonic()))
-    requested = urlsplit(url)
     while True:
         state = wd(host, "POST", f"/session/{session}/execute/sync",
                    {"script": ("return [document.readyState, "
@@ -163,7 +174,7 @@ def navigate(host, session, url, timeout=120.0, poll_s=0.01):
                     "args": []},
                    timeout=max(1.0, deadline - time.monotonic()))
         ready, swapped = (state[0], state[1]) if isinstance(state, list) else (state, True)
-        if ready == "complete" and (swapped or not sentinel):
+        if ready == "complete" and (swapped or not sentinel or same_document):
             # readyState "complete" is NOT proof the requested page loaded.
             # WebKit's network-error page is a fresh document (sentinel wiped)
             # that reaches complete, so without this check a dead pageserver
@@ -183,7 +194,11 @@ def navigate(host, session, url, timeout=120.0, poll_s=0.01):
             # the requested origin (about:, applewebdata:, blank), which is
             # what this check exists to catch.
             got = urlsplit(landed if isinstance(landed, str) else "")
-            if (got.scheme, got.netloc) != (requested.scheme, requested.netloc):
+            try:
+                off_origin = _origin(got) != _origin(requested)
+            except ValueError:  # malformed port in what the driver returned
+                off_origin = True
+            if off_origin:
                 raise WdError(
                     f"navigation landed off-origin: requested {url!r} but "
                     f"document.URL is {landed!r}; this is a failed load (error "
@@ -201,6 +216,19 @@ def navigate(host, session, url, timeout=120.0, poll_s=0.01):
 def screenshot(host, session, timeout=60.0):
     b64 = wd(host, "GET", f"/session/{session}/screenshot", timeout=timeout)
     return base64.b64decode(b64)
+
+
+def _origin(split):
+    """Canonical (scheme, host, port) for origin comparison.
+
+    The driver serializes the ACTIVE document's URL, which can differ from the
+    requested string in case and in an explicit default port while naming the
+    same origin. A malformed port raises ValueError in .port; the caller treats
+    that as off-origin.
+    """
+    scheme = split.scheme.lower()
+    default_port = {"http": 80, "https": 443}.get(scheme)
+    return (scheme, (split.hostname or "").lower(), split.port or default_port)
 
 
 def current_url(host, session, timeout=10.0):

--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,11 @@ ignore = [
     # bincode is unmaintained but v1.3.3 is considered complete
     # Not a security issue - maintainers ceased development
     "RUSTSEC-2025-0141",
+    # h2 0.3 unbounded empty DATA frames (low-severity DoS); patched only in
+    # h2 >= 0.4.16, which needs the hyper 1.x line. Client-mode-only use over
+    # trusted local transports here. Tracked by issue #859; remove with the
+    # hyper 1.x / reqwest 0.12 migration. Keep in sync with .cargo/audit.toml.
+    "RUSTSEC-2026-0258",
 ]
 
 [licenses]


### PR DESCRIPTION
Recovers the WebKit arm, brings it to the current upstream engine, and fixes a defect that made it unusable 42% of the time.

## What did not exist

Only one commit on the old `webkit-bench` branch wasn't already in main. It adds `Containerfile.webkit-bench`, `entry-webkit.sh`, `wddrive.py`, `wd_health.py` — 442 lines, purely additive — and **zero** wiring into `reqbench.sh`/`reqbench.py`. Chromium drives CDP over a WebSocket on 9222; WebKitGTK has no CDP and drives W3C WebDriver classic over HTTP on 9515 with no session discovery. `ENGINE=webkit` is an arm implementation, not a flag.

So the report's WebKit figures (restore 44 ms, navigate 221 ms, ~1.9 s first render, 147 MiB) have **no committed path that reproduces them**, and their probe sets died in the 2026-08-15 wipe. Everything here is host-side (`podman --network host`, no VM), i.e. engine evidence, not a corpus headline.

## Version audit

| | was | now |
|---|---|---|
| Chromium | 151.0.7922.137 | unchanged — already latest; identical package in bookworm *and* trixie |
| WebKitGTK | 2.50.6 (bookworm) | **2.52.5 (trixie)** — current upstream stable |

bookworm pinned one full stable series behind, so the base image moved rather than the package being pinned. **The upgrade did not fix the stall** (6/10 vs 4/11, Fisher p = 0.395 — indistinguishable), which is what makes this a live upstream defect rather than a stale-Debian artifact.

## The defect, and why it is unrecoverable

Probed during a **confirmed** stall, navigate still outstanding at t=25 s:

```
document.readyState                    -> "complete"
page's own marker                      -> "done layout_ms=1145.0 canvas_ms=160.0 checksum=65030"
document.querySelectorAll("tr").length -> 1200
GET /status, /url, /title              -> 200, all under 3 ms
```

The page finished in ~1.3 s and JavaScript still executes, and only the command fails to complete. The leading hypothesis is that WebKit drops the navigation-completion notification (the gate asymmetry in `upstream/webkit-navigate-completion-lost.md`); the proposed patch is not built or tested, and the eager/normal split supports the hypothesis without isolating it, so the artifacts label it a hypothesis rather than a root cause.

Nothing rescues it. `Session::go` arms no timer — it sends `navigateBrowsingContext` and waits on the backend indefinitely. The only deadline is the browser's `m_loadTimer` (`defaultPageLoadTimeout = 300_s`, `WebAutomationSession.cpp:92`), and an observed navigate ran **390 s** with no response, so that did not fire either. There is one shared `m_loadTimer` across four pending-callback maps and every resolving wait calls `stop()` on it (962, 968, 993, 1002).

## The fix

`pageLoadStrategy: "none"` plus polling `document.readyState` over `execute/sync`. `waitForNavigationToCompleteOnPage` returns on its first branch when the strategy is None, so the broken path is never entered, and readiness comes from a command path proven alive during the stall.

It is also *more* correct: `navigate_ms` now means navigate-to-`readyState`-complete — the same quantity as Chromium's navigate-to-load-event. A page that genuinely never loads still fails, with an error naming the actual `readyState`.

| | failed | rate |
|---|---|---|
| baseline | 13/31 | 42% |
| with fix | 1/24 | **4%** |

**Fisher exact p = 0.0015.** The single failure was a container that never became healthy because the test loop reused host ports before release; a batch with port hygiene ran 12/12. Timings are now deterministic: navigate ~1570 ms, screenshot ~95 ms, total 1678–1729 ms.

## Corrections to the report this PR forces

- The "~1.9 s first render" for WebKit clones is a **one-time process-global init** (~950 ms) that `entry-webkit.sh` fails to pay before the golden snapshot, so every clone inherits it unpaid. Verified on three fresh containers.
- The "120-second navigate-stall class at N≥8" reproduces at **N=1**. My 36% at N=1 versus the report's 41% at N=32 are consistent with one intermittent bug, not a load effect.

I also had to correct myself twice here, and both corrections are in the history: I called the stall deterministic on n=2, and I used "the session stays responsive" as evidence the browser was healthy when `Automation.getBrowsingContext` reads UI-process state only.

## Engine numbers (host-side, fixture, no VM)

| | p50 | note |
|---|---|---|
| WebKit warm | 122.0 ms | PNG-only |
| Chromium | 145.6 ms | JPEG q80 |

Base-image asymmetry is now stated in the Containerfile header: the Chromium image stays on bookworm because its Chromium version is identical and moving it would invalidate every golden measured today.

Two upstream bugs worth filing, with a self-contained 3.3 KB repro: the lost completion notification, and the 300 s deadline that fails to fire.

## Review rounds folded in

Four commits answer the code review and a simplify pass, each defect closed by a test watched failing without its fix:

- Seam and schema: wddrive error records write the `stage` key cdpdrive/reqbench read; the analyzer judges each engine's renders by that engine's schema (wd_host, session_prewired, five WD stages, html invalid for webkit); session-discovery failure escalates out of the per-rep handler instead of burning the schedule; `--arms` refuses exec/html under `--engine webkit`; webkit runs record format=png and reject CDP prewiring flags.
- navigate(): origin comparison is canonical (host case, default ports), and a fragment-only navigation no longer times out (the sentinel plant's own round trip returns document.URL; a fragmentless same-URL repeat is a reload and still requires the swap).
- Harness identity: `harness_sha256()` now covers wddrive.py, pinned by a test that the file list equals reqbench.sh's staged sources minus the analyzer.
- Make graph: webkit build routes through `reqbench.sh build` (HEALTHCHECK assert runs) and webkit run forwards BACKEND/REPS/WARMUP/RESULTS; both pinned in MakefileBenchGraph, watched red against the pre-fix Makefile.
- Artifacts: the unsealed host probe no longer states an engine comparison, and the upstream note is labeled a hypothesis.
- CI: RUSTSEC-2026-0258 (h2 0.3, patched only in the hyper 1.x line) is ignored with justification in `.cargo/audit.toml` and `deny.toml`; #859 tracks the migration that removes both entries.

Full bench suite on the branch matches the PR base's failure set exactly (the 22 pre-existing environment-bound teardown tests); the touched modules run 41/41.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebKitGTK request benchmarking alongside Chromium, including containerized runs, golden creation, verification, and measurement workflows.
  * Added WebDriver-based navigation, rendering, screenshots, session reuse, and health monitoring for WebKit benchmarks.
  * Added engine selection to benchmark commands and recorded the selected engine in results.
* **Bug Fixes**
  * Improved health reporting and navigation readiness handling.
  * Reduced intermittent WebKit page-load failures and improved failure diagnostics.
* **Tests**
  * Expanded coverage for engine routing, container contents, health checks, navigation, and benchmark reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
