### PR TITLE
bench: opt-in quiet-gate settle window; faultbench prechecks before spawn

### DIFF
--- a/bench/chromium/faultbench.py
+++ b/bench/chromium/faultbench.py
@@ -630,6 +630,25 @@ def build_schedule(cells, pages, reps, warmup, seed):
     return warm + measured
 
 
+SETTLE_POLL_S = 5.0
+
+
+def settle_wait_secs():
+    """The bounded quiet-gate settle window, shared knob with reqbench/hostcdp."""
+    raw = os.environ.get("SETTLE_WAIT_SECS", "0")
+    try:
+        value = float(raw)
+    except ValueError:
+        raise SystemExit(
+            f"[faultbench] SETTLE_WAIT_SECS must be a number of seconds, got {raw!r}"
+        )
+    if value < 0:
+        raise SystemExit(
+            f"[faultbench] SETTLE_WAIT_SECS must not be negative, got {raw!r}"
+        )
+    return value
+
+
 def host_precheck(expected_firecrackers=0):
     """Refuse to start on a host that is already busy or already running VMs.
 
@@ -637,23 +656,35 @@ def host_precheck(expected_firecrackers=0):
     background load moves every latency number. Both are invisible after the fact,
     which is why this runs before the first request rather than being reported with
     the results.
+
+    SETTLE_WAIT_SECS > 0 bounds a wait for the load to fall below MAX_START_LOAD
+    before refusing: the make one-shot chain reaches this gate seconds after its
+    own prerequisite builds, whose work a 1-minute average still carries. A
+    foreign firecracker still refuses immediately; it does not go away by waiting.
     """
-    load1 = os.getloadavg()[0]
-    foreign = firecracker_pids()
-    info = {"loadavg_1m": load1, "firecracker_pids": sorted(foreign),
-            "uptime_s": float(Path("/proc/uptime").read_text().split()[0])}
-    if len(foreign) > expected_firecrackers:
-        raise SystemExit(
-            f"[faultbench] {len(foreign)} firecracker processes already running "
-            f"({sorted(foreign)}); they would compete for CPU and pollute the host-wide "
-            f"ftrace dump. Stop them first."
-        )
-    if load1 > MAX_START_LOAD:
-        raise SystemExit(
-            f"[faultbench] 1-minute load average is {load1:.2f}, above {MAX_START_LOAD}; "
-            f"every latency number would be measuring the other workload too"
-        )
-    return info
+    deadline = time.monotonic() + settle_wait_secs()
+    while True:
+        load1 = os.getloadavg()[0]
+        foreign = firecracker_pids()
+        info = {"loadavg_1m": load1, "firecracker_pids": sorted(foreign),
+                "uptime_s": float(Path("/proc/uptime").read_text().split()[0])}
+        if len(foreign) > expected_firecrackers:
+            raise SystemExit(
+                f"[faultbench] {len(foreign)} firecracker processes already running "
+                f"({sorted(foreign)}); they would compete for CPU and pollute the host-wide "
+                f"ftrace dump. Stop them first."
+            )
+        if load1 <= MAX_START_LOAD:
+            return info
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise SystemExit(
+                f"[faultbench] 1-minute load average is {load1:.2f}, above {MAX_START_LOAD}; "
+                f"every latency number would be measuring the other workload too"
+            )
+        print(f"[faultbench] settling: load1={load1:.2f} above {MAX_START_LOAD}; "
+              f"re-sampling ({remaining:.0f}s left in the settle window)", flush=True)
+        time.sleep(min(SETTLE_POLL_S, remaining))
 
 
 class LoadSampler(threading.Thread):
@@ -729,6 +760,34 @@ def main():
                          "record so a run can be replayed in the same order")
     args = ap.parse_args()
 
+    # Every refusal must run BEFORE the output directory is dirtied and
+    # before hostserver.py is spawned: the server starts outside the teardown
+    # try/finally, so a refusal after it leaks the server, and directories
+    # made before a refusal make require_fresh_out_dir refuse the retry.
+    precheck = host_precheck()
+    print(f"[faultbench] host at start: load1={precheck['loadavg_1m']:.2f} "
+          f"firecrackers={len(precheck['firecracker_pids'])}", flush=True)
+
+    # golden snapshot tags, resolved the same way bench.sh does (content-addressed)
+    tags = {}
+    for d in SNAP_DIR.glob("cb-golden-*"):
+        if d.is_dir():
+            key = d.name.split("-")[2]
+            tags[key] = d.name
+
+    pages = [p.strip() for p in args.pages.split(",") if p.strip()] or [args.page]
+    # The seed is recorded, so a suspicious run can be replayed in the same order.
+    seed = args.seed if args.seed is not None else int(time.time())
+    cells = [c.strip() for c in args.cells.split(",") if c.strip()]
+    unknown = [c for c in cells if c not in CELLS]
+    if unknown:
+        raise SystemExit(f"[faultbench] unknown cells {unknown}; known: {sorted(CELLS)}")
+    for c in [c for c in cells if not tags.get(CELLS[c][2])]:
+        print(f"[faultbench] SKIP {c}: no golden snapshot for {CELLS[c][2]}", flush=True)
+    cells = [c for c in cells if tags.get(CELLS[c][2])]
+    if not cells:
+        raise SystemExit("[faultbench] no cell has a golden snapshot; nothing to measure")
+
     out = Path(args.out)
     require_fresh_out_dir(out)
     (out / "requests").mkdir(parents=True, exist_ok=True)
