### PR TITLE
Open the hugepage pool lock read-only and create it atomically, at every site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1244,22 +1244,22 @@ HUGEPAGE_POOL_TEST := 1200
 
 bench-hugepages: build setup-default
 	@echo "==> Allocating hugepage pool ($(HUGEPAGE_POOL_FULL) pages = $$(( $(HUGEPAGE_POOL_FULL) * 2 ))MB)..."
-	sudo sh -c 'echo $(HUGEPAGE_POOL_FULL) > /proc/sys/vm/nr_hugepages'
+	scripts/hugepage-pool-lock.sh sudo sh -c 'echo $(HUGEPAGE_POOL_FULL) > /proc/sys/vm/nr_hugepages'
 	@echo "==> Running hugepages benchmark (full)..."
 	TMPDIR=/mnt/fcvm-btrfs/tmp $(CARGO) bench --bench hugepages; \
 	RC=$$?; \
 	echo "==> Releasing hugepage pool..."; \
-	sudo sh -c 'echo 0 > /proc/sys/vm/nr_hugepages'; \
+	scripts/hugepage-pool-lock.sh sudo sh -c 'echo 0 > /proc/sys/vm/nr_hugepages'; \
 	exit $$RC
 
 bench-hugepages-test: build setup-default
 	@echo "==> Allocating hugepage pool ($(HUGEPAGE_POOL_TEST) pages = $$(( $(HUGEPAGE_POOL_TEST) * 2 ))MB)..."
-	sudo sh -c 'echo $(HUGEPAGE_POOL_TEST) > /proc/sys/vm/nr_hugepages'
+	scripts/hugepage-pool-lock.sh sudo sh -c 'echo $(HUGEPAGE_POOL_TEST) > /proc/sys/vm/nr_hugepages'
 	@echo "==> Running hugepages benchmark (test)..."
 	TMPDIR=/mnt/fcvm-btrfs/tmp $(CARGO) bench --bench hugepages -- --test; \
 	RC=$$?; \
 	echo "==> Releasing hugepage pool..."; \
-	sudo sh -c 'echo 0 > /proc/sys/vm/nr_hugepages'; \
+	scripts/hugepage-pool-lock.sh sudo sh -c 'echo 0 > /proc/sys/vm/nr_hugepages'; \
 	exit $$RC
 
 bench-container-import: build setup-default

--- a/Makefile
+++ b/Makefile
@@ -646,7 +646,11 @@ setup-hugepages:
 	else \
 		echo "==> Allocating hugepage pool ($(HUGEPAGE_POOL_TESTS) pages = $$(( $(HUGEPAGE_POOL_TESTS) * 2 ))MB)..."; \
 		sudo mkdir -p /mnt/fcvm-btrfs 2>/dev/null || true; \
-		sudo sh -c 'touch /mnt/fcvm-btrfs/hugepage-pool.lock && chmod 666 /mnt/fcvm-btrfs/hugepage-pool.lock'; \
+		# chown to the invoker: a root-owned 666 file in a sticky world-writable
+		# directory is exactly what fs.protected_regular refuses to open for
+		# anyone else, so the unprivileged flock below fails with EACCES on
+		# every run after the first. Same treatment check-disk gives ~/.cargo.
+		sudo sh -c "touch /mnt/fcvm-btrfs/hugepage-pool.lock && chmod 666 /mnt/fcvm-btrfs/hugepage-pool.lock && chown $$(id -u):$$(id -g) /mnt/fcvm-btrfs/hugepage-pool.lock"; \
 		flock -x -w 60 /mnt/fcvm-btrfs/hugepage-pool.lock \
 			sudo sh -c 'echo $(HUGEPAGE_POOL_TESTS) > /proc/sys/vm/nr_hugepages'; \
 	fi
@@ -1007,7 +1011,11 @@ FAULT_POOL ?= 4096
 bench-chromium-fault: build setup-default
 	@test -n "$(FAULT_OUT)" || (echo "ERROR: FAULT_OUT required (results directory)"; exit 1)
 	@if ls -d /mnt/fcvm-btrfs/snapshots/cb-golden-huge* >/dev/null 2>&1; then \
-		sudo sh -c 'touch /mnt/fcvm-btrfs/hugepage-pool.lock && chmod 666 /mnt/fcvm-btrfs/hugepage-pool.lock'; \
+		# chown to the invoker: a root-owned 666 file in a sticky world-writable
+		# directory is exactly what fs.protected_regular refuses to open for
+		# anyone else, so the unprivileged flock below fails with EACCES on
+		# every run after the first. Same treatment check-disk gives ~/.cargo.
+		sudo sh -c "touch /mnt/fcvm-btrfs/hugepage-pool.lock && chmod 666 /mnt/fcvm-btrfs/hugepage-pool.lock && chown $$(id -u):$$(id -g) /mnt/fcvm-btrfs/hugepage-pool.lock"; \
 		flock -x -w 60 /mnt/fcvm-btrfs/hugepage-pool.lock sh -c ' \
 			current=$$(cat /proc/sys/vm/nr_hugepages 2>/dev/null || echo 0); \
 			if [ "$$current" -lt "$(FAULT_POOL)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -639,22 +639,24 @@ setup-pjdfstest:
 
 # Hugepage pool for privileged tests (512 pages = 1GB, enough for 512MB test VMs)
 HUGEPAGE_POOL_TESTS := 512
-# The pool lock is chowned to the invoker: a root-owned 666 file in a sticky
-# world-writable directory is exactly what fs.protected_regular refuses to
-# open for anyone else, so the unprivileged flock that follows fails with
-# EACCES on every run after the first. Same treatment check-disk gives
-# ~/.cargo. (Keep this comment HERE: a `#` line inside the continued recipe
-# below is shell text and eats the trailing backslash -- that is how #868's
-# first revision produced `syntax error: unexpected end of file`.)
+# The pool lock is a DIRECTORY, shared with bench-chromium-fault and
+# bench/chromium/reqbench.sh. A lock FILE created here by root under the
+# invoker's sticky data root is refused by fs.protected_regular on the next
+# unprivileged O_CREAT open (util-linux `flock <path>` and bash `<>` both use
+# it), and chowning it to each invoker races between two users. `mkdir -p` is
+# idempotent for any creator, and a 0755 directory opens read-only for any
+# user with no O_CREAT and no ownership, so nothing privileged ever changes
+# its metadata. (Keep this comment HERE: a `#` line inside the continued
+# recipe below is shell text and eats the trailing backslash -- that is how
+# #868's first revision produced `syntax error: unexpected end of file`.)
 setup-hugepages:
 	@current=$$(cat /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages 2>/dev/null || echo 0); \
 	if [ "$$current" -ge "$(HUGEPAGE_POOL_TESTS)" ]; then \
 		echo "==> Hugepages already allocated: $$current (need $(HUGEPAGE_POOL_TESTS))"; \
 	else \
 		echo "==> Allocating hugepage pool ($(HUGEPAGE_POOL_TESTS) pages = $$(( $(HUGEPAGE_POOL_TESTS) * 2 ))MB)..."; \
-		sudo mkdir -p /mnt/fcvm-btrfs 2>/dev/null || true; \
-		sudo sh -c "touch /mnt/fcvm-btrfs/hugepage-pool.lock && chmod 666 /mnt/fcvm-btrfs/hugepage-pool.lock && chown $$(id -u):$$(id -g) /mnt/fcvm-btrfs/hugepage-pool.lock"; \
-		flock -x -w 60 /mnt/fcvm-btrfs/hugepage-pool.lock \
+		sudo mkdir -p -m 755 /mnt/fcvm-btrfs/hugepage-pool.lock.d; \
+		flock -x -w 60 /mnt/fcvm-btrfs/hugepage-pool.lock.d \
 			sudo sh -c 'echo $(HUGEPAGE_POOL_TESTS) > /proc/sys/vm/nr_hugepages'; \
 	fi
 
@@ -1014,8 +1016,8 @@ FAULT_POOL ?= 4096
 bench-chromium-fault: build setup-default
 	@test -n "$(FAULT_OUT)" || (echo "ERROR: FAULT_OUT required (results directory)"; exit 1)
 	@if ls -d /mnt/fcvm-btrfs/snapshots/cb-golden-huge* >/dev/null 2>&1; then \
-		sudo sh -c "touch /mnt/fcvm-btrfs/hugepage-pool.lock && chmod 666 /mnt/fcvm-btrfs/hugepage-pool.lock && chown $$(id -u):$$(id -g) /mnt/fcvm-btrfs/hugepage-pool.lock"; \
-		flock -x -w 60 /mnt/fcvm-btrfs/hugepage-pool.lock sh -c ' \
+		sudo mkdir -p -m 755 /mnt/fcvm-btrfs/hugepage-pool.lock.d; \
+		flock -x -w 60 /mnt/fcvm-btrfs/hugepage-pool.lock.d sh -c ' \
 			current=$$(cat /proc/sys/vm/nr_hugepages 2>/dev/null || echo 0); \
 			if [ "$$current" -lt "$(FAULT_POOL)" ]; then \
 				echo "==> Growing hugepage pool $$current -> $(FAULT_POOL) for the huge cells..."; \

--- a/Makefile
+++ b/Makefile
@@ -639,24 +639,23 @@ setup-pjdfstest:
 
 # Hugepage pool for privileged tests (512 pages = 1GB, enough for 512MB test VMs)
 HUGEPAGE_POOL_TESTS := 512
-# The pool lock is a DIRECTORY, shared with bench-chromium-fault and
-# bench/chromium/reqbench.sh. A lock FILE created here by root under the
-# invoker's sticky data root is refused by fs.protected_regular on the next
-# unprivileged O_CREAT open (util-linux `flock <path>` and bash `<>` both use
-# it), and chowning it to each invoker races between two users. `mkdir -p` is
-# idempotent for any creator, and a 0755 directory opens read-only for any
-# user with no O_CREAT and no ownership, so nothing privileged ever changes
-# its metadata. (Keep this comment HERE: a `#` line inside the continued
-# recipe below is shell text and eats the trailing backslash -- that is how
-# #868's first revision produced `syntax error: unexpected end of file`.)
+# The pool lock (/mnt/fcvm-btrfs/hugepage-pool.lock) is shared with
+# bench-chromium-fault and bench/chromium/reqbench.sh, and taken through
+# scripts/hugepage-pool-lock.sh, which opens it read-only (never O_CREAT, so
+# fs.protected_regular cannot refuse it whoever owns it) and creates it
+# atomically when absent. Do not touch, chmod, or chown the lock here: a
+# root-created file with a `flock <path>` open behind it is how every
+# unprivileged run after the first died with "Permission denied". (Keep this
+# comment HERE: a `#` line inside the continued recipe below is shell text
+# and eats the trailing backslash -- that is how #868's first revision
+# produced `syntax error: unexpected end of file`.)
 setup-hugepages:
 	@current=$$(cat /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages 2>/dev/null || echo 0); \
 	if [ "$$current" -ge "$(HUGEPAGE_POOL_TESTS)" ]; then \
 		echo "==> Hugepages already allocated: $$current (need $(HUGEPAGE_POOL_TESTS))"; \
 	else \
 		echo "==> Allocating hugepage pool ($(HUGEPAGE_POOL_TESTS) pages = $$(( $(HUGEPAGE_POOL_TESTS) * 2 ))MB)..."; \
-		sudo mkdir -p -m 755 /mnt/fcvm-btrfs/hugepage-pool.lock.d; \
-		flock -x -w 60 /mnt/fcvm-btrfs/hugepage-pool.lock.d \
+		scripts/hugepage-pool-lock.sh \
 			sudo sh -c 'echo $(HUGEPAGE_POOL_TESTS) > /proc/sys/vm/nr_hugepages'; \
 	fi
 
@@ -1016,8 +1015,7 @@ FAULT_POOL ?= 4096
 bench-chromium-fault: build setup-default
 	@test -n "$(FAULT_OUT)" || (echo "ERROR: FAULT_OUT required (results directory)"; exit 1)
 	@if ls -d /mnt/fcvm-btrfs/snapshots/cb-golden-huge* >/dev/null 2>&1; then \
-		sudo mkdir -p -m 755 /mnt/fcvm-btrfs/hugepage-pool.lock.d; \
-		flock -x -w 60 /mnt/fcvm-btrfs/hugepage-pool.lock.d sh -c ' \
+		scripts/hugepage-pool-lock.sh sh -c ' \
 			current=$$(cat /proc/sys/vm/nr_hugepages 2>/dev/null || echo 0); \
 			if [ "$$current" -lt "$(FAULT_POOL)" ]; then \
 				echo "==> Growing hugepage pool $$current -> $(FAULT_POOL) for the huge cells..."; \

--- a/Makefile
+++ b/Makefile
@@ -639,6 +639,13 @@ setup-pjdfstest:
 
 # Hugepage pool for privileged tests (512 pages = 1GB, enough for 512MB test VMs)
 HUGEPAGE_POOL_TESTS := 512
+# The pool lock is chowned to the invoker: a root-owned 666 file in a sticky
+# world-writable directory is exactly what fs.protected_regular refuses to
+# open for anyone else, so the unprivileged flock that follows fails with
+# EACCES on every run after the first. Same treatment check-disk gives
+# ~/.cargo. (Keep this comment HERE: a `#` line inside the continued recipe
+# below is shell text and eats the trailing backslash -- that is how #868's
+# first revision produced `syntax error: unexpected end of file`.)
 setup-hugepages:
 	@current=$$(cat /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages 2>/dev/null || echo 0); \
 	if [ "$$current" -ge "$(HUGEPAGE_POOL_TESTS)" ]; then \
@@ -646,10 +653,6 @@ setup-hugepages:
 	else \
 		echo "==> Allocating hugepage pool ($(HUGEPAGE_POOL_TESTS) pages = $$(( $(HUGEPAGE_POOL_TESTS) * 2 ))MB)..."; \
 		sudo mkdir -p /mnt/fcvm-btrfs 2>/dev/null || true; \
-		# chown to the invoker: a root-owned 666 file in a sticky world-writable
-		# directory is exactly what fs.protected_regular refuses to open for
-		# anyone else, so the unprivileged flock below fails with EACCES on
-		# every run after the first. Same treatment check-disk gives ~/.cargo.
 		sudo sh -c "touch /mnt/fcvm-btrfs/hugepage-pool.lock && chmod 666 /mnt/fcvm-btrfs/hugepage-pool.lock && chown $$(id -u):$$(id -g) /mnt/fcvm-btrfs/hugepage-pool.lock"; \
 		flock -x -w 60 /mnt/fcvm-btrfs/hugepage-pool.lock \
 			sudo sh -c 'echo $(HUGEPAGE_POOL_TESTS) > /proc/sys/vm/nr_hugepages'; \
@@ -1011,10 +1014,6 @@ FAULT_POOL ?= 4096
 bench-chromium-fault: build setup-default
 	@test -n "$(FAULT_OUT)" || (echo "ERROR: FAULT_OUT required (results directory)"; exit 1)
 	@if ls -d /mnt/fcvm-btrfs/snapshots/cb-golden-huge* >/dev/null 2>&1; then \
-		# chown to the invoker: a root-owned 666 file in a sticky world-writable
-		# directory is exactly what fs.protected_regular refuses to open for
-		# anyone else, so the unprivileged flock below fails with EACCES on
-		# every run after the first. Same treatment check-disk gives ~/.cargo.
 		sudo sh -c "touch /mnt/fcvm-btrfs/hugepage-pool.lock && chmod 666 /mnt/fcvm-btrfs/hugepage-pool.lock && chown $$(id -u):$$(id -g) /mnt/fcvm-btrfs/hugepage-pool.lock"; \
 		flock -x -w 60 /mnt/fcvm-btrfs/hugepage-pool.lock sh -c ' \
 			current=$$(cat /proc/sys/vm/nr_hugepages 2>/dev/null || echo 0); \

--- a/bench/chromium/bench.sh
+++ b/bench/chromium/bench.sh
@@ -208,7 +208,7 @@ cleanup() {
     cg_cleanup_all
     if [ "$HUGE_CHANGED" = 1 ]; then
         log "restoring nr_hugepages=$ORIG_HUGEPAGES"
-        sudo -n sh -c "echo $ORIG_HUGEPAGES > /proc/sys/vm/nr_hugepages" || true
+        "$REPO_ROOT/scripts/hugepage-pool-lock.sh" sudo -n sh -c "echo $ORIG_HUGEPAGES > /proc/sys/vm/nr_hugepages" || true
     fi
 }
 trap cleanup EXIT
@@ -567,7 +567,7 @@ phase0() {
     if sudo -n true 2>/dev/null; then
         local cur; cur=$(cat /proc/sys/vm/nr_hugepages)
         if [ "$cur" -lt "$HUGEPAGE_POOL" ]; then
-            sudo sh -c "echo $HUGEPAGE_POOL > /proc/sys/vm/nr_hugepages"
+            "$REPO_ROOT/scripts/hugepage-pool-lock.sh" sudo sh -c "echo $HUGEPAGE_POOL > /proc/sys/vm/nr_hugepages"
             HUGE_CHANGED=1
             cur=$(cat /proc/sys/vm/nr_hugepages)
         fi

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -1023,14 +1023,22 @@ ensure_hugepage_pool() {
     # EXCLUSIVE and atomically downgrades. Bounded waits fail closed rather
     # than hanging behind a stuck owner.
     local wait_s="${HUGEPAGE_POOL_LOCK_WAIT:-60}"
-    # A DIRECTORY, not a file (PR #868): mkdir -p is idempotent for any
-    # creator, and a 0755 directory opens read-only for any user with no
-    # O_CREAT and no ownership, so who created it never matters. A lock FILE
-    # created by root (make setup-hugepages) under a sticky user-owned data
-    # root is refused by fs.protected_regular on the next unprivileged
-    # O_CREAT open, which is what `<>` and util-linux `flock <path>` do.
-    local pool_lock="$DATA_ROOT/hugepage-pool.lock.d"
-    mkdir -p -m 755 "$pool_lock" 2>/dev/null || true
+    # Opened READ-ONLY, never with O_CREAT (PR #868): fs.protected_regular
+    # refuses an O_CREAT open of a file owned by someone else in a sticky
+    # world-writable directory, which is what `<>` did against the lock a
+    # root `make setup-hugepages` had created. flock(2) does not care about
+    # the open mode. Created atomically when absent (a hard link fails if
+    # the name exists), so concurrent creators agree on one inode; same
+    # mechanism as scripts/hugepage-pool-lock.sh, which the recipes use.
+    local pool_lock="$DATA_ROOT/hugepage-pool.lock"
+    mkdir -p "$DATA_ROOT" 2>/dev/null || true
+    if [ ! -e "$pool_lock" ]; then
+        local tmp
+        if tmp="$(mktemp -u "$pool_lock.XXXXXX" 2>/dev/null)"; then
+            { install -m 644 /dev/null "$tmp" && ln "$tmp" "$pool_lock"; } 2>/dev/null || true
+            rm -f "$tmp"
+        fi
+    fi
     if [ -z "${REQBENCH_POOL_LOCK_FD:-}" ]; then
         exec {REQBENCH_POOL_LOCK_FD}<"$pool_lock" || true
     fi

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -1039,11 +1039,36 @@ ensure_hugepage_pool() {
             rm -f "$tmp"
         fi
     fi
+    # The entry is checked before AND after opening (codex + CodeRabbit on
+    # #868): a symlink, a non-regular file, or a file owned by anyone but
+    # root, this user, or the data root's owner is refused, since its owner
+    # could repoint or recreate it under a holder and a later caller would
+    # lock a different inode. After the open, the descriptor's inode must be
+    # the path's own (lstat) inode.
+    if [ -L "$pool_lock" ]; then
+        log "hugepages: $pool_lock is a symlink (owner uid $(stat -c %u "$pool_lock")); refusing to lock through a path another user can repoint"
+        return 1
+    fi
+    if [ ! -f "$pool_lock" ]; then
+        log "hugepages: pool lock unavailable at $pool_lock (not a regular file)"
+        return 1
+    fi
+    local lock_owner root_owner
+    lock_owner="$(stat -c %u "$pool_lock")"
+    root_owner="$(stat -c %u "$DATA_ROOT")"
+    case "$lock_owner" in
+        0|"$(id -u)"|"$root_owner") ;;
+        *) log "hugepages: $pool_lock is owned by uid $lock_owner, who can recreate it under a holder; refusing"; return 1 ;;
+    esac
     if [ -z "${REQBENCH_POOL_LOCK_FD:-}" ]; then
         exec {REQBENCH_POOL_LOCK_FD}<"$pool_lock" || true
     fi
     if [ -z "${REQBENCH_POOL_LOCK_FD:-}" ]; then
         log "hugepages: pool lock unavailable at $pool_lock"
+        return 1
+    fi
+    if [ "$(stat -c %d:%i "$pool_lock")" != "$(stat -Lc %d:%i "/proc/$$/fd/$REQBENCH_POOL_LOCK_FD")" ]; then
+        log "hugepages: $pool_lock was replaced between check and open; refusing"
         return 1
     fi
     if ! flock -s -w "$wait_s" "$REQBENCH_POOL_LOCK_FD"; then

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -1023,11 +1023,16 @@ ensure_hugepage_pool() {
     # EXCLUSIVE and atomically downgrades. Bounded waits fail closed rather
     # than hanging behind a stuck owner.
     local wait_s="${HUGEPAGE_POOL_LOCK_WAIT:-60}"
-    local pool_lock="$DATA_ROOT/hugepage-pool.lock"
-    mkdir -p "$DATA_ROOT" 2>/dev/null || true
-    touch "$pool_lock" 2>/dev/null || true
+    # A DIRECTORY, not a file (PR #868): mkdir -p is idempotent for any
+    # creator, and a 0755 directory opens read-only for any user with no
+    # O_CREAT and no ownership, so who created it never matters. A lock FILE
+    # created by root (make setup-hugepages) under a sticky user-owned data
+    # root is refused by fs.protected_regular on the next unprivileged
+    # O_CREAT open, which is what `<>` and util-linux `flock <path>` do.
+    local pool_lock="$DATA_ROOT/hugepage-pool.lock.d"
+    mkdir -p -m 755 "$pool_lock" 2>/dev/null || true
     if [ -z "${REQBENCH_POOL_LOCK_FD:-}" ]; then
-        exec {REQBENCH_POOL_LOCK_FD}<>"$pool_lock" || true
+        exec {REQBENCH_POOL_LOCK_FD}<"$pool_lock" || true
     fi
     if [ -z "${REQBENCH_POOL_LOCK_FD:-}" ]; then
         log "hugepages: pool lock unavailable at $pool_lock"

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -6060,19 +6060,16 @@ class MakefileBenchGraph(unittest.TestCase):
         # And the grow must hold the cross-harness pool lock (codex P1,
         # PR #815): the pool is host-global and reqbench/faultbench/bench.sh
         # all write it.
-        self.assertIn("hugepage-pool.lock.d", recipe,
-                      "fault recipe must serialize on the shared pool lock DIRECTORY")
-        # The lock is a directory (PR #868): creatable with sudo when the data
-        # root is root-owned (fresh boxes, CodeRabbit round 2 on PR #815), and
-        # openable by any user afterwards because a 0755 directory needs no
-        # O_CREAT and no ownership to open read-only. A lock FILE created by
-        # root under the invoker's sticky data root is refused by
-        # fs.protected_regular on the next unprivileged open, and chowning it
-        # to each invoker races between two users.
-        self.assertRegex(recipe, r"sudo[^\n]*mkdir -p -m 755[^\n]*hugepage-pool\.lock\.d",
-                         "fault recipe must sudo-mkdir the pool lock directory")
+        self.assertIn("scripts/hugepage-pool-lock.sh", recipe,
+                      "fault recipe must take the shared pool lock through the helper")
+        # The helper (PR #868) opens the lock READ-ONLY, never with O_CREAT,
+        # and creates it atomically when absent (sudo when the data root is
+        # root-owned: fresh boxes, CodeRabbit round 2 on PR #815). A recipe
+        # that touches, chowns, or chmods the lock itself is the bug coming
+        # back: a root-created file is refused by fs.protected_regular on the
+        # next unprivileged O_CREAT open, and a chown races between users.
         self.assertNotRegex(recipe, r"(touch|chown|chmod)[^\n]*hugepage-pool\.lock",
-                            "fault recipe must not create, chown, or chmod a lock FILE")
+                            "fault recipe must not create, chown, or chmod the lock")
 
     def test_run_help_documents_tag(self):
         # Following the documented huge flow without TAG= on the run line
@@ -6269,7 +6266,7 @@ class SnapshotLockHeldAcrossRun(unittest.TestCase):
     def test_pool_lease_held_shared_through_phase(self):
         r, _ = self._bash(
             'mkdir -p "$RESULTS/logs"; '
-            'probe() { flock -x -n "$DATA_ROOT/hugepage-pool.lock.d" true '
+            'probe() { flock -x -n "$DATA_ROOT/hugepage-pool.lock" true '
             '  && echo POOL-FREE || echo POOL-HELD; }; '
             'export -f probe; '
             'REQBENCH_DRIVER_HOOK="probe" cmd_run',
@@ -6280,8 +6277,11 @@ class SnapshotLockHeldAcrossRun(unittest.TestCase):
         # While another process holds the pool lock exclusive, a grow must
         # not proceed concurrently: bounded wait, then fail closed.
         r, pool = self._bash(
-            'mkdir -p -m 755 "$DATA_ROOT/hugepage-pool.lock.d"; '
-            'exec 9<"$DATA_ROOT/hugepage-pool.lock.d"; flock -x 9; '
+            # The holder is an OLD reqbench.sh phase: it created the lock file
+            # and opened it read-write (codex on #868: a lock whose identity
+            # changes under an in-flight phase is not a lock).
+            'touch "$DATA_ROOT/hugepage-pool.lock"; '
+            'exec 9<>"$DATA_ROOT/hugepage-pool.lock"; flock -x 9; '
             'HUGEPAGE_POOL_LOCK_WAIT=1 ensure_hugepage_pool')
         self.assertNotEqual(r.returncode, 0,
                             "grow must not race a concurrent pool owner")

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -6060,13 +6060,19 @@ class MakefileBenchGraph(unittest.TestCase):
         # And the grow must hold the cross-harness pool lock (codex P1,
         # PR #815): the pool is host-global and reqbench/faultbench/bench.sh
         # all write it.
-        self.assertIn("hugepage-pool.lock", recipe,
-                      "fault recipe must serialize on the shared pool lock")
-        # The lock file must be creatable by unprivileged callers even when
-        # the data root is root-owned (fresh boxes): the recipe pre-creates
-        # it with sudo before flock (CodeRabbit round 2, PR #815).
-        self.assertRegex(recipe, r"sudo[^\n]*touch[^\n]*hugepage-pool\.lock",
-                         "fault recipe must sudo-pre-create the pool lock")
+        self.assertIn("hugepage-pool.lock.d", recipe,
+                      "fault recipe must serialize on the shared pool lock DIRECTORY")
+        # The lock is a directory (PR #868): creatable with sudo when the data
+        # root is root-owned (fresh boxes, CodeRabbit round 2 on PR #815), and
+        # openable by any user afterwards because a 0755 directory needs no
+        # O_CREAT and no ownership to open read-only. A lock FILE created by
+        # root under the invoker's sticky data root is refused by
+        # fs.protected_regular on the next unprivileged open, and chowning it
+        # to each invoker races between two users.
+        self.assertRegex(recipe, r"sudo[^\n]*mkdir -p -m 755[^\n]*hugepage-pool\.lock\.d",
+                         "fault recipe must sudo-mkdir the pool lock directory")
+        self.assertNotRegex(recipe, r"(touch|chown|chmod)[^\n]*hugepage-pool\.lock",
+                            "fault recipe must not create, chown, or chmod a lock FILE")
 
     def test_run_help_documents_tag(self):
         # Following the documented huge flow without TAG= on the run line
@@ -6263,7 +6269,7 @@ class SnapshotLockHeldAcrossRun(unittest.TestCase):
     def test_pool_lease_held_shared_through_phase(self):
         r, _ = self._bash(
             'mkdir -p "$RESULTS/logs"; '
-            'probe() { flock -x -n "$DATA_ROOT/hugepage-pool.lock" true '
+            'probe() { flock -x -n "$DATA_ROOT/hugepage-pool.lock.d" true '
             '  && echo POOL-FREE || echo POOL-HELD; }; '
             'export -f probe; '
             'REQBENCH_DRIVER_HOOK="probe" cmd_run',
@@ -6274,8 +6280,8 @@ class SnapshotLockHeldAcrossRun(unittest.TestCase):
         # While another process holds the pool lock exclusive, a grow must
         # not proceed concurrently: bounded wait, then fail closed.
         r, pool = self._bash(
-            'touch "$DATA_ROOT/hugepage-pool.lock"; '
-            'exec 9<>"$DATA_ROOT/hugepage-pool.lock"; flock -x 9; '
+            'mkdir -p -m 755 "$DATA_ROOT/hugepage-pool.lock.d"; '
+            'exec 9<"$DATA_ROOT/hugepage-pool.lock.d"; flock -x 9; '
             'HUGEPAGE_POOL_LOCK_WAIT=1 ensure_hugepage_pool')
         self.assertNotEqual(r.returncode, 0,
                             "grow must not race a concurrent pool owner")

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -6273,6 +6273,22 @@ class SnapshotLockHeldAcrossRun(unittest.TestCase):
             {"BACKEND": "uffd", "UFFD_MODE": "minor"})
         self.assertIn("POOL-HELD", r.stdout + r.stderr)
 
+    def test_pool_lock_refuses_a_planted_symlink(self):
+        # A symlink at the lock path, planted by another writer of the sticky
+        # data root, would be followed by the read-only open; its owner can
+        # repoint it under a holder so a later caller locks a different inode
+        # and writes the pool concurrently (codex + CodeRabbit on #868). Fail
+        # closed, pool untouched.
+        r, pool = self._bash(
+            'touch "$DATA_ROOT/elsewhere"; '
+            'ln -s "$DATA_ROOT/elsewhere" "$DATA_ROOT/hugepage-pool.lock"; '
+            'HUGEPAGE_POOL_LOCK_WAIT=1 ensure_hugepage_pool')
+        self.assertNotEqual(r.returncode, 0,
+                            "a symlinked lock path must be refused")
+        self.assertEqual(open(pool).read().strip(), "100",
+                         "pool must be untouched behind a refused lock")
+        self.assertIn("symlink", r.stdout + r.stderr)
+
     def test_pool_grow_respects_exclusive_holder(self):
         # While another process holds the pool lock exclusive, a grow must
         # not proceed concurrently: bounded wait, then fail closed.

--- a/scripts/hugepage-pool-lock.sh
+++ b/scripts/hugepage-pool-lock.sh
@@ -6,19 +6,28 @@
 # The lock is $HUGEPAGE_POOL_LOCK (default /mnt/fcvm-btrfs/hugepage-pool.lock),
 # the same file bench/chromium/reqbench.sh holds for a phase lifetime, so a
 # bench phase already in flight and a `make setup-hugepages` from another
-# checkout serialize on one inode. Two rules make one file usable by root and
-# by unprivileged callers in the same sticky, user-owned data root:
+# checkout serialize on one inode. The data root is a sticky, world-writable
+# directory owned by the box's user, and the lock has to be usable there by
+# root and by unprivileged callers. Three rules:
 #
-# - It is opened READ-ONLY, never with O_CREAT. fs.protected_regular refuses an
+# - Opened READ-ONLY, never with O_CREAT. fs.protected_regular refuses an
 #   O_CREAT open of a file owned by someone else in a sticky world-writable
-#   directory, root included, and util-linux `flock <path>` and bash `<>` both
-#   use O_CREAT. That is what a root-created lock did to every later
-#   unprivileged run (`flock: cannot open lock file ...: Permission denied`).
-#   flock(2) does not care about the open mode.
-# - It is created atomically when absent: a hard link fails if the name already
-#   exists, so concurrent creators agree on one inode. Nothing here chmods or
-#   chowns a path: `install -m` sets the mode on the file it creates, and a
-#   planted symlink at that name is replaced, not followed.
+#   directory, and util-linux `flock <path>` and bash `<>` both use O_CREAT.
+#   That is what a root-created lock did to every later unprivileged run
+#   (`flock: cannot open lock file ...: Permission denied`). flock(2) does not
+#   care about the open mode.
+# - Created atomically, as root: a hard link fails if the name already exists,
+#   so concurrent creators agree on one inode, and in a sticky directory a
+#   root-owned entry can be unlinked only by root or the directory's owner.
+#   Nothing here chmods or chowns a path: `install -m` sets the mode on the
+#   file it creates, and a planted symlink at that name is replaced, not
+#   followed.
+# - The entry is checked before AND after opening. A symlink, a non-regular
+#   file, or a file owned by anyone but root, the invoking user, or the
+#   directory's owner is refused: its owner could repoint or recreate it under
+#   a holder, and a later caller would lock a different inode and write the
+#   pool concurrently. After the open, the descriptor's inode must be the
+#   path's own (lstat) inode, which closes the window between check and open.
 #
 # The command runs as a CHILD while this script keeps fd 9: `exec` would hand
 # the descriptor to the command, and sudo closes inherited descriptors, which
@@ -28,28 +37,42 @@ lock="${HUGEPAGE_POOL_LOCK:-/mnt/fcvm-btrfs/hugepage-pool.lock}"
 wait_s="${HUGEPAGE_POOL_LOCK_WAIT:-60}"
 [ $# -gt 0 ] || { echo "usage: $0 <command...>" >&2; exit 2; }
 
-# $1 = lock path. Runs as whoever can write the directory.
+refuse() {
+	echo "hugepage-pool-lock: $*" >&2
+	exit 1
+}
+
+# $1 = lock path. Runs as root.
 create_if_absent() {
 	local tmp
 	tmp="$(mktemp -u "$1.XXXXXX")"
 	install -m 644 /dev/null "$tmp"
-	ln "$tmp" "$1" 2>/dev/null || [ -e "$1" ]
+	ln "$tmp" "$1" 2>/dev/null || true
 	rm -f "$tmp"
 }
 
-if [ ! -e "$lock" ]; then
-	dir="$(dirname "$lock")"
-	if [ -d "$dir" ] && [ -w "$dir" ]; then
-		create_if_absent "$lock"
-	else
-		sudo mkdir -p "$dir"
-		sudo bash -c "$(declare -f create_if_absent); create_if_absent \"\$1\"" _ "$lock"
-	fi
+if ! [ -e "$lock" ] && ! [ -L "$lock" ]; then
+	sudo mkdir -p "$(dirname "$lock")"
+	sudo bash -c "$(declare -f create_if_absent); create_if_absent \"\$1\"" _ "$lock"
 fi
 
+# The entry as it is on disk: stat without -L reports a symlink as itself.
+if [ -L "$lock" ]; then
+	refuse "$lock is a symlink (owner uid $(stat -c %u "$lock")); a path another user can repoint is not a lock"
+fi
+[ -f "$lock" ] || refuse "$lock is not a regular file"
+owner="$(stat -c %u "$lock")"
+dir_owner="$(stat -c %u "$(dirname "$lock")")"
+case "$owner" in
+0 | "$(id -u)" | "$dir_owner") ;;
+*) refuse "$lock is owned by uid $owner, who can recreate it under a holder; refusing" ;;
+esac
+
 exec 9<"$lock"
+if [ "$(stat -c %d:%i "$lock")" != "$(stat -Lc %d:%i "/proc/$$/fd/9")" ]; then
+	refuse "$lock was replaced between check and open; refusing"
+fi
 if ! flock -x -w "$wait_s" 9; then
-	echo "hugepage-pool-lock: $lock busy for ${wait_s}s; refusing to race the owner" >&2
-	exit 1
+	refuse "$lock busy for ${wait_s}s; refusing to race the owner"
 fi
 "$@"

--- a/scripts/hugepage-pool-lock.sh
+++ b/scripts/hugepage-pool-lock.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Run a command while holding the host-global hugepage pool lock.
+#
+#   scripts/hugepage-pool-lock.sh <command...>
+#
+# The lock is $HUGEPAGE_POOL_LOCK (default /mnt/fcvm-btrfs/hugepage-pool.lock),
+# the same file bench/chromium/reqbench.sh holds for a phase lifetime, so a
+# bench phase already in flight and a `make setup-hugepages` from another
+# checkout serialize on one inode. Two rules make one file usable by root and
+# by unprivileged callers in the same sticky, user-owned data root:
+#
+# - It is opened READ-ONLY, never with O_CREAT. fs.protected_regular refuses an
+#   O_CREAT open of a file owned by someone else in a sticky world-writable
+#   directory, root included, and util-linux `flock <path>` and bash `<>` both
+#   use O_CREAT. That is what a root-created lock did to every later
+#   unprivileged run (`flock: cannot open lock file ...: Permission denied`).
+#   flock(2) does not care about the open mode.
+# - It is created atomically when absent: a hard link fails if the name already
+#   exists, so concurrent creators agree on one inode. Nothing here chmods or
+#   chowns a path: `install -m` sets the mode on the file it creates, and a
+#   planted symlink at that name is replaced, not followed.
+#
+# The command runs as a CHILD while this script keeps fd 9: `exec` would hand
+# the descriptor to the command, and sudo closes inherited descriptors, which
+# would release the lock right before the privileged pool write.
+set -eu
+lock="${HUGEPAGE_POOL_LOCK:-/mnt/fcvm-btrfs/hugepage-pool.lock}"
+wait_s="${HUGEPAGE_POOL_LOCK_WAIT:-60}"
+[ $# -gt 0 ] || { echo "usage: $0 <command...>" >&2; exit 2; }
+
+# $1 = lock path. Runs as whoever can write the directory.
+create_if_absent() {
+	local tmp
+	tmp="$(mktemp -u "$1.XXXXXX")"
+	install -m 644 /dev/null "$tmp"
+	ln "$tmp" "$1" 2>/dev/null || [ -e "$1" ]
+	rm -f "$tmp"
+}
+
+if [ ! -e "$lock" ]; then
+	dir="$(dirname "$lock")"
+	if [ -d "$dir" ] && [ -w "$dir" ]; then
+		create_if_absent "$lock"
+	else
+		sudo mkdir -p "$dir"
+		sudo bash -c "$(declare -f create_if_absent); create_if_absent \"\$1\"" _ "$lock"
+	fi
+fi
+
+exec 9<"$lock"
+if ! flock -x -w "$wait_s" 9; then
+	echo "hugepage-pool-lock: $lock busy for ${wait_s}s; refusing to race the owner" >&2
+	exit 1
+fi
+"$@"

--- a/scripts/hugepage-pool-lock.sh
+++ b/scripts/hugepage-pool-lock.sh
@@ -16,12 +16,14 @@
 #   That is what a root-created lock did to every later unprivileged run
 #   (`flock: cannot open lock file ...: Permission denied`). flock(2) does not
 #   care about the open mode.
-# - Created atomically: a hard link fails if the name already exists, so
-#   concurrent creators agree on one inode. The invoking user creates it when
-#   the directory is writable, root (sudo) only on a fresh box whose data root
-#   is still root-owned. Nothing here chmods or chowns a path: `install -m`
-#   sets the mode on the file it creates, and a planted symlink at that name
-#   is replaced, not followed.
+# - Created atomically, as root: a hard link fails if the name already exists,
+#   so concurrent creators agree on one inode, and root is an owner every
+#   caller's allowlist accepts. Privilege is spent only on the fixed shared
+#   path, through fixed programs with quoted arguments; an overridden path
+#   (HUGEPAGE_POOL_LOCK, a test knob) is created unprivileged or refused.
+#   Nothing here chmods or chowns a path: `install -m` sets the mode on the
+#   file it creates, and a planted symlink at that name is replaced, not
+#   followed.
 # - The entry is checked before AND after opening. A symlink, a non-regular
 #   file, or a file owned by anyone but root, the invoking user, or the
 #   directory's owner is refused: its owner could repoint or recreate it under
@@ -29,11 +31,20 @@
 #   pool concurrently. After the open, the descriptor's inode must be the
 #   path's own (lstat) inode, which closes the window between check and open.
 #
+# Not defended: the data root's owner. In a sticky directory that owner can
+# unlink any entry, root-owned included, and could replace the lock under a
+# holder. That account is the box's operator (it ran setup, owns the checkout,
+# holds sudo on every box this runs on), and a lock cannot defend against its
+# own operator; moving the lock out of the data root would change the identity
+# in-flight reqbench.sh phases hold.
+#
 # The command runs as a CHILD while this script keeps fd 9: `exec` would hand
 # the descriptor to the command, and sudo closes inherited descriptors, which
 # would release the lock right before the privileged pool write.
 set -eu
-lock="${HUGEPAGE_POOL_LOCK:-/mnt/fcvm-btrfs/hugepage-pool.lock}"
+default_dir=/mnt/fcvm-btrfs
+default_lock="$default_dir/hugepage-pool.lock"
+lock="${HUGEPAGE_POOL_LOCK:-$default_lock}"
 wait_s="${HUGEPAGE_POOL_LOCK_WAIT:-60}"
 [ $# -gt 0 ] || { echo "usage: $0 <command...>" >&2; exit 2; }
 
@@ -52,13 +63,24 @@ create_if_absent() {
 }
 
 if ! [ -e "$lock" ] && ! [ -L "$lock" ]; then
-	dir="$(dirname "$lock")"
-	if [ -d "$dir" ] && [ -w "$dir" ]; then
-		create_if_absent "$lock"
+	if [ "$lock" = "$default_lock" ]; then
+		# The shared lock is created as ROOT: a stable owner every caller's
+		# allowlist accepts, whoever runs first. Privilege is spent only here,
+		# only on the fixed path, and only through fixed programs with quoted
+		# arguments: no shell string, no caller-supplied path.
+		tmp="$(mktemp -u -- "$default_lock.XXXXXXXX")"
+		sudo mkdir -p -- "$default_dir"
+		sudo install -m 644 -- /dev/null "$tmp"
+		sudo ln -- "$tmp" "$default_lock" 2>/dev/null || true
+		sudo rm -f -- "$tmp"
 	else
-		# A fresh box: the data root is root-owned until setup hands it over.
-		sudo mkdir -p "$dir"
-		sudo bash -c "$(declare -f create_if_absent); create_if_absent \"\$1\"" _ "$lock"
+		# An overridden path (HUGEPAGE_POOL_LOCK, a test knob) is never created
+		# with privileges.
+		dir="$(dirname -- "$lock")"
+		if ! [ -d "$dir" ] || ! [ -w "$dir" ]; then
+			refuse "$lock is not the shared lock and its directory is not writable; not creating it with privileges"
+		fi
+		create_if_absent "$lock"
 	fi
 fi
 

--- a/scripts/hugepage-pool-lock.sh
+++ b/scripts/hugepage-pool-lock.sh
@@ -16,12 +16,12 @@
 #   That is what a root-created lock did to every later unprivileged run
 #   (`flock: cannot open lock file ...: Permission denied`). flock(2) does not
 #   care about the open mode.
-# - Created atomically, as root: a hard link fails if the name already exists,
-#   so concurrent creators agree on one inode, and in a sticky directory a
-#   root-owned entry can be unlinked only by root or the directory's owner.
-#   Nothing here chmods or chowns a path: `install -m` sets the mode on the
-#   file it creates, and a planted symlink at that name is replaced, not
-#   followed.
+# - Created atomically: a hard link fails if the name already exists, so
+#   concurrent creators agree on one inode. The invoking user creates it when
+#   the directory is writable, root (sudo) only on a fresh box whose data root
+#   is still root-owned. Nothing here chmods or chowns a path: `install -m`
+#   sets the mode on the file it creates, and a planted symlink at that name
+#   is replaced, not followed.
 # - The entry is checked before AND after opening. A symlink, a non-regular
 #   file, or a file owned by anyone but root, the invoking user, or the
 #   directory's owner is refused: its owner could repoint or recreate it under
@@ -42,7 +42,7 @@ refuse() {
 	exit 1
 }
 
-# $1 = lock path. Runs as root.
+# $1 = lock path. Runs as whoever can write the directory.
 create_if_absent() {
 	local tmp
 	tmp="$(mktemp -u "$1.XXXXXX")"
@@ -52,8 +52,14 @@ create_if_absent() {
 }
 
 if ! [ -e "$lock" ] && ! [ -L "$lock" ]; then
-	sudo mkdir -p "$(dirname "$lock")"
-	sudo bash -c "$(declare -f create_if_absent); create_if_absent \"\$1\"" _ "$lock"
+	dir="$(dirname "$lock")"
+	if [ -d "$dir" ] && [ -w "$dir" ]; then
+		create_if_absent "$lock"
+	else
+		# A fresh box: the data root is root-owned until setup hands it over.
+		sudo mkdir -p "$dir"
+		sudo bash -c "$(declare -f create_if_absent); create_if_absent \"\$1\"" _ "$lock"
+	fi
 fi
 
 # The entry as it is on disk: stat without -L reports a symlink as itself.

--- a/tests/test_documented_make_targets.rs
+++ b/tests/test_documented_make_targets.rs
@@ -718,128 +718,260 @@ fn a_bench_that_persisted_nothing_fails_its_target() {
 
 /// The hugepage pool lock must be owned by the invoking user, not root.
 ///
-/// The hugepage pool lock is a DIRECTORY, taken by `flock` on every site.
+/// The hugepage pool lock is one FILE, opened read-only, never with O_CREAT.
 ///
 /// The pool is host-global state shared by `setup-hugepages`,
-/// `bench-chromium-fault`, and `bench/chromium/reqbench.sh`, so all three
-/// serialize on one lock under `/mnt/fcvm-btrfs`. As a file that lock had two
-/// owners' worth of trouble. A root-created file under the invoker's sticky
-/// data root is refused by `fs.protected_regular` on the next unprivileged
-/// `O_CREAT` open (util-linux `flock <path>` and bash `<>` both use it):
+/// `bench-chromium-fault`, and `bench/chromium/reqbench.sh` (which holds the
+/// lock for a phase lifetime), so all of them serialize on one inode:
+/// `/mnt/fcvm-btrfs/hugepage-pool.lock`. The recipes take it through
+/// `scripts/hugepage-pool-lock.sh`. What went wrong before, in order:
 ///
-/// ```text
-/// ==> Allocating hugepage pool (512 pages = 1024MB)...
-/// flock: cannot open lock file /mnt/fcvm-btrfs/hugepage-pool.lock: Permission denied
-/// make: *** [Makefile:643: setup-hugepages] Error 66
-/// ```
+/// - The recipes created it with `sudo touch` + `chmod 666`. `fs.protected_regular`
+///   refuses an O_CREAT open of a file owned by someone else in a sticky
+///   world-writable directory, root included, and util-linux `flock <path>` and
+///   bash `<>` both use O_CREAT. So every unprivileged run after the first died:
 ///
-/// And the first fix, `chown` to the invoker at every site, raced: two users
-/// chown in turn and the first one's `flock` opens a file the second now owns
-/// (codex, #868), while root's `chmod`/`chown` follow a symlink the directory
-/// owner can plant (CodeRabbit, #868). A directory has neither problem:
-/// `mkdir -p` is idempotent for any creator, `open(O_RDONLY)` on a 0755
-/// directory needs no ownership and no `O_CREAT`, and nothing privileged ever
-/// changes its metadata. So no site may create, touch, chown, or chmod a lock
-/// FILE, and every site must create the directory it then flocks.
+///   ```text
+///   ==> Allocating hugepage pool (512 pages = 1024MB)...
+///   flock: cannot open lock file /mnt/fcvm-btrfs/hugepage-pool.lock: Permission denied
+///   make: *** [Makefile:643: setup-hugepages] Error 66
+///   ```
+///
+/// - `chown` to the invoker at every site raced between two users (codex, #868)
+///   and made root `chmod`/`chown` a path the directory owner can replace with a
+///   symlink (CodeRabbit, #868).
+/// - A lock DIRECTORY had neither problem but changed the lock's identity, so an
+///   old reqbench.sh phase still holding the file was no longer serialized
+///   against new code holding the directory (codex, #868).
+///
+/// So: the same file, opened READ-ONLY (`flock(2)` does not care about the open
+/// mode, and protected_regular only governs O_CREAT), created atomically when
+/// absent (a hard link fails if the name exists, so concurrent creators agree on
+/// one inode), and never chmod'ed or chown'ed by anyone.
 #[test]
-fn hugepage_lock_is_a_directory_wherever_it_is_taken() {
+fn hugepage_lock_is_taken_through_the_helper_at_every_site() {
     let makefile = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Makefile"))
         .expect("read Makefile");
-    let mentions: Vec<&str> = makefile
+    let recipe_lines: Vec<&str> = makefile
         .lines()
-        .filter(|l| l.contains("hugepage-pool.lock"))
+        .filter(|l| l.starts_with('\t') && l.contains("hugepage-pool"))
         .collect();
     assert!(
-        !mentions.is_empty(),
-        "no recipe mentions hugepage-pool.lock any more; if the lock moved, move this \
-         test with it"
+        recipe_lines.len() >= 2,
+        "expected both recipes to take the hugepage pool lock; found {recipe_lines:?}"
     );
-    for line in &mentions {
+    for line in &recipe_lines {
         assert!(
-            line.contains("hugepage-pool.lock.d"),
-            "a recipe still uses the hugepage lock as a FILE, which a root-owned \
-             instance under a sticky data root makes unopenable (protected_regular):\n{line}"
+            line.contains("scripts/hugepage-pool-lock.sh"),
+            "a recipe takes the hugepage pool lock without the helper, so it is one \
+             more site that has to get O_CREAT and creation right on its own:\n{line}"
         );
-        for verb in ["touch ", "chown ", "chmod "] {
+        for verb in ["touch ", "chown ", "chmod ", "mkdir "] {
             assert!(
                 !line.contains(verb),
-                "a recipe runs `{verb}` on the hugepage lock; the directory lock needs \
-                 no ownership handoff, and a privileged metadata change under the \
-                 invoker's directory follows whatever symlink sits there:\n{line}"
+                "a recipe runs `{verb}` around the hugepage lock; creation belongs to \
+                 the helper, and a privileged metadata change under the invoker's \
+                 directory follows whatever symlink sits there:\n{line}"
             );
         }
     }
-    let takers = mentions.iter().filter(|l| l.contains("flock")).count();
-    let creators = mentions
-        .iter()
-        .filter(|l| l.contains("mkdir -p") && l.contains("-m 755"))
-        .count();
+    let helper = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/scripts/hugepage-pool-lock.sh"
+    ))
+    .expect("read scripts/hugepage-pool-lock.sh");
+    // Code lines only: the helper's comments name the very forms it avoids.
+    let helper_code: String = helper
+        .lines()
+        .filter(|l| !l.trim_start().starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n");
     assert!(
-        takers >= 2,
-        "expected both recipes to flock the pool lock; found {takers}"
+        helper_code.contains("exec 9<\"$lock\""),
+        "the helper must open the lock READ-ONLY (`exec 9<\"$lock\"`); any O_CREAT open \
+         (`flock <path>`, `<>`) is refused by protected_regular for a file someone else \
+         owns"
     );
-    assert_eq!(
-        creators, takers,
-        "every recipe that flocks the pool lock directory must first `mkdir -p -m 755` \
-         it (the explicit mode keeps it openable by other users under a restrictive \
-         umask): {creators} creators for {takers} takers"
+    assert!(
+        !helper_code.contains("<>") && !helper_code.contains("flock -x -w \"$wait_s\" \"$lock\""),
+        "the helper opens the lock with O_CREAT somewhere"
     );
+    assert!(
+        helper_code.contains("ln \"$tmp\" \"$1\""),
+        "the helper must create the lock atomically (hard link onto the final name)"
+    );
+    for verb in ["chown ", "chmod "] {
+        assert!(
+            !helper_code.contains(verb),
+            "the helper runs `{verb}`; the mode is set by `install -m` on the file it \
+             creates, and nothing may follow a path under the user's directory"
+        );
+    }
 }
 
-/// The directory form must actually serialize, in both spellings the sites use.
+/// The helper takes a lock file its caller cannot O_CREAT-open.
 ///
-/// `setup-hugepages` and `bench-chromium-fault` take the lock by PATH (util-linux
-/// `flock <dir> cmd`, which opens `O_RDONLY|O_CREAT`, gets `EISDIR`, and retries
-/// without `O_CREAT`); `reqbench.sh` holds it by FD (`exec {fd}<dir; flock -s/-x
-/// fd`) for a phase lifetime. They contend only if both forms lock the same open
-/// file description's inode, which this pins by holding the lock one way and
-/// contending the other.
+/// Staged per uid, both branches real: as root, a root-owned 1777 directory
+/// holding a lock owned by uid 65534, which protected_regular refuses to open
+/// with O_CREAT even for root (the exact production shape, mirrored); as a
+/// normal user, a 0444 lock, which a `<>` open refuses. Each fixture first
+/// proves it reproduces the failure, so a box with protected_regular off fails
+/// here instead of passing vacuously.
 #[test]
-fn hugepage_lock_directory_serializes_by_path_and_by_fd() {
-    use std::io::BufRead as _;
-    let base = std::env::temp_dir().join(format!("fcvm-hugelock-{}", std::process::id()));
-    let lock_dir = base.join("hugepage-pool.lock.d");
-    std::fs::create_dir_all(&lock_dir).expect("create lock dir");
-    let holder_script = "exec 9<\"$1\" && flock -x 9 && echo held && read -r _ <&0";
-    let mut holder = std::process::Command::new("bash")
-        .args(["-c", holder_script, "_"])
-        .arg(&lock_dir)
+fn hugepage_lock_helper_opens_the_lock_without_o_creat() {
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let lock = dir.path().join("hugepage-pool.lock");
+    std::fs::write(&lock, b"").expect("create lock");
+    let root = unsafe { libc::geteuid() } == 0;
+    if root {
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o1777))
+            .expect("chmod 1777");
+        std::os::unix::fs::chown(&lock, Some(65534), Some(65534)).expect("chown to nobody");
+        let refused = std::process::Command::new("flock")
+            .args(["-x", "-n"])
+            .arg(&lock)
+            .arg("true")
+            .status()
+            .expect("run flock by path");
+        assert!(
+            !refused.success(),
+            "fixture does not reproduce: `flock <path>` (O_CREAT) on a file owned by \
+             another uid in a sticky directory succeeded, so fs.protected_regular is off \
+             on this box and this test cannot show the helper avoiding it"
+        );
+    } else {
+        std::fs::set_permissions(&lock, std::fs::Permissions::from_mode(0o444))
+            .expect("chmod 0444");
+        let refused = std::process::Command::new("bash")
+            .args(["-c", "exec 9<>\"$1\"", "_"])
+            .arg(&lock)
+            .status()
+            .expect("run <> open");
+        assert!(
+            !refused.success(),
+            "fixture does not reproduce: a `<>` open of a 0444 lock succeeded"
+        );
+    }
+
+    let out = std::process::Command::new(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/scripts/hugepage-pool-lock.sh"
+    ))
+    .env("HUGEPAGE_POOL_LOCK", &lock)
+    .env("HUGEPAGE_POOL_LOCK_WAIT", "2")
+    .args([
+        "sh",
+        "-c",
+        "flock -x -n 9 && echo not-held || echo held-by-parent",
+    ])
+    .output()
+    .expect("run helper");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        out.status.success(),
+        "the helper failed to take a lock it only needs to open read-only:\n{text}"
+    );
+    // The child inherits fd 9 and the parent holds the exclusive lock on the
+    // same open file description, so a second `flock -x -n 9` in the child
+    // succeeds trivially (same description). What matters above is that the
+    // helper got there at all; the contention property is pinned by
+    // `hugepage_lock_helper_holds_the_lock_while_the_command_runs`.
+    if root {
+        let _ = std::os::unix::fs::chown(&lock, Some(0), Some(0));
+    }
+}
+
+/// Concurrent first-time creators end up on ONE inode, and the helper keeps
+/// the lock for the whole command (it must not `exec` into it: sudo closes
+/// inherited descriptors, which would release the lock right before the
+/// privileged pool write it exists to serialize).
+#[test]
+fn hugepage_lock_helper_holds_the_lock_while_the_command_runs() {
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let lock = dir.path().join("hugepage-pool.lock");
+    let helper = concat!(env!("CARGO_MANIFEST_DIR"), "/scripts/hugepage-pool-lock.sh");
+
+    // Eight racers create the lock at once and each reports the inode behind
+    // its fd 9.
+    let racers: Vec<_> = (0..8)
+        .map(|_| {
+            std::process::Command::new(helper)
+                .env("HUGEPAGE_POOL_LOCK", &lock)
+                .env("HUGEPAGE_POOL_LOCK_WAIT", "10")
+                .args(["sh", "-c", "stat -L -c %i /proc/self/fd/9"])
+                .stdout(std::process::Stdio::piped())
+                .spawn()
+                .expect("spawn racer")
+        })
+        .collect();
+    let mut inodes = std::collections::BTreeSet::new();
+    for racer in racers {
+        let out = racer.wait_with_output().expect("racer exit");
+        assert!(out.status.success(), "a racer failed: {out:?}");
+        inodes.insert(String::from_utf8_lossy(&out.stdout).trim().to_string());
+    }
+    assert_eq!(
+        inodes.len(),
+        1,
+        "concurrent creators locked different inodes {inodes:?}; the lock file was \
+         replaced under a holder"
+    );
+    let meta = std::fs::metadata(&lock).expect("lock exists");
+    assert_eq!(meta.permissions().mode() & 0o777, 0o644, "lock mode");
+    let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .filter(|n| n != "hugepage-pool.lock")
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "creation left temp files behind: {leftovers:?}"
+    );
+
+    // Hold the lock via the helper; a by-path contender must be refused until
+    // the held command exits.
+    let mut holder = std::process::Command::new(helper)
+        .env("HUGEPAGE_POOL_LOCK", &lock)
+        .args(["sh", "-c", "echo held; read -r _"])
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .spawn()
-        .expect("spawn by-fd holder");
-    let mut first = String::new();
-    std::io::BufReader::new(holder.stdout.take().unwrap())
-        .read_line(&mut first)
-        .expect("read holder's line");
-    assert_eq!(first.trim(), "held", "the by-fd holder never took the lock");
-
-    let contended = std::process::Command::new("flock")
-        .args(["-x", "-n"])
-        .arg(&lock_dir)
-        .arg("true")
+        .expect("spawn holder");
+    {
+        use std::io::BufRead as _;
+        let mut line = String::new();
+        std::io::BufReader::new(holder.stdout.as_mut().unwrap())
+            .read_line(&mut line)
+            .expect("holder line");
+        assert_eq!(line.trim(), "held");
+    }
+    let contended = std::process::Command::new("bash")
+        .args(["-c", "exec 9<\"$1\" && flock -x -n 9", "_"])
+        .arg(&lock)
         .status()
-        .expect("run by-path contender");
+        .expect("contender");
     assert!(
         !contended.success(),
-        "`flock -x -n <dir> true` SUCCEEDED while a by-fd holder had the directory \
-         exclusively: the two forms are not locking the same thing"
+        "a contender took the lock while the helper's command was still running"
     );
-
-    // Release: the holder exits on any stdin line, and its fd 9 closes with it.
     drop(holder.stdin.take());
     let _ = holder.wait();
-    let free = std::process::Command::new("flock")
-        .args(["-x", "-n"])
-        .arg(&lock_dir)
-        .arg("true")
+    let free = std::process::Command::new("bash")
+        .args(["-c", "exec 9<\"$1\" && flock -x -n 9", "_"])
+        .arg(&lock)
         .status()
-        .expect("run by-path taker");
+        .expect("taker");
     assert!(
         free.success(),
-        "the directory stayed locked after its holder exited"
+        "the lock stayed held after the helper's command exited"
     );
-    std::fs::remove_dir_all(&base).ok();
 }
 
 /// Every recipe that creates the hugepage lock must be valid shell AS MAKE RUNS IT.

--- a/tests/test_documented_make_targets.rs
+++ b/tests/test_documented_make_targets.rs
@@ -815,6 +815,27 @@ fn hugepage_lock_is_taken_through_the_helper_at_every_site() {
              creates, and nothing may follow a path under the user's directory"
         );
     }
+    // Privilege is spent only on the fixed shared path, through fixed programs
+    // (CodeRabbit on #868): never `sudo bash -c`/`sudo sh -c`, never a
+    // caller-supplied path.
+    // `$tmp` is the one derived name sudo may see, and only as a sibling of
+    // the fixed path.
+    assert!(
+        helper_code.contains("tmp=\"$(mktemp -u -- \"$default_lock.XXXXXXXX\")\""),
+        "the temp name sudo creates must be derived from the fixed shared path"
+    );
+    for line in helper_code.lines().filter(|l| l.contains("sudo ")) {
+        assert!(
+            !line.contains("sudo bash -c") && !line.contains("sudo sh -c"),
+            "the helper hands sudo a shell string:\n{line}"
+        );
+        assert!(
+            line.contains("$default_lock")
+                || line.contains("$default_dir")
+                || line.contains("\"$tmp\""),
+            "the helper runs sudo on something other than the fixed shared lock:\n{line}"
+        );
+    }
 }
 
 /// Run `program` as an unprivileged stand-in when the tests are root.
@@ -915,6 +936,132 @@ fn hugepage_lock_helper_opens_the_lock_without_o_creat() {
         // Hand the directory back so the tempdir can be removed.
         let _ = std::os::unix::fs::chown(dir.path(), Some(0), Some(0));
     }
+}
+
+/// Every writer of the hugepage pool takes the shared lock (codex on #868).
+///
+/// The pool is host-global, and reqbench.sh holds the lock SHARED for a whole
+/// phase precisely so that nobody shrinks the pool under its clones. A writer
+/// that skips the lock (`bench-hugepages*` restoring the pool to zero, bench.sh
+/// growing or restoring it) defeats that lease. So every line that writes
+/// `nr_hugepages`, in the Makefile and in every bench/scripts shell script, must
+/// be an argument of `scripts/hugepage-pool-lock.sh`, on the same line or on an
+/// earlier line of the same backslash-continued command. reqbench.sh writes
+/// through `$HUGEPAGE_POOL_FILE` under its own lease, which
+/// bench/chromium/test_reqbench.py pins (`test_pool_grow_respects_exclusive_holder`),
+/// so this enumeration deliberately keys on the literal path.
+#[test]
+fn every_hugepage_pool_writer_takes_the_lock() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut files = vec![root.join("Makefile")];
+    for dir in ["bench/chromium", "scripts"] {
+        for entry in std::fs::read_dir(root.join(dir)).expect(dir) {
+            let path = entry.expect("entry").path();
+            if path.extension().is_some_and(|e| e == "sh") {
+                files.push(path);
+            }
+        }
+    }
+    let writes_pool = |line: &str| {
+        let code = line.trim_start();
+        !code.starts_with('#')
+            && line.contains("nr_hugepages")
+            && (line.contains("> /proc/sys/vm/nr_hugepages")
+                || line.contains("tee")
+                || line.contains("sysctl"))
+    };
+    let mut writers = 0;
+    for file in &files {
+        let text = std::fs::read_to_string(file).expect("read");
+        let lines: Vec<&str> = text.lines().collect();
+        for (i, line) in lines.iter().enumerate() {
+            if !writes_pool(line) {
+                continue;
+            }
+            writers += 1;
+            let mut covered = line.contains("hugepage-pool-lock.sh");
+            let mut j = i;
+            while !covered && j > 0 && lines[j - 1].trim_end().ends_with('\\') {
+                j -= 1;
+                covered = lines[j].contains("hugepage-pool-lock.sh");
+            }
+            assert!(
+                covered,
+                "{}:{}: writes nr_hugepages outside scripts/hugepage-pool-lock.sh; a bench \
+                 phase holding the pool lease can have the pool shrunk under its clones:\n{line}",
+                file.strip_prefix(root).unwrap().display(),
+                i + 1
+            );
+        }
+    }
+    assert!(
+        writers >= 8,
+        "expected the six Makefile writers and bench.sh's two; found {writers}. If a \
+         writer moved, move this pin with it."
+    );
+}
+
+/// An overridden lock path is never created with privileges (CodeRabbit on
+/// #868): `HUGEPAGE_POOL_LOCK` is a test knob, and a caller-supplied path must
+/// not reach `sudo`. Only the fixed default path is created as root, through
+/// fixed programs. A `sudo` stub first on PATH records any escalation.
+#[test]
+fn hugepage_lock_helper_never_escalates_for_an_overridden_path() {
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let bin = dir.path().join("bin");
+    std::fs::create_dir(&bin).expect("bin");
+    let marker = dir.path().join("sudo-was-called");
+    std::fs::write(
+        bin.join("sudo"),
+        format!("#!/bin/sh\ntouch {}\nexit 1\n", marker.display()),
+    )
+    .expect("stub");
+    std::fs::set_permissions(bin.join("sudo"), std::fs::Permissions::from_mode(0o755))
+        .expect("chmod");
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let helper = concat!(env!("CARGO_MANIFEST_DIR"), "/scripts/hugepage-pool-lock.sh");
+    let run = |lock: &std::path::Path| {
+        let out = std::process::Command::new(helper)
+            .env("PATH", &path)
+            .env("HUGEPAGE_POOL_LOCK", lock)
+            .env("HUGEPAGE_POOL_LOCK_WAIT", "2")
+            .args(["sh", "-c", "echo took-it"])
+            .output()
+            .expect("run helper");
+        let text = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        (out.status.success() && text.contains("took-it"), text)
+    };
+
+    // Absent lock in a writable directory: created unprivileged.
+    let (ok, text) = run(&dir.path().join("hugepage-pool.lock"));
+    assert!(
+        ok,
+        "the helper failed to create an overridden lock unprivileged:\n{text}"
+    );
+    assert!(
+        !marker.exists(),
+        "the helper reached for sudo to create a caller-supplied path:\n{text}"
+    );
+
+    // Absent lock where nothing can be created: refused, still without sudo.
+    let (ok, text) = run(std::path::Path::new("/proc/self/hugepage-pool.lock"));
+    assert!(
+        !ok,
+        "the helper claimed to lock a path it cannot create:\n{text}"
+    );
+    assert!(
+        !marker.exists(),
+        "the helper escalated to create a caller-supplied path under /proc:\n{text}"
+    );
 }
 
 /// A symlink at the lock path is refused, not followed (codex, CodeRabbit on

