### PR TITLE
Fresh-box setup, the --dns gateway resolver, and a hermetic corpus replay

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -563,6 +563,19 @@ The ordering below matters; each step's trap is noted inline.
 # 1. KVM access (new login session required after; a live ssh master keeps old groups)
 sudo usermod -aG kvm $USER
 
+# 1b. Unprivileged user namespaces. Ubuntu 24.04 ships
+#     kernel.apparmor_restrict_unprivileged_userns=1, which makes rootless
+#     podman and skopeo fail: `unshare -U -r true` reports "write failed
+#     /proc/self/uid_map: Operation not permitted" and the first image export
+#     dies with "Error during unshare(...): Operation not permitted". Every
+#     long-lived fcvm box gets this from terraform (dev-user-data.tf), so the
+#     requirement was invisible to anyone following these steps by hand.
+sudo tee /etc/sysctl.d/99-fcvm.conf >/dev/null <<'SYSCTL'
+kernel.unprivileged_userns_clone=1
+kernel.apparmor_restrict_unprivileged_userns=0
+SYSCTL
+sudo sysctl -p /etc/sysctl.d/99-fcvm.conf
+
 # 2. Packages (Ubuntu 24.04). btrfs-progs is needed by the very next step;
 #    bc/bison/flex/libelf-dev are the kernel fallback build's dependencies —
 #    setup builds a kernel locally whenever a profile's release artifact is

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -570,6 +570,17 @@ sudo usermod -aG kvm $USER
 #     dies with "Error during unshare(...): Operation not permitted". Every
 #     long-lived fcvm box gets this from terraform (dev-user-data.tf), so the
 #     requirement was invisible to anyone following these steps by hand.
+#
+#     THIS IS FOR A DEDICATED fcvm OR CI BOX, and host isolation is the
+#     precondition for the whole quickstart. The two settings are host-wide:
+#     they let ANY local user create a user namespace and hold root inside it,
+#     which is what AppArmor's restriction exists to withhold, and they widen
+#     the kernel surface an unprivileged local account can reach (every
+#     CAP_SYS_ADMIN-gated interface a namespace makes available, and the
+#     userns-reachable bug classes behind them). On a box other people log in
+#     to, that is a boundary you are removing for them too. fcvm cannot run
+#     rootless without it, so the answer for a shared host is a separate box,
+#     not a narrower sysctl.
 sudo tee /etc/sysctl.d/99-fcvm.conf >/dev/null <<'SYSCTL'
 kernel.unprivileged_userns_clone=1
 kernel.apparmor_restrict_unprivileged_userns=0
@@ -582,7 +593,17 @@ sudo sysctl -p /etc/sysctl.d/99-fcvm.conf
 #     test_allow_other_with_fuse_conf, "Test requires user_allow_other in
 #     /etc/fuse.conf". CI and both test Containerfiles set it, so only a
 #     hand-built box is missing it.
-grep -q '^user_allow_other' /etc/fuse.conf || echo user_allow_other | sudo tee -a /etc/fuse.conf
+#
+#     This is also host-wide: it lets any local user mount a FUSE filesystem
+#     other UIDs can read, which is the point here (pjdfstest switches uid
+#     across a fuse-pipe mount) and is another reason step 1b's dedicated box
+#     is the precondition.
+#
+#     The guard matches the directive and nothing else, because that is what
+#     fuse-pipe accepts (`l.trim() == "user_allow_other"`, mount.rs). A prefix
+#     match calls `user_allow_other # comment` configured while every mount
+#     still takes SessionACL::Owner and the test above keeps failing.
+grep -Eq '^[[:space:]]*user_allow_other[[:space:]]*$' /etc/fuse.conf || echo user_allow_other | sudo tee -a /etc/fuse.conf
 
 # 2. Packages (Ubuntu 24.04). btrfs-progs is needed by the very next step;
 #    bc/bison/flex/libelf-dev are the kernel fallback build's dependencies —

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -566,10 +566,12 @@ sudo usermod -aG kvm $USER
 # 2. Packages (Ubuntu 24.04). btrfs-progs is needed by the very next step;
 #    bc/bison/flex/libelf-dev are the kernel fallback build's dependencies —
 #    setup builds a kernel locally whenever a profile's release artifact is
-#    absent, and a fresh box hits that path.
+#    absent, and a fresh box hits that path. libseccomp-dev is the firecracker
+#    fork's: setup builds it from source and the link fails with
+#    "cannot find -lseccomp" without the headers.
 sudo apt-get install -y build-essential git jq qemu-utils busybox-static \
     pkg-config libssl-dev clang make podman skopeo uidmap slirp4netns fuse3 passt \
-    btrfs-progs bc bison flex libelf-dev
+    btrfs-progs bc bison flex libelf-dev libseccomp-dev
 
 # 3. Fast local storage. Instance-store NVMe is WIPED by a cloud stop/start —
 #    put /mnt/fcvm-btrfs on it (rebuildable cache), keep sources on the durable

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -576,6 +576,14 @@ kernel.apparmor_restrict_unprivileged_userns=0
 SYSCTL
 sudo sysctl -p /etc/sysctl.d/99-fcvm.conf
 
+# 1c. AllowOther mounts. Without user_allow_other, fuse-pipe falls back to
+#     SessionACL::Owner (fuse-pipe/src/client/mount.rs) and
+#     `make test-unit` fails on fuse-pipe::test_allow_other
+#     test_allow_other_with_fuse_conf, "Test requires user_allow_other in
+#     /etc/fuse.conf". CI and both test Containerfiles set it, so only a
+#     hand-built box is missing it.
+grep -q '^user_allow_other' /etc/fuse.conf || echo user_allow_other | sudo tee -a /etc/fuse.conf
+
 # 2. Packages (Ubuntu 24.04). btrfs-progs is needed by the very next step;
 #    bc/bison/flex/libelf-dev are the kernel fallback build's dependencies —
 #    setup builds a kernel locally whenever a profile's release artifact is

--- a/bench/chromium/.gitignore
+++ b/bench/chromium/.gitignore
@@ -27,10 +27,12 @@ results/**
 !results/**/dns-evidence.json
 !results/**/diag/summary.json
 !results/**/dns-owner.log
-# The replay server's own logs: dns-evidence.json records their sha256 and
-# campaign_summary refuses the run unless both are present and match.
+# The replay server's own logs and the campaign's per-bracket record of what
+# it served: dns-evidence.json records the sha256 of all three and
+# campaign_summary refuses the run unless every one is present and matches.
 !results/**/corpus-dns.log
 !results/**/corpus-access.log
+!results/**/replay-queries.log
 !results/**/campaign-*-summary.json
 # The withdrawal marker: its first line is why the run may never be quoted,
 # and campaign_summary refuses the run while it is present.

--- a/bench/chromium/AGENTS.md
+++ b/bench/chromium/AGENTS.md
@@ -163,15 +163,17 @@ true` the same way. The marker is tracked (`!results/**/WITHDRAWN` in
 stays unquotable (REVIEW.md).
 
 A corpus campaign's run directory also keeps the replay server's two logs,
-`corpus-dns.log` and `corpus-access.log`, tracked because `dns-evidence.json`
-records their sha256 and `campaign_summary.py` refuses the run unless both are
-present and match. Expect them to be large: the DNS log has one line per query
-and the access log one line per HTTP request the server answered, from the
-campaign's startup probes through the three verify brackets and every rep of
-every arm of the measured run, so it is the biggest record in the directory
-and a short one means the server was not serving the whole run.
+`corpus-dns.log` and `corpus-access.log`, plus the campaign's own
+`replay-queries.log`, one line per verify bracket. All three are tracked
+because `dns-evidence.json` records their sha256 and `campaign_summary.py`
+refuses the run unless each is present and matches. Expect the server's two
+to be large: the DNS log has one line per query and the access log one line
+per HTTP request the server answered, from the campaign's startup probes
+through the three verify brackets and every rep of every arm of the measured
+run, so it is the biggest record in the directory and a short one means the
+server was not serving the whole run.
 
-The evidence is only as good as the checks behind it, and four of them are
+The evidence is only as good as the checks behind it, and six of them are
 easy to get wrong:
 
 - The server's exit status. `corpus_serve.py` exits 1 when a log line could
@@ -194,6 +196,15 @@ easy to get wrong:
   variable first, and reports what it ignored; `verify-dns.json` carries
   `proxies_disabled` and `run_verify` refuses a bracket without it. Any new
   in-guest probe that opens a URL needs the same treatment.
+- What the replay server answered, as against what it was asked.
+  `verify_replay_answered_the_guest` selects `qtype == 1` rows whose
+  `answer` is `10.0.2.2`, because `corpus_serve.py` logs every other query
+  type with `answer: ""`: a hostname whose A came from a resolver cache
+  while only its AAAA reached the replay would otherwise close the bracket
+  on a row that carries no answer. The whole function is checked command by
+  command, since it is reached through `run_verify X || campaign_fail ...`
+  and bash suspends errexit for everything on the left of `||`, so an
+  unchecked `comm`, count or append renders a pass nothing evaluated.
 - The verify brackets themselves. `passed: true` is also what HOP D writes
   when it was given nothing to check, and a bracket is a plain file in the
   run directory. `write_dns_evidence` records each bracket's sha256 as

--- a/bench/chromium/campaign_summary.py
+++ b/bench/chromium/campaign_summary.py
@@ -99,6 +99,14 @@ SEAL_FIELDS = (
     "snapshot_config_sha256",
 )
 WITHDRAWN_MARKER = "WITHDRAWN"
+# One verify bracket's record, as corpus_campaign.sh's
+# verify_replay_answered_the_guest prints it: the stage, the row the bracket's
+# window opened at, how many queries fell in it, how many of the corpus hosts
+# were seen answered inside it, and which were not.
+REPLAY_QUERY_RECORD = re.compile(
+    r"^(?P<stage>\S+) since_row=(?P<since>\d+) queries=(?P<queries>\d+) "
+    r"hosts_seen=(?P<seen>\d+)/(?P<wanted>\d+) missing=(?P<missing>\S+)$"
+)
 # The replay evidence a run must still carry to be indexable: the two logs the
 # replay server writes, and the campaign's own per-bracket record of what it
 # was asked for. That third file is the only thing tying each bracket's window
@@ -422,6 +430,68 @@ def check_verify_bracket(run_dir, name, verify, resolver, measured_urls, measure
     return dns_server
 
 
+def check_replay_queries(run_dir, name, data):
+    """Read the bracket records back, rather than only hashing them.
+
+    A hash pins bytes; it does not say the bytes mean anything. Every other
+    artifact the evidence cites is re-derived at this boundary -- dns-owner.log
+    against the recorded sample count, each bracket through
+    check_verify_bracket -- and this one was pinned and unread, which made it
+    the cheapest thing to forge in a directory the index is asked to publish.
+
+    A run the campaign produced carries exactly one well-formed record per
+    bracket, because verify_replay_answered_the_guest fails the bracket when
+    the append fails or a name went unanswered, and campaign_fail turns any
+    failed bracket into `unclean`. That is a property of runs it produced, not
+    of directories this reads. Note that a failing bracket writes its record
+    BEFORE the `missing` gate, deliberately, so a `missing=` other than none is
+    exactly the trace of a bracket that did not pass.
+    """
+    text = data.decode("utf-8", "replace")
+    lines = [line for line in text.splitlines() if line != ""]
+    if len(lines) != len(VERIFY_STAGES):
+        raise RunError(
+            f"{run_dir}: {name} holds {len(lines)} bracket record(s), not the "
+            f"{len(VERIFY_STAGES)} a clean campaign writes ({', '.join(VERIFY_STAGES)})"
+        )
+    previous = -1
+    for stage, line in zip(VERIFY_STAGES, lines):
+        record = REPLAY_QUERY_RECORD.match(line)
+        if record is None:
+            raise RunError(f"{run_dir}: {name} line is not a bracket record: {line!r}")
+        if record["stage"] != stage:
+            raise RunError(
+                f"{run_dir}: {name} names bracket {record['stage']!r} where the "
+                f"{stage!r} record belongs; the brackets run in "
+                f"{', '.join(VERIFY_STAGES)} order"
+            )
+        if record["missing"] != "none":
+            raise RunError(
+                f"{run_dir}: {name} records the {stage} bracket missing "
+                f"{record['missing']}, so this replay server did not answer "
+                "those names inside that bracket's window"
+            )
+        seen, wanted = int(record["seen"]), int(record["wanted"])
+        if wanted < 1:
+            raise RunError(
+                f"{run_dir}: {name} records the {stage} bracket over 0 hosts, "
+                "so it checked nothing"
+            )
+        if seen != wanted:
+            raise RunError(
+                f"{run_dir}: {name} records the {stage} bracket seeing "
+                f"{seen} of {wanted} hosts answered, with none reported missing"
+            )
+        since = int(record["since"])
+        if since <= previous:
+            raise RunError(
+                f"{run_dir}: {name} opens the {stage} bracket at row {since}, "
+                f"not after the previous bracket's {previous}; a window that "
+                "reaches back credits an earlier bracket's queries to this one"
+            )
+        previous = since
+
+
 def check_evidence(run_dir, evidence, sources, guest_dns, measured_urls, run_id):
     """Hold a clean verdict to the files it cites; raise RunError otherwise.
 
@@ -554,12 +624,14 @@ def check_evidence(run_dir, evidence, sources, guest_dns, measured_urls, run_id)
         path = os.path.join(run_dir, name)
         if not os.path.isfile(path):
             raise RunError(f"{run_dir}: {name} cited by dns-evidence.json is missing")
-        _data, digest = sources.read_hashed(path)
+        data, digest = sources.read_hashed(path)
         if digest != want:
             raise RunError(
                 f"{run_dir}: {name} sha256 {digest} does not match the "
                 f"{want} dns-evidence.json recorded at the verdict"
             )
+        if name == "replay-queries.log":
+            check_replay_queries(run_dir, name, data)
     return answers
 
 

--- a/bench/chromium/campaign_summary.py
+++ b/bench/chromium/campaign_summary.py
@@ -430,7 +430,7 @@ def check_verify_bracket(run_dir, name, verify, resolver, measured_urls, measure
     return dns_server
 
 
-def check_replay_queries(run_dir, name, data):
+def check_replay_queries(run_dir, name, data, dns_data, stage_hosts, answers):
     """Read the bracket records back, rather than only hashing them.
 
     A hash pins bytes; it does not say the bytes mean anything. Every other
@@ -446,6 +446,21 @@ def check_replay_queries(run_dir, name, data):
     of directories this reads. Note that a failing bracket writes its record
     BEFORE the `missing` gate, deliberately, so a `missing=` other than none is
     exactly the trace of a bracket that did not pass.
+
+    The counts a record carries are its own claim about corpus-dns.log, and
+    reading only the record left them tied to nothing: `queries=0
+    hosts_seen=14/14 missing=none` is impossible and was accepted, and a clean
+    fixture whose DNS log held one row claimed 42 queries over 14 hosts and
+    indexed (Codex, 2026-08-30). So each claim is re-derived from the log the
+    same way replay_qnames_since derives it: an A query this server answered
+    with an address a bracket recorded.
+
+    A bracket's window runs from its own `since_row` to the point the bracket
+    ended, which nothing records, so the window read here runs to the NEXT
+    bracket's `since_row` (the end of the log, for the last). That is a
+    superset of the real window, which is the direction that cannot refuse a
+    run the campaign produced: the log must merely hold at least what the
+    record claimed.
     """
     text = data.decode("utf-8", "replace")
     lines = [line for line in text.splitlines() if line != ""]
@@ -454,8 +469,21 @@ def check_replay_queries(run_dir, name, data):
             f"{run_dir}: {name} holds {len(lines)} bracket record(s), not the "
             f"{len(VERIFY_STAGES)} a clean campaign writes ({', '.join(VERIFY_STAGES)})"
         )
+    # The log's rows, by the line index since_row counts in (replay_log_rows
+    # is `wc -l`). A row that will not parse is not a qualifying answer and is
+    # not dropped from the indexing, since the window bounds are line numbers.
+    rows = []
+    for raw in dns_data.decode("utf-8", "replace").splitlines():
+        try:
+            rows.append(json.loads(raw))
+        except ValueError:
+            rows.append(None)
+    windows = [int(REPLAY_QUERY_RECORD.match(line)["since"])
+               if REPLAY_QUERY_RECORD.match(line) else None
+               for line in lines]
+
     previous = -1
-    for stage, line in zip(VERIFY_STAGES, lines):
+    for index, (stage, line) in enumerate(zip(VERIFY_STAGES, lines)):
         record = REPLAY_QUERY_RECORD.match(line)
         if record is None:
             raise RunError(f"{run_dir}: {name} line is not a bracket record: {line!r}")
@@ -482,6 +510,20 @@ def check_replay_queries(run_dir, name, data):
                 f"{run_dir}: {name} records the {stage} bracket seeing "
                 f"{seen} of {wanted} hosts answered, with none reported missing"
             )
+        queries = int(record["queries"])
+        if queries < seen:
+            raise RunError(
+                f"{run_dir}: {name} records the {stage} bracket seeing {seen} "
+                f"hosts answered inside a window holding {queries} queries, "
+                "which cannot have happened"
+            )
+        hosts = stage_hosts.get(stage) or set()
+        if wanted != len(hosts):
+            raise RunError(
+                f"{run_dir}: {name} records the {stage} bracket over {wanted} "
+                f"hosts, but verify-dns-{stage}.json names {len(hosts)}; the "
+                "bracket and its record must be about the same hosts"
+            )
         since = int(record["since"])
         if since <= previous:
             raise RunError(
@@ -490,6 +532,30 @@ def check_replay_queries(run_dir, name, data):
                 "reaches back credits an earlier bracket's queries to this one"
             )
         previous = since
+        # Re-derive the claim from corpus-dns.log over a superset of the
+        # bracket's window: since_row to the next bracket's, or the end.
+        nxt = windows[index + 1] if index + 1 < len(windows) else len(rows)
+        if nxt is None or nxt > len(rows):
+            nxt = len(rows)
+        answered = [row for row in rows[since:nxt]
+                    if isinstance(row, dict)
+                    and isinstance(row.get("qname"), str)
+                    and row.get("qtype") == 1
+                    and canonical_ip(row.get("answer")) in answers]
+        if len(answered) < queries:
+            raise RunError(
+                f"{run_dir}: {name} records {queries} answered queries for the "
+                f"{stage} bracket, but corpus-dns.log holds {len(answered)} "
+                f"from row {since} to {nxt}; the record claims answers this "
+                "replay server never logged"
+            )
+        unlogged = hosts - {row["qname"] for row in answered}
+        if unlogged:
+            raise RunError(
+                f"{run_dir}: {name} records the {stage} bracket seeing every "
+                f"host answered, but corpus-dns.log logs no answer from row "
+                f"{since} to {nxt} for {', '.join(sorted(unlogged))}"
+            )
 
 
 def check_evidence(run_dir, evidence, sources, guest_dns, measured_urls, run_id):
@@ -595,6 +661,7 @@ def check_evidence(run_dir, evidence, sources, guest_dns, measured_urls, run_id)
     measured_hosts = {urlsplit(url).netloc for url in measured_urls}
     resolver = guest_dns if isinstance(guest_dns, str) and guest_dns else None
     answers = set()
+    stage_hosts = {}
     for stage in VERIFY_STAGES:
         name = f"verify-dns-{stage}.json"
         if name not in cited:
@@ -616,7 +683,9 @@ def check_evidence(run_dir, evidence, sources, guest_dns, measured_urls, run_id)
             run_dir, name, verify, resolver, set(measured_urls), measured_hosts
         )
         answers |= bracket_answers(run_dir, name, verify)
+        stage_hosts[stage] = set(verify.get("hosts") or {})
     # The replay server's own logs, pinned by hash at the verdict.
+    bodies = {}
     for field, name in REPLAY_LOGS.items():
         want = evidence.get(field)
         if not is_sha256(want):
@@ -630,8 +699,15 @@ def check_evidence(run_dir, evidence, sources, guest_dns, measured_urls, run_id)
                 f"{run_dir}: {name} sha256 {digest} does not match the "
                 f"{want} dns-evidence.json recorded at the verdict"
             )
-        if name == "replay-queries.log":
-            check_replay_queries(run_dir, name, data)
+        bodies[name] = data
+    check_replay_queries(
+        run_dir,
+        "replay-queries.log",
+        bodies["replay-queries.log"],
+        bodies["corpus-dns.log"],
+        stage_hosts,
+        answers,
+    )
     return answers
 
 

--- a/bench/chromium/campaign_summary.py
+++ b/bench/chromium/campaign_summary.py
@@ -99,9 +99,15 @@ SEAL_FIELDS = (
     "snapshot_config_sha256",
 )
 WITHDRAWN_MARKER = "WITHDRAWN"
+# The replay evidence a run must still carry to be indexable: the two logs the
+# replay server writes, and the campaign's own per-bracket record of what it
+# was asked for. That third file is the only thing tying each bracket's window
+# to the queries this server received, so a run that lost it cannot be read
+# back to check the brackets against.
 REPLAY_LOGS = {
     "corpus_dns_log_sha256": "corpus-dns.log",
     "corpus_access_log_sha256": "corpus-access.log",
+    "replay_queries_log_sha256": "replay-queries.log",
 }
 
 

--- a/bench/chromium/corpus_campaign.sh
+++ b/bench/chromium/corpus_campaign.sh
@@ -157,12 +157,16 @@ say() { printf '\n=== %s\n' "$*"; }
 #      any load event took longer than DIAG_MAX_LOAD_MS
 #      ($RESULTS/diag/summary.json).
 #   1b. every bracket then requires this campaign's corpus_serve to have
-#      LOGGED a query for every corpus host in the rows its DNS log grew by
-#      while the bracket ran ($RESULTS/replay-queries.log). HOP D reads the
-#      answer; this reads the other end of the same query, so an answer that
-#      came from anywhere else (a corpus_serve leaked from an earlier
-#      campaign, an /etc/hosts baked into the golden, a resolver cache in the
-#      clone) fails the bracket. The peer address cannot carry that evidence:
+#      ANSWERED an A query with 10.0.2.2 for every corpus host, in the rows
+#      its DNS log grew by while the bracket ran
+#      ($RESULTS/replay-queries.log). HOP D reads the answer; this reads the
+#      other end of the same query, so an answer that came from anywhere else
+#      (a corpus_serve leaked from an earlier campaign, an /etc/hosts baked
+#      into the golden, a resolver cache in the clone) fails the bracket. The
+#      record type is part of that: corpus_serve logs an AAAA with answer "",
+#      so a name whose A came from a cache while only its AAAA arrived here
+#      leaves a row that says nothing about the answer HOP D saw. The peer
+#      address cannot carry the evidence either:
 #      pasta translates the guest's source to host loopback for a loopback
 #      destination (fwd_nat_from_tap, fwd.c), so every guest query is logged
 #      from 127.0.0.1, with only the guest's UDP source port preserved. The
@@ -205,16 +209,22 @@ corpus_hosts() {
 }
 
 # The other end of HOP D's query. HOP D reads what the clone RESOLVED; this
-# reads what this campaign's replay server was ASKED, so a bracket only passes
+# reads what this campaign's replay server ANSWERED, so a bracket only passes
 # when the two are the same event. A leaked corpus_serve from an earlier
 # campaign, an /etc/hosts baked into the golden, or a resolver cache in the
 # clone all answer 10.0.2.2 without this server ever being consulted.
 #
+# It is the answer and not merely the query, because a hostname can reach this
+# server on a lookup that carried no answer: corpus_serve answers A queries
+# with --answer-ip and logs every other type with answer "". A clone whose A
+# result came from a resolver cache while its AAAA arrived here leaves a row
+# for the name that says nothing about where the 10.0.2.2 came from.
+#
 # The peer address cannot say who asked: pasta translates a guest's source
 # address to host loopback whenever the destination is loopback
 # (fwd_nat_from_tap in fwd.c), so guest queries and the campaign's own host-side
-# dig are both logged from 127.0.0.1. What ties a query to the bracket is the
-# rows the log grew by while it ran, and the names those rows asked for.
+# dig are both logged from 127.0.0.1. What ties an answer to the bracket is the
+# rows the log grew by while it ran, and the names those rows carry.
 #
 # The boundary is the log's length, not a clock reading. `date +%s` truncates,
 # so a query the preceding phase made a fraction of a second before the bracket
@@ -222,11 +232,19 @@ corpus_hosts() {
 # answers for it. The settle wait, the golden and the diag all render these
 # same names immediately before a bracket runs.
 #
+# This function decides a bracket, and it runs with errexit off: it is reached
+# through `run_verify X || campaign_fail ...`, and bash suspends errexit for the
+# whole call tree on the left of `||`. Every command below is therefore checked
+# where its failure would change the verdict. Unchecked, a tool that could not
+# run prints nothing, an empty difference reads as "no host is missing", and the
+# bracket renders a pass it never evaluated.
+#
 # $1 = stage, $2 = rows the log held when the bracket opened.
 verify_replay_answered_the_guest() {
     local stage="$1" since="$2" log="$RESULTS/corpus-dns.log"
-    local seen missing queries wanted
-    wanted=$(printf '%s\n' "$CORPUS_HOSTS" | tr ',' '\n' | awk 'NF' | sort -u)
+    local seen missing queries wanted wanted_n hosts_seen
+    wanted=$(printf '%s\n' "$CORPUS_HOSTS" | tr ',' '\n' | awk 'NF' | sort -u) \
+        || { echo "FAILED: verify ($stage): cannot list the corpus hosts to check" >&2; return 1; }
     if [ ! -s "$log" ]; then
         echo "FAILED: verify ($stage): $log holds no queries, so this campaign's replay server answered nothing; HOP D's answers came from somewhere else" >&2
         return 1
@@ -235,32 +253,53 @@ verify_replay_answered_the_guest() {
     # empty query set, which would read as "nothing asked" either way.
     seen=$(replay_qnames_since "$log" "$since" | sort -u) \
         || { echo "FAILED: verify ($stage): cannot read the replay DNS log $log" >&2; return 1; }
-    queries=$(replay_qnames_since "$log" "$since" | wc -l) || queries=0
-    missing=$(comm -23 <(printf '%s\n' "$wanted") <(printf '%s\n' "$seen") | paste -sd, -)
+    queries=$(replay_qnames_since "$log" "$since" | wc -l) \
+        || { echo "FAILED: verify ($stage): cannot count the answers $log holds after row $since" >&2; return 1; }
+    missing=$(comm -23 <(printf '%s\n' "$wanted") <(printf '%s\n' "$seen") | paste -sd, -) \
+        || { echo "FAILED: verify ($stage): cannot compare the corpus hosts against the names this campaign's replay server answered" >&2; return 1; }
+    hosts_seen=$(comm -12 <(printf '%s\n' "$wanted") <(printf '%s\n' "$seen") | wc -l) \
+        || { echo "FAILED: verify ($stage): cannot count the corpus hosts this campaign's replay server answered" >&2; return 1; }
+    wanted_n=$(printf '%s\n' "$wanted" | wc -l) \
+        || { echo "FAILED: verify ($stage): cannot count the corpus hosts" >&2; return 1; }
+    # The bracket's own record, written before the verdict below so that a
+    # failing bracket also leaves the line saying what it saw. An append that
+    # cannot be written fails the bracket: write_dns_evidence hashes whatever
+    # the file already holds, which in every bracket after the first is an
+    # earlier bracket's line, so a record that never landed would be hashed as
+    # evidence of a bracket that ran.
     printf '%s since_row=%s queries=%s hosts_seen=%s/%s missing=%s\n' \
-        "$stage" "$since" "$queries" \
-        "$(comm -12 <(printf '%s\n' "$wanted") <(printf '%s\n' "$seen") | wc -l)" \
-        "$(printf '%s\n' "$wanted" | wc -l)" "${missing:-none}" \
-        >>"$RESULTS/replay-queries.log"
+        "$stage" "$since" "$queries" "$hosts_seen" "$wanted_n" "${missing:-none}" \
+        >>"$RESULTS/replay-queries.log" \
+        || { echo "FAILED: verify ($stage): cannot record this bracket in $RESULTS/replay-queries.log" >&2; return 1; }
     if [ -n "$missing" ]; then
-        echo "FAILED: verify ($stage): this campaign's replay server logged no query for $missing after row $since, so the clone's answers for those names did not come from it" >&2
+        echo "FAILED: verify ($stage): this campaign's replay server logged no A answer of 10.0.2.2 for $missing after row $since, so the clone's answers for those names did not come from it" >&2
         return 1
     fi
-    say "verify ($stage): replay served $queries queries covering every corpus host"
+    say "verify ($stage): replay answered $queries A queries covering every corpus host"
 }
 
 replay_log_rows() {
     # The replay DNS log's length now. corpus_serve writes each row with one
-    # flushed write under a lock (JsonlLog), so this counts whole rows.
+    # flushed write under a lock (JsonlLog), so this counts whole rows. A count
+    # that cannot be taken returns 1 rather than 0: 0 is a real answer (the log
+    # is empty), and printing it for a failed count opens the bracket's window
+    # to the whole file, which is how an earlier phase's queries answer for it.
     local log="$RESULTS/corpus-dns.log" n=0
-    if [ -f "$log" ]; then n=$(wc -l <"$log"); fi
+    if [ -f "$log" ]; then n=$(wc -l <"$log") || return 1; fi
     printf '%s' "$((n))"
 }
 
 replay_qnames_since() {
-    # $1 = the replay DNS log, $2 = rows to skip. A row jq cannot parse fails
-    # the pipeline, and so the bracket.
-    tail -n +"$(($2 + 1))" "$1" | jq -r 'select((.qname | type) == "string") | .qname' 2>/dev/null
+    # $1 = the replay DNS log, $2 = rows to skip. Only the A queries this
+    # server ANSWERED with 10.0.2.2 count, which is the answer HOP D read in
+    # the guest (--answer-ip below, VERIFY_DNS_ANSWER above). corpus_serve
+    # logs every other query type with answer "" (serve_dns), so counting any
+    # row for a hostname would pass a name whose A result came from a resolver
+    # cache while only its AAAA reached this server. A row jq cannot parse
+    # fails the pipeline, and so the bracket.
+    tail -n +"$(($2 + 1))" "$1" \
+        | jq -r 'select((.qname | type) == "string" and .qtype == 1 and .answer == "10.0.2.2")
+                 | .qname' 2>/dev/null
 }
 
 run_verify() {
@@ -272,7 +311,8 @@ run_verify() {
     # Before the sub-make: the replay log's length. Every query the bracket
     # provokes is appended after this row, and nothing an earlier phase asked
     # for is.
-    since_row=$(replay_log_rows)
+    since_row=$(replay_log_rows) \
+        || { echo "FAILED: verify ($stage): cannot measure the replay DNS log, so this bracket has no window to check" >&2; return 1; }
     # Every check below is a claim about a list of names, and every one of
     # them is vacuously true when the list is empty: jq's `all` over an empty
     # array is true, and "the replay answered for every corpus host" holds

--- a/bench/chromium/corpus_campaign.sh
+++ b/bench/chromium/corpus_campaign.sh
@@ -172,6 +172,17 @@ say() { printf '\n=== %s\n' "$*"; }
 #      1-min load every DNS_SAMPLE_INTERVAL seconds while the run is in
 #      flight ($RESULTS/dns-owner.log). The quiet gate reads the load once,
 #      before the run; the samples are what says it stayed quiet.
+#      Only the measured run is sampled, because it is the only phase whose
+#      output is a number. The golden produces a snapshot, whose bytes do not
+#      depend on how busy the box was. The settle phase's whole output IS a
+#      load reading. The verify brackets assert WHICH server answered, an
+#      identity with no timing in it. The diag's one time-based limit
+#      (DIAG_MAX_LOAD_MS) fails closed, so contention can make it refuse but
+#      never pass wrongly, and reqbench.sh's cmd_diag says the same in the
+#      other direction: "No quiet-host guard, nothing here is measured".
+#      campaign_summary re-derives load_samples and load_max_1min from the
+#      dns-owner.log column and holds dns-evidence.json to them, so the run's
+#      load record is checked rather than trusted.
 #   3. $RESULTS/dns-evidence.json ties them together with each bracket's
 #      sha256 (verify_file_sha256), the replay server's own DNS and access
 #      logs and the per-bracket replay-queries.log (sha256), its exit status

--- a/bench/chromium/corpus_campaign.sh
+++ b/bench/chromium/corpus_campaign.sh
@@ -157,28 +157,29 @@ say() { printf '\n=== %s\n' "$*"; }
 #      any load event took longer than DIAG_MAX_LOAD_MS
 #      ($RESULTS/diag/summary.json).
 #   1b. every bracket then requires this campaign's corpus_serve to have
-#      LOGGED a query for every corpus host while the bracket ran
-#      ($RESULTS/replay-queries.log). HOP D reads the answer; this reads the
-#      other end of the same query, so an answer that came from anywhere else
-#      (a corpus_serve leaked from an earlier campaign, an /etc/hosts baked
-#      into the golden, a resolver cache in the clone) fails the bracket. The
-#      peer address cannot carry that evidence: pasta translates the guest's
-#      source to host loopback for a loopback destination (fwd_nat_from_tap,
-#      fwd.c), so every guest query is logged from 127.0.0.1, with only the
-#      guest's UDP source port preserved. The bracket's time window and the
-#      set of names are what tie the queries to the clone.
+#      LOGGED a query for every corpus host in the rows its DNS log grew by
+#      while the bracket ran ($RESULTS/replay-queries.log). HOP D reads the
+#      answer; this reads the other end of the same query, so an answer that
+#      came from anywhere else (a corpus_serve leaked from an earlier
+#      campaign, an /etc/hosts baked into the golden, a resolver cache in the
+#      clone) fails the bracket. The peer address cannot carry that evidence:
+#      pasta translates the guest's source to host loopback for a loopback
+#      destination (fwd_nat_from_tap, fwd.c), so every guest query is logged
+#      from 127.0.0.1, with only the guest's UDP source port preserved. The
+#      rows the bracket added and the set of names are what tie the queries
+#      to the clone.
 #   2. a sampler names the owner of 127.0.0.1:53, the dnsmasq state and the
 #      1-min load every DNS_SAMPLE_INTERVAL seconds while the run is in
 #      flight ($RESULTS/dns-owner.log). The quiet gate reads the load once,
 #      before the run; the samples are what says it stayed quiet.
 #   3. $RESULTS/dns-evidence.json ties them together with each bracket's
 #      sha256 (verify_file_sha256), the replay server's own DNS and access
-#      logs (sha256), its exit status
+#      logs and the per-bracket replay-queries.log (sha256), its exit status
 #      (corpus_serve_exit_status, from $RESULTS/corpus-serve.status), the
 #      maximum 1-min load over the samples (load_max_1min), and a verdict:
 #      "clean" only when all three brackets are present and passed, every
 #      sample names this campaign's corpus_serve with dnsmasq inactive, the
-#      sampler lived until the run ended, both replay logs exist, the server
+#      sampler lived until the run ended, all three replay logs exist, the server
 #      exited 0 (its logs are complete only then), and dnsmasq is inactive
 #      after the clone restores.
 engine_target() {
@@ -202,9 +203,15 @@ corpus_hosts() {
 # address to host loopback whenever the destination is loopback
 # (fwd_nat_from_tap in fwd.c), so guest queries and the campaign's own host-side
 # dig are both logged from 127.0.0.1. What ties a query to the bracket is the
-# window it arrived in and the name it asked for.
+# rows the log grew by while it ran, and the names those rows asked for.
 #
-# $1 = stage, $2 = epoch seconds captured before the bracket ran.
+# The boundary is the log's length, not a clock reading. `date +%s` truncates,
+# so a query the preceding phase made a fraction of a second before the bracket
+# opened carries a ts at or above the second the bracket would record, and
+# answers for it. The settle wait, the golden and the diag all render these
+# same names immediately before a bracket runs.
+#
+# $1 = stage, $2 = rows the log held when the bracket opened.
 verify_replay_answered_the_guest() {
     local stage="$1" since="$2" log="$RESULTS/corpus-dns.log"
     local seen missing queries wanted
@@ -215,23 +222,34 @@ verify_replay_answered_the_guest() {
     fi
     # A jq that cannot read the log fails the bracket rather than reporting an
     # empty query set, which would read as "nothing asked" either way.
-    seen=$(jq -r --argjson since "$since" \
-            'select((.ts | type) == "number" and .ts >= $since) | .qname' "$log" 2>/dev/null | sort -u) \
+    seen=$(replay_qnames_since "$log" "$since" | sort -u) \
         || { echo "FAILED: verify ($stage): cannot read the replay DNS log $log" >&2; return 1; }
-    queries=$(jq -r --argjson since "$since" \
-            'select((.ts | type) == "number" and .ts >= $since) | .qname' "$log" 2>/dev/null | wc -l) \
-        || queries=0
+    queries=$(replay_qnames_since "$log" "$since" | wc -l) || queries=0
     missing=$(comm -23 <(printf '%s\n' "$wanted") <(printf '%s\n' "$seen") | paste -sd, -)
-    printf '%s since=%s queries=%s hosts_seen=%s/%s missing=%s\n' \
+    printf '%s since_row=%s queries=%s hosts_seen=%s/%s missing=%s\n' \
         "$stage" "$since" "$queries" \
         "$(comm -12 <(printf '%s\n' "$wanted") <(printf '%s\n' "$seen") | wc -l)" \
         "$(printf '%s\n' "$wanted" | wc -l)" "${missing:-none}" \
         >>"$RESULTS/replay-queries.log"
     if [ -n "$missing" ]; then
-        echo "FAILED: verify ($stage): this campaign's replay server logged no query for $missing since $since, so the clone's answers for those names did not come from it" >&2
+        echo "FAILED: verify ($stage): this campaign's replay server logged no query for $missing after row $since, so the clone's answers for those names did not come from it" >&2
         return 1
     fi
     say "verify ($stage): replay served $queries queries covering every corpus host"
+}
+
+replay_log_rows() {
+    # The replay DNS log's length now. corpus_serve writes each row with one
+    # flushed write under a lock (JsonlLog), so this counts whole rows.
+    local log="$RESULTS/corpus-dns.log" n=0
+    if [ -f "$log" ]; then n=$(wc -l <"$log"); fi
+    printf '%s' "$((n))"
+}
+
+replay_qnames_since() {
+    # $1 = the replay DNS log, $2 = rows to skip. A row jq cannot parse fails
+    # the pipeline, and so the bracket.
+    tail -n +"$(($2 + 1))" "$1" | jq -r 'select((.qname | type) == "string") | .qname' 2>/dev/null
 }
 
 run_verify() {
@@ -239,11 +257,11 @@ run_verify() {
     # and its verify logs on every call, so each bracket copies its own out
     # under the stage name. A bracket passes only when the sub-make exits 0
     # AND the evidence it left says passed=true.
-    local stage="$1" copy="$RESULTS/verify-dns-$1.json" f started
-    # Before the sub-make: every query the bracket provokes lands at or after
-    # this second. `date +%s` truncates, so the window can only open early,
-    # which cannot admit a query from a later bracket.
-    started=$(date +%s)
+    local stage="$1" copy="$RESULTS/verify-dns-$1.json" f since_row
+    # Before the sub-make: the replay log's length. Every query the bracket
+    # provokes is appended after this row, and nothing an earlier phase asked
+    # for is.
+    since_row=$(replay_log_rows)
     # Every check below is a claim about a list of names, and every one of
     # them is vacuously true when the list is empty: jq's `all` over an empty
     # array is true, and "the replay answered for every corpus host" holds
@@ -285,7 +303,7 @@ run_verify() {
         and all($hosts | split(",")[]; . as $h | $e.hosts[$h].ok == true)
         and all($urls | split(",")[]; . as $u | $e.urls[$u].ok == true)' "$copy" >/dev/null \
         || { echo "FAILED: verify ($stage): $copy does not record passed=true through 10.0.2.2 with proxies disabled for every corpus host and URL" >&2; return 1; }
-    verify_replay_answered_the_guest "$stage" "$started" || return 1
+    verify_replay_answered_the_guest "$stage" "$since_row" || return 1
 }
 
 run_diag() {
@@ -481,7 +499,11 @@ write_dns_evidence() {
             verify_sha='{}'
         fi
     done
-    for f in corpus-dns.log corpus-access.log; do
+    # The two logs the replay server writes, and this campaign's record of what
+    # each bracket saw it serve. campaign_summary refuses a run that cannot
+    # produce all three, so a verdict written without one names a run that can
+    # never be published.
+    for f in corpus-dns.log corpus-access.log replay-queries.log; do
         if [ ! -s "$RESULTS/$f" ]; then
             verdict=unclean; reason="${reason:-replay log $f is missing or empty}"
         fi

--- a/bench/chromium/corpus_campaign.sh
+++ b/bench/chromium/corpus_campaign.sh
@@ -244,6 +244,16 @@ run_verify() {
     # this second. `date +%s` truncates, so the window can only open early,
     # which cannot admit a query from a later bracket.
     started=$(date +%s)
+    # Every check below is a claim about a list of names, and every one of
+    # them is vacuously true when the list is empty: jq's `all` over an empty
+    # array is true, and "the replay answered for every corpus host" holds
+    # when there are no corpus hosts. A bracket in that state prints a pass it
+    # has no basis for, the same shape as a gate reporting CLEAR because its
+    # tooling was missing. The empty-log guard in
+    # verify_replay_answered_the_guest does not cover it: the second and third
+    # brackets always meet a log the first one filled.
+    [ -n "$CORPUS_HOSTS" ] && [ -n "$URLS" ] \
+        || { echo "FAILED: verify ($stage): the corpus names no hosts or no URLs, so every check in this bracket would pass without evaluating anything" >&2; return 1; }
     say "verify ($stage): render hops + baked resolver on a restored clone"
     # Both removed first: this function runs as `run_verify X || ...`, where
     # bash keeps errexit off, so an unchecked cp that failed would leave the

--- a/bench/chromium/corpus_campaign.sh
+++ b/bench/chromium/corpus_campaign.sh
@@ -750,6 +750,11 @@ say "replay server up: DNS -> 10.0.2.2, HTTPS 200"
 # error page, which is a perfectly plausible-looking fast number rather than an
 # error. Cheap: 14 local requests against a server already proven up.
 missing=""
+# Counted here rather than re-derived for the pass line below: a count taken
+# from the list a second time can disagree with the loop, and did. `printf
+# '%s'` writes no trailing newline, so the `wc -l` that reported this counted
+# the separators and every run announced 13 URLs for the 14 it had fetched.
+checked=0
 for url in $(printf '%s\n' "$URLS" | tr ',' ' '); do
     host=$(printf '%s' "$url" | sed -E 's#^https?://([^/]+).*#\1#')
     ucode=$(curl -sk --noproxy '*' -o /dev/null -w '%{http_code}' --max-time 10 \
@@ -758,6 +763,7 @@ for url in $(printf '%s\n' "$URLS" | tr ',' ' '); do
     200 | 30[1278]) ;;
     *) missing="$missing\n  $ucode  $url" ;;
     esac
