### PR TITLE
reqbench: bind the golden to the image the build phase produced

### DIFF
--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -457,8 +457,28 @@ assert_vm_artifacts_absent() {
     return "$left"
 }
 
+# The build-to-golden handshake file for $IMAGE. cmd_build records the image
+# ID it published here; cmd_golden refuses a tag that resolves elsewhere.
+built_image_id_file() {
+    printf '%s/reqbench-locks/built-image-%s.id\n' \
+        "$DATA_ROOT" "$(printf '%s' "$IMAGE" | tr '/:' '__')"
+}
+
 cmd_build() {
     log "building $IMAGE"
+    # The bundle sealed this invocation's request code at process start, but
+    # the image build COPYs from the live repository. An edit in between puts
+    # different render bytes in the exec arm (image copy) than in the CDP arm
+    # (bundle copy) while every seal check passes: the staging guard compares
+    # git HEAD only, which cannot see an uncommitted edit.
+    if [ -n "${REQBENCH_RUNTIME_BUNDLE:-}" ]; then
+        local sealed_source
+        for sealed_source in render.py cdpdrive.py wddrive.py; do
+            cmp -s "$REPO/bench/chromium/$sealed_source" \
+                "$REQBENCH_RUNTIME_BUNDLE/$sealed_source" \
+                || { log "FATAL: $sealed_source in $REPO/bench/chromium diverged from the sealed runtime bundle; the image would bake different bytes than this run executes"; return 1; }
+        done
+    fi
     # --format docker is LOAD-BEARING: podman's default OCI format DROPS
     # HEALTHCHECK with only a warning, and fcvm's health gate is what
     # triggers the golden snapshot (src/health.rs AND-logic).
@@ -471,6 +491,22 @@ cmd_build() {
     # marker that entry.sh touches only after a full navigate + screenshot.
     podman inspect "$IMAGE" --format '{{json .HealthCheck}}' | grep -q health_state \
         || { log "FATAL: image has no HEALTHCHECK naming health_state.sh (OCI format drop, or the Containerfile changed without this check)"; return 1; }
+    # Record the ID this build published so cmd_golden, which runs as a
+    # separate process with the TAG lock released in between, can refuse a
+    # tag another worktree repointed in that window.
+    local built_id id_file id_tmp
+    built_id=$(podman image inspect --format '{{.Id}}' "$IMAGE") \
+        || { log "FATAL: cannot read the image ID podman published for $IMAGE"; return 1; }
+    built_id="sha256:${built_id#sha256:}"
+    [[ "$built_id" =~ ^sha256:[0-9a-f]{64}$ ]] \
+        || { log "FATAL: podman reported invalid image ID '$built_id' for $IMAGE"; return 1; }
+    mkdir -p "$DATA_ROOT/reqbench-locks"
+    id_file=$(built_image_id_file)
+    id_tmp=$(mktemp "$id_file.XXXXXX") \
+        || { log "FATAL: cannot stage the built-image record next to $id_file"; return 1; }
+    printf '%s\n' "$built_id" >"$id_tmp"
+    mv -f "$id_tmp" "$id_file"
+    log "build: published $IMAGE as $built_id"
 }
 
 cmd_golden() {
@@ -499,6 +535,22 @@ cmd_golden() {
         image_cache_key="${image_digest#sha256:}"
     else
         image_cache_key="${image_id#sha256:}"
+    fi
+    # The checks below only prove this process's own observation is
+    # self-consistent. When cmd_build recorded which ID it published, require
+    # the tag to still resolve there: build and golden run as separate
+    # processes with the TAG lock released between them, and a tag swap in
+    # that window would snapshot the replacement.
+    local built_id_file built_image_id=""
+    built_id_file=$(built_image_id_file)
+    if [ -e "$built_id_file" ]; then
+        built_image_id=$(tr -d '[:space:]' <"$built_id_file")
+        [[ "$built_image_id" =~ ^sha256:[0-9a-f]{64}$ ]] \
+            || { log "golden: recorded built-image ID in $built_id_file is invalid: '$built_image_id'"; return 1; }
+        if [ "$image_id" != "$built_image_id" ]; then
+            log "golden: $IMAGE resolved to $image_id but the build phase recorded $built_image_id; the tag was repointed between build and golden"
+            return 1
+        fi
     fi
     # --publish carries host -> guest; fc-agent DNATs the published port to
     # guest loopback (fc-agent/src/network.rs::publish_to_loopback), the hop
@@ -539,14 +591,15 @@ cmd_golden() {
     $SUDO python3 - "$DATA_ROOT/snapshots/$TAG/config.json" \
         "$DATA_ROOT/snapshots/$TAG/reqbench-provenance.json" \
         "$DATA_ROOT/snapshots/$TAG.lock" "$IMAGE" "$image_id" "$image_digest" \
-        "$image_cache_key" "$prepared_generation" "$prepared_digest" \
+        "$image_cache_key" "$built_image_id" \
+        "$prepared_generation" "$prepared_digest" \
         "$(sha256sum "$FCVM" | cut -d' ' -f1)" \
         "$(sha256sum "$HERE/MANIFEST.sha256" | cut -d' ' -f1)" \
         "${REQBENCH_SOURCE_REVISION:-}" <<'PY'
 import fcntl, hashlib, json, os, sys, tempfile, uuid
 (
     config_path, output_path, lock_path, image_label, image_id, image_digest,
-    image_cache_key, prepared_generation, prepared_digest,
+    image_cache_key, built_image_id, prepared_generation, prepared_digest,
     fcvm_sha256, runtime_bundle_sha256, source_revision,
 ) = sys.argv[1:]
 lock = open(lock_path, "a+")
@@ -600,6 +653,9 @@ record = {
     "image_id": image_id,
     "image_digest": image_digest,
     "image_cache_key": image_cache_key,
+    # The ID cmd_build recorded, when a build preceded this golden; null for
+    # a golden taken against a pre-existing image with no build record.
+    "built_image_id": built_image_id or None,
     "creator_fcvm_sha256": fcvm_sha256,
     "creator_runtime_bundle_sha256": runtime_bundle_sha256,
     "source_revision": source_revision,

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -466,40 +466,72 @@ built_image_id_file() {
 
 cmd_build() {
     log "building $IMAGE"
-    # The bundle sealed this invocation's request code at process start, but
-    # the image build COPYs from the live repository. An edit in between puts
-    # different render bytes in the exec arm (image copy) than in the CDP arm
-    # (bundle copy) while every seal check passes: the staging guard compares
-    # git HEAD only, which cannot see an uncommitted edit.
+    local sealed_source ctx built_id id_file id_tmp iid_tmp
+    # Fail-fast pre-check. The bundle sealed this invocation's request code at
+    # process start, but the repository is what feeds the image, and the
+    # staging guard compares git HEAD only, which cannot see an uncommitted
+    # edit. Diverged bytes here mean the exec arm (image copy) and the CDP
+    # arm (bundle copy) would run different render code under a passing seal.
     if [ -n "${REQBENCH_RUNTIME_BUNDLE:-}" ]; then
-        local sealed_source
         for sealed_source in render.py cdpdrive.py wddrive.py; do
             cmp -s "$REPO/bench/chromium/$sealed_source" \
                 "$REQBENCH_RUNTIME_BUNDLE/$sealed_source" \
                 || { log "FATAL: $sealed_source in $REPO/bench/chromium diverged from the sealed runtime bundle; the image would bake different bytes than this run executes"; return 1; }
         done
     fi
+    # Podman reads COPY sources when the build executes, not when the check
+    # above ran, so an edit landing in between would still bake into the
+    # image. Build from an immutable staged context instead: the
+    # Containerfiles COPY only bench/chromium top-level files and
+    # bench/chromium/pages/, and the sealed sources come from the runtime
+    # bundle, not the repository. A Containerfile that grows a COPY source
+    # outside this set fails the build loudly; extend the staging here.
+    ctx=$(mktemp -d "$RESULTS/logs/build-context.XXXXXX") \
+        || { log "FATAL: cannot create a staged build context under $RESULTS/logs"; return 1; }
+    mkdir -p "$ctx/bench/chromium"
+    find "$REPO/bench/chromium" -maxdepth 1 -type f \
+        -exec cp --reflink=auto -t "$ctx/bench/chromium" {} + \
+        || { log "FATAL: cannot stage bench/chromium sources into $ctx"; return 1; }
+    cp -a --reflink=auto "$REPO/bench/chromium/pages" "$ctx/bench/chromium/pages" \
+        || { log "FATAL: cannot stage bench/chromium/pages into $ctx"; return 1; }
+    cp --reflink=auto "$REPO/$CONTAINERFILE" "$ctx/$CONTAINERFILE" \
+        || { log "FATAL: cannot stage $CONTAINERFILE into $ctx"; return 1; }
+    if [ -n "${REQBENCH_RUNTIME_BUNDLE:-}" ]; then
+        for sealed_source in render.py cdpdrive.py wddrive.py; do
+            cp --reflink=auto "$REQBENCH_RUNTIME_BUNDLE/$sealed_source" \
+                "$ctx/bench/chromium/$sealed_source" \
+                || { log "FATAL: cannot stage sealed $sealed_source into $ctx"; return 1; }
+        done
+    fi
     # --format docker is LOAD-BEARING: podman's default OCI format DROPS
     # HEALTHCHECK with only a warning, and fcvm's health gate is what
     # triggers the golden snapshot (src/health.rs AND-logic).
-    podman build --format docker -t "$IMAGE" -f "$REPO/$CONTAINERFILE" "$REPO"
+    # --iidfile is equally load-bearing: podman records the ID of the image
+    # THIS build produced as part of the build operation itself. Inspecting
+    # the tag afterwards reads whatever the tag points at by then, which a
+    # concurrent retag in that window can change.
+    iid_tmp=$(mktemp "$RESULTS/logs/build-iid.XXXXXX") \
+        || { log "FATAL: cannot stage the image-ID capture under $RESULTS/logs"; return 1; }
+    podman build --format docker --iidfile "$iid_tmp" -t "$IMAGE" \
+        -f "$ctx/$CONTAINERFILE" "$ctx"
+    built_id=$(tr -d '[:space:]' <"$iid_tmp")
+    rm -f "$iid_tmp"
+    rm -rf -- "$ctx"
+    built_id="sha256:${built_id#sha256:}"
+    [[ "$built_id" =~ ^sha256:[0-9a-f]{64}$ ]] \
+        || { log "FATAL: podman recorded no valid image ID for $IMAGE (got '$built_id')"; return 1; }
     # The warm gate lives or dies here. fcvm treats a MISSING healthcheck as a
     # PASS, so an image that lost it snapshots a COLD browser and every clone's
     # "warm" latency is really a first-paint number. Assert the healthcheck
-    # exists AND is ours: health_state.sh, which reports healthy only for a
-    # FRESH verdict from the resident checker, which in turn requires the warm
-    # marker that entry.sh touches only after a full navigate + screenshot.
-    podman inspect "$IMAGE" --format '{{json .HealthCheck}}' | grep -q health_state \
+    # exists AND is ours, on the built ID rather than the retaggable tag:
+    # health_state.sh reports healthy only for a FRESH verdict from the
+    # resident checker, which in turn requires the warm marker that entry.sh
+    # touches only after a full navigate + screenshot.
+    podman inspect "$built_id" --format '{{json .HealthCheck}}' | grep -q health_state \
         || { log "FATAL: image has no HEALTHCHECK naming health_state.sh (OCI format drop, or the Containerfile changed without this check)"; return 1; }
     # Record the ID this build published so cmd_golden, which runs as a
     # separate process with the TAG lock released in between, can refuse a
     # tag another worktree repointed in that window.
-    local built_id id_file id_tmp
-    built_id=$(podman image inspect --format '{{.Id}}' "$IMAGE") \
-        || { log "FATAL: cannot read the image ID podman published for $IMAGE"; return 1; }
-    built_id="sha256:${built_id#sha256:}"
-    [[ "$built_id" =~ ^sha256:[0-9a-f]{64}$ ]] \
-        || { log "FATAL: podman reported invalid image ID '$built_id' for $IMAGE"; return 1; }
     mkdir -p "$DATA_ROOT/reqbench-locks"
     id_file=$(built_image_id_file)
     id_tmp=$(mktemp "$id_file.XXXXXX") \

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -458,10 +458,14 @@ assert_vm_artifacts_absent() {
 }
 
 # The build-to-golden handshake file for $IMAGE. cmd_build records the image
-# ID it published here; cmd_golden refuses a tag that resolves elsewhere.
+# ID it published here; cmd_golden consumes it (reads and removes it in one
+# rename) so a later golden with no preceding build cannot inherit a stale
+# record. The filename keys on a hash of the full image name: character
+# substitution is not injective (localhost/a_b:c and localhost/a:b_c would
+# share one file and clobber each other's records).
 built_image_id_file() {
     printf '%s/reqbench-locks/built-image-%s.id\n' \
-        "$DATA_ROOT" "$(printf '%s' "$IMAGE" | tr '/:' '__')"
+        "$DATA_ROOT" "$(printf '%s' "$IMAGE" | sha256sum | cut -c1-32)"
 }
 
 cmd_build() {
@@ -576,7 +580,15 @@ cmd_golden() {
     local built_id_file built_image_id=""
     built_id_file=$(built_image_id_file)
     if [ -e "$built_id_file" ]; then
-        built_image_id=$(tr -d '[:space:]' <"$built_id_file")
+        # Claim the record atomically: the rename makes this golden the only
+        # consumer, and removal afterwards keeps a later golden that had no
+        # build of its own from attesting this build's ID as its provenance.
+        local built_id_claim
+        built_id_claim="$built_id_file.consumed.$$"
+        mv "$built_id_file" "$built_id_claim" \
+            || { log "golden: cannot claim the built-image record $built_id_file"; return 1; }
+        built_image_id=$(tr -d '[:space:]' <"$built_id_claim")
+        rm -f "$built_id_claim"
         [[ "$built_image_id" =~ ^sha256:[0-9a-f]{64}$ ]] \
             || { log "golden: recorded built-image ID in $built_id_file is invalid: '$built_image_id'"; return 1; }
         if [ "$image_id" != "$built_image_id" ]; then

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -4025,9 +4025,12 @@ exit 1
             self.assertIn("golden: PREPARE FAILED", result.stderr)
 
     def _built_id_path(self, data_root, image="localhost/chromium-bench-req"):
-        mangled = image.replace("/", "_").replace(":", "_")
+        # Same encoding as built_image_id_file: a hash of the full image name,
+        # because character substitution collides (localhost/a_b:c and
+        # localhost/a:b_c share one substituted name).
+        key = hashlib.sha256(image.encode()).hexdigest()[:32]
         return os.path.join(
-            data_root, "reqbench-locks", f"built-image-{mangled}.id",
+            data_root, "reqbench-locks", f"built-image-{key}.id",
         )
 
     def _golden_image_identity_fixture(self, d, snapshot_cache_key,
@@ -4287,6 +4290,49 @@ exit 1
             )) as source:
                 provenance = json.load(source)
             self.assertEqual(provenance["built_image_id"], recorded)
+
+    def test_golden_consumes_the_build_record(self):
+        """The record is one build-to-golden handshake, not a standing fact.
+
+        Left in place, a later golden with no build of its own would inherit
+        it: either attesting a stale built_image_id in provenance or rejecting
+        a legitimately retagged pre-existing image.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            recorded = "sha256:" + "b" * 64
+            result, _argv, _digest, _image_id = self._golden_image_identity_fixture(
+                d, "a" * 64, built_image_id=recorded,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr[-1600:])
+            self.assertFalse(
+                os.path.exists(self._built_id_path(d)),
+                "the build record must be consumed by the golden that read it",
+            )
+
+    def test_build_record_paths_do_not_collide_across_image_names(self):
+        """Substitution encodings collide (localhost/a_b:c vs localhost/a:b_c);
+        the record key must be injective, and the shell and the test helper
+        must agree on it byte for byte.
+        """
+        colliders = ("localhost/a_b:c", "localhost/a:b_c")
+        with tempfile.TemporaryDirectory() as d:
+            paths = [self._built_id_path(d, image) for image in colliders]
+            self.assertNotEqual(
+                paths[0], paths[1],
+                "two distinct image names share one build-record file",
+            )
+            for image in colliders:
+                shell = subprocess.run(
+                    ["bash", "-c",
+                     'export REQBENCH_STAGED=1 IMAGE="$1" DATA_ROOT="$2"; '
+                     'source "$3" >/dev/null 2>&1; built_image_id_file',
+                     "-", image, d, os.path.join(HERE, "reqbench.sh")],
+                    capture_output=True, text=True,
+                )
+                self.assertEqual(
+                    shell.stdout.strip(), self._built_id_path(d, image),
+                    f"shell and test helper disagree on the record path for {image}",
+                )
 
     def test_build_refuses_a_render_py_that_diverged_from_the_sealed_bundle(self):
         """The exec arm runs the image's render.py, the cdp arm the bundle's.

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -4024,8 +4024,19 @@ exit 1
             self.assertNotEqual(result.returncode, 0, result.stderr)
             self.assertIn("golden: PREPARE FAILED", result.stderr)
 
-    def _golden_image_identity_fixture(self, d, snapshot_cache_key):
+    def _built_id_path(self, data_root, image="localhost/chromium-bench-req"):
+        mangled = image.replace("/", "_").replace(":", "_")
+        return os.path.join(
+            data_root, "reqbench-locks", f"built-image-{mangled}.id",
+        )
+
+    def _golden_image_identity_fixture(self, d, snapshot_cache_key,
+                                       built_image_id=None):
         env, binx = self._env(d, DATA_ROOT=d)
+        if built_image_id is not None:
+            os.makedirs(os.path.join(d, "reqbench-locks"), exist_ok=True)
+            with open(self._built_id_path(d), "w") as f:
+                f.write(built_image_id + "\n")
         argv = os.path.join(d, "fcvm-argv.log")
         digest = "a" * 64
         image_id = "b" * 64
@@ -4205,6 +4216,122 @@ exit 1
             self.assertNotEqual(result.returncode, 0, result.stderr)
             self.assertIn("the image tag changed during golden creation", result.stderr)
             self.assertIn(digest, result.stderr)
+
+    def test_build_records_the_image_id_it_published(self):
+        """golden can only bind to the build's image if the build says which one.
+
+        `make bench-chromium-request-golden` runs build and golden as separate
+        reqbench.sh processes with the TAG lock released between them; a tag
+        swap in that window makes golden snapshot the replacement while every
+        check inside cmd_golden still passes, because those checks only prove
+        cmd_golden's own observation is self-consistent.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            env, binx = self._env(d, DATA_ROOT=d, REQBENCH_STAGED="1")
+            image_id = "b" * 64
+            self._write(os.path.join(binx, "podman"), f'''#!/bin/bash
+case "$1" in
+  build) exit 0 ;;
+  inspect) echo '{{"Test":["CMD-SHELL","/opt/bench/health_state.sh"]}}'; exit 0 ;;
+  image)
+      [ "$2" = inspect ] || exit 1
+      echo {image_id}
+      exit 0
+      ;;
+esac
+exit 1
+''')
+            result = subprocess.run(
+                [self.SH, "build"], env=env,
+                capture_output=True, text=True, timeout=60,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr[-1600:])
+            recorded = self._read_if_exists(self._built_id_path(d), "<missing>")
+            self.assertEqual(recorded.strip(), "sha256:" + image_id)
+
+    def test_golden_refuses_an_image_that_is_not_the_one_build_produced(self):
+        """A build record that names a different image ID must stop the golden.
+
+        cmd_golden's in-process checks close the inspect-to-prepare and
+        prepare-to-provenance windows, but nothing binds golden's inspect to
+        the image cmd_build published in its separate process.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            recorded = "sha256:" + "e" * 64
+            result, argv, _digest, image_id = self._golden_image_identity_fixture(
+                d, "a" * 64, built_image_id=recorded,
+            )
+            self.assertNotEqual(result.returncode, 0, result.stdout)
+            self.assertIn(recorded, result.stderr)
+            self.assertIn("sha256:" + image_id, result.stderr)
+            self.assertNotIn(
+                "podman prepare", argv,
+                "golden snapshotted an image the build did not produce",
+            )
+
+    def test_golden_records_a_matching_build_id_in_provenance(self):
+        """A matching record must pass and land in reqbench-provenance.json."""
+        with tempfile.TemporaryDirectory() as d:
+            recorded = "sha256:" + "b" * 64
+            result, _argv, _digest, _image_id = self._golden_image_identity_fixture(
+                d, "a" * 64, built_image_id=recorded,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr[-1600:])
+            with open(os.path.join(
+                d, "snapshots", "cb-req-golden", "reqbench-provenance.json",
+            )) as source:
+                provenance = json.load(source)
+            self.assertEqual(provenance["built_image_id"], recorded)
+
+    def test_build_refuses_a_render_py_that_diverged_from_the_sealed_bundle(self):
+        """The exec arm runs the image's render.py, the cdp arm the bundle's.
+
+        cmd_build COPYs render.py from the live repository while the bundle
+        sealed its own copy at process start, and the staging guard only
+        compares git HEAD, which cannot see an uncommitted edit. Diverged
+        bytes must be refused before the image build runs.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            env, binx = self._env(d, DATA_ROOT=d)
+            srcrepo = os.path.join(d, "srcrepo")
+            bench_dir = os.path.join(srcrepo, "bench", "chromium")
+            os.makedirs(bench_dir)
+            for name in ("cdpdrive.py", "wddrive.py"):
+                shutil.copyfile(
+                    os.path.join(HERE, name), os.path.join(bench_dir, name),
+                )
+            with open(os.path.join(HERE, "render.py")) as f:
+                render = f.read()
+            with open(os.path.join(bench_dir, "render.py"), "w") as f:
+                f.write(render + "\n# uncommitted edit made after staging\n")
+            subprocess.run(
+                ["git", "init", "-q", srcrepo],
+                check=True, capture_output=True, text=True,
+            )
+            subprocess.run(
+                ["git", "-C", srcrepo, "add", "-A"],
+                check=True, capture_output=True, text=True,
+            )
+            subprocess.run(
+                ["git", "-C", srcrepo, "-c", "user.name=t",
+                 "-c", "user.email=t@example.com", "commit", "-qm", "seed"],
+                check=True, capture_output=True, text=True,
+            )
+            built_marker = os.path.join(d, "podman-build-ran")
+            self._write(os.path.join(binx, "podman"), f'''#!/bin/bash
+[ "$1" = build ] && touch {built_marker}
+exit 0
+''')
+            result = subprocess.run(
+                [self.SH, "build"], env=dict(env, REQBENCH_SOURCE_REPO=srcrepo),
+                capture_output=True, text=True, timeout=120,
+            )
+            self.assertNotEqual(result.returncode, 0, result.stdout)
+            self.assertIn("render.py", result.stderr)
+            self.assertFalse(
+                os.path.exists(built_marker),
+                "the image build ran against diverged render bytes",
+            )
 
     def _run_stub(self, d, backend, analyzer_rc=0, sudo_env_reset=False):
         env, binx = self._env(d, BACKEND=backend, REPS="1", WARMUP="0")

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -4229,15 +4229,20 @@ exit 1
         with tempfile.TemporaryDirectory() as d:
             env, binx = self._env(d, DATA_ROOT=d, REQBENCH_STAGED="1")
             image_id = "b" * 64
+            # No `image inspect` branch: the ID must come from the build's
+            # own --iidfile, so a regression back to inspecting the mutable
+            # tag after the build fails here instead of passing silently.
             self._write(os.path.join(binx, "podman"), f'''#!/bin/bash
 case "$1" in
-  build) exit 0 ;;
-  inspect) echo '{{"Test":["CMD-SHELL","/opt/bench/health_state.sh"]}}'; exit 0 ;;
-  image)
-      [ "$2" = inspect ] || exit 1
-      echo {image_id}
+  build)
+      prev=""
+      for a in "$@"; do
+          [ "$prev" = --iidfile ] && printf 'sha256:{image_id}' > "$a"
+          prev="$a"
+      done
       exit 0
       ;;
+  inspect) echo '{{"Test":["CMD-SHELL","/opt/bench/health_state.sh"]}}'; exit 0 ;;
 esac
 exit 1
 ''')
@@ -4331,6 +4336,117 @@ exit 0
             self.assertFalse(
                 os.path.exists(built_marker),
                 "the image build ran against diverged render bytes",
+            )
+
+    def test_build_records_the_id_of_the_image_it_built_not_the_tags(self):
+        """RED BEFORE THE FIX: cmd_build inspected $IMAGE only after podman
+        build returned, so a retag in that window recorded the replacement's
+        ID and the build-to-golden handshake then blessed the replacement.
+        --iidfile captures the built image's ID as part of the build
+        operation itself. The stub plays the retag: the build writes BUILT to
+        its --iidfile while any later inspect of the tag answers SWAPPED."""
+        with tempfile.TemporaryDirectory() as d:
+            env, binx = self._env(d, DATA_ROOT=d, REQBENCH_STAGED="1")
+            built = "a" * 64
+            swapped = "f" * 64
+            self._write(os.path.join(binx, "podman"), f'''#!/bin/bash
+case "$1" in
+  build)
+      prev=""
+      for a in "$@"; do
+          [ "$prev" = --iidfile ] && printf 'sha256:{built}' > "$a"
+          prev="$a"
+      done
+      exit 0
+      ;;
+  inspect) echo '{{"Test":["CMD-SHELL","/opt/bench/health_state.sh"]}}'; exit 0 ;;
+  image)
+      [ "$2" = inspect ] || exit 1
+      echo {swapped}
+      exit 0
+      ;;
+esac
+exit 1
+''')
+            result = subprocess.run(
+                [self.SH, "build"], env=env,
+                capture_output=True, text=True, timeout=60,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr[-1600:])
+            recorded = self._read_if_exists(
+                self._built_id_path(d), "<missing>").strip()
+            self.assertEqual(
+                recorded, "sha256:" + built,
+                "the handshake recorded an ID read from the mutable tag "
+                "after the build returned",
+            )
+
+    def test_build_bakes_the_sealed_bytes_when_the_repo_mutates_mid_build(self):
+        """RED BEFORE THE FIX: the cmp pre-check read the repository, then
+        podman read the SAME mutable repository as its build context, so an
+        edit landing between the check and podman's COPY still baked diverged
+        bytes while the cdp arm ran the sealed copy. The build must read from
+        an immutable staged context whose sealed sources come from the
+        runtime bundle. The stub plays the mid-build editor: it appends to
+        the repository's render.py first, then records the render bytes the
+        build context actually holds."""
+        with tempfile.TemporaryDirectory() as d:
+            env, binx = self._env(d, DATA_ROOT=d)
+            srcrepo = os.path.join(d, "srcrepo")
+            bench_dir = os.path.join(srcrepo, "bench", "chromium")
+            os.makedirs(os.path.join(bench_dir, "pages"))
+            with open(os.path.join(bench_dir, "pages", "medium.html"), "w") as f:
+                f.write("<html></html>\n")
+            for name in ("render.py", "cdpdrive.py", "wddrive.py"):
+                shutil.copyfile(
+                    os.path.join(HERE, name), os.path.join(bench_dir, name),
+                )
+            with open(os.path.join(
+                    srcrepo, "Containerfile.chromium-bench"), "w") as f:
+                f.write("FROM scratch\nCOPY bench/chromium/render.py /opt/\n")
+            subprocess.run(
+                ["git", "init", "-q", srcrepo],
+                check=True, capture_output=True, text=True,
+            )
+            subprocess.run(
+                ["git", "-C", srcrepo, "add", "-A"],
+                check=True, capture_output=True, text=True,
+            )
+            subprocess.run(
+                ["git", "-C", srcrepo, "-c", "user.name=t",
+                 "-c", "user.email=t@example.com", "commit", "-qm", "seed"],
+                check=True, capture_output=True, text=True,
+            )
+            baked = os.path.join(d, "baked-render.py")
+            self._write(os.path.join(binx, "podman"), f'''#!/bin/bash
+if [ "$1" = build ]; then
+    # The mid-build edit: it lands after every pre-check has passed, exactly
+    # when the real podman would be reading COPY sources from the context.
+    echo "# edit landed while podman was reading the context" \
+        >> {srcrepo}/bench/chromium/render.py
+    prev=""; ctx=""; iid=""
+    for a in "$@"; do
+        [ "$prev" = --iidfile ] && iid="$a"
+        prev="$a"; ctx="$a"
+    done
+    [ -z "$iid" ] || printf 'sha256:%s' "$(printf 'c%.0s' {{1..64}})" > "$iid"
+    cp "$ctx/bench/chromium/render.py" {baked}
+    exit 0
+fi
+[ "$1" = inspect ] && {{ echo '{{"Test":["CMD-SHELL","/opt/bench/health_state.sh"]}}'; exit 0; }}
+[ "$1 $2" = "image inspect" ] && {{ echo {"b" * 64}; exit 0; }}
+exit 1
+''')
+            result = subprocess.run(
+                [self.SH, "build"], env=dict(env, REQBENCH_SOURCE_REPO=srcrepo),
+                capture_output=True, text=True, timeout=120,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr[-1600:])
+            with open(os.path.join(HERE, "render.py")) as f:
+                sealed = f.read()
+            self.assertEqual(
+                self._read_if_exists(baked, "<no context recorded>"), sealed,
+                "the image baked repository bytes, not the sealed bundle's",
             )
 
     def _run_stub(self, d, backend, analyzer_rc=0, sudo_env_reset=False):


### PR DESCRIPTION
make bench-chromium-request-golden runs cmd_build and cmd_golden as separate
reqbench.sh processes with the TAG lock released between them. The checks
inside cmd_golden (disk cache key, prepared generation) only prove that
golden's own observation is self-consistent, so a tag repointed in that
window was snapshotted silently, with provenance stamped from the swap.

cmd_build now records the image ID it published (normalized sha256:<64hex>,
atomic mktemp+mv) in $DATA_ROOT/reqbench-locks/built-image-<image>.id, and
cmd_golden, right after its atomic inspect, refuses a tag whose ID differs
from that record, naming both IDs. The record (or null when no build
preceded the golden) is committed into reqbench-provenance.json as
built_image_id. The tag, not the ID, is still what prepare receives: the
existing disk-key and prepared-generation checks close the windows inside
cmd_golden.

cmd_build also refuses to build when render.py, cdpdrive.py or wddrive.py in
the live repository differ from the sealed runtime bundle: the image COPYs
render.py from the repository while the cdp arm runs the bundle copy, and
the staging guard compares git HEAD only, which cannot see an uncommitted
edit, so the two arms could run different render code under a passing seal.

Fixes #813.

Tests (bench/chromium, stub-podman harness, no VM): four new tests, each
watched failing on the unfixed tree first:
- test_build_records_the_image_id_it_published:
  AssertionError: '<missing>' != 'sha256:bbb...b'
- test_golden_refuses_an_image_that_is_not_the_one_build_produced:
  AssertionError: 0 == 0 (golden exited 0 despite a mismatched record)
- test_golden_records_a_matching_build_id_in_provenance:
  KeyError: 'built_image_id'
- test_build_refuses_a_render_py_that_diverged_from_the_sealed_bundle:
  'render.py' not found in stderr, and the podman build marker existed
All four pass with the fix. Full suite: python3 -m unittest test_reqbench,
189 tests, failures=18 errors=4, failure names identical to the clean-main
baseline run (185 tests, failures=18 errors=4; environment-bound teardown
classes, no KVM on this box).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Builds now use a sealed, immutable source snapshot to prevent unintended source changes during image creation.
  - The exact image produced during a build is recorded and verified before generating golden results.
  - Golden runs now reject images that differ from the recorded build image.
  - Snapshot provenance now includes and validates the built image identity.

- **Tests**
  - Added regression coverage for image identity tracking, source validation, provenance recording, and immutable build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->