### PR TITLE
Review gate: close seven more fail-open holes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -168,8 +168,9 @@ branch logged 0 times across 137 runs, a `grep '^ *FAIL'` blind to nextest's `TR
 Every one of them was green for its whole life.
 
 Enforcement: `scripts/check-review-threads.sh <pr>` fails while any review thread is
-unresolved, and while any finding — inline OR in a PR-level review body — carries no
-disposition. One vocabulary for both:
+unresolved, and while any finding carries no disposition, whether it arrived inline, in a
+PR-level review body from anyone but the PR author, or in a top-level PR comment. One
+vocabulary for all of them:
 
 A head that no reviewer has anything to say about is still reviewed: the gate counts a
 listed review bot's (`VERDICT_BOTS`) no-findings result as coverage of the head when the
@@ -212,9 +213,17 @@ Three rules the gate enforces, each of them a hole it once had:
   or a plain top-level PR comment (`gh pr comment`). The last of those was invisible to the
   gate for a while, which meant a claim posted exactly the way the docs suggested could sit
   on a PR reporting CLEAR.
-- **But not everything is a claim.** The PR author's own words, and a bot's top-level
-  notification, are not findings. Treating every non-empty body as one blocked PRs that had
-  no findings at all — including on `@codex review`, the command the docs tell you to post.
+- **But not everything is a claim.** An APPROVED review is GitHub saying the reviewer is
+  not asking for changes. A listed notification bot's comment is not a finding, nor is a
+  documented trigger command (`@codex review`, `@coderabbitai review`). Nor is a REVIEW BODY
+  FROM THE PR AUTHOR: a review is the channel this gate names for answering, so counting the
+  author's own review as a claim made every acknowledgement create the obligation it was
+  posted to discharge, and the count grew by one each round (#874 was carrying 4 such bodies,
+  #872 five). The author's TOP-LEVEL COMMENT is still a claim, because that is where a
+  self-reported defect lands. None of this re-admits `REVIEW-ACK:` as a disposition; it
+  answers nothing, it has simply stopped being a question. Treating every non-empty body as a
+  finding blocked PRs that had none at all, `@codex review` included, which is the command
+  the docs tell you to post.
 - **The head commit must have been reviewed.** Answering every finding proves nothing if
   nobody reviewed the code you are merging. This gate shipped with five open findings that
   way: the branch was pushed, the prior round was answered, the gate went CLEAR, and it

--- a/scripts/check-review-threads.sh
+++ b/scripts/check-review-threads.sh
@@ -491,10 +491,22 @@ fi
 #
 #   - REVIEWS carry a state. GitHub's own APPROVED means "I am not asking for changes";
 #     that is a semantic fact, not a guess about the prose. COMMENTED and
-#     CHANGES_REQUESTED carry findings and need answers — from anyone, author included.
+#     CHANGES_REQUESTED carry findings and need answers — from anyone EXCEPT the PR author.
+#     A review body from the author is the answer this gate asks for two paragraphs below
+#     ("Post a review on the PR OPENING with one of ..."), so counting it as a claim made
+#     every acknowledgement create the obligation it was posted to discharge, and the count
+#     grew by one each round: #874 carried 4 such bodies and #872 5, all the author's own
+#     acks, burying the bot findings that really had no answer. The head-coverage rule
+#     discounts the author for the same reason. This does NOT re-admit REVIEW-ACK as a
+#     disposition: it answers nothing, it merely stops being a claim itself. And the
+#     exemption belongs to a LOGIN, which is unique across GitHub accounts, so nobody else
+#     can wear it; an empty or absent author matches nothing, because on a payload that
+#     names no author "" == "" would exempt every unattributed body on it.
 #   - TOP-LEVEL COMMENTS have no state, so everything counts unless it is on a short,
 #     documented ignore list: bot logins that only ever post notifications, and the
-#     literal trigger phrases this skill tells you to post. An unknown bot counts.
+#     literal trigger phrases this skill tells you to post. An unknown bot counts, and so
+#     does the AUTHOR: a comment is where a self-reported defect lands, and a review is
+#     where an answer does. That asymmetry is the whole rule.
 #
 # Add to IGNORED_COMMENT_AUTHORS deliberately, and never a bot that reviews.
 IGNORED_COMMENT_AUTHORS=${IGNORED_COMMENT_AUTHORS:-vercel,vercel[bot],dependabot,dependabot[bot],github-actions,github-actions[bot],codecov,codecov[bot]}
@@ -711,11 +723,12 @@ fi
 # The coverage check below asks only whether some row names the head and postdates its
 # arrival, so a comment carrying several results is judged row by row.
 bodies=$(jq -s --arg ignore "$IGNORED_COMMENT_AUTHORS" --arg trig "$TRIGGER_RE" --arg bots "$VERDICT_BOTS" \
-   --arg codex "$CODEX_LOGIN" \
+   --arg codex "$CODEX_LOGIN" --arg me "$prauthor" \
    "$VERDICT_JQ"'($ignore | split(",")) as $skip
   | ($bots | split(",")) as $botlogins
   | (.[0] | map({author, state, body, at: .submittedAt,
-                 claimable: ((.state // "COMMENTED") != "APPROVED")}))
+                 claimable: (((.state // "COMMENTED") != "APPROVED")
+                             and (($me == "") or ((.author.login // "") != $me)))}))
   + (.[1] | map(. as $c
       | (($c.author.__typename // "") == "Bot" and ($c.author.login | IN($botlogins[]))) as $listed
       | ($listed and ($c.body | is_verdict)) as $v

--- a/scripts/check-review-threads.sh
+++ b/scripts/check-review-threads.sh
@@ -64,21 +64,35 @@ REVIEWS_PAGE_SIZE=${REVIEWS_PAGE_SIZE:-100}
 # either Z or a +HH:MM offset, and yields null for anything else. Every comparison below is
 # between parsed instants. A null orders against nothing: it grants no coverage and answers
 # no claim, and where the field is one the gate validates, the gate says so and exits 2.
+#
+# The day is checked against the month's real length before the conversion, because mktime
+# NORMALISES: without that check "2026-02-31T01:00:00Z" converts to 2026-03-03T01:00:00Z and
+# orders as an instant three days after anything it names. The zone offset's minutes field
+# is minutes; added as seconds it puts every half- and quarter-hour zone up to 44 minutes
+# out, and for a positive offset the error runs late, which is the fail-open direction.
 TS_JQ='def ts:
   if type != "string" then null
   else (capture("^(?<y>[0-9]{4})-(?<mo>[0-9]{2})-(?<d>[0-9]{2})[Tt](?<h>[0-9]{2}):(?<mi>[0-9]{2}):(?<s>[0-9]{2})(\\.(?<frac>[0-9]+))?([Zz]|(?<zsign>[+-])(?<zh>[0-9]{2}):?(?<zm>[0-9]{2}))$") // null) as $c
   | if $c == null then null
-    else ($c.mo | tonumber) as $mo | ($c.d | tonumber) as $dd
+    else ($c.y | tonumber) as $yy
+       | ($c.mo | tonumber) as $mo | ($c.d | tonumber) as $dd
        | ($c.h | tonumber) as $hh | ($c.mi | tonumber) as $mm | ($c.s | tonumber) as $ss
        | (($c.zh // "0") | tonumber) as $zh | (($c.zm // "0") | tonumber) as $zm
-       | if $mo < 1 or $mo > 12 or $dd < 1 or $dd > 31 or $hh > 23 or $mm > 59 or $ss > 60
+       | (if $mo == 2 then (if ((($yy % 4) == 0) and ((($yy % 100) != 0) or (($yy % 400) == 0)))
+                            then 29 else 28 end)
+          elif ($mo == 4 or $mo == 6 or $mo == 9 or $mo == 11) then 30
+          else 31 end) as $dim
+       | if $mo < 1 or $mo > 12 or $dd < 1 or $dd > $dim or $hh > 23 or $mm > 59 or $ss > 60
             or $zh > 23 or $zm > 59 then null
-         else ([($c.y | tonumber), $mo - 1, $dd, $hh, $mm, $ss, 0, 0] | mktime)
+         else ([$yy, $mo - 1, $dd, $hh, $mm, $ss, 0, 0] | mktime)
               + (if $c.frac then ("0." + $c.frac | tonumber) else 0 end)
-              - (if $c.zsign == "-" then -1 else 1 end) * ($zh * 3600 + $zm)
+              - (if $c.zsign == "-" then -1 else 1 end) * ($zh * 3600 + $zm * 60)
          end
     end
   end;'
+
+# What a thread contributes to the verdict, in a form the two reads can be compared in.
+THREAD_FP_JQ='[ .[] | {id, isResolved, total: (.comments.totalCount // null)} ] | sort_by(.id | tostring)'
 
 fetch_payload() {
   local pr=$1 cursor=null threads='[]' reviews='[]' prcomments='[]' prauthor='' headoid=''
@@ -97,6 +111,7 @@ fetch_payload() {
             author { login }
             headRefOid
             commits(last: 1) { nodes { commit { committedDate checkSuites(first: 10) { nodes { createdAt } } } } }
+            prcommits: commits(last: 100) { nodes { commit { oid } } }
             reviews(first: $REVIEWS_PAGE_SIZE$rafter) {
               pageInfo { hasNextPage endCursor }
               nodes { author { login } state body submittedAt commit { oid } }
@@ -112,6 +127,8 @@ fetch_payload() {
     headoid=$(jq -r '.data.repository.pullRequest.headRefOid // ""' <<<"$rresp")
     headdate=$(jq -r '.data.repository.pullRequest.commits.nodes[0].commit.committedDate // ""' <<<"$rresp")
     headsuites=$(jq -c '.data.repository.pullRequest.commits.nodes[0].commit.checkSuites.nodes // []' <<<"$rresp")
+    # The PR's own commits, which is the universe an abbreviated sha resolves against.
+    prcommits=$(jq -c '.data.repository.pullRequest.prcommits.nodes // []' <<<"$rresp")
     [ "$(jq -r '.data.repository.pullRequest.reviews.pageInfo.hasNextPage' <<<"$rresp")" = "true" ] || break
     rcursor=$(jq -r '.data.repository.pullRequest.reviews.pageInfo.endCursor' <<<"$rresp")
   done
@@ -242,6 +259,60 @@ fetch_payload() {
     rc2cursor=$(jq -r '.data.repository.pullRequest.comments.pageInfo.endCursor' <<<"$rc2resp")
   done
 
+  # Re-read the REVIEWS and the THREAD LIST after all paging, for the same reason. A claim
+  # can land in either while the gate is working, and neither was looked at again: a review
+  # body edited to add a P1, or a whole thread opened, arrived after the only read of it and
+  # went unjudged. The comments are carried into the payload so the gate judges the FINAL
+  # snapshot of them; reviews and threads are compared instead, because re-paging every
+  # thread body would double the cost of the slowest part of the run. Either one moving means
+  # the reading was taken from data that has since changed, so it blocks.
+  local rv2='[]' rv2cursor=null rv2after="" rv2resp
+  while :; do
+    [ "$rv2cursor" != "null" ] && rv2after=", after: \"$rv2cursor\""
+    rv2resp=$(gh api graphql -f query="
+      { repository(owner: \"$REPO_OWNER\", name: \"$REPO_NAME\") {
+          pullRequest(number: $pr) {
+            reviews(first: $REVIEWS_PAGE_SIZE$rv2after) {
+              pageInfo { hasNextPage endCursor }
+              nodes { author { login } state body submittedAt commit { oid } }
+            } } } }" 2>/dev/null) || return 1
+    rv2=$(jq -s '.[0] + (.[1].data.repository.pullRequest.reviews.nodes // [])' \
+          <(echo "$rv2") <(echo "$rv2resp"))
+    [ "$(jq -r '.data.repository.pullRequest.reviews.pageInfo.hasNextPage' <<<"$rv2resp")" = "true" ] || break
+    rv2cursor=$(jq -r '.data.repository.pullRequest.reviews.pageInfo.endCursor' <<<"$rv2resp")
+  done
+  if [ "$(jq -cS . <<<"$reviews")" != "$(jq -cS . <<<"$rv2")" ]; then
+    echo "verdict: BLOCKED — the reviews on this PR changed while this gate was reading it." >&2
+    echo "The reading below was taken from what they said before. Re-run against a PR that is" >&2
+    echo "holding still." >&2
+    return 2
+  fi
+
+  # Only id, isResolved and the comment count: those are what the verdict turns on, and they
+  # are the fields the oversized-thread paging above does not rewrite, so the first read can
+  # be compared after it.
+  local th2='[]' th2cursor=null th2after="" th2resp
+  while :; do
+    [ "$th2cursor" != "null" ] && th2after=", after: \"$th2cursor\""
+    th2resp=$(gh api graphql -f query="
+      { repository(owner: \"$REPO_OWNER\", name: \"$REPO_NAME\") {
+          pullRequest(number: $pr) {
+            reviewThreads(first: 100$th2after) {
+              pageInfo { hasNextPage endCursor }
+              nodes { id isResolved comments(first: 1) { totalCount } }
+            } } } }" 2>/dev/null) || return 1
+    th2=$(jq -s '.[0] + (.[1].data.repository.pullRequest.reviewThreads.nodes // [])' \
+          <(echo "$th2") <(echo "$th2resp"))
+    [ "$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<<"$th2resp")" = "true" ] || break
+    th2cursor=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor' <<<"$th2resp")
+  done
+  if [ "$(jq -c "$THREAD_FP_JQ" <<<"$threads")" != "$(jq -c "$THREAD_FP_JQ" <<<"$th2")" ]; then
+    echo "verdict: BLOCKED — the review threads on this PR changed while this gate was" >&2
+    echo "reading them. The reading below was taken from what they said before. Re-run" >&2
+    echo "against a PR that is holding still." >&2
+    return 2
+  fi
+
   # Re-read the head AFTER all paging. A push landing mid-evaluation would otherwise leave
   # $headoid describing the commit captured by the first query, and the coverage check
   # would happily certify a SHA the PR no longer points at.
@@ -266,8 +337,10 @@ fetch_payload() {
         --slurpfile c <(printf '%s' "$prcomments") \
         --slurpfile rc <(printf '%s' "$recheckcomments") \
         --arg a "$prauthor" --arg h "$headoid" --arg d "$headdate" --argjson cs "${headsuites:-[]}" \
+        --argjson pc "${prcommits:-[]}" \
      '{data:{repository:{pullRequest:{author:{login:$a}, headRefOid:$h,
                                       commits:{nodes:[{commit:{committedDate:$d, checkSuites:{nodes:$cs}}}]},
+                                      prcommits:{nodes:$pc},
                                       reviewThreads:{nodes:$t[0]}, reviews:{nodes:$r[0]},
                                       comments:{nodes:$c[0]},
                                       recheck:{comments:{nodes:$rc[0]}}}}}}'
@@ -342,6 +415,16 @@ if ! jq -e "$TS_JQ"'all(((.body // "") | type) == "string"
   echo "verdict: BLOCKED — a top-level PR comment has a non-text body or no parsable createdAt." >&2
   exit 2
 fi
+# A comment is MUTABLE and createdAt does not move when it is edited, so ordering the body
+# the gate is reading by createdAt dates the wrong thing: a comment opened before a
+# disposition and edited afterwards to add a defect reads as answered by it. updatedAt dates
+# the current body, and a body with no parsable updatedAt cannot be ordered at all.
+if ! jq -e "$TS_JQ"'all(((.body // "") | test("[^[:space:]]") | not) or ((.updatedAt | ts) != null))' \
+     >/dev/null 2>&1 <<<"$prcomments"; then
+  echo "verdict: BLOCKED — a top-level PR comment has no parsable updatedAt, so this gate" >&2
+  echo "cannot date the body it is reading against the answers to it." >&2
+  exit 2
+fi
 # The coverage check below certifies that the HEAD was reviewed, so a payload that names
 # no head is one it cannot judge. This used to skip the check instead, which made "no
 # head" and "no reviews" both read as CLEAR: nothing to answer is not nothing reviewed.
@@ -354,7 +437,8 @@ fi
 
 # Reviews and top-level comments are two containers for the same thing: a PR-level
 # statement. Judge them as one list, so an answer posted either way settles a claim posted
-# either way. `at` normalises submittedAt/createdAt.
+# either way. `at` normalises submittedAt/updatedAt: a review is dated by its submission and
+# a comment by its last edit, which is when its current body came to say what it says.
 #
 # `claimable` — what needs an answer — took several tries, and every wrong version made
 # the same mistake: inferring whether something is a FINDING from who wrote it.
@@ -459,11 +543,25 @@ def verdict_sha:
   verdict_lines as $l
   | if ($l | length) == 2 and ($l[1] | test(reviewed_re)) then ($l[1] | capture(reviewed_re) | .sha) else "" end;
 def codex_summary_marker: "<!-- codex-pull-request-review-summary -->";
-def is_codex_summary: ((. // "") | contains(codex_summary_marker));
 def summary_cells:
   split("|") | map(gsub("^[[:space:]]+|[[:space:]]+$"; ""))
   | (if (.[0] // "") == "" then .[1:] else . end)
   | (if (.[-1] // "") == "" then .[:-1] else . end);
+def summary_lines:
+  ((. // "") | gsub("<!--(.|\n)*?-->"; "")
+    | gsub("<details> <summary>ℹ️ About Codex in GitHub</summary>(.|\n)*?</details>"; "")
+    | split("\n") | map(gsub("^[[:space:]]+|[[:space:]]+$"; ""))
+    | map(select(length > 0)));
+def is_codex_summary:
+  (((. // "") | sub("^[[:space:]]+"; "")) | startswith(codex_summary_marker))
+  and (summary_lines as $l
+       | ($l | length) >= 5
+       and ($l[0] == "## Codex Review Summary")
+       and ($l[1] == "This comment shows the latest Codex review activity on this pull request.")
+       and ($l[2] == "| Review | Status | Commit | Review trigger |")
+       and (($l[3] | summary_cells) as $sep
+            | ($sep | length) == 4 and ($sep | all(.[]; test("^:?-{3,}:?$"))))
+       and ($l[4:] | all(.[]; startswith("|") and endswith("|"))));
 def summary_rows:
   [ (. // "") | split("\n")[] | gsub("^[[:space:]]+|[[:space:]]+$"; "")
     | select(startswith("|")) | summary_cells ]
@@ -493,41 +591,12 @@ def walkthrough_sha:
 # any other, never coverage. Entries are logins; their mention handles (@codex,
 # @coderabbitai) are the ones TRIGGER_RE accepts.
 VERDICT_BOTS=${VERDICT_BOTS:-chatgpt-codex-connector,coderabbitai}
+# The review summary belongs to ONE of them. Accepting it from any listed bot made a
+# CodeRabbit comment carrying the marker a Codex verdict: exempt from dispositions, with its
+# table read as head coverage.
+CODEX_LOGIN=${CODEX_LOGIN:-chatgpt-codex-connector}
 
 prauthor=$(jq -r '.data.repository.pullRequest.author.login // ""' <<<"$payload" 2>/dev/null)
-#
-# Each top-level comment also records `reviewed_rows`: every {sha, at} pair by which a
-# listed bot says it reviewed a commit, and when it said so. There are three sources, and
-# each dates itself differently, which is the whole difficulty:
-#   - Codex's legacy verdict names one commit and is posted once, so its createdAt is the
-#     time of the result.
-#   - Codex's review-summary comment names one commit per table row and is edited in place,
-#     so only a row's own datetime dates that row.
-#   - CodeRabbit's walkthrough names the range it reviewed and is edited in place, so its
-#     updatedAt is the time of the result.
-# The coverage check below asks only whether some row names the head and postdates its
-# arrival, so a comment carrying several results is judged row by row.
-bodies=$(jq -s --arg ignore "$IGNORED_COMMENT_AUTHORS" --arg trig "$TRIGGER_RE" --arg bots "$VERDICT_BOTS" \
-   "$VERDICT_JQ"'($ignore | split(",")) as $skip
-  | ($bots | split(",")) as $botlogins
-  | (.[0] | map({author, state, body, at: .submittedAt,
-                 claimable: ((.state // "COMMENTED") != "APPROVED")}))
-  + (.[1] | map(. as $c
-      | (($c.author.__typename // "") == "Bot" and ($c.author.login | IN($botlogins[]))) as $listed
-      | ($listed and ($c.body | is_verdict)) as $v
-      | ($listed and ($c.body | is_codex_summary)) as $sum
-      | {author, state: "COMMENT", body, at: .createdAt,
-         verdict: ($v or $sum),
-         reviewed_rows: ((if $v then [{sha: ($c.body | verdict_sha), at: .createdAt}]
-                          elif $sum then ($c.body | summary_rows)
-                          elif $listed then [{sha: ($c.body | walkthrough_sha), at: (.updatedAt // "")}]
-                          else [] end)
-                         | map(select((.sha // "") != "" and (.at // "") != ""))),
-         claimable: ((.author.login | IN($skip[]) | not)
-                     and ((.body // "") | test($trig; "i") | not)
-                     and (($v or $sum) | not))}))' \
-         <(echo "$reviews") <(echo "$prcomments")) || {
-  echo "verdict: BLOCKED — could not merge PR-level bodies." >&2; exit 2; }
 
 # A coverage-bearing comment must still say, at the END of the run, what it said at the
 # start. `bodies` above was built from the FIRST read of the comments; the walkthrough and
@@ -544,12 +613,13 @@ bodies=$(jq -s --arg ignore "$IGNORED_COMMENT_AUTHORS" --arg trig "$TRIGGER_RE" 
 # shape, makes the fingerprints differ, which blocks.
 COVERAGE_FP_JQ="$VERDICT_JQ"'($bots | split(",")) as $botlogins
   | [ .[] | select(((.author.__typename // "") == "Bot") and (.author.login | IN($botlogins[])))
-          | select(((.body // "") | is_verdict) or ((.body // "") | is_codex_summary)
+          | select(((.body // "") | is_verdict)
+                   or (((.author.login // "") == $codex) and ((.body // "") | is_codex_summary))
                    or ((.body // "") | contains(cr_summarize_marker)))
           | {login: .author.login, createdAt: (.createdAt // ""),
              updatedAt: (.updatedAt // ""), body: (.body // "")} ]
   | sort_by([.createdAt, .login, .body])'
-capturedfp=$(jq -c --arg bots "$VERDICT_BOTS" "$COVERAGE_FP_JQ" <<<"$prcomments") || {
+capturedfp=$(jq -c --arg bots "$VERDICT_BOTS" --arg codex "$CODEX_LOGIN" "$COVERAGE_FP_JQ" <<<"$prcomments") || {
   echo "verdict: BLOCKED — could not read the coverage-bearing comments." >&2; exit 2; }
 if [ "$capturedfp" != "[]" ]; then
   recheckcomments=$(jq -c '.data.repository.pullRequest.recheck.comments.nodes // "absent"' \
@@ -566,7 +636,7 @@ if [ "$capturedfp" != "[]" ]; then
     echo "verdict: BLOCKED — the second read of the PR comments is not an array of comments." >&2
     exit 2
   fi
-  recheckfp=$(jq -c --arg bots "$VERDICT_BOTS" "$COVERAGE_FP_JQ" <<<"$recheckcomments") || {
+  recheckfp=$(jq -c --arg bots "$VERDICT_BOTS" --arg codex "$CODEX_LOGIN" "$COVERAGE_FP_JQ" <<<"$recheckcomments") || {
     echo "verdict: BLOCKED — could not read the re-fetched coverage-bearing comments." >&2; exit 2; }
   if [ "$capturedfp" != "$recheckfp" ]; then
     echo "verdict: BLOCKED — a comment that can grant head coverage changed under us while" >&2
@@ -575,6 +645,60 @@ if [ "$capturedfp" != "[]" ]; then
     exit 2
   fi
 fi
+
+# The verdict is computed from the FINAL read of the comments, not the one the run opened
+# with. The fingerprint above only covers comments that can grant coverage, so everything
+# else that moved while the gate paged threads used to be invisible: a P1 posted mid-run was
+# never judged, and a disposition deleted mid-run still answered its claim. Where the payload
+# carries no second read there is nothing later to judge, and the first read is the final one.
+finalcomments=$(jq -c '.data.repository.pullRequest.recheck.comments.nodes // "absent"' \
+  <<<"$payload" 2>/dev/null)
+if [ "$finalcomments" != '"absent"' ] && [ -n "$finalcomments" ]; then
+  prcomments=$finalcomments
+  if ! jq -e "$TS_JQ"'type == "array" and all(((.body // "") | type) == "string"
+                  and (((.body // "") | test("[^[:space:]]") | not)
+                       or (((.createdAt | ts) != null) and ((.updatedAt | ts) != null))))' \
+       >/dev/null 2>&1 <<<"$prcomments"; then
+    echo "verdict: BLOCKED — the second read of the PR comments has a comment this gate" >&2
+    echo "cannot judge: a non-text body, or no parsable createdAt/updatedAt." >&2
+    exit 2
+  fi
+fi
+
+#
+# Each top-level comment also records `reviewed_rows`: every {sha, at} pair by which a
+# listed bot says it reviewed a commit, and when it said so. There are three sources, and
+# each dates itself differently, which is the whole difficulty:
+#   - Codex's legacy verdict names one commit and is posted once, so its createdAt is the
+#     time of the result.
+#   - Codex's review-summary comment names one commit per table row and is edited in place,
+#     so only a row's own datetime dates that row.
+#   - CodeRabbit's walkthrough names the range it reviewed and is edited in place, so its
+#     updatedAt is the time of the result.
+# The coverage check below asks only whether some row names the head and postdates its
+# arrival, so a comment carrying several results is judged row by row.
+bodies=$(jq -s --arg ignore "$IGNORED_COMMENT_AUTHORS" --arg trig "$TRIGGER_RE" --arg bots "$VERDICT_BOTS" \
+   --arg codex "$CODEX_LOGIN" \
+   "$VERDICT_JQ"'($ignore | split(",")) as $skip
+  | ($bots | split(",")) as $botlogins
+  | (.[0] | map({author, state, body, at: .submittedAt,
+                 claimable: ((.state // "COMMENTED") != "APPROVED")}))
+  + (.[1] | map(. as $c
+      | (($c.author.__typename // "") == "Bot" and ($c.author.login | IN($botlogins[]))) as $listed
+      | ($listed and ($c.body | is_verdict)) as $v
+      | ($listed and (($c.author.login // "") == $codex) and ($c.body | is_codex_summary)) as $sum
+      | {author, state: "COMMENT", body, at: .updatedAt,
+         verdict: ($v or $sum),
+         reviewed_rows: ((if $v then [{sha: ($c.body | verdict_sha), at: .createdAt}]
+                          elif $sum then ($c.body | summary_rows)
+                          elif $listed then [{sha: ($c.body | walkthrough_sha), at: (.updatedAt // "")}]
+                          else [] end)
+                         | map(select((.sha // "") != "" and (.at // "") != ""))),
+         claimable: ((.author.login | IN($skip[]) | not)
+                     and ((.body // "") | test($trig; "i") | not)
+                     and (($v or $sum) | not))}))' \
+         <(echo "$reviews") <(echo "$prcomments")) || {
+  echo "verdict: BLOCKED — could not merge PR-level bodies." >&2; exit 2; }
 
 # Observability seam for the probe. Paging is about what was FETCHED, and the verdict is a
 # poor proxy for that — the probe authors everything it posts, and the author-exclusion rule
@@ -729,14 +853,14 @@ if [ "${REQUIRE_REVIEWED_HEAD:-1}" = "1" ]; then
   # of its own. It counts for THIS head only when the bot itself names the head. A result
   # merely dated after the head arrived is not bound: a review of the old head that
   # finishes after the push is dated the same way. What names the head, per bot:
-  #   - Codex writes the commit it reviewed into the verdict. That sha must be a prefix
-  #     of the head. A verdict naming an older commit was issued for that commit and is
-  #     ignored here (it still needs no disposition).
+  #   - Codex writes the commit it reviewed into the verdict. That sha must NAME the head.
+  #     A verdict naming an older commit was issued for that commit and is ignored here (it
+  #     still needs no disposition).
   #   - Codex's review-summary comment (the shape it has posted since 2026-08-28) names a
-  #     commit per table row, and a row counts when it says Completed, names a prefix of
-  #     the head, and its own datetime postdates arrival. A table holding any row that is
-  #     not a finished Completed review covers nothing at all, because a review still
-  #     running is one whose findings have not landed. When Codex does have findings it
+  #     commit per table row, and a row counts when it says Completed, names the head, and
+  #     its own datetime postdates arrival. A table holding any row that is not a finished
+  #     Completed review covers nothing at all, because a review still running is one whose
+  #     findings have not landed. When Codex does have findings it
   #     posts a review object, which `reviewed` counts, and those findings answer to
   #     dispositions exactly as they did before.
   #   - CodeRabbit's "Full review finished." reply names nothing, so it never covers a
@@ -764,6 +888,21 @@ if [ "${REQUIRE_REVIEWED_HEAD:-1}" = "1" ]; then
   # name a later suite than the one that actually created first. And an arrival that will
   # not parse dates nothing, which is a block: as a string it still ranked against every
   # verdict, and one sorting below them certified the head.
+  # A sha a bot names is usually ABBREVIATED (Codex writes 7 characters), and a prefix is
+  # not an identity: reviewed commit `deadbee0` and head `deadbeef` share `deadbee`, so
+  # matching the head with startswith let a result for the old head certify the new one.
+  # An abbreviation is resolved against the PR's own commits, which is the only universe a
+  # review row can be naming, and it covers the head only when it resolves to exactly one
+  # commit and that commit IS the head. A full sha is compared as an identity and needs no
+  # resolution. An ambiguous or unresolvable abbreviation names nothing and binds nothing.
+  proids=$(jq -c '[.data.repository.pullRequest.prcommits.nodes[]?.commit.oid // empty]' \
+    <<<"$payload" 2>/dev/null) || {
+    echo "verdict: BLOCKED — could not read the PR's commit list." >&2; exit 2; }
+  if ! jq -e 'type == "array" and all(type == "string")' >/dev/null 2>&1 <<<"$proids"; then
+    echo "verdict: BLOCKED — the PR's commit list is not a list of object ids, so an" >&2
+    echo "abbreviated sha in a review result cannot be resolved to a commit." >&2
+    exit 2
+  fi
   suitetimes=$(jq -c '[.data.repository.pullRequest.commits.nodes[0].commit.checkSuites.nodes[]?.createdAt // empty]' \
     <<<"$payload" 2>/dev/null) || {
     echo "verdict: BLOCKED — could not read the head commit's check suites." >&2; exit 2; }
@@ -774,12 +913,21 @@ if [ "${REQUIRE_REVIEWED_HEAD:-1}" = "1" ]; then
   fi
   arrived=$(jq -r "$TS_JQ"'min_by(ts) // ""' <<<"$suitetimes") || {
     echo "verdict: BLOCKED — could not date the head's arrival." >&2; exit 2; }
-  verdicts=$(jq -r --arg me "$prauthor" --arg hd "$arrived" --arg h "$headoid" "$TS_JQ"'
+  verdicts=$(jq -r --arg me "$prauthor" --arg hd "$arrived" --arg h "$headoid" \
+             --argjson oids "$proids" "$TS_JQ"'
     ($hd | ts) as $hat
-    | [ .[] | select(.state == "COMMENT" and .author.login != $me)
+    | ($h | ascii_downcase) as $hl
+    | def names_head($sha):
+        ($sha | ascii_downcase) as $s
+        | if $s == "" then false
+          elif $s == $hl then true
+          else ([ $oids[] | ascii_downcase | select(startswith($s)) ] | unique) as $cand
+               | ($cand | length) == 1 and ($cand[0] == $hl)
+          end;
+      [ .[] | select(.state == "COMMENT" and .author.login != $me)
         | select(any(.reviewed_rows[]?; . as $row
                      | ($row.at | ts) as $rat
-                     | ($row.sha // "") != "" and ($h | startswith($row.sha))
+                     | ($row.sha // "") != "" and names_head($row.sha)
                      and $hat != null and $rat != null and $rat > $hat)) ]
     | length' <<<"$bodies") || {
     echo "verdict: BLOCKED — could not evaluate no-findings verdicts." >&2; exit 2; }

--- a/scripts/check-review-threads.sh
+++ b/scripts/check-review-threads.sh
@@ -50,6 +50,8 @@ COMMENTS_PAGE_SIZE=${COMMENTS_PAGE_SIZE:-100}
 # Same idea for the reviews connection, so its paging is reachable on an ordinary PR
 # instead of one with 100+ submitted reviews.
 REVIEWS_PAGE_SIZE=${REVIEWS_PAGE_SIZE:-100}
+# And for the PR's commits, whose paging needs a PR with 100+ commits to reach.
+COMMITS_PAGE_SIZE=${COMMITS_PAGE_SIZE:-100}
 
 # Ordering timestamps. GitHub does not return them all in one shape: check-suite and
 # comment timestamps are whole-second ("2026-01-02T00:30:00Z"), while the datetime Codex
@@ -92,67 +94,21 @@ TS_JQ='def ts:
   end;'
 
 # What a thread contributes to the verdict, in a form the two reads can be compared in.
-THREAD_FP_JQ='[ .[] | {id, isResolved, total: (.comments.totalCount // null)} ] | sort_by(.id | tostring)'
+# The comment bodies are IN it: they are what the disposition and unresolved-listing rules
+# read, and an in-place edit moves neither the thread's flags nor its comment count. pageInfo
+# is deliberately out, since a cursor is not content and one differing between two reads of
+# the same threads would block on nothing.
+THREAD_FP_JQ='[ .[] | {id, isResolved, isOutdated, total: (.comments.totalCount // null),
+                       comments: [ .comments.nodes[]? | {author: (.author.login // null), path,
+                                                         line, originalLine, body: (.body // null)} ]} ]
+  | sort_by(.id | tostring)'
 
-fetch_payload() {
-  local pr=$1 cursor=null threads='[]' reviews='[]' prcomments='[]' prauthor='' headoid=''
-
-  # Reviews are their OWN connection and must be paged on their OWN cursor. They used to
-  # ride along inside the reviewThreads loop, which was wrong twice over: past 100 reviews
-  # a defect claim in review 101 was never fetched at all (CLEAR with nothing answered),
-  # and on a PR with 2+ pages of THREADS the same first review page was appended once per
-  # iteration, duplicating every claim.
-  local rcursor=null rafter="" rresp
-  while :; do
-    [ "$rcursor" != "null" ] && rafter=", after: \"$rcursor\""
-    rresp=$(gh api graphql -f query="
-      { repository(owner: \"$REPO_OWNER\", name: \"$REPO_NAME\") {
-          pullRequest(number: $pr) {
-            author { login }
-            headRefOid
-            commits(last: 1) { nodes { commit { committedDate checkSuites(first: 10) { nodes { createdAt } } } } }
-            prcommits: commits(last: 100) { nodes { commit { oid } } }
-            reviews(first: $REVIEWS_PAGE_SIZE$rafter) {
-              pageInfo { hasNextPage endCursor }
-              nodes { author { login } state body submittedAt commit { oid } }
-            } } } }" 2>/dev/null) || return 1
-    if [ "$(jq -r '.data.repository.pullRequest // "null"' <<<"$rresp")" = "null" ]; then
-      echo "verdict: BLOCKED — no pull request #$pr in $REPO_OWNER/$REPO_NAME (or it is" >&2
-      echo "not visible to this token). Refusing to report CLEAR for a PR never read." >&2
-      return 2
-    fi
-    reviews=$(jq -s '.[0] + (.[1].data.repository.pullRequest.reviews.nodes // [])' \
-          <(echo "$reviews") <(echo "$rresp"))
-    prauthor=$(jq -r '.data.repository.pullRequest.author.login // ""' <<<"$rresp")
-    headoid=$(jq -r '.data.repository.pullRequest.headRefOid // ""' <<<"$rresp")
-    headdate=$(jq -r '.data.repository.pullRequest.commits.nodes[0].commit.committedDate // ""' <<<"$rresp")
-    headsuites=$(jq -c '.data.repository.pullRequest.commits.nodes[0].commit.checkSuites.nodes // []' <<<"$rresp")
-    # The PR's own commits, which is the universe an abbreviated sha resolves against.
-    prcommits=$(jq -c '.data.repository.pullRequest.prcommits.nodes // []' <<<"$rresp")
-    [ "$(jq -r '.data.repository.pullRequest.reviews.pageInfo.hasNextPage' <<<"$rresp")" = "true" ] || break
-    rcursor=$(jq -r '.data.repository.pullRequest.reviews.pageInfo.endCursor' <<<"$rresp")
-  done
-
-  # THIRD place a finding can live: a top-level PR comment. Not a thread, not a review —
-  # its own `comments` connection. This gate told people to answer with `gh pr comment`
-  # while never reading what that command produces, so a defect claim posted the way the
-  # docs suggest could sit on a PR that reported CLEAR.
-  local ccursor2=null cafter="" cresp2
-  while :; do
-    [ "$ccursor2" != "null" ] && cafter=", after: \"$ccursor2\""
-    cresp2=$(gh api graphql -f query="
-      { repository(owner: \"$REPO_OWNER\", name: \"$REPO_NAME\") {
-          pullRequest(number: $pr) {
-            comments(first: $REVIEWS_PAGE_SIZE$cafter) {
-              pageInfo { hasNextPage endCursor }
-              nodes { author { login __typename } body createdAt updatedAt }
-            } } } }" 2>/dev/null) || return 1
-    prcomments=$(jq -s '.[0] + (.[1].data.repository.pullRequest.comments.nodes // [])' \
-          <(echo "$prcomments") <(echo "$cresp2"))
-    [ "$(jq -r '.data.repository.pullRequest.comments.pageInfo.hasNextPage' <<<"$cresp2")" = "true" ] || break
-    ccursor2=$(jq -r '.data.repository.pullRequest.comments.pageInfo.endCursor' <<<"$cresp2")
-  done
-
+# ONE read of the PR's review threads: every thread, every comment, with each oversized
+# thread's comments paged to the end. Prints the thread array on stdout; says why and
+# returns non-zero when a page could not be fetched. fetch_payload calls it TWICE, and the
+# two reads must agree.
+fetch_threads() {
+  local pr=$1 cursor=null threads='[]'
   while :; do
     local after="" resp
     # `\"` here, NOT `\\\"`: the latter puts a literal backslash into the GraphQL
@@ -234,6 +190,91 @@ fetch_payload() {
     threads=$(jq --arg id "$tid" --slurpfile c <(printf '%s' "$all_comments") \
       'map(if .id == $id then .comments.nodes = $c[0] else . end)' <<<"$threads")
   done
+  printf '%s' "$threads"
+}
+
+fetch_payload() {
+  local pr=$1 threads='[]' reviews='[]' prcomments='[]' prauthor='' headoid=''
+
+  # Reviews are their OWN connection and must be paged on their OWN cursor. They used to
+  # ride along inside the reviewThreads loop, which was wrong twice over: past 100 reviews
+  # a defect claim in review 101 was never fetched at all (CLEAR with nothing answered),
+  # and on a PR with 2+ pages of THREADS the same first review page was appended once per
+  # iteration, duplicating every claim.
+  local rcursor=null rafter="" rresp
+  while :; do
+    [ "$rcursor" != "null" ] && rafter=", after: \"$rcursor\""
+    rresp=$(gh api graphql -f query="
+      { repository(owner: \"$REPO_OWNER\", name: \"$REPO_NAME\") {
+          pullRequest(number: $pr) {
+            author { login }
+            headRefOid
+            commits(last: 1) { nodes { commit { committedDate checkSuites(first: 10) { nodes { createdAt } } } } }
+            reviews(first: $REVIEWS_PAGE_SIZE$rafter) {
+              pageInfo { hasNextPage endCursor }
+              nodes { author { login } state body submittedAt commit { oid } }
+            } } } }" 2>/dev/null) || return 1
+    if [ "$(jq -r '.data.repository.pullRequest // "null"' <<<"$rresp")" = "null" ]; then
+      echo "verdict: BLOCKED — no pull request #$pr in $REPO_OWNER/$REPO_NAME (or it is" >&2
+      echo "not visible to this token). Refusing to report CLEAR for a PR never read." >&2
+      return 2
+    fi
+    reviews=$(jq -s '.[0] + (.[1].data.repository.pullRequest.reviews.nodes // [])' \
+          <(echo "$reviews") <(echo "$rresp"))
+    prauthor=$(jq -r '.data.repository.pullRequest.author.login // ""' <<<"$rresp")
+    headoid=$(jq -r '.data.repository.pullRequest.headRefOid // ""' <<<"$rresp")
+    headdate=$(jq -r '.data.repository.pullRequest.commits.nodes[0].commit.committedDate // ""' <<<"$rresp")
+    headsuites=$(jq -c '.data.repository.pullRequest.commits.nodes[0].commit.checkSuites.nodes // []' <<<"$rresp")
+    [ "$(jq -r '.data.repository.pullRequest.reviews.pageInfo.hasNextPage' <<<"$rresp")" = "true" ] || break
+    rcursor=$(jq -r '.data.repository.pullRequest.reviews.pageInfo.endCursor' <<<"$rresp")
+  done
+
+  # The PR's own commits: the universe an abbreviated sha in a review result resolves
+  # against. Its own connection, paged on its own cursor to completion. It used to ride the
+  # reviews query as `commits(last: 100)`, which truncates in silence: past 100 commits an
+  # omitted OLDER commit sharing the head's seven-character prefix made the abbreviation
+  # look unambiguous, so a result issued for that commit certified the head. totalCount
+  # travels with the list, and the reader refuses a list that does not account for it, so a
+  # fetch that stopped early blocks instead of resolving against a fragment.
+  local pccursor=null pcafter="" pcresp prcommitcount=null prcommits='[]'
+  while :; do
+    [ "$pccursor" != "null" ] && pcafter=", after: \"$pccursor\""
+    pcresp=$(gh api graphql -f query="
+      { repository(owner: \"$REPO_OWNER\", name: \"$REPO_NAME\") {
+          pullRequest(number: $pr) {
+            commits(first: $COMMITS_PAGE_SIZE$pcafter) {
+              totalCount
+              pageInfo { hasNextPage endCursor }
+              nodes { commit { oid } }
+            } } } }" 2>/dev/null) || return 1
+    prcommits=$(jq -s '.[0] + (.[1].data.repository.pullRequest.commits.nodes // [])' \
+          <(echo "$prcommits") <(echo "$pcresp"))
+    prcommitcount=$(jq -r '.data.repository.pullRequest.commits.totalCount // "null"' <<<"$pcresp")
+    [ "$(jq -r '.data.repository.pullRequest.commits.pageInfo.hasNextPage' <<<"$pcresp")" = "true" ] || break
+    pccursor=$(jq -r '.data.repository.pullRequest.commits.pageInfo.endCursor' <<<"$pcresp")
+  done
+
+  # THIRD place a finding can live: a top-level PR comment. Not a thread, not a review —
+  # its own `comments` connection. This gate told people to answer with `gh pr comment`
+  # while never reading what that command produces, so a defect claim posted the way the
+  # docs suggest could sit on a PR that reported CLEAR.
+  local ccursor2=null cafter="" cresp2
+  while :; do
+    [ "$ccursor2" != "null" ] && cafter=", after: \"$ccursor2\""
+    cresp2=$(gh api graphql -f query="
+      { repository(owner: \"$REPO_OWNER\", name: \"$REPO_NAME\") {
+          pullRequest(number: $pr) {
+            comments(first: $REVIEWS_PAGE_SIZE$cafter) {
+              pageInfo { hasNextPage endCursor }
+              nodes { author { login __typename } body createdAt updatedAt }
+            } } } }" 2>/dev/null) || return 1
+    prcomments=$(jq -s '.[0] + (.[1].data.repository.pullRequest.comments.nodes // [])' \
+          <(echo "$prcomments") <(echo "$cresp2"))
+    [ "$(jq -r '.data.repository.pullRequest.comments.pageInfo.hasNextPage' <<<"$cresp2")" = "true" ] || break
+    ccursor2=$(jq -r '.data.repository.pullRequest.comments.pageInfo.endCursor' <<<"$cresp2")
+  done
+
+  threads=$(fetch_threads "$pr") || return $?
 
   # Re-read the COMMENTS after all paging, for the same reason the head is re-read below —
   # and it is not the same check. Two of the three coverage signals live in comments that
@@ -288,24 +329,16 @@ fetch_payload() {
     return 2
   fi
 
-  # Only id, isResolved and the comment count: those are what the verdict turns on, and they
-  # are the fields the oversized-thread paging above does not rewrite, so the first read can
-  # be compared after it.
-  local th2='[]' th2cursor=null th2after="" th2resp
-  while :; do
-    [ "$th2cursor" != "null" ] && th2after=", after: \"$th2cursor\""
-    th2resp=$(gh api graphql -f query="
-      { repository(owner: \"$REPO_OWNER\", name: \"$REPO_NAME\") {
-          pullRequest(number: $pr) {
-            reviewThreads(first: 100$th2after) {
-              pageInfo { hasNextPage endCursor }
-              nodes { id isResolved comments(first: 1) { totalCount } }
-            } } } }" 2>/dev/null) || return 1
-    th2=$(jq -s '.[0] + (.[1].data.repository.pullRequest.reviewThreads.nodes // [])' \
-          <(echo "$th2") <(echo "$th2resp"))
-    [ "$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<<"$th2resp")" = "true" ] || break
-    th2cursor=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor' <<<"$th2resp")
-  done
+  # The second read is the SAME read, comments and all. It used to fetch only id,
+  # isResolved and comments.totalCount, on the theory that those are what the verdict turns
+  # on. They are not: the verdict turns on the BODIES from the first read, and GitHub lets a
+  # review comment be edited in place, which moves none of those three. A disposition edited
+  # mid-run into something that disposes of nothing left the fingerprint identical, and the
+  # gate certified the thread from a reply that no longer existed. Reading the comments twice
+  # costs the slowest part of the run twice; a cheaper comparison that cannot see an edit
+  # costs correctness.
+  local th2
+  th2=$(fetch_threads "$pr") || return $?
   if [ "$(jq -c "$THREAD_FP_JQ" <<<"$threads")" != "$(jq -c "$THREAD_FP_JQ" <<<"$th2")" ]; then
     echo "verdict: BLOCKED — the review threads on this PR changed while this gate was" >&2
     echo "reading them. The reading below was taken from what they said before. Re-run" >&2
@@ -337,10 +370,10 @@ fetch_payload() {
         --slurpfile c <(printf '%s' "$prcomments") \
         --slurpfile rc <(printf '%s' "$recheckcomments") \
         --arg a "$prauthor" --arg h "$headoid" --arg d "$headdate" --argjson cs "${headsuites:-[]}" \
-        --argjson pc "${prcommits:-[]}" \
+        --slurpfile pc <(printf '%s' "${prcommits:-[]}") --argjson pct "${prcommitcount:-null}" \
      '{data:{repository:{pullRequest:{author:{login:$a}, headRefOid:$h,
                                       commits:{nodes:[{commit:{committedDate:$d, checkSuites:{nodes:$cs}}}]},
-                                      prcommits:{nodes:$pc},
+                                      prcommits:{totalCount:$pct, nodes:$pc[0]},
                                       reviewThreads:{nodes:$t[0]}, reviews:{nodes:$r[0]},
                                       comments:{nodes:$c[0]},
                                       recheck:{comments:{nodes:$rc[0]}}}}}}'
@@ -895,6 +928,22 @@ if [ "${REQUIRE_REVIEWED_HEAD:-1}" = "1" ]; then
   # review row can be naming, and it covers the head only when it resolves to exactly one
   # commit and that commit IS the head. A full sha is compared as an identity and needs no
   # resolution. An ambiguous or unresolvable abbreviation names nothing and binds nothing.
+  # A FRAGMENT of the commit list is worse than none of it: `deadbee` is ambiguous across
+  # the PR's real commits and unique across the hundred that happened to be fetched, and the
+  # second reading certifies a head nobody reviewed. The list is paged to completion above
+  # and carries the totalCount GitHub reported, so a payload whose list does not account for
+  # every commit blocks. An ABSENT list is a different thing and stays allowed: no universe
+  # resolves no abbreviation, which is the fail-closed direction, and it is the shape of
+  # every fixture captured before this gate read the commits at all.
+  if [ "$(jq -r '.data.repository.pullRequest | has("prcommits")' <<<"$payload" 2>/dev/null)" = "true" ] \
+     && ! jq -e '.data.repository.pullRequest.prcommits
+                 | (.totalCount | type) == "number" and (.totalCount == (.nodes | length))' \
+          >/dev/null 2>&1 <<<"$payload"; then
+    echo "verdict: BLOCKED — the PR's commit list does not account for every commit on the" >&2
+    echo "PR, so an abbreviated sha in a review result would resolve against a fragment of" >&2
+    echo "it and could name the head by accident. Re-run, or re-capture the fixture." >&2
+    exit 2
+  fi
   proids=$(jq -c '[.data.repository.pullRequest.prcommits.nodes[]?.commit.oid // empty]' \
     <<<"$payload" 2>/dev/null) || {
     echo "verdict: BLOCKED — could not read the PR's commit list." >&2; exit 2; }

--- a/scripts/test-check-review-threads.sh
+++ b/scripts/test-check-review-threads.sh
@@ -1103,6 +1103,48 @@ edit_case "two identical thread reads still reach a verdict" 0 "CLEAR"
 COMMENTS_PAGE_SIZE=2 GATE_TEST_THREADS1=paged \
   edit_case "two identical paged thread reads still reach a verdict" 0 "CLEAR"
 
+echo "== finding 41: an acknowledgement is not a new obligation =="
+# A PR-level REVIEW body from the PR author was claimable like everyone else's, so the answer
+# this gate itself asks for ("Post a review on the PR OPENING with one of RED-VERIFIED: /
+# NOT-A-DEFECT: / DISAGREE:") became a NEW claim the moment it did not open with one of those
+# three words. Every round left one more unanswered body behind, and the count only grew:
+# #874 was carrying 4 of them and #872 5, all the author's own acks, drowning the bot findings
+# that genuinely had no answer. A review from the author is an answer to this PR, not a
+# finding against it, and the head-coverage rule already discounts the author for the same
+# reason. Everyone else's review body is claimable exactly as before, and the vocabulary is
+# unchanged: REVIEW-ACK is still not a disposition and still answers nothing, it merely stops
+# being a claim itself.
+AUTHOR_ACK='{"author":{"login":"me"},"state":"COMMENTED","submittedAt":"2026-01-05T00:00:00Z","body":"REVIEW-ACK: round 3, three findings closed in abc1234"}'
+BOT_CLAIM='{"author":{"login":"codex"},"state":"COMMENTED","submittedAt":"2026-01-01T00:00:00Z","body":"P1: this drops the last row"}'
+AUTHOR_DISP='{"author":{"login":"me"},"state":"COMMENTED","submittedAt":"2026-01-02T00:00:00Z","body":"RED-VERIFIED: tests/row.rs"}'
+run_case "an author review body with no disposition does not block" \
+  "$(wrap '[]' "[$AUTHOR_ACK]")" 0 "CLEAR"
+run_case "an author ack posted after the last disposition does not re-block" \
+  "$(wrap '[]' "[$BOT_CLAIM,$AUTHOR_DISP,$AUTHOR_ACK]")" 0 "CLEAR"
+# Guards, green before and after: nobody else is exempt, an author disposition still answers
+# the claims that came before it, and the exemption belongs to the author's login, so it
+# cannot be worn by a review that names no author, nor by anyone at all on a payload that
+# names no author. (GitHub logins are unique across accounts, so no bot can hold the author's
+# login; what IS reachable is an empty or absent one, and matching "" against "" would exempt
+# every unattributed body on such a payload.)
+run_case "a non-author review body with no disposition still blocks" \
+  "$(wrap '[]' '[{"author":{"login":"reviewer"},"state":"COMMENTED","submittedAt":"2026-01-05T00:00:00Z","body":"REVIEW-ACK: round 3, three findings closed in abc1234"}]')" \
+  1 "carry no disposition"
+run_case "an author disposition still answers a claim dated before it" \
+  "$(wrap '[]' "[$BOT_CLAIM,$AUTHOR_DISP]")" 0 "CLEAR"
+run_case "a review naming no author is not the author's" \
+  "$(wrap '[]' '[{"author":null,"state":"COMMENTED","submittedAt":"2026-01-05T00:00:00Z","body":"P1: this drops the last row"}]')" \
+  1 "carry no disposition"
+run_case "a payload naming no author exempts nobody" \
+  "$(printf '{"data":{"repository":{"pullRequest":{"author":{"login":""},"headRefOid":"deadbeef","reviewThreads":{"nodes":[]},"reviews":{"nodes":[%s,{"author":null,"state":"COMMENTED","submittedAt":"2026-01-05T00:00:00Z","body":"P1: this drops the last row"}]}}}}}' "$COVER")" \
+  1 "carry no disposition"
+# And the author's TOP-LEVEL COMMENT stays claimable: that is where a self-reported defect
+# lands, and finding 17 pins it. Only the review body, which is the channel this gate names
+# for answering, is an answer by construction.
+run_case "the author's own top-level comment is still claimable" \
+  "$(wrap4 me '[]' '[]' "[$(cmt me User 2026-01-05T00:00:00Z '"P1: this drops records"')]")" \
+  1 "carry no disposition"
+
 echo
 echo "passed=$pass failed=$fail"
 [ "$fail" -eq 0 ]

--- a/scripts/test-check-review-threads.sh
+++ b/scripts/test-check-review-threads.sh
@@ -145,13 +145,13 @@ run_case "reviewer confirmation after a disposition clears" \
 echo "== finding 13: findings in top-level PR comments count too =="
 wrap3() { printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","reviewThreads":{"nodes":%s},"reviews":{"nodes":%s},"comments":{"nodes":%s}}}}}' "$1" "$(covered "${2:-[]}")" "${3:-[]}"; }
 run_case "undisposed top-level PR comment blocks" \
-  "$(wrap3 '[]' '[]' '[{"author":{"login":"codex"},"createdAt":"2026-01-01T00:00:00Z","body":"P1: this silently drops the last row"}]')" \
+  "$(wrap3 '[]' '[]' '[{"author":{"login":"codex"},"createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z","body":"P1: this silently drops the last row"}]')" \
   1 "BLOCKED"
 run_case "disposed top-level PR comment clears" \
-  "$(wrap3 '[]' '[]' '[{"author":{"login":"codex"},"createdAt":"2026-01-01T00:00:00Z","body":"P1: this silently drops the last row"},{"author":{"login":"me"},"createdAt":"2026-01-02T00:00:00Z","body":"DISAGREE: the guard above rejects that input"}]')" \
+  "$(wrap3 '[]' '[]' '[{"author":{"login":"codex"},"createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z","body":"P1: this silently drops the last row"},{"author":{"login":"me"},"createdAt":"2026-01-02T00:00:00Z","updatedAt":"2026-01-02T00:00:00Z","body":"DISAGREE: the guard above rejects that input"}]')" \
   0 "CLEAR"
 run_case "a PR comment can answer a review body" \
-  "$(wrap3 '[]' '[{"author":{"login":"codex"},"state":"COMMENTED","submittedAt":"2026-01-01T00:00:00Z","body":"P1: drops a row"}]' '[{"author":{"login":"me"},"createdAt":"2026-01-02T00:00:00Z","body":"RED-VERIFIED: row.test.ts"}]')" \
+  "$(wrap3 '[]' '[{"author":{"login":"codex"},"state":"COMMENTED","submittedAt":"2026-01-01T00:00:00Z","body":"P1: drops a row"}]' '[{"author":{"login":"me"},"createdAt":"2026-01-02T00:00:00Z","updatedAt":"2026-01-02T00:00:00Z","body":"RED-VERIFIED: row.test.ts"}]')" \
   0 "CLEAR"
 run_case "malformed PR comment data exits 2" \
   "$(wrap3 '[]' '[]' '"nonsense"')" 2 "BLOCKED"
@@ -160,16 +160,16 @@ echo "== finding 15: only real claimants raise PR-level claims =="
 wrap4() { printf '{"data":{"repository":{"pullRequest":{"author":{"login":"%s"},"headRefOid":"deadbeef","reviewThreads":{"nodes":%s},"reviews":{"nodes":%s},"comments":{"nodes":%s}}}}}' "$1" "$2" "$(covered "${3:-[]}")" "${4:-[]}"; }
 # The command this skill documents — posted by the PR author — is not a finding.
 run_case "author's own @codex review comment does not block" \
-  "$(wrap4 me '[]' '[]' '[{"author":{"login":"me","__typename":"User"},"createdAt":"2026-01-01T00:00:00Z","body":"@codex review"}]')" \
+  "$(wrap4 me '[]' '[]' '[{"author":{"login":"me","__typename":"User"},"createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z","body":"@codex review"}]')" \
   0 "CLEAR"
 run_case "deploy bot notification does not block" \
-  "$(wrap4 me '[]' '[]' '[{"author":{"login":"vercel","__typename":"Bot"},"createdAt":"2026-01-01T00:00:00Z","body":"Deployment ready at https://preview.example"}]')" \
+  "$(wrap4 me '[]' '[]' '[{"author":{"login":"vercel","__typename":"Bot"},"createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z","body":"Deployment ready at https://preview.example"}]')" \
   0 "CLEAR"
 run_case "a human finding in a top-level comment still blocks" \
-  "$(wrap4 me '[]' '[]' '[{"author":{"login":"reviewer","__typename":"User"},"createdAt":"2026-01-01T00:00:00Z","body":"P1: this drops the last row"}]')" \
+  "$(wrap4 me '[]' '[]' '[{"author":{"login":"reviewer","__typename":"User"},"createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z","body":"P1: this drops the last row"}]')" \
   1 "BLOCKED"
 run_case "a reviewing bot's top-level comment still blocks" \
-  "$(wrap4 me '[]' '[{"author":{"login":"codex"},"state":"COMMENTED","submittedAt":"2026-01-01T00:00:00Z","body":""}]' '[{"author":{"login":"codex","__typename":"Bot"},"createdAt":"2026-01-02T00:00:00Z","body":"P1: this drops the last row"}]')" \
+  "$(wrap4 me '[]' '[{"author":{"login":"codex"},"state":"COMMENTED","submittedAt":"2026-01-01T00:00:00Z","body":""}]' '[{"author":{"login":"codex","__typename":"Bot"},"createdAt":"2026-01-02T00:00:00Z","updatedAt":"2026-01-02T00:00:00Z","body":"P1: this drops the last row"}]')" \
   1 "BLOCKED"
 run_case "a bot REVIEW body still blocks" \
   "$(wrap4 me '[]' '[{"author":{"login":"codex"},"state":"COMMENTED","submittedAt":"2026-01-01T00:00:00Z","body":"P1: this drops the last row"}]' '[]')" \
@@ -189,10 +189,10 @@ run_case "no reviews at all is an unreviewed head, not a clear one (was CLEAR)" 
 
 echo "== finding 17: authorship does not decide what is a finding =="
 run_case "author's own defect report is claimable" \
-  "$(wrap4 me '[]' '[]' '[{"author":{"login":"me","__typename":"User"},"createdAt":"2026-01-01T00:00:00Z","body":"P1: this drops records"}]')" \
+  "$(wrap4 me '[]' '[]' '[{"author":{"login":"me","__typename":"User"},"createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z","body":"P1: this drops records"}]')" \
   1 "BLOCKED"
 run_case "a standalone bot finding with no review history is claimable" \
-  "$(wrap4 me '[]' '[]' '[{"author":{"login":"codex","__typename":"Bot"},"createdAt":"2026-01-01T00:00:00Z","body":"P1: this drops the last row"}]')" \
+  "$(wrap4 me '[]' '[]' '[{"author":{"login":"codex","__typename":"Bot"},"createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z","body":"P1: this drops the last row"}]')" \
   1 "BLOCKED"
 run_case "an APPROVED review body is not a finding" \
   "$(wrap4 me '[]' '[{"author":{"login":"reviewer"},"state":"APPROVED","submittedAt":"2026-01-01T00:00:00Z","body":"LGTM, nice work"}]' '[]')" \
@@ -201,10 +201,10 @@ run_case "a COMMENTED review body still is" \
   "$(wrap4 me '[]' '[{"author":{"login":"reviewer"},"state":"COMMENTED","submittedAt":"2026-01-01T00:00:00Z","body":"LGTM, nice work"}]' '[]')" \
   1 "BLOCKED"
 run_case "a bare @codex trigger is not a finding" \
-  "$(wrap4 me '[]' '[]' '[{"author":{"login":"anyone","__typename":"User"},"createdAt":"2026-01-01T00:00:00Z","body":"@codex review"}]')" \
+  "$(wrap4 me '[]' '[]' '[{"author":{"login":"anyone","__typename":"User"},"createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z","body":"@codex review"}]')" \
   0 "CLEAR"
 run_case "a finding that merely mentions @codex still blocks" \
-  "$(wrap4 me '[]' '[]' '[{"author":{"login":"anyone","__typename":"User"},"createdAt":"2026-01-01T00:00:00Z","body":"@codex review this: P1 it drops rows"}]')" \
+  "$(wrap4 me '[]' '[]' '[{"author":{"login":"anyone","__typename":"User"},"createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z","body":"@codex review this: P1 it drops rows"}]')" \
   1 "BLOCKED"
 
 echo "== finding 18: the author reviewing their own push is not coverage =="
@@ -479,7 +479,10 @@ echo "== finding 29: a head with no review result of any kind is unreviewed, not
 # must be covered whether or not any review object exists, a PR with no review at all is
 # an unreviewed head, and a payload that names no head cannot be judged (regression case
 # below).
-wrap8() { printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{"nodes":%s}}}]},"reviewThreads":{"nodes":[]},"reviews":{"nodes":[]},"comments":{"nodes":[%s]},"recheck":{"comments":{"nodes":[%s]}}}}}}' "$1" "$2" "${3:-$2}"; }
+# The PR's own commits, which is the universe an abbreviated sha is resolved against
+# (finding 37). $4 overrides it; by default the head is the only commit.
+PRCOMMITS_HEAD='[{"commit":{"oid":"deadbeef"}}]'
+wrap8() { printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{"nodes":%s}}}]},"prcommits":{"nodes":%s},"reviewThreads":{"nodes":[]},"reviews":{"nodes":[]},"comments":{"nodes":[%s]},"recheck":{"comments":{"nodes":[%s]}}}}}}' "$1" "${4:-$PRCOMMITS_HEAD}" "$2" "${3:-$2}"; }
 SUITE='[{"createdAt":"2026-01-02T00:30:00Z"}]'
 run_case "reviews [] and a codex verdict naming an older sha is an unreviewed head" \
   "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_body ' Bravo.' abc123def4)")")" \
@@ -647,8 +650,8 @@ run_case "arrival is the earliest check suite by instant, not by string" \
   "$(wrap8 '[{"createdAt":"2026-01-02T00:30:00.900Z"},{"createdAt":"2026-01-02T00:30:00Z"}]' "$(cmt "$CODEX" Bot 2026-01-02T00:30:00.500Z "$(codex_body ' Bravo.' deadbeef)")")" \
   0 "HEAD COVERED"
 # An unparsable timestamp orders against nothing, so it grants no coverage and answers no
-# claim. Where the gate validates the field it says so and exits 2; where it does not
-# (updatedAt), the comment simply binds nothing.
+# claim. Every field the gate orders by is validated, so it says so and exits 2 rather than
+# carrying an unordered value into a comparison. updatedAt joined that list with finding 36.
 run_case "a check-suite timestamp that will not parse blocks" \
   "$(wrap8 '[{"createdAt":"2026-01-02T00:30"}]' "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_body ' Bravo.' deadbeef)")")" \
   2 "check-suite timestamp"
@@ -658,9 +661,9 @@ run_case "a review body whose timestamp will not parse blocks" \
 run_case "an answer whose timestamp will not parse answers nothing" \
   "$(wrap4 me '[]' '[]' "[$(cmt codex Bot 2026-01-02T00:30:00Z '"P1: this drops the last row"'),$(cmt me User yesterday '"RED-VERIFIED: tests/row.rs"')]")" \
   2 "no parsable createdAt"
-run_case "a walkthrough whose updatedAt will not parse is not coverage" \
+run_case "a walkthrough whose updatedAt will not parse blocks" \
   "$(wrap7 "[$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_walk none clean "$BASE40" "$HEAD40")" 'a while ago'),$ANSWER]")" \
-  1 "UNREVIEWED HEAD"
+  2 "no parsable updatedAt"
 # Guard: the parse is UTC (jq mktime is timegm), so a verdict must not depend on where the
 # runner sits. The same fixture under a non-UTC zone reaches the same verdict.
 export TZ=America/New_York
@@ -668,6 +671,208 @@ run_case "the same-second verdict holds under a non-UTC host timezone" \
   "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T00:20:00Z "$(codex_summary "$(sum_row Completed 2026-01-02T00:30:00.100Z deadbee)")" 2026-01-02T00:30:05Z)")" \
   0 "HEAD COVERED"
 unset TZ
+
+echo "== finding 33: a zone offset's minutes are minutes, not seconds =="
+# `ts` built the offset as $zh * 3600 + $zm, adding the MINUTES field as seconds. Z, +00:00
+# and every whole-hour offset are exact, which is why the +01:00 case above passes; a
+# half- or quarter-hour zone is off by $zm * 59 seconds, up to 44 minutes. The direction is
+# fail-open for positive offsets on both ordering sites: the instant reads LATER than it is,
+# so a verdict recorded before the head arrived covers it, and a claim edited after its
+# answer reads as though it came first.
+# Head arrival is 2026-01-02T00:30:00Z in every wrap8 case below.
+run_case "a +05:30 verdict 5 minutes before arrival is not coverage" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T05:55:00+05:30 "$(codex_body ' Bravo.' deadbeef)")")" \
+  1 "UNREVIEWED HEAD"
+run_case "a +09:30 verdict a minute before arrival is not coverage" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T09:59:00+09:30 "$(codex_body ' Bravo.' deadbeef)")")" \
+  1 "UNREVIEWED HEAD"
+run_case "a +12:45 verdict a minute before arrival is not coverage" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T13:14:00+12:45 "$(codex_body ' Bravo.' deadbeef)")")" \
+  1 "UNREVIEWED HEAD"
+# A negative half-hour offset reads EARLIER than it is, which fails open on the claim side:
+# the claim's true instant 04:05:00Z is after the answer's 04:00:00Z, so it is unanswered.
+run_case "a -03:30 claim posted after its answer is not answered by it" \
+  "$(wrap4 me '[]' '[]' "[$(cmt codex Bot 2026-01-02T00:35:00-03:30 '"P1: this drops the last row"'),$(cmt me User 2026-01-02T04:00:00Z '"RED-VERIFIED: tests/row.rs"')]")" \
+  1 "carry no disposition"
+# Guards, green before and after: a half-hour verdict that really is after arrival covers,
+# and whole-hour offsets were never affected.
+run_case "a +09:30 verdict 5 minutes after arrival covers the head" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T10:05:00+09:30 "$(codex_body ' Bravo.' deadbeef)")")" \
+  0 "HEAD COVERED"
+
+echo "== finding 34: only Codex, in the whole shape it posts, writes a review summary =="
+# is_codex_summary was `contains("<!-- codex-pull-request-review-summary -->")` applied to
+# any listed bot, so two things followed. CodeRabbit carrying that marker became a Codex
+# summary: exempt from dispositions, and its table read as coverage. And a real finding from
+# Codex that merely QUOTED the marker stopped being claimable, which is a P1 exiting CLEAR
+# with nothing answered. The marker must open the comment, the comment must be the whole
+# posted shape (heading, the one-line explanation, the four-column table header, its
+# separator, and table rows to the end), and the account must be Codex.
+codex_summary_plus() { jq -n --argjson b "$(codex_summary "$1")" --arg x "$2" '$b + "\n\n" + $x'; }
+run_case "a coderabbit comment in the codex summary shape is a finding, not coverage" \
+  "$(wrap8 "$SUITE" "$(cmt coderabbitai Bot 2026-01-02T00:20:00Z "$(codex_summary "$(sum_row Completed 2026-01-02T01:00:00.123456Z deadbee)")" 2026-01-02T01:00:05Z)")" \
+  1 "carry no disposition" "UNREVIEWED HEAD"
+run_case "a codex finding that quotes the summary marker is claimable" \
+  "$(wrap9 "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(jq -n '"P1: this drops the last row.\n\nThe run is in the summary comment (<!-- codex-pull-request-review-summary -->)."')")")" \
+  1 "carry no disposition"
+run_case "a codex summary with a finding appended after the table is claimable, not coverage" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T00:20:00Z "$(codex_summary_plus "$(sum_row Completed 2026-01-02T01:00:00.123456Z deadbee)" 'P1: this drops the last row')" 2026-01-02T01:00:05Z)")" \
+  1 "carry no disposition" "UNREVIEWED HEAD"
+run_case "a codex summary missing the table header is claimable, not coverage" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T00:20:00Z "$(jq -n --arg r "$(sum_row Completed 2026-01-02T01:00:00.123456Z deadbee)" '"<!-- codex-pull-request-review-summary -->\n\n\($r)"')" 2026-01-02T01:00:05Z)")" \
+  1 "carry no disposition" "UNREVIEWED HEAD"
+# Guards, green before and after: the shape Codex actually posts still covers and still needs
+# no disposition, and CodeRabbit's own walkthrough is judged by its own rule.
+run_case "the posted codex summary shape still covers the head" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T00:20:00Z "$(codex_summary "$(sum_row Completed 2026-01-02T01:00:00.123456Z deadbee)")" 2026-01-02T01:00:05Z)")" \
+  0 "HEAD COVERED"
+run_case "a coderabbit walkthrough is still judged as a walkthrough" \
+  "$(wrap7 "[$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_walk none clean "$BASE40" "$HEAD40")" 2026-01-02T01:00:00Z),$ANSWER]")" \
+  0 "HEAD COVERED"
+
+echo "== finding 35: the gate judges the FINAL snapshot, not the one it opened with =="
+# The second read existed only to fingerprint the comments that can grant coverage, and the
+# verdict was still computed from the FIRST read. Everything else that arrived or vanished
+# while the gate paged threads was invisible: a P1 posted mid-run went unjudged, and a
+# disposition deleted mid-run still answered its claim. The PR-level bodies are now taken
+# from the final read of the comments.
+COV_C=$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_body ' Bravo.' deadbeef)")
+LATE_CLAIM=$(cmt reviewer User 2026-01-02T01:10:00Z '"P1: this drops the last row"')
+LATE_DISP=$(cmt me User 2026-01-02T01:20:00Z '"NOT-A-DEFECT: the guard above rejects that input"')
+NEW_CLAIM=$(cmt reviewer User 2026-01-02T01:30:00Z '"P1: this one landed while the gate was paging"')
+run_case "a disposition deleted between the two reads leaves its claim unanswered" \
+  "$(wrap8 "$SUITE" "$COV_C,$LATE_CLAIM,$LATE_DISP" "$COV_C,$LATE_CLAIM")" \
+  1 "carry no disposition"
+run_case "a claim that lands between the two reads is judged, not missed" \
+  "$(wrap8 "$SUITE" "$COV_C" "$COV_C,$NEW_CLAIM")" \
+  1 "carry no disposition"
+# Guards, green before and after: an unchanged second read reaches the same verdict, and a
+# disposition present in both still answers.
+run_case "an unchanged second read reaches the same verdict" \
+  "$(wrap8 "$SUITE" "$COV_C,$LATE_CLAIM,$LATE_DISP" "$COV_C,$LATE_CLAIM,$LATE_DISP")" \
+  0 "HEAD COVERED"
+
+echo "== finding 35: reviews and threads are consistency-checked too =="
+# Comments are re-read and re-judged; reviews and threads are re-read and COMPARED, because
+# re-paging every thread body would double the cost of the slowest part of the run. Either
+# one moving means the reading was taken from data that has since changed, so it blocks.
+# Both are live-path properties, so both go through the gh shim: with only one read of each,
+# the second file is never fetched and the run reports CLEAR.
+mkdir -p "$TMP/bin"
+printf '{"data":{"repository":{"pullRequest":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}' > "$TMP/comments.json"
+printf '{"data":{"repository":{"pullRequest":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}' > "$TMP/comments2.json"
+printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}' > "$TMP/threads.json"
+printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"T1","isResolved":false,"comments":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"reviewer"},"path":"a.ts","line":1,"body":"P1: this landed while the gate was paging"}]}}]}}}}}' > "$TMP/threads2.json"
+review_payload() { printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{"nodes":[{"createdAt":"2026-01-02T00:30:00Z"}]}}}]},"prcommits":{"nodes":[{"commit":{"oid":"deadbeef"}}]},"reviews":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"reviewer"},"state":"COMMENTED","submittedAt":"2026-01-02T01:00:00Z","body":%s,"commit":{"oid":"deadbeef"}}]}}}}}' "$1"; }
+review_payload '""' > "$TMP/reviews.json"
+review_payload '"P1: this landed while the gate was paging"' > "$TMP/reviews2.json"
+cat > "$TMP/bin/gh" <<'SHIM'
+#!/bin/bash
+nth() { local f=$GATE_TEST_DIR/$1.count n; n=$(cat "$f" 2>/dev/null || echo 0); n=$((n+1)); printf '%s' "$n" > "$f"; printf '%s' "$n"; }
+case "$*" in
+  *reviewThreads*)
+    if [ "$(nth threads)" -le 1 ]; then cat "$GATE_TEST_DIR/threads.json"; else cat "$GATE_TEST_DIR/${GATE_TEST_THREADS2:-threads}.json"; fi ;;
+  *"reviews(first"*)
+    if [ "$(nth reviews)" -le 1 ]; then cat "$GATE_TEST_DIR/reviews.json"; else cat "$GATE_TEST_DIR/${GATE_TEST_REVIEWS2:-reviews}.json"; fi ;;
+  *"comments(first"*)  cat "$GATE_TEST_DIR/comments.json" ;;
+  *headRefOid*)        printf 'deadbeef\n' ;;  # the recheck passes --jq
+esac
+SHIM
+chmod +x "$TMP/bin/gh"
+live_case() {
+  local name=$1 want_rc=$2 want_txt=$3 out rc
+  rm -f "$TMP/threads.count" "$TMP/reviews.count"
+  out=$(GATE_TEST_DIR="$TMP" PATH="$TMP/bin:$PATH" bash "$GATE" 1 2>&1); rc=$?
+  if [ "$rc" = "$want_rc" ] && grep -qF "$want_txt" <<<"$out"; then
+    echo "  PASS  $name"; pass=$((pass+1))
+  else
+    echo "  FAIL  $name (rc=$rc want=$want_rc)"; sed 's/^/          /' <<<"$out" | head -4; fail=$((fail+1))
+  fi
+}
+GATE_TEST_REVIEWS2=reviews2 live_case "a review body edited between the two reads blocks" 2 "reviews on this PR changed"
+GATE_TEST_THREADS2=threads2 live_case "a thread opened between the two reads blocks" 2 "review threads on this PR changed"
+# Guard, green before and after: unchanged reviews and threads reach a verdict.
+live_case "unchanged reviews and threads still reach a verdict" 0 "CLEAR"
+
+echo "== finding 36: a comment is dated by its last edit, not by its creation =="
+# Comments are mutable and GitHub keeps createdAt fixed across edits. Ordering claims and
+# answers by createdAt therefore reads the CURRENT body against the ORIGINAL time: a comment
+# opened Jan 1, edited Jan 3 to add a defect, counted as answered by a Jan 2 disposition.
+# updatedAt dates the body the gate is actually reading, and is validated like createdAt.
+run_case "a comment edited after its answer is not answered by it" \
+  "$(wrap4 me '[]' '[]' "[$(cmt reviewer User 2026-01-01T00:00:00Z '"P1: this drops the last row"' 2026-01-03T00:00:00Z),$(cmt me User 2026-01-02T00:00:00Z '"RED-VERIFIED: tests/row.rs"')]")" \
+  1 "carry no disposition"
+run_case "a disposition edited after the claim answers it" \
+  "$(wrap4 me '[]' '[]' "[$(cmt reviewer User 2026-01-02T00:00:00Z '"P1: this drops the last row"'),$(cmt me User 2026-01-01T00:00:00Z '"RED-VERIFIED: tests/row.rs"' 2026-01-03T00:00:00Z)]")" \
+  0 "CLEAR"
+run_case "a PR comment whose updatedAt will not parse blocks" \
+  "$(wrap4 me '[]' '[]' "[$(cmt reviewer User 2026-01-02T00:30:00Z '"P1: this drops the last row"' 'a while ago')]")" \
+  2 "no parsable updatedAt"
+# Guards, green before and after: an unedited comment orders the same either way, and an
+# edit that lands before the answer is still answered.
+run_case "a comment edited before its answer is still answered" \
+  "$(wrap4 me '[]' '[]' "[$(cmt reviewer User 2026-01-01T00:00:00Z '"P1: this drops the last row"' 2026-01-02T00:00:00Z),$(cmt me User 2026-01-03T00:00:00Z '"RED-VERIFIED: tests/row.rs"')]")" \
+  0 "CLEAR"
+
+echo "== finding 37: a seven-character prefix is not a commit identity =="
+# Coverage matched the sha a bot named against the head with `startswith`, so any commit
+# whose abbreviation prefixes the head could cover it: a result for the OLD head, named as
+# `deadbee`, certified the NEW head `deadbeef`. An abbreviation now has to resolve to
+# exactly one of the PR's commits and that commit has to be the head; a full sha still
+# matches by identity.
+# deadbee abbreviates both of these, so on this PR it names neither.
+PRCOMMITS_AMBIG='[{"commit":{"oid":"deadbee0"}},{"commit":{"oid":"deadbeef"}}]'
+# The head is not in this list, so deadbee resolves to a commit that is not the head.
+PRCOMMITS_OTHER='[{"commit":{"oid":"deadbee0"}}]'
+run_case "a summary row naming a prefix two PR commits share is not coverage" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T00:20:00Z "$(codex_summary "$(sum_row Completed 2026-01-02T01:00:00.123456Z deadbee)")" 2026-01-02T01:00:05Z),$ANSWER" "" "$PRCOMMITS_AMBIG")" \
+  1 "UNREVIEWED HEAD"
+run_case "a codex verdict naming a prefix two PR commits share is not coverage" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_body ' Bravo.' deadbee)")" "" "$PRCOMMITS_AMBIG")" \
+  1 "UNREVIEWED HEAD"
+run_case "an abbreviation that resolves to a commit other than the head is not coverage" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_body ' Bravo.' deadbee)")" "" "$PRCOMMITS_OTHER")" \
+  1 "UNREVIEWED HEAD"
+# Guards, green before and after: an abbreviation unique among the PR's commits still
+# resolves to the head, and a full sha matches by identity without resolving anything.
+run_case "an abbreviation unique among the PR's commits still covers" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_body ' Bravo.' deadbee)")")" \
+  0 "HEAD COVERED"
+run_case "the full head sha still covers" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_body ' Bravo.' deadbeef)")")" \
+  0 "HEAD COVERED"
+run_case "an abbreviation of a sibling commit is not coverage" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_body ' Bravo.' deadbee0)")" "" "$PRCOMMITS_AMBIG")" \
+  1 "UNREVIEWED HEAD"
+
+echo "== finding 38: a date that does not exist is not a date =="
+# mktime NORMALISES out-of-range components, so "2026-02-31T01:00:00Z" converts to
+# 2026-03-03T01:00:00Z and orders as a real instant three days later. Every ordering site
+# then treats it as a timestamp, and a summary row or a check suite carrying one can grant
+# coverage. The day is now checked against the month's real length, leap years included.
+SUITE_MAR='[{"createdAt":"2026-03-02T00:30:00Z"}]'
+run_case "a summary row dated 2026-02-31 is not coverage" \
+  "$(wrap8 "$SUITE_MAR" "$(cmt "$CODEX" Bot 2026-03-02T00:20:00Z "$(codex_summary "$(sum_row Completed 2026-02-31T01:00:00.123456Z deadbee)")" 2026-03-02T01:00:05Z),$ANSWER")" \
+  1 "UNREVIEWED HEAD"
+run_case "a check-suite timestamp of 2026-02-31 blocks" \
+  "$(wrap8 '[{"createdAt":"2026-02-31T00:30:00Z"}]' "$(cmt "$CODEX" Bot 2026-03-04T01:00:00Z "$(codex_body ' Bravo.' deadbeef)")")" \
+  2 "check-suite timestamp"
+run_case "a check-suite timestamp of 2026-02-29 blocks (2026 is not a leap year)" \
+  "$(wrap8 '[{"createdAt":"2026-02-29T00:30:00Z"}]' "$(cmt "$CODEX" Bot 2026-03-04T01:00:00Z "$(codex_body ' Bravo.' deadbeef)")")" \
+  2 "check-suite timestamp"
+run_case "a check-suite timestamp of 2026-04-31 blocks (April has 30 days)" \
+  "$(wrap8 '[{"createdAt":"2026-04-31T00:30:00Z"}]' "$(cmt "$CODEX" Bot 2026-05-04T01:00:00Z "$(codex_body ' Bravo.' deadbeef)")")" \
+  2 "check-suite timestamp"
+run_case "a review submittedAt of 2026-02-31 blocks" \
+  "$(wrap '[]' '[{"author":{"login":"x"},"state":"COMMENTED","submittedAt":"2026-02-31T00:00:00Z","body":"P1: this drops the last row"}]')" \
+  2 "no parsable submittedAt"
+# Guards, green before and after: real dates still parse, including a leap day.
+run_case "2028-02-29 is a real date and still orders" \
+  "$(wrap8 '[{"createdAt":"2028-02-29T00:30:00Z"}]' "$(cmt "$CODEX" Bot 2028-02-29T01:00:00Z "$(codex_body ' Bravo.' deadbeef)")")" \
+  0 "HEAD COVERED"
+run_case "2026-02-28 is a real date and still orders" \
+  "$(wrap8 '[{"createdAt":"2026-02-28T00:30:00Z"}]' "$(cmt "$CODEX" Bot 2026-02-28T01:00:00Z "$(codex_body ' Bravo.' deadbeef)")")" \
+  0 "HEAD COVERED"
 
 echo "== regression: the original behaviours still hold =="
 run_case "unresolved thread blocks" \

--- a/scripts/test-check-review-threads.sh
+++ b/scripts/test-check-review-threads.sh
@@ -480,9 +480,10 @@ echo "== finding 29: a head with no review result of any kind is unreviewed, not
 # an unreviewed head, and a payload that names no head cannot be judged (regression case
 # below).
 # The PR's own commits, which is the universe an abbreviated sha is resolved against
-# (finding 37). $4 overrides it; by default the head is the only commit.
-PRCOMMITS_HEAD='[{"commit":{"oid":"deadbeef"}}]'
-wrap8() { printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{"nodes":%s}}}]},"prcommits":{"nodes":%s},"reviewThreads":{"nodes":[]},"reviews":{"nodes":[]},"comments":{"nodes":[%s]},"recheck":{"comments":{"nodes":[%s]}}}}}}' "$1" "${4:-$PRCOMMITS_HEAD}" "$2" "${3:-$2}"; }
+# (finding 37). $4 overrides it, as the whole connection: the nodes plus the totalCount
+# that says how many there are (finding 39). By default the head is the only commit.
+PRCOMMITS_HEAD='{"totalCount":1,"nodes":[{"commit":{"oid":"deadbeef"}}]}'
+wrap8() { printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{"nodes":%s}}}]},"prcommits":%s,"reviewThreads":{"nodes":[]},"reviews":{"nodes":[]},"comments":{"nodes":[%s]},"recheck":{"comments":{"nodes":[%s]}}}}}}' "$1" "${4:-$PRCOMMITS_HEAD}" "$2" "${3:-$2}"; }
 SUITE='[{"createdAt":"2026-01-02T00:30:00Z"}]'
 run_case "reviews [] and a codex verdict naming an older sha is an unreviewed head" \
   "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_body ' Bravo.' abc123def4)")")" \
@@ -592,6 +593,11 @@ run_case "a comment that cannot grant coverage may differ between the reads" \
            "[$CLEAN_WALK,$(cmt onlooker User 2026-01-02T00:50:00Z '"edited wording"' 2026-01-02T01:30:00Z),$ANSWER]")" \
   0 "HEAD COVERED"
 
+# Every gh shim below answers the PR's commit list from this file: the two heads the live
+# cases use, and the totalCount that says the list is whole (finding 39). A case about
+# resolving an abbreviation overwrites it.
+PRCOMMITS_LIVE=$(printf '{"data":{"repository":{"pullRequest":{"commits":{"totalCount":2,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"commit":{"oid":"deadbeef"}},{"commit":{"oid":"%s"}}]}}}}}' "$HEAD40")
+
 echo "== finding 31: the LIVE path takes the second read =="
 # --from-file can only prove the comparison. That the gate actually re-fetches is a property
 # of fetch_payload, so it is tested through the gh shim: the second `comments(first:` query
@@ -605,6 +611,7 @@ printf '{"data":{"repository":{"pullRequest":{"comments":{"pageInfo":{"hasNextPa
 cat > "$TMP/bin/gh" <<'SHIM'
 #!/bin/bash
 case "$*" in
+  *"commits(first"*)   cat "$GATE_TEST_DIR/prcommits.json" ;;
   *reviewThreads*)     cat "$GATE_TEST_DIR/threads.json" ;;
   *"reviews(first"*)   cat "$GATE_TEST_DIR/reviews.json" ;;
   *"comments(first"*)
@@ -614,6 +621,7 @@ case "$*" in
   *headRefOid*)        printf '%s\n' "$GATE_TEST_HEAD" ;;  # the recheck passes --jq
 esac
 SHIM
+printf '%s' "$PRCOMMITS_LIVE" > "$TMP/prcommits.json"
 chmod +x "$TMP/bin/gh"
 rm -f "$TMP/ccount"
 out=$(GATE_TEST_DIR="$TMP" GATE_TEST_HEAD="$HEAD40" PATH="$TMP/bin:$PATH" bash "$GATE" 1 2>&1); rc=$?
@@ -763,13 +771,14 @@ printf '{"data":{"repository":{"pullRequest":{"comments":{"pageInfo":{"hasNextPa
 printf '{"data":{"repository":{"pullRequest":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}' > "$TMP/comments2.json"
 printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}' > "$TMP/threads.json"
 printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"T1","isResolved":false,"comments":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"reviewer"},"path":"a.ts","line":1,"body":"P1: this landed while the gate was paging"}]}}]}}}}}' > "$TMP/threads2.json"
-review_payload() { printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{"nodes":[{"createdAt":"2026-01-02T00:30:00Z"}]}}}]},"prcommits":{"nodes":[{"commit":{"oid":"deadbeef"}}]},"reviews":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"reviewer"},"state":"COMMENTED","submittedAt":"2026-01-02T01:00:00Z","body":%s,"commit":{"oid":"deadbeef"}}]}}}}}' "$1"; }
+review_payload() { printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{"nodes":[{"createdAt":"2026-01-02T00:30:00Z"}]}}}]},"prcommits":{"totalCount":1,"nodes":[{"commit":{"oid":"deadbeef"}}]},"reviews":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"reviewer"},"state":"COMMENTED","submittedAt":"2026-01-02T01:00:00Z","body":%s,"commit":{"oid":"deadbeef"}}]}}}}}' "$1"; }
 review_payload '""' > "$TMP/reviews.json"
 review_payload '"P1: this landed while the gate was paging"' > "$TMP/reviews2.json"
 cat > "$TMP/bin/gh" <<'SHIM'
 #!/bin/bash
 nth() { local f=$GATE_TEST_DIR/$1.count n; n=$(cat "$f" 2>/dev/null || echo 0); n=$((n+1)); printf '%s' "$n" > "$f"; printf '%s' "$n"; }
 case "$*" in
