### PR TITLE
Bound working-set recording to a per-clone window after handshake

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -452,6 +452,14 @@ pub struct SnapshotServeArgs {
     /// - `off`: no recording, no replay — every clone faults every page in.
     #[arg(long, value_name = "on|off", env = "FCVM_UFFD_PREFETCH")]
     pub uffd_prefetch: Option<String>,
+
+    /// Seconds after a clone's UFFD handshake during which its demand faults are recorded
+    /// into the snapshot's working set. Past the window the clone is served exactly as
+    /// before but no longer recorded, so a long-lived clone cannot grow the hint into its
+    /// lifetime footprint. 0 records nothing; replay of an existing hint is unaffected.
+    /// Default: 300 (a safety bound pending empirical tuning, see issue #858).
+    #[arg(long, value_name = "secs", env = "FCVM_UFFD_PREFETCH_RECORD_WINDOW")]
+    pub uffd_prefetch_record_window: Option<u64>,
 }
 
 #[derive(Args, Debug)]

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -20,7 +20,9 @@ use crate::state::{
     generate_vm_id, truncate_id, validate_vm_name, StateManager, VmState, VmStatus,
 };
 use crate::storage::{validate_snapshot_name, SnapshotGeneration, SnapshotManager};
-use crate::uffd::{Prefetch, UffdBacking, UffdServer};
+use crate::uffd::{
+    record_window_from_env, Prefetch, UffdBacking, UffdServer, DEFAULT_PREFETCH_RECORD_WINDOW,
+};
 use crate::volume::{SpawnedVolumes, VolumeConfig};
 
 use super::common::{
@@ -911,6 +913,13 @@ async fn cmd_snapshot_serve(args: SnapshotServeArgs) -> Result<()> {
         None => Prefetch::On,
     };
 
+    // How long after its handshake each clone's faults keep being recorded into that set
+    // (--uffd-prefetch-record-window / FCVM_UFFD_PREFETCH_RECORD_WINDOW).
+    let record_window = args
+        .uffd_prefetch_record_window
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_PREFETCH_RECORD_WINDOW);
+
     // The server names its own socket after this process's (pid, start_time), so no two
     // live servers can collide on it. Clones rebuild the same name from the serve state
     // file (see `cmd_snapshot_run`).
@@ -924,6 +933,7 @@ async fn cmd_snapshot_serve(args: SnapshotServeArgs) -> Result<()> {
         &paths::data_dir(),
         backing,
         prefetch,
+        record_window,
     )
     .await
     .context("creating UFFD server")?;
@@ -1909,6 +1919,7 @@ async fn cmd_snapshot_run_inner(
             };
             let backing = setup_try!(UffdBacking::from_env(hugepages));
             let prefetch = setup_try!(Prefetch::from_env());
+            let record_window = setup_try!(record_window_from_env());
             info!(
                 reason = %reason,
                 mode = backing.name(),
@@ -1940,6 +1951,7 @@ async fn cmd_snapshot_run_inner(
                 &data_dir,
                 backing,
                 prefetch,
+                record_window,
             )
             .await
             .context("creating implicit UFFD server"));

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -21,7 +21,8 @@ use crate::state::{
 };
 use crate::storage::{validate_snapshot_name, SnapshotGeneration, SnapshotManager};
 use crate::uffd::{
-    record_window_from_env, Prefetch, UffdBacking, UffdServer, DEFAULT_PREFETCH_RECORD_WINDOW,
+    record_window_from_env, Prefetch, ServeShape, UffdBacking, UffdServer,
+    DEFAULT_PREFETCH_RECORD_WINDOW,
 };
 use crate::volume::{SpawnedVolumes, VolumeConfig};
 
@@ -931,9 +932,11 @@ async fn cmd_snapshot_serve(args: SnapshotServeArgs) -> Result<()> {
             .join("config.json"),
         &super::common::snapshot_sibling(&paths::snapshot_dir().join(&args.snapshot_name), "lock"),
         &paths::data_dir(),
-        backing,
-        prefetch,
-        record_window,
+        ServeShape {
+            backing,
+            prefetch,
+            record_window,
+        },
     )
     .await
     .context("creating UFFD server")?;
@@ -1949,9 +1952,11 @@ async fn cmd_snapshot_run_inner(
                     "lock",
                 ),
                 &data_dir,
