### PR TITLE
check-review-threads: a recheck page that cannot be read blocks instead of emptying the list

### DIFF
--- a/scripts/check-review-threads.sh
+++ b/scripts/check-review-threads.sh
@@ -103,6 +103,41 @@ THREAD_FP_JQ='[ .[] | {id, isResolved, isOutdated, total: (.comments.totalCount 
                                                          line, originalLine, body: (.body // null)} ]} ]
   | sort_by(.id | tostring)'
 
+# Every paging loop below folds a page in with `<connection>.nodes // []` and then reads
+# `hasNextPage` from that same page. Both readings turn a response the loop CANNOT READ into
+# "this connection is empty and it is finished": a null `pullRequest` (a wrong number, a
+# renamed repo, a token that cannot see the PR, a partial GraphQL result) contributes no
+# nodes, and hasNextPage evaluates to null rather than "true", so the loop stops holding [].
+# `[]` is indistinguishable from a connection that is genuinely empty, and the verdict is
+# then computed from a list nobody fetched. That is the gate's recurring fail-open shape: a
+# check that could not evaluate anything reporting that it found nothing. On the recheck
+# comments loop it dropped every top-level claim while the run reported CLEAR (#882).
+#
+# So no page is folded in before this says it can be read: parsable JSON, a pullRequest that
+# is there, the named connection present, a `nodes` array, and a boolean `hasNextPage`.
+# Anything else blocks with a reason and returns 2, the code this gate already uses for
+# "cannot evaluate". It prints to stderr because the fetchers' stdout is the payload.
+require_page() {
+  local resp=$1 path=$2 what=$3 pr=${4:-} why=""
+  if ! jq -e 'type == "object"' >/dev/null 2>&1 <<<"$resp"; then
+    why="the response is not JSON this gate can read"
+  elif [[ $path == data.repository.pullRequest.* ]] \
+       && [ "$(jq -r '.data.repository.pullRequest // "null"' <<<"$resp")" = "null" ]; then
+    why="no pull request #$pr in $REPO_OWNER/$REPO_NAME (or it is not visible to this token)"
+  elif ! jq -e --arg p "$path" 'getpath($p | split("."))
+         | type == "object" and (.nodes | type) == "array"
+         and (.pageInfo.hasNextPage | type) == "boolean"' >/dev/null 2>&1 <<<"$resp"; then
+    why="the page carries no nodes array and no boolean hasNextPage"
+  else
+    return 0
+  fi
+  echo "verdict: BLOCKED — could not read $what: $why." >&2
+  echo "A page this gate could not read is not an empty page. Folding one in as [] is" >&2
+  echo "indistinguishable from a connection that is genuinely empty, so this run refuses" >&2
+  echo "to report a verdict computed from a list nobody fetched." >&2
+  return 2
+}
+
 # ONE read of the PR's review threads: every thread, every comment, with each oversized
 # thread's comments paged to the end. Prints the thread array on stdout; says why and
 # returns non-zero when a page could not be fetched. fetch_payload calls it TWICE, and the
@@ -133,11 +168,7 @@ fetch_threads() {
     # pullRequest with no GraphQL error. Coalescing that to [] turned "I could not find
     # this PR" into "this PR has nothing to answer" and exited CLEAR. A gate that cannot
     # find its subject must block, never bless it.
-    if [ "$(jq -r '.data.repository.pullRequest // "null"' <<<"$resp")" = "null" ]; then
-      echo "verdict: BLOCKED — no pull request #$pr in $REPO_OWNER/$REPO_NAME (or it is" >&2
-      echo "not visible to this token). Refusing to report CLEAR for a PR never read." >&2
-      return 2
-    fi
+    require_page "$resp" data.repository.pullRequest.reviewThreads "the review threads" "$pr" || return 2
 
     threads=$(jq -s '.[0] + (.[1].data.repository.pullRequest.reviewThreads.nodes // [])' \
           <(echo "$threads") <(echo "$resp"))
@@ -176,6 +207,11 @@ fetch_threads() {
         echo "verdict: BLOCKED — could not page comments for thread $tid." >&2
         return 1
       }
+      # A node the query cannot resolve (a deleted thread, an id this token cannot see)
+      # comes back as a null `node`, which folded in as an empty page and read hasNextPage
+      # as null: the loop ended and the thread was judged from the pages fetched so far,
+      # exactly the truncation the failure branch above refuses to accept.
+      require_page "$cresp" data.node.comments "the comments page for thread $tid" || return 2
       all_comments=$(jq -c -s '.[0] + (.[1].data.node.comments.nodes // [])' \
         <(echo "$all_comments") <(echo "$cresp"))
       if [ "$(jq -r '.data.node.comments.pageInfo.hasNextPage' <<<"$cresp")" = "true" ]; then
@@ -214,11 +250,7 @@ fetch_payload() {
               pageInfo { hasNextPage endCursor }
               nodes { author { login } state body submittedAt commit { oid } }
             } } } }" 2>/dev/null) || return 1