+  *"commits(first"*)   cat "$GATE_TEST_DIR/prcommits.json" ;;
   *reviewThreads*)
     if [ "$(nth threads)" -le 1 ]; then cat "$GATE_TEST_DIR/threads.json"; else cat "$GATE_TEST_DIR/${GATE_TEST_THREADS2:-threads}.json"; fi ;;
   *"reviews(first"*)
@@ -778,6 +787,7 @@ case "$*" in
   *headRefOid*)        printf 'deadbeef\n' ;;  # the recheck passes --jq
 esac
 SHIM
+printf '%s' "$PRCOMMITS_LIVE" > "$TMP/prcommits.json"
 chmod +x "$TMP/bin/gh"
 live_case() {
   local name=$1 want_rc=$2 want_txt=$3 out rc
@@ -821,9 +831,9 @@ echo "== finding 37: a seven-character prefix is not a commit identity =="
 # exactly one of the PR's commits and that commit has to be the head; a full sha still
 # matches by identity.
 # deadbee abbreviates both of these, so on this PR it names neither.
-PRCOMMITS_AMBIG='[{"commit":{"oid":"deadbee0"}},{"commit":{"oid":"deadbeef"}}]'
+PRCOMMITS_AMBIG='{"totalCount":2,"nodes":[{"commit":{"oid":"deadbee0"}},{"commit":{"oid":"deadbeef"}}]}'
 # The head is not in this list, so deadbee resolves to a commit that is not the head.
-PRCOMMITS_OTHER='[{"commit":{"oid":"deadbee0"}}]'
+PRCOMMITS_OTHER='{"totalCount":1,"nodes":[{"commit":{"oid":"deadbee0"}}]}'
 run_case "a summary row naming a prefix two PR commits share is not coverage" \
   "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T00:20:00Z "$(codex_summary "$(sum_row Completed 2026-01-02T01:00:00.123456Z deadbee)")" 2026-01-02T01:00:05Z),$ANSWER" "" "$PRCOMMITS_AMBIG")" \
   1 "UNREVIEWED HEAD"