-                backing,
-                prefetch,
-                record_window,
+                ServeShape {
+                    backing,
+                    prefetch,
+                    record_window,
+                },
             )
             .await
             .context("creating implicit UFFD server"));

--- a/src/uffd/mod.rs
+++ b/src/uffd/mod.rs
@@ -4,6 +4,9 @@ mod server;
 mod working_set;
 
 pub use handler::UffdHandler;
-pub use server::{preflight_clone_hugepages, Prefetch, UffdBacking, UffdServer};
+pub use server::{
+    preflight_clone_hugepages, record_window_from_env, Prefetch, UffdBacking, UffdServer,
+    DEFAULT_PREFETCH_RECORD_WINDOW,
+};
 /// Exported so integration tests can read back what a real restore recorded.
 pub use working_set::WorkingSetStore;

--- a/src/uffd/mod.rs
+++ b/src/uffd/mod.rs
@@ -5,8 +5,8 @@ mod working_set;
 
 pub use handler::UffdHandler;
 pub use server::{
-    preflight_clone_hugepages, record_window_from_env, Prefetch, UffdBacking, UffdServer,
-    DEFAULT_PREFETCH_RECORD_WINDOW,
+    preflight_clone_hugepages, record_window_from_env, Prefetch, ServeShape, UffdBacking,
+    UffdServer, DEFAULT_PREFETCH_RECORD_WINDOW,
 };
 /// Exported so integration tests can read back what a real restore recorded.
 pub use working_set::WorkingSetStore;

--- a/src/uffd/server.rs
+++ b/src/uffd/server.rs
@@ -538,6 +538,21 @@ pub fn record_window_from_env() -> Result<Duration> {
     }
 }
 