-    if [ "$(jq -r '.data.repository.pullRequest // "null"' <<<"$rresp")" = "null" ]; then
-      echo "verdict: BLOCKED — no pull request #$pr in $REPO_OWNER/$REPO_NAME (or it is" >&2
-      echo "not visible to this token). Refusing to report CLEAR for a PR never read." >&2
-      return 2
-    fi
+    require_page "$rresp" data.repository.pullRequest.reviews "the reviews" "$pr" || return 2
     reviews=$(jq -s '.[0] + (.[1].data.repository.pullRequest.reviews.nodes // [])' \
           <(echo "$reviews") <(echo "$rresp"))
     prauthor=$(jq -r '.data.repository.pullRequest.author.login // ""' <<<"$rresp")
@@ -247,6 +279,7 @@ fetch_payload() {
               pageInfo { hasNextPage endCursor }
               nodes { commit { oid } }
             } } } }" 2>/dev/null) || return 1
+    require_page "$pcresp" data.repository.pullRequest.commits "the PR's commit list" "$pr" || return 2
     prcommits=$(jq -s '.[0] + (.[1].data.repository.pullRequest.commits.nodes // [])' \
           <(echo "$prcommits") <(echo "$pcresp"))
     prcommitcount=$(jq -r '.data.repository.pullRequest.commits.totalCount // "null"' <<<"$pcresp")
@@ -268,6 +301,7 @@ fetch_payload() {
               pageInfo { hasNextPage endCursor }
               nodes { author { login __typename } body createdAt updatedAt }
             } } } }" 2>/dev/null) || return 1
+    require_page "$cresp2" data.repository.pullRequest.comments "the top-level comments" "$pr" || return 2
     prcomments=$(jq -s '.[0] + (.[1].data.repository.pullRequest.comments.nodes // [])' \
           <(echo "$prcomments") <(echo "$cresp2"))
     [ "$(jq -r '.data.repository.pullRequest.comments.pageInfo.hasNextPage' <<<"$cresp2")" = "true" ] || break
@@ -294,6 +328,7 @@ fetch_payload() {
               pageInfo { hasNextPage endCursor }
               nodes { author { login __typename } body createdAt updatedAt }
             } } } }" 2>/dev/null) || return 1
+    require_page "$rc2resp" data.repository.pullRequest.comments "the second read of the top-level comments" "$pr" || return 2
     recheckcomments=$(jq -s '.[0] + (.[1].data.repository.pullRequest.comments.nodes // [])' \
           <(echo "$recheckcomments") <(echo "$rc2resp"))
     [ "$(jq -r '.data.repository.pullRequest.comments.pageInfo.hasNextPage' <<<"$rc2resp")" = "true" ] || break
@@ -317,6 +352,7 @@ fetch_payload() {
               pageInfo { hasNextPage endCursor }
               nodes { author { login } state body submittedAt commit { oid } }
             } } } }" 2>/dev/null) || return 1
+    require_page "$rv2resp" data.repository.pullRequest.reviews "the second read of the reviews" "$pr" || return 2
     rv2=$(jq -s '.[0] + (.[1].data.repository.pullRequest.reviews.nodes // [])' \
           <(echo "$rv2") <(echo "$rv2resp"))
     [ "$(jq -r '.data.repository.pullRequest.reviews.pageInfo.hasNextPage' <<<"$rv2resp")" = "true" ] || break
@@ -354,7 +390,16 @@ fetch_payload() {
     { repository(owner: \"$REPO_OWNER\", name: \"$REPO_NAME\") {
         pullRequest(number: $pr) { headRefOid } } }" \
     --jq '.data.repository.pullRequest.headRefOid' 2>/dev/null) || return 1
-  if [ -n "$headnow" ] && [ "$headnow" != "$headoid" ]; then
+  # `--jq` prints an EMPTY line when its filter lands on a null pullRequest, and the check
+  # used to skip on an empty result: the one read that exists to catch a push landing
+  # mid-run was disabled by precisely the response that says the gate could not see the PR.
+  if [ -z "$headnow" ] || [ "$headnow" = "null" ]; then
+    echo "verdict: BLOCKED — the re-read of the head named no commit, so this gate cannot" >&2
+    echo "tell whether a push landed while it was reading the PR. Re-run against a PR this" >&2
+    echo "token can see." >&2
+    return 2
+  fi
+  if [ "$headnow" != "$headoid" ]; then
     echo "verdict: BLOCKED — the head moved from ${headoid:0:9} to ${headnow:0:9} while this" >&2
     echo "gate was reading the PR. Re-run against a branch that is holding still." >&2
     return 2

--- a/scripts/check-review-threads.sh
+++ b/scripts/check-review-threads.sh
@@ -128,10 +128,24 @@ require_page() {
          | type == "object" and (.nodes | type) == "array"
          and (.pageInfo.hasNextPage | type) == "boolean"' >/dev/null 2>&1 <<<"$resp"; then
     why="the page carries no nodes array and no boolean hasNextPage"
+  # hasNextPage without a cursor is the same hole one field over: the page says another
+  # page follows and names nothing to fetch it with. `jq -r` renders a null endCursor as
+  # the STRING "null", which is the outer loops' own "no cursor yet" sentinel, so the next
+  # request omits `after` and asks for the FIRST page again, and the same page answers
+  # forever. An empty cursor sends `after: ""`. The oversized-thread loop tests the cursor
+  # for "null"/empty as its exit condition instead, so it ENDS and the thread is judged
+  # from the pages that did arrive. A literal "null" is rejected for the same reason a null
+  # is: the call sites cannot tell it apart from the sentinel.
+  elif ! jq -e --arg p "$path" 'getpath($p | split("."))
+         | .pageInfo.hasNextPage == false
+           or ((.pageInfo.endCursor | type) == "string"
+               and (.pageInfo.endCursor | length) > 0
+               and .pageInfo.endCursor != "null")' >/dev/null 2>&1 <<<"$resp"; then
+    why="the page says another page follows and names no cursor to fetch it with"
   else
     return 0
   fi
-  echo "verdict: BLOCKED — could not read $what: $why." >&2
+  echo "verdict: BLOCKED. Could not read $what: $why." >&2
   echo "A page this gate could not read is not an empty page. Folding one in as [] is" >&2
   echo "indistinguishable from a connection that is genuinely empty, so this run refuses" >&2
   echo "to report a verdict computed from a list nobody fetched." >&2
@@ -195,6 +209,17 @@ fetch_threads() {
       '.[] | select(.id == $id) | .comments.pageInfo.endCursor // "null"' <<<"$threads")
     all_comments=$(jq -c --arg id "$tid" \
       '.[] | select(.id == $id) | .comments.nodes' <<<"$threads")
+    # require_page checked the reviewThreads page; this cursor comes from a comments
+    # connection nested INSIDE one of its nodes, which that check does not reach. The
+    # thread is here because it holds more comments than one page, so a cursor the loop
+    # cannot use means the tail can never be asked for, and the loop below would simply
+    # not run.
+    if [ "$ccursor" = "null" ] || [ -z "$ccursor" ]; then
+      echo "verdict: BLOCKED. Cannot page thread $tid: it holds more comments than one" >&2
+      echo "page and its first page names no cursor to fetch the rest with. A thread judged" >&2
+      echo "from the comments that did arrive is a thread nobody finished reading." >&2
+      return 2
+    fi
     while [ "$ccursor" != "null" ] && [ -n "$ccursor" ]; do
       cresp=$(gh api graphql -f query="
         { node(id: \"$tid\") { ... on PullRequestReviewThread {
@@ -394,7 +419,7 @@ fetch_payload() {
   # used to skip on an empty result: the one read that exists to catch a push landing
   # mid-run was disabled by precisely the response that says the gate could not see the PR.
   if [ -z "$headnow" ] || [ "$headnow" = "null" ]; then
-    echo "verdict: BLOCKED — the re-read of the head named no commit, so this gate cannot" >&2
+    echo "verdict: BLOCKED. The re-read of the head named no commit, so this gate cannot" >&2
     echo "tell whether a push landed while it was reading the PR. Re-run against a PR this" >&2
     echo "token can see." >&2
     return 2

--- a/scripts/test-check-review-threads.sh
+++ b/scripts/test-check-review-threads.sh
@@ -1145,6 +1145,100 @@ run_case "the author's own top-level comment is still claimable" \
   "$(wrap4 me '[]' '[]' "[$(cmt me User 2026-01-05T00:00:00Z '"P1: this drops records"')]")" \
   1 "carry no disposition"
 
+echo "== finding 42: a page this gate cannot read is not an empty page =="
+# Every paging loop folded each page in with `<connection>.nodes // []` and then read
+# hasNextPage from the same page. Both readings turn a response the loop CANNOT READ into
+# "this connection is empty and it is finished": a null `pullRequest` — a wrong number, a
+# renamed repo, a token that cannot see the PR, a partial GraphQL result — contributes no
+# nodes, and hasNextPage evaluates to null rather than "true", so the loop stops holding [].
+# `[]` is indistinguishable from a connection that is genuinely empty, which is the gate's
+# recurring fail-open shape: a check that could not evaluate anything reporting that it
+# found nothing. On the recheck comments loop it dropped every top-level claim.
+#
+# All of these are properties of the fetch, so they go through a gh shim. The fixture below
+# carries an unanswered claim in the top-level comments and a stranger's review of the head,
+# so a run that reads every page reports the claim and a run that silently empties a page
+# reports CLEAR.
+mkdir -p "$TMP/bin"
+CLAIM42=$(cmt reviewer User 2026-01-02T01:00:00Z '"P1: this drops the last row"')
+printf '{"data":{"repository":{"pullRequest":null}}}' > "$TMP/nullpr.json"
+printf '{"data":{"repository":{"pullRequest":{}}}}' > "$TMP/noconn.json"
+printf '{"data":{"node":null}}' > "$TMP/nullnode.json"
+printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}' > "$TMP/threads.json"
+# One resolved thread whose comments do not fit a page: the finding and its disposition on
+# page 1, one more comment on page 2. With COMMENTS_PAGE_SIZE=2 the gate pages it.
+printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"T1","isResolved":true,"isOutdated":false,"comments":{"totalCount":3,"pageInfo":{"hasNextPage":true,"endCursor":"CUR1"},"nodes":[{"author":{"login":"reviewer"},"path":"a.ts","line":1,"originalLine":1,"body":"this drops the last row"},{"author":{"login":"me"},"path":"a.ts","line":1,"originalLine":1,"body":"NOT-A-DEFECT: renamed only, no behaviour change"}]}}]}}}}}' > "$TMP/pagedthreads.json"
+printf '{"data":{"node":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"onlooker"},"path":"a.ts","line":1,"originalLine":1,"body":"discussion"}]}}}}' > "$TMP/threadpage.json"
+printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{"nodes":[{"createdAt":"2026-01-02T00:30:00Z"}]}}}]},"reviews":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"reviewer"},"state":"COMMENTED","submittedAt":"2026-01-02T01:00:00Z","body":"","commit":{"oid":"deadbeef"}}]}}}}}' > "$TMP/reviews.json"
+printf '{"data":{"repository":{"pullRequest":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[%s]}}}}}' "$CLAIM42" > "$TMP/comments.json"
+printf '{"data":{"repository":{"pullRequest":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}' > "$TMP/nocomments.json"
+printf '%s' "$PRCOMMITS_LIVE" > "$TMP/prcommits.json"
+cat > "$TMP/bin/gh" <<'SHIM'
+#!/bin/bash
+# GATE_TEST_NULL names the ONE read answered with a page the gate cannot use
+# (nullpr.json, or GATE_TEST_BAD=noconn for a pullRequest with no connection on it);
+# every other read is answered normally. Connections read twice take a 1 or a 2.
+nth() { local f=$GATE_TEST_DIR/$1.count n; n=$(cat "$f" 2>/dev/null || echo 0); n=$((n+1)); printf '%s' "$n" > "$f"; printf '%s' "$n"; }
+which_read() { printf '%s%d' "$1" "$(( $(nth "$1") >= 2 ? 2 : 1 ))"; }
+bad() { cat "$GATE_TEST_DIR/${GATE_TEST_BAD:-nullpr}.json"; }
+case "$*" in
+  *"commits(first"*)
+    if [ "${GATE_TEST_NULL:-}" = commits ]; then bad
+    else cat "$GATE_TEST_DIR/prcommits.json"; fi ;;
+  *"node(id"*)
+    if [ "${GATE_TEST_NULL:-}" = node ]; then cat "$GATE_TEST_DIR/nullnode.json"
+    else cat "$GATE_TEST_DIR/threadpage.json"; fi ;;
+  *reviewThreads*)
+    if [ "${GATE_TEST_NULL:-}" = "$(which_read threads)" ]; then bad
+    else cat "$GATE_TEST_DIR/${GATE_TEST_THREADS:-threads}.json"; fi ;;
+  *"reviews(first"*)
+    if [ "${GATE_TEST_NULL:-}" = "$(which_read reviews)" ]; then bad
+    else cat "$GATE_TEST_DIR/reviews.json"; fi ;;
+  *"comments(first"*)
+    if [ "${GATE_TEST_NULL:-}" = "$(which_read comments)" ]; then bad
+    else cat "$GATE_TEST_DIR/${GATE_TEST_COMMENTS:-comments}.json"; fi ;;
+  *headRefOid*)
+    # gh --jq prints an empty line when the filter lands on a null pullRequest.
+    if [ "${GATE_TEST_NULL:-}" = headread ]; then printf '\n'
+    else printf 'deadbeef\n'; fi ;;
+esac
+SHIM
+chmod +x "$TMP/bin/gh"
+page_case() {
+  local name=$1 want_rc=$2 want_txt=$3 out rc
+  rm -f "$TMP"/threads.count "$TMP"/reviews.count "$TMP"/comments.count
+  out=$(GATE_TEST_DIR="$TMP" PATH="$TMP/bin:$PATH" bash "$GATE" 1 2>&1); rc=$?
+  if [ "$rc" = "$want_rc" ] && grep -qF "$want_txt" <<<"$out"; then
+    echo "  PASS  $name"; pass=$((pass+1))
+  else
+    echo "  FAIL  $name (rc=$rc want=$want_rc)"; sed 's/^/          /' <<<"$out" | head -4; fail=$((fail+1))
+  fi
+}
+# The reported defect: the second read of the comments, which is the read the verdict is
+# computed from. Emptied, it takes every top-level claim with it and the run reports CLEAR.
+GATE_TEST_NULL=comments2 \
+  page_case "a recheck comment page with a null pullRequest blocks" 2 "no pull request"
+GATE_TEST_NULL=comments2 GATE_TEST_BAD=noconn \
+  page_case "a recheck comment page with no comments connection blocks" 2 "no nodes array"
+GATE_TEST_NULL=comments1 \
+  page_case "the first comment page with a null pullRequest blocks" 2 "no pull request"
+GATE_TEST_NULL=reviews2 \
+  page_case "a reviews recheck page with a null pullRequest blocks as unread" 2 "no pull request"
+GATE_TEST_NULL=commits \
+  page_case "a commit page with a null pullRequest blocks as unread" 2 "no pull request"
+GATE_TEST_NULL=headread \
+  page_case "a head re-read naming no commit blocks" 2 "re-read of the head"
+COMMENTS_PAGE_SIZE=2 GATE_TEST_THREADS=pagedthreads GATE_TEST_COMMENTS=nocomments GATE_TEST_NULL=node \
+  page_case "a thread comment page with a null node blocks instead of truncating" 2 "comments page for thread"
+# Guards, green before and after: the first thread page already blocked on a null
+# pullRequest and still does, pages that can all be read still reach a verdict, and the
+# fixture without the claim still reaches CLEAR — which is what the red above reported.
+GATE_TEST_NULL=threads1 \
+  page_case "the first thread page with a null pullRequest still blocks" 2 "no pull request"
+page_case "every page readable reaches a verdict on the claim" 1 "carry no disposition"
+GATE_TEST_COMMENTS=nocomments \
+  page_case "every page readable and no claim still clears" 0 "CLEAR"
+
 echo
 echo "passed=$pass failed=$fail"
 [ "$fail" -eq 0 ]