+    checked=$((checked + 1))
 done
 if [ -n "$missing" ]; then
     # shellcheck disable=SC2059
@@ -765,7 +771,7 @@ if [ -n "$missing" ]; then
     echo "A partial corpus measures error pages as renders. Re-record the corpus." >&2
     exit 3
 fi
-say "corpus complete: all $(printf '%s' "$URLS" | tr ',' '\n' | wc -l) URLs replay locally"
+say "corpus complete: all $checked URLs replay locally"
 say "fcvm binary $FCVM_BIN sha256=$FCVM_SHA (recorded per run in cell.fcvm_sha256)"
 
 # --- golden ----------------------------------------------------------------

--- a/bench/chromium/corpus_campaign.sh
+++ b/bench/chromium/corpus_campaign.sh
@@ -19,6 +19,17 @@
 # why this needs 127.0.0.1:53 specifically. Ubuntu's dnsmasq owns that socket,
 # so the campaign stops it and restarts it on the way out. Host name resolution
 # is unaffected: /etc/resolv.conf points at systemd-resolved on 127.0.0.53.
+#
+# Port 53 arrives at the loopback only because fcvm hands pasta `-D none` for a
+# guest whose resolver is the gateway (resolver_is_pasta_gateway,
+# src/network/pasta.rs). Without it pasta redirects the guest's port 53 to the
+# host's OWN resolver whenever /etc/resolv.conf names a loopback address, and
+# the replay never sees the query: on a dnsmasq box that resolver is 127.0.0.1,
+# which is where corpus_serve happens to be, so the campaign appeared to work;
+# on a systemd-resolved box it is 127.0.0.53 and the guest resolved against the
+# live internet. dnsmasq is stopped here for the socket, not for that.
+# scripts/probe-pasta-dns-gateway.sh asks the pinned pasta binary which server
+# answers, with the flag and without it, in a few seconds and without a VM.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -118,6 +129,7 @@ acquire_diag_lock || exit 2
 # one. The content-addressed runtime bundles under runtime/ and the phase
 # logs under logs/ are not the record and stay.
 rm -f "$RESULTS"/dns-evidence.json "$RESULTS"/verify-dns*.json "$RESULTS"/dns-owner.log \
+    "$RESULTS"/replay-queries.log \
     "$RESULTS"/corpus-dns.log "$RESULTS"/corpus-access.log "$RESULTS"/corpus-serve.status \
     "$RESULTS"/reqbench.jsonl "$RESULTS"/analysis.json "$RESULTS"/diag/summary.json
 release_diag_lock
@@ -144,6 +156,17 @@ say() { printf '\n=== %s\n' "$*"; }
 #      reached an address other than 10.0.2.2, any name did not resolve, or
 #      any load event took longer than DIAG_MAX_LOAD_MS
 #      ($RESULTS/diag/summary.json).
+#   1b. every bracket then requires this campaign's corpus_serve to have
+#      LOGGED a query for every corpus host while the bracket ran
+#      ($RESULTS/replay-queries.log). HOP D reads the answer; this reads the
+#      other end of the same query, so an answer that came from anywhere else
+#      (a corpus_serve leaked from an earlier campaign, an /etc/hosts baked
+#      into the golden, a resolver cache in the clone) fails the bracket. The
+#      peer address cannot carry that evidence: pasta translates the guest's
+#      source to host loopback for a loopback destination (fwd_nat_from_tap,
+#      fwd.c), so every guest query is logged from 127.0.0.1, with only the
+#      guest's UDP source port preserved. The bracket's time window and the
+#      set of names are what tie the queries to the clone.
 #   2. a sampler names the owner of 127.0.0.1:53, the dnsmasq state and the
 #      1-min load every DNS_SAMPLE_INTERVAL seconds while the run is in
 #      flight ($RESULTS/dns-owner.log). The quiet gate reads the load once,
@@ -169,12 +192,58 @@ corpus_hosts() {
         | awk 'NF && !seen[$0]++' | paste -sd, -
 }
 
+# The other end of HOP D's query. HOP D reads what the clone RESOLVED; this
+# reads what this campaign's replay server was ASKED, so a bracket only passes
+# when the two are the same event. A leaked corpus_serve from an earlier
+# campaign, an /etc/hosts baked into the golden, or a resolver cache in the
+# clone all answer 10.0.2.2 without this server ever being consulted.
+#
+# The peer address cannot say who asked: pasta translates a guest's source
+# address to host loopback whenever the destination is loopback
+# (fwd_nat_from_tap in fwd.c), so guest queries and the campaign's own host-side
+# dig are both logged from 127.0.0.1. What ties a query to the bracket is the
+# window it arrived in and the name it asked for.
+#
+# $1 = stage, $2 = epoch seconds captured before the bracket ran.
+verify_replay_answered_the_guest() {
+    local stage="$1" since="$2" log="$RESULTS/corpus-dns.log"
+    local seen missing queries wanted
+    wanted=$(printf '%s\n' "$CORPUS_HOSTS" | tr ',' '\n' | awk 'NF' | sort -u)
+    if [ ! -s "$log" ]; then
+        echo "FAILED: verify ($stage): $log holds no queries, so this campaign's replay server answered nothing; HOP D's answers came from somewhere else" >&2
+        return 1
+    fi
+    # A jq that cannot read the log fails the bracket rather than reporting an
+    # empty query set, which would read as "nothing asked" either way.
+    seen=$(jq -r --argjson since "$since" \
+            'select((.ts | type) == "number" and .ts >= $since) | .qname' "$log" 2>/dev/null | sort -u) \
+        || { echo "FAILED: verify ($stage): cannot read the replay DNS log $log" >&2; return 1; }
+    queries=$(jq -r --argjson since "$since" \
+            'select((.ts | type) == "number" and .ts >= $since) | .qname' "$log" 2>/dev/null | wc -l) \
+        || queries=0
+    missing=$(comm -23 <(printf '%s\n' "$wanted") <(printf '%s\n' "$seen") | paste -sd, -)
+    printf '%s since=%s queries=%s hosts_seen=%s/%s missing=%s\n' \
+        "$stage" "$since" "$queries" \
+        "$(comm -12 <(printf '%s\n' "$wanted") <(printf '%s\n' "$seen") | wc -l)" \
+        "$(printf '%s\n' "$wanted" | wc -l)" "${missing:-none}" \
+        >>"$RESULTS/replay-queries.log"
+    if [ -n "$missing" ]; then
+        echo "FAILED: verify ($stage): this campaign's replay server logged no query for $missing since $since, so the clone's answers for those names did not come from it" >&2
+        return 1
+    fi
+    say "verify ($stage): replay served $queries queries covering every corpus host"
+}
+
 run_verify() {
     # $1 = pre | before-run | after-run. reqbench overwrites verify-dns.json
     # and its verify logs on every call, so each bracket copies its own out
     # under the stage name. A bracket passes only when the sub-make exits 0
     # AND the evidence it left says passed=true.
-    local stage="$1" copy="$RESULTS/verify-dns-$1.json" f
+    local stage="$1" copy="$RESULTS/verify-dns-$1.json" f started
+    # Before the sub-make: every query the bracket provokes lands at or after
+    # this second. `date +%s` truncates, so the window can only open early,
+    # which cannot admit a query from a later bracket.
+    started=$(date +%s)
     say "verify ($stage): render hops + baked resolver on a restored clone"
     # Both removed first: this function runs as `run_verify X || ...`, where
     # bash keeps errexit off, so an unchecked cp that failed would leave the
@@ -206,6 +275,7 @@ run_verify() {
         and all($hosts | split(",")[]; . as $h | $e.hosts[$h].ok == true)
         and all($urls | split(",")[]; . as $u | $e.urls[$u].ok == true)' "$copy" >/dev/null \
         || { echo "FAILED: verify ($stage): $copy does not record passed=true through 10.0.2.2 with proxies disabled for every corpus host and URL" >&2; return 1; }
+    verify_replay_answered_the_guest "$stage" "$started" || return 1
 }
 
 run_diag() {
@@ -429,6 +499,7 @@ write_dns_evidence() {
         --argjson load_max "$load_max" --argjson load_samples "$load_samples" \
         --arg first "$first_mismatch" --arg reason "$reason" --arg owner_log "$log" \
         --arg dns_sha "$(sha256_or_empty "$RESULTS/corpus-dns.log")" \
+        --arg replay_queries_sha "$(sha256_or_empty "$RESULTS/replay-queries.log")" \
         --arg access_sha "$(sha256_or_empty "$RESULTS/corpus-access.log")" \
         --argjson serve_status "$serve_status_json" \
         --argjson verify_sha "$verify_sha" \
@@ -444,6 +515,7 @@ write_dns_evidence() {
           verify_files: $ARGS.positional,
           verify_file_sha256: $verify_sha,
           corpus_dns_log_sha256: (if $dns_sha == "" then null else $dns_sha end),
+          replay_queries_log_sha256: (if $replay_queries_sha == "" then null else $replay_queries_sha end),
           corpus_access_log_sha256: (if $access_sha == "" then null else $access_sha end),
           corpus_serve_exit_status: $serve_status,
           reason: (if $reason == "" then null else $reason end),

--- a/bench/chromium/corpus_serve.py
+++ b/bench/chromium/corpus_serve.py
@@ -176,11 +176,14 @@ class Handler(http.server.BaseHTTPRequestHandler):
         blocks the 404 before the renderer sees it, reports net::ERR_FAILED,
         and receives no response, so the trace records no remote address and
         cannot say the request was answered here rather than off the box.
-        Measured 2026-08-29 over a 42-render diag: 32 traced rows carried no
-        remote address, every one of them cross-origin and every one answered
-        by this server (27 GET 404, 2 POST 404, 3 HEAD 501). The status is
-        unchanged, so a url the corpus does not hold still says so, in the
-        status, in the access log and in /––misses.
+        Measured 2026-08-29 over a 42-render diag whose results were not
+        kept: 32 traced rows carried no remote address, every one of them
+        cross-origin and every one answered by this server (27 GET 404, 2
+        POST 404, 3 HEAD 501). Those counts are why this code is shaped the
+        way it is; they are not a sealed record and nothing may be quoted
+        from them. What holds the behaviour is test_corpus_serve_logs.py.
+        The status is unchanged, so a url the corpus does not hold still
+        says so, in the status, in the access log and in /––misses.
         """
         if not self._cors_sent:
             self._cors_sent = True

--- a/bench/chromium/corpus_serve.py
+++ b/bench/chromium/corpus_serve.py
@@ -13,6 +13,11 @@ Resolution order for a request URL u:
   2. match ignoring the query string (analytics beacons carry per-view ids)
   3. 404, counted in /––misses (read by the checker for the report)
 
+GET, HEAD and POST all resolve that way; OPTIONS is answered as a preflight.
+Every reply carries the CORS headers, the 404 included, because a reply the
+browser blocks is a reply the network trace cannot attribute to this server
+(see Handler.end_headers).
+
 Two optional logs, one JSON object per line, flushed per line so a log left
 behind by a killed process is complete up to its last answered request:
   --dns-log PATH     {ts, peer, qname, qtype, answer} per DNS query; answer is
@@ -100,6 +105,9 @@ class Handler(http.server.BaseHTTPRequestHandler):
     access_log = None
     _log_status = None
     _log_bytes = 0
+    # Set per request in handle_one_request; end_headers sends the CORS
+    # headers once, on whichever reply the request gets.
+    _cors_sent = False
 
     def handle_one_request(self):
         # One access line per parsed request, written after the response has
@@ -111,6 +119,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
         t0 = time.monotonic()
         self._log_status = None
         self._log_bytes = 0
+        self._cors_sent = False
         try:
             super().handle_one_request()
         finally:
@@ -149,18 +158,54 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 pass
         super().send_header(keyword, value)
 
-    def _serve(self):
+    def end_headers(self):
+        """Add the CORS headers to whatever reply is being sent, then close
+        the header block.
+
+        Every reply goes through here: a replayed body, a replayed redirect,
+        the 404 for a url the corpus does not hold, and the base class's
+        error replies. They all need the headers, for one reason.
+
+        Cross-origin subresources (fonts, module scripts, manifests) are CORS
+        requests; the real CDNs send ACAO and dropping it turned every such
+        fetch into net::ERR_FAILED on replay (Guardian, 2026-08-13). Echo the
+        Origin rather than "*": credentialed fetches (CMP/geo APIs) reject
+        the wildcard, and those gate consent overlays the pixel check sees.
+
+        A miss needs them as much as a hit does. Without them the browser
+        blocks the 404 before the renderer sees it, reports net::ERR_FAILED,
+        and receives no response, so the trace records no remote address and
+        cannot say the request was answered here rather than off the box.
+        Measured 2026-08-29 over a 42-render diag: 32 traced rows carried no
+        remote address, every one of them cross-origin and every one answered
+        by this server (27 GET 404, 2 POST 404, 3 HEAD 501). The status is
+        unchanged, so a url the corpus does not hold still says so, in the
+        status, in the access log and in /––misses.
+        """
+        if not self._cors_sent:
+            self._cors_sent = True
+            # A request line the parser rejected has no headers to read.
+            headers = getattr(self, "headers", None)
+            origin = headers.get("Origin") if headers is not None else None
+            self.send_header("Access-Control-Allow-Origin", origin or "*")
+            if origin:
+                self.send_header("Access-Control-Allow-Credentials", "true")
+                self.send_header("Vary", "Origin")
+        super().end_headers()
+
+    def _serve(self, body=True):
         host = (self.headers.get("Host") or "").split(":")[0]
         u = urllib.parse.urlparse(self.path)
         entry = self.exact.get((host, u.path, u.query)) or \
             self.noquery.get((host, u.path))
         if self.path == "/––misses":
-            body = json.dumps(self.misses).encode()
+            payload = json.dumps(self.misses).encode()
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
-            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Content-Length", str(len(payload)))
             self.end_headers()
-            self.wfile.write(body)
+            if body:
+                self.wfile.write(payload)
             return
         if entry is None:
             r = self.redirects.get((host, u.path, u.query)) or \
@@ -202,33 +247,29 @@ class Handler(http.server.BaseHTTPRequestHandler):
             self.send_header("Content-Type", mime)
         self.send_header("Content-Length", str(len(data)))
         self.send_header("Cache-Control", "no-store")
-        # Cross-origin subresources (fonts, module scripts, manifests) are CORS
-        # requests; the real CDNs send ACAO and dropping it turned every such
-        # fetch into net::ERR_FAILED on replay (Guardian, 2026-08-13). Echo the
-        # Origin rather than "*": credentialed fetches (CMP/geo APIs) reject
-        # the wildcard, and those gate consent overlays the pixel check sees.
-        origin = self.headers.get("Origin")
-        self.send_header("Access-Control-Allow-Origin", origin or "*")
-        if origin:
-            self.send_header("Access-Control-Allow-Credentials", "true")
-            self.send_header("Vary", "Origin")
         self.end_headers()
-        self.wfile.write(data)
+        if body:
+            self.wfile.write(data)
 
     def do_OPTIONS(self):
         # CORS preflight for credentialed fetches (CMP/geo chains): without
         # this the base handler answers 501 and the chain dies before any
         # ACAO header is ever consulted.
-        origin = self.headers.get("Origin") or "*"
         self.send_response(204)
-        self.send_header("Access-Control-Allow-Origin", origin)
-        self.send_header("Access-Control-Allow-Credentials", "true")
-        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Methods", "GET, HEAD, POST, OPTIONS")
         self.send_header(
             "Access-Control-Allow-Headers",
             self.headers.get("Access-Control-Request-Headers") or "*",
         )
         self.end_headers()
+
+    def do_HEAD(self):
+        # The same lookup as GET, headers only. Left to the base class every
+        # HEAD is a 501, which for a recorded url is not the status the
+        # origin gave (www.rtp.pt/rtp-sensor, in the corpus, answered 501 on
+        # 2026-08-29) and for any url is an answer keyed on the method rather
+        # than on what the corpus holds.
+        self._serve(body=False)
 
     do_GET = _serve
     do_POST = _serve  # beacons POST; replay their captured (or 404) response

--- a/bench/chromium/test_campaign.py
+++ b/bench/chromium/test_campaign.py
@@ -624,9 +624,27 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
                 seen[key] = value
         return seen
 
-    def _run(self, script, env, timeout=60):
-        return subprocess.run(["bash", "-c", script], env=env,
+    def _run(self, script, env, timeout=60, prefix=()):
+        return subprocess.run([*prefix, "bash", "-c", script], env=env,
                               capture_output=True, text=True, timeout=timeout)
+
+    def _mode_bits_enforced(self):
+        """A prefix that makes `chmod 0444` deny writes at every uid.
+
+        Mode bits only stop a process that lacks CAP_DAC_OVERRIDE, and root
+        keeps it, so under a root suite the write a test is trying to fail
+        succeeded and the test asserted nothing. Dropping the capability from
+        the bounding set costs one exec and leaves the scenario otherwise
+        identical. An unprivileged run needs no prefix and cannot use one:
+        applying a bounding set takes CAP_SETPCAP.
+        """
+        if os.geteuid() != 0:
+            return []
+        if shutil.which("setpriv") is None:
+            self.fail("BLOCKED: running as root without setpriv, so "
+                      "CAP_DAC_OVERRIDE cannot be dropped and the mode bits "
+                      "below would not deny the write this test is about")
+        return ["setpriv", "--bounding-set=-dac_override,-dac_read_search"]
 
     def test_verify_carries_the_corpus_resolver_knobs_and_keeps_its_evidence(self):
         """run_verify must hand reqbench every corpus host and URL, the replay
@@ -919,6 +937,12 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
         left, so the campaign was clean with a later bracket's record never
         written.
 
+        The record is made unwritable by mode bits, which only bind a process
+        without CAP_DAC_OVERRIDE, so the run drops that capability. Under a
+        root suite the append had otherwise succeeded and this asserted
+        nothing: `0 != 7 : a bracket whose record could not be written was
+        accepted` (Codex, 2026-08-30).
+
         RED BEFORE THE FIX: exit 0 and VERIFIED, with replay-queries.log still
         holding nothing but the earlier bracket's line.
         """
@@ -937,7 +961,7 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
                       f'{self._helpers()}\nCORPUS_HOSTS=$(corpus_hosts)\n'
                       'run_verify before-run || { echo REFUSED; exit 7; }\necho VERIFIED\n')
             try:
-                result = self._run(script, env)
+                result = self._run(script, env, prefix=self._mode_bits_enforced())
             finally:
                 os.chmod(record, 0o644)
             self.assertEqual(result.returncode, 7,
@@ -1053,6 +1077,12 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
         into verify-dns-<stage>.json was unchecked, so when it failed the
         `jq -e` that follows validated whatever copy was already there.
 
+        The stale copy is held down by mode bits, so the run drops
+        CAP_DAC_OVERRIDE. Root overwrote it instead, and the fresh evidence
+        then failed `jq -e` for the ordinary reason: green against a campaign
+        with both the `rm -f` and the checked `cp` removed, which is the
+        regression this pins.
+
         RED BEFORE THE FIX: VERIFIED printed, exit 0, over a bracket whose
         fresh evidence says passed=false.
         """
@@ -1068,7 +1098,7 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
                       f'{self._helpers()}\nCORPUS_HOSTS=$(corpus_hosts)\n'
                       'run_verify pre || { echo REFUSED; exit 7; }\necho VERIFIED\n')
             try:
-                result = self._run(script, env)
+                result = self._run(script, env, prefix=self._mode_bits_enforced())
             finally:
                 if os.path.exists(stale):
                     os.chmod(stale, 0o644)

--- a/bench/chromium/test_campaign.py
+++ b/bench/chromium/test_campaign.py
@@ -441,11 +441,20 @@ class DnsBrackets(unittest.TestCase):
         r"(GUEST_DNS=10\.0\.2\.2[^\n]*\\\n[^\n]*engine_target golden\)[^\n]*)")
     URL_LINE = re.compile(r'^URLS="([^"]+)"$', re.M)
 
+    # MAKE_DNS_QNAMES: the names the clone this sub-make stands for resolved,
+    # appended to the replay server's DNS log AS THE BRACKET RUNS -- the same
+    # order as the real thing, where corpus_serve logs each query while the
+    # sub-make is in flight. A bracket that expects the log to say otherwise
+    # sets this to a subset, or to nothing.
     FAKE_MAKE = """#!/bin/bash
 env > "$MAKE_ENV_DUMP"
 echo "$*" > "$MAKE_ARGV"
 [ -z "${MAKE_VERIFY_JSON:-}" ] || printf '%s\\n' "$MAKE_VERIFY_JSON" > "$RESULTS/verify-dns.json"
 [ -z "${MAKE_DIAG_JSON:-}" ] || { mkdir -p "$RESULTS/diag"; printf '%s\\n' "$MAKE_DIAG_JSON" > "$RESULTS/diag/summary.json"; }
+for qname in ${MAKE_DNS_QNAMES:-}; do
+    printf '{"ts":%s,"peer":"127.0.0.1:40001","qname":"%s","qtype":1,"answer":"10.0.2.2"}\\n' \\
+        "$(date +%s)" "$qname" >> "$RESULTS/corpus-dns.log"
+done
 exit "${MAKE_RC:-0}"
 """
     # Decoy :53 listeners with OTHER pids, as on the bench host itself:
@@ -538,6 +547,9 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
             LOADAVG_FILE=loadavg,
             RESULTS=results, LOGDIR=logs, REPO=tmp, TAG="cb-req-corpus",
             ENGINE="chromium",
+            # The passing shape: the clone asked the replay server for every
+            # corpus host while the bracket ran.
+            MAKE_DNS_QNAMES=" ".join(self._hosts_of(self._urls())),
         )
         return env, results
 
@@ -654,6 +666,84 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
                 self.assertNotEqual(result.returncode, 0,
                                     f"{label}: accepted\n{result.stdout}")
                 self.assertNotIn("VERIFIED", result.stdout)
+
+    def test_a_bracket_the_replay_server_never_answered_is_refused(self):
+        """HOP D reads what the clone RESOLVED. On its own that cannot say
+        WHERE the answer came from: a corpus_serve leaked from an earlier
+        campaign, an /etc/hosts baked into the golden, or a resolver cache in
+        the clone all answer 10.0.2.2 with this campaign's replay server never
+        consulted. The bracket must also see the query arrive here.
+
+        RED BEFORE THE FIX: every case below printed VERIFIED with exit 0
+        while corpus-dns.log held nothing from the bracket.
+        """
+        urls = self._urls()
+        hosts = self._hosts_of(urls)
+        # (names the clone asked for, the fragment the refusal must carry)
+        cases = {
+            "no query at all": ("", "holds no queries"),
+            "one host answered elsewhere": (" ".join(hosts[:-1]), hosts[-1]),
+        }
+        for label, (qnames, expected) in cases.items():
+            with self.subTest(label), tempfile.TemporaryDirectory() as tmp:
+                env, _results = self._fakes(tmp)
+                env["MAKE_VERIFY_JSON"] = self._bracket_evidence(urls)
+                env["MAKE_DNS_QNAMES"] = qnames
+                script = (f'set -euo pipefail\nsay() {{ :; }}\nURLS="{urls}"\n'
+                          f'{self._helpers()}\nCORPUS_HOSTS=$(corpus_hosts)\n'
+                          'run_verify pre\necho VERIFIED\n')
+                result = self._run(script, env)
+                self.assertNotEqual(result.returncode, 0,
+                                    f"{label}: accepted\n{result.stdout}")
+                self.assertNotIn("VERIFIED", result.stdout)
+                self.assertIn(expected, result.stderr,
+                              f"{label}: the refusal does not say what was "
+                              f"missing\n{result.stderr}")
+
+    def test_an_earlier_campaigns_queries_cannot_answer_for_this_bracket(self):
+        """The replay log is append-only across a campaign, so "the log
+        mentions this host" is not evidence: the queries have to fall inside
+        the bracket's own window.
+
+        RED BEFORE THE FIX: a log full of yesterday's queries passed.
+        """
+        urls = self._urls()
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            with open(os.path.join(results, "corpus-dns.log"), "w") as handle:
+                for host in self._hosts_of(urls):
+                    handle.write(json.dumps({
+                        "ts": 1755000000.0, "peer": "127.0.0.1:41552",
+                        "qname": host, "qtype": 1, "answer": "10.0.2.2"}) + "\n")
+            env["MAKE_VERIFY_JSON"] = self._bracket_evidence(urls)
+            env["MAKE_DNS_QNAMES"] = ""
+            script = (f'set -euo pipefail\nsay() {{ :; }}\nURLS="{urls}"\n'
+                      f'{self._helpers()}\nCORPUS_HOSTS=$(corpus_hosts)\n'
+                      'run_verify pre\necho VERIFIED\n')
+            result = self._run(script, env)
+            self.assertNotEqual(result.returncode, 0,
+                                f"a stale replay log was accepted\n{result.stdout}")
+            self.assertNotIn("VERIFIED", result.stdout)
+
+    def test_a_passing_bracket_records_what_the_replay_served(self):
+        """The count is the record that the two ends of the query met. Without
+        a file saying so, a later reader has HOP D's answer and nothing that
+        ties it to this campaign's server."""
+        urls = self._urls()
+        hosts = self._hosts_of(urls)
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            env["MAKE_VERIFY_JSON"] = self._bracket_evidence(urls)
+            script = (f'set -euo pipefail\nsay() {{ :; }}\nURLS="{urls}"\n'
+                      f'{self._helpers()}\nCORPUS_HOSTS=$(corpus_hosts)\n'
+                      'run_verify pre\necho VERIFIED\n')
+            result = self._run(script, env)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            line = read_if_exists(os.path.join(results, "replay-queries.log")).strip()
+            self.assertTrue(line, "the bracket left no replay-queries.log")
+            self.assertIn("pre ", line)
+            self.assertIn(f"hosts_seen={len(hosts)}/{len(hosts)}", line)
+            self.assertIn("missing=none", line)
 
     def test_a_stale_read_only_bracket_copy_cannot_stand_in(self):
         """run_verify is called as `run_verify pre || campaign_fail ...`, and
@@ -1627,6 +1717,7 @@ class DiagPhase(unittest.TestCase):
     _run = DnsBrackets._run
     _helpers = DnsBrackets._helpers
     _urls = DnsBrackets._urls
+    _hosts_of = staticmethod(DnsBrackets._hosts_of)
 
     DIAG_BLOCK = re.compile(
         r'(run_diag \|\| campaign_fail[^\n]*\n'

--- a/bench/chromium/test_campaign.py
+++ b/bench/chromium/test_campaign.py
@@ -700,6 +700,45 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
                               f"{label}: the refusal does not say what was "
                               f"missing\n{result.stderr}")
 
+    def test_a_bracket_with_no_corpus_names_is_refused(self):
+        """Every check in the bracket is a claim about a list of names, and
+        every one of them is vacuously true when that list is empty: jq's
+        `all` over an empty array is true, and "the replay answered for every
+        corpus host" holds when there are no corpus hosts. A bracket left in
+        that state renders a verdict it cannot support, the same shape as a
+        gate reporting CLEAR because its tooling was missing.
+
+        The corpus URL list is a literal in the script today, so this state is
+        not reachable by configuration; it is one edit away, and the edit
+        would land as a passing campaign rather than a failing one.
+
+        RED BEFORE THE FIX: exit 0 and VERIFIED, against a corpus-dns.log the
+        bracket never saw a single line written to.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            env["MAKE_VERIFY_JSON"] = json.dumps({
+                "dns_server": "10.0.2.2", "hosts": {}, "urls": {},
+                "proxies_disabled": True, "passed": True,
+            })
+            env["MAKE_DNS_QNAMES"] = ""
+            # The second and third brackets always meet a log the first
+            # bracket filled, so the empty-log guard above them cannot stand
+            # in for this one. One line from an earlier bracket is enough.
+            with open(os.path.join(results, "corpus-dns.log"), "w") as handle:
+                handle.write(json.dumps({
+                    "ts": 1755000000.0, "peer": "127.0.0.1:41552",
+                    "qname": "example.com", "qtype": 1, "answer": "10.0.2.2",
+                }) + "\n")
+            script = ('set -euo pipefail\nsay() { :; }\nURLS=""\n'
+                      f'{self._helpers()}\nCORPUS_HOSTS=$(corpus_hosts)\n'
+                      'run_verify pre\necho VERIFIED\n')
+            result = self._run(script, env)
+            self.assertNotEqual(result.returncode, 0,
+                                f"an empty corpus was accepted\n{result.stdout}")
+            self.assertNotIn("VERIFIED", result.stdout)
+            self.assertIn("names no hosts", result.stderr, result.stderr)
+
     def test_an_earlier_campaigns_queries_cannot_answer_for_this_bracket(self):
         """The replay log is append-only across a campaign, so "the log
         mentions this host" is not evidence: the queries have to fall inside

--- a/bench/chromium/test_campaign.py
+++ b/bench/chromium/test_campaign.py
@@ -21,6 +21,7 @@ import http.server
 import json
 import os
 import re
+import shutil
 import subprocess
 import tempfile
 import threading
@@ -803,6 +804,64 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
                                 f"a stale replay log was accepted\n{result.stdout}")
             self.assertNotIn("VERIFIED", result.stdout)
 
+    def _pin_the_clock(self, tmp, epoch: str) -> None:
+        """A `date` on PATH that answers `+%s` with one fixed second.
+
+        The bracket boundary and the queries around it are a sub-second
+        apart in the real thing, which no test can schedule. Pinning the
+        second the campaign sees makes "the preceding phase's query landed
+        in the second this bracket opened" an exact input rather than a
+        race. Every other `date` call reaches the real binary.
+        """
+        real = shutil.which("date")
+        self.assertIsNotNone(real, "date is missing; this test cannot evaluate anything")
+        path = os.path.join(tmp, "bin", "date")
+        with open(path, "w") as handle:
+            handle.write('#!/bin/bash\n'
+                         'if [ "${1:-}" = +%s ]; then echo "$FAKE_EPOCH"; exit 0; fi\n'
+                         f'exec {real} "$@"\n')
+        os.chmod(path, 0o755)
+
+    def test_a_query_from_the_phase_before_the_bracket_cannot_answer_for_it(self):
+        """The boundary has to separate the two ends of one second.
+
+        `date +%s` truncates, so a query the preceding phase made 0.4 s
+        before the bracket opened carries a ts at or above the second the
+        bracket recorded, and satisfied it. The settle wait, the golden and
+        the diag all render the same corpus names immediately before a
+        bracket runs, so this is the ordinary case, not a contrived one.
+        The boundary is the replay log's own length instead: everything this
+        bracket provoked is appended after it.
+
+        RED BEFORE THE FIX: `a query from the phase before the bracket was
+        accepted` -- exit 0 and VERIFIED, against a log whose every line was
+        written before run_verify was called.
+        """
+        urls = self._urls()
+        epoch = "1755000000"
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            self._pin_the_clock(tmp, epoch)
+            env["FAKE_EPOCH"] = epoch
+            with open(os.path.join(results, "corpus-dns.log"), "w") as handle:
+                for host in self._hosts_of(urls):
+                    handle.write(json.dumps({
+                        "ts": float(epoch) + 0.4, "peer": "127.0.0.1:41552",
+                        "qname": host, "qtype": 1, "answer": "10.0.2.2"}) + "\n")
+            env["MAKE_VERIFY_JSON"] = self._bracket_evidence(urls)
+            # The clone this bracket stands for asked the replay server
+            # nothing at all.
+            env["MAKE_DNS_QNAMES"] = ""
+            script = (f'set -euo pipefail\nsay() {{ :; }}\nURLS="{urls}"\n'
+                      f'{self._helpers()}\nCORPUS_HOSTS=$(corpus_hosts)\n'
+                      'run_verify pre\necho VERIFIED\n')
+            result = self._run(script, env)
+            self.assertNotEqual(
+                result.returncode, 0,
+                "a query from the phase before the bracket was accepted\n"
+                + result.stdout)
+            self.assertNotIn("VERIFIED", result.stdout)
+
     def test_a_passing_bracket_records_what_the_replay_served(self):
         """The count is the record that the two ends of the query met. Without
         a file saying so, a later reader has HOP D's answer and nothing that
@@ -1161,7 +1220,9 @@ read -r _ < "$GO"
                       "a campaign that dies mid-run leaks the replay server")
 
     BRACKETS = ("pre", "before-run", "after-run")
