### PR TITLE
cargo-target-link: lease whole recipes, and bound the fallback reclaim by mount and owner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,6 +336,27 @@ help:
 cargo-target-link:
 	@BTRFS_ROOT="$(BTRFS_ROOT)" "$(MAKEFILE_DIR)scripts/cargo-target-link.sh"
 
+# One lease per RECIPE, for the recipes that reach through target/ outside
+# Cargo.
+#
+# cargo-target-run.sh leases the published generation for the length of one
+# Cargo process. A concurrent make waiting to republish target/ is granted the
+# exclusive lease the moment that process exits, so a recipe that writes a file
+# through the link and then reads it back can read a generation its own build
+# never wrote. make runs a recipe line as `$(SHELL) $(.SHELLFLAGS) "<line>"`,
+# so naming the wrapper as a target-specific SHELL puts the whole line inside
+# one shared lease; each such line names the targets below, and
+# makefile_leases_every_raw_target_access pins that no raw target/ access is
+# left outside one.
+#
+# `private` keeps the wrapper off the prerequisites, whose recipes run before
+# target/ exists (cargo-target-link is what creates it). It is deliberately NOT
+# the Makefile-wide SHELL: that also governs parse-time $(shell ...) and every
+# recipe of every target, including in the scratch checkouts that
+# tests/test_dep_provenance.rs stages with a partial scripts/ directory, where
+# every recipe line then dies with `Error 127`.
+TARGET_LEASE_SHELL := $(MAKEFILE_DIR)scripts/cargo-target-run.sh
+
 # Disk space check - fails if either root or btrfs is too full
 # Requires 10GB free on root (for cargo target) and 15GB on btrfs (for VMs)
 check-disk: cargo-target-link
@@ -392,6 +413,7 @@ check-disk: cargo-target-link
 # Clean leftover test data (VM disks, snapshots, state files)
 # Preserves cached assets (kernels, rootfs, initrd, image-cache)
 # CRITICAL: Uses fcvm's proper cleanup commands to handle btrfs CoW correctly
+clean-test-data: private SHELL := $(TARGET_LEASE_SHELL)
 clean-test-data: build
 	@echo "==> Killing stale VM processes from previous runs..."
 	@sudo pkill -9 firecracker 2>/dev/null; sudo pkill -9 pasta 2>/dev/null; sudo kill -9 $$(pgrep -x sleep -P 1) 2>/dev/null; sleep 1; true
@@ -465,6 +487,14 @@ dep-provenance:
 # build targets therefore snapshot the provenance before their cargo
 # commands, re-derive it after, and fail on any difference instead of
 # logging a line about a tree cargo never saw.
+#
+# The cargo commands, the copy that reads their output back through target/,
+# and the config sync that runs the binary they produced are one recipe line,
+# so one lease covers all of it. The sync is best-effort (the config is
+# embedded at compile time and only needs pushing to the user config dir), so
+# `test -x` is what states that the binary must exist; `|| true` on the sync
+# would otherwise let `make build` report success with no target/release/fcvm.
+build: private SHELL := $(TARGET_LEASE_SHELL)
 build: cargo-target-link dep-provenance
 	@echo "==> Building..."
 	@set -e; \
@@ -477,9 +507,9 @@ build: cargo-target-link dep-provenance
 	if [ "$$before" != "$$after" ]; then \
 		printf 'ERROR: dependency provenance changed during the build\nbefore:\n%s\nafter:\n%s\n' "$$before" "$$after" >&2; \
 		exit 1; \
-	fi
-	@# Sync embedded config to user config dir (config is embedded at compile time)
-	@./target/release/fcvm setup --generate-config --force 2>/dev/null || true
+	fi; \
+	test -x target/release/fcvm; \
+	./target/release/fcvm setup --generate-config --force 2>/dev/null || true
 
 # Host-native tools used by the kernel-builder AMI/workflow. Unlike `build`,
 # this does not require a musl Rust target for the guest agent.
@@ -494,6 +524,7 @@ build-host-tools: cargo-target-link dep-provenance
 		exit 1; \
 	fi
 
+build-fc-mock: private SHELL := $(TARGET_LEASE_SHELL)
 build-fc-mock: cargo-target-link
 	@echo "==> Building fc-mock..."
 	CARGO_TARGET_DIR=target $(CARGO) build --release -p fc-mock
@@ -502,6 +533,7 @@ build-fc-mock: cargo-target-link
 	sudo install -m 755 target/release/fc-mock /usr/local/bin/fc-mock
 
 # Test that the release binary works without source tree (simulates cargo install)
+test-packaging: private SHELL := $(TARGET_LEASE_SHELL)
 test-packaging: build
 	@echo "==> Testing packaging (simulates cargo install)..."
 	./scripts/test-packaging.sh target/release/fcvm
@@ -526,6 +558,7 @@ _test-all: cargo-target-link
 	RUST_LOG="$(TEST_LOG)" \
 	$(TEST_CONFIG_WRAPPER) ./scripts/no-sudo.sh $(NEXTEST) $(NEXTEST_CAPTURE) $(FILTER)
 
+_test-root: private SHELL := $(TARGET_LEASE_SHELL)
 _test-root: cargo-target-link
 	@if find target/ -user root -print -quit 2>/dev/null | grep -q .; then \
 		echo "==> WARNING: root-owned files in target/ (from sudo cargo?). Fixing ownership..."; \
@@ -694,6 +727,7 @@ setup-btrfs:
 	@sudo mkdir -p $(CONTAINER_DATA_DIR)/{state,snapshots,vm-disks}
 	@sudo chown -R $$(id -un):$$(id -gn) $(CONTAINER_DATA_DIR)
 
+setup-default: private SHELL := $(TARGET_LEASE_SHELL)
 setup-default: build setup-btrfs
 	@FREE_GB=$$(df -BG /mnt/fcvm-btrfs 2>/dev/null | awk 'NR==2 {gsub("G",""); print $$4}'); \
 	if [ -n "$$FREE_GB" ] && [ "$$FREE_GB" -lt 15 ]; then \
@@ -719,12 +753,14 @@ setup-default: build setup-btrfs
 # download) downloads it again and the job republishes the exact artifact the
 # operator asked to replace. A post-run existence check cannot catch that, since
 # a download leaves the same file. KERNEL_FILE names the artifact to assert on.
+release-default-kernel: private SHELL := $(TARGET_LEASE_SHELL)
 release-default-kernel: build setup-btrfs
 	@if [ "$(FORCE)" = "1" ] && [ -z "$(KERNEL_FILE)" ]; then 		echo "ERROR: FORCE=1 needs KERNEL_FILE=<vmlinux-...bin> to assert the rebuild produced it"; 		exit 1; 	fi
 	sudo ./target/release/fcvm setup --generate-config --force
 	@if [ "$(FORCE)" = "1" ]; then 		echo "==> FORCE: rebuilding from source, bypassing the published release"; 		sudo ./target/release/fcvm setup --kernel-profile default --force-build-kernels 			--config "$(CURDIR)/rootfs-config.toml"; 	else 		sudo ./target/release/fcvm setup --kernel-profile default --build-kernels 			--config "$(CURDIR)/rootfs-config.toml"; 	fi
 	@if [ -n "$(KERNEL_FILE)" ] && [ ! -f "/mnt/fcvm-btrfs/kernels/$(KERNEL_FILE)" ]; then 		echo "ERROR: setup finished without producing /mnt/fcvm-btrfs/kernels/$(KERNEL_FILE)"; 		ls -la /mnt/fcvm-btrfs/kernels/; 		exit 1; 	fi
 
+setup-fcvm: private SHELL := $(TARGET_LEASE_SHELL)
 setup-fcvm: setup-default
 	@echo "==> Running fcvm setup --kernel-profile nested..."
 	./target/release/fcvm setup --kernel-profile nested --build-kernels
@@ -733,6 +769,7 @@ setup-fcvm: setup-default
 
 # Build and install host kernel with all patches from kernel/patches/
 # Requires reboot to activate the new kernel
+install-host-kernel: private SHELL := $(TARGET_LEASE_SHELL)
 install-host-kernel: build setup-btrfs
 	sudo ./target/release/fcvm setup --kernel-profile nested --build-kernels --install-host-kernel
 
@@ -744,6 +781,7 @@ container-setup-fcvm: container-build setup-btrfs
 	@sudo chown -R $$(id -un):$$(id -gn) /mnt/fcvm-btrfs/firecracker 2>/dev/null || true
 	$(CONTAINER_RUN) $(CONTAINER_TAG) make build _setup-fcvm
 
+_setup-fcvm: private SHELL := $(TARGET_LEASE_SHELL)
 _setup-fcvm:
 	@FREE_GB=$$(df -BG /mnt/fcvm-btrfs 2>/dev/null | awk 'NR==2 {gsub("G",""); print $$4}'); \
 	if [ -n "$$FREE_GB" ] && [ "$$FREE_GB" -lt 15 ]; then \
@@ -953,6 +991,7 @@ require-clean-tree:
 		exit 2; \
 	fi
 
+bench-chromium-corpus: private SHELL := $(TARGET_LEASE_SHELL)
 bench-chromium-corpus: require-clean-tree build setup-default
 	@mkdir -p "$(dir $(CORPUS_RUN_DIR))"
 	@# Reserve, do not reuse: plain mkdir FAILS on collision. `mkdir -p` would
@@ -1064,6 +1103,7 @@ test-chromium-fault:
 #
 # Every cell and every publication gate is required: an accidental benchmark is
 # worse than no benchmark, so there are no defaults to fall back on.