--- a/scripts/test-check-review-threads.sh
+++ b/scripts/test-check-review-threads.sh
@@ -1148,8 +1148,8 @@ run_case "the author's own top-level comment is still claimable" \
 echo "== finding 42: a page this gate cannot read is not an empty page =="
 # Every paging loop folded each page in with `<connection>.nodes // []` and then read
 # hasNextPage from the same page. Both readings turn a response the loop CANNOT READ into
-# "this connection is empty and it is finished": a null `pullRequest` — a wrong number, a
-# renamed repo, a token that cannot see the PR, a partial GraphQL result — contributes no
+# "this connection is empty and it is finished": a null `pullRequest` (a wrong number, a
+# renamed repo, a token that cannot see the PR, a partial GraphQL result) contributes no
 # nodes, and hasNextPage evaluates to null rather than "true", so the loop stops holding [].
 # `[]` is indistinguishable from a connection that is genuinely empty, which is the gate's
 # recurring fail-open shape: a check that could not evaluate anything reporting that it
@@ -1169,6 +1169,13 @@ printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasN
 # page 1, one more comment on page 2. With COMMENTS_PAGE_SIZE=2 the gate pages it.
 printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"T1","isResolved":true,"isOutdated":false,"comments":{"totalCount":3,"pageInfo":{"hasNextPage":true,"endCursor":"CUR1"},"nodes":[{"author":{"login":"reviewer"},"path":"a.ts","line":1,"originalLine":1,"body":"this drops the last row"},{"author":{"login":"me"},"path":"a.ts","line":1,"originalLine":1,"body":"NOT-A-DEFECT: renamed only, no behaviour change"}]}}]}}}}}' > "$TMP/pagedthreads.json"
 printf '{"data":{"node":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"onlooker"},"path":"a.ts","line":1,"originalLine":1,"body":"discussion"}]}}}}' > "$TMP/threadpage.json"
