### PR TITLE
Hash the guest-visible boot inputs into the snapshot key (#821)

### DIFF
--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -37,7 +37,7 @@ pub use snapshot::{
 };
 pub(crate) use vm_config::{
     build_launch_config, build_runtime_boot_args, cleanup_nfs_exports, configure_and_boot_vm,
-    setup_nfs_exports,
+    setup_nfs_exports, GuestBootInputs,
 };
 use vm_config::{run_vm_setup, VmSetupParams};
 
@@ -1205,6 +1205,7 @@ async fn prepare_vm_for_lifecycle(
             runtime_config.firecracker_bin.as_deref(),
             image_disk_identity.clone(),
             vm_config::effective_extra_boot_args(&runtime_config),
+            GuestBootInputs::resolve(args.dns.as_deref(), &runtime_config),
         );
         let key = config.snapshot_key();
 
@@ -2751,6 +2752,7 @@ mod tests {
                 None,
                 None,
                 extra,
+                GuestBootInputs::default(),
             )
             .snapshot_key()
         };
@@ -2776,6 +2778,112 @@ mod tests {
             key(&base, None),
             key(&base, Some("arm64.nv2".to_string())),
             "extra boot args must change the key"
+        );
+    }
+
+    /// #821 helper: snapshot key of a config built through the real
+    /// constructor from the given guest boot inputs. The host-derived DNS
+    /// values and the FUSE knobs are guest-visible boot inputs, baked into
+    /// the guest at boot and therefore into any snapshot taken from it, so
+    /// two runs differing only in one of them must never share a snapshot.
+    /// Before FirecrackerConfig carried these fields the keys came out equal
+    /// and a cache hit silently served a guest built with the other value.
+    fn boot_inputs_key(inputs: GuestBootInputs) -> String {
+        use std::path::Path;
+        build_firecracker_config(
+            &test_args(),
+            "sha256:test",
+            Path::new("/kernel"),
+            Path::new("/rootfs"),
+            Path::new("/initrd"),
+            None,
+            ImageMode::Overlay,
+            None,
+            None,
+            None,
+            inputs,
+        )
+        .snapshot_key()
+    }
+
+    #[test]
+    fn host_dns_fallback_changes_snapshot_key() {
+        let dns = |servers: &[&str]| GuestBootInputs {
+            host_dns: servers.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        };
+        assert_ne!(
+            boot_inputs_key(GuestBootInputs::default()),
+            boot_inputs_key(dns(&["1.1.1.1"])),
+            "host DNS fallback must change the key"
+        );
+        assert_ne!(
+            boot_inputs_key(dns(&["1.1.1.1"])),
+            boot_inputs_key(dns(&["8.8.8.8"])),
+            "hosts with different resolv.conf servers must not share a snapshot"
+        );
+    }
+
+    #[test]
+    fn dns_search_changes_snapshot_key() {
+        assert_ne!(
+            boot_inputs_key(GuestBootInputs::default()),
+            boot_inputs_key(GuestBootInputs {
+                dns_search: vec!["corp.example".to_string()],
+                ..Default::default()
+            }),
+            "DNS search domains must change the key"
+        );
+    }
+
+    #[test]
+    fn fuse_readers_changes_snapshot_key() {
+        assert_ne!(
+            boot_inputs_key(GuestBootInputs {
+                fuse_readers: Some("8".to_string()),
+                ..Default::default()
+            }),
+            boot_inputs_key(GuestBootInputs {
+                fuse_readers: Some("64".to_string()),
+                ..Default::default()
+            }),
+            "fuse_readers must change the key"
+        );
+    }
+
+    #[test]
+    fn fuse_trace_rate_changes_snapshot_key() {
+        assert_ne!(
+            boot_inputs_key(GuestBootInputs::default()),
+            boot_inputs_key(GuestBootInputs {
+                fuse_trace_rate: Some("100".to_string()),
+                ..Default::default()
+            }),
+            "fuse_trace_rate must change the key"
+        );
+    }
+
+    #[test]
+    fn fuse_max_write_changes_snapshot_key() {
+        assert_ne!(
+            boot_inputs_key(GuestBootInputs::default()),
+            boot_inputs_key(GuestBootInputs {
+                fuse_max_write: Some("32768".to_string()),
+                ..Default::default()
+            }),
+            "fuse_max_write must change the key"
+        );
+    }
+
+    #[test]
+    fn no_writeback_cache_changes_snapshot_key() {
+        assert_ne!(
+            boot_inputs_key(GuestBootInputs::default()),
+            boot_inputs_key(GuestBootInputs {
+                no_writeback_cache: true,
+                ..Default::default()
+            }),
+            "no_writeback_cache must change the key"
         );
     }
 

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -1188,6 +1188,11 @@ async fn prepare_vm_for_lifecycle(
             .unwrap_or(false),
         std::env::var("FCVM_BOOTPLAN").as_deref() == Ok("vsock"),
     );