--- a/tests/test_documented_make_targets.rs
+++ b/tests/test_documented_make_targets.rs
@@ -718,11 +718,14 @@ fn a_bench_that_persisted_nothing_fails_its_target() {
 
 /// The hugepage pool lock must be owned by the invoking user, not root.
 ///
-/// Both `setup-hugepages` recipes create `/mnt/fcvm-btrfs/hugepage-pool.lock`
-/// with `sudo touch` and `chmod 666`. On a box where `/mnt/fcvm-btrfs` is a
-/// sticky world-writable directory (mode 1777, as a fresh setup leaves it),
-/// `fs.protected_regular` then refuses every later unprivileged open of that
-/// root-owned file -- so `make test-root` dies at the very first step:
+/// The hugepage pool lock is a DIRECTORY, taken by `flock` on every site.
+///
+/// The pool is host-global state shared by `setup-hugepages`,
+/// `bench-chromium-fault`, and `bench/chromium/reqbench.sh`, so all three
+/// serialize on one lock under `/mnt/fcvm-btrfs`. As a file that lock had two
+/// owners' worth of trouble. A root-created file under the invoker's sticky
+/// data root is refused by `fs.protected_regular` on the next unprivileged
+/// `O_CREAT` open (util-linux `flock <path>` and bash `<>` both use it):
 ///
 /// ```text
 /// ==> Allocating hugepage pool (512 pages = 1024MB)...
@@ -730,29 +733,113 @@ fn a_bench_that_persisted_nothing_fails_its_target() {
 /// make: *** [Makefile:643: setup-hugepages] Error 66
 /// ```
 ///
-/// CI never sees it because the runner user owns the whole volume. The recipe
-/// must hand the lock to the invoker the way `check-disk` already hands over
-/// `~/.cargo`, on EVERY site that creates it.
+/// And the first fix, `chown` to the invoker at every site, raced: two users
+/// chown in turn and the first one's `flock` opens a file the second now owns
+/// (codex, #868), while root's `chmod`/`chown` follow a symlink the directory
+/// owner can plant (CodeRabbit, #868). A directory has neither problem:
+/// `mkdir -p` is idempotent for any creator, `open(O_RDONLY)` on a 0755
+/// directory needs no ownership and no `O_CREAT`, and nothing privileged ever
+/// changes its metadata. So no site may create, touch, chown, or chmod a lock
+/// FILE, and every site must create the directory it then flocks.
 #[test]
-fn hugepage_lock_is_chowned_to_the_invoker_wherever_it_is_created() {
+fn hugepage_lock_is_a_directory_wherever_it_is_taken() {
     let makefile = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Makefile"))
         .expect("read Makefile");
-    let creators: Vec<&str> = makefile
+    let mentions: Vec<&str> = makefile
         .lines()
-        .filter(|l| l.contains("touch /mnt/fcvm-btrfs/hugepage-pool.lock"))
+        .filter(|l| l.contains("hugepage-pool.lock"))
         .collect();
     assert!(
-        !creators.is_empty(),
-        "no recipe creates /mnt/fcvm-btrfs/hugepage-pool.lock any more; if the lock \
-         moved, move this test with it"
+        !mentions.is_empty(),
+        "no recipe mentions hugepage-pool.lock any more; if the lock moved, move this \
+         test with it"
     );
-    for line in creators {
+    for line in &mentions {
         assert!(
-            line.contains("chown $$(id -u):$$(id -g) /mnt/fcvm-btrfs/hugepage-pool.lock"),
-            "a recipe creates the hugepage lock without chowning it to the invoker, so a \
-             sticky /mnt/fcvm-btrfs refuses the next unprivileged flock (protected_regular):\n{line}"
+            line.contains("hugepage-pool.lock.d"),
+            "a recipe still uses the hugepage lock as a FILE, which a root-owned \
+             instance under a sticky data root makes unopenable (protected_regular):\n{line}"
         );
+        for verb in ["touch ", "chown ", "chmod "] {
+            assert!(
+                !line.contains(verb),
+                "a recipe runs `{verb}` on the hugepage lock; the directory lock needs \
+                 no ownership handoff, and a privileged metadata change under the \
+                 invoker's directory follows whatever symlink sits there:\n{line}"
+            );
+        }
     }
+    let takers = mentions.iter().filter(|l| l.contains("flock")).count();
+    let creators = mentions
+        .iter()
+        .filter(|l| l.contains("mkdir -p") && l.contains("-m 755"))
+        .count();
+    assert!(
+        takers >= 2,
+        "expected both recipes to flock the pool lock; found {takers}"
+    );
+    assert_eq!(
+        creators, takers,
+        "every recipe that flocks the pool lock directory must first `mkdir -p -m 755` \
+         it (the explicit mode keeps it openable by other users under a restrictive \
+         umask): {creators} creators for {takers} takers"
+    );
+}
+
+/// The directory form must actually serialize, in both spellings the sites use.
+///
+/// `setup-hugepages` and `bench-chromium-fault` take the lock by PATH (util-linux
+/// `flock <dir> cmd`, which opens `O_RDONLY|O_CREAT`, gets `EISDIR`, and retries
+/// without `O_CREAT`); `reqbench.sh` holds it by FD (`exec {fd}<dir; flock -s/-x
+/// fd`) for a phase lifetime. They contend only if both forms lock the same open
+/// file description's inode, which this pins by holding the lock one way and
+/// contending the other.
+#[test]
+fn hugepage_lock_directory_serializes_by_path_and_by_fd() {
+    use std::io::BufRead as _;
+    let base = std::env::temp_dir().join(format!("fcvm-hugelock-{}", std::process::id()));
+    let lock_dir = base.join("hugepage-pool.lock.d");
+    std::fs::create_dir_all(&lock_dir).expect("create lock dir");
+    let holder_script = "exec 9<\"$1\" && flock -x 9 && echo held && read -r _ <&0";
+    let mut holder = std::process::Command::new("bash")
+        .args(["-c", holder_script, "_"])
+        .arg(&lock_dir)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn by-fd holder");
+    let mut first = String::new();
+    std::io::BufReader::new(holder.stdout.take().unwrap())
+        .read_line(&mut first)
+        .expect("read holder's line");
+    assert_eq!(first.trim(), "held", "the by-fd holder never took the lock");
+
+    let contended = std::process::Command::new("flock")
+        .args(["-x", "-n"])
+        .arg(&lock_dir)
+        .arg("true")
+        .status()
+        .expect("run by-path contender");
+    assert!(
+        !contended.success(),
+        "`flock -x -n <dir> true` SUCCEEDED while a by-fd holder had the directory \
+         exclusively: the two forms are not locking the same thing"
+    );
+
+    // Release: the holder exits on any stdin line, and its fd 9 closes with it.
+    drop(holder.stdin.take());
+    let _ = holder.wait();
+    let free = std::process::Command::new("flock")
+        .args(["-x", "-n"])
+        .arg(&lock_dir)
+        .arg("true")
+        .status()
+        .expect("run by-path taker");
+    assert!(
+        free.success(),
+        "the directory stayed locked after its holder exited"
+    );
+    std::fs::remove_dir_all(&base).ok();
 }
 
 /// Every recipe that creates the hugepage lock must be valid shell AS MAKE RUNS IT.

--- a/tests/test_documented_make_targets.rs
+++ b/tests/test_documented_make_targets.rs
@@ -754,3 +754,41 @@ fn hugepage_lock_is_chowned_to_the_invoker_wherever_it_is_created() {
         );
     }
 }
+
+/// Every recipe that creates the hugepage lock must be valid shell AS MAKE RUNS IT.
+///
+/// #868's first revision put explanatory `#` lines inside a backslash-continued
+/// recipe. In a Makefile a tab-indented `#` line is shell text, and a shell
+/// comment swallows the trailing backslash, cutting the command in half:
+///
+/// ```text
+/// /bin/bash: -c: line 8: syntax error: unexpected end of file
+/// make: *** [Makefile:643: setup-hugepages] Error 2
+/// ```
+///
+/// `make -n` printed it happily, and a first version of THIS test -- `make -n`
+/// piped into `bash -n` -- passed against the broken Makefile, because what make
+/// prints is not what make hands the shell. So the recipe is run through make
+/// itself with `SHELL='bash -n'`: make invokes the shell exactly as it would in
+/// CI, and the shell only parses. The threshold is forced high so the allocating
+/// branch (the one with the lock) is the code path taken. Nothing is executed,
+/// so no sudo, no /proc write.
+#[test]
+fn hugepage_lock_recipes_are_valid_shell_as_make_runs_them() {
+    let repo = concat!(env!("CARGO_MANIFEST_DIR"));
+    let out = std::process::Command::new("make")
+        .args([
+            "setup-hugepages",
+            "HUGEPAGE_POOL_TESTS=99999",
+            "SHELL=bash -n",
+        ])
+        .current_dir(repo)
+        .output()
+        .expect("run make with a syntax-only shell");
+    assert!(
+        out.status.success(),
+        "the setup-hugepages recipe is not valid shell as make runs it:\n{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/tests/test_documented_make_targets.rs
+++ b/tests/test_documented_make_targets.rs
@@ -715,3 +715,42 @@ fn a_bench_that_persisted_nothing_fails_its_target() {
         );
     }
 }
+
+/// The hugepage pool lock must be owned by the invoking user, not root.
+///
+/// Both `setup-hugepages` recipes create `/mnt/fcvm-btrfs/hugepage-pool.lock`
+/// with `sudo touch` and `chmod 666`. On a box where `/mnt/fcvm-btrfs` is a
+/// sticky world-writable directory (mode 1777, as a fresh setup leaves it),
+/// `fs.protected_regular` then refuses every later unprivileged open of that
+/// root-owned file -- so `make test-root` dies at the very first step:
+///
+/// ```text
+/// ==> Allocating hugepage pool (512 pages = 1024MB)...
+/// flock: cannot open lock file /mnt/fcvm-btrfs/hugepage-pool.lock: Permission denied
+/// make: *** [Makefile:643: setup-hugepages] Error 66
+/// ```
+///
+/// CI never sees it because the runner user owns the whole volume. The recipe
+/// must hand the lock to the invoker the way `check-disk` already hands over
+/// `~/.cargo`, on EVERY site that creates it.
+#[test]
+fn hugepage_lock_is_chowned_to_the_invoker_wherever_it_is_created() {
+    let makefile = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Makefile"))
+        .expect("read Makefile");
+    let creators: Vec<&str> = makefile
+        .lines()
+        .filter(|l| l.contains("touch /mnt/fcvm-btrfs/hugepage-pool.lock"))
+        .collect();
+    assert!(
+        !creators.is_empty(),
+        "no recipe creates /mnt/fcvm-btrfs/hugepage-pool.lock any more; if the lock \
+         moved, move this test with it"
+    );
+    for line in creators {
+        assert!(
+            line.contains("chown $$(id -u):$$(id -g) /mnt/fcvm-btrfs/hugepage-pool.lock"),
+            "a recipe creates the hugepage lock without chowning it to the invoker, so a \
+             sticky /mnt/fcvm-btrfs refuses the next unprivileged flock (protected_regular):\n{line}"
+        );
+    }
+}

--- a/tests/test_documented_make_targets.rs
+++ b/tests/test_documented_make_targets.rs
@@ -800,6 +800,14 @@ fn hugepage_lock_is_taken_through_the_helper_at_every_site() {
         helper_code.contains("ln \"$tmp\" \"$1\""),
         "the helper must create the lock atomically (hard link onto the final name)"
     );
+    assert!(
+        helper_code.contains("[ -L \"$lock\" ]"),
+        "the helper must refuse a symlink at the lock path before opening it"
+    );
+    assert!(
+        helper_code.contains("stat -Lc %d:%i \"/proc/$$/fd/9\""),
+        "the helper must verify, after the open, that fd 9 is the path's own inode"
+    );
     for verb in ["chown ", "chmod "] {
         assert!(
             !helper_code.contains(verb),
@@ -809,81 +817,165 @@ fn hugepage_lock_is_taken_through_the_helper_at_every_site() {
     }
 }
 
-/// The helper takes a lock file its caller cannot O_CREAT-open.
+/// A stand-in for the lock's caller that is never root.
 ///
-/// Staged per uid, both branches real: as root, a root-owned 1777 directory
-/// holding a lock owned by uid 65534, which protected_regular refuses to open
-/// with O_CREAT even for root (the exact production shape, mirrored); as a
-/// normal user, a 0444 lock, which a `<>` open refuses. Each fixture first
-/// proves it reproduces the failure, so a box with protected_regular off fails
-/// here instead of passing vacuously.
+/// The read-only open matters only for an unprivileged opener: for root,
+/// "protected_regular would refuse O_CREAT" and "the owner is untrusted" are
+/// the same condition (a file owned by neither root nor the directory's
+/// owner). So under sudo the helper is driven as `nobody`, from a copy the
+/// tests place where `nobody` can read it.
+fn as_unprivileged(dir: &std::path::Path, program: &str) -> std::process::Command {
+    if unsafe { libc::geteuid() } == 0 {
+        let mut c = std::process::Command::new("sudo");
+        c.args([
+            "-u",
+            "nobody",
+            "--preserve-env=HUGEPAGE_POOL_LOCK,HUGEPAGE_POOL_LOCK_WAIT",
+        ]);
+        c.arg(program);
+        c
+    } else {
+        let _ = dir;
+        std::process::Command::new(program)
+    }
+}
+
+/// A copy of the helper an unprivileged stand-in can execute.
+fn helper_copy(dir: &std::path::Path) -> String {
+    use std::os::unix::fs::PermissionsExt as _;
+    let src = concat!(env!("CARGO_MANIFEST_DIR"), "/scripts/hugepage-pool-lock.sh");
+    let dst = dir.join("hugepage-pool-lock.sh");
+    std::fs::copy(src, &dst).expect("copy helper");
+    std::fs::set_permissions(&dst, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+    dst.to_string_lossy().into_owned()
+}
+
+/// The helper takes a root-owned lock in a user-owned sticky directory, the
+/// production shape, as an unprivileged caller.
+///
+/// The fixture first proves the failure it guards against: `flock <path>`
+/// (O_CREAT) is refused there by protected_regular. A box with the sysctl off
+/// fails here instead of passing vacuously.
 #[test]
 fn hugepage_lock_helper_opens_the_lock_without_o_creat() {
     use std::os::unix::fs::PermissionsExt as _;
     let dir = tempfile::tempdir().expect("tempdir");
-    let lock = dir.path().join("hugepage-pool.lock");
-    std::fs::write(&lock, b"").expect("create lock");
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o1777))
+        .expect("chmod 1777");
     let root = unsafe { libc::geteuid() } == 0;
     if root {
-        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o1777))
-            .expect("chmod 1777");
-        std::os::unix::fs::chown(&lock, Some(65534), Some(65534)).expect("chown to nobody");
-        let refused = std::process::Command::new("flock")
-            .args(["-x", "-n"])
-            .arg(&lock)
-            .arg("true")
-            .status()
-            .expect("run flock by path");
-        assert!(
-            !refused.success(),
-            "fixture does not reproduce: `flock <path>` (O_CREAT) on a file owned by \
-             another uid in a sticky directory succeeded, so fs.protected_regular is off \
-             on this box and this test cannot show the helper avoiding it"
-        );
-    } else {
-        std::fs::set_permissions(&lock, std::fs::Permissions::from_mode(0o444))
-            .expect("chmod 0444");
-        let refused = std::process::Command::new("bash")
-            .args(["-c", "exec 9<>\"$1\"", "_"])
-            .arg(&lock)
-            .status()
-            .expect("run <> open");
-        assert!(
-            !refused.success(),
-            "fixture does not reproduce: a `<>` open of a 0444 lock succeeded"
-        );
+        // The stand-in is nobody, so the directory's owner must be nobody
+        // for the shape to hold (file owner outside {opener, dir owner}).
+        std::os::unix::fs::chown(dir.path(), Some(65534), Some(65534)).expect("chown dir");
     }
+    let lock = dir.path().join("hugepage-pool.lock");
+    let created = std::process::Command::new("sudo")
+        .args(["install", "-m", "644", "/dev/null"])
+        .arg(&lock)
+        .status()
+        .expect("sudo install");
+    assert!(created.success(), "stage a root-owned lock");
+    let helper = helper_copy(dir.path());
 
-    let out = std::process::Command::new(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/scripts/hugepage-pool-lock.sh"
-    ))
-    .env("HUGEPAGE_POOL_LOCK", &lock)
-    .env("HUGEPAGE_POOL_LOCK_WAIT", "2")
-    .args([
-        "sh",
-        "-c",
-        "flock -x -n 9 && echo not-held || echo held-by-parent",
-    ])
-    .output()
-    .expect("run helper");
+    let refused = as_unprivileged(dir.path(), "flock")
+        .args(["-x", "-n"])
+        .arg(&lock)
+        .arg("true")
+        .status()
+        .expect("flock by path");
+    assert!(
+        !refused.success(),
+        "fixture does not reproduce: `flock <path>` (O_CREAT) on a root-owned lock in a \
+         user-owned sticky directory succeeded, so fs.protected_regular is off on this box"
+    );
+
+    let out = as_unprivileged(dir.path(), &helper)
+        .env("HUGEPAGE_POOL_LOCK", &lock)
+        .env("HUGEPAGE_POOL_LOCK_WAIT", "2")
+        .args(["sh", "-c", "echo took-it"])
+        .output()
+        .expect("run helper");
     let text = format!(
         "{}{}",
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr)
     );
     assert!(
-        out.status.success(),
-        "the helper failed to take a lock it only needs to open read-only:\n{text}"
+        out.status.success() && text.contains("took-it"),
+        "the helper failed to take a root-owned lock it only needs to open read-only:\n{text}"
     );