+# The same comments page, claiming a page after it and naming no cursor to fetch that page
+# with. Folded in and read for hasNextPage, it ends the loop on a thread nobody finished.
+printf '{"data":{"node":{"comments":{"pageInfo":{"hasNextPage":true,"endCursor":null},"nodes":[{"author":{"login":"onlooker"},"path":"a.ts","line":1,"originalLine":1,"body":"discussion"}]}}}}' > "$TMP/nodenocursor.json"
+# A resolved thread of 3 comments whose FIRST page (the one that arrives with the thread
+# list) already says another page follows and names no cursor. The disposition is on the
+# page nobody can ask for, so a run that skips the paging judges the thread undisposed.
+printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"T1","isResolved":true,"isOutdated":false,"comments":{"totalCount":3,"pageInfo":{"hasNextPage":true,"endCursor":null},"nodes":[{"author":{"login":"reviewer"},"path":"a.ts","line":1,"originalLine":1,"body":"this drops the last row"},{"author":{"login":"onlooker"},"path":"a.ts","line":1,"originalLine":1,"body":"discussion"}]}}]}}}}}' > "$TMP/pagednocursor.json"
 printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{"nodes":[{"createdAt":"2026-01-02T00:30:00Z"}]}}}]},"reviews":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"reviewer"},"state":"COMMENTED","submittedAt":"2026-01-02T01:00:00Z","body":"","commit":{"oid":"deadbeef"}}]}}}}}' > "$TMP/reviews.json"
 printf '{"data":{"repository":{"pullRequest":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[%s]}}}}}' "$CLAIM42" > "$TMP/comments.json"
 printf '{"data":{"repository":{"pullRequest":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}' > "$TMP/nocomments.json"