+    // Resolved ONCE for the whole launch. The same values feed the snapshot
+    // key (via fc_config or the fallback launch config) and the bridged
+    // network's guest DNS below, so the hashed value and the guest-visible
+    // value cannot diverge on a mid-launch resolv.conf change (#863).
+    let boot_inputs = GuestBootInputs::resolve(args.dns.as_deref(), &runtime_config);
     let (fc_config, snapshot_key, prepare_target): (
         Option<crate::firecracker::FirecrackerConfig>,
         Option<String>,
@@ -1205,7 +1210,7 @@ async fn prepare_vm_for_lifecycle(
             runtime_config.firecracker_bin.as_deref(),
             image_disk_identity.clone(),
             vm_config::effective_extra_boot_args(&runtime_config),
-            GuestBootInputs::resolve(args.dns.as_deref(), &runtime_config),
+            boot_inputs.clone(),
         );
         let key = config.snapshot_key();
 
@@ -1454,11 +1459,24 @@ async fn prepare_vm_for_lifecycle(
 
     let tap_device = format!("tap-{}", truncate_id(&vm_id, 8));
     let mut network: Box<dyn NetworkManager> = match args.network {
-        NetworkMode::Bridged => Box::new(BridgedNetwork::new(
-            vm_id.clone(),
-            tap_device.clone(),
-            port_mappings.clone(),
-        )),
+        NetworkMode::Bridged => {
+            // The guest's resolver is the first hashed host_dns entry,
+            // threaded from the same resolution the snapshot key saw instead
+            // of re-read inside setup() (#863). Fail closed like the old
+            // in-setup read did: a bridged guest NATs straight out and needs
+            // a real resolver, and --dns is the override.
+            if args.dns.is_none() && boot_inputs.host_dns.is_empty() {
+                bail!(
+                    "no usable host DNS server for bridged mode (VMs cannot use a \
+                     loopback stub resolver; on systemd-resolved hosts mount \
+                     /run/systemd/resolve). Pass --dns to override."
+                );
+            }
+            Box::new(
+                BridgedNetwork::new(vm_id.clone(), tap_device.clone(), port_mappings.clone())
+                    .with_dns_server(boot_inputs.host_dns.first().cloned()),
+            )
+        }
         NetworkMode::Routed => {
             let mut net =
                 RoutedNetwork::new(vm_id.clone(), tap_device.clone(), port_mappings.clone());
@@ -1755,6 +1773,7 @@ async fn prepare_vm_for_lifecycle(
             image_disk_path: image_disk_path.as_deref(),
             fc_config,
             runtime_config: &runtime_config,
+            boot_inputs,
         },
         network.as_mut(),
         &state_manager,
@@ -2788,10 +2807,10 @@ mod tests {
     /// two runs differing only in one of them must never share a snapshot.
     /// Before FirecrackerConfig carried these fields the keys came out equal
     /// and a cache hit silently served a guest built with the other value.
-    fn boot_inputs_key(inputs: GuestBootInputs) -> String {
+    fn key_for(args: &RunArgs, inputs: GuestBootInputs) -> String {
         use std::path::Path;
         build_firecracker_config(
-            &test_args(),
+            args,
             "sha256:test",
             Path::new("/kernel"),
             Path::new("/rootfs"),
@@ -2804,6 +2823,76 @@ mod tests {
             inputs,
         )
         .snapshot_key()
+    }
+
+    fn boot_inputs_key(inputs: GuestBootInputs) -> String {
+        key_for(&test_args(), inputs)
+    }
+
+    /// #863: bridged mode forwards exactly one resolver to the guest
+    /// (network_config.dns_server is the first host entry), so the key must
+    /// hash exactly that. Keying the whole host list cold-boots a guest whose
+    /// cmdline is identical whenever a secondary nameserver changes. Rootless
+    /// mode emits the whole list, so every entry must keep keying there.
+    #[test]
+    fn bridged_mode_keys_only_the_emitted_dns() {
+        let dns = |servers: &[&str]| GuestBootInputs {
+            host_dns: servers.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        };
+        let bridged = |servers: &[&str]| {
+            let mut args = test_args();
+            args.network = NetworkMode::Bridged;
+            key_for(&args, dns(servers))
+        };
+        assert_eq!(
+            bridged(&["1.1.1.1", "8.8.8.8"]),
+            bridged(&["1.1.1.1", "9.9.9.9"]),
+            "a secondary nameserver never reaches a bridged guest and must not change its key"
+        );
+        assert_ne!(
+            bridged(&["1.1.1.1", "8.8.8.8"]),
+            bridged(&["8.8.8.8", "8.8.8.8"]),
+            "the first resolver IS emitted to a bridged guest and must change the key"
+        );
+        assert_ne!(
+            boot_inputs_key(dns(&["1.1.1.1", "8.8.8.8"])),
+            boot_inputs_key(dns(&["1.1.1.1", "9.9.9.9"])),
+            "rootless mode emits the whole list, so a secondary change must still key"
+        );
+    }
+
+    /// #863: with no --map, fc-agent never calls mount_fuse_volumes
+    /// (fc-agent/src/agent.rs gates it on plan.volumes, and the four knobs are
+    /// read only inside fc-agent/src/fuse/mod.rs's mount path), so the knobs
+    /// cannot affect a volume-free guest and must not fragment its key.
+    #[test]
+    fn fuse_knobs_do_not_fragment_volume_free_keys() {
+        let knobs = || GuestBootInputs {
+            fuse_readers: Some("8".to_string()),
+            fuse_trace_rate: Some("100".to_string()),
+            fuse_max_write: Some("32768".to_string()),
+            no_writeback_cache: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            boot_inputs_key(GuestBootInputs::default()),
+            boot_inputs_key(knobs()),
+            "FUSE knobs are dormant without volumes and must not change the key"
+        );
+        assert_ne!(
+            key_for(&fuse_volume_args(), GuestBootInputs::default()),
+            key_for(&fuse_volume_args(), knobs()),
+            "with a volume mapped the knobs shape the guest's FUSE mounts and must key"
+        );
+    }
+
+    /// Args with a FUSE volume mapped: the four FUSE knobs only reach the
+    /// guest's mount path when the run maps volumes.
+    fn fuse_volume_args() -> RunArgs {
+        let mut args = test_args();
+        args.map = vec!["/tmp/data:/data".to_string()];
+        args
     }
 
     #[test]
@@ -2839,51 +2928,66 @@ mod tests {
     #[test]
     fn fuse_readers_changes_snapshot_key() {
         assert_ne!(
-            boot_inputs_key(GuestBootInputs {
-                fuse_readers: Some("8".to_string()),
-                ..Default::default()
-            }),
-            boot_inputs_key(GuestBootInputs {
-                fuse_readers: Some("64".to_string()),
-                ..Default::default()
-            }),
-            "fuse_readers must change the key"
+            key_for(
+                &fuse_volume_args(),
+                GuestBootInputs {
+                    fuse_readers: Some("8".to_string()),
+                    ..Default::default()
+                }
+            ),
+            key_for(
+                &fuse_volume_args(),
+                GuestBootInputs {
+                    fuse_readers: Some("64".to_string()),
+                    ..Default::default()
+                }
+            ),
+            "fuse_readers must change the key of a run with volumes"
         );
     }
 
     #[test]
     fn fuse_trace_rate_changes_snapshot_key() {
         assert_ne!(
-            boot_inputs_key(GuestBootInputs::default()),
-            boot_inputs_key(GuestBootInputs {
-                fuse_trace_rate: Some("100".to_string()),
-                ..Default::default()
-            }),
-            "fuse_trace_rate must change the key"
+            key_for(&fuse_volume_args(), GuestBootInputs::default()),
+            key_for(
+                &fuse_volume_args(),
+                GuestBootInputs {
+                    fuse_trace_rate: Some("100".to_string()),
+                    ..Default::default()
+                }
+            ),
+            "fuse_trace_rate must change the key of a run with volumes"
         );
     }
 
     #[test]
     fn fuse_max_write_changes_snapshot_key() {
         assert_ne!(
-            boot_inputs_key(GuestBootInputs::default()),
-            boot_inputs_key(GuestBootInputs {
-                fuse_max_write: Some("32768".to_string()),
-                ..Default::default()
-            }),
-            "fuse_max_write must change the key"
+            key_for(&fuse_volume_args(), GuestBootInputs::default()),
+            key_for(
+                &fuse_volume_args(),
+                GuestBootInputs {
+                    fuse_max_write: Some("32768".to_string()),
+                    ..Default::default()
+                }
+            ),
+            "fuse_max_write must change the key of a run with volumes"
         );
     }
 
     #[test]
     fn no_writeback_cache_changes_snapshot_key() {
         assert_ne!(
-            boot_inputs_key(GuestBootInputs::default()),
-            boot_inputs_key(GuestBootInputs {
-                no_writeback_cache: true,
-                ..Default::default()
-            }),
-            "no_writeback_cache must change the key"
+            key_for(&fuse_volume_args(), GuestBootInputs::default()),
+            key_for(
+                &fuse_volume_args(),
+                GuestBootInputs {
+                    no_writeback_cache: true,
+                    ..Default::default()
+                }
+            ),
+            "no_writeback_cache must change the key of a run with volumes"
         );
     }
 

--- a/src/commands/podman/snapshot.rs
+++ b/src/commands/podman/snapshot.rs
@@ -317,6 +317,7 @@ pub(super) fn build_firecracker_config(
     use crate::firecracker::{BootSource, Drive, FcNetworkMode, FirecrackerConfig, MachineConfig};
 
     let network_mode: FcNetworkMode = args.network.into();
+    let boot_inputs = boot_inputs.for_launch(network_mode, !args.map.is_empty());
 
     let port_mappings = crate::network::PortMapping::parse_all_lenient(&args.publish);
 

--- a/src/commands/podman/snapshot.rs
+++ b/src/commands/podman/snapshot.rs
@@ -309,6 +309,7 @@ pub(super) fn build_firecracker_config(
     firecracker_bin: Option<&Path>,
     image_disk_identity: Option<String>,
     extra_boot_args: Option<String>,
+    boot_inputs: super::vm_config::GuestBootInputs,
 ) -> crate::firecracker::FirecrackerConfig {
     // image_identifier is the digest for localhost images (content-addressed cache key).
     // args.image is the original name (what the guest uses to find the image).
@@ -377,6 +378,12 @@ pub(super) fn build_firecracker_config(
         agent_strace: args.strace_agent,
         extra_boot_args,
         image_disk_identity,
+        host_dns: boot_inputs.host_dns,
+        dns_search: boot_inputs.dns_search,
+        fuse_readers: boot_inputs.fuse_readers,
+        fuse_trace_rate: boot_inputs.fuse_trace_rate,
+        fuse_max_write: boot_inputs.fuse_max_write,
+        no_writeback_cache: boot_inputs.no_writeback_cache,
     }
 }
 

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -182,12 +182,14 @@ fn rebuild_proxy_url(parsed: &Url, host: String, port: u16) -> String {
 
 /// Build runtime boot arguments for the kernel command line.
 ///
-/// These are per-instance values NOT included in the snapshot cache key:
-/// network IP config, IPv6, DNS, strace, profile boot args, FUSE tuning.
+/// Per-instance network values (`ip=`, `ipv6=`, and the mode's DNS choice in
+/// `network_config`) are excluded from the snapshot key by design. Every other
+/// token is emitted from `launch_config`, the same hashed FirecrackerConfig
+/// the snapshot key is computed from, so the hashed value and the value the
+/// guest boots with cannot diverge (#821).
 pub(crate) fn build_runtime_boot_args(
-    args: &RunArgs,
     network_config: &crate::network::NetworkConfig,
-    runtime_config: &crate::commands::common::RuntimeConfig,
+    launch_config: &crate::firecracker::FirecrackerConfig,
 ) -> String {
     let mut boot_args = String::new();
 
@@ -224,15 +226,15 @@ pub(crate) fn build_runtime_boot_args(
         boot_args.push_str(&format!("ipv6={}|{}", guest_ipv6, host_ipv6));
     }
 
-    // Pass DNS servers to guest for resolv.conf configuration
-    // Both rootless and bridged: use host DNS servers directly (reachable via
-    // pasta's L4 translation or bridge/NAT respectively)
+    // Pass DNS servers to guest for resolv.conf configuration: the mode's
+    // DNS choice (pasta forwarder, bridged host DNS, or the --dns override
+    // recorded in network_config), else the hashed host fallback resolved at
+    // config construction (#821).
     {
         let dns_servers = if let Some(ref dns) = network_config.dns_server {
-            // Use the network-mode-specific DNS (pasta forwarder or host DNS)
             vec![dns.clone()]
         } else {
-            crate::network::get_host_dns_servers().unwrap_or_default()
+            launch_config.host_dns.clone()
         };
 
         if !dns_servers.is_empty() {
@@ -244,26 +246,19 @@ pub(crate) fn build_runtime_boot_args(
         }
 
         // Pass search domains for short hostname resolution
-        if let Ok(content) = std::fs::read_to_string("/run/systemd/resolve/resolv.conf")
-            .or_else(|_| std::fs::read_to_string("/etc/resolv.conf"))
-        {
-            let search: Vec<&str> = content
-                .lines()
-                .filter_map(|l| l.trim().strip_prefix("search "))
-                .next()
-                .map(|s| s.split_whitespace().collect())
-                .unwrap_or_default();
-            if !search.is_empty() {
-                if !boot_args.is_empty() {
-                    boot_args.push(' ');
-                }
-                boot_args.push_str(&format!("fcvm_dns_search={}", search.join("|")));
+        if !launch_config.dns_search.is_empty() {
+            if !boot_args.is_empty() {
+                boot_args.push(' ');
             }
+            boot_args.push_str(&format!(
+                "fcvm_dns_search={}",
+                launch_config.dns_search.join("|")
+            ));
         }
     }
 
     // Enable fc-agent strace debugging if requested
-    if args.strace_agent {
+    if launch_config.agent_strace {
         if !boot_args.is_empty() {
             boot_args.push(' ');
         }
@@ -272,8 +267,7 @@ pub(crate) fn build_runtime_boot_args(
     }
 
     // Additional boot args from RuntimeConfig (kernel profile) or FCVM_BOOT_ARGS env var
-    let extra_boot_args = effective_extra_boot_args(runtime_config);
-    if let Some(ref extra) = extra_boot_args {
+    if let Some(ref extra) = launch_config.extra_boot_args {
         if !boot_args.is_empty() {
             boot_args.push(' ');
         }
@@ -281,11 +275,7 @@ pub(crate) fn build_runtime_boot_args(
     }
 
     // Pass FUSE reader count to fc-agent via kernel command line (from RuntimeConfig or env)
-    let fuse_readers = runtime_config
-        .fuse_readers
-        .map(|r| r.to_string())
-        .or_else(|| std::env::var("FCVM_FUSE_READERS").ok());
-    if let Some(readers) = fuse_readers {
+    if let Some(ref readers) = launch_config.fuse_readers {
         if !boot_args.is_empty() {
             boot_args.push(' ');
         }
@@ -293,7 +283,7 @@ pub(crate) fn build_runtime_boot_args(
     }
 
     // Pass FUSE trace rate to fc-agent via kernel command line.
-    if let Ok(rate) = std::env::var("FCVM_FUSE_TRACE_RATE") {
+    if let Some(ref rate) = launch_config.fuse_trace_rate {
         if !boot_args.is_empty() {
             boot_args.push(' ');
         }
@@ -304,8 +294,8 @@ pub(crate) fn build_runtime_boot_args(
     // deterministic-interleaving instrumentation — see the failpoint crate).
     // Validated up front: guest specs are sleep-only and whitespace-free, and a
     // bad spec must fail the run before a VM boots, not silently un-arm a test.
-    if let Ok(spec) = std::env::var("FCVM_GUEST_FAILPOINT") {
-        if let Err(e) = failpoint::validate_guest_spec(&spec) {
+    if let Some(ref spec) = launch_config.guest_failpoint {
+        if let Err(e) = failpoint::validate_guest_spec(spec) {
             panic!("invalid FCVM_GUEST_FAILPOINT: {e}");
         }
         if !boot_args.is_empty() {
@@ -315,7 +305,7 @@ pub(crate) fn build_runtime_boot_args(
     }
 
     // Pass FUSE max_write to fc-agent via kernel command line.
-    if let Ok(max_write) = std::env::var("FCVM_FUSE_MAX_WRITE") {
+    if let Some(ref max_write) = launch_config.fuse_max_write {
         if !boot_args.is_empty() {
             boot_args.push(' ');
         }
@@ -323,7 +313,7 @@ pub(crate) fn build_runtime_boot_args(
     }
 
     // Pass FUSE writeback cache disable flag to fc-agent via kernel command line.
-    if std::env::var("FCVM_NO_WRITEBACK_CACHE").is_ok() {
+    if launch_config.no_writeback_cache {
         if !boot_args.is_empty() {
             boot_args.push(' ');
         }
@@ -968,9 +958,9 @@ pub(super) async fn run_vm_setup(
 /// The extra kernel boot args a launch will actually append.
 ///
 /// Resolves the kernel profile's `boot_args`, falling back to FCVM_BOOT_ARGS.
-/// One derivation, used both by the snapshot-key config (hashed) and by the
-/// runtime cmdline assembly (applied), so the hashed value and the applied
-/// value cannot drift.
+/// Resolved once at FirecrackerConfig construction (hashed);
+/// build_runtime_boot_args emits the config's value, so the hashed value and
+/// the applied value cannot drift.
 pub(crate) fn effective_extra_boot_args(
     runtime_config: &crate::commands::common::RuntimeConfig,
 ) -> Option<String> {
@@ -978,6 +968,66 @@ pub(crate) fn effective_extra_boot_args(
         .boot_args
         .clone()
         .or_else(|| std::env::var("FCVM_BOOT_ARGS").ok())
+}
+
+/// Guest-visible boot inputs read from the host, resolved once per
+/// FirecrackerConfig construction. Each is forwarded to fc-agent on the
+/// kernel cmdline and baked into the booted guest, so each is stored on the
+/// config (and therefore in the snapshot key) and emitted from there by
+/// build_runtime_boot_args (#821). A second read at emission time would be a
+/// window for the guest to boot with a value the key never saw.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct GuestBootInputs {
+    pub host_dns: Vec<String>,
+    pub dns_search: Vec<String>,
+    pub fuse_readers: Option<String>,
+    pub fuse_trace_rate: Option<String>,
+    pub fuse_max_write: Option<String>,
+    pub no_writeback_cache: bool,
+}
+
+impl GuestBootInputs {
+    /// Read the host state and env knobs that shape the guest at boot.
+    ///
+    /// `dns_override` is --dns: when set it wins outright (hashed via
+    /// FirecrackerConfig.dns_server), the host fallback is never emitted, and
+    /// hashing the host list anyway would only fragment cache keys between
+    /// hosts whose guests boot identically.
+    pub(crate) fn resolve(
+        dns_override: Option<&str>,
+        runtime_config: &crate::commands::common::RuntimeConfig,
+    ) -> Self {
+        let host_dns = if dns_override.is_some() {
+            Vec::new()
+        } else {
+            crate::network::get_host_dns_servers().unwrap_or_default()
+        };
+        let dns_search = std::fs::read_to_string("/run/systemd/resolve/resolv.conf")
+            .or_else(|_| std::fs::read_to_string("/etc/resolv.conf"))
+            .map(|content| parse_search_domains(&content))
+            .unwrap_or_default();
+        Self {
+            host_dns,
+            dns_search,
+            fuse_readers: runtime_config
+                .fuse_readers
+                .map(|r| r.to_string())
+                .or_else(|| std::env::var("FCVM_FUSE_READERS").ok()),
+            fuse_trace_rate: std::env::var("FCVM_FUSE_TRACE_RATE").ok(),
+            fuse_max_write: std::env::var("FCVM_FUSE_MAX_WRITE").ok(),
+            no_writeback_cache: std::env::var("FCVM_NO_WRITEBACK_CACHE").is_ok(),
+        }
+    }
+}
+
+/// The first `search` line of a resolv.conf, split into domains.
+fn parse_search_domains(resolv: &str) -> Vec<String> {
+    resolv
+        .lines()
+        .filter_map(|l| l.trim().strip_prefix("search "))
+        .next()
+        .map(|s| s.split_whitespace().map(str::to_string).collect())
+        .unwrap_or_default()
 }
 
 /// Build the FirecrackerConfig used to cold-boot a VM from a disk.
@@ -993,6 +1043,7 @@ pub(crate) fn build_launch_config(
     initrd_path: &std::path::Path,
     cmd_args: &Option<Vec<String>>,
     runtime_config: &crate::commands::common::RuntimeConfig,
+    boot_inputs: GuestBootInputs,
 ) -> crate::firecracker::FirecrackerConfig {
     use crate::firecracker::{BootSource, Drive, FcNetworkMode, FirecrackerConfig, MachineConfig};
     let network_mode: FcNetworkMode = args.network.into();
@@ -1056,6 +1107,12 @@ pub(crate) fn build_launch_config(
         // Launch-only config: never hashed into a snapshot key, so the image
         // disk's build identity is not resolved here.
         image_disk_identity: None,
+        host_dns: boot_inputs.host_dns,
+        dns_search: boot_inputs.dns_search,
+        fuse_readers: boot_inputs.fuse_readers,
+        fuse_trace_rate: boot_inputs.fuse_trace_rate,
+        fuse_max_write: boot_inputs.fuse_max_write,
+        no_writeback_cache: boot_inputs.no_writeback_cache,
     }
 }
 
@@ -1444,10 +1501,11 @@ async fn run_vm_setup_inner(
                 initrd_path,
                 &cmd_args,
                 runtime_config,
+                GuestBootInputs::resolve(args.dns.as_deref(), runtime_config),
             )
         });
 
-    let mut runtime_boot_args = build_runtime_boot_args(args, network_config, runtime_config);
+    let mut runtime_boot_args = build_runtime_boot_args(network_config, &launch_config);
     if bootplan_over_vsock {
         // fc-agent reads this kernel arg to select the vsock boot-plan transport.
         runtime_boot_args.push_str(" fcvm_bootplan=vsock");
@@ -1542,11 +1600,10 @@ mod tests {
     /// Fail-closed inventory of the runtime kernel-cmdline tokens. Everything
     /// build_runtime_boot_args emits is guest-visible, so each token must be
     /// either derived from a hashed FirecrackerConfig field or consciously
-    /// listed here as per-instance (excluded from the snapshot key by design)
-    /// or as tracked unhashed state (#821). A new push_str token fails this
-    /// test until its author hashes it into the key or adds it below with a
-    /// disposition — the fail-open alternative is a --dns-style silent
-    /// cache-hit bug.
+    /// listed here as per-instance (excluded from the snapshot key by
+    /// design). A new push_str token fails this test until its author hashes
+    /// it into the key or adds it below with a disposition; the fail-open
+    /// alternative is a --dns-style silent cache-hit bug.
     #[test]
     fn runtime_boot_arg_tokens_are_hashed_or_allowlisted() {
         const EXPECTED: &[(&str, &str)] = &[
@@ -1561,23 +1618,17 @@ mod tests {
             (
                 "fcvm_dns",
                 "--dns override hashed via FirecrackerConfig.dns_server; the \
-                 no-override host fallback is tracked in #821",
+                 no-override host fallback hashed via FirecrackerConfig.host_dns",
             ),
-            (
-                "fcvm_dns_search",
-                "host-derived at launch; unhashed, tracked in #821",
-            ),
+            ("fcvm_dns_search", "hashed via FirecrackerConfig.dns_search"),
             (
                 "fc_agent_strace",
                 "hashed via FirecrackerConfig.agent_strace",
             ),
-            (
-                "fuse_readers",
-                "guest-visible knob; unhashed, tracked in #821",
-            ),
+            ("fuse_readers", "hashed via FirecrackerConfig.fuse_readers"),
             (
                 "fuse_trace_rate",
-                "guest-visible knob; unhashed, tracked in #821",
+                "hashed via FirecrackerConfig.fuse_trace_rate",
             ),
             (
                 "fcvm_failpoint",
@@ -1585,11 +1636,11 @@ mod tests {
             ),
             (
                 "fuse_max_write",
-                "guest-visible knob; unhashed, tracked in #821",
+                "hashed via FirecrackerConfig.fuse_max_write",
             ),
             (
                 "no_writeback_cache",
-                "guest-visible knob; unhashed, tracked in #821",
+                "hashed via FirecrackerConfig.no_writeback_cache",
             ),
         ];
         let src = include_str!("vm_config.rs");
@@ -1637,6 +1688,92 @@ mod tests {
              FirecrackerConfig (see the guest_failpoint field for the pattern) \
              or add it to EXPECTED with a disposition"
         );
+    }
+
+    /// #821: the kernel cmdline must be emitted from the hashed config, not
+    /// re-read from the host at launch. A second read is a window for the
+    /// guest to boot with a value the snapshot key never saw.
+    #[test]
+    fn runtime_boot_args_emit_the_hashed_config_values() {
+        let config = crate::firecracker::FirecrackerConfig {
+            host_dns: vec!["192.0.2.1".to_string(), "192.0.2.2".to_string()],
+            dns_search: vec!["corp.example".to_string(), "internal".to_string()],
+            fuse_readers: Some("64".to_string()),
+            fuse_trace_rate: Some("100".to_string()),
+            fuse_max_write: Some("32768".to_string()),
+            no_writeback_cache: true,
+            ..Default::default()
+        };
+        let network_config = crate::network::NetworkConfig::default();
+
+        let boot_args = build_runtime_boot_args(&network_config, &config);
+        for token in [
+            "fcvm_dns=192.0.2.1|192.0.2.2",
+            "fcvm_dns_search=corp.example|internal",
+            "fuse_readers=64",
+            "fuse_trace_rate=100",
+            "fuse_max_write=32768",
+            "no_writeback_cache=1",
+        ] {
+            assert!(
+                boot_args.contains(token),
+                "expected {token:?} in boot args {boot_args:?}"
+            );
+        }
+    }
+
+    /// The mode's DNS choice (pasta forwarder, bridged host DNS, or the --dns
+    /// override recorded in network_config) wins over the hashed host
+    /// fallback, which only applies when the mode provides no DNS.
+    #[test]
+    fn runtime_boot_args_prefer_mode_dns_over_host_fallback() {
+        let config = crate::firecracker::FirecrackerConfig {
+            host_dns: vec!["192.0.2.1".to_string()],
+            ..Default::default()
+        };
+        let network_config = crate::network::NetworkConfig {
+            dns_server: Some("10.0.2.3".to_string()),
+            ..Default::default()
+        };
+
+        let boot_args = build_runtime_boot_args(&network_config, &config);
+        assert!(
+            boot_args.contains("fcvm_dns=10.0.2.3"),
+            "boot args: {boot_args:?}"
+        );
+        assert!(
+            !boot_args.contains("192.0.2.1"),
+            "host fallback must not be emitted when the mode provides DNS: {boot_args:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_prefers_runtime_config_fuse_readers_and_drops_fallback_on_dns_override() {
+        let runtime_config = crate::commands::common::RuntimeConfig {
+            firecracker_bin: None,
+            firecracker_args: None,
+            boot_args: None,
+            fuse_readers: Some(8),
+        };
+        let inputs = GuestBootInputs::resolve(Some("10.0.2.2"), &runtime_config);
+        assert_eq!(inputs.fuse_readers.as_deref(), Some("8"));
+        assert!(
+            inputs.host_dns.is_empty(),
+            "--dns wins outright, so the host fallback must not fragment the key"
+        );
+    }
+
+    #[test]
+    fn parse_search_domains_takes_first_search_line() {
+        assert_eq!(
+            parse_search_domains("nameserver 192.0.2.1\nsearch corp.example internal\n"),
+            vec!["corp.example", "internal"]
+        );
+        assert_eq!(
+            parse_search_domains("search a.example\nsearch b.example\n"),
+            vec!["a.example"]
+        );
+        assert!(parse_search_domains("nameserver 192.0.2.1\n").is_empty());
     }
 
     #[test]

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -182,11 +182,14 @@ fn rebuild_proxy_url(parsed: &Url, host: String, port: u16) -> String {
 
 /// Build runtime boot arguments for the kernel command line.
 ///
-/// Per-instance network values (`ip=`, `ipv6=`, and the mode's DNS choice in
-/// `network_config`) are excluded from the snapshot key by design. Every other
-/// token is emitted from `launch_config`, the same hashed FirecrackerConfig
-/// the snapshot key is computed from, so the hashed value and the value the
-/// guest boots with cannot diverge (#821).
+/// Per-instance network values (`ip=` and `ipv6=` addresses) are excluded
+/// from the snapshot key by design. The mode's DNS choice in `network_config`
+/// is either a constant (pasta's forwarder), the --dns override (hashed via
+/// dns_server), or bridged mode's first host resolver (hashed via host_dns
+/// and threaded into BridgedNetwork from the same resolution, #863). Every
+/// other token is emitted from `launch_config`, the same hashed
+/// FirecrackerConfig the snapshot key is computed from, so the hashed value
+/// and the value the guest boots with cannot diverge (#821).
 pub(crate) fn build_runtime_boot_args(
     network_config: &crate::network::NetworkConfig,
     launch_config: &crate::firecracker::FirecrackerConfig,
@@ -227,9 +230,10 @@ pub(crate) fn build_runtime_boot_args(
     }
 
     // Pass DNS servers to guest for resolv.conf configuration: the mode's
-    // DNS choice (pasta forwarder, bridged host DNS, or the --dns override
-    // recorded in network_config), else the hashed host fallback resolved at
-    // config construction (#821).
+    // DNS choice recorded in network_config (pasta forwarder, the bridged
+    // first-hashed-host_dns entry threaded at network construction, or the
+    // --dns override), else the hashed host fallback resolved at config
+    // construction (#821).
     {
         let dns_servers = if let Some(ref dns) = network_config.dns_server {
             vec![dns.clone()]
@@ -878,6 +882,10 @@ pub(super) struct VmSetupParams<'a> {
     pub image_disk_path: Option<&'a std::path::Path>,
     pub fc_config: Option<crate::firecracker::FirecrackerConfig>,
     pub runtime_config: &'a crate::commands::common::RuntimeConfig,
+    /// The launch's single GuestBootInputs resolution. When fc_config is None
+    /// (snapshots disabled) the fallback launch config is built from this
+    /// same copy instead of reading the host again mid-launch.
+    pub boot_inputs: GuestBootInputs,
 }
 
 /// Helper function that runs VM setup and returns VmManager on success.
@@ -1018,6 +1026,34 @@ impl GuestBootInputs {
             no_writeback_cache: std::env::var("FCVM_NO_WRITEBACK_CACHE").is_ok(),
         }
     }
+
+    /// Drop the inputs this launch cannot observe, so the key hashes exactly
+    /// what the guest boots with (#863). Applied by both config constructors:
+    ///
+    /// * Bridged mode forwards a single resolver to the guest
+    ///   (network_config.dns_server carries the first host entry), so only
+    ///   the first entry can reach it; keying the rest would cold-boot a
+    ///   guest whose cmdline is identical when a secondary nameserver moves.
+    /// * The four FUSE knobs are read only inside fc-agent's FUSE mount path
+    ///   (fc-agent/src/fuse/mod.rs), and mount_fuse_volumes runs only when
+    ///   the boot plan carries volumes (fc-agent/src/agent.rs), so a
+    ///   volume-free run boots identically under any of their values.
+    pub(crate) fn for_launch(
+        mut self,
+        network_mode: crate::firecracker::FcNetworkMode,
+        has_fuse_volumes: bool,
+    ) -> Self {
+        if matches!(network_mode, crate::firecracker::FcNetworkMode::Bridged) {
+            self.host_dns.truncate(1);
+        }
+        if !has_fuse_volumes {
+            self.fuse_readers = None;
+            self.fuse_trace_rate = None;
+            self.fuse_max_write = None;
+            self.no_writeback_cache = false;
+        }
+        self
+    }
 }
 
 /// The first `search` line of a resolv.conf, split into domains.
@@ -1047,6 +1083,7 @@ pub(crate) fn build_launch_config(
 ) -> crate::firecracker::FirecrackerConfig {
     use crate::firecracker::{BootSource, Drive, FcNetworkMode, FirecrackerConfig, MachineConfig};
     let network_mode: FcNetworkMode = args.network.into();
+    let boot_inputs = boot_inputs.for_launch(network_mode, !args.map.is_empty());
     // Collect extra disk specifications
     let mut extra_disks: Vec<String> = Vec::new();
     extra_disks.extend(args.disk.iter().cloned());
@@ -1363,6 +1400,7 @@ async fn run_vm_setup_inner(
         image_disk_path,
         fc_config,
         runtime_config,
+        boot_inputs,
     } = params;
     // Setup storage - just need CoW copy (fc-agent is injected via initrd at boot)
     let vm_dir = data_dir.join("disks");
@@ -1501,7 +1539,7 @@ async fn run_vm_setup_inner(
                 initrd_path,
                 &cmd_args,
                 runtime_config,
-                GuestBootInputs::resolve(args.dns.as_deref(), runtime_config),
+                boot_inputs,
             )
         });
 
@@ -1618,7 +1656,8 @@ mod tests {
             (
                 "fcvm_dns",
                 "--dns override hashed via FirecrackerConfig.dns_server; the \
-                 no-override host fallback hashed via FirecrackerConfig.host_dns",
+                 no-override host fallback (and bridged mode's threaded first \
+                 resolver) hashed via FirecrackerConfig.host_dns",
             ),
             ("fcvm_dns_search", "hashed via FirecrackerConfig.dns_search"),
             (

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -1688,8 +1688,13 @@ async fn cmd_snapshot_run_inner(
     // Setup networking based on mode - reuse guest_ip from snapshot if available
     let network: Box<dyn NetworkManager> = match network_mode {
         FcNetworkMode::Bridged => {
+            // The clone reports the resolver the snapshot captured, not the
+            // restore host's current one: the guest's resolv.conf is already
+            // baked into the restored memory, and the reboot plan deliberately
+            // re-bakes the captured value (see run_args_from_snapshot_metadata).
             let mut net =
-                BridgedNetwork::new(vm_id.clone(), tap_device.clone(), port_mappings.clone());
+                BridgedNetwork::new(vm_id.clone(), tap_device.clone(), port_mappings.clone())
+                    .with_dns_server(saved_network.dns_server.clone());
             // If snapshot has saved network config with guest_ip, use it
             if let Some(ref guest_ip) = saved_network.guest_ip {
                 net = net.with_guest_ip(guest_ip.clone());

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -3100,9 +3100,9 @@ async fn build_clone_reboot_plan(
         &initrd_path,
         &None,
         runtime_config,
+        super::podman::GuestBootInputs::resolve(synth_args.dns.as_deref(), runtime_config),
     );
-    let boot_args =
-        super::podman::build_runtime_boot_args(&synth_args, network_config, runtime_config);
+    let boot_args = super::podman::build_runtime_boot_args(network_config, &launch_config);
 
     let volume_mappings = synth_args
         .map

--- a/src/firecracker/config.rs
+++ b/src/firecracker/config.rs
@@ -155,6 +155,48 @@ pub struct FirecrackerConfig {
     /// attached disk) is skip-serialized so those keys are unchanged.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub image_disk_identity: Option<String>,
+    /// Host-derived DNS fallback (the host's resolv.conf servers), used when
+    /// --dns is absent. fc-agent writes these into the guest's resolv.conf at
+    /// boot, so they are baked into any snapshot; without this field a host
+    /// resolver change cache-hits a snapshot answering with the old servers
+    /// (#821). Empty when --dns overrides it (the fallback is never emitted
+    /// then, and hashing it would fragment keys between hosts whose guests
+    /// boot identically). Empty (the default) is skip-serialized so existing
+    /// keys are unchanged.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub host_dns: Vec<String>,
+    /// Host-derived DNS search domains (resolv.conf `search` line), forwarded
+    /// as `fcvm_dns_search=` and written into the guest's resolv.conf at boot.
+    /// Baked into snapshots, so part of the cache key (#821). Empty (the
+    /// default) is skip-serialized so existing keys are unchanged.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dns_search: Vec<String>,
+    /// FUSE reader thread count (RuntimeConfig.fuse_readers or
+    /// FCVM_FUSE_READERS), forwarded as `fuse_readers=`. Changes fc-agent's
+    /// FUSE thread and memory shape captured in the snapshot, so part of the
+    /// cache key (#821). None (the default) is skip-serialized so existing
+    /// keys are unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fuse_readers: Option<String>,
+    /// FUSE per-operation trace rate (FCVM_FUSE_TRACE_RATE), forwarded as
+    /// `fuse_trace_rate=`. Guest-visible boot behavior baked into snapshots,
+    /// so part of the cache key (#821). None (the default) is skip-serialized
+    /// so existing keys are unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fuse_trace_rate: Option<String>,
+    /// FUSE max_write cap (FCVM_FUSE_MAX_WRITE), forwarded as
+    /// `fuse_max_write=`. Guest-visible boot behavior baked into snapshots,
+    /// so part of the cache key (#821). None (the default) is skip-serialized
+    /// so existing keys are unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fuse_max_write: Option<String>,
+    /// Whether the guest disables the FUSE writeback cache
+    /// (FCVM_NO_WRITEBACK_CACHE), forwarded as `no_writeback_cache=1`.
+    /// Guest-visible boot behavior baked into snapshots, so part of the cache
+    /// key (#821). false (the default) is skip-serialized so existing keys
+    /// are unchanged.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub no_writeback_cache: bool,
 }
 
 impl Default for FirecrackerConfig {
@@ -190,6 +232,12 @@ impl Default for FirecrackerConfig {
             agent_strace: false,
             extra_boot_args: None,
             image_disk_identity: None,
+            host_dns: Vec::new(),
+            dns_search: Vec::new(),
+            fuse_readers: None,
+            fuse_trace_rate: None,
+            fuse_max_write: None,
+            no_writeback_cache: false,
         }
     }
 }
@@ -618,6 +666,60 @@ mod tests {
         config3.image_disk_identity = Some("2007:73678848:1765581300.000000000".to_string());
         assert_ne!(config1.snapshot_key(), config2.snapshot_key());
         assert_ne!(config2.snapshot_key(), config3.snapshot_key());
+    }
+
+    /// The host-derived DNS fallback is written into the guest's resolv.conf
+    /// at boot, so hosts whose resolv.conf differs must not share a snapshot,
+    /// and a host resolver change must be a cache miss (#821).
+    #[test]
+    fn test_snapshot_key_changes_with_host_dns() {
+        let config1 = test_config();
+        let mut config2 = test_config();
+        config2.host_dns = vec!["1.1.1.1".to_string()];
+        let mut config3 = test_config();
+        config3.host_dns = vec!["8.8.8.8".to_string()];
+        assert_ne!(config1.snapshot_key(), config2.snapshot_key());
+        assert_ne!(config2.snapshot_key(), config3.snapshot_key());
+    }
+
+    #[test]
+    fn test_snapshot_key_changes_with_dns_search() {
+        let config1 = test_config();
+        let mut config2 = test_config();
+        config2.dns_search = vec!["corp.example".to_string()];
+        assert_ne!(config1.snapshot_key(), config2.snapshot_key());
+    }
+
+    #[test]
+    fn test_snapshot_key_changes_with_fuse_readers() {
+        let config1 = test_config();
+        let mut config2 = test_config();
+        config2.fuse_readers = Some("64".to_string());
+        assert_ne!(config1.snapshot_key(), config2.snapshot_key());
+    }
+
+    #[test]
+    fn test_snapshot_key_changes_with_fuse_trace_rate() {
+        let config1 = test_config();
+        let mut config2 = test_config();
+        config2.fuse_trace_rate = Some("100".to_string());
+        assert_ne!(config1.snapshot_key(), config2.snapshot_key());
+    }
+
+    #[test]
+    fn test_snapshot_key_changes_with_fuse_max_write() {
+        let config1 = test_config();
+        let mut config2 = test_config();
+        config2.fuse_max_write = Some("32768".to_string());
+        assert_ne!(config1.snapshot_key(), config2.snapshot_key());
+    }
+
+    #[test]
+    fn test_snapshot_key_changes_with_no_writeback_cache() {
+        let config1 = test_config();
+        let mut config2 = test_config();
+        config2.no_writeback_cache = true;
+        assert_ne!(config1.snapshot_key(), config2.snapshot_key());
     }
 
     #[test]

--- a/src/network/bridged.rs
+++ b/src/network/bridged.rs
@@ -2,8 +2,7 @@ use anyhow::{Context, Result};
 use tracing::{debug, info, warn};
 
 use super::{
-    get_host_dns_servers, namespace, portmap, types::generate_mac, veth, NetworkConfig,
-    NetworkManager, PortMapping,
+    namespace, portmap, types::generate_mac, veth, NetworkConfig, NetworkManager, PortMapping,
 };
 use crate::state::truncate_id;
 
@@ -122,6 +121,11 @@ pub struct BridgedNetwork {
     guest_ip_override: Option<String>,
     /// VM ID to use for subnet calculation (for cache restore with fresh networking)
     network_vm_id: Option<String>,
+    /// The resolver the guest is told to use, threaded in by the caller.
+    /// Fresh boots pass the launch config's first hashed host_dns entry so
+    /// the snapshot key and the guest-visible value cannot diverge; clone
+    /// restores pass the resolver captured in the snapshot metadata (#863).
+    dns_server: Option<String>,
 
     // Network state (populated during setup)
     namespace_id: Option<String>,
@@ -144,6 +148,7 @@ impl BridgedNetwork {
             port_mappings,
             guest_ip_override: None,
             network_vm_id: None,
+            dns_server: None,
             namespace_id: None,
             host_veth: None,
             guest_veth: None,
@@ -154,6 +159,15 @@ impl BridgedNetwork {
             is_clone: false,
             veth_inner_ip: None,
         }
+    }
+
+    /// Set the resolver setup() reports as the guest's DNS server. setup()
+    /// deliberately has no fallback read of the host's resolv.conf: the
+    /// caller resolved this value once, alongside whatever hashed or recorded
+    /// it, and a second read here could disagree with that copy.
+    pub fn with_dns_server(mut self, dns_server: Option<String>) -> Self {
+        self.dns_server = dns_server;
+        self
     }
 
     /// Set guest IP to use (for clones - use same IP as original VM)
@@ -478,9 +492,9 @@ impl NetworkManager for BridgedNetwork {
             return Err(e).context("ensuring global NAT for 10.0.0.0/8");
         }
 
-        // Step 7: Get DNS server for VM
-        let dns_servers = get_host_dns_servers().context("getting DNS servers")?;
-        let dns_server = dns_servers.first().cloned();
+        // Step 7: The guest's DNS server, threaded in by the caller (see the
+        // dns_server field). Not re-read from the host here.
+        let dns_server = self.dns_server.clone();
 
         // Step 8: Setup port mappings if any
         if !self.port_mappings.is_empty() {
@@ -649,10 +663,12 @@ mod tests {
     /// RED before the fix: kernel_routes_peer_via_veth returned `true` on any
     /// spawn error or nonzero exit, so a candidate nobody could verify was
     /// taken as verified — the same silent acceptance #820 is about. The fake
-    /// `ip` here exits 1; nextest runs each test in its own process, so
-    /// prepending to PATH cannot leak into a sibling test.
+    /// `ip` here exits 1; nextest runs each test in its own process, but
+    /// plain `cargo test` does not, so the PATH mutation additionally holds
+    /// PATH_IP_LOCK against siblings that spawn the real `ip` by name.
     #[tokio::test]
     async fn an_unavailable_route_verdict_is_an_error_not_an_acceptance() {
+        let _path_lock = crate::network::PATH_IP_LOCK.lock().await;
         let dir = std::env::temp_dir().join(format!("fcvm-fakeip-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let fake = dir.join("ip");
@@ -679,6 +695,27 @@ mod tests {
         assert!(
             format!("{err:#}").contains("ip route get"),
             "the error must name the probe that failed: {err:#}"
+        );
+    }
+
+    /// #863: the bridged guest's resolver is threaded in from the launch
+    /// config, the same value the snapshot key hashed. setup() must not read
+    /// the host's resolv.conf itself: a mid-launch change would save the
+    /// snapshot under one resolver's key while the guest boots with another.
+    #[test]
+    fn setup_does_not_reread_host_dns() {
+        let src = include_str!("bridged.rs");
+        let start = src
+            .find("async fn setup")
+            .expect("setup present in bridged.rs");
+        let end = src[start..]
+            .find("async fn cleanup")
+            .expect("cleanup still follows setup")
+            + start;
+        assert!(
+            !src[start..end].contains("get_host_dns_servers"),
+            "BridgedNetwork::setup reads host DNS itself; thread the launch config's \
+             hashed value via with_dns_server instead"
         );
     }
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -107,6 +107,16 @@ pub trait NetworkManager: Send + Sync {
     fn as_any(&self) -> &dyn std::any::Any;
 }
 
+/// Serializes tests whose behavior depends on resolving `ip` through the
+/// process-global PATH. Plain `cargo test` runs every test in one process, so
+/// a test that points PATH at a fake `ip` races any sibling that spawns the
+/// real one by name (nextest's process-per-test isolation never sees this).
+/// Both kinds of test hold this lock: the PATH mutator and the by-name
+/// spawner. tokio's Mutex because the mutator holds it across an await, and
+/// it does not poison when a holder's assertion panics.
+#[cfg(test)]
+pub(crate) static PATH_IP_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 /// Get host DNS servers for VMs
 ///
 /// Returns DNS servers that VMs can use. Checks /run/systemd/resolve/resolv.conf

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -3115,9 +3115,12 @@ mod tests {
 
     /// The batch really does run under `bash -c` and really does abort at the
     /// first failure — verified against the host's actual `ip` binary, in the
-    /// current namespace, using read-only `link show` commands.
+    /// current namespace, using read-only `link show` commands. The script
+    /// resolves `ip` through PATH, so this holds PATH_IP_LOCK against the
+    /// bridged fake-`ip` test when plain `cargo test` shares one process.
     #[test]
     fn ip_batch_script_runs_and_aborts_on_first_failure() {
+        let _path_lock = crate::network::PATH_IP_LOCK.blocking_lock();
         let ok = IpBatchScript::new(
             vec![
                 ("show loopback".to_string(), "link show lo".to_string()),


### PR DESCRIPTION
build_runtime_boot_args read six guest-visible values from the host at launch time without them being part of the snapshot key: the fcvm_dns host fallback and fcvm_dns_search (both from the host's resolv.conf), fuse_readers, fuse_trace_rate, fuse_max_write, and no_writeback_cache. A cache hit could therefore serve a snapshot baked with different guest behavior, e.g. a host resolver change left every cached snapshot answering with the old DNS servers.

Following the guest_failpoint pattern, the six values are now resolved once at FirecrackerConfig construction (GuestBootInputs::resolve, called by build_firecracker_config and build_launch_config) and stored in new skip-serialized fields, and build_runtime_boot_args emits every non-per-instance token from that hashed config instead of re-reading env vars and resolv.conf, so the hashed value and the emitted value cannot diverge. Only ip= and ipv6= (plus the mode's DNS choice in network_config) remain per-instance. The host fallback stays empty when --dns overrides it: the fallback is never emitted then, and hashing it would fragment keys between hosts whose guests boot identically. All new fields skip-serialize at their defaults, so existing cache keys are unchanged; test_snapshot_key_golden still pins 4278f265ad63, unmodified. The #818 token-audit dispositions flip from "unhashed, tracked in #821" to the hashing field for each token.

Red, watched failing on the unfixed constructors (keys identical on both sides of every assert):

  commands::podman::tests::host_dns_fallback_changes_snapshot_key
  commands::podman::tests::dns_search_changes_snapshot_key
  commands::podman::tests::fuse_readers_changes_snapshot_key
  commands::podman::tests::fuse_trace_rate_changes_snapshot_key
  commands::podman::tests::fuse_max_write_changes_snapshot_key
  commands::podman::tests::no_writeback_cache_changes_snapshot_key
    assertion `left != right` failed: fuse_max_write must change the key
      left: "a65206085631"  right: "a65206085631"
  commands::podman::vm_config::tests::runtime_boot_args_emit_the_hashed_config_values
    expected "fcvm_dns=192.0.2.1|192.0.2.2" in boot args
    "fcvm_dns=<real host resolv.conf servers> fcvm_dns_search=<real host domains>"

Green after the fix: cargo test --lib -p fcvm reports 490 passed, 0 failed, including the six new per-field key pins in firecracker::config::tests and the unchanged golden key test. Vacuity check: marking host_dns #[serde(skip)] turns test_snapshot_key_changes_with_host_dns and host_dns_fallback_changes_snapshot_key red again. cargo fmt --check and cargo clippy -p fcvm --lib --tests -- -D warnings are both clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved bridged networking by consistently applying configured DNS servers and search domains.
  * Added support for configuring FUSE performance settings and writeback-cache behavior.
  * Snapshot and launch settings now preserve relevant DNS and filesystem configuration.

* **Bug Fixes**
  * Prevented inconsistent guest networking caused by rereading host DNS settings during launch.
  * Improved snapshot invalidation when DNS or FUSE-related settings change.
  * Avoided unnecessary snapshot changes for unused volume settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->