-    REPLAY_LOGS = ("corpus-dns.log", "corpus-access.log")
+    # The two logs the replay server writes, and the campaign's own record of
+    # what each bracket saw it serve. dns-evidence.json hashes all three.
+    REPLAY_LOGS = ("corpus-dns.log", "corpus-access.log", "replay-queries.log")
 
     RUN_ID = "20260828-000000-corpus"
 
@@ -1383,23 +1444,35 @@ wait_sampler_gone() {
     def test_a_missing_or_empty_replay_log_is_unclean(self):
         """The replay server's own logs are the other half of the evidence;
         a null hash was recorded without lowering the verdict.
+        replay-queries.log is held to the same rule: it is the only record
+        tying each bracket's window to the queries this server received, and
+        campaign_summary refuses a run that cannot produce it, so a verdict
+        written without it names a run that can never be published.
 
         RED BEFORE THE FIX: verdict clean with corpus_dns_log_sha256 null.
+
+        RED BEFORE THE SECOND FIX (replay-queries.log): `'clean' != 'unclean'`
+        for both the missing and the empty case.
         """
-        with tempfile.TemporaryDirectory() as tmp:
-            env, results = self._fakes(tmp)
-            self._leave_files(results, logs=("corpus-access.log",))
-            evidence, _ = self._sample(env, results, files=False)
-            self.assertEqual(evidence["verdict"], "unclean", evidence)
-            self.assertIsNone(evidence["corpus_dns_log_sha256"])
-            self.assertIn("corpus-dns.log", evidence["reason"])
-        with tempfile.TemporaryDirectory() as tmp:
-            env, results = self._fakes(tmp)
-            self._leave_files(results)
-            open(os.path.join(results, "corpus-access.log"), "w").close()
-            evidence, _ = self._sample(env, results, files=False)
-            self.assertEqual(evidence["verdict"], "unclean", evidence)
-            self.assertIn("corpus-access.log", evidence["reason"])
+        for name in self.REPLAY_LOGS:
+            field = name.rsplit(".", 1)[0].replace("-", "_") + "_log_sha256"
+            with self.subTest(log=name, state="missing"), \
+                    tempfile.TemporaryDirectory() as tmp:
+                env, results = self._fakes(tmp)
+                self._leave_files(
+                    results, logs=[o for o in self.REPLAY_LOGS if o != name])
+                evidence, _ = self._sample(env, results, files=False)
+                self.assertEqual(evidence["verdict"], "unclean", evidence)
+                self.assertIsNone(evidence[field])
+                self.assertIn(name, evidence["reason"])
+            with self.subTest(log=name, state="empty"), \
+                    tempfile.TemporaryDirectory() as tmp:
+                env, results = self._fakes(tmp)
+                self._leave_files(results)
+                open(os.path.join(results, name), "w").close()
+                evidence, _ = self._sample(env, results, files=False)
+                self.assertEqual(evidence["verdict"], "unclean", evidence)
+                self.assertIn(name, evidence["reason"])
 
     def test_a_sampler_that_died_mid_run_is_unclean(self):
         """One clean sample followed by a dead sampler was accepted: the
@@ -1471,8 +1544,9 @@ wait_sampler_gone() {
                 self.assertIn("cannot write", result.stderr,
                               f"the failed {tool} was not what made the verdict unclean")
                 self.assertEqual(sorted(os.listdir(results)),
-                                 sorted(["analysis.json", "dns-owner.log", "corpus-dns.log",
-                                         "corpus-access.log", "corpus-serve.status"]
+                                 sorted(["analysis.json", "dns-owner.log",
+                                         "corpus-serve.status"]
+                                        + list(self.REPLAY_LOGS)
                                         + [f"verify-dns-{s}.json" for s in self.BRACKETS]),
                                  "a partial evidence file or temp file was left behind")
 

--- a/bench/chromium/test_campaign.py
+++ b/bench/chromium/test_campaign.py
@@ -486,6 +486,12 @@ class DnsBrackets(unittest.TestCase):
     # order as the real thing, where corpus_serve logs each query while the
     # sub-make is in flight. A bracket that expects the log to say otherwise
     # sets this to a subset, or to nothing.
+    # MAKE_DNS_QNAMES_AAAA and MAKE_DNS_QNAMES_OTHER_ANSWER: the rows that
+    # reach this server WITHOUT it supplying the answer HOP D saw. corpus_serve
+    # answers A queries with --answer-ip and logs every other type with
+    # answer "" (serve_dns), so a name whose A came from a resolver cache
+    # while only its AAAA arrived here is a row in this log that says nothing
+    # about the answer.
     FAKE_MAKE = """#!/bin/bash
 env > "$MAKE_ENV_DUMP"
 echo "$*" > "$MAKE_ARGV"
@@ -493,6 +499,14 @@ echo "$*" > "$MAKE_ARGV"
 [ -z "${MAKE_DIAG_JSON:-}" ] || { mkdir -p "$RESULTS/diag"; printf '%s\\n' "$MAKE_DIAG_JSON" > "$RESULTS/diag/summary.json"; }
 for qname in ${MAKE_DNS_QNAMES:-}; do
     printf '{"ts":%s,"peer":"127.0.0.1:40001","qname":"%s","qtype":1,"answer":"10.0.2.2"}\\n' \\
+        "$(date +%s)" "$qname" >> "$RESULTS/corpus-dns.log"
+done
+for qname in ${MAKE_DNS_QNAMES_AAAA:-}; do
+    printf '{"ts":%s,"peer":"127.0.0.1:40001","qname":"%s","qtype":28,"answer":""}\\n' \\
+        "$(date +%s)" "$qname" >> "$RESULTS/corpus-dns.log"
+done
+for qname in ${MAKE_DNS_QNAMES_OTHER_ANSWER:-}; do
+    printf '{"ts":%s,"peer":"127.0.0.1:40001","qname":"%s","qtype":1,"answer":"10.0.2.3"}\\n' \\
         "$(date +%s)" "$qname" >> "$RESULTS/corpus-dns.log"
 done
 exit "${MAKE_RC:-0}"
@@ -881,6 +895,157 @@ for a in "$@"; do if [ "$a" = --quiet ]; then quiet=1; else args+=("$a"); fi; do
             self.assertIn("pre ", line)
             self.assertIn(f"hosts_seen={len(hosts)}/{len(hosts)}", line)
             self.assertIn("missing=none", line)
+
+    def _stub_tool(self, tmp, name, body="#!/bin/bash\nexit 1\n"):
+        """A tool of that name, first on the bracket's PATH, that cannot run.
+
+        The campaign renders its verdict through these; a verdict from a tool
+        that could not evaluate anything is the `jq: command not found`
+        shape, and must block rather than pass.
+        """
+        path = os.path.join(tmp, "bin", name)
+        with open(path, "w") as handle:
+            handle.write(body)
+        os.chmod(path, 0o755)
+
+    def test_a_bracket_whose_record_cannot_be_written_is_refused(self):
+        """The append is the bracket's own record, and its failure was silent.
+
+        run_verify is called as `run_verify pre || campaign_fail ...`, which
+        turns errexit off inside the function, so a redirection that could not
+        be written left the rest of the bracket to carry on: `[ -n "$missing" ]`
+        was false, `say` succeeded, and the function returned 0.
+        write_dns_evidence then hashed the nonempty file an EARLIER bracket had
+        left, so the campaign was clean with a later bracket's record never
+        written.
+
+        RED BEFORE THE FIX: exit 0 and VERIFIED, with replay-queries.log still
+        holding nothing but the earlier bracket's line.
+        """
+        urls = self._urls()
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            env["MAKE_VERIFY_JSON"] = self._bracket_evidence(urls)
+            record = os.path.join(results, "replay-queries.log")
+            hosts = len(self._hosts_of(urls))
+            earlier = (f"pre since_row=0 queries={hosts} "
+                       f"hosts_seen={hosts}/{hosts} missing=none\n")
+            with open(record, "w") as handle:
+                handle.write(earlier)
+            os.chmod(record, 0o444)
+            script = (f'set -euo pipefail\nsay() {{ :; }}\nURLS="{urls}"\n'
+                      f'{self._helpers()}\nCORPUS_HOSTS=$(corpus_hosts)\n'
+                      'run_verify before-run || { echo REFUSED; exit 7; }\necho VERIFIED\n')
+            try:
+                result = self._run(script, env)
+            finally:
+                os.chmod(record, 0o644)
+            self.assertEqual(result.returncode, 7,
+                             "a bracket whose record could not be written was "
+                             f"accepted\n{result.stdout}{result.stderr}")
+            self.assertNotIn("VERIFIED", result.stdout)
+            self.assertIn("replay-queries.log", result.stderr, result.stderr)
+            with open(record) as handle:
+                self.assertEqual(handle.read(), earlier,
+                                 "the earlier bracket's line is all this verdict "
+                                 "would have had to hash")
+
+    def test_a_bracket_answered_for_another_record_type_is_refused(self):
+        """A row is only this server's answer when it IS the answer.
+
+        corpus_serve answers A queries with --answer-ip and logs every other
+        type with answer "" (serve_dns). Counting any row for the hostname
+        passes a name whose A result came from a resolver cache while only its
+        AAAA reached this server, which is not the 10.0.2.2 HOP D recorded.
+
+        RED BEFORE THE FIX: both cases printed VERIFIED with exit 0.
+        """
+        urls = self._urls()
+        hosts = self._hosts_of(urls)
+        cases = {
+            "only the AAAA reached the replay": "MAKE_DNS_QNAMES_AAAA",
+            "an answer this server never gave": "MAKE_DNS_QNAMES_OTHER_ANSWER",
+        }
+        for label, knob in cases.items():
+            with self.subTest(label), tempfile.TemporaryDirectory() as tmp:
+                env, _results = self._fakes(tmp)
+                env["MAKE_VERIFY_JSON"] = self._bracket_evidence(urls)
+                env["MAKE_DNS_QNAMES"] = " ".join(hosts[:-1])
+                env[knob] = hosts[-1]
+                script = (f'set -euo pipefail\nsay() {{ :; }}\nURLS="{urls}"\n'
+                          f'{self._helpers()}\nCORPUS_HOSTS=$(corpus_hosts)\n'
+                          'run_verify pre\necho VERIFIED\n')
+                result = self._run(script, env)
+                self.assertNotEqual(result.returncode, 0,
+                                    f"{label}: accepted\n{result.stdout}")
+                self.assertNotIn("VERIFIED", result.stdout)
+                self.assertIn(hosts[-1], result.stderr,
+                              f"{label}: the refusal does not name the host the "
+                              f"replay never answered for\n{result.stderr}")
+
+    def test_a_bracket_whose_comparison_could_not_run_is_refused(self):
+        """`comm` decides the verdict, so a `comm` that cannot run must block.
+
+        The difference was taken unchecked, and a comm that fails prints
+        nothing, which reads as "no host is missing". The bracket then passed
+        while the line it wrote said hosts_seen=0/10: a verdict rendered by a
+        tool that evaluated nothing, the shape of the `jq: command not found`
+        CLEAR in AGENTS.md.
+
+        RED BEFORE THE FIX: exit 0 and VERIFIED, with the bracket's own record
+        reading `pre since_row=0 queries=10 hosts_seen=0/10 missing=none`.
+        """
+        urls = self._urls()
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            self._stub_tool(tmp, "comm")
+            env["MAKE_VERIFY_JSON"] = self._bracket_evidence(urls)
+            script = (f'set -euo pipefail\nsay() {{ :; }}\nURLS="{urls}"\n'
+                      f'{self._helpers()}\nCORPUS_HOSTS=$(corpus_hosts)\n'
+                      'run_verify pre\necho VERIFIED\n')
+            result = self._run(script, env)
+            self.assertNotEqual(
+                result.returncode, 0,
+                "a bracket whose comparison never ran was accepted\n"
+                + result.stdout
+                + read_if_exists(os.path.join(results, "replay-queries.log")))
+            self.assertNotIn("VERIFIED", result.stdout)
+            self.assertIn("cannot compare", result.stderr, result.stderr)
+
+    def test_a_bracket_that_could_not_measure_its_window_is_refused(self):
+        """The window's boundary is a count, and it fell back to 0 unchecked.
+
+        since_row is what keeps the preceding phase's queries out of the
+        bracket. replay_log_rows swallowed a failed count and printed 0, which
+        opens the window to the whole log, so the bracket is answered by rows
+        written before it ran: exactly what
+        test_an_earlier_campaigns_queries_cannot_answer_for_this_bracket
+        refuses, reachable again through a tool that could not count.
+
+        RED BEFORE THE FIX: exit 0 and VERIFIED, against a log whose every row
+        predates the bracket and a clone that asked this server nothing.
+        """
+        urls = self._urls()
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            self._stub_tool(tmp, "wc")
+            with open(os.path.join(results, "corpus-dns.log"), "w") as handle:
+                for host in self._hosts_of(urls):
+                    handle.write(json.dumps({
+                        "ts": 1755000000.0, "peer": "127.0.0.1:41552",
+                        "qname": host, "qtype": 1, "answer": "10.0.2.2"}) + "\n")
+            env["MAKE_VERIFY_JSON"] = self._bracket_evidence(urls)
+            env["MAKE_DNS_QNAMES"] = ""
+            script = (f'set -euo pipefail\nsay() {{ :; }}\nURLS="{urls}"\n'
+                      f'{self._helpers()}\nCORPUS_HOSTS=$(corpus_hosts)\n'
+                      'run_verify pre\necho VERIFIED\n')
+            result = self._run(script, env)
+            self.assertNotEqual(result.returncode, 0,
+                                "a bracket that could not measure its window was "
+                                f"accepted\n{result.stdout}")
+            self.assertNotIn("VERIFIED", result.stdout)
+            self.assertIn("cannot measure the replay DNS log", result.stderr,
+                          result.stderr)
 
     def test_a_stale_read_only_bracket_copy_cannot_stand_in(self):
         """run_verify is called as `run_verify pre || campaign_fail ...`, and

--- a/bench/chromium/test_campaign.py
+++ b/bench/chromium/test_campaign.py
@@ -275,6 +275,45 @@ class PartialCorpus(unittest.TestCase):
                          "this refused because nothing was reachable rather "
                          "than because the corpus is partial")
 
+    def test_the_pass_line_counts_every_url_it_probed(self):
+        """The line that reports the probe's result has to name the number of
+        URLs the probe actually checked.
+
+        `printf '%s'` writes no trailing newline, so `wc -l` counted the
+        separators rather than the fields and the campaign announced 13 URLs
+        for the 14 it had just fetched, in every run:
+
+            === corpus complete: all 13 URLs replay locally
+
+        Red: `'2' != '1' : the pass line reports 1 URLs after probing 2`.
+        """
+        block = re.search(r"(missing=\"\"\n.*?\nfi)\n", campaign(), re.S)
+        self.assertIsNotNone(block, "the corpus completeness probe is gone")
+        line = re.search(r'^say "corpus complete: .*$', campaign(), re.M)
+        self.assertIsNotNone(line, "the corpus completeness pass line is gone")
+
+        server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), self.OnlyOne)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        self.addCleanup(server.server_close)
+        self.addCleanup(server.shutdown)
+        probe = self.retarget(block.group(1), server.server_port)
+
+        with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as script:
+            script.write('set -u\nsay() { printf "%s\\n" "$*"; }\n'
+                         'URLS="http://x/served,http://x/served"\n'
+                         f'{probe}\n{line.group(0)}\n')
+            path = script.name
+        self.addCleanup(os.unlink, path)
+        result = subprocess.run(["bash", path], capture_output=True, text=True,
+                                timeout=60)
+        self.assertEqual(result.returncode, 0,
+                         f"{result.stdout}{result.stderr}")
+        reported = re.search(r"corpus complete: all (\d+) URLs", result.stdout)
+        self.assertIsNotNone(reported, f"no pass line printed\n{result.stdout}")
+        self.assertEqual(reported.group(1), "2",
+                         f"the pass line reports {reported.group(1)} URLs "
+                         f"after probing 2")
+
     def test_a_complete_corpus_passes(self):
         """The guard must not refuse a corpus that IS complete."""
         block = re.search(r"(missing=\"\"\n.*?\nfi)\n", campaign(), re.S)

--- a/bench/chromium/test_campaign_summary.py
+++ b/bench/chromium/test_campaign_summary.py
@@ -125,17 +125,53 @@ class EvidenceIgnoreRules(unittest.TestCase):
 
 
 VERIFY_STAGES = ("pre", "before-run", "after-run")
+# The hosts write_verify's bracket names, which the replay logs must agree with.
+DEFAULT_BRACKET_HOSTS = {"example.com": {"answer": "10.0.2.2", "ok": True}}
 # The replay server's own logs plus the campaign's per-bracket record of what
-# it served, with the line each carries in a run directory.
+# it served. The bracket records are read back against corpus-dns.log, so the two agree
+# here the way a campaign leaves them: one A answer per bracket for the single
+# host write_verify's bracket names, each in its own window.
 CORPUS_LOGS = {
-    "corpus-dns.log": '{"ts": 1.0, "qname": "example.com"}\n',
+    "corpus-dns.log": "".join(
+        '{"ts": %s, "peer": "10.0.2.100", "qname": "example.com", '
+        '"qtype": 1, "answer": "10.0.2.2"}\n' % ts
+        for ts in (1.0, 2.0, 3.0)
+    ),
     "corpus-access.log": '{"ts": 1.0, "path": "/", "status": 200}\n',
-    "replay-queries.log": (
-        "pre since_row=0 queries=14 hosts_seen=14/14 missing=none\n"
-        "before-run since_row=14 queries=14 hosts_seen=14/14 missing=none\n"
-        "after-run since_row=28 queries=14 hosts_seen=14/14 missing=none\n"
+    "replay-queries.log": "".join(
+        f"{stage} since_row={row} queries=1 hosts_seen=1/1 missing=none\n"
+        for row, stage in enumerate(VERIFY_STAGES)
     ),
 }
+
+
+def campaign_logs(stage_hosts):
+    """The three replay logs a campaign leaves, for these brackets.
+
+    campaign_summary reads the bracket records back against corpus-dns.log, so
+    a fixture cannot state the two independently: each bracket's window holds
+    one A answer per host that bracket names, answered with the address that
+    bracket recorded, and the record counts exactly those.
+    """
+    dns, records, row = [], [], 0
+    for stage in VERIFY_STAGES:
+        hosts = stage_hosts.get(stage) or {}
+        for host, entry in hosts.items():
+            answer = (entry or {}).get("answer") if isinstance(entry, dict) else None
+            dns.append(json.dumps({"ts": 1.0 + row, "peer": "10.0.2.100",
+                                   "qname": host, "qtype": 1, "answer": answer}))
+        records.append(
+            f"{stage} since_row={row} queries={len(hosts)} "
+            f"hosts_seen={len(hosts)}/{len(hosts)} missing=none"
+        )
+        row += len(hosts)
+    return {
+        "corpus-dns.log": "".join(line + "\n" for line in dns),
+        "corpus-access.log": CORPUS_LOGS["corpus-access.log"],
+        "replay-queries.log": "".join(line + "\n" for line in records),
+    }
+
+
 # The seal identity reqbench.py stamps into every record's meta and
 # reqanalyze carries into the cell: the runtime bundle reqbench.sh sealed,
 # the binaries and sources hashed into it, the source revision, and the
@@ -315,6 +351,7 @@ def write_run(
             handle.write(f"{withdrawn}\nsecond line: detail the refusal need not quote\n")
     if dns_verdict is not None:
         verify_files = []
+        stage_hosts = {}
         verify_hashes = {}
         for stage in VERIFY_STAGES:
             verify_path = os.path.join(run_dir, f"verify-dns-{stage}.json")
@@ -324,8 +361,10 @@ def write_run(
             paths[f"verify-{stage}"] = verify_path
             verify_files.append(verify_path)
             verify_hashes[f"verify-dns-{stage}.json"] = sha256_file(verify_path)
+            with open(verify_path) as handle:
+                stage_hosts[stage] = json.load(handle).get("hosts") or {}
         hashes = {}
-        for name, line in {**CORPUS_LOGS, **(corpus_logs or {})}.items():
+        for name, line in {**campaign_logs(stage_hosts), **(corpus_logs or {})}.items():
             log_path = os.path.join(run_dir, name)
             with open(log_path, "w") as handle:
                 handle.write(line)
@@ -1462,42 +1501,69 @@ class CampaignSummary(unittest.TestCase):
         softest target of the set, because a forged directory only has to
         carry non-empty bytes and a matching digest.
 
+        Reading only the record is not enough either, because its counts are
+        its own claim about corpus-dns.log: `queries=0 hosts_seen=1/1` is
+        impossible, and a record may claim answers the log never logged. Each
+        claim is re-derived from the log over a superset of the bracket's
+        window.
+
         The campaign gates each record at write time, so a run it produced
         carries three well-formed ones. That says nothing about a directory
         the index is asked to read: the gate that matters is the one at the
         boundary where the bytes are trusted.
 
-        RED BEFORE THE FIX: every case below indexed, `AssertionError: 0 != 0`
-        with `wrote ...: 1 cell(s)`.
+        RED BEFORE THE FIX: every record-shape case indexed,
+        `AssertionError: 0 != 0` with `wrote ...: 1 cell(s)`.
+
+        RED BEFORE THE SECOND FIX (the cross-check against corpus-dns.log):
+        the four cases below that forge counts or hosts indexed the same way.
         """
-        clean = CORPUS_LOGS["replay-queries.log"]
+        clean = campaign_logs({stage: DEFAULT_BRACKET_HOSTS for stage in VERIFY_STAGES})
+        records = clean["replay-queries.log"]
         cases = (
             ("a bracket's record dropped",
-             "\n".join(clean.splitlines()[:2]) + "\n"),
+             {"replay-queries.log": "\n".join(records.splitlines()[:2]) + "\n"}),
             ("a fourth record nobody wrote",
-             clean + "after-run since_row=42 queries=14 hosts_seen=14/14 missing=none\n"),
+             {"replay-queries.log": records
+              + "after-run since_row=3 queries=1 hosts_seen=1/1 missing=none\n"}),
             ("the same bracket three times",
-             clean.replace("before-run", "pre").replace("after-run", "pre")),
+             {"replay-queries.log":
+              records.replace("before-run", "pre").replace("after-run", "pre")}),
             ("the brackets out of order",
-             "\n".join(reversed(clean.splitlines())) + "\n"),
+             {"replay-queries.log": "\n".join(reversed(records.splitlines())) + "\n"}),
             ("a bracket that reported names it never saw answered",
-             clean.replace("after-run since_row=28 queries=14 hosts_seen=14/14 missing=none",
-                           "after-run since_row=28 queries=14 hosts_seen=12/14 "
-                           "missing=example.com,news.ycombinator.com")),
+             {"replay-queries.log": records.replace(
+                 "after-run since_row=2 queries=1 hosts_seen=1/1 missing=none",
+                 "after-run since_row=2 queries=1 hosts_seen=0/1 missing=example.com")}),
             ("a bracket whose hosts_seen does not reach its total",
-             clean.replace("hosts_seen=14/14 missing=none",
-                           "hosts_seen=13/14 missing=none", 1)),
+             {"replay-queries.log": records.replace(
+                 "hosts_seen=1/1 missing=none", "hosts_seen=0/1 missing=none", 1)}),
             ("a bracket that was asked about no hosts at all",
-             clean.replace("hosts_seen=14/14", "hosts_seen=0/0")),
+             {"replay-queries.log": records.replace("hosts_seen=1/1", "hosts_seen=0/0")}),
+            ("a bracket counting hosts its own evidence does not name",
+             {"replay-queries.log": records.replace("hosts_seen=1/1", "hosts_seen=14/14")}),
             ("a window that reaches back over an earlier bracket",
-             clean.replace("after-run since_row=28", "after-run since_row=0")),
+             {"replay-queries.log": records.replace("after-run since_row=2",
+                                                    "after-run since_row=0")}),
             ("a line that is not a bracket record",
-             clean + "x\n"),
+             {"replay-queries.log": records + "x\n"}),
+            # The record's counts are claims about the DNS log, and until they
+            # were derived from it a record could say anything.
+            ("hosts answered inside a window that held no queries",
+             {"replay-queries.log": records.replace("queries=1", "queries=0")}),
+            ("more answered queries than this server ever logged",
+             {"replay-queries.log": records.replace("queries=1", "queries=5")}),
+            ("every host answered, with no answer in the log for any of them",
+             {"corpus-dns.log": clean["corpus-dns.log"].replace(
+                 '"qname": "example.com"', '"qname": "elsewhere.test"')}),
+            ("every host answered, by a server answering another address",
+             {"corpus-dns.log": clean["corpus-dns.log"].replace(
+                 '"answer": "10.0.2.2"', '"answer": "203.0.113.99"')}),
         )
-        for label, body in cases:
+        for label, logs in cases:
             with self.subTest(label), tempfile.TemporaryDirectory() as d:
                 run_dir = os.path.join(d, "run")
-                write_run(run_dir, corpus_logs={"replay-queries.log": body})
+                write_run(run_dir, corpus_logs=logs)
                 out = os.path.join(d, "campaign-x-summary.json")
                 rc, text = self._summarize(out, [run_dir])
                 self.assertNotEqual(rc, 0, f"{label}: {text}")

--- a/bench/chromium/test_campaign_summary.py
+++ b/bench/chromium/test_campaign_summary.py
@@ -65,6 +65,7 @@ class EvidenceIgnoreRules(unittest.TestCase):
         "!results/**/dns-owner.log",
         "!results/**/corpus-dns.log",
         "!results/**/corpus-access.log",
+        "!results/**/replay-queries.log",
         "!results/**/campaign-*-summary.json",
         "!results/**/WITHDRAWN",
     )
@@ -78,6 +79,7 @@ class EvidenceIgnoreRules(unittest.TestCase):
         "results/run-x/dns-owner.log",
         "results/run-x/corpus-dns.log",
         "results/run-x/corpus-access.log",
+        "results/run-x/replay-queries.log",
         "results/campaign-x-summary.json",
         "results/campaign-x/campaign-x-summary.json",
         "results/run-x/WITHDRAWN",
@@ -123,7 +125,13 @@ class EvidenceIgnoreRules(unittest.TestCase):
 
 
 VERIFY_STAGES = ("pre", "before-run", "after-run")
-CORPUS_LOGS = ("corpus-dns.log", "corpus-access.log")
+# The replay server's own logs plus the campaign's per-bracket record of what
+# it served, with the line each carries in a run directory.
+CORPUS_LOGS = {
+    "corpus-dns.log": '{"ts": 1.0, "qname": "example.com"}\n',
+    "corpus-access.log": '{"ts": 1.0, "path": "/", "status": 200}\n',
+    "replay-queries.log": "pre since_row=0 queries=14 hosts_seen=14/14 missing=none\n",
+}
 # The seal identity reqbench.py stamps into every record's meta and
 # reqanalyze carries into the cell: the runtime bundle reqbench.sh sealed,
 # the binaries and sources hashed into it, the source revision, and the