@@ -1180,22 +1187,31 @@ cat > "$TMP/bin/gh" <<'SHIM'
 # every other read is answered normally. Connections read twice take a 1 or a 2.
 nth() { local f=$GATE_TEST_DIR/$1.count n; n=$(cat "$f" 2>/dev/null || echo 0); n=$((n+1)); printf '%s' "$n" > "$f"; printf '%s' "$n"; }
 which_read() { printf '%s%d' "$1" "$(( $(nth "$1") >= 2 ? 2 : 1 ))"; }
-bad() { cat "$GATE_TEST_DIR/${GATE_TEST_BAD:-nullpr}.json"; }
+# $1 names the connection being read, which the nocursor page has to carry.
+# GATE_TEST_BAD=nocursor answers with a page of that connection claiming another page
+# follows while naming no cursor to fetch it with; GATE_TEST_CURSOR holds the JSON for
+# endCursor, null by default and "" for the empty-string shape.
+bad() {
+  if [ "${GATE_TEST_BAD:-nullpr}" = nocursor ]; then
+    printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","%s":{"totalCount":1,"pageInfo":{"hasNextPage":true,"endCursor":%s},"nodes":[]}}}}}' \
+      "$1" "${GATE_TEST_CURSOR:-null}"
+  else cat "$GATE_TEST_DIR/${GATE_TEST_BAD:-nullpr}.json"; fi
+}
 case "$*" in
   *"commits(first"*)
-    if [ "${GATE_TEST_NULL:-}" = commits ]; then bad
+    if [ "${GATE_TEST_NULL:-}" = commits ]; then bad commits
     else cat "$GATE_TEST_DIR/prcommits.json"; fi ;;
   *"node(id"*)
-    if [ "${GATE_TEST_NULL:-}" = node ]; then cat "$GATE_TEST_DIR/nullnode.json"
+    if [ "${GATE_TEST_NULL:-}" = node ]; then cat "$GATE_TEST_DIR/${GATE_TEST_NODEBAD:-nullnode}.json"
     else cat "$GATE_TEST_DIR/threadpage.json"; fi ;;
   *reviewThreads*)
-    if [ "${GATE_TEST_NULL:-}" = "$(which_read threads)" ]; then bad
+    if [ "${GATE_TEST_NULL:-}" = "$(which_read threads)" ]; then bad reviewThreads
     else cat "$GATE_TEST_DIR/${GATE_TEST_THREADS:-threads}.json"; fi ;;
   *"reviews(first"*)
-    if [ "${GATE_TEST_NULL:-}" = "$(which_read reviews)" ]; then bad
+    if [ "${GATE_TEST_NULL:-}" = "$(which_read reviews)" ]; then bad reviews
     else cat "$GATE_TEST_DIR/reviews.json"; fi ;;
   *"comments(first"*)
-    if [ "${GATE_TEST_NULL:-}" = "$(which_read comments)" ]; then bad
+    if [ "${GATE_TEST_NULL:-}" = "$(which_read comments)" ]; then bad comments
     else cat "$GATE_TEST_DIR/${GATE_TEST_COMMENTS:-comments}.json"; fi ;;
   *headRefOid*)
     # gh --jq prints an empty line when the filter lands on a null pullRequest.