-    // The child inherits fd 9 and the parent holds the exclusive lock on the
-    // same open file description, so a second `flock -x -n 9` in the child
-    // succeeds trivially (same description). What matters above is that the
-    // helper got there at all; the contention property is pinned by
-    // `hugepage_lock_helper_holds_the_lock_while_the_command_runs`.
-    if root {
-        let _ = std::os::unix::fs::chown(&lock, Some(0), Some(0));
-    }
+}
+
+/// A symlink at the lock path is refused, not followed (codex, CodeRabbit on
+/// #868): whoever planted it can repoint it under a holder, and the next
+/// caller would lock a different inode.
+#[test]
+fn hugepage_lock_helper_refuses_a_planted_symlink() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let elsewhere = dir.path().join("elsewhere");
+    std::fs::write(&elsewhere, b"").expect("target file");
+    let lock = dir.path().join("hugepage-pool.lock");
+    std::os::unix::fs::symlink(&elsewhere, &lock).expect("planted symlink");
+    let helper = concat!(env!("CARGO_MANIFEST_DIR"), "/scripts/hugepage-pool-lock.sh");
+    let out = std::process::Command::new(helper)
+        .env("HUGEPAGE_POOL_LOCK", &lock)
+        .env("HUGEPAGE_POOL_LOCK_WAIT", "2")
+        .args(["sh", "-c", "echo took-it"])
+        .output()
+        .expect("run helper");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.status.success() && !text.contains("took-it"),
+        "the helper locked THROUGH a planted symlink instead of refusing it:\n{text}"
+    );
+    assert!(
+        text.contains("symlink"),
+        "the refusal must say why:\n{text}"
+    );
+    assert!(
+        lock.is_symlink(),
+        "the helper must not replace an entry it did not create"
+    );
+}
+
+/// A lock owned by anyone but root, the invoking user, or the directory's
+/// owner is refused: that owner can unlink and recreate it under a holder.
+#[test]
+fn hugepage_lock_helper_refuses_a_lock_another_user_can_recreate() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let lock = dir.path().join("hugepage-pool.lock");
+    std::fs::write(&lock, b"").expect("lock");
+    let chowned = std::process::Command::new("sudo")
+        .args(["chown", "65534:65534"])
+        .arg(&lock)
+        .status()
+        .expect("sudo chown");
+    assert!(chowned.success(), "stage a lock owned by another uid");
+    let helper = concat!(env!("CARGO_MANIFEST_DIR"), "/scripts/hugepage-pool-lock.sh");
+    let out = std::process::Command::new(helper)
+        .env("HUGEPAGE_POOL_LOCK", &lock)
+        .env("HUGEPAGE_POOL_LOCK_WAIT", "2")
+        .args(["sh", "-c", "echo took-it"])
+        .output()
+        .expect("run helper");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.status.success() && !text.contains("took-it"),
+        "the helper trusted a lock owned by uid 65534, who can recreate it under a \
+         holder:\n{text}"
+    );
+    assert!(
+        text.contains("owned by uid 65534"),
+        "the refusal must say why:\n{text}"
+    );
 }
 
 /// Concurrent first-time creators end up on ONE inode, and the helper keeps

--- a/tests/test_documented_make_targets.rs
+++ b/tests/test_documented_make_targets.rs
@@ -817,25 +817,21 @@ fn hugepage_lock_is_taken_through_the_helper_at_every_site() {
     }
 }
 
-/// A stand-in for the lock's caller that is never root.
+/// Run `program` as an unprivileged stand-in when the tests are root.
 ///
 /// The read-only open matters only for an unprivileged opener: for root,
 /// "protected_regular would refuse O_CREAT" and "the owner is untrusted" are
 /// the same condition (a file owned by neither root nor the directory's
-/// owner). So under sudo the helper is driven as `nobody`, from a copy the
-/// tests place where `nobody` can read it.
-fn as_unprivileged(dir: &std::path::Path, program: &str) -> std::process::Command {
+/// owner). Under the privileged runner the helper is therefore driven as uid
+/// 65534 through `setpriv`, from a copy placed where that uid can read it. No
+/// sudo anywhere: `make test-fast` shims it to fail, and root needs none.
+fn as_unprivileged(program: &str) -> std::process::Command {
     if unsafe { libc::geteuid() } == 0 {
-        let mut c = std::process::Command::new("sudo");
-        c.args([
-            "-u",
-            "nobody",
-            "--preserve-env=HUGEPAGE_POOL_LOCK,HUGEPAGE_POOL_LOCK_WAIT",
-        ]);
+        let mut c = std::process::Command::new("setpriv");
+        c.args(["--reuid=65534", "--regid=65534", "--clear-groups"]);
         c.arg(program);
         c
     } else {
-        let _ = dir;
         std::process::Command::new(program)
     }
 }
@@ -850,46 +846,57 @@ fn helper_copy(dir: &std::path::Path) -> String {
     dst.to_string_lossy().into_owned()
 }
 
-/// The helper takes a root-owned lock in a user-owned sticky directory, the
-/// production shape, as an unprivileged caller.
+/// The helper opens the lock read-only, never with O_CREAT.
 ///
-/// The fixture first proves the failure it guards against: `flock <path>`
-/// (O_CREAT) is refused there by protected_regular. A box with the sysctl off
-/// fails here instead of passing vacuously.
+/// Two fixtures, one per lane, each proving the failure it guards against
+/// before showing the helper succeed:
+/// - as root (the privileged lanes): the production shape, a root-owned lock
+///   in a user-owned 1777 directory, opened by uid 65534, where `flock <path>`
+///   (O_CREAT) is refused by protected_regular;
+/// - as a user (the unprivileged lanes, where no other uid's file can be
+///   staged): a 0444 lock of one's own, which a `<>` open refuses.
+///
+/// A box with the sysctl off fails the root branch instead of passing it.
 #[test]
 fn hugepage_lock_helper_opens_the_lock_without_o_creat() {
     use std::os::unix::fs::PermissionsExt as _;
     let dir = tempfile::tempdir().expect("tempdir");
-    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o1777))
-        .expect("chmod 1777");
-    let root = unsafe { libc::geteuid() } == 0;
-    if root {
-        // The stand-in is nobody, so the directory's owner must be nobody
-        // for the shape to hold (file owner outside {opener, dir owner}).
-        std::os::unix::fs::chown(dir.path(), Some(65534), Some(65534)).expect("chown dir");
-    }
     let lock = dir.path().join("hugepage-pool.lock");
