### PR TITLE
Make the fast-teardown leak test own the contract it can assert, and its log capture honest

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -779,16 +779,16 @@ fn spawn_log_consumer_opts<R: tokio::io::AsyncRead + Unpin + Send + 'static>(
                         }
                         continue;
                     }
-                    // Any other read error is the stream itself failing; there
-                    // is nothing further to read, and the marker records it.
+                    // Any other read error is the stream itself failing, and
+                    // whatever the child wrote after it is lost. That is NOT
+                    // end-of-stream: the failure record below is what
+                    // `wait_for_log_eof` turns into an error, and the clean
+                    // marker is deliberately not written.
                     Err(e) => {
                         if let Some(ref log) = logger {
-                            log.log_raw(&format!(
-                                "[fcvm-test] {} consumer stopped on a read error: {}",
-                                name, e
-                            ));
+                            log.log_raw(&format!("{}{}", log_failure_prefix(is_stderr), e));
                         }
-                        break;
+                        return;
                     }
                 };
                 let prefix = if is_stderr {
@@ -842,6 +842,16 @@ fn log_eof_marker(is_stderr: bool) -> &'static str {
     }
 }
 
+/// The record a consumer writes instead of the marker when its stream FAILS.
+/// The read error follows the prefix on the same line.
+fn log_failure_prefix(is_stderr: bool) -> &'static str {
+    if is_stderr {
+        "[fcvm-test] child stderr capture failed: "
+    } else {
+        "[fcvm-test] child stdout capture failed: "
+    }
+}
+
 /// Wait until BOTH of a spawned fcvm's log consumers have drained their streams
 /// into `log_path`, then return. Call this after the child has exited and before
 /// asserting on the log's contents.
@@ -862,6 +872,20 @@ pub async fn wait_for_log_eof(log_path: &std::path::Path, timeout: Duration) -> 
         // the harness's own records with a timestamp, so nothing but the marker
         // itself can produce this line. A substring test would be satisfied by
         // an argv or a child line that merely quotes the marker's text.
+        // A failed stream never reaches end-of-stream; report it rather than
+        // wait out the timeout, and never certify the file as complete.
+        for is_stderr in [false, true] {
+            if let Some(line) = text
+                .lines()
+                .find(|line| line.starts_with(log_failure_prefix(is_stderr)))
+            {
+                anyhow::bail!(
+                    "log {} is incomplete: {}",
+                    log_path.display(),
+                    line.trim_start_matches("[fcvm-test] ")
+                );
+            }
+        }
         let reached = |marker: &str| text.lines().any(|line| line == marker);
         if reached(log_eof_marker(false)) && reached(log_eof_marker(true)) {
             return Ok(());

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -731,7 +731,7 @@ pub fn spawn_log_consumer_stderr_with_logger(
 /// When a logger is provided:
 /// - All lines (including DEBUG/TRACE) are written to the file
 /// - Only non-debug lines are printed to console for cleaner output
-fn spawn_log_consumer_to_file<R: tokio::io::AsyncRead + Unpin + Send + 'static>(
+pub fn spawn_log_consumer_to_file<R: tokio::io::AsyncRead + Unpin + Send + 'static>(
     reader: Option<R>,
     name: &str,
     logger: Option<TestLogger>,
@@ -760,7 +760,37 @@ fn spawn_log_consumer_opts<R: tokio::io::AsyncRead + Unpin + Send + 'static>(
         tokio::spawn(async move {
             let reader = BufReader::new(reader);
             let mut lines = reader.lines();
-            while let Ok(Some(line)) = lines.next_line().await {
+            loop {
+                let line = match lines.next_line().await {
+                    Ok(Some(line)) => line,
+                    Ok(None) => break,
+                    // One unreadable line (a guest console is not obliged to
+                    // emit UTF-8) must not end the capture: the rest of the
+                    // stream is still coming, and the end-of-stream marker
+                    // below would then certify a truncated log as complete.
+                    // tokio has already consumed the offending line, so the
+                    // next read starts at the line after it.
+                    Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
+                        if let Some(ref log) = logger {
+                            log.log_raw(&format!(
+                                "[fcvm-test] {} consumer skipped an unreadable line: {}",
+                                name, e
+                            ));
+                        }
+                        continue;
+                    }
+                    // Any other read error is the stream itself failing; there
+                    // is nothing further to read, and the marker records it.
+                    Err(e) => {
+                        if let Some(ref log) = logger {
+                            log.log_raw(&format!(
+                                "[fcvm-test] {} consumer stopped on a read error: {}",
+                                name, e
+                            ));
+                        }
+                        break;
+                    }
+                };
                 let prefix = if is_stderr {
                     format!("[{} ERR]", name)
                 } else {
@@ -781,6 +811,15 @@ fn spawn_log_consumer_opts<R: tokio::io::AsyncRead + Unpin + Send + 'static>(
                 }
             }
 
+            // The stream is closed: every line this consumer will ever write is
+            // in the file. `Child::wait()` only waits for the PROCESS; this task
+            // can still be copying buffered output when it returns, so a test that
+            // reads the log right after `wait()` races it. The marker is what
+            // `wait_for_log_eof` polls for.
+            if let Some(ref log) = logger {
+                log.log_raw(log_eof_marker(is_stderr));
+            }
+
             // Print log file path when stderr stream ends (once per process)
             if is_stderr {
                 if let Some(ref log) = logger {
@@ -788,6 +827,54 @@ fn spawn_log_consumer_opts<R: tokio::io::AsyncRead + Unpin + Send + 'static>(
                 }
             }
         });
+    }
+}
+
+/// The line a log consumer appends when its stream reaches end-of-file.
+///
+/// Deliberately free of the words tests grep log files for (error, panic,
+/// leak, cleanup, delete), so its presence never trips an absence check.
+fn log_eof_marker(is_stderr: bool) -> &'static str {
+    if is_stderr {
+        "[fcvm-test] child stderr reached end of stream"
+    } else {
+        "[fcvm-test] child stdout reached end of stream"
+    }
+}
+
+/// Wait until BOTH of a spawned fcvm's log consumers have drained their streams
+/// into `log_path`, then return. Call this after the child has exited and before
+/// asserting on the log's contents.
+///
+/// The consumers spawned by `spawn_fcvm_with_env_and_log_path` (and every helper
+/// built on it) are detached tokio tasks; the child's exit does not join them,
+/// and a stream only closes once every holder of its write end has exited, which
+/// for fcvm includes the VMM it spawned. Reading the file before both end-of-stream
+/// markers are present can miss the last lines fcvm wrote: a positive control
+/// looking for a shutdown line fails spuriously, and an absence check passes
+/// vacuously against a still-filling file.
+pub async fn wait_for_log_eof(log_path: &std::path::Path, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let text = std::fs::read_to_string(log_path)
+            .with_context(|| format!("reading log {}", log_path.display()))?;
+        // Whole-line match: child output is written with a `[name]` prefix and
+        // the harness's own records with a timestamp, so nothing but the marker
+        // itself can produce this line. A substring test would be satisfied by
+        // an argv or a child line that merely quotes the marker's text.
+        let reached = |marker: &str| text.lines().any(|line| line == marker);
+        if reached(log_eof_marker(false)) && reached(log_eof_marker(true)) {
+            return Ok(());
+        }
+        anyhow::ensure!(
+            std::time::Instant::now() < deadline,
+            "log {} did not reach end of stream on both stdout and stderr within {:?}; \
+             the child (or a process holding its pipes) is still alive, or the log \
+             consumer is wedged",
+            log_path.display(),
+            timeout
+        );
+        tokio::time::sleep(POLL_INTERVAL).await;
     }
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -758,32 +758,45 @@ fn spawn_log_consumer_opts<R: tokio::io::AsyncRead + Unpin + Send + 'static>(
         let name = name.to_string();
         let has_logger = logger.is_some();
         tokio::spawn(async move {
-            let reader = BufReader::new(reader);
-            let mut lines = reader.lines();
+            let mut reader = BufReader::new(reader);
+            let mut raw = Vec::new();
             loop {
-                let line = match lines.next_line().await {
-                    Ok(Some(line)) => line,
-                    Ok(None) => break,
-                    // One unreadable line (a guest console is not obliged to
-                    // emit UTF-8) must not end the capture: the rest of the
-                    // stream is still coming, and the end-of-stream marker
-                    // below would then certify a truncated log as complete.
-                    // tokio has already consumed the offending line, so the
-                    // next read starts at the line after it.
-                    Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
-                        if let Some(ref log) = logger {
-                            log.log_raw(&format!(
-                                "[fcvm-test] {} consumer skipped an unreadable line: {}",
-                                name, e
-                            ));
+                raw.clear();
+                // `read_until` + `from_utf8`, not `Lines`: tokio's `Lines` reports
+                // a UTF-8 decode failure AND an `InvalidData` error from the
+                // reader itself the same way, and only the former is "one bad
+                // line, keep going". Every reader error ends the capture with
+                // the failure record below, never the clean marker.
+                let line = match reader.read_until(b'\n', &mut raw).await {
+                    Ok(0) => break,
+                    Ok(_) => {
+                        if raw.last() == Some(&b'\n') {
+                            raw.pop();
+                            if raw.last() == Some(&b'\r') {
+                                raw.pop();
+                            }
                         }
-                        continue;
+                        match String::from_utf8(std::mem::take(&mut raw)) {
+                            Ok(line) => line,
+                            // A guest console is not obliged to emit UTF-8. One
+                            // undecodable line must not end the capture: the rest
+                            // of the stream is still coming.
+                            Err(e) => {
+                                if let Some(ref log) = logger {
+                                    log.log_raw(&format!(
+                                        "[fcvm-test] {} consumer skipped an unreadable line: {}",
+                                        name, e
+                                    ));
+                                }
+                                continue;
+                            }
+                        }
                     }
-                    // Any other read error is the stream itself failing, and
-                    // whatever the child wrote after it is lost. That is NOT
-                    // end-of-stream: the failure record below is what
-                    // `wait_for_log_eof` turns into an error, and the clean
-                    // marker is deliberately not written.
+                    // The stream itself failed, whatever the error's kind:
+                    // whatever the child wrote after this is lost, so this is
+                    // NOT end-of-stream. `wait_for_log_eof` turns the record
+                    // into an error; the clean marker is deliberately not
+                    // written.
                     Err(e) => {
                         if let Some(ref log) = logger {
                             log.log_raw(&format!("{}{}", log_failure_prefix(is_stderr), e));

--- a/tests/test_log_capture.rs
+++ b/tests/test_log_capture.rs
@@ -61,6 +61,62 @@ async fn log_capture_continues_past_an_unreadable_line() {
     );
 }
 
+/// A reader that serves one line and then fails with a non-UTF-8 error.
+struct TornPipe {
+    served: bool,
+}
+
+impl tokio::io::AsyncRead for TornPipe {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        let me = self.get_mut();
+        if !me.served {
+            me.served = true;
+            buf.put_slice(b"only line before the tear\n");
+            std::task::Poll::Ready(Ok(()))
+        } else {
+            std::task::Poll::Ready(Err(std::io::Error::other("pipe torn")))
+        }
+    }
+}
+
+#[tokio::test]
+async fn wait_for_log_eof_reports_a_failed_capture_instead_of_certifying_it() {
+    let logger = common::TestLogger::new("log-capture-torn");
+    let path = logger.path().clone();
+    let stderr: &'static [u8] = b"";
+    common::spawn_log_consumer_to_file(
+        Some(TornPipe { served: false }),
+        "torn",
+        Some(logger.clone()),
+        false,
+    );
+    common::spawn_log_consumer_to_file(Some(stderr), "torn", Some(logger), true);
+
+    // A read error is not end-of-stream: whatever the child wrote after it
+    // was never captured. Certifying that file complete lets an absence
+    // check pass against a truncated log, so the waiter must fail instead.
+    let result = common::wait_for_log_eof(&path, Duration::from_secs(5)).await;
+    let text = std::fs::read_to_string(&path).unwrap();
+    let err = match result {
+        Ok(()) => panic!(
+            "wait_for_log_eof certified a capture whose stream failed mid-way as complete:\n{text}"
+        ),
+        Err(e) => e.to_string(),
+    };
+    assert!(
+        err.contains("pipe torn"),
+        "the waiter's error must carry the read error, not a timeout:\n{err}\n{text}"
+    );
+    assert!(
+        text.contains("only line before the tear"),
+        "the lines before the failure must still be in the file:\n{text}"
+    );
+}
+
 #[tokio::test]
 async fn wait_for_log_eof_ignores_a_child_line_that_quotes_the_marker() {
     let logger = common::TestLogger::new("log-capture-quoted-marker");

--- a/tests/test_log_capture.rs
+++ b/tests/test_log_capture.rs
@@ -1,0 +1,105 @@
+//! The test log capture must be complete before a test reads it.
+//!
+//! `spawn_fcvm_with_env_and_log_path` copies a child's stdout and stderr into a
+//! log file from two detached tasks. Tests assert on that file after the child
+//! exits, and a capture that is silently incomplete turns an absence check into
+//! a vacuous pass. Two ways it was incomplete, each pinned here by a test that
+//! failed before its fix:
+//!
+//! - one unreadable line (invalid UTF-8 from a guest console) ended the copy
+//!   loop, dropping everything after it, and the end-of-stream marker then
+//!   certified the truncated file as complete;
+//! - `wait_for_log_eof` matched the marker as a substring, so a child line that
+//!   quoted it (or an argv that contained it) released the waiter while the
+//!   stream was still draining.
+
+mod common;
+
+use std::time::Duration;
+use tokio::io::AsyncWriteExt;
+
+/// Ends when the log holds an exact `marker` line, or panics after `timeout`.
+async fn wait_for_line(path: &std::path::Path, marker: &str, timeout: Duration) {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let text = std::fs::read_to_string(path).unwrap_or_default();
+        if text.lines().any(|l| l == marker) {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "no line {marker:?} in {} after {timeout:?}",
+            path.display()
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test]
+async fn log_capture_continues_past_an_unreadable_line() {
+    let logger = common::TestLogger::new("log-capture-utf8");
+    let path = logger.path().clone();
+    // Line 2 is not UTF-8. Before the fix the copy loop treated the resulting
+    // read error as end-of-stream and line 3 never reached the file.
+    let stdout: &'static [u8] = b"before-the-bad-line\n\xff\xfe\n after-the-bad-line\n";
+    let stderr: &'static [u8] = b"";
+    common::spawn_log_consumer_to_file(Some(stdout), "utf8", Some(logger.clone()), false);
+    common::spawn_log_consumer_to_file(Some(stderr), "utf8", Some(logger), true);
+
+    common::wait_for_log_eof(&path, Duration::from_secs(5))
+        .await
+        .expect("both consumers reach end of stream");
+    let text = std::fs::read_to_string(&path).unwrap();
+    assert!(
+        text.contains("after-the-bad-line"),
+        "the line after the unreadable one was dropped; the capture is truncated \
+         and the end-of-stream marker certified it anyway:\n{text}"
+    );
+    assert!(
+        text.contains("before-the-bad-line"),
+        "the line before the unreadable one is missing:\n{text}"
+    );
+}
+
+#[tokio::test]
+async fn wait_for_log_eof_ignores_a_child_line_that_quotes_the_marker() {
+    let logger = common::TestLogger::new("log-capture-quoted-marker");
+    let path = logger.path().clone();
+    let (reader, mut writer) = tokio::io::duplex(256);
+    let stderr: &'static [u8] = b"";
+    common::spawn_log_consumer_to_file(Some(reader), "quoter", Some(logger.clone()), false);
+    common::spawn_log_consumer_to_file(Some(stderr), "quoter", Some(logger), true);
+
+    // The child prints the marker's text as ordinary output, then keeps going.
+    // A substring match releases the waiter here; the real marker is a line of
+    // its own, written only when this stream closes.
+    writer
+        .write_all(b"[fcvm-test] child stdout reached end of stream\n")
+        .await
+        .unwrap();
+    wait_for_line(
+        &path,
+        "[quoter] [fcvm-test] child stdout reached end of stream",
+        Duration::from_secs(5),
+    )
+    .await;
+    let late = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        writer.write_all(b"late line\n").await.unwrap();
+        drop(writer);
+    });
+
+    common::wait_for_log_eof(&path, Duration::from_secs(5))
+        .await
+        .expect("both consumers reach end of stream");
+    // Snapshot the file the instant the waiter returns: what it certified
+    // complete is what gets judged, not what drained while we awaited the
+    // writer afterwards.
+    let text = std::fs::read_to_string(&path).unwrap();
+    late.await.unwrap();
+    assert!(
+        text.contains("late line"),
+        "wait_for_log_eof returned before the stream closed, released by a child \
+         line that merely quoted the marker:\n{text}"
+    );
+}

--- a/tests/test_log_capture.rs
+++ b/tests/test_log_capture.rs
@@ -83,6 +83,70 @@ impl tokio::io::AsyncRead for TornPipe {
     }
 }
 
+/// A reader that serves one line, then fails with an `InvalidData` I/O error,
+/// then reports end-of-stream.
+struct InvalidDataThenEof {
+    step: u8,
+}
+
+impl tokio::io::AsyncRead for InvalidDataThenEof {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        let me = self.get_mut();
+        me.step += 1;
+        match me.step {
+            1 => {
+                buf.put_slice(b"served before the failure\n");
+                std::task::Poll::Ready(Ok(()))
+            }
+            2 => std::task::Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "reader reported corrupt input",
+            ))),
+            _ => std::task::Poll::Ready(Ok(())), // EOF
+        }
+    }
+}
+
+#[tokio::test]
+async fn a_reader_invalid_data_error_is_a_failed_capture_not_a_skipped_line() {
+    // tokio's `Lines` reports a UTF-8 decode failure AND an `InvalidData`
+    // error from the reader itself the same way. Only the former is "one bad
+    // line, keep going"; the latter is the stream failing, and an EOF after it
+    // must not certify the capture complete (CodeRabbit on #869).
+    let logger = common::TestLogger::new("log-capture-reader-invalid-data");
+    let path = logger.path().clone();
+    let stderr: &'static [u8] = b"";
+    common::spawn_log_consumer_to_file(
+        Some(InvalidDataThenEof { step: 0 }),
+        "rid",
+        Some(logger.clone()),
+        false,
+    );
+    common::spawn_log_consumer_to_file(Some(stderr), "rid", Some(logger), true);
+
+    let result = common::wait_for_log_eof(&path, Duration::from_secs(5)).await;
+    let text = std::fs::read_to_string(&path).unwrap();
+    let err = match result {
+        Ok(()) => panic!(
+            "a reader error of kind InvalidData was treated as a skipped line and the \
+             following EOF certified the capture complete:\n{text}"
+        ),
+        Err(e) => e.to_string(),
+    };
+    assert!(
+        err.contains("reader reported corrupt input"),
+        "the waiter's error must carry the reader's error:\n{err}\n{text}"
+    );
+    assert!(
+        text.contains("served before the failure"),
+        "lines before the failure stay:\n{text}"
+    );
+}
+
 #[tokio::test]
 async fn wait_for_log_eof_reports_a_failed_capture_instead_of_certifying_it() {
     let logger = common::TestLogger::new("log-capture-torn");

--- a/tests/test_signal_cleanup.rs
+++ b/tests/test_signal_cleanup.rs
@@ -1828,25 +1828,27 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
         // below must hold against it rather than hope to precede it.
         //
         // The trigger is precise: `load_state_by_pid` cleans only on a MISS,
-        // and a dead PID whose file still exists IS a miss (its identity check
-        // fails). So `fcvm exec --pid <the dead clone>` runs the cleanup, reaps
-        // the clone's own file, and then fails because there is no such VM --
-        // the expected outcome. Two earlier drafts reaped nothing: `fcvm ls`
-        // (`list_vms` does not clean) and `exec --pid <base>` (a hit, so the
-        // cleanup never ran). Both passed; neither proved anything.
+        // and the cleanup it runs scans EVERY state file, not just the one
+        // asked for. So the PID passed here is one no process can ever hold
+        // (`pid_max` is at most 2^22; `u32::MAX` is far above it): always a
+        // miss, so the cleanup always runs, and never a hit on some OTHER
+        // test's VM that happened to be handed the dead clone's PID number,
+        // which `exec --pid <the dead clone>` would have run `true` inside.
+        // Two earlier drafts reaped nothing: `fcvm ls` (`list_vms` does not
+        // clean) and `exec --pid <base>` (a hit, so the cleanup never ran).
+        // Both passed; neither proved anything. Hence the assertion after it.
         let reaper = tokio::process::Command::new(common::find_fcvm_binary()?)
-            .args(["exec", "--pid", &clone_pid.to_string(), "--", "true"])
+            .args(["exec", "--pid", &u32::MAX.to_string(), "--", "true"])
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status()
             .await
             .context("running `fcvm exec` as the stale-state reaper")?;
-        anyhow::ensure!(
-            !reaper.success(),
-            "`fcvm exec --pid {clone_pid}` SUCCEEDED against a SIGKILLed clone: that PID \
-             now belongs to a live VM, so the identity check that gates stale-state \
-             cleanup is not doing its job"
-        );
+        // Verdicts are RECORDED here and asserted after the fixture is torn down
+        // (below, with the others): a panic at this point would skip the
+        // baseline's and the serve's graceful shutdown and the snapshot delete.
+        let reaper_hit_a_vm = reaper.success();
+        let state_reaped = !state_file.exists();
 
         let deadline = std::time::Instant::now() + Duration::from_secs(15);
         while std::time::Instant::now() < deadline {
@@ -1868,7 +1870,6 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
             t.kill_if_running();
         }
 
-        let state_survived = state_file.exists();
         let data_survived = data_dir.is_dir();
 
         // Clean up the rest of the fixture before asserting, so a failure does not also
@@ -1902,6 +1903,20 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
         }
 
         assert!(
+            !reaper_hit_a_vm,
+            "`fcvm exec --pid {}` SUCCEEDED: no process can hold that PID, so a hit \
+             means load_state_by_pid no longer checks the PID at all",
+            u32::MAX
+        );
+        assert!(
+            state_reaped,
+            "the reaper ran and the SIGKILLed clone's state file {} was still there \
+             afterwards: `fcvm exec --pid <impossible>` no longer reaches \
+             cleanup_stale_state on a miss, or the cleanup no longer treats a dead PID \
+             as stale. The rest of this test relies on that reap being deterministic.",
+            state_file.display()
+        );
+        assert!(
             survivors.is_empty(),
             "LEAK: the fast teardown's single SIGKILL to fcvm left these orphaned to init: \
              {:?}. The PR_SET_PDEATHSIG chain through the snapshot-restore spawn path is \
@@ -1922,12 +1937,25 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
         // tolerate. The killed process's own debug log is the direct evidence:
         // `cleanup_vm` logs "cleaning up resources" and `delete_state` logs
         // "delete_state: deleting state file"; under SIGKILL neither can appear.
+        // Both of the clone's log consumers must have drained before the file is
+        // read: `Child::wait()` returns when fcvm is dead, not when the tasks
+        // copying its last buffered lines have finished.
+        common::wait_for_log_eof(&clone_log, Duration::from_secs(30))
+            .await
+            .context("waiting for the clone's log to drain")?;
         let clone_trace = std::fs::read_to_string(&clone_log)
             .with_context(|| format!("reading the clone's debug log {}", clone_log.display()))?;
+        // A line the CLONE PROCESS wrote, not the harness: the helper's own
+        // "Spawned fcvm ... args=["snapshot", ...]" record is in this file before
+        // a single byte of child output, so any word from the command line would
+        // be satisfied by an empty capture and the absence checks below would
+        // pass against nothing. "VM resume completed" is logged by fcvm's restore
+        // path (src/commands/common.rs) before the guest can become healthy, and
+        // the clone was healthy when it was killed.
         assert!(
-            clone_trace.contains("snapshot"),
-            "the clone's debug log {} carries no restore trace at all; an absence check \
-             against an empty or wrong log proves nothing",
+            clone_trace.contains("VM resume completed"),
+            "the clone's debug log {} carries no restore line written by the clone \
+             itself; an absence check against an empty or wrong log proves nothing",
             clone_log.display()
         );
         for self_cleanup in ["delete_state: deleting state file", "cleaning up resources"] {
@@ -1937,13 +1965,6 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
                  cleanup path that runs under SIGKILL, and reqbench.py's synchronous \
                  on-disk reap should be revisited ({})",
                 clone_log.display()
-            );
-        }
-        if !state_survived {
-            println!(
-                "  note: the clone's state file was reaped by another fcvm's \
-                 cleanup_stale_state (the deliberate `fcvm exec --pid <dead clone>` above, or a concurrent \
-                 test); the clone itself deleted nothing, which is the contract"
             );
         }
         assert!(
@@ -1992,6 +2013,9 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
         // down gracefully, so its log MUST show the very line the clone's log must
         // not. A detector that cannot fire is the class of test this repo keeps
         // finding; this proves it fires on the path where the event is real.
+        common::wait_for_log_eof(&base_log, Duration::from_secs(30))
+            .await
+            .context("waiting for the baseline's log to drain")?;
         let base_trace = std::fs::read_to_string(&base_log)
             .with_context(|| format!("reading the baseline's debug log {}", base_log.display()))?;
         assert!(

--- a/tests/test_signal_cleanup.rs
+++ b/tests/test_signal_cleanup.rs
@@ -1653,9 +1653,9 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
             common::unique_names("fastteardown");
 
         // Baseline VM -> snapshot -> memory server: the exact topology the bench uses.
-        let (mut base_child, base_pid) = common::spawn_fcvm_with_logs(
+        let (mut base_child, base_pid, base_log) = common::spawn_fcvm_with_env_and_log_path(
             &["podman", "run", "--name", &base_name, common::TEST_IMAGE],
-            &base_name,
+            &[],
         )
         .await
         .context("spawning baseline VM")?;
@@ -1686,7 +1686,7 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
         common::poll_serve_ready(&snapshot_name, serve_pid, 60).await?;
 
         // The clone: no --exec, exactly as the `cdp-fast` arm restores it.
-        let (mut clone_child, clone_pid) = common::spawn_fcvm_with_logs(
+        let (mut clone_child, clone_pid, clone_log) = common::spawn_fcvm_with_env_and_log_path(
             &[
                 "snapshot",
                 "run",
@@ -1695,7 +1695,7 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
                 "--name",
                 &clone_name,
             ],
-            &clone_name,
+            &[],
         )
         .await
         .context("spawning clone")?;
@@ -1814,6 +1814,40 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
         send_signal(clone_pid, "KILL").context("SIGKILL to clone fcvm")?;
         let _ = clone_child.wait().await;
 
+        // THE REAPER, ON PURPOSE. `StateManager::load_state_by_pid` and
+        // `allocate_loopback_ip` both run `cleanup_stale_state`, which removes
+        // the state file of any dead PID -- this clone's, the instant it is
+        // dead. So every `fcvm exec --pid`, every `snapshot ... --pid`, and
+        // every VM START on the box is a reaper. In the shared container state
+        // dir that is exactly what a CONCURRENT test's fcvm did on 2026-08-28
+        // (Container-x64, #867: a starting `uffd-slot-exit-base-…` logged
+        // "cleanup_stale_state: removing state file for dead or replaced
+        // process pid=<this clone>"), and this test then asserted the file had
+        // survived and failed. Main was green only by scheduling. Running a
+        // reaper here makes that interleaving deterministic, so the assertions
+        // below must hold against it rather than hope to precede it.
+        //
+        // The trigger is precise: `load_state_by_pid` cleans only on a MISS,
+        // and a dead PID whose file still exists IS a miss (its identity check
+        // fails). So `fcvm exec --pid <the dead clone>` runs the cleanup, reaps
+        // the clone's own file, and then fails because there is no such VM --
+        // the expected outcome. Two earlier drafts reaped nothing: `fcvm ls`
+        // (`list_vms` does not clean) and `exec --pid <base>` (a hit, so the
+        // cleanup never ran). Both passed; neither proved anything.
+        let reaper = tokio::process::Command::new(common::find_fcvm_binary()?)
+            .args(["exec", "--pid", &clone_pid.to_string(), "--", "true"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .await
+            .context("running `fcvm exec` as the stale-state reaper")?;
+        anyhow::ensure!(
+            !reaper.success(),
+            "`fcvm exec --pid {clone_pid}` SUCCEEDED against a SIGKILLed clone: that PID \
+             now belongs to a live VM, so the identity check that gates stale-state \
+             cleanup is not doing its job"
+        );
+
         let deadline = std::time::Instant::now() + Duration::from_secs(15);
         while std::time::Instant::now() < deadline {
             if !fc.running() && !holder.running() && !pasta.running() {
@@ -1881,13 +1915,37 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
 
         // The other half of the contract: SIGKILL cannot be caught, so cleanup_vm did NOT run
         // and BOTH on-disk artifacts are still there. The harness must reap both synchronously.
+        // The contract fcvm owns is narrower than "the file is still there": it is
+        // that fcvm's OWN cleanup did not run under SIGKILL. Whether the file is
+        // still there also depends on every other fcvm on the box (see the reaper
+        // above), which this test does not control and reqbench.py must already
+        // tolerate. The killed process's own debug log is the direct evidence:
+        // `cleanup_vm` logs "cleaning up resources" and `delete_state` logs
+        // "delete_state: deleting state file"; under SIGKILL neither can appear.
+        let clone_trace = std::fs::read_to_string(&clone_log)
+            .with_context(|| format!("reading the clone's debug log {}", clone_log.display()))?;
         assert!(
-            state_survived,
-            "expected the clone's state file to SURVIVE the SIGKILL (at {}). If it is gone, \
-             fcvm gained a cleanup path that runs under SIGKILL and reqbench.py's synchronous \
-             on-disk reap should be revisited.",
-            state_file.display()
+            clone_trace.contains("snapshot"),
+            "the clone's debug log {} carries no restore trace at all; an absence check \
+             against an empty or wrong log proves nothing",
+            clone_log.display()
         );
+        for self_cleanup in ["delete_state: deleting state file", "cleaning up resources"] {
+            assert!(
+                !clone_trace.contains(self_cleanup),
+                "the SIGKILLed clone's own log contains {self_cleanup:?}: fcvm gained a \
+                 cleanup path that runs under SIGKILL, and reqbench.py's synchronous \
+                 on-disk reap should be revisited ({})",
+                clone_log.display()
+            );
+        }
+        if !state_survived {
+            println!(
+                "  note: the clone's state file was reaped by another fcvm's \
+                 cleanup_stale_state (the deliberate `fcvm exec --pid <dead clone>` above, or a concurrent \
+                 test); the clone itself deleted nothing, which is the contract"
+            );
+        }
         assert!(
             data_survived,
             "expected the clone's data dir to SURVIVE the SIGKILL (at {}). It holds a reflinked \
@@ -1930,6 +1988,19 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
             snapshot_name
         );
 
+        // POSITIVE CONTROL for the absence check above: the baseline was torn
+        // down gracefully, so its log MUST show the very line the clone's log must
+        // not. A detector that cannot fire is the class of test this repo keeps
+        // finding; this proves it fires on the path where the event is real.
+        let base_trace = std::fs::read_to_string(&base_log)
+            .with_context(|| format!("reading the baseline's debug log {}", base_log.display()))?;
+        assert!(
+            base_trace.contains("delete_state: deleting state file"),
+            "the baseline's graceful teardown logged no state-file delete in {}; the \
+             self-cleanup detector above would then be checking for a line fcvm \
+             never emits",
+            base_log.display()
+        );
         println!("test_bench_fast_teardown_leaks_nothing_clone PASSED");
         Ok::<(), anyhow::Error>(())
     })

--- a/tests/test_signal_cleanup.rs
+++ b/tests/test_signal_cleanup.rs
@@ -1837,17 +1837,24 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
         // Two earlier drafts reaped nothing: `fcvm ls` (`list_vms` does not
         // clean) and `exec --pid <base>` (a hit, so the cleanup never ran).
         // Both passed; neither proved anything. Hence the assertion after it.
-        let reaper = tokio::process::Command::new(common::find_fcvm_binary()?)
-            .args(["exec", "--pid", &u32::MAX.to_string(), "--", "true"])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .await
-            .context("running `fcvm exec` as the stale-state reaper")?;
+        let reaper = match common::find_fcvm_binary() {
+            Ok(fcvm) => tokio::process::Command::new(fcvm)
+                .args(["exec", "--pid", &u32::MAX.to_string(), "--", "true"])
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .await
+                .context("running `fcvm exec` as the stale-state reaper"),
+            Err(e) => Err(e),
+        };
         // Verdicts are RECORDED here and asserted after the fixture is torn down
-        // (below, with the others): a panic at this point would skip the
+        // (below, with the others): a panic or `?` at this point would skip the
         // baseline's and the serve's graceful shutdown and the snapshot delete.
-        let reaper_hit_a_vm = reaper.success();
+        // That includes the reaper failing to START (fd or process exhaustion
+        // is exactly when it would), which is why its spawn error is a verdict
+        // too and not an early return.
+        let reaper_hit_a_vm = matches!(&reaper, Ok(status) if status.success());
+        let reaper_could_not_run = reaper.err().map(|e| format!("{e:#}"));
         let state_reaped = !state_file.exists();
 
         let deadline = std::time::Instant::now() + Duration::from_secs(15);
@@ -1902,6 +1909,12 @@ fn test_bench_fast_teardown_leaks_nothing_clone() -> Result<()> {
             std::fs::remove_dir_all(d).ok();
         }
 
+        assert!(
+            reaper_could_not_run.is_none(),
+            "the stale-state reaper (`fcvm exec --pid {}`) could not be run: {}",
+            u32::MAX,
+            reaper_could_not_run.clone().unwrap_or_default()
+        );
         assert!(
             !reaper_hit_a_vm,
             "`fcvm exec --pid {}` SUCCEEDED: no process can hold that PID, so a hit \


### PR DESCRIPTION
`test_bench_fast_teardown_leaks_nothing_clone` failed on #867's Container-x64 (TRY 1 and TRY 2) while main was green:

```
expected the clone's state file to SURVIVE the SIGKILL (at /mnt/fcvm-btrfs/container/state/vm-b50d00d5….json).
If it is gone, fcvm gained a cleanup path that runs under SIGKILL ...
```

## Cause, from the log

fcvm gained no such path. The same job's log shows who deleted the file: a concurrent test's fcvm, starting its own VM, logged `cleanup_stale_state: removing state file for dead or replaced process pid=1692488`, and 1692488 was this test's SIGKILLed clone. `cleanup_stale_state` runs on every `load_state_by_pid` miss and every `allocate_loopback_ip`, so every VM start on the box reaps dead PIDs' state files. Main was green only by scheduling.

## What changed, by commit

1. `dc2bf9a9` The test asserts the contract fcvm owns: its own cleanup did not run under SIGKILL, read from the killed process's captured debug log (`cleanup_vm` logs "cleaning up resources", `delete_state` logs "delete_state: deleting state file"; neither may appear). The race is forced rather than avoided: after the SIGKILL the test runs a stale-state reaper itself, so the file is reaped deterministically and the rest of the test holds against that. A positive control requires the baseline's graceful-teardown log to contain the very line the clone's must not. Isolation via a private state dir was rejected: the loopback-IP allocator's lock lives there.
2. `463aa89f` Three Codex findings. The reaper is `fcvm exec --pid 4294967295` (always a miss, so the sweep always runs, and never a hit on another test's VM that inherited the dead clone's PID), and the file-gone verdict is asserted after fixture teardown. The clone-log guard requires `VM resume completed`, a line the clone's restore path writes, instead of `snapshot`, which the harness's own spawn record satisfied on an empty capture. Both logs are read only after `common::wait_for_log_eof`: each consumer appends an end-of-stream line when its reader closes, and the waiter polls for both (whole-line match). A local codex pass on that fix added: a read error of kind `InvalidData` no longer ends the copy loop (the line is skipped and noted), and the marker must match a whole line. Two pre-existing gaps in `cleanup_stale_state` it found are #870.
3. `12062407` A non-`InvalidData` read error writes a distinct `capture failed` record and no end-of-stream marker; `wait_for_log_eof` turns that into an error instead of certifying a truncated file (Codex and CodeRabbit).
4. `558f73fd` The reaper's spawn/wait result is recorded and asserted after teardown like its exit status; a `?` there returned early with the baseline, the serve, and the snapshot still alive (Codex).
5. This head: the consumer reads with `read_until` and decodes with `from_utf8`, so only a UTF-8 decode failure is a skipped line; tokio's `Lines` had reported a reader's own `InvalidData` error the same way, and an EOF after it would have stamped a truncated capture clean (CodeRabbit).

## Test evidence

Full VM runs of `test_bench_fast_teardown_leaks_nothing_clone` (~2 s each, both VMs restore from cached snapshots), each mutation watched failing:

- previous assertion restored, reaper kept: FAIL `expected the clone's state file to SURVIVE the SIGKILL`; detector pointed at the BASE log: FAIL `own log contains "delete_state: deleting state file"`.
- old test, consumer delayed 5 s: FAIL at the baseline positive control, the clone checks having passed on a log holding only the spawn line; new test under the same delay: PASS in 6.2 s.
- consumer dropping every child line: FAIL at the `VM resume completed` guard.
- reaper pointed at the live baseline with `false`: FAIL at the file-gone verdict.
- reaper binary `/nonexistent/fcvm` on the previous head: the test returned early and left the baseline's state file, its vm-disks directory, and the snapshot behind; on this head it fails at the recorded verdict and leaves nothing.
- clean: PASS.

`tests/test_log_capture.rs` (new): `log_capture_continues_past_an_unreadable_line`, `wait_for_log_eof_ignores_a_child_line_that_quotes_the_marker`, `wait_for_log_eof_reports_a_failed_capture_instead_of_certifying_it`, `a_reader_invalid_data_error_is_a_failed_capture_not_a_skipped_line`, each failing against the helper before its fix.

`make lint` clean.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log capture reliability when streams contain unreadable data, allowing capture to continue where possible.
  * Capture failures are now reported clearly instead of being mistaken for successful completion.
  * End-of-stream detection is more precise and avoids false completion from misleading log content.
  * Improved cleanup handling during forced process termination, helping prevent stale runtime state and ensuring graceful shutdowns are recorded correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->