@@ -311,10 +319,10 @@ def write_run(
             verify_files.append(verify_path)
             verify_hashes[f"verify-dns-{stage}.json"] = sha256_file(verify_path)
         hashes = {}
-        for name in CORPUS_LOGS:
+        for name, line in CORPUS_LOGS.items():
             log_path = os.path.join(run_dir, name)
             with open(log_path, "w") as handle:
-                handle.write('{"ts": 1.0, "qname": "example.com"}\n')
+                handle.write(line)
             paths[name] = log_path
             hashes[name] = sha256_file(log_path)
         owner_log = os.path.join(run_dir, "dns-owner.log")
@@ -340,6 +348,7 @@ def write_run(
             "verify_file_sha256": verify_hashes,
             "corpus_dns_log_sha256": hashes["corpus-dns.log"],
             "corpus_access_log_sha256": hashes["corpus-access.log"],
+            "replay_queries_log_sha256": hashes["replay-queries.log"],
             "corpus_serve_exit_status": 0,
             "reason": None,
             "verdict": dns_verdict,
@@ -1393,18 +1402,47 @@ class CampaignSummary(unittest.TestCase):
         """The sha256 in the evidence pins the replay logs; a log that no
         longer matches is a log something appended to after the verdict.
 
+        replay-queries.log is one of them. It is the only record tying each
+        bracket's window to the queries this replay server received, so a run
+        that lost it or grew it after the verdict must not be indexable.
+
         RED BEFORE THE FIX: AssertionError: 0 == 0 : wrote ...: 1 cell(s)
+
+        RED BEFORE THE SECOND FIX (replay-queries.log): the same, plus
+        `replay-queries.log is missing` never refused anything.
         """
-        with tempfile.TemporaryDirectory() as d:
-            run_dir = os.path.join(d, "run")
-            paths = write_run(run_dir)
-            with open(paths["corpus-dns.log"], "a") as handle:
-                handle.write('{"ts": 2.0, "qname": "late.example"}\n')
-            out = os.path.join(d, "campaign-x-summary.json")
-            rc, text = self._summarize(out, [run_dir])
-            self.assertNotEqual(rc, 0, text)
-            self.assertFalse(os.path.exists(out))
-            self.assertIn("corpus-dns.log", text)
+        for name in CORPUS_LOGS:
+            with self.subTest(log=name, change="appended"), \
+                    tempfile.TemporaryDirectory() as d:
+                run_dir = os.path.join(d, "run")
+                paths = write_run(run_dir)
+                with open(paths[name], "a") as handle:
+                    handle.write("after the verdict\n")
+                out = os.path.join(d, "campaign-x-summary.json")
+                rc, text = self._summarize(out, [run_dir])
+                self.assertNotEqual(rc, 0, text)
+                self.assertFalse(os.path.exists(out))
+                self.assertIn(name, text)
+            with self.subTest(log=name, change="removed"), \
+                    tempfile.TemporaryDirectory() as d:
+                run_dir = os.path.join(d, "run")
+                paths = write_run(run_dir)
+                os.remove(paths[name])
+                out = os.path.join(d, "campaign-x-summary.json")
+                rc, text = self._summarize(out, [run_dir])
+                self.assertNotEqual(rc, 0, text)
+                self.assertFalse(os.path.exists(out))
+                self.assertIn(name, text)
+            with self.subTest(log=name, change="unhashed"), \
+                    tempfile.TemporaryDirectory() as d:
+                run_dir = os.path.join(d, "run")
+                field = "%s_log_sha256" % name.rsplit(".", 1)[0].replace("-", "_")
+                write_run(run_dir, evidence_overrides={field: None})
+                out = os.path.join(d, "campaign-x-summary.json")
+                rc, text = self._summarize(out, [run_dir])
+                self.assertNotEqual(rc, 0, text)
+                self.assertFalse(os.path.exists(out))
+                self.assertIn(name, text)
 
     def test_clean_evidence_without_samples_or_a_live_sampler_refuses(self):
         """RED BEFORE THE FIX: AssertionError: 0 == 0 : wrote ...: 1 cell(s) (x4)"""

--- a/bench/chromium/test_campaign_summary.py
+++ b/bench/chromium/test_campaign_summary.py
@@ -130,7 +130,11 @@ VERIFY_STAGES = ("pre", "before-run", "after-run")
 CORPUS_LOGS = {
     "corpus-dns.log": '{"ts": 1.0, "qname": "example.com"}\n',
     "corpus-access.log": '{"ts": 1.0, "path": "/", "status": 200}\n',
-    "replay-queries.log": "pre since_row=0 queries=14 hosts_seen=14/14 missing=none\n",
+    "replay-queries.log": (
+        "pre since_row=0 queries=14 hosts_seen=14/14 missing=none\n"
+        "before-run since_row=14 queries=14 hosts_seen=14/14 missing=none\n"
+        "after-run since_row=28 queries=14 hosts_seen=14/14 missing=none\n"
+    ),
 }
 # The seal identity reqbench.py stamps into every record's meta and
 # reqanalyze carries into the cell: the runtime bundle reqbench.sh sealed,
@@ -236,6 +240,7 @@ def write_run(
     cell_overrides=None,
     analysis_overrides=None,
     withdrawn=None,
+    corpus_logs=None,
 ):
     """A minimal run directory shaped like reqanalyze + the campaign evidence.
 
@@ -249,7 +254,8 @@ def write_run(
     way corpus_campaign.sh writes them; evidence_overrides rewrites evidence
     fields on top, verify_overrides rewrites bracket fields on every bracket
     before they are hashed, and verify_stage_overrides rewrites them on one
-    named stage.
+    named stage. corpus_logs replaces a replay log's body before it is hashed,
+    so a run can be written whose evidence pins bytes the index has to read.
     load_max_1min is the 1-min load the campaign's sampler recorded, carried
     on every owner line and reported in the evidence; None writes an owner
     log and evidence from before the sampler recorded it.
@@ -319,7 +325,7 @@ def write_run(
             verify_files.append(verify_path)
             verify_hashes[f"verify-dns-{stage}.json"] = sha256_file(verify_path)
         hashes = {}
-        for name, line in CORPUS_LOGS.items():
+        for name, line in {**CORPUS_LOGS, **(corpus_logs or {})}.items():
             log_path = os.path.join(run_dir, name)
             with open(log_path, "w") as handle:
                 handle.write(line)
@@ -1443,6 +1449,60 @@ class CampaignSummary(unittest.TestCase):
                 self.assertNotEqual(rc, 0, text)
                 self.assertFalse(os.path.exists(out))
                 self.assertIn(name, text)
+
+    def test_a_replay_query_record_that_proves_nothing_refuses(self):
+        """The hash pins the bytes; nothing read them.
+
+        replay-queries.log is the only record tying each bracket's window to
+        the queries this replay server received, and check_evidence hashed it
+        and threw the bytes away. Every other pinned artifact is read back:
+        dns-owner.log's line count is checked against the recorded sample
+        count and every line parsed, and each verify bracket is re-derived by
+        check_verify_bracket. This one was pinned and unread, which is the
+        softest target of the set, because a forged directory only has to
+        carry non-empty bytes and a matching digest.
+
+        The campaign gates each record at write time, so a run it produced
+        carries three well-formed ones. That says nothing about a directory
+        the index is asked to read: the gate that matters is the one at the
+        boundary where the bytes are trusted.
+
+        RED BEFORE THE FIX: every case below indexed, `AssertionError: 0 != 0`
+        with `wrote ...: 1 cell(s)`.
+        """
+        clean = CORPUS_LOGS["replay-queries.log"]
+        cases = (
+            ("a bracket's record dropped",
+             "\n".join(clean.splitlines()[:2]) + "\n"),
+            ("a fourth record nobody wrote",
+             clean + "after-run since_row=42 queries=14 hosts_seen=14/14 missing=none\n"),
+            ("the same bracket three times",
+             clean.replace("before-run", "pre").replace("after-run", "pre")),
+            ("the brackets out of order",
+             "\n".join(reversed(clean.splitlines())) + "\n"),
+            ("a bracket that reported names it never saw answered",
+             clean.replace("after-run since_row=28 queries=14 hosts_seen=14/14 missing=none",
+                           "after-run since_row=28 queries=14 hosts_seen=12/14 "
+                           "missing=example.com,news.ycombinator.com")),
+            ("a bracket whose hosts_seen does not reach its total",
+             clean.replace("hosts_seen=14/14 missing=none",
+                           "hosts_seen=13/14 missing=none", 1)),
+            ("a bracket that was asked about no hosts at all",
+             clean.replace("hosts_seen=14/14", "hosts_seen=0/0")),
+            ("a window that reaches back over an earlier bracket",
+             clean.replace("after-run since_row=28", "after-run since_row=0")),
+            ("a line that is not a bracket record",
+             clean + "x\n"),
+        )
+        for label, body in cases:
+            with self.subTest(label), tempfile.TemporaryDirectory() as d:
+                run_dir = os.path.join(d, "run")
+                write_run(run_dir, corpus_logs={"replay-queries.log": body})
+                out = os.path.join(d, "campaign-x-summary.json")
+                rc, text = self._summarize(out, [run_dir])
+                self.assertNotEqual(rc, 0, f"{label}: {text}")
+                self.assertFalse(os.path.exists(out), label)
+                self.assertIn("replay-queries.log", text, label)
 
     def test_clean_evidence_without_samples_or_a_live_sampler_refuses(self):
         """RED BEFORE THE FIX: AssertionError: 0 == 0 : wrote ...: 1 cell(s) (x4)"""

--- a/bench/chromium/test_corpus_serve_logs.py
+++ b/bench/chromium/test_corpus_serve_logs.py
@@ -751,7 +751,9 @@ class ReplyContract(ReplayFixture, unittest.TestCase):
     rows carried no remote address; corpus-access.log holds a line for every
     one of them (27 GET answered 404, 2 POST answered 404, 3 HEAD answered
     501) and every one was cross-origin. The replay had answered all 32 and
-    the trace could not say so.
+    the trace could not say so. That diag's results were not kept, so those
+    counts are the provenance of this change rather than a record anything may
+    be quoted from; the tests below are what hold the behaviour.
 
     Watched red against corpus_serve.py at 336ac438; the failure is quoted on
     each test.

--- a/bench/chromium/test_corpus_serve_logs.py
+++ b/bench/chromium/test_corpus_serve_logs.py
@@ -271,10 +271,12 @@ class DnsLog(unittest.TestCase):
         self.assertFalse(thread.is_alive(), "serve_dns kept running on a closed socket")
 
 
-class AccessLog(unittest.TestCase):
-    """--access-log: {ts, peer, method, host, path, status, bytes, duration_ms}.
+class ReplayFixture:
+    """A shipped ReplayServer over a one-file corpus, for the cases below.
 
-    Red: `AttributeError: module 'corpus_serve' has no attribute 'JsonlLog'`.
+    A mixin rather than a base TestCase: unittest re-runs the tests it finds
+    on a subclass, so inheriting the fixture from AccessLog would run the log
+    tests a second time under the reply-contract class's name.
     """
 
     BODY = b"hello from the corpus\n"
@@ -288,6 +290,9 @@ class AccessLog(unittest.TestCase):
             json.dump({"resources": {
                 "https://example.test/a.txt": {"file": "a.txt", "status": 200,
                                                "mime": "text/plain"},
+            }, "redirects": {
+                "https://example.test/old.txt": {"status": 301,
+                                                 "location": "https://example.test/a.txt"},
             }}, handle)
         return os.path.join(d, "corpus")
 
@@ -324,6 +329,13 @@ class AccessLog(unittest.TestCase):
         if log is not None:
             self.addCleanup(log.close)
         return self._replay(d, log)[0]
+
+
+class AccessLog(ReplayFixture, unittest.TestCase):
+    """--access-log: {ts, peer, method, host, path, status, bytes, duration_ms}.
+
+    Red: `AttributeError: module 'corpus_serve' has no attribute 'JsonlLog'`.
+    """
 
     def _rows(self, server, log_path: str) -> list:
         """The log once every handler `server` dequeued has finished.
@@ -722,6 +734,180 @@ class AccessLog(unittest.TestCase):
                               f"corpus_serve exited {early_exit} while a handler was still running")
             self.assertEqual(proc.returncode, 0,
                              f"corpus_serve exited {proc.returncode} on SIGTERM:\n{output}")
+
+
+class ReplyContract(ReplayFixture, unittest.TestCase):
+    """Every reply this server makes has to be one the browser will deliver.
+
+    A cross-origin fetch is a CORS request, and a reply without
+    Access-Control-Allow-Origin is blocked before the renderer sees it:
+    Chromium reports net::ERR_FAILED, emits no Network.responseReceived, and
+    the trace row carries no remote address. reqbench's diag then counts the
+    request as one it cannot attribute (no_remote_ip), which is what it
+    should do, because at that point nothing in the record says whether the
+    replay answered it or it left the box.
+
+    That is not hypothetical. In the 42-render diag of 2026-08-29, 32 traced
+    rows carried no remote address; corpus-access.log holds a line for every
+    one of them (27 GET answered 404, 2 POST answered 404, 3 HEAD answered
+    501) and every one was cross-origin. The replay had answered all 32 and
+    the trace could not say so.
+
+    Watched red against corpus_serve.py at 336ac438; the failure is quoted on
+    each test.
+    """
+
+    def _request(self, port, method, path, host="cdn.test", origin=None):
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        self.addCleanup(conn.close)
+        headers = {"Host": host}
+        if origin is not None:
+            headers["Origin"] = origin
+        conn.request(method, path, headers=headers)
+        response = conn.getresponse()
+        return response, response.read()
+
+    def test_a_miss_carries_the_cors_headers_a_hit_carries(self):
+        """Red: `None != 'https://page.test' : the 404 for a url the corpus
+        does not hold carries no Access-Control-Allow-Origin, so a
+        cross-origin fetch of it is blocked and its trace row names no
+        remote address`.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            server = self._server(d, None)
+            response, body = self._request(server.server_port, "GET",
+                                           "/absent.json", origin="https://page.test")
+            self.assertEqual((response.status, body), (404, b""))
+            self.assertEqual(response.headers.get("Access-Control-Allow-Origin"),
+                             "https://page.test",
+                             "the 404 for a url the corpus does not hold carries no "
+                             "Access-Control-Allow-Origin, so a cross-origin fetch of "
+                             "it is blocked and its trace row names no remote address")
+            self.assertEqual(response.headers.get("Access-Control-Allow-Credentials"),
+                             "true")
+            self.assertEqual(response.headers.get("Vary"), "Origin")
+
+    def test_a_miss_without_an_origin_allows_any(self):
+        with tempfile.TemporaryDirectory() as d:
+            server = self._server(d, None)
+            response, _ = self._request(server.server_port, "GET", "/absent.json")
+            self.assertEqual(response.status, 404)
+            self.assertEqual(response.headers.get("Access-Control-Allow-Origin"), "*")
+            self.assertIsNone(response.headers.get("Access-Control-Allow-Credentials"))
+
+    def test_a_replayed_redirect_carries_them(self):
+        """The captured redirect map answers before the corpus is consulted,
+        so its reply is a third one that has to survive a CORS check.
+
+        Red: `None != 'https://page.test' : a replayed redirect carries no
+        Access-Control-Allow-Origin`.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            server = self._server(d, None)
+            response, _ = self._request(server.server_port, "GET", "/old.txt",
+                                        host="example.test", origin="https://page.test")
+            self.assertEqual(response.status, 301)
+            self.assertEqual(response.headers.get("Location"),
+                             "https://example.test/a.txt")
+            self.assertEqual(response.headers.get("Access-Control-Allow-Origin"),
+                             "https://page.test",
+                             "a replayed redirect carries no Access-Control-Allow-Origin")
+
+    def test_a_method_with_no_handler_still_carries_them(self):
+        """The base class answers 501 for a method this server does not
+        implement. That reply is as cross-origin as any other.
+
+        Red: `None != 'https://page.test' : the 501 for an unhandled method
+        carries no Access-Control-Allow-Origin`.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            server = self._server(d, None)
+            response, _ = self._request(server.server_port, "PUT", "/a.txt",
+                                        host="example.test", origin="https://page.test")
+            self.assertEqual(response.status, 501)
+            self.assertEqual(response.headers.get("Access-Control-Allow-Origin"),
+                             "https://page.test",
+                             "the 501 for an unhandled method carries no "
+                             "Access-Control-Allow-Origin")
+
+    def test_head_is_answered_from_the_corpus(self):
+        """A HEAD of a recorded url gets that url's status and length and no
+        body, not the base class's 501 for an unimplemented method.
+        www.rtp.pt/rtp-sensor is in the corpus and was answered 501 three
+        times in the 2026-08-29 diag.
+
+        Red: `501 != 200 : HEAD of a recorded url is answered on the method
+        rather than from the corpus`.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            server = self._server(d, None)
+            response, body = self._request(server.server_port, "HEAD", "/a.txt",
+                                           host="example.test")
+            self.assertEqual(response.status, 200,
+                             "HEAD of a recorded url is answered on the method "
+                             "rather than from the corpus")
+            self.assertEqual(body, b"", "HEAD replied with a body")
+            self.assertEqual(response.headers.get("Content-Length"),
+                             str(len(self.BODY)))
+            self.assertEqual(response.headers.get("Content-Type"),
+                             "text/plain; charset=utf-8")
+
+    def test_head_of_a_url_the_corpus_does_not_hold_is_a_404(self):
+        with tempfile.TemporaryDirectory() as d:
+            server = self._server(d, None)
+            response, body = self._request(server.server_port, "HEAD", "/absent.json",
+                                           origin="https://page.test")
+            self.assertEqual(response.status, 404)
+            self.assertEqual(body, b"")
+            self.assertEqual(response.headers.get("Access-Control-Allow-Origin"),
+                             "https://page.test")
+
+    def test_every_reply_names_one_allowed_origin(self):
+        """Two Access-Control-Allow-Origin headers are worse than none: the
+        browser rejects a reply that names more than one value. The preflight
+        and the hit both used to send the header themselves, so a second
+        sender has to leave exactly one behind.
+
+        Red with the explicit send left in do_OPTIONS beside the shared one:
+        `['*', '*'] has length 2, expected 1`.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            server = self._server(d, None)
+            for method, path, host in (("OPTIONS", "/a.txt", "example.test"),
+                                       ("GET", "/a.txt", "example.test"),
+                                       ("GET", "/old.txt", "example.test"),
+                                       ("GET", "/absent.json", "cdn.test"),
+                                       ("HEAD", "/a.txt", "example.test")):
+                response, _ = self._request(server.server_port, method, path,
+                                            host=host, origin="https://page.test")
+                names = response.headers.get_all("Access-Control-Allow-Origin") or []
+                self.assertEqual(len(names), 1,
+                                 f"{method} {path} sent {names}")
+
+    def test_the_preflight_still_lists_the_methods_it_allows(self):
+        with tempfile.TemporaryDirectory() as d:
+            server = self._server(d, None)
+            response, _ = self._request(server.server_port, "OPTIONS", "/absent.json",
+                                        origin="https://page.test")
+            self.assertEqual(response.status, 204)
+            self.assertEqual(response.headers.get("Access-Control-Allow-Origin"),
+                             "https://page.test")
+            self.assertEqual(response.headers.get("Access-Control-Allow-Credentials"),
+                             "true")
+            self.assertIn("HEAD", response.headers.get("Access-Control-Allow-Methods"))
+
+    def test_a_miss_is_still_a_miss(self):
+        """The headers are the fix; the status is not. A url the corpus does
+        not hold has to keep saying so, or a stub would be indistinguishable
+        from a recording.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            server = self._server(d, None)
+            response, body = self._request(server.server_port, "GET", "/absent.json",
+                                           origin="https://page.test")
+            self.assertEqual((response.status, body), (404, b""))
+            self.assertEqual(server.RequestHandlerClass.misses,
+                             ["cdn.test/absent.json"])
 
 
 class Flags(unittest.TestCase):

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -9547,10 +9547,21 @@ class CampaignSummaryFromAnalyzerOutput(unittest.TestCase):
         # The replay server's own logs and the campaign's per-bracket record of
         # what it served. campaign_summary requires all three beside the
         # evidence, each hashing to what the verdict recorded.
-        for name in ("corpus-dns.log", "corpus-access.log", "replay-queries.log"):
+        # replay-queries.log is read back rather than only hashed, so it holds
+        # the record a clean campaign writes: one per bracket, in order, over
+        # windows that do not overlap.
+        bodies = {
+            "corpus-dns.log": '{"ts": 1.0}\n',
+            "corpus-access.log": '{"ts": 1.0}\n',
+            "replay-queries.log": "".join(
+                f"{stage} since_row={row} queries=14 hosts_seen=14/14 missing=none\n"
+                for row, stage in enumerate(("pre", "before-run", "after-run"))
+            ),
+        }
+        for name, body in bodies.items():
             path = os.path.join(run_dir, name)
             with open(path, "w") as handle:
-                handle.write('{"ts": 1.0}\n')
+                handle.write(body)
             with open(path, "rb") as handle:
                 hashes[name] = hashlib.sha256(handle.read()).hexdigest()
         with open(os.path.join(run_dir, "dns-owner.log"), "w") as handle:

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -81,6 +81,21 @@ def spawn_mixed_parent(linger_bin, fast_bin):
     return subprocess.Popen([sys.executable, "-c", code, linger_bin, fast_bin])
 
 
+def _execed_children(pid, want, parent_comm):
+    """One sample: (children, comms, has `pid` got `want` exec'd children?).
+
+    `comm` is the exec witness: `fork()` copies the parent's, `execve()`
+    replaces it, so a child whose comm still matches its parent's has not
+    exec'd yet.
+    """
+    kids = reqbench.children_of(pid)
+    comms = [reqbench.proc_comm(k) for k in kids]
+    settled = len(kids) >= want and all(
+        c is not None and c != parent_comm for c in comms
+    )
+    return kids, comms, settled
+
+
 def wait_for_execed_children(pid, want, timeout):
     """Wait until `pid` has `want` children that have finished exec'ing.
 
@@ -99,13 +114,8 @@ def wait_for_execed_children(pid, want, timeout):
     """
     parent_comm = reqbench.proc_comm(pid)
     deadline = time.monotonic() + timeout
-    kids, comms = [], []
     while True:
-        kids = reqbench.children_of(pid)
-        comms = [reqbench.proc_comm(k) for k in kids]
-        settled = len(kids) >= want and all(
-            c is not None and c != parent_comm for c in comms
-        )
+        kids, comms, settled = _execed_children(pid, want, parent_comm)
         if settled or time.monotonic() >= deadline:
             return kids, comms
         time.sleep(0.005)
@@ -149,14 +159,41 @@ def spawn_pdeathsig_parent_ignoring_sigterm(child_argv):
 
 
 def wait_for_child(pid, timeout=5.0):
-    """Block until `pid` has forked at least one child. Returns the child list."""
+    """Block until `pid` has a child that has finished exec'ing.
+
+    Waiting for the fork alone is not enough, and here the consequence is worse
+    than a misread name. `spawn_pdeathsig_parent` arms PR_SET_PDEATHSIG from
+    `preexec_fn`, which runs in the child after `fork` and before `execve`,
+    while `/proc/<pid>/task/<tid>/children` lists the child from the fork
+    onward. A caller that stops at "a child exists" can therefore kill the
+    parent while the child is still pre-`prctl`, and PR_SET_PDEATHSIG armed
+    after the parent has already exited never fires at all: the child is
+    reparented and outlives the teardown for good. The fixture then proves
+    nothing about the code under test, because the teardown aborts on the
+    survivor instead of reaching the branch the test came for.
+
+    Measured on one contended core, 30 reps of
+    TeardownNormalLeakVerdict.test_on_disk_leftovers_are_reaped_but_still_abort_the_run:
+    3 aborted with `left {pid: 'sleep'} alive after 2.0s`, `fcvm_exit_ms` 1.1
+    and `all_gone` false after the full budget. That is not scheduling latency,
+    it is a child that was never armed.
+
+    `execve` runs strictly after `preexec_fn`, so a child whose comm no longer
+    matches its parent's has already armed. Returns the child list.
+    """
+    parent_comm = reqbench.proc_comm(pid)
     deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        kids = reqbench.children_of(pid)
-        if kids:
+    while True:
+        kids, comms, settled = _execed_children(pid, 1, parent_comm)
+        if settled:
             return kids
+        if time.monotonic() >= deadline:
+            raise AssertionError(
+                f"pid {pid} never forked a child that finished exec within "
+                f"{timeout}s (children={kids} comms={comms} "
+                f"parent_comm={parent_comm!r})"
+            )
         time.sleep(0.005)
-    raise AssertionError(f"pid {pid} never forked a child")
 
 
 def kill_tree(p):
@@ -699,11 +736,23 @@ class TeardownNormalLeakVerdict(unittest.TestCase):
                     data,
                     verify_disk_cleanup=True,
                 )
-            self.assertFalse(cm.exception.teardown["disk_cleanup_verified"])
+            # Name the abort before reading anything off it. `teardown_normal`
+            # raises this same type for a process survivor and for a failed
+            # child attribution, and neither reaches the disk stage, so neither
+            # carries `disk_cleanup_verified`. A bare subscript turns "the
+            # fixture lost a race" into `KeyError: 'disk_cleanup_verified'` and
+            # buries the message that says what actually went wrong.
+            teardown = cm.exception.teardown
+            self.assertIn("left on-disk state", str(cm.exception), teardown)
+            self.assertIn(
+                "disk_cleanup_verified",
+                teardown,
+                f"the disk abort must report its verdict: {teardown}",
+            )
+            self.assertFalse(teardown["disk_cleanup_verified"])
             self.assertFalse(os.path.exists(state))
             self.assertFalse(os.path.exists(state + ".lock"))
             self.assertFalse(os.path.exists(data))
-            self.assertIn("left on-disk state", str(cm.exception))
 
 
 class TeardownAttributionFailure(unittest.TestCase):

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -87,13 +87,17 @@ def _execed_children(pid, want, parent_comm):
     `comm` is the exec witness: `fork()` copies the parent's, `execve()`
     replaces it, so a child whose comm still matches its parent's has not
     exec'd yet.
+
+    A witness has to be readable at both ends. `proc_comm` swallows its OSError
+    and returns `""`, so an unreadable `/proc/<pid>/comm` is silence, not
+    evidence, at the child end and at the parent end alike. And the question is
+    how MANY children have exec'd, not whether all of them have: a parent with
+    an unrelated child still has the one the caller asked to wait for.
     """
     kids = reqbench.children_of(pid)
     comms = [reqbench.proc_comm(k) for k in kids]
-    settled = len(kids) >= want and all(
-        c is not None and c != parent_comm for c in comms
-    )
-    return kids, comms, settled
+    witnesses = sum(1 for c in comms if c and parent_comm and c != parent_comm)
+    return kids, comms, witnesses >= want
 
 
 def wait_for_execed_children(pid, want, timeout):
@@ -1522,6 +1526,69 @@ class TeardownFastCpuAccounting(unittest.TestCase):
                 )
             finally:
                 kill_tree(p)
+
+
+class ExecWitnessCounting(unittest.TestCase):
+    """`_execed_children` counts exec witnesses; it does not poll every child.
+
+    RED BEFORE THE FIX, all three, against `settled = len(kids) >= want and
+    all(c is not None and c != parent_comm for c in comms)`:
+
+        AssertionError: False is not true : one exec'd child satisfies want=1
+        AssertionError: True is not false : an unreadable comm is not an exec witness
+        AssertionError: True is not false : an unreadable parent comm proves nothing
+    """
+
+    @contextmanager
+    def _procfs(self, kids, comms):
+        """Stub `children_of`/`proc_comm`. `comms` maps pid -> comm."""
+        real_children, real_comm = reqbench.children_of, reqbench.proc_comm
+        reqbench.children_of = lambda pid: list(kids)
+        reqbench.proc_comm = lambda pid: comms[pid]
+        try:
+            yield
+        finally:
+            reqbench.children_of, reqbench.proc_comm = real_children, real_comm
+
+    def test_an_unrelated_child_does_not_hide_a_ready_one(self):
+        """`all(...)` made every child a precondition for any one of them.
+
+        A parent that has forked two children, one of which has exec'd, has
+        the one child `wait_for_execed_children(pid, 1, timeout)` asked for.
+        Requiring the other to have exec'd too makes that call time out and
+        the caller assert on a name it never waited for.
+        """
+        with self._procfs([10, 11], {10: "fastexit", 11: "python3"}):
+            kids, comms, settled = _execed_children(1, 1, "python3")
+        self.assertEqual(kids, [10, 11])
+        self.assertEqual(comms, ["fastexit", "python3"])
+        self.assertTrue(settled, "one exec'd child satisfies want=1")
+
+    def test_two_wanted_is_still_two(self):
+        """Counting witnesses must not settle below `want`."""
+        with self._procfs([10, 11], {10: "fastexit", 11: "python3"}):
+            _, _, settled = _execed_children(1, 2, "python3")
+        self.assertFalse(settled, "only one child has exec'd")
+        with self._procfs([10, 11], {10: "fastexit", 11: "lingersleep"}):
+            _, _, settled = _execed_children(1, 2, "python3")
+        self.assertTrue(settled, "both children have exec'd")
+
+    def test_an_unreadable_comm_is_not_an_exec_witness(self):
+        """`proc_comm` swallows the OSError and returns `""`.
+
+        `"" != parent_comm` is true, so an unreadable `/proc/<pid>/comm` used
+        to report an `execve` that was never observed — the caller then read
+        the name it was waiting for from a child that may still be pre-exec.
+        """
+        with self._procfs([10], {10: ""}):
+            _, _, settled = _execed_children(1, 1, "python3")
+        self.assertFalse(settled, "an unreadable comm is not an exec witness")
+
+    def test_an_unreadable_parent_comm_proves_nothing(self):
+        """With no parent comm there is nothing for a child's to differ from."""
+        with self._procfs([10], {10: "python3"}):
+            _, _, settled = _execed_children(1, 1, "")
+        self.assertFalse(settled, "an unreadable parent comm proves nothing")
 
 
 class FindStateIsEventDriven(unittest.TestCase):

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -9428,7 +9428,10 @@ class CampaignSummaryFromAnalyzerOutput(unittest.TestCase):
                 verify_hashes[f"verify-dns-{stage}.json"] = hashlib.sha256(
                     handle.read()).hexdigest()
         hashes = {}
-        for name in ("corpus-dns.log", "corpus-access.log"):
+        # The replay server's own logs and the campaign's per-bracket record of
+        # what it served. campaign_summary requires all three beside the
+        # evidence, each hashing to what the verdict recorded.
+        for name in ("corpus-dns.log", "corpus-access.log", "replay-queries.log"):
             path = os.path.join(run_dir, name)
             with open(path, "w") as handle:
                 handle.write('{"ts": 1.0}\n')
@@ -9451,6 +9454,7 @@ class CampaignSummaryFromAnalyzerOutput(unittest.TestCase):
             "verify_file_sha256": verify_hashes,
             "corpus_dns_log_sha256": hashes["corpus-dns.log"],
             "corpus_access_log_sha256": hashes["corpus-access.log"],
+            "replay_queries_log_sha256": hashes["replay-queries.log"],
             "corpus_serve_exit_status": 0,
             "reason": None,
             "verdict": verdict,
@@ -9543,7 +9547,7 @@ class CampaignSummaryFromAnalyzerOutput(unittest.TestCase):
                 "analysis.json", "dns-evidence.json", "verify-dns-pre.json",
                 "verify-dns-before-run.json", "verify-dns-after-run.json",
                 "dns-owner.log", "corpus-dns.log", "corpus-access.log",
-                "summary.json",
+                "replay-queries.log", "summary.json",
             },
         )
 

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -9547,16 +9547,23 @@ class CampaignSummaryFromAnalyzerOutput(unittest.TestCase):
         # The replay server's own logs and the campaign's per-bracket record of
         # what it served. campaign_summary requires all three beside the
         # evidence, each hashing to what the verdict recorded.
-        # replay-queries.log is read back rather than only hashed, so it holds
-        # the record a clean campaign writes: one per bracket, in order, over
-        # windows that do not overlap.
+        # replay-queries.log is read back against corpus-dns.log rather than
+        # only hashed, so the two agree the way a campaign leaves them: one
+        # record per bracket, in order, over its own window, and in that
+        # window one A answer per host the bracket names.
+        dns, records, row = [], [], 0
+        for stage in ("pre", "before-run", "after-run"):
+            for host in hosts:
+                dns.append(json.dumps({"ts": 1.0 + row, "peer": "10.0.2.100",
+                                       "qname": host, "qtype": 1,
+                                       "answer": "10.0.2.2"}))
+            records.append(f"{stage} since_row={row} queries={len(hosts)} "
+                           f"hosts_seen={len(hosts)}/{len(hosts)} missing=none")
+            row += len(hosts)
         bodies = {
-            "corpus-dns.log": '{"ts": 1.0}\n',
+            "corpus-dns.log": "".join(line + "\n" for line in dns),
             "corpus-access.log": '{"ts": 1.0}\n',
-            "replay-queries.log": "".join(
-                f"{stage} since_row={row} queries=14 hosts_seen=14/14 missing=none\n"
-                for row, stage in enumerate(("pre", "before-run", "after-run"))
-            ),
+            "replay-queries.log": "".join(line + "\n" for line in records),
         }
         for name, body in bodies.items():
             path = os.path.join(run_dir, name)

--- a/fuse-pipe/src/client/mount.rs
+++ b/fuse-pipe/src/client/mount.rs
@@ -31,6 +31,17 @@ fn join_with_timeout<T>(thread: JoinHandle<T>, timeout: Duration) -> bool {
     true
 }
 
+/// Does this /etc/fuse.conf let a non-root user mount with allow_other?
+///
+/// libfuse reads the file line by line and takes a line as the directive only
+/// when it IS the directive: `user_allow_other # comment`, `user_allow_others`
+/// and a commented-out line all leave allow_other unavailable, and a mount
+/// that asks for it anyway falls back to SessionACL::Owner. Surrounding
+/// whitespace is not part of the directive.
+pub fn fuse_conf_allows_other(contents: &str) -> bool {
+    contents.lines().any(|l| l.trim() == "user_allow_other")
+}
+
 /// Maximum retries for Session::new when kernel resources not yet released.
 const SESSION_NEW_MAX_RETRIES: u32 = 5;
 /// Delay between Session::new retries.
@@ -332,7 +343,7 @@ fn mount_internal<P: AsRef<Path>>(
     // Root can always use it; non-root needs user_allow_other in /etc/fuse.conf
     let is_root = unsafe { libc::geteuid() } == 0;
     let fuse_conf_allows = std::fs::read_to_string("/etc/fuse.conf")
-        .map(|s| s.lines().any(|l| l.trim() == "user_allow_other"))
+        .map(|s| fuse_conf_allows_other(&s))
         .unwrap_or(false);
 
     let acl = if is_root || fuse_conf_allows {
@@ -572,7 +583,7 @@ fn mount_fuse_session<P: AsRef<Path>>(
     // Root can always use it; non-root needs user_allow_other in /etc/fuse.conf
     let is_root = unsafe { libc::geteuid() } == 0;
     let fuse_conf_allows = std::fs::read_to_string("/etc/fuse.conf")
-        .map(|s| s.lines().any(|l| l.trim() == "user_allow_other"))
+        .map(|s| fuse_conf_allows_other(&s))
         .unwrap_or(false);
 
     let acl = if is_root || fuse_conf_allows {
@@ -635,4 +646,80 @@ fn mount_fuse_session<P: AsRef<Path>>(
 
     debug!(target: "fuse-pipe::client", "FUSE session exited");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fuse_conf_allows_other;
+
+    /// The fresh-box quickstart tells a reader to add user_allow_other to
+    /// /etc/fuse.conf when a grep says it is absent, and names `make
+    /// test-unit` as what fails without it. If that grep accepts a file this
+    /// mount does not, the reader is told the box is configured while every
+    /// mount here still takes SessionACL::Owner, and the test the quickstart
+    /// cites keeps failing with nothing to change.
+    ///
+    /// RED BEFORE THE FIX: the documented `grep -q '^user_allow_other'`
+    /// accepted `user_allow_other # comment` and `user_allow_otherwise`,
+    /// which this file rejects, and rejected the two indented spellings,
+    /// which it accepts. Four of the ten cases below disagreed; the
+    /// assertion reports the first.
+    #[test]
+    fn the_quickstart_guard_accepts_exactly_what_this_mount_accepts() {
+        let doc = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../.claude/CLAUDE.md");
+        let text = std::fs::read_to_string(&doc)
+            .unwrap_or_else(|e| panic!("BLOCKED: cannot read {}: {e}", doc.display()));
+        let line = text
+            .lines()
+            .find(|l| l.starts_with("grep") && l.contains("user_allow_other"))
+            .unwrap_or_else(|| {
+                panic!("the quickstart's /etc/fuse.conf guard is gone from {}", doc.display())
+            });
+        // The guard is the test half of `<guard> || <append>`.
+        let guard = line.split("||").next().expect("a guard before the append").trim();
+        assert!(
+            guard.contains("/etc/fuse.conf"),
+            "the documented guard does not read /etc/fuse.conf: {guard}"
+        );
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let conf = dir.path().join("fuse.conf");
+        let cases = [
+            "user_allow_other\n",
+            "  user_allow_other  \n",
+            "\tuser_allow_other\n",
+            "user_allow_other # comment\n",
+            "user_allow_otherwise\n",
+            "#user_allow_other\n",
+            "# user_allow_other\n",
+            "mount_max = 1000\nuser_allow_other\n",
+            "mount_max = 1000\n",
+            "",
+        ];
+        for case in cases {
+            std::fs::write(&conf, case).expect("write fuse.conf");
+            let command = guard.replace("/etc/fuse.conf", conf.to_str().expect("utf-8 path"));
+            let status = std::process::Command::new("sh")
+                .arg("-c")
+                .arg(&command)
+                .status()
+                .unwrap_or_else(|e| panic!("BLOCKED: cannot run the documented guard: {e}"));
+            // grep answers 0 (matched) or 1 (did not). Anything else is a
+            // guard that could not evaluate the file, which says nothing.
+            let code = status.code().unwrap_or_else(|| panic!("BLOCKED: {command} was signalled"));
+            assert!(
+                code == 0 || code == 1,
+                "BLOCKED: the documented guard exited {code} on {case:?}, so it evaluated nothing"
+            );
+            assert_eq!(
+                code == 0,
+                fuse_conf_allows_other(case),
+                "the quickstart's guard and this mount disagree about {case:?}: \
+                 the guard says {}, the mount says {}",
+                if code == 0 { "configured" } else { "not configured" },
+                if fuse_conf_allows_other(case) { "configured" } else { "not configured" },
+            );
+        }
+    }
 }

--- a/fuse-pipe/src/client/mount.rs
+++ b/fuse-pipe/src/client/mount.rs
@@ -666,18 +666,24 @@ mod tests {
     /// assertion reports the first.
     #[test]
     fn the_quickstart_guard_accepts_exactly_what_this_mount_accepts() {
-        let doc = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../.claude/CLAUDE.md");
+        let doc = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../.claude/CLAUDE.md");
         let text = std::fs::read_to_string(&doc)
             .unwrap_or_else(|e| panic!("BLOCKED: cannot read {}: {e}", doc.display()));
         let line = text
             .lines()
             .find(|l| l.starts_with("grep") && l.contains("user_allow_other"))
             .unwrap_or_else(|| {
-                panic!("the quickstart's /etc/fuse.conf guard is gone from {}", doc.display())
+                panic!(
+                    "the quickstart's /etc/fuse.conf guard is gone from {}",
+                    doc.display()
+                )
             });
         // The guard is the test half of `<guard> || <append>`.
-        let guard = line.split("||").next().expect("a guard before the append").trim();
+        let guard = line
+            .split("||")
+            .next()
+            .expect("a guard before the append")
+            .trim();
         assert!(
             guard.contains("/etc/fuse.conf"),
             "the documented guard does not read /etc/fuse.conf: {guard}"
@@ -707,7 +713,9 @@ mod tests {
                 .unwrap_or_else(|e| panic!("BLOCKED: cannot run the documented guard: {e}"));
             // grep answers 0 (matched) or 1 (did not). Anything else is a
             // guard that could not evaluate the file, which says nothing.
-            let code = status.code().unwrap_or_else(|| panic!("BLOCKED: {command} was signalled"));
+            let code = status
+                .code()
+                .unwrap_or_else(|| panic!("BLOCKED: {command} was signalled"));
             assert!(
                 code == 0 || code == 1,
                 "BLOCKED: the documented guard exited {code} on {case:?}, so it evaluated nothing"
@@ -717,8 +725,16 @@ mod tests {
                 fuse_conf_allows_other(case),
                 "the quickstart's guard and this mount disagree about {case:?}: \
                  the guard says {}, the mount says {}",
-                if code == 0 { "configured" } else { "not configured" },
-                if fuse_conf_allows_other(case) { "configured" } else { "not configured" },
+                if code == 0 {
+                    "configured"
+                } else {
+                    "not configured"
+                },
+                if fuse_conf_allows_other(case) {
+                    "configured"
+                } else {
+                    "not configured"
+                },
             );
         }
     }

--- a/scripts/probe-pasta-dns-gateway.sh
+++ b/scripts/probe-pasta-dns-gateway.sh
@@ -37,7 +37,14 @@ if [ "${1:-}" != "--inside" ]; then
     PASTA_BIN="${PASTA_BIN:-$(ls -t /mnt/fcvm-btrfs/pasta/pasta-*.bin 2>/dev/null | head -1 || true)}"
     [ -x "${PASTA_BIN:-}" ] \
         || { echo "BLOCKED: no pasta binary; set PASTA_BIN or run 'make setup-fcvm'" >&2; exit 2; }
-    unshare --user --map-root-user --net --mount --fork -- \
+    # --pid --mount-proc makes the --inside shell init of a PID namespace, and
+    # --kill-child ties that shell's life to this one. The two DNS responders
+    # below never return on their own: each loops on recvfrom forever, and a
+    # non-interactive shell exits without reaping its background jobs, so
+    # without a PID namespace every run left both of them holding the private
+    # net and mount namespaces open. PID 1 exiting is what ends them, on the
+    # success path, on a failed expectation, and on a kill.
+    unshare --user --map-root-user --net --mount --pid --mount-proc --kill-child --fork -- \
         "$0" --inside "$PASTA_BIN" "$(mktemp -d)" \
         || exit $?
     exit 0

--- a/scripts/probe-pasta-dns-gateway.sh
+++ b/scripts/probe-pasta-dns-gateway.sh
@@ -19,7 +19,7 @@
 # user + net + mount namespace, so the :53 listeners and the resolv.conf this
 # reads are that namespace's, and the host's DNS configuration is untouched.
 #
-#   scripts/probe-pasta-dns-gateway.sh
+#   PASTA_BIN=<assets_dir>/pasta/pasta-<sha>.bin scripts/probe-pasta-dns-gateway.sh
 #
 # Exit 0 both expectations held, 1 an expectation failed, 2 could not run.
 set -euo pipefail
@@ -34,9 +34,22 @@ if [ "${1:-}" != "--inside" ]; then
         command -v "$tool" >/dev/null 2>&1 \
             || { echo "BLOCKED: '$tool' missing; this probe cannot evaluate anything" >&2; exit 2; }
     done
-    PASTA_BIN="${PASTA_BIN:-$(ls -t /mnt/fcvm-btrfs/pasta/pasta-*.bin 2>/dev/null | head -1 || true)}"
-    [ -x "${PASTA_BIN:-}" ] \
-        || { echo "BLOCKED: no pasta binary; set PASTA_BIN or run 'make setup-fcvm'" >&2; exit 2; }
+    # The caller names the binary. Which pasta fcvm runs is a function of the
+    # ACTIVE config: get_pasta_for_config (src/setup/pasta.rs) content-
+    # addresses it over the passt repo, the pinned commit, every embedded
+    # patch and the host libc, under paths.assets_dir. Neither half is
+    # available here. Reading the config would mean copying find_config_file's
+    # five-step lookup (--config, FCVM_CONFIG_DIR, SUDO_USER's home, XDG,
+    # /etc, next to the binary) into bash, where it would diverge silently.
+    # Picking the newest pasta-*.bin under the default assets dir, which this
+    # did, answers a different question: on a box carrying more than one pin
+    # it runs a stale artifact, and on a non-default assets_dir it reports no
+    # binary at all. Either way the verdict would be about something other
+    # than the runtime under review, which is worse than no verdict.
+    [ -n "${PASTA_BIN:-}" ] \
+        || { echo "BLOCKED: set PASTA_BIN to the pasta fcvm resolves for your config: <paths.assets_dir>/pasta/pasta-<sha>.bin, whose path 'fcvm setup' logs" >&2; exit 2; }
+    [ -x "$PASTA_BIN" ] \
+        || { echo "BLOCKED: PASTA_BIN=$PASTA_BIN is not an executable file" >&2; exit 2; }
     # --pid --mount-proc makes the --inside shell init of a PID namespace, and
     # --kill-child ties that shell's life to this one. The two DNS responders
     # below never return on their own: each loops on recvfrom forever, and a

--- a/scripts/probe-pasta-dns-gateway.sh
+++ b/scripts/probe-pasta-dns-gateway.sh
@@ -60,8 +60,15 @@ if [ "${1:-}" != "--inside" ]; then
     # without a PID namespace every run left both of them holding the private
     # net and mount namespaces open. PID 1 exiting is what ends them, on the
     # success path, on a failed expectation, and on a kill.
+    # The work directory is created HERE, so it exists on the host before
+    # unshare starts, and the --inside shell's trap is not reached at all when
+    # unshare fails (userns off, a restrictive AppArmor profile). Owned here
+    # too, or every refused attempt leaves one more directory in TMPDIR.
+    WORK=$(mktemp -d) \
+        || { echo "BLOCKED: cannot create a work directory under ${TMPDIR:-/tmp}" >&2; exit 2; }
+    trap 'rm -rf "$WORK"' EXIT
     unshare --user --map-root-user --net --mount --pid --mount-proc --kill-child --fork -- \
-        "$0" --inside "$PASTA_BIN" "$(mktemp -d)" \
+        "$0" --inside "$PASTA_BIN" "$WORK" \
         || exit $?
     exit 0
 fi

--- a/scripts/probe-pasta-dns-gateway.sh
+++ b/scripts/probe-pasta-dns-gateway.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Does a guest's DNS to the pasta gateway reach a service on host 127.0.0.1:53?
+#
+# fcvm's `--dns 10.0.2.2` says "resolve at the host loopback service behind the
+# gateway". pasta does not always do that: conf.c's add_dns_resolv4() sets
+# dns_match to the gateway whenever the HOST's first /etc/resolv.conf nameserver
+# is a loopback address, and fwd_nat_from_tap() applies that redirect before the
+# gateway-to-loopback translation, so the query lands on the host's own resolver
+# instead. fcvm passes `-D none` for such a guest to switch the redirect off
+# (src/network/pasta.rs, resolver_is_pasta_gateway).
+#
+# The unit tests can only check that the flag is in the argument vector. This
+# probe runs the pinned pasta binary and asks which server actually answered,
+# and it asserts BOTH directions: with the flag the replay answers, without it
+# the host's resolver does. A probe that only checked the fixed case would pass
+# on a pasta that never redirected anything.
+#
+# No VM, no privileged port on the real host: everything runs inside a private
+# user + net + mount namespace, so the :53 listeners and the resolv.conf this
+# reads are that namespace's, and the host's DNS configuration is untouched.
+#
+#   scripts/probe-pasta-dns-gateway.sh
+#
+# Exit 0 both expectations held, 1 an expectation failed, 2 could not run.
+set -euo pipefail
+
+REPLAY_ANSWER=10.0.2.2       # what the "corpus_serve" stand-in answers
+RESOLVER_ANSWER=203.0.113.99 # what the "host resolver" stand-in answers
+GUEST_GATEWAY=10.0.2.2
+GUEST_IP=10.0.2.100
+
+if [ "${1:-}" != "--inside" ]; then
+    for tool in unshare nsenter dig ip python3; do
+        command -v "$tool" >/dev/null 2>&1 \
+            || { echo "BLOCKED: '$tool' missing; this probe cannot evaluate anything" >&2; exit 2; }
+    done
+    PASTA_BIN="${PASTA_BIN:-$(ls -t /mnt/fcvm-btrfs/pasta/pasta-*.bin 2>/dev/null | head -1 || true)}"
+    [ -x "${PASTA_BIN:-}" ] \
+        || { echo "BLOCKED: no pasta binary; set PASTA_BIN or run 'make setup-fcvm'" >&2; exit 2; }
+    unshare --user --map-root-user --net --mount --fork -- \
+        "$0" --inside "$PASTA_BIN" "$(mktemp -d)" \
+        || exit $?
+    exit 0
+fi
+
+PASTA_BIN="$2"
+WORK="$3"
+trap 'rm -rf "$WORK"' EXIT
+
+# A wildcard A responder, the shape corpus_serve.py's DNS side has.
+cat >"$WORK/responder.py" <<'PY'
+import socket, struct, sys
+bind_addr, answer_ip, label = sys.argv[1], sys.argv[2], sys.argv[3]
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+s.bind((bind_addr, 53))
+print(f"{label} listening on {bind_addr}:53 answering {answer_ip}", flush=True)
+while True:
+    data, peer = s.recvfrom(512)
+    if len(data) < 12:
+        continue
+    i = 12
+    while i < len(data) and data[i]:
+        i += 1 + data[i]
+    print(f"{label} query from {peer[0]}:{peer[1]}", flush=True)
+    header = data[:2] + struct.pack("!HHHHH", 0x8180, 1, 1, 0, 0)
+    answer = b"\xc0\x0c" + struct.pack("!HHIH", 1, 1, 60, 4) + socket.inet_aton(answer_ip)
+    s.sendto(header + data[12:i + 5] + answer, peer)
+PY
+
+ip link set lo up
+# pasta needs an interface with a default route as its template. Both ends of
+# this veth pair stay inside the namespace; nothing leaves it.
+ip link add veth0 type veth peer name veth1
+ip addr add 192.0.2.1/24 dev veth0
+ip addr add 192.0.2.2/24 dev veth1
+ip link set veth0 up
+ip link set veth1 up
+ip route add default via 192.0.2.2 dev veth0
+
+python3 "$WORK/responder.py" 127.0.0.53 "$RESOLVER_ANSWER" host-resolver >"$WORK/resolver.log" 2>&1 &
+python3 "$WORK/responder.py" 127.0.0.1 "$REPLAY_ANSWER" replay >"$WORK/replay.log" 2>&1 &
+for _ in $(seq 1 50); do
+    grep -q listening "$WORK/resolver.log" && grep -q listening "$WORK/replay.log" && break
+    sleep 0.1
+done
+grep -q listening "$WORK/resolver.log" && grep -q listening "$WORK/replay.log" \
+    || { echo "BLOCKED: the responders did not bind" >&2; cat "$WORK"/*.log >&2; exit 2; }
+
+# The systemd-resolved shape: the host's first nameserver is a loopback address
+# that is NOT where the replay is. Bound in this mount namespace only.
+printf 'nameserver 127.0.0.53\n' >"$WORK/resolv.conf"
+mount --bind "$WORK/resolv.conf" /etc/resolv.conf
+
+ask() {
+    # $@ = extra pasta flags. Prints what the guest's resolver answered.
+    local nspid pastapid answer
+    unshare --user --map-root-user --net -- sleep 60 &
+    nspid=$!
+    for _ in $(seq 1 50); do [ -e "/proc/$nspid/ns/net" ] && break; sleep 0.1; done
+    "$PASTA_BIN" --foreground --quiet --runas 0:0 --ns-ifname pasta0 \
+        -a "$GUEST_IP" -n 255.255.255.0 -g "$GUEST_GATEWAY" --no-dhcp \
+        --ipv4-only --no-ndp --no-dhcpv6 --no-ra \
+        -t none -u none -T none -U none --config-net "$@" "$nspid" \
+        >"$WORK/pasta.log" 2>&1 &
+    pastapid=$!
+    for _ in $(seq 1 50); do
+        nsenter -t "$nspid" -U -n --preserve-credentials -- ip -o addr show pasta0 2>/dev/null \
+            | grep -q "$GUEST_IP" && break
+        sleep 0.1
+    done
+    answer=$(nsenter -t "$nspid" -U -n --preserve-credentials -- \
+        dig +short +time=2 +tries=1 +noedns "@$GUEST_GATEWAY" example.com 2>/dev/null | head -1 || true)
+    kill "$pastapid" "$nspid" 2>/dev/null || true
+    wait "$pastapid" "$nspid" 2>/dev/null || true
+    printf '%s' "$answer"
+}
+
+rc=0
+with=$(ask -D none)
+if [ "$with" = "$REPLAY_ANSWER" ]; then
+    echo "OK   with -D none:    $with (the replay on host 127.0.0.1:53 answered)"
+else
+    echo "FAIL with -D none:    '$with', want $REPLAY_ANSWER; the guest's query did not reach host 127.0.0.1:53" >&2
+    cat "$WORK/pasta.log" >&2
+    rc=1
+fi
+without=$(ask)
+if [ "$without" = "$RESOLVER_ANSWER" ]; then
+    echo "OK   without it:      $without (pasta redirected port 53 to the host's own resolver)"
+else
+    echo "FAIL without it:      '$without', want $RESOLVER_ANSWER; this probe cannot tell the two wirings apart" >&2
+    cat "$WORK/pasta.log" >&2
+    rc=1
+fi
+exit "$rc"

--- a/scripts/probe-pasta-dns-gateway.sh
+++ b/scripts/probe-pasta-dns-gateway.sh
@@ -48,7 +48,10 @@ if [ "${1:-}" != "--inside" ]; then
     # than the runtime under review, which is worse than no verdict.
     [ -n "${PASTA_BIN:-}" ] \
         || { echo "BLOCKED: set PASTA_BIN to the pasta fcvm resolves for your config: <paths.assets_dir>/pasta/pasta-<sha>.bin, whose path 'fcvm setup' logs" >&2; exit 2; }
-    [ -x "$PASTA_BIN" ] \
+    # -f as well as -x: for a directory -x means "may traverse", so every
+    # directory the caller can enter passes -x alone, walks past this exit and
+    # fails at the invocation below, by which point the message is about DNS.
+    [ -f "$PASTA_BIN" ] && [ -x "$PASTA_BIN" ] \
         || { echo "BLOCKED: PASTA_BIN=$PASTA_BIN is not an executable file" >&2; exit 2; }
     # --pid --mount-proc makes the --inside shell init of a PID namespace, and
     # --kill-child ties that shell's life to this one. The two DNS responders

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -201,7 +201,10 @@ pub struct RunArgs {
     /// boot, so it is baked into any snapshot taken from this VM. Rootless
     /// guests reach host loopback services via the pasta gateway 10.0.2.2,
     /// so `--dns 10.0.2.2` points the guest at a DNS server bound on host
-    /// 127.0.0.1 (the corpus replay benchmark arm).
+    /// 127.0.0.1 (the corpus replay benchmark arm). Naming the gateway also
+    /// stops pasta claiming the guest's port 53 for the host's own resolver,
+    /// which would otherwise send those queries somewhere else entirely
+    /// (src/network/pasta.rs, resolver_is_pasta_gateway).
     #[arg(long)]
     pub dns: Option<String>,
 

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -1512,9 +1512,14 @@ async fn prepare_vm_for_lifecycle(
                 .await
                 .context("allocating loopback IP")?;
 
+            // --dns reaches pasta as well as the guest: naming the pasta
+            // gateway as the resolver means "the service on host
+            // 127.0.0.1:53", and pasta must be told not to claim port 53 for
+            // the host's own resolver instead (see resolver_is_pasta_gateway).
             Box::new(
                 PastaNetwork::new(vm_id.clone(), tap_device.clone(), port_mappings.clone())
-                    .with_loopback_ip(loopback_ip),
+                    .with_loopback_ip(loopback_ip)
+                    .with_dns_server(args.dns.clone()),
             )
         }
     };

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -1749,9 +1749,16 @@ async fn cmd_snapshot_run_inner(
                 .context("allocating loopback IP"));
 
             // With bridge mode, guest IP is always 10.0.2.100 on pasta network
-            // Each clone runs in its own namespace, so no IP conflict
+            // Each clone runs in its own namespace, so no IP conflict.
+            //
+            // The clone's pasta is wired for the resolver the snapshot baked,
+            // the same value the reboot plan re-bakes into the guest's
+            // resolv.conf. A golden made with --dns 10.0.2.2 restores with
+            // pasta's DNS special case off, so its guests keep reaching the
+            // host loopback service the golden was recorded against.
             let net = PastaNetwork::new(vm_id.clone(), tap_device.clone(), port_mappings.clone())
                 .with_loopback_ip(loopback_ip)
+                .with_dns_server(saved_network.dns_server.clone())
                 .with_restore_mode();
             Box::new(net)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ pub mod paths;
 pub mod setup;
 pub mod state;
 pub mod storage;
+#[cfg(test)]
+pub(crate) mod test_env;
 pub mod uffd;
 pub mod utils;
 pub mod version_cache;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub mod setup;
 pub mod state;
 pub mod storage;
 #[cfg(test)]
-pub(crate) mod test_env;
+mod test_env;
 pub mod uffd;
 pub mod utils;
 pub mod version_cache;

--- a/src/network/bridged.rs
+++ b/src/network/bridged.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use std::path::Path;
 use tracing::{debug, info, warn};
 
 use super::{
@@ -68,14 +69,30 @@ fn peer_of(host_ip: &str) -> Option<String> {
 /// same `ip` binary, so a run that cannot ask this question was never going
 /// to finish setup anyway.
 async fn kernel_routes_peer_via_veth(veth_name: &str, peer_ip: &str) -> Result<bool> {
-    let output = tokio::process::Command::new("ip")
+    kernel_routes_peer_via_veth_with(Path::new("ip"), veth_name, peer_ip).await
+}
+
+/// The probe, with the `ip` binary named.
+///
+/// A parameter so the unavailable-verdict case is exercised by pointing this
+/// at a stub, rather than by prepending a directory to the process's PATH:
+/// `std::env::set_var` is undefined behaviour while any other thread reads the
+/// environment, and plain `cargo test` runs this crate's suite with a thread
+/// per test, about twenty of which spawn a program by bare name.
+async fn kernel_routes_peer_via_veth_with(
+    ip_bin: &Path,
+    veth_name: &str,
+    peer_ip: &str,
+) -> Result<bool> {
+    let ip = ip_bin.display();
+    let output = tokio::process::Command::new(ip_bin)
         .args(["route", "get", peer_ip])
         .output()
         .await
-        .with_context(|| format!("running `ip route get {peer_ip}`"))?;
+        .with_context(|| format!("running `{ip} route get {peer_ip}`"))?;
     if !output.status.success() {
         anyhow::bail!(
-            "`ip route get {peer_ip}` failed ({}): {}",
+            "`{ip} route get {peer_ip}` failed ({}): {}",
             output.status,
             String::from_utf8_lossy(&output.stderr).trim()
         );
@@ -663,18 +680,13 @@ mod tests {
     /// RED before the fix: kernel_routes_peer_via_veth returned `true` on any
     /// spawn error or nonzero exit, so a candidate nobody could verify was
     /// taken as verified, the same silent acceptance #820 is about. The fake
-    /// `ip` here exits 1; nextest runs each test in its own process, but
-    /// plain `cargo test` does not, so the PATH mutation goes through the
-    /// crate-wide environment lock, which excludes both the other mutators and
-    /// the siblings that spawn the real `ip` by name. Prepending is deliberate:
-    /// the rest of PATH stays intact, so a sibling spawning any other program
-    /// by name is unaffected even inside the window.
+    /// `ip` here exits 1, and it is named to the probe instead of being put on
+    /// PATH: the process is shared with every sibling test under plain
+    /// `cargo test`, and nothing this test does may be visible to them.
     #[tokio::test]
     async fn an_unavailable_route_verdict_is_an_error_not_an_acceptance() {
-        let mut env = crate::test_env::lock_process_env_async().await;
-        let dir = std::env::temp_dir().join(format!("fcvm-fakeip-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let fake = dir.join("ip");
+        let dir = tempfile::tempdir().expect("temp dir for the stub ip");
+        let fake = dir.path().join("ip");
         std::fs::write(
             &fake,
             "#!/bin/sh\necho 'RTNETLINK answers: Network is unreachable' >&2\nexit 1\n",
@@ -684,13 +696,9 @@ mod tests {
             use std::os::unix::fs::PermissionsExt;
             std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755)).unwrap();
         }
-        let prev = std::env::var("PATH").unwrap_or_default();
-        env.set("PATH", format!("{}:{}", dir.display(), prev));
 
-        let verdict = kernel_routes_peer_via_veth("veth0-vm-abc12", "10.0.0.2").await;
+        let verdict = kernel_routes_peer_via_veth_with(&fake, "veth0-vm-abc12", "10.0.0.2").await;
 
-        drop(env);
-        let _ = std::fs::remove_dir_all(&dir);
         let err = verdict.expect_err(
             "an `ip route get` that cannot answer must be an error; returning true \
              accepts an unverified subnet, which is the #820 failure itself",

--- a/src/network/bridged.rs
+++ b/src/network/bridged.rs
@@ -662,13 +662,16 @@ mod tests {
     ///
     /// RED before the fix: kernel_routes_peer_via_veth returned `true` on any
     /// spawn error or nonzero exit, so a candidate nobody could verify was
-    /// taken as verified — the same silent acceptance #820 is about. The fake
+    /// taken as verified, the same silent acceptance #820 is about. The fake
     /// `ip` here exits 1; nextest runs each test in its own process, but
-    /// plain `cargo test` does not, so the PATH mutation additionally holds
-    /// PATH_IP_LOCK against siblings that spawn the real `ip` by name.
+    /// plain `cargo test` does not, so the PATH mutation goes through the
+    /// crate-wide environment lock, which excludes both the other mutators and
+    /// the siblings that spawn the real `ip` by name. Prepending is deliberate:
+    /// the rest of PATH stays intact, so a sibling spawning any other program
+    /// by name is unaffected even inside the window.
     #[tokio::test]
     async fn an_unavailable_route_verdict_is_an_error_not_an_acceptance() {
-        let _path_lock = crate::network::PATH_IP_LOCK.lock().await;
+        let mut env = crate::test_env::lock_process_env_async().await;
         let dir = std::env::temp_dir().join(format!("fcvm-fakeip-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let fake = dir.join("ip");
@@ -682,11 +685,11 @@ mod tests {
             std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755)).unwrap();
         }
         let prev = std::env::var("PATH").unwrap_or_default();
-        std::env::set_var("PATH", format!("{}:{}", dir.display(), prev));
+        env.set("PATH", format!("{}:{}", dir.display(), prev));
 
         let verdict = kernel_routes_peer_via_veth("veth0-vm-abc12", "10.0.0.2").await;
 
-        std::env::set_var("PATH", prev);
+        drop(env);
         let _ = std::fs::remove_dir_all(&dir);
         let err = verdict.expect_err(
             "an `ip route get` that cannot answer must be an error; returning true \

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -107,16 +107,6 @@ pub trait NetworkManager: Send + Sync {
     fn as_any(&self) -> &dyn std::any::Any;
 }
 
-/// Serializes tests whose behavior depends on resolving `ip` through the
-/// process-global PATH. Plain `cargo test` runs every test in one process, so
-/// a test that points PATH at a fake `ip` races any sibling that spawns the
-/// real one by name (nextest's process-per-test isolation never sees this).
-/// Both kinds of test hold this lock: the PATH mutator and the by-name
-/// spawner. tokio's Mutex because the mutator holds it across an await, and
-/// it does not poison when a holder's assertion panics.
-#[cfg(test)]
-pub(crate) static PATH_IP_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
 /// The resolv.conf files fcvm reads to learn the host's nameservers, most
 /// authoritative first.
 ///

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -1,6 +1,8 @@
 use anyhow::{Context, Result};
 use std::collections::VecDeque;
-use std::path::PathBuf;
+use std::ffi::OsString;
+use std::net::IpAddr;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -812,6 +814,10 @@ pub struct PastaNetwork {
     loopback_ip: Option<String>, // Unique loopback IP for port forwarding (127.x.y.z)
     holder_pid: Option<u32>,     // Namespace PID (set in post_start)
     restore_mode: bool,          // Skip port probe in post_start (VM not loaded yet)
+    // The resolver this launch bakes into the guest's resolv.conf (--dns, or
+    // the snapshot's baked value on a restore). None for the default rootless
+    // guest, which takes pasta's own DNS handling.
+    dns_server: Option<String>,
 }
 
 impl PastaNetwork {
@@ -922,6 +928,7 @@ impl PastaNetwork {
             loopback_ip: None,
             holder_pid: None,
             restore_mode: false,
+            dns_server: None,
         }
     }
 
@@ -948,6 +955,15 @@ impl PastaNetwork {
     /// the VM is resumed and fc-agent has sent its gratuitous ARP.
     pub fn with_restore_mode(mut self) -> Self {
         self.restore_mode = true;
+        self
+    }
+
+    /// Set the resolver this launch bakes into the guest's resolv.conf.
+    ///
+    /// Rootless mode sets no resolver of its own, so this is `--dns` on the
+    /// boot path and the snapshot's baked value on a restore.
+    pub fn with_dns_server(mut self, dns_server: Option<String>) -> Self {
+        self.dns_server = dns_server;
         self
     }
 
@@ -1161,6 +1177,179 @@ impl PastaNetwork {
         Some(proxy_url)
     }
 
+    /// Is `dns_server` the address pasta answers for as the guest's gateway?
+    ///
+    /// Parsed rather than matched as text, so the IPv6 gateway is recognised
+    /// in any of its spellings.
+    fn resolver_is_pasta_gateway(dns_server: Option<&str>) -> bool {
+        let Some(addr) = dns_server.and_then(|s| s.trim().parse::<IpAddr>().ok()) else {
+            return false;
+        };
+        [GUEST_GATEWAY, GUEST_IPV6_GATEWAY]
+            .iter()
+            .filter_map(|gw| gw.parse::<IpAddr>().ok())
+            .any(|gw| gw == addr)
+    }
+
+    /// The complete pasta argument vector for this launch, in invocation order.
+    ///
+    /// Split out from the spawn so a unit test can assert the wiring: these
+    /// arguments decide where the guest's packets land, and a flag that is
+    /// computed but never passed looks exactly like one that works.
+    fn build_pasta_args(
+        &self,
+        pid_file: &Path,
+        namespace_pid: u32,
+        host_ipv6: Option<&str>,
+        run_as_root: bool,
+    ) -> Vec<OsString> {
+        let mut args: Vec<OsString> = vec![
+            "--foreground".into(),
+            "--quiet".into(),
+            "-P".into(),
+            pid_file.as_os_str().to_os_string(),
+        ];
+        let mut push = |arg: &str| args.push(OsString::from(arg));
+
+        // When running as root (e.g., sudo in tests), pasta drops to nobody by
+        // default and then can't access the user namespace. Tell it to stay as root.
+        if run_as_root {
+            push("--runas");
+            push("0:0");
+        }
+
+        // Don't use --config-net: it sets an IP on pasta0's kernel interface, which
+        // conflicts with the bridge (kernel responds to ARP for that IP via bridge's
+        // weak host model, stealing traffic from pasta's userspace L2 handler).
+        // Instead, pasta creates the TAP but we bring it up in build_bridge_script().
+        //
+        // -a must be the VM's actual IP (GUEST_IP), not the gateway. pasta uses -a
+        // as the "guest address" and ignores ARP requests for it (don't resolve self).
+        // If -a == gateway, pasta ignores ARP for the gateway and the VM can't route.
+        push("--ns-ifname");
+        push(&self.pasta_device);
+        push("-a");
+        push(GUEST_IP); // VM's actual IP — pasta ignores ARP for this address
+        push("-n");
+        push("255.255.255.0");
+        push("-g");
+        push(GUEST_GATEWAY); // Gateway — pasta responds to ARP for this
+        push("--no-dhcp");
+
+        // If host has global IPv6, configure pasta for IPv6 outbound
+        if let Some(ipv6) = host_ipv6 {
+            // Add IPv6 guest address and gateway so pasta handles IPv6 L2↔L4 translation.
+            // -a/-g can each be specified twice (once IPv4, once IPv6).
+            push("-a");
+            push(GUEST_IPV6); // Guest IPv6 address — pasta ignores NDP for this
+            push("-g");
+            push(GUEST_IPV6_GATEWAY); // IPv6 gateway — pasta responds to NDP for this
+            push("-o");
+            push(ipv6); // Outbound source address for IPv6
+
+            // Keep NDP enabled: the guest needs NDP Neighbor Solicitation/Advertisement
+            // to resolve the IPv6 gateway's MAC address (like ARP for IPv4).
+            // Disable only RA (router advertisements) and DHCPv6 — we configure the
+            // guest's IPv6 address statically via kernel cmdline, not SLAAC.
+            push("--no-ra");
+            push("--no-dhcpv6");
+        } else {
+            // No host IPv6 — disable IPv6 entirely
+            push("--ipv4-only");
+            // NDP/RA/DHCPv6 are moot with --ipv4-only, but be explicit
+            push("--no-ndp");
+            push("--no-dhcpv6");
+            push("--no-ra");
+        }
+
+        // pasta reads the HOST's /etc/resolv.conf, and when its first
+        // nameserver is a loopback address it claims the gateway for DNS:
+        // conf.c's add_dns_resolv4() sets dns_match = map_host_loopback, which
+        // defaults to the gateway passed above, and fwd_nat_from_tap() in
+        // fwd.c applies that redirect BEFORE the gateway-to-loopback
+        // translation. A guest told to resolve at 10.0.2.2 then reaches
+        // whatever the host resolves with (127.0.0.53 under systemd-resolved,
+        // 127.0.0.1 under dnsmasq) rather than the service bound on host
+        // 127.0.0.1:53, which is what --dns 10.0.2.2 names. The result is
+        // host-dependent: the corpus replay benchmark worked on a dnsmasq box
+        // and silently resolved against the live internet on a
+        // systemd-resolved one.
+        //
+        // -D none clears dns_match, so port 53 goes through the same
+        // gateway-to-loopback translation as every other port. Only launches
+        // that named the gateway as their resolver get it; a default rootless
+        // guest keeps pasta's DNS handling.
+        if Self::resolver_is_pasta_gateway(self.dns_server.as_deref()) {
+            push("-D");
+            push("none");
+        }
+
+        // Port forwarding: pasta binds on host, L2 frames go through bridge to VM
+        if self.port_mappings.is_empty() {
+            push("-t");
+            push("none");
+            push("-u");
+            push("none");
+        } else {
+            let mut tcp_specs = Vec::new();
+            let mut udp_specs = Vec::new();
+
+            for mapping in &self.port_mappings {
+                let bind_addr = match &mapping.host_ip {
+                    Some(ip) => ip.as_str(),
+                    None => self.loopback_ip.as_deref().unwrap_or("127.0.0.1"),
+                };
+
+                // pasta spec: "bind_addr/host_port:guest_port"
+                let spec = format!("{}/{}:{}", bind_addr, mapping.host_port, mapping.guest_port);
+
+                match mapping.proto {
+                    Protocol::Tcp => tcp_specs.push(spec),
+                    Protocol::Udp => udp_specs.push(spec),
+                }
+
+                info!(
+                    proto = ?mapping.proto,
+                    host = %format!("{}:{}", bind_addr, mapping.host_port),
+                    guest = %format!("{}:{}", self.guest_ip, mapping.guest_port),
+                    "adding port forward"
+                );
+            }
+
+            if tcp_specs.is_empty() {
+                push("-t");
+                push("none");
+            } else {
+                for spec in &tcp_specs {
+                    push("-t");
+                    push(spec);
+                }
+            }
+            if udp_specs.is_empty() {
+                push("-u");
+                push("none");
+            } else {
+                for spec in &udp_specs {
+                    push("-u");
+                    push(spec);
+                }
+            }
+        }
+
+        // Disable host→namespace port forwarding (reverse direction).
+        // These don't affect outbound traffic — pasta's L2↔L4 translation handles
+        // that independently. Matches Podman's invocation pattern.
+        push("-T");
+        push("none");
+        push("-U");
+        push("none");
+
+        // Attach to the holder's namespace
+        push(&namespace_pid.to_string());
+
+        args
+    }
+
     /// Start pasta process attached to the namespace
     ///
     /// pasta creates its own TAP device (pasta0) in the namespace and provides
@@ -1220,113 +1409,15 @@ impl PastaNetwork {
         let pasta_bin = crate::setup::get_pasta_for_config(config.pasta.as_ref())?;
         info!(pasta_bin = %pasta_bin.display(), "resolved pasta binary");
 
+        let args = self.build_pasta_args(
+            &pid_file,
+            namespace_pid,
+            host_ipv6.as_deref(),
+            nix::unistd::geteuid().is_root(),
+        );
+        debug!(pasta_args = ?args, "pasta arguments");
         let mut cmd = Command::new(&pasta_bin);
-        cmd.arg("--foreground")
-            .arg("--quiet")
-            .arg("-P")
-            .arg(&pid_file);
-
-        // When running as root (e.g., sudo in tests), pasta drops to nobody by
-        // default and then can't access the user namespace. Tell it to stay as root.
-        if nix::unistd::geteuid().is_root() {
-            cmd.arg("--runas").arg("0:0");
-        }
-
-        // Don't use --config-net: it sets an IP on pasta0's kernel interface, which
-        // conflicts with the bridge (kernel responds to ARP for that IP via bridge's
-        // weak host model, stealing traffic from pasta's userspace L2 handler).
-        // Instead, pasta creates the TAP but we bring it up in build_bridge_script().
-        //
-        // -a must be the VM's actual IP (GUEST_IP), not the gateway. pasta uses -a
-        // as the "guest address" and ignores ARP requests for it (don't resolve self).
-        // If -a == gateway, pasta ignores ARP for the gateway and the VM can't route.
-        cmd.arg("--ns-ifname")
-            .arg(&self.pasta_device)
-            .arg("-a")
-            .arg(GUEST_IP) // VM's actual IP — pasta ignores ARP for this address
-            .arg("-n")
-            .arg("255.255.255.0")
-            .arg("-g")
-            .arg(GUEST_GATEWAY) // Gateway — pasta responds to ARP for this
-            .arg("--no-dhcp");
-
-        // If host has global IPv6, configure pasta for IPv6 outbound
-        if let Some(ref ipv6) = host_ipv6 {
-            // Add IPv6 guest address and gateway so pasta handles IPv6 L2↔L4 translation.
-            // -a/-g can each be specified twice (once IPv4, once IPv6).
-            cmd.arg("-a")
-                .arg(GUEST_IPV6) // Guest IPv6 address — pasta ignores NDP for this
-                .arg("-g")
-                .arg(GUEST_IPV6_GATEWAY) // IPv6 gateway — pasta responds to NDP for this
-                .arg("-o")
-                .arg(ipv6); // Outbound source address for IPv6
-
-            // Keep NDP enabled: the guest needs NDP Neighbor Solicitation/Advertisement
-            // to resolve the IPv6 gateway's MAC address (like ARP for IPv4).
-            // Disable only RA (router advertisements) and DHCPv6 — we configure the
-            // guest's IPv6 address statically via kernel cmdline, not SLAAC.
-            cmd.arg("--no-ra").arg("--no-dhcpv6");
-        } else {
-            // No host IPv6 — disable IPv6 entirely
-            cmd.arg("--ipv4-only")
-                // NDP/RA/DHCPv6 are moot with --ipv4-only, but be explicit
-                .arg("--no-ndp")
-                .arg("--no-dhcpv6")
-                .arg("--no-ra");
-        }
-
-        // Port forwarding: pasta binds on host, L2 frames go through bridge to VM
-        if self.port_mappings.is_empty() {
-            cmd.arg("-t").arg("none").arg("-u").arg("none");
-        } else {
-            let mut tcp_specs = Vec::new();
-            let mut udp_specs = Vec::new();
-
-            for mapping in &self.port_mappings {
-                let bind_addr = match &mapping.host_ip {
-                    Some(ip) => ip.as_str(),
-                    None => self.loopback_ip.as_deref().unwrap_or("127.0.0.1"),
-                };
-
-                // pasta spec: "bind_addr/host_port:guest_port"
-                let spec = format!("{}/{}:{}", bind_addr, mapping.host_port, mapping.guest_port);
-
-                match mapping.proto {
-                    Protocol::Tcp => tcp_specs.push(spec),
-                    Protocol::Udp => udp_specs.push(spec),
-                }
-
-                info!(
-                    proto = ?mapping.proto,
-                    host = %format!("{}:{}", bind_addr, mapping.host_port),
-                    guest = %format!("{}:{}", self.guest_ip, mapping.guest_port),
-                    "adding port forward"
-                );
-            }
-
-            if tcp_specs.is_empty() {
-                cmd.arg("-t").arg("none");
-            } else {
-                for spec in &tcp_specs {
-                    cmd.arg("-t").arg(spec);
-                }
-            }
-            if udp_specs.is_empty() {
-                cmd.arg("-u").arg("none");
-            } else {
-                for spec in &udp_specs {
-                    cmd.arg("-u").arg(spec);
-                }
-            }
-        }
-
-        // Disable host→namespace port forwarding (reverse direction).
-        // These don't affect outbound traffic — pasta's L2↔L4 translation handles
-        // that independently. Matches Podman's invocation pattern.
-        cmd.arg("-T").arg("none").arg("-U").arg("none");
-
-        // Attach to the holder's namespace
-        cmd.arg(namespace_pid.to_string());
+        cmd.args(&args);
 
         cmd.stdin(Stdio::null())
             .stdout(Stdio::null())
@@ -2055,6 +2146,218 @@ impl NetworkManager for PastaNetwork {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Render an argument vector as strings for assertions.
+    fn arg_strings(args: &[OsString]) -> Vec<String> {
+        args.iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    /// Does `args` contain `needle` as a consecutive run?
+    fn contains_run(args: &[String], needle: &[&str]) -> bool {
+        args.windows(needle.len()).any(|w| w == needle)
+    }
+
+    /// The argument vector pasta is actually spawned with, for a plain rootless
+    /// launch. Pins the flags the guest's routing depends on: the gateway pasta
+    /// answers ARP for, the guest address it must not answer for, and the
+    /// trailing namespace PID that decides which namespace is connected.
+    #[test]
+    fn pasta_args_carry_the_guest_addressing_and_the_namespace_pid() {
+        let network = PastaNetwork::new("args-plain".into(), "tap0".into(), vec![]);
+        let args = arg_strings(&network.build_pasta_args(
+            Path::new("/run/pasta-args-plain.pid"),
+            4242,
+            None,
+            false,
+        ));
+
+        assert!(contains_run(&args, &["-a", "10.0.2.100"]), "{args:?}");
+        assert!(contains_run(&args, &["-g", "10.0.2.2"]), "{args:?}");
+        assert!(contains_run(&args, &["-n", "255.255.255.0"]), "{args:?}");
+        assert!(contains_run(&args, &["--no-dhcp"]), "{args:?}");
+        assert!(contains_run(&args, &["--ipv4-only"]), "{args:?}");
+        assert!(
+            contains_run(&args, &["-P", "/run/pasta-args-plain.pid"]),
+            "{args:?}"
+        );
+        assert!(
+            contains_run(&args, &["-t", "none", "-u", "none"]),
+            "{args:?}"
+        );
+        assert!(
+            contains_run(&args, &["-T", "none", "-U", "none"]),
+            "{args:?}"
+        );
+        assert_eq!(
+            args.last().map(String::as_str),
+            Some("4242"),
+            "the namespace PID is pasta's trailing positional argument: {args:?}"
+        );
+        assert!(
+            !args.iter().any(|a| a == "--runas"),
+            "--runas is for the root launch only: {args:?}"
+        );
+    }
+
+    /// Root launches keep uid/gid at 0:0 (pasta otherwise drops to nobody and
+    /// cannot reach the holder's user namespace), and a host with global IPv6
+    /// gets the second -a/-g pair plus the outbound source address.
+    #[test]
+    fn pasta_args_cover_the_root_and_ipv6_launches() {
+        let network = PastaNetwork::new("args-v6".into(), "tap0".into(), vec![]);
+        let args = arg_strings(&network.build_pasta_args(
+            Path::new("/run/pasta-args-v6.pid"),
+            7,
+            Some("2001:db8::1"),
+            true,
+        ));
+
+        assert!(contains_run(&args, &["--runas", "0:0"]), "{args:?}");
+        assert!(contains_run(&args, &["-a", "fd00::100"]), "{args:?}");
+        assert!(contains_run(&args, &["-g", "fd00::2"]), "{args:?}");
+        assert!(contains_run(&args, &["-o", "2001:db8::1"]), "{args:?}");
+        assert!(contains_run(&args, &["--no-ra", "--no-dhcpv6"]), "{args:?}");
+        assert!(
+            !args.iter().any(|a| a == "--ipv4-only"),
+            "an IPv6-capable host must not disable IPv6: {args:?}"
+        );
+    }
+
+    /// Port mappings become one -t/-u spec each, bound to the VM's loopback IP
+    /// when the mapping named no host address.
+    #[test]
+    fn pasta_args_bind_port_mappings_to_the_vm_loopback_ip() {
+        let network = PastaNetwork::new(
+            "args-ports".into(),
+            "tap0".into(),
+            vec![
+                PortMapping {
+                    host_ip: None,
+                    host_port: 8080,
+                    guest_port: 80,
+                    proto: Protocol::Tcp,
+                },
+                PortMapping {
+                    host_ip: Some("127.0.0.9".into()),
+                    host_port: 5300,
+                    guest_port: 53,
+                    proto: Protocol::Udp,
+                },
+            ],
+        )
+        .with_loopback_ip("127.0.0.5".into());
+        let args = arg_strings(&network.build_pasta_args(
+            Path::new("/run/pasta-args-ports.pid"),
+            9,
+            None,
+            false,
+        ));
+
+        assert!(
+            contains_run(&args, &["-t", "127.0.0.5/8080:80"]),
+            "{args:?}"
+        );
+        assert!(
+            contains_run(&args, &["-u", "127.0.0.9/5300:53"]),
+            "{args:?}"
+        );
+    }
+
+    /// pasta reads the HOST's /etc/resolv.conf, and when its first nameserver
+    /// is a loopback address (systemd-resolved's 127.0.0.53, dnsmasq's
+    /// 127.0.0.1) it silently claims the gateway for DNS: conf.c's
+    /// `add_dns_resolv4()` sets `dns_match = map_host_loopback`, and
+    /// `fwd_nat_from_tap()` in fwd.c tests that BEFORE the gateway-to-loopback
+    /// translation. Guest queries to 10.0.2.2:53 then go to whatever the host
+    /// resolves with, not to the service bound on host 127.0.0.1:53 that
+    /// `--dns 10.0.2.2` names.
+    ///
+    /// `-D none` clears `dns_match`, so port 53 falls through to the same
+    /// translation as every other port. Only the launches that asked for the
+    /// gateway as their resolver get it; a default rootless guest still uses
+    /// pasta's DNS handling, and never names the gateway anyway
+    /// (`is_usable_nameserver` drops loopback resolvers from the host list).
+    ///
+    /// This test sees the argument vector and nothing else.
+    /// `scripts/probe-pasta-dns-gateway.sh` runs the pinned pasta binary and
+    /// asks which server actually answered, with the flag and without it.
+    #[test]
+    fn a_gateway_resolver_disables_pastas_dns_special_case() {
+        for resolver in ["10.0.2.2", "fd00::2", "fd00:0:0:0:0:0:0:2"] {
+            let network = PastaNetwork::new("args-dns".into(), "tap0".into(), vec![])
+                .with_dns_server(Some(resolver.to_string()));
+            let args = arg_strings(&network.build_pasta_args(
+                Path::new("/run/pasta-args-dns.pid"),
+                11,
+                None,
+                false,
+            ));
+            assert!(
+                contains_run(&args, &["-D", "none"]),
+                "resolver {resolver} is the pasta gateway, so pasta's DNS \
+                 special case must be off: {args:?}"
+            );
+        }
+    }
+
+    /// Every other resolver leaves pasta's DNS handling alone. A default
+    /// rootless guest (no --dns) reaches the host's resolver through pasta,
+    /// and that must keep working.
+    #[test]
+    fn other_resolvers_leave_pastas_dns_handling_alone() {
+        for resolver in [None, Some("8.8.8.8"), Some("127.0.0.1"), Some("not-an-ip")] {
+            let network = PastaNetwork::new("args-dns-other".into(), "tap0".into(), vec![])
+                .with_dns_server(resolver.map(str::to_string));
+            let args = arg_strings(&network.build_pasta_args(
+                Path::new("/run/pasta-args-dns-other.pid"),
+                12,
+                None,
+                false,
+            ));
+            assert!(
+                !args.iter().any(|a| a == "-D"),
+                "resolver {resolver:?} is not the pasta gateway; pasta's DNS \
+                 handling must be left as it is: {args:?}"
+            );
+        }
+    }
+
+    /// Both rootless launch paths must hand pasta the resolver the guest will
+    /// actually use, or the decision above is made from a `None` that nothing
+    /// set and pasta keeps its DNS special case. A boot passes `--dns`; a
+    /// restore passes the value the snapshot baked. Asserted at the source
+    /// because neither call site can be reached from a unit test: both sit
+    /// inside functions that spawn a VM.
+    #[test]
+    fn both_rootless_launch_paths_hand_pasta_the_guest_resolver() {
+        for (label, src) in [
+            ("podman run", include_str!("../commands/podman/mod.rs")),
+            ("snapshot run", include_str!("../commands/snapshot.rs")),
+        ] {
+            let sites: Vec<_> = src.match_indices("PastaNetwork::new").collect();
+            assert_eq!(
+                sites.len(),
+                1,
+                "{label} builds {} PastaNetworks; every one of them needs the \
+                 guest's resolver, so this test must cover each",
+                sites.len()
+            );
+            let start = sites[0].0;
+            let end = start
+                + src[start..]
+                    .find(';')
+                    .expect("a construction statement ends in a semicolon");
+            assert!(
+                src[start..end].contains(".with_dns_server("),
+                "{label} builds its PastaNetwork without the guest's resolver, so \
+                 pasta keeps its DNS special case and a --dns naming the gateway \
+                 reaches the host's own resolver instead: {}",
+                &src[start..end]
+            );
+        }
+    }
 
     /// A failed cleanup step must surface as an Err. Callers treat cleanup's
     /// Ok as proof the host resources are gone: `cleanup_vm_verified`

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -3652,14 +3652,12 @@ mod tests {
     }
 
     /// The batch really does run under `bash -c` and really does abort at the
-    /// first failure — verified against the host's actual `ip` binary, in the
+    /// first failure, verified against the host's actual `ip` binary, in the
     /// current namespace, using read-only `link show` commands. The script
-    /// resolves `ip` through PATH, so this holds the crate-wide environment
-    /// lock against the bridged fake-`ip` test when plain `cargo test` shares
-    /// one process.
+    /// resolves `ip` through PATH, which is safe to rely on because no test in
+    /// this crate changes it.
     #[test]
     fn ip_batch_script_runs_and_aborts_on_first_failure() {
-        let _env = crate::test_env::lock_process_env();
         let ok = IpBatchScript::new(
             vec![
                 ("show loopback".to_string(), "link show lo".to_string()),

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -3654,11 +3654,12 @@ mod tests {
     /// The batch really does run under `bash -c` and really does abort at the
     /// first failure — verified against the host's actual `ip` binary, in the
     /// current namespace, using read-only `link show` commands. The script
-    /// resolves `ip` through PATH, so this holds PATH_IP_LOCK against the
-    /// bridged fake-`ip` test when plain `cargo test` shares one process.
+    /// resolves `ip` through PATH, so this holds the crate-wide environment
+    /// lock against the bridged fake-`ip` test when plain `cargo test` shares
+    /// one process.
     #[test]
     fn ip_batch_script_runs_and_aborts_on_first_failure() {
-        let _path_lock = crate::network::PATH_IP_LOCK.blocking_lock();
+        let _env = crate::test_env::lock_process_env();
         let ok = IpBatchScript::new(
             vec![
                 ("show loopback".to_string(), "link show lo".to_string()),

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -1016,21 +1016,44 @@ async fn profile_firecracker_for_setup_vm(profile_name: &str) -> Result<Option<P
     Ok(None)
 }
 
-/// The resolution order itself, with the profile's Firecracker already looked
-/// up. Split out from [`setup_vm_firecracker_bin`] so the order is asserted
+/// The resolution order, with the profile's Firecracker already looked up.
+/// Split out from [`setup_vm_firecracker_bin`] so the order is asserted
 /// without a config file or an assets directory.
+///
+/// This reads the two process-globals the order depends on and hands them to
+/// [`setup_vm_firecracker_bin_resolved`], which is the whole rule as a pure
+/// function. Making PATH an argument is what lets the order test say "nothing
+/// on PATH" without emptying the real one: the library suite shares one
+/// process under plain `cargo test`, and an empty PATH there breaks every
+/// sibling test that spawns a program by bare name.
 fn setup_vm_firecracker_bin_from(profile_firecracker: Option<PathBuf>) -> Result<PathBuf> {
-    if let Ok(path) = std::env::var("FCVM_FIRECRACKER_BIN") {
+    setup_vm_firecracker_bin_resolved(
+        std::env::var_os("FCVM_FIRECRACKER_BIN"),
+        profile_firecracker,
+        std::env::var_os("PATH"),
+    )
+}
+
+/// `FCVM_FIRECRACKER_BIN`, then the profile's Firecracker, then `search_path`.
+fn setup_vm_firecracker_bin_resolved(
+    env_override: Option<std::ffi::OsString>,
+    profile_firecracker: Option<PathBuf>,
+    search_path: Option<std::ffi::OsString>,
+) -> Result<PathBuf> {
+    if let Some(path) = env_override {
         let p = PathBuf::from(&path);
         if !p.exists() {
-            bail!("FCVM_FIRECRACKER_BIN={} does not exist", path);
+            bail!("FCVM_FIRECRACKER_BIN={} does not exist", p.display());
         }
         return Ok(p);
     }
     if let Some(path) = profile_firecracker {
         return Ok(path);
     }
-    which::which("firecracker").context(
+    // `which_in` takes a cwd, but consults it only for a binary name that
+    // contains a path separator; "firecracker" never does.
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
+    which::which_in("firecracker", search_path, cwd).context(
         "firecracker not found in PATH; set FCVM_FIRECRACKER_BIN to the binary \
          fcvm built under <assets_dir>/firecracker/",
     )
@@ -2572,59 +2595,7 @@ fn path_to_str(path: &Path) -> Result<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Puts one process-global environment variable back the way it was.
-    ///
-    /// A test that mutates PATH or FCVM_FIRECRACKER_BIN and restores it on
-    /// its last line restores nothing when an assertion fires first, and a
-    /// test that removes a variable it did not record cannot put it back at
-    /// all. Both are the same bug: the restore has to be tied to the scope,
-    /// not to reaching the end of it.
-    struct EnvVarGuard {
-        key: &'static str,
-        previous: Option<std::ffi::OsString>,
-    }
-
-    impl EnvVarGuard {
-        /// Record the current value, then set this one.
-        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-            let guard = Self {
-                key,
-                previous: std::env::var_os(key),
-            };
-            std::env::set_var(key, value);
-            guard
-        }
-
-        /// Record the current value, then unset the variable.
-        fn unset(key: &'static str) -> Self {
-            let guard = Self {
-                key,
-                previous: std::env::var_os(key),
-            };
-            std::env::remove_var(key);
-            guard
-        }
-
-        /// Another value for the same variable, still restored by this guard.
-        fn set_to(&self, value: impl AsRef<std::ffi::OsStr>) {
-            std::env::set_var(self.key, value);
-        }
-
-        /// Unset the variable, still restored by this guard.
-        fn unset_now(&self) {
-            std::env::remove_var(self.key);
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            match self.previous.take() {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
+    use crate::test_env::lock_process_env;
 
     #[test]
     fn firecracker_commit_pins_deserialize_for_global_and_profile_configs() {
@@ -2680,15 +2651,22 @@ firecracker_commit = "27305f49ab3a5d862dc56b5108713b6536d2baa7"
         }
     }
 
-    /// FCVM_FIRECRACKER_BIN and PATH are both process-globals, so the whole
-    /// resolution order is asserted in one test rather than racing across
-    /// several.
+    /// The whole resolution order, asserted without touching the process
+    /// environment: the override and the search path are both arguments.
     ///
     /// The profile arm is the one a fresh host depends on. `fcvm setup` builds
     /// a Firecracker under the assets directory and then boots the rootfs setup
     /// VM, so consulting PATH alone failed with "firecracker not found in PATH"
     /// on a box with no system-wide Firecracker, immediately after printing the
     /// path of the binary it had just built.
+    ///
+    /// RED BEFORE THE FIX: this test set `PATH=""` process-wide, so the bare
+    /// `sh` spawn below died with
+    /// `spawning sh by name must keep working while this test runs:
+    /// Os { code: 2, kind: NotFound, message: "No such file or directory" }`.
+    /// That spawn is what every sibling test doing the same thing hits when it
+    /// lands in the window, which is the defect: nextest gives each test its
+    /// own process, plain `cargo test` gives the library suite one.
     #[test]
     fn setup_vm_firecracker_bin_prefers_env_then_profile_then_path() {
         let real = std::env::current_exe().expect("test binary path");
@@ -2698,26 +2676,34 @@ firecracker_commit = "27305f49ab3a5d862dc56b5108713b6536d2baa7"
         let built = assets.path().join("firecracker-default-0123456789ab.bin");
         std::fs::write(&built, b"#!/bin/sh\nexit 0\n").expect("write stub");
 
-        // An empty PATH removes whatever system-wide Firecracker this box may
-        // have, so the assertions below observe the profile arm. Both
-        // variables are held by a guard: any assertion below can end the test
-        // early, and the process must not be left with an empty PATH or
-        // without the FCVM_FIRECRACKER_BIN it was started with.
-        let _path = EnvVarGuard::set("PATH", "");
-        let firecracker_bin = EnvVarGuard::set("FCVM_FIRECRACKER_BIN", &real);
+        // A search path holding one empty directory removes whatever
+        // system-wide Firecracker this box may have, so the assertions below
+        // observe the profile arm. It is an argument, not the process PATH, so
+        // no sibling test can see it.
+        let empty_dir = tempfile::tempdir().expect("temp search dir");
+        let nothing_on_path = || Some(std::ffi::OsString::from(empty_dir.path()));
+        let override_of = |p: &std::path::Path| Some(std::ffi::OsString::from(p));
 
         // Set and existing: returned as-is, ahead of the profile's binary.
         assert_eq!(
-            setup_vm_firecracker_bin_from(Some(built.clone())).unwrap(),
+            setup_vm_firecracker_bin_resolved(
+                override_of(&real),
+                Some(built.clone()),
+                nothing_on_path()
+            )
+            .unwrap(),
             real
         );
 
         // Set and missing: the error names the variable, so the reader knows
         // which knob is wrong instead of getting a bare ENOENT.
-        firecracker_bin.set_to("/nonexistent/firecracker");
-        let err = setup_vm_firecracker_bin_from(Some(built.clone()))
-            .unwrap_err()
-            .to_string();
+        let err = setup_vm_firecracker_bin_resolved(
+            override_of(std::path::Path::new("/nonexistent/firecracker")),
+            Some(built.clone()),
+            nothing_on_path(),
+        )
+        .unwrap_err()
+        .to_string();
         assert!(
             err.contains("FCVM_FIRECRACKER_BIN"),
             "error should name the variable, got: {err}"
@@ -2725,61 +2711,63 @@ firecracker_commit = "27305f49ab3a5d862dc56b5108713b6536d2baa7"
 
         // Unset, a Firecracker built for the profile, nothing on PATH: the
         // built binary is used rather than the setup failing.
-        firecracker_bin.unset_now();
         assert_eq!(
-            setup_vm_firecracker_bin_from(Some(built.clone()))
+            setup_vm_firecracker_bin_resolved(None, Some(built.clone()), nothing_on_path())
                 .expect("the Firecracker fcvm built must satisfy the setup VM"),
             built
         );
 
         // Unset, nothing built, nothing on PATH: still an error, and it names
         // the override so the reader has somewhere to go.
-        let err = setup_vm_firecracker_bin_from(None).unwrap_err().to_string();
+        let err = setup_vm_firecracker_bin_resolved(None, None, nothing_on_path())
+            .unwrap_err()
+            .to_string();
         assert!(
             err.contains("FCVM_FIRECRACKER_BIN"),
             "error should name the override, got: {err}"
         );
+
+        // The process the suite shares is untouched: PATH still resolves a
+        // bare program name, which is what ~20 sibling tests rely on.
+        let sh = std::process::Command::new("sh")
+            .args(["-c", "exit 0"])
+            .status()
+            .expect("spawning sh by name must keep working while this test runs");
+        assert!(sh.success(), "sh -c 'exit 0' should succeed");
     }
 
-    /// The guard has to survive the case it exists for: an assertion that
-    /// fires while the variable is held at a test value.
-    ///
-    /// RED BEFORE THE FIX (the guard without its Drop): `PATH was left at the
-    /// test's value after a panic: left: Err(NotPresent), right: Ok("before")`
-    /// -- the guard recorded the previous value and never put it back, which
-    /// is what the hand-written save/restore in the test above did whenever an
-    /// assertion fired first.
+    /// The wrapper reads the two process-globals and the resolver applies
+    /// them. Only `FCVM_FIRECRACKER_BIN` is mutated here, under the shared
+    /// environment lock: nothing else in the crate reads it, and PATH stays
+    /// whatever the process was started with.
     #[test]
-    fn an_env_var_guard_restores_its_variable_through_a_panic() {
-        const KEY: &str = "FCVM_ENV_GUARD_PROBE";
+    fn setup_vm_firecracker_bin_from_reads_the_environment_override() {
+        let real = std::env::current_exe().expect("test binary path");
+        let mut env = lock_process_env();
 
-        // A variable that was set keeps its value.
-        std::env::set_var(KEY, "before");
-        let panicked = std::panic::catch_unwind(|| {
-            let guard = EnvVarGuard::set(KEY, "during");
-            assert_eq!(std::env::var(KEY).as_deref(), Ok("during"));
-            guard.unset_now();
-            panic!("the assertion this stands in for");
-        });
-        assert!(panicked.is_err(), "the probe did not panic");
+        env.set("FCVM_FIRECRACKER_BIN", &real);
         assert_eq!(
-            std::env::var(KEY).as_deref(),
-            Ok("before"),
-            "PATH was left at the test's value after a panic"
+            setup_vm_firecracker_bin_from(None).unwrap(),
+            real,
+            "the wrapper must consult FCVM_FIRECRACKER_BIN"
         );
 
-        // A variable that was not set stays unset.
-        std::env::remove_var(KEY);
-        let panicked = std::panic::catch_unwind(|| {
-            let _guard = EnvVarGuard::unset(KEY);
-            let _also = EnvVarGuard::set(KEY, "during");
-            panic!("the assertion this stands in for");
-        });
-        assert!(panicked.is_err(), "the probe did not panic");
+        env.set("FCVM_FIRECRACKER_BIN", "/nonexistent/firecracker");
+        let err = setup_vm_firecracker_bin_from(None).unwrap_err().to_string();
+        assert!(
+            err.contains("FCVM_FIRECRACKER_BIN"),
+            "error should name the variable, got: {err}"
+        );
+
+        // Unset, and a profile binary present: the wrapper falls through to it
+        // without consulting PATH.
+        env.unset("FCVM_FIRECRACKER_BIN");
+        let assets = tempfile::tempdir().expect("temp assets dir");
+        let built = assets.path().join("firecracker-default-0123456789ab.bin");
+        std::fs::write(&built, b"#!/bin/sh\nexit 0\n").expect("write stub");
         assert_eq!(
-            std::env::var_os(KEY),
-            None,
-            "a variable the test invented outlived it"
+            setup_vm_firecracker_bin_from(Some(built.clone())).unwrap(),
+            built
         );
     }
 
@@ -2788,12 +2776,14 @@ firecracker_commit = "27305f49ab3a5d862dc56b5108713b6536d2baa7"
     #[test]
     fn find_config_file_propagates_a_relative_fcvm_config_dir() {
         // A set-but-invalid override must ERROR, not silently fall through to
-        // some other config location (nextest runs each test in its own
-        // process, so the env mutation cannot leak).
-        std::env::set_var("FCVM_CONFIG_DIR", "relative/not-absolute");
+        // some other config location. The lookup chain reads the variable, so
+        // this one cannot become an argument; it goes through the shared
+        // environment lock instead, and the handle puts the old value back
+        // even when the assertion below fires first.
+        let mut env = lock_process_env();
+        env.set("FCVM_CONFIG_DIR", "relative/not-absolute");
         let err = find_config_file(None)
             .expect_err("a relative FCVM_CONFIG_DIR must be an error, not a fallthrough");
-        std::env::remove_var("FCVM_CONFIG_DIR");
         assert!(
             format!("{err:#}").contains("absolute"),
             "error should name the absolute-path requirement: {err:#}"

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -747,7 +747,20 @@ pub fn generate_setup_script(plan: &Plan) -> String {
 /// a nested env-reset `sudo podman build` did not ("image not known").
 /// An fcvm-private variable cannot perturb any other tool.
 pub fn fcvm_config_dir() -> Result<std::path::PathBuf> {
-    if let Some(dir) = std::env::var_os("FCVM_CONFIG_DIR") {
+    fcvm_config_dir_from(std::env::var_os("FCVM_CONFIG_DIR"))
+}
+
+/// The rule, with the override already read.
+///
+/// Split out so the relative-path refusal is asserted by passing a value
+/// rather than by writing `FCVM_CONFIG_DIR` into the process:
+/// `std::env::set_var` is undefined behaviour while any other thread reads the
+/// environment, and plain `cargo test` runs this crate's suite with a thread
+/// per test.
+fn fcvm_config_dir_from(
+    config_dir_override: Option<std::ffi::OsString>,
+) -> Result<std::path::PathBuf> {
+    if let Some(dir) = config_dir_override {
         let dir = std::path::PathBuf::from(dir);
         // Relative paths are refused rather than resolved: the value crosses
         // process boundaries (nextest -> sudo -> fcvm -> nested launches) where
@@ -804,6 +817,15 @@ pub fn generate_config(force: bool) -> Result<PathBuf> {
 ///    5c. CARGO_MANIFEST_DIR (debug builds only)
 /// 6. ERROR (no embedded fallback)
 pub fn find_config_file(explicit_path: Option<&str>) -> Result<PathBuf> {
+    find_config_file_with(explicit_path, std::env::var_os("FCVM_CONFIG_DIR"))
+}
+
+/// The chain, with the `FCVM_CONFIG_DIR` override already read. A parameter
+/// for the same reason [`fcvm_config_dir_from`] takes one.
+fn find_config_file_with(
+    explicit_path: Option<&str>,
+    config_dir_override: Option<std::ffi::OsString>,
+) -> Result<PathBuf> {
     // 1. Explicit --config
     if let Some(path) = explicit_path {
         let p = PathBuf::from(path);
@@ -829,8 +851,8 @@ pub fn find_config_file(explicit_path: Option<&str>) -> Result<PathBuf> {
     // not the invoking user's ~/.config/fcvm. A set-but-invalid override
     // (relative path) is an error, not a fallback — silently reading a
     // different file is the failure this chain exists to remove.
-    if std::env::var_os("FCVM_CONFIG_DIR").is_some() {
-        let config_dir = fcvm_config_dir()?;
+    if config_dir_override.is_some() {
+        let config_dir = fcvm_config_dir_from(config_dir_override.clone())?;
         let p = config_dir.join(CONFIG_FILE);
         if p.exists() {
             return Ok(p);
@@ -842,7 +864,7 @@ pub fn find_config_file(explicit_path: Option<&str>) -> Result<PathBuf> {
 
     // 3. SUDO_USER's config (when running with sudo). Skipped entirely when an
     // FCVM_CONFIG_DIR override is set — see above.
-    if std::env::var_os("FCVM_CONFIG_DIR").is_none() {
+    if config_dir_override.is_none() {
         if let Ok(sudo_user) = std::env::var("SUDO_USER") {
             // Get the invoking user's home directory
             match nix::unistd::User::from_name(&sudo_user) {
@@ -863,7 +885,7 @@ pub fn find_config_file(explicit_path: Option<&str>) -> Result<PathBuf> {
     }
 
     // 4. Default user config dir (XDG); FCVM_CONFIG_DIR-set case handled above.
-    if let Ok(config_dir) = fcvm_config_dir() {
+    if let Ok(config_dir) = fcvm_config_dir_from(config_dir_override) {
         let p = config_dir.join(CONFIG_FILE);
         if p.exists() {
             return Ok(p);
@@ -2595,7 +2617,6 @@ fn path_to_str(path: &Path) -> Result<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_env::lock_process_env;
 
     #[test]
     fn firecracker_commit_pins_deserialize_for_global_and_profile_configs() {
@@ -2736,39 +2757,103 @@ firecracker_commit = "27305f49ab3a5d862dc56b5108713b6536d2baa7"
         assert!(sh.success(), "sh -c 'exit 0' should succeed");
     }
 
-    /// The wrapper reads the two process-globals and the resolver applies
-    /// them. Only `FCVM_FIRECRACKER_BIN` is mutated here, under the shared
-    /// environment lock: nothing else in the crate reads it, and PATH stays
-    /// whatever the process was started with.
+    /// Tells a re-executed copy of this test binary to run the child arm of
+    /// `setup_vm_firecracker_bin_from_reads_the_environment_override`.
+    const FIRECRACKER_WRAPPER_CHILD: &str = "FCVM_TEST_FIRECRACKER_WRAPPER_CHILD";
+
+    /// The wrapper reads the two process globals and the resolver applies
+    /// them.
+    ///
+    /// `FCVM_FIRECRACKER_BIN` is set on a CHILD with `Command::env`, and this
+    /// test re-executes its own binary to be that child. Setting it here
+    /// instead would be `std::env::set_var`, which is undefined behaviour
+    /// while any other thread reads the environment; plain `cargo test` runs
+    /// this crate's suite with a thread per test, so there is always such a
+    /// thread. The child's own environment is private to it, so the three
+    /// cases below need no lock and are visible to nothing else.
     #[test]
     fn setup_vm_firecracker_bin_from_reads_the_environment_override() {
+        if let Some(case) = std::env::var_os(FIRECRACKER_WRAPPER_CHILD) {
+            return firecracker_wrapper_child(&case.to_string_lossy());
+        }
+
         let real = std::env::current_exe().expect("test binary path");
-        let mut env = lock_process_env();
-
-        env.set("FCVM_FIRECRACKER_BIN", &real);
-        assert_eq!(
-            setup_vm_firecracker_bin_from(None).unwrap(),
-            real,
-            "the wrapper must consult FCVM_FIRECRACKER_BIN"
-        );
-
-        env.set("FCVM_FIRECRACKER_BIN", "/nonexistent/firecracker");
-        let err = setup_vm_firecracker_bin_from(None).unwrap_err().to_string();
-        assert!(
-            err.contains("FCVM_FIRECRACKER_BIN"),
-            "error should name the variable, got: {err}"
-        );
-
-        // Unset, and a profile binary present: the wrapper falls through to it
-        // without consulting PATH.
-        env.unset("FCVM_FIRECRACKER_BIN");
         let assets = tempfile::tempdir().expect("temp assets dir");
         let built = assets.path().join("firecracker-default-0123456789ab.bin");
         std::fs::write(&built, b"#!/bin/sh\nexit 0\n").expect("write stub");
-        assert_eq!(
-            setup_vm_firecracker_bin_from(Some(built.clone())).unwrap(),
-            built
+
+        for (case, value) in [
+            ("set-and-present", Some(real.clone().into_os_string())),
+            (
+                "set-and-missing",
+                Some(std::ffi::OsString::from("/nonexistent/firecracker")),
+            ),
+            ("unset", None),
+        ] {
+            let mut child = std::process::Command::new(&real);
+            child
+                .args([
+                    "--exact",
+                    "setup::rootfs::tests::setup_vm_firecracker_bin_from_reads_the_environment_override",
+                    "--nocapture",
+                ])
+                .env(FIRECRACKER_WRAPPER_CHILD, case)
+                .env("FCVM_TEST_FIRECRACKER_STUB", &built);
+            match value {
+                Some(v) => child.env("FCVM_FIRECRACKER_BIN", v),
+                None => child.env_remove("FCVM_FIRECRACKER_BIN"),
+            };
+            let out = child.output().expect("re-running this test binary");
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            // A filter that matches nothing runs zero tests and exits 0, which
+            // would make every case below pass without evaluating anything.
+            assert!(
+                stdout.contains(&format!("child arm ran: {case}")),
+                "the child never reached the arm for '{case}', so this case \
+                 asserted nothing:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            );
+            assert!(
+                out.status.success(),
+                "the '{case}' child failed ({}):\nstdout:\n{stdout}\nstderr:\n{stderr}",
+                out.status
+            );
+        }
+    }
+
+    /// One case of the test above, running in a child whose environment the
+    /// parent set with `Command::env`.
+    fn firecracker_wrapper_child(case: &str) {
+        let stub = PathBuf::from(
+            std::env::var_os("FCVM_TEST_FIRECRACKER_STUB").expect("the parent names a stub"),
         );
+        match case {
+            "set-and-present" => {
+                let real = std::env::current_exe().expect("test binary path");
+                assert_eq!(
+                    setup_vm_firecracker_bin_from(None).unwrap(),
+                    real,
+                    "the wrapper must consult FCVM_FIRECRACKER_BIN"
+                );
+            }
+            "set-and-missing" => {
+                let err = setup_vm_firecracker_bin_from(None).unwrap_err().to_string();
+                assert!(
+                    err.contains("FCVM_FIRECRACKER_BIN"),
+                    "error should name the variable, got: {err}"
+                );
+            }
+            // Unset, and a profile binary present: the wrapper falls through
+            // to it without consulting PATH.
+            "unset" => {
+                assert_eq!(
+                    setup_vm_firecracker_bin_from(Some(stub.clone())).unwrap(),
+                    stub
+                );
+            }
+            other => panic!("unknown child case '{other}'"),
+        }
+        println!("child arm ran: {case}");
     }
 
     /// A --config path that does not exist must fail, not quietly fall back to
@@ -2776,17 +2861,31 @@ firecracker_commit = "27305f49ab3a5d862dc56b5108713b6536d2baa7"
     #[test]
     fn find_config_file_propagates_a_relative_fcvm_config_dir() {
         // A set-but-invalid override must ERROR, not silently fall through to
-        // some other config location. The lookup chain reads the variable, so
-        // this one cannot become an argument; it goes through the shared
-        // environment lock instead, and the handle puts the old value back
-        // even when the assertion below fires first.
-        let mut env = lock_process_env();
-        env.set("FCVM_CONFIG_DIR", "relative/not-absolute");
-        let err = find_config_file(None)
+        // some other config location. The override is an argument, so the
+        // process the rest of the suite shares keeps its own FCVM_CONFIG_DIR.
+        let err = find_config_file_with(None, Some("relative/not-absolute".into()))
             .expect_err("a relative FCVM_CONFIG_DIR must be an error, not a fallthrough");
         assert!(
             format!("{err:#}").contains("absolute"),
             "error should name the absolute-path requirement: {err:#}"
+        );
+    }
+
+    /// The wrapper reads the variable the chain is documented to honour.
+    /// Without this, `find_config_file_with` could be correct while nothing
+    /// ever handed it the override.
+    #[test]
+    fn find_config_file_reads_the_config_dir_override() {
+        let src = include_str!("rootfs.rs");
+        let start = src
+            .find("pub fn find_config_file(explicit_path: Option<&str>)")
+            .expect("find_config_file present in rootfs.rs");
+        let body = &src[start..start + src[start..].find("\n}\n").expect("its closing brace")];
+        assert!(
+            body.contains(
+                r#"find_config_file_with(explicit_path, std::env::var_os("FCVM_CONFIG_DIR"))"#
+            ),
+            "find_config_file must pass FCVM_CONFIG_DIR to the chain, got:\n{body}"
         );
     }
 

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -2700,9 +2700,9 @@ firecracker_commit = "27305f49ab3a5d862dc56b5108713b6536d2baa7"
 
         // An empty PATH removes whatever system-wide Firecracker this box may
         // have, so the assertions below observe the profile arm. Both
-        // variables are held by a guard: an assertion below fires before the
-        // end of the test, and the process must not be left with an empty
-        // PATH or without the FCVM_FIRECRACKER_BIN it was started with.
+        // variables are held by a guard: any assertion below can end the test
+        // early, and the process must not be left with an empty PATH or
+        // without the FCVM_FIRECRACKER_BIN it was started with.
         let _path = EnvVarGuard::set("PATH", "");
         let firecracker_bin = EnvVarGuard::set("FCVM_FIRECRACKER_BIN", &real);
 

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -2573,6 +2573,59 @@ fn path_to_str(path: &Path) -> Result<&str> {
 mod tests {
     use super::*;
 
+    /// Puts one process-global environment variable back the way it was.
+    ///
+    /// A test that mutates PATH or FCVM_FIRECRACKER_BIN and restores it on
+    /// its last line restores nothing when an assertion fires first, and a
+    /// test that removes a variable it did not record cannot put it back at
+    /// all. Both are the same bug: the restore has to be tied to the scope,
+    /// not to reaching the end of it.
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        /// Record the current value, then set this one.
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let guard = Self {
+                key,
+                previous: std::env::var_os(key),
+            };
+            std::env::set_var(key, value);
+            guard
+        }
+
+        /// Record the current value, then unset the variable.
+        fn unset(key: &'static str) -> Self {
+            let guard = Self {
+                key,
+                previous: std::env::var_os(key),
+            };
+            std::env::remove_var(key);
+            guard
+        }
+
+        /// Another value for the same variable, still restored by this guard.
+        fn set_to(&self, value: impl AsRef<std::ffi::OsStr>) {
+            std::env::set_var(self.key, value);
+        }
+
+        /// Unset the variable, still restored by this guard.
+        fn unset_now(&self) {
+            std::env::remove_var(self.key);
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
     #[test]
     fn firecracker_commit_pins_deserialize_for_global_and_profile_configs() {
         let global: FirecrackerConfig = toml::from_str(
@@ -2646,12 +2699,14 @@ firecracker_commit = "27305f49ab3a5d862dc56b5108713b6536d2baa7"
         std::fs::write(&built, b"#!/bin/sh\nexit 0\n").expect("write stub");
 
         // An empty PATH removes whatever system-wide Firecracker this box may
-        // have, so the assertions below observe the profile arm.
-        let prev_path = std::env::var("PATH").unwrap_or_default();
-        std::env::set_var("PATH", "");
+        // have, so the assertions below observe the profile arm. Both
+        // variables are held by a guard: an assertion below fires before the
+        // end of the test, and the process must not be left with an empty
+        // PATH or without the FCVM_FIRECRACKER_BIN it was started with.
+        let _path = EnvVarGuard::set("PATH", "");
+        let firecracker_bin = EnvVarGuard::set("FCVM_FIRECRACKER_BIN", &real);
 
         // Set and existing: returned as-is, ahead of the profile's binary.
-        std::env::set_var("FCVM_FIRECRACKER_BIN", &real);
         assert_eq!(
             setup_vm_firecracker_bin_from(Some(built.clone())).unwrap(),
             real
@@ -2659,7 +2714,7 @@ firecracker_commit = "27305f49ab3a5d862dc56b5108713b6536d2baa7"
 
         // Set and missing: the error names the variable, so the reader knows
         // which knob is wrong instead of getting a bare ENOENT.
-        std::env::set_var("FCVM_FIRECRACKER_BIN", "/nonexistent/firecracker");
+        firecracker_bin.set_to("/nonexistent/firecracker");
         let err = setup_vm_firecracker_bin_from(Some(built.clone()))
             .unwrap_err()
             .to_string();
@@ -2670,7 +2725,7 @@ firecracker_commit = "27305f49ab3a5d862dc56b5108713b6536d2baa7"
 
         // Unset, a Firecracker built for the profile, nothing on PATH: the
         // built binary is used rather than the setup failing.
-        std::env::remove_var("FCVM_FIRECRACKER_BIN");
+        firecracker_bin.unset_now();
         assert_eq!(
             setup_vm_firecracker_bin_from(Some(built.clone()))
                 .expect("the Firecracker fcvm built must satisfy the setup VM"),
@@ -2684,8 +2739,48 @@ firecracker_commit = "27305f49ab3a5d862dc56b5108713b6536d2baa7"
             err.contains("FCVM_FIRECRACKER_BIN"),
             "error should name the override, got: {err}"
         );
+    }
 
-        std::env::set_var("PATH", prev_path);
+    /// The guard has to survive the case it exists for: an assertion that
+    /// fires while the variable is held at a test value.
+    ///
+    /// RED BEFORE THE FIX (the guard without its Drop): `PATH was left at the
+    /// test's value after a panic: left: Err(NotPresent), right: Ok("before")`
+    /// -- the guard recorded the previous value and never put it back, which
+    /// is what the hand-written save/restore in the test above did whenever an
+    /// assertion fired first.
+    #[test]
+    fn an_env_var_guard_restores_its_variable_through_a_panic() {
+        const KEY: &str = "FCVM_ENV_GUARD_PROBE";
+
+        // A variable that was set keeps its value.
+        std::env::set_var(KEY, "before");
+        let panicked = std::panic::catch_unwind(|| {
+            let guard = EnvVarGuard::set(KEY, "during");
+            assert_eq!(std::env::var(KEY).as_deref(), Ok("during"));
+            guard.unset_now();
+            panic!("the assertion this stands in for");
+        });
+        assert!(panicked.is_err(), "the probe did not panic");
+        assert_eq!(
+            std::env::var(KEY).as_deref(),
+            Ok("before"),
+            "PATH was left at the test's value after a panic"
+        );
+
+        // A variable that was not set stays unset.
+        std::env::remove_var(KEY);
+        let panicked = std::panic::catch_unwind(|| {
+            let _guard = EnvVarGuard::unset(KEY);
+            let _also = EnvVarGuard::set(KEY, "during");
+            panic!("the assertion this stands in for");
+        });
+        assert!(panicked.is_err(), "the probe did not panic");
+        assert_eq!(
+            std::env::var_os(KEY),
+            None,
+            "a variable the test invented outlived it"
+        );
     }
 
     /// A --config path that does not exist must fail, not quietly fall back to

--- a/src/setup/rootfs.rs
+++ b/src/setup/rootfs.rs
@@ -967,17 +967,68 @@ pub fn load_config(explicit_path: Option<&str>) -> Result<(Plan, String, String)
 
 /// Resolve the Firecracker binary for the rootfs setup VM.
 ///
-/// FCVM_FIRECRACKER_BIN first, then PATH. Without this the setup VM shelled out
-/// to a bare "firecracker", so a host that has never installed one system-wide
-/// failed with a plain "No such file or directory" even though fcvm had just
-/// built a Firecracker of its own under the assets directory.
-fn setup_vm_firecracker_bin() -> Result<PathBuf> {
+/// Order: `FCVM_FIRECRACKER_BIN`, then the Firecracker fcvm built for this
+/// kernel profile, then PATH. The environment variable is a deliberate
+/// override, so it wins. The profile's binary is the one fcvm goes on to run
+/// VMs with, so it beats an unrelated system-wide Firecracker of a different
+/// version. PATH is the last resort, and used to be the only one after the
+/// override: `fcvm setup` on a host that has never installed Firecracker
+/// system-wide failed with "firecracker not found in PATH" immediately after
+/// printing the path of the Firecracker it had just built for the profile.
+async fn setup_vm_firecracker_bin(profile_name: &str) -> Result<PathBuf> {
+    // Resolving a profile's Firecracker reads the config and fails when the
+    // profile names a build this host has not made. An override wins outright,
+    // so it must not be able to trip over that work.
+    let profile_firecracker = if std::env::var_os("FCVM_FIRECRACKER_BIN").is_some() {
+        None
+    } else {
+        profile_firecracker_for_setup_vm(profile_name).await?
+    };
+    setup_vm_firecracker_bin_from(profile_firecracker)
+}
+
+/// The Firecracker `fcvm setup` built for the setup VM's kernel profile.
+///
+/// A profile that configures no Firecracker of its own (the btrfs profile, for
+/// one) falls back to the default profile, which config loading hands the
+/// global `[firecracker]` build. `podman run` picks a profile's Firecracker the
+/// same way, in `runtime_config_from_kernel_profiles`.
+async fn profile_firecracker_for_setup_vm(profile_name: &str) -> Result<Option<PathBuf>> {
+    let mut names = vec![profile_name];
+    if profile_name != "default" {
+        names.push("default");
+    }
+    for name in names {
+        let Some(profile) = get_kernel_profile(name)? else {
+            continue;
+        };
+        if let Some(path) =
+            crate::setup::kernel::get_configured_firecracker_for_profile(&profile, name).await?
+        {
+            info!(
+                firecracker_bin = %path.display(),
+                profile = %name,
+                "setup VM uses the Firecracker built for this profile"
+            );
+            return Ok(Some(path));
+        }
+    }
+    Ok(None)
+}
+
+/// The resolution order itself, with the profile's Firecracker already looked
+/// up. Split out from [`setup_vm_firecracker_bin`] so the order is asserted
+/// without a config file or an assets directory.
+fn setup_vm_firecracker_bin_from(profile_firecracker: Option<PathBuf>) -> Result<PathBuf> {
     if let Ok(path) = std::env::var("FCVM_FIRECRACKER_BIN") {
         let p = PathBuf::from(&path);
         if !p.exists() {
             bail!("FCVM_FIRECRACKER_BIN={} does not exist", path);
         }
         return Ok(p);
+    }
+    if let Some(path) = profile_firecracker {
+        return Ok(path);
     }
     which::which("firecracker").context(
         "firecracker not found in PATH; set FCVM_FIRECRACKER_BIN to the binary \
@@ -2322,7 +2373,7 @@ async fn boot_vm_for_setup(
         "starting Firecracker for Layer 2 setup (serial output: {})",
         serial_path.display()
     );
-    let firecracker_bin = setup_vm_firecracker_bin()?;
+    let firecracker_bin = setup_vm_firecracker_bin(kernel_profile_name).await?;
     let mut fc_cmd = Command::new(&firecracker_bin);
     fc_cmd
         .args([
@@ -2576,25 +2627,65 @@ firecracker_commit = "27305f49ab3a5d862dc56b5108713b6536d2baa7"
         }
     }
 
-    /// FCVM_FIRECRACKER_BIN is a process-global, so these run in one test.
+    /// FCVM_FIRECRACKER_BIN and PATH are both process-globals, so the whole
+    /// resolution order is asserted in one test rather than racing across
+    /// several.
+    ///
+    /// The profile arm is the one a fresh host depends on. `fcvm setup` builds
+    /// a Firecracker under the assets directory and then boots the rootfs setup
+    /// VM, so consulting PATH alone failed with "firecracker not found in PATH"
+    /// on a box with no system-wide Firecracker, immediately after printing the
+    /// path of the binary it had just built.
     #[test]
-    fn setup_vm_firecracker_bin_honors_env_var() {
+    fn setup_vm_firecracker_bin_prefers_env_then_profile_then_path() {
         let real = std::env::current_exe().expect("test binary path");
+        // Stands in for <assets_dir>/firecracker/firecracker-default-<sha>.bin,
+        // the binary `fcvm setup` builds just before booting the setup VM.
+        let assets = tempfile::tempdir().expect("temp assets dir");
+        let built = assets.path().join("firecracker-default-0123456789ab.bin");
+        std::fs::write(&built, b"#!/bin/sh\nexit 0\n").expect("write stub");
 
-        // Set and existing: returned as-is, rather than searching PATH.
+        // An empty PATH removes whatever system-wide Firecracker this box may
+        // have, so the assertions below observe the profile arm.
+        let prev_path = std::env::var("PATH").unwrap_or_default();
+        std::env::set_var("PATH", "");
+
+        // Set and existing: returned as-is, ahead of the profile's binary.
         std::env::set_var("FCVM_FIRECRACKER_BIN", &real);
-        assert_eq!(setup_vm_firecracker_bin().unwrap(), real);
+        assert_eq!(
+            setup_vm_firecracker_bin_from(Some(built.clone())).unwrap(),
+            real
+        );
 
         // Set and missing: the error names the variable, so the reader knows
         // which knob is wrong instead of getting a bare ENOENT.
         std::env::set_var("FCVM_FIRECRACKER_BIN", "/nonexistent/firecracker");
-        let err = setup_vm_firecracker_bin().unwrap_err().to_string();
+        let err = setup_vm_firecracker_bin_from(Some(built.clone()))
+            .unwrap_err()
+            .to_string();
         assert!(
             err.contains("FCVM_FIRECRACKER_BIN"),
             "error should name the variable, got: {err}"
         );
 
+        // Unset, a Firecracker built for the profile, nothing on PATH: the
+        // built binary is used rather than the setup failing.
         std::env::remove_var("FCVM_FIRECRACKER_BIN");
+        assert_eq!(
+            setup_vm_firecracker_bin_from(Some(built.clone()))
+                .expect("the Firecracker fcvm built must satisfy the setup VM"),
+            built
+        );
+
+        // Unset, nothing built, nothing on PATH: still an error, and it names
+        // the override so the reader has somewhere to go.
+        let err = setup_vm_firecracker_bin_from(None).unwrap_err().to_string();
+        assert!(
+            err.contains("FCVM_FIRECRACKER_BIN"),
+            "error should name the override, got: {err}"
+        );
+
+        std::env::set_var("PATH", prev_path);
     }
 
     /// A --config path that does not exist must fail, not quietly fall back to

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -1,12 +1,18 @@
-//! Serialized access to the process-wide environment, for tests.
+//! The rule this crate's tests follow about the process-wide environment: they
+//! do not touch it.
 //!
-//! `std::env::set_var` changes state every thread in the process shares.
-//! Under nextest that is invisible, because each test gets its own process.
-//! Plain `cargo test` runs the whole library suite in one process with a
-//! thread per test, so a test that empties PATH makes any sibling that
-//! resolves a program by name fail with a bare ENOENT while it does so. About
-//! twenty tests in this crate spawn by bare name: `sh`, `bash`, `true`,
-//! `sleep`, `cat`, `git`, `tar`, `xz`, `ip`.
+//! `std::env::set_var` and `remove_var` change state every thread in the
+//! process shares, and on Unix they are undefined behaviour while any other
+//! thread reads the environment. Rust 2024 makes both `unsafe` for exactly
+//! that reason. A mutex among the writers does not fix it: the readers are
+//! `std::env::var`, `Command::new` resolving a bare program name, and every
+//! library call underneath them, none of which take a lock.
+//!
+//! Under nextest the sharing is invisible, because each test gets its own
+//! process. Plain `cargo test` runs the whole library suite in one process
+//! with a thread per test, so about twenty tests here are resolving `sh`,
+//! `bash`, `true`, `sleep`, `cat`, `git`, `tar`, `xz` or `ip` through PATH at
+//! any moment.
 //!
 //! Measured at 3f5bfddb on a 192-core box, when the Firecracker
 //! resolution-order test still set `PATH=""`: 42 of 50 plain
@@ -20,208 +26,60 @@
 //! spawns by absolute path and times out under the load of 192 test threads.
 //! No ENOENT.
 //!
-//! Two rules follow.
+//! With every mutation removed rather than locked: 30 of 30 plain
+//! `cargo test --release --no-default-features -p fcvm --lib` runs passed,
+//! 539 tests each, on a 64-core box carrying other work.
 //!
-//! A test whose subject can take the value as a parameter must do that and
-//! leave the environment alone. `setup::rootfs::setup_vm_firecracker_bin_from`
-//! reads `FCVM_FIRECRACKER_BIN` and PATH and hands both to
-//! `setup_vm_firecracker_bin_resolved`, so the resolution-order test states
-//! "nothing on PATH" as an argument instead of emptying the real one.
+//! Two ways to write the test instead, both in use here.
 //!
-//! A test that genuinely needs the process environment goes through
-//! [`lock_process_env`], and so does a test whose own result depends on
-//! resolving a program name through PATH. [`ProcessEnv::set`] and
-//! [`ProcessEnv::unset`] exist only on the handle the lock hands back, so
-//! taking the lock is a consequence of mutating rather than something each
-//! test has to remember. The scan in
-//! `no_test_mutates_the_process_environment_outside_this_module` holds the
-//! other half: no test may reach `std::env::set_var` directly.
-
-use std::ffi::{OsStr, OsString};
-
-/// Held by every test that mutates the process environment, and by every test
-/// whose result depends on resolving a program name through PATH.
-///
-/// A tokio mutex because the one async holder keeps it across an await, and
-/// because it does not poison when a holder's assertion panics.
-static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
-/// Take the environment, from a synchronous test.
-pub(crate) fn lock_process_env() -> ProcessEnv {
-    ProcessEnv::new(ENV_LOCK.blocking_lock())
-}
-
-/// Take the environment, from an async test. `blocking_lock` panics inside a
-/// runtime, so an async holder needs this one.
-pub(crate) async fn lock_process_env_async() -> ProcessEnv {
-    ProcessEnv::new(ENV_LOCK.lock().await)
-}
-
-/// Take the environment only if it is free, for the test that observes the
-/// exclusion itself.
-pub(crate) fn try_lock_process_env() -> Option<ProcessEnv> {
-    ENV_LOCK.try_lock().ok().map(ProcessEnv::new)
-}
-
-/// Exclusive use of the process environment, with the original values put
-/// back on drop.
-///
-/// Restoring on drop rather than on a test's last line matters for the same
-/// reason the lock does: an assertion that fires early must not leave PATH or
-/// `FCVM_FIRECRACKER_BIN` at a test's value for the rest of the run.
-pub(crate) struct ProcessEnv {
-    /// First-seen value per key, so repeated writes still restore the original.
-    restore: Vec<(&'static str, Option<OsString>)>,
-    /// Released after `Drop::drop` has put every value back: a struct's fields
-    /// are dropped after its own `Drop` runs, so the next holder never sees a
-    /// half-restored environment.
-    _lock: tokio::sync::MutexGuard<'static, ()>,
-}
-
-impl ProcessEnv {
-    fn new(lock: tokio::sync::MutexGuard<'static, ()>) -> Self {
-        Self {
-            restore: Vec::new(),
-            _lock: lock,
-        }
-    }
-
-    /// Set a variable for as long as this handle lives.
-    pub(crate) fn set(&mut self, key: &'static str, value: impl AsRef<OsStr>) {
-        self.record(key);
-        std::env::set_var(key, value);
-    }
-
-    /// Unset a variable for as long as this handle lives.
-    pub(crate) fn unset(&mut self, key: &'static str) {
-        self.record(key);
-        std::env::remove_var(key);
-    }
-
-    fn record(&mut self, key: &'static str) {
-        if !self.restore.iter().any(|(seen, _)| *seen == key) {
-            self.restore.push((key, std::env::var_os(key)));
-        }
-    }
-}
-
-impl Drop for ProcessEnv {
-    fn drop(&mut self) {
-        for (key, previous) in std::mem::take(&mut self.restore).into_iter().rev() {
-            match previous {
-                Some(value) => std::env::set_var(key, value),
-                None => std::env::remove_var(key),
-            }
-        }
-    }
-}
+//! Pass the value to the code under test. `setup::rootfs::find_config_file`
+//! reads `FCVM_CONFIG_DIR` and hands it to `find_config_file_with`, and
+//! `setup_vm_firecracker_bin_from` reads `FCVM_FIRECRACKER_BIN` and PATH and
+//! hands both to `setup_vm_firecracker_bin_resolved`, so the rules those
+//! encode are asserted with arguments. `network::bridged`'s route probe takes
+//! the `ip` binary as a parameter for the same reason, so its fail-closed test
+//! names a stub instead of prepending a directory to PATH.
+//!
+//! Set it on a child with `Command::env`. A child's environment is private to
+//! it, so nothing in this process observes the write.
+//! `setup_vm_firecracker_bin_from_reads_the_environment_override` re-executes
+//! the test binary once per case to prove the wrapper reads the variable at
+//! all, which is the one claim an argument cannot carry.
+//!
+//! `no_test_mutates_the_process_environment_outside_this_module` below holds
+//! the half neither technique can state: no source in the crate may
+//! reach `set_var` or `remove_var`, bar the single production writer it names.
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::path::{Path, PathBuf};
 
-    /// A name nothing in the crate reads, so "unset before" is a fact rather
-    /// than an assumption.
-    const PROBE: &str = "FCVM_ENV_GUARD_PROBE";
-
-    /// The handle has to survive the case it exists for: an assertion that
-    /// fires while a variable is held at a test's value.
+    /// The whole rule: no source in this crate mutates the process
+    /// environment, except the one production writer named below.
     ///
-    /// RED BEFORE THE FIX (the handle without its Drop): `PATH was left at the
-    /// test's value after a panic`.
-    #[test]
-    fn a_process_env_handle_restores_its_variables_through_a_panic() {
-        // A variable that was set keeps its value. PATH is the one this module
-        // is about, and it is set in every environment fcvm builds in.
-        let before = {
-            let _held = lock_process_env();
-            std::env::var_os("PATH").expect("PATH is set for this process")
-        };
-        let panicked = std::panic::catch_unwind(|| {
-            let mut env = lock_process_env();
-            env.set("PATH", "/fcvm-test-only");
-            assert_eq!(
-                std::env::var_os("PATH").as_deref(),
-                Some(OsStr::new("/fcvm-test-only"))
-            );
-            env.unset("PATH");
-            panic!("the assertion this stands in for");
-        });
-        assert!(panicked.is_err(), "the probe did not panic");
-
-        // A variable that was not set stays unset.
-        let panicked = std::panic::catch_unwind(|| {
-            let mut env = lock_process_env();
-            env.unset(PROBE);
-            env.set(PROBE, "during");
-            panic!("the assertion this stands in for");
-        });
-        assert!(panicked.is_err(), "the probe did not panic");
-
-        // Both reads happen under the lock. Every mutation in the suite is
-        // scoped to a handle that restores on drop, so what a lock holder sees
-        // is the value the process started with, whatever a sibling test is in
-        // the middle of. Reading them unlocked would race the bridged PATH
-        // prepend.
-        let _held = lock_process_env();
-        assert_eq!(
-            std::env::var_os("PATH"),
-            Some(before),
-            "PATH was left at the test's value after a panic"
-        );
-        assert_eq!(
-            std::env::var_os(PROBE),
-            None,
-            "a variable the test invented outlived it"
-        );
-    }
-
-    /// Two mutators cannot overlap. Stated with `try_lock` rather than a
-    /// sleeping thread, so the observation is a fact and not a deadline.
-    #[test]
-    fn a_second_mutator_cannot_take_the_environment_while_one_holds_it() {
-        let held = lock_process_env();
-        assert!(
-            try_lock_process_env().is_none(),
-            "a second handle was issued while the first was alive, so two \
-             tests could mutate the environment at once"
-        );
-        drop(held);
-        // Release is asserted by taking it again, which BLOCKS when a sibling
-        // is mid-mutation instead of reporting a failure. A `try_lock` here
-        // was red 30 times out of 30 under plain `cargo test`, which is the
-        // suite working; a handle that never released hangs here rather than
-        // passing.
-        drop(lock_process_env());
-    }
-
-    /// The half of the rule the type cannot state: no test may call
-    /// `std::env::set_var` or `remove_var` itself and bypass the lock.
+    /// RED BEFORE THE FIX: 6 lines, the last of this module's own mutators.
+    ///   test_env.rs:92: std::env::set_var(key, value);
+    ///   test_env.rs:98: std::env::remove_var(key);
+    ///   test_env.rs:112: Some(value) => std::env::set_var(key, value),
+    ///   test_env.rs:113: None => std::env::remove_var(key),
+    ///   test_env.rs:224: r#"unsafe { std::env::set_var("PATH", updated) };"#,
+    ///   test_env.rs:248: || (!trimmed.contains("set_var(") ...
     ///
-    /// RED BEFORE THE FIX: 12 sites, the whole set the Codex finding is about.
-    ///   network/bridged.rs:685: std::env::set_var("PATH", format!("{}:{}", ...
-    ///   network/bridged.rs:689: std::env::set_var("PATH", prev);
-    ///   setup/rootfs.rs:2595: std::env::set_var(key, value);
-    ///   setup/rootfs.rs:2605: std::env::remove_var(key);
-    ///   setup/rootfs.rs:2611: std::env::set_var(self.key, value);
-    ///   setup/rootfs.rs:2616: std::env::remove_var(self.key);
-    ///   setup/rootfs.rs:2623: Some(value) => std::env::set_var(self.key, value),
-    ///   setup/rootfs.rs:2624: None => std::env::remove_var(self.key),
-    ///   setup/rootfs.rs:2765: std::env::set_var(KEY, "before");
-    ///   setup/rootfs.rs:2780: std::env::remove_var(KEY);
-    ///   setup/rootfs.rs:2801: std::env::set_var("FCVM_CONFIG_DIR", "relative/not-absolute");
-    ///   setup/rootfs.rs:2804: std::env::remove_var("FCVM_CONFIG_DIR");
-    ///
-    /// Production writers are listed here rather than excluded by location:
-    /// there is exactly one, it runs before any thread exists, and a second
-    /// one deserves to be read before it is added.
+    /// The last two are this test's own literals, and they are why the scan
+    /// used to skip this file. It no longer skips anything: the needles and
+    /// the permitted line are assembled at run time, so this source does not
+    /// contain them and the module that held the exception is covered like
+    /// every other.
     #[test]
     fn no_test_mutates_the_process_environment_outside_this_module() {
-        /// (file name, exact source line) of every permitted production write.
-        const PRODUCTION_WRITERS: &[(&str, &str)] = &[(
+        let needles = [format!("{}_var(", "set"), format!("{}_var(", "remove")];
+        // (file name, exact source line) of every permitted production write.
+        // Listed here rather than excluded by location: there is exactly one,
+        // it runs before any thread exists, and a second one deserves to be
+        // read before it is added.
+        let production_writers = [(
             "utils.rs",
-            r#"unsafe { std::env::set_var("PATH", updated) };"#,
+            format!(r#"unsafe {{ std::env::{}_var("PATH", updated) }};"#, "set"),
         )];
 
         let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
@@ -234,6 +92,13 @@ mod tests {
             files.len(),
             src.display()
         );
+        let this_file = src.join("test_env.rs");
+        assert!(
+            files.contains(&this_file),
+            "the walk missed {}, so the scan no longer covers the module the \
+             mutators used to live in",
+            this_file.display()
+        );
 
         let mut offenders = Vec::new();
         for file in &files {
@@ -241,20 +106,15 @@ mod tests {
                 .file_name()
                 .and_then(|n| n.to_str())
                 .unwrap_or_default();
-            if name == "test_env.rs" {
-                continue;
-            }
             let text = std::fs::read_to_string(file).expect("reading a crate source file");
             for (index, line) in text.lines().enumerate() {
                 let trimmed = line.trim();
-                if trimmed.starts_with("//")
-                    || (!trimmed.contains("set_var(") && !trimmed.contains("remove_var("))
-                {
+                if trimmed.starts_with("//") || !needles.iter().any(|n| trimmed.contains(n)) {
                     continue;
                 }
-                if PRODUCTION_WRITERS
+                if production_writers
                     .iter()
-                    .any(|(f, l)| *f == name && *l == trimmed)
+                    .any(|(f, l)| *f == name && l == trimmed)
                 {
                     continue;
                 }
@@ -268,9 +128,10 @@ mod tests {
 
         assert!(
             offenders.is_empty(),
-            "these lines mutate the process environment without crate::test_env's \
-             lock; route them through lock_process_env(), or pass the value to \
-             the code under test as a parameter:\n  {}",
+            "these lines mutate the process environment, which is undefined \
+             behaviour while a sibling test thread reads it; pass the value to \
+             the code under test as a parameter, or set it on a child with \
+             Command::env:\n  {}",
             offenders.join("\n  ")
         );
     }

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -1,0 +1,288 @@
+//! Serialized access to the process-wide environment, for tests.
+//!
+//! `std::env::set_var` changes state every thread in the process shares.
+//! Under nextest that is invisible, because each test gets its own process.
+//! Plain `cargo test` runs the whole library suite in one process with a
+//! thread per test, so a test that empties PATH makes any sibling that
+//! resolves a program by name fail with a bare ENOENT while it does so. About
+//! twenty tests in this crate spawn by bare name: `sh`, `bash`, `true`,
+//! `sleep`, `cat`, `git`, `tar`, `xz`, `ip`.
+//!
+//! Measured at 3f5bfddb on a 192-core box, when the Firecracker
+//! resolution-order test still set `PATH=""`: 42 of 50 plain
+//! `cargo test -p fcvm --lib` runs failed, across seven different siblings,
+//! most often `setup::kernel::tests::vm_kernel_build_replaces_interrupted_cached_source_archive`
+//! (spawns `tar`, 41 runs) and
+//! `uffd::server::tests::dropping_unpolled_admitted_task_kills_the_pinned_vmm`
+//! (spawns `sleep`, 7 runs). Skipping only that one test and changing nothing
+//! else: 2 of 30, both
+//! `firecracker::vm::tests::start_reports_immediate_firecracker_exit`, which
+//! spawns by absolute path and times out under the load of 192 test threads.
+//! No ENOENT.
+//!
+//! Two rules follow.
+//!
+//! A test whose subject can take the value as a parameter must do that and
+//! leave the environment alone. `setup::rootfs::setup_vm_firecracker_bin_from`
+//! reads `FCVM_FIRECRACKER_BIN` and PATH and hands both to
+//! `setup_vm_firecracker_bin_resolved`, so the resolution-order test states
+//! "nothing on PATH" as an argument instead of emptying the real one.
+//!
+//! A test that genuinely needs the process environment goes through
+//! [`lock_process_env`], and so does a test whose own result depends on
+//! resolving a program name through PATH. [`ProcessEnv::set`] and
+//! [`ProcessEnv::unset`] exist only on the handle the lock hands back, so
+//! taking the lock is a consequence of mutating rather than something each
+//! test has to remember. The scan in
+//! `no_test_mutates_the_process_environment_outside_this_module` holds the
+//! other half: no test may reach `std::env::set_var` directly.
+
+use std::ffi::{OsStr, OsString};
+
+/// Held by every test that mutates the process environment, and by every test
+/// whose result depends on resolving a program name through PATH.
+///
+/// A tokio mutex because the one async holder keeps it across an await, and
+/// because it does not poison when a holder's assertion panics.
+static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Take the environment, from a synchronous test.
+pub(crate) fn lock_process_env() -> ProcessEnv {
+    ProcessEnv::new(ENV_LOCK.blocking_lock())
+}
+
+/// Take the environment, from an async test. `blocking_lock` panics inside a
+/// runtime, so an async holder needs this one.
+pub(crate) async fn lock_process_env_async() -> ProcessEnv {
+    ProcessEnv::new(ENV_LOCK.lock().await)
+}
+
+/// Take the environment only if it is free, for the test that observes the
+/// exclusion itself.
+pub(crate) fn try_lock_process_env() -> Option<ProcessEnv> {
+    ENV_LOCK.try_lock().ok().map(ProcessEnv::new)
+}
+
+/// Exclusive use of the process environment, with the original values put
+/// back on drop.
+///
+/// Restoring on drop rather than on a test's last line matters for the same
+/// reason the lock does: an assertion that fires early must not leave PATH or
+/// `FCVM_FIRECRACKER_BIN` at a test's value for the rest of the run.
+pub(crate) struct ProcessEnv {
+    /// First-seen value per key, so repeated writes still restore the original.
+    restore: Vec<(&'static str, Option<OsString>)>,
+    /// Released after `Drop::drop` has put every value back: a struct's fields
+    /// are dropped after its own `Drop` runs, so the next holder never sees a
+    /// half-restored environment.
+    _lock: tokio::sync::MutexGuard<'static, ()>,
+}
+
+impl ProcessEnv {
+    fn new(lock: tokio::sync::MutexGuard<'static, ()>) -> Self {
+        Self {
+            restore: Vec::new(),
+            _lock: lock,
+        }
+    }
+
+    /// Set a variable for as long as this handle lives.
+    pub(crate) fn set(&mut self, key: &'static str, value: impl AsRef<OsStr>) {
+        self.record(key);
+        std::env::set_var(key, value);
+    }
+
+    /// Unset a variable for as long as this handle lives.
+    pub(crate) fn unset(&mut self, key: &'static str) {
+        self.record(key);
+        std::env::remove_var(key);
+    }
+
+    fn record(&mut self, key: &'static str) {
+        if !self.restore.iter().any(|(seen, _)| *seen == key) {
+            self.restore.push((key, std::env::var_os(key)));
+        }
+    }
+}
+
+impl Drop for ProcessEnv {
+    fn drop(&mut self) {
+        for (key, previous) in std::mem::take(&mut self.restore).into_iter().rev() {
+            match previous {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    /// A name nothing in the crate reads, so "unset before" is a fact rather
+    /// than an assumption.
+    const PROBE: &str = "FCVM_ENV_GUARD_PROBE";
+
+    /// The handle has to survive the case it exists for: an assertion that
+    /// fires while a variable is held at a test's value.
+    ///
+    /// RED BEFORE THE FIX (the handle without its Drop): `PATH was left at the
+    /// test's value after a panic`.
+    #[test]
+    fn a_process_env_handle_restores_its_variables_through_a_panic() {
+        // A variable that was set keeps its value. PATH is the one this module
+        // is about, and it is set in every environment fcvm builds in.
+        let before = {
+            let _held = lock_process_env();
+            std::env::var_os("PATH").expect("PATH is set for this process")
+        };
+        let panicked = std::panic::catch_unwind(|| {
+            let mut env = lock_process_env();
+            env.set("PATH", "/fcvm-test-only");
+            assert_eq!(
+                std::env::var_os("PATH").as_deref(),
+                Some(OsStr::new("/fcvm-test-only"))
+            );
+            env.unset("PATH");
+            panic!("the assertion this stands in for");
+        });
+        assert!(panicked.is_err(), "the probe did not panic");
+
+        // A variable that was not set stays unset.
+        let panicked = std::panic::catch_unwind(|| {
+            let mut env = lock_process_env();
+            env.unset(PROBE);
+            env.set(PROBE, "during");
+            panic!("the assertion this stands in for");
+        });
+        assert!(panicked.is_err(), "the probe did not panic");
+
+        // Both reads happen under the lock. Every mutation in the suite is
+        // scoped to a handle that restores on drop, so what a lock holder sees
+        // is the value the process started with, whatever a sibling test is in
+        // the middle of. Reading them unlocked would race the bridged PATH
+        // prepend.
+        let _held = lock_process_env();
+        assert_eq!(
+            std::env::var_os("PATH"),
+            Some(before),
+            "PATH was left at the test's value after a panic"
+        );
+        assert_eq!(
+            std::env::var_os(PROBE),
+            None,
+            "a variable the test invented outlived it"
+        );
+    }
+
+    /// Two mutators cannot overlap. Stated with `try_lock` rather than a
+    /// sleeping thread, so the observation is a fact and not a deadline.
+    #[test]
+    fn a_second_mutator_cannot_take_the_environment_while_one_holds_it() {
+        let held = lock_process_env();
+        assert!(
+            try_lock_process_env().is_none(),
+            "a second handle was issued while the first was alive, so two \
+             tests could mutate the environment at once"
+        );
+        drop(held);
+        // Release is asserted by taking it again, which BLOCKS when a sibling
+        // is mid-mutation instead of reporting a failure. A `try_lock` here
+        // was red 30 times out of 30 under plain `cargo test`, which is the
+        // suite working; a handle that never released hangs here rather than
+        // passing.
+        drop(lock_process_env());
+    }
+
+    /// The half of the rule the type cannot state: no test may call
+    /// `std::env::set_var` or `remove_var` itself and bypass the lock.
+    ///
+    /// RED BEFORE THE FIX: 12 sites, the whole set the Codex finding is about.
+    ///   network/bridged.rs:685: std::env::set_var("PATH", format!("{}:{}", ...
+    ///   network/bridged.rs:689: std::env::set_var("PATH", prev);
+    ///   setup/rootfs.rs:2595: std::env::set_var(key, value);
+    ///   setup/rootfs.rs:2605: std::env::remove_var(key);
+    ///   setup/rootfs.rs:2611: std::env::set_var(self.key, value);
+    ///   setup/rootfs.rs:2616: std::env::remove_var(self.key);
+    ///   setup/rootfs.rs:2623: Some(value) => std::env::set_var(self.key, value),
+    ///   setup/rootfs.rs:2624: None => std::env::remove_var(self.key),
+    ///   setup/rootfs.rs:2765: std::env::set_var(KEY, "before");
+    ///   setup/rootfs.rs:2780: std::env::remove_var(KEY);
+    ///   setup/rootfs.rs:2801: std::env::set_var("FCVM_CONFIG_DIR", "relative/not-absolute");
+    ///   setup/rootfs.rs:2804: std::env::remove_var("FCVM_CONFIG_DIR");
+    ///
+    /// Production writers are listed here rather than excluded by location:
+    /// there is exactly one, it runs before any thread exists, and a second
+    /// one deserves to be read before it is added.
+    #[test]
+    fn no_test_mutates_the_process_environment_outside_this_module() {
+        /// (file name, exact source line) of every permitted production write.
+        const PRODUCTION_WRITERS: &[(&str, &str)] = &[(
+            "utils.rs",
+            r#"unsafe { std::env::set_var("PATH", updated) };"#,
+        )];
+
+        let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut files = Vec::new();
+        collect_rust_sources(&src, &mut files);
+        assert!(
+            files.len() > 30,
+            "the walk found {} files under {}, so this test would pass by \
+             seeing nothing",
+            files.len(),
+            src.display()
+        );
+
+        let mut offenders = Vec::new();
+        for file in &files {
+            let name = file
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or_default();
+            if name == "test_env.rs" {
+                continue;
+            }
+            let text = std::fs::read_to_string(file).expect("reading a crate source file");
+            for (index, line) in text.lines().enumerate() {
+                let trimmed = line.trim();
+                if trimmed.starts_with("//")
+                    || (!trimmed.contains("set_var(") && !trimmed.contains("remove_var("))
+                {
+                    continue;
+                }
+                if PRODUCTION_WRITERS
+                    .iter()
+                    .any(|(f, l)| *f == name && *l == trimmed)
+                {
+                    continue;
+                }
+                offenders.push(format!(
+                    "{}:{}: {trimmed}",
+                    file.strip_prefix(&src).unwrap_or(file).display(),
+                    index + 1
+                ));
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "these lines mutate the process environment without crate::test_env's \
+             lock; route them through lock_process_env(), or pass the value to \
+             the code under test as a parameter:\n  {}",
+            offenders.join("\n  ")
+        );
+    }
+
+    fn collect_rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+        for entry in std::fs::read_dir(dir).expect("reading a crate source directory") {
+            let path = entry.expect("reading a directory entry").path();
+            if path.is_dir() {
+                collect_rust_sources(&path, out);
+            } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+                out.push(path);
+            }
+        }
+    }
+}

--- a/tests/test_probe_pasta_dns_gateway.rs
+++ b/tests/test_probe_pasta_dns_gateway.rs
@@ -1,0 +1,166 @@
+//! `scripts/probe-pasta-dns-gateway.sh` must not outlive itself.
+//!
+//! The probe starts two Python DNS responders inside a private user, network
+//! and mount namespace. Neither ever returns: each loops on `recvfrom`
+//! forever. Nothing in the script ends them, and a non-interactive shell does
+//! not reap background jobs on exit, so every run used to leave two processes
+//! holding those namespaces open. The probe is meant to be cheap enough to run
+//! whenever the pasta wiring is in question, which is exactly the usage that
+//! accumulates them.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Every tool the probe and this test shell out to. A missing one means the
+/// test could not evaluate anything, which must block rather than pass.
+fn require_tools() {
+    for tool in ["unshare", "ip", "python3", "bash", "mount"] {
+        let found = Command::new("sh")
+            .arg("-c")
+            .arg(format!("command -v {tool} >/dev/null 2>&1"))
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        assert!(found, "BLOCKED: '{tool}' is missing; this test cannot evaluate anything");
+    }
+    // The probe's own namespace. Without unprivileged user namespaces it
+    // cannot start at all, and neither can rootless fcvm.
+    let status = Command::new("unshare")
+        .args(["--user", "--map-root-user", "--net", "--mount", "--fork", "--", "true"])
+        .status()
+        .expect("run unshare");
+    assert!(
+        status.success(),
+        "BLOCKED: this box cannot create a user+net+mount namespace, so the probe \
+         cannot run here (kernel.unprivileged_userns_clone / \
+         kernel.apparmor_restrict_unprivileged_userns)"
+    );
+}
+
+fn write_exec(path: &Path, body: &str) {
+    std::fs::write(path, body).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+    let mut perms = std::fs::metadata(path).expect("stat stub").permissions();
+    std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+    std::fs::set_permissions(path, perms).expect("chmod stub");
+}
+
+/// Processes whose command line mentions `needle`, by host pid.
+fn processes_matching(needle: &str) -> Vec<String> {
+    let mut found = Vec::new();
+    let entries = std::fs::read_dir("/proc").expect("read /proc");
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let pid = match name.to_string_lossy().parse::<u32>() {
+            Ok(pid) => pid,
+            Err(_) => continue,
+        };
+        let cmdline = match std::fs::read(format!("/proc/{pid}/cmdline")) {
+            Ok(bytes) => String::from_utf8_lossy(&bytes).replace('\0', " "),
+            Err(_) => continue,
+        };
+        if cmdline.contains(needle) {
+            found.push(format!("{pid}: {}", cmdline.trim()));
+        }
+    }
+    found
+}
+
+/// The probe runs to its normal end and leaves nothing behind.
+///
+/// The pasta binary, the namespace entry and the query are stubbed: what is
+/// under test is the lifetime of the responders the probe starts, not the
+/// verdict it renders about pasta. Everything else is the shipped script,
+/// including the namespace it builds and the exit path it takes.
+///
+/// RED BEFORE THE FIX: `the probe left 2 process(es) alive after exiting with
+/// exit status: 0`, naming `responder.py 127.0.0.53 203.0.113.99
+/// host-resolver` and `responder.py 127.0.0.1 10.0.2.2 replay`, both still
+/// running under the probe's own work directory after it printed its two OK
+/// lines.
+#[test]
+fn the_probe_leaves_no_dns_responder_behind() {
+    require_tools();
+    let script = repo_root().join("scripts/probe-pasta-dns-gateway.sh");
+    assert!(script.is_file(), "the probe is gone from {}", script.display());
+
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let bin = tmp.path().join("bin");
+    std::fs::create_dir_all(&bin).expect("create stub bin");
+
+    // A pasta that stays up until the probe kills it, so the probe follows its
+    // ordinary path through both `ask` calls.
+    write_exec(&bin.join("pasta"), "#!/bin/bash\nexec sleep 60\n");
+    // The probe reaches the guest through `nsenter -t <pid> -U -n -- <cmd>`,
+    // twice: once to wait for pasta0 to carry the guest address, once to ask
+    // the resolver. Both are answered here, the second from a counter so the
+    // two arms differ, because a real answer needs the VM-less pasta wiring
+    // this test is not measuring.
+    let calls = tmp.path().join("dig-calls");
+    write_exec(
+        &bin.join("nsenter"),
+        &format!(
+            "#!/bin/bash\n\
+             for a in \"$@\"; do\n\
+             \tcase \"$a\" in\n\
+             \t\tdig) n=$(cat {calls} 2>/dev/null || echo 0); n=$((n + 1)); echo \"$n\" >{calls}\n\
+             \t\t\t[ \"$n\" = 1 ] && echo 10.0.2.2 || echo 203.0.113.99\n\
+             \t\t\texit 0 ;;\n\
+             \t\tpasta0) echo '2: pasta0    inet 10.0.2.100/24 scope global pasta0' ; exit 0 ;;\n\
+             \tesac\n\
+             done\n\
+             exit 0\n",
+            calls = calls.display()
+        ),
+    );
+    // dig only has to exist: the probe's tool check looks it up before the
+    // namespace, and the query itself goes through the stub above.
+    write_exec(&bin.join("dig"), "#!/bin/bash\nexit 0\n");
+
+    // The probe's work directory comes from `mktemp -d`, so pointing TMPDIR
+    // here makes every responder's command line carry this path and nothing
+    // else on the box does.
+    let work_root = tmp.path().join("work");
+    std::fs::create_dir_all(&work_root).expect("create work root");
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let output = Command::new("bash")
+        .arg(&script)
+        .env("PATH", &path)
+        .env("TMPDIR", &work_root)
+        .env("PASTA_BIN", bin.join("pasta"))
+        .output()
+        .expect("run the probe");
+
+    let needle = work_root.to_string_lossy().to_string();
+    // The kernel tears the subtree down as the namespace's init exits; give it
+    // a moment rather than racing the exit.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut alive = processes_matching(&needle);
+    while !alive.is_empty() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+        alive = processes_matching(&needle);
+    }
+    for line in &alive {
+        // Do not leave a leak behind for the next test to trip over.
+        if let Some(pid) = line.split(':').next().and_then(|p| p.parse::<i32>().ok()) {
+            unsafe { libc::kill(pid, libc::SIGKILL) };
+        }
+    }
+    assert!(
+        alive.is_empty(),
+        "the probe left {} process(es) alive after exiting with {}:\n{}\nstdout:\n{}\nstderr:\n{}",
+        alive.len(),
+        output.status,
+        alive.join("\n"),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}

--- a/tests/test_probe_pasta_dns_gateway.rs
+++ b/tests/test_probe_pasta_dns_gateway.rs
@@ -139,6 +139,20 @@ fn the_probe_leaves_no_dns_responder_behind() {
         .output()
         .expect("run the probe");
 
+    // A probe that never got as far as starting the responders leaves nothing
+    // behind for a reason that says nothing about reaping, so the assertion
+    // below would pass vacuously. Both OK lines mean it ran to its normal end.
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    assert!(
+        output.status.success()
+            && stdout.contains("OK   with -D none")
+            && stdout.contains("OK   without it"),
+        "BLOCKED: the probe did not reach its normal end, so this says nothing \
+         about reaping. status {}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        output.status,
+    );
+
     let needle = work_root.to_string_lossy().to_string();
     // The kernel tears the subtree down as the namespace's init exits; give it
     // a moment rather than racing the exit.
@@ -156,11 +170,9 @@ fn the_probe_leaves_no_dns_responder_behind() {
     }
     assert!(
         alive.is_empty(),
-        "the probe left {} process(es) alive after exiting with {}:\n{}\nstdout:\n{}\nstderr:\n{}",
+        "the probe left {} process(es) alive after exiting with {}:\n{}\nstdout:\n{stdout}",
         alive.len(),
         output.status,
         alive.join("\n"),
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
     );
 }

--- a/tests/test_probe_pasta_dns_gateway.rs
+++ b/tests/test_probe_pasta_dns_gateway.rs
@@ -26,12 +26,23 @@ fn require_tools() {
             .status()
             .map(|s| s.success())
             .unwrap_or(false);
-        assert!(found, "BLOCKED: '{tool}' is missing; this test cannot evaluate anything");
+        assert!(
+            found,
+            "BLOCKED: '{tool}' is missing; this test cannot evaluate anything"
+        );
     }
     // The probe's own namespace. Without unprivileged user namespaces it
     // cannot start at all, and neither can rootless fcvm.
     let status = Command::new("unshare")
-        .args(["--user", "--map-root-user", "--net", "--mount", "--fork", "--", "true"])
+        .args([
+            "--user",
+            "--map-root-user",
+            "--net",
+            "--mount",
+            "--fork",
+            "--",
+            "true",
+        ])
         .status()
         .expect("run unshare");
     assert!(
@@ -86,7 +97,11 @@ fn processes_matching(needle: &str) -> Vec<String> {
 fn the_probe_leaves_no_dns_responder_behind() {
     require_tools();
     let script = repo_root().join("scripts/probe-pasta-dns-gateway.sh");
-    assert!(script.is_file(), "the probe is gone from {}", script.display());
+    assert!(
+        script.is_file(),
+        "the probe is gone from {}",
+        script.display()
+    );
 
     let tmp = tempfile::tempdir().expect("temp dir");
     let bin = tmp.path().join("bin");

--- a/tests/test_probe_pasta_dns_gateway.rs
+++ b/tests/test_probe_pasta_dns_gateway.rs
@@ -278,6 +278,91 @@ fn the_probe_refuses_a_pasta_bin_that_is_not_a_regular_file() {
     );
 }
 
+/// A namespace the kernel refuses must not leave a work directory behind.
+///
+/// `mktemp -d` runs in the OUTER shell, so the directory exists on the host
+/// before `unshare` starts, while the `trap` that removes it is installed by
+/// the `--inside` shell. An `unshare` that fails, on a box with unprivileged
+/// user namespaces switched off or under a restrictive AppArmor profile, never
+/// reaches that trap, so every attempt left one more directory in TMPDIR. The
+/// probe is meant to be cheap to re-run while the pasta wiring is in question,
+/// which is exactly the usage that accumulates them.
+///
+/// `unshare` is stubbed to fail, because the alternative is turning off
+/// unprivileged user namespaces on the host running the test.
+///
+/// RED BEFORE THE FIX:
+///
+/// ```text
+/// the probe left 1 director(ies) in its TMPDIR after exiting with exit status: 1:
+/// tmp.qkV3rXo1aE
+/// ```
+#[test]
+fn the_probe_leaves_no_work_directory_when_the_namespace_fails() {
+    require_tools();
+    let script = repo_root().join("scripts/probe-pasta-dns-gateway.sh");
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let bin = tmp.path().join("bin");
+    std::fs::create_dir_all(&bin).expect("create stub bin");
+    write_guest_stubs(&bin, &tmp.path().join("dig-calls"));
+    // The kernel's refusal, without having to reconfigure the host. The tool
+    // check ahead of it only asks whether `unshare` is on PATH.
+    write_exec(
+        &bin.join("unshare"),
+        "#!/bin/bash
+exit 1
+",
+    );
+    write_exec(
+        &bin.join("pasta"),
+        "#!/bin/bash
+exec sleep 60
+",
+    );
+    let work_root = tmp.path().join("work");
+    std::fs::create_dir_all(&work_root).expect("create work root");
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    let output = Command::new("bash")
+        .arg(&script)
+        .env("PATH", &path)
+        .env("TMPDIR", &work_root)
+        .env("PASTA_BIN", bin.join("pasta"))
+        .output()
+        .expect("run the probe");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    // A probe that stopped before `mktemp -d` leaves nothing behind for a
+    // reason that says nothing about the trap.
+    assert!(
+        !stderr.contains("this probe cannot evaluate anything") && !stderr.contains("BLOCKED:"),
+        "BLOCKED: the probe stopped before it reached the namespace, so this \
+         says nothing about the work directory:\nstderr:\n{stderr}"
+    );
+    assert!(
+        !output.status.success(),
+        "the stubbed unshare was supposed to fail the run:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let left: Vec<String> = std::fs::read_dir(&work_root)
+        .expect("read work root")
+        .flatten()
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+    assert!(
+        left.is_empty(),
+        "the probe left {} director(ies) in its TMPDIR after exiting with {}:\n{}",
+        left.len(),
+        output.status,
+        left.join("\n"),
+    );
+}
+
 /// The probe runs to its normal end and leaves nothing behind.
 ///
 /// The pasta binary, the namespace entry and the query are stubbed: what is

--- a/tests/test_probe_pasta_dns_gateway.rs
+++ b/tests/test_probe_pasta_dns_gateway.rs
@@ -60,6 +60,34 @@ fn write_exec(path: &Path, body: &str) {
     std::fs::set_permissions(path, perms).expect("chmod stub");
 }
 
+/// The two commands the probe reaches the guest with, stubbed.
+///
+/// `nsenter -t <pid> -U -n -- <cmd>` runs twice per `ask`: once to wait for
+/// pasta0 to carry the guest address, once to ask the resolver. Both are
+/// answered here, the second from a counter so the two arms differ, because a
+/// real answer needs the VM-less pasta wiring these tests are not measuring.
+/// `dig` only has to exist: the probe's tool check looks it up before the
+/// namespace, and the query itself goes through the `nsenter` stub.
+fn write_guest_stubs(bin: &Path, calls: &Path) {
+    write_exec(
+        &bin.join("nsenter"),
+        &format!(
+            "#!/bin/bash\n\
+             for a in \"$@\"; do\n\
+             \tcase \"$a\" in\n\
+             \t\tdig) n=$(cat {calls} 2>/dev/null || echo 0); n=$((n + 1)); echo \"$n\" >{calls}\n\
+             \t\t\t[ \"$n\" = 1 ] && echo 10.0.2.2 || echo 203.0.113.99\n\
+             \t\t\texit 0 ;;\n\
+             \t\tpasta0) echo '2: pasta0    inet 10.0.2.100/24 scope global pasta0' ; exit 0 ;;\n\
+             \tesac\n\
+             done\n\
+             exit 0\n",
+            calls = calls.display()
+        ),
+    );
+    write_exec(&bin.join("dig"), "#!/bin/bash\nexit 0\n");
+}
+
 /// Processes whose command line mentions `needle`, by host pid.
 fn processes_matching(needle: &str) -> Vec<String> {
     let mut found = Vec::new();
@@ -114,24 +142,7 @@ fn the_probe_refuses_to_guess_which_pasta_to_run() {
     let tmp = tempfile::tempdir().expect("temp dir");
     let bin = tmp.path().join("bin");
     std::fs::create_dir_all(&bin).expect("create stub bin");
-    let calls = tmp.path().join("dig-calls");
-    write_exec(
-        &bin.join("nsenter"),
-        &format!(
-            "#!/bin/bash\n\
-             for a in \"$@\"; do\n\
-             \tcase \"$a\" in\n\
-             \t\tdig) n=$(cat {calls} 2>/dev/null || echo 0); n=$((n + 1)); echo \"$n\" >{calls}\n\
-             \t\t\t[ \"$n\" = 1 ] && echo 10.0.2.2 || echo 203.0.113.99\n\
-             \t\t\texit 0 ;;\n\
-             \t\tpasta0) echo '2: pasta0    inet 10.0.2.100/24 scope global pasta0' ; exit 0 ;;\n\
-             \tesac\n\
-             done\n\
-             exit 0\n",
-            calls = calls.display()
-        ),
-    );
-    write_exec(&bin.join("dig"), "#!/bin/bash\nexit 0\n");
+    write_guest_stubs(&bin, &tmp.path().join("dig-calls"));
     let work_root = tmp.path().join("work");
     std::fs::create_dir_all(&work_root).expect("create work root");
     let path = format!(
@@ -186,6 +197,87 @@ fn the_probe_refuses_to_guess_which_pasta_to_run() {
     );
 }
 
+/// A directory passes `test -x`. The `PASTA_BIN` guard must still refuse it.
+///
+/// `-x` asks whether the caller may execute the path, and for a directory that
+/// means traverse it, so every directory this test can enter satisfies it. A
+/// `PASTA_BIN` naming one therefore walked past the documented exit-2 path and
+/// the run carried on: private namespace, veth pair, both DNS responders, and
+/// only then an invocation of a path that can never be a program. The caller
+/// got back a verdict about DNS with no mention of what they had supplied.
+///
+/// The guard sits ahead of all of that, so a refusal needs none of the stubs
+/// below; they are here to keep the pre-fix run bounded.
+///
+/// RED BEFORE THE FIX:
+///
+/// ```text
+/// assertion `left == right` failed: a directory passed the guard and the probe
+/// ran the whole thing: exit status: 0
+/// stdout:
+/// OK   with -D none:    10.0.2.2 (the replay on host 127.0.0.1:53 answered)
+/// OK   without it:      203.0.113.99 (pasta redirected port 53 to the host's own resolver)
+///   left: Some(0)
+///  right: Some(2)
+/// ```
+///
+/// Two OK lines about a pasta that was never executed.
+#[test]
+fn the_probe_refuses_a_pasta_bin_that_is_not_a_regular_file() {
+    require_tools();
+    let script = repo_root().join("scripts/probe-pasta-dns-gateway.sh");
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let bin = tmp.path().join("bin");
+    std::fs::create_dir_all(&bin).expect("create stub bin");
+    write_guest_stubs(&bin, &tmp.path().join("dig-calls"));
+    let work_root = tmp.path().join("work");
+    std::fs::create_dir_all(&work_root).expect("create work root");
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    // What the caller hands over: a directory where a binary was meant to be,
+    // which is what a truncated path or an assets directory produces.
+    let dir = tmp.path().join("pasta-is-a-directory");
+    std::fs::create_dir_all(&dir).expect("create the directory to hand the guard");
+
+    let output = Command::new("bash")
+        .arg(&script)
+        .env("PATH", &path)
+        .env("TMPDIR", &work_root)
+        .env("PASTA_BIN", &dir)
+        .output()
+        .expect("run the probe");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    // A probe that stopped on a missing tool exits 2 for a reason that says
+    // nothing about the guard, so the assertion below would pass vacuously.
+    assert!(
+        !stderr.contains("this probe cannot evaluate anything"),
+        "BLOCKED: the probe stopped on a missing tool, so this says nothing \
+         about the guard:\nstderr:\n{stderr}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "a directory passed the guard and the probe ran the whole thing: {}\n\
+         stdout:\n{stdout}\nstderr:\n{stderr}",
+        output.status,
+    );
+    assert!(
+        !stdout.contains("OK ") && !stdout.contains("FAIL "),
+        "the probe rendered a verdict about a path that is not a \
+         program:\nstdout:\n{stdout}"
+    );
+    assert!(
+        stderr.contains(&dir.to_string_lossy().to_string()),
+        "a refusal must name the path it was given:\nstderr:\n{stderr}"
+    );
+}
+
 /// The probe runs to its normal end and leaves nothing behind.
 ///
 /// The pasta binary, the namespace entry and the query are stubbed: what is
@@ -215,31 +307,7 @@ fn the_probe_leaves_no_dns_responder_behind() {
     // A pasta that stays up until the probe kills it, so the probe follows its
     // ordinary path through both `ask` calls.
     write_exec(&bin.join("pasta"), "#!/bin/bash\nexec sleep 60\n");
-    // The probe reaches the guest through `nsenter -t <pid> -U -n -- <cmd>`,
-    // twice: once to wait for pasta0 to carry the guest address, once to ask
-    // the resolver. Both are answered here, the second from a counter so the
-    // two arms differ, because a real answer needs the VM-less pasta wiring
-    // this test is not measuring.
-    let calls = tmp.path().join("dig-calls");
-    write_exec(
-        &bin.join("nsenter"),
-        &format!(
-            "#!/bin/bash\n\
-             for a in \"$@\"; do\n\
-             \tcase \"$a\" in\n\
-             \t\tdig) n=$(cat {calls} 2>/dev/null || echo 0); n=$((n + 1)); echo \"$n\" >{calls}\n\
-             \t\t\t[ \"$n\" = 1 ] && echo 10.0.2.2 || echo 203.0.113.99\n\
-             \t\t\texit 0 ;;\n\
-             \t\tpasta0) echo '2: pasta0    inet 10.0.2.100/24 scope global pasta0' ; exit 0 ;;\n\
-             \tesac\n\
-             done\n\
-             exit 0\n",
-            calls = calls.display()
-        ),
-    );
-    // dig only has to exist: the probe's tool check looks it up before the
-    // namespace, and the query itself goes through the stub above.
-    write_exec(&bin.join("dig"), "#!/bin/bash\nexit 0\n");
+    write_guest_stubs(&bin, &tmp.path().join("dig-calls"));
 
     // The probe's work directory comes from `mktemp -d`, so pointing TMPDIR
     // here makes every responder's command line carry this path and nothing

--- a/tests/test_probe_pasta_dns_gateway.rs
+++ b/tests/test_probe_pasta_dns_gateway.rs
@@ -81,6 +81,111 @@ fn processes_matching(needle: &str) -> Vec<String> {
     found
 }
 
+/// With no `PASTA_BIN`, the probe must refuse rather than pick a binary out of
+/// a directory listing.
+///
+/// Which pasta fcvm runs is a function of the ACTIVE config: the binary is
+/// content-addressed under `paths.assets_dir`, and the config that names both
+/// is found through a lookup chain this script cannot replicate. A listing
+/// answers a different question, so the probe would report on an artifact that
+/// is not the one under review.
+///
+/// The situation is built rather than waited for: a tmpfs over `/mnt` inside a
+/// private mount namespace, holding one plausible-looking `pasta-*.bin` that
+/// records nothing and sleeps. Everything else is the shipped script.
+///
+/// RED BEFORE THE FIX:
+///
+/// ```text
+/// assertion `left == right` failed: the probe resolved a pasta out of the
+/// assets directory and ran the whole thing: exit status: 0
+/// stdout:
+/// OK   with -D none:    10.0.2.2 (the replay on host 127.0.0.1:53 answered)
+/// OK   without it:      203.0.113.99 (pasta redirected port 53 to the host's own resolver)
+///   left: Some(0)
+///  right: Some(2)
+/// ```
+///
+/// Two OK lines: a verdict about a binary the caller never named.
+#[test]
+fn the_probe_refuses_to_guess_which_pasta_to_run() {
+    require_tools();
+    let script = repo_root().join("scripts/probe-pasta-dns-gateway.sh");
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let bin = tmp.path().join("bin");
+    std::fs::create_dir_all(&bin).expect("create stub bin");
+    let calls = tmp.path().join("dig-calls");
+    write_exec(
+        &bin.join("nsenter"),
+        &format!(
+            "#!/bin/bash\n\
+             for a in \"$@\"; do\n\
+             \tcase \"$a\" in\n\
+             \t\tdig) n=$(cat {calls} 2>/dev/null || echo 0); n=$((n + 1)); echo \"$n\" >{calls}\n\
+             \t\t\t[ \"$n\" = 1 ] && echo 10.0.2.2 || echo 203.0.113.99\n\
+             \t\t\texit 0 ;;\n\
+             \t\tpasta0) echo '2: pasta0    inet 10.0.2.100/24 scope global pasta0' ; exit 0 ;;\n\
+             \tesac\n\
+             done\n\
+             exit 0\n",
+            calls = calls.display()
+        ),
+    );
+    write_exec(&bin.join("dig"), "#!/bin/bash\nexit 0\n");
+    let work_root = tmp.path().join("work");
+    std::fs::create_dir_all(&work_root).expect("create work root");
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    // A private /mnt so the plant is this test's, and the box's real assets
+    // directory is neither read nor written.
+    let plant = "set -e\n\
+         mount -t tmpfs none /mnt\n\
+         mkdir -p /mnt/fcvm-btrfs/pasta\n\
+         printf '#!/bin/sh\\nexec sleep 60\\n' >/mnt/fcvm-btrfs/pasta/pasta-stale.bin\n\
+         chmod +x /mnt/fcvm-btrfs/pasta/pasta-stale.bin\n\
+         exec bash \"$0\"\n";
+    let output = Command::new("unshare")
+        .args([
+            "--user",
+            "--map-root-user",
+            "--mount",
+            "--fork",
+            "--",
+            "bash",
+            "-c",
+            plant,
+        ])
+        .arg(&script)
+        .env("PATH", &path)
+        .env("TMPDIR", &work_root)
+        .env_remove("PASTA_BIN")
+        .output()
+        .expect("run the probe");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "the probe resolved a pasta out of the assets directory and ran the \
+         whole thing: {}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        output.status,
+    );
+    assert!(
+        !stdout.contains("OK ") && !stdout.contains("FAIL "),
+        "the probe rendered a verdict without being told which binary to \
+         test:\nstdout:\n{stdout}"
+    );
+    assert!(
+        stderr.contains("PASTA_BIN"),
+        "a refusal must name what the caller has to supply:\nstderr:\n{stderr}"
+    );
+}
+
 /// The probe runs to its normal end and leaves nothing behind.
 ///
 /// The pasta binary, the namespace entry and the query are stubbed: what is


### PR DESCRIPTION
Nine fixes found by taking a brand new 192-core box and following the documented "Fresh Bare-Metal Box Quickstart" end to end, then running the corpus benchmark campaign on it. Every one was invisible from the repo: the long-lived fcvm boxes are provisioned by terraform, so the hand-written setup path had drifted, and the campaign depended on a property of those boxes that nobody had written down.

The campaign now runs to completion on a machine that had never seen fcvm, and its measured run is publishable.

## The one that matters: `--dns` did not do what it says

`fcvm podman run --dns 10.0.2.2` promised the guest would resolve through host `127.0.0.1:53` and silently delivered whatever the host itself resolved with. Any user of that flag hit this; the benchmark is only where it surfaced.

pasta redirects the guest's port 53 to the host's own resolver *before* the gateway-to-loopback mapping every other port takes. In passt at the pinned commit `e1a6d9e`:

- `conf.c add_dns_resolv4()` records the host's first `/etc/resolv.conf` nameserver as `dns_host`, and when that nameserver is loopback it sets `dns_match = map_host_loopback`.
- `conf.c:1840` defaults `map_host_loopback` to `guest_gw`, which is exactly the `-g 10.0.2.2` fcvm passes, so `dns_match` becomes the gateway.
- `fwd.c:907 fwd_nat_from_tap()` tests `is_dns_flow() && oaddr == dns_match` and rewrites the destination to `dns_host` *before* reaching `nat_outbound()`, which is the function that maps the gateway to `127.0.0.1`.

Measured, with the replay server on host `127.0.0.1:53` answering a wildcard `10.0.2.2`:

```
guest TCP  -> 10.0.2.2:80  reaches the replay   (access log: host=example.com status=200)
guest DNS  -> 10.0.2.2:53  never arrives        (guest resolved example.com to real Cloudflare)
```

The campaign had therefore only ever worked by coincidence, on hosts whose first nameserver is `127.0.0.1` (dnsmasq), which is the whole reason `corpus_campaign.sh` carries a dnsmasq stop/restart trap. On a systemd-resolved host the guest silently resolved against the live internet.

Fix: pass pasta `-D none` when the launch's resolver parses as the pasta gateway, which zeroes `dns_match`/`dns_host` so port 53 falls through `nat_outbound` like every other port. It holds whatever the host's resolver is and touches no host DNS configuration. Default guest networking is unchanged: the flag is gated on `with_dns_server()`, and `is_usable_nameserver` drops loopback resolvers from the host list, so a default guest can never name the gateway.

`scripts/probe-pasta-dns-gateway.sh` reproduces both directions in 0.45 s using the pinned pasta binary alone in a private namespace, with no fcvm, no VM and no vsock:

```
with -D none:   10.0.2.2        (the replay answered)
without it:     203.0.113.99    (pasta redirected to the host's own resolver)
```

Regressions checked on real VMs: a default `fcvm podman run alpine` still gets the VPC resolver and real public answers; and `--dns 10.0.2.2` with nothing listening now fails the guest closed rather than resolving via the host.

## The replay was answering, and the browser was throwing the answers away

With DNS fixed, the diagnostic still refused 9 requests across the three ad-heavy news pages as unattributable. They were not missing from the corpus: all 32 unaddressed rows across 42 traces have a matching access-log line (27 GET 404, 2 POST 404, 3 HEAD 501). The hit path sent `Access-Control-Allow-Origin`; the 404 path and the base class's 501 did not, so Chromium blocked each reply before the renderer, emitted no `Network.responseReceived`, and reported `ERR_FAILED` with no remote address.

The gate was correct to refuse a request whose reply the browser discarded. The replay was wrong. CORS headers now go out from `end_headers`, so every reply carries them, and `do_HEAD` resolves like GET rather than falling to the base class (one corpus URL, `www.rtp.pt/rtp-sensor`, was answered 501 purely because HEAD had no handler). Statuses are unchanged: the full run logs 2561 misses as 404 and zero 501s.

## Fresh-box setup, three gaps

Each of these stops `make setup-fcvm` dead on a machine that has never run fcvm, and each is configured out of band on the real boxes by `dev-user-data.tf`:

- `libseccomp-dev` is missing from the package list, so building the firecracker fork fails at link with `cannot find -lseccomp`.
- `kernel.apparmor_restrict_unprivileged_userns=1` is Ubuntu 24.04's default, so rootless podman and skopeo cannot unshare and the first image export dies with `Error during unshare(...): Operation not permitted`.
- `/etc/fuse.conf` needs `user_allow_other`.

Plus one code defect on the same path: `setup_vm_firecracker_bin` resolved `FCVM_FIRECRACKER_BIN` then `PATH`, and never the Firecracker fcvm had just built and printed the path of seconds earlier, so a fresh box failed with `firecracker not found in PATH` immediately after `✓ Firecracker ready`. Resolution order is now the explicit override, then the profile's own binary, then PATH.

## Two fail-open holes in the campaign's own checks

- A verify bracket asserts over a list of names, and every such assertion is vacuously true on an empty list, so a bracket that checked nothing passed. It now refuses a bracket with no corpus hosts or no URLs.
- A bracket now also has to see this campaign's replay server log a query for every corpus host inside the bracket's own window, rather than accepting a log some earlier phase filled.
- `printf '%s'` writes no trailing newline, so `wc -l` counted separators and every campaign reported `all 13 URLs replay locally` after probing 14.

## The campaign, end to end

Run `reqbench-20260829-221948-corpus`, tag `cb-req-corpus-hermetic`, on a box that had never run fcvm.

Diagnostic: `passed=true`, 0 violations, 42/42 renders, teardown failures 0, bundle intact, and every URL's observed remote addresses are `{"10.0.2.2": n}` and nothing else (elmundo 549, rtp 596, guardian 251).

Measured, 202 reps per arm after 28 warmup, 0 failed, failure-rate CI [0, 1.59%]:

| arm | blocking p50 | wall p50 |
|---|---|---|
| cdp | 765.3 ms [591.7, 809.3] | 843.4 ms [679.1, 890.5] |
| cdp-fast | 765.0 ms [601.9, 814.2] | 884.6 ms [721.4, 939.9] |
| noop | 44.9 ms [44.8, 44.9] | 327.4 ms [325.6, 330.6] |

cdp to cdp-fast: blocking -0.35 ms [-186.3, +193.0], wall +41.2 ms [-146.2, +225.3]; neither significant. Drift control n=202, -0.03 ms [-0.12, +0.10], inside the 10 ms equivalence margin. Teardown reap p50 113.7 ms, all_gone confirmed 230/230.

Per-URL load-event p50 on the cdp arm: example.com 67.9, news.ycombinator.com 165.9, todomvc 224-313, wikipedia 424.8, MDN 447.2, developers.cloudflare.com 521.0, blog.cloudflare.com 521.6, theguardian 876.6, rtp.pt 2145.1, elmundo.es 3364.6. elmundo is the slowest page in the corpus, which is all it ever was.

`publishable: true`, `gate.passed=true` with zero reasons, stall gate passed over 460 evaluated renders, dns evidence `verdict=clean`, corpus_serve exit 0.

## Checks

`make lint` clean. `make test-unit` 958 passed. `make test-chromium` 578 passed. Every fix is closed by a test watched failing before it, and each was reverted once afterwards to confirm it goes red again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved rootless networking and snapshot restoration with consistent guest DNS handling.
  - Added complete replay-query evidence tracking for Chromium campaigns.
  - Added replay-server support for HEAD requests, redirects, errors, CORS, and preflight requests.
  - Added a namespace-isolated pasta DNS gateway probe.

- **Bug Fixes**
  - Improved DNS verification accuracy by isolating queries to each replay interval.
  - Prevented orphaned DNS responder processes and strengthened evidence validation.

- **Documentation**
  - Expanded setup instructions, dependency guidance, and `--dns` configuration details.

- **Tests**
  - Expanded coverage for networking, replay evidence, server responses, and process cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->