+bench-chromium-scale: private SHELL := $(TARGET_LEASE_SHELL)
 bench-chromium-scale: build
 	@test -n "$(SCALE_RATES)" || (echo "ERROR: SCALE_RATES required (for example 2,4,8)"; exit 1)
 	@test -n "$(SCALE_BURSTS)" || (echo "ERROR: SCALE_BURSTS required (must be at least 5)"; exit 1)

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -119,24 +119,198 @@ any_fallback_payload() {
 # unpublished payload is unreachable (nothing but target/ ever names one) and
 # it sits on the root filesystem this indirection exists to keep free, while
 # nothing else reclaims it: the pruner enumerates a checkout's target/ and the
-# btrfs generations, never a checkout's other entries. A payload another
-# build still leases is kept, and stays unreachable.
+# btrfs generations, never a checkout's other entries. A payload another build
+# still leases is kept, and stays unreachable.
+#
+# Removal is destructive, so the walk is fd-relative and bounded. openat2 with
+# RESOLVE_BENEATH|NO_XDEV|NO_SYMLINKS refuses to leave the payload and refuses
+# to descend into a mount; a payload sits in the checkout for the length of an
+# outage, and the dentry of a mount placed under it can be the only reference
+# another namespace has to that data. A child whose device differs is the same
+# refusal for a file bind mount, which opens like an ordinary file.
+#
+# A payload owned by another uid is never removed. The container lane runs as
+# root against the same bind-mounted checkout, so a root-owned payload beside a
+# user-owned one is an ordinary state, and root is not stopped by permissions.
+#
+# Every outcome is named. Failing the run is reserved for a payload this
+# identity owns and could not reclaim: nothing else enumerates it and its name
+# is never published again, so no later run clears it either, and each outage
+# cycle would leave one more tree on the root filesystem.
 discard_unpublished_fallbacks() {
-	local keep="${1:-}" entry lease_fd
-	for entry in "$LOCAL_TARGET_PREFIX".generation-*; do
-		[ -d "$entry" ] || continue
-		[ "$entry" != "$keep" ] || continue
-		exec {lease_fd}<"$entry" || continue
-		if ! flock -x -n "$lease_fd"; then
-			echo "==> WARNING: $entry is leased by another build and is not reclaimed" >&2
-		elif rm -rf -- "$entry"; then
-			echo "==> Reclaimed the unpublished fallback payload $entry" >&2
-		else
-			# Another uid's leftovers, say. It stays unreachable either way.
-			echo "==> WARNING: $entry cannot be removed and is not reclaimed" >&2
-		fi
-		exec {lease_fd}<&-
-	done
+	local keep="${1:-}"
+	/usr/bin/python3 -c '
+import ctypes
+import errno
+import fcntl
+import os
+import stat
+import sys
+
+checkout, prefix, keep = sys.argv[1:4]
+
+RESOLVE_NO_XDEV = 0x01
+RESOLVE_NO_MAGICLINKS = 0x02
+RESOLVE_NO_SYMLINKS = 0x04
+RESOLVE_BENEATH = 0x08
+SYS_OPENAT2 = 437
+DIR_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+
+libc = ctypes.CDLL(None, use_errno=True)
+libc.syscall.restype = ctypes.c_long
+
+
+class OpenHow(ctypes.Structure):
+    _fields_ = [
+        ("flags", ctypes.c_uint64),
+        ("mode", ctypes.c_uint64),
+        ("resolve", ctypes.c_uint64),
+    ]
+
+
+class MountBoundary(RuntimeError):
+    pass
+
+
+def open_beneath(parent_fd, name):
+    how = OpenHow(
+        flags=DIR_FLAGS,
+        mode=0,
+        resolve=(
+            RESOLVE_NO_XDEV
+            | RESOLVE_NO_MAGICLINKS
+            | RESOLVE_NO_SYMLINKS
+            | RESOLVE_BENEATH
+        ),
+    )
+    fd = libc.syscall(
+        ctypes.c_long(SYS_OPENAT2),
+        ctypes.c_int(parent_fd),
+        ctypes.c_char_p(os.fsencode(name)),
+        ctypes.byref(how),
+        ctypes.sizeof(how),
+    )
+    if fd >= 0:
+        return fd
+    code = ctypes.get_errno()
+    if code == errno.EXDEV:
+        raise MountBoundary(f"{name} is a mount point")
+    if code == errno.ENOSYS:
+        raise RuntimeError("openat2 is unavailable; refusing an unbounded removal")
+    raise OSError(code, os.strerror(code), name)
+
+
+def prune(directory_fd, device):
+    for name in os.listdir(directory_fd):
+        info = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+        if info.st_dev != device:
+            raise MountBoundary(f"{name} crosses a mount boundary")
+        if stat.S_ISDIR(info.st_mode):
+            child_fd = open_beneath(directory_fd, name)
+            try:
+                prune(child_fd, device)
+            finally:
+                os.close(child_fd)
+            os.rmdir(name, dir_fd=directory_fd)
+        else:
+            os.unlink(name, dir_fd=directory_fd)
+
+
+def report(message):
+    print(message, file=sys.stderr, flush=True)
+
+
+failed = False
+checkout_fd = os.open(checkout, DIR_FLAGS)
+try:
+    for name in sorted(os.listdir(checkout_fd)):
+        if not name.startswith(prefix):
+            continue
+        path = os.path.join(checkout, name)
+        if path == keep:
+            continue
+        try:
+            info = os.stat(name, dir_fd=checkout_fd, follow_symlinks=False)
+        except OSError as error:
+            report(f"==> ERROR: cannot stat the fallback payload {path}: {error.strerror}")
+            failed = True
+            continue
+        if not stat.S_ISDIR(info.st_mode):
+            report(f"==> ERROR: the fallback payload {path} is not a directory; not reclaimed")
+            failed = True
+            continue
+        if info.st_uid != os.geteuid():
+            report(
+                f"==> WARNING: the fallback payload {path} is owned by uid {info.st_uid}, not "
+                f"{os.geteuid()}; it is not this identity to reclaim and stays on the root "
+                f"filesystem"
+            )
+            continue
+        try:
+            payload_fd = open_beneath(checkout_fd, name)
+        except MountBoundary as error:
+            report(f"==> ERROR: refusing to reclaim the fallback payload {path}: {error}")
+            failed = True
+            continue
+        except OSError as error:
+            report(
+                f"==> ERROR: cannot open the fallback payload {path} to reclaim it: "
+                f"{error.strerror}"
+            )
+            failed = True
+            continue
+        try:
+            try:
+                fcntl.flock(payload_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                report(f"==> WARNING: {path} is leased by another build and is not reclaimed")
+                continue
+            payload = os.fstat(payload_fd)
+            prune(payload_fd, payload.st_dev)
+            final = os.stat(name, dir_fd=checkout_fd, follow_symlinks=False)
+            if (final.st_dev, final.st_ino) != (payload.st_dev, payload.st_ino):
+                raise RuntimeError("the payload name changed inode while it was reclaimed")
+            os.rmdir(name, dir_fd=checkout_fd)
+        except (MountBoundary, OSError, RuntimeError) as error:
+            report(f"==> ERROR: cannot reclaim the fallback payload {path}: {error}")
+            failed = True
+        else:
+            report(f"==> Reclaimed the unpublished fallback payload {path}")
+        finally:
+            os.close(payload_fd)
+finally:
+    os.close(checkout_fd)
+raise SystemExit(1 if failed else 0)
+' "$p" "$(basename -- "$LOCAL_TARGET_PREFIX").generation-" "$keep"
+}
+
+# What does `target` resolve to, with the errno preserved? `[ -d target ]`
+# reports the same false for "nothing is published there" and for "resolving it
+# was refused", and only the first makes replacing the link safe: a build past
+# the checkout lock holds nothing but its generation lease, so dropping the
+# pathname without taking that lease splits it across two trees. Exit 0 is a
+# directory, 3 is proven absent (ENOENT/ENOTDIR), and every other status is a
+# resolution failure the caller must refuse on.
+target_resolution_state() {
+	local rc=0
+	/usr/bin/python3 -c '
+import errno
+import os
+import stat
+import sys
+
+try:
+    metadata = os.stat(sys.argv[1])
+except OSError as error:
+    if error.errno in (errno.ENOENT, errno.ENOTDIR):
+        raise SystemExit(3)
+    print(f"cannot resolve {sys.argv[1]}: {os.strerror(error.errno)}", file=sys.stderr)
+    raise SystemExit(4)
+if not stat.S_ISDIR(metadata.st_mode):
+    print(f"{sys.argv[1]} resolves to a non-directory", file=sys.stderr)
+    raise SystemExit(5)
+' "$1" || rc=$?
+	return "$rc"
 }
 
 publish_target_link() {
@@ -199,7 +373,12 @@ require_writable_local_target() {
 		exit 1
 	fi
 	rm -f -- "$probe"
-	discard_unpublished_fallbacks "$payload"
+	if ! discard_unpublished_fallbacks "$payload"; then
+		echo "ERROR: a fallback payload this run owns could not be reclaimed; nothing else \
+enumerates it and its name is never published again, so it stays on the root filesystem until \
+it is removed by hand" >&2
+		exit 1
+	fi
 }
 
 # Drops the checkout's managed target/ link; the generation stays for the
@@ -219,12 +398,23 @@ drop_managed_link() {
 		"$BTRFS_ROOT"/cargo-target/* | "$LOCAL_TARGET_PREFIX".generation-*) ;;
 		*) return 0 ;;
 	esac
-	if [[ -z ${old_target_lease_fd:-} ]] && [ -d target ]; then
-		if ! exec {old_target_lease_fd}<target; then
-			echo "ERROR: cannot open the published directory $linked to lease it; a running build may still hold it, refusing to replace target/" >&2
-			exit 1
-		fi
-		flock -x "$old_target_lease_fd"
+	if [[ -z ${old_target_lease_fd:-} ]]; then
+		local resolution=0
+		target_resolution_state target || resolution=$?
+		case "$resolution" in
+			0)
+				if ! exec {old_target_lease_fd}<target; then
+					echo "ERROR: cannot open the published directory $linked to lease it; a running build may still hold it, refusing to replace target/" >&2
+					exit 1
+				fi
+				flock -x "$old_target_lease_fd"
+				;;
+			3) ;;
+			*)
+				echo "ERROR: cannot tell whether target/ → $linked still publishes a directory (rc=$resolution); a running build may hold it, refusing to replace target/" >&2
+				exit 1
+				;;
+		esac
 	fi
 	case "$linked" in
 		"$LOCAL_TARGET_PREFIX".generation-*) return 0 ;;
@@ -233,15 +423,57 @@ drop_managed_link() {
 	rm -f -- target
 }
 
-fallback_to_local() {
-	echo "==> WARNING: $1; build artifacts stay on the root filesystem" >&2
-	drop_managed_link
-	# `--rotate` promises a clean target/; a retained link or directory, or a
-	# republished fallback payload, would report one while its payload survives.
-	if ((FORCE_ROTATE)) && { [ -L target ] || [ -d target ] || any_fallback_payload; }; then
+# True while every generation this checkout could publish is durably retired
+# or proven absent. Dropping a link is not a clean: the generation keeps its
+# payload, and the next run reuses an unretired one and republishes every byte
+# the clean reported gone. A generation whose state cannot be read is refused
+# for the same reason.
+managed_namespace_is_retired() {
+	local entry state fd rc
+	for entry in "$WT_TARGET" "$WT_TARGET".generation-*; do
+		state=0
+		target_resolution_state "$entry" || state=$?
+		case "$state" in
+			3) continue ;;
+			0) ;;
+			*)
+				echo "ERROR: cannot tell whether $entry still holds a payload (rc=$state)" >&2
+				return 1
+				;;
+		esac
+		if ! exec {fd}<"$entry"; then
+			echo "ERROR: cannot open $entry to read its retirement state" >&2
+			return 1
+		fi
+		rc=0
+		target_is_retired "$fd" || rc=$?
+		exec {fd}<&-
+		case "$rc" in
+			0) ;;
+			*)
+				echo "ERROR: $entry keeps its payload and is not retired (rc=$rc)" >&2
+				return 1
+				;;
+		esac
+	done
+	return 0
+}
+
+# `--rotate` promises a clean target/. A retained link or directory, a
+# republished fallback payload, or a managed generation that was never retired
+# would each report one while its payload survives.
+refuse_unsafe_rotation() {
+	((FORCE_ROTATE)) || return 0
+	if [ -L target ] || [ -d target ] || any_fallback_payload || ! managed_namespace_is_retired; then
 		echo "ERROR: local target/ cannot be atomically rotated without the managed btrfs namespace; refusing unsafe clean" >&2
 		exit 1
 	fi
+}
+
+fallback_to_local() {
+	echo "==> WARNING: $1; build artifacts stay on the root filesystem" >&2
+	drop_managed_link
+	refuse_unsafe_rotation
 	require_writable_local_target
 	exit 0
 }
@@ -363,21 +595,34 @@ if [ -e target ] && ! [ -L target ]; then
 fi
 
 candidate="$WT_TARGET"
-if [ -L target ] && [ -d target ]; then
+if [ -L target ]; then
 	linked="$(readlink target)"
 	# target/ is replaced only under an exclusive lease on the generation it
 	# publishes: a cargo wrapper past the checkout→target lock handoff holds
 	# only that lease, shared, and the flock below blocks until it is done. A
 	# generation that cannot be opened cannot be leased, so replacing it is
-	# refused; a 0333 generation still accepts cargo's writes.
-	if ! exec {old_target_lease_fd}<target; then
-		echo "ERROR: cannot open the published generation $linked to lease it; a running build may still hold it, refusing to replace target/" >&2
-		exit 1
-	fi
-	flock -x "$old_target_lease_fd"
-	case "$linked" in
-		"$WT_TARGET"|"$WT_TARGET".generation-*)
-			candidate="$linked"
+	# refused; a 0333 generation still accepts cargo's writes. A link that does
+	# not resolve publishes nothing and needs no lease, but only a PROVEN absent
+	# destination says so; a refused resolution is not the same answer.
+	resolution=0
+	target_resolution_state target || resolution=$?
+	case "$resolution" in
+		0)
+			if ! exec {old_target_lease_fd}<target; then
+				echo "ERROR: cannot open the published generation $linked to lease it; a running build may still hold it, refusing to replace target/" >&2
+				exit 1
+			fi
+			flock -x "$old_target_lease_fd"
+			case "$linked" in
+				"$WT_TARGET"|"$WT_TARGET".generation-*)
+					candidate="$linked"
+					;;
+			esac
+			;;
+		3) ;;
+		*)
+			echo "ERROR: cannot tell whether target/ → $linked still publishes a directory (rc=$resolution); a running build may hold it, refusing to replace target/" >&2
+			exit 1
 			;;
 	esac
 fi
@@ -460,10 +705,7 @@ if [[ -n ${candidate_lease_fd:-} && $candidate_lease_fd != "$final_lease_fd" ]];
 	exec {candidate_lease_fd}<&-
 fi
 else
-	if ((FORCE_ROTATE)) && { [ -d target ] || any_fallback_payload; }; then
-		echo "ERROR: local target/ cannot be atomically rotated without the managed btrfs namespace; refusing unsafe clean" >&2
-		exit 1
-	fi
+	refuse_unsafe_rotation
 	if ! [ -d "$BTRFS_ROOT" ]; then
 		echo "==> NOTE: $BTRFS_ROOT is not a directory; build artifacts stay on the root filesystem"
 	fi

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -133,6 +133,15 @@ any_fallback_payload() {
 # root against the same bind-mounted checkout, so a root-owned payload beside a
 # user-owned one is an ordinary state, and root is not stopped by permissions.
 #
+# Ownership is decided on a stat of a name and the removal runs on a descriptor
+# opened from that same name, which is a second resolution. Both decisions are
+# therefore remade on the descriptor before anything is unlinked: its uid must
+# be this identity and its (st_dev, st_ino) must be the pair the check ran on.
+# Without that, a rename in between hands the walk a directory nothing checked,
+# and the comparison before the rmdir proves only that the name still resolves
+# to the replacement, so the foreign-owner guard is defeated and another
+# identity loses a tree.
+#
 # Every outcome is named. Failing the run is reserved for a payload this
 # identity owns and could not reclaim: nothing else enumerates it and its name
 # is never published again, so no later run clears it either, and each outage
@@ -200,6 +209,15 @@ def open_beneath(parent_fd, name):
     raise OSError(code, os.strerror(code), name)
 
 
+def remove_directory(directory_fd, name, decided):
+    # rmdir takes a name, not a descriptor, so the identity behind the name is
+    # checked once more against the stat the removal was decided on.
+    final = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+    if (final.st_dev, final.st_ino) != (decided.st_dev, decided.st_ino):
+        raise RuntimeError(f"{name} changed identity while it was being reclaimed")
+    os.rmdir(name, dir_fd=directory_fd)
+
+
 def prune(directory_fd, device):
     for name in os.listdir(directory_fd):
         info = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
@@ -208,10 +226,17 @@ def prune(directory_fd, device):
         if stat.S_ISDIR(info.st_mode):
             child_fd = open_beneath(directory_fd, name)
             try:
+                # The name was resolved a second time to open it. Descend only
+                # into the directory the checks above were made about.
+                opened = os.fstat(child_fd)
+                if (opened.st_dev, opened.st_ino) != (info.st_dev, info.st_ino):
+                    raise RuntimeError(
+                        f"{name} changed identity while it was being reclaimed"
+                    )
                 prune(child_fd, device)
             finally:
                 os.close(child_fd)
-            os.rmdir(name, dir_fd=directory_fd)
+            remove_directory(directory_fd, name, info)
         else:
             os.unlink(name, dir_fd=directory_fd)
 
@@ -260,17 +285,35 @@ try:
             failed = True
             continue
         try:
+            # The ownership check above and the open are two resolutions of one
+            # name, and everything below acts on the descriptor. Remake both
+            # decisions on it: a rename in that window otherwise hands the walk
+            # a directory nothing checked, and the comparison before the rmdir
+            # would only prove the name still resolves to that replacement.
+            opened = os.fstat(payload_fd)
+            if opened.st_uid != os.geteuid():
+                report(
+                    f"==> ERROR: the fallback payload {path} is owned by uid {opened.st_uid} "
+                    f"once opened, not {os.geteuid()}; it changed identity between its "
+                    f"ownership check and the open and is not reclaimed"
+                )
+                failed = True
+                continue
+            if (opened.st_dev, opened.st_ino) != (info.st_dev, info.st_ino):
+                report(
+                    f"==> ERROR: the fallback payload {path} changed identity between its "
+                    f"ownership check and the open ({info.st_dev}:{info.st_ino} is now "
+                    f"{opened.st_dev}:{opened.st_ino}); it is not reclaimed"
+                )
+                failed = True
+                continue
             try:
                 fcntl.flock(payload_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
             except BlockingIOError:
                 report(f"==> WARNING: {path} is leased by another build and is not reclaimed")
                 continue
-            payload = os.fstat(payload_fd)
-            prune(payload_fd, payload.st_dev)
-            final = os.stat(name, dir_fd=checkout_fd, follow_symlinks=False)
-            if (final.st_dev, final.st_ino) != (payload.st_dev, payload.st_ino):
-                raise RuntimeError("the payload name changed inode while it was reclaimed")
-            os.rmdir(name, dir_fd=checkout_fd)
+            prune(payload_fd, opened.st_dev)
+            remove_directory(checkout_fd, name, opened)
         except (MountBoundary, OSError, RuntimeError) as error:
             report(f"==> ERROR: cannot reclaim the fallback payload {path}: {error}")
             failed = True

--- a/scripts/cargo-target-run.sh
+++ b/scripts/cargo-target-run.sh
@@ -1,15 +1,28 @@
 #!/usr/bin/env bash
-# Run one Cargo command while holding this worktree target's shared lease.
+# Run one command while holding this worktree target's shared lease.
 #
 # runner-disk-preflight.sh locks the same physical generation exclusively
 # before reclaiming idle payload. It retires that inode before changing cache
 # bytes; this wrapper then asks cargo-target-link.sh to publish a fresh sibling
 # generation. Physical target dentries are never deleted or renamed.
+#
+# Two callers, one lease. `$(CARGO)` prefixes every Cargo command with this
+# script, and a recipe whose raw `target/` accesses must all resolve to one
+# generation names it as that recipe's SHELL, which make invokes as
+# `$(SHELL) -c "<recipe line>"`. The lease is taken before the line runs and
+# released when it ends, so nothing can republish `target/` in the middle of a
+# recipe that writes a file through the link and then reads it back.
 set -euo pipefail
 
 if (($# == 0)); then
-	echo "usage: $0 <cargo> [args...]" >&2
+	echo "usage: $0 <command> [args...]   |   $0 -c <recipe line>" >&2
 	exit 2
+fi
+
+# make hands a SHELL the recipe line after `-c`. `exec` would read that as its
+# own empty-environment flag and then try to execute the line as a filename.
+if [[ $1 == -c ]]; then
+	set -- /bin/bash "$@"
 fi
 
 if ! command -v flock >/dev/null 2>&1; then

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -2660,7 +2660,18 @@ fn persistent_runner_entrypoints_route_cargo_through_the_lease() {
 fn cargo_target_link_keeps_a_bind_mounted_target_when_btrfs_is_unwritable() {
     let checkout = tempfile::tempdir().expect("checkout tempdir");
     // The bind-mounted target/: a real directory that already exists.
-    std::fs::create_dir(checkout.path().join("target")).expect("pre-existing target/");
+    let target = checkout.path().join("target");
+    std::fs::create_dir(&target).expect("pre-existing target/");
+    // Retention is about THIS dentry. A run that deletes it and creates
+    // another writable directory in its place satisfies "target/ is a real
+    // directory" while the bind mount it carried is gone, so the identity and
+    // the contents are what the assertions read. Both are needed: a
+    // delete-and-recreate here reuses the same inode number, so it is the
+    // sentinel that catches it.
+    let sentinel = target.join("carried-by-the-mount");
+    std::fs::write(&sentinel, b"data only reachable through the mounted dentry")
+        .expect("write sentinel into the pre-existing target/");
+    let before = std::fs::symlink_metadata(&target).expect("stat the pre-existing target/");
 
     let unwritable_tmp = tempfile::tempdir().expect("btrfs stand-in");
     let btrfs_root: PathBuf = if nix_geteuid_is_root() {
@@ -2687,12 +2698,23 @@ fn cargo_target_link_keeps_a_bind_mounted_target_when_btrfs_is_unwritable() {
         "the recipe failed instead of keeping the existing target/ when the btrfs \
          volume is present but unwritable:\n{out}"
     );
-    let target = checkout.path().join("target");
     assert!(
         target.is_dir() && !target.is_symlink(),
         "target/ should have been kept as the real (bind-mounted) directory it was; \
          it is now {:?}\n{out}",
         std::fs::symlink_metadata(&target).map(|m| m.file_type())
+    );
+    let after = std::fs::symlink_metadata(&target).expect("stat the retained target/");
+    assert_eq!(
+        (before.dev(), before.ino()),
+        (after.dev(), after.ino()),
+        "target/ is a directory again but not the SAME one: dev/ino changed, so the dentry the \
+         bind mount was attached to was unlinked and replaced:\n{out}"
+    );
+    assert_eq!(
+        std::fs::read(&sentinel).ok().as_deref(),
+        Some(b"data only reachable through the mounted dentry".as_slice()),
+        "the retained target/ lost the contents it came in with:\n{out}"
     );
     assert_target_usable(checkout.path(), "unwritable btrfs volume");
 }
@@ -2899,44 +2921,7 @@ fn cargo_target_link_falls_back_when_the_managed_dir_cannot_be_opened() {
 /// cannot. Both tempdirs are handed to that uid, and scripts/ is copied where it
 /// can read them (the script sources cargo-target-lib.sh next to itself).
 fn run_link_unprivileged(dir: &Path, btrfs_root: &Path) -> (bool, String) {
-    use std::os::unix::fs::PermissionsExt as _;
-    if unsafe { libc::geteuid() } != 0 {
-        return run_link(dir, btrfs_root);
-    }
-    let tools = tempfile::tempdir().expect("tools tempdir");
-    std::fs::set_permissions(tools.path(), std::fs::Permissions::from_mode(0o755)).expect("0755");
-    let scripts = tools.path().join("scripts");
-    std::fs::create_dir(&scripts).expect("scripts dir");
-    for name in ["cargo-target-link.sh", "cargo-target-lib.sh"] {
-        std::fs::copy(repo_root().join("scripts").join(name), scripts.join(name)).expect(name);
-    }
-    std::fs::set_permissions(
-        scripts.join("cargo-target-link.sh"),
-        std::fs::Permissions::from_mode(0o755),
-    )
-    .expect("0755");
-    for owned in [dir, btrfs_root] {
-        let chowned = Command::new("chown")
-            .args(["-R", "65534:65534"])
-            .arg(owned)
-            .status()
-            .expect("chown -R");
-        assert!(chowned.success(), "hand {} to uid 65534", owned.display());
-    }
-    let out = Command::new("setpriv")
-        .args(["--reuid=65534", "--regid=65534", "--clear-groups"])
-        .arg(scripts.join("cargo-target-link.sh"))
-        .env("BTRFS_ROOT", btrfs_root)
-        .env_remove("CARGO_TARGET_LINK_LOCKED")
-        .current_dir(dir)
-        .output()
-        .expect("run scripts/cargo-target-link.sh as uid 65534");
-    let text = format!(
-        "{}{}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr)
-    );
-    (out.status.success(), text)
+    run_link_unprivileged_with(dir, btrfs_root, &[])
 }
 
 /// `run_link` with extra script arguments (`--rotate`).
@@ -3587,5 +3572,937 @@ fn cargo_target_link_publishes_a_fresh_fallback_after_a_clean() {
     assert_ne!(
         republished, first_payload,
         "run 4 reused an earlier outage's payload instead of publishing a fresh one:\n{out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Reclaiming a fallback payload, and dropping a link, are destructive acts.
+// ---------------------------------------------------------------------------
+
+/// `run_link_with`, but as uid 65534 when the tests are root: root can open and
+/// write any directory, so a fixture about permissions must run as someone who
+/// cannot. Both tempdirs are handed to that uid, and scripts/ is copied where
+/// it can read them (the script sources cargo-target-lib.sh next to itself). A
+/// btrfs root that does not exist is the volume-is-gone fixture and is left
+/// alone.
+fn run_link_unprivileged_with(dir: &Path, btrfs_root: &Path, args: &[&str]) -> (bool, String) {
+    if unsafe { libc::geteuid() } != 0 {
+        return run_link_with(dir, btrfs_root, args);
+    }
+    let tools = tempfile::tempdir().expect("tools tempdir");
+    std::fs::set_permissions(tools.path(), std::fs::Permissions::from_mode(0o755)).expect("0755");
+    let scripts = tools.path().join("scripts");
+    std::fs::create_dir(&scripts).expect("scripts dir");
+    for name in ["cargo-target-link.sh", "cargo-target-lib.sh"] {
+        std::fs::copy(repo_root().join("scripts").join(name), scripts.join(name)).expect(name);
+    }
+    std::fs::set_permissions(
+        scripts.join("cargo-target-link.sh"),
+        std::fs::Permissions::from_mode(0o755),
+    )
+    .expect("0755");
+    for owned in [dir, btrfs_root] {
+        if !owned.exists() {
+            continue;
+        }
+        let chowned = Command::new("chown")
+            .args(["-R", "65534:65534"])
+            .arg(owned)
+            .status()
+            .expect("chown -R");
+        assert!(chowned.success(), "hand {} to uid 65534", owned.display());
+    }
+    let out = Command::new("setpriv")
+        .args(["--reuid=65534", "--regid=65534", "--clear-groups"])
+        .arg(scripts.join("cargo-target-link.sh"))
+        .args(args)
+        .env("BTRFS_ROOT", btrfs_root)
+        .env_remove("CARGO_TARGET_LINK_LOCKED")
+        .current_dir(dir)
+        .output()
+        .expect("run scripts/cargo-target-link.sh as uid 65534");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (out.status.success(), text)
+}
+
+/// Stage a checkout that has been through a volume outage: `target/` publishes
+/// a checkout-local fallback payload. Returns that payload.
+#[cfg(feature = "privileged-tests")]
+fn stage_outage_fallback(checkout: &Path, absent_volume: &Path) -> PathBuf {
+    let (ok, out) = run_link(checkout, absent_volume);
+    assert!(ok, "the outage run failed:\n{out}");
+    assert_local_fallback_link(checkout, absent_volume, "volume down")
+}
+
+/// Reclaiming an unpublished payload must not cross a mount boundary.
+///
+/// `rm -rf` descends into whatever is mounted underneath and unlinks it. A
+/// payload sits in the checkout for the life of an outage, which is exactly
+/// when a bind mount can be placed under it; the data behind that mount belongs
+/// to someone else and its dentry may be the only reference another mount
+/// namespace has. The reclaim must refuse to descend and say so.
+#[cfg(feature = "privileged-tests")]
+#[test]
+fn cargo_target_link_refuses_to_reclaim_a_payload_across_a_mount_boundary() {
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let volume_parent = tempfile::tempdir().expect("volume parent");
+    let btrfs = volume_parent.path().join("fcvm-btrfs");
+    let payload = stage_outage_fallback(checkout.path(), &btrfs);
+
+    let source = tempfile::tempdir().expect("bind source");
+    let sentinel = source.path().join("must-survive");
+    std::fs::write(&sentinel, b"mounted data").expect("write mounted sentinel");
+    let mountpoint = payload.join("mounted-source");
+    std::fs::create_dir_all(&mountpoint).expect("mountpoint inside the payload");
+    let status = Command::new("mount")
+        .args([
+            std::ffi::OsStr::new("--bind"),
+            source.path().as_os_str(),
+            mountpoint.as_os_str(),
+        ])
+        .status()
+        .expect("run bind mount");
+    assert!(status.success(), "bind mount failed: {status:?}");
+    let mount = BindMountGuard(mountpoint.clone());
+
+    std::fs::create_dir_all(&btrfs).expect("the volume comes back");
+    let (ok, out) = run_link(checkout.path(), &btrfs);
+
+    assert!(
+        sentinel.exists(),
+        "reclaiming {payload:?} crossed the bind mount at {mountpoint:?} and deleted unrelated \
+         mounted data:\n{out}"
+    );
+    assert!(
+        !ok,
+        "a payload the run could not reclaim was reported as a successful setup; it stays on \
+         the root filesystem this indirection exists to keep free:\n{out}"
+    );
+    assert!(
+        out.contains(&payload.display().to_string()),
+        "the refusal does not name the payload that was left behind:\n{out}"
+    );
+    mount.unmount();
+}
+
+/// A payload owned by another uid is never reclaimed, and never silently.
+///
+/// The container lane runs as root against a bind-mounted checkout, so a
+/// payload written there is root-owned on the host. Removing another identity's
+/// tree is not this script's business, and root can do it without noticing.
+/// Refusing is right; refusing without a word is what lets payloads accumulate.
+#[cfg(feature = "privileged-tests")]
+#[test]
+fn cargo_target_link_refuses_to_reclaim_a_payload_owned_by_another_user() {
+    assert!(
+        nix_geteuid_is_root(),
+        "BLOCKED: this fixture needs root to create a payload owned by another uid"
+    );
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let volume_parent = tempfile::tempdir().expect("volume parent");
+    let btrfs = volume_parent.path().join("fcvm-btrfs");
+    let ours = stage_outage_fallback(checkout.path(), &btrfs);
+
+    let foreign = checkout
+        .path()
+        .join(".cargo-target-local.generation-foreign");
+    std::fs::create_dir(&foreign).expect("foreign payload");
+    let sentinel = foreign.join("must-survive");
+    std::fs::write(&sentinel, b"another identity's build").expect("write foreign sentinel");
+    let chowned = Command::new("chown")
+        .args(["-R", "65534:65534"])
+        .arg(&foreign)
+        .status()
+        .expect("chown -R");
+    assert!(chowned.success(), "hand the foreign payload to uid 65534");
+
+    std::fs::create_dir_all(&btrfs).expect("the volume comes back");
+    let (ok, out) = run_link(checkout.path(), &btrfs);
+
+    assert!(
+        sentinel.exists(),
+        "the reclaim removed a payload owned by uid 65534:\n{out}"
+    );
+    assert!(
+        out.contains(&foreign.display().to_string()),
+        "a payload that cannot be reclaimed was passed over without a word, so nothing tells an \
+         operator why the root filesystem keeps filling:\n{out}"
+    );
+    assert!(
+        ok,
+        "a foreign-owned payload failed the run; a checkout shared by the host user and the \
+         container root would then never build again:\n{out}"
+    );
+    assert!(
+        !ours.exists(),
+        "our own unpublished payload {ours:?} was left behind:\n{out}"
+    );
+}
+
+/// A payload this identity owns and cannot reclaim fails the run.
+///
+/// It is on the root filesystem, nothing else enumerates it, and its name is
+/// never published again, so no later run reclaims it either. Passing over it
+/// turns one directory into one tree per outage cycle.
+#[test]
+fn cargo_target_link_fails_closed_on_a_payload_it_cannot_reclaim() {
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let volume_parent = tempfile::tempdir().expect("volume parent");
+    let btrfs = volume_parent.path().join("fcvm-btrfs");
+    let (ok, out) = run_link_unprivileged(checkout.path(), &btrfs);
+    assert!(ok, "the outage run failed:\n{out}");
+
+    let stuck = checkout.path().join(".cargo-target-local.generation-stuck");
+    std::fs::create_dir(&stuck).expect("second payload");
+    std::fs::write(stuck.join("artifact"), b"unreachable").expect("write into it");
+    std::fs::set_permissions(&stuck, std::fs::Permissions::from_mode(0o000)).expect("chmod 000");
+
+    std::fs::create_dir_all(&btrfs).expect("the volume comes back");
+    let (ok, out) = run_link_unprivileged(checkout.path(), &btrfs);
+
+    let restored = std::fs::set_permissions(&stuck, std::fs::Permissions::from_mode(0o755));
+    assert!(
+        out.contains(&stuck.display().to_string()),
+        "the run passed over a payload it could not open without naming it:\n{out}"
+    );
+    assert!(
+        !ok,
+        "the run reported success while leaving a payload it owns and cannot reclaim on the \
+         root filesystem:\n{out}"
+    );
+    restored.expect("restore mode for cleanup");
+}
+
+/// `[ -d target ]` is false both when the link dangles and when resolving it is
+/// refused. Only the first proves nothing is published there. A build past the
+/// checkout lock holds nothing but the generation's shared lease, so replacing
+/// `target/` without taking that lease splits it across two trees; a resolution
+/// error must fail closed instead.
+#[test]
+fn cargo_target_link_refuses_to_drop_a_link_it_cannot_resolve() {
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let btrfs = tempfile::tempdir().expect("btrfs stand-in");
+    let cargo_target = btrfs.path().join("cargo-target");
+    let blocked = cargo_target.join("blocked");
+    let generation = blocked.join("held-generation");
+    std::fs::create_dir_all(&generation).expect("published generation");
+    std::fs::write(generation.join("artifact"), b"a running build's output").expect("artifact");
+    let target = checkout.path().join("target");
+    std::os::unix::fs::symlink(&generation, &target).expect("managed link");
+
+    if unsafe { libc::geteuid() } == 0 {
+        let chowned = Command::new("chown")
+            .args(["-R", "65534:65534"])
+            .arg(checkout.path())
+            .arg(btrfs.path())
+            .status()
+            .expect("chown -R");
+        assert!(chowned.success(), "hand the fixture to uid 65534");
+    }
+    // Search denied on an ancestor: the destination exists, resolving it does
+    // not. 0555 on cargo-target also makes `mkdir -p $WT_TARGET` fail, which is
+    // what sends the run down the unusable-volume path.
+    std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o000)).expect("chmod 000");
+    std::fs::set_permissions(&cargo_target, std::fs::Permissions::from_mode(0o555))
+        .expect("chmod 555");
+
+    let (ok, out) = run_link_unprivileged(checkout.path(), btrfs.path());
+
+    let restored = (
+        std::fs::set_permissions(&cargo_target, std::fs::Permissions::from_mode(0o755)),
+        std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o755)),
+    );
+    let still_linked = std::fs::read_link(&target);
+    assert_eq!(
+        still_linked.as_deref().ok(),
+        Some(generation.as_path()),
+        "target/ was repointed away from a generation whose lease could not be taken, so a \
+         build still resolving through it now writes into a different tree:\n{out}"
+    );
+    assert!(
+        !ok,
+        "a resolution failure was treated as a dangling link and the run reported success:\n{out}"
+    );
+    restored.0.expect("restore cargo-target mode");
+    restored.1.expect("restore blocked mode");
+}
+
+/// `--rotate` promises a clean namespace. A candidate that cannot be written
+/// cannot be retired, so the fallback must refuse rather than report a clean
+/// while the generation keeps every byte the clean said was gone: the next run
+/// finds it unretired and republishes it.
+#[test]
+fn cargo_target_link_rotate_refuses_an_unretired_generation_it_cannot_write() {
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let btrfs = tempfile::tempdir().expect("btrfs stand-in");
+    let worktree_dir = managed_worktree_dir(checkout.path(), btrfs.path());
+    std::fs::create_dir_all(&worktree_dir).expect("managed worktree dir");
+    let artifact = worktree_dir.join("cargo-cache-entry");
+    std::fs::write(&artifact, b"payload the clean claims to remove").expect("artifact");
+    if unsafe { libc::geteuid() } == 0 {
+        let chowned = Command::new("chown")
+            .args(["-R", "65534:65534"])
+            .arg(checkout.path())
+            .arg(btrfs.path())
+            .status()
+            .expect("chown -R");
+        assert!(chowned.success(), "hand the fixture to uid 65534");
+    }
+    // Readable and searchable, not writable: the lease opens, the retirement
+    // marker cannot be written, so the candidate cannot be retired.
+    std::fs::set_permissions(&worktree_dir, std::fs::Permissions::from_mode(0o555))
+        .expect("chmod 555");
+
+    let (ok, out) = run_link_unprivileged_with(checkout.path(), btrfs.path(), &["--rotate"]);
+
+    let restored = std::fs::set_permissions(&worktree_dir, std::fs::Permissions::from_mode(0o755));
+    assert!(
+        artifact.exists(),
+        "control failed: the fixture's payload disappeared, so the assertion below proves \
+         nothing:\n{out}"
+    );
+    assert!(
+        !ok,
+        "--rotate reported a clean target while {worktree_dir:?} kept its payload unretired; \
+         the next run reuses it and republishes everything the clean said was gone:\n{out}"
+    );
+    restored.expect("restore worktree dir mode");
+}
+
+// ---------------------------------------------------------------------------
+// One lease per RECIPE, not per Cargo process.
+// ---------------------------------------------------------------------------
+
+/// Mark a generation retired exactly as `retire_target` does.
+fn retire_generation(generation: &Path) {
+    let marked = Command::new("/usr/bin/python3")
+        .args([
+            "-c",
+            "import os, sys; os.setxattr(sys.argv[1], b'user.fcvm.retired', b'v1')",
+        ])
+        .arg(generation)
+        .status()
+        .expect("python3");
+    assert!(
+        marked.success(),
+        "set the retirement xattr on {} (user xattrs must be supported there)",
+        generation.display()
+    );
+}
+
+/// Is `path`'s flock free for the given mode? `flock -n` exits 42 on contention.
+fn lease_is_available(path: &Path, mode: &str) -> bool {
+    let status = Command::new("flock")
+        .args([mode, "-n", "-E", "42"])
+        .arg(path)
+        .arg("/bin/true")
+        .status()
+        .expect("probe the generation lease");
+    match status.code() {
+        Some(0) => true,
+        Some(42) => false,
+        other => panic!("lease probe on {path:?} failed for another reason: {other:?}"),
+    }
+}
+
+/// Run one recipe line through the wrapper exactly as make would (`SHELL -c
+/// '<line>'`) and hold it there. The line reports through a FIFO rather than
+/// stdout, which also carries the rotation notice from the link script.
+fn spawn_leased_recipe_line(checkout: &Path, btrfs_root: &Path, ready: &Path) -> ChildGuard {
+    ChildGuard(Some(
+        Command::new(repo_root().join("scripts/cargo-target-run.sh"))
+            .args(["-c", "printf R >\"$READY\"; IFS= read -r _"])
+            .env("BTRFS_ROOT", btrfs_root)
+            .env("CARGO_TARGET_DIR", "target")
+            .env("READY", ready)
+            .current_dir(checkout)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .spawn()
+            .expect("run a recipe line through the target lease wrapper"),
+    ))
+}
+
+/// The wrapper has to be usable as a recipe's `SHELL`, because that is the only
+/// way one lease covers a whole recipe line: make runs `$(SHELL) -c '<line>'`.
+/// The lease it holds must be SHARED, or every concurrent reader of the same
+/// generation stalls for the length of the recipe.
+#[test]
+fn cargo_target_run_wrapper_leases_a_recipe_line_shared() {
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let btrfs = tempfile::tempdir().expect("btrfs stand-in");
+    let (ok, out) = run_link(checkout.path(), btrfs.path());
+    assert!(ok, "publishing the initial generation failed:\n{out}");
+    let generation =
+        std::fs::read_link(checkout.path().join("target")).expect("published generation");
+
+    let signals = tempfile::tempdir().expect("signal directory");
+    let ready = open_fifo(&signals.path().join("recipe-line-ready"));
+    let mut child = spawn_leased_recipe_line(
+        checkout.path(),
+        btrfs.path(),
+        &signals.path().join("recipe-line-ready"),
+    );
+    assert_eq!(
+        read_marker_with_timeout(ready, "the recipe line the wrapper was given"),
+        b'R',
+        "the wrapper did not run the recipe line make hands to a SHELL"
+    );
+    assert!(
+        !lease_is_available(&generation, "-x"),
+        "no lease is held while the recipe line runs, so a concurrent make can republish \
+         target/ between one command in the recipe and the next"
+    );
+    assert!(
+        lease_is_available(&generation, "-s"),
+        "the recipe line holds the generation EXCLUSIVELY; every other reader of the same \
+         generation stalls until the line ends"
+    );
+
+    child
+        .child_mut()
+        .stdin
+        .take()
+        .expect("wrapper stdin")
+        .write_all(b"release\n")
+        .expect("release the recipe line");
+    let status = child.wait().expect("reap the wrapper");
+    assert!(status.success(), "the wrapper failed: {status:?}");
+}
+
+/// A recipe line that arrives on a retired generation rotates first and then
+/// holds the FRESH one, still shared. Handing the line an exclusive lease, or
+/// none at all, are the two ways the rotation path breaks the contract.
+#[test]
+fn cargo_target_run_wrapper_leases_a_rotated_generation_shared() {
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let btrfs = tempfile::tempdir().expect("btrfs stand-in");
+    let (ok, out) = run_link(checkout.path(), btrfs.path());
+    assert!(ok, "publishing the initial generation failed:\n{out}");
+    let retired = std::fs::read_link(checkout.path().join("target")).expect("published generation");
+    retire_generation(&retired);
+
+    let signals = tempfile::tempdir().expect("signal directory");
+    let ready = open_fifo(&signals.path().join("recipe-line-ready"));
+    let mut child = spawn_leased_recipe_line(
+        checkout.path(),
+        btrfs.path(),
+        &signals.path().join("recipe-line-ready"),
+    );
+    assert_eq!(
+        read_marker_with_timeout(ready, "the recipe line after a rotation"),
+        b'R',
+        "the wrapper did not run the recipe line after rotating a retired generation"
+    );
+    let fresh =
+        std::fs::read_link(checkout.path().join("target")).expect("read the rotated target link");
+    assert_ne!(
+        fresh, retired,
+        "the recipe line ran against the retired generation the pruner is about to empty"
+    );
+    assert!(
+        !lease_is_available(&fresh, "-x"),
+        "the rotated generation is not leased, so the rest of the recipe can be republished \
+         out from under it"
+    );
+    assert!(
+        lease_is_available(&fresh, "-s"),
+        "the rotation left the recipe line holding the fresh generation exclusively"
+    );
+
+    child
+        .child_mut()
+        .stdin
+        .take()
+        .expect("wrapper stdin")
+        .write_all(b"release\n")
+        .expect("release the recipe line");
+    let status = child.wait().expect("reap the wrapper");
+    assert!(status.success(), "the wrapper failed: {status:?}");
+}
+
+/// Logical recipe lines per target (backslash continuations joined), plus the
+/// targets whose recipe runs under the lease wrapper.
+fn makefile_recipes(makefile: &str) -> (Vec<(String, String)>, HashSet<String>) {
+    let mut recipes: Vec<(String, String)> = Vec::new();
+    let mut leased: HashSet<String> = HashSet::new();
+    let mut current: Vec<String> = Vec::new();
+    let mut pending = String::new();
+    for line in makefile.lines() {
+        if let Some(rest) = line.strip_prefix('\t') {
+            pending.push_str(rest);
+            if rest.trim_end().ends_with('\\') {
+                pending.push('\n');
+                continue;
+            }
+            for target in &current {
+                recipes.push((target.clone(), pending.clone()));
+            }
+            pending.clear();
+            continue;
+        }
+        if !pending.is_empty() {
+            for target in &current {
+                recipes.push((target.clone(), pending.clone()));
+            }
+            pending.clear();
+        }
+        let Some((names, rest)) = line.split_once(':') else {
+            current.clear();
+            continue;
+        };
+        if rest.starts_with('=') || names.starts_with(['#', ' ', '\t', '.']) {
+            current.clear();
+            continue;
+        }
+        let targets: Vec<String> = names.split_whitespace().map(str::to_owned).collect();
+        if rest.trim_start().starts_with("private SHELL") {
+            leased.extend(targets);
+            current.clear();
+            continue;
+        }
+        current = targets;
+    }
+    (recipes, leased)
+}
+
+/// Does this recipe command read or write through the `target/` symlink itself?
+///
+/// `CARGO_TARGET_DIR=target` names no path component, and `cargo-target-run.sh`
+/// is a script name, so only a `target/` preceded by a separator counts.
+fn touches_raw_target(command: &str) -> bool {
+    let body = command
+        .trim_start()
+        .trim_start_matches(['@', '-', '+'])
+        .trim_start();
+    if body.starts_with('#') {
+        return false;
+    }
+    let bytes = body.as_bytes();
+    body.match_indices("target/").any(|(at, _)| match at {
+        0 => true,
+        _ => matches!(bytes[at - 1], b' ' | b'\t' | b'/' | b'"' | b'\'' | b'='),
+    })
+}
+
+/// Every recipe line that reaches through `target/` outside Cargo must hold the
+/// generation lease while it runs.
+///
+/// `cargo-target-run.sh` leases only for the length of one Cargo process, so a
+/// concurrent `make` republishes `target/` in the gaps. `build` writes
+/// `fc-agent` through the link, copies it back through the link, and then runs
+/// the binary it just produced; a repoint in between sends the read into a
+/// generation the write never reached, and the last step is masked by
+/// `|| true`, so the recipe can report success with no `target/release/fcvm`.
+#[test]
+fn makefile_leases_every_raw_target_access() {
+    let makefile = std::fs::read_to_string(repo_root().join("Makefile")).expect("read Makefile");
+    let (recipes, leased) = makefile_recipes(&makefile);
+
+    // Positive control: the parser must find recipe lines that are known to be
+    // there, or its emptiness proves nothing.
+    assert!(
+        recipes
+            .iter()
+            .any(|(target, command)| target == "build" && command.contains("-p fcvm")),
+        "the Makefile parser found no `build` recipe; it is not reading the rules it thinks it is"
+    );
+    assert!(
+        touches_raw_target("\tcp target/$(MUSL_TARGET)/release/fc-agent target/release/fc-agent")
+            && touches_raw_target("\t@./target/release/fcvm setup")
+            && !touches_raw_target("\t@# Symlink ~/.cargo and target/ to btrfs")
+            && !touches_raw_target("\tCARGO_TARGET_DIR=target $(CARGO) build")
+            && !touches_raw_target("\t@\"$(MAKEFILE_DIR)scripts/cargo-target-run.sh\" cargo build"),
+        "the raw-target detector does not classify the known cases correctly"
+    );
+
+    let unleased: Vec<String> = recipes
+        .iter()
+        .filter(|(target, command)| touches_raw_target(command) && !leased.contains(target))
+        .map(|(target, command)| format!("{target}: {}", command.lines().next().unwrap_or("")))
+        .collect();
+    assert!(
+        unleased.is_empty(),
+        "these recipe lines reach through target/ without holding the generation lease, so a \
+         concurrent make can repoint the link underneath them: {unleased:#?}"
+    );
+
+    assert!(
+        makefile.lines().any(|line| {
+            let trimmed = line.trim_start();
+            trimmed.starts_with("TARGET_LEASE_SHELL")
+                && trimmed.contains("scripts/cargo-target-run.sh")
+        }),
+        "TARGET_LEASE_SHELL must be scripts/cargo-target-run.sh: it is the script that already \
+         implements the lease, and the one a scratch checkout that runs any cargo-bearing target \
+         already stages, so no recipe can die with `Error 127` for a shell it cannot resolve"
+    );
+    for line in makefile.lines() {
+        if let Some((_, rest)) = line.split_once(':') {
+            if rest.trim_start().starts_with("private SHELL") {
+                assert!(
+                    rest.contains("$(TARGET_LEASE_SHELL)"),
+                    "a target-specific SHELL names something other than TARGET_LEASE_SHELL: {line}"
+                );
+            }
+        }
+    }
+    let global_shell: Vec<&str> = makefile
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim_start();
+            trimmed.starts_with("SHELL=")
+                || trimmed.starts_with("SHELL =")
+                || trimmed.starts_with("SHELL :=")
+                || trimmed.starts_with("SHELL::=")
+        })
+        .filter(|line| {
+            let value = line.split_once('=').map(|(_, v)| v.trim()).unwrap_or("");
+            !matches!(value, "/bin/bash" | "/bin/sh")
+        })
+        .collect();
+    assert!(
+        global_shell.is_empty(),
+        "the Makefile-wide SHELL is something other than a plain shell. A wrapper there runs \
+         for every recipe line and every parse-time $(shell ...), including cargo-target-link \
+         itself, whose script then blocks forever on the generation lease the wrapper is \
+         already holding; and every scratch checkout that stages a partial scripts/ dies with \
+         `Error 127`: {global_shell:#?}"
+    );
+
+    let build_body = recipes
+        .iter()
+        .find(|(target, command)| target == "build" && command.contains("-p fc-agent"))
+        .map(|(_, command)| command.clone())
+        .expect("`build` has no recipe line that builds fc-agent");
+    for needed in [
+        "cp target/$(MUSL_TARGET)/release/fc-agent",
+        "./target/release/fcvm setup",
+    ] {
+        assert!(
+            build_body.contains(needed),
+            "`{needed}` is not in the same recipe line as the cargo commands that produce what \
+             it reads. One recipe line is one shell and one lease; a separate line takes a new \
+             lease, and the link can be repointed in between:\n{build_body}"
+        );
+    }
+}
+
+/// The identity `make` must run as when this binary is root: the Makefile
+/// refuses root on the host, so the privileged lane hands its children back to
+/// the user sudo recorded. Same constraint as tests/test_dep_provenance.rs.
+fn make_child_identity() -> Option<(u32, u32)> {
+    if unsafe { libc::geteuid() } != 0
+        || Path::new("/.dockerenv").exists()
+        || Path::new("/run/.containerenv").exists()
+    {
+        return None;
+    }
+    let parse = |key: &str| -> Option<u32> { std::env::var(key).ok()?.parse().ok() };
+    match (parse("SUDO_UID"), parse("SUDO_GID")) {
+        (Some(uid), Some(gid)) => Some((uid, gid)),
+        _ => panic!(
+            "BLOCKED: running as root on a host with no SUDO_UID/SUDO_GID; the Makefile refuses \
+             root and this test has no user to hand make to"
+        ),
+    }
+}
+
+fn hand_tree_to_make_child(root: &Path) {
+    let Some((uid, gid)) = make_child_identity() else {
+        return;
+    };
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        std::os::unix::fs::chown(&path, Some(uid), Some(gid))
+            .unwrap_or_else(|error| panic!("chown {}: {error}", path.display()));
+        if path.is_dir() && !path.is_symlink() {
+            for entry in std::fs::read_dir(&path).expect("read scratch dir") {
+                stack.push(entry.expect("scratch entry").path());
+            }
+        }
+    }
+}
+
+fn scratch_make(fcvm_dir: &Path, btrfs_root: &Path, args: &[&str]) -> Command {
+    let mut command = Command::new("make");
+    command
+        .arg("-C")
+        .arg(fcvm_dir)
+        .args(args)
+        .env("BTRFS_ROOT", btrfs_root)
+        .env_remove("MAKEFLAGS")
+        .env_remove("MFLAGS")
+        .env_remove("CARGO_TARGET_LINK_LOCKED");
+    if let Some((uid, gid)) = make_child_identity() {
+        use std::os::unix::process::CommandExt;
+        command.uid(uid).gid(gid);
+    }
+    command
+}
+
+fn write_script(path: &Path, body: &str) {
+    std::fs::write(path, body).unwrap_or_else(|error| panic!("write {}: {error}", path.display()));
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).expect("chmod 755");
+}
+
+fn open_fifo(path: &Path) -> std::fs::File {
+    let status = Command::new("mkfifo").arg(path).status().expect("mkfifo");
+    assert!(status.success(), "mkfifo {path:?} failed: {status:?}");
+    // Read+write so neither end blocks on open and a write outlives its reader.
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .unwrap_or_else(|error| panic!("open {path:?}: {error}"))
+}
+
+/// `build` produces `fc-agent` through the link, copies it back through the
+/// link, and runs the binary it just built. One shared lease has to cover all
+/// of that: `cargo-target-run.sh` releases when each Cargo process exits, and a
+/// concurrent `make` waiting to republish `target/` is granted the exclusive
+/// lease in that gap. The copy then reads a generation the build never wrote,
+/// and `2>/dev/null || true` on the last step turns the missing binary into a
+/// successful `make build`.
+///
+/// The lease is observed, not inferred: a helper blocks on the exclusive lease
+/// from the moment the first Cargo process is about to exit, and must still be
+/// blocked when the recipe reaches its last raw `target/` access. The final
+/// assertion that it acquires once `make` returns is the control -- without it
+/// a helper that never ran would pass.
+#[test]
+fn make_build_holds_one_generation_lease_across_the_whole_recipe() {
+    assert!(
+        Command::new("make").arg("--version").output().is_ok(),
+        "BLOCKED: `make` is not runnable, so this test cannot evaluate the recipe it guards"
+    );
+    let scratch = tempfile::tempdir().expect("scratch tempdir");
+    std::fs::set_permissions(scratch.path(), std::fs::Permissions::from_mode(0o755))
+        .expect("chmod 755");
+    let fcvm_dir = scratch.path().join("fcvm");
+    let btrfs = scratch.path().join("btrfs");
+    let signals = scratch.path().join("signals");
+    let tools = scratch.path().join("tools");
+    for directory in [&fcvm_dir.join("scripts"), &btrfs, &signals, &tools] {
+        std::fs::create_dir_all(directory).expect("scratch layout");
+    }
+    std::fs::copy(repo_root().join("Makefile"), fcvm_dir.join("Makefile")).expect("Makefile");
+    for name in [
+        "cargo-target-link.sh",
+        "cargo-target-run.sh",
+        "cargo-target-lib.sh",
+    ] {
+        let destination = fcvm_dir.join("scripts").join(name);
+        std::fs::copy(repo_root().join("scripts").join(name), &destination).expect(name);
+        std::fs::set_permissions(&destination, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod 755");
+    }
+
+    let cargo_ready_path = signals.join("cargo-ready");
+    let cargo_release_path = signals.join("cargo-release");
+    let fcvm_ready_path = signals.join("fcvm-ready");
+    let fcvm_release_path = signals.join("fcvm-release");
+    let cargo_ready = open_fifo(&cargo_ready_path);
+    let mut cargo_release = open_fifo(&cargo_release_path);
+    let fcvm_ready = open_fifo(&fcvm_ready_path);
+    let mut fcvm_release = open_fifo(&fcvm_release_path);
+    let marker = signals.join("exclusive-lease-was-granted");
+
+    let stub_fcvm = tools.join("fcvm-stub");
+    write_script(
+        &stub_fcvm,
+        "#!/usr/bin/env bash\n\
+         printf F >\"$FCVM_READY\"\n\
+         IFS= read -r _ <\"$FCVM_RELEASE\"\n",
+    );
+    let stub_cargo = tools.join("cargo-stub");
+    write_script(
+        &stub_cargo,
+        "#!/usr/bin/env bash\n\
+         set -euo pipefail\n\
+         dir=\"${CARGO_TARGET_DIR:-target}\"\n\
+         package=\"\"; triple=\"\"; previous=\"\"\n\
+         for argument in \"$@\"; do\n\
+           case \"$previous\" in\n\
+             -p) package=\"$argument\" ;;\n\
+             --target) triple=\"$argument\" ;;\n\
+           esac\n\
+           previous=\"$argument\"\n\
+         done\n\
+         out=\"$dir/release\"\n\
+         [ -z \"$triple\" ] || out=\"$dir/$triple/release\"\n\
+         mkdir -p \"$out\"\n\
+         if [ \"$package\" = fcvm ]; then\n\
+           cp \"$STUB_FCVM\" \"$out/fcvm\"\n\
+           chmod 755 \"$out/fcvm\"\n\
+           printf C >\"$CARGO_READY\"\n\
+           IFS= read -r _ <\"$CARGO_RELEASE\"\n\
+         else\n\
+           printf agent >\"$out/$package\"\n\
+         fi\n",
+    );
+
+    hand_tree_to_make_child(scratch.path());
+    let published = scratch_make(&fcvm_dir, &btrfs, &["cargo-target-link"])
+        .output()
+        .expect("publish the generation");
+    assert!(
+        published.status.success(),
+        "make cargo-target-link failed in the scratch checkout:\n{}{}",
+        String::from_utf8_lossy(&published.stdout),
+        String::from_utf8_lossy(&published.stderr)
+    );
+    let generation =
+        std::fs::read_link(fcvm_dir.join("target")).expect("the scratch checkout has no link");
+
+    hand_tree_to_make_child(scratch.path());
+    let build_log = scratch.path().join("make-build.log");
+    let build = ChildGuard(Some(
+        scratch_make(&fcvm_dir, &btrfs, &["build"])
+            .env("CARGO_BIN", &stub_cargo)
+            .env("STUB_FCVM", &stub_fcvm)
+            .env("CARGO_READY", &cargo_ready_path)
+            .env("CARGO_RELEASE", &cargo_release_path)
+            .env("FCVM_READY", &fcvm_ready_path)
+            .env("FCVM_RELEASE", &fcvm_release_path)
+            .stdout(std::fs::File::create(&build_log).expect("build log"))
+            .stderr(
+                std::fs::File::options()
+                    .append(true)
+                    .open(&build_log)
+                    .expect("build log"),
+            )
+            .spawn()
+            .expect("spawn make build"),
+    ));
+    let log = || std::fs::read_to_string(&build_log).unwrap_or_default();
+
+    assert_eq!(
+        read_marker_with_timeout(cargo_ready, "the first Cargo process"),
+        b'C',
+        "make build never reached its first cargo command:\n{}",
+        log()
+    );
+    let mut waiter = ChildGuard(Some(
+        Command::new("/bin/bash")
+            .args([
+                "-c",
+                "exec {fd}<\"$1\"; printf W; flock -x \"$fd\"; : >\"$2\"",
+                "lease-waiter",
+            ])
+            .arg(&generation)
+            .arg(&marker)
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn the exclusive-lease waiter"),
+    ));
+    let waiter_stdout = waiter.child_mut().stdout.take().expect("waiter stdout");
+    assert_eq!(
+        read_marker_with_timeout(waiter_stdout, "the exclusive-lease waiter"),
+        b'W',
+        "the waiter never reached its blocking flock, so it proves nothing"
+    );
+
+    cargo_release
+        .write_all(b"go\n")
+        .expect("release the first cargo command");
+    assert_eq!(
+        read_marker_with_timeout(fcvm_ready, "the binary the recipe just built"),
+        b'F',
+        "make build never ran the binary its own recipe produced:\n{}",
+        log()
+    );
+    assert!(
+        !marker.exists(),
+        "the generation lease was released between the recipe's cargo commands and its last \
+         raw target/ access, so a concurrent make can repoint target/ in that window and the \
+         recipe reads a tree its own build never wrote:\n{}",
+        log()
+    );
+    fcvm_release
+        .write_all(b"go\n")
+        .expect("release the recipe's last step");
+
+    let status = build.wait().expect("reap make build");
+    assert!(status.success(), "make build failed:\n{}", log());
+    assert_eq!(
+        std::fs::read(generation.join("release/fc-agent"))
+            .ok()
+            .as_deref(),
+        Some(b"agent".as_slice()),
+        "the recipe did not leave fc-agent in the generation it held:\n{}",
+        log()
+    );
+    // Control: the waiter was genuinely blocked on the lease, not broken.
+    wait_for_path(&marker);
+    let status = waiter.wait().expect("reap the lease waiter");
+    assert!(status.success(), "the lease waiter failed: {status:?}");
+}
+
+/// The lease wrapper must not become a requirement of recipes that scratch
+/// checkouts run.
+///
+/// tests/test_dep_provenance.rs stages a checkout holding the Makefile and at
+/// most two scripts. A Makefile-wide `SHELL` pointed at a wrapper script kills
+/// every recipe line in such a tree with `Error 127`, including targets that
+/// never touch `target/`. This is the same staging, run from this binary, so a
+/// filtered run of these tests cannot miss it.
+#[test]
+fn scratch_checkouts_still_run_the_targets_that_stage_no_scripts() {
+    assert!(
+        Command::new("make").arg("--version").output().is_ok(),
+        "BLOCKED: `make` is not runnable, so this test cannot evaluate the recipes it guards"
+    );
+    let scratch = tempfile::tempdir().expect("scratch tempdir");
+    std::fs::set_permissions(scratch.path(), std::fs::Permissions::from_mode(0o755))
+        .expect("chmod 755");
+    let fcvm_dir = scratch.path().join("fcvm");
+    let btrfs = scratch.path().join("btrfs");
+    std::fs::create_dir_all(fcvm_dir.join("scripts")).expect("scratch layout");
+    std::fs::create_dir_all(&btrfs).expect("btrfs stand-in");
+    std::fs::copy(repo_root().join("Makefile"), fcvm_dir.join("Makefile")).expect("Makefile");
+    hand_tree_to_make_child(scratch.path());
+
+    // Exactly what dep_provenance_reports_describe_lock_source_and_missing
+    // stages: the Makefile and nothing else.
+    let out = scratch_make(&fcvm_dir, &btrfs, &["dep-provenance"])
+        .output()
+        .expect("run make dep-provenance");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        out.status.success() && text.contains("fuse-backend-rs: "),
+        "make dep-provenance needs a script this checkout does not stage:\n{text}"
+    );
+
+    // And what mid_build_dependency_change_fails_the_build stages: two stubs,
+    // one of which stands in for every cargo command.
+    write_script(
+        &fcvm_dir.join("scripts/cargo-target-link.sh"),
+        "#!/usr/bin/env bash\nexit 0\n",
+    );
+    write_script(
+        &fcvm_dir.join("scripts/cargo-target-run.sh"),
+        "#!/usr/bin/env bash\necho \"stub cargo: $*\"\n",
+    );
+    hand_tree_to_make_child(scratch.path());
+    let out = scratch_make(&fcvm_dir, &btrfs, &["build-host-tools"])
+        .output()
+        .expect("run make build-host-tools");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        out.status.success() && text.contains("stub cargo: "),
+        "make build-host-tools needs a script this checkout does not stage:\n{text}"
     );
 }

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -3743,6 +3743,196 @@ fn cargo_target_link_refuses_to_reclaim_a_payload_owned_by_another_user() {
     );
 }
 
+/// Run the script with the reclaim's ownership check and its open of `victim`
+/// separated by a rename, so the descriptor the reclaim goes on to prune is
+/// never the directory that check approved.
+///
+/// The interleave is by construction, not by timing: the swap runs inside the
+/// `os.stat` call whose result the ownership check reads, so the open that
+/// follows can only ever see the replacement. The hook is a `sitecustomize`
+/// module on `PYTHONPATH`, which CPython imports before it runs the reclaim, so
+/// the script, its walk and its removal are the real ones.
+fn run_link_with_payload_swapped_after_its_check(
+    dir: &Path,
+    btrfs_root: &Path,
+    victim: &str,
+    replacement: &Path,
+) -> (bool, String) {
+    let hook_dir = tempfile::tempdir().expect("hook tempdir");
+    std::fs::set_permissions(hook_dir.path(), std::fs::Permissions::from_mode(0o755))
+        .expect("0755");
+    let checkout = dir.to_string_lossy().into_owned();
+    let replacement_path = replacement.to_string_lossy().into_owned();
+    let program = format!(
+        r#"import os
+
+_real_stat = os.stat
+_checkout = {checkout:?}
+_victim = {victim:?}
+_replacement = {replacement_path:?}
+_moved_aside = os.path.join(_checkout, "payload-moved-aside")
+_marker = os.path.join(_checkout, "swap-performed")
+
+
+def _stat(path, *args, dir_fd=None, follow_symlinks=True, **kwargs):
+    info = _real_stat(path, *args, dir_fd=dir_fd, follow_symlinks=follow_symlinks, **kwargs)
+    if dir_fd is not None and path == _victim and not os.path.lexists(_marker):
+        os.rename(os.path.join(_checkout, _victim), _moved_aside)
+        os.rename(_replacement, os.path.join(_checkout, _victim))
+        with open(_marker, "w") as handle:
+            handle.write("swapped\n")
+    return info
+
+
+os.stat = _stat
+"#
+    );
+    std::fs::write(hook_dir.path().join("sitecustomize.py"), program).expect("write the hook");
+    let out = Command::new(repo_root().join("scripts/cargo-target-link.sh"))
+        .env("BTRFS_ROOT", btrfs_root)
+        .env("PYTHONPATH", hook_dir.path())
+        .env_remove("CARGO_TARGET_LINK_LOCKED")
+        .current_dir(dir)
+        .output()
+        .expect("run scripts/cargo-target-link.sh");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (out.status.success(), text)
+}
+
+/// Assert the swapped-in tree came through the run whole.
+fn assert_bystander_survived(swapped: &Path, before: &std::fs::Metadata, out: &str) {
+    assert!(
+        swapped.is_dir(),
+        "the reclaim removed {swapped:?}, the tree renamed onto the payload name after the \
+         ownership check approved a different directory:\n{out}"
+    );
+    let sentinel = swapped.join("must-survive");
+    let contents = std::fs::read(&sentinel).unwrap_or_else(|error| {
+        panic!(
+            "the reclaim pruned {sentinel:?}, so a tree its ownership check never saw was \
+             erased: {error}\n{out}"
+        )
+    });
+    assert_eq!(
+        contents, b"a tree the reclaim never checked",
+        "the reclaim rewrote the contents of a tree its ownership check never saw:\n{out}"
+    );
+    let after = std::fs::symlink_metadata(swapped).expect("stat the swapped-in tree");
+    assert_eq!(
+        (after.dev(), after.ino()),
+        (before.dev(), before.ino()),
+        "the swapped-in tree was removed and something else took its name; the reclaim acted \
+         on it under a check made about a different inode:\n{out}"
+    );
+}
+
+/// A payload's ownership check and the open that follows are two separate
+/// resolutions of one pathname. A rename in between hands the reclaim a
+/// descriptor for a directory nothing checked, and the comparison further down
+/// only proves the pathname still names that replacement, so its tree is pruned
+/// and removed on the strength of a check made about a different inode.
+#[test]
+fn cargo_target_link_refuses_a_payload_whose_identity_changed_before_it_was_opened() {
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let btrfs = tempfile::tempdir().expect("btrfs stand-in");
+    let victim_name = ".cargo-target-local.generation-victim";
+    std::fs::create_dir(checkout.path().join(victim_name)).expect("unpublished payload");
+    let bystander = checkout.path().join("bystander");
+    std::fs::create_dir(&bystander).expect("bystander tree");
+    std::fs::write(
+        bystander.join("must-survive"),
+        b"a tree the reclaim never checked",
+    )
+    .expect("write the bystander sentinel");
+    let before = std::fs::symlink_metadata(&bystander).expect("stat the bystander");
+
+    let (ok, out) = run_link_with_payload_swapped_after_its_check(
+        checkout.path(),
+        btrfs.path(),
+        victim_name,
+        &bystander,
+    );
+
+    assert!(
+        checkout.path().join("swap-performed").is_file(),
+        "the swap never happened, so this run says nothing about the window it is about:\n{out}"
+    );
+    let swapped = checkout.path().join(victim_name);
+    assert_bystander_survived(&swapped, &before, &out);
+    assert!(
+        out.contains(&swapped.display().to_string()),
+        "a payload the reclaim refused was passed over without naming it:\n{out}"
+    );
+    assert!(
+        out.contains("changed identity"),
+        "the refusal does not say why the payload was left alone:\n{out}"
+    );
+    assert!(
+        !ok,
+        "the run reported success while a payload it owns went unreclaimed; nothing else \
+         enumerates it and its name is never published again:\n{out}"
+    );
+}
+
+/// The same window, defeating the guard it exists for. A payload owned by
+/// another uid is never removed, and the container lane runs as root against
+/// the same bind-mounted checkout, so root is not stopped by permissions once
+/// the check has been made about a different inode.
+#[cfg(feature = "privileged-tests")]
+#[test]
+fn cargo_target_link_refuses_a_payload_swapped_for_another_users_tree() {
+    assert!(
+        nix_geteuid_is_root(),
+        "BLOCKED: this fixture needs root to stage a tree owned by another uid"
+    );
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let btrfs = tempfile::tempdir().expect("btrfs stand-in");
+    let victim_name = ".cargo-target-local.generation-victim";
+    std::fs::create_dir(checkout.path().join(victim_name)).expect("unpublished payload");
+    let foreign = checkout.path().join("another-identitys-tree");
+    std::fs::create_dir(&foreign).expect("foreign tree");
+    std::fs::write(
+        foreign.join("must-survive"),
+        b"a tree the reclaim never checked",
+    )
+    .expect("write the foreign sentinel");
+    let chowned = Command::new("chown")
+        .args(["-R", "65534:65534"])
+        .arg(&foreign)
+        .status()
+        .expect("chown -R");
+    assert!(chowned.success(), "hand the foreign tree to uid 65534");
+    let before = std::fs::symlink_metadata(&foreign).expect("stat the foreign tree");
+
+    let (ok, out) = run_link_with_payload_swapped_after_its_check(
+        checkout.path(),
+        btrfs.path(),
+        victim_name,
+        &foreign,
+    );
+
+    assert!(
+        checkout.path().join("swap-performed").is_file(),
+        "the swap never happened, so this run says nothing about the window it is about:\n{out}"
+    );
+    let swapped = checkout.path().join(victim_name);
+    assert_bystander_survived(&swapped, &before, &out);
+    assert!(
+        out.contains(&swapped.display().to_string()) && out.contains("65534"),
+        "the run erased or passed over another identity's tree without naming it and the uid \
+         that owns it:\n{out}"
+    );
+    assert!(
+        !ok,
+        "the run reported success while a payload it owns went unreclaimed; nothing else \
+         enumerates it and its name is never published again:\n{out}"
+    );
+}
+
 /// A payload this identity owns and cannot reclaim fails the run.
 ///
 /// It is on the root filesystem, nothing else enumerates it, and its name is


### PR DESCRIPTION
The six findings in #876, each closed by a test watched failing against the unfixed tree first.

**Mount and owner bounds on the reclaim (finding 1).** `rm -rf` descends into whatever is mounted under a fallback payload and unlinks it. The payload sits in the checkout for the length of a volume outage, which is when such a mount can appear. Reclamation now walks fd-relative with `openat2` under `RESOLVE_BENEATH|NO_XDEV|NO_SYMLINKS` and refuses a child whose device differs, which is the same refusal a file bind mount gets. A payload owned by another uid is never removed, because the container lane runs as root against the same bind-mounted checkout and root is not stopped by permissions.

**errno preserved, so an unreadable target is not mistaken for an absent one (finding 2).** `[ -d target ]` was false both when `target` was absent and when its resolution was refused. Only the first makes replacing the link safe, since a build past the checkout lock holds nothing but its generation lease. A helper now preserves errno: `ENOENT` and `ENOTDIR` prove absence, anything else fails closed. It is used in `drop_managed_link` and in the publish path, which had the same conflation.

**`--rotate` refuses an unretired generation it cannot write (finding 3).** Rotation could report a clean namespace while a generation still held its payload unretired. The next run reuses that generation and republishes every byte the clean said was gone. The fallback now refuses unless every generation in this checkout's managed namespace is durably retired or proven absent.

**One lease per recipe (finding 4).** `cargo-target-run.sh` leases the published generation for the length of one Cargo process. `build` writes fc-agent through `target/`, copies it back, and then runs the binary it produced, so a concurrent `make` waiting to republish `target/` is granted the exclusive lease the moment a Cargo process exits, and the copy can read a generation the build never wrote. `|| true` on the last step then turns the missing binary into a successful `make build`. The wrapper now accepts `-c <line>`, which is how make invokes a `SHELL`, and the twelve recipes that reach through `target/` outside Cargo name it as a target-specific `SHELL`. `build`'s cargo commands, the copy and the config sync are one recipe line, so one lease spans all of them, and `test -x target/release/fcvm` states that the binary must exist. `makefile_leases_every_raw_target_access` pins that no raw `target/` access is left outside a lease.

**Reclaim failures are no longer silent (finding 5).** `[ -d ]` and a bare `|| continue` skipped an unopenable payload without a word. Every outcome is now named. A payload this identity owns and could not reclaim fails the run, because nothing else enumerates it and its name is never published again, so no later run clears it either. A foreign-owned one is reported and kept rather than failing, which would leave a checkout shared by the host user and the container root unable to build at all.

**The retention test asserts contents (finding 6).** The unwritable-volume retention test asserted only that `target/` is a directory, so a delete-and-recreate passed it. It now carries a sentinel and asserts device, inode and contents. All three matter: a delete-and-recreate reuses the same inode number here, so the sentinel is what catches it.

## The Makefile-wide SHELL was tried and rejected

A single `SHELL := scripts/cargo-target-run.sh` for the whole Makefile is the obvious shape and it does not work. It governs parse-time `$(shell ...)` and every recipe of every target, so `cargo-target-link` itself runs under the wrapper, and its script then blocks forever on the generation lease the wrapper is already holding (observed: `flock <checkout> cargo-target-link.sh` stuck until killed). It also reaches the scratch checkouts that `tests/test_dep_provenance.rs` stages with a partial `scripts/` directory, where every recipe line dies with `Error 127`, including targets that never touch `target/`. `private` on the target-specific `SHELL` keeps the wrapper off the prerequisites, whose recipes run before `target/` exists.

Both regressions are covered by tests in `tests/test_cargo_target_link.rs`, so they run with the rest of that binary and a filtered run cannot skip them: `make_build_holds_one_generation_lease_across_the_whole_recipe` blocks a helper on the exclusive lease from the moment the first Cargo process is about to exit and requires it still blocked at the recipe's last raw `target/` access, and `scratch_checkouts_still_run_the_targets_that_stage_no_scripts` stages exactly what the dep-provenance tests stage and runs `dep-provenance` and `build-host-tools` in it.

One behaviour note for reviewers: `build`'s recipe references `$(MAKE)`, so GNU make executes that line even under `-n`, which is why `make -n build` really builds. That was already true on main; folding the config sync onto the same line means `make -n build` now also syncs the config.

## Test evidence

```
make test-unit                                                913 tests run: 913 passed, 0 skipped
make test-root FILTER="-E 'binary(test_cargo_target_link)'"   63 tests run: 63 passed, 0 skipped
make test-unit FILTER="-E 'binary(test_dep_provenance)'"      3 tests run: 3 passed, 0 skipped
make lint                                                     exit 0 (advisories ok, bans ok, licenses ok, sources ok)
bash -n / shellcheck -S warning on scripts/cargo-target-link.sh, scripts/cargo-target-run.sh   clean
make -n build, make -n clean, make dep-provenance             exit 0
```

The full `make test-unit` matters here: a filtered run is what let a regression through on an earlier round.

Rebased onto main at f64ed5cf. The Makefile merged with main's `STALL_MAX_MS` change to `analyze-chromium-request`, which is a different recipe and is unchanged by this branch.

Closes #876.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd
