### PR TITLE
bridged: give per-VM names the collision detection routed already has

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -765,7 +765,7 @@ signal breaks the stale mux session and triggers immediate vsock reconnection.
 │ Host Namespace                                                   │
 │  ┌──────────────┐        veth pair         ┌──────────────────┐ │
 │  │ veth_outer   │◄─────────────────────────►│ VM Namespace     │ │
-│  │ 172.30.x.1   │                          │ (fcvm-vm-xxxxx)  │ │
+│  │ 172.30.x.1   │                          │ (fcvm-vm-xxxxxx) │ │
 │  └──────────────┘                          │                  │ │
 │                                            │  veth_inner      │ │
 │  iptables DNAT (scoped to veth IP):        │  172.30.x.2      │ │

--- a/src/commands/podman/mod.rs
+++ b/src/commands/podman/mod.rs
@@ -1457,6 +1457,8 @@ async fn prepare_vm_for_lifecycle(
         );
     }
 
+    // Bridged and routed re-derive this from the namespace they reserve (see
+    // network::names); read the settled name back from network_config.
     let tap_device = format!("tap-{}", truncate_id(&vm_id, 8));
     let mut network: Box<dyn NetworkManager> = match args.network {
         NetworkMode::Bridged => {

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -1674,6 +1674,8 @@ async fn cmd_snapshot_run_inner(
     }
 
     // Setup networking - use saved network config from snapshot
+    // Bridged and routed re-derive this from the namespace they reserve (see
+    // network::names); read the settled name back from network_config.
     let tap_device = format!("tap-{}", truncate_id(&vm_id, 8));
     let port_mappings = snapshot_config.metadata.port_mappings.clone();
 

--- a/src/network/bridged.rs
+++ b/src/network/bridged.rs
@@ -3,9 +3,9 @@ use std::path::Path;
 use tracing::{debug, info, warn};
 
 use super::{
-    namespace, portmap, types::generate_mac, veth, NetworkConfig, NetworkManager, PortMapping,
+    names, namespace, portmap, types::generate_mac, veth, NetworkConfig, NetworkManager,
+    PortMapping,
 };
-use crate::state::truncate_id;
 
 /// Derive the host-side IP for a given subnet_id
 fn derive_host_ip(subnet_id: u16, is_clone: bool) -> String {
@@ -158,6 +158,11 @@ pub struct BridgedNetwork {
 }
 
 impl BridgedNetwork {
+    /// `tap_device` is the caller's derivation of the TAP name. `setup()`
+    /// replaces it with the name from the reservation it makes, because the
+    /// TAP is created inside the reserved namespace and has to be named from
+    /// the same base. Read the settled name back from the returned
+    /// `NetworkConfig` (or `tap_device()`), never from the argument.
     pub fn new(vm_id: String, tap_device: String, port_mappings: Vec<PortMapping>) -> Self {
         Self {
             vm_id,
@@ -246,14 +251,26 @@ impl NetworkManager for BridgedNetwork {
         // Namespace and veth pair are subnet-independent; they exist before
         // subnet selection so each candidate /30 can be assigned to the real
         // veth and verified against the kernel's actual routing decision.
-        let namespace_id = format!("fcvm-{}", truncate_id(&self.vm_id, 8));
-        namespace::create_namespace(&namespace_id)
+        //
+        // The names come from names::reserve, which creates the namespace and
+        // so decides which VM owns the base. Two vm_ids that share the leading
+        // hex digits used to derive the same names, and creating the namespace
+        // silently adopted the first VM's: the second then failed on `veth
+        // pair: File exists` or `TUNSETIFF: Device or resource busy`, and its
+        // cleanup deleted the namespace the first VM was still running in
+        // (#888).
+        let vm_names = names::reserve(&self.vm_id, &["veth0-", "veth1-"])
             .await
-            .context("creating network namespace")?;
+            .context("reserving per-VM network names")?;
+        let namespace_id = vm_names.namespace.clone();
         self.namespace_id = Some(namespace_id.clone());
 
-        let host_veth = format!("veth0-{}", truncate_id(&self.vm_id, 8));
-        let guest_veth = format!("veth1-{}", truncate_id(&self.vm_id, 8));
+        let host_veth = vm_names.link("veth0-");
+        let guest_veth = vm_names.link("veth1-");
+        // The TAP is created inside the reserved namespace, so its name is
+        // settled by the reservation and not by the caller's derivation, which
+        // two VMs sharing leading hex digits render identically.
+        self.tap_device = vm_names.link("tap-");
         if let Err(e) = veth::create_veth_pair(&host_veth, &guest_veth, &namespace_id).await {
             let _ = self.cleanup().await;
             return Err(e).context("creating veth pair");

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,5 +1,6 @@
 pub mod bridged;
 pub mod egress_proxy;
+pub mod names;
 pub mod namespace;
 pub mod pasta;
 pub mod portmap;

--- a/src/network/names.rs
+++ b/src/network/names.rs
@@ -1,0 +1,213 @@
+//! Names for the host objects one VM owns: its network namespace, its veth
+//! pair, and its TAP device.
+//!
+//! Every name is derived from `vm_id` so a live VM is recognisable in `ip
+//! netns list` and `ip link show`. The derivation has to be short: Linux caps
+//! an interface name at 15 characters and the longest prefix built on it is
+//! `veth0-`, which leaves nine. Nine characters of a `vm-<32 hex>` id is `vm-`
+//! plus six hex digits, so the derived name is a guess at uniqueness, not an
+//! identity. 100 clones draw a duplicate about 0.03% of the time; at the five
+//! hex digits this used before it was 0.5%, which is what #888 hit.
+//!
+//! [`reserve`] therefore settles ownership with `ip netns add`, which fails
+//! when the name is taken. That is the only compare-and-swap available here,
+//! and it needs no host-wide lock: a caller that loses the race is told to
+//! pick another base rather than being handed a namespace another VM's
+//! interfaces already live in.
+
+use anyhow::{Context, Result};
+use tracing::warn;
+
+use super::{namespace, veth};
+use crate::state::truncate_id;
+
+/// Characters of `vm_id` carried by a derived name.
+pub const NAME_BASE_LEN: usize = 9;
+
+/// Namespace name prefix, shared by the bridged and routed modes.
+pub const NAMESPACE_PREFIX: &str = "fcvm-";
+
+/// The longest interface prefix any caller builds on a base (`veth0-`).
+const LONGEST_LINK_PREFIX: usize = 6;
+
+/// Linux's IFNAMSIZ minus the trailing NUL.
+const MAX_IF_NAME_LEN: usize = 15;
+
+const _: () = assert!(
+    LONGEST_LINK_PREFIX + NAME_BASE_LEN <= MAX_IF_NAME_LEN,
+    "derived interface names must fit in IFNAMSIZ"
+);
+
+const _: () = assert!(
+    NAME_BASE_LEN == 9,
+    "candidate_base renders `vm-` plus six hex digits"
+);
+
+/// Bases to try before giving up.
+const MAX_ATTEMPTS: u32 = 100;
+
+/// The names reserved for one VM.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VmNetworkNames {
+    /// The `vm-<hex>` fragment every name for this VM is built from.
+    pub base: String,
+    /// The network namespace, already created by [`reserve`].
+    pub namespace: String,
+}
+
+impl VmNetworkNames {
+    /// A name in this VM's family, e.g. `link("veth0-")` or `link("tap-")`.
+    pub fn link(&self, prefix: &str) -> String {
+        format!("{}{}", prefix, self.base)
+    }
+}
+
+/// The name base to try on `attempt`.
+///
+/// Attempt 0 is the leading characters of `vm_id`, so the usual name still
+/// reads back to the VM that owns it. Later attempts rehash the id with the
+/// attempt number instead of appending a counter: appending pushes the veth
+/// names past IFNAMSIZ, and truncating to make room lets two attempts land on
+/// one name, since a hex id can end in digits (`vm-1111111` + `1` and
+/// `vm-111111` + `11` both truncate to `vm-11111111`).
+fn candidate_base(vm_id: &str, attempt: u32) -> String {
+    if attempt == 0 {
+        return truncate_id(vm_id, NAME_BASE_LEN).to_string();
+    }
+
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    vm_id.hash(&mut hasher);
+    attempt.hash(&mut hasher);
+    format!("vm-{:06x}", hasher.finish() & 0xff_ffff)
+}
+
+/// Reserve a namespace, and with it a name base, for this VM.
+///
+/// `link_prefixes` are the interface prefixes the caller will create in the
+/// host namespace from the returned base. They are probed so a base whose
+/// interfaces leaked from a dead VM is skipped instead of failing later at
+/// `ip link add`; creating the namespace is what actually settles ownership.
+pub async fn reserve(vm_id: &str, link_prefixes: &[&str]) -> Result<VmNetworkNames> {
+    for attempt in 0..MAX_ATTEMPTS {
+        let base = candidate_base(vm_id, attempt);
+        let names = VmNetworkNames {
+            namespace: format!("{}{}", NAMESPACE_PREFIX, base),
+            base,
+        };
+
+        if let Some(taken) = link_prefixes
+            .iter()
+            .map(|prefix| names.link(prefix))
+            .find(|name| veth::link_exists(name))
+        {
+            warn!(
+                vm_id = %vm_id, link = %taken, attempt,
+                "interface name is taken, trying another name base"
+            );
+            continue;
+        }
+
+        match namespace::create_namespace(&names.namespace)
+            .await
+            .with_context(|| format!("creating network namespace {}", names.namespace))?
+        {
+            namespace::NamespaceCreation::Created => {
+                if attempt > 0 {
+                    warn!(
+                        vm_id = %vm_id, namespace = %names.namespace, attempt,
+                        "name base collided, reserved a rehashed base"
+                    );
+                }
+                return Ok(names);
+            }
+            namespace::NamespaceCreation::AlreadyExists => {
+                warn!(
+                    vm_id = %vm_id, namespace = %names.namespace, attempt,
+                    "namespace name belongs to another VM, trying another name base"
+                );
+            }
+        }
+    }
+
+    anyhow::bail!(
+        "no free network name base for {vm_id} after {MAX_ATTEMPTS} attempts. \
+         Check for leaked namespaces with `ip netns list` and interfaces with `ip link show`"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The arm64 pair from #888 shares five hex digits and differs at the
+    /// sixth, so the widened base alone separates it.
+    #[test]
+    fn ids_differing_at_the_sixth_hex_digit_derive_different_bases() {
+        let a = candidate_base("vm-ca1c071bafd64b8a9ad3211f7fe5d7d0", 0);
+        let b = candidate_base("vm-ca1c0a5654134eb3b0b854f7dc9710a", 0);
+        assert_eq!(a, "vm-ca1c07");
+        assert_eq!(b, "vm-ca1c0a");
+        assert_ne!(a, b);
+    }
+
+    /// The x64 pair from #888 shares SIX hex digits, so widening does not
+    /// separate it and never could have. Their derived names are equal, and
+    /// only the later attempts move off. This is why `reserve` reserves
+    /// rather than trusting the derivation.
+    #[test]
+    fn ids_sharing_six_hex_digits_still_collide_so_later_attempts_must_differ() {
+        let a = "vm-e7f5d11346f04cc280d9f9db7dc45124";
+        let b = "vm-e7f5d1a1d4fd4728a1216b803888393c";
+        assert_eq!(candidate_base(a, 0), "vm-e7f5d1");
+        assert_eq!(candidate_base(a, 0), candidate_base(b, 0));
+        for attempt in 1..=8 {
+            assert_ne!(
+                candidate_base(a, attempt),
+                candidate_base(b, attempt),
+                "attempt {attempt} must separate two ids sharing six hex digits"
+            );
+        }
+    }
+
+    /// Every attempt has to stay inside IFNAMSIZ once a prefix is added.
+    ///
+    /// The distinctness check guards the rehash: the append-and-truncate
+    /// scheme it replaced rendered two attempts as one name for an id ending
+    /// in digits, wasting attempts on a candidate already rejected.
+    #[test]
+    fn every_attempt_fits_ifnamsiz_and_is_distinct() {
+        let vm_id = "vm-1111111111111111111111111111111f";
+        let mut seen = std::collections::HashSet::new();
+        for attempt in 0..MAX_ATTEMPTS {
+            let base = candidate_base(vm_id, attempt);
+            assert_eq!(base.len(), NAME_BASE_LEN, "attempt {attempt}: {base}");
+            assert!(
+                LONGEST_LINK_PREFIX + base.len() <= MAX_IF_NAME_LEN,
+                "attempt {attempt}: veth0-{base} exceeds IFNAMSIZ"
+            );
+            assert!(
+                seen.insert(base.clone()),
+                "attempt {attempt} repeats {base}"
+            );
+        }
+    }
+
+    /// A short id (tests and fixtures use them) must not panic or overrun.
+    #[test]
+    fn a_short_vm_id_is_carried_whole() {
+        assert_eq!(candidate_base("vm-abc", 0), "vm-abc");
+    }
+
+    #[test]
+    fn link_names_are_built_from_the_reserved_base() {
+        let names = VmNetworkNames {
+            base: "vm-e7f5d1".to_string(),
+            namespace: "fcvm-vm-e7f5d1".to_string(),
+        };
+        assert_eq!(names.link("veth0-"), "veth0-vm-e7f5d1");
+        assert_eq!(names.link("tap-"), "tap-vm-e7f5d1");
+    }
+}

--- a/src/network/namespace.rs
+++ b/src/network/namespace.rs
@@ -1,13 +1,41 @@
 use anyhow::{Context, Result};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tokio::process::Command;
 use tracing::{debug, warn};
 
-/// Creates a named network namespace
+/// Directory `ip netns` keeps its named namespaces in.
+const NETNS_DIR: &str = "/var/run/netns";
+
+/// What `create_namespace` found.
 ///
-/// This uses `ip netns add` to create a persistent namespace in /var/run/netns/.
-/// The namespace will survive even if no processes are in it.
-pub async fn create_namespace(ns_name: &str) -> Result<()> {
+/// A separate outcome rather than an error so a caller searching for a free
+/// name can move on, and so no caller can mistake "somebody else's namespace"
+/// for "mine".
+#[must_use]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NamespaceCreation {
+    /// This call created the namespace.
+    Created,
+    /// The name was already taken; this call created nothing.
+    AlreadyExists,
+}
+
+/// The file `ip netns` uses to represent a named namespace.
+pub fn namespace_path(ns_name: &str) -> PathBuf {
+    Path::new(NETNS_DIR).join(ns_name)
+}
+
+/// Creates a named network namespace in /var/run/netns/.
+///
+/// The namespace survives even if no processes are in it.
+///
+/// An existing name is reported as `AlreadyExists`, never adopted. `ip netns
+/// add` fails with EEXIST, which makes it the compare-and-swap that decides
+/// which VM owns a name. Adopting instead put two VMs' interfaces in one
+/// namespace: the second VM's veth or TAP creation failed on a name the first
+/// VM already held, and its cleanup then deleted the namespace the first VM
+/// was still running in (#888).
+pub async fn create_namespace(ns_name: &str) -> Result<NamespaceCreation> {
     debug!(namespace = %ns_name, "creating network namespace");
 
     let output = Command::new("ip")
@@ -18,15 +46,14 @@ pub async fn create_namespace(ns_name: &str) -> Result<()> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        // Ignore "File exists" error - namespace already created
         if stderr.contains("File exists") {
-            warn!(namespace = %ns_name, "namespace already exists, reusing");
-            return Ok(());
+            debug!(namespace = %ns_name, "namespace name is taken by another VM");
+            return Ok(NamespaceCreation::AlreadyExists);
         }
         anyhow::bail!("failed to create namespace {}: {}", ns_name, stderr);
     }
 
-    Ok(())
+    Ok(NamespaceCreation::Created)
 }
 
 /// Deletes a named network namespace
@@ -57,8 +84,7 @@ pub async fn delete_namespace(ns_name: &str) -> Result<()> {
 
 /// Checks if a namespace exists
 pub async fn namespace_exists(ns_name: &str) -> bool {
-    let ns_path = format!("/var/run/netns/{}", ns_name);
-    Path::new(&ns_path).exists()
+    namespace_path(ns_name).exists()
 }
 
 /// Executes a command inside a network namespace
@@ -143,11 +169,17 @@ mod tests {
         let _ = delete_namespace(ns_name).await;
 
         // Create namespace
-        create_namespace(ns_name).await.unwrap();
+        assert_eq!(
+            create_namespace(ns_name).await.unwrap(),
+            NamespaceCreation::Created
+        );
         assert!(namespace_exists(ns_name).await);
 
-        // Creating again should be idempotent
-        create_namespace(ns_name).await.unwrap();
+        // Creating again must report the name as taken, never adopt it (#888)
+        assert_eq!(
+            create_namespace(ns_name).await.unwrap(),
+            NamespaceCreation::AlreadyExists
+        );
 
         // Delete namespace
         delete_namespace(ns_name).await.unwrap();
@@ -166,7 +198,10 @@ mod tests {
         let _ = delete_namespace(ns_name).await;
 
         // Create namespace
-        create_namespace(ns_name).await.unwrap();
+        assert_eq!(
+            create_namespace(ns_name).await.unwrap(),
+            NamespaceCreation::Created
+        );
 
         // Execute command in namespace
         let output = exec_in_namespace(ns_name, &["ip", "link", "show"])

--- a/src/network/pasta.rs
+++ b/src/network/pasta.rs
@@ -11,7 +11,6 @@ use tracing::{debug, info, warn};
 
 use super::{types::generate_mac, NetworkConfig, NetworkManager, PortMapping, Protocol};
 use crate::paths;
-use crate::state::truncate_id;
 
 /// Guest network addressing — pasta provides L2↔L4 translation via bridge
 const GUEST_IP: &str = "10.0.2.100";
@@ -760,6 +759,15 @@ impl IpBatchScript {
     }
 }
 
+/// Name of the PID file pasta signals readiness through.
+///
+/// The whole `vm_id`, not a truncation of it: this is a file name in
+/// `data_dir` with no length limit, and two VMs sharing a name would delete
+/// each other's file as stale and then read the other's readiness (#888).
+fn pasta_pid_file_name(vm_id: &str) -> String {
+    format!("pasta-{vm_id}.pid")
+}
+
 /// Rootless networking using pasta with bridge architecture
 ///
 /// This mode uses user namespaces and pasta (from passt project) for true
@@ -1355,7 +1363,7 @@ impl PastaNetwork {
     /// pasta creates its own TAP device (pasta0) in the namespace and provides
     /// L2↔L4 translation to the host. Uses PID file for readiness signaling.
     pub async fn start_pasta(&mut self, namespace_pid: u32) -> Result<()> {
-        let pid_file = paths::data_dir().join(format!("pasta-{}.pid", truncate_id(&self.vm_id, 8)));
+        let pid_file = paths::data_dir().join(pasta_pid_file_name(&self.vm_id));
 
         // Register the inotify watch BEFORE the stale-file cleanup and spawn:
         // pasta's PID-file write after this point always produces an event, so

--- a/src/network/routed.rs
+++ b/src/network/routed.rs
@@ -1,12 +1,12 @@
 use anyhow::{Context, Result};
 use tracing::{info, warn};
 
+use super::names;
 use super::namespace;
 use super::tcp_proxy;
 use super::types::generate_mac;
 use super::veth;
 use super::{NetworkConfig, NetworkManager, PortMapping, Protocol};
-use crate::state::truncate_id;
 
 /// Guest network addressing (same as pasta/bridged for Firecracker compatibility)
 const GUEST_IP: &str = "10.0.2.100";
@@ -64,6 +64,9 @@ pub struct RoutedNetwork {
 }
 
 impl RoutedNetwork {
+    /// `tap_device` is the caller's derivation of the TAP name. `setup()`
+    /// replaces it with the name from the reservation it makes, for the same
+    /// reason as `BridgedNetwork::new`.
     pub fn new(vm_id: String, tap_device: String, port_mappings: Vec<PortMapping>) -> Self {
         Self {
             vm_id,
@@ -368,50 +371,6 @@ impl RoutedNetwork {
 #[async_trait::async_trait]
 impl NetworkManager for RoutedNetwork {
     async fn setup(&mut self) -> Result<NetworkConfig> {
-        // Generate unique namespace/veth names. Use hash-based short ID with
-        // collision detection: if the namespace already exists, bump a counter.
-        // Linux interface names are max 15 chars, so we use 5-char suffixes.
-        let (ns_name, host_veth, guest_veth) = {
-            let base = truncate_id(&self.vm_id, 8);
-            let mut ns = format!("fcvm-{}", base);
-            let mut hv = format!("veth-{}", base);
-            let mut gv = format!("vns-{}", base);
-
-            // Check for collision (another VM with same truncated ID).
-            // Bounded to 100 iterations to prevent infinite loops.
-            let mut found = !std::path::Path::new(&format!("/var/run/netns/{}", ns)).exists();
-            if !found {
-                for i in 1u32..=100 {
-                    warn!(namespace = %ns, "namespace collision, retrying with suffix");
-                    let suffix = format!("{}{}", base, i);
-                    // Truncate to keep within IFNAMSIZ (15 chars)
-                    let short = &suffix[..suffix.len().min(10)];
-                    ns = format!("fcvm-{}", short);
-                    hv = format!("veth-{}", short);
-                    gv = format!("vns-{}", short);
-                    if !std::path::Path::new(&format!("/var/run/netns/{}", ns)).exists() {
-                        found = true;
-                        break;
-                    }
-                }
-            }
-            if !found {
-                anyhow::bail!(
-                    "could not find a free namespace name after 100 attempts \
-                     (base={}, last tried={}). Check for stale namespaces with: ip netns list",
-                    base,
-                    ns
-                );
-            }
-            (ns, hv, gv)
-        };
-
-        info!(
-            vm_id = %self.vm_id,
-            namespace = %ns_name,
-            "setting up routed networking"
-        );
-
         // Resolve the IPv6 subnet: explicit --ipv6-prefix or auto-detect a /64
         // from host interfaces.
         let (host_ipv6, network, prefix_len) = if let Some(ref prefix) = self.ipv6_prefix {
@@ -467,9 +426,28 @@ impl NetworkManager for RoutedNetwork {
             "IPv6 addresses for routed networking"
         );
 
-        // 1. Create network namespace
-        namespace::create_namespace(&ns_name).await?;
+        // 1. Reserve the namespace and, with it, the name base for the veth
+        //    pair and the TAP. names::reserve creates the namespace, so the
+        //    creation itself decides which VM owns the base; the
+        //    check-then-create this replaced could hand one name to two VMs,
+        //    and bumped the suffix by appending and truncating, which rendered
+        //    two attempts as one name for an id ending in digits (#888).
+        let vm_names = names::reserve(&self.vm_id, &["veth-", "vns-"])
+            .await
+            .context("reserving per-VM network names")?;
+        let ns_name = vm_names.namespace.clone();
         self.namespace_id = Some(ns_name.clone());
+        let host_veth = vm_names.link("veth-");
+        let guest_veth = vm_names.link("vns-");
+        // The TAP is created inside the reserved namespace, so its name is
+        // settled by the reservation, not by the caller's derivation.
+        self.tap_device = vm_names.link("tap-");
+
+        info!(
+            vm_id = %self.vm_id,
+            namespace = %ns_name,
+            "setting up routed networking"
+        );
 
         // 1b. Turn Duplicate Address Detection off inside the namespace, before any
         //     interface exists there. Every link in here is a private point-to-point

--- a/src/network/veth.rs
+++ b/src/network/veth.rs
@@ -25,6 +25,18 @@ pub struct InNamespaceNatConfig {
     pub host_veth_ip_cidr: String,
 }
 
+/// Whether an interface of this name exists in the calling namespace.
+///
+/// `/sys/class/net` is per network namespace, so this answers for the
+/// namespace the caller is in. Both ends of a veth pair are created in the
+/// host namespace before the guest end is moved, so both names must be free
+/// here at creation time.
+pub fn link_exists(if_name: &str) -> bool {
+    std::path::Path::new("/sys/class/net")
+        .join(if_name)
+        .exists()
+}
+
 /// Creates a veth pair and moves guest side into a namespace
 ///
 /// Creates a pair of virtual ethernet devices. The host side remains in the
@@ -1028,7 +1040,9 @@ mod parse_tests {
 #[cfg(feature = "privileged-tests")]
 mod tests {
     use super::*;
-    use crate::network::namespace::{create_namespace, delete_namespace, exec_in_namespace};
+    use crate::network::namespace::{
+        create_namespace, delete_namespace, exec_in_namespace, NamespaceCreation,
+    };
 
     #[tokio::test]
     async fn test_veth_lifecycle() {
@@ -1041,7 +1055,10 @@ mod tests {
         let _ = delete_namespace(ns_name).await;
 
         // Create namespace
-        create_namespace(ns_name).await.unwrap();
+        assert_eq!(
+            create_namespace(ns_name).await.unwrap(),
+            NamespaceCreation::Created
+        );
 
         // Create veth pair
         create_veth_pair(host_veth, guest_veth, ns_name)
@@ -1082,7 +1099,10 @@ mod tests {
         let _ = delete_namespace(ns_name).await;
 
         // Create namespace
-        create_namespace(ns_name).await.unwrap();
+        assert_eq!(
+            create_namespace(ns_name).await.unwrap(),
+            NamespaceCreation::Created
+        );
 
         // Create TAP device
         create_tap_in_ns(ns_name, tap_name).await.unwrap();

--- a/tests/test_bridged_name_collision.rs
+++ b/tests/test_bridged_name_collision.rs
@@ -1,0 +1,117 @@
+//! Two VMs whose ids share their leading hex digits must not land on one set
+//! of host network names (#888).
+//!
+//! `truncate_id(vm_id, 8)` is `vm-` plus five hex digits, so 100 clones drew a
+//! duplicate about 0.5% of the time. The duplicate was not detected: `ip netns
+//! add` was allowed to adopt the existing namespace ("namespace already
+//! exists, reusing"), after which the second VM's veth or TAP creation failed
+//! on a name the first VM already held, and its cleanup deleted the namespace
+//! the first VM was still running in.
+//!
+//! Root, because it creates network namespaces and veth pairs. No VM boots.
+
+#![cfg(feature = "privileged-tests")]
+
+use std::path::Path;
+
+use fcvm::network::{BridgedNetwork, NetworkManager};
+
+/// The pair from the x64 job in #888, verbatim. They share `e7f5d1`, so the
+/// name they derive is identical no matter how wide the truncation is made
+/// short of an interface name Linux would reject: only reserving the name can
+/// separate them.
+const VM_ID_A: &str = "vm-e7f5d11346f04cc280d9f9db7dc45124";
+const VM_ID_B: &str = "vm-e7f5d1a1d4fd4728a1216b803888393c";
+
+fn link_exists(name: &str) -> bool {
+    Path::new("/sys/class/net").join(name).exists()
+}
+
+fn namespace_exists(name: &str) -> bool {
+    Path::new("/var/run/netns").join(name).exists()
+}
+
+/// The host veth of a bridged VM, from the namespace it reserved.
+fn host_veth_of(namespace: &str) -> String {
+    format!(
+        "veth0-{}",
+        namespace
+            .strip_prefix("fcvm-")
+            .expect("bridged namespaces are named fcvm-<base>")
+    )
+}
+
+#[tokio::test]
+async fn two_vm_ids_sharing_leading_hex_digits_get_separate_network_names() {
+    let mut a = BridgedNetwork::new(
+        VM_ID_A.to_string(),
+        format!("tap-{}", &VM_ID_A[..8]),
+        vec![],
+    )
+    .with_dns_server(Some("127.0.0.53".to_string()));
+    let mut b = BridgedNetwork::new(
+        VM_ID_B.to_string(),
+        format!("tap-{}", &VM_ID_B[..8]),
+        vec![],
+    )
+    .with_dns_server(Some("127.0.0.53".to_string()));
+
+    let setup_a = a.setup().await;
+    // B's setup happens with A's network fully live, which is the situation
+    // two concurrently starting clones are in.
+    let setup_b = if setup_a.is_ok() {
+        Some(b.setup().await)
+    } else {
+        None
+    };
+
+    // Read the host's view before tearing anything down.
+    let observed = setup_a.as_ref().ok().map(|config_a| {
+        let ns_a = a
+            .namespace_id()
+            .expect("A reserved a namespace")
+            .to_string();
+        let ns_b = b.namespace_id().map(str::to_string);
+        (
+            ns_a.clone(),
+            config_a.tap_device.clone(),
+            config_a.host_veth.clone(),
+            namespace_exists(&ns_a),
+            link_exists(&host_veth_of(&ns_a)),
+            ns_b,
+        )
+    });
+
+    let _ = b.cleanup().await;
+    let _ = a.cleanup().await;
+
+    let config_a = setup_a.expect("baseline VM A must set up");
+    let config_b = setup_b
+        .expect("A set up, so B must have been attempted")
+        .expect("VM B must set up alongside A, not collide with it");
+    let (ns_a, tap_a, veth_a, ns_a_alive, veth_a_alive, ns_b) = observed.expect("A set up");
+    let ns_b = ns_b.expect("B reserved a namespace");
+
+    assert_ne!(ns_a, ns_b, "B reused A's network namespace");
+    assert_ne!(
+        tap_a, config_b.tap_device,
+        "B reused A's TAP name ({tap_a})"
+    );
+    assert_ne!(veth_a, config_b.host_veth, "B reused A's host veth");
+    assert_ne!(
+        config_a.host_ip, config_b.host_ip,
+        "B reused A's host veth address"
+    );
+
+    // A must still have been there when B finished: adopting A's namespace put
+    // B's teardown in charge of it.
+    assert!(
+        ns_a_alive,
+        "A's namespace {ns_a} was gone once B finished setting up"
+    );
+    assert!(
+        veth_a_alive,
+        "A's host veth {} was gone once B finished setting up",
+        host_veth_of(&ns_a)
+    );
+}


### PR DESCRIPTION
`src/network/bridged.rs` derived every per-VM host name from `truncate_id(&self.vm_id, 8)`,
which is the literal `vm-` plus five hex digits, about 1.05M values. Two VMs whose ids share
those five digits derived one `fcvm-vm-XXXXX` namespace, one `veth0-vm-XXXXX`/`veth1-vm-XXXXX`
pair and one `tap-vm-XXXXX`. Nothing detected that. `namespace::create_namespace` treated
`File exists` as success and logged "namespace already exists, reusing", so the second VM
adopted the first's namespace and then failed on a name the first VM already held. Its cleanup
then deleted the namespace the first VM was still running in.

## Evidence

100-clone stress run, x64:

```
WARN fcvm::network::namespace: namespace already exists, reusing namespace=fcvm-vm-e7f5d
ERROR fcvm: Error: setting up network: creating veth pair: failed to create veth pair:
  RTNETLINK answers: File exists
Error: Snapshot/clone test failed: 99/100 clones became healthy
```

colliding `vm-e7f5d11346f04cc280d9f9db7dc45124` and `vm-e7f5d1a1d4fd4728a1216b803888393c`.

Pre-existing on main, not from any one PR: main run 33229058267 at `f64ed5cf`, job 99038682605,
same mechanism on arm64 with the TAP as the losing syscall instead of the veth, colliding
`vm-ca1c071bafd64b8a9ad3211f7fe5d7d0` / `vm-ca1c0a5654134eb3b0b854f7dc9710a`. That run retried
green, which is why main stayed green.

At five hex digits, 100 clones draw a duplicate about 0.5% of the time and 10 clones about
0.004%, which matches how the failures showed up.

## Fix

`src/network/names.rs` holds one name allocator, used by bridged and by routed:

- The derived base widens from 8 to 9 characters, `vm-` plus six hex digits. Nine is the
  ceiling: Linux caps an interface name at 15 characters and the longest prefix built on the
  base is `veth0-`. A const assertion pins that. This alone takes 100 clones from about 0.5%
  to about 0.03%.
- Widening is not sufficient and never could have been for the observed pair: `e7f5d1...` and
  `e7f5d1a...` share six hex digits, so they derive the same nine-character base. Ownership is
  therefore settled by `ip netns add`, which fails with EEXIST. `create_namespace` now returns
  `Created` or `AlreadyExists` instead of quietly adopting, and the allocator treats
  `AlreadyExists` as "that base belongs to another VM" and moves to the next candidate. That is
  a compare-and-swap, so it needs no host-wide lock and closes the check-then-create window
  rather than narrowing it.
- Later candidates rehash `(vm_id, attempt)` rather than appending a counter. Appending pushes
  the veth names past IFNAMSIZ, and truncating to make room renders two attempts as one name
  when an id ends in digits: `vm-1111111` + `1` and `vm-111111` + `11` both truncate to
  `vm-11111111`. The routed path had exactly that bug.
- The allocator also probes the interface names the caller will create in the host namespace,
  so a base whose veths leaked from a dead VM is skipped instead of failing later at
  `ip link add`.
- The TAP name is taken from the reserved base as well. A bridged or routed TAP is created
  inside the VM's own namespace, so its name could not clash once the namespaces are distinct,
  but the caller's derivation renders identically for two colliding ids and would put
  `tap-vm-e7f5d` in two namespaces at once. `BridgedNetwork::new` and `RoutedNetwork::new` keep
  their `tap_device` argument; `setup()` replaces it and the settled name is read back from
  `NetworkConfig` as it already was.

Routed had its own check-then-create loop with the truncation bug above. It now uses the same
allocator, which is why `routed.rs` shrinks.

## The same truncation elsewhere

`grep truncate_id` finds one other name with real exposure: `src/network/pasta.rs` built the
pasta readiness PID file as `pasta-{truncate_id(vm_id, 8)}.pid` in `data_dir`. Two rootless VMs
sharing those five digits share that path, so one deletes the other's file as stale and can
read the other's readiness. That file name has no length limit, so it now carries the whole
`vm_id`. The remaining `truncate_id` call sites are display labels (`ls`, the health monitor,
snapshot listings) and the default snapshot tag, which collide harmlessly or are
user-overridable.

## Test

`tests/test_bridged_name_collision.rs`, gated on `privileged-tests`. It builds two
`BridgedNetwork`s from the two colliding ids in the log above, with A's network live while B
sets up, and asserts B's namespace, TAP, host veth and host IP all differ from A's, and that
A's namespace and veth are still there once B has finished.

Watched failing against unmodified main, twice (before the fix and again after reverting it):

```
thread 'two_vm_ids_sharing_leading_hex_digits_get_separate_network_names' panicked at
tests/test_bridged_name_collision.rs:88:10:
VM B must set up alongside A, not collide with it: creating veth pair

Caused by:
    failed to create veth pair: RTNETLINK answers: File exists
```

With the fix:

```
PASS [   0.299s] (1/1) fcvm::test_bridged_name_collision two_vm_ids_sharing_leading_hex_digits_get_separate_network_names
```

`src/network/names.rs` carries unit tests that run in `make test-unit`: the arm64 pair is
separated by the widened base, the x64 pair is not and needs the reservation, every attempt
fits IFNAMSIZ, and no two attempts render the same base.

`make test-unit`: 971 tests run, 971 passed. `make lint`: clean.

Closes #888.