-    let created = std::process::Command::new("sudo")
-        .args(["install", "-m", "644", "/dev/null"])
-        .arg(&lock)
-        .status()
-        .expect("sudo install");
-    assert!(created.success(), "stage a root-owned lock");
+    let root = unsafe { libc::geteuid() } == 0;
     let helper = helper_copy(dir.path());
+    if root {
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o1777))
+            .expect("chmod 1777");
+        std::os::unix::fs::chown(dir.path(), Some(65534), Some(65534)).expect("chown dir");
+        std::fs::write(&lock, b"").expect("root-owned lock");
+        std::fs::set_permissions(&lock, std::fs::Permissions::from_mode(0o644)).expect("0644");
+        let refused = as_unprivileged("flock")
+            .args(["-x", "-n"])
+            .arg(&lock)
+            .arg("true")
+            .status()
+            .expect("flock by path as uid 65534");
+        assert!(
+            !refused.success(),
+            "fixture does not reproduce: `flock <path>` (O_CREAT) on a root-owned lock in \
+             a user-owned sticky directory succeeded for uid 65534, so fs.protected_regular \
+             is off on this box"
+        );
+    } else {
+        std::fs::write(&lock, b"").expect("lock");
+        std::fs::set_permissions(&lock, std::fs::Permissions::from_mode(0o444)).expect("0444");
+        let refused = std::process::Command::new("bash")
+            .args(["-c", "exec 9<>\"$1\"", "_"])
+            .arg(&lock)
+            .status()
+            .expect("run <> open");
+        assert!(
+            !refused.success(),
+            "fixture does not reproduce: a `<>` open of a 0444 lock succeeded"
+        );
+    }
 
-    let refused = as_unprivileged(dir.path(), "flock")
-        .args(["-x", "-n"])
-        .arg(&lock)
-        .arg("true")
-        .status()
-        .expect("flock by path");
-    assert!(
-        !refused.success(),
-        "fixture does not reproduce: `flock <path>` (O_CREAT) on a root-owned lock in a \
-         user-owned sticky directory succeeded, so fs.protected_regular is off on this box"
-    );
-
-    let out = as_unprivileged(dir.path(), &helper)
+    let out = as_unprivileged(&helper)
         .env("HUGEPAGE_POOL_LOCK", &lock)
         .env("HUGEPAGE_POOL_LOCK_WAIT", "2")
         .args(["sh", "-c", "echo took-it"])
@@ -902,8 +909,12 @@ fn hugepage_lock_helper_opens_the_lock_without_o_creat() {
     );
     assert!(
         out.status.success() && text.contains("took-it"),
-        "the helper failed to take a root-owned lock it only needs to open read-only:\n{text}"
+        "the helper failed to take a lock it only needs to open read-only:\n{text}"
     );
+    if root {
+        // Hand the directory back so the tempdir can be removed.
+        let _ = std::os::unix::fs::chown(dir.path(), Some(0), Some(0));
+    }
 }
 
 /// A symlink at the lock path is refused, not followed (codex, CodeRabbit on
@@ -944,17 +955,17 @@ fn hugepage_lock_helper_refuses_a_planted_symlink() {
 
 /// A lock owned by anyone but root, the invoking user, or the directory's
 /// owner is refused: that owner can unlink and recreate it under a holder.
+///
+/// Privileged lanes only: staging a file owned by another uid takes root, and
+/// `make test-fast` shims sudo to fail.
+#[cfg(feature = "privileged-tests")]
 #[test]
 fn hugepage_lock_helper_refuses_a_lock_another_user_can_recreate() {
     let dir = tempfile::tempdir().expect("tempdir");
     let lock = dir.path().join("hugepage-pool.lock");
     std::fs::write(&lock, b"").expect("lock");
-    let chowned = std::process::Command::new("sudo")
-        .args(["chown", "65534:65534"])
-        .arg(&lock)
-        .status()
-        .expect("sudo chown");
-    assert!(chowned.success(), "stage a lock owned by another uid");
+    std::os::unix::fs::chown(&lock, Some(65534), Some(65534))
+        .expect("stage a lock owned by another uid (this test runs as root)");
     let helper = concat!(env!("CARGO_MANIFEST_DIR"), "/scripts/hugepage-pool-lock.sh");
     let out = std::process::Command::new(helper)
         .env("HUGEPAGE_POOL_LOCK", &lock)


### PR DESCRIPTION
`make test-root` on a fresh-setup box dies at its first step:

```
==> Allocating hugepage pool (512 pages = 1024MB)...
flock: cannot open lock file /mnt/fcvm-btrfs/hugepage-pool.lock: Permission denied
make: *** [Makefile:643: setup-hugepages] Error 66
```

`setup-hugepages` and `bench-chromium-fault` created the lock with `sudo touch` + `chmod 666`, leaving a root-owned file. `/mnt/fcvm-btrfs` after a fresh setup is sticky and world-writable (1777), and `fs.protected_regular` refuses an `O_CREAT` open of a file owned by someone else in such a directory, which is what util-linux `flock <path>` and bash `<>` do. So the unprivileged `flock` failed on every run after the one that created the lock. CI never saw it because the runner user owns the whole volume.

## What changed

The lock keeps its identity, `/mnt/fcvm-btrfs/hugepage-pool.lock`, at all three sites that share it; what changes is how it is opened and created:

- **Opened read-only, never with `O_CREAT`.** `fs.protected_regular` only governs `O_CREAT` opens, and `flock(2)` does not care about the open mode, so the file's owner stops mattering. `scripts/hugepage-pool-lock.sh` (new; used by both recipes) does `exec 9<"$lock"` then `flock -x -w 60 9` and runs the command as a child while holding fd 9 (not `exec`: sudo closes inherited descriptors, which would release the lock right before the privileged pool write). `reqbench.sh` does the same with `exec {fd}<`.
- **Created atomically when absent.** `install -m 644 /dev/null` onto a temp name, then a hard link onto the final name, which fails if it already exists, so concurrent creators agree on one inode. Nothing chmods or chowns a path under the invoker's directory; `install` sets the mode on the file it creates and replaces a planted symlink rather than following it. The helper uses sudo for creation only when the data root is not writable (fresh boxes).

Four commits, in order:

1. `352e0789` chowned the lock file to the invoker at both recipe sites. Superseded: two users chowning in turn race (Codex), and root's `chmod`/`chown` under the invoker's directory follow whatever symlink sits there (CodeRabbit).
2. `178a40eb` moved the explanatory comments out of the continued recipes. A tab-indented `#` line inside a recipe is shell text and eats the trailing backslash; four Host-Root jobs failed with `syntax error: unexpected end of file`. Adds `hugepage_lock_recipes_are_valid_shell_as_make_runs_them`, which drives the recipe through make with `SHELL='bash -n'`.
3. `6ad74006` replaced the file with a lock directory. Superseded: it changed the lock's identity, so an old `reqbench.sh` phase still holding the file was no longer serialized against new code (Codex).
4. `952d3533` The file again, opened without `O_CREAT`, created atomically, taken through the helper.
5. `e95b42e7` The entry is checked before and after opening. A symlink, a non-regular file, or an owner outside {root, invoking user, data-root owner} is refused (that owner can repoint or recreate it under a holder; the sticky bit stops everyone else), and after the open the descriptor's inode must be the path's own. Creation is always as root (raised in review by both bots).
6. `071cc8c3` No `sudo` in the tests or in the helper's writable-directory path. `e95b42e7` failed Host-x64/arm64 and Container-x64/arm64 on CI's `no-sudo.sh` shim (`make test-fast` shadows sudo with a failing stub; `make test-unit`, which I had run locally, does not). The helper creates the lock as the invoking user when the directory is writable and uses sudo only on a fresh box whose data root is still root-owned; the other-uid fixture is `#[cfg(feature = "privileged-tests")]` and chowns directly; the production-shape open test runs the helper as uid 65534 through `setpriv` when the tests are root.

`reqbench.sh` is part of the sealed bench bundle, so its hash changes: goldens recorded before this PR must be re-recorded before a `run`.
7. This head: privilege is spent only on the fixed shared path, through fixed programs with quoted arguments (`sudo mkdir -p -- /mnt/fcvm-btrfs`, `sudo install -m 644 -- /dev/null "$tmp"`, `sudo ln -- "$tmp" "$default_lock"`, `sudo rm -f -- "$tmp"`); the shared lock is therefore root-owned, an owner every caller's allowlist accepts, and an overridden `HUGEPAGE_POOL_LOCK` is created unprivileged or refused, never with sudo (CodeRabbit CWE-73, Codex). Every remaining writer of `nr_hugepages` (the four `bench-hugepages*` lines, bench.sh's grow and exit-trap restore) goes through the helper (Codex). Two review threads are answered with DISAGREE and reasoning: a lock cannot defend against the data root's operator, and moving it out of the data root changes the identity in-flight phases depend on.

## Test evidence

`tests/test_documented_make_targets.rs`:
- `hugepage_lock_is_taken_through_the_helper_at_every_site`: both recipes go through the helper and neither touches/chowns/chmods/mkdirs around the lock; the helper opens with `exec 9<"$lock"`, creates with `ln`, and has no `chown`/`chmod`. Fails against the directory revision.
- `hugepage_lock_helper_opens_the_lock_without_o_creat`: as root, the production shape, a root-owned lock in a user-owned 1777 directory, opened by uid 65534 via `setpriv`; the fixture first proves `flock <path>` is refused there (`protected_regular=2`), then the helper succeeds. As a user, a 0444 lock of one's own that `<>` refuses.
- `hugepage_lock_helper_refuses_a_planted_symlink`, `hugepage_lock_helper_refuses_a_lock_another_user_can_recreate` (privileged lanes): a symlink at the lock path and a lock owned by uid 65534 are refused with the reason; both were accepted by `952d3533`.
- `hugepage_lock_helper_holds_the_lock_while_the_command_runs`: eight concurrent first-time creators report one inode behind fd 9, the lock is 0644 with no temp files left, and a by-path contender is refused until the helper's command exits.
- `every_hugepage_pool_writer_takes_the_lock`: enumerates every `nr_hugepages` write in the Makefile, `bench/chromium/*.sh`, `scripts/*.sh` and requires the helper on the line or its continued command; failed on `Makefile:1247` before this head, finds eight writers now.
- `hugepage_lock_helper_never_escalates_for_an_overridden_path`: a recording `sudo` stub first on PATH; an overridden path is created unprivileged, and one under `/proc/self` is refused, with the stub never called (the previous helper called sudo there).
- `hugepage_lock_recipes_are_valid_shell_as_make_runs_them` (from commit 2).

`bench/chromium/test_reqbench.py`: `test_pool_lock_refuses_a_planted_symlink` (a symlinked lock path is refused and the pool untouched; the previous head grew the pool through it); `test_pool_grow_respects_exclusive_holder` holds the lock the way an OLD phase does (`touch`, `exec 9<>`, `flock -x 9`) and the grow must block; `test_pool_lease_held_shared_through_phase` probes by path; `test_fault_target_provisions_its_hugepage_pool` pins the helper and forbids touch/chown/chmod. All three fail against the directory revision (`0 == 0 : grow must not race a concurrent pool owner`; `'POOL-HELD' not found`; helper not found). Full file: `Ran 193 tests ... OK`.

Verified in both lanes locally: `make test-fast` (sudo shimmed) and `make test-root` (privileged). `make lint` clean.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd
