### PR TITLE
cargo-target-link: an unwritable btrfs volume falls back to the local target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 target
 target/
-.cargo-target-local/
+.cargo-target-local*/
 target-root/
 target-sudo/
 artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target
 target/
+.cargo-target-local/
 target-root/
 target-sudo/
 artifacts/

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -80,36 +80,14 @@ name="$(printf '%s' "$(basename "$p")" | LC_ALL=C tr -c 'A-Za-z0-9._-' '_')"
 hash="$(printf '%s' "$p" | sha256sum | cut -c1-8)"
 WT_TARGET="$BTRFS_ROOT/cargo-target/$name-$hash"
 
-# "Is a directory" is not "is usable". On a GitHub-hosted runner /mnt/fcvm-btrfs
-# does not exist, and podman CREATES it as an empty root-owned directory to
-# satisfy CONTAINER_RUN_BASE's bind mount -- so inside the container the volume
-# passes `-d` and fails `mkdir` (Permission denied), while the checkout's own
-# target/ is a bind mount this script should simply keep. Testing `-d` alone
-# took the managed branch and died before reaching its own "retaining unmanaged
-# local target/" exit; every Weekly container-bench from 2026-08-10 on read
-#     mkdir: cannot create directory '/mnt/fcvm-btrfs/cargo-target': Permission denied
-# `-w` would not do either: root passes access(W_OK) on directories it still
-# cannot create in (procfs, a read-only mount). Try the mkdir, and let its
-# outcome decide -- loudly, because artifacts on the root filesystem are the
-# thing this indirection exists to avoid and a reader should see it happen.
-# Give up on the managed volume and leave a REAL local target/ behind.
-#
-# Loud, because artifacts on the root filesystem are the thing this indirection
-# exists to avoid and a reader should see it happen. If target/ is a managed
-# symlink it is REPLACED, not left: a link that still resolves would pass every
-# later `-d target` check while Cargo cannot create a file there (raised on
-# #867). Replacing it is safe here because this script holds the checkout lock
-# (no Cargo runs in this checkout meanwhile) and, whenever target/ resolved,
-# the exclusive lease on its generation taken below.
-# Every exit that leaves target/ as a plain local directory ends here. "Is a
-# directory" is not "is writable": procfs, a read-only mount, and (for a
-# non-root user) a 0555 directory all pass `-d`, and an unwritable target/
-# turns into an opaque cargo error several steps later, which is precisely
-# how the original outage read. So create it if absent, then prove a file
-# can be made in it.
+# Every exit that leaves target/ as a plain local directory proves a file can
+# be created in it first. `-d` passes on procfs, a read-only mount, and a 0555
+# directory. `-w` is no better for root, which passes access(W_OK) on a
+# directory it still cannot create entries in. Creating an entry is the
+# operation cargo needs, and the only test of it.
 require_writable_local_target() {
-	# A dangling UNMANAGED link (a managed one was dropped by the caller) would
-	# make `mkdir -p` fail with EEXIST, under `set -e` and before any diagnostic.
+	# A managed link was already dropped by the caller under its lease; an
+	# unmanaged dangling one is dropped here, or `mkdir -p` fails with EEXIST.
 	if [ -L target ] && ! [ -e target ]; then
 		echo "==> WARNING: dropping dangling target/ → $(readlink target); a local directory takes its place" >&2
 		rm -f -- target
@@ -133,22 +111,17 @@ require_writable_local_target() {
 	rm -f -- "$probe"
 }
 
-# A managed target/ link is dropped, never probed through, on any path that
-# holds no lease on the generation it points at: creating and removing a file
-# inside an unleased generation is the census/rewalk race the pruner's lease
-# protocol exists to prevent. Only the checkout's link goes; the generation is
-# left for the pruner.
+# Drops the checkout's managed target/ link; the generation stays for the
+# pruner. A resolving link is dropped only under an exclusive lease on the
+# generation it publishes: a cargo wrapper may hold that lease shared for the
+# life of its build, and removing the pathname under it splits the build across
+# two trees. A generation that cannot be opened cannot be leased, so the drop
+# is refused. The lease fd stays open until exit. A dangling link publishes
+# nothing and is dropped without one.
 drop_managed_link() {
 	[ -L target ] || return 0
 	case "$(readlink target)" in
 		"$BTRFS_ROOT"/cargo-target/*)
-			# The link publishes a generation a Cargo wrapper may still hold
-			# SHARED while it resolves later target/... paths. Removing the
-			# pathname under that build splits its outputs across two trees,
-			# so the generation is leased EXCLUSIVELY first (this blocks until
-			# the wrapper is done), and a generation that cannot be opened is
-			# a refusal, as for the published-generation open above. The fd
-			# stays open until exit. A dangling link publishes nothing.
 			if [[ -z ${old_target_lease_fd:-} ]] && [ -d target ]; then
 				if ! exec {old_target_lease_fd}<target; then
 					echo "ERROR: cannot open the published generation $(readlink target) to lease it; a running build may still hold it, refusing to replace target/" >&2
@@ -164,9 +137,8 @@ drop_managed_link() {
 fallback_to_local() {
 	echo "==> WARNING: $1; build artifacts stay on the root filesystem" >&2
 	drop_managed_link
-	# `--rotate` promises a logically clean target/. Retaining an unmanaged
-	# link or directory here would report a clean while its payload survives;
-	# the unusable-volume branch refuses the same way.
+	# `--rotate` promises a clean target/; a retained local link or directory
+	# would report one while its payload survives.
 	if ((FORCE_ROTATE)) && { [ -L target ] || [ -d target ]; }; then
 		echo "ERROR: local target/ cannot be atomically rotated without the managed btrfs namespace; refusing unsafe clean" >&2
 		exit 1
@@ -175,14 +147,8 @@ fallback_to_local() {
 	exit 0
 }
 
-# "Is a directory" is not "is usable": on a GitHub-hosted runner podman creates
-# a missing /mnt/fcvm-btrfs as an empty root-owned directory to satisfy the
-# bind mount, so the volume passes `-d` and the mkdir below fails. Whether an
-# EXISTING directory can be written is settled later, under its lease -- see
-# the write probe in the lease block. Probing here, before the generation is
-# leased, is the race the pruner's census/rewalk cannot tolerate (raised on
-# #867): an entry that appears after the census or vanishes during the rewalk
-# aborts the hourly preflight.
+# `mkdir -p` returns 0 on an existing directory without proving it can be
+# written; that is settled under the generation's lease, at the reuse probe.
 old_target_lease_fd=""
 btrfs_usable=0
 if [ -d "$BTRFS_ROOT" ]; then
@@ -311,15 +277,11 @@ fi
 candidate="$WT_TARGET"
 if [ -L target ] && [ -d target ]; then
 	linked="$(readlink target)"
-	# A Cargo wrapper that already crossed the checkout→target lock handoff no
-	# longer holds the checkout lease. Pin and exclusively lease its resolved
-	# generation before publishing any different symlink target.
-	# Fail closed if the published generation cannot be opened: without its
-	# lease there is no way to know whether a Cargo wrapper still holds it
-	# shared, and a generation that lost only READ permission (0333) is one
-	# Cargo can still create entries in. Replacing target/ under such a build
-	# would split it across two trees. Only the operator can fix this (chmod
-	# the generation, or remove the link by hand once nothing runs).
+	# target/ is replaced only under an exclusive lease on the generation it
+	# publishes: a cargo wrapper past the checkout→target lock handoff holds
+	# only that lease, shared, and the flock below blocks until it is done. A
+	# generation that cannot be opened cannot be leased, so replacing it is
+	# refused; a 0333 generation still accepts cargo's writes.
 	if ! exec {old_target_lease_fd}<target; then
 		echo "ERROR: cannot open the published generation $linked to lease it; a running build may still hold it, refusing to replace target/" >&2
 		exit 1
@@ -352,9 +314,9 @@ fi
 retired_rc=0
 target_is_retired "$candidate_state_fd" || retired_rc=$?
 if ((FORCE_ROTATE)) && [ "$retired_rc" != 0 ]; then
-	# Retiring writes the marker into the candidate, so one that cannot be
-	# written cannot take it; the fallback refuses under --rotate. An already
-	# retired candidate needs no marker and rotates below.
+	# Retiring writes a marker into the candidate, so an unwritable one falls
+	# back, and the fallback refuses under --rotate. An already retired
+	# candidate needs no marker.
 	if ! write_probe="$(mktemp -p "$candidate" .fcvm-write-probe.XXXXXXXX 2>/dev/null)"; then
 		fallback_to_local "$candidate cannot be written"
 	fi
@@ -370,18 +332,11 @@ case "$retired_rc" in
 		echo "==> Rotating retired target/ → $candidate"
 		;;
 	3)
-		# The candidate is REUSED, so it must be writable. The probe runs here,
-		# after the retirement check, under the exclusive lease: `mkdir -p`
-		# above is idempotent and says nothing about an EXISTING directory that
-		# has since gone read-only (ownership change, ro remount), and creating
-		# an entry is the operation Cargo needs, the one root cannot fake past
-		# EROFS. Under the lease, because the pruner holds LOCK_EX on a
-		# generation across its census and rewalk; an entry created or removed
-		# outside that lock is exactly the "target entry disappeared during
-		# reclaim" abort. A RETIRED candidate is never probed: new_generation
-		# needs only its parent writable, and a retired generation that went
-		# read-only used to fall back to a local target/ that every later run
-		# then retained.
+		# A generation is probed for writability only when it is reused, and
+		# only under its exclusive lease: the pruner holds LOCK_EX across its
+		# census and rewalk, and an entry created or removed outside the lease
+		# aborts it. A retired candidate is never probed; new_generation needs
+		# only the parent writable.
 		if ! write_probe="$(mktemp -p "$candidate" .fcvm-write-probe.XXXXXXXX 2>/dev/null)"; then
 			fallback_to_local "$candidate cannot be written"
 		fi
@@ -391,10 +346,8 @@ case "$retired_rc" in
 		final_lease_fd="$candidate_state_fd"
 		;;
 	*)
-		# The retirement marker could not be read at all. On a directory that
-		# cannot even be written (a read-only or foreign filesystem) that is
-		# just an unusable managed target, and the fallback applies; on a
-		# writable one it is a protocol error and stays fatal.
+		# An unreadable marker on an unwritable directory is an unusable
+		# volume; on a writable one it is a protocol error.
 		if ! write_probe="$(mktemp -p "$candidate" .fcvm-write-probe.XXXXXXXX 2>/dev/null)"; then
 			fallback_to_local "$candidate cannot be written"
 		fi
@@ -426,8 +379,8 @@ else
 	if ! [ -d "$BTRFS_ROOT" ]; then
 		echo "==> NOTE: $BTRFS_ROOT is not a directory; build artifacts stay on the root filesystem"
 	fi
-	# This branch never leases a generation, and target/ may still resolve into
-	# one (a rotated generation outliving the canonical path the pruner removed).
+	# target/ may still resolve into a generation that outlived its canonical
+	# path; drop_managed_link leases it before dropping the link.
 	drop_managed_link
 fi
 
@@ -451,6 +404,5 @@ if [ -L target ] && ! [ -d target ]; then
 	fi
 fi
 
-# Fail closed, for every path that reaches here (the managed link just
-# published, the unusable-volume branch, a healed or dropped dangling link).
+# Fail closed on every path that reaches here.
 require_writable_local_target

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -80,8 +80,27 @@ name="$(printf '%s' "$(basename "$p")" | LC_ALL=C tr -c 'A-Za-z0-9._-' '_')"
 hash="$(printf '%s' "$p" | sha256sum | cut -c1-8)"
 WT_TARGET="$BTRFS_ROOT/cargo-target/$name-$hash"
 
+# "Is a directory" is not "is usable". On a GitHub-hosted runner /mnt/fcvm-btrfs
+# does not exist, and podman CREATES it as an empty root-owned directory to
+# satisfy CONTAINER_RUN_BASE's bind mount -- so inside the container the volume
+# passes `-d` and fails `mkdir` (Permission denied), while the checkout's own
+# target/ is a bind mount this script should simply keep. Testing `-d` alone
+# took the managed branch and died before reaching its own "retaining unmanaged
+# local target/" exit; every Weekly container-bench from 2026-08-10 on read
+#     mkdir: cannot create directory '/mnt/fcvm-btrfs/cargo-target': Permission denied
+# `-w` would not do either: root passes access(W_OK) on directories it still
+# cannot create in (procfs, a read-only mount). Try the mkdir, and let its
+# outcome decide -- loudly, because artifacts on the root filesystem are the
+# thing this indirection exists to avoid and a reader should see it happen.
+btrfs_usable=0
 if [ -d "$BTRFS_ROOT" ]; then
-	mkdir -p "$WT_TARGET" || { echo "ERROR: cannot create $WT_TARGET" >&2; exit 1; }
+	if mkdir -p "$WT_TARGET" 2>/dev/null; then
+		btrfs_usable=1
+	else
+		echo "==> WARNING: $BTRFS_ROOT exists but $WT_TARGET cannot be created; build artifacts stay on the root filesystem" >&2
+	fi
+fi
+if ((btrfs_usable)); then
 
 retire_target() {
 	local fd="$1"
@@ -270,7 +289,9 @@ else
 		echo "ERROR: local target/ cannot be atomically rotated without the managed btrfs namespace; refusing unsafe clean" >&2
 		exit 1
 	fi
-	echo "==> NOTE: $BTRFS_ROOT is not a directory; build artifacts stay on the root filesystem"
+	if ! [ -d "$BTRFS_ROOT" ]; then
+		echo "==> NOTE: $BTRFS_ROOT is not a directory; build artifacts stay on the root filesystem"
+	fi
 fi
 
 # Self-heal a dangling link. `[ -d target ]` follows the symlink, so this is

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -26,12 +26,15 @@
 #    2026-08-08. `~/.cargo` in the Makefile's check-disk target already
 #    self-heals for exactly this reason; target/ did not.
 #
-# 3. A FALLBACK MUST BE REVERSIBLE. A real target/ the script did not create is
-#    retained for good (its dentry may carry a mount visible only in another
-#    mount namespace), so a fallback shaped as a real target/ would keep every
-#    later build on the root filesystem after the volume returned. The fallback
-#    is a symlink to a checkout-local payload, replaced like any other published
-#    link once the volume is usable again.
+# 3. A FALLBACK MUST BE REVERSIBLE, AND MUST NOT SURVIVE ITS OUTAGE. A real
+#    target/ the script did not create is retained for good (its dentry may
+#    carry a mount visible only in another mount namespace), so a fallback
+#    shaped as a real target/ would keep every later build on the root
+#    filesystem after the volume returned. The fallback is a symlink to a
+#    checkout-local payload, replaced like any other published link once the
+#    volume is usable again. Each activation publishes its OWN payload: a name
+#    the script stops publishing is never chosen again, so a later outage
+#    cannot resurrect a cargo cache that a `--rotate` in between reported gone.
 #
 # Everything below runs under an exclusive flock on the checkout directory,
 # because more than one `make` can run in one checkout (several CI entry points
@@ -86,9 +89,55 @@ p="$(pwd -P)"
 name="$(printf '%s' "$(basename "$p")" | LC_ALL=C tr -c 'A-Za-z0-9._-' '_')"
 hash="$(printf '%s' "$p" | sha256sum | cut -c1-8)"
 WT_TARGET="$BTRFS_ROOT/cargo-target/$name-$hash"
-# The fallback payload, published through target/ as a symlink and never as a
-# real target/ dentry.
-LOCAL_TARGET="$p/.cargo-target-local"
+# Fallback payloads sit beside the checkout and are published through target/
+# as a symlink, never as a real target/ dentry. mktemp names each one, so a
+# payload is reachable only while target/ names it.
+LOCAL_TARGET_PREFIX="$p/.cargo-target-local"
+
+# The fallback payload target/ publishes right now, on stdout. Non-zero when
+# target/ publishes something else.
+published_fallback() {
+	[ -L target ] || return 1
+	local linked
+	linked="$(readlink target)"
+	case "$linked" in
+		"$LOCAL_TARGET_PREFIX".generation-*) printf '%s' "$linked" ;;
+		*) return 1 ;;
+	esac
+}
+
+# True while any fallback payload exists, published or not.
+any_fallback_payload() {
+	local entry
+	for entry in "$LOCAL_TARGET_PREFIX".generation-*; do
+		[ -e "$entry" ] && return 0
+	done
+	return 1
+}
+
+# Reclaim every fallback payload except the one target/ publishes. An
+# unpublished payload is unreachable (nothing but target/ ever names one) and
+# it sits on the root filesystem this indirection exists to keep free, while
+# nothing else reclaims it: the pruner enumerates a checkout's target/ and the
+# btrfs generations, never a checkout's other entries. A payload another
+# build still leases is kept, and stays unreachable.
+discard_unpublished_fallbacks() {
+	local keep="${1:-}" entry lease_fd
+	for entry in "$LOCAL_TARGET_PREFIX".generation-*; do
+		[ -d "$entry" ] || continue
+		[ "$entry" != "$keep" ] || continue
+		exec {lease_fd}<"$entry" || continue
+		if ! flock -x -n "$lease_fd"; then
+			echo "==> WARNING: $entry is leased by another build and is not reclaimed" >&2
+		elif rm -rf -- "$entry"; then
+			echo "==> Reclaimed the unpublished fallback payload $entry" >&2
+		else
+			# Another uid's leftovers, say. It stays unreachable either way.
+			echo "==> WARNING: $entry cannot be removed and is not reclaimed" >&2
+		fi
+		exec {lease_fd}<&-
+	done
+}
 
 publish_target_link() {
 	local destination="$1" staging
@@ -106,25 +155,36 @@ publish_target_link() {
 # directory. `-w` is no better for root, which passes access(W_OK) on a
 # directory it still cannot create entries in. Creating an entry is the
 # operation cargo needs, and the only test of it. When nothing is published,
-# the fallback is a link to $LOCAL_TARGET; a real target/ dentry is never
-# created here, because every later run would retain it as unmanaged.
+# the fallback is a link to a payload created here; a real target/ dentry is
+# never created, because every later run would retain it as unmanaged.
 require_writable_local_target() {
-	# A managed link was already dropped by the caller under its lease. An
-	# unmanaged dangling link is dropped here; a dangling fallback link keeps
-	# its name and gets its payload back.
-	if [ -L target ] && ! [ -e target ] && [ "$(readlink target)" != "$LOCAL_TARGET" ]; then
-		echo "==> WARNING: dropping dangling target/ → $(readlink target); the local fallback takes its place" >&2
-		rm -f -- target
-	fi
-	if ! [ -e target ]; then
-		if ! mkdir -p -- "$LOCAL_TARGET"; then
-			echo "ERROR: cannot create the local fallback $LOCAL_TARGET:" >&2
-			ls -ld -- "$LOCAL_TARGET" "$p" >&2 2>/dev/null || true
+	local payload
+	payload="$(published_fallback)" || payload=""
+	if [ -n "$payload" ]; then
+		# A fallback link whose payload was removed keeps its name and gets an
+		# empty payload back.
+		if ! mkdir -p -- "$payload"; then
+			echo "ERROR: cannot recreate the published fallback payload $payload:" >&2
+			ls -ld -- "$payload" "$p" >&2 2>/dev/null || true
 			exit 1
 		fi
-		if ! [ -L target ]; then
-			publish_target_link "$LOCAL_TARGET"
-			echo "==> Symlinked target/ → $LOCAL_TARGET (local fallback)" >&2
+	else
+		# A managed link was already dropped by the caller under its lease. An
+		# unmanaged dangling link is dropped here.
+		if [ -L target ] && ! [ -e target ]; then
+			echo "==> WARNING: dropping dangling target/ → $(readlink target); the local fallback takes its place" >&2
+			rm -f -- target
+		fi
+		if ! [ -e target ]; then
+			# A fresh payload, never one an earlier activation published: that
+			# one holds artifacts a `--rotate` in between reported gone.
+			if ! payload="$(mktemp -d -- "$LOCAL_TARGET_PREFIX.generation-XXXXXXXX")"; then
+				echo "ERROR: cannot create a local fallback payload beside $LOCAL_TARGET_PREFIX:" >&2
+				ls -ld -- "$p" >&2 2>/dev/null || true
+				exit 1
+			fi
+			publish_target_link "$payload"
+			echo "==> Symlinked target/ → $payload (local fallback)" >&2
 		fi
 	fi
 	if [ ! -d target ]; then
@@ -139,6 +199,7 @@ require_writable_local_target() {
 		exit 1
 	fi
 	rm -f -- "$probe"
+	discard_unpublished_fallbacks "$payload"
 }
 
 # Drops the checkout's managed target/ link; the generation stays for the
@@ -155,7 +216,7 @@ drop_managed_link() {
 	local linked
 	linked="$(readlink target)"
 	case "$linked" in
-		"$BTRFS_ROOT"/cargo-target/* | "$LOCAL_TARGET") ;;
+		"$BTRFS_ROOT"/cargo-target/* | "$LOCAL_TARGET_PREFIX".generation-*) ;;
 		*) return 0 ;;
 	esac
 	if [[ -z ${old_target_lease_fd:-} ]] && [ -d target ]; then
@@ -165,7 +226,9 @@ drop_managed_link() {
 		fi
 		flock -x "$old_target_lease_fd"
 	fi
-	[ "$linked" != "$LOCAL_TARGET" ] || return 0
+	case "$linked" in
+		"$LOCAL_TARGET_PREFIX".generation-*) return 0 ;;
+	esac
 	echo "==> WARNING: dropping target/ → $linked; its volume cannot be used" >&2
 	rm -f -- target
 }
@@ -175,7 +238,7 @@ fallback_to_local() {
 	drop_managed_link
 	# `--rotate` promises a clean target/; a retained link or directory, or a
 	# republished fallback payload, would report one while its payload survives.
-	if ((FORCE_ROTATE)) && { [ -L target ] || [ -d target ] || [ -e "$LOCAL_TARGET" ]; }; then
+	if ((FORCE_ROTATE)) && { [ -L target ] || [ -d target ] || any_fallback_payload; }; then
 		echo "ERROR: local target/ cannot be atomically rotated without the managed btrfs namespace; refusing unsafe clean" >&2
 		exit 1
 	fi
@@ -383,10 +446,6 @@ case "$retired_rc" in
 esac
 
 if ! [ -L target ] || [ "$(readlink target)" != "$candidate" ]; then
-	if [ "${linked:-}" = "$LOCAL_TARGET" ]; then
-		# Nothing enumerates this path, so nothing reclaims it.
-		echo "==> WARNING: $BTRFS_ROOT is usable again; the fallback payload $LOCAL_TARGET is no longer published and is not reclaimed, remove it by hand" >&2
-	fi
 	publish_target_link "$candidate"
 	echo "==> Symlinked target/ → $candidate"
 fi
@@ -401,7 +460,7 @@ if [[ -n ${candidate_lease_fd:-} && $candidate_lease_fd != "$final_lease_fd" ]];
 	exec {candidate_lease_fd}<&-
 fi
 else
-	if ((FORCE_ROTATE)) && { [ -d target ] || [ -e "$LOCAL_TARGET" ]; }; then
+	if ((FORCE_ROTATE)) && { [ -d target ] || any_fallback_payload; }; then
 		echo "ERROR: local target/ cannot be atomically rotated without the managed btrfs namespace; refusing unsafe clean" >&2
 		exit 1
 	fi
@@ -416,7 +475,7 @@ fi
 # Self-heal a dangling link. `[ -d target ]` follows the symlink, so this is
 # false exactly when it does not resolve. A dangling fallback link is left for
 # require_writable_local_target, which recreates its payload.
-if [ -L target ] && ! [ -d target ] && [ "$(readlink target)" != "$LOCAL_TARGET" ]; then
+if [ -L target ] && ! [ -d target ] && ! published_fallback >/dev/null; then
 	TGT="$(readlink target)"
 	if ! [ -d "$BTRFS_ROOT" ]; then
 		# The VOLUME is gone, not just our directory on it. Recreating the path

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -108,7 +108,17 @@ WT_TARGET="$BTRFS_ROOT/cargo-target/$name-$hash"
 # how the original outage read. So create it if absent, then prove a file
 # can be made in it.
 require_writable_local_target() {
-	[ -e target ] || mkdir -p target
+	# A dangling UNMANAGED link (a managed one was dropped by the caller) would
+	# make `mkdir -p` fail with EEXIST, under `set -e` and before any diagnostic.
+	if [ -L target ] && ! [ -e target ]; then
+		echo "==> WARNING: dropping dangling target/ → $(readlink target); a local directory takes its place" >&2
+		rm -f -- target
+	fi
+	if ! [ -e target ] && ! mkdir -p target; then
+		echo "ERROR: cannot create a local target/ directory:" >&2
+		ls -ld target >&2 2>/dev/null || true
+		exit 1
+	fi
 	if [ ! -d target ]; then
 		echo "ERROR: target exists but is not a usable directory:" >&2
 		ls -ld target >&2
@@ -140,6 +150,13 @@ drop_managed_link() {
 fallback_to_local() {
 	echo "==> WARNING: $1; build artifacts stay on the root filesystem" >&2
 	drop_managed_link
+	# `--rotate` promises a logically clean target/. Retaining an unmanaged
+	# link or directory here would report a clean while its payload survives;
+	# the unusable-volume branch refuses the same way.
+	if ((FORCE_ROTATE)) && { [ -L target ] || [ -d target ]; }; then
+		echo "ERROR: local target/ cannot be atomically rotated without the managed btrfs namespace; refusing unsafe clean" >&2
+		exit 1
+	fi
 	require_writable_local_target
 	exit 0
 }
@@ -283,7 +300,8 @@ if [ -L target ] && [ -d target ]; then
 	# A Cargo wrapper that already crossed the checkout→target lock handoff no
 	# longer holds the checkout lease. Pin and exclusively lease its resolved
 	# generation before publishing any different symlink target.
-	exec {old_target_lease_fd}<target
+	exec {old_target_lease_fd}<target ||
+		fallback_to_local "target/ cannot be opened for its lease"
 	flock -x "$old_target_lease_fd"
 	case "$linked" in
 		"$WT_TARGET"|"$WT_TARGET".generation-*)

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -327,20 +327,16 @@ else
 		candidate_state_fd="$candidate_lease_fd"
 	fi
 fi
-# The write probe, under the exclusive lease: `mkdir -p` above is idempotent
-# and says nothing about an EXISTING directory that has since gone read-only
-# (ownership change, ro remount). Creating an entry is the operation Cargo
-# needs, and the one root cannot fake past EROFS. It happens here, and only
-# here, because the pruner holds LOCK_EX on a generation across its census and
-# rewalk -- an entry created or removed outside that lock is exactly the
-# "target entry disappeared during reclaim" abort.
-if ! write_probe="$(mktemp -p "$candidate" .fcvm-write-probe.XXXXXXXX 2>/dev/null)"; then
-	fallback_to_local "$candidate cannot be written"
-fi
-rm -f -- "$write_probe"
 retired_rc=0
 target_is_retired "$candidate_state_fd" || retired_rc=$?
-if ((FORCE_ROTATE)); then
+if ((FORCE_ROTATE)) && [ "$retired_rc" != 0 ]; then
+	# Retiring writes the marker into the candidate, so one that cannot be
+	# written cannot take it; the fallback refuses under --rotate. An already
+	# retired candidate needs no marker and rotates below.
+	if ! write_probe="$(mktemp -p "$candidate" .fcvm-write-probe.XXXXXXXX 2>/dev/null)"; then
+		fallback_to_local "$candidate cannot be written"
+	fi
+	rm -f -- "$write_probe"
 	retire_target "$candidate_state_fd"
 	retired_rc=0
 fi
@@ -352,11 +348,35 @@ case "$retired_rc" in
 		echo "==> Rotating retired target/ → $candidate"
 		;;
 	3)
+		# The candidate is REUSED, so it must be writable. The probe runs here,
+		# after the retirement check, under the exclusive lease: `mkdir -p`
+		# above is idempotent and says nothing about an EXISTING directory that
+		# has since gone read-only (ownership change, ro remount), and creating
+		# an entry is the operation Cargo needs, the one root cannot fake past
+		# EROFS. Under the lease, because the pruner holds LOCK_EX on a
+		# generation across its census and rewalk; an entry created or removed
+		# outside that lock is exactly the "target entry disappeared during
+		# reclaim" abort. A RETIRED candidate is never probed: new_generation
+		# needs only its parent writable, and a retired generation that went
+		# read-only used to fall back to a local target/ that every later run
+		# then retained.
+		if ! write_probe="$(mktemp -p "$candidate" .fcvm-write-probe.XXXXXXXX 2>/dev/null)"; then
+			fallback_to_local "$candidate cannot be written"
+		fi
+		rm -f -- "$write_probe"
 		# Downgrade the exclusive inspection lease while publishing the link.
 		flock -s "$candidate_state_fd"
 		final_lease_fd="$candidate_state_fd"
 		;;
 	*)
+		# The retirement marker could not be read at all. On a directory that
+		# cannot even be written (a read-only or foreign filesystem) that is
+		# just an unusable managed target, and the fallback applies; on a
+		# writable one it is a protocol error and stays fatal.
+		if ! write_probe="$(mktemp -p "$candidate" .fcvm-write-probe.XXXXXXXX 2>/dev/null)"; then
+			fallback_to_local "$candidate cannot be written"
+		fi
+		rm -f -- "$write_probe"
 		echo "ERROR: cannot read target retirement state for $candidate (rc=$retired_rc)" >&2
 		exit 1
 		;;

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -101,6 +101,28 @@ WT_TARGET="$BTRFS_ROOT/cargo-target/$name-$hash"
 # #867). Replacing it is safe here because this script holds the checkout lock
 # (no Cargo runs in this checkout meanwhile) and, whenever target/ resolved,
 # the exclusive lease on its generation taken below.
+# Every exit that leaves target/ as a plain local directory ends here. "Is a
+# directory" is not "is writable": procfs, a read-only mount, and (for a
+# non-root user) a 0555 directory all pass `-d`, and an unwritable target/
+# turns into an opaque cargo error several steps later, which is precisely
+# how the original outage read. So create it if absent, then prove a file
+# can be made in it.
+require_writable_local_target() {
+	[ -e target ] || mkdir -p target
+	if [ ! -d target ]; then
+		echo "ERROR: target exists but is not a usable directory:" >&2
+		ls -ld target >&2
+		exit 1
+	fi
+	local probe
+	if ! probe="$(mktemp -p target .cargo-target-link-probe.XXXXXXXX 2>/dev/null)"; then
+		echo "ERROR: target/ is a directory nothing can write; cargo cannot use it:" >&2
+		ls -ld target >&2
+		exit 1
+	fi
+	rm -f -- "$probe"
+}
+
 fallback_to_local() {
 	echo "==> WARNING: $1; build artifacts stay on the root filesystem" >&2
 	if [ -L target ]; then
@@ -108,12 +130,7 @@ fallback_to_local() {
 			"$BTRFS_ROOT"/cargo-target/*) rm -f -- target ;;
 		esac
 	fi
-	[ -e target ] || mkdir -p target
-	if [ ! -d target ]; then
-		echo "ERROR: target exists but is not a usable directory:" >&2
-		ls -ld target >&2
-		exit 1
-	fi
+	require_writable_local_target
 	exit 0
 }
 
@@ -244,6 +261,7 @@ if [ -e target ] && ! [ -L target ]; then
 		echo "ERROR: unmanaged local target/ cannot be atomically rotated; refusing unsafe clean" >&2
 		exit 1
 	fi
+	require_writable_local_target
 	echo "==> WARNING: retaining unmanaged local target/; it cannot be atomically rotated" >&2
 	exit 0
 fi
@@ -359,11 +377,6 @@ if [ -L target ] && ! [ -d target ]; then
 	fi
 fi
 
-# Fail closed: leaving target/ unusable turns into an opaque cargo error several
-# steps later, which is precisely how the original outage read.
-[ -e target ] || mkdir -p target
-if [ ! -d target ]; then
-	echo "ERROR: target exists but is not a usable directory:" >&2
-	ls -ld target >&2
-	exit 1
-fi
+# Fail closed, for every path that reaches here (the managed link just
+# published, the unusable-volume branch, a healed or dropped dangling link).
+require_writable_local_target

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -6,7 +6,7 @@
 # runs first and its postcondition is the whole contract: after it returns 0,
 # `target` IS a usable directory.
 #
-# Two properties this has to hold, both learned the hard way:
+# Three properties this has to hold, the first two learned the hard way:
 #
 # 1. PER WORKTREE. Cargo names a test binary from a hash over package
 #    name/version/features that does NOT include the checkout path, so every
@@ -25,6 +25,13 @@
 #    Not a directory (os error 20)" that took out Host-arm64 on every open PR on
 #    2026-08-08. `~/.cargo` in the Makefile's check-disk target already
 #    self-heals for exactly this reason; target/ did not.
+#
+# 3. A FALLBACK MUST BE REVERSIBLE. A real target/ the script did not create is
+#    retained for good (its dentry may carry a mount visible only in another
+#    mount namespace), so a fallback shaped as a real target/ would keep every
+#    later build on the root filesystem after the volume returned. The fallback
+#    is a symlink to a checkout-local payload, replaced like any other published
+#    link once the volume is usable again.
 #
 # Everything below runs under an exclusive flock on the checkout directory,
 # because more than one `make` can run in one checkout (several CI entry points
@@ -79,23 +86,46 @@ p="$(pwd -P)"
 name="$(printf '%s' "$(basename "$p")" | LC_ALL=C tr -c 'A-Za-z0-9._-' '_')"
 hash="$(printf '%s' "$p" | sha256sum | cut -c1-8)"
 WT_TARGET="$BTRFS_ROOT/cargo-target/$name-$hash"
+# The fallback payload, published through target/ as a symlink and never as a
+# real target/ dentry.
+LOCAL_TARGET="$p/.cargo-target-local"
 
-# Every exit that leaves target/ as a plain local directory proves a file can
-# be created in it first. `-d` passes on procfs, a read-only mount, and a 0555
+publish_target_link() {
+	local destination="$1" staging
+	staging="$(mktemp -d -- "$p/.fcvm-target-link.XXXXXXXX")"
+	ln -s -- "$destination" "$staging/target"
+	# The checkout lock excludes every cooperating resolver. Replacing only
+	# this symlink is atomic and never renames a physical target dentry (which
+	# could move a mount that exists solely in another namespace).
+	mv -Tf -- "$staging/target" target
+	rmdir -- "$staging"
+}
+
+# Every exit that leaves target/ on the root filesystem proves a file can be
+# created in it first. `-d` passes on procfs, a read-only mount, and a 0555
 # directory. `-w` is no better for root, which passes access(W_OK) on a
 # directory it still cannot create entries in. Creating an entry is the
-# operation cargo needs, and the only test of it.
+# operation cargo needs, and the only test of it. When nothing is published,
+# the fallback is a link to $LOCAL_TARGET; a real target/ dentry is never
+# created here, because every later run would retain it as unmanaged.
 require_writable_local_target() {
-	# A managed link was already dropped by the caller under its lease; an
-	# unmanaged dangling one is dropped here, or `mkdir -p` fails with EEXIST.
-	if [ -L target ] && ! [ -e target ]; then
-		echo "==> WARNING: dropping dangling target/ → $(readlink target); a local directory takes its place" >&2
+	# A managed link was already dropped by the caller under its lease. An
+	# unmanaged dangling link is dropped here; a dangling fallback link keeps
+	# its name and gets its payload back.
+	if [ -L target ] && ! [ -e target ] && [ "$(readlink target)" != "$LOCAL_TARGET" ]; then
+		echo "==> WARNING: dropping dangling target/ → $(readlink target); the local fallback takes its place" >&2
 		rm -f -- target
 	fi
-	if ! [ -e target ] && ! mkdir -p target; then
-		echo "ERROR: cannot create a local target/ directory:" >&2
-		ls -ld target >&2 2>/dev/null || true
-		exit 1
+	if ! [ -e target ]; then
+		if ! mkdir -p -- "$LOCAL_TARGET"; then
+			echo "ERROR: cannot create the local fallback $LOCAL_TARGET:" >&2
+			ls -ld -- "$LOCAL_TARGET" "$p" >&2 2>/dev/null || true
+			exit 1
+		fi
+		if ! [ -L target ]; then
+			publish_target_link "$LOCAL_TARGET"
+			echo "==> Symlinked target/ → $LOCAL_TARGET (local fallback)" >&2
+		fi
 	fi
 	if [ ! -d target ]; then
 		echo "ERROR: target exists but is not a usable directory:" >&2
@@ -113,33 +143,39 @@ require_writable_local_target() {
 
 # Drops the checkout's managed target/ link; the generation stays for the
 # pruner. A resolving link is dropped only under an exclusive lease on the
-# generation it publishes: a cargo wrapper may hold that lease shared for the
+# directory it publishes: a cargo wrapper may hold that lease shared for the
 # life of its build, and removing the pathname under it splits the build across
-# two trees. A generation that cannot be opened cannot be leased, so the drop
-# is refused. The lease fd stays open until exit. A dangling link publishes
-# nothing and is dropped without one.
+# two trees. A directory that cannot be opened cannot be leased, so the drop is
+# refused. The lease fd stays open until exit. A dangling link publishes
+# nothing and is dropped without one. The script's own fallback link is leased
+# the same way and kept, since it already publishes the directory the fallback
+# uses.
 drop_managed_link() {
 	[ -L target ] || return 0
-	case "$(readlink target)" in
-		"$BTRFS_ROOT"/cargo-target/*)
-			if [[ -z ${old_target_lease_fd:-} ]] && [ -d target ]; then
-				if ! exec {old_target_lease_fd}<target; then
-					echo "ERROR: cannot open the published generation $(readlink target) to lease it; a running build may still hold it, refusing to replace target/" >&2
-					exit 1
-				fi
-				flock -x "$old_target_lease_fd"
-			fi
-			echo "==> WARNING: dropping target/ → $(readlink target); its volume cannot be used" >&2
-			rm -f -- target ;;
+	local linked
+	linked="$(readlink target)"
+	case "$linked" in
+		"$BTRFS_ROOT"/cargo-target/* | "$LOCAL_TARGET") ;;
+		*) return 0 ;;
 	esac
+	if [[ -z ${old_target_lease_fd:-} ]] && [ -d target ]; then
+		if ! exec {old_target_lease_fd}<target; then
+			echo "ERROR: cannot open the published directory $linked to lease it; a running build may still hold it, refusing to replace target/" >&2
+			exit 1
+		fi
+		flock -x "$old_target_lease_fd"
+	fi
+	[ "$linked" != "$LOCAL_TARGET" ] || return 0
+	echo "==> WARNING: dropping target/ → $linked; its volume cannot be used" >&2
+	rm -f -- target
 }
 
 fallback_to_local() {
 	echo "==> WARNING: $1; build artifacts stay on the root filesystem" >&2
 	drop_managed_link
-	# `--rotate` promises a clean target/; a retained local link or directory
-	# would report one while its payload survives.
-	if ((FORCE_ROTATE)) && { [ -L target ] || [ -d target ]; }; then
+	# `--rotate` promises a clean target/; a retained link or directory, or a
+	# republished fallback payload, would report one while its payload survives.
+	if ((FORCE_ROTATE)) && { [ -L target ] || [ -d target ] || [ -e "$LOCAL_TARGET" ]; }; then
 		echo "ERROR: local target/ cannot be atomically rotated without the managed btrfs namespace; refusing unsafe clean" >&2
 		exit 1
 	fi
@@ -240,17 +276,6 @@ finally:
     os.close(directory_fd)
 ' "/proc/$$/fd/$fresh_lease_fd"
 	flock -s "$fresh_lease_fd"
-}
-
-publish_target_link() {
-	local destination="$1" staging
-	staging="$(mktemp -d -- "$p/.fcvm-target-link.XXXXXXXX")"
-	ln -s -- "$destination" "$staging/target"
-	# The checkout lock excludes every cooperating resolver. Replacing only
-	# this symlink is atomic and never renames a physical target dentry (which
-	# could move a mount that exists solely in another namespace).
-	mv -Tf -- "$staging/target" target
-	rmdir -- "$staging"
 }
 
 mkdir -p -- "$(dirname "$WT_TARGET")"
@@ -358,6 +383,10 @@ case "$retired_rc" in
 esac
 
 if ! [ -L target ] || [ "$(readlink target)" != "$candidate" ]; then
+	if [ "${linked:-}" = "$LOCAL_TARGET" ]; then
+		# Nothing enumerates this path, so nothing reclaims it.
+		echo "==> WARNING: $BTRFS_ROOT is usable again; the fallback payload $LOCAL_TARGET is no longer published and is not reclaimed, remove it by hand" >&2
+	fi
 	publish_target_link "$candidate"
 	echo "==> Symlinked target/ → $candidate"
 fi
@@ -372,7 +401,7 @@ if [[ -n ${candidate_lease_fd:-} && $candidate_lease_fd != "$final_lease_fd" ]];
 	exec {candidate_lease_fd}<&-
 fi
 else
-	if ((FORCE_ROTATE)) && [ -d target ]; then
+	if ((FORCE_ROTATE)) && { [ -d target ] || [ -e "$LOCAL_TARGET" ]; }; then
 		echo "ERROR: local target/ cannot be atomically rotated without the managed btrfs namespace; refusing unsafe clean" >&2
 		exit 1
 	fi
@@ -385,8 +414,9 @@ else
 fi
 
 # Self-heal a dangling link. `[ -d target ]` follows the symlink, so this is
-# false exactly when it does not resolve.
-if [ -L target ] && ! [ -d target ]; then
+# false exactly when it does not resolve. A dangling fallback link is left for
+# require_writable_local_target, which recreates its payload.
+if [ -L target ] && ! [ -d target ] && [ "$(readlink target)" != "$LOCAL_TARGET" ]; then
 	TGT="$(readlink target)"
 	if ! [ -d "$BTRFS_ROOT" ]; then
 		# The VOLUME is gone, not just our directory on it. Recreating the path

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -92,12 +92,21 @@ WT_TARGET="$BTRFS_ROOT/cargo-target/$name-$hash"
 # cannot create in (procfs, a read-only mount). Try the mkdir, and let its
 # outcome decide -- loudly, because artifacts on the root filesystem are the
 # thing this indirection exists to avoid and a reader should see it happen.
+# And "was created" is not "is writable" either: `mkdir -p` on a directory
+# that already exists succeeds without touching it, so an existing worktree
+# directory that has since gone read-only (ownership change, ro remount) would
+# pass the mkdir and then receive a symlink Cargo cannot write into -- exit 0
+# here, an opaque failure several steps later. The probe therefore CREATES an
+# entry inside the directory; that is the operation Cargo needs, and it is the
+# one root cannot fake past EROFS. (Raised on #867.)
 btrfs_usable=0
 if [ -d "$BTRFS_ROOT" ]; then
-	if mkdir -p "$WT_TARGET" 2>/dev/null; then
+	if mkdir -p "$WT_TARGET" 2>/dev/null \
+		&& write_probe="$(mktemp -p "$WT_TARGET" .fcvm-write-probe.XXXXXXXX 2>/dev/null)"; then
+		rm -f -- "$write_probe"
 		btrfs_usable=1
 	else
-		echo "==> WARNING: $BTRFS_ROOT exists but $WT_TARGET cannot be created; build artifacts stay on the root filesystem" >&2
+		echo "==> WARNING: $BTRFS_ROOT exists but $WT_TARGET cannot be written; build artifacts stay on the root filesystem" >&2
 	fi
 fi
 if ((btrfs_usable)); then

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -123,13 +123,23 @@ require_writable_local_target() {
 	rm -f -- "$probe"
 }
 
+# A managed target/ link is dropped, never probed through, on any path that
+# holds no lease on the generation it points at: creating and removing a file
+# inside an unleased generation is the census/rewalk race the pruner's lease
+# protocol exists to prevent. Only the checkout's link goes; the generation is
+# left for the pruner.
+drop_managed_link() {
+	[ -L target ] || return 0
+	case "$(readlink target)" in
+		"$BTRFS_ROOT"/cargo-target/*)
+			echo "==> WARNING: dropping target/ → $(readlink target); no lease can be taken on it" >&2
+			rm -f -- target ;;
+	esac
+}
+
 fallback_to_local() {
 	echo "==> WARNING: $1; build artifacts stay on the root filesystem" >&2
-	if [ -L target ]; then
-		case "$(readlink target)" in
-			"$BTRFS_ROOT"/cargo-target/*) rm -f -- target ;;
-		esac
-	fi
+	drop_managed_link
 	require_writable_local_target
 	exit 0
 }
@@ -355,6 +365,9 @@ else
 	if ! [ -d "$BTRFS_ROOT" ]; then
 		echo "==> NOTE: $BTRFS_ROOT is not a directory; build artifacts stay on the root filesystem"
 	fi
+	# This branch never leases a generation, and target/ may still resolve into
+	# one (a rotated generation outliving the canonical path the pruner removed).
+	drop_managed_link
 fi
 
 # Self-heal a dangling link. `[ -d target ]` follows the symlink, so this is

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -296,7 +296,8 @@ mkdir -p -- "$candidate"
 if [[ -n $old_target_lease_fd && ${linked:-} == "$candidate" ]]; then
 	candidate_state_fd="$old_target_lease_fd"
 else
-	exec {candidate_lease_fd}<"$candidate"
+	exec {candidate_lease_fd}<"$candidate" ||
+		fallback_to_local "$candidate cannot be opened for its lease"
 	if [[ -n $old_target_lease_fd ]] &&
 		[[ "$(stat -Lc '%d:%i' -- "/proc/$$/fd/$old_target_lease_fd")" == \
 		"$(stat -Lc '%d:%i' -- "/proc/$$/fd/$candidate_lease_fd")" ]]; then

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -142,7 +142,21 @@ drop_managed_link() {
 	[ -L target ] || return 0
 	case "$(readlink target)" in
 		"$BTRFS_ROOT"/cargo-target/*)
-			echo "==> WARNING: dropping target/ → $(readlink target); no lease can be taken on it" >&2
+			# The link publishes a generation a Cargo wrapper may still hold
+			# SHARED while it resolves later target/... paths. Removing the
+			# pathname under that build splits its outputs across two trees,
+			# so the generation is leased EXCLUSIVELY first (this blocks until
+			# the wrapper is done), and a generation that cannot be opened is
+			# a refusal, as for the published-generation open above. The fd
+			# stays open until exit. A dangling link publishes nothing.
+			if [[ -z ${old_target_lease_fd:-} ]] && [ -d target ]; then
+				if ! exec {old_target_lease_fd}<target; then
+					echo "ERROR: cannot open the published generation $(readlink target) to lease it; a running build may still hold it, refusing to replace target/" >&2
+					exit 1
+				fi
+				flock -x "$old_target_lease_fd"
+			fi
+			echo "==> WARNING: dropping target/ → $(readlink target); its volume cannot be used" >&2
 			rm -f -- target ;;
 	esac
 }
@@ -169,6 +183,7 @@ fallback_to_local() {
 # leased, is the race the pruner's census/rewalk cannot tolerate (raised on
 # #867): an entry that appears after the census or vanishes during the rewalk
 # aborts the hourly preflight.
+old_target_lease_fd=""
 btrfs_usable=0
 if [ -d "$BTRFS_ROOT" ]; then
 	if mkdir -p "$WT_TARGET" 2>/dev/null; then
@@ -294,7 +309,6 @@ if [ -e target ] && ! [ -L target ]; then
 fi
 
 candidate="$WT_TARGET"
-old_target_lease_fd=""
 if [ -L target ] && [ -d target ]; then
 	linked="$(readlink target)"
 	# A Cargo wrapper that already crossed the checkout→target lock handoff no

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -300,8 +300,16 @@ if [ -L target ] && [ -d target ]; then
 	# A Cargo wrapper that already crossed the checkout→target lock handoff no
 	# longer holds the checkout lease. Pin and exclusively lease its resolved
 	# generation before publishing any different symlink target.
-	exec {old_target_lease_fd}<target ||
-		fallback_to_local "target/ cannot be opened for its lease"
+	# Fail closed if the published generation cannot be opened: without its
+	# lease there is no way to know whether a Cargo wrapper still holds it
+	# shared, and a generation that lost only READ permission (0333) is one
+	# Cargo can still create entries in. Replacing target/ under such a build
+	# would split it across two trees. Only the operator can fix this (chmod
+	# the generation, or remove the link by hand once nothing runs).
+	if ! exec {old_target_lease_fd}<target; then
+		echo "ERROR: cannot open the published generation $linked to lease it; a running build may still hold it, refusing to replace target/" >&2
+		exit 1
+	fi
 	flock -x "$old_target_lease_fd"
 	case "$linked" in
 		"$WT_TARGET"|"$WT_TARGET".generation-*)

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -92,21 +92,45 @@ WT_TARGET="$BTRFS_ROOT/cargo-target/$name-$hash"
 # cannot create in (procfs, a read-only mount). Try the mkdir, and let its
 # outcome decide -- loudly, because artifacts on the root filesystem are the
 # thing this indirection exists to avoid and a reader should see it happen.
-# And "was created" is not "is writable" either: `mkdir -p` on a directory
-# that already exists succeeds without touching it, so an existing worktree
-# directory that has since gone read-only (ownership change, ro remount) would
-# pass the mkdir and then receive a symlink Cargo cannot write into -- exit 0
-# here, an opaque failure several steps later. The probe therefore CREATES an
-# entry inside the directory; that is the operation Cargo needs, and it is the
-# one root cannot fake past EROFS. (Raised on #867.)
+# Give up on the managed volume and leave a REAL local target/ behind.
+#
+# Loud, because artifacts on the root filesystem are the thing this indirection
+# exists to avoid and a reader should see it happen. If target/ is a managed
+# symlink it is REPLACED, not left: a link that still resolves would pass every
+# later `-d target` check while Cargo cannot create a file there (raised on
+# #867). Replacing it is safe here because this script holds the checkout lock
+# (no Cargo runs in this checkout meanwhile) and, whenever target/ resolved,
+# the exclusive lease on its generation taken below.
+fallback_to_local() {
+	echo "==> WARNING: $1; build artifacts stay on the root filesystem" >&2
+	if [ -L target ]; then
+		case "$(readlink target)" in
+			"$BTRFS_ROOT"/cargo-target/*) rm -f -- target ;;
+		esac
+	fi
+	[ -e target ] || mkdir -p target
+	if [ ! -d target ]; then
+		echo "ERROR: target exists but is not a usable directory:" >&2
+		ls -ld target >&2
+		exit 1
+	fi
+	exit 0
+}
+
+# "Is a directory" is not "is usable": on a GitHub-hosted runner podman creates
+# a missing /mnt/fcvm-btrfs as an empty root-owned directory to satisfy the
+# bind mount, so the volume passes `-d` and the mkdir below fails. Whether an
+# EXISTING directory can be written is settled later, under its lease -- see
+# the write probe in the lease block. Probing here, before the generation is
+# leased, is the race the pruner's census/rewalk cannot tolerate (raised on
+# #867): an entry that appears after the census or vanishes during the rewalk
+# aborts the hourly preflight.
 btrfs_usable=0
 if [ -d "$BTRFS_ROOT" ]; then
-	if mkdir -p "$WT_TARGET" 2>/dev/null \
-		&& write_probe="$(mktemp -p "$WT_TARGET" .fcvm-write-probe.XXXXXXXX 2>/dev/null)"; then
-		rm -f -- "$write_probe"
+	if mkdir -p "$WT_TARGET" 2>/dev/null; then
 		btrfs_usable=1
 	else
-		echo "==> WARNING: $BTRFS_ROOT exists but $WT_TARGET cannot be written; build artifacts stay on the root filesystem" >&2
+		echo "==> WARNING: $BTRFS_ROOT exists but $WT_TARGET cannot be created; build artifacts stay on the root filesystem" >&2
 	fi
 fi
 if ((btrfs_usable)); then
@@ -143,7 +167,8 @@ finally:
 new_generation() {
 	local retired_rc
 	while :; do
-		FRESH_GENERATION="$(mktemp -d -- "${WT_TARGET}.generation-XXXXXXXX")"
+		FRESH_GENERATION="$(mktemp -d -- "${WT_TARGET}.generation-XXXXXXXX" 2>/dev/null)" \
+			|| fallback_to_local "cannot create a fresh generation beside $WT_TARGET"
 		exec {fresh_lease_fd}<"$FRESH_GENERATION"
 		flock -x "$fresh_lease_fd"
 		retired_rc=0
@@ -255,6 +280,17 @@ else
 		candidate_state_fd="$candidate_lease_fd"
 	fi
 fi
+# The write probe, under the exclusive lease: `mkdir -p` above is idempotent
+# and says nothing about an EXISTING directory that has since gone read-only
+# (ownership change, ro remount). Creating an entry is the operation Cargo
+# needs, and the one root cannot fake past EROFS. It happens here, and only
+# here, because the pruner holds LOCK_EX on a generation across its census and
+# rewalk -- an entry created or removed outside that lock is exactly the
+# "target entry disappeared during reclaim" abort.
+if ! write_probe="$(mktemp -p "$candidate" .fcvm-write-probe.XXXXXXXX 2>/dev/null)"; then
+	fallback_to_local "$candidate cannot be written"
+fi
+rm -f -- "$write_probe"
 retired_rc=0
 target_is_retired "$candidate_state_fd" || retired_rc=$?
 if ((FORCE_ROTATE)); then

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -3125,6 +3125,61 @@ fn cargo_target_link_rotates_a_retired_generation_it_cannot_write() {
     assert_target_usable(checkout.path(), "rotated to a fresh generation");
 }
 
+/// Dropping a published managed link waits for the build that holds it
+/// (codex on #867). On the unusable-volume path the script used to unlink
+/// `target/` with no lease on the generation it published; a Cargo wrapper
+/// holding that generation SHARED would then resolve later `target/...` paths
+/// into a different tree. The script must take the generation's exclusive
+/// lease first: with a shared holder present it blocks, and the link stays.
+#[test]
+fn cargo_target_link_waits_for_a_shared_holder_before_dropping_a_managed_link() {
+    use std::os::unix::io::AsRawFd as _;
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let btrfs = tempfile::tempdir().expect("btrfs stand-in");
+    let wt = managed_worktree_dir(checkout.path(), btrfs.path());
+    std::fs::create_dir_all(wt.parent().unwrap()).expect("cargo-target parent");
+    let generation = wt.with_file_name(format!(
+        "{}.generation-held0000",
+        wt.file_name().unwrap().to_string_lossy()
+    ));
+    std::fs::create_dir_all(&generation).expect("published generation");
+    // $WT_TARGET cannot be created (dangling symlink), so the volume is unusable.
+    std::os::unix::fs::symlink(btrfs.path().join("cargo-target/absent"), &wt)
+        .expect("dangling $WT_TARGET");
+    std::os::unix::fs::symlink(&generation, checkout.path().join("target"))
+        .expect("target/ -> published generation");
+    // A Cargo wrapper mid-build: the generation is held SHARED for the run.
+    let holder = std::fs::File::open(&generation).expect("open generation");
+    let held = unsafe { libc::flock(holder.as_raw_fd(), libc::LOCK_SH) };
+    assert_eq!(held, 0, "take the shared lease");
+
+    let out = Command::new("timeout")
+        .arg("4")
+        .arg(repo_root().join("scripts/cargo-target-link.sh"))
+        .env("BTRFS_ROOT", btrfs.path())
+        .env_remove("CARGO_TARGET_LINK_LOCKED")
+        .current_dir(checkout.path())
+        .output()
+        .expect("run under timeout");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    drop(holder);
+
+    assert_eq!(
+        out.status.code(),
+        Some(124),
+        "the script did not wait for the shared holder (expected timeout exit 124):\n{text}"
+    );
+    let target = checkout.path().join("target");
+    assert!(
+        target.is_symlink() && std::fs::read_link(&target).expect("readlink") == generation,
+        "target/ was dropped while a build still held its generation\n{text}"
+    );
+}
+
 /// Every exit that leaves target/ as a plain local directory probes it first.
 ///
 /// Behavioural coverage above reaches two of the three exits; this pins all of

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -2643,3 +2643,69 @@ fn persistent_runner_entrypoints_route_cargo_through_the_lease() {
         );
     }
 }
+
+/// The volume EXISTS but cannot be written: keep the local `target/`.
+///
+/// GitHub-hosted runners have no `/mnt/fcvm-btrfs`, and podman CREATES it as an
+/// empty root-owned directory to satisfy `CONTAINER_RUN_BASE`'s bind mount. Inside
+/// the container the volume is therefore a directory (`[ -d ]` true) that the
+/// build user cannot write, while the checkout's own `target/` is a bind mount --
+/// a real directory the recipe should simply keep. The script tested `-d`, took
+/// the btrfs branch, and died on `mkdir` before reaching its own
+/// "retaining unmanaged local target/" exit:
+///
+/// ```text
+/// mkdir: cannot create directory '/mnt/fcvm-btrfs/cargo-target': Permission denied
+/// ERROR: cannot create /mnt/fcvm-btrfs/cargo-target/fcvm-1602bce1
+/// make: *** [Makefile:337: cargo-target-link] Error 1
+/// ```
+///
+/// Every Weekly `container-bench` since 2026-08-10 (the script landed 08-09; the
+/// last green Weekly was 08-03). Unwritable is produced two ways because this
+/// file also runs under sudo, where mode bits cannot stop root: as a normal user
+/// a 0o555 tempdir, as root a procfs path that no uid can `mkdir` under.
+#[test]
+fn cargo_target_link_keeps_a_bind_mounted_target_when_btrfs_is_unwritable() {
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    // The bind-mounted target/: a real directory that already exists.
+    std::fs::create_dir(checkout.path().join("target")).expect("pre-existing target/");
+
+    let unwritable_tmp = tempfile::tempdir().expect("btrfs stand-in");
+    let btrfs_root: PathBuf = if nix_geteuid_is_root() {
+        PathBuf::from("/proc")
+    } else {
+        std::fs::set_permissions(
+            unwritable_tmp.path(),
+            std::fs::Permissions::from_mode(0o555),
+        )
+        .expect("chmod 0555");
+        unwritable_tmp.path().to_path_buf()
+    };
+
+    let (ok, out) = run_link(checkout.path(), &btrfs_root);
+
+    // Restore so the tempdir can be removed whatever the outcome.
+    let _ = std::fs::set_permissions(
+        unwritable_tmp.path(),
+        std::fs::Permissions::from_mode(0o755),
+    );
+
+    assert!(
+        ok,
+        "the recipe failed instead of keeping the existing target/ when the btrfs \
+         volume is present but unwritable:\n{out}"
+    );
+    let target = checkout.path().join("target");
+    assert!(
+        target.is_dir() && !target.is_symlink(),
+        "target/ should have been kept as the real (bind-mounted) directory it was; \
+         it is now {:?}\n{out}",
+        std::fs::symlink_metadata(&target).map(|m| m.file_type())
+    );
+    assert_target_usable(checkout.path(), "unwritable btrfs volume");
+}
+
+fn nix_geteuid_is_root() -> bool {
+    // SAFETY: geteuid has no preconditions and cannot fail.
+    unsafe { libc::geteuid() == 0 }
+}

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -3070,6 +3070,60 @@ fn cargo_target_link_replaces_a_dangling_unmanaged_link_on_fallback() {
     assert_target_usable(checkout.path(), "dangling unmanaged link replaced");
 }
 
+/// A RETIRED generation that is readable but no longer writable rotates to a
+/// fresh one (codex on #867). The candidate write probe used to run before the
+/// retirement check, so `fallback_to_local` dropped the managed link and every
+/// later run retained the real local target/ it had created, putting all Cargo
+/// artifacts on the root filesystem for good. The probe now runs only when the
+/// candidate is REUSED; a retired candidate goes to `new_generation`, which
+/// needs only its parent writable. Unprivileged stand-in as elsewhere: root
+/// writes anything.
+#[test]
+fn cargo_target_link_rotates_a_retired_generation_it_cannot_write() {
+    use std::os::unix::fs::PermissionsExt as _;
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let btrfs = tempfile::tempdir().expect("btrfs stand-in");
+    let wt = managed_worktree_dir(checkout.path(), btrfs.path());
+    std::fs::create_dir_all(&wt).expect("retired generation");
+    // Mark it retired exactly as retire_target does.
+    let marked = Command::new("python3")
+        .args([
+            "-c",
+            "import os, sys; os.setxattr(sys.argv[1], b'user.fcvm.retired', b'v1')",
+        ])
+        .arg(&wt)
+        .status()
+        .expect("python3");
+    assert!(
+        marked.success(),
+        "set the retirement xattr on {} (user xattrs must be supported there)",
+        wt.display()
+    );
+    std::os::unix::fs::symlink(&wt, checkout.path().join("target")).expect("published link");
+    std::fs::set_permissions(&wt, std::fs::Permissions::from_mode(0o555)).expect("chmod 555");
+
+    let (ok, out) = run_link_unprivileged(checkout.path(), btrfs.path());
+
+    let _ = std::fs::set_permissions(&wt, std::fs::Permissions::from_mode(0o755));
+    assert!(
+        ok,
+        "the recipe failed on a retired read-only generation:\n{out}"
+    );
+    let target = checkout.path().join("target");
+    assert!(
+        target.is_symlink(),
+        "target/ was replaced by a local directory instead of rotating to a fresh \
+         managed generation:\n{out}"
+    );
+    let link = std::fs::read_link(&target).expect("readlink");
+    assert!(
+        link.to_string_lossy().contains("/cargo-target/") && link != wt,
+        "target/ should point at a FRESH managed generation, not {}\n{out}",
+        link.display()
+    );
+    assert_target_usable(checkout.path(), "rotated to a fresh generation");
+}
+
 /// Every exit that leaves target/ as a plain local directory probes it first.
 ///
 /// Behavioural coverage above reaches two of the three exits; this pins all of

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -2745,6 +2745,129 @@ fn cargo_target_link_falls_back_when_the_existing_worktree_dir_is_unwritable() {
     assert_target_usable(checkout.path(), "existing but unwritable worktree dir");
 }
 
+/// "Is a directory" is not "is writable" (codex on #867). Every path that leaves
+/// target/ as a plain local directory used to end on a `-d` test, so a target/
+/// nothing could write was reported as a successful fallback and cargo failed
+/// several steps later with its own error. The script now runs one probe,
+/// `require_writable_local_target`, at each of those exits. Two of the three are
+/// driven here through the fixture every uid can use: target/ pointing at
+/// /proc/self, a directory root itself cannot create in. The third (retaining an
+/// unmanaged REAL directory) cannot be staged for uid 0 without a mount or
+/// `chattr +i`, neither of which the container lane permits (overlayfs refuses
+/// the flag), so it is pinned structurally in
+/// `every_local_target_exit_probes_writability_first`.
+#[test]
+fn cargo_target_link_refuses_an_unwritable_local_target_when_btrfs_is_unusable() {
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    std::os::unix::fs::symlink("/proc/self", checkout.path().join("target"))
+        .expect("procfs-backed local target/");
+    let unwritable_tmp = tempfile::tempdir().expect("btrfs stand-in");
+    let btrfs_root: PathBuf = if nix_geteuid_is_root() {
+        PathBuf::from("/proc")
+    } else {
+        std::fs::set_permissions(
+            unwritable_tmp.path(),
+            std::fs::Permissions::from_mode(0o555),
+        )
+        .expect("chmod 0555");
+        unwritable_tmp.path().to_path_buf()
+    };
+
+    let (ok, out) = run_link(checkout.path(), &btrfs_root);
+    let _ = std::fs::set_permissions(
+        unwritable_tmp.path(),
+        std::fs::Permissions::from_mode(0o755),
+    );
+
+    assert!(
+        !ok,
+        "the recipe reported success with a target/ nothing can write (btrfs unusable, \
+         local target/ kept on a `-d` test alone):\n{out}"
+    );
+    assert!(
+        out.contains("nothing can write"),
+        "the failure must say the local target/ is unwritable, not something else:\n{out}"
+    );
+}
+
+#[test]
+fn cargo_target_link_refuses_an_unwritable_local_target_on_managed_fallback() {
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let btrfs = tempfile::tempdir().expect("btrfs stand-in");
+    // The managed worktree dir cannot be written, so the script falls back to
+    // the local target/ ... which is just as unwritable, and is not a managed
+    // link, so the fallback keeps it.
+    let _wt = unwritable_managed_worktree_dir(checkout.path(), btrfs.path());
+    std::os::unix::fs::symlink("/proc/self", checkout.path().join("target"))
+        .expect("procfs-backed local target/");
+
+    let (ok, out) = run_link(checkout.path(), btrfs.path());
+
+    assert!(
+        !ok,
+        "the managed-dir fallback reported success with a local target/ nothing can \
+         write:\n{out}"
+    );
+    assert!(
+        out.contains("nothing can write"),
+        "the failure must say the local target/ is unwritable, not something else:\n{out}"
+    );
+}
+
+/// Every exit that leaves target/ as a plain local directory probes it first.
+///
+/// Behavioural coverage above reaches two of the three exits; this pins all of
+/// them by shape, so a fourth exit (or a probe dropped from one) fails here.
+#[test]
+fn every_local_target_exit_probes_writability_first() {
+    let script =
+        std::fs::read_to_string(repo_root().join("scripts/cargo-target-link.sh")).expect("script");
+    let lines: Vec<&str> = script.lines().collect();
+    fn is_code(l: &str) -> bool {
+        !l.trim().is_empty() && !l.trim().starts_with('#')
+    }
+    let mut exits = 0;
+    for (i, line) in lines.iter().enumerate() {
+        if line.trim() != "exit 0" {
+            continue;
+        }
+        exits += 1;
+        let preceding: Vec<&str> = lines[..i]
+            .iter()
+            .rev()
+            .filter(|l| is_code(l))
+            .take(3)
+            .copied()
+            .collect();
+        assert!(
+            preceding
+                .iter()
+                .any(|l| l.contains("require_writable_local_target")),
+            "line {}: `exit 0` without a writability probe among the three preceding \
+             statements {:?}; a target/ that passes `-d` but cannot be written is a cargo \
+             error several steps later",
+            i + 1,
+            preceding
+        );
+    }
+    assert!(
+        exits >= 2,
+        "expected the managed-dir fallback and the unmanaged-target retention to each \
+         `exit 0`; found {exits}. If the script's shape changed, move this pin with it."
+    );
+    let last = lines
+        .iter()
+        .rev()
+        .find(|l| is_code(l))
+        .map(|l| l.trim())
+        .unwrap_or("");
+    assert_eq!(
+        last, "require_writable_local_target",
+        "the script's fall-through end (the else-branch and self-heal paths) must be \
+         the probe itself"
+    );
+}
+
 /// Helper: this checkout's managed worktree dir, exactly as the script names it.
 fn managed_worktree_dir(checkout: &Path, btrfs_root: &Path) -> PathBuf {
     let p = std::fs::canonicalize(checkout).expect("canonical checkout path");

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -3237,11 +3237,23 @@ fn managed_worktree_dir(checkout: &Path, btrfs_root: &Path) -> PathBuf {
         .join(format!("{base}-{}", &digest[..8]))
 }
 
-/// Helper: this checkout's fallback payload, exactly as the script names it.
-fn local_fallback_dir(checkout: &Path) -> PathBuf {
-    std::fs::canonicalize(checkout)
-        .expect("canonical checkout path")
-        .join(".cargo-target-local")
+/// Helper: every fallback payload this checkout holds, published or not,
+/// sorted. Each activation names its own, so more than one means an earlier
+/// payload was neither published nor reclaimed.
+fn local_fallback_payloads(checkout: &Path) -> Vec<PathBuf> {
+    let checkout = std::fs::canonicalize(checkout).expect("canonical checkout path");
+    let mut payloads: Vec<PathBuf> = std::fs::read_dir(&checkout)
+        .unwrap_or_else(|error| panic!("read {checkout:?}: {error}"))
+        .map(|entry| entry.expect("checkout entry").path())
+        .filter(|entry| {
+            entry
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with(".cargo-target-local.generation-"))
+        })
+        .collect();
+    payloads.sort();
+    payloads
 }
 
 /// The script's own fallback: `target` is a link to the checkout-local payload,
@@ -3262,9 +3274,9 @@ fn assert_local_fallback_link(checkout: &Path, btrfs_root: &Path, ctx: &str) -> 
         "{ctx}: target/ -> {link:?} points into the btrfs root {btrfs_root:?}"
     );
     assert_eq!(
-        link,
-        local_fallback_dir(checkout),
-        "{ctx}: target/ does not point at the checkout-local fallback payload"
+        local_fallback_payloads(checkout),
+        vec![link.clone()],
+        "{ctx}: target/ must publish the checkout's one fallback payload"
     );
     assert_target_usable(checkout, ctx);
     link
@@ -3437,20 +3449,18 @@ fn cargo_target_link_returns_to_btrfs_after_a_volume_outage() {
         "run 2: target/ -> {link:?} is not under the recovered volume:\n{out}"
     );
     assert_target_usable(checkout.path(), "run 2, volume back");
-    assert_eq!(
-        std::fs::read(payload.join("built-during-outage")).unwrap_or_else(|error| panic!(
-            "the outage payload {payload:?} was destroyed: {error}"
-        )),
-        b"built while the volume was down",
-        "the outage payload was modified"
-    );
     assert!(
         !target.join("built-during-outage").exists(),
         "the outage payload is still published through target/"
     );
     assert!(
+        local_fallback_payloads(checkout.path()).is_empty(),
+        "the outage payload is unreachable and sits on the root filesystem this indirection \
+         keeps free; nothing else enumerates it:\n{out}"
+    );
+    assert!(
         out.contains(payload.to_str().expect("utf-8 payload path")),
-        "run 2 must print the orphaned payload path {payload:?} so a human can remove it:\n{out}"
+        "run 2 must name the payload {payload:?} it reclaimed:\n{out}"
     );
 }
 
@@ -3494,7 +3504,7 @@ fn cargo_target_link_retains_a_real_target_it_did_not_create() {
             "{ctx}: the retained payload changed"
         );
         assert!(
-            !local_fallback_dir(checkout.path()).exists(),
+            local_fallback_payloads(checkout.path()).is_empty(),
             "{ctx}: a fallback payload was created beside a retained real target/:\n{out}"
         );
         assert_target_usable(checkout.path(), ctx);
@@ -3539,5 +3549,52 @@ fn cargo_target_link_rotate_refuses_the_local_fallback_while_the_volume_is_down(
     assert_eq!(
         std::fs::read(payload.join("artifact")).expect("read the surviving payload"),
         b"survives"
+    );
+}
+
+/// A clean the volume outlived must not leave a payload a later outage can
+/// republish.
+///
+/// The volume is absent, so a fallback payload is published and built into; the
+/// volume returns and the next run publishes a btrfs generation; `--rotate`
+/// (the `clean` recipe) reports a clean; the volume goes away again. The
+/// fallback published by the last run must be empty. Anything the first outage
+/// left in it is cargo cache and build-script output that the clean reported
+/// gone.
+#[test]
+fn cargo_target_link_publishes_a_fresh_fallback_after_a_clean() {
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let volume_parent = tempfile::tempdir().expect("volume parent");
+    let btrfs = volume_parent.path().join("fcvm-btrfs");
+    let target = checkout.path().join("target");
+
+    let (ok, out) = run_link(checkout.path(), &btrfs);
+    assert!(ok, "run 1 (volume absent) failed:\n{out}");
+    let first_payload = std::fs::read_link(&target).expect("run 1 must publish a fallback link");
+    std::fs::write(target.join("stale-artifact"), b"built before the clean")
+        .expect("write through the fallback link");
+
+    std::fs::create_dir_all(&btrfs).expect("the volume is mounted again");
+    let (ok, out) = run_link(checkout.path(), &btrfs);
+    assert!(ok, "run 2 (volume back) failed:\n{out}");
+
+    let (ok, out) = run_link_with(checkout.path(), &btrfs, &["--rotate"]);
+    assert!(ok, "run 3 (--rotate, the clean recipe) failed:\n{out}");
+
+    std::fs::remove_dir_all(&btrfs).expect("the volume goes away again");
+    let (ok, out) = run_link(checkout.path(), &btrfs);
+    assert!(ok, "run 4 (volume absent again) failed:\n{out}");
+    assert_target_usable(checkout.path(), "run 4, volume absent again");
+
+    let republished = std::fs::read_link(&target).expect("run 4 must publish a fallback link");
+    assert!(
+        !target.join("stale-artifact").exists(),
+        "target/ -> {republished:?} republishes {first_payload:?}, the payload the clean \
+         reported gone; every cargo fingerprint and build-script OUT_DIR written before the \
+         clean is back:\n{out}"
+    );
+    assert_ne!(
+        republished, first_payload,
+        "run 4 reused an earlier outage's payload instead of publishing a fresh one:\n{out}"
     );
 }

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -559,9 +559,8 @@ fn cargo_target_link_fails_loudly_on_a_non_directory_target() {
 /// the logic inline) nothing else here would notice.
 ///
 /// This reads the recipe's COMMAND lines only, not the whole file: a match
-/// anywhere in the Makefile would also be satisfied by a comment mentioning the
-/// script, which is the failure mode that made an earlier version of the AMI-hash
-/// test pass with its subject deleted.
+/// anywhere in the Makefile is also satisfied by a comment mentioning the
+/// script, which would pass with the recipe deleted.
 #[test]
 fn makefile_delegates_to_the_script() {
     let mk = std::fs::read_to_string(repo_root().join("Makefile")).expect("read Makefile");
@@ -591,10 +590,10 @@ fn makefile_delegates_to_the_script() {
     );
 }
 
-/// The disk preflight used to glob `cargo-target*`, which selected the parent
-/// `cargo-target/` directory instead of its per-worktree children.  One idle
-/// sibling could therefore never be reclaimed independently, and deleting the
-/// parent left every checkout's target symlink dangling.
+/// The disk preflight selects per-worktree children, never the parent
+/// `cargo-target/` directory. A glob that matches the parent makes an idle
+/// sibling unreclaimable on its own, and removing the parent leaves every
+/// checkout's target symlink dangling.
 ///
 /// This also exercises the lease rather than merely inspecting shell text: an
 /// old-looking target stays intact while a fake Cargo process holds the shared
@@ -2708,9 +2707,9 @@ fn nix_geteuid_is_root() -> bool {
 /// `mkdir -p` is idempotent: on an existing directory it succeeds without
 /// creating anything, so a writability probe built on it alone selects the
 /// managed branch and publishes a symlink to a directory Cargo cannot write --
-/// exit 0, then an opaque failure several steps later. Raised by Codex on #867.
-/// Ownership changes and read-only remounts both produce this state. The probe
-/// has to CREATE an entry inside the directory, not merely confirm the directory.
+/// exit 0, then an opaque failure several steps later. Ownership changes and
+/// read-only remounts both produce this state. The probe has to CREATE an entry
+/// inside the directory, not merely confirm the directory.
 ///
 /// Root cannot be stopped by mode bits, so the root branch remounts the volume
 /// read-only through a bind mount and gets EROFS instead.
@@ -2733,11 +2732,10 @@ fn cargo_target_link_falls_back_when_the_existing_worktree_dir_is_unwritable() {
     );
 }
 
-/// "Is a directory" is not "is writable" (codex on #867). Every path that leaves
-/// target/ as a plain local directory used to end on a `-d` test, so a target/
-/// nothing could write was reported as a successful fallback and cargo failed
-/// several steps later with its own error. The script now runs one probe,
-/// `require_writable_local_target`, at each of those exits. Two of the three are
+/// "Is a directory" is not "is writable". A `-d` test alone reports a target/
+/// nothing can write as a successful fallback, and cargo fails several steps
+/// later with its own error, so every path that leaves target/ as a plain local
+/// directory runs `require_writable_local_target`. Two of the three exits are
 /// driven here through the fixture every uid can use: target/ pointing at
 /// /proc/self, a directory root itself cannot create in. The third (retaining an
 /// unmanaged REAL directory) cannot be staged for uid 0 without a mount or
@@ -2803,7 +2801,7 @@ fn cargo_target_link_refuses_an_unwritable_local_target_on_managed_fallback() {
 }
 
 /// A managed link is DROPPED, never probed through, when its generation cannot
-/// be leased (codex on #867).
+/// be leased.
 ///
 /// The unusable-volume path (the volume exists but `$WT_TARGET` cannot be
 /// created) never opens a generation lease, yet `target/` can still resolve
@@ -2863,11 +2861,11 @@ fn cargo_target_link_drops_a_managed_link_it_cannot_lease() {
     );
 }
 
-/// An existing `$WT_TARGET` that cannot be OPENED falls back too (codex on
-/// #867). Losing read permission as well as write (an ownership change that
-/// leaves a fresh checkout's directory 0700, say) passes `mkdir -p`, but the
-/// generation-lease open `exec {fd}<"$candidate"` fails, and under `set -e`
-/// the script died there instead of creating the promised local target/.
+/// An existing `$WT_TARGET` that cannot be OPENED falls back too. Losing read
+/// permission as well as write (an ownership change that leaves a fresh
+/// checkout's directory 0700, say) passes `mkdir -p`, but the generation-lease
+/// open `exec {fd}<"$candidate"` fails; under `set -e` that ends the script
+/// instead of creating the promised local target/.
 /// Root can open any directory, so when the tests are root the script runs as
 /// uid 65534 through `setpriv`, from a copy of scripts/ that uid can read, over
 /// tempdirs handed to that uid.
@@ -2958,9 +2956,9 @@ fn run_link_with(dir: &Path, btrfs_root: &Path, args: &[&str]) -> (bool, String)
     (out.status.success(), text)
 }
 
-/// The PUBLISHED generation that cannot be opened FAILS CLOSED (codex on #867,
-/// reversing an earlier fallback). Without that generation's lease the script
-/// cannot know whether a Cargo wrapper still holds it shared, and a generation
+/// The PUBLISHED generation that cannot be opened FAILS CLOSED; it does not
+/// fall back. Without that generation's lease the script cannot know whether a
+/// Cargo wrapper still holds it shared, and a generation
 /// that lost only read permission (0333) is one Cargo can still create entries
 /// in; replacing `target/` under such a build would split it across two trees.
 /// Same unprivileged stand-in as the candidate case.
@@ -2994,12 +2992,12 @@ fn cargo_target_link_refuses_to_replace_a_published_generation_it_cannot_lease()
     );
 }
 
-/// `--rotate` must not report a clean it did not perform (codex on #867).
+/// `--rotate` must not report a clean it did not perform.
 ///
 /// With an UNMANAGED `target/` link and a managed candidate that cannot be
-/// written, `fallback_to_local` used to retain the link and exit 0, so `make
-/// clean` reported success while the linked directory's payload survived. The
-/// unusable-volume branch already refused this; the fallback now does too.
+/// written, retaining the link and exiting 0 reports `make clean` as done while
+/// the linked directory's payload survives. Both the unusable-volume branch and
+/// the fallback refuse instead.
 #[test]
 fn cargo_target_link_rotate_refuses_to_retain_an_unmanaged_link() {
     let checkout = tempfile::tempdir().expect("checkout tempdir");
@@ -3028,10 +3026,9 @@ fn cargo_target_link_rotate_refuses_to_retain_an_unmanaged_link() {
     );
 }
 
-/// A dangling UNMANAGED link is replaced on the fallback path, not tripped over
-/// (CodeRabbit on #867): `[ -e target ] || mkdir -p target` saw the dangling
-/// link as absent, and `mkdir -p` then failed with EEXIST under `set -e`,
-/// before the diagnostic that follows it.
+/// A dangling UNMANAGED link is replaced on the fallback path, not tripped
+/// over. It is absent to `[ -e target ]` and EEXIST to `mkdir -p target`, which
+/// under `set -e` ends the script before the diagnostic that follows.
 #[test]
 fn cargo_target_link_replaces_a_dangling_unmanaged_link_on_fallback() {
     let checkout = tempfile::tempdir().expect("checkout tempdir");
@@ -3050,13 +3047,11 @@ fn cargo_target_link_replaces_a_dangling_unmanaged_link_on_fallback() {
 }
 
 /// A RETIRED generation that is readable but no longer writable rotates to a
-/// fresh one (codex on #867). The candidate write probe used to run before the
-/// retirement check, so `fallback_to_local` dropped the managed link and every
-/// later run retained the real local target/ it had created, putting all Cargo
-/// artifacts on the root filesystem for good. The probe now runs only when the
-/// candidate is REUSED; a retired candidate goes to `new_generation`, which
-/// needs only its parent writable. Unprivileged stand-in as elsewhere: root
-/// writes anything.
+/// fresh one. The candidate write probe runs only when the candidate is REUSED:
+/// probing a retired one first sends the script to `fallback_to_local`, which
+/// drops the managed link and leaves every later run on the root filesystem,
+/// while `new_generation` needs only the parent writable. Unprivileged
+/// stand-in as elsewhere: root writes anything.
 #[test]
 fn cargo_target_link_rotates_a_retired_generation_it_cannot_write() {
     use std::os::unix::fs::PermissionsExt as _;
@@ -3103,12 +3098,12 @@ fn cargo_target_link_rotates_a_retired_generation_it_cannot_write() {
     assert_target_usable(checkout.path(), "rotated to a fresh generation");
 }
 
-/// Dropping a published managed link waits for the build that holds it
-/// (codex on #867). On the unusable-volume path the script used to unlink
-/// `target/` with no lease on the generation it published; a Cargo wrapper
-/// holding that generation SHARED would then resolve later `target/...` paths
-/// into a different tree. The script must take the generation's exclusive
-/// lease first: with a shared holder present it blocks, and the link stays.
+/// Dropping a published managed link waits for the build that holds it.
+/// Unlinking `target/` on the unusable-volume path with no lease on the
+/// generation it published lets a Cargo wrapper holding that generation SHARED
+/// resolve later `target/...` paths into a different tree. The script takes the
+/// generation's exclusive lease first: with a shared holder present it blocks,
+/// and the link stays.
 #[test]
 fn cargo_target_link_waits_for_a_shared_holder_before_dropping_a_managed_link() {
     use std::os::unix::io::AsRawFd as _;
@@ -3288,10 +3283,9 @@ fn assert_local_fallback_link(checkout: &Path, btrfs_root: &Path, ctx: &str) -> 
 /// opens, and the write probe inside the lease fails -- exactly the
 /// ownership-change / read-only-remount state, staged with a symlink.
 ///
-/// Replaces an earlier fixture that chmod'ed as a user and bind-remounted
-/// read-only as root: as UID 0 WITHOUT CAP_SYS_ADMIN (an unprivileged
-/// container) the mount was refused and the test failed before reaching the
-/// script (Codex on #867).
+/// A chmod as the invoking user does not stop root, and a read-only bind
+/// remount is refused for UID 0 WITHOUT CAP_SYS_ADMIN (an unprivileged
+/// container), which fails the test before it reaches the script.
 fn unwritable_managed_worktree_dir(checkout: &Path, btrfs_root: &Path) -> PathBuf {
     let wt = managed_worktree_dir(checkout, btrfs_root);
     std::fs::create_dir_all(wt.parent().unwrap()).expect("cargo-target parent");
@@ -3309,13 +3303,12 @@ fn unwritable_managed_worktree_dir(checkout: &Path, btrfs_root: &Path) -> PathBu
 
 /// A managed symlink whose directory has become unwritable must be REPLACED.
 ///
-/// Codex on #867 (P2): with `target` already pointing at the managed directory,
-/// the probe correctly notices the directory is unwritable, warns, and then
-/// leaves the symlink in place. The link still resolves, so the dangling-link
-/// repair is skipped and the final `-d target` check passes: exit 0 with a
-/// target Cargo cannot create files in. The fallback has to repoint an existing
-/// managed link at the local fallback -- under the generation lease it already
-/// holds for exactly this kind of replacement.
+/// With `target` already pointing at the managed directory, noticing that the
+/// directory is unwritable and warning is not enough: the link still resolves,
+/// so the dangling-link repair is skipped and the final `-d target` check
+/// passes, which is exit 0 with a target Cargo cannot create files in. The
+/// fallback repoints the existing managed link at the local payload, under the
+/// generation lease it already holds for that replacement.
 #[test]
 fn cargo_target_link_replaces_a_managed_link_to_an_unwritable_dir() {
     let checkout = tempfile::tempdir().expect("checkout tempdir");
@@ -3335,12 +3328,12 @@ fn cargo_target_link_replaces_a_managed_link_to_an_unwritable_dir() {
 
 /// The write probe must happen INSIDE the generation lease, never before it.
 ///
-/// Codex on #867 (P1): `prune-cargo-target.sh` takes LOCK_EX on a generation,
-/// takes a census of its entries, then rewalks the locked tree. A probe entry
-/// created before the script has leased the generation appears after the census
-/// with no record, and one removed during the rewalk raises
-/// "target entry disappeared during reclaim" -- so an ordinary concurrent `make`
-/// aborts the hourly preflight and its job. AGENTS.md: ZERO RACE CONDITIONS.
+/// `prune-cargo-target.sh` takes LOCK_EX on a generation, takes a census of its
+/// entries, then rewalks the locked tree. A probe entry created before the
+/// script has leased the generation appears after the census with no record,
+/// and one removed during the rewalk raises "target entry disappeared during
+/// reclaim", so an ordinary concurrent `make` aborts the hourly preflight and
+/// its job.
 ///
 /// The test IS the pruner: it holds LOCK_EX on the worktree directory and runs
 /// the script under a timeout. Correct behaviour is to block at the lease
@@ -3405,15 +3398,13 @@ fn cargo_target_link_does_not_touch_a_generation_it_has_not_leased() {
 
 /// A fallback the script created must not outlive the outage that caused it.
 ///
-/// Codex on #867 (P2): with the volume unavailable and no target/ present, the
-/// fallback created a REAL target/ directory. The next run with the volume back
-/// took the pre-protocol branch, which retains any real target/ as unmanaged, so
-/// the checkout never returned to the btrfs cache and every later build landed
-/// on the root filesystem until the disk guard quarantined the runner. The
-/// fallback now lives behind a link to a checkout-local payload, which the
-/// recovered run replaces under the same lease as any other published link.
-/// Nothing enumerates that payload, so nothing reclaims it: it stays in place
-/// and its path is printed so a human can remove it.
+/// A REAL target/ directory created while the volume is unavailable sends the
+/// next run with the volume back down the pre-protocol branch, which retains
+/// any real target/ as unmanaged: the checkout never returns to the btrfs cache
+/// and every later build lands on the root filesystem until the disk guard
+/// quarantines the runner. The fallback is a link to a checkout-local payload,
+/// which the recovered run replaces under the same lease as any other published
+/// link, and reclaims once it publishes nothing.
 #[test]
 fn cargo_target_link_returns_to_btrfs_after_a_volume_outage() {
     let checkout = tempfile::tempdir().expect("checkout tempdir");

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -2814,6 +2814,75 @@ fn cargo_target_link_refuses_an_unwritable_local_target_on_managed_fallback() {
     );
 }
 
+/// A managed link is DROPPED, never probed through, when its generation cannot
+/// be leased (codex on #867).
+///
+/// The unusable-volume path (the volume exists but `$WT_TARGET` cannot be
+/// created) never opens a generation lease, yet `target/` can still resolve
+/// into the managed tree: a rotated `.generation-*` directory outlives the
+/// canonical path the pruner removed. Probing writability THROUGH that link
+/// creates and removes a file inside a generation this run holds no lease on,
+/// which is the census/rewalk race the lease protocol exists to prevent; and if
+/// that generation is itself unwritable the script fails instead of falling
+/// back. So the link goes and a local `target/` takes its place; the generation
+/// is left untouched for the pruner. Staged for every uid: a dangling symlink
+/// at `$WT_TARGET` defeats `mkdir -p` for root too.
+#[test]
+fn cargo_target_link_drops_a_managed_link_it_cannot_lease() {
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let btrfs = tempfile::tempdir().expect("btrfs stand-in");
+    let wt = managed_worktree_dir(checkout.path(), btrfs.path());
+    std::fs::create_dir_all(wt.parent().unwrap()).expect("cargo-target parent");
+    let generation = wt.with_file_name(format!(
+        "{}.generation-stale000",
+        wt.file_name().unwrap().to_string_lossy()
+    ));
+    std::fs::create_dir_all(&generation).expect("retained generation");
+    // `set_file_time` opens a FILE; a directory's mtime is pinned with touch.
+    let pinned = std::process::Command::new("touch")
+        .args(["-d", "@1600000000"])
+        .arg(&generation)
+        .status()
+        .expect("run touch");
+    assert!(pinned.success(), "pin the generation's mtime");
+    std::os::unix::fs::symlink(btrfs.path().join("cargo-target/absent"), &wt)
+        .expect("dangling $WT_TARGET, so mkdir -p fails for every uid");
+    std::os::unix::fs::symlink(&generation, checkout.path().join("target"))
+        .expect("target/ -> retained generation");
+
+    let (ok, out) = run_link(checkout.path(), btrfs.path());
+
+    assert!(
+        ok,
+        "the recipe failed instead of falling back to a local target/:\n{out}"
+    );
+    let target = checkout.path().join("target");
+    assert!(
+        !target.is_symlink(),
+        "target/ still points into the managed tree ({}) on a path that took no lease \
+         on it\n{out}",
+        std::fs::read_link(&target)
+            .map(|l| l.display().to_string())
+            .unwrap_or_default()
+    );
+    assert_target_usable(
+        checkout.path(),
+        "managed link dropped on an unusable volume",
+    );
+    let mtime = std::fs::metadata(&generation)
+        .expect("generation still exists")
+        .modified()
+        .expect("mtime")
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("epoch")
+        .as_secs();
+    assert_eq!(
+        mtime, 1_600_000_000,
+        "the retained generation was written through (a probe file was created and \
+         removed in it) without a lease\n{out}"
+    );
+}
+
 /// Every exit that leaves target/ as a plain local directory probes it first.
 ///
 /// Behavioural coverage above reaches two of the three exits; this pins all of

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -2796,3 +2796,154 @@ fn cargo_target_link_falls_back_when_the_existing_worktree_dir_is_unwritable() {
     );
     assert_target_usable(checkout.path(), "existing but unwritable worktree dir");
 }
+
+/// Helper: this checkout's managed worktree dir, exactly as the script names it.
+fn managed_worktree_dir(checkout: &Path, btrfs_root: &Path) -> PathBuf {
+    let p = std::fs::canonicalize(checkout).expect("canonical checkout path");
+    let base: String = p
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || "._-".contains(c) {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let digest = {
+        use sha2::Digest;
+        hex::encode(sha2::Sha256::digest(p.to_string_lossy().as_bytes()))
+    };
+    btrfs_root
+        .join("cargo-target")
+        .join(format!("{base}-{}", &digest[..8]))
+}
+
+/// A managed symlink whose directory has become unwritable must be REPLACED.
+///
+/// Codex on #867 (P2): with `target` already pointing at the managed directory,
+/// the probe correctly notices the directory is unwritable, warns, and then
+/// leaves the symlink in place. The link still resolves, so the dangling-link
+/// repair is skipped and the final `-d target` check passes: exit 0 with a
+/// target Cargo cannot create files in. The fallback has to repoint an existing
+/// managed link at a real local directory -- under the generation lease it
+/// already holds for exactly this kind of replacement.
+#[test]
+fn cargo_target_link_replaces_a_managed_link_to_an_unwritable_dir() {
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let btrfs = tempfile::tempdir().expect("btrfs stand-in");
+    let wt = managed_worktree_dir(checkout.path(), btrfs.path());
+    std::fs::create_dir_all(&wt).expect("managed dir");
+    std::os::unix::fs::symlink(&wt, checkout.path().join("target")).expect("managed link");
+
+    let root = nix_geteuid_is_root();
+    if root {
+        let b = btrfs.path().to_str().unwrap();
+        let ok = Command::new("mount")
+            .args(["--bind", b, b])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+            && Command::new("mount")
+                .args(["-o", "remount,ro,bind", b])
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false);
+        assert!(ok, "could not remount the btrfs stand-in read-only as root");
+    } else {
+        std::fs::set_permissions(&wt, std::fs::Permissions::from_mode(0o555)).expect("chmod 0555");
+    }
+
+    let (ok, out) = run_link(checkout.path(), btrfs.path());
+
+    if root {
+        let _ = Command::new("umount").arg(btrfs.path()).status();
+    } else {
+        let _ = std::fs::set_permissions(&wt, std::fs::Permissions::from_mode(0o755));
+    }
+
+    assert!(ok, "the recipe failed outright:\n{out}");
+    let target = checkout.path().join("target");
+    assert!(
+        !target.is_symlink(),
+        "target/ still links to the unwritable managed directory {}; the fallback \
+         warned and walked away\n{out}",
+        std::fs::read_link(&target)
+            .map(|l| l.display().to_string())
+            .unwrap_or_default()
+    );
+    assert_target_usable(checkout.path(), "managed link to an unwritable dir");
+}
+
+/// The write probe must happen INSIDE the generation lease, never before it.
+///
+/// Codex on #867 (P1): `prune-cargo-target.sh` takes LOCK_EX on a generation,
+/// takes a census of its entries, then rewalks the locked tree. A probe entry
+/// created before the script has leased the generation appears after the census
+/// with no record, and one removed during the rewalk raises
+/// "target entry disappeared during reclaim" -- so an ordinary concurrent `make`
+/// aborts the hourly preflight and its job. AGENTS.md: ZERO RACE CONDITIONS.
+///
+/// The test IS the pruner: it holds LOCK_EX on the worktree directory and runs
+/// the script under a timeout. Correct behaviour is to block at the lease
+/// without having touched the directory -- so its mtime (which any create or
+/// unlink inside it bumps) must be unchanged when the timeout fires.
+#[test]
+fn cargo_target_link_does_not_touch_a_generation_it_has_not_leased() {
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let btrfs = tempfile::tempdir().expect("btrfs stand-in");
+    let wt = managed_worktree_dir(checkout.path(), btrfs.path());
+    std::fs::create_dir_all(&wt).expect("managed dir");
+
+    // Be the pruner: LOCK_EX on the generation directory.
+    let dir = std::fs::File::open(&wt).expect("open the generation dir");
+    use std::os::unix::io::AsRawFd;
+    let locked = unsafe { libc::flock(dir.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    assert_eq!(
+        locked,
+        0,
+        "could not take the pruner's LOCK_EX on {}",
+        wt.display()
+    );
+    // Settle so that a later create/unlink moves the mtime by a visible amount.
+    // (`touch`, not set_file_time: that helper opens for write, which a
+    // directory refuses with EISDIR.)
+    assert!(
+        Command::new("touch")
+            .args(["-d", "@1600000000"])
+            .arg(&wt)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false),
+        "could not settle the directory mtime"
+    );
+    let before = std::fs::metadata(&wt).expect("stat").mtime();
+
+    let out = Command::new("timeout")
+        .arg("4")
+        .arg(repo_root().join("scripts/cargo-target-link.sh"))
+        .env("BTRFS_ROOT", btrfs.path())
+        .env_remove("CARGO_TARGET_LINK_LOCKED")
+        .current_dir(checkout.path())
+        .output()
+        .expect("run the script under timeout");
+    let after = std::fs::metadata(&wt).expect("stat").mtime();
+    drop(dir); // releases the lock
+
+    assert_eq!(
+        out.status.code(),
+        Some(124),
+        "the script did not block on the pruner's lease; it completed with {:?}\n{}{}",
+        out.status,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        before, after,
+        "the generation directory was modified (mtime {before} -> {after}) while the \
+         pruner held its lease: the write probe ran outside the lock"
+    );
+}

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -2709,3 +2709,90 @@ fn nix_geteuid_is_root() -> bool {
     // SAFETY: geteuid has no preconditions and cannot fail.
     unsafe { libc::geteuid() == 0 }
 }
+
+/// The worktree directory EXISTS on the volume but cannot be written into.
+///
+/// `mkdir -p` is idempotent: on an existing directory it succeeds without
+/// creating anything, so a writability probe built on it alone selects the
+/// managed branch and publishes a symlink to a directory Cargo cannot write --
+/// exit 0, then an opaque failure several steps later. Raised by Codex on #867.
+/// Ownership changes and read-only remounts both produce this state. The probe
+/// has to CREATE an entry inside the directory, not merely confirm the directory.
+///
+/// Root cannot be stopped by mode bits, so the root branch remounts the volume
+/// read-only through a bind mount and gets EROFS instead.
+#[test]
+fn cargo_target_link_falls_back_when_the_existing_worktree_dir_is_unwritable() {
+    // A FRESH checkout: no target/ yet. With one pre-existing, the script's
+    // "retaining unmanaged local target/" exit fires before any symlink is
+    // published and hides exactly the defect under test.
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let btrfs = tempfile::tempdir().expect("btrfs stand-in");
+
+    // The script's own naming: sanitized basename + sha256(pwd -P)[..8].
+    let p = std::fs::canonicalize(checkout.path()).expect("canonical checkout path");
+    let base: String = p
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || "._-".contains(c) {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let digest = {
+        use sha2::Digest;
+        hex::encode(sha2::Sha256::digest(p.to_string_lossy().as_bytes()))
+    };
+    let wt_target = btrfs
+        .path()
+        .join("cargo-target")
+        .join(format!("{base}-{}", &digest[..8]));
+    std::fs::create_dir_all(&wt_target).expect("pre-create the worktree dir");
+
+    let root = nix_geteuid_is_root();
+    if root {
+        let ok = Command::new("mount")
+            .args([
+                "--bind",
+                btrfs.path().to_str().unwrap(),
+                btrfs.path().to_str().unwrap(),
+            ])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+            && Command::new("mount")
+                .args(["-o", "remount,ro,bind", btrfs.path().to_str().unwrap()])
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false);
+        assert!(ok, "could not remount the btrfs stand-in read-only as root");
+    } else {
+        std::fs::set_permissions(&wt_target, std::fs::Permissions::from_mode(0o555))
+            .expect("chmod 0555 on the worktree dir");
+    }
+
+    let (ok, out) = run_link(checkout.path(), btrfs.path());
+
+    if root {
+        let _ = Command::new("umount").arg(btrfs.path()).status();
+    } else {
+        let _ = std::fs::set_permissions(&wt_target, std::fs::Permissions::from_mode(0o755));
+    }
+
+    assert!(ok, "the recipe failed outright:\n{out}");
+    let target = checkout.path().join("target");
+    assert!(
+        !target.is_symlink(),
+        "target/ was pointed at the unwritable managed directory {}; a probe that only \
+         `mkdir -p`s an existing directory cannot see that it is unwritable\n{out}",
+        std::fs::read_link(&target)
+            .map(|l| l.display().to_string())
+            .unwrap_or_default()
+    );
+    assert_target_usable(checkout.path(), "existing but unwritable worktree dir");
+}

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -280,19 +280,12 @@ fn cargo_target_link_heals_when_btrfs_is_gone_entirely() {
     );
     assert_target_usable(work.path(), "btrfs root absent");
 
-    // And it must be a REAL local directory, not the stale link with its target
-    // recreated. `$BTRFS_ROOT` absent means the volume is unmounted; recreating
-    // the path underneath a mountpoint writes build artifacts to the small root
-    // filesystem while still looking like btrfs — the exact failure this whole
-    // indirection exists to avoid.
-    assert!(
-        std::fs::symlink_metadata(work.path().join("target"))
-            .expect("target must exist")
-            .file_type()
-            .is_dir(),
-        "target is still a symlink after the btrfs volume disappeared; artifacts would be \
-         written under the unmounted mountpoint {gone:?} — i.e. onto the root filesystem"
-    );
+    // And it must be the script's own fallback link, not the stale link with
+    // its target recreated. `$BTRFS_ROOT` absent means the volume is unmounted;
+    // recreating the path underneath a mountpoint writes build artifacts to the
+    // small root filesystem while still looking like btrfs, the exact failure
+    // this whole indirection exists to avoid.
+    assert_local_fallback_link(work.path(), &gone, "btrfs root absent");
 }
 
 /// A different textual spelling can still resolve to the same directory inode. Opening that
@@ -2733,16 +2726,11 @@ fn cargo_target_link_falls_back_when_the_existing_worktree_dir_is_unwritable() {
     let (ok, out) = run_link(checkout.path(), btrfs.path());
 
     assert!(ok, "the recipe failed outright:\n{out}");
-    let target = checkout.path().join("target");
-    assert!(
-        !target.is_symlink(),
-        "target/ was pointed at the unwritable managed directory {}; a probe that only \
-         `mkdir -p`s an existing directory cannot see that it is unwritable\n{out}",
-        std::fs::read_link(&target)
-            .map(|l| l.display().to_string())
-            .unwrap_or_default()
+    assert_local_fallback_link(
+        checkout.path(),
+        btrfs.path(),
+        "existing but unwritable worktree dir",
     );
-    assert_target_usable(checkout.path(), "existing but unwritable worktree dir");
 }
 
 /// "Is a directory" is not "is writable" (codex on #867). Every path that leaves
@@ -2856,17 +2844,9 @@ fn cargo_target_link_drops_a_managed_link_it_cannot_lease() {
         ok,
         "the recipe failed instead of falling back to a local target/:\n{out}"
     );
-    let target = checkout.path().join("target");
-    assert!(
-        !target.is_symlink(),
-        "target/ still points into the managed tree ({}) on a path that took no lease \
-         on it\n{out}",
-        std::fs::read_link(&target)
-            .map(|l| l.display().to_string())
-            .unwrap_or_default()
-    );
-    assert_target_usable(
+    assert_local_fallback_link(
         checkout.path(),
+        btrfs.path(),
         "managed link dropped on an unusable volume",
     );
     let mtime = std::fs::metadata(&generation)
@@ -2909,13 +2889,11 @@ fn cargo_target_link_falls_back_when_the_managed_dir_cannot_be_opened() {
         "the recipe died instead of falling back when the managed dir cannot be \
          opened:\n{out}"
     );
-    let target = checkout.path().join("target");
-    assert!(
-        target.is_dir() && !target.is_symlink(),
-        "target/ should be a local directory after the fallback, not {:?}\n{out}",
-        std::fs::symlink_metadata(&target).map(|m| m.file_type())
+    assert_local_fallback_link(
+        checkout.path(),
+        btrfs.path(),
+        "managed dir that cannot be opened",
     );
-    assert_target_usable(checkout.path(), "managed dir that cannot be opened");
 }
 
 /// `run_link`, but as uid 65534 when the tests are root: root can open and
@@ -3259,6 +3237,39 @@ fn managed_worktree_dir(checkout: &Path, btrfs_root: &Path) -> PathBuf {
         .join(format!("{base}-{}", &digest[..8]))
 }
 
+/// Helper: this checkout's fallback payload, exactly as the script names it.
+fn local_fallback_dir(checkout: &Path) -> PathBuf {
+    std::fs::canonicalize(checkout)
+        .expect("canonical checkout path")
+        .join(".cargo-target-local")
+}
+
+/// The script's own fallback: `target` is a link to the checkout-local payload,
+/// never a real `target/` dentry, so a later run can replace it once the volume
+/// is back. Returns the payload path.
+fn assert_local_fallback_link(checkout: &Path, btrfs_root: &Path, ctx: &str) -> PathBuf {
+    let target = checkout.join("target");
+    let link = std::fs::read_link(&target).unwrap_or_else(|error| {
+        panic!(
+            "{ctx}: target/ is not a symlink ({error}); a real target/ dentry is retained as \
+             unmanaged by every later run, so the checkout would never return to the btrfs \
+             cache. symlink_metadata={:?}",
+            std::fs::symlink_metadata(&target).map(|m| m.file_type())
+        )
+    });
+    assert!(
+        !link.starts_with(btrfs_root),
+        "{ctx}: target/ -> {link:?} points into the btrfs root {btrfs_root:?}"
+    );
+    assert_eq!(
+        link,
+        local_fallback_dir(checkout),
+        "{ctx}: target/ does not point at the checkout-local fallback payload"
+    );
+    assert_target_usable(checkout, ctx);
+    link
+}
+
 /// Make this checkout's managed worktree dir "exist but refuse writes" without
 /// any privilege: point it at procfs, where creating an entry is refused for
 /// root and non-root alike. `mkdir -p` on it succeeds (it exists), a lease fd
@@ -3291,8 +3302,8 @@ fn unwritable_managed_worktree_dir(checkout: &Path, btrfs_root: &Path) -> PathBu
 /// leaves the symlink in place. The link still resolves, so the dangling-link
 /// repair is skipped and the final `-d target` check passes: exit 0 with a
 /// target Cargo cannot create files in. The fallback has to repoint an existing
-/// managed link at a real local directory -- under the generation lease it
-/// already holds for exactly this kind of replacement.
+/// managed link at the local fallback -- under the generation lease it already
+/// holds for exactly this kind of replacement.
 #[test]
 fn cargo_target_link_replaces_a_managed_link_to_an_unwritable_dir() {
     let checkout = tempfile::tempdir().expect("checkout tempdir");
@@ -3303,16 +3314,11 @@ fn cargo_target_link_replaces_a_managed_link_to_an_unwritable_dir() {
     let (ok, out) = run_link(checkout.path(), btrfs.path());
 
     assert!(ok, "the recipe failed outright:\n{out}");
-    let target = checkout.path().join("target");
-    assert!(
-        !target.is_symlink(),
-        "target/ still links to the unwritable managed directory {}; the fallback \
-         warned and walked away\n{out}",
-        std::fs::read_link(&target)
-            .map(|l| l.display().to_string())
-            .unwrap_or_default()
+    assert_local_fallback_link(
+        checkout.path(),
+        btrfs.path(),
+        "managed link to an unwritable dir",
     );
-    assert_target_usable(checkout.path(), "managed link to an unwritable dir");
 }
 
 /// The write probe must happen INSIDE the generation lease, never before it.
@@ -3382,5 +3388,156 @@ fn cargo_target_link_does_not_touch_a_generation_it_has_not_leased() {
         before, after,
         "the generation directory was modified (mtime {before} -> {after}) while the \
          pruner held its lease: the write probe ran outside the lock"
+    );
+}
+
+/// A fallback the script created must not outlive the outage that caused it.
+///
+/// Codex on #867 (P2): with the volume unavailable and no target/ present, the
+/// fallback created a REAL target/ directory. The next run with the volume back
+/// took the pre-protocol branch, which retains any real target/ as unmanaged, so
+/// the checkout never returned to the btrfs cache and every later build landed
+/// on the root filesystem until the disk guard quarantined the runner. The
+/// fallback now lives behind a link to a checkout-local payload, which the
+/// recovered run replaces under the same lease as any other published link.
+/// Nothing enumerates that payload, so nothing reclaims it: it stays in place
+/// and its path is printed so a human can remove it.
+#[test]
+fn cargo_target_link_returns_to_btrfs_after_a_volume_outage() {
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let volume_parent = tempfile::tempdir().expect("volume parent");
+    let btrfs = volume_parent.path().join("fcvm-btrfs");
+    assert!(!btrfs.exists(), "precondition: the volume is not mounted");
+
+    let (ok, out) = run_link(checkout.path(), &btrfs);
+    assert!(ok, "run 1 (volume absent) failed:\n{out}");
+    assert_target_usable(checkout.path(), "run 1, volume absent");
+    let target = checkout.path().join("target");
+    let payload = std::fs::canonicalize(&target).expect("resolve the fallback payload");
+    std::fs::write(
+        target.join("built-during-outage"),
+        b"built while the volume was down",
+    )
+    .expect("write through target/ during the outage");
+
+    std::fs::create_dir_all(&btrfs).expect("the volume is mounted again");
+
+    let (ok, out) = run_link(checkout.path(), &btrfs);
+    assert!(ok, "run 2 (volume back) failed:\n{out}");
+    let link = std::fs::read_link(&target).unwrap_or_else(|error| {
+        panic!(
+            "run 2: target/ is not a symlink ({error}); the fallback the script created \
+             during the outage was retained as an unmanaged real target/, so this checkout \
+             never returns to the btrfs cache and every later build stays on the root \
+             filesystem:\n{out}"
+        )
+    });
+    assert!(
+        link.starts_with(btrfs.join("cargo-target")),
+        "run 2: target/ -> {link:?} is not under the recovered volume:\n{out}"
+    );
+    assert_target_usable(checkout.path(), "run 2, volume back");
+    assert_eq!(
+        std::fs::read(payload.join("built-during-outage")).unwrap_or_else(|error| panic!(
+            "the outage payload {payload:?} was destroyed: {error}"
+        )),
+        b"built while the volume was down",
+        "the outage payload was modified"
+    );
+    assert!(
+        !target.join("built-during-outage").exists(),
+        "the outage payload is still published through target/"
+    );
+    assert!(
+        out.contains(payload.to_str().expect("utf-8 payload path")),
+        "run 2 must print the orphaned payload path {payload:?} so a human can remove it:\n{out}"
+    );
+}
+
+/// A real target/ the script did not create is retained, volume or no volume.
+/// Its dentry may carry a mount that exists only in another mount namespace,
+/// and renaming or removing it could move or detach that mount; only the
+/// script's own fallback lives behind a replaceable link.
+#[test]
+fn cargo_target_link_retains_a_real_target_it_did_not_create() {
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let volume_parent = tempfile::tempdir().expect("volume parent");
+    let btrfs = volume_parent.path().join("fcvm-btrfs");
+    let target = checkout.path().join("target");
+    std::fs::create_dir(&target).expect("pre-existing real target/");
+    let artifact = target.join("pre-protocol-artifact");
+    std::fs::write(&artifact, b"not the script's to move").expect("write artifact");
+
+    for (volume_present, ctx) in [(false, "volume absent"), (true, "volume back")] {
+        if volume_present {
+            std::fs::create_dir_all(&btrfs).expect("mount the volume");
+        }
+        let (ok, out) = run_link(checkout.path(), &btrfs);
+        assert!(ok, "{ctx}: the recipe failed:\n{out}");
+        assert!(
+            std::fs::symlink_metadata(&target)
+                .expect("target/ must exist")
+                .file_type()
+                .is_dir(),
+            "{ctx}: a real target/ the script did not create was replaced by {:?}:\n{out}",
+            std::fs::read_link(&target)
+        );
+        if volume_present {
+            assert!(
+                out.contains("retaining unmanaged local target/"),
+                "{ctx}: retention must be stated:\n{out}"
+            );
+        }
+        assert_eq!(
+            std::fs::read(&artifact).expect("read the retained artifact"),
+            b"not the script's to move",
+            "{ctx}: the retained payload changed"
+        );
+        assert!(
+            !local_fallback_dir(checkout.path()).exists(),
+            "{ctx}: a fallback payload was created beside a retained real target/:\n{out}"
+        );
+        assert_target_usable(checkout.path(), ctx);
+    }
+}
+
+/// `--rotate` keeps refusing while the volume is down: the fallback link, and a
+/// fallback payload with no link over it, would both report a clean while the
+/// payload survives.
+#[test]
+fn cargo_target_link_rotate_refuses_the_local_fallback_while_the_volume_is_down() {
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let volume_parent = tempfile::tempdir().expect("volume parent");
+    let btrfs = volume_parent.path().join("fcvm-btrfs");
+    let (ok, out) = run_link(checkout.path(), &btrfs);
+    assert!(ok, "fallback failed:\n{out}");
+    let payload = assert_local_fallback_link(checkout.path(), &btrfs, "volume absent");
+    let target = checkout.path().join("target");
+    std::fs::write(target.join("artifact"), b"survives").expect("write through target/");
+
+    let (ok, out) = run_link_with(checkout.path(), &btrfs, &["--rotate"]);
+    assert!(
+        !ok && out.contains("refusing unsafe clean"),
+        "--rotate reported a clean it cannot perform on the fallback link:\n{out}"
+    );
+    assert_eq!(
+        std::fs::read_link(&target).expect("readlink"),
+        payload,
+        "a refused rotation must leave the fallback link in place"
+    );
+
+    std::fs::remove_file(&target).expect("unlink the fallback link");
+    let (ok, out) = run_link_with(checkout.path(), &btrfs, &["--rotate"]);
+    assert!(
+        !ok && out.contains("refusing unsafe clean"),
+        "--rotate republished a surviving fallback payload as a clean target/:\n{out}"
+    );
+    assert!(
+        std::fs::symlink_metadata(&target).is_err(),
+        "a refused rotation must not publish anything"
+    );
+    assert_eq!(
+        std::fs::read(payload.join("artifact")).expect("read the surviving payload"),
+        b"survives"
     );
 }

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -2728,61 +2728,9 @@ fn cargo_target_link_falls_back_when_the_existing_worktree_dir_is_unwritable() {
     // published and hides exactly the defect under test.
     let checkout = tempfile::tempdir().expect("checkout tempdir");
     let btrfs = tempfile::tempdir().expect("btrfs stand-in");
-
-    // The script's own naming: sanitized basename + sha256(pwd -P)[..8].
-    let p = std::fs::canonicalize(checkout.path()).expect("canonical checkout path");
-    let base: String = p
-        .file_name()
-        .unwrap()
-        .to_string_lossy()
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || "._-".contains(c) {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect();
-    let digest = {
-        use sha2::Digest;
-        hex::encode(sha2::Sha256::digest(p.to_string_lossy().as_bytes()))
-    };
-    let wt_target = btrfs
-        .path()
-        .join("cargo-target")
-        .join(format!("{base}-{}", &digest[..8]));
-    std::fs::create_dir_all(&wt_target).expect("pre-create the worktree dir");
-
-    let root = nix_geteuid_is_root();
-    if root {
-        let ok = Command::new("mount")
-            .args([
-                "--bind",
-                btrfs.path().to_str().unwrap(),
-                btrfs.path().to_str().unwrap(),
-            ])
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false)
-            && Command::new("mount")
-                .args(["-o", "remount,ro,bind", btrfs.path().to_str().unwrap()])
-                .status()
-                .map(|s| s.success())
-                .unwrap_or(false);
-        assert!(ok, "could not remount the btrfs stand-in read-only as root");
-    } else {
-        std::fs::set_permissions(&wt_target, std::fs::Permissions::from_mode(0o555))
-            .expect("chmod 0555 on the worktree dir");
-    }
+    let _wt = unwritable_managed_worktree_dir(checkout.path(), btrfs.path());
 
     let (ok, out) = run_link(checkout.path(), btrfs.path());
-
-    if root {
-        let _ = Command::new("umount").arg(btrfs.path()).status();
-    } else {
-        let _ = std::fs::set_permissions(&wt_target, std::fs::Permissions::from_mode(0o755));
-    }
 
     assert!(ok, "the recipe failed outright:\n{out}");
     let target = checkout.path().join("target");
@@ -2822,6 +2770,31 @@ fn managed_worktree_dir(checkout: &Path, btrfs_root: &Path) -> PathBuf {
         .join(format!("{base}-{}", &digest[..8]))
 }
 
+/// Make this checkout's managed worktree dir "exist but refuse writes" without
+/// any privilege: point it at procfs, where creating an entry is refused for
+/// root and non-root alike. `mkdir -p` on it succeeds (it exists), a lease fd
+/// opens, and the write probe inside the lease fails -- exactly the
+/// ownership-change / read-only-remount state, staged with a symlink.
+///
+/// Replaces an earlier fixture that chmod'ed as a user and bind-remounted
+/// read-only as root: as UID 0 WITHOUT CAP_SYS_ADMIN (an unprivileged
+/// container) the mount was refused and the test failed before reaching the
+/// script (Codex on #867).
+fn unwritable_managed_worktree_dir(checkout: &Path, btrfs_root: &Path) -> PathBuf {
+    let wt = managed_worktree_dir(checkout, btrfs_root);
+    std::fs::create_dir_all(wt.parent().unwrap()).expect("cargo-target parent");
+    std::os::unix::fs::symlink("/proc/self", &wt).expect("procfs-backed worktree dir");
+    assert!(
+        wt.is_dir(),
+        "the procfs stand-in does not resolve to a directory"
+    );
+    assert!(
+        std::fs::File::create(wt.join(".fcvm-fixture-probe")).is_err(),
+        "the procfs stand-in accepted a write; the fixture proves nothing"
+    );
+    wt
+}
+
 /// A managed symlink whose directory has become unwritable must be REPLACED.
 ///
 /// Codex on #867 (P2): with `target` already pointing at the managed directory,
@@ -2835,35 +2808,10 @@ fn managed_worktree_dir(checkout: &Path, btrfs_root: &Path) -> PathBuf {
 fn cargo_target_link_replaces_a_managed_link_to_an_unwritable_dir() {
     let checkout = tempfile::tempdir().expect("checkout tempdir");
     let btrfs = tempfile::tempdir().expect("btrfs stand-in");
-    let wt = managed_worktree_dir(checkout.path(), btrfs.path());
-    std::fs::create_dir_all(&wt).expect("managed dir");
+    let wt = unwritable_managed_worktree_dir(checkout.path(), btrfs.path());
     std::os::unix::fs::symlink(&wt, checkout.path().join("target")).expect("managed link");
 
-    let root = nix_geteuid_is_root();
-    if root {
-        let b = btrfs.path().to_str().unwrap();
-        let ok = Command::new("mount")
-            .args(["--bind", b, b])
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false)
-            && Command::new("mount")
-                .args(["-o", "remount,ro,bind", b])
-                .status()
-                .map(|s| s.success())
-                .unwrap_or(false);
-        assert!(ok, "could not remount the btrfs stand-in read-only as root");
-    } else {
-        std::fs::set_permissions(&wt, std::fs::Permissions::from_mode(0o555)).expect("chmod 0555");
-    }
-
     let (ok, out) = run_link(checkout.path(), btrfs.path());
-
-    if root {
-        let _ = Command::new("umount").arg(btrfs.path()).status();
-    } else {
-        let _ = std::fs::set_permissions(&wt, std::fs::Permissions::from_mode(0o755));
-    }
 
     assert!(ok, "the recipe failed outright:\n{out}");
     let target = checkout.path().join("target");

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -2980,38 +2980,39 @@ fn run_link_with(dir: &Path, btrfs_root: &Path, args: &[&str]) -> (bool, String)
     (out.status.success(), text)
 }
 
-/// The PUBLISHED generation that cannot be opened falls back too (codex on
-/// #867): `target/` already points at a managed generation, `[ -d target ]`
-/// still passes, and the pin-and-lease open `exec {old_target_lease_fd}<target`
-/// failed under `set -e` before the candidate-lease fallback existed. Same
-/// unprivileged stand-in as the candidate case.
+/// The PUBLISHED generation that cannot be opened FAILS CLOSED (codex on #867,
+/// reversing an earlier fallback). Without that generation's lease the script
+/// cannot know whether a Cargo wrapper still holds it shared, and a generation
+/// that lost only read permission (0333) is one Cargo can still create entries
+/// in; replacing `target/` under such a build would split it across two trees.
+/// Same unprivileged stand-in as the candidate case.
 #[test]
-fn cargo_target_link_falls_back_when_the_published_generation_cannot_be_opened() {
+fn cargo_target_link_refuses_to_replace_a_published_generation_it_cannot_lease() {
     use std::os::unix::fs::PermissionsExt as _;
     let checkout = tempfile::tempdir().expect("checkout tempdir");
     let btrfs = tempfile::tempdir().expect("btrfs stand-in");
     let wt = managed_worktree_dir(checkout.path(), btrfs.path());
     std::fs::create_dir_all(&wt).expect("published generation");
     std::os::unix::fs::symlink(&wt, checkout.path().join("target")).expect("published link");
-    std::fs::set_permissions(&wt, std::fs::Permissions::from_mode(0o000)).expect("chmod 000");
+    // Write and search, no read: Cargo can still create entries here, the
+    // lease open (O_RDONLY) cannot succeed.
+    std::fs::set_permissions(&wt, std::fs::Permissions::from_mode(0o333)).expect("chmod 333");
 
     let (ok, out) = run_link_unprivileged(checkout.path(), btrfs.path());
 
     let _ = std::fs::set_permissions(&wt, std::fs::Permissions::from_mode(0o755));
     assert!(
-        ok,
-        "the recipe died instead of falling back when the published generation cannot \
-         be opened:\n{out}"
+        !ok,
+        "the recipe replaced target/ under a published generation it could not lease:\n{out}"
+    );
+    assert!(
+        out.contains("refusing to replace target/"),
+        "the refusal must say why:\n{out}"
     );
     let target = checkout.path().join("target");
     assert!(
-        target.is_dir() && !target.is_symlink(),
-        "target/ should be a local directory after the fallback, not {:?}\n{out}",
-        std::fs::symlink_metadata(&target).map(|m| m.file_type())
-    );
-    assert_target_usable(
-        checkout.path(),
-        "published generation that cannot be opened",
+        target.is_symlink() && std::fs::read_link(&target).expect("readlink") == wt,
+        "target/ must be left pointing at the published generation\n{out}"
     );
 }
 

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -2883,6 +2883,86 @@ fn cargo_target_link_drops_a_managed_link_it_cannot_lease() {
     );
 }
 
+/// An existing `$WT_TARGET` that cannot be OPENED falls back too (codex on
+/// #867). Losing read permission as well as write (an ownership change that
+/// leaves a fresh checkout's directory 0700, say) passes `mkdir -p`, but the
+/// generation-lease open `exec {fd}<"$candidate"` fails, and under `set -e`
+/// the script died there instead of creating the promised local target/.
+/// Root can open any directory, so when the tests are root the script runs as
+/// uid 65534 through `setpriv`, from a copy of scripts/ that uid can read, over
+/// tempdirs handed to that uid.
+#[test]
+fn cargo_target_link_falls_back_when_the_managed_dir_cannot_be_opened() {
+    use std::os::unix::fs::PermissionsExt as _;
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let btrfs = tempfile::tempdir().expect("btrfs stand-in");
+    let wt = managed_worktree_dir(checkout.path(), btrfs.path());
+    std::fs::create_dir_all(&wt).expect("existing managed dir");
+    std::fs::set_permissions(&wt, std::fs::Permissions::from_mode(0o000)).expect("chmod 000");
+
+    let (ok, out) = run_link_unprivileged(checkout.path(), btrfs.path());
+
+    // Hand the directory back before asserting, so the tempdir can be removed.
+    let _ = std::fs::set_permissions(&wt, std::fs::Permissions::from_mode(0o755));
+    assert!(
+        ok,
+        "the recipe died instead of falling back when the managed dir cannot be \
+         opened:\n{out}"
+    );
+    let target = checkout.path().join("target");
+    assert!(
+        target.is_dir() && !target.is_symlink(),
+        "target/ should be a local directory after the fallback, not {:?}\n{out}",
+        std::fs::symlink_metadata(&target).map(|m| m.file_type())
+    );
+    assert_target_usable(checkout.path(), "managed dir that cannot be opened");
+}
+
+/// `run_link`, but as uid 65534 when the tests are root: root can open and
+/// write any directory, so a fixture about permissions must run as someone who
+/// cannot. Both tempdirs are handed to that uid, and scripts/ is copied where it
+/// can read them (the script sources cargo-target-lib.sh next to itself).
+fn run_link_unprivileged(dir: &Path, btrfs_root: &Path) -> (bool, String) {
+    use std::os::unix::fs::PermissionsExt as _;
+    if unsafe { libc::geteuid() } != 0 {
+        return run_link(dir, btrfs_root);
+    }
+    let tools = tempfile::tempdir().expect("tools tempdir");
+    std::fs::set_permissions(tools.path(), std::fs::Permissions::from_mode(0o755)).expect("0755");
+    let scripts = tools.path().join("scripts");
+    std::fs::create_dir(&scripts).expect("scripts dir");
+    for name in ["cargo-target-link.sh", "cargo-target-lib.sh"] {
+        std::fs::copy(repo_root().join("scripts").join(name), scripts.join(name)).expect(name);
+    }
+    std::fs::set_permissions(
+        scripts.join("cargo-target-link.sh"),
+        std::fs::Permissions::from_mode(0o755),
+    )
+    .expect("0755");
+    for owned in [dir, btrfs_root] {
+        let chowned = Command::new("chown")
+            .args(["-R", "65534:65534"])
+            .arg(owned)
+            .status()
+            .expect("chown -R");
+        assert!(chowned.success(), "hand {} to uid 65534", owned.display());
+    }
+    let out = Command::new("setpriv")
+        .args(["--reuid=65534", "--regid=65534", "--clear-groups"])
+        .arg(scripts.join("cargo-target-link.sh"))
+        .env("BTRFS_ROOT", btrfs_root)
+        .env_remove("CARGO_TARGET_LINK_LOCKED")
+        .current_dir(dir)
+        .output()
+        .expect("run scripts/cargo-target-link.sh as uid 65534");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (out.status.success(), text)
+}
+
 /// Every exit that leaves target/ as a plain local directory probes it first.
 ///
 /// Behavioural coverage above reaches two of the three exits; this pins all of

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -2963,6 +2963,113 @@ fn run_link_unprivileged(dir: &Path, btrfs_root: &Path) -> (bool, String) {
     (out.status.success(), text)
 }
 
+/// `run_link` with extra script arguments (`--rotate`).
+fn run_link_with(dir: &Path, btrfs_root: &Path, args: &[&str]) -> (bool, String) {
+    let out = Command::new(repo_root().join("scripts/cargo-target-link.sh"))
+        .args(args)
+        .env("BTRFS_ROOT", btrfs_root)
+        .env_remove("CARGO_TARGET_LINK_LOCKED")
+        .current_dir(dir)
+        .output()
+        .expect("run scripts/cargo-target-link.sh");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (out.status.success(), text)
+}
+
+/// The PUBLISHED generation that cannot be opened falls back too (codex on
+/// #867): `target/` already points at a managed generation, `[ -d target ]`
+/// still passes, and the pin-and-lease open `exec {old_target_lease_fd}<target`
+/// failed under `set -e` before the candidate-lease fallback existed. Same
+/// unprivileged stand-in as the candidate case.
+#[test]
+fn cargo_target_link_falls_back_when_the_published_generation_cannot_be_opened() {
+    use std::os::unix::fs::PermissionsExt as _;
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let btrfs = tempfile::tempdir().expect("btrfs stand-in");
+    let wt = managed_worktree_dir(checkout.path(), btrfs.path());
+    std::fs::create_dir_all(&wt).expect("published generation");
+    std::os::unix::fs::symlink(&wt, checkout.path().join("target")).expect("published link");
+    std::fs::set_permissions(&wt, std::fs::Permissions::from_mode(0o000)).expect("chmod 000");
+
+    let (ok, out) = run_link_unprivileged(checkout.path(), btrfs.path());
+
+    let _ = std::fs::set_permissions(&wt, std::fs::Permissions::from_mode(0o755));
+    assert!(
+        ok,
+        "the recipe died instead of falling back when the published generation cannot \
+         be opened:\n{out}"
+    );
+    let target = checkout.path().join("target");
+    assert!(
+        target.is_dir() && !target.is_symlink(),
+        "target/ should be a local directory after the fallback, not {:?}\n{out}",
+        std::fs::symlink_metadata(&target).map(|m| m.file_type())
+    );
+    assert_target_usable(
+        checkout.path(),
+        "published generation that cannot be opened",
+    );
+}
+
+/// `--rotate` must not report a clean it did not perform (codex on #867).
+///
+/// With an UNMANAGED `target/` link and a managed candidate that cannot be
+/// written, `fallback_to_local` used to retain the link and exit 0, so `make
+/// clean` reported success while the linked directory's payload survived. The
+/// unusable-volume branch already refused this; the fallback now does too.
+#[test]
+fn cargo_target_link_rotate_refuses_to_retain_an_unmanaged_link() {
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let btrfs = tempfile::tempdir().expect("btrfs stand-in");
+    let _wt = unwritable_managed_worktree_dir(checkout.path(), btrfs.path());
+    let elsewhere = tempfile::tempdir().expect("unmanaged payload dir");
+    let payload = elsewhere.path().join("payload");
+    std::fs::write(&payload, b"built artifacts").expect("payload");
+    std::os::unix::fs::symlink(elsewhere.path(), checkout.path().join("target"))
+        .expect("unmanaged link");
+
+    let (ok, out) = run_link_with(checkout.path(), btrfs.path(), &["--rotate"]);
+
+    assert!(
+        !ok,
+        "--rotate reported success while retaining an unmanaged target/ link whose \
+         payload it cannot rotate away:\n{out}"
+    );
+    assert!(
+        out.contains("refusing unsafe clean"),
+        "the refusal must say why:\n{out}"
+    );
+    assert!(
+        payload.exists(),
+        "a refused rotation must not delete the payload either"
+    );
+}
+
+/// A dangling UNMANAGED link is replaced on the fallback path, not tripped over
+/// (CodeRabbit on #867): `[ -e target ] || mkdir -p target` saw the dangling
+/// link as absent, and `mkdir -p` then failed with EEXIST under `set -e`,
+/// before the diagnostic that follows it.
+#[test]
+fn cargo_target_link_replaces_a_dangling_unmanaged_link_on_fallback() {
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let btrfs = tempfile::tempdir().expect("btrfs stand-in");
+    let _wt = unwritable_managed_worktree_dir(checkout.path(), btrfs.path());
+    std::os::unix::fs::symlink("/nonexistent/elsewhere", checkout.path().join("target"))
+        .expect("dangling unmanaged link");
+
+    let (ok, out) = run_link(checkout.path(), btrfs.path());
+
+    assert!(
+        ok,
+        "the recipe died on a dangling unmanaged target/ link instead of replacing it:\n{out}"
+    );
+    assert_target_usable(checkout.path(), "dangling unmanaged link replaced");
+}
+
 /// Every exit that leaves target/ as a plain local directory probes it first.
 ///
 /// Behavioural coverage above reaches two of the three exits; this pins all of


### PR DESCRIPTION
Weekly's `container-bench` has been red every week since 2026-08-10 (last green 2026-08-03; `scripts/cargo-target-link.sh` landed 2026-08-09):

```
mkdir: cannot create directory '/mnt/fcvm-btrfs/cargo-target': Permission denied
ERROR: cannot create /mnt/fcvm-btrfs/cargo-target/fcvm-1602bce1
make: *** [Makefile:337: cargo-target-link] Error 1
```

## Cause

The job runs on `ubuntu-latest`, where `/mnt/fcvm-btrfs` does not exist. `CONTAINER_RUN_BASE` bind-mounts it regardless, and podman creates the missing source as an empty root-owned directory to satisfy the mount. Inside the container the volume passes `-d`, so the script took the managed branch and died on `mkdir`, before reaching its own "retaining unmanaged local target/" exit that would have kept the checkout's bind-mounted `target/`.

## What changed, by commit

1. `8040074f` "Is a directory" is not "is usable": try the `mkdir` and let its outcome decide. A volume that exists but cannot be written falls back to the local `target/`, loudly. `-w` would not do: root passes `access(W_OK)` on directories it still cannot create in (procfs, read-only mounts), and this script runs as root under `test-root`.
2. `9cb530fc` Probe an EXISTING managed directory by creating inside it (`mktemp -p`), not by `mkdir -p`, which is a no-op on an existing directory and so proves nothing about writability.
3. `2a4201e2` Run that probe under the generation lease, not before it: an entry that appears after the pruner's census or vanishes during its rewalk is the race the pruner cannot tolerate (raised in review). A managed `target/` link pointing at a directory that cannot be written is replaced by a local `target/` instead of being kept.
4. `63f8b3d5` Stage "unwritable" in tests with a symlink to `/proc/self` for every uid: a mount-based fixture fails as uid 0 without `CAP_SYS_ADMIN` (raised in review), and mode bits cannot stop root.
5. `6ae47ade` One probe, `require_writable_local_target` (mkdir if absent, `-d`, then `mktemp` inside), at every exit that leaves `target/` as a plain local directory: `fallback_to_local`, the unmanaged-target retention, and the script's fall-through end. Before it, those exits ended on a `-d` test, so a `target/` nothing could write was reported as a successful fallback and cargo failed several steps later (raised in review).
6. `55892ace` A managed `target/` link is dropped, never probed through, on the unusable-volume path, which holds no lease on the generation it points at (a rotated `.generation-*` directory can outlive the canonical path the pruner removed). Creating and removing a probe file inside an unleased generation is the census/rewalk race the lease protocol exists to prevent, and an unwritable generation turned into exit 1 instead of a local fallback (raised in review). `drop_managed_link` is shared with `fallback_to_local`; the generation itself is left for the pruner.
7. `2747c0a2` An existing `$WT_TARGET` that cannot be opened (read permission lost as well as write) passes `mkdir -p` but failed the generation-lease `exec {fd}<`, and `set -e` ended the script there instead of falling back (raised in review). Every lease open now falls back to the local `target/` on failure.
8. `ad3b8056` The published-generation lease open falls back the same way; `--rotate` refuses to retain an unmanaged link or directory on the fallback path instead of reporting a clean it did not perform; a dangling unmanaged link is replaced before `mkdir -p` rather than tripping `set -e` (raised in review).
9. `0d5fb58b` The candidate write probe runs after the retirement check, only when the candidate is reused. A retired generation that had gone read-only used to fall back to a local `target/` that every later run then retained; it now rotates to a fresh generation (raised in review).
10. `c486e99c` An unleasable PUBLISHED generation fails closed instead of falling back, reversing part of commit 8. Without its lease the script cannot know whether a Cargo wrapper still holds it shared, and a generation that lost only read permission (0333) is one Cargo can still create entries in; replacing `target/` under such a build would split it across two trees (raised in review).
11. `506e1eb8` On the unusable-volume path, `drop_managed_link` leases the published generation exclusively before unlinking `target/` (blocking while a Cargo wrapper holds it shared; refusing when it cannot be opened), so a running build cannot be split across the managed and local trees (raised in review).
12. This head: comments only. The fallback region's 52 comment lines are 18, each an invariant to preserve; dates, PR numbers and history removed; code outside comments byte-identical (raised in review).

## Test evidence

`tests/test_cargo_target_link.rs`, each written first and watched failing:

- `cargo_target_link_keeps_a_bind_mounted_target_when_btrfs_is_unwritable`: CI's exact message against the script from main; passes with the fix.
- `cargo_target_link_falls_back_when_the_existing_worktree_dir_is_unwritable`: an existing managed directory that cannot be written (procfs) is not linked to.
- `cargo_target_link_replaces_a_managed_link_to_an_unwritable_dir`: a published link to such a directory is replaced by a local `target/`.
- `cargo_target_link_does_not_touch_a_generation_it_has_not_leased`: the test holds the generation's lease; the script blocks (exit 124 under `timeout 4`) and the directory's mtime is unchanged.
- `cargo_target_link_refuses_an_unwritable_local_target_when_btrfs_is_unusable`, `cargo_target_link_refuses_an_unwritable_local_target_on_managed_fallback`: a local `target/` pointing at `/proc/self` gets exit 1 and `target/ is a directory nothing can write`; both got exit 0 from the previous head.
- `cargo_target_link_waits_for_a_shared_holder_before_dropping_a_managed_link`: a shared holder on the published generation; the previous head dropped the link at once (exit 0), this head blocks (exit 124 under `timeout 4`) with the link intact.
- `cargo_target_link_drops_a_managed_link_it_cannot_lease`: `$WT_TARGET` a dangling symlink (so `mkdir -p` fails for every uid), `target/` pointing at a retained generation with its mtime pinned; the previous head exited 0 with the link in place and the generation's mtime changed by the probe. Now the link is gone, `target/` is a writable local directory, and the mtime is unchanged.
- `cargo_target_link_falls_back_when_the_managed_dir_cannot_be_opened`: `$WT_TARGET` exists with mode 0000; the previous head exited non-zero with no `target/`. As root the test runs the script as uid 65534 through `setpriv` (root can open any directory).
- `cargo_target_link_refuses_to_replace_a_published_generation_it_cannot_lease`: a published generation with mode 0333; commit 8's script replaced the link with a local directory, this head refuses and leaves the link. `cargo_target_link_rotate_refuses_to_retain_an_unmanaged_link`, `cargo_target_link_replaces_a_dangling_unmanaged_link_on_fallback`: each exited the wrong way before commit 8 (0 with a retained payload, non-zero at EEXIST).
- `cargo_target_link_rotates_a_retired_generation_it_cannot_write`: a retired (`user.fcvm.retired=v1`) generation with mode 0555; the previous head replaced the link with a local directory, this one publishes a fresh managed generation.
- `every_local_target_exit_probes_writability_first`: every `exit 0` in the script has the probe among its three preceding statements and the script ends on the probe; the retained-real-directory exit is pinned this way because as uid 0 it needs a mount or `chattr +i`, and overlayfs in the container lane refuses the flag.

44 tests pass; `make lint` (shellcheck, fmt, clippy `-D warnings`, cargo-deny) clean.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd


## Local fallback behind a link (9ebed542)

A run with the btrfs volume absent used to create a real `target/`, which every later run retained as unmanaged, so the checkout never returned to the cache (this is the state a runner is in after a reboot without the remount). The fallback payload now lives at `$checkout/.cargo-target-local` and `target/` is a symlink to it, published and leased like a managed generation; a run with the volume back replaces the link atomically and names the orphaned payload in a WARNING (the pruner does not enumerate it, and no real dentry is renamed or removed). A pre-existing real `target/` is still retained; `--rotate` still refuses while the volume is down. Tests: `cargo_target_link_returns_to_btrfs_after_a_volume_outage` (red on c4bce833), `cargo_target_link_retains_a_real_target_it_did_not_create`, `cargo_target_link_rotate_refuses_the_local_fallback_while_the_volume_is_down`; 47 user / 52 root.
