### PR TITLE
Campaign evidence and gates: in-clone resolver check, DNS provenance, replay logs, net-trace, per-URL stall gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1033,7 +1033,7 @@ bench-chromium-fault: build setup-default
 analyze-chromium-request:
 	@test -f "$(RESULTS)/reqbench.jsonl" || { echo "ERROR: no $(RESULTS)/reqbench.jsonl" >&2; exit 2; }
 	@python3 bench/chromium/reqanalyze.py --json-out "$(RESULTS)/analysis.json" \
-		"$(RESULTS)/reqbench.jsonl"
+		$(if $(STALL_MAX_MS),--stall-max-ms $(STALL_MAX_MS),) "$(RESULTS)/reqbench.jsonl"
 
 # What CI runs (ci.yml globs test_*.py). The per-harness targets below are
 # narrower dev conveniences; run THIS before pushing, because a new test file is

--- a/bench/chromium/.gitignore
+++ b/bench/chromium/.gitignore
@@ -18,9 +18,12 @@ results/**
 !results/**/charts/
 !results/**/charts/*.svg
 !results/**/summary.md
-# DNS-campaign evidence: the in-clone resolver check, the campaign verdict,
-# the diagnostic summary, the resolver-owner log and the campaign index.
+# DNS-campaign evidence: the in-clone resolver check (plus the per-bracket
+# copies verify-dns-pre/before-run/after-run.json that dns-evidence.json lists
+# in verify_files), the campaign verdict, the diagnostic summary, the
+# resolver-owner log and the campaign index.
 !results/**/verify-dns.json
+!results/**/verify-dns-*.json
 !results/**/dns-evidence.json
 !results/**/diag/summary.json
 !results/**/dns-owner.log

--- a/bench/chromium/.gitignore
+++ b/bench/chromium/.gitignore
@@ -28,6 +28,9 @@ results/**
 !results/**/diag/summary.json
 !results/**/dns-owner.log
 !results/**/campaign-*-summary.json
+# The withdrawal marker: its first line is why the run may never be quoted,
+# and campaign_summary refuses the run while it is present.
+!results/**/WITHDRAWN
 !results/**/cpuprobe-*-curated.json
 !results/**/webkit-host-probe.json
 __pycache__/

--- a/bench/chromium/.gitignore
+++ b/bench/chromium/.gitignore
@@ -27,6 +27,10 @@ results/**
 !results/**/dns-evidence.json
 !results/**/diag/summary.json
 !results/**/dns-owner.log
+# The replay server's own logs: dns-evidence.json records their sha256 and
+# campaign_summary refuses the run unless both are present and match.
+!results/**/corpus-dns.log
+!results/**/corpus-access.log
 !results/**/campaign-*-summary.json
 # The withdrawal marker: its first line is why the run may never be quoted,
 # and campaign_summary refuses the run while it is present.

--- a/bench/chromium/.gitignore
+++ b/bench/chromium/.gitignore
@@ -18,7 +18,13 @@ results/**
 !results/**/charts/
 !results/**/charts/*.svg
 !results/**/summary.md
-!results/campaign-*-summary.json
+# DNS-campaign evidence: the in-clone resolver check, the campaign verdict,
+# the diagnostic summary, the resolver-owner log and the campaign index.
+!results/**/verify-dns.json
+!results/**/dns-evidence.json
+!results/**/diag/summary.json
+!results/**/dns-owner.log
+!results/**/campaign-*-summary.json
 !results/**/cpuprobe-*-curated.json
 !results/**/webkit-host-probe.json
 __pycache__/

--- a/bench/chromium/AGENTS.md
+++ b/bench/chromium/AGENTS.md
@@ -70,7 +70,7 @@ campaign's startup probes through the three verify brackets and every rep of
 every arm of the measured run, so it is the biggest record in the directory
 and a short one means the server was not serving the whole run.
 
-The evidence is only as good as the checks behind it, and three of them are
+The evidence is only as good as the checks behind it, and four of them are
 easy to get wrong:
 
 - The server's exit status. `corpus_serve.py` exits 1 when a log line could
@@ -93,6 +93,13 @@ easy to get wrong:
   variable first, and reports what it ignored; `verify-dns.json` carries
   `proxies_disabled` and `run_verify` refuses a bracket without it. Any new
   in-guest probe that opens a URL needs the same treatment.
+- The verify brackets themselves. `passed: true` is also what HOP D writes
+  when it was given nothing to check, and a bracket is a plain file in the
+  run directory. `write_dns_evidence` records each bracket's sha256 as
+  `verify_file_sha256`; `campaign_summary.py` rereads each bracket, refuses
+  one whose hash moved since the verdict, and holds its contents to the
+  run's resolver, `proxies_disabled`, and every host and URL answered
+  through that resolver. Evidence carrying no bracket hashes is refused.
 
 ## Six methodology defects — do not reintroduce
 

--- a/bench/chromium/AGENTS.md
+++ b/bench/chromium/AGENTS.md
@@ -70,6 +70,30 @@ campaign's startup probes through the three verify brackets and every rep of
 every arm of the measured run, so it is the biggest record in the directory
 and a short one means the server was not serving the whole run.
 
+The evidence is only as good as the checks behind it, and three of them are
+easy to get wrong:
+
+- The server's exit status. `corpus_serve.py` exits 1 when a log line could
+  not be written, after the response bytes went out, and `sudo -b` discards
+  that status. The launch wrapper waits for the server and writes the status
+  to `corpus-serve.status` in the run directory; `stop_corpus_serve` waits
+  for the file, `write_dns_evidence` records it as `corpus_serve_exit_status`
+  and is unclean unless it is 0, and `campaign_summary.py` refuses evidence
+  that does not carry 0. A liveness poll cannot see this case.
+- The owner samples. `campaign_summary.py` parses every `dns-owner.log` line
+  and holds it to the rule the campaign applied at the verdict (owner is
+  `serve_pid`, dnsmasq inactive, the load column adds up to `load_samples`
+  and `load_max_1min`). The evidence's `first_mismatch: null` is a claim
+  about those lines, not proof of them.
+- Proxies in the container exec. fc-agent runs every `fcvm exec -c` under
+  the host's saved `HTTP_PROXY`/`HTTPS_PROXY`, and `urllib` honours them by
+  default, so HOP D's URL probe would fetch the live site through the proxy
+  while the hostname check beside it resolved through the replay resolver.
+  The probe installs an empty `ProxyHandler`, clears every `*_proxy`
+  variable first, and reports what it ignored; `verify-dns.json` carries
+  `proxies_disabled` and `run_verify` refuses a bracket without it. Any new
+  in-guest probe that opens a URL needs the same treatment.
+
 ## Six methodology defects — do not reintroduce
 
 1. **Matched accounting basis.** Sum memory over the SAME process set for every

--- a/bench/chromium/AGENTS.md
+++ b/bench/chromium/AGENTS.md
@@ -61,6 +61,15 @@ true` the same way. The marker is tracked (`!results/**/WITHDRAWN` in
 `bench/chromium/.gitignore`) and is never removed, because a withdrawn run
 stays unquotable (REVIEW.md).
 
+A corpus campaign's run directory also keeps the replay server's two logs,
+`corpus-dns.log` and `corpus-access.log`, tracked because `dns-evidence.json`
+records their sha256 and `campaign_summary.py` refuses the run unless both are
+present and match. Expect them to be large: the DNS log has one line per query
+and the access log one line per HTTP request the server answered, from the
+campaign's startup probes through the three verify brackets and every rep of
+every arm of the measured run, so it is the biggest record in the directory
+and a short one means the server was not serving the whole run.
+
 ## Six methodology defects — do not reintroduce
 
 1. **Matched accounting basis.** Sum memory over the SAME process set for every

--- a/bench/chromium/AGENTS.md
+++ b/bench/chromium/AGENTS.md
@@ -54,6 +54,13 @@ must not kill the run, and "the log stopped growing" is not a completion
 signal. Fresh-box prerequisites (packages, NVMe store, sibling checkouts) are
 in the repo-root AGENTS.md quickstart.
 
+To withdraw a run after the fact, add a file named `WITHDRAWN` to its results
+directory whose first line is the reason; `campaign_summary.py` refuses the run
+and quotes that line, and refuses an `analysis.json` carrying `"withdrawn":
+true` the same way. The marker is tracked (`!results/**/WITHDRAWN` in
+`bench/chromium/.gitignore`) and is never removed, because a withdrawn run
+stays unquotable (REVIEW.md).
+
 ## Six methodology defects — do not reintroduce
 
 1. **Matched accounting basis.** Sum memory over the SAME process set for every

--- a/bench/chromium/campaign_summary.py
+++ b/bench/chromium/campaign_summary.py
@@ -432,17 +432,45 @@ def load_cell(run_dir):
     }, sources.entries
 
 
+def run_identity(run_dir):
+    """The keys that name one run directory, so a second name for a run
+    already listed can be recognised: its canonical path, and the directory
+    identity the filesystem reports. A symlink alias shares the canonical
+    path; a bind mount shares only (st_dev, st_ino). A path that cannot be
+    stat'ed carries the first key alone and is refused by load_cell with its
+    own message."""
+    keys = [("path", os.path.realpath(run_dir))]
+    try:
+        stat = os.stat(run_dir)
+    except OSError:
+        return keys
+    keys.append(("dir", (stat.st_dev, stat.st_ino)))
+    return keys
+
+
 def build_index(run_dirs):
     """Every cell or a list of refusals; never a partial index."""
     cells = []
     generated_from = []
     errors = []
-    seen = set()
+    seen = {}
     for run_dir in run_dirs:
-        if run_dir in seen:
-            errors.append(f"{run_dir}: listed more than once")
+        keys = run_identity(run_dir)
+        first = next((seen[key] for key in keys if key in seen), None)
+        if first is not None:
+            # Refused, not deduped: one run reached under two names is an
+            # argument list the caller did not mean, and an index that
+            # silently dropped the second would be one experiment counted
+            # twice or a cell nobody notices is missing.
+            if first == run_dir:
+                errors.append(f"{run_dir}: listed more than once")
+            else:
+                errors.append(
+                    f"{run_dir}: is the run directory {first} under a second name"
+                )
             continue
-        seen.add(run_dir)
+        for key in keys:
+            seen[key] = run_dir
         try:
             cell, sources = load_cell(run_dir)
         except RunError as error:

--- a/bench/chromium/campaign_summary.py
+++ b/bench/chromium/campaign_summary.py
@@ -9,10 +9,12 @@ record, since an unarmed gate reports passed=true having evaluated nothing),
 dns-evidence.json (required when the cell's guest_dns names a baked resolver,
 optional otherwise; when present its verdict must be "clean", it must carry
 the replay server's exit status 0, every file it cites must be present and
-agree with it, and every sample in dns-owner.log must name its serve_pid as
-the owner of 127.0.0.1:53 with dnsmasq inactive and a load the evidence
-accounts for) and diag/summary.json (optional). The
-index names every file it was generated from with its sha256, and carries one
+agree with the sha256 it recorded, each verify bracket must record the run's
+resolver with the URL probes run under no proxy and every host and URL
+answered through it, and every sample in dns-owner.log must name its
+serve_pid as the owner of 127.0.0.1:53 with dnsmasq inactive and a load the
+evidence accounts for) and diag/summary.json (optional). The index names
+every file it was generated from with its sha256, and carries one
 cell per run: engine, cpu, memory_mib, guest_dns, the seal identity,
 publishable, stall_gate_passed, dns_verdict, load_max_1min (the maximum 1-min
 load the campaign's sampler saw during the measured run, when the evidence
@@ -150,6 +152,14 @@ def positive_int(value):
     return isinstance(value, int) and not isinstance(value, bool) and value > 0
 
 
+def is_sha256(value):
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(c in "0123456789abcdef" for c in value)
+    )
+
+
 def withdrawal_reason(marker):
     """The first line of a WITHDRAWN marker; a marker that cannot be read
     still withdraws the run."""
@@ -215,7 +225,73 @@ def check_owner_log(run_dir, evidence, owner_bytes):
         )
 
 
-def check_evidence(run_dir, evidence, sources):
+def check_verify_bracket(run_dir, name, verify, resolver):
+    """Hold one HOP D bracket to what the campaign asserted when it ran it:
+    the clone resolved through `resolver` (None takes the bracket's own, so
+    the remaining brackets are held to the first), the URL probes ran with
+    no proxy, and every corpus host and URL answered through that resolver.
+    Returns the resolver the bracket names.
+
+    passed=true is also what HOP D writes when it was given nothing to check,
+    so it is not on its own a bracket."""
+    if not isinstance(verify, dict):
+        raise RunError(f"{run_dir}: {name} is not a JSON object")
+    if verify.get("passed") is not True:
+        raise RunError(f"{run_dir}: {name} does not record passed=true")
+    dns_server = verify.get("dns_server")
+    if not isinstance(dns_server, str) or not dns_server:
+        raise RunError(
+            f"{run_dir}: {name} records dns_server={dns_server!r}; the bracket "
+            "names no resolver to have resolved through"
+        )
+    if resolver is not None and dns_server != resolver:
+        raise RunError(
+            f"{run_dir}: {name} records dns_server {dns_server!r}, not the "
+            f"{resolver!r} this run was measured through"
+        )
+    if verify.get("proxies_disabled") is not True:
+        raise RunError(
+            f"{run_dir}: {name} records proxies_disabled="
+            f"{verify.get('proxies_disabled')!r}; a URL probe that honoured the "
+            "exec's proxy fetched the live site, not the replay server"
+        )
+    hosts = verify.get("hosts")
+    if not isinstance(hosts, dict) or not hosts:
+        raise RunError(
+            f"{run_dir}: {name} records no resolved host; a bracket that "
+            "checked nothing proves nothing"
+        )
+    for host, record in sorted(hosts.items()):
+        if not isinstance(record, dict) or record.get("ok") is not True:
+            raise RunError(f"{run_dir}: {name} records {host} as {record!r}, not resolved")
+        if record.get("answer") != dns_server:
+            raise RunError(
+                f"{run_dir}: {name} records {host} answering "
+                f"{record.get('answer')!r}, not the replay address {dns_server!r}"
+            )
+    urls = verify.get("urls")
+    if not isinstance(urls, dict) or not urls:
+        raise RunError(
+            f"{run_dir}: {name} records no fetched URL; a bracket that "
+            "checked nothing proves nothing"
+        )
+    for url, record in sorted(urls.items()):
+        if not isinstance(record, dict) or record.get("ok") is not True:
+            raise RunError(f"{run_dir}: {name} records {url} as {record!r}, not fetched")
+        status = record.get("status")
+        if isinstance(status, bool) or not isinstance(status, int) or not 200 <= status <= 399:
+            raise RunError(
+                f"{run_dir}: {name} records {url} returning {status!r}, not a 2xx or 3xx"
+            )
+        if not isinstance(record.get("proxy_env_ignored"), list):
+            raise RunError(
+                f"{run_dir}: {name} does not record which proxy variables the "
+                f"{url} probe ignored, so nothing says the request left through none"
+            )
+    return dns_server
+
+
+def check_evidence(run_dir, evidence, sources, guest_dns):
     """Hold a clean verdict to the files it cites; raise RunError otherwise."""
     if not isinstance(evidence, dict):
         # Valid JSON that is not an object ([] for one) has no verdict to
@@ -267,13 +343,24 @@ def check_evidence(run_dir, evidence, sources):
             f"{run_dir}: dns-evidence.json records corpus_serve exit status "
             f"{serve_status!r}, not 0; the replay logs it hashed may be short"
         )
-    # The brackets: every stage the campaign runs, each present and passed.
+    # The brackets: every stage the campaign runs, each present, holding the
+    # bytes the verdict hashed, and asserting what the campaign asserted.
     # Basenames are resolved inside run_dir so a relocated run directory
     # still indexes; the evidence's own absolute paths are not trusted.
+    # Evidence that pins no bracket is refused rather than read: it cannot
+    # say whether the files beside it are the ones its verdict was formed on.
     verify_files = evidence.get("verify_files")
     if not isinstance(verify_files, list) or not all(isinstance(p, str) for p in verify_files):
         raise RunError(f"{run_dir}: dns-evidence.json has no verify_files list")
+    recorded = evidence.get("verify_file_sha256")
+    if not isinstance(recorded, dict):
+        raise RunError(
+            f"{run_dir}: dns-evidence.json has no verify_file_sha256 map; its "
+            "brackets are unpinned, so an edited one cannot be told from the "
+            "file the verdict read"
+        )
     cited = {os.path.basename(p) for p in verify_files}
+    resolver = guest_dns if isinstance(guest_dns, str) and guest_dns else None
     for stage in VERIFY_STAGES:
         name = f"verify-dns-{stage}.json"
         if name not in cited:
@@ -281,26 +368,29 @@ def check_evidence(run_dir, evidence, sources):
         path = os.path.join(run_dir, name)
         if not os.path.isfile(path):
             raise RunError(f"{run_dir}: {name} cited by dns-evidence.json is missing")
-        verify = sources.read_json(path)
-        if not isinstance(verify, dict) or verify.get("passed") is not True:
-            raise RunError(f"{run_dir}: {name} does not record passed=true")
+        want = recorded.get(name)
+        if not is_sha256(want):
+            raise RunError(f"{run_dir}: dns-evidence.json has no sha256 for {name}")
+        data, digest = sources.read_hashed(path)
+        if digest != want:
+            raise RunError(
+                f"{run_dir}: {name} sha256 {digest} does not match the {want} "
+                "dns-evidence.json recorded at the verdict"
+            )
+        resolver = check_verify_bracket(run_dir, name, parse_json(data, path), resolver)
     # The replay server's own logs, pinned by hash at the verdict.
     for field, name in REPLAY_LOGS.items():
-        recorded = evidence.get(field)
-        if (
-            not isinstance(recorded, str)
-            or len(recorded) != 64
-            or any(c not in "0123456789abcdef" for c in recorded)
-        ):
+        want = evidence.get(field)
+        if not is_sha256(want):
             raise RunError(f"{run_dir}: dns-evidence.json has no sha256 for {name} ({field})")
         path = os.path.join(run_dir, name)
         if not os.path.isfile(path):
             raise RunError(f"{run_dir}: {name} cited by dns-evidence.json is missing")
         _data, digest = sources.read_hashed(path)
-        if digest != recorded:
+        if digest != want:
             raise RunError(
                 f"{run_dir}: {name} sha256 {digest} does not match the "
-                f"{recorded} dns-evidence.json recorded at the verdict"
+                f"{want} dns-evidence.json recorded at the verdict"
             )
 
 
@@ -378,7 +468,7 @@ def load_cell(run_dir):
     evidence_path = os.path.join(run_dir, "dns-evidence.json")
     if os.path.isfile(evidence_path):
         evidence = sources.read_json(evidence_path)
-        check_evidence(run_dir, evidence, sources)
+        check_evidence(run_dir, evidence, sources, cell["guest_dns"])
         dns_verdict = evidence["verdict"]
         # Reported, not gated: the run driver refused a busy box at the
         # start, and evidence from before the sampler carried the load

--- a/bench/chromium/campaign_summary.py
+++ b/bench/chromium/campaign_summary.py
@@ -114,7 +114,11 @@ def positive_int(value):
 
 def check_evidence(run_dir, evidence, sources):
     """Hold a clean verdict to the files it cites; raise RunError otherwise."""
-    verdict = evidence.get("verdict") if isinstance(evidence, dict) else None
+    if not isinstance(evidence, dict):
+        # Valid JSON that is not an object ([] for one) has no verdict to
+        # read; refusing it here keeps every .get() below on a dict.
+        raise RunError(f"{run_dir}: dns-evidence.json is not a JSON object")
+    verdict = evidence.get("verdict")
     if verdict != "clean":
         raise RunError(f"{run_dir}: dns-evidence.json verdict is {verdict!r}, not 'clean'")
     if not positive_int(evidence.get("samples")):

--- a/bench/chromium/campaign_summary.py
+++ b/bench/chromium/campaign_summary.py
@@ -7,8 +7,11 @@ Each run directory holds reqanalyze's analysis.json (required; its stall_gate
 must have been armed with --stall-max-ms and must have evaluated at least one
 record, since an unarmed gate reports passed=true having evaluated nothing),
 dns-evidence.json (required when the cell's guest_dns names a baked resolver,
-optional otherwise; when present its verdict must be "clean" and every file it
-cites must be present and agree with it) and diag/summary.json (optional). The
+optional otherwise; when present its verdict must be "clean", it must carry
+the replay server's exit status 0, every file it cites must be present and
+agree with it, and every sample in dns-owner.log must name its serve_pid as
+the owner of 127.0.0.1:53 with dnsmasq inactive and a load the evidence
+accounts for) and diag/summary.json (optional). The
 index names every file it was generated from with its sha256, and carries one
 cell per run: engine, cpu, memory_mib, guest_dns, the seal identity,
 publishable, stall_gate_passed, dns_verdict, load_max_1min (the maximum 1-min
@@ -40,10 +43,20 @@ import hashlib
 import json
 import math
 import os
+import re
 import sys
 import tempfile
 
 VERIFY_STAGES = ("pre", "before-run", "after-run")
+# One :53 owner sample, as corpus_campaign.sh's dns_owner_sample prints it.
+# The load column is absent from logs written before the sampler carried it.
+OWNER_SAMPLE = re.compile(
+    r"^(?P<ts>\S+) owner_pid=(?P<owner>\S+) dnsmasq=(?P<dnsmasq>\S+)"
+    r"(?: load1=(?P<load>\S+))?$"
+)
+# The sampler accepts a load only in this shape; dns_load_stats counts only
+# these when it reports load_samples and load_max_1min.
+LOAD_NUMBER = re.compile(r"^[0-9]+(\.[0-9]+)?$")
 # The seal identity of one run, as reqbench.py stamps it into every record's
 # meta and reqanalyze carries it into the cell (CELL_FIELDS).
 SEAL_FIELDS = (
@@ -149,6 +162,59 @@ def withdrawal_reason(marker):
     return reason or "(no reason recorded in the marker)"
 
 
+def check_owner_log(run_dir, evidence, owner_bytes):
+    """Hold every sample in dns-owner.log to the rule the campaign applied at
+    the verdict: the owner of 127.0.0.1:53 is serve_pid, dnsmasq is inactive,
+    and the load column adds up to load_samples and load_max_1min. The
+    evidence's own first_mismatch is a claim about these lines, not proof;
+    a log rewritten under the same line count indexed clean on it."""
+    serve_pid = evidence.get("serve_pid")
+    if not positive_int(serve_pid):
+        raise RunError(
+            f"{run_dir}: dns-evidence.json is clean but records serve_pid="
+            f"{serve_pid!r}; the samples have no server to be held to"
+        )
+    try:
+        text = owner_bytes.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise RunError(f"{run_dir}: dns-owner.log is not UTF-8: {error}")
+    loads = []
+    for number, line in enumerate(text.splitlines(), 1):
+        match = OWNER_SAMPLE.match(line)
+        if match is None:
+            raise RunError(f"{run_dir}: dns-owner.log line {number} is not a sample: {line!r}")
+        if match["owner"] != str(serve_pid):
+            raise RunError(
+                f"{run_dir}: dns-owner.log line {number} names {match['owner']} as the "
+                f"owner of 127.0.0.1:53, not corpus_serve {serve_pid}: {line!r}"
+            )
+        if match["dnsmasq"] != "inactive":
+            raise RunError(
+                f"{run_dir}: dns-owner.log line {number} records dnsmasq="
+                f"{match['dnsmasq']}, not inactive: {line!r}"
+            )
+        if match["load"] is not None:
+            if not LOAD_NUMBER.match(match["load"]):
+                raise RunError(
+                    f"{run_dir}: dns-owner.log line {number} carries a load1 that is "
+                    f"not a number: {line!r}"
+                )
+            loads.append(float(match["load"]))
+    load_samples = evidence.get("load_samples", 0)
+    load_max = evidence.get("load_max_1min")
+    if isinstance(load_samples, bool) or not isinstance(load_samples, int):
+        raise RunError(f"{run_dir}: dns-evidence.json records load_samples={load_samples!r}")
+    if isinstance(load_max, bool) or not (load_max is None or isinstance(load_max, (int, float))):
+        raise RunError(f"{run_dir}: dns-evidence.json records load_max_1min={load_max!r}")
+    found_max = max(loads) if loads else None
+    if len(loads) != load_samples or found_max != load_max:
+        raise RunError(
+            f"{run_dir}: dns-owner.log carries {len(loads)} load sample(s) with maximum "
+            f"{found_max} but dns-evidence.json records load_samples={load_samples}, "
+            f"load_max_1min={load_max}"
+        )
+
+
 def check_evidence(run_dir, evidence, sources):
     """Hold a clean verdict to the files it cites; raise RunError otherwise."""
     if not isinstance(evidence, dict):
@@ -189,6 +255,17 @@ def check_evidence(run_dir, evidence, sources):
         raise RunError(
             f"{run_dir}: dns-evidence.json records {evidence['samples']} samples but "
             f"dns-owner.log holds {owner_lines} lines"
+        )
+    check_owner_log(run_dir, evidence, owner_bytes)
+    # The replay server's exit status, recorded by the campaign once the
+    # server was gone: 0 is the shutdown sequence completing with both logs
+    # closed; 1 is a log line it could not write after the response was
+    # sent, so the logs it hashed are short. Only 0 is a complete log.
+    serve_status = evidence.get("corpus_serve_exit_status")
+    if isinstance(serve_status, bool) or not isinstance(serve_status, int) or serve_status != 0:
+        raise RunError(
+            f"{run_dir}: dns-evidence.json records corpus_serve exit status "
+            f"{serve_status!r}, not 0; the replay logs it hashed may be short"
         )
     # The brackets: every stage the campaign runs, each present and passed.
     # Basenames are resolved inside run_dir so a relocated run directory

--- a/bench/chromium/campaign_summary.py
+++ b/bench/chromium/campaign_summary.py
@@ -11,8 +11,10 @@ optional otherwise; when present its verdict must be "clean" and every file it
 cites must be present and agree with it) and diag/summary.json (optional). The
 index names every file it was generated from with its sha256, and carries one
 cell per run: engine, cpu, memory_mib, guest_dns, the seal identity,
-publishable, stall_gate_passed, dns_verdict, the headline median blocking_ms
-per arm with its CI, and the diag summary when there is one.
+publishable, stall_gate_passed, dns_verdict, load_max_1min (the maximum 1-min
+load the campaign's sampler saw during the measured run, when the evidence
+records it), the headline median blocking_ms per arm with its CI, and the
+diag summary when there is one.
 
 The publication rule (REVIEW.md) is to quote only from sealed runs that passed
 their gates and were never withdrawn, and publishable=true alone proves none
@@ -295,11 +297,16 @@ def load_cell(run_dir):
         )
 
     dns_verdict = None
+    load_max_1min = None
     evidence_path = os.path.join(run_dir, "dns-evidence.json")
     if os.path.isfile(evidence_path):
         evidence = sources.read_json(evidence_path)
         check_evidence(run_dir, evidence, sources)
         dns_verdict = evidence["verdict"]
+        # Reported, not gated: the run driver refused a busy box at the
+        # start, and evidence from before the sampler carried the load
+        # column has no value to copy.
+        load_max_1min = evidence.get("load_max_1min")
     elif cell["guest_dns"] is not None:
         # A guest that resolved through a baked resolver is a campaign run;
         # only the bracket evidence says the resolver held for the whole
@@ -342,6 +349,7 @@ def load_cell(run_dir):
         "publishable": True,
         "stall_gate_passed": True,
         "dns_verdict": dns_verdict,
+        "load_max_1min": load_max_1min,
         "headline": headline,
         "diag": diag,
     }, sources.entries

--- a/bench/chromium/campaign_summary.py
+++ b/bench/chromium/campaign_summary.py
@@ -10,16 +10,27 @@ dns-evidence.json (required when the cell's guest_dns names a baked resolver,
 optional otherwise; when present its verdict must be "clean" and every file it
 cites must be present and agree with it) and diag/summary.json (optional). The
 index names every file it was generated from with its sha256, and carries one
-cell per run: engine, cpu, memory_mib, guest_dns, publishable,
-stall_gate_passed, dns_verdict, the headline median blocking_ms per arm with
-its CI, and the diag summary when there is one.
+cell per run: engine, cpu, memory_mib, guest_dns, the seal identity,
+publishable, stall_gate_passed, dns_verdict, the headline median blocking_ms
+per arm with its CI, and the diag summary when there is one.
 
-The index is written only when every run is publishable, every stall gate
-passed and every DNS verdict is clean. Otherwise nothing is written, an index
-already at --out is removed, and the exit status is 5, the same code reqanalyze
-uses for a refused run: an index that quietly carried an unpublishable cell
-would be quoted by someone who only opened the index. Inputs are only ever
-read, and each is read once so the hash names the bytes that were parsed.
+The publication rule (REVIEW.md) is to quote only from sealed runs that passed
+their gates and were never withdrawn, and publishable=true alone proves none
+of that. The seal is the cell's identity, SEAL_FIELDS below: the runtime
+bundle reqbench.sh sealed, the fcvm binary and harness sources hashed into
+it, the source revision, and the image and snapshot generation measured. A
+cell missing any of them is not a sealed run. A run is withdrawn by a file
+named WITHDRAWN in its directory whose first line is the reason, or by
+"withdrawn": true in its analysis.json; either refuses the run and the
+refusal quotes the reason.
+
+The index is written only when every run is sealed, publishable and not
+withdrawn, every stall gate passed and every DNS verdict is clean. Otherwise
+nothing is written, an index already at --out is removed, and the exit status
+is 5, the same code reqanalyze uses for a refused run: an index that quietly
+carried an unpublishable cell would be quoted by someone who only opened the
+index. Inputs are only ever read, and each is read once so the hash names the
+bytes that were parsed.
 """
 
 import argparse
@@ -31,6 +42,18 @@ import sys
 import tempfile
 
 VERIFY_STAGES = ("pre", "before-run", "after-run")
+# The seal identity of one run, as reqbench.py stamps it into every record's
+# meta and reqanalyze carries it into the cell (CELL_FIELDS).
+SEAL_FIELDS = (
+    "runtime_bundle_sha256",
+    "fcvm_sha256",
+    "harness_sha256",
+    "source_revision",
+    "image_id",
+    "snapshot_generation_id",
+    "snapshot_config_sha256",
+)
+WITHDRAWN_MARKER = "WITHDRAWN"
 REPLAY_LOGS = {
     "corpus_dns_log_sha256": "corpus-dns.log",
     "corpus_access_log_sha256": "corpus-access.log",
@@ -110,6 +133,18 @@ def write_json_atomic(path, value):
 
 def positive_int(value):
     return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def withdrawal_reason(marker):
+    """The first line of a WITHDRAWN marker; a marker that cannot be read
+    still withdraws the run."""
+    try:
+        with open(marker, "rb") as handle:
+            first_line = handle.readline()
+    except OSError as error:
+        return f"(marker present but unreadable: {error})"
+    reason = first_line.decode("utf-8", errors="replace").strip()
+    return reason or "(no reason recorded in the marker)"
 
 
 def check_evidence(run_dir, evidence, sources):
@@ -193,6 +228,9 @@ def check_evidence(run_dir, evidence, sources):
 def load_cell(run_dir):
     """Read one run directory into an index cell. Returns (cell, source entries)."""
     sources = Sources()
+    marker = os.path.join(run_dir, WITHDRAWN_MARKER)
+    if os.path.lexists(marker):
+        raise RunError(f"{run_dir}: withdrawn: {withdrawal_reason(marker)}")
     analysis_path = os.path.join(run_dir, "analysis.json")
     if not os.path.isfile(analysis_path):
         raise RunError(f"{run_dir}: analysis.json is missing")
@@ -200,6 +238,11 @@ def load_cell(run_dir):
     if not isinstance(analysis, dict):
         raise RunError(f"{analysis_path}: not a JSON object")
 
+    if analysis.get("withdrawn", False) is not False:
+        raise RunError(
+            f"{run_dir}: withdrawn: analysis.json records "
+            f"withdrawn={analysis.get('withdrawn')!r}"
+        )
     if analysis.get("publishable") is not True:
         reasons = (analysis.get("gate") or {}).get("reasons") or []
         raise RunError(f"{run_dir}: analysis.json is not publishable: {reasons}")
@@ -214,6 +257,15 @@ def load_cell(run_dir):
             raise RunError(
                 f"{run_dir}: analysis.json cell has no {field}; re-run reqanalyze"
             )
+    seal = {}
+    for field in SEAL_FIELDS:
+        value = cell.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise RunError(
+                f"{run_dir}: analysis.json cell has no {field}; a run without its "
+                f"seal identity ({', '.join(SEAL_FIELDS)}) is not a sealed run"
+            )
+        seal[field] = value
     stall_gate = analysis.get("stall_gate")
     if not isinstance(stall_gate, dict) or not isinstance(stall_gate.get("passed"), bool):
         raise RunError(
@@ -286,6 +338,7 @@ def load_cell(run_dir):
         "guest_dns": cell["guest_dns"],
         "backend": cell.get("backend"),
         "uffd_mode": cell.get("uffd_mode"),
+        "seal": seal,
         "publishable": True,
         "stall_gate_passed": True,
         "dns_verdict": dns_verdict,

--- a/bench/chromium/campaign_summary.py
+++ b/bench/chromium/campaign_summary.py
@@ -3,8 +3,10 @@
 
     campaign_summary.py --out PATH <run_dir>...
 
-Each run directory holds reqanalyze's analysis.json (required),
-dns-evidence.json (optional; when present its verdict must be "clean") and
+Each run directory holds reqanalyze's analysis.json (required; its stall_gate
+must have been armed with --stall-max-ms, since an unarmed gate reports
+passed=true having evaluated nothing), dns-evidence.json (optional; when
+present its verdict must be "clean") and
 diag/summary.json (optional). The index names every file it was generated
 from with its sha256, and carries one cell per run: engine, cpu, memory_mib,
 guest_dns, publishable, stall_gate_passed, dns_verdict, the headline median
@@ -95,6 +97,14 @@ def load_cell(run_dir):
     if not isinstance(stall_gate, dict) or not isinstance(stall_gate.get("passed"), bool):
         raise RunError(
             f"{run_dir}: analysis.json has no stall_gate verdict; re-run reqanalyze"
+        )
+    max_ms = stall_gate.get("max_ms")
+    if isinstance(max_ms, bool) or not isinstance(max_ms, (int, float)) or max_ms <= 0:
+        # reqanalyze without --stall-max-ms writes passed=true, evaluated=0:
+        # a gate that evaluated nothing has no pass to report.
+        raise RunError(
+            f"{run_dir}: stall_gate was not armed (max_ms is {max_ms!r}); "
+            "re-run reqanalyze --stall-max-ms N"
         )
     if stall_gate["passed"] is not True:
         raise RunError(

--- a/bench/chromium/campaign_summary.py
+++ b/bench/chromium/campaign_summary.py
@@ -4,27 +4,37 @@
     campaign_summary.py --out PATH <run_dir>...
 
 Each run directory holds reqanalyze's analysis.json (required; its stall_gate
-must have been armed with --stall-max-ms, since an unarmed gate reports
-passed=true having evaluated nothing), dns-evidence.json (optional; when
-present its verdict must be "clean") and
-diag/summary.json (optional). The index names every file it was generated
-from with its sha256, and carries one cell per run: engine, cpu, memory_mib,
-guest_dns, publishable, stall_gate_passed, dns_verdict, the headline median
-blocking_ms per arm with its CI, and the diag summary when there is one.
+must have been armed with --stall-max-ms and must have evaluated at least one
+record, since an unarmed gate reports passed=true having evaluated nothing),
+dns-evidence.json (required when the cell's guest_dns names a baked resolver,
+optional otherwise; when present its verdict must be "clean" and every file it
+cites must be present and agree with it) and diag/summary.json (optional). The
+index names every file it was generated from with its sha256, and carries one
+cell per run: engine, cpu, memory_mib, guest_dns, publishable,
+stall_gate_passed, dns_verdict, the headline median blocking_ms per arm with
+its CI, and the diag summary when there is one.
 
 The index is written only when every run is publishable, every stall gate
-passed and every DNS verdict is clean. Otherwise nothing is written and the
-exit status is 5, the same code reqanalyze uses for a refused run: an index
-that quietly carried an unpublishable cell would be quoted by someone who
-only opened the index. Inputs are only ever read.
+passed and every DNS verdict is clean. Otherwise nothing is written, an index
+already at --out is removed, and the exit status is 5, the same code reqanalyze
+uses for a refused run: an index that quietly carried an unpublishable cell
+would be quoted by someone who only opened the index. Inputs are only ever
+read, and each is read once so the hash names the bytes that were parsed.
 """
 
 import argparse
 import hashlib
 import json
+import math
 import os
 import sys
 import tempfile
+
+VERIFY_STAGES = ("pre", "before-run", "after-run")
+REPLAY_LOGS = {
+    "corpus_dns_log_sha256": "corpus-dns.log",
+    "corpus_access_log_sha256": "corpus-access.log",
+}
 
 
 class RunError(Exception):
@@ -40,20 +50,49 @@ def reject_duplicate_keys(pairs):
     return seen
 
 
-def read_json(path):
-    try:
-        with open(path) as handle:
-            return json.load(handle, object_pairs_hook=reject_duplicate_keys)
-    except (OSError, ValueError) as error:
-        raise RunError(f"{path}: cannot read: {error}")
+def reject_constant(name):
+    raise ValueError(f"non-standard JSON numeric constant {name}")
 
 
-def sha256_file(path):
-    digest = hashlib.sha256()
+def read_bytes(path):
     with open(path, "rb") as handle:
-        for chunk in iter(lambda: handle.read(1 << 20), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
+        return handle.read()
+
+
+def parse_json(data, path):
+    try:
+        return json.loads(
+            data.decode("utf-8"),
+            object_pairs_hook=reject_duplicate_keys,
+            parse_constant=reject_constant,
+        )
+    except (UnicodeDecodeError, ValueError) as error:
+        raise RunError(f"{path}: cannot parse: {error}")
+
+
+class Sources:
+    """The files one cell was read from, each read once and hashed from those bytes."""
+
+    def __init__(self):
+        self.entries = []
+
+    def read_json(self, path):
+        try:
+            data = read_bytes(path)
+        except OSError as error:
+            raise RunError(f"{path}: cannot read: {error}")
+        self.entries.append({"path": path, "sha256": hashlib.sha256(data).hexdigest()})
+        return parse_json(data, path)
+
+    def read_hashed(self, path):
+        """Record a file the index does not parse; returns its sha256."""
+        try:
+            data = read_bytes(path)
+        except OSError as error:
+            raise RunError(f"{path}: cannot read: {error}")
+        digest = hashlib.sha256(data).hexdigest()
+        self.entries.append({"path": path, "sha256": digest})
+        return data, digest
 
 
 def write_json_atomic(path, value):
@@ -69,15 +108,93 @@ def write_json_atomic(path, value):
         raise
 
 
+def positive_int(value):
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def check_evidence(run_dir, evidence, sources):
+    """Hold a clean verdict to the files it cites; raise RunError otherwise."""
+    verdict = evidence.get("verdict") if isinstance(evidence, dict) else None
+    if verdict != "clean":
+        raise RunError(f"{run_dir}: dns-evidence.json verdict is {verdict!r}, not 'clean'")
+    if not positive_int(evidence.get("samples")):
+        raise RunError(
+            f"{run_dir}: dns-evidence.json records samples={evidence.get('samples')!r}; "
+            "a clean verdict needs at least one :53 owner sample"
+        )
+    if evidence.get("first_mismatch") is not None:
+        raise RunError(
+            f"{run_dir}: dns-evidence.json is clean but records a mismatching sample: "
+            f"{evidence.get('first_mismatch')!r}"
+        )
+    if evidence.get("sampler_alive_at_stop") is not True:
+        raise RunError(
+            f"{run_dir}: dns-evidence.json does not show the :53 owner sampler "
+            "alive until the measured run ended"
+        )
+    if evidence.get("dnsmasq_active_after_restore") is not False:
+        raise RunError(f"{run_dir}: dns-evidence.json records dnsmasq active after the restores")
+    if evidence.get("dnsmasq_state_after_restore") != "inactive":
+        raise RunError(
+            f"{run_dir}: dns-evidence.json records dnsmasq state "
+            f"{evidence.get('dnsmasq_state_after_restore')!r} after the restores, not 'inactive'"
+        )
+    owner_log = os.path.join(run_dir, "dns-owner.log")
+    if not os.path.isfile(owner_log):
+        raise RunError(f"{run_dir}: dns-owner.log cited by dns-evidence.json is missing")
+    owner_bytes, _digest = sources.read_hashed(owner_log)
+    owner_lines = owner_bytes.count(b"\n")
+    if owner_lines != evidence["samples"]:
+        raise RunError(
+            f"{run_dir}: dns-evidence.json records {evidence['samples']} samples but "
+            f"dns-owner.log holds {owner_lines} lines"
+        )
+    # The brackets: every stage the campaign runs, each present and passed.
+    # Basenames are resolved inside run_dir so a relocated run directory
+    # still indexes; the evidence's own absolute paths are not trusted.
+    verify_files = evidence.get("verify_files")
+    if not isinstance(verify_files, list) or not all(isinstance(p, str) for p in verify_files):
+        raise RunError(f"{run_dir}: dns-evidence.json has no verify_files list")
+    cited = {os.path.basename(p) for p in verify_files}
+    for stage in VERIFY_STAGES:
+        name = f"verify-dns-{stage}.json"
+        if name not in cited:
+            raise RunError(f"{run_dir}: dns-evidence.json cites no {name} ({stage} bracket)")
+        path = os.path.join(run_dir, name)
+        if not os.path.isfile(path):
+            raise RunError(f"{run_dir}: {name} cited by dns-evidence.json is missing")
+        verify = sources.read_json(path)
+        if not isinstance(verify, dict) or verify.get("passed") is not True:
+            raise RunError(f"{run_dir}: {name} does not record passed=true")
+    # The replay server's own logs, pinned by hash at the verdict.
+    for field, name in REPLAY_LOGS.items():
+        recorded = evidence.get(field)
+        if (
+            not isinstance(recorded, str)
+            or len(recorded) != 64
+            or any(c not in "0123456789abcdef" for c in recorded)
+        ):
+            raise RunError(f"{run_dir}: dns-evidence.json has no sha256 for {name} ({field})")
+        path = os.path.join(run_dir, name)
+        if not os.path.isfile(path):
+            raise RunError(f"{run_dir}: {name} cited by dns-evidence.json is missing")
+        _data, digest = sources.read_hashed(path)
+        if digest != recorded:
+            raise RunError(
+                f"{run_dir}: {name} sha256 {digest} does not match the "
+                f"{recorded} dns-evidence.json recorded at the verdict"
+            )
+
+
 def load_cell(run_dir):
-    """Read one run directory into an index cell. Returns (cell, source paths)."""
+    """Read one run directory into an index cell. Returns (cell, source entries)."""
+    sources = Sources()
     analysis_path = os.path.join(run_dir, "analysis.json")
     if not os.path.isfile(analysis_path):
         raise RunError(f"{run_dir}: analysis.json is missing")
-    analysis = read_json(analysis_path)
+    analysis = sources.read_json(analysis_path)
     if not isinstance(analysis, dict):
         raise RunError(f"{analysis_path}: not a JSON object")
-    sources = [analysis_path]
 
     if analysis.get("publishable") is not True:
         reasons = (analysis.get("gate") or {}).get("reasons") or []
@@ -99,12 +216,22 @@ def load_cell(run_dir):
             f"{run_dir}: analysis.json has no stall_gate verdict; re-run reqanalyze"
         )
     max_ms = stall_gate.get("max_ms")
-    if isinstance(max_ms, bool) or not isinstance(max_ms, (int, float)) or max_ms <= 0:
+    if (
+        isinstance(max_ms, bool)
+        or not isinstance(max_ms, (int, float))
+        or not math.isfinite(max_ms)
+        or max_ms <= 0
+    ):
         # reqanalyze without --stall-max-ms writes passed=true, evaluated=0:
         # a gate that evaluated nothing has no pass to report.
         raise RunError(
             f"{run_dir}: stall_gate was not armed (max_ms is {max_ms!r}); "
             "re-run reqanalyze --stall-max-ms N"
+        )
+    if not positive_int(stall_gate.get("evaluated")):
+        raise RunError(
+            f"{run_dir}: stall_gate evaluated {stall_gate.get('evaluated')!r} "
+            "record(s); a pass over nothing is not a pass"
         )
     if stall_gate["passed"] is not True:
         raise RunError(
@@ -114,19 +241,22 @@ def load_cell(run_dir):
     dns_verdict = None
     evidence_path = os.path.join(run_dir, "dns-evidence.json")
     if os.path.isfile(evidence_path):
-        evidence = read_json(evidence_path)
-        sources.append(evidence_path)
-        dns_verdict = evidence.get("verdict") if isinstance(evidence, dict) else None
-        if dns_verdict != "clean":
-            raise RunError(
-                f"{run_dir}: dns-evidence.json verdict is {dns_verdict!r}, not 'clean'"
-            )
+        evidence = sources.read_json(evidence_path)
+        check_evidence(run_dir, evidence, sources)
+        dns_verdict = evidence["verdict"]
+    elif cell["guest_dns"] is not None:
+        # A guest that resolved through a baked resolver is a campaign run;
+        # only the bracket evidence says the resolver held for the whole
+        # measured run.
+        raise RunError(
+            f"{run_dir}: guest_dns is {cell['guest_dns']!r} but there is no "
+            "dns-evidence.json; a resolver run without its brackets is not indexed"
+        )
 
     diag = None
     diag_path = os.path.join(run_dir, "diag", "summary.json")
     if os.path.isfile(diag_path):
-        diag = read_json(diag_path)
-        sources.append(diag_path)
+        diag = sources.read_json(diag_path)
 
     arms = analysis.get("arms")
     if not isinstance(arms, dict) or not arms:
@@ -157,7 +287,7 @@ def load_cell(run_dir):
         "dns_verdict": dns_verdict,
         "headline": headline,
         "diag": diag,
-    }, sources
+    }, sources.entries
 
 
 def build_index(run_dirs):
@@ -177,9 +307,7 @@ def build_index(run_dirs):
             errors.append(str(error))
             continue
         cells.append(cell)
-        generated_from.extend(
-            {"path": path, "sha256": sha256_file(path)} for path in sources
-        )
+        generated_from.extend(sources)
     return {"generated_from": generated_from, "cells": cells}, errors
 
 
@@ -194,13 +322,21 @@ def main_with(argv=None):
     run_dirs = [os.path.normpath(run_dir) for run_dir in args.run_dir]
     index, errors = build_index(run_dirs)
     out_realpath = os.path.realpath(args.out)
+    aliases_input = False
     for entry in index["generated_from"]:
         if os.path.realpath(entry["path"]) == out_realpath:
             errors.append(f"--out {args.out} aliases input {entry['path']}")
+            aliases_input = True
     if errors:
         print("REFUSED: no index written", file=sys.stderr)
         for error in errors:
             print(f"  - {error}", file=sys.stderr)
+        # An index already at --out describes cells this refusal did not
+        # accept; it must not outlive the refusal. Never when --out is one
+        # of the inputs, which are only ever read.
+        if not aliases_input and os.path.lexists(args.out):
+            os.unlink(args.out)
+            print(f"  removed stale index {args.out}", file=sys.stderr)
         return 5
     write_json_atomic(args.out, index)
     print(f"wrote {args.out}: {len(index['cells'])} cell(s)")

--- a/bench/chromium/campaign_summary.py
+++ b/bench/chromium/campaign_summary.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Index the cells of one campaign into a single JSON file.
+
+    campaign_summary.py --out PATH <run_dir>...
+
+Each run directory holds reqanalyze's analysis.json (required),
+dns-evidence.json (optional; when present its verdict must be "clean") and
+diag/summary.json (optional). The index names every file it was generated
+from with its sha256, and carries one cell per run: engine, cpu, memory_mib,
+guest_dns, publishable, stall_gate_passed, dns_verdict, the headline median
+blocking_ms per arm with its CI, and the diag summary when there is one.
+
+The index is written only when every run is publishable, every stall gate
+passed and every DNS verdict is clean. Otherwise nothing is written and the
+exit status is 5, the same code reqanalyze uses for a refused run: an index
+that quietly carried an unpublishable cell would be quoted by someone who
+only opened the index. Inputs are only ever read.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import tempfile
+
+
+class RunError(Exception):
+    """One run directory cannot be indexed; the message says why."""
+
+
+def reject_duplicate_keys(pairs):
+    seen = {}
+    for key, value in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON key {key!r}")
+        seen[key] = value
+    return seen
+
+
+def read_json(path):
+    try:
+        with open(path) as handle:
+            return json.load(handle, object_pairs_hook=reject_duplicate_keys)
+    except (OSError, ValueError) as error:
+        raise RunError(f"{path}: cannot read: {error}")
+
+
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_json_atomic(path, value):
+    directory = os.path.dirname(os.path.abspath(path))
+    fd, temp_path = tempfile.mkstemp(prefix=".campaign-summary.", dir=directory)
+    try:
+        with os.fdopen(fd, "w") as handle:
+            json.dump(value, handle, indent=2, sort_keys=False)
+            handle.write("\n")
+        os.replace(temp_path, path)
+    except BaseException:
+        os.unlink(temp_path)
+        raise
+
+
+def load_cell(run_dir):
+    """Read one run directory into an index cell. Returns (cell, source paths)."""
+    analysis_path = os.path.join(run_dir, "analysis.json")
+    if not os.path.isfile(analysis_path):
+        raise RunError(f"{run_dir}: analysis.json is missing")
+    analysis = read_json(analysis_path)
+    if not isinstance(analysis, dict):
+        raise RunError(f"{analysis_path}: not a JSON object")
+    sources = [analysis_path]
+
+    if analysis.get("publishable") is not True:
+        reasons = (analysis.get("gate") or {}).get("reasons") or []
+        raise RunError(f"{run_dir}: analysis.json is not publishable: {reasons}")
+    cell = analysis.get("cell")
+    if not isinstance(cell, dict):
+        raise RunError(
+            f"{run_dir}: analysis.json has no top-level cell; the index takes one "
+            "run per cell, not a pooled multi-backend analysis"
+        )
+    for field in ("engine", "cpu", "memory_mib", "guest_dns"):
+        if field not in cell:
+            raise RunError(
+                f"{run_dir}: analysis.json cell has no {field}; re-run reqanalyze"
+            )
+    stall_gate = analysis.get("stall_gate")
+    if not isinstance(stall_gate, dict) or not isinstance(stall_gate.get("passed"), bool):
+        raise RunError(
+            f"{run_dir}: analysis.json has no stall_gate verdict; re-run reqanalyze"
+        )
+    if stall_gate["passed"] is not True:
+        raise RunError(
+            f"{run_dir}: stall_gate failed: {stall_gate.get('violations')}"
+        )
+
+    dns_verdict = None
+    evidence_path = os.path.join(run_dir, "dns-evidence.json")
+    if os.path.isfile(evidence_path):
+        evidence = read_json(evidence_path)
+        sources.append(evidence_path)
+        dns_verdict = evidence.get("verdict") if isinstance(evidence, dict) else None
+        if dns_verdict != "clean":
+            raise RunError(
+                f"{run_dir}: dns-evidence.json verdict is {dns_verdict!r}, not 'clean'"
+            )
+
+    diag = None
+    diag_path = os.path.join(run_dir, "diag", "summary.json")
+    if os.path.isfile(diag_path):
+        diag = read_json(diag_path)
+        sources.append(diag_path)
+
+    arms = analysis.get("arms")
+    if not isinstance(arms, dict) or not arms:
+        raise RunError(f"{run_dir}: analysis.json has no arms")
+    headline = {}
+    for arm, data in arms.items():
+        blocking = data.get("blocking_ms") if isinstance(data, dict) else None
+        median = blocking.get("median") if isinstance(blocking, dict) else None
+        if isinstance(median, bool) or not isinstance(median, (int, float)):
+            raise RunError(f"{run_dir}: arm {arm} has no blocking_ms median")
+        headline[arm] = {
+            "blocking_ms": median,
+            "blocking_ms_ci": [blocking.get("lo"), blocking.get("hi")],
+            "n": blocking.get("n"),
+        }
+
+    return {
+        "run_dir": run_dir,
+        "run_id": analysis.get("run_id"),
+        "engine": cell["engine"],
+        "cpu": cell["cpu"],
+        "memory_mib": cell["memory_mib"],
+        "guest_dns": cell["guest_dns"],
+        "backend": cell.get("backend"),
+        "uffd_mode": cell.get("uffd_mode"),
+        "publishable": True,
+        "stall_gate_passed": True,
+        "dns_verdict": dns_verdict,
+        "headline": headline,
+        "diag": diag,
+    }, sources
+
+
+def build_index(run_dirs):
+    """Every cell or a list of refusals; never a partial index."""
+    cells = []
+    generated_from = []
+    errors = []
+    seen = set()
+    for run_dir in run_dirs:
+        if run_dir in seen:
+            errors.append(f"{run_dir}: listed more than once")
+            continue
+        seen.add(run_dir)
+        try:
+            cell, sources = load_cell(run_dir)
+        except RunError as error:
+            errors.append(str(error))
+            continue
+        cells.append(cell)
+        generated_from.extend(
+            {"path": path, "sha256": sha256_file(path)} for path in sources
+        )
+    return {"generated_from": generated_from, "cells": cells}, errors
+
+
+def main_with(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Index the publishable cells of one campaign into one JSON file.",
+    )
+    parser.add_argument("--out", required=True, help="index path to write")
+    parser.add_argument("run_dir", nargs="+", help="run directories holding analysis.json")
+    args = parser.parse_args(argv)
+
+    run_dirs = [os.path.normpath(run_dir) for run_dir in args.run_dir]
+    index, errors = build_index(run_dirs)
+    out_realpath = os.path.realpath(args.out)
+    for entry in index["generated_from"]:
+        if os.path.realpath(entry["path"]) == out_realpath:
+            errors.append(f"--out {args.out} aliases input {entry['path']}")
+    if errors:
+        print("REFUSED: no index written", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 5
+    write_json_atomic(args.out, index)
+    print(f"wrote {args.out}: {len(index['cells'])} cell(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main_with())

--- a/bench/chromium/cdpdrive.py
+++ b/bench/chromium/cdpdrive.py
@@ -340,7 +340,9 @@ def reduce_net_trace(events: list, load_ts, drain_ms: float) -> dict:
     when the event never arrived; then "pending at load" means still open when
     observation ended, which is the question a stalled load asks. A redirect
     re-announces its requestId with the next url; the row keeps its first url
-    and start and counts the hop.
+    and start and counts the hop. The summary ranks slowest_10 by duration
+    (end_ms minus start_ms), not by completion time, and lists the rows that
+    had no end before the load event as pending_at_load, capped at ten each.
     """
     rows: dict = {}
     order: list = []
@@ -415,11 +417,17 @@ def reduce_net_trace(events: list, load_ts, drain_ms: float) -> dict:
             not ended or (load_ts is not None and r["end_ts"] > load_ts)
         )
         timing = r["timing"] if isinstance(r["timing"], dict) else {}
+        start_ms = rel_ms(r["start_ts"])
+        end_ms = rel_ms(r["end_ts"])
+        duration_ms = None
+        if start_ms is not None and end_ms is not None:
+            duration_ms = round(end_ms - start_ms, 3)
         requests.append({
             "request_id": rid,
             "url": r["url"],
-            "start_ms": rel_ms(r["start_ts"]),
-            "end_ms": rel_ms(r["end_ts"]),
+            "start_ms": start_ms,
+            "end_ms": end_ms,
+            "duration_ms": duration_ms,
             "remote_ip": r["remote_ip"],
             "remote_port": r["remote_port"],
             "protocol": r["protocol"],
@@ -437,10 +445,20 @@ def reduce_net_trace(events: list, load_ts, drain_ms: float) -> dict:
 
     remote_ips = Counter(row["remote_ip"] for row in requests if row["remote_ip"])
     errors = Counter(row["error_text"] for row in requests if row["failed"])
-    ended_rows = sorted(
-        (row for row in requests if row["end_ms"] is not None),
-        key=lambda row: -row["end_ms"],
+    # By duration, not by end_ms: end_ms is completion relative to the first
+    # request, so a request that started late and finished fast would outrank
+    # an earlier, longer one. Ties go to the earlier start.
+    slowest = sorted(
+        (row for row in requests if row["duration_ms"] is not None),
+        key=lambda row: (-row["duration_ms"], row["start_ms"]),
     )
+    # What held the load, earliest start first: the rows a stall
+    # investigation reads before any completed one.
+    pending = sorted(
+        (row for row in requests if row["pending_at_load"]),
+        key=lambda row: row["start_ms"] if row["start_ms"] is not None else float("inf"),
+    )
+
     def by_count(item):
         return (-item[1], item[0])
 
@@ -451,7 +469,10 @@ def reduce_net_trace(events: list, load_ts, drain_ms: float) -> dict:
         "n_pending_at_load": sum(row["pending_at_load"] for row in requests),
         "remote_ips": dict(sorted(remote_ips.items(), key=by_count)),
         "errors": dict(sorted(errors.items(), key=by_count)),
-        "slowest_10": [{"url": row["url"], "end_ms": row["end_ms"]} for row in ended_rows[:10]],
+        "slowest_10": [{"url": row["url"], "end_ms": row["end_ms"],
+                        "duration_ms": row["duration_ms"]} for row in slowest[:10]],
+        "pending_at_load": [{"url": row["url"], "start_ms": row["start_ms"]}
+                            for row in pending[:10]],
         "load_event_ms": rel_ms(load_ts),
         "drain_ms": drain_ms,
     }

--- a/bench/chromium/cdpdrive.py
+++ b/bench/chromium/cdpdrive.py
@@ -32,6 +32,14 @@ WebSocket framing comes from render.py so the host-driven arm and the in-guest
 per-request arm speak CDP through identical code; a divergence there would
 silently invalidate the A/B. Only the connect path is reimplemented here, to time
 its two halves separately.
+
+`--net-trace PATH` is a diagnostic, not a measurement. It sends `Network.enable`
+before the navigate, collects requestWillBeSent / responseReceived /
+loadingFinished / loadingFailed until Page.loadEventFired, keeps draining for
+`--net-trace-drain-ms` (default 5000) so requests still open at the load event
+show how they end, and writes PATH as {"requests": [...], "summary": {...}}.
+The record gains a "net_trace" key holding the summary. Without the flag not
+one extra CDP message is sent; test_net_trace.py pins the wire sequence.
 """
 
 import argparse
@@ -46,6 +54,7 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from collections import Counter
 from urllib.parse import urlparse
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -309,8 +318,151 @@ def transport_signal(error: BaseException, render_mod) -> str:
     return "not-transport"
 
 
+def _timing_ms(timing: dict, start_key: str, end_key: str):
+    """A ResourceTiming interval in ms, or None when Chromium reports -1 (not applicable)."""
+    start, end = timing.get(start_key, -1), timing.get(end_key, -1)
+    if not isinstance(start, (int, float)) or not isinstance(end, (int, float)):
+        return None
+    if start < 0 or end < 0:
+        return None
+    return round(end - start, 3)
+
+
+def reduce_net_trace(events: list, load_ts, drain_ms: float) -> dict:
+    """Fold one navigation's Network.* events into per-request rows and a summary.
+
+    Times are browser-clock seconds (Network.MonotonicTime), reported in ms
+    relative to the earliest requestWillBeSent, which is the navigation's own
+    document request and so sits inside the navigate command's round trip.
+    `load_ts` is Page.loadEventFired's timestamp on the same clock, or None
+    when the event never arrived; then "pending at load" means still open when
+    observation ended, which is the question a stalled load asks. A redirect
+    re-announces its requestId with the next url; the row keeps its first url
+    and start and counts the hop.
+    """
+    rows: dict = {}
+    order: list = []
+    for event in events:
+        method = event.get("method", "")
+        params = event.get("params", {})
+        rid = params.get("requestId")
+        if not method.startswith("Network.") or rid is None:
+            continue
+        row = rows.get(rid)
+        if method == "Network.requestWillBeSent":
+            if row is None:
+                rows[rid] = {
+                    "request_id": rid,
+                    "url": params.get("request", {}).get("url", ""),
+                    "start_ts": params.get("timestamp"),
+                    "end_ts": None,
+                    "remote_ip": "",
+                    "remote_port": None,
+                    "protocol": "",
+                    "status": None,
+                    "timing": None,
+                    "failed": False,
+                    "canceled": False,
+                    "error_text": "",
+                    "redirects": 0,
+                }
+                order.append(rid)
+            else:
+                row["redirects"] += 1
+            continue
+        if row is None:
+            continue  # announced before Network.enable; nothing to attach to
+        if method == "Network.responseReceived":
+            response = params.get("response", {})
+            row.update(
+                remote_ip=response.get("remoteIPAddress", ""),
+                remote_port=response.get("remotePort"),
+                protocol=response.get("protocol", ""),
+                status=response.get("status"),
+                timing=response.get("timing"),
+            )
+        elif method == "Network.loadingFinished":
+            if row["end_ts"] is None:
+                row["end_ts"] = params.get("timestamp")
+        elif method == "Network.loadingFailed":
+            if row["end_ts"] is None:
+                row["end_ts"] = params.get("timestamp")
+            row["failed"] = True
+            row["canceled"] = bool(params.get("canceled", False))
+            row["error_text"] = params.get("errorText", "")
+
+    starts = [r["start_ts"] for r in rows.values() if r["start_ts"] is not None]
+    base = min(starts) if starts else None
+
+    def rel_ms(ts):
+        if ts is None or base is None:
+            return None
+        return round((ts - base) * 1000, 3)
+
+    requests = []
+    for rid in order:
+        r = rows[rid]
+        ended = r["end_ts"] is not None
+        finished_before_load = (
+            ended and not r["failed"] and load_ts is not None and r["end_ts"] <= load_ts
+        )
+        started_by_load = load_ts is None or (
+            r["start_ts"] is not None and r["start_ts"] <= load_ts
+        )
+        pending_at_load = started_by_load and (
+            not ended or (load_ts is not None and r["end_ts"] > load_ts)
+        )
+        timing = r["timing"] if isinstance(r["timing"], dict) else {}
+        requests.append({
+            "request_id": rid,
+            "url": r["url"],
+            "start_ms": rel_ms(r["start_ts"]),
+            "end_ms": rel_ms(r["end_ts"]),
+            "remote_ip": r["remote_ip"],
+            "remote_port": r["remote_port"],
+            "protocol": r["protocol"],
+            "status": r["status"],
+            "finished_before_load": finished_before_load,
+            "pending_at_load": pending_at_load,
+            "failed": r["failed"],
+            "canceled": r["canceled"],
+            "error_text": r["error_text"],
+            "redirects": r["redirects"],
+            "dns_ms": _timing_ms(timing, "dnsStart", "dnsEnd"),
+            "connect_ms": _timing_ms(timing, "connectStart", "connectEnd"),
+            "timing": r["timing"],
+        })
+
+    remote_ips = Counter(row["remote_ip"] for row in requests if row["remote_ip"])
+    errors = Counter(row["error_text"] for row in requests if row["failed"])
+    ended_rows = sorted(
+        (row for row in requests if row["end_ms"] is not None),
+        key=lambda row: -row["end_ms"],
+    )
+    def by_count(item):
+        return (-item[1], item[0])
+
+    summary = {
+        "n_requests": len(requests),
+        "n_finished_before_load": sum(row["finished_before_load"] for row in requests),
+        "n_failed": sum(row["failed"] for row in requests),
+        "n_pending_at_load": sum(row["pending_at_load"] for row in requests),
+        "remote_ips": dict(sorted(remote_ips.items(), key=by_count)),
+        "errors": dict(sorted(errors.items(), key=by_count)),
+        "slowest_10": [{"url": row["url"], "end_ms": row["end_ms"]} for row in ended_rows[:10]],
+        "load_event_ms": rel_ms(load_ts),
+        "drain_ms": drain_ms,
+    }
+    return {"requests": requests, "summary": summary}
+
+
 def drive(args) -> dict:
     render = load_render(args.render_module)
+    # getattr, for the same reason as host_header below: reqbench builds a
+    # closed Namespace. A missing attribute or None means the trace is off,
+    # and off sends nothing the untraced path does not send.
+    trace_path = getattr(args, "net_trace", None)
+    trace_drain_ms = float(getattr(args, "net_trace_drain_ms", 5000.0))
     t0 = time.monotonic()
     deadline = t0 + args.timeout
     out: dict = {"ok": False, "cdp_host": args.cdp_host, "url": args.url, "format": args.format}
@@ -318,6 +470,8 @@ def drive(args) -> dict:
     stage = "resolve"
     stage_started = t0
     ws = None
+    cdp = None
+    load_ts = None
     try:
         if args.ws_url:
             ws_url = args.ws_url
@@ -353,6 +507,10 @@ def drive(args) -> dict:
         cdp.cmd("Page.enable", deadline=deadline)
         if args.idle_wait_ms > 0:
             cdp.cmd("Page.setLifecycleEventsEnabled", {"enabled": True}, deadline=deadline)
+        if trace_path:
+            # The one message the trace adds before the navigate. Measured
+            # arms never set the flag and stay byte-identical on the wire.
+            cdp.cmd("Network.enable", deadline=deadline)
         stages["enable_ms"] = (time.monotonic() - t) * 1000
         stages["connect_total_ms"] = (time.monotonic() - t0) * 1000
 
@@ -367,9 +525,27 @@ def drive(args) -> dict:
 
         stage = "navigate-load-event"
         stage_started = time.monotonic()
-        cdp.wait_event(lambda ev: ev["method"] == "Page.loadEventFired", deadline)
+        load_event = cdp.wait_event(lambda ev: ev["method"] == "Page.loadEventFired", deadline)
         stages["navigate_load_event_ms"] = (time.monotonic() - stage_started) * 1000
         stages["navigate_ms"] = (time.monotonic() - t) * 1000
+
+        if trace_path:
+            load_ts = load_event.get("params", {}).get("timestamp")
+            stage = "net-trace-drain"
+            stage_started = time.monotonic()
+            t = stage_started
+            if trace_drain_ms > 0:
+                # Keep reading so requests still open at the load event show
+                # how they end. wait_event stashes every event it reads; the
+                # bound is the socket timeout, the same mechanism as the idle
+                # wait above.
+                try:
+                    cdp.wait_event(
+                        lambda _ev: False, min(deadline, t + trace_drain_ms / 1000)
+                    )
+                except TimeoutError:
+                    pass
+            stages["net_trace_drain_ms"] = (time.monotonic() - t) * 1000
 
         stage = "network-idle"
         stage_started = time.monotonic()
@@ -491,6 +667,18 @@ def drive(args) -> dict:
             else "render"
         )
     finally:
+        if trace_path and cdp is not None:
+            # Written on failure too: a load event that never fired is the
+            # case the trace exists for. A filesystem error goes on the record
+            # rather than out of drive(), which never raises for its own faults.
+            trace = reduce_net_trace(cdp.events, load_ts, trace_drain_ms)
+            try:
+                with open(trace_path, "w") as f:
+                    json.dump(trace, f, separators=(",", ":"))
+                    f.write("\n")
+                out["net_trace"] = trace["summary"]
+            except OSError as e:
+                out["net_trace_error"] = f"{type(e).__name__}: {e}"
         if ws is not None:
             try:
                 ws.close()
@@ -518,6 +706,13 @@ def main() -> int:
     p.add_argument("--host-header", default="",
                    help="override the Host header on /json/list; proves Chromium's "
                         "DevTools host validation rejects non-IP, non-localhost names")
+    p.add_argument("--net-trace", default=None, metavar="PATH",
+                   help="write the navigation's Network.* events as per-request rows plus "
+                        "a summary to PATH; adds Network.enable and a post-load drain, "
+                        "so never on a measured arm")
+    p.add_argument("--net-trace-drain-ms", type=float, default=5000.0,
+                   help="with --net-trace: keep collecting events this long after "
+                        "Page.loadEventFired")
     p.add_argument("--render-module", default=os.path.join(HERE, "render.py"))
     args = p.parse_args()
     if args.print_target:

--- a/bench/chromium/cdpdrive.py
+++ b/bench/chromium/cdpdrive.py
@@ -37,9 +37,11 @@ its two halves separately.
 before the navigate, collects requestWillBeSent / responseReceived /
 loadingFinished / loadingFailed until Page.loadEventFired, keeps draining for
 `--net-trace-drain-ms` (default 5000) so requests still open at the load event
-show how they end, and writes PATH as {"requests": [...], "summary": {...}}.
-The record gains a "net_trace" key holding the summary. Without the flag not
-one extra CDP message is sent; test_net_trace.py pins the wire sequence.
+show how they end, and writes PATH whole (temp file, then rename) as
+{"requests": [...], "summary": {...}}. The record gains a "net_trace" key
+holding the summary; a PATH that could not be written puts "net_trace_error"
+on the record and exits 1. Without the flag not one extra CDP message is
+sent; test_net_trace.py pins the wire sequence.
 """
 
 import argparse
@@ -670,15 +672,24 @@ def drive(args) -> dict:
         if trace_path and cdp is not None:
             # Written on failure too: a load event that never fired is the
             # case the trace exists for. A filesystem error goes on the record
-            # rather than out of drive(), which never raises for its own faults.
+            # rather than out of drive(), which never raises for its own
+            # faults; main() then exits non-zero, since a trace that was
+            # asked for and not written is a failed invocation. The file is
+            # renamed into place whole: a reader never sees a truncated one.
             trace = reduce_net_trace(cdp.events, load_ts, trace_drain_ms)
+            temp_path = f"{trace_path}.{os.getpid()}.tmp"
             try:
-                with open(trace_path, "w") as f:
+                with open(temp_path, "w") as f:
                     json.dump(trace, f, separators=(",", ":"))
                     f.write("\n")
+                os.replace(temp_path, trace_path)
                 out["net_trace"] = trace["summary"]
             except OSError as e:
                 out["net_trace_error"] = f"{type(e).__name__}: {e}"
+                try:
+                    os.unlink(temp_path)
+                except OSError:
+                    pass
         if ws is not None:
             try:
                 ws.close()
@@ -729,7 +740,7 @@ def main() -> int:
         return 0
     out = drive(args)
     print(json.dumps(out, separators=(",", ":")), flush=True)
-    return 0 if out["ok"] else 1
+    return 0 if out["ok"] and "net_trace_error" not in out else 1
 
 
 if __name__ == "__main__":

--- a/bench/chromium/corpus_campaign.sh
+++ b/bench/chromium/corpus_campaign.sh
@@ -42,6 +42,12 @@ WARMUP="${WARMUP:-28}"          # two full 14-URL cycles; the harness fails clos
 UFFD_MODE="${UFFD_MODE:-minor}"
 UFFD_PREFETCH="${UFFD_PREFETCH:-on}"
 BACKEND="${BACKEND:-uffd}"
+# Arms reqanalyze's stall gate for the measured run. A corpus page replays
+# from the host and its load event completes in well under a second; a
+# resolver that never answers holds a navigation for ~30 s. 15 s separates
+# the two, and campaign_summary refuses an analysis whose gate was never
+# armed, so an unset value here would make every run un-indexable.
+STALL_MAX_MS="${STALL_MAX_MS:-15000}"
 STAMP="$(date +%Y%m%d-%H%M%S)"
 RESULTS="${RESULTS:-$REPO/bench/chromium/results/reqbench-$STAMP-corpus}"
 LOGDIR="${LOGDIR:-/tmp/corpus-campaign-$STAMP}"
@@ -49,6 +55,10 @@ mkdir -p "$LOGDIR"
 # Created here, not left to reqbench: the replay server's logs and the resolver
 # evidence below are written into it before any reqbench phase runs.
 mkdir -p "$RESULTS"
+# An explicit RESULTS can be reused. Evidence an earlier campaign left there
+# must not outlive this one's start: a clean verdict beside a run this
+# campaign never finished would be indexed as if it were this run's.
+rm -f "$RESULTS"/dns-evidence.json "$RESULTS"/verify-dns*.json "$RESULTS"/dns-owner.log
 
 # The 14 URLs, in the order the sealed 2026-08-14 run cycled them. Order is part
 # of the schedule: reqanalyze re-derives the expected URL per record from it, so
@@ -71,9 +81,11 @@ say() { printf '\n=== %s\n' "$*"; }
 #      DNS_SAMPLE_INTERVAL seconds while the run is in flight
 #      ($RESULTS/dns-owner.log).
 #   3. $RESULTS/dns-evidence.json ties them together with the replay server's
-#      own DNS and access logs (sha256) and a verdict: "clean" only when every
-#      bracket passed, every sample names this campaign's corpus_serve with
-#      dnsmasq inactive, and dnsmasq is still down after the clone restores.
+#      own DNS and access logs (sha256) and a verdict: "clean" only when all
+#      three brackets are present and passed, every sample names this
+#      campaign's corpus_serve with dnsmasq inactive, the sampler lived until
+#      the run ended, both replay logs exist, and dnsmasq is inactive after
+#      the clone restores.
 engine_target() {
     # $1 = golden | verify | run
     printf 'bench-%s-request-%s' "$([ "$ENGINE" = webkit ] && echo webkit || echo chromium)" "$1"
@@ -92,7 +104,10 @@ run_verify() {
     # AND the evidence it left says passed=true.
     local stage="$1" copy="$RESULTS/verify-dns-$1.json" f
     say "verify ($stage): render hops + baked resolver on a restored clone"
-    rm -f "$RESULTS/verify-dns.json"
+    # Both removed first: this function runs as `run_verify X || ...`, where
+    # bash keeps errexit off, so an unchecked cp that failed would leave the
+    # jq below validating whatever copy was already there.
+    rm -f "$RESULTS/verify-dns.json" "$copy"
     if ! VERIFY_DNS_HOSTS="$CORPUS_HOSTS" VERIFY_DNS_ANSWER=10.0.2.2 VERIFY_DNS_URLS="$URLS" \
         TAG="$TAG" ENGINE="$ENGINE" RESULTS="$RESULTS" \
         make -C "$REPO" "$(engine_target verify)" 2>&1 | tee "$LOGDIR/verify-$stage.log"; then
@@ -105,45 +120,63 @@ run_verify() {
     done
     [ -s "$RESULTS/verify-dns.json" ] \
         || { echo "FAILED: verify ($stage) left no $RESULTS/verify-dns.json (HOP D did not run)" >&2; return 1; }
-    cp "$RESULTS/verify-dns.json" "$copy"
-    jq -e '.passed == true' "$copy" >/dev/null \
-        || { echo "FAILED: verify ($stage): $copy records passed=false" >&2; return 1; }
+    cp "$RESULTS/verify-dns.json" "$copy" \
+        || { echo "FAILED: verify ($stage): cannot keep the evidence as $copy" >&2; return 1; }
+    # passed=true is also what HOP D writes when it was given nothing to
+    # check; the bracket must show the replay resolver and every corpus host
+    # and URL answered through it.
+    jq -e --arg hosts "$CORPUS_HOSTS" --arg urls "$URLS" '
+        . as $e
+        | .passed == true and .dns_server == "10.0.2.2"
+        and all($hosts | split(",")[]; . as $h | $e.hosts[$h].ok == true)
+        and all($urls | split(",")[]; . as $u | $e.urls[$u].ok == true)' "$copy" >/dev/null \
+        || { echo "FAILED: verify ($stage): $copy does not record passed=true through 10.0.2.2 for every corpus host and URL" >&2; return 1; }
 }
 
 DNS_SAMPLE_INTERVAL="${DNS_SAMPLE_INTERVAL:-10}"
 SAMPLER_PID=""
+SAMPLER_ALIVE_AT_STOP=""
 
 dns_owner_sample() {
     # One line: "<utc ts> owner_pid=<pid|none> dnsmasq=<state>". The local
     # address is matched exactly: systemd-resolved (127.0.0.53) and dnsmasq's
     # per-interface listeners share the port. sudo is what makes ss show the
     # pid behind a root-owned socket; -n so a missing grant fails the sample
-    # (owner none, verdict unclean) instead of hanging the sampler on a prompt.
-    local owner state
-    owner=$(sudo -n ss -lnup 'sport = :53' 2>/dev/null \
-        | awk '$4 == "127.0.0.1:53" && match($0, /pid=[0-9]+/) { print substr($0, RSTART + 4, RLENGTH - 4); exit }')
+    # instead of hanging the sampler on a prompt. A sample that cannot be
+    # taken returns 1 and ends the sampler (below), which the evidence
+    # records as unclean.
+    local listing owner state
+    listing=$(sudo -n ss -lnup 'sport = :53' 2>/dev/null) || return 1
+    owner=$(awk '$4 == "127.0.0.1:53" && match($0, /pid=[0-9]+/) { print substr($0, RSTART + 4, RLENGTH - 4); exit }' <<<"$listing")
     state=$(systemctl is-active dnsmasq 2>/dev/null) || state="${state:-unknown}"
     printf '%s owner_pid=%s dnsmasq=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${owner:-none}" "$state"
 }
 
 dns_owner_sampler() {
-    # $1 = log; runs until killed.
+    # $1 = log; runs until killed, or until a sample cannot be taken.
     while :; do
-        dns_owner_sample >>"$1"
+        dns_owner_sample >>"$1" || exit 1
         sleep "$DNS_SAMPLE_INTERVAL"
     done
 }
 
 start_dns_sampler() {
     : >"$RESULTS/dns-owner.log"
+    SAMPLER_ALIVE_AT_STOP=""
     dns_owner_sampler "$RESULTS/dns-owner.log" &
     SAMPLER_PID=$!
 }
 
 stop_dns_sampler() {
+    # The sampler's exit status says what ended it: 143 is this SIGTERM,
+    # anything else means it died on its own before the run ended, and the
+    # samples it left cover only part of the run. `kill -0` cannot tell
+    # the two apart (a dead, unreaped child still answers it).
     [ -n "$SAMPLER_PID" ] || return 0
+    local status=0
     kill "$SAMPLER_PID" 2>/dev/null || true
-    wait "$SAMPLER_PID" 2>/dev/null || true
+    wait "$SAMPLER_PID" 2>/dev/null || status=$?
+    if [ "$status" -eq 143 ]; then SAMPLER_ALIVE_AT_STOP=yes; else SAMPLER_ALIVE_AT_STOP=no; fi
     SAMPLER_PID=""
 }
 
@@ -159,11 +192,17 @@ sha256_or_empty() {
 
 write_dns_evidence() {
     # $1 = clean | unclean from the verify brackets, $2 = optional reason.
-    # The samples, the dnsmasq state and an absence of samples can only lower
-    # the verdict, never lift it. Prints the final verdict.
+    # Everything checked here can only lower the verdict, never lift it:
+    # the samples and whether the sampler lived to the stop, the dnsmasq
+    # state, the three bracket files and the two replay logs. Prints the
+    # final verdict; a verdict that could not be written is unclean and the
+    # function returns 1.
     local verdict="$1" reason="${2:-}" log="$RESULTS/dns-owner.log"
-    local samples=0 first_mismatch="" before=false after=false f
+    local out="$RESULTS/dns-evidence.json"
+    local samples=0 first_mismatch="" before=false after=false after_state f
+    local sampler_alive=false
     [ "$DNSMASQ_WAS_ACTIVE" = yes ] && before=true
+    [ "$SAMPLER_ALIVE_AT_STOP" = yes ] && sampler_alive=true
     if [ -s "$log" ]; then
         samples=$(wc -l <"$log")
         first_mismatch=$(dns_first_mismatch "$log" "$SERVE_PID")
@@ -172,32 +211,56 @@ write_dns_evidence() {
         verdict=unclean; reason="${reason:-no 127.0.0.1:53 owner samples were taken}"
     elif [ -n "$first_mismatch" ]; then
         verdict=unclean; reason="${reason:-a sample did not name corpus_serve $SERVE_PID with dnsmasq inactive}"
+    elif [ "$sampler_alive" != true ]; then
+        verdict=unclean; reason="${reason:-the :53 owner sampler died before the measured run ended}"
     fi
     # "after restore" is the clone restores of the measured run: read before
-    # the exit trap starts dnsmasq again, so true means something restarted it
-    # while clones were being measured.
-    if systemctl is-active --quiet dnsmasq 2>/dev/null; then
-        after=true; verdict=unclean; reason="${reason:-dnsmasq is active after the clone restores}"
+    # the exit trap starts dnsmasq again. Only "inactive" is clean: active
+    # means something restarted it while clones were being measured, and
+    # failed, activating, unknown or no answer from systemd is not evidence
+    # of absence.
+    after_state=$(systemctl is-active dnsmasq 2>/dev/null) || true
+    after_state="${after_state:-unknown}"
+    [ "$after_state" = active ] && after=true
+    if [ "$after_state" != inactive ]; then
+        verdict=unclean; reason="${reason:-dnsmasq is $after_state after the clone restores, not inactive}"
     fi
     local -a files=()
     for f in pre before-run after-run; do
         if [ -f "$RESULTS/verify-dns-$f.json" ]; then files+=("$RESULTS/verify-dns-$f.json"); fi
+        if ! jq -e '.passed == true' "$RESULTS/verify-dns-$f.json" >/dev/null 2>&1; then
+            verdict=unclean; reason="${reason:-the $f verify bracket is missing or did not pass}"
+        fi
     done
-    jq -n --argjson serve_pid "${SERVE_PID:-null}" --argjson before "$before" --argjson after "$after" \
+    for f in corpus-dns.log corpus-access.log; do
+        if [ ! -s "$RESULTS/$f" ]; then
+            verdict=unclean; reason="${reason:-replay log $f is missing or empty}"
+        fi
+    done
+    if ! jq -n --argjson serve_pid "${SERVE_PID:-null}" --argjson before "$before" --argjson after "$after" \
+        --arg after_state "$after_state" --argjson sampler_alive "$sampler_alive" \
         --argjson samples "$samples" --argjson interval "$DNS_SAMPLE_INTERVAL" \
         --arg first "$first_mismatch" --arg reason "$reason" --arg owner_log "$log" \
         --arg dns_sha "$(sha256_or_empty "$RESULTS/corpus-dns.log")" \
         --arg access_sha "$(sha256_or_empty "$RESULTS/corpus-access.log")" \
         --arg verdict "$verdict" --args \
         '{serve_pid: $serve_pid, dnsmasq_was_active_before: $before,
-          dnsmasq_active_after_restore: $after, samples: $samples,
+          dnsmasq_active_after_restore: $after,
+          dnsmasq_state_after_restore: $after_state,
+          sampler_alive_at_stop: $sampler_alive, samples: $samples,
           sample_interval_s: $interval, owner_log: $owner_log,
           first_mismatch: (if $first == "" then null else $first end),
           verify_files: $ARGS.positional,
           corpus_dns_log_sha256: (if $dns_sha == "" then null else $dns_sha end),
           corpus_access_log_sha256: (if $access_sha == "" then null else $access_sha end),
           reason: (if $reason == "" then null else $reason end),
-          verdict: $verdict}' "${files[@]}" >"$RESULTS/dns-evidence.json"
+          verdict: $verdict}' "${files[@]}" >"$out.tmp" \
+        || ! mv "$out.tmp" "$out"; then
+        rm -f "$out.tmp"
+        echo "FAILED: cannot write $out" >&2
+        printf 'unclean\n'
+        return 1
+    fi
     printf '%s\n' "$verdict"
 }
 
@@ -259,19 +322,18 @@ if systemctl is-active --quiet dnsmasq 2>/dev/null; then
 fi
 SERVE_PID=""
 
-cleanup() {
-    set +e
-    # The sampler is a background subshell of this script; nothing else reaps
-    # it when the campaign dies mid-run.
-    stop_dns_sampler
+stop_corpus_serve() {
     # `sudo kill -0`, not bare `kill -0`: corpus_serve runs as root (sudo -b)
     # while this script does not, so an unprivileged liveness probe gets EPERM
     # and the guard is ALWAYS false. The server then survives holding
-    # 127.0.0.1:53/80/443, the `systemctl start dnsmasq` below cannot bind, and
-    # the next run picks up the leaked pid and records DNSMASQ_WAS_ACTIVE=no.
+    # 127.0.0.1:53/80/443, the `systemctl start dnsmasq` in cleanup cannot
+    # bind, and the next run picks up the leaked pid and records
+    # DNSMASQ_WAS_ACTIVE=no. Called before the evidence is written (so the
+    # replay-log hashes name files nothing appends to afterwards) and again
+    # from the exit trap, which finds it already gone.
     if [ -n "$SERVE_PID" ] && sudo kill -0 "$SERVE_PID" 2>/dev/null; then
         say "stopping corpus_serve ($SERVE_PID)"
-        sudo kill "$SERVE_PID" 2>/dev/null
+        sudo kill "$SERVE_PID" 2>/dev/null || true
         # Not `wait`: the server is not a child of this shell (sudo -b detached
         # it), so wait returns immediately and proves nothing. Poll instead.
         for _ in $(seq 1 50); do
@@ -280,9 +342,17 @@ cleanup() {
         done
         if sudo kill -0 "$SERVE_PID" 2>/dev/null; then
             say "corpus_serve $SERVE_PID did not exit; escalating to SIGKILL"
-            sudo kill -9 "$SERVE_PID" 2>/dev/null
+            sudo kill -9 "$SERVE_PID" 2>/dev/null || true
         fi
     fi
+}
+
+cleanup() {
+    set +e
+    # The sampler is a background subshell of this script; nothing else reaps
+    # it when the campaign dies mid-run.
+    stop_dns_sampler
+    stop_corpus_serve
     if [ "$DNSMASQ_WAS_ACTIVE" = yes ] && ! systemctl is-active --quiet dnsmasq; then
         say "restarting dnsmasq"
         # Retry and REPORT. corpus_serve can still be releasing :53 as this runs
@@ -445,16 +515,18 @@ start_dns_sampler
 run_rc=0
 TAG="$TAG" URL="$URLS" BACKEND="$BACKEND" UFFD_MODE="$UFFD_MODE" \
     UFFD_PREFETCH="$UFFD_PREFETCH" ARMS="$ARMS" REPS="$REPS" WARMUP="$WARMUP" \
-    RESULTS="$RESULTS" ENGINE="$ENGINE" \
+    STALL_MAX_MS="$STALL_MAX_MS" RESULTS="$RESULTS" ENGINE="$ENGINE" \
     make -C "$REPO" "$(engine_target run)" 2>&1 | tee "$LOGDIR/run.log" || run_rc=$?
 stop_dns_sampler
 
 # The run's own exit is not the verdict: a run that measured cleanly against
 # the wrong resolver is worse than one that failed, so the after-run bracket
-# and the evidence are written whatever the run returned.
+# and the evidence are written whatever the run returned. The replay server
+# stops before the evidence hashes its logs.
 after_rc=0
 run_verify after-run || after_rc=$?
-verdict=$(write_dns_evidence "$([ "$after_rc" -eq 0 ] && echo clean || echo unclean)")
+stop_corpus_serve
+verdict=$(write_dns_evidence "$([ "$after_rc" -eq 0 ] && echo clean || echo unclean)") || verdict=unclean
 say "dns evidence: verdict=$verdict ($RESULTS/dns-evidence.json)"
 if [ "$run_rc" -ne 0 ] || [ "$after_rc" -ne 0 ] || [ "$verdict" != clean ]; then
     echo "FAILED: measured run exit $run_rc, after-run verify exit $after_rc, dns verdict $verdict" >&2

--- a/bench/chromium/corpus_campaign.sh
+++ b/bench/chromium/corpus_campaign.sh
@@ -57,8 +57,11 @@ mkdir -p "$LOGDIR"
 mkdir -p "$RESULTS"
 # An explicit RESULTS can be reused. Evidence an earlier campaign left there
 # must not outlive this one's start: a clean verdict beside a run this
-# campaign never finished would be indexed as if it were this run's.
-rm -f "$RESULTS"/dns-evidence.json "$RESULTS"/verify-dns*.json "$RESULTS"/dns-owner.log
+# campaign never finished would be indexed as if it were this run's, and
+# corpus_serve appends to its replay logs, so an earlier attempt's queries and
+# requests would be hashed into this run's evidence as its own.
+rm -f "$RESULTS"/dns-evidence.json "$RESULTS"/verify-dns*.json "$RESULTS"/dns-owner.log \
+    "$RESULTS"/corpus-dns.log "$RESULTS"/corpus-access.log
 
 # The 14 URLs, in the order the sealed 2026-08-14 run cycled them. Order is part
 # of the schedule: reqanalyze re-derives the expected URL per record from it, so
@@ -420,11 +423,15 @@ grep -q "loaded [1-9]" "$LOGDIR/corpus_serve.log" || {
 # after switching to a pidfile the curl below raced the TLS bind and returned
 # 000, which `set -e` turned into a bare exit 7. Poll the sockets instead, so
 # the wait is as long as it needs to be and no longer.
+# --noproxy '*' on this curl and the one below: both talk to 127.0.0.1 and
+# nothing else. With http_proxy/HTTPS_PROXY in the environment curl would go to
+# the proxy instead: a working one fetches the live site and passes an
+# incomplete replay, an unreachable one returns 000 for a replay that is up.
 answer=""
 code=""
 for _ in $(seq 1 100); do
     answer=$(dig +short +time=2 +tries=1 @127.0.0.1 blog.cloudflare.com A 2>/dev/null | head -1 || true)
-    code=$(curl -sk -o /dev/null -w '%{http_code}' --max-time 5 \
+    code=$(curl -sk --noproxy '*' -o /dev/null -w '%{http_code}' --max-time 5 \
            --resolve 'blog.cloudflare.com:443:127.0.0.1' https://blog.cloudflare.com/ 2>/dev/null || true)
     if [ "$answer" = "10.0.2.2" ] && [ "$code" = "200" ]; then break; fi
     sudo kill -0 "$SERVE_PID" 2>/dev/null || { echo "BLOCKED: corpus_serve died during startup" >&2; cat "$LOGDIR/corpus_serve.log" >&2; exit 3; }
@@ -442,7 +449,7 @@ say "replay server up: DNS -> 10.0.2.2, HTTPS 200"
 missing=""
 for url in $(printf '%s\n' "$URLS" | tr ',' ' '); do
     host=$(printf '%s' "$url" | sed -E 's#^https?://([^/]+).*#\1#')
-    ucode=$(curl -sk -o /dev/null -w '%{http_code}' --max-time 10 \
+    ucode=$(curl -sk --noproxy '*' -o /dev/null -w '%{http_code}' --max-time 10 \
             --resolve "$host:443:127.0.0.1" "$url" 2>/dev/null || true)
     case "$ucode" in
     200 | 30[1278]) ;;

--- a/bench/chromium/corpus_campaign.sh
+++ b/bench/chromium/corpus_campaign.sh
@@ -87,15 +87,17 @@ say() { printf '\n=== %s\n' "$*"; }
 #      corpus URL fetches through that resolver: once before the settle wait,
 #      once immediately before the measured run, once after it. Each bracket
 #      keeps its evidence as $RESULTS/verify-dns-<stage>.json.
-#   2. a sampler names the owner of 127.0.0.1:53 and the dnsmasq state every
-#      DNS_SAMPLE_INTERVAL seconds while the run is in flight
-#      ($RESULTS/dns-owner.log).
+#   2. a sampler names the owner of 127.0.0.1:53, the dnsmasq state and the
+#      1-min load every DNS_SAMPLE_INTERVAL seconds while the run is in
+#      flight ($RESULTS/dns-owner.log). The quiet gate reads the load once,
+#      before the run; the samples are what says it stayed quiet.
 #   3. $RESULTS/dns-evidence.json ties them together with the replay server's
-#      own DNS and access logs (sha256) and a verdict: "clean" only when all
-#      three brackets are present and passed, every sample names this
-#      campaign's corpus_serve with dnsmasq inactive, the sampler lived until
-#      the run ended, both replay logs exist, and dnsmasq is inactive after
-#      the clone restores.
+#      own DNS and access logs (sha256), the maximum 1-min load over the
+#      samples (load_max_1min), and a verdict: "clean" only when all three
+#      brackets are present and passed, every sample names this campaign's
+#      corpus_serve with dnsmasq inactive, the sampler lived until the run
+#      ended, both replay logs exist, and dnsmasq is inactive after the clone
+#      restores.
 engine_target() {
     # $1 = golden | verify | run
     printf 'bench-%s-request-%s' "$([ "$ENGINE" = webkit ] && echo webkit || echo chromium)" "$1"
@@ -144,22 +146,30 @@ run_verify() {
 }
 
 DNS_SAMPLE_INTERVAL="${DNS_SAMPLE_INTERVAL:-10}"
+# The same override reqbench.sh's quiet gate takes; tests point it at a file.
+LOADAVG_FILE="${LOADAVG_FILE:-/proc/loadavg}"
 SAMPLER_PID=""
 SAMPLER_ALIVE_AT_STOP=""
 
 dns_owner_sample() {
-    # One line: "<utc ts> owner_pid=<pid|none> dnsmasq=<state>". The local
-    # address is matched exactly: systemd-resolved (127.0.0.53) and dnsmasq's
-    # per-interface listeners share the port. sudo is what makes ss show the
-    # pid behind a root-owned socket; -n so a missing grant fails the sample
-    # instead of hanging the sampler on a prompt. A sample that cannot be
-    # taken returns 1 and ends the sampler (below), which the evidence
-    # records as unclean.
-    local listing owner state
+    # One line: "<utc ts> owner_pid=<pid|none> dnsmasq=<state> load1=<1-min
+    # load>". The local address is matched exactly: systemd-resolved
+    # (127.0.0.53) and dnsmasq's per-interface listeners share the port. sudo
+    # is what makes ss show the pid behind a root-owned socket; -n so a
+    # missing grant fails the sample instead of hanging the sampler on a
+    # prompt. The load is the first field of LOADAVG_FILE and must be a
+    # number: a column that silently went missing would read as a quiet
+    # box. A sample that cannot be taken returns 1 and ends the sampler
+    # (below), which the evidence records as unclean.
+    local listing owner state load1
     listing=$(sudo -n ss -lnup 'sport = :53' 2>/dev/null) || return 1
     owner=$(awk '$4 == "127.0.0.1:53" && match($0, /pid=[0-9]+/) { print substr($0, RSTART + 4, RLENGTH - 4); exit }' <<<"$listing")
     state=$(systemctl is-active dnsmasq 2>/dev/null) || state="${state:-unknown}"
-    printf '%s owner_pid=%s dnsmasq=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${owner:-none}" "$state"
+    load1=$(cut -d' ' -f1 "$LOADAVG_FILE" 2>/dev/null) || return 1
+    case "$load1" in
+        '' | *[!0-9.]* | .* | *. | *.*.*) return 1 ;;
+    esac
+    printf '%s owner_pid=%s dnsmasq=%s load1=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${owner:-none}" "$state" "$load1"
 }
 
 dns_owner_sampler() {
@@ -196,6 +206,19 @@ dns_first_mismatch() {
     awk -v pid="$2" '$2 != "owner_pid=" pid || $3 != "dnsmasq=inactive" { print; exit }' "$1"
 }
 
+dns_load_stats() {
+    # $1 = sample log. Prints "<count> <max>": how many samples carry a
+    # numeric load1= field and the largest value among them, as the sample
+    # wrote it (a JSON number as-is), or "0 null" when none does.
+    awk '{
+        for (i = 1; i <= NF; i++) {
+            if (substr($i, 1, 6) != "load1=") continue
+            v = substr($i, 7)
+            if (v ~ /^[0-9]+(\.[0-9]+)?$/) { n++; if (n == 1 || v + 0 > max + 0) max = v }
+        }
+    } END { printf "%d %s\n", n, (n ? max : "null") }' "$1"
+}
+
 sha256_or_empty() {
     if [ -f "$1" ]; then sha256sum "$1" | cut -d' ' -f1; fi
 }
@@ -204,18 +227,23 @@ write_dns_evidence() {
     # $1 = clean | unclean from the verify brackets, $2 = optional reason.
     # Everything checked here can only lower the verdict, never lift it:
     # the samples and whether the sampler lived to the stop, the dnsmasq
-    # state, the three bracket files and the two replay logs. Prints the
-    # final verdict; a verdict that could not be written is unclean and the
-    # function returns 1.
+    # state, the three bracket files and the two replay logs. The load
+    # maximum is reported, not judged: the run driver's own gate refused a
+    # busy box at the start, and the record is what says how busy it got.
+    # Prints the final verdict; a verdict that could not be written is
+    # unclean and the function returns 1.
     local verdict="$1" reason="${2:-}" log="$RESULTS/dns-owner.log"
     local out="$RESULTS/dns-evidence.json"
     local samples=0 first_mismatch="" before=false after=false after_state f
-    local sampler_alive=false
+    local sampler_alive=false load_stats load_samples=0 load_max=null
     [ "$DNSMASQ_WAS_ACTIVE" = yes ] && before=true
     [ "$SAMPLER_ALIVE_AT_STOP" = yes ] && sampler_alive=true
     if [ -s "$log" ]; then
         samples=$(wc -l <"$log")
         first_mismatch=$(dns_first_mismatch "$log" "$SERVE_PID")
+        load_stats=$(dns_load_stats "$log")
+        load_samples=${load_stats%% *}
+        load_max=${load_stats##* }
     fi
     if [ "$samples" -eq 0 ]; then
         verdict=unclean; reason="${reason:-no 127.0.0.1:53 owner samples were taken}"
@@ -250,6 +278,7 @@ write_dns_evidence() {
     if ! jq -n --argjson serve_pid "${SERVE_PID:-null}" --argjson before "$before" --argjson after "$after" \
         --arg after_state "$after_state" --argjson sampler_alive "$sampler_alive" \
         --argjson samples "$samples" --argjson interval "$DNS_SAMPLE_INTERVAL" \
+        --argjson load_max "$load_max" --argjson load_samples "$load_samples" \
         --arg first "$first_mismatch" --arg reason "$reason" --arg owner_log "$log" \
         --arg dns_sha "$(sha256_or_empty "$RESULTS/corpus-dns.log")" \
         --arg access_sha "$(sha256_or_empty "$RESULTS/corpus-access.log")" \
@@ -259,6 +288,7 @@ write_dns_evidence() {
           dnsmasq_state_after_restore: $after_state,
           sampler_alive_at_stop: $sampler_alive, samples: $samples,
           sample_interval_s: $interval, owner_log: $owner_log,
+          load_max_1min: $load_max, load_samples: $load_samples,
           first_mismatch: (if $first == "" then null else $first end),
           verify_files: $ARGS.positional,
           corpus_dns_log_sha256: (if $dns_sha == "" then null else $dns_sha end),
@@ -311,7 +341,7 @@ FCVM_SHA=$(sha256sum "$FCVM_BIN" | cut -d" " -f1)
 # --- preflight -------------------------------------------------------------
 # The run driver enforces its own quiet gate and would void the record anyway;
 # failing here costs seconds instead of the golden's minutes.
-load1=$(awk '{print $1}' /proc/loadavg)
+load1=$(awk '{print $1}' "$LOADAVG_FILE")
 if awk -v l="$load1" 'BEGIN{exit !(l > 2.0)}'; then
     echo "BLOCKED: 1-min load $load1 exceeds the quiet gate (2.0)" >&2
     exit 2
@@ -508,7 +538,7 @@ fi
 # the wait is bounded so a genuinely busy box still fails rather than hanging.
 settle_deadline=$(( $(date +%s) + 900 ))
 while :; do
-    load1=$(awk '{print $1}' /proc/loadavg)
+    load1=$(awk '{print $1}' "$LOADAVG_FILE")
     if awk -v l="$load1" 'BEGIN{exit !(l < 1.5)}'; then break; fi
     if [ "$(date +%s)" -ge "$settle_deadline" ]; then
         echo "BLOCKED: load stayed at $load1 for 15 min; refusing to measure on a busy box" >&2

--- a/bench/chromium/corpus_campaign.sh
+++ b/bench/chromium/corpus_campaign.sh
@@ -59,9 +59,16 @@ mkdir -p "$RESULTS"
 # must not outlive this one's start: a clean verdict beside a run this
 # campaign never finished would be indexed as if it were this run's, and
 # corpus_serve appends to its replay logs, so an earlier attempt's queries and
-# requests would be hashed into this run's evidence as its own.
+# requests would be hashed into this run's evidence as its own. The run
+# record goes too: reqbench.py appends to reqbench.jsonl, so a retry would
+# carry two run_ids and reqanalyze would emit a pooled analysis with no
+# top-level cell, and a retry that fails before its own analysis would leave
+# the earlier analysis.json beside this attempt's fresh evidence. The
+# content-addressed runtime bundles under runtime/ and the phase logs under
+# logs/ are not the record and stay.
 rm -f "$RESULTS"/dns-evidence.json "$RESULTS"/verify-dns*.json "$RESULTS"/dns-owner.log \
-    "$RESULTS"/corpus-dns.log "$RESULTS"/corpus-access.log
+    "$RESULTS"/corpus-dns.log "$RESULTS"/corpus-access.log \
+    "$RESULTS"/reqbench.jsonl "$RESULTS"/analysis.json
 
 # The 14 URLs, in the order the sealed 2026-08-14 run cycled them. Order is part
 # of the schedule: reqanalyze re-derives the expected URL per record from it, so

--- a/bench/chromium/corpus_campaign.sh
+++ b/bench/chromium/corpus_campaign.sh
@@ -91,8 +91,9 @@ say() { printf '\n=== %s\n' "$*"; }
 #      1-min load every DNS_SAMPLE_INTERVAL seconds while the run is in
 #      flight ($RESULTS/dns-owner.log). The quiet gate reads the load once,
 #      before the run; the samples are what says it stayed quiet.
-#   3. $RESULTS/dns-evidence.json ties them together with the replay server's
-#      own DNS and access logs (sha256), its exit status
+#   3. $RESULTS/dns-evidence.json ties them together with each bracket's
+#      sha256 (verify_file_sha256), the replay server's own DNS and access
+#      logs (sha256), its exit status
 #      (corpus_serve_exit_status, from $RESULTS/corpus-serve.status), the
 #      maximum 1-min load over the samples (load_max_1min), and a verdict:
 #      "clean" only when all three brackets are present and passed, every
@@ -269,10 +270,26 @@ write_dns_evidence() {
         verdict=unclean; reason="${reason:-dnsmasq is $after_state after the clone restores, not inactive}"
     fi
     local -a files=()
+    # Each bracket is pinned by the sha256 of the bytes this verdict read.
+    # The bracket file is the only record that a restored clone resolved the
+    # corpus through the replay server, and nothing else hashes it, so
+    # without this a file edited after the campaign is indistinguishable from
+    # the one the verdict accepted. A failed jq assigns empty output, which
+    # --argjson would refuse, so the map goes back to {} and the verdict is
+    # unclean.
+    local verify_sha='{}' sha
     for f in pre before-run after-run; do
         if [ -f "$RESULTS/verify-dns-$f.json" ]; then files+=("$RESULTS/verify-dns-$f.json"); fi
         if ! jq -e '.passed == true' "$RESULTS/verify-dns-$f.json" >/dev/null 2>&1; then
             verdict=unclean; reason="${reason:-the $f verify bracket is missing or did not pass}"
+        fi
+        sha=$(sha256_or_empty "$RESULTS/verify-dns-$f.json")
+        if [ -z "$sha" ]; then
+            verdict=unclean; reason="${reason:-the $f verify bracket cannot be read to hash it}"
+        elif ! verify_sha=$(jq -c --arg n "verify-dns-$f.json" --arg s "$sha" \
+                '.[$n] = $s' <<<"$verify_sha"); then
+            verdict=unclean; reason="${reason:-cannot record the sha256 of the $f verify bracket}"
+            verify_sha='{}'
         fi
     done
     for f in corpus-dns.log corpus-access.log; do
@@ -304,6 +321,7 @@ write_dns_evidence() {
         --arg dns_sha "$(sha256_or_empty "$RESULTS/corpus-dns.log")" \
         --arg access_sha "$(sha256_or_empty "$RESULTS/corpus-access.log")" \
         --argjson serve_status "$serve_status_json" \
+        --argjson verify_sha "$verify_sha" \
         --arg verdict "$verdict" --args \
         '{serve_pid: $serve_pid, dnsmasq_was_active_before: $before,
           dnsmasq_active_after_restore: $after,
@@ -313,6 +331,7 @@ write_dns_evidence() {
           load_max_1min: $load_max, load_samples: $load_samples,
           first_mismatch: (if $first == "" then null else $first end),
           verify_files: $ARGS.positional,
+          verify_file_sha256: $verify_sha,
           corpus_dns_log_sha256: (if $dns_sha == "" then null else $dns_sha end),
           corpus_access_log_sha256: (if $access_sha == "" then null else $access_sha end),
           corpus_serve_exit_status: $serve_status,

--- a/bench/chromium/corpus_campaign.sh
+++ b/bench/chromium/corpus_campaign.sh
@@ -46,6 +46,9 @@ STAMP="$(date +%Y%m%d-%H%M%S)"
 RESULTS="${RESULTS:-$REPO/bench/chromium/results/reqbench-$STAMP-corpus}"
 LOGDIR="${LOGDIR:-/tmp/corpus-campaign-$STAMP}"
 mkdir -p "$LOGDIR"
+# Created here, not left to reqbench: the replay server's logs and the resolver
+# evidence below are written into it before any reqbench phase runs.
+mkdir -p "$RESULTS"
 
 # The 14 URLs, in the order the sealed 2026-08-14 run cycled them. Order is part
 # of the schedule: reqanalyze re-derives the expected URL per record from it, so
@@ -53,6 +56,158 @@ mkdir -p "$LOGDIR"
 URLS="https://example.com/,https://news.ycombinator.com/,https://developers.cloudflare.com/,https://blog.cloudflare.com/,https://en.wikipedia.org/,https://developer.mozilla.org/en-US/,https://www.elmundo.es/,https://www.rtp.pt/noticias/,https://www.theguardian.com/international,https://todomvc.com/examples/javascript-es6/dist/,https://todomvc.com/examples/react/dist/index.html,https://todomvc.com/examples/vue/dist/,https://todomvc.com/examples/angular/dist/browser/,https://todomvc.com/examples/preact/dist/"
 
 say() { printf '\n=== %s\n' "$*"; }
+
+# --- resolver evidence -------------------------------------------------------
+# The replay wiring above is only evidence if it held for the WHOLE measured
+# run. A dnsmasq restart, a corpus_serve leaked from an earlier campaign, or a
+# golden that ignored --dns would hand the guest a different resolver, and no
+# record would say so. Three brackets close that:
+#   1. reqbench's verify (HOP D) asks a RESTORED clone, from inside the
+#      container, that every corpus host resolves to 10.0.2.2 and that every
+#      corpus URL fetches through that resolver: once before the settle wait,
+#      once immediately before the measured run, once after it. Each bracket
+#      keeps its evidence as $RESULTS/verify-dns-<stage>.json.
+#   2. a sampler names the owner of 127.0.0.1:53 and the dnsmasq state every
+#      DNS_SAMPLE_INTERVAL seconds while the run is in flight
+#      ($RESULTS/dns-owner.log).
+#   3. $RESULTS/dns-evidence.json ties them together with the replay server's
+#      own DNS and access logs (sha256) and a verdict: "clean" only when every
+#      bracket passed, every sample names this campaign's corpus_serve with
+#      dnsmasq inactive, and dnsmasq is still down after the clone restores.
+engine_target() {
+    # $1 = golden | verify | run
+    printf 'bench-%s-request-%s' "$([ "$ENGINE" = webkit ] && echo webkit || echo chromium)" "$1"
+}
+
+corpus_hosts() {
+    # The distinct hostnames of $URLS, in first-seen order.
+    printf '%s\n' "$URLS" | tr ',' '\n' | sed -E 's#^https?://([^/]+).*#\1#' \
+        | awk 'NF && !seen[$0]++' | paste -sd, -
+}
+
+run_verify() {
+    # $1 = pre | before-run | after-run. reqbench overwrites verify-dns.json
+    # and its verify logs on every call, so each bracket copies its own out
+    # under the stage name. A bracket passes only when the sub-make exits 0
+    # AND the evidence it left says passed=true.
+    local stage="$1" copy="$RESULTS/verify-dns-$1.json" f
+    say "verify ($stage): render hops + baked resolver on a restored clone"
+    rm -f "$RESULTS/verify-dns.json"
+    if ! VERIFY_DNS_HOSTS="$CORPUS_HOSTS" VERIFY_DNS_ANSWER=10.0.2.2 VERIFY_DNS_URLS="$URLS" \
+        TAG="$TAG" ENGINE="$ENGINE" RESULTS="$RESULTS" \
+        make -C "$REPO" "$(engine_target verify)" 2>&1 | tee "$LOGDIR/verify-$stage.log"; then
+        echo "FAILED: verify ($stage) did not pass; see $LOGDIR/verify-$stage.log" >&2
+        if [ -f "$RESULTS/verify-dns.json" ]; then cp "$RESULTS/verify-dns.json" "$copy"; fi
+        return 1
+    fi
+    for f in verify-serve verify-clone verify-clone2 verify-dns; do
+        if [ -f "$RESULTS/logs/$f.log" ]; then cp "$RESULTS/logs/$f.log" "$RESULTS/logs/$f-$stage.log"; fi
+    done
+    [ -s "$RESULTS/verify-dns.json" ] \
+        || { echo "FAILED: verify ($stage) left no $RESULTS/verify-dns.json (HOP D did not run)" >&2; return 1; }
+    cp "$RESULTS/verify-dns.json" "$copy"
+    jq -e '.passed == true' "$copy" >/dev/null \
+        || { echo "FAILED: verify ($stage): $copy records passed=false" >&2; return 1; }
+}
+
+DNS_SAMPLE_INTERVAL="${DNS_SAMPLE_INTERVAL:-10}"
+SAMPLER_PID=""
+
+dns_owner_sample() {
+    # One line: "<utc ts> owner_pid=<pid|none> dnsmasq=<state>". The local
+    # address is matched exactly: systemd-resolved (127.0.0.53) and dnsmasq's
+    # per-interface listeners share the port. sudo is what makes ss show the
+    # pid behind a root-owned socket; -n so a missing grant fails the sample
+    # (owner none, verdict unclean) instead of hanging the sampler on a prompt.
+    local owner state
+    owner=$(sudo -n ss -lnup 'sport = :53' 2>/dev/null \
+        | awk '$4 == "127.0.0.1:53" && match($0, /pid=[0-9]+/) { print substr($0, RSTART + 4, RLENGTH - 4); exit }')
+    state=$(systemctl is-active dnsmasq 2>/dev/null) || state="${state:-unknown}"
+    printf '%s owner_pid=%s dnsmasq=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${owner:-none}" "$state"
+}
+
+dns_owner_sampler() {
+    # $1 = log; runs until killed.
+    while :; do
+        dns_owner_sample >>"$1"
+        sleep "$DNS_SAMPLE_INTERVAL"
+    done
+}
+
+start_dns_sampler() {
+    : >"$RESULTS/dns-owner.log"
+    dns_owner_sampler "$RESULTS/dns-owner.log" &
+    SAMPLER_PID=$!
+}
+
+stop_dns_sampler() {
+    [ -n "$SAMPLER_PID" ] || return 0
+    kill "$SAMPLER_PID" 2>/dev/null || true
+    wait "$SAMPLER_PID" 2>/dev/null || true
+    SAMPLER_PID=""
+}
+
+dns_first_mismatch() {
+    # $1 = sample log, $2 = the pid every sample must name. Prints the first
+    # line naming another owner or a dnsmasq state other than inactive.
+    awk -v pid="$2" '$2 != "owner_pid=" pid || $3 != "dnsmasq=inactive" { print; exit }' "$1"
+}
+
+sha256_or_empty() {
+    if [ -f "$1" ]; then sha256sum "$1" | cut -d' ' -f1; fi
+}
+
+write_dns_evidence() {
+    # $1 = clean | unclean from the verify brackets, $2 = optional reason.
+    # The samples, the dnsmasq state and an absence of samples can only lower
+    # the verdict, never lift it. Prints the final verdict.
+    local verdict="$1" reason="${2:-}" log="$RESULTS/dns-owner.log"
+    local samples=0 first_mismatch="" before=false after=false f
+    [ "$DNSMASQ_WAS_ACTIVE" = yes ] && before=true
+    if [ -s "$log" ]; then
+        samples=$(wc -l <"$log")
+        first_mismatch=$(dns_first_mismatch "$log" "$SERVE_PID")
+    fi
+    if [ "$samples" -eq 0 ]; then
+        verdict=unclean; reason="${reason:-no 127.0.0.1:53 owner samples were taken}"
+    elif [ -n "$first_mismatch" ]; then
+        verdict=unclean; reason="${reason:-a sample did not name corpus_serve $SERVE_PID with dnsmasq inactive}"
+    fi
+    # "after restore" is the clone restores of the measured run: read before
+    # the exit trap starts dnsmasq again, so true means something restarted it
+    # while clones were being measured.
+    if systemctl is-active --quiet dnsmasq 2>/dev/null; then
+        after=true; verdict=unclean; reason="${reason:-dnsmasq is active after the clone restores}"
+    fi
+    local -a files=()
+    for f in pre before-run after-run; do
+        if [ -f "$RESULTS/verify-dns-$f.json" ]; then files+=("$RESULTS/verify-dns-$f.json"); fi
+    done
+    jq -n --argjson serve_pid "${SERVE_PID:-null}" --argjson before "$before" --argjson after "$after" \
+        --argjson samples "$samples" --argjson interval "$DNS_SAMPLE_INTERVAL" \
+        --arg first "$first_mismatch" --arg reason "$reason" --arg owner_log "$log" \
+        --arg dns_sha "$(sha256_or_empty "$RESULTS/corpus-dns.log")" \
+        --arg access_sha "$(sha256_or_empty "$RESULTS/corpus-access.log")" \
+        --arg verdict "$verdict" --args \
+        '{serve_pid: $serve_pid, dnsmasq_was_active_before: $before,
+          dnsmasq_active_after_restore: $after, samples: $samples,
+          sample_interval_s: $interval, owner_log: $owner_log,
+          first_mismatch: (if $first == "" then null else $first end),
+          verify_files: $ARGS.positional,
+          corpus_dns_log_sha256: (if $dns_sha == "" then null else $dns_sha end),
+          corpus_access_log_sha256: (if $access_sha == "" then null else $access_sha end),
+          reason: (if $reason == "" then null else $reason end),
+          verdict: $verdict}' "${files[@]}" >"$RESULTS/dns-evidence.json"
+    printf '%s\n' "$verdict"
+}
+
+campaign_fail() {
+    # A bracket failed before the measured run: record the unclean verdict so
+    # the run directory says why it holds no records, then exit.
+    write_dns_evidence unclean "$1" >/dev/null
+    echo "FAILED: $1" >&2
+    exit 1
+}
 
 # Every phase runs with debug logging: the stage attribution the analysis relies
 # on only exists in fcvm=debug output, and a caller who omitted it would produce
@@ -106,6 +261,9 @@ SERVE_PID=""
 
 cleanup() {
     set +e
+    # The sampler is a background subshell of this script; nothing else reaps
+    # it when the campaign dies mid-run.
+    stop_dns_sampler
     # `sudo kill -0`, not bare `kill -0`: corpus_serve runs as root (sudo -b)
     # while this script does not, so an unprivileged liveness probe gets EPERM
     # and the guard is ALWAYS false. The server then survives holding
@@ -163,8 +321,11 @@ say "starting corpus_serve (DNS 127.0.0.1:53 answering 10.0.2.2; HTTP 80; HTTPS 
 # passes against a server nobody is tracking. `exec` means the shell BECOMES
 # python, so $$ is the server's own pid, not a parent's.
 SERVE_PIDFILE="$LOGDIR/corpus_serve.pid"
-sudo -b sh -c 'echo $$ > "$1"; exec python3 "$2" --root "$3" --port 80 --tls-port 443 --dns-addr 127.0.0.1 --dns-port 53 --answer-ip 10.0.2.2' \
+# --dns-log / --access-log: the server's per-query DNS log and HTTP access
+# log, kept with the run; dns-evidence.json records their sha256.
+sudo -b sh -c 'echo $$ > "$1"; exec python3 "$2" --root "$3" --port 80 --tls-port 443 --dns-addr 127.0.0.1 --dns-port 53 --answer-ip 10.0.2.2 --dns-log "$4" --access-log "$5"' \
     _ "$SERVE_PIDFILE" "$REPO/bench/chromium/corpus_serve.py" "$REPO/bench/chromium/corpus-live" \
+    "$RESULTS/corpus-dns.log" "$RESULTS/corpus-access.log" \
     > "$LOGDIR/corpus_serve.log" 2>&1
 # `[ -s f ] && break` would be the last command in the body, so on the first
 # iteration (pidfile not written yet) it returns 1 and `set -e` kills the whole
@@ -233,13 +394,12 @@ say "fcvm binary $FCVM_BIN sha256=$FCVM_SHA (recorded per run in cell.fcvm_sha25
 # golden has none, so the first measured run pays cold-working-set costs that
 # every later run does not. Comparing the two is a one-variable experiment.
 PHASE="${PHASE:-all}"
+CORPUS_HOSTS=$(corpus_hosts)
 if [ "$PHASE" = all ]; then
     say "golden $TAG (GUEST_DNS=10.0.2.2 baked into resolv.conf at boot)"
-    GUEST_DNS=10.0.2.2 TAG="$TAG" ENGINE="$ENGINE" \
-        make -C "$REPO" "bench-$([ "$ENGINE" = webkit ] && echo webkit || echo chromium)-request-golden" 2>&1 | tee "$LOGDIR/golden.log"
-
-    say "verify: $([ "$ENGINE" = webkit ] && echo WebDriver || echo CDP) hops on a restored clone"
-    TAG="$TAG" ENGINE="$ENGINE" make -C "$REPO" "bench-$([ "$ENGINE" = webkit ] && echo webkit || echo chromium)-request-verify" 2>&1 | tee "$LOGDIR/verify.log"
+    GUEST_DNS=10.0.2.2 TAG="$TAG" ENGINE="$ENGINE" RESULTS="$RESULTS" \
+        make -C "$REPO" "$(engine_target golden)" 2>&1 | tee "$LOGDIR/golden.log"
+    run_verify pre || campaign_fail "verify (pre) failed on the new golden"
 else
     snap="${DATA_ROOT:-/mnt/fcvm-btrfs}/snapshots/$TAG"
     [ -f "$snap/config.json" ] || { echo "BLOCKED: PHASE=$PHASE but no golden at $snap" >&2; exit 2; }
@@ -249,6 +409,9 @@ else
     else
         say "reusing golden $TAG (NO working-set sidecar: this run records one cold)"
     fi
+    # A reused golden is only as good as its resolver still is: the snapshot
+    # may predate a corpus change, or have been made without GUEST_DNS.
+    run_verify pre || campaign_fail "verify (pre) failed on the reused golden"
 fi
 
 # --- settle -----------------------------------------------------------------
@@ -272,12 +435,31 @@ while :; do
 done
 say "box quiet (1-min load $load1)"
 
+# The settle wait is time in which the box can change under us; prove the
+# resolver again immediately before measuring.
+run_verify before-run || campaign_fail "verify (before-run) failed after the settle wait"
+
 # --- measured run ----------------------------------------------------------
 say "measured run: $REPS reps/arm, warmup $WARMUP, arms $ARMS, $BACKEND/$UFFD_MODE prefetch=$UFFD_PREFETCH"
+start_dns_sampler
+run_rc=0
 TAG="$TAG" URL="$URLS" BACKEND="$BACKEND" UFFD_MODE="$UFFD_MODE" \
     UFFD_PREFETCH="$UFFD_PREFETCH" ARMS="$ARMS" REPS="$REPS" WARMUP="$WARMUP" \
     RESULTS="$RESULTS" ENGINE="$ENGINE" \
-    make -C "$REPO" "bench-$([ "$ENGINE" = webkit ] && echo webkit || echo chromium)-request-run" 2>&1 | tee "$LOGDIR/run.log"
+    make -C "$REPO" "$(engine_target run)" 2>&1 | tee "$LOGDIR/run.log" || run_rc=$?
+stop_dns_sampler
+
+# The run's own exit is not the verdict: a run that measured cleanly against
+# the wrong resolver is worse than one that failed, so the after-run bracket
+# and the evidence are written whatever the run returned.
+after_rc=0
+run_verify after-run || after_rc=$?
+verdict=$(write_dns_evidence "$([ "$after_rc" -eq 0 ] && echo clean || echo unclean)")
+say "dns evidence: verdict=$verdict ($RESULTS/dns-evidence.json)"
+if [ "$run_rc" -ne 0 ] || [ "$after_rc" -ne 0 ] || [ "$verdict" != clean ]; then
+    echo "FAILED: measured run exit $run_rc, after-run verify exit $after_rc, dns verdict $verdict" >&2
+    exit 1
+fi
 
 say "records: $RESULTS"
 say "logs:    $LOGDIR"

--- a/bench/chromium/corpus_campaign.sh
+++ b/bench/chromium/corpus_campaign.sh
@@ -370,7 +370,11 @@ stop_corpus_serve() {
     # bind, and the next run picks up the leaked pid and records
     # DNSMASQ_WAS_ACTIVE=no. Called before the evidence is written (so the
     # replay-log hashes name files nothing appends to afterwards) and again
-    # from the exit trap, which finds it already gone.
+    # from the exit trap, which finds it already gone. On SIGTERM the server
+    # stops accepting, waits for the handlers still answering (their access
+    # lines follow their responses), closes both logs and exits, so once the
+    # poll below sees it gone the logs are complete; the SIGKILL fallback
+    # is for a handler that never finishes, which owes no line.
     if [ -n "$SERVE_PID" ] && sudo kill -0 "$SERVE_PID" 2>/dev/null; then
         say "stopping corpus_serve ($SERVE_PID)"
         sudo kill "$SERVE_PID" 2>/dev/null || true

--- a/bench/chromium/corpus_campaign.sh
+++ b/bench/chromium/corpus_campaign.sh
@@ -67,7 +67,7 @@ mkdir -p "$RESULTS"
 # content-addressed runtime bundles under runtime/ and the phase logs under
 # logs/ are not the record and stay.
 rm -f "$RESULTS"/dns-evidence.json "$RESULTS"/verify-dns*.json "$RESULTS"/dns-owner.log \
-    "$RESULTS"/corpus-dns.log "$RESULTS"/corpus-access.log \
+    "$RESULTS"/corpus-dns.log "$RESULTS"/corpus-access.log "$RESULTS"/corpus-serve.status \
     "$RESULTS"/reqbench.jsonl "$RESULTS"/analysis.json
 
 # The 14 URLs, in the order the sealed 2026-08-14 run cycled them. Order is part
@@ -92,12 +92,14 @@ say() { printf '\n=== %s\n' "$*"; }
 #      flight ($RESULTS/dns-owner.log). The quiet gate reads the load once,
 #      before the run; the samples are what says it stayed quiet.
 #   3. $RESULTS/dns-evidence.json ties them together with the replay server's
-#      own DNS and access logs (sha256), the maximum 1-min load over the
-#      samples (load_max_1min), and a verdict: "clean" only when all three
-#      brackets are present and passed, every sample names this campaign's
-#      corpus_serve with dnsmasq inactive, the sampler lived until the run
-#      ended, both replay logs exist, and dnsmasq is inactive after the clone
-#      restores.
+#      own DNS and access logs (sha256), its exit status
+#      (corpus_serve_exit_status, from $RESULTS/corpus-serve.status), the
+#      maximum 1-min load over the samples (load_max_1min), and a verdict:
+#      "clean" only when all three brackets are present and passed, every
+#      sample names this campaign's corpus_serve with dnsmasq inactive, the
+#      sampler lived until the run ended, both replay logs exist, the server
+#      exited 0 (its logs are complete only then), and dnsmasq is inactive
+#      after the clone restores.
 engine_target() {
     # $1 = golden | verify | run
     printf 'bench-%s-request-%s' "$([ "$ENGINE" = webkit ] && echo webkit || echo chromium)" "$1"
@@ -136,13 +138,16 @@ run_verify() {
         || { echo "FAILED: verify ($stage): cannot keep the evidence as $copy" >&2; return 1; }
     # passed=true is also what HOP D writes when it was given nothing to
     # check; the bracket must show the replay resolver and every corpus host
-    # and URL answered through it.
+    # and URL answered through it, with the URL probes run under no proxy
+    # (proxies_disabled): fc-agent injects the host's HTTP_PROXY/HTTPS_PROXY
+    # into the exec, and a probe that honoured them would have fetched the
+    # live site with the replay resolver never consulted.
     jq -e --arg hosts "$CORPUS_HOSTS" --arg urls "$URLS" '
         . as $e
-        | .passed == true and .dns_server == "10.0.2.2"
+        | .passed == true and .dns_server == "10.0.2.2" and .proxies_disabled == true
         and all($hosts | split(",")[]; . as $h | $e.hosts[$h].ok == true)
         and all($urls | split(",")[]; . as $u | $e.urls[$u].ok == true)' "$copy" >/dev/null \
-        || { echo "FAILED: verify ($stage): $copy does not record passed=true through 10.0.2.2 for every corpus host and URL" >&2; return 1; }
+        || { echo "FAILED: verify ($stage): $copy does not record passed=true through 10.0.2.2 with proxies disabled for every corpus host and URL" >&2; return 1; }
 }
 
 DNS_SAMPLE_INTERVAL="${DNS_SAMPLE_INTERVAL:-10}"
@@ -275,6 +280,22 @@ write_dns_evidence() {
             verdict=unclean; reason="${reason:-replay log $f is missing or empty}"
         fi
     done
+    # The replay server's exit status, as its wrapper wrote it once the
+    # process was gone. 0 is the shutdown sequence completing with both logs
+    # closed. 1 is a log line it could not write, with the response already
+    # sent, so the logs are short by at least that line; 137 is the SIGKILL
+    # escalation; no file means the server is still running, never started,
+    # or its wrapper died with it. Only 0 is clean.
+    local status_file="$RESULTS/corpus-serve.status" serve_status="" serve_status_json=null
+    if [ -f "$status_file" ]; then serve_status=$(tr -d '[:space:]' <"$status_file"); fi
+    if [[ "$serve_status" =~ ^(0|[1-9][0-9]{0,4})$ ]]; then
+        serve_status_json=$serve_status
+        if [ "$serve_status" -ne 0 ]; then
+            verdict=unclean; reason="${reason:-corpus_serve exited $serve_status, not 0, so its replay logs may be short}"
+        fi
+    else
+        verdict=unclean; reason="${reason:-corpus_serve left no exit status in $status_file}"
+    fi
     if ! jq -n --argjson serve_pid "${SERVE_PID:-null}" --argjson before "$before" --argjson after "$after" \
         --arg after_state "$after_state" --argjson sampler_alive "$sampler_alive" \
         --argjson samples "$samples" --argjson interval "$DNS_SAMPLE_INTERVAL" \
@@ -282,6 +303,7 @@ write_dns_evidence() {
         --arg first "$first_mismatch" --arg reason "$reason" --arg owner_log "$log" \
         --arg dns_sha "$(sha256_or_empty "$RESULTS/corpus-dns.log")" \
         --arg access_sha "$(sha256_or_empty "$RESULTS/corpus-access.log")" \
+        --argjson serve_status "$serve_status_json" \
         --arg verdict "$verdict" --args \
         '{serve_pid: $serve_pid, dnsmasq_was_active_before: $before,
           dnsmasq_active_after_restore: $after,
@@ -293,6 +315,7 @@ write_dns_evidence() {
           verify_files: $ARGS.positional,
           corpus_dns_log_sha256: (if $dns_sha == "" then null else $dns_sha end),
           corpus_access_log_sha256: (if $access_sha == "" then null else $access_sha end),
+          corpus_serve_exit_status: $serve_status,
           reason: (if $reason == "" then null else $reason end),
           verdict: $verdict}' "${files[@]}" >"$out.tmp" \
         || ! mv "$out.tmp" "$out"; then
@@ -372,10 +395,16 @@ stop_corpus_serve() {
     # replay-log hashes name files nothing appends to afterwards) and again
     # from the exit trap, which finds it already gone. On SIGTERM the server
     # stops accepting, waits for the handlers still answering (their access
-    # lines follow their responses), closes both logs and exits, so once the
-    # poll below sees it gone the logs are complete; the SIGKILL fallback
-    # is for a handler that never finishes, which owes no line.
-    if [ -n "$SERVE_PID" ] && sudo kill -0 "$SERVE_PID" 2>/dev/null; then
+    # lines follow their responses), closes both logs and exits 0; it exits 1
+    # when a log line could not be written, which liveness cannot see, so
+    # the exit status is what says the logs are complete. The wrapper that
+    # launched the server writes that status to $RESULTS/corpus-serve.status
+    # once the server is gone; this waits for the file and write_dns_evidence
+    # requires it to say 0. The SIGKILL fallback is for a handler that never
+    # finishes; the wrapper records 137 and the verdict is unclean.
+    local status_file="$RESULTS/corpus-serve.status"
+    [ -n "$SERVE_PID" ] || return 0
+    if sudo kill -0 "$SERVE_PID" 2>/dev/null; then
         say "stopping corpus_serve ($SERVE_PID)"
         sudo kill "$SERVE_PID" 2>/dev/null || true
         # Not `wait`: the server is not a child of this shell (sudo -b detached
@@ -388,6 +417,17 @@ stop_corpus_serve() {
             say "corpus_serve $SERVE_PID did not exit; escalating to SIGKILL"
             sudo kill -9 "$SERVE_PID" 2>/dev/null || true
         fi
+    fi
+    # A wrapper that never writes (killed with the server, never started)
+    # leaves no file, which the evidence records as unclean.
+    for _ in $(seq 1 50); do
+        if [ -f "$status_file" ]; then break; fi
+        sleep 0.1
+    done
+    if [ -f "$status_file" ]; then
+        say "corpus_serve $SERVE_PID exit status: $(tr -d '[:space:]' <"$status_file")"
+    else
+        say "corpus_serve $SERVE_PID left no exit status in $status_file"
     fi
 }
 
@@ -429,17 +469,27 @@ fi
 
 say "starting corpus_serve (DNS 127.0.0.1:53 answering 10.0.2.2; HTTP 80; HTTPS 443)"
 # The PID comes from THIS invocation, via a pidfile the wrapper shell writes
-# before exec'ing. `pgrep -f corpus_serve.py` would match any campaign's server,
-# so a concurrent run's cleanup could kill this one's and leave its own alive --
-# and the survivor still holds :53/:80/:443, so the next campaign's preflight
-# passes against a server nobody is tracking. `exec` means the shell BECOMES
-# python, so $$ is the server's own pid, not a parent's.
+# from $! of the server it started. `pgrep -f corpus_serve.py` would match any
+# campaign's server, so a concurrent run's cleanup could kill this one's and
+# leave its own alive -- and the survivor still holds :53/:80/:443, so the
+# next campaign's preflight passes against a server nobody is tracking.
+#
+# The wrapper is also what keeps the exit status: `sudo -b` detaches the
+# server from this shell, so `wait` cannot reach it and a status the server
+# exits with (1 after a log line it could not write, with the response bytes
+# already sent) would be lost. The wrapper waits for the server and writes
+# the status to $RESULTS/corpus-serve.status by rename, so a partial write is
+# never read; stop_corpus_serve waits for the file, write_dns_evidence
+# requires it to say 0, and campaign_summary refuses evidence that does not
+# carry it.
 SERVE_PIDFILE="$LOGDIR/corpus_serve.pid"
+SERVE_STATUS_FILE="$RESULTS/corpus-serve.status"
+rm -f "$SERVE_PIDFILE" "$SERVE_STATUS_FILE"
 # --dns-log / --access-log: the server's per-query DNS log and HTTP access
 # log, kept with the run; dns-evidence.json records their sha256.
-sudo -b sh -c 'echo $$ > "$1"; exec python3 "$2" --root "$3" --port 80 --tls-port 443 --dns-addr 127.0.0.1 --dns-port 53 --answer-ip 10.0.2.2 --dns-log "$4" --access-log "$5"' \
+sudo -b sh -c 'python3 "$2" --root "$3" --port 80 --tls-port 443 --dns-addr 127.0.0.1 --dns-port 53 --answer-ip 10.0.2.2 --dns-log "$4" --access-log "$5" & pid=$!; echo "$pid" > "$1"; wait "$pid"; rc=$?; echo "$rc" > "$6.tmp" && mv "$6.tmp" "$6"' \
     _ "$SERVE_PIDFILE" "$REPO/bench/chromium/corpus_serve.py" "$REPO/bench/chromium/corpus-live" \
-    "$RESULTS/corpus-dns.log" "$RESULTS/corpus-access.log" \
+    "$RESULTS/corpus-dns.log" "$RESULTS/corpus-access.log" "$SERVE_STATUS_FILE" \
     > "$LOGDIR/corpus_serve.log" 2>&1
 # `[ -s f ] && break` would be the last command in the body, so on the first
 # iteration (pidfile not written yet) it returns 1 and `set -e` kills the whole

--- a/bench/chromium/corpus_serve.py
+++ b/bench/chromium/corpus_serve.py
@@ -19,6 +19,10 @@ can read them after a run while this process is still serving:
                      the address for A queries and "" for everything else
   --access-log PATH  {ts, peer, method, host, path, status, bytes, duration_ms}
                      per HTTP and HTTPS request; host is the Host header as sent
+
+Either log is evidence the campaign hashes, so a line that cannot be written
+stops the server: the DNS responder closes its socket, and an access line
+that fails ends both HTTP listeners and main() exits 1 with the reason.
 """
 
 import argparse
@@ -105,16 +109,26 @@ class Handler(http.server.BaseHTTPRequestHandler):
         finally:
             if self.access_log is not None and self._log_status is not None:
                 headers = getattr(self, "headers", None)
-                self.access_log.write({
-                    "ts": ts,
-                    "peer": f"{self.client_address[0]}:{self.client_address[1]}",
-                    "method": getattr(self, "command", None) or "",
-                    "host": (headers.get("Host") or "") if headers is not None else "",
-                    "path": getattr(self, "path", None) or "",
-                    "status": self._log_status,
-                    "bytes": self._log_bytes,
-                    "duration_ms": (time.monotonic() - t0) * 1000,
-                })
+                try:
+                    self.access_log.write({
+                        "ts": ts,
+                        "peer": f"{self.client_address[0]}:{self.client_address[1]}",
+                        "method": getattr(self, "command", None) or "",
+                        "host": (headers.get("Host") or "") if headers is not None else "",
+                        "path": getattr(self, "path", None) or "",
+                        "status": self._log_status,
+                        "bytes": self._log_bytes,
+                        "duration_ms": (time.monotonic() - t0) * 1000,
+                    })
+                except Exception as exc:  # noqa: BLE001 - whatever it was, the line is not on disk
+                    # An answered, unlogged request is a hole in the evidence
+                    # the campaign hashes, as an unlogged DNS query is. Left to
+                    # ThreadingHTTPServer this would end one handler thread and
+                    # the server would keep answering, unlogged, for the rest
+                    # of the run. Stop every listener instead; the re-raise
+                    # puts the traceback in corpus_serve.log via handle_error.
+                    self.server.fail_closed(exc)
+                    raise
 
     def send_response(self, code, message=None):
         self._log_status = int(code)
@@ -214,6 +228,62 @@ class Handler(http.server.BaseHTTPRequestHandler):
 
     def log_message(self, *a):  # quiet
         pass
+
+
+# Serialises fail_closed across handler threads: the first failure is the one
+# recorded, and the listeners are shut down once.
+_FAIL_CLOSED = threading.Lock()
+
+
+class ReplayServer(http.server.ThreadingHTTPServer):
+    """One replay listener; `peers` is the list of listeners sharing the log.
+
+    A handler whose access line could not be written calls fail_closed(): the
+    error is recorded as log_failure on every peer and every peer's
+    serve_forever() returns, so serve_http() exits 1 with the reason instead
+    of serving on with a truncated log. Both listeners stop because the guest
+    fetches through both, and a log with only one side's lines is as short as
+    one with neither. Nothing clears the failure.
+    """
+
+    def __init__(self, address, handler, peers=None):
+        super().__init__(address, handler)
+        self.log_failure = None
+        self.peers = peers if peers is not None else []
+        self.peers.append(self)
+
+    def fail_closed(self, exc: BaseException) -> None:
+        with _FAIL_CLOSED:
+            if any(peer.log_failure is not None for peer in self.peers):
+                return
+            for peer in self.peers:
+                peer.log_failure = exc
+        # shutdown() blocks until a serve_forever loop has returned, so it
+        # runs off the handler thread; peers are stopped in list order, and
+        # main() blocks in the last one's serve_forever.
+        threading.Thread(target=self._stop_peers, name="fail-closed", daemon=True).start()
+
+    def _stop_peers(self) -> None:
+        for peer in self.peers:
+            peer.shutdown()
+
+
+def serve_http(plain: ReplayServer, tls: ReplayServer, err=None) -> int:
+    """Serve both listeners until a failed access-log write stops them.
+
+    serve_forever() returns only through ReplayServer.fail_closed (nothing
+    else calls shutdown), so a return is a failure: the reason goes to `err`
+    (stderr by default) and the status is 1. The process exits with it, the
+    guest's fetches and lookups start failing, and the campaign records the
+    run as unclean on the after-run bracket and the :53 owner samples.
+    """
+    threading.Thread(target=plain.serve_forever, daemon=True).start()
+    tls.serve_forever()
+    plain.shutdown()
+    failure = tls.log_failure or plain.log_failure
+    print(f"FAILED: an access log line could not be written, replay stopped: {failure!r}",
+          file=err or sys.stderr, flush=True)
+    return 1
 
 
 def selfsigned(tmpdir: Path):
@@ -345,18 +415,19 @@ def main():
                      daemon=True).start()
     print(f"wildcard DNS on {args.dns_addr}:{args.dns_port} -> {args.answer_ip}", flush=True)
 
-    plain = http.server.ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
-    threading.Thread(target=plain.serve_forever, daemon=True).start()
-
+    # Both listeners exist before either serves: a failure on one must find
+    # the other in `peers`, and neither answers a request before that.
+    peers = []
+    plain = ReplayServer(("127.0.0.1", args.port), Handler, peers)
     tmp = Path("/tmp/corpus-replay-cert")
     tmp.mkdir(exist_ok=True)
     crt, key = selfsigned(tmp)
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     ctx.load_cert_chain(str(crt), str(key))
-    tls = http.server.ThreadingHTTPServer(("127.0.0.1", args.tls_port), Handler)
+    tls = ReplayServer(("127.0.0.1", args.tls_port), Handler, peers)
     tls.socket = ctx.wrap_socket(tls.socket, server_side=True)
     print(f"replaying on http://127.0.0.1:{args.port} and https://127.0.0.1:{args.tls_port}", flush=True)
-    tls.serve_forever()
+    return serve_http(plain, tls)
 
 
 if __name__ == "__main__":

--- a/bench/chromium/corpus_serve.py
+++ b/bench/chromium/corpus_serve.py
@@ -251,7 +251,11 @@ def serve_dns(sock: socket.socket, answer_ip: str = "127.0.0.1",
 
     With `log`, one line per answered query: {ts, peer, qname, qtype, answer}.
     Returns when the socket is closed under it; every other error on a query
-    is dropped so one malformed packet cannot stop the replay.
+    is dropped so one malformed packet cannot stop the replay. A log line that
+    cannot be written is the one exception: an answered, unlogged query is a
+    hole in the evidence the campaign hashes, so the responder closes its
+    socket and raises. The guest then stops resolving and the campaign's :53
+    owner sampler finds no owner, and the run is refused on both counts.
     """
     while True:
         try:
@@ -283,7 +287,10 @@ def serve_dns(sock: socket.socket, answer_ip: str = "127.0.0.1",
                 resp = txid + flags + struct.pack(">HHHH", 1, 0, 0, 0) + question
                 answered = ""
             sock.sendto(resp, peer)
-            if log is not None:
+        except Exception:  # noqa: BLE001 - a malformed query must not kill the server
+            continue
+        if log is not None:
+            try:
                 log.write({
                     "ts": time.time(),
                     "peer": f"{peer[0]}:{peer[1]}",
@@ -291,8 +298,9 @@ def serve_dns(sock: socket.socket, answer_ip: str = "127.0.0.1",
                     "qtype": qtype,
                     "answer": answered,
                 })
-        except Exception:  # noqa: BLE001 - a malformed query must not kill the server
-            continue
+            except OSError:
+                sock.close()
+                raise
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/bench/chromium/corpus_serve.py
+++ b/bench/chromium/corpus_serve.py
@@ -24,10 +24,10 @@ Either log is evidence the campaign hashes once this process has exited, so
 the log has to be complete when it exits. SIGTERM and SIGINT run the shutdown
 sequence (stop_listeners): every listener stops accepting, the DNS responder
 ends, every handler already dequeued finishes and writes its line, the logs
-are closed, and main() returns 0. A line that cannot be written stops the
-server through the same sequence: the DNS responder closes its socket, an
-access line that fails ends both HTTP listeners, and main() returns 1 with
-the reason.
+are closed, and main() returns 0. A line that cannot be written, in either
+log, stops the server through the same sequence (ReplayServer.fail_closed):
+the DNS responder closes its socket as well, both HTTP listeners end, and
+main() returns 1 with the reason.
 """
 
 import argparse
@@ -405,7 +405,7 @@ def bind_dns(addr: str, port: int) -> socket.socket:
 
 
 def serve_dns(sock: socket.socket, answer_ip: str = "127.0.0.1",
-              log: JsonlLog | None = None):
+              log: JsonlLog | None = None, server: "ReplayServer | None" = None):
     """Answer every A query on `sock` with answer_ip (AAAA answered empty, forcing v4).
 
     Browser-agnostic host mapping for the replay arm: the replay container
@@ -419,8 +419,14 @@ def serve_dns(sock: socket.socket, answer_ip: str = "127.0.0.1",
     is dropped so one malformed packet cannot stop the replay. A log line that
     cannot be written is the one exception: an answered, unlogged query is a
     hole in the evidence the campaign hashes, so the responder closes its
-    socket and raises. The guest then stops resolving and the campaign's :53
-    owner sampler finds no owner, and the run is refused on both counts.
+    socket, reports the failure to `server` (any one of the HTTP listeners;
+    fail_closed stops them all and main() exits 1 with the reason) and
+    raises, which puts the traceback in corpus_serve.log. The guest then
+    stops resolving and fetching. Closing only the socket was not enough: in
+    the after-run bracket the :53 owner sampler has already stopped, so a
+    clone that still held its answers fetched through the listeners that
+    were still up, the bracket passed, and the truncated log was hashed as
+    clean.
     """
     while True:
         try:
@@ -463,8 +469,10 @@ def serve_dns(sock: socket.socket, answer_ip: str = "127.0.0.1",
                     "qtype": qtype,
                     "answer": answered,
                 })
-            except OSError:
+            except OSError as exc:
                 sock.close()
+                if server is not None:
+                    server.fail_closed(exc, "dns")
                 raise
 
 
@@ -520,8 +528,8 @@ def main():
         ctx.load_cert_chain(str(crt), str(key))
     tls.socket = ctx.wrap_socket(tls.socket, server_side=True)
 
-    dns_thread = threading.Thread(target=serve_dns, args=(dns_sock, args.answer_ip, dns_log),
-                                  daemon=True)
+    dns_thread = threading.Thread(target=serve_dns,
+                                  args=(dns_sock, args.answer_ip, dns_log, plain), daemon=True)
     dns_thread.start()
     print(f"wildcard DNS on {args.dns_addr}:{args.dns_port} -> {args.answer_ip}", flush=True)
     install_signal_handlers(plain)

--- a/bench/chromium/corpus_serve.py
+++ b/bench/chromium/corpus_serve.py
@@ -13,26 +13,33 @@ Resolution order for a request URL u:
   2. match ignoring the query string (analytics beacons carry per-view ids)
   3. 404, counted in /––misses (read by the checker for the report)
 
-Two optional logs, one JSON object per line, flushed per line so the campaign
-can read them after a run while this process is still serving:
+Two optional logs, one JSON object per line, flushed per line so a log left
+behind by a killed process is complete up to its last answered request:
   --dns-log PATH     {ts, peer, qname, qtype, answer} per DNS query; answer is
                      the address for A queries and "" for everything else
   --access-log PATH  {ts, peer, method, host, path, status, bytes, duration_ms}
                      per HTTP and HTTPS request; host is the Host header as sent
 
-Either log is evidence the campaign hashes, so a line that cannot be written
-stops the server: the DNS responder closes its socket, and an access line
-that fails ends both HTTP listeners and main() exits 1 with the reason.
+Either log is evidence the campaign hashes once this process has exited, so
+the log has to be complete when it exits. SIGTERM and SIGINT run the shutdown
+sequence (stop_listeners): every listener stops accepting, the DNS responder
+ends, every handler already dequeued finishes and writes its line, the logs
+are closed, and main() returns 0. A line that cannot be written stops the
+server through the same sequence: the DNS responder closes its socket, an
+access line that fails ends both HTTP listeners, and main() returns 1 with
+the reason.
 """
 
 import argparse
 import http.server
 import json
+import signal
 import socket
 import ssl
 import struct
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import urllib.parse
@@ -127,7 +134,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     # the server would keep answering, unlogged, for the rest
                     # of the run. Stop every listener instead; the re-raise
                     # puts the traceback in corpus_serve.log via handle_error.
-                    self.server.fail_closed(exc)
+                    self.server.fail_closed(exc, "access")
                     raise
 
     def send_response(self, code, message=None):
@@ -239,49 +246,137 @@ class ReplayServer(http.server.ThreadingHTTPServer):
     """One replay listener; `peers` is the list of listeners sharing the log.
 
     A handler whose access line could not be written calls fail_closed(): the
-    error is recorded as log_failure on every peer and every peer's
-    serve_forever() returns, so serve_http() exits 1 with the reason instead
-    of serving on with a truncated log. Both listeners stop because the guest
-    fetches through both, and a log with only one side's lines is as short as
-    one with neither. Nothing clears the failure.
+    error is recorded as log_failure on every peer, with the log's name as
+    failed_log, and every peer is asked to stop, so serve_http() runs the
+    shutdown sequence and exits 1 with the reason instead of serving on with
+    a truncated log. Both listeners stop because the guest fetches through
+    both, and a log with only one side's lines is as short as one with
+    neither. Nothing clears the failure.
     """
+
+    # A handler thread outlives shutdown(): a request dequeued before the
+    # serve loop returned is still being answered and logged. As
+    # ThreadingHTTPServer ships them the handler threads are daemon threads,
+    # which server_close() does not join and the interpreter kills at exit,
+    # so an exit right after shutdown() dropped the last access line while
+    # the client already held the response. Non-daemon threads are the ones
+    # server_close() joins (block_on_close), which is what lets
+    # stop_listeners close the log only once every line is on disk.
+    daemon_threads = False
+    block_on_close = True
 
     def __init__(self, address, handler, peers=None):
         super().__init__(address, handler)
         self.log_failure = None
+        self.failed_log = None
         self.peers = peers if peers is not None else []
         self.peers.append(self)
 
-    def fail_closed(self, exc: BaseException) -> None:
+    def fail_closed(self, exc: BaseException, log_name: str) -> None:
         with _FAIL_CLOSED:
             if any(peer.log_failure is not None for peer in self.peers):
                 return
             for peer in self.peers:
                 peer.log_failure = exc
-        # shutdown() blocks until a serve_forever loop has returned, so it
-        # runs off the handler thread; peers are stopped in list order, and
-        # main() blocks in the last one's serve_forever.
-        threading.Thread(target=self._stop_peers, name="fail-closed", daemon=True).start()
+                peer.failed_log = log_name
+        self.request_stop()
+
+    def request_stop(self) -> None:
+        """Ask every peer to stop accepting; returns at once.
+
+        shutdown() blocks until the serve loop has returned, so it cannot run
+        on that loop's own thread: a handler thread here, or the main thread
+        inside serve_forever, which is where a signal handler runs. A helper
+        thread stops the peers in list order; main() blocks in the last
+        one's serve_forever, and serve_http continues from there.
+        """
+        threading.Thread(target=self._stop_peers, name="stop", daemon=True).start()
 
     def _stop_peers(self) -> None:
         for peer in self.peers:
             peer.shutdown()
 
 
-def serve_http(plain: ReplayServer, tls: ReplayServer, err=None) -> int:
-    """Serve both listeners until a failed access-log write stops them.
+def stop_listeners(peers, logs=()) -> None:
+    """The shutdown sequence, in this order: no listener accepts another
+    connection, every handler already dequeued runs to its end, then the
+    logs are closed.
 
-    serve_forever() returns only through ReplayServer.fail_closed (nothing
-    else calls shutdown), so a return is a failure: the reason goes to `err`
-    (stderr by default) and the status is 1. The process exits with it, the
-    guest's fetches and lookups start failing, and the campaign records the
-    run as unclean on the after-run bracket and the :53 owner samples.
+    The access line is written after the response, so a client can hold the
+    whole body while the line is still to come. The campaign sends SIGTERM
+    as soon as its after-run verify returns and hashes both logs once this
+    process is gone; without the wait, the last handler's line was lost and
+    a truncated log was hashed as clean. Every handler answers one HTTP/1.0
+    request and exits, so the wait is bounded by the slowest response in
+    flight; a handler that never answered owes no line, and the campaign's
+    stop_corpus_serve escalates to SIGKILL after 5 s.
+    """
+    for peer in peers:
+        peer.shutdown()
+    for peer in peers:
+        peer.server_close()  # joins the handler threads (block_on_close)
+    for log in logs:
+        log.close()
+
+
+def stop_dns(sock: socket.socket, thread: threading.Thread) -> None:
+    """End serve_dns and wait for it: no query is answered after this
+    returns, and every answered one has its line written before the DNS log
+    is closed.
+
+    close() alone does not wake a recvfrom blocked in the kernel (the call
+    keeps the socket alive until a datagram arrives). shutdown(SHUT_RD) does,
+    with an empty datagram; on an unconnected UDP socket it raises ENOTCONN
+    and wakes the reader all the same. The responder then finds the socket
+    closed and returns. A socket serve_dns already closed on a failed write
+    is tolerated.
+    """
+    try:
+        sock.shutdown(socket.SHUT_RD)
+    except OSError:
+        pass
+    sock.close()
+    thread.join()
+
+
+def install_signal_handlers(server: ReplayServer):
+    """SIGTERM and SIGINT stop the replay with its logs complete.
+
+    The handler runs on the main thread, inside serve_forever, so it only
+    asks the peers to stop; serve_http runs the shutdown sequence once the
+    loops have returned. Returns the handler.
+    """
+    def on_signal(signum, _frame):
+        print(f"stopping on {signal.Signals(signum).name}", flush=True)
+        server.request_stop()
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        signal.signal(sig, on_signal)
+    return on_signal
+
+
+def serve_http(plain: ReplayServer, tls: ReplayServer, err=None, logs=(), dns=None) -> int:
+    """Serve both listeners until a signal or a failed log write stops them.
+
+    serve_forever() returns only through ReplayServer.request_stop (the
+    signal handler, or fail_closed; nothing else calls shutdown). The shutdown
+    sequence then runs: the DNS responder `dns` (its socket and thread) is
+    ended and joined, and stop_listeners waits for the handlers in flight
+    and closes `logs`. Returns 0 after a signal. After a failed log write the
+    reason goes to `err` (stderr by default) and the status is 1; the process
+    exits with it, the guest's fetches and lookups start failing, and the
+    campaign records the run as unclean on the after-run bracket and the :53
+    owner samples.
     """
     threading.Thread(target=plain.serve_forever, daemon=True).start()
     tls.serve_forever()
-    plain.shutdown()
+    if dns is not None:
+        stop_dns(*dns)
+    stop_listeners((tls, plain), logs)
     failure = tls.log_failure or plain.log_failure
-    print(f"FAILED: an access log line could not be written, replay stopped: {failure!r}",
+    if failure is None:
+        return 0
+    print(f"FAILED: the {tls.failed_log} log could not be written, replay stopped: {failure!r}",
           file=err or sys.stderr, flush=True)
     return 1
 
@@ -411,23 +506,29 @@ def main():
 
     dns_log = JsonlLog(args.dns_log) if args.dns_log else None
     dns_sock = bind_dns(args.dns_addr, args.dns_port)
-    threading.Thread(target=serve_dns, args=(dns_sock, args.answer_ip, dns_log),
-                     daemon=True).start()
-    print(f"wildcard DNS on {args.dns_addr}:{args.dns_port} -> {args.answer_ip}", flush=True)
 
     # Both listeners exist before either serves: a failure on one must find
     # the other in `peers`, and neither answers a request before that.
     peers = []
     plain = ReplayServer(("127.0.0.1", args.port), Handler, peers)
-    tmp = Path("/tmp/corpus-replay-cert")
-    tmp.mkdir(exist_ok=True)
-    crt, key = selfsigned(tmp)
-    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-    ctx.load_cert_chain(str(crt), str(key))
     tls = ReplayServer(("127.0.0.1", args.tls_port), Handler, peers)
+    # The key pair lives only until it is loaded: a fixed path under /tmp was
+    # shared by every server on the box, whatever user each ran as.
+    with tempfile.TemporaryDirectory(prefix="corpus-replay-cert-") as tmp:
+        crt, key = selfsigned(Path(tmp))
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ctx.load_cert_chain(str(crt), str(key))
     tls.socket = ctx.wrap_socket(tls.socket, server_side=True)
+
+    dns_thread = threading.Thread(target=serve_dns, args=(dns_sock, args.answer_ip, dns_log),
+                                  daemon=True)
+    dns_thread.start()
+    print(f"wildcard DNS on {args.dns_addr}:{args.dns_port} -> {args.answer_ip}", flush=True)
+    install_signal_handlers(plain)
     print(f"replaying on http://127.0.0.1:{args.port} and https://127.0.0.1:{args.tls_port}", flush=True)
-    return serve_http(plain, tls)
+    return serve_http(plain, tls,
+                      logs=[log for log in (Handler.access_log, dns_log) if log is not None],
+                      dns=(dns_sock, dns_thread))
 
 
 if __name__ == "__main__":

--- a/bench/chromium/corpus_serve.py
+++ b/bench/chromium/corpus_serve.py
@@ -12,6 +12,13 @@ Resolution order for a request URL u:
   1. exact match on the full url (scheme-insensitive)
   2. match ignoring the query string (analytics beacons carry per-view ids)
   3. 404, counted in /––misses (read by the checker for the report)
+
+Two optional logs, one JSON object per line, flushed per line so the campaign
+can read them after a run while this process is still serving:
+  --dns-log PATH     {ts, peer, qname, qtype, answer} per DNS query; answer is
+                     the address for A queries and "" for everything else
+  --access-log PATH  {ts, peer, method, host, path, status, bytes, duration_ms}
+                     per HTTP and HTTPS request; host is the Host header as sent
 """
 
 import argparse
@@ -23,6 +30,7 @@ import struct
 import subprocess
 import sys
 import threading
+import time
 import urllib.parse
 from pathlib import Path
 
@@ -47,12 +55,78 @@ def load_indexes(root: Path):
     return exact, noquery, redirects
 
 
+class JsonlLog:
+    """Append-only JSON-lines file; every line is flushed as it is written.
+
+    The campaign reads both replay logs while this process is still serving, so
+    a line may not sit in a stdio buffer. One lock serialises the HTTP handler
+    threads; the DNS responder is a single thread.
+    """
+
+    def __init__(self, path: str):
+        self.path = path
+        self._lock = threading.Lock()
+        self._fh = open(path, "a", encoding="utf-8")
+
+    def write(self, row: dict) -> None:
+        line = json.dumps(row, separators=(",", ":")) + "\n"
+        with self._lock:
+            self._fh.write(line)
+            self._fh.flush()
+
+    def close(self) -> None:
+        with self._lock:
+            self._fh.close()
+
+
 class Handler(http.server.BaseHTTPRequestHandler):
     exact = {}
     noquery = {}
     redirects = {}
     misses = []
     lock = threading.Lock()
+    # --access-log: a JsonlLog, or None for no log. Set once by main().
+    access_log = None
+    _log_status = None
+    _log_bytes = 0
+
+    def handle_one_request(self):
+        # One access line per parsed request, written after the response has
+        # been flushed so `bytes` and `duration_ms` cover the whole exchange.
+        # A keep-alive close or an empty request line sends no response and
+        # gets no line; a 400 for an unparsable one is logged with what the
+        # parser managed to read.
+        ts = time.time()
+        t0 = time.monotonic()
+        self._log_status = None
+        self._log_bytes = 0
+        try:
+            super().handle_one_request()
+        finally:
+            if self.access_log is not None and self._log_status is not None:
+                headers = getattr(self, "headers", None)
+                self.access_log.write({
+                    "ts": ts,
+                    "peer": f"{self.client_address[0]}:{self.client_address[1]}",
+                    "method": getattr(self, "command", None) or "",
+                    "host": (headers.get("Host") or "") if headers is not None else "",
+                    "path": getattr(self, "path", None) or "",
+                    "status": self._log_status,
+                    "bytes": self._log_bytes,
+                    "duration_ms": (time.monotonic() - t0) * 1000,
+                })
+
+    def send_response(self, code, message=None):
+        self._log_status = int(code)
+        super().send_response(code, message)
+
+    def send_header(self, keyword, value):
+        if keyword.lower() == "content-length":
+            try:
+                self._log_bytes = int(value)
+            except (TypeError, ValueError):
+                pass
+        super().send_header(keyword, value)
 
     def _serve(self):
         host = (self.headers.get("Host") or "").split(":")[0]
@@ -153,28 +227,49 @@ def selfsigned(tmpdir: Path):
     return crt, key
 
 
-def dns_responder(addr: str, port: int, answer_ip: str = "127.0.0.1"):
-    """Answer every A query with 127.0.0.1 (AAAA answered empty, forcing v4).
+def bind_dns(addr: str, port: int) -> socket.socket:
+    """Bind the responder's UDP socket; port 0 takes an ephemeral port.
+
+    Bound by the caller rather than inside the serving loop so a bind failure
+    (dnsmasq still holding :53) is a startup error, not a dead thread behind
+    HTTP servers that keep answering.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind((addr, port))
+    return sock
+
+
+def serve_dns(sock: socket.socket, answer_ip: str = "127.0.0.1",
+              log: JsonlLog | None = None):
+    """Answer every A query on `sock` with answer_ip (AAAA answered empty, forcing v4).
 
     Browser-agnostic host mapping for the replay arm: the replay container
     mounts a resolv.conf pointing here, so ANY engine (Chromium today, WebKit
     later) resolves every corpus host to this box with no engine flags — a
     space-containing --host-resolver-rules value cannot survive the container
     env word-split, which is how the flag approach died (2026-08-13).
+
+    With `log`, one line per answered query: {ts, peer, qname, qtype, answer}.
+    Returns when the socket is closed under it; every other error on a query
+    is dropped so one malformed packet cannot stop the replay.
     """
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.bind((addr, port))
     while True:
         try:
             data, peer = sock.recvfrom(512)
+        except OSError:
+            if sock.fileno() < 0:
+                return
+            continue
+        try:
             if len(data) < 12:
                 continue
             txid = data[:2]
             flags = b"\x81\x80"
             qd = data[12:]
-            # parse qname end
+            labels = []
             i = 0
             while i < len(qd) and qd[i] != 0:
+                labels.append(qd[i + 1:i + 1 + qd[i]].decode("ascii", "replace"))
                 i += qd[i] + 1
             qend = i + 1 + 4  # name + qtype/qclass
             question = qd[:qend]
@@ -183,14 +278,24 @@ def dns_responder(addr: str, port: int, answer_ip: str = "127.0.0.1"):
                 answer = (b"\xc0\x0c" + struct.pack(">HHIH", 1, 1, 5, 4)
                           + socket.inet_aton(answer_ip))
                 resp = txid + flags + struct.pack(">HHHH", 1, 1, 0, 0) + question + answer
+                answered = answer_ip
             else:  # empty NOERROR (esp. AAAA -> fall back to A)
                 resp = txid + flags + struct.pack(">HHHH", 1, 0, 0, 0) + question
+                answered = ""
             sock.sendto(resp, peer)
+            if log is not None:
+                log.write({
+                    "ts": time.time(),
+                    "peer": f"{peer[0]}:{peer[1]}",
+                    "qname": ".".join(labels),
+                    "qtype": qtype,
+                    "answer": answered,
+                })
         except Exception:  # noqa: BLE001 - a malformed query must not kill the server
             continue
 
 
-def main():
+def build_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser()
     ap.add_argument("--root", default=str(HERE / "corpus-live"))
     ap.add_argument("--port", type=int, default=80)
@@ -201,6 +306,17 @@ def main():
     # replay: 10.0.2.2, the pasta gateway, which maps guest connections onto
     # the host's loopback where this server listens.
     ap.add_argument("--answer-ip", default="127.0.0.1")
+    ap.add_argument("--dns-log", default=None, metavar="PATH",
+                    help="append one JSON line per DNS query: "
+                         "ts, peer, qname, qtype, answer")
+    ap.add_argument("--access-log", default=None, metavar="PATH",
+                    help="append one JSON line per HTTP/HTTPS request: "
+                         "ts, peer, method, host, path, status, bytes, duration_ms")
+    return ap
+
+
+def main():
+    ap = build_parser()
     args = ap.parse_args()
     # Validate up front: inet_aton runs inside the responder's broad exception
     # handler, so a malformed address would silently drop every A query while
@@ -212,10 +328,12 @@ def main():
         ap.error(f"--answer-ip is not a valid IPv4 address: {args.answer_ip!r}")
 
     Handler.exact, Handler.noquery, Handler.redirects = load_indexes(Path(args.root))
+    Handler.access_log = JsonlLog(args.access_log) if args.access_log else None
     print(f"loaded {len(Handler.exact)} urls", flush=True)
 
-    threading.Thread(target=dns_responder,
-                     args=(args.dns_addr, args.dns_port, args.answer_ip),
+    dns_log = JsonlLog(args.dns_log) if args.dns_log else None
+    dns_sock = bind_dns(args.dns_addr, args.dns_port)
+    threading.Thread(target=serve_dns, args=(dns_sock, args.answer_ip, dns_log),
                      daemon=True).start()
     print(f"wildcard DNS on {args.dns_addr}:{args.dns_port} -> {args.answer_ip}", flush=True)
 

--- a/bench/chromium/reqanalyze.py
+++ b/bench/chromium/reqanalyze.py
@@ -32,6 +32,15 @@ Every rule here exists because of a defect listed in bench/chromium/AGENTS.md:
     median and taking the median of {firecracker 110 ms, holder 0, pasta 0}
     publishes 0 — it medians the straggler away, which is the opposite of the
     thing being measured.
+  * A URL whose host is a name needs a resolver, and the meta must name it
+    (`guest_dns`). A corpus run that records no resolver had its hostnames
+    answered by something the record does not say, so it is refused. IP
+    literals and localhost need none. `engine` and `guest_dns` are cell
+    fields: runs that differ in either never pool.
+  * A load event that takes tens of seconds is a stall, not a slow page. With
+    `--stall-max-ms N` every record whose navigate_load_event_ms exceeds N is
+    listed under `stall_gate` and the run is refused. `per_url` reports each
+    URL of a multi-URL run on its own so a pooled median cannot hide one page.
 """
 
 import argparse
@@ -46,9 +55,11 @@ import statistics
 import sys
 import tempfile
 import uuid
+from urllib.parse import urlsplit
 
 
 MIN_CDP_ATTEMPTS_PER_BACKEND = 200
+SUPPORTED_ENGINES = ("chromium", "webkit")
 
 
 def is_cdp_class(arm):
@@ -64,7 +75,7 @@ def is_cdp_class(arm):
 MIN_NOOP_ATTEMPTS = 6
 DRIFT_EQUIVALENCE_MARGIN_MS = 10.0
 QUIET_LOADAVG1_LIMIT = 2.0
-ANALYZER_SCHEMA_VERSION = 4
+ANALYZER_SCHEMA_VERSION = 5
 SEALED_ANALYZER_FD_ENV = "REQANALYZE_SEALED_FD"
 ANALYZER_SOURCE_PATH_ENV = "REQANALYZE_SOURCE_PATH"
 
@@ -76,6 +87,8 @@ CELL_FIELDS = (
     "uffd_mode",
     "arms",
     "url",
+    "engine",
+    "guest_dns",
     "format",
     "quality",
     "image",
@@ -180,6 +193,72 @@ def clopper_pearson(k: int, n: int, conf: float = 0.95):
     return lo, hi
 
 
+def declared_urls(meta):
+    """The URL set a meta declares: `urls` when present, else `url` split on commas."""
+    urls = meta.get("urls")
+    if (
+        isinstance(urls, list)
+        and urls
+        and all(isinstance(url, str) and url.strip() for url in urls)
+    ):
+        return [url.strip() for url in urls]
+    url = meta.get("url")
+    if isinstance(url, str):
+        return [part.strip() for part in url.split(",") if part.strip()]
+    return []
+
+
+def url_needs_resolver(url):
+    """Whether a URL's host is a name only a resolver can answer.
+
+    False for an IP literal or localhost, None when the URL has no host.
+    """
+    try:
+        host = urlsplit(url).hostname
+    except ValueError:
+        return None
+    if not host:
+        return None
+    if host == "localhost":
+        return False
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        return True
+    return False
+
+
+def record_url(record):
+    """The URL a record rendered: its own stamp, else the render's."""
+    url = record.get("url")
+    if isinstance(url, str) and url:
+        return url
+    render = record.get("render")
+    if isinstance(render, dict):
+        url = render.get("url")
+        if isinstance(url, str) and url:
+            return url
+    return None
+
+
+def render_stage(record, key):
+    """One finite render.stages timing, or None when the record lacks it."""
+    render = record.get("render")
+    if not isinstance(render, dict):
+        return None
+    stages = render.get("stages")
+    if not isinstance(stages, dict):
+        return None
+    value = stages.get(key)
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+    ):
+        return None
+    return value
+
+
 def _cell_from_meta(meta, source):
     errors = []
     cell = {}
@@ -234,6 +313,24 @@ def _cell_from_meta(meta, source):
             )
         elif field in ("ws_url_prewired", "allow_busy"):
             valid = isinstance(value, bool)
+        elif field == "engine":
+            # The harness stamps the engine once per run; an absent stamp is
+            # chromium, the same reading _validate_schedule gives it.
+            value = meta.get("engine") or "chromium"
+            valid = value in SUPPORTED_ENGINES
+        elif field == "guest_dns":
+            # null: the guest used the host resolvers (fixture runs). A string
+            # must be the canonical IP literal fcvm baked into resolv.conf.
+            if value is None:
+                valid = True
+            else:
+                try:
+                    valid = (
+                        isinstance(value, str)
+                        and str(ipaddress.ip_address(value)) == value
+                    )
+                except ValueError:
+                    valid = False
         else:
             valid = (
                 isinstance(value, str) and bool(value.strip())
@@ -257,6 +354,21 @@ def _cell_from_meta(meta, source):
                 else value.strip() if isinstance(value, str)
                 else value
             )
+    if "url" in cell:
+        declared = meta.get("urls")
+        if declared is not None:
+            split = [part.strip() for part in cell["url"].split(",") if part.strip()]
+            if not (
+                isinstance(declared, list)
+                and declared
+                and all(isinstance(url, str) and url.strip() for url in declared)
+            ):
+                errors.append(f"{source} metadata urls is not a list of URLs")
+            elif [url.strip() for url in declared] != split:
+                errors.append(
+                    f"{source} metadata urls {declared!r} do not match url "
+                    f"{cell['url']!r}"
+                )
     if cell.get("backend") not in (None, "file", "uffd"):
         errors.append(f"{source} metadata has unsupported backend {cell['backend']!r}")
     if cell.get("uffd_mode") not in (None, "file", "copy", "minor"):
@@ -425,6 +537,25 @@ def _validate_arms(arms, label, errors):
         errors.append(
             f"{label} publication schedule requires noop and a CDP arm"
         )
+
+
+def _validate_resolver(meta, label, errors):
+    """A URL whose host is a name needs the resolver the meta records.
+
+    Appended after the record checks rather than raised as a cell error: a
+    cell error stops schedule validation, and a corpus run without guest_dns
+    still has to have every one of its records judged.
+    """
+    guest_dns = meta.get("guest_dns")
+    for url in declared_urls(meta):
+        needs_resolver = url_needs_resolver(url)
+        if needs_resolver is None:
+            errors.append(f"{label} metadata declares URL {url!r} without a hostname")
+        elif needs_resolver and guest_dns is None:
+            errors.append(
+                f"{label} metadata declares URL {url!r} whose hostname needs "
+                "a resolver but records no guest_dns"
+            )
 
 
 def _validate_schedule(dataset):
@@ -1112,6 +1243,7 @@ def _validate_schedule(dataset):
             f"{label} record order does not match seed {seed}; first mismatch "
             f"at ordinal {mismatch[0]} expected={mismatch[1]} observed={mismatch[2]}"
         )
+    _validate_resolver(meta, label, errors)
     dataset["run_id"] = run_id
 
 
@@ -1476,7 +1608,7 @@ def failure_class(r: dict) -> str:
 
 def analyze_backend(
     recs, metas, backend, cell, cell_id, run_id, sources,
-    source_artifacts, metadata_errors,
+    source_artifacts, metadata_errors, stall_max_ms=None,
 ):
     live = [r for r in recs if not r.get("warmup")]
     warm = [r for r in recs if r.get("warmup")]
@@ -1788,6 +1920,109 @@ def analyze_backend(
                 by["exec"], lambda r: r.get("render_total_ms")
             )
 
+    # ---- 4b. per-URL breakdown. A pooled corpus median hides the page that
+    # stalled; each URL gets its own medians, load-event time and count of
+    # distinct screenshots (an error page renders to the same bytes every time).
+    urls = []
+    for m in metas:
+        for url in declared_urls(m):
+            if url not in urls:
+                urls.append(url)
+    for r in live:
+        url = record_url(r)
+        if url is not None and url not in urls:
+            urls.append(url)
+    out["per_url"] = {}
+    for url in urls:
+        out["per_url"][url] = {}
+        for a in arms:
+            rows = [r for r in by[a] if record_url(r) == url]
+            out["per_url"][url][a] = {
+                "n": len(rows),
+                "blocking_ms": metric_summary(rows, lambda r: r.get("blocking_ms")),
+                "navigate_load_event_ms": metric_summary(
+                    rows, lambda r: render_stage(r, "navigate_load_event_ms")
+                ),
+                "total_ms": metric_summary(
+                    rows, lambda r: render_stage(r, "total_ms")
+                ),
+                "distinct_image_sha256": len({
+                    r["render"]["image_sha256"]
+                    for r in rows
+                    if isinstance(r.get("render"), dict)
+                    and isinstance(r["render"].get("image_sha256"), str)
+                }),
+            }
+    if len(urls) > 1:
+        print("\n" + "-" * 78)
+        print("PER URL (measured successes: blocking, load event, distinct screenshots)")
+        print("-" * 78)
+        for url in urls:
+            print(f"  {url}")
+            for a in arms:
+                per = out["per_url"][url][a]
+                if not per["n"]:
+                    continue
+                blocking = per["blocking_ms"]
+                load_event = per["navigate_load_event_ms"]
+                print(
+                    f"    {a:9s} n={per['n']:<4d} blocking "
+                    f"{fmt(blocking['median'], blocking['lo'], blocking['hi'])}  "
+                    f"load-event "
+                    f"{fmt(load_event['median'], load_event['lo'], load_event['hi'])}  "
+                    f"images {per['distinct_image_sha256']}"
+                )
+
+    # ---- 4c. stall gate. A load event that takes tens of seconds is the guest
+    # waiting on something other than the page (a resolver that never answers,
+    # for one), and one such record inside a pooled median is invisible.
+    engine = next((m.get("engine") or "chromium" for m in metas), "chromium")
+    violations = []
+    evaluated = 0
+    if stall_max_ms is not None:
+        for r in recs:
+            arm = r.get("arm")
+            value = render_stage(r, "navigate_load_event_ms")
+            # cdpdrive times the load event on every successful render; a
+            # chromium success without the stage has not shown it did not
+            # stall. WebDriver classic exposes no such stage.
+            must_carry = (
+                r.get("ok") is True and is_cdp_class(arm) and engine != "webkit"
+            )
+            if value is None and not must_carry:
+                continue
+            if value is not None:
+                evaluated += 1
+            if value is None or value > stall_max_ms:
+                violations.append({
+                    "url": record_url(r),
+                    "arm": arm,
+                    "navigate_load_event_ms": value,
+                    "rep": r.get("rep"),
+                    "warmup": bool(r.get("warmup")),
+                    "record_id": r.get("record_id"),
+                })
+    out["stall_gate"] = {
+        "max_ms": stall_max_ms,
+        "passed": not violations,
+        "evaluated": evaluated,
+        "violations": violations,
+    }
+    print("\n" + "-" * 78)
+    print("STALL GATE (render.stages.navigate_load_event_ms, every record incl. warmup)")
+    print("-" * 78)
+    if stall_max_ms is None:
+        print("  not evaluated (no --stall-max-ms)")
+    else:
+        print(f"  limit {stall_max_ms:g} ms  evaluated {evaluated}  "
+              f"violations {len(violations)}  "
+              + ("PASS" if not violations else "FAIL -- do not publish"))
+        for violation in violations:
+            print(f"    {violation['arm']:9s} rep={violation['rep']}"
+                  f"{' [warmup]' if violation['warmup'] else ''} "
+                  f"load-event={violation['navigate_load_event_ms']!r} "
+                  f"url={violation['url']}")
+
     # ---- 5. teardown, three separate numbers, never one
     print("\n" + "-" * 78)
     print("TEARDOWN -- three numbers, deliberately not summed into one")
@@ -2024,6 +2259,11 @@ def analyze_backend(
         reasons.append("one or more teardowns were not confirmed gone")
     if any_unverified_disk_cleanup:
         reasons.append("one or more clone teardowns did not confirm on-disk cleanup")
+    if not out["stall_gate"]["passed"]:
+        reasons.append(
+            f"stall_gate: {len(violations)} record(s) exceed or lack "
+            f"navigate_load_event_ms under the {stall_max_ms:g} ms limit"
+        )
 
     out["gate"] = {
         "passed": not reasons,
@@ -2046,6 +2286,7 @@ def analyze_backend(
         },
         "cdp_sample_size": out["cdp_sample_size"],
         "baseline_drift": out["drift"],
+        "stall_gate": out["stall_gate"],
         "teardown": {
             "passed": not any_unconfirmed_teardown and not any_unverified_disk_cleanup,
             "unconfirmed": unconfirmed_teardowns,
@@ -2068,7 +2309,14 @@ def main_with(argv=None):
     ap.add_argument("--json-out", default="")
     ap.add_argument("--no-gate", action="store_true",
                     help="exit 0 even when this run is unpublishable (exploratory only)")
+    ap.add_argument("--stall-max-ms", type=float, default=None,
+                    help="refuse publication when any record's navigate_load_event_ms "
+                         "exceeds this many milliseconds (default: no stall gate)")
     args = ap.parse_args(argv)
+    if args.stall_max_ms is not None and not (
+        math.isfinite(args.stall_max_ms) and args.stall_max_ms > 0
+    ):
+        ap.error("--stall-max-ms must be a positive number of milliseconds")
     analyzer_artifact = read_source_artifact(__file__)
 
     # Valid metadata segments with the exact same cell can contribute to one
@@ -2129,6 +2377,7 @@ def main_with(argv=None):
             group.get("cell"), group.get("cell_id"), group.get("run_id"), group["sources"],
             group.get("source_artifacts", []),
             group["metadata_errors"],
+            stall_max_ms=args.stall_max_ms,
         )
 
     overall_reasons = [
@@ -2196,6 +2445,22 @@ def main_with(argv=None):
                 "passed": publishable,
                 "reasons": overall_reasons,
                 "exit_code_overridden": exit_code_overridden,
+            },
+            "stall_gate": {
+                "max_ms": args.stall_max_ms,
+                "passed": all(
+                    backend["stall_gate"]["passed"]
+                    for backend in backend_results.values()
+                ),
+                "evaluated": sum(
+                    backend["stall_gate"]["evaluated"]
+                    for backend in backend_results.values()
+                ),
+                "violations": [
+                    violation
+                    for backend in backend_results.values()
+                    for violation in backend["stall_gate"]["violations"]
+                ],
             },
         }
 

--- a/bench/chromium/reqanalyze.py
+++ b/bench/chromium/reqanalyze.py
@@ -871,6 +871,13 @@ def _validate_schedule(dataset):
                                 f"{rlabel} CDP render {field}={render.get(field)!r} "
                                 f"does not match {expected_value!r}"
                             )
+                    # per_url buckets by the record's own url stamp, so the
+                    # stamp is held to the schedule as strictly as render.url.
+                    if "url" in record and record.get("url") != expected_url:
+                        errors.append(
+                            f"{rlabel} record url {record.get('url')!r} does not "
+                            f"match the scheduled {expected_url!r}"
+                        )
                     if engine != "webkit" and render.get("idle_timeout") != 0:
                         errors.append(
                             f"{rlabel} CDP render did not complete its declared idle policy"

--- a/bench/chromium/reqanalyze.py
+++ b/bench/chromium/reqanalyze.py
@@ -42,7 +42,9 @@ Every rule here exists because of a defect listed in bench/chromium/AGENTS.md:
     for webkit, whose WebDriver navigate returns at the load event) exceeds N,
     is negative, or is missing from a successful render is listed under
     `stall_gate` and the run is refused. `per_url` reports each URL of a
-    multi-URL run on its own so a pooled median cannot hide one page.
+    multi-URL run on its own so a pooled median cannot hide one page; its
+    load-completing summary is keyed by the same engine-selected stage, which
+    every entry names in `load_stage`.
 """
 
 import argparse
@@ -1930,8 +1932,18 @@ def analyze_backend(
             )
 
     # ---- 4b. per-URL breakdown. A pooled corpus median hides the page that
-    # stalled; each URL gets its own medians, load-event time and count of
+    # stalled; each URL gets its own medians, load-completing time and count of
     # distinct screenshots (an error page renders to the same bytes every time).
+    engine = next((m.get("engine") or "chromium" for m in metas), "chromium")
+    # cdpdrive times the load event on every successful render. WebDriver
+    # classic exposes no such stage, but its navigate call returns at the
+    # load event, so for webkit the load-completing duration is navigate_ms.
+    # per_url and the stall gate (4c) read this one stage: reading
+    # navigate_load_event_ms for every engine left every webkit URL at n=0
+    # with a null median, and an armed gate that skipped webkit records
+    # passed having evaluated nothing. Each per_url entry names the stage in
+    # load_stage and carries its summary under that stage's own name.
+    load_stage = "navigate_ms" if engine == "webkit" else "navigate_load_event_ms"
     urls = []
     for m in metas:
         for url in declared_urls(m):
@@ -1949,8 +1961,9 @@ def analyze_backend(
             out["per_url"][url][a] = {
                 "n": len(rows),
                 "blocking_ms": metric_summary(rows, lambda r: r.get("blocking_ms")),
-                "navigate_load_event_ms": metric_summary(
-                    rows, lambda r: render_stage(r, "navigate_load_event_ms")
+                "load_stage": load_stage,
+                load_stage: metric_summary(
+                    rows, lambda r: render_stage(r, load_stage)
                 ),
                 "total_ms": metric_summary(
                     rows, lambda r: render_stage(r, "total_ms")
@@ -1964,7 +1977,7 @@ def analyze_backend(
             }
     if len(urls) > 1:
         print("\n" + "-" * 78)
-        print("PER URL (measured successes: blocking, load event, distinct screenshots)")
+        print(f"PER URL (measured successes: blocking, {load_stage}, distinct screenshots)")
         print("-" * 78)
         for url in urls:
             print(f"  {url}")
@@ -1973,30 +1986,25 @@ def analyze_backend(
                 if not per["n"]:
                     continue
                 blocking = per["blocking_ms"]
-                load_event = per["navigate_load_event_ms"]
+                load = per[load_stage]
                 print(
                     f"    {a:9s} n={per['n']:<4d} blocking "
                     f"{fmt(blocking['median'], blocking['lo'], blocking['hi'])}  "
-                    f"load-event "
-                    f"{fmt(load_event['median'], load_event['lo'], load_event['hi'])}  "
+                    f"{load_stage} "
+                    f"{fmt(load['median'], load['lo'], load['hi'])}  "
                     f"images {per['distinct_image_sha256']}"
                 )
 
     # ---- 4c. stall gate. A load event that takes tens of seconds is the guest
     # waiting on something other than the page (a resolver that never answers,
-    # for one), and one such record inside a pooled median is invisible.
-    engine = next((m.get("engine") or "chromium" for m in metas), "chromium")
-    # cdpdrive times the load event on every successful render. WebDriver
-    # classic exposes no such stage, but its navigate call returns at the
-    # load event, so a stall lands in navigate_ms; an armed gate that
-    # skipped webkit records passed having evaluated nothing.
-    stall_stage = "navigate_ms" if engine == "webkit" else "navigate_load_event_ms"
+    # for one), and one such record inside a pooled median is invisible. The
+    # gate reads the engine-selected load_stage chosen above 4b.
     violations = []
     evaluated = 0
     if stall_max_ms is not None:
         for r in recs:
             arm = r.get("arm")
-            value = render_stage(r, stall_stage)
+            value = render_stage(r, load_stage)
             # A success without the stage has not shown it did not stall.
             must_carry = r.get("ok") is True and is_cdp_class(arm)
             if value is None and not must_carry:
@@ -2008,8 +2016,8 @@ def analyze_backend(
                 violations.append({
                     "url": record_url(r),
                     "arm": arm,
-                    "stage": stall_stage,
-                    stall_stage: value,
+                    "stage": load_stage,
+                    load_stage: value,
                     "rep": r.get("rep"),
                     "warmup": bool(r.get("warmup")),
                     "record_id": r.get("record_id"),
@@ -2021,7 +2029,7 @@ def analyze_backend(
         "violations": violations,
     }
     print("\n" + "-" * 78)
-    print(f"STALL GATE (render.stages.{stall_stage}, every record incl. warmup)")
+    print(f"STALL GATE (render.stages.{load_stage}, every record incl. warmup)")
     print("-" * 78)
     if stall_max_ms is None:
         print("  not evaluated (no --stall-max-ms)")
@@ -2032,7 +2040,7 @@ def analyze_backend(
         for violation in violations:
             print(f"    {violation['arm']:9s} rep={violation['rep']}"
                   f"{' [warmup]' if violation['warmup'] else ''} "
-                  f"{stall_stage}={violation[stall_stage]!r} "
+                  f"{load_stage}={violation[load_stage]!r} "
                   f"url={violation['url']}")
 
     # ---- 5. teardown, three separate numbers, never one
@@ -2274,7 +2282,7 @@ def analyze_backend(
     if not out["stall_gate"]["passed"]:
         reasons.append(
             f"stall_gate: {len(violations)} record(s) exceed or lack "
-            f"{stall_stage} under the {stall_max_ms:g} ms limit"
+            f"{load_stage} under the {stall_max_ms:g} ms limit"
         )
 
     out["gate"] = {

--- a/bench/chromium/reqanalyze.py
+++ b/bench/chromium/reqanalyze.py
@@ -38,9 +38,11 @@ Every rule here exists because of a defect listed in bench/chromium/AGENTS.md:
     literals and localhost need none. `engine` and `guest_dns` are cell
     fields: runs that differ in either never pool.
   * A load event that takes tens of seconds is a stall, not a slow page. With
-    `--stall-max-ms N` every record whose navigate_load_event_ms exceeds N is
-    listed under `stall_gate` and the run is refused. `per_url` reports each
-    URL of a multi-URL run on its own so a pooled median cannot hide one page.
+    `--stall-max-ms N` every record whose navigate_load_event_ms (navigate_ms
+    for webkit, whose WebDriver navigate returns at the load event) exceeds N,
+    is negative, or is missing from a successful render is listed under
+    `stall_gate` and the run is refused. `per_url` reports each URL of a
+    multi-URL run on its own so a pooled median cannot hide one page.
 """
 
 import argparse
@@ -1984,27 +1986,30 @@ def analyze_backend(
     # waiting on something other than the page (a resolver that never answers,
     # for one), and one such record inside a pooled median is invisible.
     engine = next((m.get("engine") or "chromium" for m in metas), "chromium")
+    # cdpdrive times the load event on every successful render. WebDriver
+    # classic exposes no such stage, but its navigate call returns at the
+    # load event, so a stall lands in navigate_ms; an armed gate that
+    # skipped webkit records passed having evaluated nothing.
+    stall_stage = "navigate_ms" if engine == "webkit" else "navigate_load_event_ms"
     violations = []
     evaluated = 0
     if stall_max_ms is not None:
         for r in recs:
             arm = r.get("arm")
-            value = render_stage(r, "navigate_load_event_ms")
-            # cdpdrive times the load event on every successful render; a
-            # chromium success without the stage has not shown it did not
-            # stall. WebDriver classic exposes no such stage.
-            must_carry = (
-                r.get("ok") is True and is_cdp_class(arm) and engine != "webkit"
-            )
+            value = render_stage(r, stall_stage)
+            # A success without the stage has not shown it did not stall.
+            must_carry = r.get("ok") is True and is_cdp_class(arm)
             if value is None and not must_carry:
                 continue
             if value is not None:
                 evaluated += 1
-            if value is None or value > stall_max_ms:
+            # A negative duration was not timed either.
+            if value is None or value < 0 or value > stall_max_ms:
                 violations.append({
                     "url": record_url(r),
                     "arm": arm,
-                    "navigate_load_event_ms": value,
+                    "stage": stall_stage,
+                    stall_stage: value,
                     "rep": r.get("rep"),
                     "warmup": bool(r.get("warmup")),
                     "record_id": r.get("record_id"),
@@ -2016,7 +2021,7 @@ def analyze_backend(
         "violations": violations,
     }
     print("\n" + "-" * 78)
-    print("STALL GATE (render.stages.navigate_load_event_ms, every record incl. warmup)")
+    print(f"STALL GATE (render.stages.{stall_stage}, every record incl. warmup)")
     print("-" * 78)
     if stall_max_ms is None:
         print("  not evaluated (no --stall-max-ms)")
@@ -2027,7 +2032,7 @@ def analyze_backend(
         for violation in violations:
             print(f"    {violation['arm']:9s} rep={violation['rep']}"
                   f"{' [warmup]' if violation['warmup'] else ''} "
-                  f"load-event={violation['navigate_load_event_ms']!r} "
+                  f"{stall_stage}={violation[stall_stage]!r} "
                   f"url={violation['url']}")
 
     # ---- 5. teardown, three separate numbers, never one
@@ -2269,7 +2274,7 @@ def analyze_backend(
     if not out["stall_gate"]["passed"]:
         reasons.append(
             f"stall_gate: {len(violations)} record(s) exceed or lack "
-            f"navigate_load_event_ms under the {stall_max_ms:g} ms limit"
+            f"{stall_stage} under the {stall_max_ms:g} ms limit"
         )
 
     out["gate"] = {

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -98,6 +98,7 @@ import ctypes
 import errno
 import fcntl
 import hashlib
+import ipaddress
 import json
 import os
 import platform
@@ -1228,6 +1229,27 @@ def snapshot_generation(data_root: str, snapshot_name: str) -> dict:
         raise RuntimeError(f"snapshot config {path} has invalid network_mode {network_mode!r}")
     if not isinstance(port_mappings, list):
         raise RuntimeError(f"snapshot config {path} has no port_mappings list")
+    # The guest resolver the golden was prepared with (`fcvm podman prepare
+    # --dns`, reqbench.sh GUEST_DNS). fcvm records it as
+    # metadata.network_config.dns_server; null means the guest used the host
+    # resolvers, which is what a fixture run wants and what a corpus run must
+    # never have (the analyzer refuses hostnames without a named resolver).
+    network_config = metadata.get("network_config")
+    dns_server = None
+    if network_config is not None:
+        if not isinstance(network_config, dict):
+            raise RuntimeError(f"snapshot config {path} has no network_config object")
+        dns_server = network_config.get("dns_server")
+        if dns_server is not None:
+            try:
+                canonical_dns_server = str(ipaddress.ip_address(dns_server))
+            except (TypeError, ValueError):
+                canonical_dns_server = None
+            if canonical_dns_server != dns_server:
+                raise RuntimeError(
+                    f"snapshot config {path} has invalid network_config.dns_server "
+                    f"{dns_server!r}: expected an IP literal"
+                )
 
     provenance_path = os.path.join(
         data_root, "snapshots", snapshot_name, "reqbench-provenance.json"
@@ -1319,6 +1341,7 @@ def snapshot_generation(data_root: str, snapshot_name: str) -> dict:
         "memory_mib": memory_mib,
         "network_mode": network_mode,
         "port_mappings": port_mappings,
+        "dns_server": dns_server,
     }
 
 
@@ -4160,6 +4183,7 @@ def main_with_resources(resources: ExitStack) -> int:
             "uffd_mode": uffd_mode,
             "warmup": args.warmup, "url": args.url, "urls": args.urls, "format": args.format,
             "engine": args.engine,
+            "guest_dns": snapshot["dns_server"],
             "quality": args.quality,
             "source_revision": current_source_revision,
             "fcvm_path": args.fcvm,

--- a/bench/chromium/reqbench.py
+++ b/bench/chromium/reqbench.py
@@ -1229,11 +1229,11 @@ def snapshot_generation(data_root: str, snapshot_name: str) -> dict:
         raise RuntimeError(f"snapshot config {path} has invalid network_mode {network_mode!r}")
     if not isinstance(port_mappings, list):
         raise RuntimeError(f"snapshot config {path} has no port_mappings list")
-    # The guest resolver the golden was prepared with (`fcvm podman prepare
-    # --dns`, reqbench.sh GUEST_DNS). fcvm records it as
-    # metadata.network_config.dns_server; null means the guest used the host
-    # resolvers, which is what a fixture run wants and what a corpus run must
-    # never have (the analyzer refuses hostnames without a named resolver).
+    # The resolver fcvm gave the guest, as metadata.network_config.dns_server.
+    # With `fcvm podman prepare --dns` (reqbench.sh GUEST_DNS) it is the
+    # requested one; without, rootless guests record null and bridged guests
+    # record the host's first resolver. Which of those it is comes from the
+    # provenance's guest_dns below, not from this value.
     network_config = metadata.get("network_config")
     dns_server = None
     if network_config is not None:
@@ -1298,6 +1298,33 @@ def snapshot_generation(data_root: str, snapshot_name: str) -> dict:
         or any(character not in "0123456789abcdef" for character in image_cache_key)
     ):
         raise RuntimeError(f"snapshot provenance {provenance_path} has invalid image_cache_key")
+    # guest_dns is the resolver the golden REQUESTED (null: none), which is
+    # what the run meta records and the analyzer gates on. The effective
+    # dns_server is not a substitute: a bridged guest inherits the host's
+    # resolver without anyone asking for it, and a run that resolved its
+    # hostnames on the live internet must not read as one with a controlled
+    # resolver. When one was requested the snapshot has to have baked it.
+    if "guest_dns" not in provenance:
+        raise RuntimeError(
+            f"snapshot provenance {provenance_path} records no guest_dns; "
+            "recreate the golden snapshot with reqbench.sh golden"
+        )
+    guest_dns = provenance["guest_dns"]
+    if guest_dns is not None:
+        try:
+            canonical_guest_dns = str(ipaddress.ip_address(guest_dns))
+        except (TypeError, ValueError):
+            canonical_guest_dns = None
+        if not isinstance(guest_dns, str) or canonical_guest_dns != guest_dns:
+            raise RuntimeError(
+                f"snapshot provenance {provenance_path} has invalid guest_dns "
+                f"{guest_dns!r}: expected an IP literal or null"
+            )
+        if dns_server != guest_dns:
+            raise RuntimeError(
+                f"snapshot provenance {provenance_path} requested guest_dns "
+                f"{guest_dns!r} but the snapshot baked dns_server {dns_server!r}"
+            )
     image_disk_path = metadata.get("image_disk_path")
     if (
         not isinstance(image_disk_path, str)
@@ -1342,6 +1369,7 @@ def snapshot_generation(data_root: str, snapshot_name: str) -> dict:
         "network_mode": network_mode,
         "port_mappings": port_mappings,
         "dns_server": dns_server,
+        "guest_dns": guest_dns,
     }
 
 
@@ -4183,7 +4211,7 @@ def main_with_resources(resources: ExitStack) -> int:
             "uffd_mode": uffd_mode,
             "warmup": args.warmup, "url": args.url, "urls": args.urls, "format": args.format,
             "engine": args.engine,
-            "guest_dns": snapshot["dns_server"],
+            "guest_dns": snapshot["guest_dns"],
             "quality": args.quality,
             "source_revision": current_source_revision,
             "fcvm_path": args.fcvm,

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -822,11 +822,12 @@ wd_session_id() {
 # checks the clone against it from inside the container, where Chromium runs.
 #
 # VERIFY_DNS_HOSTS  comma-separated hostnames; each must resolve to
-#                   VERIFY_DNS_ANSWER inside the container. Unset: only the
-#                   recorded resolver is written, no assertion is made, so the
-#                   default golden (no GUEST_DNS) verifies as before.
+#                   VERIFY_DNS_ANSWER inside the container.
 # VERIFY_DNS_URLS   comma-separated URLs; each in-container GET must return a
 #                   2xx or 3xx status through the resolver under test.
+# With both unset only the recorded resolver is written and no assertion is
+# made, so the default golden (no GUEST_DNS) verifies as before. Either one
+# set requires a baked resolver and checks both resolv.conf views.
 # Evidence lands in $RESULTS/verify-dns.json either way.
 VERIFY_DNS_HOSTS="${VERIFY_DNS_HOSTS:-}"
 VERIFY_DNS_ANSWER="${VERIFY_DNS_ANSWER:-10.0.2.2}"
@@ -853,14 +854,12 @@ verify_guest_dns() {
         "$cfg" 2>>"$errlog") \
         || { echo "HOP D BLOCKED: cannot read metadata.network_config.dns_server from $cfg (jq missing, or config.json unreadable)" >&2; return 1; }
     local -a hosts=() urls=()
-    if [ -n "$VERIFY_DNS_HOSTS" ]; then
-        IFS=',' read -ra hosts <<<"$VERIFY_DNS_HOSTS"
-        IFS=',' read -ra urls <<<"$VERIFY_DNS_URLS"
-    fi
+    [ -z "$VERIFY_DNS_HOSTS" ] || IFS=',' read -ra hosts <<<"$VERIFY_DNS_HOSTS"
+    [ -z "$VERIFY_DNS_URLS" ] || IFS=',' read -ra urls <<<"$VERIFY_DNS_URLS"
     echo "--- HOP D: baked resolver INSIDE the restored clone (dns_server=${dns_server:-null}, ${#hosts[@]} host(s), ${#urls[@]} url(s)) ---"
     local failed=0 resolv_vm="" resolv_container="" hosts_json='{}' urls_json='{}'
-    if [ -z "$VERIFY_DNS_HOSTS" ]; then
-        echo "  VERIFY_DNS_HOSTS unset: recording the snapshot's resolver, asserting nothing"
+    if [ -z "$VERIFY_DNS_HOSTS" ] && [ -z "$VERIFY_DNS_URLS" ]; then
+        echo "  VERIFY_DNS_HOSTS and VERIFY_DNS_URLS unset: recording the snapshot's resolver, asserting nothing"
     elif [ -z "$dns_server" ]; then
         failed=1
         echo "HOP D FAILED: corpus verify requires a baked resolver, but metadata.network_config.dns_server is null (golden made without GUEST_DNS?)" >&2
@@ -868,19 +867,32 @@ verify_guest_dns() {
         local want="nameserver $dns_server" view
         # Both views: fc-agent writes the VM's resolv.conf from the boot plan
         # and podman derives the container's from it. Chromium reads the
-        # second, so the first being right is not enough.
+        # second, so the first being right is not enough. The exec status is
+        # kept: output from an exec that did not complete proves nothing.
+        local rc_vm=0 rc_container=0
         resolv_vm=$($SUDO "$FCVM" exec --pid "$cpid" --vm -- cat /etc/resolv.conf 2>>"$errlog") \
-            || resolv_vm="${resolv_vm:-}"
+            || rc_vm=$?
         resolv_container=$($SUDO "$FCVM" exec --pid "$cpid" -c -- cat /etc/resolv.conf 2>>"$errlog") \
-            || resolv_container="${resolv_container:-}"
+            || rc_container=$?
         for view in vm container; do
-            local text="$resolv_vm"
-            [ "$view" = vm ] || text="$resolv_container"
-            if grep -qx -- "$want" <<<"$text"; then
-                echo "  $view /etc/resolv.conf names $dns_server"
-            else
+            local text="$resolv_vm" rc="$rc_vm" others=""
+            [ "$view" = vm ] || { text="$resolv_container"; rc="$rc_container"; }
+            if [ "$rc" -ne 0 ]; then
+                failed=1
+                echo "HOP D FAILED: reading $view /etc/resolv.conf exited $rc (got: $(tr '\n' '|' <<<"$text"))" >&2
+            elif ! grep -qx -- "$want" <<<"$text"; then
                 failed=1
                 echo "HOP D FAILED: $view /etc/resolv.conf has no '$want' line (got: $(tr '\n' '|' <<<"$text"))" >&2
+            else
+                # glibc walks the whole nameserver list, so a second entry
+                # answers the moment the replay server misses a query.
+                others=$(grep -E '^[[:space:]]*nameserver[[:space:]]' <<<"$text" | grep -vx -- "$want" || true)
+                if [ -n "$others" ]; then
+                    failed=1
+                    echo "HOP D FAILED: $view /etc/resolv.conf also names a fallback resolver ($(tr '\n' '|' <<<"$others")), which would answer whenever $dns_server does not" >&2
+                else
+                    echo "  $view /etc/resolv.conf names $dns_server and nothing else"
+                fi
             fi
         done
         local host answer ok

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -837,10 +837,25 @@ VERIFY_DNS_URLS="${VERIFY_DNS_URLS:-}"
 # error processor is replaced so every status comes back as a number instead
 # of an exception; redirects are therefore not followed, and a 3xx counts as
 # the request having reached the replay server. Both bench images ship python3.
-VERIFY_DNS_URL_PROBE='import ssl,sys,urllib.request as u
+#
+# No proxy, whatever the environment says. fc-agent runs every container exec
+# under the host's saved HTTP_PROXY/HTTPS_PROXY/no_proxy/NO_PROXY
+# (fc-agent/src/exec.rs, read_proxy_settings), and build_opener() installs a
+# ProxyHandler from the environment by default, so the request would go to
+# the proxy and come back with the live site's status while the hostname
+# check next to it resolved through the replay resolver. The empty
+# ProxyHandler replaces the default one and every *_proxy variable is
+# removed before the request, so the only place it can go is the host the
+# resolver under test names. The probe prints the status and the proxy
+# variables it found and ignored (comma-separated, or "none"); the evidence
+# records both.
+VERIFY_DNS_URL_PROBE='import os,ssl,sys,urllib.request as u
+p=sorted(k for k in os.environ if k.lower().endswith("_proxy"))
+for k in p: del os.environ[k]
 c=ssl._create_unverified_context()
 H=type("H",(u.HTTPErrorProcessor,),{"http_response":lambda s,q,r:r,"https_response":lambda s,q,r:r})
-print(u.build_opener(u.HTTPSHandler(context=c),H).open(u.Request(sys.argv[1]),timeout=30).status)'
+r=u.build_opener(u.ProxyHandler({}),u.HTTPSHandler(context=c),H).open(u.Request(sys.argv[1]),timeout=30)
+print(r.status,",".join(p) or "none")'
 
 verify_guest_dns() {
     local cpid="$1" cfg="$DATA_ROOT/snapshots/$TAG/config.json"
@@ -911,30 +926,50 @@ verify_guest_dns() {
             hosts_json=$(jq -c --arg h "$host" --arg a "$answer" --argjson ok "$ok" \
                 '.[$h] = {answer: $a, ok: $ok}' <<<"$hosts_json")
         done
-        local url status
+        local url line status proxy_env rc
         for url in "${urls[@]}"; do
             [ -n "$url" ] || continue
-            status=$($SUDO "$FCVM" exec --pid "$cpid" -c -- python3 -c "$VERIFY_DNS_URL_PROBE" "$url" 2>>"$errlog") \
-                || status="${status:-}<exec rc=$?>"
-            if [[ "$status" =~ ^[0-9]+$ ]] && [ "$status" -ge 200 ] && [ "$status" -le 399 ]; then
+            rc=0
+            line=$($SUDO "$FCVM" exec --pid "$cpid" -c -- python3 -c "$VERIFY_DNS_URL_PROBE" "$url" 2>>"$errlog") \
+                || rc=$?
+            # "<status> <ignored proxy variables|none>". A line without the
+            # second field did not come from the probe above and proves
+            # nothing about where the request went.
+            status=${line%% *}
+            proxy_env=""
+            [ "$line" = "$status" ] || proxy_env=${line#* }
+            [ "$rc" -eq 0 ] || status="${line:-}<exec rc=$rc>"
+            if [ "$rc" -eq 0 ] && [ -n "$proxy_env" ] && [[ "$status" =~ ^[0-9]+$ ]] \
+                && [ "$status" -ge 200 ] && [ "$status" -le 399 ]; then
                 ok=true
             else
                 ok=false; failed=1
-                echo "HOP D FAILED: GET $url inside the clone returned '$status', want 200-399" >&2
+                if [ "$rc" -eq 0 ] && [ -z "$proxy_env" ]; then
+                    echo "HOP D FAILED: GET $url inside the clone printed '$line', not the probe's '<status> <ignored proxies>'" >&2
+                else
+                    echo "HOP D FAILED: GET $url inside the clone returned '$status', want 200-399" >&2
+                fi
             fi
-            echo "  GET $url -> $status ($ok)"
-            urls_json=$(jq -c --arg u "$url" --arg s "$status" --argjson ok "$ok" \
-                '.[$u] = {status: (if ($s | test("^[0-9]+$")) then ($s | tonumber) else null end), ok: $ok}' \
+            echo "  GET $url -> $status ($ok)${proxy_env:+ proxy_env_ignored=$proxy_env}"
+            urls_json=$(jq -c --arg u "$url" --arg s "$status" --argjson ok "$ok" --arg p "$proxy_env" \
+                '.[$u] = {status: (if ($s | test("^[0-9]+$")) then ($s | tonumber) else null end), ok: $ok,
+                          proxy_env_ignored: (if $p == "" then null elif $p == "none" then [] else ($p | split(",")) end)}' \
                 <<<"$urls_json")
         done
     fi
     local passed=true
     [ "$failed" -eq 0 ] || passed=false
+    # proxies_disabled: every URL probe reported the proxy variables it
+    # ignored, so none of the requests can have left through a proxy; null
+    # when no URL was probed.
     jq -n --arg dns "$dns_server" --arg rv "$resolv_vm" --arg rc "$resolv_container" \
         --argjson hosts "$hosts_json" --argjson urls "$urls_json" \
         --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --argjson passed "$passed" \
         '{dns_server: (if $dns == "" then null else $dns end), resolv_conf_vm: $rv,
-          resolv_conf_container: $rc, hosts: $hosts, urls: $urls, timestamp: $ts, passed: $passed}' \
+          resolv_conf_container: $rc, hosts: $hosts, urls: $urls,
+          proxies_disabled: (if ($urls | length) == 0 then null
+                             else ($urls | to_entries | all(.value.proxy_env_ignored != null)) end),
+          timestamp: $ts, passed: $passed}' \
         >"$out.tmp" && mv "$out.tmp" "$out" \
         || { echo "HOP D BLOCKED: cannot write $out" >&2; return 1; }
     [ "$failed" -eq 0 ] || return 1

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -639,12 +639,12 @@ cmd_golden() {
         "$prepared_generation" "$prepared_digest" \
         "$(sha256sum "$FCVM" | cut -d' ' -f1)" \
         "$(sha256sum "$HERE/MANIFEST.sha256" | cut -d' ' -f1)" \
-        "${REQBENCH_SOURCE_REVISION:-}" <<'PY'
+        "${REQBENCH_SOURCE_REVISION:-}" "$GUEST_DNS" <<'PY'
 import fcntl, hashlib, json, os, sys, tempfile, uuid
 (
     config_path, output_path, lock_path, image_label, image_id, image_digest,
     image_cache_key, built_image_id, prepared_generation, prepared_digest,
-    fcvm_sha256, runtime_bundle_sha256, source_revision,
+    fcvm_sha256, runtime_bundle_sha256, source_revision, guest_dns,
 ) = sys.argv[1:]
 lock = open(lock_path, "a+")
 fcntl.flock(lock, fcntl.LOCK_SH)
@@ -687,7 +687,20 @@ if config_sha256 != prepared_digest:
         f"snapshot config digest {config_sha256!r} does not match prepare's "
         f"({prepared_digest!r}); the generation changed in place"
     )
+# --dns is a request; metadata.network_config.dns_server is what fc-agent
+# wrote to the guest's resolv.conf. A golden whose snapshot records another
+# resolver would carry provenance claiming a replay wiring it does not have.
+# Only checked when GUEST_DNS was given: without it fcvm fills dns_server
+# from the host resolver, so the recorded null means "not requested".
+baked_dns = (metadata.get("network_config") or {}).get("dns_server")
+if guest_dns and baked_dns != guest_dns:
+    raise SystemExit(
+        f"GUEST_DNS={guest_dns!r} was requested but the snapshot's "
+        f"metadata.network_config.dns_server is {baked_dns!r}; the guest did not "
+        "bake the resolver this golden claims"
+    )
 record = {
+    "guest_dns": guest_dns or None,
     "snapshot_generation_id": generation_id,
     "snapshot_config_sha256": config_sha256,
     "snapshot_created_at": config.get("created_at"),
@@ -799,6 +812,123 @@ wd_session_id() {
         | tr -d '[:space:]' || true
 }
 
+# HOP D: the baked resolver, asked of the restored clone itself.
+#
+# The corpus campaign bakes GUEST_DNS into the golden so every corpus hostname
+# resolves to the pasta gateway and lands on the host replay server. HOPs A-C
+# reach the clone by IP and prove nothing about that: a clone whose resolv.conf
+# came back pointing at a real resolver renders the live site and records a
+# plausible number. This hop reads the resolver the snapshot recorded, then
+# checks the clone against it from inside the container, where Chromium runs.
+#
+# VERIFY_DNS_HOSTS  comma-separated hostnames; each must resolve to
+#                   VERIFY_DNS_ANSWER inside the container. Unset: only the
+#                   recorded resolver is written, no assertion is made, so the
+#                   default golden (no GUEST_DNS) verifies as before.
+# VERIFY_DNS_URLS   comma-separated URLs; each in-container GET must return a
+#                   2xx or 3xx status through the resolver under test.
+# Evidence lands in $RESULTS/verify-dns.json either way.
+VERIFY_DNS_HOSTS="${VERIFY_DNS_HOSTS:-}"
+VERIFY_DNS_ANSWER="${VERIFY_DNS_ANSWER:-10.0.2.2}"
+VERIFY_DNS_URLS="${VERIFY_DNS_URLS:-}"
+# In-container GET with an unverified TLS context: the replay server's
+# certificate is self-signed and the resolver is the thing under test. The
+# error processor is replaced so every status comes back as a number instead
+# of an exception; redirects are therefore not followed, and a 3xx counts as
+# the request having reached the replay server. Both bench images ship python3.
+VERIFY_DNS_URL_PROBE='import ssl,sys,urllib.request as u
+c=ssl._create_unverified_context()
+H=type("H",(u.HTTPErrorProcessor,),{"http_response":lambda s,q,r:r,"https_response":lambda s,q,r:r})
+print(u.build_opener(u.HTTPSHandler(context=c),H).open(u.Request(sys.argv[1]),timeout=30).status)'
+
+verify_guest_dns() {
+    local cpid="$1" cfg="$DATA_ROOT/snapshots/$TAG/config.json"
+    local out="$RESULTS/verify-dns.json" errlog="$RESULTS/logs/verify-dns.log"
+    local dns_server
+    # jq's exit status is the readability test: a missing binary, a missing or
+    # unreadable file and invalid JSON all land here. BLOCKED rather than
+    # FAILED, and no evidence file: nothing was evaluated, so nothing can be
+    # reported, passing or failing.
+    dns_server=$($SUDO jq -r '.metadata.network_config.dns_server | if type == "string" then . else "" end' \
+        "$cfg" 2>>"$errlog") \
+        || { echo "HOP D BLOCKED: cannot read metadata.network_config.dns_server from $cfg (jq missing, or config.json unreadable)" >&2; return 1; }
+    local -a hosts=() urls=()
+    if [ -n "$VERIFY_DNS_HOSTS" ]; then
+        IFS=',' read -ra hosts <<<"$VERIFY_DNS_HOSTS"
+        IFS=',' read -ra urls <<<"$VERIFY_DNS_URLS"
+    fi
+    echo "--- HOP D: baked resolver INSIDE the restored clone (dns_server=${dns_server:-null}, ${#hosts[@]} host(s), ${#urls[@]} url(s)) ---"
+    local failed=0 resolv_vm="" resolv_container="" hosts_json='{}' urls_json='{}'
+    if [ -z "$VERIFY_DNS_HOSTS" ]; then
+        echo "  VERIFY_DNS_HOSTS unset: recording the snapshot's resolver, asserting nothing"
+    elif [ -z "$dns_server" ]; then
+        failed=1
+        echo "HOP D FAILED: corpus verify requires a baked resolver, but metadata.network_config.dns_server is null (golden made without GUEST_DNS?)" >&2
+    else
+        local want="nameserver $dns_server" view
+        # Both views: fc-agent writes the VM's resolv.conf from the boot plan
+        # and podman derives the container's from it. Chromium reads the
+        # second, so the first being right is not enough.
+        resolv_vm=$($SUDO "$FCVM" exec --pid "$cpid" --vm -- cat /etc/resolv.conf 2>>"$errlog") \
+            || resolv_vm="${resolv_vm:-}"
+        resolv_container=$($SUDO "$FCVM" exec --pid "$cpid" -c -- cat /etc/resolv.conf 2>>"$errlog") \
+            || resolv_container="${resolv_container:-}"
+        for view in vm container; do
+            local text="$resolv_vm"
+            [ "$view" = vm ] || text="$resolv_container"
+            if grep -qx -- "$want" <<<"$text"; then
+                echo "  $view /etc/resolv.conf names $dns_server"
+            else
+                failed=1
+                echo "HOP D FAILED: $view /etc/resolv.conf has no '$want' line (got: $(tr '\n' '|' <<<"$text"))" >&2
+            fi
+        done
+        local host answer ok
+        for host in "${hosts[@]}"; do
+            [ -n "$host" ] || continue
+            answer=$($SUDO "$FCVM" exec --pid "$cpid" -c -- python3 -c \
+                'import socket,sys;print(socket.gethostbyname(sys.argv[1]))' "$host" 2>>"$errlog") \
+                || answer="${answer:-}<exec rc=$?>"
+            if [ "$answer" = "$VERIFY_DNS_ANSWER" ]; then
+                ok=true
+            else
+                ok=false; failed=1
+                echo "HOP D FAILED: $host resolved to '$answer' inside the clone, want $VERIFY_DNS_ANSWER" >&2
+            fi
+            echo "  $host -> $answer ($ok)"
+            hosts_json=$(jq -c --arg h "$host" --arg a "$answer" --argjson ok "$ok" \
+                '.[$h] = {answer: $a, ok: $ok}' <<<"$hosts_json")
+        done
+        local url status
+        for url in "${urls[@]}"; do
+            [ -n "$url" ] || continue
+            status=$($SUDO "$FCVM" exec --pid "$cpid" -c -- python3 -c "$VERIFY_DNS_URL_PROBE" "$url" 2>>"$errlog") \
+                || status="${status:-}<exec rc=$?>"
+            if [[ "$status" =~ ^[0-9]+$ ]] && [ "$status" -ge 200 ] && [ "$status" -le 399 ]; then
+                ok=true
+            else
+                ok=false; failed=1
+                echo "HOP D FAILED: GET $url inside the clone returned '$status', want 200-399" >&2
+            fi
+            echo "  GET $url -> $status ($ok)"
+            urls_json=$(jq -c --arg u "$url" --arg s "$status" --argjson ok "$ok" \
+                '.[$u] = {status: (if ($s | test("^[0-9]+$")) then ($s | tonumber) else null end), ok: $ok}' \
+                <<<"$urls_json")
+        done
+    fi
+    local passed=true
+    [ "$failed" -eq 0 ] || passed=false
+    jq -n --arg dns "$dns_server" --arg rv "$resolv_vm" --arg rc "$resolv_container" \
+        --argjson hosts "$hosts_json" --argjson urls "$urls_json" \
+        --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --argjson passed "$passed" \
+        '{dns_server: (if $dns == "" then null else $dns end), resolv_conf_vm: $rv,
+          resolv_conf_container: $rc, hosts: $hosts, urls: $urls, timestamp: $ts, passed: $passed}' \
+        >"$out.tmp" && mv "$out.tmp" "$out" \
+        || { echo "HOP D BLOCKED: cannot write $out" >&2; return 1; }
+    [ "$failed" -eq 0 ] || return 1
+    echo "  OK evidence in $out"
+}
+
 cmd_verify() {
     # Every hop feeds this counter and the function RETURNS it. Each hop used to
     # be `... || echo "HOP X FAILED"`, which makes the compound command SUCCEED —
@@ -849,6 +979,8 @@ cmd_verify() {
     [ "$ENGINE" = webkit ] && health_probe=wd_health.py
     $SUDO "$FCVM" exec --pid "$cpid" -c -- python3 "/opt/bench/$health_probe" \
         || { echo "HOP A FAILED (in-container $ENGINE health round trip)"; fail=1; }
+
+    verify_guest_dns "$cpid" || fail=1
 
     if [ "$ENGINE" = webkit ]; then
         echo "--- HOP B: GET /status from the HOST against $ip:$CDP_PORT ---"

--- a/bench/chromium/reqbench.sh
+++ b/bench/chromium/reqbench.sh
@@ -1113,6 +1113,10 @@ HUGEPAGES="${HUGEPAGES:-0}"
 # corpus replay arm sets GUEST_DNS=10.0.2.2 so every corpus hostname
 # resolves through the host-loopback replay server via the pasta gateway.
 GUEST_DNS="${GUEST_DNS:-}"
+# Arms the analyzer's stall gate (reqanalyze --stall-max-ms). Empty leaves the
+# gate unarmed, which campaign_summary refuses to index; the corpus campaign
+# sets it.
+STALL_MAX_MS="${STALL_MAX_MS:-}"
 # Overridable for unit tests only; production is the real kernel knob.
 HUGEPAGE_POOL_FILE="${HUGEPAGE_POOL_FILE:-/proc/sys/vm/nr_hugepages}"
 
@@ -1370,11 +1374,17 @@ cmd_run() {
     # the run contract and propagate its gate status.
     if [ "$rc" -eq 0 ]; then
         log "run: applying publication gates"
-        $SUDO python3 "$HERE/reqanalyze.py" --json-out "$RESULTS/analysis.json" \
-            "$RESULTS/reqbench.jsonl" || rc=$?
+        apply_publication_gates || rc=$?
     fi
     log "run: results in $RESULTS (backend=$BACKEND, gated run exit $rc)"
     return $rc
+}
+
+apply_publication_gates() {
+    local -a stall_args=()
+    [ -z "$STALL_MAX_MS" ] || stall_args=(--stall-max-ms "$STALL_MAX_MS")
+    $SUDO python3 "$HERE/reqanalyze.py" --json-out "$RESULTS/analysis.json" \
+        "${stall_args[@]}" "$RESULTS/reqbench.jsonl"
 }
 
 # Only dispatch when EXECUTED. Sourcing the file makes its helpers unit-testable

--- a/bench/chromium/test_campaign.py
+++ b/bench/chromium/test_campaign.py
@@ -514,6 +514,10 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
         logs = os.path.join(tmp, "logs")
         os.makedirs(results, exist_ok=True)
         os.makedirs(logs, exist_ok=True)
+        # /proc/loadavg's shape, at a value the real box will not show, so a
+        # sampler that read the real file instead of LOADAVG_FILE is caught.
+        loadavg = os.path.join(tmp, "loadavg")
+        self._set_load(loadavg, "0.42")
         env = dict(os.environ)
         env.update(
             PATH=binx + os.pathsep + env["PATH"],
@@ -522,10 +526,16 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
             SS_CALLS=os.path.join(tmp, "ss-calls"),
             SS_OWNER="4242", SS_OTHER="999",
             FAKE_DNSMASQ_STATE=dnsmasq,
+            LOADAVG_FILE=loadavg,
             RESULTS=results, LOGDIR=logs, REPO=tmp, TAG="cb-req-corpus",
             ENGINE="chromium",
         )
         return env, results
+
+    @staticmethod
+    def _set_load(loadavg, load1):
+        with open(loadavg, "w") as handle:
+            handle.write(f"{load1} 0.30 0.20 1/100 1234\n")
 
     def _make_env(self, env):
         seen = {}
@@ -883,7 +893,7 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
             with open(os.path.join(results, "dns-owner.log")) as handle:
                 lines = handle.read().splitlines()
             self.assertEqual(lines[2], evidence["first_mismatch"])
-            self.assertRegex(lines[0], r"^\S+ owner_pid=4242 dnsmasq=inactive$")
+            self.assertRegex(lines[0], r"^\S+ owner_pid=4242 dnsmasq=inactive load1=0\.42$")
 
     def test_a_steady_owner_with_dnsmasq_down_is_clean(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1018,6 +1028,101 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
                                  sorted(["dns-owner.log", "corpus-dns.log", "corpus-access.log"]
                                         + [f"verify-dns-{s}.json" for s in self.BRACKETS]),
                                  "a partial evidence file or temp file was left behind")
+
+    def test_every_sample_carries_the_one_minute_load(self):
+        """The quiet gate reads the load once, before the run, and nothing
+        recorded it while clones were being measured, so a build or a stray
+        process that arrived mid-run left no evidence in the record. Each
+        sample now ends in load1=<first field of LOADAVG_FILE>, read from
+        /proc/loadavg by default, and the evidence reports the maximum over
+        the samples as load_max_1min with load_samples counting them.
+
+        RED BEFORE THE FIX: AssertionError: Regex didn't match:
+        '^\\S+ owner_pid=4242 dnsmasq=inactive load1=0\\.42$' not found in
+        '2026-08-28T..Z owner_pid=4242 dnsmasq=inactive', then
+        KeyError: 'load_max_1min'.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            raise_load = (f'sleep 0.3\nprintf "1.87 0.30 0.20 1/100 1234\\n" '
+                          f'> "{env["LOADAVG_FILE"]}"\nsleep 0.3\n')
+            evidence, _ = self._sample(env, results, mid_run=raise_load)
+            with open(os.path.join(results, "dns-owner.log")) as handle:
+                lines = handle.read().splitlines()
+            self.assertGreaterEqual(len(lines), 4)
+            self.assertRegex(lines[0], r"^\S+ owner_pid=4242 dnsmasq=inactive load1=0\.42$")
+            self.assertRegex(lines[-1], r"^\S+ owner_pid=4242 dnsmasq=inactive load1=1\.87$")
+            for line in lines:
+                self.assertRegex(line, r" load1=(0\.42|1\.87)$")
+            self.assertEqual(evidence["verdict"], "clean", evidence)
+            self.assertEqual(evidence["load_max_1min"], 1.87)
+            self.assertEqual(evidence["load_samples"], len(lines))
+            self.assertEqual(evidence["samples"], len(lines))
+
+    def test_a_sample_whose_load_cannot_be_read_ends_the_sampler(self):
+        """A load column that silently went missing would read as a quiet
+        box. An unreadable LOADAVG_FILE fails the sample, which ends the
+        sampler, which the evidence records as unclean.
+
+        RED BEFORE THE FIX: AssertionError: 'unclean' != 'clean'.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            cut_load = f'rm -f "{env["LOADAVG_FILE"]}"\nsleep 0.3\n'
+            evidence, _ = self._sample(env, results, mid_run=cut_load)
+            self.assertEqual(evidence["verdict"], "unclean", evidence)
+            self.assertIs(evidence["sampler_alive_at_stop"], False)
+            self.assertIn("sampler", evidence["reason"])
+            with open(os.path.join(results, "dns-owner.log")) as handle:
+                lines = handle.read().splitlines()
+            for line in lines:
+                self.assertRegex(line, r" load1=0\.42$")
+
+    def test_the_evidence_reports_the_maximum_load_over_the_samples(self):
+        """write_dns_evidence over a fixture owner log: the maximum of the
+        load1 column as a number, and the count of samples carrying one. An
+        owner log from before the column existed yields null and 0 rather
+        than a verdict change; the sampler, not the evidence, is what
+        guarantees the column is present.
+
+        RED BEFORE THE FIX: KeyError: 'load_max_1min'.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            self._leave_files(results)
+            with open(os.path.join(results, "dns-owner.log"), "w") as handle:
+                handle.write(
+                    "2026-08-28T00:00:00Z owner_pid=4242 dnsmasq=inactive load1=0.31\n"
+                    "2026-08-28T00:00:10Z owner_pid=4242 dnsmasq=inactive load1=1.87\n"
+                    "2026-08-28T00:00:20Z owner_pid=4242 dnsmasq=inactive load1=0.90\n")
+            script = (f'set -u\n{self._helpers()}\nRESULTS="{results}"\n'
+                      'SERVE_PID=4242\nDNSMASQ_WAS_ACTIVE=yes\nSAMPLER_ALIVE_AT_STOP=yes\n'
+                      'write_dns_evidence clean\n')
+            result = self._run(script, env)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            with open(os.path.join(results, "dns-evidence.json")) as handle:
+                evidence = json.load(handle)
+            self.assertEqual(evidence["verdict"], "clean", evidence)
+            self.assertEqual(evidence["load_max_1min"], 1.87)
+            self.assertIsInstance(evidence["load_max_1min"], float)
+            self.assertEqual(evidence["load_samples"], 3)
+            self.assertEqual(evidence["samples"], 3)
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            self._leave_files(results)
+            with open(os.path.join(results, "dns-owner.log"), "w") as handle:
+                handle.write("2026-08-28T00:00:00Z owner_pid=4242 dnsmasq=inactive\n" * 2)
+            script = (f'set -u\n{self._helpers()}\nRESULTS="{results}"\n'
+                      'SERVE_PID=4242\nDNSMASQ_WAS_ACTIVE=yes\nSAMPLER_ALIVE_AT_STOP=yes\n'
+                      'write_dns_evidence clean\n')
+            result = self._run(script, env)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            with open(os.path.join(results, "dns-evidence.json")) as handle:
+                evidence = json.load(handle)
+            self.assertEqual(evidence["verdict"], "clean", evidence)
+            self.assertIsNone(evidence["load_max_1min"])
+            self.assertEqual(evidence["load_samples"], 0)
+            self.assertEqual(evidence["samples"], 2)
 
     def test_a_bracket_failure_cannot_be_lifted_by_clean_samples(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/bench/chromium/test_campaign.py
+++ b/bench/chromium/test_campaign.py
@@ -322,6 +322,7 @@ exit "${MAKE_RC:-0}"
     # the SS_CHANGE_AT-th call on.
     FAKE_SS = """#!/bin/bash
 n=$(cat "$SS_CALLS" 2>/dev/null || echo 0); n=$((n + 1)); echo "$n" > "$SS_CALLS"
+if [ -n "${SS_FAIL_AT:-}" ] && [ "$n" -ge "$SS_FAIL_AT" ]; then exit 1; fi
 pid="$SS_OWNER"
 if [ -n "${SS_CHANGE_AT:-}" ] && [ "$n" -ge "$SS_CHANGE_AT" ]; then pid="$SS_OTHER"; fi
 cat <<SSOUT
@@ -339,6 +340,30 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
 [ "$FAKE_DNSMASQ_STATE" = active ] && exit 0 || exit 3
 """
     FAKE_SUDO = '#!/bin/bash\n[ "${1:-}" = -n ] && shift\nexec "$@"\n'
+
+    @staticmethod
+    def _hosts_of(urls: str) -> list:
+        hosts = []
+        for url in urls.split(","):
+            host = url.split("://", 1)[1].split("/", 1)[0]
+            if host not in hosts:
+                hosts.append(host)
+        return hosts
+
+    def _bracket_evidence(self, corpus_urls: str, **overrides) -> str:
+        """verify-dns.json as HOP D writes it for a passing corpus clone."""
+        evidence = {
+            "dns_server": "10.0.2.2",
+            "resolv_conf_vm": "nameserver 10.0.2.2\n",
+            "resolv_conf_container": "nameserver 10.0.2.2\n",
+            "hosts": {h: {"answer": "10.0.2.2", "ok": True}
+                      for h in self._hosts_of(corpus_urls)},
+            "urls": {u: {"status": 200, "ok": True} for u in corpus_urls.split(",")},
+            "timestamp": "2026-08-28T00:00:00Z",
+            "passed": True,
+        }
+        evidence.update(overrides)
+        return json.dumps(evidence)
 
     def _helpers(self) -> str:
         block = self.HELPERS.search(campaign())
@@ -402,7 +427,7 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
                 hosts.append(host)
         with tempfile.TemporaryDirectory() as tmp:
             env, results = self._fakes(tmp)
-            env["MAKE_VERIFY_JSON"] = '{"passed": true}'
+            env["MAKE_VERIFY_JSON"] = self._bracket_evidence(urls)
             script = (f'set -euo pipefail\nsay() {{ :; }}\nURLS="{urls}"\n{self._helpers()}\n'
                       'CORPUS_HOSTS=$(corpus_hosts)\nrun_verify pre\necho VERIFIED\n')
             result = self._run(script, env)
@@ -419,7 +444,7 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
             with open(env["MAKE_ARGV"]) as handle:
                 self.assertIn("bench-chromium-request-verify", handle.read())
             with open(os.path.join(results, "verify-dns-pre.json")) as handle:
-                self.assertEqual(json.load(handle), {"passed": True})
+                self.assertEqual(json.load(handle), json.loads(env["MAKE_VERIFY_JSON"]))
 
     def test_verify_refuses_failed_or_missing_resolver_evidence(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -427,7 +452,7 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
             base = (f'set -euo pipefail\nsay() {{ :; }}\nURLS="{self._urls()}"\n{self._helpers()}\n'
                     'CORPUS_HOSTS=$(corpus_hosts)\n')
             # verify's make exits 0 but HOP D recorded passed=false.
-            env["MAKE_VERIFY_JSON"] = '{"passed": false}'
+            env["MAKE_VERIFY_JSON"] = self._bracket_evidence(self._urls(), passed=False)
             result = self._run(base + "run_verify before-run\necho VERIFIED\n", env)
             self.assertNotEqual(result.returncode, 0, "passed=false was accepted")
             self.assertNotIn("VERIFIED", result.stdout)
@@ -441,10 +466,136 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
             self.assertIn("verify-dns.json", result.stderr)
             # verify's make itself failed.
             env["MAKE_RC"] = "1"
-            env["MAKE_VERIFY_JSON"] = '{"passed": true}'
+            env["MAKE_VERIFY_JSON"] = self._bracket_evidence(self._urls())
             result = self._run(base + "run_verify pre\necho VERIFIED\n", env)
             self.assertNotEqual(result.returncode, 0, "a failed verify make was accepted")
             self.assertNotIn("VERIFIED", result.stdout)
+
+    def test_a_bracket_that_asserted_nothing_is_refused(self):
+        """`passed: true` is what HOP D writes when it was given nothing to
+        check. run_verify accepted it, so a bracket with an empty host list
+        (or a resolver other than the replay's, or a host it never asked
+        about) read as clean.
+
+        RED BEFORE THE FIX: `{"passed": true}` and the other three shapes
+        all printed VERIFIED with exit 0.
+        """
+        urls = self._urls()
+        hosts = self._hosts_of(urls)
+        partial = json.loads(self._bracket_evidence(urls))
+        del partial["hosts"][hosts[-1]]
+        cases = {
+            "asserted nothing": '{"passed": true}',
+            "another resolver": self._bracket_evidence(urls, dns_server="10.0.2.3"),
+            "a host never asked": json.dumps(partial),
+            "a url that failed": self._bracket_evidence(
+                urls, urls={u: {"status": 404, "ok": False} for u in urls.split(",")}),
+        }
+        for label, evidence in cases.items():
+            with self.subTest(label), tempfile.TemporaryDirectory() as tmp:
+                env, _results = self._fakes(tmp)
+                env["MAKE_VERIFY_JSON"] = evidence
+                script = (f'set -euo pipefail\nsay() {{ :; }}\nURLS="{urls}"\n'
+                          f'{self._helpers()}\nCORPUS_HOSTS=$(corpus_hosts)\n'
+                          'run_verify pre\necho VERIFIED\n')
+                result = self._run(script, env)
+                self.assertNotEqual(result.returncode, 0,
+                                    f"{label}: accepted\n{result.stdout}")
+                self.assertNotIn("VERIFIED", result.stdout)
+
+    def test_a_stale_read_only_bracket_copy_cannot_stand_in(self):
+        """run_verify is called as `run_verify pre || campaign_fail ...`, and
+        bash turns errexit off inside a function invoked that way. The copy
+        into verify-dns-<stage>.json was unchecked, so when it failed the
+        `jq -e` that follows validated whatever copy was already there.
+
+        RED BEFORE THE FIX: VERIFIED printed, exit 0, over a bracket whose
+        fresh evidence says passed=false.
+        """
+        urls = self._urls()
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            stale = os.path.join(results, "verify-dns-pre.json")
+            with open(stale, "w") as handle:
+                handle.write(self._bracket_evidence(urls))
+            os.chmod(stale, 0o444)
+            env["MAKE_VERIFY_JSON"] = self._bracket_evidence(urls, passed=False)
+            script = (f'set -euo pipefail\nsay() {{ :; }}\nURLS="{urls}"\n'
+                      f'{self._helpers()}\nCORPUS_HOSTS=$(corpus_hosts)\n'
+                      'run_verify pre || { echo REFUSED; exit 7; }\necho VERIFIED\n')
+            try:
+                result = self._run(script, env)
+            finally:
+                if os.path.exists(stale):
+                    os.chmod(stale, 0o644)
+            self.assertEqual(result.returncode, 7, result.stdout + result.stderr)
+            self.assertNotIn("VERIFIED", result.stdout)
+            with open(stale) as handle:
+                self.assertIs(json.load(handle)["passed"], False,
+                              "the stale copy survived under the stage name")
+
+    def test_the_run_sub_make_receives_the_stall_limit(self):
+        """reqanalyze's stall gate is armed by STALL_MAX_MS, and
+        campaign_summary refuses an analysis whose gate was never armed;
+        the campaign passed nothing, so every run it produced was
+        un-indexable by construction.
+
+        RED BEFORE THE FIX: no STALL_MAX_MS default line in the campaign,
+        and the run's make saw no STALL_MAX_MS.
+        """
+        body = campaign()
+        default = re.search(r'^STALL_MAX_MS="\$\{STALL_MAX_MS:-(\d+)\}"$', body, re.M)
+        self.assertIsNotNone(default, "the campaign sets no STALL_MAX_MS default")
+        self.assertEqual(default.group(1), "15000")
+        block = re.search(r'(TAG="\$TAG" URL="\$URLS" BACKEND=.*?\|\| run_rc=\$\?)',
+                          body, re.S)
+        self.assertIsNotNone(block, "the measured run invocation is gone")
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            env.pop("STALL_MAX_MS", None)
+            script = ('set -euo pipefail\nsay() { :; }\n'
+                      f'URLS="{self._urls()}"\nBACKEND=uffd\nUFFD_MODE=minor\n'
+                      'UFFD_PREFETCH=on\nARMS=noop,cdp\nREPS=1\nWARMUP=1\n'
+                      f'{default.group(0)}\n{self._helpers()}\nrun_rc=0\n'
+                      f'{block.group(1)}\necho "run_rc=$run_rc"\n')
+            result = self._run(script, env)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            seen = self._make_env(env)
+            self.assertEqual(seen.get("STALL_MAX_MS"), "15000")
+            self.assertEqual(seen.get("RESULTS"), results)
+            with open(env["MAKE_ARGV"]) as handle:
+                self.assertIn("bench-chromium-request-run", handle.read())
+
+    def test_stale_evidence_from_an_earlier_campaign_is_cleared_at_start(self):
+        """An explicit RESULTS can be reused. A clean dns-evidence.json left
+        by an earlier campaign, beside a run this campaign never finished,
+        would be indexed as if it were this run's.
+
+        RED BEFORE THE FIX: the block after `mkdir -p "$RESULTS"` removed
+        nothing.
+        """
+        block = re.search(r'(mkdir -p "\$RESULTS"\n(?:#[^\n]*\n)*rm -f [^\n]*\n)',
+                          campaign())
+        self.assertIsNotNone(block, "the campaign does not clear stale evidence at start")
+        with tempfile.TemporaryDirectory() as tmp:
+            results = os.path.join(tmp, "results")
+            os.makedirs(results)
+            stale = ["dns-evidence.json", "verify-dns-after-run.json",
+                     "verify-dns.json", "dns-owner.log"]
+            for name in stale:
+                with open(os.path.join(results, name), "w") as handle:
+                    handle.write('{"verdict": "clean", "passed": true}\n')
+            with open(os.path.join(results, "analysis.json"), "w") as handle:
+                handle.write("{}\n")
+            result = subprocess.run(
+                ["bash", "-c", f'set -euo pipefail\nRESULTS="{results}"\n{block.group(1)}'],
+                capture_output=True, text=True, timeout=30)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            for name in stale:
+                self.assertFalse(os.path.exists(os.path.join(results, name)),
+                                 f"stale {name} survived the campaign start")
+            self.assertTrue(os.path.exists(os.path.join(results, "analysis.json")),
+                            "the start wiped more than the evidence")
 
     def test_the_golden_sub_make_receives_results_and_the_baked_resolver(self):
         block = self.GOLDEN.search(campaign())
@@ -486,15 +637,42 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
         self.assertLess(run, sampler_off, "sampler stops before the measured run")
         self.assertLess(sampler_off, after, "after-run verify runs under the sampler")
         self.assertLess(after, evidence, "evidence is written before the after-run verify")
+        # The evidence hashes the replay server's logs; a server still
+        # serving appends after the hash. It stops first, and the exit trap
+        # finds it already gone.
+        serve_off = body.index("stop_corpus_serve\n", after)
+        self.assertLess(serve_off, evidence,
+                        "the replay logs are hashed while corpus_serve still writes them")
+        call = body[evidence:body.index("\n", evidence)]
+        self.assertIn("|| verdict=unclean", call,
+                      "an evidence write that fails must not leave verdict=clean: " + call)
         cleanup = body.split("cleanup() {", 1)[1].split("\n}\n", 1)[0]
         self.assertIn("stop_dns_sampler", cleanup,
                       "a campaign that dies mid-run leaks the sampler")
+        self.assertIn("stop_corpus_serve", cleanup,
+                      "a campaign that dies mid-run leaks the replay server")
 
-    def _sample(self, env, results, verdict_in="clean", seconds=0.6):
+    BRACKETS = ("pre", "before-run", "after-run")
+    REPLAY_LOGS = ("corpus-dns.log", "corpus-access.log")
+
+    def _leave_files(self, results, brackets=BRACKETS, logs=REPLAY_LOGS,
+                     bracket_passed=True):
+        """What the campaign leaves in $RESULTS before write_dns_evidence."""
+        for stage in brackets:
+            with open(os.path.join(results, f"verify-dns-{stage}.json"), "w") as handle:
+                handle.write(json.dumps({"passed": bracket_passed}) + "\n")
+        for name in logs:
+            with open(os.path.join(results, name), "w") as handle:
+                handle.write(name + "\n")
+
+    def _sample(self, env, results, verdict_in="clean", seconds=0.6, mid_run="",
+                files=True):
+        if files:
+            self._leave_files(results)
         script = (f'set -u\n{self._helpers()}\n'
                   f'RESULTS="{results}"\nSERVE_PID=4242\nDNSMASQ_WAS_ACTIVE=yes\n'
                   'DNS_SAMPLE_INTERVAL=0.05\nstart_dns_sampler\n'
-                  f'sleep {seconds}\nstop_dns_sampler\n'
+                  f'sleep {seconds}\n{mid_run}\nstop_dns_sampler\n'
                   f'write_dns_evidence {verdict_in}\n')
         result = self._run(script, env)
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -519,24 +697,125 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
     def test_a_steady_owner_with_dnsmasq_down_is_clean(self):
         with tempfile.TemporaryDirectory() as tmp:
             env, results = self._fakes(tmp)
-            for name in ("corpus-dns.log", "corpus-access.log"):
-                with open(os.path.join(results, name), "w") as handle:
-                    handle.write(name + "\n")
-            with open(os.path.join(results, "verify-dns-pre.json"), "w") as handle:
-                handle.write('{"passed": true}\n')
             evidence, _ = self._sample(env, results)
             self.assertEqual(evidence["verdict"], "clean", evidence)
             self.assertEqual(evidence["serve_pid"], 4242)
             self.assertIs(evidence["dnsmasq_was_active_before"], True)
             self.assertIs(evidence["dnsmasq_active_after_restore"], False)
+            self.assertEqual(evidence["dnsmasq_state_after_restore"], "inactive")
+            self.assertIs(evidence["sampler_alive_at_stop"], True)
             self.assertGreaterEqual(evidence["samples"], 3)
             self.assertIsNone(evidence["first_mismatch"])
             self.assertEqual(evidence["verify_files"],
-                             [os.path.join(results, "verify-dns-pre.json")])
+                             [os.path.join(results, f"verify-dns-{s}.json")
+                              for s in self.BRACKETS])
             for key, name in (("corpus_dns_log_sha256", "corpus-dns.log"),
                               ("corpus_access_log_sha256", "corpus-access.log")):
                 self.assertEqual(evidence[key],
                                  hashlib.sha256((name + "\n").encode()).hexdigest())
+
+    def test_a_missing_or_failed_bracket_is_unclean(self):
+        """Three brackets run; a verdict built from fewer is a verdict over a
+        run whose resolver went unproven on one side.
+
+        RED BEFORE THE FIX: verdict clean with two brackets, and clean with a
+        bracket that recorded passed=false.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            self._leave_files(results, brackets=("pre", "before-run"))
+            evidence, _ = self._sample(env, results, files=False)
+            self.assertEqual(evidence["verdict"], "unclean", evidence)
+            self.assertIn("after-run", evidence["reason"])
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            self._leave_files(results, bracket_passed=False)
+            evidence, _ = self._sample(env, results, files=False)
+            self.assertEqual(evidence["verdict"], "unclean", evidence)
+            self.assertIn("pre", evidence["reason"])
+
+    def test_a_missing_or_empty_replay_log_is_unclean(self):
+        """The replay server's own logs are the other half of the evidence;
+        a null hash was recorded without lowering the verdict.
+
+        RED BEFORE THE FIX: verdict clean with corpus_dns_log_sha256 null.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            self._leave_files(results, logs=("corpus-access.log",))
+            evidence, _ = self._sample(env, results, files=False)
+            self.assertEqual(evidence["verdict"], "unclean", evidence)
+            self.assertIsNone(evidence["corpus_dns_log_sha256"])
+            self.assertIn("corpus-dns.log", evidence["reason"])
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            self._leave_files(results)
+            open(os.path.join(results, "corpus-access.log"), "w").close()
+            evidence, _ = self._sample(env, results, files=False)
+            self.assertEqual(evidence["verdict"], "unclean", evidence)
+            self.assertIn("corpus-access.log", evidence["reason"])
+
+    def test_a_sampler_that_died_mid_run_is_unclean(self):
+        """One clean sample followed by a dead sampler was accepted: the
+        evidence required samples > 0 and no mismatch, nothing about the
+        sampler covering the run. Its exit status now says whether the
+        stop is what ended it; a sample that cannot be taken (sudo -n
+        refused, ss missing) ends it on its own, with or without errexit.
+
+        RED BEFORE THE FIX: verdict clean, and KeyError: 'sampler_alive_at_stop'.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            env["SS_FAIL_AT"] = "3"
+            evidence, _ = self._sample(env, results)
+            self.assertEqual(evidence["verdict"], "unclean", evidence)
+            self.assertIs(evidence["sampler_alive_at_stop"], False)
+            self.assertGreaterEqual(evidence["samples"], 2)
+            self.assertIsNone(evidence["first_mismatch"])
+            with open(os.path.join(results, "dns-owner.log")) as handle:
+                lines = handle.read().splitlines()
+            self.assertEqual(len(lines), 2, "the sampler kept going after a failed sample")
+            self.assertIn("sampler", evidence["reason"])
+
+    def test_an_unknown_dnsmasq_state_after_the_run_is_unclean(self):
+        """`systemctl is-active --quiet` exits non-zero for failed,
+        activating and unknown alike, and all of them read as inactive.
+
+        RED BEFORE THE FIX: verdict clean with dnsmasq state unknown.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp, dnsmasq="unknown")
+            evidence, _ = self._sample(env, results)
+            self.assertEqual(evidence["verdict"], "unclean", evidence)
+            self.assertEqual(evidence["dnsmasq_state_after_restore"], "unknown")
+            self.assertIs(evidence["dnsmasq_active_after_restore"], False)
+
+    def test_an_unwritable_evidence_file_is_an_unclean_verdict(self):
+        """write_dns_evidence printed its verdict after the write, whatever
+        the write did; a failed jq or redirect still yielded `clean` and a
+        campaign exit of 0 with no evidence on disk.
+
+        RED BEFORE THE FIX: stdout `clean`, exit 0.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            self._leave_files(results)
+            with open(os.path.join(results, "dns-owner.log"), "w") as handle:
+                handle.write("2026-08-28T00:00:00Z owner_pid=4242 dnsmasq=inactive\n")
+            os.chmod(results, 0o555)
+            script = (f'set -u\n{self._helpers()}\nRESULTS="{results}"\n'
+                      'SERVE_PID=4242\nDNSMASQ_WAS_ACTIVE=yes\nSAMPLER_ALIVE_AT_STOP=yes\n'
+                      'write_dns_evidence clean\n')
+            try:
+                result = self._run(script, env)
+            finally:
+                os.chmod(results, 0o755)
+            self.assertNotEqual(result.returncode, 0, "a failed evidence write returned 0")
+            self.assertEqual(result.stdout.strip(), "unclean")
+            self.assertEqual(sorted(os.listdir(results)),
+                             sorted(["dns-owner.log", "corpus-dns.log", "corpus-access.log"]
+                                    + [f"verify-dns-{s}.json" for s in self.BRACKETS]),
+                             "a partial evidence file or temp file was left behind")
 
     def test_a_bracket_failure_cannot_be_lifted_by_clean_samples(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/bench/chromium/test_campaign.py
+++ b/bench/chromium/test_campaign.py
@@ -16,7 +16,9 @@ the campaign runs rather than a paraphrase of them.
 Run: python3 -m unittest test_campaign -v
 """
 
+import hashlib
 import http.server
+import json
 import os
 import re
 import subprocess
@@ -283,6 +285,299 @@ class PartialCorpus(unittest.TestCase):
         self.assertIn("COMPLETE", result.stdout,
                       f"a complete corpus was refused\n{result.stderr}")
 
+
+class DnsBrackets(unittest.TestCase):
+    """Resolver evidence around the measured run: verify on each side, sample between.
+
+    The replay wiring (guest resolv.conf -> pasta gateway -> corpus_serve on
+    127.0.0.1:53) is only evidence if it held for the WHOLE measured run. A
+    dnsmasq restart, a server leaked from an earlier campaign, or a golden that
+    ignored --dns would hand the guest a different resolver, and nothing in a
+    record would say so. Three brackets close that: reqbench's HOP D verify
+    before and after the run (and once more on golden reuse), a sampler naming
+    the owner of 127.0.0.1:53 every DNS_SAMPLE_INTERVAL seconds while the run
+    is in flight, and dns-evidence.json tying them to the replay server's logs.
+
+    Behavioural where the block can run without a VM (the helper functions are
+    lifted out of the shipped script and executed against fakes on PATH, as
+    PartialCorpus does), structural for the ordering of the calls in the main
+    flow.
+    """
+
+    HELPERS = re.compile(
+        r"(engine_target\(\) \{\n.*?\ncampaign_fail\(\) \{\n.*?\n\}\n)", re.S)
+    GOLDEN = re.compile(
+        r"(GUEST_DNS=10\.0\.2\.2[^\n]*\\\n[^\n]*engine_target golden\)[^\n]*)")
+    URL_LINE = re.compile(r'^URLS="([^"]+)"$', re.M)
+
+    FAKE_MAKE = """#!/bin/bash
+env > "$MAKE_ENV_DUMP"
+echo "$*" > "$MAKE_ARGV"
+[ -z "${MAKE_VERIFY_JSON:-}" ] || printf '%s\\n' "$MAKE_VERIFY_JSON" > "$RESULTS/verify-dns.json"
+exit "${MAKE_RC:-0}"
+"""
+    # Decoy :53 listeners with OTHER pids, as on the bench host itself:
+    # systemd-resolved on 127.0.0.53 and dnsmasq on the bridge addresses. Only
+    # the 127.0.0.1:53 line names the replay server, and its pid changes from
+    # the SS_CHANGE_AT-th call on.
+    FAKE_SS = """#!/bin/bash
+n=$(cat "$SS_CALLS" 2>/dev/null || echo 0); n=$((n + 1)); echo "$n" > "$SS_CALLS"
+pid="$SS_OWNER"
+if [ -n "${SS_CHANGE_AT:-}" ] && [ "$n" -ge "$SS_CHANGE_AT" ]; then pid="$SS_OTHER"; fi
+cat <<SSOUT
+State  Recv-Q Send-Q Local Address:Port Peer Address:PortProcess
+UNCONN 0      0          127.0.0.53%lo:53        0.0.0.0:*    users:(("systemd-resolve",pid=17853,fd=14))
+UNCONN 0      0          192.168.94.37:53        0.0.0.0:*    users:(("dnsmasq",pid=1363,fd=55))
+UNCONN 0      0              127.0.0.1:53        0.0.0.0:*    users:(("python3",pid=$pid,fd=7))
+SSOUT
+"""
+    FAKE_SYSTEMCTL = """#!/bin/bash
+quiet=0; args=()
+for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; done
+[ "${args[0]:-}" = is-active ] || exit 1
+[ "$quiet" = 1 ] || echo "$FAKE_DNSMASQ_STATE"
+[ "$FAKE_DNSMASQ_STATE" = active ] && exit 0 || exit 3
+"""
+    FAKE_SUDO = '#!/bin/bash\n[ "${1:-}" = -n ] && shift\nexec "$@"\n'
+
+    def _helpers(self) -> str:
+        block = self.HELPERS.search(campaign())
+        self.assertIsNotNone(block, "the resolver evidence helpers are gone "
+                                    "from the campaign (engine_target .. campaign_fail)")
+        return block.group(1)
+
+    def _urls(self) -> str:
+        line = self.URL_LINE.search(campaign())
+        self.assertIsNotNone(line, "the corpus URL list is gone")
+        return line.group(1)
+
+    def _fakes(self, tmp, dnsmasq="inactive"):
+        """Fake make/ss/systemctl/sudo on PATH; each records what it saw."""
+        binx = os.path.join(tmp, "bin")
+        os.makedirs(binx, exist_ok=True)
+        for name, body in (("make", self.FAKE_MAKE), ("ss", self.FAKE_SS),
+                           ("systemctl", self.FAKE_SYSTEMCTL), ("sudo", self.FAKE_SUDO)):
+            path = os.path.join(binx, name)
+            with open(path, "w") as handle:
+                handle.write(body)
+            os.chmod(path, 0o755)
+        results = os.path.join(tmp, "results")
+        logs = os.path.join(tmp, "logs")
+        os.makedirs(results, exist_ok=True)
+        os.makedirs(logs, exist_ok=True)
+        env = dict(os.environ)
+        env.update(
+            PATH=binx + os.pathsep + env["PATH"],
+            MAKE_ENV_DUMP=os.path.join(tmp, "make-env"),
+            MAKE_ARGV=os.path.join(tmp, "make-argv"),
+            SS_CALLS=os.path.join(tmp, "ss-calls"),
+            SS_OWNER="4242", SS_OTHER="999",
+            FAKE_DNSMASQ_STATE=dnsmasq,
+            RESULTS=results, LOGDIR=logs, REPO=tmp, TAG="cb-req-corpus",
+            ENGINE="chromium",
+        )
+        return env, results
+
+    def _make_env(self, env):
+        seen = {}
+        with open(env["MAKE_ENV_DUMP"]) as handle:
+            for line in handle.read().splitlines():
+                key, _, value = line.partition("=")
+                seen[key] = value
+        return seen
+
+    def _run(self, script, env, timeout=60):
+        return subprocess.run(["bash", "-c", script], env=env,
+                              capture_output=True, text=True, timeout=timeout)
+
+    def test_verify_carries_the_corpus_resolver_knobs_and_keeps_its_evidence(self):
+        """run_verify must hand reqbench every corpus host and URL, the replay
+        answer, and THIS run's RESULTS, and keep the bracket's evidence under
+        its own name, since reqbench overwrites verify-dns.json."""
+        urls = self._urls()
+        hosts = []
+        for url in urls.split(","):
+            host = url.split("://", 1)[1].split("/", 1)[0]
+            if host not in hosts:
+                hosts.append(host)
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            env["MAKE_VERIFY_JSON"] = '{"passed": true}'
+            script = (f'set -euo pipefail\nsay() {{ :; }}\nURLS="{urls}"\n{self._helpers()}\n'
+                      'CORPUS_HOSTS=$(corpus_hosts)\nrun_verify pre\necho VERIFIED\n')
+            result = self._run(script, env)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("VERIFIED", result.stdout)
+            seen = self._make_env(env)
+            self.assertEqual(seen.get("VERIFY_DNS_HOSTS"), ",".join(hosts),
+                             "verify was not told the corpus hosts")
+            self.assertEqual(seen.get("VERIFY_DNS_ANSWER"), "10.0.2.2")
+            self.assertEqual(seen.get("VERIFY_DNS_URLS"), urls)
+            self.assertEqual(seen.get("RESULTS"), results,
+                             "verify's logs land outside the run directory")
+            self.assertEqual(seen.get("TAG"), "cb-req-corpus")
+            with open(env["MAKE_ARGV"]) as handle:
+                self.assertIn("bench-chromium-request-verify", handle.read())
+            with open(os.path.join(results, "verify-dns-pre.json")) as handle:
+                self.assertEqual(json.load(handle), {"passed": True})
+
+    def test_verify_refuses_failed_or_missing_resolver_evidence(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            base = (f'set -euo pipefail\nsay() {{ :; }}\nURLS="{self._urls()}"\n{self._helpers()}\n'
+                    'CORPUS_HOSTS=$(corpus_hosts)\n')
+            # verify's make exits 0 but HOP D recorded passed=false.
+            env["MAKE_VERIFY_JSON"] = '{"passed": false}'
+            result = self._run(base + "run_verify before-run\necho VERIFIED\n", env)
+            self.assertNotEqual(result.returncode, 0, "passed=false was accepted")
+            self.assertNotIn("VERIFIED", result.stdout)
+            self.assertTrue(os.path.exists(os.path.join(results, "verify-dns-before-run.json")),
+                            "the failed bracket's evidence was not kept")
+            # verify wrote nothing at all (HOP D never ran).
+            env.pop("MAKE_VERIFY_JSON")
+            result = self._run(base + "run_verify after-run\necho VERIFIED\n", env)
+            self.assertNotEqual(result.returncode, 0,
+                                "a verify with no HOP D evidence was accepted")
+            self.assertIn("verify-dns.json", result.stderr)
+            # verify's make itself failed.
+            env["MAKE_RC"] = "1"
+            env["MAKE_VERIFY_JSON"] = '{"passed": true}'
+            result = self._run(base + "run_verify pre\necho VERIFIED\n", env)
+            self.assertNotEqual(result.returncode, 0, "a failed verify make was accepted")
+            self.assertNotIn("VERIFIED", result.stdout)
+
+    def test_the_golden_sub_make_receives_results_and_the_baked_resolver(self):
+        block = self.GOLDEN.search(campaign())
+        self.assertIsNotNone(block, "the golden invocation is gone or no longer "
+                                    "names engine_target golden")
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            script = f'set -euo pipefail\nsay() {{ :; }}\n{self._helpers()}\n{block.group(1)}\n'
+            result = self._run(script, env)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            seen = self._make_env(env)
+            self.assertEqual(seen.get("RESULTS"), results,
+                             "the golden's logs land outside the run directory")
+            self.assertEqual(seen.get("GUEST_DNS"), "10.0.2.2")
+            with open(env["MAKE_ARGV"]) as handle:
+                self.assertIn("bench-chromium-request-golden", handle.read())
+
+    def test_every_phase_verifies_on_both_sides_of_the_measured_run(self):
+        """Ordering in the main flow, which cannot run without a VM."""
+        body = campaign()
+        phases = re.search(r'if \[ "\$PHASE" = all \]; then\n(.*?)\nelse\n(.*?)\nfi\n',
+                           body, re.S)
+        self.assertIsNotNone(phases, "the PHASE branch is gone")
+        self.assertIn("run_verify pre", phases.group(1))
+        self.assertIn("run_verify pre", phases.group(2),
+                      "PHASE=run reuses the golden without verifying its resolver")
+        quiet = body.index('say "box quiet')
+        before = body.index("run_verify before-run")
+        sampler_on = body.index("start_dns_sampler\n", before)
+        run = body.index("engine_target run)")
+        # From `run` on: the exit trap calls stop_dns_sampler too, earlier in
+        # the file.
+        sampler_off = body.index("stop_dns_sampler\n", run)
+        after = body.index("run_verify after-run")
+        evidence = body.index("write_dns_evidence ", after)
+        self.assertLess(quiet, before, "before-run verify precedes the settle wait")
+        self.assertLess(before, sampler_on, "sampler starts before the before-run verify")
+        self.assertLess(sampler_on, run, "sampler starts after the measured run")
+        self.assertLess(run, sampler_off, "sampler stops before the measured run")
+        self.assertLess(sampler_off, after, "after-run verify runs under the sampler")
+        self.assertLess(after, evidence, "evidence is written before the after-run verify")
+        cleanup = body.split("cleanup() {", 1)[1].split("\n}\n", 1)[0]
+        self.assertIn("stop_dns_sampler", cleanup,
+                      "a campaign that dies mid-run leaks the sampler")
+
+    def _sample(self, env, results, verdict_in="clean", seconds=0.6):
+        script = (f'set -u\n{self._helpers()}\n'
+                  f'RESULTS="{results}"\nSERVE_PID=4242\nDNSMASQ_WAS_ACTIVE=yes\n'
+                  'DNS_SAMPLE_INTERVAL=0.05\nstart_dns_sampler\n'
+                  f'sleep {seconds}\nstop_dns_sampler\n'
+                  f'write_dns_evidence {verdict_in}\n')
+        result = self._run(script, env)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        with open(os.path.join(results, "dns-evidence.json")) as handle:
+            return json.load(handle), result
+
+    def test_a_port_owner_change_mid_run_is_unclean(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            env["SS_CHANGE_AT"] = "3"
+            evidence, _ = self._sample(env, results)
+            self.assertEqual(evidence["verdict"], "unclean",
+                             f"127.0.0.1:53 changed hands and the verdict is clean: {evidence}")
+            self.assertGreaterEqual(evidence["samples"], 3)
+            self.assertIsNotNone(evidence["first_mismatch"])
+            self.assertIn("owner_pid=999", evidence["first_mismatch"])
+            with open(os.path.join(results, "dns-owner.log")) as handle:
+                lines = handle.read().splitlines()
+            self.assertEqual(lines[2], evidence["first_mismatch"])
+            self.assertRegex(lines[0], r"^\S+ owner_pid=4242 dnsmasq=inactive$")
+
+    def test_a_steady_owner_with_dnsmasq_down_is_clean(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            for name in ("corpus-dns.log", "corpus-access.log"):
+                with open(os.path.join(results, name), "w") as handle:
+                    handle.write(name + "\n")
+            with open(os.path.join(results, "verify-dns-pre.json"), "w") as handle:
+                handle.write('{"passed": true}\n')
+            evidence, _ = self._sample(env, results)
+            self.assertEqual(evidence["verdict"], "clean", evidence)
+            self.assertEqual(evidence["serve_pid"], 4242)
+            self.assertIs(evidence["dnsmasq_was_active_before"], True)
+            self.assertIs(evidence["dnsmasq_active_after_restore"], False)
+            self.assertGreaterEqual(evidence["samples"], 3)
+            self.assertIsNone(evidence["first_mismatch"])
+            self.assertEqual(evidence["verify_files"],
+                             [os.path.join(results, "verify-dns-pre.json")])
+            for key, name in (("corpus_dns_log_sha256", "corpus-dns.log"),
+                              ("corpus_access_log_sha256", "corpus-access.log")):
+                self.assertEqual(evidence[key],
+                                 hashlib.sha256((name + "\n").encode()).hexdigest())
+
+    def test_a_bracket_failure_cannot_be_lifted_by_clean_samples(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            evidence, _ = self._sample(env, results, verdict_in="unclean")
+            self.assertEqual(evidence["verdict"], "unclean")
+            self.assertIsNone(evidence["first_mismatch"])
+
+    def test_dnsmasq_active_after_the_run_is_unclean(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp, dnsmasq="active")
+            evidence, _ = self._sample(env, results)
+            self.assertEqual(evidence["verdict"], "unclean")
+            self.assertIs(evidence["dnsmasq_active_after_restore"], True)
+
+    def test_no_samples_is_unclean(self):
+        """An empty owner log is absence of evidence, not evidence of a
+        clean run."""
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            script = (f'set -u\n{self._helpers()}\nRESULTS="{results}"\n'
+                      'SERVE_PID=4242\nDNSMASQ_WAS_ACTIVE=no\nwrite_dns_evidence clean\n')
+            result = self._run(script, env)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            with open(os.path.join(results, "dns-evidence.json")) as handle:
+                evidence = json.load(handle)
+            self.assertEqual(evidence["verdict"], "unclean")
+            self.assertEqual(evidence["samples"], 0)
+            self.assertIs(evidence["dnsmasq_was_active_before"], False)
+
+    def test_the_replay_server_logs_into_the_run_directory(self):
+        """corpus_serve's DNS and access logs are the other half of the
+        evidence: the sha256 in dns-evidence.json must name files that live
+        with the run, not in a /tmp the next campaign overwrites."""
+        serve = re.search(r"sudo -b sh -c '([^']*)'(.*?)\n\n", campaign(), re.S)
+        self.assertIsNotNone(serve, "the corpus_serve launch line is gone")
+        inner, args = serve.groups()
+        self.assertIn("--dns-log", inner)
+        self.assertIn("--access-log", inner)
+        self.assertIn('"$RESULTS/corpus-dns.log"', args)
+        self.assertIn('"$RESULTS/corpus-access.log"', args)
 
 if __name__ == "__main__":
     unittest.main()

--- a/bench/chromium/test_campaign.py
+++ b/bench/chromium/test_campaign.py
@@ -542,8 +542,12 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
 
     @staticmethod
     def _set_load(loadavg, load1):
-        with open(loadavg, "w") as handle:
+        """Write, then rename over: the sampler reads this file by name every
+        DNS_SAMPLE_INTERVAL, and a truncate followed by a write leaves it a
+        window in which the load column is empty."""
+        with open(loadavg + ".new", "w") as handle:
             handle.write(f"{load1} 0.30 0.20 1/100 1234\n")
+        os.replace(loadavg + ".new", loadavg)
 
     def _make_env(self, env):
         seen = {}
@@ -1123,11 +1127,27 @@ wait_sampler_gone() {
         '^\\S+ owner_pid=4242 dnsmasq=inactive load1=0\\.42$' not found in
         '2026-08-28T..Z owner_pid=4242 dnsmasq=inactive', then
         KeyError: 'load_max_1min'.
+
+        The mid-run swap must be atomic, or the test fails for a reason it
+        is not about (CodeRabbit, 2026-08-28). RED WITH THE SWAP WRITTEN IN
+        PLACE, over the same interleaving: `AssertionError: 97 != 0 :
+        TIMEOUT after 30s: dns-owner.log never reached 4 rows`, because the
+        sample taken while the file was truncated read an empty load1 and
+        the sampler ended. The shipped campaign has no such write: it
+        truncates dns-owner.log before the sampler exists, and both files
+        another process reads, dns-evidence.json and corpus-serve.status,
+        are written to a temp file and renamed.
         """
         with tempfile.TemporaryDirectory() as tmp:
             env, results = self._fakes(tmp)
-            raise_load = (f'printf "1.87 0.30 0.20 1/100 1234\\n" '
-                          f'> "{env["LOADAVG_FILE"]}"\nwait_last_load 1.87\n')
+            loadavg = env["LOADAVG_FILE"]
+            # The swap writes a second file and renames it over the first,
+            # and a sample is taken while both exist. In place, the sample
+            # landing between the truncate and the bytes reads an empty
+            # load1, which ends the sampler.
+            raise_load = (f'printf "1.87 0.30 0.20 1/100 1234\\n" > "{loadavg}.new"\n'
+                          f'wait_rows 4\nmv "{loadavg}.new" "{loadavg}"\n'
+                          'wait_last_load 1.87\n')
             evidence, _ = self._sample(env, results, rows=3, mid_run=raise_load)
             with open(os.path.join(results, "dns-owner.log")) as handle:
                 lines = handle.read().splitlines()

--- a/bench/chromium/test_campaign.py
+++ b/bench/chromium/test_campaign.py
@@ -884,14 +884,64 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
             with open(os.path.join(results, "corpus-serve.status"), "w") as handle:
                 handle.write(serve_status + "\n")
 
-    def _sample(self, env, results, verdict_in="clean", seconds=0.6, mid_run="",
+    # Waits for what the assertion needs, never for a duration. A fixed
+    # sleep here assumed a sample rate the box has to deliver: at 0.3 s per
+    # `ss` call the 0.6 s this used to sleep buys one sample, the
+    # SS_CHANGE_AT-th call never happens, and the owner-change case reports
+    # clean (Codex, 2026-08-28). Each helper ends the script with a message
+    # and a non-zero status when its deadline passes, so a wait that will
+    # never finish fails the test loudly instead of hanging to the
+    # subprocess timeout.
+    SYNC = """
+sync_deadline() { echo $((SECONDS + 30)); }
+sync_expired() {
+    [ "$SECONDS" -lt "$1" ] && return 1
+    echo "TIMEOUT after ${2}: $3" >&2
+    exit 97
+}
+wait_rows() {
+    # $1 = rows dns-owner.log must carry before the script goes on.
+    local deadline; deadline=$(sync_deadline)
+    while [ "$(wc -l <"$RESULTS/dns-owner.log" 2>/dev/null || echo 0)" -lt "$1" ]; do
+        sync_expired "$deadline" 30s "dns-owner.log never reached $1 rows"
+        sleep 0.02
+    done
+}
+wait_last_load() {
+    # $1 = the load1 value the newest sample must carry.
+    local deadline; deadline=$(sync_deadline)
+    while [ "$(sed -n 's/.* load1=//p' "$RESULTS/dns-owner.log" 2>/dev/null | tail -n 1)" != "$1" ]; do
+        sync_expired "$deadline" 30s "no sample carried load1=$1"
+        sleep 0.02
+    done
+}
+wait_sampler_gone() {
+    # The sampler ended on its own. `kill -0` cannot see this (a dead,
+    # unreaped child still answers it) and `wait` would consume the status
+    # stop_dns_sampler reads, so this watches the process state: Z once it
+    # has exited and is waiting to be reaped.
+    local deadline state; deadline=$(sync_deadline)
+    while :; do
+        state=$(sed -e 's/^.*) //' -e 's/ .*//' "/proc/$SAMPLER_PID/stat" 2>/dev/null || true)
+        case "${state:-gone}" in gone | Z) return 0 ;; esac
+        sync_expired "$deadline" 30s "the sampler is still running"
+        sleep 0.02
+    done
+}
+"""
+
+    def _sample(self, env, results, verdict_in="clean", rows=1, mid_run="",
                 files=True):
+        """Sample until dns-owner.log carries `rows` rows, run `mid_run`,
+        stop, write the evidence. `rows` is what the caller's assertions
+        need, and mid_run has the SYNC helpers to wait for anything it
+        causes."""
         if files:
             self._leave_files(results)
-        script = (f'set -u\n{self._helpers()}\n'
+        script = (f'set -u\n{self._helpers()}\n{self.SYNC}\n'
                   f'RESULTS="{results}"\nSERVE_PID=4242\nDNSMASQ_WAS_ACTIVE=yes\n'
                   'DNS_SAMPLE_INTERVAL=0.05\nstart_dns_sampler\n'
-                  f'sleep {seconds}\n{mid_run}\nstop_dns_sampler\n'
+                  f'wait_rows {rows}\n{mid_run}\nstop_dns_sampler\n'
                   f'write_dns_evidence {verdict_in}\n')
         result = self._run(script, env)
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -899,10 +949,17 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
             return json.load(handle), result
 
     def test_a_port_owner_change_mid_run_is_unclean(self):
+        """The owner changes from the third sample on, so the case only
+        exists once three samples are in the log.
+
+        RED WITH A SLOW SAMPLER (0.3 s per `ss` call, the fixed 0.6 s sleep
+        this used to wait): "127.0.0.1:53 changed hands and the verdict is
+        clean", samples 1.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             env, results = self._fakes(tmp)
             env["SS_CHANGE_AT"] = "3"
-            evidence, _ = self._sample(env, results)
+            evidence, _ = self._sample(env, results, rows=3)
             self.assertEqual(evidence["verdict"], "unclean",
                              f"127.0.0.1:53 changed hands and the verdict is clean: {evidence}")
             self.assertGreaterEqual(evidence["samples"], 3)
@@ -914,9 +971,14 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
             self.assertRegex(lines[0], r"^\S+ owner_pid=4242 dnsmasq=inactive load1=0\.42$")
 
     def test_a_steady_owner_with_dnsmasq_down_is_clean(self):
+        """The clean case, over the same three samples.
+
+        RED WITH A SLOW SAMPLER: AssertionError: 1 not greater than or equal
+        to 3.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             env, results = self._fakes(tmp)
-            evidence, _ = self._sample(env, results)
+            evidence, _ = self._sample(env, results, rows=3)
             self.assertEqual(evidence["verdict"], "clean", evidence)
             self.assertEqual(evidence["serve_pid"], 4242)
             self.assertIs(evidence["dnsmasq_was_active_before"], True)
@@ -986,7 +1048,8 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
         with tempfile.TemporaryDirectory() as tmp:
             env, results = self._fakes(tmp)
             env["SS_FAIL_AT"] = "3"
-            evidence, _ = self._sample(env, results)
+            evidence, _ = self._sample(env, results, rows=2,
+                                       mid_run="wait_sampler_gone\n")
             self.assertEqual(evidence["verdict"], "unclean", evidence)
             self.assertIs(evidence["sampler_alive_at_stop"], False)
             self.assertGreaterEqual(evidence["samples"], 2)
@@ -1063,9 +1126,9 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
         """
         with tempfile.TemporaryDirectory() as tmp:
             env, results = self._fakes(tmp)
-            raise_load = (f'sleep 0.3\nprintf "1.87 0.30 0.20 1/100 1234\\n" '
-                          f'> "{env["LOADAVG_FILE"]}"\nsleep 0.3\n')
-            evidence, _ = self._sample(env, results, mid_run=raise_load)
+            raise_load = (f'printf "1.87 0.30 0.20 1/100 1234\\n" '
+                          f'> "{env["LOADAVG_FILE"]}"\nwait_last_load 1.87\n')
+            evidence, _ = self._sample(env, results, rows=3, mid_run=raise_load)
             with open(os.path.join(results, "dns-owner.log")) as handle:
                 lines = handle.read().splitlines()
             self.assertGreaterEqual(len(lines), 4)
@@ -1087,7 +1150,7 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
         """
         with tempfile.TemporaryDirectory() as tmp:
             env, results = self._fakes(tmp)
-            cut_load = f'rm -f "{env["LOADAVG_FILE"]}"\nsleep 0.3\n'
+            cut_load = f'rm -f "{env["LOADAVG_FILE"]}"\nwait_sampler_gone\n'
             evidence, _ = self._sample(env, results, mid_run=cut_load)
             self.assertEqual(evidence["verdict"], "unclean", evidence)
             self.assertIs(evidence["sampler_alive_at_stop"], False)

--- a/bench/chromium/test_campaign.py
+++ b/bench/chromium/test_campaign.py
@@ -999,6 +999,25 @@ wait_sampler_gone() {
                 self.assertEqual(evidence[key],
                                  hashlib.sha256((name + "\n").encode()).hexdigest())
 
+    def test_the_evidence_pins_each_bracket_by_hash(self):
+        """The bracket files are the only record that a restored clone
+        resolved the corpus through the replay server, and nothing else
+        hashes them. The verdict records each bracket's sha256 so a reader of
+        the run directory can tell the file the verdict read from one edited
+        after it.
+
+        RED BEFORE THE FIX: KeyError: 'verify_file_sha256'.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            evidence, _ = self._sample(env, results)
+            want = {}
+            for stage in self.BRACKETS:
+                name = f"verify-dns-{stage}.json"
+                with open(os.path.join(results, name), "rb") as handle:
+                    want[name] = hashlib.sha256(handle.read()).hexdigest()
+            self.assertEqual(evidence["verify_file_sha256"], want)
+
     def test_a_missing_or_failed_bracket_is_unclean(self):
         """Three brackets run; a verdict built from fewer is a verdict over a
         run whose resolver went unproven on one side.

--- a/bench/chromium/test_campaign.py
+++ b/bench/chromium/test_campaign.py
@@ -719,14 +719,16 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
             for name in stale:
                 with open(os.path.join(results, name), "w") as handle:
                     handle.write('{"verdict": "clean", "passed": true}\n')
-            with open(os.path.join(results, "analysis.json"), "w") as handle:
-                handle.write("{}\n")
+            bundle = os.path.join(results, "runtime", "c" * 64, "MANIFEST.sha256")
+            os.makedirs(os.path.dirname(bundle))
+            with open(bundle, "w") as handle:
+                handle.write("0" * 64 + "  fcvm\n")
             result = self._run_start_cleanup(results)
             self.assertEqual(result.returncode, 0, result.stderr)
             for name in stale:
                 self.assertFalse(os.path.exists(os.path.join(results, name)),
                                  f"stale {name} survived the campaign start")
-            self.assertTrue(os.path.exists(os.path.join(results, "analysis.json")),
+            self.assertTrue(os.path.exists(bundle),
                             "the start wiped more than the evidence")
 
     def test_stale_replay_logs_from_an_earlier_campaign_are_cleared_at_start(self):
@@ -749,6 +751,42 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
             for name in self.REPLAY_LOGS:
                 self.assertFalse(os.path.exists(os.path.join(results, name)),
                                  f"stale {name} survived the campaign start")
+
+    def test_a_stale_run_record_from_an_earlier_attempt_is_cleared_at_start(self):
+        """reqbench.py opens reqbench.jsonl for append, so a retry into a
+        reused RESULTS appends a second run_id and reqanalyze emits a pooled
+        multi-run analysis with no top-level cell, which campaign_summary
+        refuses. A retry that fails before its own analysis leaves the
+        earlier attempt's analysis.json beside this attempt's fresh DNS
+        evidence. Both go at start. The content-addressed runtime bundles
+        and the phase logs are not this attempt's record and stay.
+
+        RED BEFORE THE FIX: `stale reqbench.jsonl survived the campaign start`.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            results = os.path.join(tmp, "results")
+            os.makedirs(os.path.join(results, "logs"))
+            stale = {
+                "reqbench.jsonl": '{"kind": "meta", "run_id": "earlier"}\n',
+                "analysis.json": '{"publishable": true, "run_id": "earlier"}\n',
+            }
+            for name, text in stale.items():
+                with open(os.path.join(results, name), "w") as handle:
+                    handle.write(text)
+            kept = [os.path.join(results, "runtime", "c" * 64, "MANIFEST.sha256"),
+                    os.path.join(results, "logs", "golden.log")]
+            os.makedirs(os.path.dirname(kept[0]))
+            for path in kept:
+                with open(path, "w") as handle:
+                    handle.write("earlier attempt\n")
+            result = self._run_start_cleanup(results)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            for name in stale:
+                self.assertFalse(os.path.exists(os.path.join(results, name)),
+                                 f"stale {name} survived the campaign start")
+            for path in kept:
+                self.assertTrue(os.path.exists(path),
+                                f"the start wiped {os.path.relpath(path, results)}")
 
     def test_the_golden_sub_make_receives_results_and_the_baked_resolver(self):
         block = self.GOLDEN.search(campaign())

--- a/bench/chromium/test_campaign.py
+++ b/bench/chromium/test_campaign.py
@@ -286,6 +286,130 @@ class PartialCorpus(unittest.TestCase):
                       f"a complete corpus was refused\n{result.stderr}")
 
 
+class LocalProbesIgnoreProxies(unittest.TestCase):
+    """The replay probes talk to 127.0.0.1 and nothing else.
+
+    A proxy in the environment (a bench host behind an egress proxy, a shell
+    with http_proxy exported) sends curl to the proxy instead of the replay
+    server unless the URL's host is in no_proxy, and the corpus hosts are not.
+    A working proxy then fetches the LIVE site, so an incomplete replay passes
+    the completeness probe on live status codes; an unreachable proxy rejects a
+    replay that is complete. Neither reads as a proxy problem: the first is a
+    plausible campaign, the second is `BLOCKED: HTTPS replay returned '000'`.
+
+    Both probes run here against a local stub with every proxy variable set to
+    an address nothing listens on (127.0.0.1:9). curl reads http_proxy in lower
+    case only (the CGI convention) and https_proxy in either case; all four are
+    set so the retargeted http:// probe sees what the shipped https:// one
+    would. A control runs the same probe with --noproxy removed and requires it
+    to fail, so a pass cannot come from an environment curl never saw. dig
+    honours no proxy variable and needs nothing.
+
+    Watched red 2026-08-28 against corpus_campaign.sh at 13cb9543; the failure
+    text is quoted on each test.
+    """
+
+    DEAD_PROXY = "http://127.0.0.1:9"
+    READINESS = re.compile(
+        r'(answer=""\ncode=""\nfor _ in \$\(seq 1 100\); do\n.*?\ndone\n'
+        r'\[ "\$answer" = "10\.0\.2\.2" \][^\n]*\n\[ "\$code" = "200" \][^\n]*\n)', re.S)
+
+    def _env(self) -> dict:
+        env = {k: v for k, v in os.environ.items()
+               if k.lower() not in ("http_proxy", "https_proxy", "all_proxy", "no_proxy")}
+        for name in ("http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY"):
+            env[name] = self.DEAD_PROXY
+        return env
+
+    def _stub(self, served: str) -> int:
+        class Stub(PartialCorpus.OnlyOne):
+            pass
+
+        Stub.served = served
+        server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Stub)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        self.addCleanup(server.server_close)
+        self.addCleanup(server.shutdown)
+        return server.server_port
+
+    def _run(self, script: str, env: dict):
+        with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as handle:
+            handle.write(script)
+            path = handle.name
+        self.addCleanup(os.unlink, path)
+        return subprocess.run(["bash", path], env=env, capture_output=True,
+                              text=True, timeout=60)
+
+    def _control(self, script: str, env: dict):
+        """The same probe with --noproxy removed must go to the dead proxy."""
+        stripped = script.replace("--noproxy '*' ", "")
+        control = self._run(stripped, env)
+        self.assertEqual(control.returncode, 3,
+                         "the control probe reached the stub through the proxy "
+                         "environment, so a pass here would prove nothing\n"
+                         + control.stdout + control.stderr)
+        return control
+
+    def test_the_completeness_probe_reaches_the_replay_server_through_a_proxy_environment(self):
+        """Red: exit 3, `BLOCKED: the corpus does not serve every configured
+        URL:` naming `000  http://x/served`."""
+        block = re.search(r"(missing=\"\"\n.*?\nfi)\n", campaign(), re.S)
+        self.assertIsNotNone(block, "the corpus completeness probe is gone")
+        probe = PartialCorpus.retarget(block.group(1), self._stub("/served"))
+        script = f'set -u\nURLS="http://x/served"\n{probe}\necho COMPLETE\n'
+        env = self._env()
+        control = self._control(script, env)
+        self.assertIn("000  http://x/served", control.stderr)
+        result = self._run(script, env)
+        self.assertEqual(result.returncode, 0,
+                         "a complete corpus was refused because curl went to the "
+                         f"proxy instead of 127.0.0.1\n{result.stdout}{result.stderr}")
+        self.assertIn("COMPLETE", result.stdout)
+
+    def test_the_readiness_probe_reaches_the_replay_server_through_a_proxy_environment(self):
+        """Red: exit 3, `BLOCKED: HTTPS replay returned '000' for blog.cloudflare.com`."""
+        block = self.READINESS.search(campaign())
+        self.assertIsNotNone(block, "the replay readiness probe is gone")
+        port = self._stub("/")
+        probe = (block.group(1)
+                 .replace("--resolve 'blog.cloudflare.com:443:127.0.0.1' "
+                          "https://blog.cloudflare.com/",
+                          f"--connect-to 'blog.cloudflare.com:80:127.0.0.1:{port}' "
+                          "http://blog.cloudflare.com/")
+                 .replace("curl -sk", "curl -s")
+                 # The shipped loop polls 100 times at 0.2 s for a server that
+                 # is still binding; the stub is up before the probe starts, so
+                 # two rounds bound the failing case at under a second.
+                 .replace("seq 1 100", "seq 1 2"))
+        for applied in ("--connect-to", "http://blog.cloudflare.com/", "seq 1 2"):
+            self.assertIn(applied, probe, "the retarget did not apply; the probe "
+                                          "would hit 127.0.0.1:443, not the stub")
+        self.assertNotIn("-sk", probe)
+        with tempfile.TemporaryDirectory() as tmp:
+            binx = os.path.join(tmp, "bin")
+            logs = os.path.join(tmp, "logs")
+            os.makedirs(binx)
+            os.makedirs(logs)
+            for name, body in (("dig", "#!/bin/bash\necho 10.0.2.2\n"),
+                               ("sudo", DnsBrackets.FAKE_SUDO)):
+                path = os.path.join(binx, name)
+                with open(path, "w") as handle:
+                    handle.write(body)
+                os.chmod(path, 0o755)
+            open(os.path.join(logs, "corpus_serve.log"), "w").close()
+            env = self._env()
+            env["PATH"] = binx + os.pathsep + env["PATH"]
+            script = (f'set -euo pipefail\nLOGDIR="{logs}"\nSERVE_PID=$$\n'
+                      f'{probe}\necho READY\n')
+            control = self._control(script, env)
+            self.assertIn("returned '000'", control.stderr)
+            result = self._run(script, env)
+            self.assertEqual(result.returncode, 0,
+                             "a replay server that is up was reported down because "
+                             f"curl went to the proxy instead of 127.0.0.1\n{result.stderr}")
+            self.assertIn("READY", result.stdout)
+
+
 class DnsBrackets(unittest.TestCase):
     """Resolver evidence around the measured run: verify on each side, sample between.
 
@@ -566,6 +690,19 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
             with open(env["MAKE_ARGV"]) as handle:
                 self.assertIn("bench-chromium-request-run", handle.read())
 
+    # The rm may continue over backslash-newlines; the block runs whole.
+    START_CLEANUP = re.compile(
+        r'(mkdir -p "\$RESULTS"\n(?:#[^\n]*\n)*rm -f (?:[^\n]*\\\n)*[^\n]*\n)')
+
+    def _run_start_cleanup(self, results: str):
+        """Execute the block after `mkdir -p "$RESULTS"` that clears an
+        earlier campaign's evidence, against a pre-filled RESULTS."""
+        block = self.START_CLEANUP.search(campaign())
+        self.assertIsNotNone(block, "the campaign does not clear stale evidence at start")
+        return subprocess.run(
+            ["bash", "-c", f'set -euo pipefail\nRESULTS="{results}"\n{block.group(1)}'],
+            capture_output=True, text=True, timeout=30)
+
     def test_stale_evidence_from_an_earlier_campaign_is_cleared_at_start(self):
         """An explicit RESULTS can be reused. A clean dns-evidence.json left
         by an earlier campaign, beside a run this campaign never finished,
@@ -574,9 +711,6 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
         RED BEFORE THE FIX: the block after `mkdir -p "$RESULTS"` removed
         nothing.
         """
-        block = re.search(r'(mkdir -p "\$RESULTS"\n(?:#[^\n]*\n)*rm -f [^\n]*\n)',
-                          campaign())
-        self.assertIsNotNone(block, "the campaign does not clear stale evidence at start")
         with tempfile.TemporaryDirectory() as tmp:
             results = os.path.join(tmp, "results")
             os.makedirs(results)
@@ -587,15 +721,34 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
                     handle.write('{"verdict": "clean", "passed": true}\n')
             with open(os.path.join(results, "analysis.json"), "w") as handle:
                 handle.write("{}\n")
-            result = subprocess.run(
-                ["bash", "-c", f'set -euo pipefail\nRESULTS="{results}"\n{block.group(1)}'],
-                capture_output=True, text=True, timeout=30)
+            result = self._run_start_cleanup(results)
             self.assertEqual(result.returncode, 0, result.stderr)
             for name in stale:
                 self.assertFalse(os.path.exists(os.path.join(results, name)),
                                  f"stale {name} survived the campaign start")
             self.assertTrue(os.path.exists(os.path.join(results, "analysis.json")),
                             "the start wiped more than the evidence")
+
+    def test_stale_replay_logs_from_an_earlier_campaign_are_cleared_at_start(self):
+        """corpus_serve opens both replay logs for append (JsonlLog), so a
+        reused RESULTS carries an earlier attempt's queries and requests into
+        the logs this campaign hashes into dns-evidence.json as its own. The
+        server writes them from its first query, so they go with the rest of
+        the stale evidence, before it starts.
+
+        RED BEFORE THE FIX: `stale corpus-dns.log survived the campaign start`.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            results = os.path.join(tmp, "results")
+            os.makedirs(results)
+            for name in self.REPLAY_LOGS:
+                with open(os.path.join(results, name), "w") as handle:
+                    handle.write('{"ts": 0, "peer": "earlier attempt"}\n')
+            result = self._run_start_cleanup(results)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            for name in self.REPLAY_LOGS:
+                self.assertFalse(os.path.exists(os.path.join(results, name)),
+                                 f"stale {name} survived the campaign start")
 
     def test_the_golden_sub_make_receives_results_and_the_baked_resolver(self):
         block = self.GOLDEN.search(campaign())
@@ -795,27 +948,38 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
         the write did; a failed jq or redirect still yielded `clean` and a
         campaign exit of 0 with no evidence on disk.
 
+        The write is failed by a jq or an mv on PATH that exits 1, one per
+        subtest, so both halves of `jq ... >tmp || ! mv tmp out` are covered.
+        The first version made $RESULTS read-only instead, and root writes
+        into a 0o555 directory: under sudo the write succeeded and this test
+        failed with `0 == 0 : a failed evidence write returned 0` (Codex,
+        2026-08-28). A stub on PATH fails the same way for every uid.
+
         RED BEFORE THE FIX: stdout `clean`, exit 0.
         """
-        with tempfile.TemporaryDirectory() as tmp:
-            env, results = self._fakes(tmp)
-            self._leave_files(results)
-            with open(os.path.join(results, "dns-owner.log"), "w") as handle:
-                handle.write("2026-08-28T00:00:00Z owner_pid=4242 dnsmasq=inactive\n")
-            os.chmod(results, 0o555)
-            script = (f'set -u\n{self._helpers()}\nRESULTS="{results}"\n'
-                      'SERVE_PID=4242\nDNSMASQ_WAS_ACTIVE=yes\nSAMPLER_ALIVE_AT_STOP=yes\n'
-                      'write_dns_evidence clean\n')
-            try:
+        for tool in ("jq", "mv"):
+            with self.subTest(tool), tempfile.TemporaryDirectory() as tmp:
+                env, results = self._fakes(tmp)
+                self._leave_files(results)
+                with open(os.path.join(results, "dns-owner.log"), "w") as handle:
+                    handle.write("2026-08-28T00:00:00Z owner_pid=4242 dnsmasq=inactive\n")
+                stub = os.path.join(tmp, "bin", tool)
+                with open(stub, "w") as handle:
+                    handle.write("#!/bin/bash\nexit 1\n")
+                os.chmod(stub, 0o755)
+                script = (f'set -u\n{self._helpers()}\nRESULTS="{results}"\n'
+                          'SERVE_PID=4242\nDNSMASQ_WAS_ACTIVE=yes\nSAMPLER_ALIVE_AT_STOP=yes\n'
+                          'write_dns_evidence clean\n')
                 result = self._run(script, env)
-            finally:
-                os.chmod(results, 0o755)
-            self.assertNotEqual(result.returncode, 0, "a failed evidence write returned 0")
-            self.assertEqual(result.stdout.strip(), "unclean")
-            self.assertEqual(sorted(os.listdir(results)),
-                             sorted(["dns-owner.log", "corpus-dns.log", "corpus-access.log"]
-                                    + [f"verify-dns-{s}.json" for s in self.BRACKETS]),
-                             "a partial evidence file or temp file was left behind")
+                self.assertNotEqual(result.returncode, 0,
+                                    f"a failed {tool} in the evidence write returned 0")
+                self.assertEqual(result.stdout.strip(), "unclean")
+                self.assertIn("cannot write", result.stderr,
+                              f"the failed {tool} was not what made the verdict unclean")
+                self.assertEqual(sorted(os.listdir(results)),
+                                 sorted(["dns-owner.log", "corpus-dns.log", "corpus-access.log"]
+                                        + [f"verify-dns-{s}.json" for s in self.BRACKETS]),
+                                 "a partial evidence file or temp file was left behind")
 
     def test_a_bracket_failure_cannot_be_lifted_by_clean_samples(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/bench/chromium/test_campaign.py
+++ b/bench/chromium/test_campaign.py
@@ -42,6 +42,13 @@ def campaign() -> str:
         return handle.read()
 
 
+def read_if_exists(path, default=""):
+    if not os.path.exists(path):
+        return default
+    with open(path) as handle:
+        return handle.read()
+
+
 class RunPackaging(unittest.TestCase):
     """One run, one directory, one stamp -- decided once."""
 
@@ -483,6 +490,7 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
             "hosts": {h: {"answer": "10.0.2.2", "ok": True}
                       for h in self._hosts_of(corpus_urls)},
             "urls": {u: {"status": 200, "ok": True} for u in corpus_urls.split(",")},
+            "proxies_disabled": True,
             "timestamp": "2026-08-28T00:00:00Z",
             "passed": True,
         }
@@ -624,6 +632,11 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
             "a host never asked": json.dumps(partial),
             "a url that failed": self._bracket_evidence(
                 urls, urls={u: {"status": 404, "ok": False} for u in urls.split(",")}),
+            # HOP D's URL probe records that it ran with proxies disabled;
+            # a bracket that does not say so may have fetched through the
+            # proxy fc-agent injects into the exec, live site and all.
+            "proxies not disabled": self._bracket_evidence(urls, proxies_disabled=False),
+            "proxy handling unrecorded": self._bracket_evidence(urls, proxies_disabled=None),
         }
         for label, evidence in cases.items():
             with self.subTest(label), tempfile.TemporaryDirectory() as tmp:
@@ -725,7 +738,7 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
             results = os.path.join(tmp, "results")
             os.makedirs(results)
             stale = ["dns-evidence.json", "verify-dns-after-run.json",
-                     "verify-dns.json", "dns-owner.log"]
+                     "verify-dns.json", "dns-owner.log", "corpus-serve.status"]
             for name in stale:
                 with open(os.path.join(results, name), "w") as handle:
                     handle.write('{"verdict": "clean", "passed": true}\n')
@@ -857,14 +870,19 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
     REPLAY_LOGS = ("corpus-dns.log", "corpus-access.log")
 
     def _leave_files(self, results, brackets=BRACKETS, logs=REPLAY_LOGS,
-                     bracket_passed=True):
-        """What the campaign leaves in $RESULTS before write_dns_evidence."""
+                     bracket_passed=True, serve_status="0"):
+        """What the campaign leaves in $RESULTS before write_dns_evidence:
+        the bracket files, the replay logs and corpus-serve.status, the exit
+        status the server's wrapper writes once it is gone (None: no file)."""
         for stage in brackets:
             with open(os.path.join(results, f"verify-dns-{stage}.json"), "w") as handle:
                 handle.write(json.dumps({"passed": bracket_passed}) + "\n")
         for name in logs:
             with open(os.path.join(results, name), "w") as handle:
                 handle.write(name + "\n")
+        if serve_status is not None:
+            with open(os.path.join(results, "corpus-serve.status"), "w") as handle:
+                handle.write(serve_status + "\n")
 
     def _sample(self, env, results, verdict_in="clean", seconds=0.6, mid_run="",
                 files=True):
@@ -1025,7 +1043,8 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
                 self.assertIn("cannot write", result.stderr,
                               f"the failed {tool} was not what made the verdict unclean")
                 self.assertEqual(sorted(os.listdir(results)),
-                                 sorted(["dns-owner.log", "corpus-dns.log", "corpus-access.log"]
+                                 sorted(["dns-owner.log", "corpus-dns.log", "corpus-access.log",
+                                         "corpus-serve.status"]
                                         + [f"verify-dns-{s}.json" for s in self.BRACKETS]),
                                  "a partial evidence file or temp file was left behind")
 
@@ -1152,6 +1171,148 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
             self.assertEqual(evidence["verdict"], "unclean")
             self.assertEqual(evidence["samples"], 0)
             self.assertIs(evidence["dnsmasq_was_active_before"], False)
+
+    def test_a_replay_server_that_did_not_exit_zero_is_unclean(self):
+        """corpus_serve exits 1 when a log line could not be written, after
+        the response bytes were already sent (007b726d, 181fcbbb). Its exit
+        status was discarded by `sudo -b`: stop_corpus_serve polled liveness
+        only, and the evidence hashed the truncated log as clean. The wrapper
+        now writes the status to $RESULTS/corpus-serve.status once the server
+        is gone, and a clean verdict needs that file to say 0; a missing or
+        non-zero status is unclean with the reason, and the evidence carries
+        it as corpus_serve_exit_status.
+
+        RED BEFORE THE FIX: verdict clean with corpus-serve.status holding 1,
+        clean with no status file, and KeyError: 'corpus_serve_exit_status'.
+        """
+        cases = {"1": 1, "137": 137, None: None}
+        for status, recorded in cases.items():
+            with self.subTest(status=status), tempfile.TemporaryDirectory() as tmp:
+                env, results = self._fakes(tmp)
+                self._leave_files(results, serve_status=status)
+                script = (f'set -u\n{self._helpers()}\nRESULTS="{results}"\n'
+                          'SERVE_PID=4242\nDNSMASQ_WAS_ACTIVE=yes\nSAMPLER_ALIVE_AT_STOP=yes\n'
+                          'printf "%s owner_pid=4242 dnsmasq=inactive load1=0.42\\n" '
+                          '2026-08-28T00:00:00Z 2026-08-28T00:00:10Z > "$RESULTS/dns-owner.log"\n'
+                          'write_dns_evidence clean\n')
+                result = self._run(script, env)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout.strip(), "unclean",
+                                 f"corpus_serve exit status {status!r} was hashed as clean")
+                with open(os.path.join(results, "dns-evidence.json")) as handle:
+                    evidence = json.load(handle)
+                self.assertEqual(evidence["verdict"], "unclean", evidence)
+                self.assertEqual(evidence["corpus_serve_exit_status"], recorded)
+                self.assertIn("corpus_serve", evidence["reason"])
+                if status is not None:
+                    self.assertIn(status, evidence["reason"])
+                else:
+                    self.assertIn("corpus-serve.status", evidence["reason"])
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            evidence, _ = self._sample(env, results)
+            self.assertEqual(evidence["verdict"], "clean", evidence)
+            self.assertEqual(evidence["corpus_serve_exit_status"], 0)
+
+    STOP_SERVE = re.compile(r"(stop_corpus_serve\(\) \{\n.*?\n\}\n)", re.S)
+    # The launch: the pidfile name through the liveness check on the pid it
+    # published. The readiness probes that follow need the real server.
+    START_SERVE = re.compile(
+        r'(SERVE_PIDFILE="\$LOGDIR/corpus_serve\.pid"\n.*?\n'
+        r'sudo kill -0 "\$SERVE_PID" 2>/dev/null \|\| \{ echo "BLOCKED: corpus_serve pid[^\n]*\n)',
+        re.S)
+    # Stands in for corpus_serve.py under the shipped launch line: the same
+    # startup line, its own pid where the test can read it, and on SIGTERM
+    # the exit status the test chose, as the real server exits 1 after a
+    # log line it could not write.
+    FAKE_SERVE = """import os, signal, sys, time
+signal.signal(signal.SIGTERM,
+              lambda *_: sys.exit(int(os.environ.get("FAKE_SERVE_EXIT", "0"))))
+print("loaded 3 urls", flush=True)
+with open(os.environ["FAKE_SERVE_PIDOUT"], "w") as handle:
+    handle.write(f"{os.getpid()}\\n")
+while True:
+    time.sleep(0.05)
+"""
+    FAKE_SUDO_B = ('#!/bin/bash\n[ "${1:-}" = -n ] && shift\n'
+                   'if [ "${1:-}" = -b ]; then shift; "$@" & exit 0; fi\nexec "$@"\n')
+
+    def _serve_harness(self, tmp, exit_status):
+        env, results = self._fakes(tmp)
+        for name, body in (("sudo", self.FAKE_SUDO_B),):
+            path = os.path.join(tmp, "bin", name)
+            with open(path, "w") as handle:
+                handle.write(body)
+            os.chmod(path, 0o755)
+        serve_dir = os.path.join(tmp, "bench", "chromium")
+        os.makedirs(serve_dir)
+        with open(os.path.join(serve_dir, "corpus_serve.py"), "w") as handle:
+            handle.write(self.FAKE_SERVE)
+        env.update(FAKE_SERVE_EXIT=str(exit_status),
+                   FAKE_SERVE_PIDOUT=os.path.join(tmp, "serve-pid"))
+        start = self.START_SERVE.search(campaign())
+        self.assertIsNotNone(start, "the corpus_serve launch block is gone")
+        stop = self.STOP_SERVE.search(campaign())
+        self.assertIsNotNone(stop, "stop_corpus_serve is gone")
+        # One owner sample naming the server that was started, and a live
+        # sampler and inactive dnsmasq, so the exit status is the only thing
+        # that can lower the verdict. The stop waits for the stand-in to have
+        # installed its handler (it writes its pid after), as the campaign's
+        # readiness probes do for the real server.
+        script = (f'set -euo pipefail\nsay() {{ :; }}\n{self._helpers()}\n'
+                  f'SERVE_PID=""\n{stop.group(1)}\n{start.group(1)}\n'
+                  'echo "started $SERVE_PID"\n'
+                  'for _ in $(seq 1 100); do [ -s "$FAKE_SERVE_PIDOUT" ] && break; sleep 0.05; done\n'
+                  'printf "%s owner_pid=%s dnsmasq=inactive load1=0.42\\n" '
+                  '2026-08-28T00:00:00Z "$SERVE_PID" > "$RESULTS/dns-owner.log"\n'
+                  'SAMPLER_ALIVE_AT_STOP=yes\nDNSMASQ_WAS_ACTIVE=yes\n'
+                  'stop_corpus_serve\necho "stopped $SERVE_PID"\n'
+                  'write_dns_evidence clean\n')
+        return env, results, script
+
+    def test_the_replay_server_exit_status_is_recorded_when_it_stops(self):
+        """The shipped launch line and stop_corpus_serve, run against a
+        stand-in server under a sudo that honours -b. The pidfile must name
+        the server itself (the sampler matches that pid against the owner of
+        127.0.0.1:53), the stop must wait for the status the wrapper writes
+        once the server is gone, and the evidence must carry it: 3 is
+        unclean with the reason, 0 is clean.
+
+        RED BEFORE THE FIX: no corpus-serve.status was written at all, so
+        `MISSING != '3'`, and write_dns_evidence printed clean over it.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results, script = self._serve_harness(tmp, 3)
+            self._leave_files(results, serve_status=None)
+            result = self._run(script, env, timeout=120)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            with open(os.path.join(tmp, "logs", "corpus_serve.pid")) as handle:
+                published = handle.read().strip()
+            with open(env["FAKE_SERVE_PIDOUT"]) as handle:
+                self.assertEqual(published, handle.read().strip(),
+                                 "the pidfile names the wrapper, not the server")
+            self.assertIn(f"started {published}", result.stdout)
+            status_path = os.path.join(results, "corpus-serve.status")
+            self.assertEqual(read_if_exists(status_path, "MISSING").strip(), "3",
+                             "the server's exit status was not recorded when it stopped")
+            self.assertEqual(result.stdout.strip().splitlines()[-1], "unclean")
+            with open(os.path.join(results, "dns-evidence.json")) as handle:
+                evidence = json.load(handle)
+            self.assertEqual(evidence["verdict"], "unclean", evidence)
+            self.assertEqual(evidence["corpus_serve_exit_status"], 3)
+            self.assertIn("corpus_serve", evidence["reason"])
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results, script = self._serve_harness(tmp, 0)
+            self._leave_files(results, serve_status=None)
+            result = self._run(script, env, timeout=120)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(read_if_exists(
+                os.path.join(results, "corpus-serve.status"), "MISSING").strip(), "0")
+            self.assertEqual(result.stdout.strip().splitlines()[-1], "clean")
+            with open(os.path.join(results, "dns-evidence.json")) as handle:
+                evidence = json.load(handle)
+            self.assertEqual(evidence["verdict"], "clean", evidence)
+            self.assertEqual(evidence["corpus_serve_exit_status"], 0)
 
     def test_the_replay_server_logs_into_the_run_directory(self):
         """corpus_serve's DNS and access logs are the other half of the

--- a/bench/chromium/test_campaign_summary.py
+++ b/bench/chromium/test_campaign_summary.py
@@ -556,6 +556,33 @@ class CampaignSummary(unittest.TestCase):
             self.assertFalse(os.path.exists(out), "the stale index survived")
             self.assertIn("removed", text)
 
+    def test_dns_evidence_that_is_not_a_json_object_refuses(self):
+        """A dns-evidence.json holding valid JSON that is not an object ([]
+        here) was read as a missing verdict by the inline guard on the
+        verdict line, so the refusal said `verdict is None, not 'clean'`
+        about a file that has no verdict field at all, and every .get()
+        after that line relied on the same guard. Non-object evidence is now
+        rejected first, by name.
+
+        RED BEFORE THE FIX: AssertionError: 'dns-evidence.json is not a JSON
+        object' not found in "REFUSED: no index written\n  - .../run:
+        dns-evidence.json verdict is None, not 'clean'\n  removed stale index
+        .../campaign-x-summary.json\n"
+        """
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            paths = write_run(run_dir)
+            out = os.path.join(d, "campaign-x-summary.json")
+            rc, text = self._summarize(out, [run_dir])
+            self.assertEqual(rc, 0, text)
+            with open(paths["dns_evidence"], "w") as handle:
+                handle.write("[]\n")
+            rc, text = self._summarize(out, [run_dir])
+            self.assertNotEqual(rc, 0, text)
+            self.assertFalse(os.path.exists(out), "the stale index survived")
+            self.assertIn(run_dir, text)
+            self.assertIn("dns-evidence.json is not a JSON object", text)
+
     def test_the_index_cannot_alias_an_input(self):
         with tempfile.TemporaryDirectory() as d:
             run_dir = os.path.join(d, "run")

--- a/bench/chromium/test_campaign_summary.py
+++ b/bench/chromium/test_campaign_summary.py
@@ -47,6 +47,12 @@ class EvidenceIgnoreRules(unittest.TestCase):
     `results/run-x/verify-dns-pre.json is ignored and would be lost on the
     next wipe` (three subtests) and the literal `!results/**/verify-dns-*.json`
     was absent.
+
+    RED BEFORE THE THIRD FIX: campaign_summary requires corpus-dns.log and
+    corpus-access.log beside dns-evidence.json and verifies their sha256
+    before indexing a run, but both matched `results/**`, so
+    `results/run-x/corpus-dns.log is ignored and would be lost on the next
+    wipe` (two subtests) and the two literal negations were absent.
     """
 
     IGNORE = os.path.join(HERE, ".gitignore")
@@ -56,6 +62,8 @@ class EvidenceIgnoreRules(unittest.TestCase):
         "!results/**/dns-evidence.json",
         "!results/**/diag/summary.json",
         "!results/**/dns-owner.log",
+        "!results/**/corpus-dns.log",
+        "!results/**/corpus-access.log",
         "!results/**/campaign-*-summary.json",
         "!results/**/WITHDRAWN",
     )
@@ -67,6 +75,8 @@ class EvidenceIgnoreRules(unittest.TestCase):
         "results/run-x/dns-evidence.json",
         "results/run-x/diag/summary.json",
         "results/run-x/dns-owner.log",
+        "results/run-x/corpus-dns.log",
+        "results/run-x/corpus-access.log",
         "results/campaign-x-summary.json",
         "results/campaign-x/campaign-x-summary.json",
         "results/run-x/WITHDRAWN",

--- a/bench/chromium/test_campaign_summary.py
+++ b/bench/chromium/test_campaign_summary.py
@@ -154,6 +154,7 @@ def write_run(
     stall_max_ms=15000,
     stall_evaluated=404,
     samples=12,
+    load_max_1min=0.42,
     evidence_overrides=None,
     cell_overrides=None,
     analysis_overrides=None,
@@ -167,6 +168,9 @@ def write_run(
     names three passing verify brackets, an owner log with `samples` lines
     and the two replay logs with their real sha256, the way
     corpus_campaign.sh writes them; evidence_overrides rewrites fields on top.
+    load_max_1min is the 1-min load the campaign's sampler recorded, carried
+    on every owner line and reported in the evidence; None writes an owner
+    log and evidence from before the sampler recorded it.
     The cell carries SEAL; cell_overrides rewrites cell fields (a None value
     removes the field) and analysis_overrides rewrites top-level fields.
     withdrawn=<reason> writes a WITHDRAWN marker whose first line is the
@@ -232,9 +236,11 @@ def write_run(
             paths[name] = log_path
             hashes[name] = sha256_file(log_path)
         owner_log = os.path.join(run_dir, "dns-owner.log")
+        load_column = "" if load_max_1min is None else f" load1={load_max_1min}"
         with open(owner_log, "w") as handle:
             handle.write(
-                "2026-08-28T00:00:00Z owner_pid=4242 dnsmasq=inactive\n" * samples
+                f"2026-08-28T00:00:00Z owner_pid=4242 dnsmasq=inactive{load_column}\n"
+                * samples
             )
         paths["owner_log"] = owner_log
         evidence = {
@@ -253,6 +259,9 @@ def write_run(
             "reason": None,
             "verdict": dns_verdict,
         }
+        if load_max_1min is not None:
+            evidence["load_max_1min"] = load_max_1min
+            evidence["load_samples"] = samples
         evidence.update(evidence_overrides or {})
         paths["dns_evidence"] = os.path.join(run_dir, "dns-evidence.json")
         with open(paths["dns_evidence"], "w") as handle:
@@ -406,6 +415,34 @@ class CampaignSummary(unittest.TestCase):
         self.assertIsNone(cell["dns_verdict"])
         self.assertIsNone(cell["guest_dns"])
         self.assertIsNone(cell["diag"])
+
+    def test_the_maximum_load_is_carried_into_the_cell(self):
+        """The campaign samples the 1-min load through the measured run and
+        dns-evidence.json reports the maximum as load_max_1min; the index
+        carries it so a reader sees it beside the numbers without opening
+        the run. Evidence from before the sampler recorded it indexes with
+        null.
+
+        RED BEFORE THE FIX: KeyError: 'load_max_1min'.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            write_run(run_dir, load_max_1min=1.87)
+            out = os.path.join(d, "campaign-x-summary.json")
+            rc, text = self._summarize(out, [run_dir])
+            self.assertEqual(rc, 0, text)
+            with open(out) as handle:
+                index = json.load(handle)
+        self.assertEqual(index["cells"][0]["load_max_1min"], 1.87)
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            write_run(run_dir, load_max_1min=None)
+            out = os.path.join(d, "campaign-x-summary.json")
+            rc, text = self._summarize(out, [run_dir])
+            self.assertEqual(rc, 0, text)
+            with open(out) as handle:
+                index = json.load(handle)
+        self.assertIsNone(index["cells"][0]["load_max_1min"])
 
     def test_an_armed_gate_that_evaluated_nothing_refuses(self):
         """max_ms alone is not proof the gate looked at anything.

--- a/bench/chromium/test_campaign_summary.py
+++ b/bench/chromium/test_campaign_summary.py
@@ -26,6 +26,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import unittest.mock
 from contextlib import redirect_stderr, redirect_stdout
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -780,6 +781,60 @@ class CampaignSummary(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             _paths, text = self._refused(d, analysis_overrides={"withdrawn": True})
             self.assertIn("withdrawn", text)
+
+    def test_one_run_listed_under_two_names_refuses(self):
+        """`seen` held the argument strings, so `results/run` and a symlink
+        to it were loaded as two cells and one experiment was counted twice
+        in the campaign. A second name for a run already listed is refused,
+        naming both paths, rather than quietly deduped: the caller passed an
+        argument list they did not mean, and an index that hid it would be
+        quoted by someone who never saw the argument list.
+
+        RED BEFORE THE FIX: rc 0 and 2 cells, both from one run directory.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            write_run(run_dir)
+            alias = os.path.join(d, "alias")
+            os.symlink(run_dir, alias)
+            out = os.path.join(d, "index.json")
+            rc, text = self._summarize(out, [run_dir, alias])
+            self.assertNotEqual(rc, 0, text)
+            self.assertFalse(os.path.exists(out),
+                             "an index was written over a double-counted run")
+            self.assertIn(alias, text)
+            self.assertIn(run_dir, text)
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            write_run(run_dir)
+            out = os.path.join(d, "index.json")
+            rc, text = self._summarize(out, [run_dir, run_dir])
+            self.assertNotEqual(rc, 0, text)
+            self.assertIn("more than once", text)
+            self.assertFalse(os.path.exists(out))
+
+    def test_one_run_reached_by_two_paths_refuses_on_its_inode(self):
+        """A bind mount, unlike a symlink, gives the same directory two
+        canonical paths, so the path key alone would let it through. The
+        directory identity the filesystem reports (st_dev, st_ino) is the
+        second key. Bind-mounting needs root, so the shape is reproduced by
+        holding os.path.realpath to the identity function, which is what a
+        bind mount does to these two paths.
+
+        RED BEFORE THE FIX: rc 0 and 2 cells, both from one run directory.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            write_run(run_dir)
+            alias = os.path.join(d, "alias")
+            os.symlink(run_dir, alias)
+            out = os.path.join(d, "index.json")
+            with unittest.mock.patch("os.path.realpath", side_effect=lambda p: p):
+                rc, text = self._summarize(out, [run_dir, alias])
+            self.assertNotEqual(rc, 0, text)
+            self.assertFalse(os.path.exists(out))
+            self.assertIn(alias, text)
+            self.assertIn(run_dir, text)
 
     def test_the_index_cannot_alias_an_input(self):
         with tempfile.TemporaryDirectory() as d:

--- a/bench/chromium/test_campaign_summary.py
+++ b/bench/chromium/test_campaign_summary.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""campaign_summary.py and the evidence ignore rules, pinned.
+
+campaign_summary.py indexes the cells of one campaign. It reads, never
+writes, each run directory, and it writes the index only when every run is
+publishable and every DNS verdict is clean: an index that quietly carried an
+unpublishable cell would be quoted by someone who only opened the index.
+
+The ignore rules matter for the reason the 2026-08-15 instance-store wipe
+taught: the evidence files that back a claim (verify-dns.json,
+dns-evidence.json, diag/summary.json, dns-owner.log, campaign-*-summary.json)
+have to show up in `git status` so they get committed, while raw run output
+stays ignored.
+
+Every test here was watched red before the matching change; the failure each
+produced is quoted in its docstring.
+
+Run: python3 -m unittest test_campaign_summary -v
+"""
+
+import hashlib
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+import campaign_summary  # noqa: E402
+
+
+class EvidenceIgnoreRules(unittest.TestCase):
+    """Evidence files are negated out of the results ignore; raw output is not.
+
+    RED BEFORE THE FIX: verify-dns.json, dns-evidence.json and dns-owner.log
+    were ignored by `results/**` (git check-ignore exit 0), and the literal
+    negations for them were absent from bench/chromium/.gitignore.
+    """
+
+    IGNORE = os.path.join(HERE, ".gitignore")
+    NEGATIONS = (
+        "!results/**/verify-dns.json",
+        "!results/**/dns-evidence.json",
+        "!results/**/diag/summary.json",
+        "!results/**/dns-owner.log",
+        "!results/**/campaign-*-summary.json",
+    )
+    EVIDENCE = (
+        "results/run-x/verify-dns.json",
+        "results/run-x/dns-evidence.json",
+        "results/run-x/diag/summary.json",
+        "results/run-x/dns-owner.log",
+        "results/campaign-x-summary.json",
+        "results/campaign-x/campaign-x-summary.json",
+    )
+    RAW = (
+        "results/run-x/reqbench.jsonl",
+        "results/run-x/requests/0.json",
+        "results/run-x/raw.json",
+        "results/run-x/report.md",
+    )
+
+    def _ignored(self, relative):
+        result = subprocess.run(
+            ["git", "-C", HERE, "check-ignore", "-q", "--no-index", relative],
+            capture_output=True, text=True, timeout=30,
+        )
+        # 0 = ignored, 1 = not ignored; anything else means git could not
+        # evaluate the rules, which must block rather than pass.
+        self.assertIn(
+            result.returncode, (0, 1),
+            f"git check-ignore could not evaluate {relative}: {result.stderr}",
+        )
+        return result.returncode == 0
+
+    def test_the_negations_are_written_down(self):
+        with open(self.IGNORE) as handle:
+            lines = [line.strip() for line in handle]
+        for negation in self.NEGATIONS:
+            self.assertIn(negation, lines, f"{self.IGNORE} lacks {negation}")
+
+    def test_git_does_not_ignore_the_evidence_files(self):
+        for relative in self.EVIDENCE:
+            with self.subTest(path=relative):
+                self.assertFalse(
+                    self._ignored(relative),
+                    f"{relative} is ignored and would be lost on the next wipe",
+                )
+
+    def test_git_still_ignores_raw_run_output(self):
+        for relative in self.RAW:
+            with self.subTest(path=relative):
+                self.assertTrue(self._ignored(relative), f"{relative} is not ignored")
+
+
+def write_run(
+    run_dir,
+    *,
+    publishable=True,
+    stall_passed=True,
+    dns_verdict="clean",
+    diag=None,
+    guest_dns="10.0.2.2",
+    engine="chromium",
+):
+    """A minimal run directory shaped like reqanalyze + the campaign evidence.
+
+    dns_verdict=None omits dns-evidence.json; diag=None omits diag/summary.json.
+    """
+    os.makedirs(run_dir, exist_ok=True)
+    analysis = {
+        "publishable": publishable,
+        "gate": {"passed": publishable, "reasons": [] if publishable else ["x"]},
+        "run_id": "0" * 32,
+        "backend": "uffd",
+        "cell": {
+            "backend": "uffd",
+            "uffd_mode": "minor",
+            "engine": engine,
+            "cpu": 2,
+            "memory_mib": 1024,
+            "guest_dns": guest_dns,
+            "url": "https://example.com/",
+        },
+        "arms": {
+            "cdp": {
+                "blocking_ms": {"median": 647.2, "lo": 567.6, "hi": 702.9, "n": 202},
+                "wall_ms": {"median": 700.0, "lo": 600.0, "hi": 800.0, "n": 202},
+            },
+            "noop": {
+                "blocking_ms": {"median": 41.1, "lo": 40.0, "hi": 42.5, "n": 202},
+            },
+        },
+        "stall_gate": {"max_ms": 15000, "passed": stall_passed, "violations": []},
+    }
+    paths = {"analysis": os.path.join(run_dir, "analysis.json")}
+    with open(paths["analysis"], "w") as handle:
+        json.dump(analysis, handle)
+    if dns_verdict is not None:
+        paths["dns_evidence"] = os.path.join(run_dir, "dns-evidence.json")
+        with open(paths["dns_evidence"], "w") as handle:
+            json.dump({"verdict": dns_verdict, "queries": 14}, handle)
+    if diag is not None:
+        os.makedirs(os.path.join(run_dir, "diag"), exist_ok=True)
+        paths["diag"] = os.path.join(run_dir, "diag", "summary.json")
+        with open(paths["diag"], "w") as handle:
+            json.dump(diag, handle)
+    return paths
+
+
+def sha256_file(path):
+    with open(path, "rb") as handle:
+        return hashlib.sha256(handle.read()).hexdigest()
+
+
+def tree_digest(root):
+    digests = {}
+    for directory, _dirs, files in os.walk(root):
+        for name in files:
+            path = os.path.join(directory, name)
+            digests[os.path.relpath(path, root)] = sha256_file(path)
+    return digests
+
+
+class CampaignSummary(unittest.TestCase):
+    """One index per campaign, written only when every cell can be quoted.
+
+    RED BEFORE THE FIX: ModuleNotFoundError: No module named 'campaign_summary'.
+    """
+
+    def _summarize(self, out, run_dirs):
+        stdout, stderr = io.StringIO(), io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            rc = campaign_summary.main_with(["--out", out] + list(run_dirs))
+        return rc, stdout.getvalue() + stderr.getvalue()
+
+    def test_one_clean_run_is_indexed(self):
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "reqbench-20260828-000000-corpus")
+            paths = write_run(run_dir, diag={"dns_owner": "corpus_serve", "stalls": 0})
+            out_dir = os.path.join(d, "index")
+            os.makedirs(out_dir)
+            out = os.path.join(out_dir, "campaign-20260828-summary.json")
+            before = tree_digest(run_dir)
+            rc, text = self._summarize(out, [run_dir])
+            self.assertEqual(rc, 0, text)
+            self.assertEqual(os.listdir(out_dir), [os.path.basename(out)])
+            self.assertEqual(tree_digest(run_dir), before, "inputs were modified")
+            with open(out) as handle:
+                index = json.load(handle)
+            self.assertEqual(
+                {entry["path"] for entry in index["generated_from"]},
+                set(paths.values()),
+            )
+            for entry in index["generated_from"]:
+                self.assertEqual(entry["sha256"], sha256_file(entry["path"]))
+        self.assertEqual(len(index["cells"]), 1)
+        cell = index["cells"][0]
+        self.assertEqual(cell["run_dir"], run_dir)
+        self.assertEqual(cell["engine"], "chromium")
+        self.assertEqual(cell["cpu"], 2)
+        self.assertEqual(cell["memory_mib"], 1024)
+        self.assertEqual(cell["guest_dns"], "10.0.2.2")
+        self.assertIs(cell["publishable"], True)
+        self.assertIs(cell["stall_gate_passed"], True)
+        self.assertEqual(cell["dns_verdict"], "clean")
+        self.assertEqual(cell["headline"]["cdp"]["blocking_ms"], 647.2)
+        self.assertEqual(cell["headline"]["cdp"]["blocking_ms_ci"], [567.6, 702.9])
+        self.assertEqual(cell["headline"]["cdp"]["n"], 202)
+        self.assertEqual(cell["headline"]["noop"]["blocking_ms"], 41.1)
+        self.assertEqual(cell["diag"], {"dns_owner": "corpus_serve", "stalls": 0})
+
+    def test_an_unclean_dns_verdict_refuses_and_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as d:
+            clean = os.path.join(d, "clean")
+            tainted = os.path.join(d, "tainted")
+            write_run(clean)
+            write_run(tainted, dns_verdict="contaminated")
+            out_dir = os.path.join(d, "index")
+            os.makedirs(out_dir)
+            out = os.path.join(out_dir, "campaign-x-summary.json")
+            before = tree_digest(d)
+            rc, text = self._summarize(out, [clean, tainted])
+            self.assertNotEqual(rc, 0)
+            self.assertEqual(os.listdir(out_dir), [], "the index was written anyway")
+            self.assertIn("tainted", text)
+            self.assertIn("contaminated", text)
+            self.assertEqual(tree_digest(d), before, "inputs were modified")
+
+    def test_an_unpublishable_analysis_refuses_and_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            write_run(run_dir, publishable=False)
+            out = os.path.join(d, "campaign-x-summary.json")
+            rc, text = self._summarize(out, [run_dir])
+            self.assertNotEqual(rc, 0)
+            self.assertFalse(os.path.exists(out))
+            self.assertIn("publishable", text)
+
+    def test_a_failed_stall_gate_refuses_even_if_marked_publishable(self):
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            write_run(run_dir, stall_passed=False)
+            out = os.path.join(d, "campaign-x-summary.json")
+            rc, text = self._summarize(out, [run_dir])
+            self.assertNotEqual(rc, 0)
+            self.assertFalse(os.path.exists(out))
+            self.assertIn("stall_gate", text)
+
+    def test_a_missing_analysis_refuses(self):
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            os.makedirs(run_dir)
+            out = os.path.join(d, "campaign-x-summary.json")
+            rc, text = self._summarize(out, [run_dir])
+            self.assertNotEqual(rc, 0)
+            self.assertFalse(os.path.exists(out))
+            self.assertIn("analysis.json", text)
+
+    def test_absent_dns_evidence_is_recorded_as_null(self):
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            write_run(run_dir, dns_verdict=None, guest_dns=None)
+            out = os.path.join(d, "campaign-x-summary.json")
+            rc, text = self._summarize(out, [run_dir])
+            self.assertEqual(rc, 0, text)
+            with open(out) as handle:
+                index = json.load(handle)
+        cell = index["cells"][0]
+        self.assertIsNone(cell["dns_verdict"])
+        self.assertIsNone(cell["guest_dns"])
+        self.assertIsNone(cell["diag"])
+
+    def test_the_index_cannot_alias_an_input(self):
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            paths = write_run(run_dir)
+            before = sha256_file(paths["analysis"])
+            rc, text = self._summarize(paths["analysis"], [run_dir])
+            self.assertNotEqual(rc, 0)
+            self.assertEqual(sha256_file(paths["analysis"]), before)
+
+    def test_the_cli_entry_point(self):
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            write_run(run_dir)
+            out = os.path.join(d, "campaign-x-summary.json")
+            result = subprocess.run(
+                [
+                    sys.executable, os.path.join(HERE, "campaign_summary.py"),
+                    "--out", out, run_dir,
+                ],
+                capture_output=True, text=True, timeout=60,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            with open(out) as handle:
+                index = json.load(handle)
+        self.assertEqual(index["cells"][0]["run_dir"], run_dir)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/chromium/test_campaign_summary.py
+++ b/bench/chromium/test_campaign_summary.py
@@ -118,10 +118,14 @@ def write_run(
     diag=None,
     guest_dns="10.0.2.2",
     engine="chromium",
+    stall_max_ms=15000,
+    stall_evaluated=404,
 ):
     """A minimal run directory shaped like reqanalyze + the campaign evidence.
 
     dns_verdict=None omits dns-evidence.json; diag=None omits diag/summary.json.
+    stall_max_ms=None is what reqanalyze writes when it ran without
+    --stall-max-ms (passed true, evaluated 0).
     """
     os.makedirs(run_dir, exist_ok=True)
     analysis = {
@@ -147,7 +151,12 @@ def write_run(
                 "blocking_ms": {"median": 41.1, "lo": 40.0, "hi": 42.5, "n": 202},
             },
         },
-        "stall_gate": {"max_ms": 15000, "passed": stall_passed, "violations": []},
+        "stall_gate": {
+            "max_ms": stall_max_ms,
+            "passed": stall_passed,
+            "evaluated": stall_evaluated,
+            "violations": [],
+        },
     }
     paths = {"analysis": os.path.join(run_dir, "analysis.json")}
     with open(paths["analysis"], "w") as handle:
@@ -262,6 +271,24 @@ class CampaignSummary(unittest.TestCase):
             self.assertNotEqual(rc, 0)
             self.assertFalse(os.path.exists(out))
             self.assertIn("stall_gate", text)
+
+    def test_an_unarmed_stall_gate_refuses(self):
+        """reqbench.sh runs reqanalyze without --stall-max-ms, and the
+        analyzer then writes stall_gate {max_ms: null, passed: true,
+        evaluated: 0}. A pass from a gate that evaluated nothing is not a
+        pass; the index must refuse it rather than print stall_gate_passed.
+
+        RED BEFORE THE FIX: AssertionError: 0 == 0 : wrote .../campaign-x-summary.json: 1 cell(s)
+        """
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            write_run(run_dir, stall_max_ms=None, stall_evaluated=0)
+            out = os.path.join(d, "campaign-x-summary.json")
+            rc, text = self._summarize(out, [run_dir])
+            self.assertNotEqual(rc, 0, text)
+            self.assertFalse(os.path.exists(out))
+            self.assertIn("stall_gate", text)
+            self.assertIn("--stall-max-ms", text)
 
     def test_a_missing_analysis_refuses(self):
         with tempfile.TemporaryDirectory() as d:

--- a/bench/chromium/test_campaign_summary.py
+++ b/bench/chromium/test_campaign_summary.py
@@ -109,6 +109,24 @@ class EvidenceIgnoreRules(unittest.TestCase):
                 self.assertTrue(self._ignored(relative), f"{relative} is not ignored")
 
 
+VERIFY_STAGES = ("pre", "before-run", "after-run")
+CORPUS_LOGS = ("corpus-dns.log", "corpus-access.log")
+
+
+def write_verify(path, passed=True):
+    """One HOP D evidence file in reqbench.sh's shape."""
+    with open(path, "w") as handle:
+        json.dump({
+            "dns_server": "10.0.2.2",
+            "resolv_conf_vm": "nameserver 10.0.2.2\n",
+            "resolv_conf_container": "nameserver 10.0.2.2\n",
+            "hosts": {"example.com": {"answer": "10.0.2.2", "ok": passed}},
+            "urls": {"https://example.com/": {"status": 200, "ok": passed}},
+            "timestamp": "2026-08-28T00:00:00Z",
+            "passed": passed,
+        }, handle)
+
+
 def write_run(
     run_dir,
     *,
@@ -120,12 +138,18 @@ def write_run(
     engine="chromium",
     stall_max_ms=15000,
     stall_evaluated=404,
+    samples=12,
+    evidence_overrides=None,
 ):
     """A minimal run directory shaped like reqanalyze + the campaign evidence.
 
-    dns_verdict=None omits dns-evidence.json; diag=None omits diag/summary.json.
-    stall_max_ms=None is what reqanalyze writes when it ran without
-    --stall-max-ms (passed true, evaluated 0).
+    dns_verdict=None omits dns-evidence.json and everything it names; diag=None
+    omits diag/summary.json. stall_max_ms=None is what reqanalyze writes when
+    it ran without --stall-max-ms (passed true, evaluated 0). The evidence
+    names three passing verify brackets, an owner log with `samples` lines
+    and the two replay logs with their real sha256, the way
+    corpus_campaign.sh writes them; evidence_overrides rewrites fields on top.
+    Returns every path the index is expected to read.
     """
     os.makedirs(run_dir, exist_ok=True)
     analysis = {
@@ -162,9 +186,45 @@ def write_run(
     with open(paths["analysis"], "w") as handle:
         json.dump(analysis, handle)
     if dns_verdict is not None:
+        verify_files = []
+        for stage in VERIFY_STAGES:
+            verify_path = os.path.join(run_dir, f"verify-dns-{stage}.json")
+            write_verify(verify_path)
+            paths[f"verify-{stage}"] = verify_path
+            verify_files.append(verify_path)
+        hashes = {}
+        for name in CORPUS_LOGS:
+            log_path = os.path.join(run_dir, name)
+            with open(log_path, "w") as handle:
+                handle.write('{"ts": 1.0, "qname": "example.com"}\n')
+            paths[name] = log_path
+            hashes[name] = sha256_file(log_path)
+        owner_log = os.path.join(run_dir, "dns-owner.log")
+        with open(owner_log, "w") as handle:
+            handle.write(
+                "2026-08-28T00:00:00Z owner_pid=4242 dnsmasq=inactive\n" * samples
+            )
+        paths["owner_log"] = owner_log
+        evidence = {
+            "serve_pid": 4242,
+            "dnsmasq_was_active_before": True,
+            "dnsmasq_active_after_restore": False,
+            "dnsmasq_state_after_restore": "inactive",
+            "sampler_alive_at_stop": True,
+            "samples": samples,
+            "sample_interval_s": 10,
+            "owner_log": owner_log,
+            "first_mismatch": None,
+            "verify_files": verify_files,
+            "corpus_dns_log_sha256": hashes["corpus-dns.log"],
+            "corpus_access_log_sha256": hashes["corpus-access.log"],
+            "reason": None,
+            "verdict": dns_verdict,
+        }
+        evidence.update(evidence_overrides or {})
         paths["dns_evidence"] = os.path.join(run_dir, "dns-evidence.json")
         with open(paths["dns_evidence"], "w") as handle:
-            json.dump({"verdict": dns_verdict, "queries": 14}, handle)
+            json.dump(evidence, handle)
     if diag is not None:
         os.makedirs(os.path.join(run_dir, "diag"), exist_ok=True)
         paths["diag"] = os.path.join(run_dir, "diag", "summary.json")
@@ -313,6 +373,188 @@ class CampaignSummary(unittest.TestCase):
         self.assertIsNone(cell["dns_verdict"])
         self.assertIsNone(cell["guest_dns"])
         self.assertIsNone(cell["diag"])
+
+    def test_an_armed_gate_that_evaluated_nothing_refuses(self):
+        """max_ms alone is not proof the gate looked at anything.
+
+        RED BEFORE THE FIX: AssertionError: 0 == 0 : wrote .../campaign-x-summary.json: 1 cell(s)
+        """
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            write_run(run_dir, stall_evaluated=0)
+            out = os.path.join(d, "campaign-x-summary.json")
+            rc, text = self._summarize(out, [run_dir])
+            self.assertNotEqual(rc, 0, text)
+            self.assertFalse(os.path.exists(out))
+            self.assertIn("evaluated", text)
+
+    def test_a_nan_stall_limit_refuses(self):
+        """json.load accepts NaN, and `NaN <= 0` is False, so a NaN limit
+        read as armed.
+
+        RED BEFORE THE FIX: AssertionError: 0 == 0 : wrote .../campaign-x-summary.json: 1 cell(s)
+        """
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            write_run(run_dir, stall_max_ms=float("nan"))
+            out = os.path.join(d, "campaign-x-summary.json")
+            rc, text = self._summarize(out, [run_dir])
+            self.assertNotEqual(rc, 0, text)
+            self.assertFalse(os.path.exists(out))
+
+    def test_a_resolver_run_without_dns_evidence_refuses(self):
+        """A run whose guest resolved through a baked resolver is a campaign
+        run, and the bracket evidence is the only thing that says the
+        resolver held for the whole measured run. Absent evidence was
+        indexed as dns_verdict null.
+
+        RED BEFORE THE FIX: AssertionError: 0 == 0 : wrote .../campaign-x-summary.json: 1 cell(s)
+        """
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            write_run(run_dir, dns_verdict=None, guest_dns="10.0.2.2")
+            out = os.path.join(d, "campaign-x-summary.json")
+            rc, text = self._summarize(out, [run_dir])
+            self.assertNotEqual(rc, 0, text)
+            self.assertFalse(os.path.exists(out))
+            self.assertIn("dns-evidence.json", text)
+
+    def _refused(self, d, **run_kwargs):
+        run_dir = os.path.join(d, "run")
+        paths = write_run(run_dir, **run_kwargs)
+        out = os.path.join(d, "campaign-x-summary.json")
+        rc, text = self._summarize(out, [run_dir])
+        self.assertNotEqual(rc, 0, text)
+        self.assertFalse(os.path.exists(out))
+        return paths, text
+
+    def test_clean_evidence_naming_a_missing_verify_bracket_refuses(self):
+        """The verdict is only as good as the brackets it cites.
+
+        RED BEFORE THE FIX: AssertionError: 0 == 0 : wrote ...: 1 cell(s) (x3)
+        """
+        with tempfile.TemporaryDirectory() as d:
+            paths = write_run(os.path.join(d, "run"))
+            os.unlink(paths["verify-after-run"])
+            out = os.path.join(d, "campaign-x-summary.json")
+            rc, text = self._summarize(out, [paths["analysis"].rsplit("/", 1)[0]])
+            self.assertNotEqual(rc, 0, text)
+            self.assertFalse(os.path.exists(out))
+            self.assertIn("verify-dns-after-run.json", text)
+        with tempfile.TemporaryDirectory() as d:
+            paths = write_run(os.path.join(d, "run"))
+            write_verify(paths["verify-before-run"], passed=False)
+            out = os.path.join(d, "campaign-x-summary.json")
+            rc, text = self._summarize(out, [os.path.join(d, "run")])
+            self.assertNotEqual(rc, 0, text)
+            self.assertIn("verify-dns-before-run.json", text)
+        with tempfile.TemporaryDirectory() as d:
+            # The evidence lists two brackets; the campaign runs three.
+            _paths, text = self._refused(
+                d, evidence_overrides={"verify_files": [
+                    os.path.join(d, "run", "verify-dns-pre.json"),
+                    os.path.join(d, "run", "verify-dns-after-run.json"),
+                ]},
+            )
+            self.assertIn("before-run", text)
+
+    def test_clean_evidence_whose_replay_log_changed_refuses(self):
+        """The sha256 in the evidence pins the replay logs; a log that no
+        longer matches is a log something appended to after the verdict.
+
+        RED BEFORE THE FIX: AssertionError: 0 == 0 : wrote ...: 1 cell(s)
+        """
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            paths = write_run(run_dir)
+            with open(paths["corpus-dns.log"], "a") as handle:
+                handle.write('{"ts": 2.0, "qname": "late.example"}\n')
+            out = os.path.join(d, "campaign-x-summary.json")
+            rc, text = self._summarize(out, [run_dir])
+            self.assertNotEqual(rc, 0, text)
+            self.assertFalse(os.path.exists(out))
+            self.assertIn("corpus-dns.log", text)
+
+    def test_clean_evidence_without_samples_or_a_live_sampler_refuses(self):
+        """RED BEFORE THE FIX: AssertionError: 0 == 0 : wrote ...: 1 cell(s) (x4)"""
+        with tempfile.TemporaryDirectory() as d:
+            _paths, text = self._refused(d, evidence_overrides={"samples": 0})
+            self.assertIn("samples", text)
+        with tempfile.TemporaryDirectory() as d:
+            # samples claims more lines than the owner log holds.
+            _paths, text = self._refused(d, evidence_overrides={"samples": 13})
+            self.assertIn("dns-owner.log", text)
+        with tempfile.TemporaryDirectory() as d:
+            _paths, text = self._refused(
+                d, evidence_overrides={"sampler_alive_at_stop": False},
+            )
+            self.assertIn("sampler", text)
+        with tempfile.TemporaryDirectory() as d:
+            _paths, text = self._refused(
+                d, evidence_overrides={"dnsmasq_state_after_restore": "unknown"},
+            )
+            self.assertIn("dnsmasq", text)
+
+    def test_the_hash_names_the_bytes_that_were_parsed(self):
+        """Parsing a file and hashing it later are two reads; an atomic
+        replacement in between produced a cell from one generation and a
+        hash for another. One read feeds both.
+
+        RED BEFORE THE FIX: AttributeError: module 'campaign_summary' has no
+        attribute 'read_bytes' (the parse and the hash were separate opens).
+        """
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            paths = write_run(run_dir)
+            with open(paths["analysis"], "rb") as handle:
+                parsed_bytes = handle.read()
+            real_read = campaign_summary.read_bytes
+
+            def read_then_replace(path):
+                data = real_read(path)
+                if path == paths["analysis"]:
+                    replacement = json.loads(data)
+                    replacement["run_id"] = "1" * 32
+                    with open(path, "w") as handle:
+                        json.dump(replacement, handle)
+                return data
+
+            out = os.path.join(d, "campaign-x-summary.json")
+            with mock.patch.object(campaign_summary, "read_bytes", read_then_replace):
+                rc, text = self._summarize(out, [run_dir])
+            self.assertEqual(rc, 0, text)
+            with open(out) as handle:
+                index = json.load(handle)
+        entry = next(
+            entry for entry in index["generated_from"]
+            if entry["path"] == paths["analysis"]
+        )
+        self.assertEqual(entry["sha256"], hashlib.sha256(parsed_bytes).hexdigest())
+        self.assertEqual(index["cells"][0]["run_id"], "0" * 32)
+
+    def test_a_refused_rerun_removes_the_stale_index(self):
+        """`REFUSED: no index written` left the previous index in place, so
+        a reader who opened it after a failed re-index quoted cells the
+        refusal had just rejected.
+
+        RED BEFORE THE FIX: AssertionError: True is not false : the stale index survived
+        """
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            paths = write_run(run_dir)
+            out = os.path.join(d, "campaign-x-summary.json")
+            rc, text = self._summarize(out, [run_dir])
+            self.assertEqual(rc, 0, text)
+            with open(paths["dns_evidence"]) as handle:
+                evidence = json.load(handle)
+            evidence["verdict"] = "unclean"
+            with open(paths["dns_evidence"], "w") as handle:
+                json.dump(evidence, handle)
+            rc, text = self._summarize(out, [run_dir])
+            self.assertNotEqual(rc, 0)
+            self.assertFalse(os.path.exists(out), "the stale index survived")
+            self.assertIn("removed", text)
 
     def test_the_index_cannot_alias_an_input(self):
         with tempfile.TemporaryDirectory() as d:

--- a/bench/chromium/test_campaign_summary.py
+++ b/bench/chromium/test_campaign_summary.py
@@ -57,6 +57,7 @@ class EvidenceIgnoreRules(unittest.TestCase):
         "!results/**/diag/summary.json",
         "!results/**/dns-owner.log",
         "!results/**/campaign-*-summary.json",
+        "!results/**/WITHDRAWN",
     )
     EVIDENCE = (
         "results/run-x/verify-dns.json",
@@ -68,6 +69,7 @@ class EvidenceIgnoreRules(unittest.TestCase):
         "results/run-x/dns-owner.log",
         "results/campaign-x-summary.json",
         "results/campaign-x/campaign-x-summary.json",
+        "results/run-x/WITHDRAWN",
     )
     RAW = (
         "results/run-x/reqbench.jsonl",
@@ -111,6 +113,19 @@ class EvidenceIgnoreRules(unittest.TestCase):
 
 VERIFY_STAGES = ("pre", "before-run", "after-run")
 CORPUS_LOGS = ("corpus-dns.log", "corpus-access.log")
+# The seal identity reqbench.py stamps into every record's meta and
+# reqanalyze carries into the cell: the runtime bundle reqbench.sh sealed,
+# the binaries and sources hashed into it, the source revision, and the
+# image and snapshot generation that were measured.
+SEAL = {
+    "runtime_bundle_sha256": "8" * 64,
+    "fcvm_sha256": "a" * 64,
+    "harness_sha256": "c" * 64,
+    "source_revision": "b" * 40,
+    "image_id": "sha256:" + "e" * 64,
+    "snapshot_generation_id": "33333333-3333-4333-8333-333333333333",
+    "snapshot_config_sha256": "5" * 64,
+}
 
 
 def write_verify(path, passed=True):
@@ -140,6 +155,9 @@ def write_run(
     stall_evaluated=404,
     samples=12,
     evidence_overrides=None,
+    cell_overrides=None,
+    analysis_overrides=None,
+    withdrawn=None,
 ):
     """A minimal run directory shaped like reqanalyze + the campaign evidence.
 
@@ -149,23 +167,33 @@ def write_run(
     names three passing verify brackets, an owner log with `samples` lines
     and the two replay logs with their real sha256, the way
     corpus_campaign.sh writes them; evidence_overrides rewrites fields on top.
-    Returns every path the index is expected to read.
+    The cell carries SEAL; cell_overrides rewrites cell fields (a None value
+    removes the field) and analysis_overrides rewrites top-level fields.
+    withdrawn=<reason> writes a WITHDRAWN marker whose first line is the
+    reason. Returns every path the index is expected to read.
     """
     os.makedirs(run_dir, exist_ok=True)
+    cell = {
+        "backend": "uffd",
+        "uffd_mode": "minor",
+        "engine": engine,
+        "cpu": 2,
+        "memory_mib": 1024,
+        "guest_dns": guest_dns,
+        "url": "https://example.com/",
+        **SEAL,
+    }
+    for field, value in (cell_overrides or {}).items():
+        if value is None:
+            cell.pop(field, None)
+        else:
+            cell[field] = value
     analysis = {
         "publishable": publishable,
         "gate": {"passed": publishable, "reasons": [] if publishable else ["x"]},
         "run_id": "0" * 32,
         "backend": "uffd",
-        "cell": {
-            "backend": "uffd",
-            "uffd_mode": "minor",
-            "engine": engine,
-            "cpu": 2,
-            "memory_mib": 1024,
-            "guest_dns": guest_dns,
-            "url": "https://example.com/",
-        },
+        "cell": cell,
         "arms": {
             "cdp": {
                 "blocking_ms": {"median": 647.2, "lo": 567.6, "hi": 702.9, "n": 202},
@@ -182,9 +210,13 @@ def write_run(
             "violations": [],
         },
     }
+    analysis.update(analysis_overrides or {})
     paths = {"analysis": os.path.join(run_dir, "analysis.json")}
     with open(paths["analysis"], "w") as handle:
         json.dump(analysis, handle)
+    if withdrawn is not None:
+        with open(os.path.join(run_dir, "WITHDRAWN"), "w") as handle:
+            handle.write(f"{withdrawn}\nsecond line: detail the refusal need not quote\n")
     if dns_verdict is not None:
         verify_files = []
         for stage in VERIFY_STAGES:
@@ -288,6 +320,7 @@ class CampaignSummary(unittest.TestCase):
         self.assertEqual(cell["guest_dns"], "10.0.2.2")
         self.assertIs(cell["publishable"], True)
         self.assertIs(cell["stall_gate_passed"], True)
+        self.assertEqual(cell["seal"], SEAL)
         self.assertEqual(cell["dns_verdict"], "clean")
         self.assertEqual(cell["headline"]["cdp"]["blocking_ms"], 647.2)
         self.assertEqual(cell["headline"]["cdp"]["blocking_ms_ci"], [567.6, 702.9])
@@ -582,6 +615,46 @@ class CampaignSummary(unittest.TestCase):
             self.assertFalse(os.path.exists(out), "the stale index survived")
             self.assertIn(run_dir, text)
             self.assertIn("dns-evidence.json is not a JSON object", text)
+
+    def test_a_cell_without_its_seal_identity_refuses(self):
+        """publishable=true was the only publication-state proof the index
+        took. The rule (REVIEW.md) is to quote only sealed runs, and the
+        seal is the cell's identity: reqbench.sh's runtime bundle hash, the
+        fcvm and harness hashes sealed into it, the source revision, the
+        image ID and the snapshot generation with its config digest. A cell
+        missing any of them, or carrying one blank, was indexed.
+
+        RED BEFORE THE FIX: AssertionError: 0 == 0 : wrote
+        .../campaign-x-summary.json: 1 cell(s) (seven missing-field subtests
+        and the blank one)
+        """
+        for field in SEAL:
+            with self.subTest(field=field), tempfile.TemporaryDirectory() as d:
+                _paths, text = self._refused(d, cell_overrides={field: None})
+                self.assertIn(field, text)
+        with tempfile.TemporaryDirectory() as d:
+            _paths, text = self._refused(d, cell_overrides={"source_revision": "  "})
+            self.assertIn("source_revision", text)
+
+    def test_a_withdrawn_run_refuses_with_its_reason(self):
+        """Withdrawn runs stay unquotable forever (REVIEW.md), and nothing in
+        a run directory said so to the index. A file named WITHDRAWN in the
+        run directory withdraws it; its first line is the reason and the
+        refusal quotes it. An analysis.json carrying "withdrawn": true is
+        refused the same way.
+
+        RED BEFORE THE FIX: AssertionError: 0 == 0 : wrote
+        .../campaign-x-summary.json: 1 cell(s) (both cases)
+        """
+        reason = "measured on a tree without pasta's pdeathsig"
+        with tempfile.TemporaryDirectory() as d:
+            _paths, text = self._refused(d, withdrawn=reason)
+            self.assertIn("withdrawn", text)
+            self.assertIn(reason, text)
+            self.assertNotIn("second line", text)
+        with tempfile.TemporaryDirectory() as d:
+            _paths, text = self._refused(d, analysis_overrides={"withdrawn": True})
+            self.assertIn("withdrawn", text)
 
     def test_the_index_cannot_alias_an_input(self):
         with tempfile.TemporaryDirectory() as d:

--- a/bench/chromium/test_campaign_summary.py
+++ b/bench/chromium/test_campaign_summary.py
@@ -139,18 +139,24 @@ SEAL = {
 }
 
 
-def write_verify(path, passed=True):
-    """One HOP D evidence file in reqbench.sh's shape."""
+def write_verify(path, passed=True, **overrides):
+    """One HOP D evidence file in reqbench.sh's shape; overrides rewrite
+    fields on top of a bracket that resolved every corpus host and URL
+    through the replay resolver with the proxy variables ignored."""
+    record = {
+        "dns_server": "10.0.2.2",
+        "resolv_conf_vm": "nameserver 10.0.2.2\n",
+        "resolv_conf_container": "nameserver 10.0.2.2\n",
+        "hosts": {"example.com": {"answer": "10.0.2.2", "ok": passed}},
+        "urls": {"https://example.com/": {"status": 200, "ok": passed,
+                                          "proxy_env_ignored": []}},
+        "proxies_disabled": True,
+        "timestamp": "2026-08-28T00:00:00Z",
+        "passed": passed,
+    }
+    record.update(overrides)
     with open(path, "w") as handle:
-        json.dump({
-            "dns_server": "10.0.2.2",
-            "resolv_conf_vm": "nameserver 10.0.2.2\n",
-            "resolv_conf_container": "nameserver 10.0.2.2\n",
-            "hosts": {"example.com": {"answer": "10.0.2.2", "ok": passed}},
-            "urls": {"https://example.com/": {"status": 200, "ok": passed}},
-            "timestamp": "2026-08-28T00:00:00Z",
-            "passed": passed,
-        }, handle)
+        json.dump(record, handle)
 
 
 def write_run(
@@ -167,6 +173,8 @@ def write_run(
     samples=12,
     load_max_1min=0.42,
     evidence_overrides=None,
+    verify_overrides=None,
+    verify_stage_overrides=None,
     cell_overrides=None,
     analysis_overrides=None,
     withdrawn=None,
@@ -176,9 +184,12 @@ def write_run(
     dns_verdict=None omits dns-evidence.json and everything it names; diag=None
     omits diag/summary.json. stall_max_ms=None is what reqanalyze writes when
     it ran without --stall-max-ms (passed true, evaluated 0). The evidence
-    names three passing verify brackets, an owner log with `samples` lines
-    and the two replay logs with their real sha256, the way
-    corpus_campaign.sh writes them; evidence_overrides rewrites fields on top.
+    names three passing verify brackets with their real sha256, an owner log
+    with `samples` lines and the two replay logs with their real sha256, the
+    way corpus_campaign.sh writes them; evidence_overrides rewrites evidence
+    fields on top, verify_overrides rewrites bracket fields on every bracket
+    before they are hashed, and verify_stage_overrides rewrites them on one
+    named stage.
     load_max_1min is the 1-min load the campaign's sampler recorded, carried
     on every owner line and reported in the evidence; None writes an owner
     log and evidence from before the sampler recorded it.
@@ -234,11 +245,15 @@ def write_run(
             handle.write(f"{withdrawn}\nsecond line: detail the refusal need not quote\n")
     if dns_verdict is not None:
         verify_files = []
+        verify_hashes = {}
         for stage in VERIFY_STAGES:
             verify_path = os.path.join(run_dir, f"verify-dns-{stage}.json")
-            write_verify(verify_path)
+            overrides = dict(verify_overrides or {})
+            overrides.update((verify_stage_overrides or {}).get(stage, {}))
+            write_verify(verify_path, **overrides)
             paths[f"verify-{stage}"] = verify_path
             verify_files.append(verify_path)
+            verify_hashes[f"verify-dns-{stage}.json"] = sha256_file(verify_path)
         hashes = {}
         for name in CORPUS_LOGS:
             log_path = os.path.join(run_dir, name)
@@ -265,6 +280,7 @@ def write_run(
             "owner_log": owner_log,
             "first_mismatch": None,
             "verify_files": verify_files,
+            "verify_file_sha256": verify_hashes,
             "corpus_dns_log_sha256": hashes["corpus-dns.log"],
             "corpus_access_log_sha256": hashes["corpus-access.log"],
             "corpus_serve_exit_status": 0,
@@ -539,6 +555,108 @@ class CampaignSummary(unittest.TestCase):
                 ]},
             )
             self.assertIn("before-run", text)
+
+    def test_a_verify_bracket_rewritten_after_the_verdict_refuses(self):
+        """The bracket file is the whole record that a restored clone
+        resolved the corpus through the replay server, and it is a plain file
+        in the run directory. A bracket saying the clone resolved through
+        8.8.8.8, with the proxy probes disabled=false and no host or URL
+        checked at all, still carried passed=true and was indexed clean.
+
+        RED BEFORE THE FIX: AssertionError: 0 == 0 : wrote
+        .../campaign-x-summary.json: 1 cell(s)
+        """
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            paths = write_run(run_dir)
+            write_verify(paths["verify-before-run"], dns_server="8.8.8.8",
+                         proxies_disabled=False, hosts={}, urls={})
+            out = os.path.join(d, "campaign-x-summary.json")
+            rc, text = self._summarize(out, [run_dir])
+            self.assertNotEqual(rc, 0, text)
+            self.assertFalse(os.path.exists(out))
+            self.assertIn("verify-dns-before-run.json", text)
+
+    def test_evidence_that_does_not_pin_its_brackets_refuses(self):
+        """Fail closed: evidence written before the verdict hashed its
+        brackets cannot say whether the files beside it are the ones it read,
+        so it is not evidence the index can revalidate.
+
+        RED BEFORE THE FIX: AssertionError: 0 == 0 : wrote
+        .../campaign-x-summary.json: 1 cell(s)
+        """
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            paths = write_run(run_dir)
+            with open(paths["dns_evidence"]) as handle:
+                evidence = json.load(handle)
+            del evidence["verify_file_sha256"]
+            with open(paths["dns_evidence"], "w") as handle:
+                json.dump(evidence, handle)
+            out = os.path.join(d, "campaign-x-summary.json")
+            rc, text = self._summarize(out, [run_dir])
+            self.assertNotEqual(rc, 0, text)
+            self.assertFalse(os.path.exists(out))
+            self.assertIn("verify_file_sha256", text)
+
+    # Each shape is a bracket the campaign would have refused at the verdict,
+    # written with its own hash so only the index-time revalidation can catch
+    # it: the resolver under test, the proxy state of the URL probes, and
+    # that anything was checked at all.
+    BRACKETS_THAT_PROVE_NOTHING = (
+        ({"hosts": {}}, "no resolved host"),
+        ({"urls": {}}, "no fetched URL"),
+        ({"proxies_disabled": False}, "proxies_disabled"),
+        ({"dns_server": "8.8.8.8",
+          "hosts": {"example.com": {"answer": "8.8.8.8", "ok": True}}}, "8.8.8.8"),
+        ({"hosts": {"example.com": {"answer": "93.184.216.34", "ok": True}}},
+         "93.184.216.34"),
+        ({"urls": {"https://example.com/": {"status": 500, "ok": True,
+                                            "proxy_env_ignored": []}}}, "500"),
+        ({"urls": {"https://example.com/": {"status": 200, "ok": True,
+                                            "proxy_env_ignored": None}}},
+         "proxy variables"),
+    )
+
+    def test_a_bracket_that_proves_nothing_refuses(self):
+        """passed=true is also what HOP D writes when it was given nothing to
+        check, so the index holds every bracket to what the campaign asserted
+        when it ran it.
+
+        RED BEFORE THE FIX: AssertionError: 0 == 0 : wrote
+        .../campaign-x-summary.json: 1 cell(s), on all seven shapes.
+        """
+        for overrides, expected in self.BRACKETS_THAT_PROVE_NOTHING:
+            with self.subTest(bracket=overrides), tempfile.TemporaryDirectory() as d:
+                _paths, text = self._refused(d, verify_overrides=overrides)
+                self.assertIn("verify-dns-", text)
+                self.assertIn(expected, text)
+
+    def test_brackets_that_disagree_on_the_resolver_refuse(self):
+        """A cell with no guest_dns has no resolver to hold the brackets to,
+        so the first bracket's is the reference and the other two are held to
+        it: three brackets naming three resolvers describe three different
+        runs. Each bracket carries its own sha256, so only the index-time
+        revalidation can see this. The agreeing run is the control.
+
+        RED BEFORE THE FIX: AssertionError: 0 == 0 : wrote
+        .../campaign-x-summary.json: 1 cell(s)
+        """
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            write_run(run_dir, guest_dns=None)
+            out = os.path.join(d, "campaign-x-summary.json")
+            rc, text = self._summarize(out, [run_dir])
+            self.assertEqual(rc, 0, text)
+        with tempfile.TemporaryDirectory() as d:
+            _paths, text = self._refused(d, guest_dns=None, verify_stage_overrides={
+                "after-run": {
+                    "dns_server": "8.8.8.8",
+                    "hosts": {"example.com": {"answer": "8.8.8.8", "ok": True}},
+                },
+            })
+            self.assertIn("verify-dns-after-run.json", text)
+            self.assertIn("8.8.8.8", text)
 
     def test_clean_evidence_whose_replay_log_changed_refuses(self):
         """The sha256 in the evidence pins the replay logs; a log that no

--- a/bench/chromium/test_campaign_summary.py
+++ b/bench/chromium/test_campaign_summary.py
@@ -40,11 +40,19 @@ class EvidenceIgnoreRules(unittest.TestCase):
     RED BEFORE THE FIX: verify-dns.json, dns-evidence.json and dns-owner.log
     were ignored by `results/**` (git check-ignore exit 0), and the literal
     negations for them were absent from bench/chromium/.gitignore.
+
+    RED BEFORE THE SECOND FIX: the campaign keeps each verify bracket as
+    verify-dns-<stage>.json (pre, before-run, after-run) and dns-evidence.json
+    lists them in verify_files, but only the unsuffixed name was negated, so
+    `results/run-x/verify-dns-pre.json is ignored and would be lost on the
+    next wipe` (three subtests) and the literal `!results/**/verify-dns-*.json`
+    was absent.
     """
 
     IGNORE = os.path.join(HERE, ".gitignore")
     NEGATIONS = (
         "!results/**/verify-dns.json",
+        "!results/**/verify-dns-*.json",
         "!results/**/dns-evidence.json",
         "!results/**/diag/summary.json",
         "!results/**/dns-owner.log",
@@ -52,6 +60,9 @@ class EvidenceIgnoreRules(unittest.TestCase):
     )
     EVIDENCE = (
         "results/run-x/verify-dns.json",
+        "results/run-x/verify-dns-pre.json",
+        "results/run-x/verify-dns-before-run.json",
+        "results/run-x/verify-dns-after-run.json",
         "results/run-x/dns-evidence.json",
         "results/run-x/diag/summary.json",
         "results/run-x/dns-owner.log",

--- a/bench/chromium/test_campaign_summary.py
+++ b/bench/chromium/test_campaign_summary.py
@@ -266,6 +266,7 @@ def write_run(
             "verify_files": verify_files,
             "corpus_dns_log_sha256": hashes["corpus-dns.log"],
             "corpus_access_log_sha256": hashes["corpus-access.log"],
+            "corpus_serve_exit_status": 0,
             "reason": None,
             "verdict": dns_verdict,
         }
@@ -574,6 +575,83 @@ class CampaignSummary(unittest.TestCase):
                 d, evidence_overrides={"dnsmasq_state_after_restore": "unknown"},
             )
             self.assertIn("dnsmasq", text)
+
+    def test_evidence_without_the_replay_server_exit_status_refuses(self):
+        """corpus_serve exits 1 after a log line it could not write, with the
+        response bytes already sent; the campaign records the status the
+        server's wrapper leaves as corpus_serve_exit_status. A verdict that
+        does not carry status 0 is a verdict over logs that may be short.
+
+        RED BEFORE THE FIX: AssertionError: 0 == 0 : wrote
+        .../campaign-x-summary.json: 1 cell(s) (every subtest)
+        """
+        cases = {"exit 1": 1, "exit 137": 137, "null": None, "bool": True, "string": "0"}
+        for label, status in cases.items():
+            with self.subTest(label), tempfile.TemporaryDirectory() as d:
+                _paths, text = self._refused(
+                    d, evidence_overrides={"corpus_serve_exit_status": status})
+                self.assertIn("corpus_serve", text)
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "run")
+            paths = write_run(run_dir)
+            with open(paths["dns_evidence"]) as handle:
+                evidence = json.load(handle)
+            del evidence["corpus_serve_exit_status"]
+            with open(paths["dns_evidence"], "w") as handle:
+                json.dump(evidence, handle)
+            out = os.path.join(d, "campaign-x-summary.json")
+            rc, text = self._summarize(out, [run_dir])
+            self.assertNotEqual(rc, 0, text)
+            self.assertFalse(os.path.exists(out))
+            self.assertIn("corpus_serve", text)
+
+    def test_an_owner_log_whose_lines_contradict_the_evidence_refuses(self):
+        """The owner log was accepted by line count, and first_mismatch: null
+        was taken on trust: a log rewritten to name owner_pid=9999 on every
+        line still indexed clean. The index now reads every sample and holds
+        it to the rule the campaign applied at the verdict: each names
+        serve_pid as the owner of 127.0.0.1:53 with dnsmasq inactive, the
+        lines carrying load1 number load_samples and their maximum is
+        load_max_1min, and every line parses as a sample. The first
+        contradiction refuses the run.
+
+        RED BEFORE THE FIX: AssertionError: 0 == 0 : wrote
+        .../campaign-x-summary.json: 1 cell(s) (every subtest)
+        """
+        good = "2026-08-28T00:00:00Z owner_pid=4242 dnsmasq=inactive load1=0.42\n"
+        cases = {
+            "another owner on every line": (
+                good.replace("owner_pid=4242", "owner_pid=9999") * 12, "9999"),
+            "no owner on one line": (
+                good * 5 + good.replace("owner_pid=4242", "owner_pid=none") + good * 6,
+                "owner_pid=none"),
+            "dnsmasq active on one line": (
+                good * 11 + good.replace("dnsmasq=inactive", "dnsmasq=active"),
+                "dnsmasq=active"),
+            "a load above the recorded maximum": (
+                good * 3 + good.replace("load1=0.42", "load1=5.00") + good * 8, "5.0"),
+            "fewer load samples than recorded": (
+                good * 11 + good.replace(" load1=0.42", ""), "load"),
+            "a line that is not a sample": (
+                good * 11 + "not a sample\n", "not a sample"),
+        }
+        for label, (log, quoted) in cases.items():
+            with self.subTest(label), tempfile.TemporaryDirectory() as d:
+                run_dir = os.path.join(d, "run")
+                paths = write_run(run_dir)
+                with open(paths["owner_log"], "w") as handle:
+                    handle.write(log)
+                out = os.path.join(d, "campaign-x-summary.json")
+                rc, text = self._summarize(out, [run_dir])
+                self.assertNotEqual(rc, 0, text)
+                self.assertFalse(os.path.exists(out))
+                self.assertIn("dns-owner.log", text)
+                self.assertIn(quoted, text)
+        with tempfile.TemporaryDirectory() as d:
+            # Clean evidence naming no server pid has nothing to hold the
+            # samples to.
+            _paths, text = self._refused(d, evidence_overrides={"serve_pid": None})
+            self.assertIn("serve_pid", text)
 
     def test_the_hash_names_the_bytes_that_were_parsed(self):
         """Parsing a file and hashing it later are two reads; an atomic

--- a/bench/chromium/test_corpus_serve_logs.py
+++ b/bench/chromium/test_corpus_serve_logs.py
@@ -4,9 +4,11 @@
 The campaign reads $RESULTS/corpus-dns.log and $RESULTS/corpus-access.log after
 a run to show which resolver the guest used and which hosts it fetched. Each
 line has to carry the fields that reader keys on, and it has to be on disk
-before the run's next step reads it, so every test below reads the log while
-the server that wrote it is still running: a line held in a stdio buffer would
-not be there.
+once the handler that answered has finished, so every test below reads the log
+before it is closed: a line held in a stdio buffer would not be there. The
+access line follows the response, so the HTTP tests wait for the handler
+through the shipped shutdown sequence (stop_listeners, which joins it) rather
+than read the moment the client has the body.
 
 Watched red 2026-08-28 against corpus_serve.py at 4d172153; the failure text is
 quoted on each test.
@@ -19,11 +21,16 @@ import http.client
 import io
 import json
 import os
+import re
+import signal
 import socket
 import struct
+import subprocess
 import sys
 import tempfile
+import textwrap
 import threading
+import time
 import unittest
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -62,6 +69,7 @@ class DnsLog(unittest.TestCase):
             target=corpus_serve.serve_dns, args=(sock, answer_ip, log), daemon=True,
         )
         thread.start()
+        self._dns = (sock, thread)
 
         def stop():
             # close() does not wake a recvfrom already blocked in the kernel
@@ -82,6 +90,18 @@ class DnsLog(unittest.TestCase):
         self.addCleanup(stop)
         return port
 
+    def _rows(self, log_path: str) -> list:
+        """The log once the responder has ended.
+
+        The line follows the answer, so a client holding the reply can still
+        be ahead of the line; reading the file at that moment found zero rows
+        once in 25 runs of this module (2026-08-28). The shipped stop_dns
+        ends the responder and joins it; the log stays open, so a line that
+        is there was flushed by the responder, not by close().
+        """
+        corpus_serve.stop_dns(*self._dns)
+        return read_jsonl(log_path)
+
     def _ask(self, port: int, name: str, qtype: int):
         client = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.addCleanup(client.close)
@@ -98,7 +118,7 @@ class DnsLog(unittest.TestCase):
             reply, me = self._ask(port, "blog.cloudflare.com", QTYPE_A)
             self.assertEqual(socket.inet_ntoa(reply[-4:]), "10.0.2.2",
                              "the responder no longer answers A queries")
-            rows = read_jsonl(log_path)
+            rows = self._rows(log_path)
             self.assertEqual(len(rows), 1, rows)
             row = rows[0]
             self.assertEqual(sorted(row), ["answer", "peer", "qname", "qtype", "ts"])
@@ -113,7 +133,7 @@ class DnsLog(unittest.TestCase):
             log_path = os.path.join(d, "corpus-dns.log")
             port = self._responder(log_path)
             self._ask(port, "fonts.gstatic.com", QTYPE_AAAA)
-            (row,) = read_jsonl(log_path)
+            (row,) = self._rows(log_path)
             self.assertEqual(row["qname"], "fonts.gstatic.com")
             self.assertEqual(row["qtype"], QTYPE_AAAA)
             self.assertEqual(row["answer"], "")
@@ -124,7 +144,7 @@ class DnsLog(unittest.TestCase):
             port = self._responder(log_path)
             for name in ("a.test", "b.test", "c.test"):
                 self._ask(port, name, QTYPE_A)
-            self.assertEqual([r["qname"] for r in read_jsonl(log_path)],
+            self.assertEqual([r["qname"] for r in self._rows(log_path)],
                              ["a.test", "b.test", "c.test"])
 
     def test_without_a_log_the_responder_still_answers_and_writes_nothing(self):
@@ -221,11 +241,12 @@ class AccessLog(unittest.TestCase):
             }}, handle)
         return os.path.join(d, "corpus")
 
-    def _replay(self, d: str, log=None, peers=None, start=True):
+    def _replay(self, d: str, log=None, peers=None, start=True, handler=None):
         """The shipped server class over a one-file corpus on an ephemeral port.
 
         Returns (server, thread). With start=False the thread is None and the
-        caller runs serve_forever itself, as serve_http does.
+        caller runs serve_forever itself, as serve_http does. `handler` is the
+        handler class to serve with (default corpus_serve.Handler).
         """
         from pathlib import Path
 
@@ -233,7 +254,7 @@ class AccessLog(unittest.TestCase):
 
         # A subclass, so the handler's class-level tables and log stay private
         # to this test instead of mutating corpus_serve.Handler for the suite.
-        class H(corpus_serve.Handler):
+        class H(handler or corpus_serve.Handler):
             pass
 
         H.exact, H.noquery, H.redirects = exact, noquery, redirects
@@ -252,7 +273,19 @@ class AccessLog(unittest.TestCase):
         log = corpus_serve.JsonlLog(log_path) if log_path else None
         if log is not None:
             self.addCleanup(log.close)
-        return self._replay(d, log)[0].server_port
+        return self._replay(d, log)[0]
+
+    def _rows(self, server, log_path: str) -> list:
+        """The log once every handler `server` dequeued has finished.
+
+        The access line is written after the response, so a client holding
+        the whole body can still be ahead of the line; reading the file at
+        that moment found zero rows once in 454 (2026-08-28). The shipped
+        shutdown sequence waits for the handlers; the log stays open, so a
+        line that is there was flushed by the handler, not by close().
+        """
+        corpus_serve.stop_listeners([server])
+        return read_jsonl(log_path)
 
     def _get(self, port: int, path: str, host: str = "example.test"):
         conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
@@ -265,10 +298,10 @@ class AccessLog(unittest.TestCase):
     def test_a_hit_is_logged_with_host_path_status_and_body_bytes(self):
         with tempfile.TemporaryDirectory() as d:
             log_path = os.path.join(d, "corpus-access.log")
-            port = self._server(d, log_path)
-            status, body, me = self._get(port, "/a.txt")
+            server = self._server(d, log_path)
+            status, body, me = self._get(server.server_port, "/a.txt")
             self.assertEqual((status, body), (200, self.BODY))
-            (row,) = read_jsonl(log_path)
+            (row,) = self._rows(server, log_path)
             self.assertEqual(sorted(row), ["bytes", "duration_ms", "host", "method",
                                            "path", "peer", "status", "ts"])
             self.assertEqual(row["method"], "GET")
@@ -283,10 +316,10 @@ class AccessLog(unittest.TestCase):
     def test_a_miss_is_logged_as_a_404_with_zero_bytes(self):
         with tempfile.TemporaryDirectory() as d:
             log_path = os.path.join(d, "corpus-access.log")
-            port = self._server(d, log_path)
-            status, _, _ = self._get(port, "/absent.js?v=1", host="cdn.test")
+            server = self._server(d, log_path)
+            status, _, _ = self._get(server.server_port, "/absent.js?v=1", host="cdn.test")
             self.assertEqual(status, 404)
-            (row,) = read_jsonl(log_path)
+            (row,) = self._rows(server, log_path)
             self.assertEqual(row["host"], "cdn.test")
             self.assertEqual(row["path"], "/absent.js?v=1")
             self.assertEqual(row["status"], 404)
@@ -297,17 +330,18 @@ class AccessLog(unittest.TestCase):
         the TLS listener); the log records the header as sent."""
         with tempfile.TemporaryDirectory() as d:
             log_path = os.path.join(d, "corpus-access.log")
-            port = self._server(d, log_path)
-            status, body, _ = self._get(port, "/a.txt", host="example.test:443")
+            server = self._server(d, log_path)
+            status, body, _ = self._get(server.server_port, "/a.txt", host="example.test:443")
             self.assertEqual((status, body), (200, self.BODY))
-            (row,) = read_jsonl(log_path)
+            (row,) = self._rows(server, log_path)
             self.assertEqual(row["host"], "example.test:443")
 
     def test_without_a_log_serving_is_unchanged_and_nothing_is_written(self):
         with tempfile.TemporaryDirectory() as d:
-            port = self._server(d, None)
-            status, body, _ = self._get(port, "/a.txt")
+            server = self._server(d, None)
+            status, body, _ = self._get(server.server_port, "/a.txt")
             self.assertEqual((status, body), (200, self.BODY))
+            corpus_serve.stop_listeners([server])
             self.assertEqual(sorted(os.listdir(d)), ["corpus"])
 
 
@@ -366,7 +400,8 @@ class AccessLog(unittest.TestCase):
                              "serve_forever kept running after a failed access-log write")
             self.assertIsInstance(server.log_failure, OSError)
             self.assertEqual(server.log_failure.errno, errno.ENOSPC)
-            self.assertEqual(len(read_jsonl(log_path)), 1,
+            self.assertEqual(server.failed_log, "access")
+            self.assertEqual(len(self._rows(server, log_path)), 1,
                              "the line that failed to write is in the log")
             conn = http.client.HTTPConnection("127.0.0.1", port, timeout=1)
             self.addCleanup(conn.close)
@@ -416,6 +451,161 @@ class AccessLog(unittest.TestCase):
                           "the failure was not recorded on the other listener")
             self.assertIn("FAILED", err.getvalue())
             self.assertIn("No space left on device", err.getvalue())
+
+    def test_a_signal_stop_waits_for_the_handlers_in_flight_before_closing_the_log(self):
+        """The access line follows the response, so a client can hold the
+        whole body while the line is still unwritten. The campaign sends
+        SIGTERM the moment the after-run verify returns and hashes the log
+        once the process is gone, so a process that exited on the signal
+        without waiting for that handler left a truncated log that was
+        hashed as clean. The stop must end accepting, wait for every handler
+        already dequeued, then close the logs, and serve_http returns 0.
+
+        The handler holds its thread after answering until the test releases
+        it, so the stop lands with the response read and the line to come,
+        and a stop that returns before the release did not wait.
+
+        Red: `AttributeError: module 'corpus_serve' has no attribute
+        'install_signal_handlers'`; with a handler that ended the loops and
+        closed the log without the wait: `False is not true : serve_http
+        returned while a handler was still running`.
+        """
+        release = threading.Event()
+        self.addCleanup(release.set)
+
+        class Held(corpus_serve.Handler):
+            def do_GET(self):
+                self._serve()
+                release.wait(timeout=10)
+
+        with tempfile.TemporaryDirectory() as d:
+            log_path = os.path.join(d, "corpus-access.log")
+            log = corpus_serve.JsonlLog(log_path)
+            peers = []
+            plain, _ = self._replay(d, log, peers, start=False, handler=Held)
+            tls, _ = self._replay(d, log, peers, start=False, handler=Held)
+            returned = []
+            loop = threading.Thread(
+                target=lambda: returned.append(corpus_serve.serve_http(plain, tls, logs=[log])),
+                daemon=True)
+            loop.start()
+            self.addCleanup(lambda: (plain.shutdown(), tls.shutdown())
+                            if loop.is_alive() else None)
+            # The real handler, installed and then put back: unittest runs
+            # this on the main thread, where signal.signal is allowed.
+            saved = {sig: signal.getsignal(sig) for sig in (signal.SIGTERM, signal.SIGINT)}
+            for sig, previous in saved.items():
+                self.addCleanup(signal.signal, sig, previous)
+            on_signal = corpus_serve.install_signal_handlers(tls)
+            for sig in saved:
+                self.assertIs(signal.getsignal(sig), on_signal, f"{sig!r} is not handled")
+            status, body, _ = self._get(plain.server_port, "/a.txt")
+            self.assertEqual((status, body), (200, self.BODY))
+            on_signal(signal.SIGTERM, None)
+            # serve_forever polls its shutdown flag every 0.5 s, so ending
+            # both loops takes up to 1 s; a stop that waits then blocks on
+            # the held handler and cannot return before the release.
+            loop.join(timeout=2)
+            self.assertTrue(loop.is_alive(), "serve_http returned while a handler was still running")
+            release.set()
+            loop.join(timeout=5)
+            self.assertFalse(loop.is_alive(), "serve_http did not return once the handler had finished")
+            self.assertEqual(returned, [0])
+            rows = read_jsonl(log_path)
+            self.assertEqual(len(rows), 1,
+                             "the access line of the request in flight at the stop is not in the log")
+            self.assertEqual((rows[0]["status"], rows[0]["bytes"]), (200, len(self.BODY)))
+            with self.assertRaises(ValueError, msg="the log is still open after the stop"):
+                log.write({"late": True})
+            conn = http.client.HTTPConnection("127.0.0.1", plain.server_port, timeout=1)
+            self.addCleanup(conn.close)
+            with self.assertRaises(OSError, msg="a request was answered after the stop"):
+                conn.request("GET", "/a.txt", headers={"Host": "example.test"})
+                conn.getresponse()
+
+    def test_sigterm_to_the_process_leaves_the_last_access_line_on_disk(self):
+        """main() end to end, the way stop_corpus_serve ends it: a real
+        SIGTERM to the process while the handler of an already answered
+        request is still running. The process must exit 0 with that
+        request's line in the log.
+
+        The wrapper makes the shipped handler hold its thread after
+        answering until a flag file appears, and announces the HTTP port
+        serve_http was given, which main() does not print when asked for
+        port 0.
+
+        Red: `0 != 1 : the access line of the request in flight at SIGTERM
+        is not in the log (exit -15 before the handler finished)`, the
+        signal's default action; with a handler that ended the loops and
+        closed the log without the wait, the same with exit 0.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            root = self._corpus(d)
+            log_path = os.path.join(d, "corpus-access.log")
+            flag = os.path.join(d, "release")
+            wrapper = textwrap.dedent(f"""
+                import os, sys, time
+                sys.path.insert(0, {HERE!r})
+                import corpus_serve
+
+                def held(self):
+                    corpus_serve.Handler._serve(self)
+                    deadline = time.monotonic() + 10
+                    while not os.path.exists({flag!r}) and time.monotonic() < deadline:
+                        time.sleep(0.01)
+
+                corpus_serve.Handler.do_GET = held
+                serve_http = corpus_serve.serve_http
+
+                def announce(plain, tls, *args, **kwargs):
+                    print("PORT", plain.server_port, flush=True)
+                    return serve_http(plain, tls, *args, **kwargs)
+
+                corpus_serve.serve_http = announce
+                sys.exit(corpus_serve.main())
+            """)
+            proc = subprocess.Popen(
+                [sys.executable, "-c", wrapper, "--root", root, "--port", "0",
+                 "--tls-port", "0", "--dns-addr", "127.0.0.1", "--dns-port", "0",
+                 "--access-log", log_path, "--dns-log", os.path.join(d, "corpus-dns.log")],
+                stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+            watchdog = threading.Timer(30, proc.kill)
+            watchdog.start()
+            self.addCleanup(watchdog.cancel)
+            self.addCleanup(proc.stdout.close)
+            self.addCleanup(proc.kill)
+            port = None
+            head = []
+            for line in proc.stdout:
+                head.append(line)
+                found = re.match(r"PORT (\d+)$", line.strip())
+                if found:
+                    port = int(found.group(1))
+                    break
+            self.assertIsNotNone(port, "corpus_serve did not start:\n" + "".join(head))
+            status, body, _ = self._get(port, "/a.txt")
+            self.assertEqual((status, body), (200, self.BODY))
+            proc.send_signal(signal.SIGTERM)
+            # serve_forever polls its shutdown flag every 0.5 s, so ending
+            # both loops takes up to 1 s; a process that waits then blocks
+            # on the held handler and cannot exit before the flag appears.
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                pass
+            early_exit = proc.returncode
+            open(flag, "w").close()
+            rest = proc.stdout.read()
+            proc.wait(timeout=10)
+            output = "".join(head) + rest
+            rows = read_jsonl(log_path)
+            self.assertEqual(len(rows), 1, "the access line of the request in flight at SIGTERM "
+                             f"is not in the log (exit {early_exit} before the handler finished):\n{output}")
+            self.assertEqual((rows[0]["status"], rows[0]["bytes"]), (200, len(self.BODY)))
+            self.assertIsNone(early_exit,
+                              f"corpus_serve exited {early_exit} while a handler was still running")
+            self.assertEqual(proc.returncode, 0,
+                             f"corpus_serve exited {proc.returncode} on SIGTERM:\n{output}")
 
 
 class Flags(unittest.TestCase):

--- a/bench/chromium/test_corpus_serve_logs.py
+++ b/bench/chromium/test_corpus_serve_logs.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""corpus_serve.py's replay logs: one JSON line per DNS query and per HTTP request.
+
+The campaign reads $RESULTS/corpus-dns.log and $RESULTS/corpus-access.log after
+a run to show which resolver the guest used and which hosts it fetched. Each
+line has to carry the fields that reader keys on, and it has to be on disk
+before the run's next step reads it, so every test below reads the log while
+the server that wrote it is still running: a line held in a stdio buffer would
+not be there.
+
+Watched red 2026-08-28 against corpus_serve.py at 4d172153; the failure text is
+quoted on each test.
+
+Run: python3 -m unittest test_corpus_serve_logs -v
+"""
+
+import http.client
+import json
+import os
+import socket
+import struct
+import sys
+import tempfile
+import threading
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+import corpus_serve  # noqa: E402
+
+QTYPE_A = 1
+QTYPE_AAAA = 28
+
+
+def dns_query(name: str, qtype: int, txid: int = 0x1234) -> bytes:
+    """A standard recursion-desired query, one question, built by hand."""
+    packet = struct.pack(">HHHHHH", txid, 0x0100, 1, 0, 0, 0)
+    for label in name.split("."):
+        packet += bytes([len(label)]) + label.encode()
+    return packet + b"\x00" + struct.pack(">HH", qtype, 1)
+
+
+def read_jsonl(path: str) -> list:
+    with open(path) as handle:
+        return [json.loads(line) for line in handle if line.strip()]
+
+
+class DnsLog(unittest.TestCase):
+    """--dns-log: {ts, peer, qname, qtype, answer} per query, flushed per line.
+
+    Red: `AttributeError: module 'corpus_serve' has no attribute 'bind_dns'`.
+    """
+
+    def _responder(self, log_path=None, answer_ip="10.0.2.2"):
+        sock = corpus_serve.bind_dns("127.0.0.1", 0)
+        self.addCleanup(sock.close)
+        log = corpus_serve.JsonlLog(log_path) if log_path else None
+        if log is not None:
+            self.addCleanup(log.close)
+        thread = threading.Thread(
+            target=corpus_serve.serve_dns, args=(sock, answer_ip, log), daemon=True,
+        )
+        thread.start()
+        return sock.getsockname()[1]
+
+    def _ask(self, port: int, name: str, qtype: int):
+        client = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.addCleanup(client.close)
+        client.settimeout(5)
+        client.bind(("127.0.0.1", 0))  # an unbound client reports 0.0.0.0 as its name
+        client.sendto(dns_query(name, qtype), ("127.0.0.1", port))
+        reply, _ = client.recvfrom(512)
+        return reply, "%s:%d" % client.getsockname()
+
+    def test_an_a_query_is_logged_with_the_answer_it_got(self):
+        with tempfile.TemporaryDirectory() as d:
+            log_path = os.path.join(d, "corpus-dns.log")
+            port = self._responder(log_path)
+            reply, me = self._ask(port, "blog.cloudflare.com", QTYPE_A)
+            self.assertEqual(socket.inet_ntoa(reply[-4:]), "10.0.2.2",
+                             "the responder no longer answers A queries")
+            rows = read_jsonl(log_path)
+            self.assertEqual(len(rows), 1, rows)
+            row = rows[0]
+            self.assertEqual(sorted(row), ["answer", "peer", "qname", "qtype", "ts"])
+            self.assertEqual(row["qname"], "blog.cloudflare.com")
+            self.assertEqual(row["qtype"], QTYPE_A)
+            self.assertEqual(row["answer"], "10.0.2.2")
+            self.assertEqual(row["peer"], me)
+            self.assertIsInstance(row["ts"], float)
+
+    def test_an_aaaa_query_is_logged_with_an_empty_answer(self):
+        with tempfile.TemporaryDirectory() as d:
+            log_path = os.path.join(d, "corpus-dns.log")
+            port = self._responder(log_path)
+            self._ask(port, "fonts.gstatic.com", QTYPE_AAAA)
+            (row,) = read_jsonl(log_path)
+            self.assertEqual(row["qname"], "fonts.gstatic.com")
+            self.assertEqual(row["qtype"], QTYPE_AAAA)
+            self.assertEqual(row["answer"], "")
+
+    def test_every_query_is_its_own_line(self):
+        with tempfile.TemporaryDirectory() as d:
+            log_path = os.path.join(d, "corpus-dns.log")
+            port = self._responder(log_path)
+            for name in ("a.test", "b.test", "c.test"):
+                self._ask(port, name, QTYPE_A)
+            self.assertEqual([r["qname"] for r in read_jsonl(log_path)],
+                             ["a.test", "b.test", "c.test"])
+
+    def test_without_a_log_the_responder_still_answers_and_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as d:
+            port = self._responder(None)
+            reply, _ = self._ask(port, "blog.cloudflare.com", QTYPE_A)
+            self.assertEqual(socket.inet_ntoa(reply[-4:]), "10.0.2.2")
+            self.assertEqual(os.listdir(d), [])
+
+    def test_closing_the_socket_ends_the_responder_thread(self):
+        """A closed socket must end serve_dns, not spin it on EBADF forever.
+
+        The responder's broad exception handler turned a closed socket into a
+        busy loop at 100% of one core for the rest of the process. Every test
+        above closes its socket in cleanup, so without this the suite itself
+        would leave spinning threads behind.
+
+        close() from this thread does not wake a recvfrom already blocked in
+        the kernel; the in-flight call keeps the socket alive until a datagram
+        arrives. One datagram after the close is what releases it, and what
+        the loop does next is the thing under test.
+        """
+        sock = corpus_serve.bind_dns("127.0.0.1", 0)
+        port = sock.getsockname()[1]
+        thread = threading.Thread(target=corpus_serve.serve_dns,
+                                  args=(sock, "10.0.2.2", None), daemon=True)
+        thread.start()
+        reply, _ = self._ask(port, "blog.cloudflare.com", QTYPE_A)
+        self.assertEqual(socket.inet_ntoa(reply[-4:]), "10.0.2.2")
+        sock.close()
+        wake = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.addCleanup(wake.close)
+        wake.sendto(dns_query("wake.test", QTYPE_A), ("127.0.0.1", port))
+        thread.join(timeout=5)
+        self.assertFalse(thread.is_alive(), "serve_dns kept running on a closed socket")
+
+
+class AccessLog(unittest.TestCase):
+    """--access-log: {ts, peer, method, host, path, status, bytes, duration_ms}.
+
+    Red: `AttributeError: module 'corpus_serve' has no attribute 'JsonlLog'`.
+    """
+
+    BODY = b"hello from the corpus\n"
+
+    def _corpus(self, d: str):
+        site = os.path.join(d, "corpus", "example")
+        os.makedirs(site)
+        with open(os.path.join(site, "a.txt"), "wb") as handle:
+            handle.write(self.BODY)
+        with open(os.path.join(site, "index.json"), "w") as handle:
+            json.dump({"resources": {
+                "https://example.test/a.txt": {"file": "a.txt", "status": 200,
+                                               "mime": "text/plain"},
+            }}, handle)
+        return os.path.join(d, "corpus")
+
+    def _server(self, d: str, log_path=None):
+        from pathlib import Path
+
+        exact, noquery, redirects = corpus_serve.load_indexes(Path(self._corpus(d)))
+        log = corpus_serve.JsonlLog(log_path) if log_path else None
+        if log is not None:
+            self.addCleanup(log.close)
+
+        # A subclass, so the handler's class-level tables and log stay private
+        # to this test instead of mutating corpus_serve.Handler for the suite.
+        class H(corpus_serve.Handler):
+            pass
+
+        H.exact, H.noquery, H.redirects = exact, noquery, redirects
+        H.misses = []
+        H.access_log = log
+        server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), H)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        self.addCleanup(server.server_close)
+        self.addCleanup(server.shutdown)
+        return server.server_port
+
+    def _get(self, port: int, path: str, host: str = "example.test"):
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        self.addCleanup(conn.close)
+        conn.request("GET", path, headers={"Host": host})
+        me = "%s:%d" % conn.sock.getsockname()  # gone once the HTTP/1.0 body is read
+        response = conn.getresponse()
+        return response.status, response.read(), me
+
+    def test_a_hit_is_logged_with_host_path_status_and_body_bytes(self):
+        with tempfile.TemporaryDirectory() as d:
+            log_path = os.path.join(d, "corpus-access.log")
+            port = self._server(d, log_path)
+            status, body, me = self._get(port, "/a.txt")
+            self.assertEqual((status, body), (200, self.BODY))
+            (row,) = read_jsonl(log_path)
+            self.assertEqual(sorted(row), ["bytes", "duration_ms", "host", "method",
+                                           "path", "peer", "status", "ts"])
+            self.assertEqual(row["method"], "GET")
+            self.assertEqual(row["host"], "example.test")
+            self.assertEqual(row["path"], "/a.txt")
+            self.assertEqual(row["status"], 200)
+            self.assertEqual(row["bytes"], len(self.BODY))
+            self.assertEqual(row["peer"], me)
+            self.assertIsInstance(row["ts"], float)
+            self.assertGreaterEqual(row["duration_ms"], 0.0)
+
+    def test_a_miss_is_logged_as_a_404_with_zero_bytes(self):
+        with tempfile.TemporaryDirectory() as d:
+            log_path = os.path.join(d, "corpus-access.log")
+            port = self._server(d, log_path)
+            status, _, _ = self._get(port, "/absent.js?v=1", host="cdn.test")
+            self.assertEqual(status, 404)
+            (row,) = read_jsonl(log_path)
+            self.assertEqual(row["host"], "cdn.test")
+            self.assertEqual(row["path"], "/absent.js?v=1")
+            self.assertEqual(row["status"], 404)
+            self.assertEqual(row["bytes"], 0)
+
+    def test_the_host_header_port_is_kept_out_of_the_lookup_but_in_the_log(self):
+        """The lookup strips :port (the guest sends Host: example.test:443 to
+        the TLS listener); the log records the header as sent."""
+        with tempfile.TemporaryDirectory() as d:
+            log_path = os.path.join(d, "corpus-access.log")
+            port = self._server(d, log_path)
+            status, body, _ = self._get(port, "/a.txt", host="example.test:443")
+            self.assertEqual((status, body), (200, self.BODY))
+            (row,) = read_jsonl(log_path)
+            self.assertEqual(row["host"], "example.test:443")
+
+    def test_without_a_log_serving_is_unchanged_and_nothing_is_written(self):
+        with tempfile.TemporaryDirectory() as d:
+            port = self._server(d, None)
+            status, body, _ = self._get(port, "/a.txt")
+            self.assertEqual((status, body), (200, self.BODY))
+            self.assertEqual(sorted(os.listdir(d)), ["corpus"])
+
+
+class Flags(unittest.TestCase):
+    """Both logs are optional command-line flags that default to off.
+
+    Red: `AttributeError: module 'corpus_serve' has no attribute 'build_parser'`.
+    """
+
+    def test_both_flags_parse_and_default_to_none(self):
+        parser = corpus_serve.build_parser()
+        off = parser.parse_args([])
+        self.assertIsNone(off.dns_log)
+        self.assertIsNone(off.access_log)
+        on = parser.parse_args(["--dns-log", "/r/corpus-dns.log",
+                                "--access-log", "/r/corpus-access.log"])
+        self.assertEqual(on.dns_log, "/r/corpus-dns.log")
+        self.assertEqual(on.access_log, "/r/corpus-access.log")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/chromium/test_corpus_serve_logs.py
+++ b/bench/chromium/test_corpus_serve_logs.py
@@ -452,6 +452,66 @@ class AccessLog(unittest.TestCase):
             self.assertIn("FAILED", err.getvalue())
             self.assertIn("No space left on device", err.getvalue())
 
+    def test_a_dns_log_line_that_cannot_be_written_stops_the_http_listeners(self):
+        """A DNS line that could not be written closed the responder's socket
+        and raised in its own thread, and nothing else: the HTTP listeners
+        kept answering. In the after-run bracket the :53 owner sampler has
+        already stopped, the clone resolves what it still holds and fetches
+        through the listeners that are still up, the bracket passes, and the
+        truncated DNS log is hashed as clean. The failure must reach the
+        server-wide state the access log's failure uses, so every listener
+        stops and main() exits 1 with the reason.
+
+        The line follows the answer, so the query whose line fails is still
+        answered; what must not happen is an HTTP request after it.
+
+        Red: the responder thread died on `TypeError: serve_dns() got an
+        unexpected keyword argument 'server'` before answering, so the first
+        query timed out (`TimeoutError: timed out`); with the argument
+        accepted and unused: `True is not false : the HTTP listener kept
+        serving after a failed DNS-log write`.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            access_log = corpus_serve.JsonlLog(os.path.join(d, "corpus-access.log"))
+            self.addCleanup(access_log.close)
+            server, thread = self._replay(d, access_log)
+            dns_log_path = os.path.join(d, "corpus-dns.log")
+            dns_log = self.BreaksAfter(dns_log_path, 1)
+            self.addCleanup(dns_log.close)
+            sock = corpus_serve.bind_dns("127.0.0.1", 0)
+            port = sock.getsockname()[1]
+            seen = []
+            saved_hook = threading.excepthook
+            threading.excepthook = lambda args: seen.append(args.exc_value)
+            self.addCleanup(setattr, threading, "excepthook", saved_hook)
+            responder = threading.Thread(target=corpus_serve.serve_dns,
+                                         args=(sock, "10.0.2.2", dns_log),
+                                         kwargs={"server": server}, daemon=True)
+            responder.start()
+            for name in ("first.test", "second.test"):
+                client = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                self.addCleanup(client.close)
+                client.settimeout(5)
+                client.sendto(dns_query(name, QTYPE_A), ("127.0.0.1", port))
+                reply, _ = client.recvfrom(512)
+                self.assertEqual(socket.inet_ntoa(reply[-4:]), "10.0.2.2", f"{name} was not answered")
+            responder.join(timeout=5)
+            self.assertFalse(responder.is_alive(), "serve_dns kept serving after a failed log write")
+            thread.join(timeout=5)
+            self.assertFalse(thread.is_alive(),
+                             "the HTTP listener kept serving after a failed DNS-log write")
+            self.assertIsInstance(server.log_failure, OSError)
+            self.assertEqual(server.log_failure.errno, errno.ENOSPC)
+            self.assertEqual(server.failed_log, "dns")
+            self.assertEqual([r["qname"] for r in read_jsonl(dns_log_path)], ["first.test"])
+            self.assertTrue(seen and isinstance(seen[0], OSError),
+                            f"the failure no longer reaches corpus_serve.log through the thread: {seen}")
+            conn = http.client.HTTPConnection("127.0.0.1", server.server_port, timeout=1)
+            self.addCleanup(conn.close)
+            with self.assertRaises(OSError, msg="a request was answered after the failed DNS-log write"):
+                conn.request("GET", "/a.txt", headers={"Host": "example.test"})
+                conn.getresponse()
+
     def test_a_signal_stop_waits_for_the_handlers_in_flight_before_closing_the_log(self):
         """The access line follows the response, so a client can hold the
         whole body while the line is still unwritten. The campaign sends

--- a/bench/chromium/test_corpus_serve_logs.py
+++ b/bench/chromium/test_corpus_serve_logs.py
@@ -54,15 +54,31 @@ class DnsLog(unittest.TestCase):
 
     def _responder(self, log_path=None, answer_ip="10.0.2.2"):
         sock = corpus_serve.bind_dns("127.0.0.1", 0)
-        self.addCleanup(sock.close)
+        port = sock.getsockname()[1]
         log = corpus_serve.JsonlLog(log_path) if log_path else None
-        if log is not None:
-            self.addCleanup(log.close)
         thread = threading.Thread(
             target=corpus_serve.serve_dns, args=(sock, answer_ip, log), daemon=True,
         )
         thread.start()
-        return sock.getsockname()[1]
+
+        def stop():
+            # close() does not wake a recvfrom already blocked in the kernel
+            # (see test_closing_the_socket_ends_the_responder_thread); one
+            # datagram after the close releases it, and the thread is then
+            # joined so no test leaves a blocked responder behind.
+            sock.close()
+            wake = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            try:
+                wake.sendto(dns_query("wake.test", QTYPE_A), ("127.0.0.1", port))
+            finally:
+                wake.close()
+            thread.join(timeout=5)
+            if log is not None:
+                log.close()
+            self.assertFalse(thread.is_alive(), "serve_dns outlived its test")
+
+        self.addCleanup(stop)
+        return port
 
     def _ask(self, port: int, name: str, qtype: int):
         client = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -115,6 +131,45 @@ class DnsLog(unittest.TestCase):
             reply, _ = self._ask(port, "blog.cloudflare.com", QTYPE_A)
             self.assertEqual(socket.inet_ntoa(reply[-4:]), "10.0.2.2")
             self.assertEqual(os.listdir(d), [])
+
+    def test_a_log_that_cannot_be_written_ends_the_responder(self):
+        """A query answered but not logged is a hole in the evidence the
+        campaign hashes. The broad handler swallowed the write error and the
+        resolver kept answering, unlogged, for the rest of the run. It now
+        closes its socket and ends: the guest stops resolving, the :53 owner
+        sampler sees no owner, and the run is refused on both counts.
+
+        Red: the second query was answered (thread alive, socket open).
+        """
+        class BrokenLog:
+            def write(self, _row):
+                raise OSError(28, "No space left on device")
+
+            def close(self):
+                pass
+
+        sock = corpus_serve.bind_dns("127.0.0.1", 0)
+        port = sock.getsockname()[1]
+        seen = []
+        saved_hook = threading.excepthook
+        threading.excepthook = lambda args: seen.append(args.exc_value)
+        self.addCleanup(setattr, threading, "excepthook", saved_hook)
+        thread = threading.Thread(target=corpus_serve.serve_dns,
+                                  args=(sock, "10.0.2.2", BrokenLog()), daemon=True)
+        thread.start()
+        reply, _ = self._ask(port, "blog.cloudflare.com", QTYPE_A)
+        self.assertEqual(socket.inet_ntoa(reply[-4:]), "10.0.2.2",
+                         "the query before the failed write must still be answered")
+        thread.join(timeout=5)
+        self.assertFalse(thread.is_alive(), "serve_dns kept serving after a failed log write")
+        self.assertEqual(sock.fileno(), -1, "the responder left its socket open")
+        self.assertTrue(seen and isinstance(seen[0], OSError), seen)
+        client = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.addCleanup(client.close)
+        client.settimeout(1)
+        client.sendto(dns_query("second.test", QTYPE_A), ("127.0.0.1", port))
+        with self.assertRaises(OSError):
+            client.recvfrom(512)
 
     def test_closing_the_socket_ends_the_responder_thread(self):
         """A closed socket must end serve_dns, not spin it on EBADF forever.

--- a/bench/chromium/test_corpus_serve_logs.py
+++ b/bench/chromium/test_corpus_serve_logs.py
@@ -93,11 +93,11 @@ class DnsLog(unittest.TestCase):
     def _rows(self, log_path: str) -> list:
         """The log once the responder has ended.
 
-        The line follows the answer, so a client holding the reply can still
-        be ahead of the line; reading the file at that moment found zero rows
-        once in 25 runs of this module (2026-08-28). The shipped stop_dns
-        ends the responder and joins it; the log stays open, so a line that
-        is there was flushed by the responder, not by close().
+        The line follows the answer, so a client that already holds the reply
+        can be ahead of the line, and a read at that moment sees a log that
+        is short by it. The shipped stop_dns ends the responder and joins it;
+        the log stays open, so a line that is there was flushed by the
+        responder, not by close().
         """
         corpus_serve.stop_dns(*self._dns)
         return read_jsonl(log_path)
@@ -278,11 +278,11 @@ class AccessLog(unittest.TestCase):
     def _rows(self, server, log_path: str) -> list:
         """The log once every handler `server` dequeued has finished.
 
-        The access line is written after the response, so a client holding
-        the whole body can still be ahead of the line; reading the file at
-        that moment found zero rows once in 454 (2026-08-28). The shipped
-        shutdown sequence waits for the handlers; the log stays open, so a
-        line that is there was flushed by the handler, not by close().
+        The access line is written after the response, so a client that
+        already holds the whole body can be ahead of the line, and a read at
+        that moment sees a log that is short by it. The shipped shutdown
+        sequence waits for the handlers; the log stays open, so a line that
+        is there was flushed by the handler, not by close().
         """
         corpus_serve.stop_listeners([server])
         return read_jsonl(log_path)

--- a/bench/chromium/test_corpus_serve_logs.py
+++ b/bench/chromium/test_corpus_serve_logs.py
@@ -14,7 +14,9 @@ quoted on each test.
 Run: python3 -m unittest test_corpus_serve_logs -v
 """
 
+import errno
 import http.client
+import io
 import json
 import os
 import socket
@@ -209,7 +211,7 @@ class AccessLog(unittest.TestCase):
 
     def _corpus(self, d: str):
         site = os.path.join(d, "corpus", "example")
-        os.makedirs(site)
+        os.makedirs(site, exist_ok=True)
         with open(os.path.join(site, "a.txt"), "wb") as handle:
             handle.write(self.BODY)
         with open(os.path.join(site, "index.json"), "w") as handle:
@@ -219,13 +221,15 @@ class AccessLog(unittest.TestCase):
             }}, handle)
         return os.path.join(d, "corpus")
 
-    def _server(self, d: str, log_path=None):
+    def _replay(self, d: str, log=None, peers=None, start=True):
+        """The shipped server class over a one-file corpus on an ephemeral port.
+
+        Returns (server, thread). With start=False the thread is None and the
+        caller runs serve_forever itself, as serve_http does.
+        """
         from pathlib import Path
 
         exact, noquery, redirects = corpus_serve.load_indexes(Path(self._corpus(d)))
-        log = corpus_serve.JsonlLog(log_path) if log_path else None
-        if log is not None:
-            self.addCleanup(log.close)
 
         # A subclass, so the handler's class-level tables and log stay private
         # to this test instead of mutating corpus_serve.Handler for the suite.
@@ -235,11 +239,20 @@ class AccessLog(unittest.TestCase):
         H.exact, H.noquery, H.redirects = exact, noquery, redirects
         H.misses = []
         H.access_log = log
-        server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), H)
-        threading.Thread(target=server.serve_forever, daemon=True).start()
+        server = corpus_serve.ReplayServer(("127.0.0.1", 0), H, peers)
         self.addCleanup(server.server_close)
-        self.addCleanup(server.shutdown)
-        return server.server_port
+        thread = None
+        if start:
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            self.addCleanup(server.shutdown)
+        return server, thread
+
+    def _server(self, d: str, log_path=None):
+        log = corpus_serve.JsonlLog(log_path) if log_path else None
+        if log is not None:
+            self.addCleanup(log.close)
+        return self._replay(d, log)[0].server_port
 
     def _get(self, port: int, path: str, host: str = "example.test"):
         conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
@@ -296,6 +309,113 @@ class AccessLog(unittest.TestCase):
             status, body, _ = self._get(port, "/a.txt")
             self.assertEqual((status, body), (200, self.BODY))
             self.assertEqual(sorted(os.listdir(d)), ["corpus"])
+
+
+    class BreaksAfter:
+        """A JsonlLog that writes its first `n` rows and fails every one
+        after, as a disk that fills part way through a run would."""
+
+        def __init__(self, path: str, n: int):
+            self.inner = corpus_serve.JsonlLog(path)
+            self.n = n
+            self.calls = 0
+            self._lock = threading.Lock()
+
+        def write(self, row: dict) -> None:
+            with self._lock:
+                self.calls += 1
+                if self.calls > self.n:
+                    raise OSError(errno.ENOSPC, "No space left on device")
+            self.inner.write(row)
+
+        def close(self) -> None:
+            self.inner.close()
+
+    @staticmethod
+    def _quiet(server):
+        # The handler re-raises after fail_closed, so the server's
+        # handle_error prints the traceback: wanted in corpus_serve.log,
+        # noise here.
+        server.handle_error = lambda _request, _address: None
+
+    def test_a_log_that_cannot_be_written_stops_the_server(self):
+        """A request answered but not logged is a hole in the evidence the
+        campaign hashes, the same as an unlogged DNS query. The write raised
+        inside one ThreadingHTTPServer handler thread, that thread died, and
+        the server kept answering, unlogged, for the rest of the run: the
+        URL brackets passed and write_dns_evidence hashed a truncated log.
+
+        The line is written after the response, so the request whose line
+        fails is still answered; what must not happen is a third one.
+
+        Red: `serve_forever kept running after a failed access-log write`.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            log_path = os.path.join(d, "corpus-access.log")
+            log = self.BreaksAfter(log_path, 1)
+            self.addCleanup(log.close)
+            server, thread = self._replay(d, log)
+            self._quiet(server)
+            port = server.server_port
+            self.assertEqual(self._get(port, "/a.txt")[0], 200)
+            self.assertEqual(self._get(port, "/a.txt")[0], 200,
+                             "the line is written after the response, so the "
+                             "request whose line fails is still answered")
+            thread.join(timeout=5)
+            self.assertFalse(thread.is_alive(),
+                             "serve_forever kept running after a failed access-log write")
+            self.assertIsInstance(server.log_failure, OSError)
+            self.assertEqual(server.log_failure.errno, errno.ENOSPC)
+            self.assertEqual(len(read_jsonl(log_path)), 1,
+                             "the line that failed to write is in the log")
+            conn = http.client.HTTPConnection("127.0.0.1", port, timeout=1)
+            self.addCleanup(conn.close)
+            with self.assertRaises(OSError,
+                                   msg="a third request was answered after the failed write"):
+                conn.request("GET", "/a.txt", headers={"Host": "example.test"})
+                conn.getresponse()
+
+    def test_a_failed_write_on_one_listener_ends_both_and_serve_http_returns_1(self):
+        """The guest fetches through HTTP and HTTPS alike, so a log missing
+        one listener's lines is as short as one missing both. main() blocks
+        in serve_http: a failure on the HTTP listener, served from a helper
+        thread, must also end the HTTPS serve_forever the main thread sits
+        in, and serve_http must return 1 with the reason on `err`.
+
+        Both listeners are plain HTTP here; TLS is not what is under test.
+
+        Red: `AttributeError: module 'corpus_serve' has no attribute
+        'serve_http'`.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            log = self.BreaksAfter(os.path.join(d, "corpus-access.log"), 1)
+            self.addCleanup(log.close)
+            peers = []
+            plain, _ = self._replay(d, log, peers, start=False)
+            tls, _ = self._replay(d, log, peers, start=False)
+            self._quiet(plain)
+            self._quiet(tls)
+            err = io.StringIO()
+            returned = []
+            loop = threading.Thread(
+                target=lambda: returned.append(corpus_serve.serve_http(plain, tls, err)),
+                daemon=True)
+            loop.start()
+            # A loop still running after the assertions below is a failed
+            # test; stop it so it does not spin on closed sockets afterwards.
+            self.addCleanup(lambda: (plain.shutdown(), tls.shutdown())
+                            if loop.is_alive() else None)
+            self.assertEqual(self._get(tls.server_port, "/a.txt")[0], 200)
+            self.assertEqual(self._get(plain.server_port, "/a.txt")[0], 200)
+            loop.join(timeout=5)
+            self.assertFalse(loop.is_alive(), "serve_http kept serving after a "
+                                              "failed access-log write on the HTTP listener")
+            self.assertEqual(returned, [1])
+            self.assertIsInstance(plain.log_failure, OSError)
+            self.assertIs(tls.log_failure, plain.log_failure,
+                          "the failure was not recorded on the other listener")
+            self.assertIn("FAILED", err.getvalue())
+            self.assertIn("No space left on device", err.getvalue())
 
 
 class Flags(unittest.TestCase):

--- a/bench/chromium/test_net_trace.py
+++ b/bench/chromium/test_net_trace.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""cdpdrive --net-trace: per-request Network.* rows for one navigation.
+
+The measured arms send exactly the CDP messages they send today. The trace is
+a diagnostic that adds `Network.enable` and a post-load drain, so it must be
+opt-in, and the opt-out path must be provably identical on the wire. Both
+sides are pinned here against a fake CDP endpoint that speaks real RFC 6455,
+so render.py's event stash and the socket-timeout drain are the code under
+test rather than a paraphrase of them. The argparse.Namespace shape follows
+CdpDriveNavigationFailurePhases in test_reqbench.py.
+
+Watched red 2026-08-28 against cdpdrive.py at 4d172153; the failure text is
+quoted on each test.
+
+Run: python3 -m unittest test_net_trace -v
+"""
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import shutil
+import socket
+import struct
+import sys
+import tempfile
+import threading
+import time
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+import cdpdrive  # noqa: E402
+
+WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+JPEG = b"\xff\xd8\xff\xe0" + b"\x00" * 16 + b"\xff\xd9"
+
+
+class FakeCdpServer:
+    """One-connection WebSocket server answering CDP commands from a script.
+
+    `script(method, params)` returns `(result, events)`. The result goes back
+    under the command's id; each event is then sent as a CDP notification, and
+    a float in the list is a pause in seconds, which is how "ended after the
+    load event" is staged. Every command method is recorded in `methods`, in
+    the order it arrived, so a test can hold the wire sequence to an exact list.
+    """
+
+    def __init__(self, script):
+        self.script = script
+        self.methods = []
+        self._buf = b""
+        self.listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.listener.bind(("127.0.0.1", 0))
+        self.listener.listen(1)
+        self.port = self.listener.getsockname()[1]
+        self.ws_url = f"ws://127.0.0.1:{self.port}/devtools/page/TARGET"
+        self.thread = threading.Thread(target=self._run, daemon=True)
+        self.thread.start()
+
+    def close(self):
+        if self.thread.is_alive():
+            # A test that failed before connecting leaves the thread in accept();
+            # a throwaway connection releases it instead of waiting out the timeout.
+            try:
+                socket.create_connection(("127.0.0.1", self.port), timeout=1).close()
+            except OSError:
+                pass
+        self.thread.join(timeout=10)
+        self.listener.close()
+
+    def _run(self):
+        self.listener.settimeout(10)
+        conn, _ = self.listener.accept()
+        conn.settimeout(10)
+        try:
+            self._upgrade(conn)
+            while True:
+                text = self._recv_text(conn)
+                if text is None:
+                    return
+                request = json.loads(text)
+                self.methods.append(request["method"])
+                result, events = self.script(request["method"], request.get("params", {}))
+                self._send_text(conn, json.dumps({"id": request["id"], "result": result}))
+                for event in events:
+                    if isinstance(event, float):
+                        time.sleep(event)
+                        continue
+                    self._send_text(conn, json.dumps(event))
+        except OSError:
+            return
+        finally:
+            conn.close()
+
+    def _exact(self, conn, n):
+        while len(self._buf) < n:
+            chunk = conn.recv(65536)
+            if not chunk:
+                return None
+            self._buf += chunk
+        out, self._buf = self._buf[:n], self._buf[n:]
+        return out
+
+    def _upgrade(self, conn):
+        while b"\r\n\r\n" not in self._buf:
+            chunk = conn.recv(4096)
+            if not chunk:
+                raise OSError("client closed during upgrade")
+            self._buf += chunk
+        head, _, self._buf = self._buf.partition(b"\r\n\r\n")
+        key = ""
+        for line in head.decode().split("\r\n"):
+            name, _, value = line.partition(":")
+            if name.strip().lower() == "sec-websocket-key":
+                key = value.strip()
+        accept = base64.b64encode(hashlib.sha1((key + WS_GUID).encode()).digest()).decode()
+        conn.sendall(
+            b"HTTP/1.1 101 Switching Protocols\r\n"
+            b"Upgrade: websocket\r\nConnection: Upgrade\r\n"
+            b"Sec-WebSocket-Accept: " + accept.encode() + b"\r\n\r\n"
+        )
+
+    def _recv_text(self, conn):
+        while True:
+            header = self._exact(conn, 2)
+            if header is None:
+                return None
+            b1, b2 = header
+            opcode, masked, n = b1 & 0x0F, b2 & 0x80, b2 & 0x7F
+            if n == 126:
+                (n,) = struct.unpack("!H", self._exact(conn, 2))
+            elif n == 127:
+                (n,) = struct.unpack("!Q", self._exact(conn, 8))
+            mask = self._exact(conn, 4) if masked else b""
+            payload = self._exact(conn, n)
+            if payload is None:
+                return None
+            if masked:
+                payload = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+            if opcode == 0x8:
+                return None
+            if opcode == 0x1:
+                return payload.decode()
+
+    @staticmethod
+    def _send_text(conn, text):
+        payload = text.encode()
+        n = len(payload)
+        if n < 126:
+            header = struct.pack("!BB", 0x81, n)
+        elif n < 65536:
+            header = struct.pack("!BBH", 0x81, 126, n)
+        else:
+            header = struct.pack("!BBQ", 0x81, 127, n)
+        conn.sendall(header + payload)
+
+
+def request_will_be_sent(rid, url, ts):
+    return {"method": "Network.requestWillBeSent",
+            "params": {"requestId": rid, "loaderId": "L1", "timestamp": ts,
+                       "request": {"url": url, "method": "GET"}}}
+
+
+def response_received(rid, ts, ip, port, protocol, status, dns=(-1, -1)):
+    return {"method": "Network.responseReceived",
+            "params": {"requestId": rid, "loaderId": "L1", "timestamp": ts,
+                       "response": {"url": "", "status": status, "protocol": protocol,
+                                    "remoteIPAddress": ip, "remotePort": port,
+                                    "timing": {"requestTime": ts, "dnsStart": dns[0],
+                                               "dnsEnd": dns[1]}}}}
+
+
+def loading_finished(rid, ts):
+    return {"method": "Network.loadingFinished",
+            "params": {"requestId": rid, "timestamp": ts, "encodedDataLength": 1}}
+
+
+def loading_failed(rid, ts, error, canceled=False):
+    return {"method": "Network.loadingFailed",
+            "params": {"requestId": rid, "timestamp": ts, "type": "Image",
+                       "errorText": error, "canceled": canceled}}
+
+
+def load_event_fired(ts):
+    return {"method": "Page.loadEventFired", "params": {"timestamp": ts}}
+
+
+# Five requests around one load event at t=1000.100 on the browser clock:
+# r1, r2 finish before it; r3 fails before it; r4 is open at the load event
+# and finishes 350 ms later, after the pause; r5 starts after the load event
+# and never ends.
+NAV_EVENTS = [
+    request_will_be_sent("r1", "http://site.test/", 1000.000),
+    request_will_be_sent("r2", "http://cdn.test/a.js", 1000.010),
+    request_will_be_sent("r3", "http://tracker.test/pixel", 1000.020),
+    request_will_be_sent("r4", "http://slow.test/font.woff", 1000.030),
+    response_received("r1", 1000.050, "10.0.2.2", 80, "http/1.1", 200, dns=(1.0, 3.5)),
+    loading_finished("r1", 1000.060),
+    response_received("r2", 1000.070, "10.0.2.2", 80, "http/1.1", 200),
+    loading_finished("r2", 1000.080),
+    loading_failed("r3", 1000.090, "net::ERR_NAME_NOT_RESOLVED"),
+    load_event_fired(1000.100),
+    0.05,
+    response_received("r4", 1000.400, "93.184.216.34", 443, "h2", 200),
+    loading_finished("r4", 1000.450),
+    request_will_be_sent("r5", "http://late.test/beacon", 1000.500),
+]
+
+
+def scripted(nav_events):
+    def script(method, _params):
+        if method == "Page.navigate":
+            return {"frameId": "F", "loaderId": "L1"}, list(nav_events)
+        if method == "Page.captureScreenshot":
+            return {"data": base64.b64encode(JPEG).decode()}, []
+        return {}, []
+    return script
+
+
+def args_for(server, **overrides):
+    """CdpDriveNavigationFailurePhases._args, pointed at the fake endpoint."""
+    ns = argparse.Namespace(
+        cdp_host="127.0.0.1:1", url="http://site.test/", format="jpeg", quality=80,
+        timeout=5.0, idle_wait_ms=0.0, out_prefix="", ws_url=server.ws_url,
+        connect_retries=1, nav_timing=False, print_target=False,
+        host_header="", render_module=os.path.join(HERE, "render.py"),
+    )
+    for key, value in overrides.items():
+        setattr(ns, key, value)
+    return ns
+
+
+class NetTraceRecorded(unittest.TestCase):
+    """With --net-trace the file and the record carry the summary.
+
+    Red: `KeyError: 'net_trace'` (the flag was ignored and no file was written).
+    """
+
+    def _drive(self, nav_events=NAV_EVENTS, drain_ms=500.0, **overrides):
+        server = FakeCdpServer(scripted(nav_events))
+        self.addCleanup(server.close)
+        d = tempfile.mkdtemp(prefix="net-trace-")
+        self.addCleanup(shutil.rmtree, d)
+        path = os.path.join(d, "trace.json")
+        out = cdpdrive.drive(args_for(server, net_trace=path, net_trace_drain_ms=drain_ms,
+                                      **overrides))
+        return out, path, server
+
+    def test_summary_counts_pending_at_load_remote_ips_and_errors(self):
+        out, path, server = self._drive()
+        self.assertTrue(out["ok"], out)
+        summary = out["net_trace"]
+        self.assertEqual(summary["n_requests"], 5)
+        self.assertEqual(summary["n_finished_before_load"], 2)
+        self.assertEqual(summary["n_failed"], 1)
+        self.assertEqual(summary["n_pending_at_load"], 1,
+                         "r4 was the only request open at the load event; r5 "
+                         "started after it and must not count")
+        self.assertEqual(summary["remote_ips"], {"10.0.2.2": 2, "93.184.216.34": 1})
+        self.assertEqual(summary["errors"], {"net::ERR_NAME_NOT_RESOLVED": 1})
+        self.assertEqual(summary["slowest_10"][0],
+                         {"url": "http://slow.test/font.woff", "end_ms": 450.0})
+        self.assertEqual(summary["load_event_ms"], 100.0)
+        self.assertEqual(server.methods,
+                         ["Page.enable", "Network.enable", "Page.navigate",
+                          "Page.captureScreenshot"])
+
+    def test_file_rows_carry_per_request_fields_and_match_the_record(self):
+        out, path, _ = self._drive()
+        with open(path) as handle:
+            trace = json.load(handle)
+        self.assertEqual(sorted(trace), ["requests", "summary"])
+        self.assertEqual(trace["summary"], out["net_trace"])
+        rows = {row["url"]: row for row in trace["requests"]}
+        self.assertEqual(len(rows), 5)
+        r1 = rows["http://site.test/"]
+        self.assertEqual((r1["start_ms"], r1["end_ms"]), (0.0, 60.0))
+        self.assertEqual((r1["remote_ip"], r1["remote_port"], r1["protocol"], r1["status"]),
+                         ("10.0.2.2", 80, "http/1.1", 200))
+        self.assertTrue(r1["finished_before_load"])
+        self.assertFalse(r1["failed"])
+        self.assertEqual(r1["error_text"], "")
+        self.assertEqual(r1["dns_ms"], 2.5)
+        r3 = rows["http://tracker.test/pixel"]
+        self.assertTrue(r3["failed"])
+        self.assertFalse(r3["finished_before_load"])
+        self.assertEqual(r3["error_text"], "net::ERR_NAME_NOT_RESOLVED")
+        r4 = rows["http://slow.test/font.woff"]
+        self.assertFalse(r4["finished_before_load"])
+        self.assertTrue(r4["pending_at_load"])
+        self.assertEqual(r4["end_ms"], 450.0)
+        r5 = rows["http://late.test/beacon"]
+        self.assertIsNone(r5["end_ms"])
+        self.assertFalse(r5["pending_at_load"])
+
+    def test_the_drain_is_bounded_by_net_trace_drain_ms(self):
+        out, _, _ = self._drive(drain_ms=200.0)
+        self.assertTrue(out["ok"], out)
+        drain = out["stages"]["net_trace_drain_ms"]
+        self.assertGreaterEqual(drain, 200.0)
+        self.assertLess(drain, 1500.0, f"drain ran {drain} ms against a 200 ms bound")
+
+    def test_a_trace_is_still_written_when_the_load_event_never_fires(self):
+        """The stall is the case the trace exists for, so it must survive it."""
+        stalled = [
+            request_will_be_sent("r1", "http://site.test/", 1000.000),
+            request_will_be_sent("r2", "http://slow.test/font.woff", 1000.010),
+            response_received("r1", 1000.050, "10.0.2.2", 80, "http/1.1", 200),
+            loading_finished("r1", 1000.060),
+        ]
+        out, path, _ = self._drive(stalled, timeout=1.0)
+        self.assertFalse(out["ok"])
+        self.assertEqual(out["stage"], "navigate-load-event")
+        self.assertTrue(os.path.exists(path), "no trace for the failure it exists to explain")
+        summary = out["net_trace"]
+        self.assertIsNone(summary["load_event_ms"])
+        self.assertEqual(summary["n_requests"], 2)
+        self.assertEqual(summary["n_finished_before_load"], 0)
+        self.assertEqual(summary["n_pending_at_load"], 1)
+
+
+class NetTraceOff(unittest.TestCase):
+    """Without the flag the wire sequence is today's, message for message."""
+
+    TODAY = ["Page.enable", "Page.navigate", "Page.captureScreenshot"]
+
+    def _drive(self, **overrides):
+        server = FakeCdpServer(scripted(NAV_EVENTS))
+        self.addCleanup(server.close)
+        out = cdpdrive.drive(args_for(server, **overrides))
+        server.close()
+        return out, server
+
+    def test_no_attribute_sends_no_network_enable(self):
+        """reqbench.py builds a closed Namespace without net_trace."""
+        out, server = self._drive()
+        self.assertTrue(out["ok"], out)
+        self.assertEqual(server.methods, self.TODAY)
+        self.assertNotIn("net_trace", out)
+        self.assertNotIn("net_trace_drain_ms", out["stages"])
+
+    def test_net_trace_none_sends_no_network_enable(self):
+        """The CLI default is None, and None means off."""
+        with tempfile.TemporaryDirectory() as d:
+            out, server = self._drive(net_trace=None, net_trace_drain_ms=5000.0)
+            self.assertTrue(out["ok"], out)
+            self.assertEqual(server.methods, self.TODAY)
+            self.assertNotIn("net_trace", out)
+            self.assertEqual(os.listdir(d), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/chromium/test_net_trace.py
+++ b/bench/chromium/test_net_trace.py
@@ -280,7 +280,10 @@ class NetTraceRecorded(unittest.TestCase):
         self.assertEqual(summary["remote_ips"], {"10.0.2.2": 2, "93.184.216.34": 1})
         self.assertEqual(summary["errors"], {"net::ERR_NAME_NOT_RESOLVED": 1})
         self.assertEqual(summary["slowest_10"][0],
-                         {"url": "http://slow.test/font.woff", "end_ms": 450.0})
+                         {"url": "http://slow.test/font.woff", "end_ms": 450.0,
+                          "duration_ms": 420.0})
+        self.assertEqual(summary["pending_at_load"],
+                         [{"url": "http://slow.test/font.woff", "start_ms": 30.0}])
         self.assertEqual(summary["load_event_ms"], 100.0)
         self.assertEqual(server.methods,
                          ["Page.enable", "Network.enable", "Page.navigate",
@@ -313,6 +316,56 @@ class NetTraceRecorded(unittest.TestCase):
         r5 = rows["http://late.test/beacon"]
         self.assertIsNone(r5["end_ms"])
         self.assertFalse(r5["pending_at_load"])
+
+    def test_slowest_ranks_by_duration_and_names_the_rows_open_at_load(self):
+        """slowest_10 was sorted by end_ms, completion relative to the first
+        request, so a request that started late and finished fast outranked
+        an earlier, longer one, and a request still open at the load event,
+        the first thing a stall investigation reads, was not in the summary
+        at all. Rank by duration, carry it per entry, and list the open rows.
+
+        Red: `{'url': 'http://fast.test/late', 'end_ms': 350.0}` first, then
+        `KeyError: 'pending_at_load'`.
+        """
+        events = [
+            request_will_be_sent("r1", "http://slow.test/long", 1000.000),
+            request_will_be_sent("r2", "http://hang.test/open", 1000.010),
+            request_will_be_sent("r3", "http://fast.test/late", 1000.250),
+            response_received("r1", 1000.290, "10.0.2.2", 80, "http/1.1", 200),
+            loading_finished("r1", 1000.300),
+            response_received("r3", 1000.340, "10.0.2.2", 80, "http/1.1", 200),
+            loading_finished("r3", 1000.350),
+            load_event_fired(1000.400),
+        ]
+        out, _, _ = self._drive(events, drain_ms=100.0)
+        self.assertTrue(out["ok"], out)
+        summary = out["net_trace"]
+        self.assertEqual(summary["slowest_10"], [
+            {"url": "http://slow.test/long", "end_ms": 300.0, "duration_ms": 300.0},
+            {"url": "http://fast.test/late", "end_ms": 350.0, "duration_ms": 100.0},
+        ])
+        self.assertEqual(summary["pending_at_load"],
+                         [{"url": "http://hang.test/open", "start_ms": 10.0}])
+        self.assertEqual(summary["n_pending_at_load"], 1)
+
+    def test_pending_at_load_lists_at_most_ten_rows_in_start_order(self):
+        """Twelve requests open at the load event: the list names the ten
+        that started first, and the count still says twelve.
+
+        Red: `KeyError: 'pending_at_load'`.
+        """
+        events = [request_will_be_sent(f"r{i}", f"http://open.test/{i}", 1000.0 + i / 1000)
+                  for i in range(12)]
+        events.append(request_will_be_sent("done", "http://done.test/", 1000.020))
+        events.append(loading_finished("done", 1000.030))
+        trace = cdpdrive.reduce_net_trace(events, 1000.100, 100.0)
+        summary = trace["summary"]
+        self.assertEqual(summary["n_pending_at_load"], 12)
+        self.assertEqual(summary["pending_at_load"],
+                         [{"url": f"http://open.test/{i}", "start_ms": float(i)}
+                          for i in range(10)])
+        self.assertEqual(summary["slowest_10"],
+                         [{"url": "http://done.test/", "end_ms": 30.0, "duration_ms": 10.0}])
 
     def test_the_drain_is_bounded_by_net_trace_drain_ms(self):
         out, _, _ = self._drive(drain_ms=200.0)

--- a/bench/chromium/test_net_trace.py
+++ b/bench/chromium/test_net_trace.py
@@ -23,6 +23,7 @@ import os
 import shutil
 import socket
 import struct
+import subprocess
 import sys
 import tempfile
 import threading
@@ -51,6 +52,7 @@ class FakeCdpServer:
     def __init__(self, script):
         self.script = script
         self.methods = []
+        self.messages = []  # (method, params) in wire order
         self._buf = b""
         self.listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -84,6 +86,7 @@ class FakeCdpServer:
                     return
                 request = json.loads(text)
                 self.methods.append(request["method"])
+                self.messages.append((request["method"], request.get("params", {})))
                 result, events = self.script(request["method"], request.get("params", {}))
                 self._send_text(conn, json.dumps({"id": request["id"], "result": result}))
                 for event in events:
@@ -211,22 +214,36 @@ NAV_EVENTS = [
 ]
 
 
+NAV_ENTRY = {
+    "domainLookupStart": 1.0, "domainLookupEnd": 2.0, "connectStart": 2.0,
+    "connectEnd": 3.0, "requestStart": 3.0, "responseStart": 4.0,
+    "responseEnd": 5.0, "loadEventEnd": 6.0,
+}
+
+
 def scripted(nav_events):
     def script(method, _params):
         if method == "Page.navigate":
             return {"frameId": "F", "loaderId": "L1"}, list(nav_events)
         if method == "Page.captureScreenshot":
             return {"data": base64.b64encode(JPEG).decode()}, []
+        if method == "Runtime.evaluate":
+            return {"result": {"type": "string", "value": json.dumps(NAV_ENTRY)}}, []
         return {}, []
     return script
 
 
 def args_for(server, **overrides):
-    """CdpDriveNavigationFailurePhases._args, pointed at the fake endpoint."""
+    """reqbench.py's closed cdpdrive Namespace, pointed at the fake endpoint.
+
+    nav_timing=True, idle_wait_ms=0 and host_header="" are what the measured
+    producer sets (reqbench.py, run_cdp_request), so the wire sequence pinned
+    below is the measured arm's.
+    """
     ns = argparse.Namespace(
         cdp_host="127.0.0.1:1", url="http://site.test/", format="jpeg", quality=80,
         timeout=5.0, idle_wait_ms=0.0, out_prefix="", ws_url=server.ws_url,
-        connect_retries=1, nav_timing=False, print_target=False,
+        connect_retries=1, nav_timing=True, print_target=False,
         host_header="", render_module=os.path.join(HERE, "render.py"),
     )
     for key, value in overrides.items():
@@ -267,7 +284,7 @@ class NetTraceRecorded(unittest.TestCase):
         self.assertEqual(summary["load_event_ms"], 100.0)
         self.assertEqual(server.methods,
                          ["Page.enable", "Network.enable", "Page.navigate",
-                          "Page.captureScreenshot"])
+                          "Page.captureScreenshot", "Runtime.evaluate"])
 
     def test_file_rows_carry_per_request_fields_and_match_the_record(self):
         out, path, _ = self._drive()
@@ -323,10 +340,59 @@ class NetTraceRecorded(unittest.TestCase):
         self.assertEqual(summary["n_pending_at_load"], 1)
 
 
-class NetTraceOff(unittest.TestCase):
-    """Without the flag the wire sequence is today's, message for message."""
+class NetTraceWrite(unittest.TestCase):
+    """The trace file is whole or absent, and a trace that was asked for and
+    not written fails the CLI.
 
-    TODAY = ["Page.enable", "Page.navigate", "Page.captureScreenshot"]
+    Red: an empty trace.json left behind by an interrupted write
+    (`open(path, "w")` truncates before json.dump runs), and exit 0 from a
+    CLI whose --net-trace PATH does not exist afterwards.
+    """
+
+    def test_an_interrupted_write_leaves_no_partial_file(self):
+        from unittest import mock
+        server = FakeCdpServer(scripted(NAV_EVENTS))
+        self.addCleanup(server.close)
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "trace.json")
+            with mock.patch("json.dump", side_effect=OSError(28, "No space left on device")):
+                out = cdpdrive.drive(args_for(server, net_trace=path, net_trace_drain_ms=100.0))
+            self.assertTrue(out["ok"], out)
+            self.assertIn("net_trace_error", out)
+            self.assertIn("No space left", out["net_trace_error"])
+            self.assertFalse(os.path.exists(path), "a partial trace file was left behind")
+            self.assertEqual(os.listdir(d), [], "a temp file was left behind")
+
+    def test_a_trace_that_could_not_be_written_fails_the_cli(self):
+        server = FakeCdpServer(scripted(NAV_EVENTS))
+        self.addCleanup(server.close)
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "no-such-dir", "trace.json")
+            result = subprocess.run(
+                [sys.executable, os.path.join(HERE, "cdpdrive.py"),
+                 "127.0.0.1:1", "http://site.test/", "--ws-url", server.ws_url,
+                 "--format", "jpeg", "--timeout", "5", "--connect-retries", "1",
+                 "--net-trace", path, "--net-trace-drain-ms", "100"],
+                capture_output=True, text=True, timeout=60)
+            self.assertNotEqual(result.returncode, 0,
+                                "exit 0 with no trace file\n" + result.stdout + result.stderr)
+            record = json.loads(result.stdout.strip().splitlines()[-1])
+            self.assertTrue(record["ok"], record)
+            self.assertIn("net_trace_error", record)
+            self.assertFalse(os.path.exists(path))
+
+
+class NetTraceOff(unittest.TestCase):
+    """Without the flag the wire is the measured arm's, message for message.
+
+    The fake records (method, params) in wire order, and the trace-on run is
+    held to exactly one extra message: Network.enable before Page.navigate.
+    Verified red by fault injection (an unconditional Network.enable in
+    cdpdrive.drive fails both trace-off tests and the one-extra-message
+    assertion).
+    """
+
+    TODAY = ["Page.enable", "Page.navigate", "Page.captureScreenshot", "Runtime.evaluate"]
 
     def _drive(self, **overrides):
         server = FakeCdpServer(scripted(NAV_EVENTS))
@@ -335,22 +401,41 @@ class NetTraceOff(unittest.TestCase):
         server.close()
         return out, server
 
+    def _assert_measured_wire(self, out, server):
+        self.assertTrue(out["ok"], out)
+        self.assertEqual([m for m, _ in server.messages], self.TODAY)
+        self.assertEqual(server.messages[0], ("Page.enable", {}))
+        self.assertEqual(server.messages[1], ("Page.navigate", {"url": "http://site.test/"}))
+        self.assertEqual(server.messages[3][1].get("returnByValue"), True)
+        self.assertNotIn("net_trace", out)
+        self.assertNotIn("net_trace_error", out)
+        self.assertNotIn("net_trace_drain_ms", out["stages"])
+        self.assertIn("nav_timing_ms", out["stages"])
+
     def test_no_attribute_sends_no_network_enable(self):
         """reqbench.py builds a closed Namespace without net_trace."""
         out, server = self._drive()
-        self.assertTrue(out["ok"], out)
-        self.assertEqual(server.methods, self.TODAY)
-        self.assertNotIn("net_trace", out)
-        self.assertNotIn("net_trace_drain_ms", out["stages"])
+        self._assert_measured_wire(out, server)
 
     def test_net_trace_none_sends_no_network_enable(self):
         """The CLI default is None, and None means off."""
+        out, server = self._drive(net_trace=None, net_trace_drain_ms=5000.0)
+        self._assert_measured_wire(out, server)
+
+    def test_the_trace_adds_exactly_one_message(self):
+        off_out, off_server = self._drive()
         with tempfile.TemporaryDirectory() as d:
-            out, server = self._drive(net_trace=None, net_trace_drain_ms=5000.0)
-            self.assertTrue(out["ok"], out)
-            self.assertEqual(server.methods, self.TODAY)
-            self.assertNotIn("net_trace", out)
-            self.assertEqual(os.listdir(d), [])
+            on_server = FakeCdpServer(scripted(NAV_EVENTS))
+            self.addCleanup(on_server.close)
+            on_out = cdpdrive.drive(args_for(
+                on_server, net_trace=os.path.join(d, "trace.json"), net_trace_drain_ms=100.0))
+            on_server.close()
+        self.assertTrue(off_out["ok"] and on_out["ok"], (off_out, on_out))
+        on = list(on_server.messages)
+        self.assertEqual(on[1], ("Network.enable", {}))
+        del on[1]
+        self.assertEqual(on, off_server.messages,
+                         "the trace changed more than the one Network.enable")
 
 
 if __name__ == "__main__":

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -7879,6 +7879,7 @@ class CampaignSummaryFromAnalyzerOutput(unittest.TestCase):
     def _evidence(run_dir, verdict):
         """dns-evidence.json plus every file it names, as the campaign leaves them."""
         verify_files = []
+        verify_hashes = {}
         for stage in ("pre", "before-run", "after-run"):
             path = os.path.join(run_dir, f"verify-dns-{stage}.json")
             with open(path, "w") as handle:
@@ -7892,6 +7893,9 @@ class CampaignSummaryFromAnalyzerOutput(unittest.TestCase):
                     "timestamp": "2026-08-28T00:00:00Z", "passed": True,
                 }, handle)
             verify_files.append(path)
+            with open(path, "rb") as handle:
+                verify_hashes[f"verify-dns-{stage}.json"] = hashlib.sha256(
+                    handle.read()).hexdigest()
         hashes = {}
         for name in ("corpus-dns.log", "corpus-access.log"):
             path = os.path.join(run_dir, name)
@@ -7912,6 +7916,7 @@ class CampaignSummaryFromAnalyzerOutput(unittest.TestCase):
             "owner_log": os.path.join(run_dir, "dns-owner.log"),
             "first_mismatch": None,
             "verify_files": verify_files,
+            "verify_file_sha256": verify_hashes,
             "corpus_dns_log_sha256": hashes["corpus-dns.log"],
             "corpus_access_log_sha256": hashes["corpus-access.log"],
             "corpus_serve_exit_status": 0,

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -7446,6 +7446,32 @@ class AnalyzerPerUrl(unittest.TestCase):
             out["per_url"]["http://127.0.0.1:8000/medium.html"]["cdp"]["n"], 200,
         )
 
+    def test_a_record_url_that_contradicts_its_render_is_a_schedule_error(self):
+        """per_url buckets by the record's own url stamp. The schedule check
+        validated only render.url, so a record could sit in one URL's
+        bucket while its render proves it rendered another, and the run
+        stayed publishable."""
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(d, "r.jsonl")
+            dst = os.path.join(d, "r.json")
+            self.write(src)
+
+            def cross(record):
+                self.assertEqual(record["url"], self.URLS[0])
+                record["url"] = self.URLS[1]  # render.url stays URLS[0]
+
+            AnalyzerAvailability._mutate_record(src, "cdp", cross)
+            rc = _run_analyzer_fast(["--json-out", dst, src])
+            with open(dst) as source:
+                out = json.load(source)
+        self.assertIs(out["publishable"], False)
+        self.assertEqual(rc, 5)
+        errors = out["gate"]["backend_metadata"]["errors"]
+        self.assertTrue(
+            any("url" in error and self.URLS[1] in error for error in errors),
+            errors,
+        )
+
 
 class AnalyzerStallGate(unittest.TestCase):
     """A load event that takes tens of seconds is a stall, not a slow page.

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -2508,7 +2508,7 @@ class AnalyzerAvailability(unittest.TestCase):
             "kind": "meta", "run_id": run_id, "seed": seed, "backend": backend,
             "uffd_mode": "file" if backend == "file" else "copy",
             "arms": arms, "reps": measured, "warmup": warmup,
-            "url": "http://fixture/medium.html", "format": "jpeg", "quality": 80,
+            "url": "http://127.0.0.1:8000/medium.html", "format": "jpeg", "quality": 80,
             "image": "localhost/chromium-bench-req",
             "image_id": "sha256:" + "d" * 64, "snapshot": f"snapshot-{backend}",
             "snapshot_generation_id": (
@@ -2585,6 +2585,8 @@ class AnalyzerAvailability(unittest.TestCase):
                             "resolve_ms": 0.1, "tcp_ms": 0.08,
                             "upgrade_ms": 0.1, "enable_ms": 0.1,
                             "connect_total_ms": 0.4, "navigate_ms": 1.0,
+                            "navigate_command_ms": 0.2,
+                            "navigate_load_event_ms": 0.8,
                             "idle_ms": 0.0, "screenshot_ms": 1.0,
                             "decode_ms": 0.1, "nav_timing_ms": 0.1,
                             "total_ms": value,
@@ -6949,3 +6951,590 @@ class PerRequestPrivateDirty(unittest.TestCase):
             302_048,
             "a complete sample must still total",
         )
+
+
+class SnapshotGenerationDns(unittest.TestCase):
+    """snapshot_generation returns the golden's recorded guest resolver.
+
+    The corpus arm bakes GUEST_DNS into the golden (`fcvm podman prepare
+    --dns`), which fcvm records as metadata.network_config.dns_server in the
+    snapshot's config.json. The run meta has to carry that value so the
+    analyzer can refuse a corpus run whose hostnames were resolved by nothing
+    the record names.
+
+    RED BEFORE THE FIX: KeyError: 'dns_server' for the override case,
+    `'dns_server' not found in {'generation_id': ...}` for the null and
+    absent cases, and `RuntimeError not raised` for the rejected resolver.
+    """
+
+    SNAPSHOT = SnapshotGenerationIdentity.SNAPSHOT
+    GENERATION_ID = "11111111-1111-4111-8111-111111111111"
+
+    @classmethod
+    def write_generation(cls, data_root, network_config):
+        """The identity fixture plus a network_config block (None omits it)."""
+        config_path, _digest = SnapshotGenerationIdentity._write_generation(
+            data_root, cls.GENERATION_ID,
+        )
+        if network_config is None:
+            return
+        with open(config_path) as source:
+            config = json.load(source)
+        config["metadata"]["network_config"] = network_config
+        config_json = (
+            json.dumps(config, sort_keys=True, separators=(",", ":")) + "\n"
+        ).encode()
+        with open(config_path, "wb") as target:
+            target.write(config_json)
+        provenance_path = os.path.join(
+            data_root, "snapshots", cls.SNAPSHOT, "reqbench-provenance.json",
+        )
+        with open(provenance_path) as source:
+            provenance = json.load(source)
+        provenance["snapshot_config_sha256"] = hashlib.sha256(config_json).hexdigest()
+        with open(provenance_path, "w") as target:
+            json.dump(provenance, target)
+
+    def test_a_dns_override_is_returned_as_dns_server(self):
+        with tempfile.TemporaryDirectory() as data_root:
+            self.write_generation(data_root, {"dns_server": "10.0.2.2"})
+            generation = reqbench.snapshot_generation(data_root, self.SNAPSHOT)
+            self.assertEqual(generation["dns_server"], "10.0.2.2")
+
+    def test_no_override_is_returned_as_none(self):
+        with tempfile.TemporaryDirectory() as data_root:
+            self.write_generation(
+                data_root, {"dns_server": None, "tap_device": "tap0"},
+            )
+            generation = reqbench.snapshot_generation(data_root, self.SNAPSHOT)
+            self.assertIn("dns_server", generation)
+            self.assertIsNone(generation["dns_server"])
+
+    def test_an_absent_network_config_is_none(self):
+        with tempfile.TemporaryDirectory() as data_root:
+            self.write_generation(data_root, None)
+            generation = reqbench.snapshot_generation(data_root, self.SNAPSHOT)
+            self.assertIn("dns_server", generation)
+            self.assertIsNone(generation["dns_server"])
+
+    def test_a_resolver_that_is_not_an_ip_literal_is_rejected(self):
+        with tempfile.TemporaryDirectory() as data_root:
+            self.write_generation(data_root, {"dns_server": "resolver.local"})
+            with self.assertRaisesRegex(RuntimeError, "dns_server"):
+                reqbench.snapshot_generation(data_root, self.SNAPSHOT)
+
+
+class RunMetaGuestDns(unittest.TestCase):
+    """reqbench.main stamps the golden's resolver and the engine into the meta.
+
+    Drives the real `main` against stubbed arms, the same way
+    SnapshotGenerationIdentity does, so the field is observed in the record
+    the analyzer reads rather than asserted about the source.
+
+    RED BEFORE THE FIX: KeyError: 'guest_dns' for the override case and
+    `'guest_dns' not found in {'kind': 'meta', ...}` for the null case.
+    """
+
+    SNAPSHOT = SnapshotGenerationIdentity.SNAPSHOT
+
+    def _drive_main(self, data_root, network_config):
+        SnapshotGenerationDns.write_generation(data_root, network_config)
+        runtime_bundle = os.path.join(data_root, "runtime")
+        os.makedirs(runtime_bundle)
+        manifest_path = os.path.join(runtime_bundle, "MANIFEST.sha256")
+        with open(manifest_path, "w") as target:
+            target.write("sealed runtime fixture\n")
+        fcvm = os.path.join(runtime_bundle, "fcvm")
+        with open(fcvm, "w") as target:
+            target.write("#!/bin/sh\nexit 0\n")
+        os.chmod(fcvm, 0o755)
+        exact_hashes = {
+            os.path.realpath(fcvm): "c" * 64,
+            os.path.realpath(manifest_path): "d" * 64,
+        }
+
+        def record(arm, rep):
+            return {
+                "arm": arm, "rep": rep, "ok": True,
+                "blocking_ms": 1.0, "wall_ms": 1.0, "teardown": {},
+            }
+
+        saved = {
+            "HERE": reqbench.HERE,
+            "run_noop_request": reqbench.run_noop_request,
+            "run_cdp_request": reqbench.run_cdp_request,
+            "sha256_file": reqbench.sha256_file,
+            "harness_sha256": reqbench.harness_sha256,
+            "command_text": reqbench.command_text,
+            "pending_signal": reqbench._pending_harness_signal,
+            "argv": sys.argv,
+            "sigint": signal.getsignal(signal.SIGINT),
+            "sigterm": signal.getsignal(signal.SIGTERM),
+        }
+        env_updates = {
+            "REQBENCH_RUNTIME_BUNDLE": runtime_bundle,
+            "REQBENCH_SOURCE_REVISION": "e" * 40,
+            "REQBENCH_GUARD_LOADAVG1": "0.1",
+            "REQBENCH_GUARD_VM_PROCESSES": "0",
+            "REQBENCH_QUIET_LOADAVG1_LIMIT": "2.0",
+            "REQBENCH_QUIET_GUARD": "1",
+            "ALLOW_BUSY": "0",
+        }
+        saved_env = {key: os.environ.get(key) for key in env_updates}
+        out_dir = os.path.join(data_root, "results")
+        try:
+            os.environ.update(env_updates)
+            reqbench.HERE = runtime_bundle
+            reqbench.run_noop_request = lambda _args, rep: record("noop", rep)
+            reqbench.run_cdp_request = (
+                lambda _args, rep, fast, probe=None:
+                record("cdp-fast" if fast else "cdp", rep)
+            )
+            reqbench.sha256_file = (
+                lambda path: exact_hashes[os.path.realpath(path)]
+            )
+            reqbench.harness_sha256 = lambda: "f" * 64
+            reqbench.command_text = lambda _argv: "fcvm fixture"
+            reqbench._pending_harness_signal = 0
+            sys.argv = [
+                "reqbench.py",
+                "--snapshot-tag", self.SNAPSHOT,
+                "--snapshot-name", self.SNAPSHOT,
+                "--url", "http://127.0.0.1:8000/medium.html",
+                "--arms", "noop,cdp",
+                "--reps", "1",
+                "--warmup", "0",
+                "--image", "localhost/chromium-bench-req",
+                "--image-id", "sha256:" + "b" * 64,
+                "--network-mode", "rootless",
+                "--cpu", "2",
+                "--memory-mib", "1024",
+                "--fcvm", fcvm,
+                "--data-root", data_root,
+                "--out-dir", out_dir,
+                "--run-id", "2" * 32,
+            ]
+            with redirect_stdout(io.StringIO()):
+                rc = reqbench.main()
+        finally:
+            reqbench.HERE = saved["HERE"]
+            reqbench.run_noop_request = saved["run_noop_request"]
+            reqbench.run_cdp_request = saved["run_cdp_request"]
+            reqbench.sha256_file = saved["sha256_file"]
+            reqbench.harness_sha256 = saved["harness_sha256"]
+            reqbench.command_text = saved["command_text"]
+            reqbench._pending_harness_signal = saved["pending_signal"]
+            sys.argv = saved["argv"]
+            signal.signal(signal.SIGINT, saved["sigint"])
+            signal.signal(signal.SIGTERM, saved["sigterm"])
+            for key, value in saved_env.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+        self.assertEqual(rc, 0)
+        with open(os.path.join(out_dir, "reqbench.jsonl")) as source:
+            meta = json.loads(source.readline())
+        self.assertEqual(meta["kind"], "meta")
+        return meta
+
+    def test_the_resolver_override_is_recorded(self):
+        with tempfile.TemporaryDirectory() as data_root:
+            meta = self._drive_main(data_root, {"dns_server": "10.0.2.2"})
+        self.assertEqual(meta["guest_dns"], "10.0.2.2")
+        self.assertEqual(meta["engine"], "chromium")
+
+    def test_no_override_is_recorded_as_null(self):
+        with tempfile.TemporaryDirectory() as data_root:
+            meta = self._drive_main(data_root, {"dns_server": None})
+        self.assertIn("guest_dns", meta)
+        self.assertIsNone(meta["guest_dns"])
+
+
+def _run_analyzer_fast(argv):
+    """main_with under the fast median/shift stubs, stdout captured.
+
+    Same substitution AnalyzerAvailability._run_gate_fixture makes: these
+    tests target gate truth and output shape, not the bootstrap.
+    """
+    from unittest import mock
+    with (
+        mock.patch.object(
+            reqanalyze, "median_ci", AnalyzerAvailability._fast_median_ci,
+        ),
+        mock.patch.object(
+            reqanalyze, "hodges_lehmann_shift", AnalyzerAvailability._fast_shift,
+        ),
+        redirect_stdout(io.StringIO()),
+    ):
+        return reqanalyze.main_with(argv)
+
+
+def _rewrite_records(path, mutate):
+    """Apply `mutate(row)` to every non-meta row of a jsonl fixture in place."""
+    with open(path) as source:
+        rows = [json.loads(line) for line in source]
+    for row in rows:
+        if row.get("kind") != "meta":
+            mutate(row)
+    with open(path, "w") as target:
+        for row in rows:
+            target.write(json.dumps(row) + "\n")
+
+
+class AnalyzerResolverGate(unittest.TestCase):
+    """A run whose URLs need a resolver must name the resolver in its meta.
+
+    The corpus arm answers every corpus hostname from a replay server the
+    guest reaches through GUEST_DNS. A run that declares hostnames but records
+    no guest_dns resolved them somewhere the record does not say, so its
+    numbers cannot be defended and the analyzer refuses them. Fixture runs
+    address the page server by IP literal (or localhost) and need no
+    resolver, so they publish without one.
+
+    RED BEFORE THE FIX: the corpus-without-guest_dns, bad-guest_dns and
+    bad-engine metas all published (`AssertionError: True is not False`),
+    and the cell carried no guest_dns (KeyError: 'guest_dns').
+    """
+
+    CORPUS = ["https://example.com/", "https://developer.mozilla.org/en-US/"]
+
+    @staticmethod
+    def write_multi_url(path, urls, **overrides):
+        """A clean 200-rep backend whose records cycle through `urls`."""
+        AnalyzerAvailability._write_clean_backend(
+            path, "file", 200, 384.0,
+            url=",".join(urls), urls=list(urls), **overrides,
+        )
+
+        def cycle(row):
+            url = urls[row["rep"] % len(urls)]
+            row["url"] = url
+            if isinstance(row.get("render"), dict):
+                row["render"]["url"] = url
+
+        _rewrite_records(path, cycle)
+
+    def _analyze(self, d, write):
+        src = os.path.join(d, "r.jsonl")
+        dst = os.path.join(d, "r.json")
+        write(src)
+        rc = _run_analyzer_fast(["--json-out", dst, src])
+        with open(dst) as source:
+            return rc, json.load(source)
+
+    def test_corpus_hostnames_without_guest_dns_are_not_publishable(self):
+        with tempfile.TemporaryDirectory() as d:
+            rc, out = self._analyze(
+                d, lambda src: self.write_multi_url(src, self.CORPUS),
+            )
+        self.assertIs(out["publishable"], False)
+        self.assertEqual(rc, 5)
+        errors = out["gate"]["backend_metadata"]["errors"]
+        self.assertTrue(
+            any("guest_dns" in error for error in errors),
+            f"the refusal must name the missing resolver: {errors}",
+        )
+        self.assertTrue(
+            any("guest_dns" in error and "example.com" in error for error in errors),
+            f"the refusal must name a hostname that needed it: {errors}",
+        )
+
+    def test_corpus_hostnames_with_guest_dns_are_publishable(self):
+        with tempfile.TemporaryDirectory() as d:
+            rc, out = self._analyze(
+                d,
+                lambda src: self.write_multi_url(
+                    src, self.CORPUS, guest_dns="10.0.2.2",
+                ),
+            )
+        self.assertIs(out["publishable"], True, out["gate"]["reasons"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(out["cell"]["guest_dns"], "10.0.2.2")
+        self.assertEqual(out["cell"]["engine"], "chromium")
+
+    def test_a_fixture_url_without_guest_dns_is_publishable(self):
+        """Positive control for the gate: an IP-literal host needs no resolver.
+
+        Cannot go red against the unfixed analyzer on its own (it published
+        everything). It was watched red against a deliberate over-strict
+        gate that demanded guest_dns for every URL, which is the mistake it
+        guards against.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            rc, out = self._analyze(
+                d,
+                lambda src: AnalyzerAvailability._write_clean_backend(
+                    src, "file", 200, 384.0,
+                ),
+            )
+        self.assertEqual(
+            out["cell"]["url"], "http://127.0.0.1:8000/medium.html",
+        )
+        self.assertIs(out["publishable"], True, out["gate"]["reasons"])
+        self.assertEqual(rc, 0)
+        self.assertIn("guest_dns", out["cell"])
+        self.assertIsNone(out["cell"]["guest_dns"])
+        self.assertEqual(out["cell"]["engine"], "chromium")
+
+    def test_localhost_without_guest_dns_is_publishable(self):
+        with tempfile.TemporaryDirectory() as d:
+            rc, out = self._analyze(
+                d,
+                lambda src: AnalyzerAvailability._write_clean_backend(
+                    src, "file", 200, 384.0,
+                    url="http://localhost:8000/medium.html",
+                ),
+            )
+        self.assertIs(out["publishable"], True, out["gate"]["reasons"])
+        self.assertEqual(rc, 0)
+
+    def test_a_guest_dns_that_is_not_an_ip_literal_is_a_metadata_error(self):
+        with tempfile.TemporaryDirectory() as d:
+            rc, out = self._analyze(
+                d,
+                lambda src: self.write_multi_url(
+                    src, self.CORPUS, guest_dns="resolver.local",
+                ),
+            )
+        self.assertIs(out["publishable"], False)
+        self.assertEqual(rc, 5)
+        errors = out["gate"]["backend_metadata"]["errors"]
+        self.assertTrue(any("guest_dns" in error for error in errors), errors)
+
+    def test_an_unsupported_engine_is_a_metadata_error(self):
+        with tempfile.TemporaryDirectory() as d:
+            rc, out = self._analyze(
+                d,
+                lambda src: AnalyzerAvailability._write_clean_backend(
+                    src, "file", 200, 384.0, engine="gecko",
+                ),
+            )
+        self.assertIs(out["publishable"], False)
+        self.assertEqual(rc, 5)
+        errors = out["gate"]["backend_metadata"]["errors"]
+        self.assertTrue(any("engine" in error for error in errors), errors)
+
+    def test_a_url_set_that_contradicts_url_is_a_metadata_error(self):
+        with tempfile.TemporaryDirectory() as d:
+            rc, out = self._analyze(
+                d,
+                lambda src: AnalyzerAvailability._write_clean_backend(
+                    src, "file", 200, 384.0,
+                    urls=["http://127.0.0.1:8000/other.html"],
+                ),
+            )
+        self.assertIs(out["publishable"], False)
+        self.assertEqual(rc, 5)
+        errors = out["gate"]["backend_metadata"]["errors"]
+        self.assertTrue(any("urls" in error for error in errors), errors)
+
+    def test_runs_with_different_guest_dns_never_pool(self):
+        with tempfile.TemporaryDirectory() as d:
+            a = os.path.join(d, "a.jsonl")
+            b = os.path.join(d, "b.jsonl")
+            dst = os.path.join(d, "r.json")
+            self.write_multi_url(a, self.CORPUS, guest_dns="10.0.2.2")
+            self.write_multi_url(b, self.CORPUS, guest_dns="10.0.2.3")
+            rc = _run_analyzer_fast(["--json-out", dst, a, b])
+            with open(dst) as source:
+                result = json.load(source)
+        # Two complete cells, analyzed side by side, never as one sample: each
+        # is publishable on its own (200 measured attempts), so the exit is 0.
+        self.assertEqual(len(result["backends"]), 2)
+        self.assertEqual(
+            {cell["cell"]["guest_dns"] for cell in result["backends"].values()},
+            {"10.0.2.2", "10.0.2.3"},
+        )
+        self.assertEqual(
+            len({cell["cell_id"] for cell in result["backends"].values()}), 2,
+        )
+        self.assertTrue(
+            all(cell["publishable"] for cell in result["backends"].values()),
+            result["gate"]["reasons"],
+        )
+        self.assertEqual(rc, 0)
+
+
+class AnalyzerPerUrl(unittest.TestCase):
+    """A multi-URL run reports every URL on its own.
+
+    A corpus median hides the one page that stalled; the corpus campaign
+    needs the per-page medians, load-event times and the count of distinct
+    screenshots (an error page renders to the same bytes every time).
+
+    RED BEFORE THE FIX: KeyError: 'per_url'.
+    """
+
+    URLS = ["http://127.0.0.1:8000/a.html", "http://127.0.0.1:8000/b.html"]
+    BLOCKING = {URLS[0]: 300.0, URLS[1]: 500.0}
+    LOAD_EVENT = {URLS[0]: 120.0, URLS[1]: 240.0}
+
+    @classmethod
+    def write(cls, path):
+        AnalyzerResolverGate.write_multi_url(path, cls.URLS)
+
+        def shape(row):
+            url = row["url"]
+            if row["arm"] == "noop":
+                return
+            row["blocking_ms"] = cls.BLOCKING[url]
+            row["wall_ms"] = cls.BLOCKING[url] + 1.0
+            render = row.get("render")
+            if not isinstance(render, dict):
+                return
+            render["stages"]["navigate_load_event_ms"] = cls.LOAD_EVENT[url]
+            render["stages"]["total_ms"] = cls.BLOCKING[url]
+            if url == cls.URLS[0]:
+                render["image_sha256"] = "a" * 64
+            else:
+                # Two distinct renders of the second page.
+                render["image_sha256"] = ("b" if row["rep"] % 4 == 1 else "c") * 64
+
+        _rewrite_records(path, shape)
+
+    def test_per_url_medians_are_split_by_url(self):
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(d, "r.jsonl")
+            dst = os.path.join(d, "r.json")
+            self.write(src)
+            rc = _run_analyzer_fast(["--json-out", dst, src])
+            with open(dst) as source:
+                out = json.load(source)
+        self.assertEqual(rc, 0, out["gate"]["reasons"])
+        self.assertEqual(list(out["per_url"]), self.URLS)
+        for url in self.URLS:
+            for arm in ("cdp", "cdp-fast"):
+                cell = out["per_url"][url][arm]
+                self.assertEqual(cell["n"], 100, (url, arm))
+                self.assertEqual(cell["blocking_ms"]["median"], self.BLOCKING[url])
+                self.assertEqual(cell["blocking_ms"]["n"], 100)
+                self.assertIn("lo", cell["blocking_ms"])
+                self.assertIn("hi", cell["blocking_ms"])
+                self.assertEqual(
+                    cell["navigate_load_event_ms"]["median"], self.LOAD_EVENT[url],
+                )
+                self.assertEqual(cell["total_ms"]["median"], self.BLOCKING[url])
+            noop = out["per_url"][url]["noop"]
+            self.assertEqual(noop["n"], 100)
+            self.assertEqual(noop["blocking_ms"]["median"], 50.0)
+            self.assertEqual(noop["navigate_load_event_ms"]["n"], 0)
+            self.assertEqual(noop["distinct_image_sha256"], 0)
+        self.assertEqual(out["per_url"][self.URLS[0]]["cdp"]["distinct_image_sha256"], 1)
+        self.assertEqual(out["per_url"][self.URLS[1]]["cdp"]["distinct_image_sha256"], 2)
+        # The pooled figures the existing consumers read are unchanged.
+        self.assertEqual(out["arms"]["cdp"]["blocking_ms"]["median"], 400.0)
+        self.assertEqual(out["arms"]["cdp"]["blocking_ms"]["n"], 200)
+
+    def test_a_single_url_run_reports_its_one_url(self):
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(d, "r.jsonl")
+            dst = os.path.join(d, "r.json")
+            AnalyzerAvailability._write_clean_backend(src, "file", 200, 384.0)
+            rc = _run_analyzer_fast(["--json-out", dst, src])
+            with open(dst) as source:
+                out = json.load(source)
+        self.assertEqual(rc, 0, out["gate"]["reasons"])
+        self.assertEqual(list(out["per_url"]), ["http://127.0.0.1:8000/medium.html"])
+        self.assertEqual(
+            out["per_url"]["http://127.0.0.1:8000/medium.html"]["cdp"]["n"], 200,
+        )
+
+
+class AnalyzerStallGate(unittest.TestCase):
+    """A load event that takes tens of seconds is a stall, not a slow page.
+
+    A resolver that never answers turns a navigation into a ~30 s wait that
+    a pooled median absorbs. With --stall-max-ms the analyzer lists every
+    such record and refuses to publish the run.
+
+    RED BEFORE THE FIX: `error: unrecognized arguments: --stall-max-ms 15000`
+    (argparse SystemExit 2) for every test that passes the flag, and
+    KeyError: 'stall_gate' for the inert case.
+    """
+
+    URL = "http://127.0.0.1:8000/medium.html"
+
+    @staticmethod
+    def _write(path, load_event_ms, *, warmup=False, drop_stage=False):
+        AnalyzerAvailability._write_clean_backend(path, "file", 200, 384.0)
+
+        def mutate(record):
+            stages = record["render"]["stages"]
+            if drop_stage:
+                del stages["navigate_load_event_ms"]
+            else:
+                stages["navigate_load_event_ms"] = load_event_ms
+
+        AnalyzerAvailability._mutate_record(path, "cdp", mutate, warmup=warmup)
+
+    def _analyze(self, d, extra_argv):
+        src = os.path.join(d, "r.jsonl")
+        dst = os.path.join(d, "r.json")
+        rc = _run_analyzer_fast(extra_argv + ["--json-out", dst, src])
+        with open(dst) as source:
+            return rc, json.load(source)
+
+    def test_a_31s_load_event_fails_the_gate_and_publication(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write(os.path.join(d, "r.jsonl"), 31000.0)
+            rc, out = self._analyze(d, ["--stall-max-ms", "15000"])
+        gate = out["stall_gate"]
+        self.assertEqual(gate["max_ms"], 15000)
+        self.assertIs(gate["passed"], False)
+        self.assertEqual(len(gate["violations"]), 1, gate)
+        violation = gate["violations"][0]
+        self.assertEqual(violation["url"], self.URL)
+        self.assertEqual(violation["arm"], "cdp")
+        self.assertEqual(violation["navigate_load_event_ms"], 31000.0)
+        self.assertIs(out["publishable"], False)
+        self.assertIn("stall_gate", " ".join(out["gate"]["reasons"]))
+        self.assertIs(out["gate"]["stall_gate"]["passed"], False)
+        self.assertEqual(rc, 5)
+
+    def test_a_load_event_within_the_limit_passes(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write(os.path.join(d, "r.jsonl"), 14999.0)
+            rc, out = self._analyze(d, ["--stall-max-ms", "15000"])
+        self.assertIs(out["stall_gate"]["passed"], True)
+        self.assertEqual(out["stall_gate"]["violations"], [])
+        self.assertIs(out["publishable"], True, out["gate"]["reasons"])
+        self.assertEqual(rc, 0)
+
+    def test_without_a_limit_the_gate_is_inert(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write(os.path.join(d, "r.jsonl"), 31000.0)
+            rc, out = self._analyze(d, [])
+        self.assertEqual(
+            out["stall_gate"],
+            {"max_ms": None, "passed": True, "evaluated": 0, "violations": []},
+        )
+        self.assertIs(out["publishable"], True, out["gate"]["reasons"])
+        self.assertEqual(rc, 0)
+
+    def test_a_warmup_stall_is_still_a_violation(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write(os.path.join(d, "r.jsonl"), 31000.0, warmup=True)
+            rc, out = self._analyze(d, ["--stall-max-ms", "15000"])
+        self.assertIs(out["stall_gate"]["passed"], False)
+        self.assertIs(out["stall_gate"]["violations"][0]["warmup"], True)
+        self.assertEqual(rc, 5)
+
+    def test_a_successful_render_without_the_stage_cannot_pass(self):
+        """A record that never timed its load event has not shown it did not stall."""
+        with tempfile.TemporaryDirectory() as d:
+            self._write(os.path.join(d, "r.jsonl"), None, drop_stage=True)
+            rc, out = self._analyze(d, ["--stall-max-ms", "15000"])
+        self.assertIs(out["stall_gate"]["passed"], False)
+        self.assertIsNone(out["stall_gate"]["violations"][0]["navigate_load_event_ms"])
+        self.assertEqual(rc, 5)
+
+    def test_a_non_positive_limit_is_refused(self):
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(d, "r.jsonl")
+            AnalyzerAvailability._write_clean_backend(src, "file", 200, 384.0)
+            from contextlib import redirect_stderr
+            with self.assertRaises(SystemExit) as raised:
+                with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                    reqanalyze.main_with(["--stall-max-ms", "0", src])
+            self.assertEqual(raised.exception.code, 2)

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -31,11 +31,12 @@ import time
 import types
 import unittest
 import urllib.request
-from contextlib import contextmanager, redirect_stdout
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, HERE)
 
+import campaign_summary  # noqa: E402
 import reqanalyze  # noqa: E402
 import reqbench  # noqa: E402
 
@@ -7547,3 +7548,97 @@ class AnalyzerStallGate(unittest.TestCase):
             # An unknown flag also exits 2, which let this pass before the
             # flag existed; the refusal has to be the range check.
             self.assertIn("positive", stderr.getvalue())
+
+
+class CampaignSummaryFromAnalyzerOutput(unittest.TestCase):
+    """campaign_summary.py reads what reqanalyze.py actually writes.
+
+    test_campaign_summary.py drives the index from hand-written analysis.json
+    fixtures, so a field the analyzer spells differently, or a gate the
+    analyzer leaves unarmed, would pass both modules' own tests and fail only
+    on a real campaign. This runs the analyzer on a corpus-shaped run (two
+    hostnames, guest_dns set) and hands its analysis.json, plus a
+    dns-evidence.json in corpus_campaign.sh's shape, to the index.
+
+    RED BEFORE THE FIX: without --stall-max-ms the analyzer writes stall_gate
+    {max_ms: null, passed: true, evaluated: 0} and the index accepted it:
+    AssertionError: 0 == 0 : wrote .../campaign-x-summary.json: 1 cell(s).
+    The armed case is the positive control.
+    """
+
+    CORPUS = ["https://example.com/", "https://developer.mozilla.org/en-US/"]
+
+    @staticmethod
+    def _evidence(run_dir, verdict):
+        return {
+            "serve_pid": 4242,
+            "dnsmasq_was_active_before": True,
+            "dnsmasq_active_after_restore": False,
+            "samples": 12,
+            "sample_interval_s": 10,
+            "owner_log": os.path.join(run_dir, "dns-owner.log"),
+            "first_mismatch": None,
+            "verify_files": [os.path.join(run_dir, "verify-dns-pre.json")],
+            "corpus_dns_log_sha256": "0" * 64,
+            "corpus_access_log_sha256": "0" * 64,
+            "reason": None,
+            "verdict": verdict,
+        }
+
+    def _run_dir(self, d, analyzer_argv):
+        run_dir = os.path.join(d, "reqbench-20260828-000000-corpus")
+        os.makedirs(run_dir)
+        src = os.path.join(run_dir, "reqbench.jsonl")
+        AnalyzerResolverGate.write_multi_url(src, self.CORPUS, guest_dns="10.0.2.2")
+        analysis = os.path.join(run_dir, "analysis.json")
+        rc = _run_analyzer_fast(analyzer_argv + ["--json-out", analysis, src])
+        self.assertEqual(rc, 0)
+        with open(os.path.join(run_dir, "dns-evidence.json"), "w") as handle:
+            json.dump(self._evidence(run_dir, "clean"), handle)
+        return run_dir
+
+    @staticmethod
+    def _summarize(out, run_dirs):
+        stdout, stderr = io.StringIO(), io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            rc = campaign_summary.main_with(["--out", out] + list(run_dirs))
+        return rc, stdout.getvalue() + stderr.getvalue()
+
+    def test_an_analysis_without_a_stall_limit_is_not_indexed(self):
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = self._run_dir(d, [])
+            with open(os.path.join(run_dir, "analysis.json")) as source:
+                gate = json.load(source)["stall_gate"]
+            self.assertIsNone(gate["max_ms"])
+            self.assertEqual(gate["evaluated"], 0)
+            out = os.path.join(d, "campaign-x-summary.json")
+            rc, text = self._summarize(out, [run_dir])
+            self.assertNotEqual(rc, 0, text)
+            self.assertFalse(os.path.exists(out))
+            self.assertIn("--stall-max-ms", text)
+
+    def test_a_gated_analysis_with_clean_evidence_is_indexed(self):
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = self._run_dir(d, ["--stall-max-ms", "15000"])
+            out = os.path.join(d, "campaign-x-summary.json")
+            rc, text = self._summarize(out, [run_dir])
+            self.assertEqual(rc, 0, text)
+            with open(out) as source:
+                index = json.load(source)
+        self.assertEqual(len(index["cells"]), 1)
+        cell = index["cells"][0]
+        self.assertEqual(cell["engine"], "chromium")
+        self.assertEqual(cell["cpu"], 2)
+        self.assertEqual(cell["memory_mib"], 1024)
+        self.assertEqual(cell["guest_dns"], "10.0.2.2")
+        self.assertEqual(cell["backend"], "file")
+        self.assertEqual(cell["uffd_mode"], "file")
+        self.assertIs(cell["stall_gate_passed"], True)
+        self.assertEqual(cell["dns_verdict"], "clean")
+        self.assertEqual(cell["headline"]["cdp"]["blocking_ms"], 384.0)
+        self.assertEqual(cell["headline"]["cdp"]["n"], 200)
+        self.assertEqual(
+            {os.path.basename(entry["path"]) for entry in index["generated_from"]},
+            {"analysis.json", "dns-evidence.json"},
+        )
+

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -7497,6 +7497,70 @@ class AnalyzerPerUrl(unittest.TestCase):
         # The pooled figures the existing consumers read are unchanged.
         self.assertEqual(out["arms"]["cdp"]["blocking_ms"]["median"], 400.0)
         self.assertEqual(out["arms"]["cdp"]["blocking_ms"]["n"], 200)
+        for url in self.URLS:
+            for arm in ("cdp", "cdp-fast", "noop"):
+                self.assertEqual(
+                    out["per_url"][url][arm]["load_stage"], "navigate_load_event_ms",
+                )
+
+    NAVIGATE = {URLS[0]: 180.0, URLS[1]: 360.0}
+
+    @classmethod
+    def write_webkit(cls, path):
+        """The multi-URL fixture reshaped into a webkit run. WebDriver
+        classic exposes no load-event stage; its navigate call returns at
+        the load event, so the load-completing duration is navigate_ms."""
+        AnalyzerResolverGate.write_multi_url(path, cls.URLS, engine="webkit")
+
+        def reshape(row):
+            render = row.get("render")
+            if not isinstance(render, dict):
+                return
+            row["render"] = {
+                "ok": True, "url": render["url"], "format": render["format"],
+                "engine": "webkit", "wd_host": row["endpoint"],
+                "session_prewired": True,
+                "stages": {
+                    "resolve_ms": 0.1, "connect_total_ms": 0.4,
+                    "navigate_ms": cls.NAVIGATE[row["url"]], "screenshot_ms": 1.0,
+                    "total_ms": render["stages"]["total_ms"],
+                },
+                "image_bytes": 1024, "image_sha256": "9" * 64,
+            }
+
+        _rewrite_records(path, reshape)
+
+    def test_a_webkit_run_reports_its_navigate_round_trip_per_url(self):
+        """per_url read navigate_load_event_ms for every engine, so a webkit
+        URL reported n=0 and a null median while its records carried the
+        load-completing duration as navigate_ms, the stage the stall gate
+        already selects by engine. The block now reads that stage and names
+        it in load_stage.
+
+        RED BEFORE THE FIX: KeyError: 'load_stage'; on the same fixture the
+        block's navigate_load_event_ms summary read
+        {"median": null, "lo": null, "hi": null, "n": 0} for every webkit URL.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(d, "r.jsonl")
+            dst = os.path.join(d, "r.json")
+            self.write_webkit(src)
+            rc = _run_analyzer_fast(["--json-out", dst, src])
+            with open(dst) as source:
+                out = json.load(source)
+        self.assertEqual(rc, 0, out["gate"]["reasons"])
+        self.assertEqual(list(out["per_url"]), self.URLS)
+        for url in self.URLS:
+            for arm in ("cdp", "cdp-fast"):
+                cell = out["per_url"][url][arm]
+                self.assertEqual(cell["load_stage"], "navigate_ms", (url, arm))
+                self.assertNotIn("navigate_load_event_ms", cell)
+                self.assertEqual(cell["n"], 100, (url, arm))
+                self.assertEqual(cell["navigate_ms"]["n"], 100, (url, arm))
+                self.assertEqual(cell["navigate_ms"]["median"], self.NAVIGATE[url])
+            noop = out["per_url"][url]["noop"]
+            self.assertEqual(noop["load_stage"], "navigate_ms")
+            self.assertEqual(noop["navigate_ms"]["n"], 0)
 
     def test_a_single_url_run_reports_its_one_url(self):
         with tempfile.TemporaryDirectory() as d:

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -7575,6 +7575,157 @@ class AnalyzerStallGate(unittest.TestCase):
             # flag existed; the refusal has to be the range check.
             self.assertIn("positive", stderr.getvalue())
 
+    def test_a_negative_load_event_is_a_violation(self):
+        """A stage that ran backwards was not timed; it cannot prove the
+        render did not stall, and the gate treated it as within the limit."""
+        with tempfile.TemporaryDirectory() as d:
+            self._write(os.path.join(d, "r.jsonl"), -1.0)
+            rc, out = self._analyze(d, ["--stall-max-ms", "15000"])
+        gate = out["stall_gate"]
+        self.assertIs(gate["passed"], False, gate)
+        self.assertEqual(len(gate["violations"]), 1, gate)
+        self.assertEqual(gate["violations"][0]["navigate_load_event_ms"], -1.0)
+        self.assertIs(out["publishable"], False)
+        self.assertEqual(rc, 5)
+
+    @staticmethod
+    def _webkit(path, navigate_ms):
+        """The chromium fixture reshaped into a webkit run.
+
+        WebDriver classic exposes no load-event stage; its navigate call
+        returns at the load event, so a stall lands in navigate_ms.
+        """
+        AnalyzerAvailability._write_clean_backend(
+            path, "file", 200, 384.0, engine="webkit",
+        )
+
+        def reshape(row):
+            render = row.get("render")
+            if not isinstance(render, dict):
+                return
+            row["render"] = {
+                "ok": True, "url": render["url"], "format": render["format"],
+                "engine": "webkit", "wd_host": row["endpoint"],
+                "session_prewired": True,
+                "stages": {
+                    "resolve_ms": 0.1, "connect_total_ms": 0.4,
+                    "navigate_ms": navigate_ms, "screenshot_ms": 1.0,
+                    "total_ms": render["stages"]["total_ms"],
+                },
+                "image_bytes": 1024, "image_sha256": "9" * 64,
+            }
+
+        _rewrite_records(path, reshape)
+
+    def test_a_webkit_run_is_gated_on_its_navigate_round_trip(self):
+        """An armed gate that skipped every webkit record reported
+        passed=true having evaluated nothing, so a webkit stall of any
+        length published."""
+        with tempfile.TemporaryDirectory() as d:
+            self._webkit(os.path.join(d, "r.jsonl"), 1.0)
+            rc, out = self._analyze(d, ["--stall-max-ms", "15000"])
+        self.assertIs(out["publishable"], True, out["gate"]["reasons"])
+        self.assertEqual(rc, 0)
+        self.assertIs(out["stall_gate"]["passed"], True)
+        self.assertEqual(out["stall_gate"]["evaluated"], 404)
+        with tempfile.TemporaryDirectory() as d:
+            self._webkit(os.path.join(d, "r.jsonl"), 31000.0)
+            rc, out = self._analyze(d, ["--stall-max-ms", "15000"])
+        self.assertIs(out["stall_gate"]["passed"], False, out["stall_gate"])
+        self.assertEqual(rc, 5)
+        violation = out["stall_gate"]["violations"][0]
+        self.assertEqual(violation["stage"], "navigate_ms")
+        self.assertEqual(violation["navigate_ms"], 31000.0)
+
+
+class PublicationGateInvocation(unittest.TestCase):
+    """`reqbench.sh run` arms the analyzer's stall gate from STALL_MAX_MS.
+
+    reqanalyze grew --stall-max-ms and campaign_summary refuses an analysis
+    whose gate was never armed, but nothing passed the flag: every run the
+    campaign produced was un-indexable by construction. The analyzer call
+    is a function so it can be driven here with a python3 stub on PATH, the
+    way HugepageGuards drives the pool helpers.
+
+    RED BEFORE THE FIX: bash: line 1: apply_publication_gates: command not
+    found (the call was inline in cmd_run), and `make -n` printed the
+    analyze recipe without --stall-max-ms.
+    """
+
+    SH = os.path.join(HERE, "reqbench.sh")
+    REPO = os.path.dirname(os.path.dirname(HERE))
+
+    def _gate(self, env_extra):
+        d = tempfile.mkdtemp(prefix="pubgate-")
+        self.addCleanup(shutil.rmtree, d)
+        binx = os.path.join(d, "bin")
+        os.makedirs(binx)
+        argv_log = os.path.join(d, "python3-argv")
+        for name, body in (
+            ("sudo", '#!/bin/bash\nexec "$@"\n'),
+            ("python3", f'#!/bin/bash\nprintf "%s\\n" "$@" > "{argv_log}"\nexit 0\n'),
+        ):
+            with open(os.path.join(binx, name), "w") as handle:
+                handle.write(body)
+            os.chmod(os.path.join(binx, name), 0o755)
+        results = os.path.join(d, "results")
+        os.makedirs(results)
+        env = dict(os.environ)
+        env.pop("STALL_MAX_MS", None)
+        env.update(
+            PATH=binx + os.pathsep + env["PATH"],
+            TAG="tag-under-test",
+            STATE_DIR=os.path.join(d, "state"),
+            RESULTS=results,
+        )
+        env.update(env_extra)
+        result = subprocess.run(
+            ["bash", "-c", f'source "{self.SH}" && apply_publication_gates'],
+            capture_output=True, text=True, env=env, timeout=60)
+        argv = []
+        if os.path.exists(argv_log):
+            with open(argv_log) as handle:
+                argv = handle.read().splitlines()
+        return result, argv, results
+
+    def test_stall_max_ms_reaches_the_analyzer(self):
+        result, argv, results = self._gate({"STALL_MAX_MS": "15000"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(argv and argv[0].endswith("reqanalyze.py"), argv)
+        self.assertIn("--stall-max-ms", argv)
+        self.assertEqual(argv[argv.index("--stall-max-ms") + 1], "15000")
+        self.assertEqual(argv[argv.index("--json-out") + 1],
+                         os.path.join(results, "analysis.json"))
+        self.assertEqual(argv[-1], os.path.join(results, "reqbench.jsonl"))
+
+    def test_an_unset_knob_leaves_the_gate_unarmed(self):
+        """The fixture runs (medium.html) keep their existing behaviour."""
+        result, argv, _results = self._gate({})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(argv and argv[0].endswith("reqanalyze.py"), argv)
+        self.assertNotIn("--stall-max-ms", argv)
+
+    def test_the_make_analyze_target_passes_the_knob(self):
+        """`make analyze-chromium-request` calls reqanalyze directly and has
+        to arm the gate the same way."""
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "reqbench.jsonl"), "w") as handle:
+                handle.write("{}\n")
+            armed = subprocess.run(
+                ["make", "-n", "-C", self.REPO, "analyze-chromium-request",
+                 f"RESULTS={d}", "STALL_MAX_MS=15000"],
+                capture_output=True, text=True, timeout=120)
+            self.assertEqual(armed.returncode, 0, armed.stderr[-2000:])
+            self.assertIn("reqanalyze.py", armed.stdout)
+            self.assertIn("--stall-max-ms 15000", armed.stdout)
+            unarmed = subprocess.run(
+                ["make", "-n", "-C", self.REPO, "analyze-chromium-request",
+                 f"RESULTS={d}"],
+                capture_output=True, text=True, timeout=120)
+            self.assertEqual(unarmed.returncode, 0, unarmed.stderr[-2000:])
+            self.assertIn("reqanalyze.py", unarmed.stdout)
+            self.assertNotIn("--stall-max-ms", unarmed.stdout)
+
 
 class CampaignSummaryFromAnalyzerOutput(unittest.TestCase):
     """campaign_summary.py reads what reqanalyze.py actually writes.

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -7813,17 +7813,41 @@ class CampaignSummaryFromAnalyzerOutput(unittest.TestCase):
 
     @staticmethod
     def _evidence(run_dir, verdict):
+        """dns-evidence.json plus every file it names, as the campaign leaves them."""
+        verify_files = []
+        for stage in ("pre", "before-run", "after-run"):
+            path = os.path.join(run_dir, f"verify-dns-{stage}.json")
+            with open(path, "w") as handle:
+                json.dump({
+                    "dns_server": "10.0.2.2", "resolv_conf_vm": "nameserver 10.0.2.2\n",
+                    "resolv_conf_container": "nameserver 10.0.2.2\n",
+                    "hosts": {"example.com": {"answer": "10.0.2.2", "ok": True}},
+                    "urls": {"https://example.com/": {"status": 200, "ok": True}},
+                    "timestamp": "2026-08-28T00:00:00Z", "passed": True,
+                }, handle)
+            verify_files.append(path)
+        hashes = {}
+        for name in ("corpus-dns.log", "corpus-access.log"):
+            path = os.path.join(run_dir, name)
+            with open(path, "w") as handle:
+                handle.write('{"ts": 1.0}\n')
+            with open(path, "rb") as handle:
+                hashes[name] = hashlib.sha256(handle.read()).hexdigest()
+        with open(os.path.join(run_dir, "dns-owner.log"), "w") as handle:
+            handle.write("2026-08-28T00:00:00Z owner_pid=4242 dnsmasq=inactive\n" * 12)
         return {
             "serve_pid": 4242,
             "dnsmasq_was_active_before": True,
             "dnsmasq_active_after_restore": False,
+            "dnsmasq_state_after_restore": "inactive",
+            "sampler_alive_at_stop": True,
             "samples": 12,
             "sample_interval_s": 10,
             "owner_log": os.path.join(run_dir, "dns-owner.log"),
             "first_mismatch": None,
-            "verify_files": [os.path.join(run_dir, "verify-dns-pre.json")],
-            "corpus_dns_log_sha256": "0" * 64,
-            "corpus_access_log_sha256": "0" * 64,
+            "verify_files": verify_files,
+            "corpus_dns_log_sha256": hashes["corpus-dns.log"],
+            "corpus_access_log_sha256": hashes["corpus-access.log"],
             "reason": None,
             "verdict": verdict,
         }
@@ -7882,6 +7906,10 @@ class CampaignSummaryFromAnalyzerOutput(unittest.TestCase):
         self.assertEqual(cell["headline"]["cdp"]["n"], 200)
         self.assertEqual(
             {os.path.basename(entry["path"]) for entry in index["generated_from"]},
-            {"analysis.json", "dns-evidence.json"},
+            {
+                "analysis.json", "dns-evidence.json", "verify-dns-pre.json",
+                "verify-dns-before-run.json", "verify-dns-after-run.json",
+                "dns-owner.log", "corpus-dns.log", "corpus-access.log",
+            },
         )
 

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -7886,7 +7886,9 @@ class CampaignSummaryFromAnalyzerOutput(unittest.TestCase):
                     "dns_server": "10.0.2.2", "resolv_conf_vm": "nameserver 10.0.2.2\n",
                     "resolv_conf_container": "nameserver 10.0.2.2\n",
                     "hosts": {"example.com": {"answer": "10.0.2.2", "ok": True}},
-                    "urls": {"https://example.com/": {"status": 200, "ok": True}},
+                    "urls": {"https://example.com/": {"status": 200, "ok": True,
+                                                      "proxy_env_ignored": []}},
+                    "proxies_disabled": True,
                     "timestamp": "2026-08-28T00:00:00Z", "passed": True,
                 }, handle)
             verify_files.append(path)
@@ -7912,6 +7914,7 @@ class CampaignSummaryFromAnalyzerOutput(unittest.TestCase):
             "verify_files": verify_files,
             "corpus_dns_log_sha256": hashes["corpus-dns.log"],
             "corpus_access_log_sha256": hashes["corpus-access.log"],
+            "corpus_serve_exit_status": 0,
             "reason": None,
             "verdict": verdict,
         }

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -2188,6 +2188,7 @@ class SnapshotGenerationIdentity(unittest.TestCase):
             "creator_fcvm_sha256": "c" * 64,
             "creator_runtime_bundle_sha256": "d" * 64,
             "source_revision": "e" * 40,
+            "guest_dns": None,
         }
         with open(
             os.path.join(snapshot_dir, "reqbench-provenance.json"), "w"
@@ -6972,35 +6973,85 @@ class SnapshotGenerationDns(unittest.TestCase):
     GENERATION_ID = "11111111-1111-4111-8111-111111111111"
 
     @classmethod
-    def write_generation(cls, data_root, network_config):
-        """The identity fixture plus a network_config block (None omits it)."""
+    def write_generation(cls, data_root, network_config, guest_dns=None,
+                         drop_guest_dns=False):
+        """The identity fixture plus a network_config block (None omits it).
+
+        guest_dns is what the golden's provenance records as the requested
+        resolver (reqbench.sh GUEST_DNS, null when none was requested);
+        drop_guest_dns removes the key, the shape of a pre-feature golden.
+        """
         config_path, _digest = SnapshotGenerationIdentity._write_generation(
             data_root, cls.GENERATION_ID,
         )
-        if network_config is None:
-            return
-        with open(config_path) as source:
-            config = json.load(source)
-        config["metadata"]["network_config"] = network_config
-        config_json = (
-            json.dumps(config, sort_keys=True, separators=(",", ":")) + "\n"
-        ).encode()
-        with open(config_path, "wb") as target:
-            target.write(config_json)
         provenance_path = os.path.join(
             data_root, "snapshots", cls.SNAPSHOT, "reqbench-provenance.json",
         )
         with open(provenance_path) as source:
             provenance = json.load(source)
-        provenance["snapshot_config_sha256"] = hashlib.sha256(config_json).hexdigest()
+        if network_config is not None:
+            with open(config_path) as source:
+                config = json.load(source)
+            config["metadata"]["network_config"] = network_config
+            config_json = (
+                json.dumps(config, sort_keys=True, separators=(",", ":")) + "\n"
+            ).encode()
+            with open(config_path, "wb") as target:
+                target.write(config_json)
+            provenance["snapshot_config_sha256"] = hashlib.sha256(config_json).hexdigest()
+        provenance["guest_dns"] = guest_dns
+        if drop_guest_dns:
+            del provenance["guest_dns"]
         with open(provenance_path, "w") as target:
             json.dump(provenance, target)
 
     def test_a_dns_override_is_returned_as_dns_server(self):
         with tempfile.TemporaryDirectory() as data_root:
-            self.write_generation(data_root, {"dns_server": "10.0.2.2"})
+            self.write_generation(
+                data_root, {"dns_server": "10.0.2.2"}, guest_dns="10.0.2.2",
+            )
             generation = reqbench.snapshot_generation(data_root, self.SNAPSHOT)
             self.assertEqual(generation["dns_server"], "10.0.2.2")
+            self.assertEqual(generation["guest_dns"], "10.0.2.2")
+
+    def test_a_host_filled_resolver_without_an_override_is_not_a_guest_dns(self):
+        """Bridged goldens carry the host's first resolver in dns_server
+        when no --dns was given (src/commands/podman/mod.rs,
+        with_dns_server(host_dns.first())). That resolver was recorded as
+        guest_dns, so a run that resolved its hostnames on the live
+        internet satisfied the analyzer's "names its resolver" gate.
+
+        RED BEFORE THE FIX: KeyError: 'guest_dns'.
+        """
+        with tempfile.TemporaryDirectory() as data_root:
+            self.write_generation(
+                data_root, {"dns_server": "192.168.94.1"}, guest_dns=None,
+            )
+            generation = reqbench.snapshot_generation(data_root, self.SNAPSHOT)
+            self.assertEqual(generation["dns_server"], "192.168.94.1")
+            self.assertIsNone(generation["guest_dns"])
+
+    def test_a_provenance_without_guest_dns_is_refused(self):
+        """A golden made before the field existed cannot say whether its
+        resolver was requested; it is re-recorded, not guessed at.
+
+        RED BEFORE THE FIX: RuntimeError not raised.
+        """
+        with tempfile.TemporaryDirectory() as data_root:
+            self.write_generation(
+                data_root, {"dns_server": "10.0.2.2"}, drop_guest_dns=True,
+            )
+            with self.assertRaisesRegex(RuntimeError, "guest_dns"):
+                reqbench.snapshot_generation(data_root, self.SNAPSHOT)
+
+    def test_an_override_the_snapshot_did_not_bake_is_refused(self):
+        """RED BEFORE THE FIX: RuntimeError not raised."""
+        with tempfile.TemporaryDirectory() as data_root:
+            self.write_generation(
+                data_root, {"dns_server": "10.0.2.3"}, guest_dns="10.0.2.2",
+            )
+            with self.assertRaisesRegex(RuntimeError, "10.0.2.2"):
+                reqbench.snapshot_generation(data_root, self.SNAPSHOT)
 
     def test_no_override_is_returned_as_none(self):
         with tempfile.TemporaryDirectory() as data_root:
@@ -7038,8 +7089,10 @@ class RunMetaGuestDns(unittest.TestCase):
 
     SNAPSHOT = SnapshotGenerationIdentity.SNAPSHOT
 
-    def _drive_main(self, data_root, network_config):
-        SnapshotGenerationDns.write_generation(data_root, network_config)
+    def _drive_main(self, data_root, network_config, guest_dns=None):
+        SnapshotGenerationDns.write_generation(
+            data_root, network_config, guest_dns=guest_dns,
+        )
         runtime_bundle = os.path.join(data_root, "runtime")
         os.makedirs(runtime_bundle)
         manifest_path = os.path.join(runtime_bundle, "MANIFEST.sha256")
@@ -7141,7 +7194,9 @@ class RunMetaGuestDns(unittest.TestCase):
 
     def test_the_resolver_override_is_recorded(self):
         with tempfile.TemporaryDirectory() as data_root:
-            meta = self._drive_main(data_root, {"dns_server": "10.0.2.2"})
+            meta = self._drive_main(
+                data_root, {"dns_server": "10.0.2.2"}, guest_dns="10.0.2.2",
+            )
         self.assertEqual(meta["guest_dns"], "10.0.2.2")
         self.assertEqual(meta["engine"], "chromium")
 
@@ -7149,6 +7204,17 @@ class RunMetaGuestDns(unittest.TestCase):
         with tempfile.TemporaryDirectory() as data_root:
             meta = self._drive_main(data_root, {"dns_server": None})
         self.assertIn("guest_dns", meta)
+        self.assertIsNone(meta["guest_dns"])
+
+    def test_a_host_filled_resolver_is_recorded_as_null(self):
+        """The meta's guest_dns is the resolver the golden REQUESTED, from
+        its provenance; the effective dns_server a bridged guest inherits
+        from the host is not a controlled resolver.
+
+        RED BEFORE THE FIX: AssertionError: '192.168.94.1' is not None.
+        """
+        with tempfile.TemporaryDirectory() as data_root:
+            meta = self._drive_main(data_root, {"dns_server": "192.168.94.1"})
         self.assertIsNone(meta["guest_dns"])
 
 

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -7278,6 +7278,8 @@ class AnalyzerResolverGate(unittest.TestCase):
         self.assertEqual(out["cell"]["engine"], "chromium")
 
     def test_localhost_without_guest_dns_is_publishable(self):
+        """Positive control, like the fixture-URL case above: red only against
+        the over-strict gate."""
         with tempfile.TemporaryDirectory() as d:
             rc, out = self._analyze(
                 d,
@@ -7312,8 +7314,11 @@ class AnalyzerResolverGate(unittest.TestCase):
             )
         self.assertIs(out["publishable"], False)
         self.assertEqual(rc, 5)
+        # The CELL must reject it. The render-engine mismatch check already
+        # mentions "engine", so a looser assertion passed on the unfixed tree.
+        self.assertIsNone(out["cell"])
         errors = out["gate"]["backend_metadata"]["errors"]
-        self.assertTrue(any("engine" in error for error in errors), errors)
+        self.assertTrue(any("no valid engine" in error for error in errors), errors)
 
     def test_a_url_set_that_contradicts_url_is_a_metadata_error(self):
         with tempfile.TemporaryDirectory() as d:
@@ -7534,7 +7539,11 @@ class AnalyzerStallGate(unittest.TestCase):
             src = os.path.join(d, "r.jsonl")
             AnalyzerAvailability._write_clean_backend(src, "file", 200, 384.0)
             from contextlib import redirect_stderr
+            stderr = io.StringIO()
             with self.assertRaises(SystemExit) as raised:
-                with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                with redirect_stdout(io.StringIO()), redirect_stderr(stderr):
                     reqanalyze.main_with(["--stall-max-ms", "0", src])
             self.assertEqual(raised.exception.code, 2)
+            # An unknown flag also exits 2, which let this pass before the
+            # flag existed; the refusal has to be the range check.
+            self.assertIn("positive", stderr.getvalue())

--- a/bench/chromium/test_verify_dns.py
+++ b/bench/chromium/test_verify_dns.py
@@ -19,11 +19,13 @@ real.
 Run: python3 -m unittest test_verify_dns -v
 """
 
+import http.server
 import json
 import os
 import subprocess
 import sys
 import tempfile
+import threading
 import unittest
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -72,7 +74,17 @@ PY
         "-c cat /etc/resolv.conf") printf '%b' "$STUB_RESOLV_CONTAINER"; exit "${STUB_RESOLV_RC:-0}" ;;
         "-c python3 /opt/bench/"*) exit 0 ;;
         "-c python3 -c "*gethostbyname*) echo "$STUB_ANSWER" ;;
-        "-c python3 -c "*urllib*) echo "$STUB_URL_STATUS" ;;
+        "-c python3 -c "*urllib*)
+            # $1=python3 $2=-c $3=<probe text> $4=<url>. With STUB_RUN_URL_PROBE
+            # the shipped probe text runs for real, under the proxy variables
+            # fc-agent injects into every container exec (HTTP_PROXY,
+            # HTTPS_PROXY, no_proxy, NO_PROXY from the host's saved settings).
+            if [ "${STUB_RUN_URL_PROBE:-0}" = 1 ]; then
+                exec env HTTP_PROXY="$STUB_PROXY_ADDR" HTTPS_PROXY="$STUB_PROXY_ADDR" \
+                    no_proxy=intranet.example NO_PROXY=intranet.example \
+                    "$STUB_PYTHON" -c "$3" "$4"
+            fi
+            echo "$STUB_URL_STATUS none" ;;
         *) echo "stub fcvm: unexpected exec: $view $*" >&2; exit 97 ;;
       esac ;;
   *) exit 0 ;;
@@ -171,6 +183,92 @@ class VerifyDnsHop(unittest.TestCase):
         with open(path) as handle:
             return json.load(handle)
 
+    class Answer200(http.server.BaseHTTPRequestHandler):
+        """Answers 200 to every request and records the request line's
+        path. Standing in for the replay server it sees "/one"; standing in
+        for a proxy it sees the absolute URL urllib sends a proxy."""
+        seen = None
+
+        def log_message(self, *_args):
+            pass
+
+        def do_GET(self):
+            self.seen.append(self.path)
+            self.send_response(200)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+    def _http_stub(self):
+        class Stub(self.Answer200):
+            seen = []
+        server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Stub)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        self.addCleanup(server.server_close)
+        self.addCleanup(server.shutdown)
+        return server.server_port, Stub.seen
+
+    def test_the_url_probe_ignores_the_proxy_the_exec_environment_carries(self):
+        """fc-agent runs every container exec under the host's saved
+        HTTP_PROXY and HTTPS_PROXY (fc-agent/src/exec.rs, read_proxy_settings),
+        and urllib.request.build_opener() installs a ProxyHandler from the
+        environment. The hostname check resolved through the baked resolver
+        while each URL request went to the proxy: a working proxy fetched the
+        live site, the status came back 200 and HOP D passed without the
+        replay server having answered one URL.
+
+        The stub exec runs the shipped probe text under that environment.
+        The proxy variables name a local stub that answers 200 to anything
+        (the live site through a working proxy); the URLs name a second stub
+        standing in for the replay server. A control sends a default urllib
+        request through the same environment and requires the proxy stub to
+        answer it, so a pass here cannot come from an environment the probe
+        never saw. The evidence must say the probe ran with proxies disabled
+        and which variables it ignored.
+
+        RED BEFORE THE FIX: the proxy stub answered both URLs
+        (['http://127.0.0.1:P/one', 'http://127.0.0.1:P/two']) and the replay
+        stub answered none.
+        """
+        replay_port, replay_seen = self._http_stub()
+        proxy_port, proxy_seen = self._http_stub()
+        proxy = f"http://127.0.0.1:{proxy_port}"
+        urls = f"http://127.0.0.1:{replay_port}/one,http://127.0.0.1:{replay_port}/two"
+        control_env = {k: v for k, v in os.environ.items()
+                       if not k.lower().endswith("_proxy")}
+        control_env.update(HTTP_PROXY=proxy, HTTPS_PROXY=proxy)
+        control = subprocess.run(
+            [sys.executable, "-c",
+             "import sys, urllib.request as u; "
+             "print(u.build_opener().open(sys.argv[1], timeout=10).status)",
+             f"http://127.0.0.1:{replay_port}/control"],
+            env=control_env, capture_output=True, text=True, timeout=60)
+        self.assertEqual(control.returncode, 0, control.stderr)
+        self.assertEqual(proxy_seen, [f"http://127.0.0.1:{replay_port}/control"],
+                         "the control request did not go through the proxy stub, "
+                         "so this environment proves nothing about the probe")
+        self.assertEqual(replay_seen, [])
+        del proxy_seen[:]
+        with tempfile.TemporaryDirectory() as d:
+            env, state_dir = self._fixture(d, urls=urls)
+            env.update(STUB_RUN_URL_PROBE="1", STUB_PROXY_ADDR=proxy)
+            result = self._verify(env)
+            self.assertEqual(result.returncode, 0,
+                             f"{result.stdout}\n{result.stderr[-2500:]}")
+            self.assertEqual(proxy_seen, [],
+                             "the URL probe went through the proxy the exec "
+                             "environment named instead of to the replay server")
+            self.assertEqual(sorted(replay_seen), ["/one", "/two"],
+                             "the replay server did not answer every corpus URL")
+            evidence = self._evidence(env)
+            self.assertIs(evidence["passed"], True)
+            self.assertIs(evidence["proxies_disabled"], True)
+            for url in urls.split(","):
+                self.assertEqual(evidence["urls"][url], {
+                    "status": 200, "ok": True,
+                    "proxy_env_ignored": ["HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY", "no_proxy"],
+                })
+            self.assertEqual(os.listdir(state_dir), [])
+
     def test_a_clone_answering_the_real_address_fails_hop_d(self):
         """The failure the hop exists for: the guest resolves example.com to
         its real address, so a render would fetch the live site, not the
@@ -210,7 +308,7 @@ class VerifyDnsHop(unittest.TestCase):
                 self.assertEqual(evidence["hosts"][host],
                                  {"answer": "10.0.2.2", "ok": True})
             for url in URLS.split(","):
-                self.assertEqual(evidence["urls"][url], {"status": 200, "ok": True})
+                self.assertEqual(evidence["urls"][url], {"status": 200, "ok": True, "proxy_env_ignored": []})
             self.assertTrue(evidence["timestamp"])
             execs = read_if_exists(env["STUB_EXEC_LOG"]).splitlines()
             self.assertIn("--vm cat /etc/resolv.conf", execs,
@@ -250,7 +348,7 @@ class VerifyDnsHop(unittest.TestCase):
             evidence = self._evidence(env)
             self.assertIs(evidence["passed"], False)
             self.assertEqual(evidence["urls"]["https://example.com/"],
-                             {"status": 404, "ok": False})
+                             {"status": 404, "ok": False, "proxy_env_ignored": []})
 
     def test_hosts_without_a_baked_resolver_fail(self):
         """A golden made without GUEST_DNS carries no resolver to verify
@@ -316,7 +414,7 @@ class VerifyDnsHop(unittest.TestCase):
             evidence = self._evidence(env)
             self.assertIs(evidence["passed"], False)
             self.assertEqual(evidence["urls"]["https://example.com/"],
-                             {"status": 404, "ok": False})
+                             {"status": 404, "ok": False, "proxy_env_ignored": []})
         with tempfile.TemporaryDirectory() as d:
             env, _ = self._fixture(d, hosts="")
             result = self._verify(env)
@@ -326,7 +424,7 @@ class VerifyDnsHop(unittest.TestCase):
             self.assertIs(evidence["passed"], True)
             self.assertEqual(evidence["hosts"], {})
             for url in URLS.split(","):
-                self.assertEqual(evidence["urls"][url], {"status": 200, "ok": True})
+                self.assertEqual(evidence["urls"][url], {"status": 200, "ok": True, "proxy_env_ignored": []})
         with tempfile.TemporaryDirectory() as d:
             # URLs alone, with no baked resolver to fetch through: refuse.
             env, _ = self._fixture(d, hosts="", dns_server=None)

--- a/bench/chromium/test_verify_dns.py
+++ b/bench/chromium/test_verify_dns.py
@@ -27,6 +27,7 @@ import sys
 import tempfile
 import threading
 import unittest
+from unittest import mock
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 SH = os.path.join(HERE, "reqbench.sh")
@@ -148,7 +149,13 @@ class VerifyDnsHop(unittest.TestCase):
         fcvm = os.path.join(d, "fcvm")
         write_exec(fcvm, FCVM_STUB)
         write_exec(os.path.join(d, "fc-agent"), "#!/bin/bash\nexit 0\n")
-        env = dict(os.environ)
+        # The probe under test reports every *_proxy variable it found and
+        # ignored, and the assertions name exactly the ones the stub exec
+        # installs, so the fixture environment must carry none of its own. A
+        # box exporting YARN_HTTPS_PROXY or npm_config_http_proxy would
+        # otherwise add names no test installed.
+        env = {k: v for k, v in os.environ.items()
+               if not k.lower().endswith("_proxy")}
         env.update(
             PATH=binx + os.pathsep + env["PATH"],
             TAG=TAG,
@@ -207,28 +214,11 @@ class VerifyDnsHop(unittest.TestCase):
         self.addCleanup(server.shutdown)
         return server.server_port, Stub.seen
 
-    def test_the_url_probe_ignores_the_proxy_the_exec_environment_carries(self):
-        """fc-agent runs every container exec under the host's saved
-        HTTP_PROXY and HTTPS_PROXY (fc-agent/src/exec.rs, read_proxy_settings),
-        and urllib.request.build_opener() installs a ProxyHandler from the
-        environment. The hostname check resolved through the baked resolver
-        while each URL request went to the proxy: a working proxy fetched the
-        live site, the status came back 200 and HOP D passed without the
-        replay server having answered one URL.
-
-        The stub exec runs the shipped probe text under that environment.
-        The proxy variables name a local stub that answers 200 to anything
-        (the live site through a working proxy); the URLs name a second stub
-        standing in for the replay server. A control sends a default urllib
-        request through the same environment and requires the proxy stub to
-        answer it, so a pass here cannot come from an environment the probe
-        never saw. The evidence must say the probe ran with proxies disabled
-        and which variables it ignored.
-
-        RED BEFORE THE FIX: the proxy stub answered both URLs
-        (['http://127.0.0.1:P/one', 'http://127.0.0.1:P/two']) and the replay
-        stub answered none.
-        """
+    def _probe_under_the_exec_proxy_environment(self):
+        """The URL probe, run for real under the proxy variables the stub
+        exec installs, with a control proving that environment reaches a
+        proxy. Every request must land on the replay stub, and the evidence
+        must name exactly the four variables the exec installed."""
         replay_port, replay_seen = self._http_stub()
         proxy_port, proxy_seen = self._http_stub()
         proxy = f"http://127.0.0.1:{proxy_port}"
@@ -268,6 +258,46 @@ class VerifyDnsHop(unittest.TestCase):
                     "proxy_env_ignored": ["HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY", "no_proxy"],
                 })
             self.assertEqual(os.listdir(state_dir), [])
+
+    def test_the_url_probe_ignores_the_proxy_the_exec_environment_carries(self):
+        """fc-agent runs every container exec under the host's saved
+        HTTP_PROXY and HTTPS_PROXY (fc-agent/src/exec.rs, read_proxy_settings),
+        and urllib.request.build_opener() installs a ProxyHandler from the
+        environment. The hostname check resolved through the baked resolver
+        while each URL request went to the proxy: a working proxy fetched the
+        live site, the status came back 200 and HOP D passed without the
+        replay server having answered one URL.
+
+        The stub exec runs the shipped probe text under that environment.
+        The proxy variables name a local stub that answers 200 to anything
+        (the live site through a working proxy); the URLs name a second stub
+        standing in for the replay server. A control sends a default urllib
+        request through the same environment and requires the proxy stub to
+        answer it, so a pass here cannot come from an environment the probe
+        never saw. The evidence must say the probe ran with proxies disabled
+        and which variables it ignored.
+
+        RED BEFORE THE FIX: the proxy stub answered both URLs
+        (['http://127.0.0.1:P/one', 'http://127.0.0.1:P/two']) and the replay
+        stub answered none.
+        """
+        self._probe_under_the_exec_proxy_environment()
+
+    def test_ambient_proxy_variables_do_not_change_the_probe_evidence(self):
+        """proxy_env_ignored names the variables the probe found in the exec
+        environment, so the fixture must install that environment rather than
+        inherit the box's. Development boxes export proxy names beyond the
+        four the exec installs (YARN_HTTPS_PROXY, npm_config_http_proxy from
+        node tooling), and an inherited one lands in the evidence.
+
+        RED WITHOUT THE FIX: proxy_env_ignored came back
+        ['HTTPS_PROXY', 'HTTP_PROXY', 'NO_PROXY', 'YARN_HTTPS_PROXY',
+        'no_proxy', 'npm_config_http_proxy'].
+        """
+        with mock.patch.dict(os.environ, {
+                "YARN_HTTPS_PROXY": "http://127.0.0.1:9/",
+                "npm_config_http_proxy": "http://127.0.0.1:9/"}):
+            self._probe_under_the_exec_proxy_environment()
 
     def test_a_clone_answering_the_real_address_fails_hop_d(self):
         """The failure the hop exists for: the guest resolves example.com to

--- a/bench/chromium/test_verify_dns.py
+++ b/bench/chromium/test_verify_dns.py
@@ -68,8 +68,8 @@ PY
       shift 3; view="$1"; shift; shift   # exec --pid P <view> -- argv...
       line="$view $*"; printf '%s\n' "${line//$'\n'/ }" >> "$STUB_EXEC_LOG"   # one line per exec
       case "$view $*" in
-        "--vm cat /etc/resolv.conf") printf '%b' "$STUB_RESOLV_VM" ;;
-        "-c cat /etc/resolv.conf") printf '%b' "$STUB_RESOLV_CONTAINER" ;;
+        "--vm cat /etc/resolv.conf") printf '%b' "$STUB_RESOLV_VM"; exit "${STUB_RESOLV_RC:-0}" ;;
+        "-c cat /etc/resolv.conf") printf '%b' "$STUB_RESOLV_CONTAINER"; exit "${STUB_RESOLV_RC:-0}" ;;
         "-c python3 /opt/bench/"*) exit 0 ;;
         "-c python3 -c "*gethostbyname*) echo "$STUB_ANSWER" ;;
         "-c python3 -c "*urllib*) echo "$STUB_URL_STATUS" ;;
@@ -113,7 +113,7 @@ class VerifyDnsHop(unittest.TestCase):
     def _fixture(self, d, dns_server="10.0.2.2", config=True, hosts=HOSTS,
                  urls=URLS, answer="10.0.2.2", resolv_vm="nameserver 10.0.2.2\n",
                  resolv_container="nameserver 10.0.2.2\n", url_status="200",
-                 drop_config=False):
+                 drop_config=False, resolv_rc=0):
         data = os.path.join(d, "data")
         state_dir = os.path.join(data, "state")
         snap = os.path.join(data, "snapshots", TAG)
@@ -156,6 +156,7 @@ class VerifyDnsHop(unittest.TestCase):
             STUB_RESOLV_CONTAINER=resolv_container,
             STUB_URL_STATUS=url_status,
             STUB_DROP_CONFIG="1" if drop_config else "0",
+            STUB_RESOLV_RC=str(resolv_rc),
         )
         return env, state_dir
 
@@ -279,6 +280,76 @@ class VerifyDnsHop(unittest.TestCase):
             self.assertIsNone(evidence["dns_server"])
             self.assertEqual(evidence["hosts"], {})
             self.assertEqual(evidence["urls"], {})
+
+    def test_a_failed_resolver_read_fails_even_with_plausible_output(self):
+        """`fcvm exec` that prints the wanted line and exits non-zero is
+        an exec that did not complete (a torn-down clone, a container that
+        is not the one Chromium runs in); its stdout proves nothing. The
+        hop kept the stdout and discarded the exit status.
+
+        RED BEFORE THE FIX: AssertionError: 0 == 0 (verify passed) and
+        evidence passed=true.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            env, _ = self._fixture(d, resolv_rc=3)
+            result = self._verify(env)
+            self.assertNotEqual(result.returncode, 0,
+                                "verify passed on a resolver read that exited 3\n"
+                                + result.stdout)
+            self.assertIn("HOP D FAILED", result.stderr)
+            self.assertIn("exited 3", result.stderr)
+            self.assertIs(self._evidence(env)["passed"], False)
+
+    def test_urls_alone_are_still_verified(self):
+        """VERIFY_DNS_URLS without VERIFY_DNS_HOSTS ran zero checks and
+        recorded passed=true; the URL fetches are assertions in their own
+        right and need the baked resolver just the same.
+
+        RED BEFORE THE FIX: AssertionError: 0 == 0 (a 404 through the
+        resolver under test passed) and evidence urls == {}.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            env, _ = self._fixture(d, hosts="", url_status="404")
+            result = self._verify(env)
+            self.assertNotEqual(result.returncode, 0, result.stdout)
+            self.assertIn("HOP D FAILED", result.stderr)
+            evidence = self._evidence(env)
+            self.assertIs(evidence["passed"], False)
+            self.assertEqual(evidence["urls"]["https://example.com/"],
+                             {"status": 404, "ok": False})
+        with tempfile.TemporaryDirectory() as d:
+            env, _ = self._fixture(d, hosts="")
+            result = self._verify(env)
+            self.assertEqual(result.returncode, 0,
+                             f"{result.stdout}\n{result.stderr[-2500:]}")
+            evidence = self._evidence(env)
+            self.assertIs(evidence["passed"], True)
+            self.assertEqual(evidence["hosts"], {})
+            for url in URLS.split(","):
+                self.assertEqual(evidence["urls"][url], {"status": 200, "ok": True})
+        with tempfile.TemporaryDirectory() as d:
+            # URLs alone, with no baked resolver to fetch through: refuse.
+            env, _ = self._fixture(d, hosts="", dns_server=None)
+            result = self._verify(env)
+            self.assertNotEqual(result.returncode, 0, result.stdout)
+            self.assertIn("baked resolver", result.stderr)
+
+    def test_a_second_nameserver_fails(self):
+        """glibc walks the nameserver list: a resolv.conf that names the
+        baked resolver AND a public one renders the live site the moment
+        the replay server misses a query. One matching line was enough.
+
+        RED BEFORE THE FIX: AssertionError: 0 == 0 (verify passed with
+        8.8.8.8 as a fallback resolver).
+        """
+        with tempfile.TemporaryDirectory() as d:
+            env, _ = self._fixture(
+                d, resolv_container="nameserver 10.0.2.2\\nnameserver 8.8.8.8\\n")
+            result = self._verify(env)
+            self.assertNotEqual(result.returncode, 0, result.stdout)
+            self.assertIn("HOP D FAILED", result.stderr)
+            self.assertIn("8.8.8.8", result.stderr)
+            self.assertIs(self._evidence(env)["passed"], False)
 
     def test_an_unreadable_config_blocks_hop_d(self):
         """Fail closed: a hop that could not read the snapshot has no basis

--- a/bench/chromium/test_verify_dns.py
+++ b/bench/chromium/test_verify_dns.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""HOP D of `reqbench.sh verify`: the baked resolver, proven inside a RESTORED clone.
+
+The corpus campaign bakes GUEST_DNS=10.0.2.2 into the golden so every corpus
+hostname resolves to the pasta gateway and lands on the host replay server.
+HOPs A-C prove the render path by IP; none of them proves that a restored
+clone still resolves through the baked server. A clone whose resolv.conf came
+back pointing at a real resolver would render the live site and record a
+plausible number. HOP D asks the clone itself, and the golden records the
+resolver it asked for so the two can be compared later.
+
+Driven the way HugepageGuards drives reqbench.sh: the script is sourced with a
+stub $FCVM on PATH and a fixture config.json, so no VM, sudo or podman is
+involved. The stub answers `snapshot serve`, `snapshot run`, `ls --json` and
+every `exec` form cmd_verify uses, and publishes/removes a state file the way
+a real clone does, so the ordered teardown at the end of cmd_verify runs for
+real.
+
+Run: python3 -m unittest test_verify_dns -v
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SH = os.path.join(HERE, "reqbench.sh")
+TAG = "tag-under-test"
+HOSTS = "example.com,blog.cloudflare.com"
+URLS = "https://example.com/,https://blog.cloudflare.com/"
+RUN_ID = "0" * 32
+
+# Stands in for fcvm. Every exec is appended to $STUB_EXEC_LOG as
+# "<view> <argv...>" so a test can prove which questions HOP D asked the clone.
+FCVM_STUB = r'''#!/bin/bash
+echo "$*" >> "$STUB_ARGV"
+case "$1 $2" in
+  "snapshot serve")
+      # Simulates the snapshot directory vanishing after the hugepage check
+      # (the only reader before HOP D) so HOP D meets an unreadable config.
+      [ "${STUB_DROP_CONFIG:-0}" = 1 ] && rm -f "$FCVM_DATA_DIR/snapshots/$TAG/config.json"
+      echo "Serve PID: $$"; echo "Waiting for VMs"; exec sleep 30 ;;
+  "snapshot run")
+      name=""; prev=""
+      for a in "$@"; do [ "$prev" = --name ] && name="$a"; prev="$a"; done
+      vm_id="vm-$(printf '%s' "$name" | sha256sum | cut -c1-32)"
+      state="$STATE_DIR/$vm_id.json"
+      read -r st < /proc/$$/stat; st=${st##*) }; read -ra f <<< "$st"
+      printf '{"vm_id":"%s","name":"%s","pid":%s,"pid_start_time":%s,"config":{"network":{"loopback_ip":"127.0.0.1"}}}\n' \
+          "$vm_id" "$name" "$$" "${f[19]}" > "$state"
+      sleep 30 & sl=$!
+      trap 'kill $sl 2>/dev/null; rm -f "$state"; exit 0' TERM
+      wait $sl; rm -f "$state"; exit 0 ;;
+  "ls --json")
+      pid=""; [ "${3:-}" = --pid ] && pid="$4"
+      "$STUB_PYTHON" - "$STATE_DIR" "$pid" <<'PY'
+import glob, json, os, sys
+rows = [json.load(open(p)) for p in glob.glob(os.path.join(sys.argv[1], "vm-*.json"))]
+if sys.argv[2]:
+    rows = [r for r in rows if str(r["pid"]) == sys.argv[2]]
+print(json.dumps(rows))
+PY
+      ;;
+  "exec --pid")
+      shift 3; view="$1"; shift; shift   # exec --pid P <view> -- argv...
+      line="$view $*"; printf '%s\n' "${line//$'\n'/ }" >> "$STUB_EXEC_LOG"   # one line per exec
+      case "$view $*" in
+        "--vm cat /etc/resolv.conf") printf '%b' "$STUB_RESOLV_VM" ;;
+        "-c cat /etc/resolv.conf") printf '%b' "$STUB_RESOLV_CONTAINER" ;;
+        "-c python3 /opt/bench/"*) exit 0 ;;
+        "-c python3 -c "*gethostbyname*) echo "$STUB_ANSWER" ;;
+        "-c python3 -c "*urllib*) echo "$STUB_URL_STATUS" ;;
+        *) echo "stub fcvm: unexpected exec: $view $*" >&2; exit 97 ;;
+      esac ;;
+  *) exit 0 ;;
+esac
+'''
+
+# Stands in for the HOST python3. HOP B feeds a script on stdin ("-") and HOP C
+# and target_id run cdpdrive.py; both are outside HOP D and answered trivially.
+# Everything else (the -c one-liners that parse `fcvm ls --json`) runs the real
+# interpreter, so the harness's own state parsing is exercised unchanged.
+PYTHON_STUB = '''#!/bin/bash
+case "$1" in
+  *cdpdrive.py)
+      for a in "$@"; do [ "$a" = --print-target ] && {{ echo TARGET-1; exit 0; }}; done
+      exit 0 ;;
+  -) cat >/dev/null; exit 0 ;;
+esac
+exec {python} "$@"
+'''
+
+
+def write_exec(path, body):
+    with open(path, "w") as handle:
+        handle.write(body)
+    os.chmod(path, 0o755)
+
+
+def read_if_exists(path, default=""):
+    if not os.path.exists(path):
+        return default
+    with open(path) as handle:
+        return handle.read()
+
+
+class VerifyDnsHop(unittest.TestCase):
+    """cmd_verify end to end against the stub, with HOP D's inputs varied."""
+
+    def _fixture(self, d, dns_server="10.0.2.2", config=True, hosts=HOSTS,
+                 urls=URLS, answer="10.0.2.2", resolv_vm="nameserver 10.0.2.2\n",
+                 resolv_container="nameserver 10.0.2.2\n", url_status="200",
+                 drop_config=False):
+        data = os.path.join(d, "data")
+        state_dir = os.path.join(data, "state")
+        snap = os.path.join(data, "snapshots", TAG)
+        os.makedirs(state_dir)
+        os.makedirs(snap)
+        if config:
+            network = {"guest_ip": "10.0.2.100"}
+            if dns_server is not None:
+                network["dns_server"] = dns_server
+            with open(os.path.join(snap, "config.json"), "w") as handle:
+                json.dump({
+                    "generation_id": "12345678-1234-4234-8234-123456789abc",
+                    "metadata": {"hugepages": False, "memory_mib": 1024,
+                                 "network_config": network},
+                }, handle)
+        binx = os.path.join(d, "bin")
+        os.makedirs(binx)
+        write_exec(os.path.join(binx, "python3"),
+                   PYTHON_STUB.format(python=sys.executable))
+        fcvm = os.path.join(d, "fcvm")
+        write_exec(fcvm, FCVM_STUB)
+        write_exec(os.path.join(d, "fc-agent"), "#!/bin/bash\nexit 0\n")
+        env = dict(os.environ)
+        env.update(
+            PATH=binx + os.pathsep + env["PATH"],
+            TAG=TAG,
+            STATE_DIR=state_dir,
+            RESULTS=os.path.join(d, "results"),
+            RUNID=RUN_ID,
+            FCVM=fcvm,
+            FC_AGENT=os.path.join(d, "fc-agent"),
+            VERIFY_DNS_HOSTS=hosts,
+            VERIFY_DNS_ANSWER="10.0.2.2",
+            VERIFY_DNS_URLS=urls,
+            STUB_PYTHON=sys.executable,
+            STUB_ARGV=os.path.join(d, "argv.log"),
+            STUB_EXEC_LOG=os.path.join(d, "exec.log"),
+            STUB_ANSWER=answer,
+            STUB_RESOLV_VM=resolv_vm,
+            STUB_RESOLV_CONTAINER=resolv_container,
+            STUB_URL_STATUS=url_status,
+            STUB_DROP_CONFIG="1" if drop_config else "0",
+        )
+        return env, state_dir
+
+    def _verify(self, env):
+        return subprocess.run(
+            ["bash", "-c", f'source "{SH}" && cmd_verify'],
+            env=env, capture_output=True, text=True, timeout=180)
+
+    def _evidence(self, env):
+        path = os.path.join(env["RESULTS"], "verify-dns.json")
+        self.assertTrue(os.path.exists(path), f"no {path} was written")
+        with open(path) as handle:
+            return json.load(handle)
+
+    def test_a_clone_answering_the_real_address_fails_hop_d(self):
+        """The failure the hop exists for: the guest resolves example.com to
+        its real address, so a render would fetch the live site, not the
+        replay. Every other hop passes; only HOP D can see it."""
+        with tempfile.TemporaryDirectory() as d:
+            env, state_dir = self._fixture(d, answer="93.184.216.34")
+            result = self._verify(env)
+            self.assertNotEqual(
+                result.returncode, 0,
+                "verify passed a clone that resolves the corpus to the live "
+                f"internet\n{result.stdout}{result.stderr}")
+            self.assertIn("HOP D FAILED", result.stderr)
+            evidence = self._evidence(env)
+            self.assertIs(evidence["passed"], False)
+            self.assertEqual(evidence["hosts"]["example.com"],
+                             {"answer": "93.184.216.34", "ok": False})
+            # The hop failed and the ordered teardown still ran: both clone
+            # state files are gone, exactly as after a passing verify.
+            self.assertEqual(os.listdir(state_dir), [],
+                             "a failed HOP D skipped the clone teardown")
+
+    def test_a_clone_resolving_through_the_baked_resolver_passes(self):
+        with tempfile.TemporaryDirectory() as d:
+            env, state_dir = self._fixture(
+                d, resolv_vm="search .\\nnameserver 10.0.2.2\\n",
+                resolv_container="nameserver 10.0.2.2\\nsearch .\\n")
+            result = self._verify(env)
+            self.assertEqual(result.returncode, 0,
+                             f"{result.stdout}\n{result.stderr[-2500:]}")
+            self.assertIn("HOP D", result.stdout)
+            evidence = self._evidence(env)
+            self.assertIs(evidence["passed"], True)
+            self.assertEqual(evidence["dns_server"], "10.0.2.2")
+            self.assertIn("nameserver 10.0.2.2", evidence["resolv_conf_vm"])
+            self.assertIn("nameserver 10.0.2.2", evidence["resolv_conf_container"])
+            for host in HOSTS.split(","):
+                self.assertEqual(evidence["hosts"][host],
+                                 {"answer": "10.0.2.2", "ok": True})
+            for url in URLS.split(","):
+                self.assertEqual(evidence["urls"][url], {"status": 200, "ok": True})
+            self.assertTrue(evidence["timestamp"])
+            execs = read_if_exists(env["STUB_EXEC_LOG"]).splitlines()
+            self.assertIn("--vm cat /etc/resolv.conf", execs,
+                          "HOP D never read the VM's resolv.conf")
+            self.assertIn("-c cat /etc/resolv.conf", execs,
+                          "HOP D never read the container's resolv.conf")
+            for host in HOSTS.split(","):
+                self.assertTrue(
+                    any("gethostbyname" in line and line.endswith(" " + host)
+                        for line in execs),
+                    f"HOP D never resolved {host} inside the container:\n"
+                    + "\n".join(execs))
+            for url in URLS.split(","):
+                self.assertTrue(
+                    any("urllib" in line and line.endswith(" " + url)
+                        for line in execs),
+                    f"HOP D never fetched {url} inside the container")
+            self.assertEqual(os.listdir(state_dir), [])
+
+    def test_a_container_view_pointing_elsewhere_fails(self):
+        """podman rewrites resolv.conf for the container; the VM's copy
+        being right proves nothing about what Chromium reads."""
+        with tempfile.TemporaryDirectory() as d:
+            env, _ = self._fixture(d, resolv_container="nameserver 10.0.2.3\\n")
+            result = self._verify(env)
+            self.assertNotEqual(result.returncode, 0, result.stdout)
+            self.assertIn("HOP D FAILED", result.stderr)
+            self.assertIn("container", result.stderr)
+            self.assertIs(self._evidence(env)["passed"], False)
+
+    def test_a_replay_status_outside_2xx_3xx_fails(self):
+        with tempfile.TemporaryDirectory() as d:
+            env, _ = self._fixture(d, url_status="404")
+            result = self._verify(env)
+            self.assertNotEqual(result.returncode, 0, result.stdout)
+            self.assertIn("HOP D FAILED", result.stderr)
+            evidence = self._evidence(env)
+            self.assertIs(evidence["passed"], False)
+            self.assertEqual(evidence["urls"]["https://example.com/"],
+                             {"status": 404, "ok": False})
+
+    def test_hosts_without_a_baked_resolver_fail(self):
+        """A golden made without GUEST_DNS carries no resolver to verify
+        against; a corpus verify of it must refuse, not vacuously pass."""
+        with tempfile.TemporaryDirectory() as d:
+            env, _ = self._fixture(d, dns_server=None)
+            result = self._verify(env)
+            self.assertNotEqual(result.returncode, 0, result.stdout)
+            self.assertIn("HOP D FAILED", result.stderr)
+            self.assertIn("baked resolver", result.stderr)
+            evidence = self._evidence(env)
+            self.assertIs(evidence["passed"], False)
+            self.assertIsNone(evidence["dns_server"])
+            self.assertNotIn("gethostbyname", read_if_exists(env["STUB_EXEC_LOG"]),
+                             "HOP D resolved hosts with no resolver to hold them to")
+
+    def test_no_hosts_records_the_resolver_and_passes(self):
+        """The default (medium.html) golden has nothing to assert; HOP D
+        records what the snapshot says and stays out of the way."""
+        with tempfile.TemporaryDirectory() as d:
+            env, _ = self._fixture(d, dns_server=None, hosts="", urls="")
+            result = self._verify(env)
+            self.assertEqual(result.returncode, 0,
+                             f"{result.stdout}\n{result.stderr[-2500:]}")
+            evidence = self._evidence(env)
+            self.assertIs(evidence["passed"], True)
+            self.assertIsNone(evidence["dns_server"])
+            self.assertEqual(evidence["hosts"], {})
+            self.assertEqual(evidence["urls"], {})
+
+    def test_an_unreadable_config_blocks_hop_d(self):
+        """Fail closed: a hop that could not read the snapshot has no basis
+        for a verdict, and must say BLOCKED rather than FAILED or nothing."""
+        with tempfile.TemporaryDirectory() as d:
+            env, state_dir = self._fixture(d, drop_config=True)
+            result = self._verify(env)
+            self.assertNotEqual(result.returncode, 0, result.stdout)
+            self.assertIn("HOP D BLOCKED", result.stderr)
+            self.assertFalse(
+                os.path.exists(os.path.join(env["RESULTS"], "verify-dns.json")),
+                "a blocked hop wrote evidence for checks it never ran")
+            self.assertEqual(os.listdir(state_dir), [],
+                             "a blocked HOP D skipped the clone teardown")
+
+
+class GoldenGuestDns(unittest.TestCase):
+    """The golden records the resolver it asked for, and checks it landed.
+
+    `podman prepare --dns` is a request; metadata.network_config.dns_server in
+    the installed snapshot is what fc-agent actually wrote to resolv.conf. The
+    provenance carries GUEST_DNS as `guest_dns` so a later reader can compare
+    the request against every verify's evidence, and the golden refuses a
+    snapshot whose recorded resolver is not the one requested.
+    """
+
+    def _golden(self, d, guest_dns, baked):
+        binx = os.path.join(d, "bin")
+        os.makedirs(binx)
+        os.makedirs(os.path.join(d, "state"))
+        network = {} if baked is None else {"dns_server": baked}
+        config = json.dumps({
+            "generation_id": "12345678-1234-4234-8234-123456789abc",
+            "created_at": "2026-08-09T00:00:00Z",
+            "vm_id": "vm-11111111111111111111111111111111",
+            "metadata": {
+                "image": "localhost/chromium-bench-req",
+                "image_disk_path": "/image-cache/%s.storage-v2.img" % ("a" * 64),
+                "network_config": network,
+            },
+        })
+        fcvm = os.path.join(d, "fcvm")
+        write_exec(fcvm, f'''#!/bin/bash
+case "$1 $2" in
+  "podman prepare")
+      mkdir -p "$DATA_ROOT/snapshots/$TAG"
+      : > "$DATA_ROOT/snapshots/$TAG.lock"
+      printf '%s\\n' {config!r} > "$DATA_ROOT/snapshots/$TAG/config.json"
+      digest=$(sha256sum "$DATA_ROOT/snapshots/$TAG/config.json" | cut -d" " -f1)
+      printf '{{"status":"prepared","generation_id":"%s","config_digest":"%s"}}\\n' \\
+          "12345678-1234-4234-8234-123456789abc" "$digest"
+      ;;
+esac
+''')
+        write_exec(os.path.join(d, "fc-agent"), "#!/bin/bash\nexit 0\n")
+        write_exec(os.path.join(binx, "podman"), '''#!/bin/bash
+if [ "$1 $2" = "image inspect" ]; then
+    echo '[{"Digest":"sha256:%s","Id":"%s"}]'
+    exit 0
+fi
+exit 1
+''' % ("a" * 64, "b" * 64))
+        env = dict(os.environ)
+        env.pop("GUEST_DNS", None)
+        env.update(
+            PATH=binx + os.pathsep + env["PATH"],
+            RESULTS=os.path.join(d, "results"),
+            STATE_DIR=os.path.join(d, "state"),
+            DATA_ROOT=d,
+            ALLOW_BUSY="1",
+            RUNID=RUN_ID,
+            FCVM=fcvm,
+            FC_AGENT=os.path.join(d, "fc-agent"),
+        )
+        if guest_dns is not None:
+            env["GUEST_DNS"] = guest_dns
+        result = subprocess.run([SH, "golden"], env=env, capture_output=True,
+                                text=True, timeout=120)
+        provenance = os.path.join(d, "snapshots", "cb-req-golden",
+                                  "reqbench-provenance.json")
+        return result, provenance
+
+    def test_guest_dns_is_recorded_when_the_snapshot_baked_it(self):
+        with tempfile.TemporaryDirectory() as d:
+            result, provenance = self._golden(d, "10.0.2.2", "10.0.2.2")
+            self.assertEqual(result.returncode, 0, result.stderr[-2000:])
+            with open(provenance) as handle:
+                self.assertEqual(json.load(handle)["guest_dns"], "10.0.2.2")
+
+    def test_a_snapshot_baked_with_another_resolver_fails_the_golden(self):
+        """A --dns the guest ignored is exactly the silent contamination the
+        corpus campaign cannot afford: the golden must not be installed with
+        provenance claiming a resolver its resolv.conf does not have."""
+        with tempfile.TemporaryDirectory() as d:
+            result, provenance = self._golden(d, "10.0.2.2", "10.0.2.3")
+            self.assertNotEqual(result.returncode, 0,
+                                "golden accepted a snapshot whose resolver is "
+                                f"not the one requested\n{result.stdout}")
+            self.assertIn("10.0.2.2", result.stderr)
+            self.assertIn("10.0.2.3", result.stderr)
+            self.assertFalse(os.path.exists(provenance),
+                             "provenance was written for a refused golden")
+
+    def test_an_unset_guest_dns_records_null(self):
+        """fcvm fills dns_server from the host resolver when --dns is not
+        given, so null means "not requested", never "no resolver"."""
+        with tempfile.TemporaryDirectory() as d:
+            result, provenance = self._golden(d, None, "10.0.2.3")
+            self.assertEqual(result.returncode, 0, result.stderr[-2000:])
+            with open(provenance) as handle:
+                record = json.load(handle)
+            self.assertIn("guest_dns", record)
+            self.assertIsNone(record["guest_dns"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Groundwork for the final corpus campaign: the campaign can now prove, from inside a restored clone and for the whole measured window, which resolver the guest used, and a page that does not finish rendering fails publication instead of hiding in a median. No measured behaviour changes; the sealed bundle changes (`reqbench.py`, `reqanalyze.py`, `cdpdrive.py`), so every golden is re-recorded before the next run.

## What changed

**In-clone resolver gate (HOP D in `cmd_verify`, `bench/chromium/reqbench.sh`).** Reads `metadata.network_config.dns_server` from the golden's `config.json` (unreadable = `HOP D BLOCKED`). With `VERIFY_DNS_HOSTS` set: the VM's and the container's `/etc/resolv.conf` must carry only that nameserver, each corpus host must resolve inside the container to `VERIFY_DNS_ANSWER` (10.0.2.2), and each `VERIFY_DNS_URLS` entry must answer 200–399 through pasta over TLS. Every `fcvm exec` status is held; a resolver read that exits non-zero fails the hop. Evidence in `$RESULTS/verify-dns.json`. The golden records `guest_dns` in `reqbench-provenance.json` and asserts it equals what the snapshot baked.

**Campaign bracketing (`bench/chromium/corpus_campaign.sh`).** `RESULTS` is passed to the golden and verify sub-makes; HOP D runs three times (pre, after settle immediately before the run, after the run); a sampler records the owner of host `127.0.0.1:53` and dnsmasq's state every 10 s to `dns-owner.log`; `corpus_serve.py` writes `corpus-dns.log` and `corpus-access.log`; the server is stopped before the logs are hashed; `dns-evidence.json` carries the verdict (`clean` only with three passed brackets, a live sampler whose every sample names the replay server, dnsmasq inactive throughout and restored after, both logs present and hashed), written tmp+rename, `unclean` on any failure. The existing dnsmasq stop/restart trap is unchanged; nothing else touches a host service. `STALL_MAX_MS=15000` is the campaign default.

**Provenance and gates (`reqbench.py`, `reqanalyze.py`).** `snapshot_generation` returns the golden's `dns_server`; the run meta records `guest_dns` (the requested resolver; a golden whose provenance predates the key, or whose override was not baked, is refused) and `engine`; both are cell fields, so runs with different resolvers never pool. The analyzer refuses a corpus run (any non-IP hostname) without `guest_dns`, gains `per_url` (per URL, per arm: n, medians and CIs of blocking, load event and total, distinct screenshots) and `stall_gate` (`--stall-max-ms`; `navigate_load_event_ms` for Chromium, `navigate_ms` for WebKit; negative or missing timings are violations; `publishable=false` on any violation). A record whose top-level `url` contradicts its schedule is a schedule error.

**Replay-server and driver evidence (`corpus_serve.py`, `cdpdrive.py`).** `--dns-log`/`--access-log`: one flushed JSON line per query/request; a log that cannot be written ends the responder rather than serving silently. `cdpdrive.py --net-trace PATH`: `Network.*` events for one navigation, drained 5 s past the load event, with `remoteIPAddress`, pending-at-load and error histograms, written whole (`os.replace`), exit 1 if it cannot be written. With the flag unset the wire sequence is pinned exactly: `Page.enable`, `Page.navigate`, `Page.captureScreenshot`, `Runtime.evaluate`, nothing else.

**`bench/chromium/campaign_summary.py`.** Indexes runs from `analysis.json` + `dns-evidence.json`; refuses any unpublishable analysis, an unarmed or unevaluated stall gate, a missing or unclean DNS verdict, or log hashes that do not match the files beside the run; never edits inputs; removes a stale index on refusal. `.gitignore` negations track the evidence files (`verify-dns*.json`, `dns-evidence.json`, `dns-owner.log`, `campaign-*-summary.json`) while raw run output stays ignored.

Not in this PR: the `diag` phase that invokes `--net-trace` per URL (next PR, with its Makefile target), and the elmundo fix itself, which that phase is for.

## Review

Three implementers on disjoint file sets, an integration pass, then a local `codex exec` refutation of the merged diff: 14 findings, 12 fixed with a red test each (unarmed stall gate indexed as passed; WebKit gate passing with `evaluated=0`; negative timings passing; `per_url` corrupted by a contradicting `url`; HOP D passing a failed exec; stale evidence reused on shell failure paths; evidence presence and hashes not enforced; sampler death reading clean; net-trace partial writes; and more), 2 rejected with reasons in the commits (tracking tens of MB of access logs; extracting a helper from a sealed file for a test).

## Test evidence

`python3 -m unittest discover -s bench/chromium -p 'test_*.py'`: `Ran 438 tests ... OK` (332 on main). Every new test was watched failing on the tree without its change; the red text is quoted in each commit. `make lint` clean.

## Review round 2 (Codex on 13cb9543)

- `73111ba1` Both local curl probes pass `--noproxy '*'` (a proxy in the environment could fake replay completeness or fail a valid replay); the start cleanup also drops `corpus-dns.log`/`corpus-access.log` (append-mode files that would carry an earlier attempt into the hashed evidence); the unwritable-evidence test fails a stub `jq`/`mv` instead of relying on a 0o555 directory root ignores.
- `b91d81c8` A failed access-log write stops both replay listeners and `corpus_serve.py` exits 1 with the reason, instead of killing one handler thread while the server kept serving.

Each with a test watched failing first; 443 tests OK.

## Review round 3 (Codex and CodeRabbit on b91d81c8)

- `c46ac48d` The start cleanup also drops an earlier attempt's `reqbench.jsonl` (append mode) and `analysis.json`.
- `127aabbb` `per_url` reads the engine-selected load stage (`navigate_ms` for WebKit) and names it (`load_stage`); WebKit URLs no longer report `n=0`.
- `347403c8` Non-object `dns-evidence.json` is refused by name.
- `d10b0f2d` The index requires the cell's seal identity and refuses withdrawn runs (a `WITHDRAWN` marker file or `"withdrawn": true`, documented in `bench/chromium/AGENTS.md`).

Each with a test watched failing first; 448 tests OK.

## Review round 4 (CodeRabbit nitpicks on b91d81c8)

- `5ac63e14` The net-trace `slowest_10` ranks by duration and carries `duration_ms`; `pending_at_load` lists the rows still open at the load event.
- `2f8a9da9` The `:53`-owner sampler records the 1-minute load on every sample; `dns-evidence.json` reports `load_max_1min` and `load_samples`, carried into the index cell.

454 tests OK.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional network tracing with request timing, failures, redirects, remote addresses, and slowest requests.
  * Added campaign summary indexes combining benchmark results and verification evidence.
  * Added configurable load-event stall thresholds and engine-specific timing reports.
  * Added guest DNS configuration tracking and validation.

* **Bug Fixes**
  * Improved DNS and proxy verification reliability.
  * Replay services now shut down gracefully while preserving final log entries.
  * Benchmark evidence, duplicate runs, and stale artifacts are handled more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->