@@ -901,12 +911,14 @@ printf '{"data":{"repository":{"pullRequest":{"comments":{"pageInfo":{"hasNextPa
 cat > "$TMP/bin/gh" <<'SHIM'
 #!/bin/bash
 case "$*" in
+  *"commits(first"*)   cat "$GATE_TEST_DIR/prcommits.json" ;;
   *reviewThreads*)     cat "$GATE_TEST_DIR/threads.json" ;;
   *"reviews(first"*)   cat "$GATE_TEST_DIR/reviews.json" ;;
   *"comments(first"*)  cat "$GATE_TEST_DIR/comments.json" ;;
   *headRefOid*)        printf 'deadbeef\n' ;;  # the recheck passes --jq; apply it here
 esac
 SHIM
+printf '%s' "$PRCOMMITS_LIVE" > "$TMP/prcommits.json"
 chmod +x "$TMP/bin/gh"
 out=$(GATE_TEST_DIR="$TMP" PATH="$TMP/bin:$PATH" bash "$GATE" 1 2>&1); rc=$?
 if [ "$rc" = 0 ] && grep -qF "CLEAR" <<<"$out" && ! grep -qi "argument list too long" <<<"$out"; then
@@ -927,6 +939,7 @@ printf '{"data":{"node":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor"
 cat > "$TMP/bin/gh" <<'SHIM'
 #!/bin/bash
 case "$*" in