+/// How a UFFD server serves pages: the materialisation mode plus the working-set
+/// recording and replay knobs. `snapshot serve` resolves one from its CLI flags; the
+/// implicit server inside `snapshot run` resolves one from the environment.
+#[derive(Clone, Copy, Debug)]
+pub struct ServeShape {
+    /// Private per-clone `UFFDIO_COPY` (default) or one shared memfd resolved with
+    /// `UFFDIO_CONTINUE`.
+    pub backing: UffdBacking,
+    /// Whether clones replay the snapshot's recorded working set.
+    pub prefetch: Prefetch,
+    /// How long after its UFFD handshake each clone's demand faults keep being
+    /// recorded into that set. See [`DEFAULT_PREFETCH_RECORD_WINDOW`].
+    pub record_window: Duration,
+}
+
 /// Async UFFD server that serves memory pages for multiple VMs from a single snapshot
 pub struct UffdServer {
     snapshot_id: String,
@@ -577,10 +592,14 @@ impl UffdServer {
         generation_config_path: &Path,
         generation_lock_path: &Path,
         dir: &Path,
-        backing: UffdBacking,
-        prefetch: Prefetch,
-        record_window: Duration,
+        shape: ServeShape,
     ) -> Result<Self> {
+        let ServeShape {
+            backing,
+            prefetch,
+            record_window,
+        } = shape;
+
         // Before anything else: prove we can fail closed on this kernel.
         require_peer_pidfd_support()?;
 

--- a/src/uffd/server.rs
+++ b/src/uffd/server.rs
@@ -479,6 +479,9 @@ pub enum Prefetch {
 struct CloneWorkingSet {
     store: Option<Arc<WorkingSetStore>>,
     persistence: Option<WorkingSetPersistence>,
+    /// Per-clone recording window, anchored at the UFFD handshake. Only consulted when
+    /// `store` is present, so the zero this derives under `Default` never gates anything.
+    record_window: Duration,
 }
 
 impl Prefetch {
@@ -500,6 +503,41 @@ impl Prefetch {
     }
 }
 
+/// Env var overriding [`DEFAULT_PREFETCH_RECORD_WINDOW`], in whole seconds.
+pub const PREFETCH_RECORD_WINDOW_ENV: &str = "FCVM_UFFD_PREFETCH_RECORD_WINDOW";
+
+/// How long after its UFFD handshake a clone's demand faults are recorded into the
+/// snapshot's working-set hint. Faults past the window are served normally but no longer
+/// recorded, so the sidecar converges to the union of restore windows instead of the
+/// lifetime footprint of the longest-lived clone (issue #858: one clone that ran for hours
+/// grew a 128 GiB guest's hint from 6.5 GiB to 122 GiB).
+///
+/// 300 s is a safety bound pending empirical tuning, not a measured optimum: the slowest
+/// restore-to-guest-ACK observed in issue #858 is 28.5 s on a 128 GiB guest, so this sits
+/// more than 10x past it and cannot truncate an honest restore working set. The 128 GiB
+/// workload measurement that would justify a tighter default is tracked in the issue.
+pub const DEFAULT_PREFETCH_RECORD_WINDOW: Duration = Duration::from_secs(300);
+
+/// Parse a [`PREFETCH_RECORD_WINDOW_ENV`] / `--uffd-prefetch-record-window` value.
+///
+/// `0` records nothing (replay of an already-recorded hint is unaffected).
+pub fn parse_record_window(raw: &str) -> Result<Duration> {
+    let secs: u64 = raw.trim().parse().with_context(|| {
+        format!("{PREFETCH_RECORD_WINDOW_ENV}={raw:?} is not a whole number of seconds")
+    })?;
+    Ok(Duration::from_secs(secs))
+}
+
+/// Resolve the recording window from the environment, defaulting to
+/// [`DEFAULT_PREFETCH_RECORD_WINDOW`]. Used by the implicit server inside
+/// `snapshot run`, which has no serve CLI to carry the flag.
+pub fn record_window_from_env() -> Result<Duration> {
+    match std::env::var(PREFETCH_RECORD_WINDOW_ENV) {
+        Ok(value) => parse_record_window(&value),
+        Err(_) => Ok(DEFAULT_PREFETCH_RECORD_WINDOW),
+    }
+}
+
 /// Async UFFD server that serves memory pages for multiple VMs from a single snapshot
 pub struct UffdServer {
     snapshot_id: String,
@@ -510,6 +548,7 @@ pub struct UffdServer {
     mem_size: usize,
     working_set: Option<Arc<WorkingSetStore>>,
     working_set_persistence: Option<WorkingSetPersistence>,
+    record_window: Duration,
 }
 
 impl UffdServer {
@@ -540,6 +579,7 @@ impl UffdServer {
         dir: &Path,
         backing: UffdBacking,
         prefetch: Prefetch,
+        record_window: Duration,
     ) -> Result<Self> {
         // Before anything else: prove we can fail closed on this kernel.
         require_peer_pidfd_support()?;
@@ -667,6 +707,7 @@ impl UffdServer {
             mem_size,
             working_set,
             working_set_persistence,
+            record_window,
         })
     }
 
@@ -785,6 +826,7 @@ impl UffdServer {
                             let working_set = CloneWorkingSet {
                                 store: self.working_set.clone(),
                                 persistence: self.working_set_persistence.clone(),
+                                record_window: self.record_window,
                             };
                             let mem_size = self.mem_size;
                             let admitted_slot = Arc::clone(&admitted);
@@ -1258,6 +1300,11 @@ struct VmState {
     fault_count: u64,
     pending_continues: std::collections::BTreeMap<usize, PendingContinue>,
     recorded: Option<PageSet>,
+    /// When this clone's recording window closes. `None` means unbounded (a window too
+    /// large for the clock to represent). Faults are always SERVED regardless; the deadline
+    /// only stops them being recorded, so the persisted hint stays a restore working set
+    /// instead of growing into a long-lived clone's lifetime footprint (issue #858).
+    record_until: Option<std::time::Instant>,
     started: std::time::Instant,
     /// `Some` only under `FCVM_UFFD_FAULT_TRACE`; see [`FaultTrace`].
     trace: Option<FaultTrace>,
@@ -1282,6 +1329,15 @@ impl VmState {
         if let (Some((offset, t0)), Some(t)) = (trace, self.trace.as_mut()) {
             let t1 = t.now_ns();
             t.record(offset, t0, t1);
+        }
+    }
+
+    /// The recorder for a demand fault observed at `now`, or `None` once the recording
+    /// window has closed.
+    fn fault_recorder(&mut self, now: std::time::Instant) -> Option<&mut PageSet> {
+        match self.record_until {
+            Some(deadline) if now >= deadline => None,
+            _ => self.recorded.as_mut(),
         }
     }
 }
@@ -1351,6 +1407,7 @@ async fn handle_vm_page_faults(
     let CloneWorkingSet {
         store: working_set,
         persistence: working_set_persistence,
+        record_window,
     } = working_set;
     let page_size = mappings.first().map(|m| m.page_size).unwrap_or(4096);
     let page_mask = !(page_size - 1);
@@ -1389,6 +1446,10 @@ async fn handle_vm_page_faults(
         fault_count: 0,
         pending_continues: std::collections::BTreeMap::new(),
         recorded: working_set.as_deref().map(WorkingSetStore::recorder),
+        // Anchored here, right after the handshake: the window is measured from the
+        // moment this clone could first fault, not from server startup. A window the
+        // clock cannot represent (checked_add overflow) means unbounded recording.
+        record_until: started.checked_add(record_window),
         started,
         trace: FaultTrace::from_env(&vm_id, started),
     };
@@ -1719,7 +1780,8 @@ fn drain_events(uffd: &Uffd, ctx: &VmContext<'_>, state: &mut VmState) -> Result
 
                     // Record demand, never replay: the set converges on what the guest
                     // actually requested rather than recursively recording its prediction.
-                    if let Some(recorder) = state.recorded.as_mut() {
+                    // Recording stops at the clone's window deadline; serving does not.
+                    if let Some(recorder) = state.fault_recorder(std::time::Instant::now()) {
                         recorder.insert_range(offset_in_file as u64, page_size as u64);
                     }
 
@@ -2510,6 +2572,7 @@ mod tests {
             fault_count: 0,
             pending_continues: std::collections::BTreeMap::new(),
             recorded: None,
+            record_until: None,
             started: origin,
             trace: Some(FaultTrace {
                 path: path.clone(),
@@ -2674,6 +2737,121 @@ mod tests {
         assert_eq!(Prefetch::parse("off").unwrap(), Prefetch::Off);
         assert!(Prefetch::parse("true").is_err());
         assert!(Prefetch::parse("").is_err());
+    }
+
+    #[test]
+    fn record_window_parses_whole_seconds_only() {
+        assert_eq!(parse_record_window("0").unwrap(), Duration::from_secs(0));
+        assert_eq!(
+            parse_record_window(" 300 ").unwrap(),
+            Duration::from_secs(300)
+        );
+        assert!(parse_record_window("5s").is_err());
+        assert!(parse_record_window("-1").is_err());
+        assert!(parse_record_window("").is_err());
+    }
+
+    /// Issue #858: a clone that outlives its recording window must keep being SERVED but
+    /// stop being RECORDED, or the persisted hint grows into the clone's lifetime
+    /// footprint (measured: hours of uptime took a 128 GiB guest's hint from 6.5 GiB to
+    /// 122 GiB). With the window forced to zero, a resolved fault must record nothing.
+    #[test]
+    fn a_fault_past_the_recording_window_is_not_recorded() {
+        let mem_len = 64 * 4096u64;
+        let started = std::time::Instant::now();
+
+        let mut past_window = VmState {
+            fault_count: 0,
+            pending_continues: std::collections::BTreeMap::new(),
+            recorded: Some(PageSet::empty(mem_len)),
+            record_until: Some(started), // zero-length window: closed before any fault
+            started,
+            trace: None,
+        };
+        let fault_time = started + Duration::from_secs(1);
+        if let Some(recorder) = past_window.fault_recorder(fault_time) {
+            recorder.insert_range(0, 4096);
+        }
+        assert!(
+            past_window.recorded.as_ref().unwrap().is_empty(),
+            "a fault resolved past the recording window must not be recorded"
+        );
+
+        // Positive control: the same fault inside the window IS recorded, so the gate
+        // above cannot pass by never recording anything.
+        let mut in_window = VmState {
+            fault_count: 0,
+            pending_continues: std::collections::BTreeMap::new(),
+            recorded: Some(PageSet::empty(mem_len)),
+            record_until: started.checked_add(DEFAULT_PREFETCH_RECORD_WINDOW),
+            started,
+            trace: None,
+        };
+        if let Some(recorder) = in_window.fault_recorder(fault_time) {
+            recorder.insert_range(0, 4096);
+        }
+        assert_eq!(
+            in_window.recorded.as_ref().unwrap().len(),
+            1,
+            "a fault inside the window must still be recorded"
+        );
+    }
+
+    /// Issue #858, store level: a clone whose faults all land past its recording window
+    /// must contribute zero learned pages to the snapshot's working set, while a clone
+    /// faulting inside the window still teaches the store.
+    #[test]
+    fn observations_past_the_window_contribute_no_learned_pages() {
+        let fixture = tempfile::tempdir().unwrap();
+        let memory_path = fixture.path().join("memory.bin");
+        let config_path = fixture.path().join("config.json");
+        let generation_lock_path = fixture.path().join("snapshot.lock");
+        let mem_len = 64 * 4096u64;
+        std::fs::write(&memory_path, vec![0u8; mem_len as usize]).unwrap();
+        std::fs::write(&config_path, b"generation-1").unwrap();
+        let store = Arc::new(
+            WorkingSetStore::open(&memory_path, mem_len, &config_path, &generation_lock_path)
+                .unwrap(),
+        );
+
+        let started = std::time::Instant::now();
+        let fault_time = started + Duration::from_secs(1);
+        let clone_state = |window: Duration| VmState {
+            fault_count: 0,
+            pending_continues: std::collections::BTreeMap::new(),
+            recorded: Some(store.recorder()),
+            record_until: started.checked_add(window),
+            started,
+            trace: None,
+        };
+
+        // Every fault of this clone lands after its (zero-length) window.
+        let mut late = clone_state(Duration::ZERO);
+        for offset in [0u64, 4096, 8192] {
+            if let Some(recorder) = late.fault_recorder(fault_time) {
+                recorder.insert_range(offset, 4096);
+            }
+        }
+        let persistence = WorkingSetPersistence::new(Arc::clone(&store)).unwrap();
+        persist_observed_working_set("vm-late", Some(persistence.clone()), late.recorded.take());
+        assert!(
+            store.to_prefetch().is_empty(),
+            "faults past the window must not become learned pages in the store"
+        );
+
+        // The same faults inside the window are learned, proving the merge path works.
+        let mut timely = clone_state(DEFAULT_PREFETCH_RECORD_WINDOW);
+        for offset in [0u64, 4096, 8192] {
+            if let Some(recorder) = timely.fault_recorder(fault_time) {
+                recorder.insert_range(offset, 4096);
+            }
+        }
+        persist_observed_working_set("vm-timely", Some(persistence), timely.recorded.take());
+        assert_eq!(
+            store.to_prefetch().len(),
+            3,
+            "faults inside the window must still be learned"
+        );
     }
 
     /// The implicit-restore socket must fit in `sun_path` under the LONGEST path fcvm

--- a/src/uffd/working_set.rs
+++ b/src/uffd/working_set.rs
@@ -749,7 +749,9 @@ impl WorkingSetStore {
 /// and 95 percent. Half the guest separates the two populations with margin on both
 /// sides.
 pub fn hint_covers_most_of_the_image(hint_bytes: u64, mem_len: u64) -> bool {
-    hint_bytes.saturating_mul(2) > mem_len
+    // Division, not saturating_mul(2): doubling saturates at u64::MAX and
+    // would call a more-than-half hint safe at the boundary.
+    hint_bytes > mem_len / 2
 }
 
 /// Read and validate a recorded set. `None` means "nothing usable here" — always a normal
@@ -1404,6 +1406,10 @@ mod tests {
         // Honest restore working sets must not be flagged.
         assert!(!hint_covers_most_of_the_image(13 * GIB / 2, guest));
         assert!(!hint_covers_most_of_the_image(14 * GIB, guest));
+        // Saturation boundary: doubling u64::MAX / 2 + 1 saturates to u64::MAX,
+        // which is not strictly greater than a u64::MAX-byte image, so the
+        // multiply form called a more-than-half hint safe.
+        assert!(hint_covers_most_of_the_image(u64::MAX / 2 + 1, u64::MAX));
 
         // The two poisoned sidecars from the issue must be.
         assert!(hint_covers_most_of_the_image(84 * GIB, guest));

--- a/src/uffd/working_set.rs
+++ b/src/uffd/working_set.rs
@@ -532,8 +532,11 @@ impl WorkingSetStore {
                         guest_mib = mem_len / (1024 * 1024),
                         "recorded working set covers more than half the guest, which looks \
                          like a lifetime footprint rather than a restore working set (issue \
-                         #858); replay will populate all of it. Delete the sidecar to \
-                         re-record."
+                         #858); replay will populate all of it. To re-record: stop the serve \
+                         process, delete the sidecar, then restart the serve. Deleting it \
+                         while a serve is running does not repair that server; the loaded \
+                         hint stays in its in-memory union and the persistence worker can \
+                         write the sidecar again."
                     );
                 }
                 set
@@ -1412,6 +1415,73 @@ mod tests {
 
         // An empty hint on an empty image is not suspect.
         assert!(!hint_covers_most_of_the_image(0, 0));
+    }
+
+    /// The suspect-hint warning must order the repair as stop, delete, restart. Deleting
+    /// the sidecar while the serve is still running does not repair that server: the
+    /// suspect set stays in `WorkingSetStore::known`, later clones still replay it, and
+    /// the persistence worker can rewrite the sidecar, racing the deletion.
+    #[test]
+    fn suspect_hint_warning_orders_stop_before_delete_before_restart() {
+        #[derive(Clone, Default)]
+        struct Captured(Arc<Mutex<Vec<u8>>>);
+
+        impl Write for Captured {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Captured {
+            type Writer = Captured;
+
+            fn make_writer(&'a self) -> Self::Writer {
+                self.clone()
+            }
+        }
+
+        // Persist a hint covering more than half the image (33 of 64 granules).
+        let mem_len = 64 * GRANULE;
+        let image = fake_image("suspect-warning", mem_len);
+        {
+            let store = open_store(&image, mem_len);
+            let mut set = store.recorder();
+            set.insert_range(0, 33 * GRANULE);
+            store.merge_and_persist(&set).unwrap();
+        }
+
+        let captured = Captured::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(captured.clone())
+            .with_ansi(false)
+            .finish();
+        tracing::subscriber::with_default(subscriber, || {
+            let _ = open_store(&image, mem_len);
+        });
+
+        let log = String::from_utf8(captured.0.lock().unwrap().clone()).unwrap();
+        assert!(
+            log.contains("covers more than half the guest"),
+            "the suspect warning must fire for this hint; captured: {log}"
+        );
+        let stop = log
+            .find("stop the serve")
+            .unwrap_or_else(|| panic!("guidance must start with stopping the serve: {log}"));
+        let delete = log
+            .find("delete the sidecar")
+            .unwrap_or_else(|| panic!("guidance must include deleting the sidecar: {log}"));
+        let restart = log
+            .find("restart the serve")
+            .unwrap_or_else(|| panic!("guidance must end with restarting the serve: {log}"));
+        assert!(
+            stop < delete && delete < restart,
+            "repair steps must read stop, then delete, then restart: {log}"
+        );
     }
 
     #[test]

--- a/src/uffd/working_set.rs
+++ b/src/uffd/working_set.rs
@@ -524,6 +524,18 @@ impl WorkingSetStore {
                     key = ?key,
                     "loaded recorded restore working set"
                 );
+                if hint_covers_most_of_the_image(set.bytes(), mem_len) {
+                    warn!(
+                        target: "uffd",
+                        path = %path.display(),
+                        hint_mib = set.bytes() / (1024 * 1024),
+                        guest_mib = mem_len / (1024 * 1024),
+                        "recorded working set covers more than half the guest, which looks \
+                         like a lifetime footprint rather than a restore working set (issue \
+                         #858); replay will populate all of it. Delete the sidecar to \
+                         re-record."
+                    );
+                }
                 set
             }
             None => PageSet::empty(mem_len),
@@ -724,6 +736,17 @@ impl WorkingSetStore {
             }
         }
     }
+}
+
+/// Whether a recorded hint is so large relative to the guest that it looks like a
+/// lifetime footprint rather than a restore working set.
+///
+/// Honest restore working sets measured 5 to 11 percent of guest memory (6.5 and 14 GiB
+/// of a 128 GiB guest, issue #858); the two poisoned sidecars observed there covered 66
+/// and 95 percent. Half the guest separates the two populations with margin on both
+/// sides.
+pub fn hint_covers_most_of_the_image(hint_bytes: u64, mem_len: u64) -> bool {
+    hint_bytes.saturating_mul(2) > mem_len
 }
 
 /// Read and validate a recorded set. `None` means "nothing usable here" — always a normal
@@ -1365,6 +1388,30 @@ mod tests {
             .expect("the retry must acquire the released sidecar");
         assert!(outcome.persisted);
         assert_eq!(open_store(&image, mem_len).to_prefetch().len(), 2);
+    }
+
+    /// Issue #858's poisoned-sidecar tell: a hint covering most of the guest cannot be a
+    /// restore working set. The thresholds pin the measured populations: honest sets were
+    /// 6.5 and 14 GiB of a 128 GiB guest, poisoned ones 84 and 122 GiB.
+    #[test]
+    fn a_hint_covering_most_of_the_guest_is_flagged_as_suspect() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+        let guest = 128 * GIB;
+
+        // Honest restore working sets must not be flagged.
+        assert!(!hint_covers_most_of_the_image(13 * GIB / 2, guest));
+        assert!(!hint_covers_most_of_the_image(14 * GIB, guest));
+
+        // The two poisoned sidecars from the issue must be.
+        assert!(hint_covers_most_of_the_image(84 * GIB, guest));
+        assert!(hint_covers_most_of_the_image(122 * GIB, guest));
+
+        // Exactly half is the boundary: not suspect at half, suspect one granule past it.
+        assert!(!hint_covers_most_of_the_image(64 * GIB, guest));
+        assert!(hint_covers_most_of_the_image(64 * GIB + GRANULE, guest));
+
+        // An empty hint on an empty image is not suspect.
+        assert!(!hint_covers_most_of_the_image(0, 0));
     }
 
     #[test]


### PR DESCRIPTION
A serve unions every clone's faulted pages into the snapshot's working-set
sidecar for the clone's whole life, so one long-lived clone turns the restore
hint into its lifetime footprint (issue #858: hours of uptime grew a 128 GiB
guest's hint from 6.5 GiB to 122 GiB, and a day of serving grew it to 84 GiB,
which also consumed the hugepage pool headroom the next clone's reservation
needed).

Each clone now gets a recording deadline anchored at its UFFD handshake.
Faults past the deadline are served exactly as before but no longer recorded,
so the sidecar converges to the union of restore windows. Replay is unchanged.
Knob: --uffd-prefetch-record-window <secs> on snapshot serve, or
FCVM_UFFD_PREFETCH_RECORD_WINDOW for the implicit server inside snapshot run.
0 records nothing. The 300 s default is a safety bound pending empirical
tuning: the slowest restore-to-guest-ACK in the issue is 28.5 s, so the
default sits more than 10x past it and cannot truncate an honest restore
working set; the 128 GiB workload measurement is tracked in the issue.

A window cannot repair a sidecar already poisoned on disk, so serve startup
now warns when a loaded hint covers more than half the guest (honest restore
sets measured 5 to 11 percent of guest memory, the two poisoned ones 66 and
95 percent) and names the sidecar to delete.

Tests, each watched failing before the gate and the predicate were added
(cargo test --lib -p fcvm uffd:: on the ungated code, 75 passed 3 failed):

  a_fault_past_the_recording_window_is_not_recorded
    panicked at src/uffd/server.rs: a fault resolved past the recording
    window must not be recorded
  observations_past_the_window_contribute_no_learned_pages
    panicked at src/uffd/server.rs: faults past the window must not become
    learned pages in the store
  a_hint_covering_most_of_the_guest_is_flagged_as_suspect
    panicked at src/uffd/working_set.rs: assertion failed:
    hint_covers_most_of_the_image(84 * GIB, guest)

With the fix: cargo test --lib -p fcvm uffd:: reports 78 passed, 0 failed.
cargo check --all-targets -p fcvm and cargo fmt -p fcvm -- --check pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable UFFD prefetch recording windows through the CLI or `FCVM_UFFD_PREFETCH_RECORD_WINDOW`.
  * Recording defaults to 300 seconds and can be disabled with a zero-second setting; replay of existing hints remains available.
* **Bug Fixes**
  * Improved working-set detection by warning when hints cover more than half of the guest image.
  * Added guidance for recovering from likely lifetime-footprint hints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->