@@ -744,31 +803,8 @@ def main():
         stdout=open(out / "logs" / "hostserver.log", "w"), stderr=subprocess.STDOUT)
     time.sleep(1.0)
 
-    # golden snapshot tags, resolved the same way bench.sh does (content-addressed)
-    tags = {}
-    for d in SNAP_DIR.glob("cb-golden-*"):
-        if d.is_dir():
-            key = d.name.split("-")[2]
-            tags[key] = d.name
-
     runid = time.strftime("%H%M%S")
     results = []
-    pages = [p.strip() for p in args.pages.split(",") if p.strip()] or [args.page]
-    # The seed is recorded, so a suspicious run can be replayed in the same order.
-    seed = args.seed if args.seed is not None else int(time.time())
-    cells = [c.strip() for c in args.cells.split(",") if c.strip()]
-    unknown = [c for c in cells if c not in CELLS]
-    if unknown:
-        raise SystemExit(f"[faultbench] unknown cells {unknown}; known: {sorted(CELLS)}")
-    for c in [c for c in cells if not tags.get(CELLS[c][2])]:
-        print(f"[faultbench] SKIP {c}: no golden snapshot for {CELLS[c][2]}", flush=True)
-    cells = [c for c in cells if tags.get(CELLS[c][2])]
-    if not cells:
-        raise SystemExit("[faultbench] no cell has a golden snapshot; nothing to measure")
-
-    precheck = host_precheck()
-    print(f"[faultbench] host at start: load1={precheck['loadavg_1m']:.2f} "
-          f"firecrackers={len(precheck['firecracker_pids'])}", flush=True)
     (out / "run.json").write_text(json.dumps({
         "runid": runid, "seed": seed, "cells": cells, "pages": pages,
         "reps": args.reps, "warmup": args.warmup, "label": args.label,

--- a/bench/chromium/faultbench.py
+++ b/bench/chromium/faultbench.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import random
 import re
@@ -641,6 +642,13 @@ def settle_wait_secs():
     except ValueError:
         raise SystemExit(
             f"[faultbench] SETTLE_WAIT_SECS must be a number of seconds, got {raw!r}"
+        )
+    # float() accepts 'nan' and 'inf', and nan also slips the negative check
+    # (nan compares false to everything); either would make the bounded
+    # window unbounded, so require a finite value.
+    if not math.isfinite(value):
+        raise SystemExit(
+            f"[faultbench] SETTLE_WAIT_SECS must be a finite number of seconds, got {raw!r}"
         )
     if value < 0:
         raise SystemExit(

--- a/bench/chromium/hostcdp.sh
+++ b/bench/chromium/hostcdp.sh
@@ -46,6 +46,8 @@ quiet_sample() {
     if awk -v l="$la" 'BEGIN{exit !(l >= 1.0)}'; then return 1; fi
     return 0
 }
+# Base 10: "08" passes the validator and is invalid octal to bash arithmetic.
+SETTLE_WAIT_SECS=$((10#$SETTLE_WAIT_SECS))
 deadline=$((SECONDS + SETTLE_WAIT_SECS))
 until quiet_sample; do
     if [ "$SECONDS" -ge "$deadline" ]; then

--- a/bench/chromium/hostcdp.sh
+++ b/bench/chromium/hostcdp.sh
@@ -19,19 +19,39 @@ CDP_PORT="${CDP_PORT:-9222}"
 RUNID="${RUNID:-$(tr -d - </proc/sys/kernel/random/uuid)}"
 RESULTS="${RESULTS:-$HERE/results/hostcdp-$RUNID}"
 CNAME="hostcdp-$$"
+LOADAVG_FILE="${LOADAVG_FILE:-/proc/loadavg}"
 
 mkdir -p "$RESULTS"
 log() { printf '%s %s\n' "$(date +%H:%M:%S)" "$*" >&2; }
 
 # Same quiet-box refusal as the VM harness: a contaminated baseline poisons
-# every ratio computed against it.
-la=$(cut -d' ' -f1 /proc/loadavg)
-fc=$(pgrep -c firecracker || true)
-# Same 1.0 gate as faultbench; the earlier printf-rounding form refused at 0.70.
-if [ "${ALLOW_BUSY:-0}" != 1 ] && { [ "${fc:-0}" -gt 0 ] || awk -v l="$la" 'BEGIN{exit !(l >= 1.0)}'; }; then
-    log "REFUSING: load=$la firecracker=$fc. ALLOW_BUSY=1 overrides and taints the run."
-    exit 3
-fi
+# every ratio computed against it. SETTLE_WAIT_SECS > 0 bounds a wait for the
+# box to go quiet before refusing (same knob as reqbench.sh guard_quiet; the
+# Makefile runs this right after `build`, whose load a 1-minute average still
+# carries). Default 0 keeps the fail-fast refusal.
+SETTLE_WAIT_SECS="${SETTLE_WAIT_SECS:-0}"
+[[ "$SETTLE_WAIT_SECS" =~ ^[0-9]+$ ]] \
+    || { log "SETTLE_WAIT_SECS must be a whole number of seconds (got '$SETTLE_WAIT_SECS')"; exit 2; }
+quiet_sample() {
+    la=$(cut -d' ' -f1 "$LOADAVG_FILE")
+    fc=$(pgrep -c firecracker || true)
+    [ "${ALLOW_BUSY:-0}" != 1 ] || return 0
+    [ "${fc:-0}" -eq 0 ] || return 1
+    # Same 1.0 gate as faultbench; the earlier printf-rounding form refused at 0.70.
+    if awk -v l="$la" 'BEGIN{exit !(l >= 1.0)}'; then return 1; fi
+    return 0
+}
+deadline=$((SECONDS + SETTLE_WAIT_SECS))
+until quiet_sample; do
+    if [ "$SECONDS" -ge "$deadline" ]; then
+        log "REFUSING: load=$la firecracker=$fc. ALLOW_BUSY=1 overrides and taints the run."
+        exit 3
+    fi
+    nap=$((deadline - SECONDS))
+    [ "$nap" -le 5 ] || nap=5
+    log "settling: load=$la firecracker=$fc; re-sampling in ${nap}s ($((deadline - SECONDS))s left in the ${SETTLE_WAIT_SECS}s window)"
+    sleep "$nap"
+done
 
 cleanup() { podman rm -f "$CNAME" >/dev/null 2>&1 || true; }
 trap cleanup EXIT

--- a/bench/chromium/hostcdp.sh
+++ b/bench/chromium/hostcdp.sh
@@ -33,7 +33,12 @@ SETTLE_WAIT_SECS="${SETTLE_WAIT_SECS:-0}"
 [[ "$SETTLE_WAIT_SECS" =~ ^[0-9]+$ ]] \
     || { log "SETTLE_WAIT_SECS must be a whole number of seconds (got '$SETTLE_WAIT_SECS')"; exit 2; }
 quiet_sample() {
-    la=$(cut -d' ' -f1 "$LOADAVG_FILE")
+    la=$(cut -d' ' -f1 "$LOADAVG_FILE" || true)
+    # This function runs as an `until` condition, where set -e is suppressed
+    # and awk reads an empty string as 0, so a missing, unreadable, or empty
+    # LOADAVG_FILE would otherwise pass the gate without a load reading.
+    [[ "$la" =~ ^[0-9]+([.][0-9]+)?$ ]] \
+        || { log "REFUSING: no numeric 1-minute load readable from $LOADAVG_FILE (got '$la')"; exit 2; }
     fc=$(pgrep -c firecracker || true)
     [ "${ALLOW_BUSY:-0}" != 1 ] || return 0
     [ "${fc:-0}" -eq 0 ] || return 1

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -388,7 +388,7 @@ vm_process_count() {
     printf '%s\n' "$count"
 }
 
-guard_quiet() {
+guard_quiet_sample() {
     # Match comm, not argv. Repository paths in a tmux/Codex command line used to
     # make `pgrep -f` count the benchmark operator as an fcvm process. Prefixes
     # are required because content-addressed Firecracker names and Linux's
@@ -425,6 +425,36 @@ guard_quiet() {
     fi
     QUIET_GUARD_LOADAVG1="$la"
     QUIET_GUARD_VM_PROCESSES="$fc"
+}
+
+guard_quiet() {
+    # SETTLE_WAIT_SECS > 0 turns a busy first sample into a bounded re-sample
+    # loop. The one-shot chain (cmd_all) reaches this gate seconds after its
+    # own build, golden and verify phases, so the 1-minute load average still
+    # carries that prerequisite work; without the window a cold invocation
+    # refuses on its own wake and a retry repeats the phony prerequisites.
+    # Default 0 keeps the standalone fail-fast refusal.
+    local settle="${SETTLE_WAIT_SECS:-0}"
+    [[ "$settle" =~ ^[0-9]+$ ]] || {
+        log "REFUSING: SETTLE_WAIT_SECS must be a whole number of seconds (got '$settle')"
+        return 3
+    }
+    local rc=0
+    guard_quiet_sample || rc=$?
+    [ "$rc" -ne 0 ] || return 0
+    [ "$settle" -gt 0 ] || return "$rc"
+    local deadline=$((SECONDS + settle)) nap
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        nap=$((deadline - SECONDS))
+        [ "$nap" -le 5 ] || nap=5
+        log "settling: box is busy; re-sampling in ${nap}s ($((deadline - SECONDS))s left in the ${settle}s window)"
+        sleep "$nap"
+        rc=0
+        guard_quiet_sample || rc=$?
+        [ "$rc" -ne 0 ] || return 0
+    done
+    log "REFUSING: box still busy after ${settle}s settle wait"
+    return "$rc"
 }
 
 state_pid_by_name() {
@@ -1117,7 +1147,13 @@ if [ "${BASH_SOURCE[0]}" = "$0" ]; then
         golden) cmd_golden ;;
         verify) cmd_verify ;;
         run)    cmd_run ;;
-        all)    cmd_build; cmd_golden; cmd_verify; cmd_run ;;
+        all)
+            # The chain's own build/golden/verify phases are the load the run
+            # gate reads a minute later; default the settle window so a cold
+            # one-shot does not refuse on its own wake. An explicit
+            # SETTLE_WAIT_SECS wins.
+            export SETTLE_WAIT_SECS="${SETTLE_WAIT_SECS:-120}"
+            cmd_build; cmd_golden; cmd_verify; cmd_run ;;
         *) echo "usage: $0 {build|golden|verify|run|all}" >&2; exit 2 ;;
     esac
 fi

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -439,6 +439,9 @@ guard_quiet() {
         log "REFUSING: SETTLE_WAIT_SECS must be a whole number of seconds (got '$settle')"
         return 3
     }
+    # Base 10: "08" passes the validator and is invalid octal to bash
+    # arithmetic, and "010" would silently mean eight.
+    settle=$((10#$settle))
     local rc=0
     guard_quiet_sample || rc=$?
     [ "$rc" -ne 0 ] || return 0

--- a/bench/chromium/test_faultbench.py
+++ b/bench/chromium/test_faultbench.py
@@ -7,6 +7,7 @@ survives: a corrupt number reads exactly like a real one.
 """
 import json
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -245,6 +246,86 @@ class ServeIdentity(unittest.TestCase):
         }))
         self.assertEqual(faultbench.serve_pid_for("t", "copy"), 4444)
         self.assertIsNone(faultbench.serve_pid_for("t", "minor"))
+
+
+class _FakeSubprocess:
+    """faultbench's view of the subprocess module, with Popen recorded.
+
+    run() stays real (main shells out for the host IPv4 address); Popen is
+    what starts hostserver.py, and a test must never leak a real one.
+    """
+
+    def __init__(self, record):
+        self.record = record
+        self.run = subprocess.run
+        self.STDOUT = subprocess.STDOUT
+        self.PIPE = subprocess.PIPE
+        self.DEVNULL = subprocess.DEVNULL
+
+    def Popen(self, *args, **kwargs):
+        self.record.append(args[0] if args else kwargs.get("args"))
+
+        class Dummy:
+            def poll(self):
+                return None
+
+            def terminate(self):
+                pass
+
+            def kill(self):
+                pass
+
+            def wait(self, timeout=None):
+                return 0
+
+        return Dummy()
+
+
+class QuietGate(unittest.TestCase):
+    """The start-load check and its SETTLE_WAIT_SECS knob."""
+
+    def patch(self, obj, name, value):
+        real = getattr(obj, name)
+        setattr(obj, name, value)
+        self.addCleanup(setattr, obj, name, real)
+
+    def test_the_start_load_check_settles_within_the_settle_window(self):
+        """`make bench-chromium-fault` runs build and setup right before this
+        gate, so a fail-fast cold chain refuses on its own prerequisite wake
+        and a retry repeats the prerequisites. SETTLE_WAIT_SECS bounds a wait
+        for the load to fall, same knob as reqbench.sh and hostcdp.sh."""
+        samples = iter([(9.9, 0.0, 0.0), (9.5, 0.0, 0.0), (0.2, 0.0, 0.0)])
+        self.patch(os, "getloadavg", lambda: next(samples))
+        self.patch(faultbench, "firecracker_pids", lambda: set())
+        naps = []
+        self.patch(faultbench.time, "sleep", naps.append)
+        os.environ["SETTLE_WAIT_SECS"] = "30"
+        self.addCleanup(os.environ.pop, "SETTLE_WAIT_SECS", None)
+        info = faultbench.host_precheck()
+        self.assertEqual(info["loadavg_1m"], 0.2)
+        self.assertEqual(len(naps), 2, "one nap per busy re-sample")
+
+    def test_a_busy_refusal_spawns_nothing_and_keeps_the_out_dir_fresh(self):
+        """A refused run must be retryable with the same --out.
+
+        A hostserver started before host_precheck sits outside the teardown
+        try/finally, so a refusal leaks it; require_fresh_out_dir and the
+        mkdirs running earlier still means the retry is refused for the
+        directory the refused run itself dirtied.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            out = Path(d) / "run"
+            spawned = []
+            self.patch(faultbench, "subprocess", _FakeSubprocess(spawned))
+            self.patch(os, "getloadavg", lambda: (9.9, 0.0, 0.0))
+            self.patch(faultbench, "firecracker_pids", lambda: set())
+            self.patch(sys, "argv", ["faultbench.py", "--out", str(out)])
+            with self.assertRaises(SystemExit) as caught:
+                faultbench.main()
+            self.assertIn("load average", str(caught.exception))
+            self.assertEqual(spawned, [], "a refused run spawned a child")
+            # Raises SystemExit("not empty") if the refusal dirtied it.
+            faultbench.require_fresh_out_dir(out)
 
 
 if __name__ == "__main__":

--- a/bench/chromium/test_faultbench.py
+++ b/bench/chromium/test_faultbench.py
@@ -305,6 +305,19 @@ class QuietGate(unittest.TestCase):
         self.assertEqual(info["loadavg_1m"], 0.2)
         self.assertEqual(len(naps), 2, "one nap per busy re-sample")
 
+    def test_a_non_finite_settle_window_is_rejected(self):
+        """SETTLE_WAIT_SECS promises a BOUNDED settle window. float() accepts
+        'nan' and 'inf', and neither trips the negative check (nan compares
+        false to everything), so on a busy host the deadline never expires:
+        `remaining <= 0` never holds and host_precheck resamples forever."""
+        for raw in ("nan", "inf", "Infinity"):
+            with self.subTest(raw=raw):
+                os.environ["SETTLE_WAIT_SECS"] = raw
+                self.addCleanup(os.environ.pop, "SETTLE_WAIT_SECS", None)
+                with self.assertRaises(SystemExit) as caught:
+                    faultbench.settle_wait_secs()
+                self.assertIn("finite", str(caught.exception))
+
     def test_a_busy_refusal_spawns_nothing_and_keeps_the_out_dir_fresh(self):
         """A refused run must be retryable with the same --out.
 

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -4670,6 +4670,49 @@ class HostCdpQuietGate(unittest.TestCase):
             self.assertNotIn("REFUSING", result.stderr)
             self.assertNotEqual(result.returncode, 3, result.stderr)
 
+    def test_an_unreadable_loadavg_file_fails_closed(self):
+        """RED BEFORE THE FIX: with LOADAVG_FILE missing or empty, `cut`
+        fails inside the `until quiet_sample` condition where set -e is
+        suppressed, `la` comes back empty, awk reads the empty string as 0,
+        and the gate passes without ever evaluating host load. A mistyped
+        override then starts the container (stub exit 7 here) instead of
+        refusing. The script must exit 2 before reaching podman."""
+        for fixture in ("missing", "empty"):
+            with self.subTest(fixture=fixture), \
+                    tempfile.TemporaryDirectory() as d:
+                binx = os.path.join(d, "bin")
+                os.makedirs(binx)
+                loadavg = os.path.join(d, "loadavg")
+                if fixture == "empty":
+                    open(loadavg, "w").close()
+                stubs = {
+                    "pgrep": "#!/bin/bash\necho 0\nexit 1\n",
+                    # Reaching podman means the gate passed; exit 7 is
+                    # distinguishable from the validation refusal exit 2.
+                    "podman": "#!/bin/bash\nexit 7\n",
+                }
+                for name, body in stubs.items():
+                    path = os.path.join(binx, name)
+                    with open(path, "w") as f:
+                        f.write(body)
+                    os.chmod(path, 0o755)
+                env = dict(os.environ)
+                env.update(
+                    PATH=binx + os.pathsep + env["PATH"],
+                    LOADAVG_FILE=loadavg,
+                    ALLOW_BUSY="0",
+                    RESULTS=os.path.join(d, "results"),
+                )
+                result = subprocess.run(
+                    ["bash", self.SH], env=env,
+                    capture_output=True, text=True, timeout=60,
+                )
+                self.assertEqual(
+                    result.returncode, 2,
+                    f"gate did not fail closed: rc={result.returncode} "
+                    f"stderr={result.stderr[-800:]}")
+                self.assertIn(loadavg, result.stderr)
+
 
 class SustainedRateUncertainty(unittest.TestCase):
     """The throughput HEADLINE must carry uncertainty, like everything else here.

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -4500,6 +4500,98 @@ done
                 "2.0001=busy:3", "3=busy:3",
             ])
 
+    def _settle_env(self, d, **extra):
+        """A busy loadavg fixture plus an empty ps fixture, for guard tests."""
+        fixture = os.path.join(d, "ps.txt")
+        loadavg = os.path.join(d, "loadavg")
+        open(fixture, "w").close()
+        with open(loadavg, "w") as f:
+            f.write("9.99 0 0 1/1 1\n")
+        env, binx = self._env(
+            d, ALLOW_BUSY="0", PS_FIXTURE=fixture, LOADAVG_FILE=loadavg,
+            **extra,
+        )
+        self._write(os.path.join(binx, "ps"), '#!/bin/bash\ncat "$PS_FIXTURE"\n')
+        return env
+
+    def test_quiet_guard_settles_within_the_opt_in_window(self):
+        """SETTLE_WAIT_SECS turns one busy sample into a bounded re-sample loop.
+
+        The one-shot chain (cmd_all) reaches the run gate seconds after its own
+        build, golden and verify phases, so the 1-minute load average it reads
+        still carries that prerequisite work. Without the window a cold
+        `make bench-chromium-request-all` refuses because of its own wake, and
+        a retry repeats the phony prerequisites.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            env = self._settle_env(d, SETTLE_WAIT_SECS="30")
+            script = f'''
+source {self.SH!r}
+trap - EXIT INT TERM
+( sleep 2; printf '0.10 0 0 1/1 1\n' > "$LOADAVG_FILE" ) &
+helper=$!
+if guard_quiet; then
+    echo settled
+else
+    echo "refused:$?"
+fi
+wait "$helper"
+'''
+            result = subprocess.run(
+                ["bash", "-c", script], env=env,
+                capture_output=True, text=True, timeout=60,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                result.stdout.strip(), "settled", result.stderr[-800:],
+            )
+
+    def test_quiet_guard_still_refuses_when_the_settle_window_elapses(self):
+        """A box that never goes quiet is refused, with the wait named."""
+        with tempfile.TemporaryDirectory() as d:
+            env = self._settle_env(d, SETTLE_WAIT_SECS="1")
+            script = f'''
+source {self.SH!r}
+trap - EXIT INT TERM
+if guard_quiet; then
+    echo quiet
+else
+    echo "refused:$?"
+fi
+'''
+            result = subprocess.run(
+                ["bash", "-c", script], env=env,
+                capture_output=True, text=True, timeout=60,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), "refused:3")
+            self.assertIn("still busy after 1s settle wait", result.stderr)
+
+    def test_all_gives_its_own_chain_a_settle_default(self):
+        """cmd_all runs the gate right after its own prerequisite phases."""
+        for preset, expected in ((None, "120"), ("7", "7")):
+            with self.subTest(preset=preset), tempfile.TemporaryDirectory() as d:
+                extra = {"REQBENCH_STAGED": "1", "DATA_ROOT": d}
+                if preset is not None:
+                    extra["SETTLE_WAIT_SECS"] = preset
+                env, binx = self._env(d, **extra)
+                capture = os.path.join(d, "settle.txt")
+                # cmd_build's podman invocation is the first child the chain
+                # runs; failing there keeps the test to the dispatch line.
+                self._write(os.path.join(binx, "podman"), f'''#!/bin/bash
+echo "settle=${{SETTLE_WAIT_SECS:-<unset>}}" >> {capture}
+exit 1
+''')
+                result = subprocess.run(
+                    [self.SH, "all"], env=env,
+                    capture_output=True, text=True, timeout=60,
+                )
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+                self.assertIn(
+                    f"settle={expected}",
+                    self._read_if_exists(capture, "<no podman invocation>"),
+                )
+
     def test_target_id_waits_for_readiness_and_skips_devtools_pages(self):
         """RED BEFORE THE FIX: `target_id` was a SINGLE-SHOT urlopen with
         `2>/dev/null || true`, and `start_clone` returns as soon as the state file
@@ -4523,6 +4615,60 @@ done
                                    capture_output=True, text=True, timeout=120)
             self.assertEqual(r.stdout.strip(), "ABC123",
                              f"stdout={r.stdout!r} stderr={r.stderr[-800:]}")
+
+
+class HostCdpQuietGate(unittest.TestCase):
+    """hostcdp.sh shares reqbench's SETTLE_WAIT_SECS quiet-gate knob.
+
+    The Makefile runs the host baseline right after `build`, so its tighter
+    1.0 gate is even easier for the chain to trip on its own wake.
+    """
+
+    SH = os.path.join(HERE, "hostcdp.sh")
+
+    def test_the_gate_settles_with_the_same_knob(self):
+        with tempfile.TemporaryDirectory() as d:
+            binx = os.path.join(d, "bin")
+            os.makedirs(binx)
+            loadavg = os.path.join(d, "loadavg")
+            with open(loadavg, "w") as f:
+                f.write("9.99 0 0 1/1 1\n")
+            stubs = {
+                # No firecrackers; the load fixture is the only busy signal.
+                "pgrep": "#!/bin/bash\necho 0\nexit 1\n",
+                # Failing the container start right after the gate keeps the
+                # test to the gate itself; exit 7 is distinguishable from the
+                # gate's refusal exit 3.
+                "podman": "#!/bin/bash\nexit 7\n",
+            }
+            for name, body in stubs.items():
+                path = os.path.join(binx, name)
+                with open(path, "w") as f:
+                    f.write(body)
+                os.chmod(path, 0o755)
+            env = dict(os.environ)
+            env.update(
+                PATH=binx + os.pathsep + env["PATH"],
+                LOADAVG_FILE=loadavg,
+                SETTLE_WAIT_SECS="30",
+                ALLOW_BUSY="0",
+                RESULTS=os.path.join(d, "results"),
+            )
+            helper = subprocess.Popen(
+                ["bash", "-c",
+                 f'sleep 2; printf "0.10 0 0 1/1 1\\n" > {loadavg}'],
+            )
+            try:
+                result = subprocess.run(
+                    ["bash", self.SH], env=env,
+                    capture_output=True, text=True, timeout=60,
+                )
+            finally:
+                helper.wait(timeout=10)
+            self.assertIn("settling", result.stderr)
+            self.assertIn("9.99", result.stderr)
+            self.assertNotIn("REFUSING", result.stderr)
+            self.assertNotEqual(result.returncode, 3, result.stderr)
 
 
 class SustainedRateUncertainty(unittest.TestCase):

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -4546,6 +4546,38 @@ wait "$helper"
                 result.stdout.strip(), "settled", result.stderr[-800:],
             )
 
+    def test_quiet_guard_reads_a_leading_zero_window_as_decimal(self):
+        """`08` is a whole number to the validator and invalid octal to bash.
+
+        `$((SECONDS + 08))` fails with "value too great for base" and `010`
+        would silently mean eight. The deadline must be computed from the
+        value parsed in base 10 (CodeRabbit on #865).
+        """
+        with tempfile.TemporaryDirectory() as d:
+            env = self._settle_env(d, SETTLE_WAIT_SECS="08")
+            script = f"""
+source {self.SH!r}
+trap - EXIT INT TERM
+( sleep 2; printf '0.10 0 0 1/1 1\n' > "$LOADAVG_FILE" ) &
+helper=$!
+if guard_quiet; then
+    echo settled
+else
+    echo "refused:$?"
+fi
+wait "$helper"
+"""
+            result = subprocess.run(
+                ["bash", "-c", script], env=env,
+                capture_output=True, text=True, timeout=60,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                result.stdout.strip(), "settled", result.stderr[-800:],
+            )
+            self.assertNotIn("value too great for base", result.stderr)
+            self.assertIn("8s window", result.stderr)
+
     def test_quiet_guard_still_refuses_when_the_settle_window_elapses(self):
         """A box that never goes quiet is refused, with the wait named."""
         with tempfile.TemporaryDirectory() as d:
@@ -4625,6 +4657,48 @@ class HostCdpQuietGate(unittest.TestCase):
     """
 
     SH = os.path.join(HERE, "hostcdp.sh")
+
+    def test_the_gate_reads_a_leading_zero_window_as_decimal(self):
+        # Same octal trap as reqbench's guard_quiet (CodeRabbit on #865):
+        # "08" must be an eight-second window, not a bash arithmetic error.
+        with tempfile.TemporaryDirectory() as d:
+            binx = os.path.join(d, "bin")
+            os.makedirs(binx)
+            loadavg = os.path.join(d, "loadavg")
+            with open(loadavg, "w") as f:
+                f.write("9.99 0 0 1/1 1\n")
+            stubs = {
+                "pgrep": "#!/bin/bash\necho 0\nexit 1\n",
+                "podman": "#!/bin/bash\nexit 7\n",
+            }
+            for name, body in stubs.items():
+                path = os.path.join(binx, name)
+                with open(path, "w") as f:
+                    f.write(body)
+                os.chmod(path, 0o755)
+            env = dict(os.environ)
+            env.update(
+                PATH=binx + os.pathsep + env["PATH"],
+                LOADAVG_FILE=loadavg,
+                SETTLE_WAIT_SECS="08",
+                ALLOW_BUSY="0",
+                RESULTS=os.path.join(d, "results"),
+            )
+            helper = subprocess.Popen(
+                ["bash", "-c",
+                 f'sleep 2; printf "0.10 0 0 1/1 1\\n" > {loadavg}'],
+            )
+            try:
+                result = subprocess.run(
+                    ["bash", self.SH], env=env,
+                    capture_output=True, text=True, timeout=60,
+                )
+            finally:
+                helper.wait(timeout=10)
+            self.assertNotIn("value too great for base", result.stderr)
+            self.assertIn("8s window", result.stderr)
+            self.assertNotIn("REFUSING", result.stderr)
+            self.assertNotEqual(result.returncode, 3, result.stderr)
 
     def test_the_gate_settles_with_the_same_knob(self):
         with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
The one-shot targets trip their own quiet-host gates: bench-chromium-request-all
and bench-chromium-fault run build, setup and image work seconds before a gate
that reads a 1-minute load average, so a cold invocation refuses because of its
own prerequisite wake and a retry repeats the phony prerequisites.

reqbench.sh guard_quiet now takes SETTLE_WAIT_SECS: 0 (the default) keeps the
fail-fast refusal, a positive value re-samples about every 5s until the deadline
and then refuses with the last sample. cmd_all defaults it to 120 for its own
chain; an explicit value wins. hostcdp.sh gets the same knob around its tighter
1.0 gate (plus a LOADAVG_FILE override so the gate is testable against a
fixture, matching reqbench.sh), and faultbench.py's host_precheck settles the
MAX_START_LOAD check the same way while still refusing a foreign firecracker
immediately.

faultbench.py also runs host_precheck before anything with side effects:
hostserver.py was started before the precheck and outside the teardown
try/finally, so a refusal leaked the server, and require_fresh_out_dir plus the
mkdirs ran even earlier, so the retry was refused for the directory the refused
run itself dirtied. Order is now precheck, cell/tag validation, out-dir
freshness, then the spawn.

Fixes the first two items of #814. The third item there (bench.sh's unlocked
nr_hugepages shrink racing the pool flock reqbench/setup-hugepages take) is a
separate mutator and is not touched here.

Tests, each watched failing on the unfixed tree first:
- test_reqbench.ReqbenchShell.test_quiet_guard_settles_within_the_opt_in_window:
  'refused:3' != 'settled' (busy loadavg fixture rewritten quiet by a helper
  after 2s; unfixed guard refused on the first sample)
- test_reqbench.ReqbenchShell.test_quiet_guard_still_refuses_when_the_settle_window_elapses:
  'still busy after 1s settle wait' not found in stderr
- test_reqbench.ReqbenchShell.test_all_gives_its_own_chain_a_settle_default:
  'settle=120' not found in 'settle=<unset>'
- test_reqbench.HostCdpQuietGate.test_the_gate_settles_with_the_same_knob:
  'settling' not found in stderr (unfixed script read the real /proc/loadavg,
  load 28, and refused)
- test_faultbench.QuietGate.test_the_start_load_check_settles_within_the_settle_window:
  SystemExit '1-minute load average is 9.90' on the first sample
- test_faultbench.QuietGate.test_a_busy_refusal_spawns_nothing_and_keeps_the_out_dir_fresh:
  'load average' not found in 'no cell has a golden snapshot' (main had already
  spawned the recorded hostserver Popen and dirtied --out)
All six pass with the fix. Full suites: python3 -m unittest test_reqbench, 189
tests, failures=18 errors=4, failure names identical to the clean-main baseline
(185 tests, failures=18 errors=4; environment-bound teardown classes, no KVM on
this box); python3 -m unittest test_faultbench, 25 tests, OK.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Benchmark commands can now wait for host load to settle before execution.
  - The settling period is configurable, bounded, and supports a default duration for full runs.
  - Host load-average sources can be selected when supported.

- **Bug Fixes**
  - Busy or contaminated hosts are rejected safely after the settling window expires.
  - Invalid, missing, empty, or non-finite load and settling values now fail closed.
  - Preflight checks run before creating output directories or starting host services, keeping refused runs clean and reusable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Later commits

- `cbf9cab9` The quiet gate fails closed when the 1-minute load cannot be read (an unreadable `LOADAVG_FILE` is a refusal, not a pass), and `SETTLE_WAIT_SECS` must be a whole number of seconds (`inf`, `nan`, negatives and fractions are refused with the value named).
- `65834065` The settle window is parsed in base 10: `08` passed the validator and was invalid octal to bash arithmetic (`value too great for base`), `010` would have meant eight. `test_quiet_guard_reads_a_leading_zero_window_as_decimal` and `test_the_gate_reads_a_leading_zero_window_as_decimal` were watched failing with bash's error first; 192/192 after.