+  *"commits(first"*)   cat "$GATE_TEST_DIR/prcommits.json" ;;
   *"node(id"*)         cat "$GATE_TEST_DIR/threadpage.json" ;;
   *reviewThreads*)     cat "$GATE_TEST_DIR/threads.json" ;;
   *"reviews(first"*)   cat "$GATE_TEST_DIR/reviews.json" ;;
@@ -934,6 +947,7 @@ case "$*" in
   *headRefOid*)        printf 'deadbeef\n' ;;  # the recheck passes --jq; apply it here
 esac
 SHIM
+printf '%s' "$PRCOMMITS_LIVE" > "$TMP/prcommits.json"
 chmod +x "$TMP/bin/gh"
 out=$(COMMENTS_PAGE_SIZE=2 GATE_TEST_DIR="$TMP" PATH="$TMP/bin:$PATH" bash "$GATE" 1 2>&1); rc=$?
 if [ "$rc" = 0 ] && grep -qF "CLEAR" <<<"$out" && ! grep -qi "argument list too long" <<<"$out"; then
@@ -943,6 +957,151 @@ else
   sed 's/^/          /' <<<"$out" | head -4
   fail=$((fail+1))
 fi
+
+echo "== finding 39: an abbreviation resolves against the WHOLE commit list, or none =="
+# The PR's commits arrived as `commits(last: 100)`, and names_head resolves an abbreviated
+# sha against that list. Past 100 commits an omitted OLDER commit sharing the head's
+# seven-character prefix is invisible: the abbreviation resolves to the head alone, reads
+# as unambiguous, and a result issued for the old commit certifies the head. The connection
+# is now paged to completion and carries the count of what it should hold, so a list that
+# does not account for every commit resolves nothing.
+PRCOMMITS_TRUNC='{"totalCount":2,"nodes":[{"commit":{"oid":"deadbeef"}}]}'
+PRCOMMITS_NOCOUNT='{"nodes":[{"commit":{"oid":"deadbeef"}}]}'
+run_case "a commit list holding fewer commits than it says blocks" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_body ' Bravo.' deadbee)")" "" "$PRCOMMITS_TRUNC")" \
+  2 "does not account for every commit"
+run_case "a commit list that says nothing about its size blocks" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_body ' Bravo.' deadbee)")" "" "$PRCOMMITS_NOCOUNT")" \
+  2 "does not account for every commit"
+# Guards, green before and after: a complete list still resolves an abbreviation, and a
+# payload with no commit list at all is no universe, so an abbreviation resolves to nothing
+# while a full sha still matches by identity.
+run_case "a complete commit list still resolves the abbreviation" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_body ' Bravo.' deadbee)")")" \
+  0 "HEAD COVERED"
+run_case "no commit list at all resolves no abbreviation" \
+  "$(wrap6 "[$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_body ' Bravo.' deadbee)")]")" \
+  1 "UNREVIEWED HEAD"
+run_case "no commit list at all still matches a full sha by identity" \
+  "$(wrap6 "[$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_body ' Bravo.' deadbeef)")]")" \
+  0 "HEAD COVERED"
+
+echo "== finding 39: the LIVE path pages the commit list to completion =="
+# --from-file can only prove the completeness check. That the gate FETCHES every commit is
+# a property of fetch_payload, so it goes through the gh shim: 150 commits whose oldest
+# shares the head's seven-character prefix. One `commits(last: 100)` omits that commit, the
+# verdict's `deadbee` resolves to the head alone, and the head reads as covered by a result
+# bound to nothing. With both pages fetched it is ambiguous, and it covers nothing.
+mkdir -p "$TMP/bin"
+HEAD150=deadbeef00000000000000000000000000000000
+python3 - "$TMP" "$HEAD150" <<'COMMITS'
+import json, sys
+tmp, head = sys.argv[1:3]
+old = "deadbee0" + "0" * 32                       # shares deadbee with the head
+oids = [old] + ["%040x" % (0xaaa0000 + i) for i in range(148)] + [head]
+assert len(oids) == 150 and len(set(oids)) == 150
+def page(nodes, has_next, cursor):
+    return {"data": {"repository": {"pullRequest": {"commits": {
+        "totalCount": len(oids),
+        "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
+        "nodes": [{"commit": {"oid": o}} for o in nodes]}}}}}
+json.dump(page(oids[:100], True, "C1"), open(tmp + "/prcommits.json", "w"))
+json.dump(page(oids[100:], False, None), open(tmp + "/prcommits2.json", "w"))
+# What `commits(last: 100)` returned: the NEWEST 100, without the old commit that shares
+# the head's prefix. An unpaged gate reads this and resolves deadbee to the head alone.
+json.dump({"data": {"repository": {"pullRequest": {
+    "author": {"login": "me"}, "headRefOid": head,
+    "commits": {"nodes": [{"commit": {"committedDate": "2026-01-02T00:00:00Z",
+        "checkSuites": {"nodes": [{"createdAt": "2026-01-02T00:30:00Z"}]}}}]},
+    "prcommits": {"nodes": [{"commit": {"oid": o}} for o in oids[50:]]},
+    "reviews": {"pageInfo": {"hasNextPage": False, "endCursor": None}, "nodes": []}}}}},
+    open(tmp + "/reviews.json", "w"))
+COMMITS
+printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}' > "$TMP/threads.json"
+printf '{"data":{"repository":{"pullRequest":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[%s]}}}}}' \
+  "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_body ' Bravo.' deadbee)")" > "$TMP/comments.json"
+cat > "$TMP/bin/gh" <<'SHIM'
+#!/bin/bash
+case "$*" in
+  *"commits(first"*)
+    n=$(cat "$GATE_TEST_DIR/pcount" 2>/dev/null || echo 0); n=$((n+1))
+    printf '%s' "$n" > "$GATE_TEST_DIR/pcount"
+    if [ "$n" -le 1 ]; then cat "$GATE_TEST_DIR/prcommits.json"; else cat "$GATE_TEST_DIR/prcommits2.json"; fi ;;
+  *reviewThreads*)     cat "$GATE_TEST_DIR/threads.json" ;;
+  *"reviews(first"*)   cat "$GATE_TEST_DIR/reviews.json" ;;
+  *"comments(first"*)  cat "$GATE_TEST_DIR/comments.json" ;;
+  *headRefOid*)        printf '%s\n' "$GATE_TEST_HEAD" ;;  # the recheck passes --jq
+esac
+SHIM
+chmod +x "$TMP/bin/gh"
+rm -f "$TMP/pcount"
+out=$(GATE_TEST_DIR="$TMP" GATE_TEST_HEAD="$HEAD150" PATH="$TMP/bin:$PATH" bash "$GATE" 1 2>&1); rc=$?
+if [ "$rc" = 1 ] && grep -qF "UNREVIEWED HEAD" <<<"$out" && [ "$(cat "$TMP/pcount" 2>/dev/null || echo 0)" -ge 2 ]; then
+  echo "  PASS  the live path pages every commit, so a shared prefix stays ambiguous"; pass=$((pass+1))
+else
+  echo "  FAIL  the live path pages every commit, so a shared prefix stays ambiguous (rc=$rc, commit fetches=$(cat "$TMP/pcount" 2>/dev/null || echo 0))"
+  sed 's/^/          /' <<<"$out" | head -4
+  fail=$((fail+1))
+fi
+
+echo "== finding 40: the thread comparison must read the comment BODIES =="
+# The second read of the threads fetched only id, isResolved and comments.totalCount, and
+# the verdict is computed from the first read's BODIES. GitHub lets a review comment be
+# edited in place, which moves none of those three: a disposition edited mid-run into
+# something that disposes of nothing leaves the fingerprint identical, and the gate certifies
+# a thread from a reply that no longer exists. Both reads now fetch the comments, paging the
+# oversized ones exactly as the first read does, and any difference blocks.
+mkdir -p "$TMP/bin"
+thread_read() {  # $1 the reply on the thread, $2 totalCount, $3.. the page-1 comments
+  local reply=$1
+  printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"T1","isResolved":true,"isOutdated":false,"comments":{"totalCount":2,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"reviewer"},"path":"a.ts","line":1,"originalLine":1,"body":"this drops the last row"},{"author":{"login":"me"},"path":"a.ts","line":1,"originalLine":1,"body":%s}]}}]}}}}}' "$reply"
+}
+thread_read '"NOT-A-DEFECT: renamed only, no behaviour change"' > "$TMP/threads.json"
+thread_read '"Actually the rename changed behaviour, this still drops the row"' > "$TMP/threads2.json"
+printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{"nodes":[{"createdAt":"2026-01-02T00:30:00Z"}]}}}]},"reviews":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"reviewer"},"state":"COMMENTED","submittedAt":"2026-01-02T01:00:00Z","body":"","commit":{"oid":"deadbeef"}}]}}}}}' > "$TMP/reviews.json"
+printf '{"data":{"repository":{"pullRequest":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}' > "$TMP/comments.json"
+# An oversized thread: page 1 holds the finding and one line of chatter, page 2 holds the
+# reply, and the reply is what gets edited between the reads.
+printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"T1","isResolved":true,"isOutdated":false,"comments":{"totalCount":3,"pageInfo":{"hasNextPage":true,"endCursor":"CUR1"},"nodes":[{"author":{"login":"reviewer"},"path":"a.ts","line":1,"originalLine":1,"body":"this drops the last row"},{"author":{"login":"onlooker"},"path":"a.ts","line":1,"originalLine":1,"body":"discussion"}]}}]}}}}}' > "$TMP/paged.json"
+threadpage() { printf '{"data":{"node":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"me"},"path":"a.ts","line":1,"originalLine":1,"body":%s}]}}}}' "$1"; }
+threadpage '"NOT-A-DEFECT: renamed only, no behaviour change"' > "$TMP/threadpage.json"
+threadpage '"Actually the rename changed behaviour, this still drops the row"' > "$TMP/threadpage2.json"
+printf '%s' "$PRCOMMITS_LIVE" > "$TMP/prcommits.json"
+cat > "$TMP/bin/gh" <<'SHIM'
+#!/bin/bash
+nth() { local f=$GATE_TEST_DIR/$1.count n; n=$(cat "$f" 2>/dev/null || echo 0); n=$((n+1)); printf '%s' "$n" > "$f"; printf '%s' "$n"; }
+case "$*" in
+  *"commits(first"*)   cat "$GATE_TEST_DIR/prcommits.json" ;;
+  *"node(id"*)
+    if [ "$(nth page)" -le 1 ]; then cat "$GATE_TEST_DIR/threadpage.json"
+    else cat "$GATE_TEST_DIR/${GATE_TEST_PAGE2:-threadpage}.json"; fi ;;
+  *reviewThreads*)
+    if [ "$(nth threads)" -le 1 ]; then cat "$GATE_TEST_DIR/${GATE_TEST_THREADS1:-threads}.json"
+    else cat "$GATE_TEST_DIR/${GATE_TEST_THREADS2:-${GATE_TEST_THREADS1:-threads}}.json"; fi ;;
+  *"reviews(first"*)   cat "$GATE_TEST_DIR/reviews.json" ;;
+  *"comments(first"*)  cat "$GATE_TEST_DIR/comments.json" ;;
+  *headRefOid*)        printf 'deadbeef\n' ;;  # the recheck passes --jq
+esac
+SHIM
+chmod +x "$TMP/bin/gh"
+edit_case() {
+  local name=$1 want_rc=$2 want_txt=$3 out rc
+  rm -f "$TMP/threads.count" "$TMP/page.count"
+  out=$(GATE_TEST_DIR="$TMP" PATH="$TMP/bin:$PATH" bash "$GATE" 1 2>&1); rc=$?
+  if [ "$rc" = "$want_rc" ] && grep -qF "$want_txt" <<<"$out"; then
+    echo "  PASS  $name"; pass=$((pass+1))
+  else
+    echo "  FAIL  $name (rc=$rc want=$want_rc)"; sed 's/^/          /' <<<"$out" | head -4; fail=$((fail+1))
+  fi
+}
+GATE_TEST_THREADS2=threads2 \
+  edit_case "a disposition edited between the two reads blocks" 2 "review threads on this PR changed"
+COMMENTS_PAGE_SIZE=2 GATE_TEST_THREADS1=paged GATE_TEST_PAGE2=threadpage2 \
+  edit_case "a disposition edited on a comment PAGE blocks" 2 "review threads on this PR changed"
+# Guards, green before and after: two identical reads reach a verdict, paged or not.
+edit_case "two identical thread reads still reach a verdict" 0 "CLEAR"
+COMMENTS_PAGE_SIZE=2 GATE_TEST_THREADS1=paged \
+  edit_case "two identical paged thread reads still reach a verdict" 0 "CLEAR"
 
 echo
 echo "passed=$pass failed=$fail"