@@ -1207,7 +1223,9 @@ chmod +x "$TMP/bin/gh"
 page_case() {
   local name=$1 want_rc=$2 want_txt=$3 out rc
   rm -f "$TMP"/threads.count "$TMP"/reviews.count "$TMP"/comments.count
-  out=$(GATE_TEST_DIR="$TMP" PATH="$TMP/bin:$PATH" bash "$GATE" 1 2>&1); rc=$?
+  # `timeout`, because a loop that omits `after` and re-requests the first page never
+  # returns. The run has to end in a FAIL naming the case, not in a hung harness.
+  out=$(GATE_TEST_DIR="$TMP" PATH="$TMP/bin:$PATH" timeout 20 bash "$GATE" 1 2>&1); rc=$?
   if [ "$rc" = "$want_rc" ] && grep -qF "$want_txt" <<<"$out"; then
     echo "  PASS  $name"; pass=$((pass+1))
   else
@@ -1232,12 +1250,38 @@ COMMENTS_PAGE_SIZE=2 GATE_TEST_THREADS=pagedthreads GATE_TEST_COMMENTS=nocomment
   page_case "a thread comment page with a null node blocks instead of truncating" 2 "comments page for thread"
 # Guards, green before and after: the first thread page already blocked on a null
 # pullRequest and still does, pages that can all be read still reach a verdict, and the
-# fixture without the claim still reaches CLEAR — which is what the red above reported.
+# fixture without the claim still reaches CLEAR, which is what the red above reported.
 GATE_TEST_NULL=threads1 \
   page_case "the first thread page with a null pullRequest still blocks" 2 "no pull request"
 page_case "every page readable reaches a verdict on the claim" 1 "carry no disposition"
 GATE_TEST_COMMENTS=nocomments \
   page_case "every page readable and no claim still clears" 0 "CLEAR"
+
+echo "== finding 43: a page saying more follows must name the cursor to fetch it with =="
+# require_page validated hasNextPage and not endCursor, so a page could say "another page
+# follows" and name nothing to fetch it with. Both readings of that page are wrong in the
+# gate's usual direction. In the outer loops `jq -r` renders a null endCursor as the STRING
+# "null", which is the loops' own "no cursor yet" sentinel, so the next request omits
+# `after` and asks for the FIRST page again: the same page answers, forever. An empty-string
+# cursor sends `after: ""` and, on a source that ignores it, loops the same way. In the
+# oversized-thread loop the cursor is instead tested for "null"/empty as the exit condition,
+# so the loop ENDS and the thread is judged from the pages fetched so far, which is the
+# truncation the transient-failure branch beside it already refuses to accept.
+GATE_TEST_NULL=comments2 GATE_TEST_BAD=nocursor \
+  page_case "a recheck comment page with hasNextPage and no cursor blocks" 2 "names no cursor"
+GATE_TEST_NULL=comments2 GATE_TEST_BAD=nocursor GATE_TEST_CURSOR='""' \
+  page_case "a recheck comment page with an empty-string cursor blocks" 2 "names no cursor"
+GATE_TEST_NULL=threads1 GATE_TEST_BAD=nocursor \
+  page_case "a thread page with hasNextPage and no cursor blocks" 2 "names no cursor"
+COMMENTS_PAGE_SIZE=2 GATE_TEST_THREADS=pagedthreads GATE_TEST_COMMENTS=nocomments \
+  GATE_TEST_NULL=node GATE_TEST_NODEBAD=nodenocursor \
+  page_case "a thread comment page with no cursor blocks instead of truncating" 2 "names no cursor"
+COMMENTS_PAGE_SIZE=2 GATE_TEST_THREADS=pagednocursor GATE_TEST_COMMENTS=nocomments \
+  page_case "an oversized thread whose first page names no cursor blocks" 2 "thread T1"
+# Guard, green before and after: hasNextPage false with a null endCursor is what the LAST
+# page of every connection looks like, and it has to keep reaching a verdict. Every fixture
+# above ends that way, so a rule written as "endCursor must be a string" would fail here.
+page_case "a last page with hasNextPage false and a null cursor still reaches a verdict" 1 "carry no disposition"
 
 echo
 echo "passed=$pass failed=$fail"


### PR DESCRIPTION
Every paging loop in `scripts/check-review-threads.sh` folded each page in with
`<connection>.nodes // []` and then read `hasNextPage` from that same page. A response whose
`pullRequest` is null contributes no nodes and reads `hasNextPage` as null rather than
`"true"`, so the loop ends holding `[]`. That is indistinguishable from a connection which is
genuinely empty, and the verdict is then computed from a list nobody fetched. On the recheck
comments loop it emptied `recheckcomments`, which the final `bodies` construction takes as
the final read of the comments, dropping every top-level claim.

`require_page()` checks a page before it is folded in: parsable JSON, a `pullRequest` that is
there, the named connection present, a `nodes` array, and a boolean `hasNextPage`. Anything
else prints why and returns 2, the code this gate already uses for "cannot evaluate".

## Audit of every page-folding site, and what each does now

| Site | Before | Now |
|---|---|---|
| review threads, `fetch_threads` (both reads) | null `pullRequest` blocked; a `pullRequest` with no `reviewThreads` connection folded in as empty | both block |
| an oversized thread's comments, `node(id:)` | a null `node` folded in as an empty page and ended the loop, so the thread was judged from the pages fetched so far | blocks |
| reviews, first read | null `pullRequest` blocked; missing connection folded in as empty | both block |
| the PR's commit list | unguarded; the empty list reached the reader with `totalCount` null and was rejected there as a truncated list | blocks at the fetch, saying the page could not be read |
| top-level comments, first read | unguarded | blocks |
| top-level comments, recheck | unguarded (#882) | blocks |
| reviews, recheck | unguarded; the empty second read blocked claiming the reviews had changed | blocks with what happened |
| the head re-read | `--jq` prints an empty line when its filter lands on a null `pullRequest`, and an empty result skipped the comparison, disabling the one read that exists to catch a push landing mid-run | blocks |

## Test evidence

`scripts/test-check-review-threads.sh` gains "finding 42": 10 cases driven through the gh
shim, since the fetch is a live-path property that `--from-file` cannot reach. The fixture
carries an unanswered claim in the top-level comments and a stranger's review of the head, so
a run that reads every page reports the claim and a run that empties a page reports CLEAR.

Seven cases were watched failing against the unfixed script, three are guards that pass either
way:

```
== finding 42: a page this gate cannot read is not an empty page ==
  FAIL  a recheck comment page with a null pullRequest blocks (rc=0 want=2)
          review threads: 0 total, 0 unresolved
          verdict: CLEAR — every thread resolved and disposed, every review body answered.
  FAIL  a recheck comment page with no comments connection blocks (rc=0 want=2)
          review threads: 0 total, 0 unresolved
          verdict: CLEAR — every thread resolved and disposed, every review body answered.
  FAIL  the first comment page with a null pullRequest blocks (rc=1 want=2)
  FAIL  a reviews recheck page with a null pullRequest blocks as unread (rc=2 want=2)
          verdict: BLOCKED — the reviews on this PR changed while this gate was reading it.
  FAIL  a commit page with a null pullRequest blocks as unread (rc=2 want=2)
  FAIL  a head re-read naming no commit blocks (rc=1 want=2)
  FAIL  a thread comment page with a null node blocks instead of truncating (rc=0 want=2)
          review threads: 1 total, 0 unresolved
          verdict: CLEAR — every thread resolved and disposed, every review body answered.
  PASS  the first thread page with a null pullRequest still blocks
  PASS  every page readable reaches a verdict on the claim
  PASS  every page readable and no claim still clears

passed=179 failed=7
```

The two `rc=2 want=2` lines fail on the reason, not the exit code: the run blocked while
naming something that had not happened. Reverting the fix alone, with the cases in place,
reproduces the same 7 red.

With the fix:

```
$ bash scripts/test-check-review-threads.sh
passed=186 failed=0
```

```
$ make test-unit FILTER="-E 'binary(test_log_scan)'"
     Summary [   0.219s] 24 tests run: 24 passed, 0 skipped
```

```
$ shellcheck -S warning scripts/check-review-threads.sh scripts/test-check-review-threads.sh
$ bash -n scripts/check-review-threads.sh
```

Live read-only run against a real PR, which exercises reviews, commits, top-level comments
twice, review threads twice and the head re-read under the new guard, and a second run at
`COMMENTS_PAGE_SIZE=1` to force the `node(id:)` comment paging:

```
$ REPO_OWNER=ejc3 REPO_NAME=fcvm bash scripts/check-review-threads.sh 881
review threads: 1 total, 0 unresolved

  UNREVIEWED HEAD  9313fe296 — no review object on this commit from anyone but the author, and no no-findings verdict bound to it

verdict: BLOCKED — the head commit has not been reviewed.
Every finding raised so far is answered, but the code being merged is not the code
anyone reviewed. Wait for a review of 9313fe296, or re-request one.
(exit 1, byte-identical to the same run against the script on main)
```

Closes #882.

https://claude.ai/code/session_01QBekRuBULNUgUSGYmgkjyd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of paginated review data when additional pages are indicated but no usable continuation cursor is provided.
  * Review checks now stop safely instead of truncating results or repeatedly requesting the same page.
  * Improved handling of incomplete or unreadable pull request, comment, review, commit, and thread data.
  * Head-change checks now correctly block when refreshed data is unavailable.

* **Tests**
  * Added coverage for malformed pagination responses, including missing and empty continuation cursors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->