--- a/tests/fixtures/review-threads-clear.json
+++ b/tests/fixtures/review-threads-clear.json
@@ -47,6 +47,7 @@
           },
           "nodes": [
             {
+              "id": "PRRT_fixture_clear_0",
               "isResolved": true,
               "isOutdated": true,
               "comments": {

--- a/tests/fixtures/review-threads-resolved-proven.json
+++ b/tests/fixtures/review-threads-resolved-proven.json
@@ -47,6 +47,7 @@
           },
           "nodes": [
             {
+              "id": "PRRT_fixture_resolved-proven_0",
               "isResolved": true,
               "isOutdated": false,
               "comments": {

--- a/tests/fixtures/review-threads-resolved-unproven.json
+++ b/tests/fixtures/review-threads-resolved-unproven.json
@@ -47,6 +47,7 @@
           },
           "nodes": [
             {
+              "id": "PRRT_fixture_resolved-unproven_0",
               "isResolved": true,
               "isOutdated": false,
               "comments": {

--- a/tests/fixtures/review-threads-selfproof.json
+++ b/tests/fixtures/review-threads-selfproof.json
@@ -47,6 +47,7 @@
           },
           "nodes": [
             {
+              "id": "PRRT_fixture_selfproof_0",
               "isResolved": true,
               "isOutdated": false,
               "comments": {

--- a/tests/fixtures/review-threads-unresolved.json
+++ b/tests/fixtures/review-threads-unresolved.json
@@ -47,6 +47,7 @@
           },
           "nodes": [
             {
+              "id": "PRRT_fixture_unresolved_0",
               "isResolved": true,
               "isOutdated": true,
               "comments": {
@@ -64,6 +65,7 @@
               }
             },
             {
+              "id": "PRRT_fixture_unresolved_1",
               "isResolved": false,
               "isOutdated": true,
               "comments": {
@@ -81,6 +83,7 @@
               }
             },
             {
+              "id": "PRRT_fixture_unresolved_2",
               "isResolved": false,
               "isOutdated": false,
               "comments": {

--- a/tests/test_log_scan.rs
+++ b/tests/test_log_scan.rs
@@ -446,6 +446,20 @@ fn fixture_shape_problem(name: &str, text: &str) -> Option<String> {
                  and it is the only field that means 'resolved'. {hint}"
             ));
         }
+        // The other two fields the query selects on a thread. `id` is what the gate pages an
+        // oversized thread's comments by, and what orders the two reads it compares;
+        // `isOutdated` is the flag the unresolved rule ignores on purpose, and a fixture
+        // without it cannot show that an outdated finding still counts.
+        if !thread["id"].is_string() {
+            return Some(format!(
+                "fixture {name}: reviewThreads.nodes[{i}].id is not a string. {hint}"
+            ));
+        }
+        if !thread["isOutdated"].is_boolean() {
+            return Some(format!(
+                "fixture {name}: reviewThreads.nodes[{i}].isOutdated is not a boolean. {hint}"
+            ));
+        }
         let Some(comments) = thread["comments"]["nodes"].as_array() else {
             return Some(format!(
                 "fixture {name}: reviewThreads.nodes[{i}].comments.nodes is not an array. \
@@ -490,7 +504,8 @@ fn the_fixture_shape_check_reads_the_payload_not_the_text() {
         "commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z",
           "checkSuites":{"nodes":[{"createdAt":"2026-01-02T00:30:00Z"}]}}}]},
         "reviews":{"nodes":[]},
-        "reviewThreads":{"nodes":[{"isResolved":false,"comments":{"nodes":[
+        "reviewThreads":{"nodes":[{"id":"PRRT_inline_1","isResolved":false,"isOutdated":false,
+          "comments":{"nodes":[
           {"author":{"login":"reviewer"},"path":"a.rs","line":1,"originalLine":1,
            "body":"P1: this drops the last row"}]}}]}
       }}}}"#;
@@ -510,7 +525,8 @@ fn the_fixture_shape_check_reads_the_payload_not_the_text() {
           "checkSuites":{"nodes":[{"createdAt":"2026-01-02T00:30:00Z"}]}}}]},
         "reviews":{"nodes":[]},
         "comments":{"nodes":[]},
-        "reviewThreads":{"nodes":[{"isResolved":false,"comments":{"nodes":[
+        "reviewThreads":{"nodes":[{"id":"PRRT_inline_2","isResolved":false,"isOutdated":false,
+          "comments":{"nodes":[
           {"author":{"login":"reviewer"},"path":"a.rs","line":1,"originalLine":1,
            "body":"P1: this drops the last row"}]}}]}
       }}}}"#;
@@ -518,6 +534,76 @@ fn the_fixture_shape_check_reads_the_payload_not_the_text() {
         fixture_shape_problem("complete", complete),
         None,
         "a payload carrying every field the query selects must be accepted"
+    );
+}
+
+/// A thread comes back from the query with an `id` and an `isOutdated` flag, so a fixture
+/// without them is a shape GitHub cannot return.
+///
+/// The validator checked `isResolved` alone. `id` is what the gate keys an oversized
+/// thread's comment paging on, and what orders the two reads it compares; `isOutdated` is
+/// the flag the unresolved rule deliberately ignores, and a fixture that omits it cannot
+/// show that it does. Five fixtures were missing the id, and so was the payload the test
+/// above accepts as complete: a check that certifies a shape the live query never produces.
+#[test]
+fn a_fixture_thread_without_an_id_or_an_outdated_flag_is_rejected() {
+    let payload = |thread_fields: &str| {
+        format!(
+            r#"{{"data":{{"repository":{{"pullRequest":{{
+        "author":{{"login":"me"}},
+        "headRefOid":"deadbeef",
+        "commits":{{"nodes":[{{"commit":{{"committedDate":"2026-01-02T00:00:00Z",
+          "checkSuites":{{"nodes":[{{"createdAt":"2026-01-02T00:30:00Z"}}]}}}}}}]}},
+        "reviews":{{"nodes":[]}},
+        "comments":{{"nodes":[]}},
+        "reviewThreads":{{"nodes":[{{{thread_fields},"comments":{{"nodes":[
+          {{"author":{{"login":"reviewer"}},"path":"a.rs","line":1,"originalLine":1,
+           "body":"P1: this drops the last row"}}]}}}}]}}
+      }}}}}}}}"#
+        )
+    };
+
+    assert!(
+        fixture_shape_problem(
+            "no-id",
+            &payload(r#""isResolved":false,"isOutdated":false"#)
+        )
+        .is_some(),
+        "a thread with no `id` must be rejected: the query selects it, and the gate pages \
+         an oversized thread's comments by it."
+    );
+    assert!(
+        fixture_shape_problem(
+            "id-not-a-string",
+            &payload(r#""id":7,"isResolved":false,"isOutdated":false"#)
+        )
+        .is_some(),
+        "an `id` that is not a string is not the id the query returns."
+    );
+    assert!(
+        fixture_shape_problem(
+            "no-outdated",
+            &payload(r#""id":"PRRT_x","isResolved":false"#)
+        )
+        .is_some(),
+        "a thread with no `isOutdated` must be rejected: the query selects it, and a \
+         fixture that omits it cannot show that an outdated finding still counts."
+    );
+    assert!(
+        fixture_shape_problem(
+            "outdated-not-a-bool",
+            &payload(r#""id":"PRRT_x","isResolved":false,"isOutdated":"true""#)
+        )
+        .is_some(),
+        "the string \"true\" is not the boolean the query returns."
+    );
+    assert_eq!(
+        fixture_shape_problem(
+            "complete",
+            &payload(r#""id":"PRRT_x","isResolved":false,"isOutdated":false"#)
+        ),
+        None,
+        "a thread carrying every field the query selects must be accepted"
     );
 }
 

--- a/tests/test_log_scan.rs
+++ b/tests/test_log_scan.rs
@@ -391,14 +391,138 @@ fn the_gate_handles_a_real_captured_pr_response() {
 
 /// Every fixture must carry the fields the live query actually selects. A fixture missing
 /// one would make the gate silently skip a check it believes it performed.
+///
+/// The check reads the payload rather than searching its text. A substring search cannot
+/// say WHERE a name appears, and every PR-level name also occurs inside a thread comment,
+/// so `"comments"` is found in a payload that carries no PR-level comments connection at
+/// all. `the_fixture_shape_check_reads_the_payload_not_the_text` pins that.
+fn fixture_shape_problem(name: &str, text: &str) -> Option<String> {
+    let hint = "Regenerate it with scripts/capture-review-threads-fixture.sh, or add the \
+                field by hand; a fixture that does not match the query lets a test pass \
+                against data the code can never receive.";
+    let doc: serde_json::Value = match serde_json::from_str(text) {
+        Ok(v) => v,
+        Err(e) => return Some(format!("fixture {name} is not JSON: {e}")),
+    };
+    let pr = &doc["data"]["repository"]["pullRequest"];
+    if !pr.is_object() {
+        return Some(format!(
+            "fixture {name} has no .data.repository.pullRequest object. {hint}"
+        ));
+    }
+    // The head, and the check suites that date its arrival. Without them the gate answers
+    // "this gate cannot tell whether the code being merged was reviewed", which is a BLOCK,
+    // so every test using such a fixture fails for a reason unrelated to what it asserts.
+    if !pr["headRefOid"].is_string() {
+        return Some(format!(
+            "fixture {name}: .data.repository.pullRequest.headRefOid is not a string. {hint}"
+        ));
+    }
+    let suites = &pr["commits"]["nodes"][0]["commit"]["checkSuites"]["nodes"];
+    if !suites.is_array() {
+        return Some(format!(
+            "fixture {name}: .commits.nodes[0].commit.checkSuites.nodes is not an array. {hint}"
+        ));
+    }
+    // The three connections a claim can arrive in. Each is its own PR-level field: a
+    // thread's comments connection is not the PR's.
+    for field in ["reviews", "comments", "reviewThreads"] {
+        if !pr[field]["nodes"].is_array() {
+            return Some(format!(
+                "fixture {name}: .data.repository.pullRequest.{field}.nodes is not an \
+                 array. {hint}"
+            ));
+        }
+    }
+    for (i, thread) in pr["reviewThreads"]["nodes"]
+        .as_array()
+        .expect("checked above")
+        .iter()
+        .enumerate()
+    {
+        if !thread["isResolved"].is_boolean() {
+            return Some(format!(
+                "fixture {name}: reviewThreads.nodes[{i}].isResolved is not a boolean, \
+                 and it is the only field that means 'resolved'. {hint}"
+            ));
+        }
+        let Some(comments) = thread["comments"]["nodes"].as_array() else {
+            return Some(format!(
+                "fixture {name}: reviewThreads.nodes[{i}].comments.nodes is not an array. \
+                 {hint}"
+            ));
+        };
+        for (j, comment) in comments.iter().enumerate() {
+            let at = format!("reviewThreads.nodes[{i}].comments.nodes[{j}]");
+            for (path, value) in [
+                ("author.login", &comment["author"]["login"]),
+                ("body", &comment["body"]),
+                ("path", &comment["path"]),
+            ] {
+                if !value.is_string() {
+                    return Some(format!(
+                        "fixture {name}: {at}.{path} is not a string. {hint}"
+                    ));
+                }
+            }
+            // Both are selected and either may be null; the gate falls back from one to
+            // the other, so a fixture that omits either is answering a question the live
+            // query does not.
+            for key in ["line", "originalLine"] {
+                if comment.get(key).is_none() {
+                    return Some(format!("fixture {name}: {at} has no `{key}` key. {hint}"));
+                }
+            }
+        }
+    }
+    None
+}
+
+/// A payload whose only `comments` key is a thread's must not pass the PR-level check.
+#[test]
+fn the_fixture_shape_check_reads_the_payload_not_the_text() {
+    // This payload carries every PR-level field but `comments`, and the only `"comments"`
+    // in its text is the thread's own connection. A substring search finds that one and
+    // reports the fixture complete.
+    let no_pr_comments = r#"{"data":{"repository":{"pullRequest":{
+        "author":{"login":"me"},
+        "headRefOid":"deadbeef",
+        "commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z",
+          "checkSuites":{"nodes":[{"createdAt":"2026-01-02T00:30:00Z"}]}}}]},
+        "reviews":{"nodes":[]},
+        "reviewThreads":{"nodes":[{"isResolved":false,"comments":{"nodes":[
+          {"author":{"login":"reviewer"},"path":"a.rs","line":1,"originalLine":1,
+           "body":"P1: this drops the last row"}]}}]}
+      }}}}"#;
+    assert!(
+        fixture_shape_problem("no-pr-comments", no_pr_comments).is_some(),
+        "a payload with no PR-level comments connection must be rejected; finding the \
+         word inside a thread's own comments connection is not finding the field."
+    );
+
+    // The same payload with the PR-level connections really present is accepted, so the
+    // rejection above is about the missing fields and not about the shape check refusing
+    // everything.
+    let complete = r#"{"data":{"repository":{"pullRequest":{
+        "author":{"login":"me"},
+        "headRefOid":"deadbeef",
+        "commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z",
+          "checkSuites":{"nodes":[{"createdAt":"2026-01-02T00:30:00Z"}]}}}]},
+        "reviews":{"nodes":[]},
+        "comments":{"nodes":[]},
+        "reviewThreads":{"nodes":[{"isResolved":false,"comments":{"nodes":[
+          {"author":{"login":"reviewer"},"path":"a.rs","line":1,"originalLine":1,
+           "body":"P1: this drops the last row"}]}}]}
+      }}}}"#;
+    assert_eq!(
+        fixture_shape_problem("complete", complete),
+        None,
+        "a payload carrying every field the query selects must be accepted"
+    );
+}
+
 #[test]
 fn every_fixture_matches_the_shape_the_query_returns() {
-    const REQUIRED: [&str; 5] = ["author", "body", "line", "originalLine", "path"];
-    // The gate reads these too, and a fixture without them is judged under a rule it
-    // cannot satisfy: no head means "this gate cannot tell whether the code being merged
-    // was reviewed", which is a BLOCK, so every test using such a fixture fails for a
-    // reason that has nothing to do with what it asserts.
-    const REQUIRED_PR_LEVEL: [&str; 4] = ["headRefOid", "checkSuites", "reviews", "comments"];
     let dir = repo_root().join("tests/fixtures");
     let mut checked = 0;
 
@@ -409,26 +533,7 @@ fn every_fixture_matches_the_shape_the_query_returns() {
             continue;
         }
         let text = std::fs::read_to_string(&path).expect("read fixture");
-        for field in REQUIRED {
-            assert!(
-                text.contains(&format!("\"{field}\"")),
-                "fixture {name} is missing the `{field}` field that the live query selects. \
-                 A fixture that does not match the query lets a test pass against data the \
-                 code can never receive."
-            );
-        }
-        for field in REQUIRED_PR_LEVEL {
-            assert!(
-                text.contains(&format!("\"{field}\"")),
-                "fixture {name} is missing the `{field}` field the gate reads at PR level. \
-                 Regenerate it with scripts/capture-review-threads-fixture.sh, or add the \
-                 field by hand; a fixture the gate cannot judge blocks on its own shape."
-            );
-        }
-        assert!(
-            text.contains("\"isResolved\""),
-            "fixture {name} lacks isResolved — the only field that means 'resolved'."
-        );
+        assert_eq!(fixture_shape_problem(&name, &text), None);
         checked += 1;
     }
     assert!(

--- a/tests/test_log_scan.rs
+++ b/tests/test_log_scan.rs
@@ -758,6 +758,79 @@ fn malformed_thread_data_blocks_instead_of_clearing() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+/// The answer this gate asks for must not become a new question.
+///
+/// A PR-level review body from the PR author was claimable like anyone else's, so the review
+/// the gate tells you to post ("Post a review on the PR OPENING with one of RED-VERIFIED: /
+/// NOT-A-DEFECT: / DISAGREE:") became a fresh unanswered claim whenever it opened with
+/// anything else, and the count grew by one every round: #874 carried 4 such bodies and #872
+/// 5, all the author's own acks, burying the bot findings that really had no answer. A review
+/// from the author is an answer to this PR, not a finding against it, and the head-coverage
+/// rule already discounts the author for the same reason. Everyone else stays claimable, and
+/// the three-token vocabulary is unchanged: REVIEW-ACK answers nothing, it just stops being a
+/// claim itself.
+///
+/// The shell harness (scripts/test-check-review-threads.sh, "finding 41") carries the full
+/// matrix, including the author's top-level COMMENT staying claimable; this one runs in CI.
+#[test]
+fn an_authors_review_body_is_an_answer_not_a_new_claim() {
+    require_jq();
+    let payload = |ack_author: &str| {
+        format!(
+            r#"{{"data":{{"repository":{{"pullRequest":{{
+        "author":{{"login":"me"}},
+        "headRefOid":"deadbeef",
+        "commits":{{"nodes":[{{"commit":{{"committedDate":"2026-01-02T00:00:00Z",
+          "checkSuites":{{"nodes":[{{"createdAt":"2026-01-02T00:30:00Z"}}]}}}}}}]}},
+        "reviewThreads":{{"nodes":[]}},
+        "comments":{{"nodes":[]}},
+        "reviews":{{"nodes":[
+          {{"author":{{"login":"reviewer"}},"state":"APPROVED","submittedAt":"2026-01-02T01:00:00Z",
+           "body":"","commit":{{"oid":"deadbeef"}}}},
+          {{"author":{{"login":"{ack_author}"}},"state":"COMMENTED",
+           "submittedAt":"2026-01-03T00:00:00Z",
+           "body":"REVIEW-ACK: round 3, three findings closed in abc1234"}}]}}
+      }}}}}}}}"#
+        )
+    };
+
+    let dir = std::env::temp_dir().join(format!("fcvm-gate-ack-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let run = |name: &str, body: String| {
+        let f = dir.join(name);
+        std::fs::write(&f, body).unwrap();
+        let out = Command::new("bash")
+            .arg(repo_root().join("scripts/check-review-threads.sh"))
+            .arg("--from-file")
+            .arg(&f)
+            .output()
+            .expect("check-review-threads.sh must be runnable");
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        (combined, out.status.code().unwrap_or(-1))
+    };
+
+    let (out, code) = run("author-ack.json", payload("me"));
+    assert_eq!(
+        code, 0,
+        "the PR author's own review body is an answer, not a claim. Counting it as one \
+         makes every acknowledgement create the obligation it was posted to discharge.\n{out}"
+    );
+    assert!(out.contains("CLEAR"), "{out}");
+
+    let (out, code) = run("stranger-ack.json", payload("reviewer"));
+    assert_eq!(
+        code, 1,
+        "the same body from anyone else is a PR-level statement that still needs one of \
+         RED-VERIFIED / NOT-A-DEFECT / DISAGREE.\n{out}"
+    );
+    assert!(out.contains("carry no disposition"), "{out}");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 /// A timestamp comparison must be between INSTANTS, not between strings.
 ///
 /// The gate's timestamps do not all arrive in one shape. Check-suite and comment


### PR DESCRIPTION
Seven holes in `scripts/check-review-threads.sh`, each closed by a test watched failing first. Found by a local `codex exec` review of #873 plus one adversarial pass; recorded in #878.

- `ts()` added a zone offset's minutes as seconds, so `2026-01-02T10:00:00+09:30` parsed 1770 s late. Fail-open for positive half and quarter-hour zones on both ordering sites.
- Any listed bot comment containing the Codex summary marker became non-claimable, so a real P1 quoting that marker exited CLEAR with no disposition. The account and the complete anchored shape are now required.
- The second read fingerprinted only coverage-shaped comments while evaluation used the first snapshot, so a P1 posted or a disposition deleted during paging was ignored.
- Comments were ordered by `createdAt`, so a comment edited later to add a defect counted as answered by an earlier disposition. Ordering now uses `updatedAt`, and every field the gate orders by is validated.
- Seven-character sha prefixes were treated as commit identity, so a reviewed commit sharing a prefix with the head could cover it. Abbreviations resolve to full OIDs.
- `mktime` normalized impossible dates, so `2026-02-31` became March 3 and could grant coverage.
- The Rust fixture shape check searched raw text, so the PR-level `comments` assertion passed when the field was absent.

Tests: `scripts/test-check-review-threads.sh` 125 -> 159 cases, `passed=159 failed=0`; `test_log_scan` 21 -> 22, all passing. One pre-existing case moved to a stronger outcome (a walkthrough whose `updatedAt` will not parse now exits 2 rather than 1, because `updatedAt` became a field the gate orders by).

Closes #878.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved review-status checks for unresolved, outdated, or modified review threads.
  - Ensured complete commit history is checked when validating referenced commits.
  - Improved detection and validation of review summaries and abbreviated commit IDs.
  - Ensured decisions use the latest available reviews, threads, and comments.
  - Refined handling of author acknowledgements and review claims.
  - Strengthened validation for timestamps and malformed review data.

- **Tests**
  - Expanded coverage for paginated commits, edited comments, thread metadata, and author acknowledgements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->