### PR TITLE
routed: the probe-selected resolver carries only the search domains it can serve

### DIFF
--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -1107,8 +1107,8 @@ impl GuestBootInputs {
     ///   routed guest. detect_ipv6_dns reads only the host's resolv.conf for
     ///   that, so the same selector runs here and the groups narrow to it.
     ///   Its probe fallback selects the AWS VPC resolver, which belongs to no
-    ///   source, so instead of a group the search domains narrow to the zones
-    ///   that resolver is authoritative for (#886).
+    ///   source, so instead of a group the search domains narrow to the one
+    ///   zone that resolver is authoritative for, this host's own (#886).
     /// * The four FUSE knobs are read only inside fc-agent's FUSE mount path
     ///   (fc-agent/src/fuse/mod.rs), and mount_fuse_volumes runs only when
     ///   the boot plan carries volumes (fc-agent/src/agent.rs), so a
@@ -1143,12 +1143,13 @@ impl GuestBootInputs {
             // so has no group to select. Narrowing to a group would empty the
             // search list and break the VPC suffix that resolver does serve,
             // and leaving the list whole sends an unrelated source's private
-            // suffix to it. Neither: the search domains narrow to the zones
-            // the probed resolver is authoritative for (#886).
+            // suffix to it. Neither: the search domains narrow to the one zone
+            // the probed resolver is authoritative for, which is this host's
+            // own VPC internal zone and not every zone shaped like one (#886).
             let groups = std::mem::take(&mut self.dns);
             self.dns = match crate::network::first_ipv6_nameserver(&groups) {
                 Some(server) => crate::network::narrowed_to(groups, &server),
-                None => crate::network::search_narrowed_to_aws_vpc_zones(groups),
+                None => crate::network::search_narrowed_to_local_aws_vpc_zone(groups),
             };
         }
         if !has_fuse_volumes {
@@ -2019,6 +2020,23 @@ mod tests {
         ]
     }
 
+    /// The same EC2 host with a VPN link into another region's VPC, which
+    /// contributes that VPC's internal zone to the merged search list. AWS
+    /// hands an instance exactly one internal zone, so the second one belongs
+    /// to a VPC this host's resolver does not serve.
+    fn ec2_host_with_a_foreign_vpc_zone() -> [crate::network::ResolvSource; 2] {
+        [
+            resolv_source(
+                crate::network::RESOLV_CONF_SOURCES[0],
+                "nameserver 10.0.0.2\nsearch us-west-1.compute.internal\n",
+            ),
+            resolv_source(
+                crate::network::ETC_RESOLV_CONF,
+                "nameserver 10.99.0.53\nsearch eu-west-1.compute.internal corp.example\n",
+            ),
+        ]
+    }
+
     /// Bridged forwards ONE resolver, so the guest must see only the suffixes
     /// belonging to it. Keeping the whole merged search list expands a short
     /// name with a private suffix from a source whose resolver was never
@@ -2125,8 +2143,9 @@ mod tests {
     /// `ip-10-0-1-49.us-west-1.compute.internal` with A 10.0.1.49, identically
     /// to the host's own 10.0.0.2 and to 169.254.169.253, and returns NXDOMAIN
     /// for `db.corp.example` carrying the root SOA, meaning it recursed the
-    /// private label into the public DNS on the way. So the VPC suffix belongs
-    /// with that resolver and the unrelated one does not (#886, CWE-200).
+    /// private label into the public DNS on the way. So the host's own VPC
+    /// suffix belongs with that resolver and the unrelated one does not
+    /// (#886, CWE-200).
     #[test]
     fn routed_on_the_probe_path_forwards_only_the_suffixes_the_probed_resolver_serves() {
         let inputs = GuestBootInputs::from_sources(None, &ec2_host(), &no_runtime_knobs())
@@ -2193,6 +2212,48 @@ mod tests {
         assert!(
             boot_args.contains("fcvm_dns_search=corp.example|lab.example"),
             "every forwarded resolver keeps its suffixes: {boot_args:?}"
+        );
+    }
+
+    /// The probe path on a host that carries a second AWS VPC internal zone.
+    /// `<region>.compute.internal` names the region, and the probed resolver
+    /// answers for its own VPC only: measured on an EC2 instance in us-west-1,
+    /// `ip-10-0-1-49.eu-west-1.compute.internal` comes back NXDOMAIN with no
+    /// authority, the same verdict that resolver gives `db.corp.example`. A
+    /// zone shape test alone would forward it, so the narrowing is to the one
+    /// zone this host was given, not to every zone that looks like one.
+    #[test]
+    fn routed_on_the_probe_path_forwards_only_the_hosts_own_vpc_zone() {
+        let inputs = GuestBootInputs::from_sources(
+            None,
+            &ec2_host_with_a_foreign_vpc_zone(),
+            &no_runtime_knobs(),
+        )
+        .for_launch(crate::firecracker::FcNetworkMode::Routed, false);
+
+        assert_eq!(
+            inputs.dns_search(),
+            vec!["us-west-1.compute.internal"],
+            "a foreign region's VPC zone is NXDOMAIN at the probed resolver"
+        );
+
+        let config = crate::firecracker::FirecrackerConfig {
+            host_dns: inputs.host_dns(),
+            dns_search: inputs.dns_search(),
+            ..Default::default()
+        };
+        let network_config = crate::network::NetworkConfig {
+            dns_server: Some(crate::network::AWS_VPC_IPV6_RESOLVER.to_string()),
+            ..Default::default()
+        };
+        let boot_args = build_runtime_boot_args(&network_config, &config);
+        assert!(
+            !boot_args.contains("eu-west-1"),
+            "another VPC's internal zone must not reach the guest: {boot_args:?}"
+        );
+        assert!(
+            boot_args.contains("fcvm_dns_search=us-west-1.compute.internal"),
+            "the host's own VPC zone still reaches the guest: {boot_args:?}"
         );
     }
 

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -1106,9 +1106,9 @@ impl GuestBootInputs {
     ///   the sources name, because an IPv4 resolver is unreachable from a
     ///   routed guest. detect_ipv6_dns reads only the host's resolv.conf for
     ///   that, so the same selector runs here and the groups narrow to it.
-    ///   Its probe fallback (fd00:ec2::253) belongs to no source and leaves
-    ///   the groups whole, since that resolver does serve the VPC suffix the
-    ///   host carries and emptying the list would break it: see #886.
+    ///   Its probe fallback selects the AWS VPC resolver, which belongs to no
+    ///   source, so instead of a group the search domains narrow to the zones
+    ///   that resolver is authoritative for (#886).
     /// * The four FUSE knobs are read only inside fc-agent's FUSE mount path
     ///   (fc-agent/src/fuse/mod.rs), and mount_fuse_volumes runs only when
     ///   the boot plan carries volumes (fc-agent/src/agent.rs), so a
@@ -1139,16 +1139,17 @@ impl GuestBootInputs {
             // to it exactly as bridged's do.
             //
             // When no source names an IPv6 server, detect_ipv6_dns falls back
-            // to probing the AWS VPC resolver at fd00:ec2::253, which belongs
-            // to no source and so has no group to narrow to. The groups are
-            // left whole there rather than emptied: that resolver does serve
-            // the VPC suffix the host's resolv.conf carries, and dropping it
-            // would break short-name resolution that works today. A suffix
-            // from an unrelated source still reaches it, which is #886.
-            if let Some(server) = crate::network::first_ipv6_nameserver(&self.dns) {
-                let groups = std::mem::take(&mut self.dns);
-                self.dns = crate::network::narrowed_to(groups, &server);
-            }
+            // to probing the AWS VPC resolver, which belongs to no source and
+            // so has no group to select. Narrowing to a group would empty the
+            // search list and break the VPC suffix that resolver does serve,
+            // and leaving the list whole sends an unrelated source's private
+            // suffix to it. Neither: the search domains narrow to the zones
+            // the probed resolver is authoritative for (#886).
+            let groups = std::mem::take(&mut self.dns);
+            self.dns = match crate::network::first_ipv6_nameserver(&groups) {
+                Some(server) => crate::network::narrowed_to(groups, &server),
+                None => crate::network::search_narrowed_to_aws_vpc_zones(groups),
+            };
         }
         if !has_fuse_volumes {
             self.fuse_readers = None;
@@ -2001,6 +2002,23 @@ mod tests {
         ]
     }
 
+    /// An EC2 host with no IPv6 nameserver, so routed falls back to probing.
+    /// The run file holds what AWS DHCP handed out (the VPC resolver and the
+    /// VPC's internal zone); /etc/resolv.conf holds an unrelated corporate
+    /// resolver and its private suffix.
+    fn ec2_host() -> [crate::network::ResolvSource; 2] {
+        [
+            resolv_source(
+                crate::network::RESOLV_CONF_SOURCES[0],
+                "nameserver 10.0.0.2\nsearch us-west-1.compute.internal\n",
+            ),
+            resolv_source(
+                crate::network::ETC_RESOLV_CONF,
+                "nameserver 10.99.0.53\nsearch corp.example\n",
+            ),
+        ]
+    }
+
     /// Bridged forwards ONE resolver, so the guest must see only the suffixes
     /// belonging to it. Keeping the whole merged search list expands a short
     /// name with a private suffix from a source whose resolver was never
@@ -2098,24 +2116,55 @@ mod tests {
         );
     }
 
-    /// The probe fallback: no source names an IPv6 server, so detect_ipv6_dns
-    /// probes the AWS VPC resolver at fd00:ec2::253, which belongs to no
-    /// source and has no group to narrow to. The list is left whole on purpose
-    /// rather than emptied, because that resolver does serve the VPC suffix
-    /// the host's resolv.conf carries and emptying it would break short-name
-    /// resolution that works today. A suffix from an unrelated source still
-    /// reaches that resolver: #886 tracks closing that, and this test exists so
-    /// the decision is deliberate rather than an oversight.
+    /// An EC2 host on routed's probe-fallback path: one source carries the
+    /// AWS DHCP option set's VPC suffix, another carries an unrelated private
+    /// suffix, and neither names an IPv6 server, so `detect_ipv6_dns` probes
+    /// the AWS VPC resolver.
+    ///
+    /// Measured on an EC2 instance in us-west-1: that resolver answers
+    /// `ip-10-0-1-49.us-west-1.compute.internal` with A 10.0.1.49, identically
+    /// to the host's own 10.0.0.2 and to 169.254.169.253, and returns NXDOMAIN
+    /// for `db.corp.example` carrying the root SOA, meaning it recursed the
+    /// private label into the public DNS on the way. So the VPC suffix belongs
+    /// with that resolver and the unrelated one does not (#886, CWE-200).
     #[test]
-    fn routed_without_an_ipv6_source_keeps_the_search_list() {
-        let inputs = GuestBootInputs::from_sources(None, &two_source_host(), &no_runtime_knobs())
+    fn routed_on_the_probe_path_forwards_only_the_suffixes_the_probed_resolver_serves() {
+        let inputs = GuestBootInputs::from_sources(None, &ec2_host(), &no_runtime_knobs())
             .for_launch(crate::firecracker::FcNetworkMode::Routed, false);
 
-        assert_eq!(inputs.host_dns(), vec!["10.1.0.2", "192.0.2.53"]);
         assert_eq!(
             inputs.dns_search(),
-            vec!["corp.example", "lab.example"],
-            "nothing was selected, so nothing is narrowed away"
+            vec!["us-west-1.compute.internal"],
+            "the probed VPC resolver serves the VPC zone and NXDOMAINs the rest"
+        );
+        assert_eq!(
+            inputs.host_dns(),
+            vec!["10.0.0.2", "10.99.0.53"],
+            "the probe replaces the guest's resolver in the network config, so \
+             the groups' servers are not what narrows"
+        );
+
+        let config = crate::firecracker::FirecrackerConfig {
+            host_dns: inputs.host_dns(),
+            dns_search: inputs.dns_search(),
+            ..Default::default()
+        };
+        // What RoutedNetwork::setup puts in the network config when the probe
+        // answers: the probed server replaces the guest's resolver list.
+        let network_config = crate::network::NetworkConfig {
+            dns_server: Some(crate::network::AWS_VPC_IPV6_RESOLVER.to_string()),
+            ..Default::default()
+        };
+
+        let boot_args = build_runtime_boot_args(&network_config, &config);
+        assert!(
+            !boot_args.contains("corp.example"),
+            "a suffix the probed resolver recurses into the public DNS must not \
+             be emitted: {boot_args:?}"
+        );
+        assert!(
+            boot_args.contains("fcvm_dns_search=us-west-1.compute.internal"),
+            "the suffix the probed resolver does serve still reaches the guest: {boot_args:?}"
         );
     }
 
@@ -2143,6 +2192,37 @@ mod tests {
         );
         assert!(
             boot_args.contains("fcvm_dns_search=corp.example|lab.example"),
+            "every forwarded resolver keeps its suffixes: {boot_args:?}"
+        );
+    }
+
+    /// The probe-path narrowing must stay confined to the probe path. Rootless
+    /// forwards every source's resolver, including the corporate one, so every
+    /// source's suffixes still resolve there and dropping the non-AWS suffix
+    /// would break short names that work today. Same host as
+    /// `routed_on_the_probe_path_forwards_only_the_suffixes_the_probed_resolver_serves`,
+    /// so an over-correction that narrows by domain rather than by mode is red
+    /// here.
+    #[test]
+    fn the_probe_narrowing_does_not_reach_a_mode_that_forwards_every_resolver() {
+        let inputs = GuestBootInputs::from_sources(None, &ec2_host(), &no_runtime_knobs())
+            .for_launch(crate::firecracker::FcNetworkMode::Rootless, false);
+
+        assert_eq!(inputs.host_dns(), vec!["10.0.0.2", "10.99.0.53"]);
+        assert_eq!(
+            inputs.dns_search(),
+            vec!["us-west-1.compute.internal", "corp.example"],
+            "the corporate resolver reaches this guest, so its suffix must too"
+        );
+
+        let config = crate::firecracker::FirecrackerConfig {
+            host_dns: inputs.host_dns(),
+            dns_search: inputs.dns_search(),
+            ..Default::default()
+        };
+        let boot_args = build_runtime_boot_args(&crate::network::NetworkConfig::default(), &config);
+        assert!(
+            boot_args.contains("fcvm_dns_search=us-west-1.compute.internal|corp.example"),
             "every forwarded resolver keeps its suffixes: {boot_args:?}"
         );
     }

--- a/src/commands/podman/vm_config.rs
+++ b/src/commands/podman/vm_config.rs
@@ -1108,7 +1108,8 @@ impl GuestBootInputs {
     ///   that, so the same selector runs here and the groups narrow to it.
     ///   Its probe fallback selects the AWS VPC resolver, which belongs to no
     ///   source, so instead of a group the search domains narrow to the one
-    ///   zone that resolver is authoritative for, this host's own (#886).
+    ///   AWS VPC internal zone the snapshot names, and to nothing when it
+    ///   names several (#886).
     /// * The four FUSE knobs are read only inside fc-agent's FUSE mount path
     ///   (fc-agent/src/fuse/mod.rs), and mount_fuse_volumes runs only when
     ///   the boot plan carries volumes (fc-agent/src/agent.rs), so a
@@ -1143,13 +1144,14 @@ impl GuestBootInputs {
             // so has no group to select. Narrowing to a group would empty the
             // search list and break the VPC suffix that resolver does serve,
             // and leaving the list whole sends an unrelated source's private
-            // suffix to it. Neither: the search domains narrow to the one zone
-            // the probed resolver is authoritative for, which is this host's
-            // own VPC internal zone and not every zone shaped like one (#886).
+            // suffix to it. Neither: the search domains narrow to the one AWS
+            // VPC internal zone the snapshot names, region label and all, and
+            // to nothing at all when it names several, because nothing in a
+            // resolv.conf snapshot says which of them this host owns (#886).
             let groups = std::mem::take(&mut self.dns);
             self.dns = match crate::network::first_ipv6_nameserver(&groups) {
                 Some(server) => crate::network::narrowed_to(groups, &server),
-                None => crate::network::search_narrowed_to_local_aws_vpc_zone(groups),
+                None => crate::network::search_narrowed_to_sole_aws_vpc_zone(groups),
             };
         }
         if !has_fuse_volumes {
@@ -2037,6 +2039,39 @@ mod tests {
         ]
     }
 
+    /// The same pair with the foreign zone FIRST, which a merged
+    /// systemd-resolved list or a VPN link's own ordering can produce. Nothing
+    /// else differs, so a rule that answers differently for the two orderings
+    /// is reading search order as evidence of which link owns a domain.
+    fn ec2_host_with_a_foreign_vpc_zone_first() -> [crate::network::ResolvSource; 2] {
+        [
+            resolv_source(
+                crate::network::RESOLV_CONF_SOURCES[0],
+                "nameserver 10.0.0.2\nsearch eu-west-1.compute.internal\n",
+            ),
+            resolv_source(
+                crate::network::ETC_RESOLV_CONF,
+                "nameserver 10.99.0.53\nsearch us-west-1.compute.internal corp.example\n",
+            ),
+        ]
+    }
+
+    /// An EC2 host whose DHCP option set carries a custom `.compute.internal`
+    /// subdomain, with the region's real zone named after it. `foo` is not a
+    /// region, so this host names one VPC zone and not two.
+    fn ec2_host_with_a_custom_compute_internal_domain() -> [crate::network::ResolvSource; 2] {
+        [
+            resolv_source(
+                crate::network::RESOLV_CONF_SOURCES[0],
+                "nameserver 10.0.0.2\nsearch foo.compute.internal\n",
+            ),
+            resolv_source(
+                crate::network::ETC_RESOLV_CONF,
+                "nameserver 10.99.0.53\nsearch us-west-1.compute.internal\n",
+            ),
+        ]
+    }
+
     /// Bridged forwards ONE resolver, so the guest must see only the suffixes
     /// belonging to it. Keeping the whole merged search list expands a short
     /// name with a private suffix from a source whose resolver was never
@@ -2215,18 +2250,60 @@ mod tests {
         );
     }
 
-    /// The probe path on a host that carries a second AWS VPC internal zone.
-    /// `<region>.compute.internal` names the region, and the probed resolver
-    /// answers for its own VPC only: measured on an EC2 instance in us-west-1,
+    /// The probe path on a host carrying a second AWS VPC internal zone. AWS
+    /// gives an instance exactly one, so one of these came from another link,
+    /// and measured on an EC2 instance in us-west-1
     /// `ip-10-0-1-49.eu-west-1.compute.internal` comes back NXDOMAIN with no
-    /// authority, the same verdict that resolver gives `db.corp.example`. A
-    /// zone shape test alone would forward it, so the narrowing is to the one
-    /// zone this host was given, not to every zone that looks like one.
+    /// authority, the same verdict that resolver gives `db.corp.example`.
+    ///
+    /// Which of the two is this host's is not in the resolv.conf snapshot, and
+    /// order is not evidence: systemd-resolved merges every link's domains into
+    /// one file in an order of its own. So routed forwards neither and emits no
+    /// search list at all. The guest resolves by fully qualified name; the
+    /// alternative is a private label sent to a resolver that NXDOMAINs it,
+    /// with the usable zone dropped in its place.
     #[test]
-    fn routed_on_the_probe_path_forwards_only_the_hosts_own_vpc_zone() {
+    fn routed_on_the_probe_path_forwards_no_zone_when_the_host_names_two() {
+        for sources in [
+            ec2_host_with_a_foreign_vpc_zone(),
+            ec2_host_with_a_foreign_vpc_zone_first(),
+        ] {
+            let inputs = GuestBootInputs::from_sources(None, &sources, &no_runtime_knobs())
+                .for_launch(crate::firecracker::FcNetworkMode::Routed, false);
+
+            assert!(
+                inputs.dns_search().is_empty(),
+                "two VPC zones and no evidence of which is this host's, got {:?}",
+                inputs.dns_search()
+            );
+
+            let config = crate::firecracker::FirecrackerConfig {
+                host_dns: inputs.host_dns(),
+                dns_search: inputs.dns_search(),
+                ..Default::default()
+            };
+            let network_config = crate::network::NetworkConfig {
+                dns_server: Some(crate::network::AWS_VPC_IPV6_RESOLVER.to_string()),
+                ..Default::default()
+            };
+            let boot_args = build_runtime_boot_args(&network_config, &config);
+            assert!(
+                !boot_args.contains("fcvm_dns_search"),
+                "no search list may be emitted when the host's zone is unknown: {boot_args:?}"
+            );
+        }
+    }
+
+    /// The probe path on a host whose DHCP domain-name is a custom
+    /// `.compute.internal` subdomain rather than a region's zone, with the real
+    /// zone named after it. Measured on an EC2 instance in us-west-1,
+    /// `foo.compute.internal` is NXDOMAIN with no authority, so a suffix test
+    /// forwards a suffix that cannot resolve and drops the zone that can.
+    #[test]
+    fn routed_on_the_probe_path_skips_a_compute_internal_suffix_that_names_no_region() {
         let inputs = GuestBootInputs::from_sources(
             None,
-            &ec2_host_with_a_foreign_vpc_zone(),
+            &ec2_host_with_a_custom_compute_internal_domain(),
             &no_runtime_knobs(),
         )
         .for_launch(crate::firecracker::FcNetworkMode::Routed, false);
@@ -2234,7 +2311,7 @@ mod tests {
         assert_eq!(
             inputs.dns_search(),
             vec!["us-west-1.compute.internal"],
-            "a foreign region's VPC zone is NXDOMAIN at the probed resolver"
+            "foo names no region, so the host names one VPC zone, not two"
         );
 
         let config = crate::firecracker::FirecrackerConfig {
@@ -2248,8 +2325,8 @@ mod tests {
         };
         let boot_args = build_runtime_boot_args(&network_config, &config);
         assert!(
-            !boot_args.contains("eu-west-1"),
-            "another VPC's internal zone must not reach the guest: {boot_args:?}"
+            !boot_args.contains("foo.compute.internal"),
+            "a region-less compute.internal suffix must not reach the guest: {boot_args:?}"
         );
         assert!(
             boot_args.contains("fcvm_dns_search=us-west-1.compute.internal"),

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -315,19 +315,19 @@ pub const AWS_VPC_IPV6_RESOLVER: &str = "fd00:ec2::253";
 
 /// A search domain that is an AWS VPC internal zone.
 ///
-/// The zone is `<region>.compute.internal`, or `ec2.internal` in us-east-1,
-/// and it is the domain-name AWS DHCP hands the host. The `<region>` label is
-/// validated, not merely the suffix: `foo.compute.internal` is a custom
-/// domain-name, and the measurement on [`sole_aws_vpc_zone`] records the
-/// probed resolver answering it NXDOMAIN exactly as it answers an unrelated
-/// private suffix. Accepting it forwards a suffix that cannot resolve, and
-/// hides a real zone named after it.
+/// The zone is `<region>.compute.internal` outside us-east-1, or `ec2.internal`
+/// in us-east-1, and it is the domain-name AWS DHCP hands the host. The
+/// `<region>` label is validated, not merely the suffix: `foo.compute.internal`
+/// is a custom domain-name, and the measurement on [`sole_aws_vpc_zone`]
+/// records the probed resolver answering it NXDOMAIN exactly as it answers an
+/// unrelated private suffix. Accepting it forwards a suffix that cannot
+/// resolve, and hides a real zone named after it.
 fn is_aws_vpc_internal_zone(domain: &str) -> bool {
     let domain = normalized_zone(domain);
     domain == "ec2.internal"
         || domain
             .strip_suffix(".compute.internal")
-            .is_some_and(is_aws_region_label)
+            .is_some_and(|region| region != "us-east-1" && is_aws_region_label(region))
 }
 
 /// An AWS region name: two or more lowercase words of at least two letters,
@@ -352,7 +352,7 @@ fn is_aws_vpc_internal_zone(domain: &str) -> bool {
 /// Where it encodes a guess about them it goes stale on the same schedule and
 /// just as quietly, which is what a positional model of the name turned out to
 /// be. One uniform claim about every word makes fewer guesses to be wrong
-/// about, and `every_published_aws_region_label_survives_the_probe_narrowing`
+/// about, and `every_published_aws_region_label_is_recognized`
 /// checks the remaining ones against AWS's own region list rather than against
 /// the examples someone remembered.
 ///
@@ -947,6 +947,39 @@ mod tests {
         }
     }
 
+    /// us-east-1 uses `ec2.internal`, not the region-shaped zone used by every
+    /// other AWS region. Treating the unused spelling as this host's zone
+    /// forwards a suffix the VPC resolver does not serve.
+    #[test]
+    fn us_east_1_compute_internal_is_not_a_vpc_zone() {
+        let groups = resolver_groups(&[readable(
+            RESOLV_CONF_SOURCES[0],
+            "nameserver 10.0.0.2\nsearch us-east-1.compute.internal\n",
+        )]);
+
+        assert!(
+            search_domains_of(&search_narrowed_to_sole_aws_vpc_zone(groups)).is_empty(),
+            "us-east-1's VPC resolver serves ec2.internal, not \
+             us-east-1.compute.internal"
+        );
+    }
+
+    /// The unused us-east-1 spelling is not a second VPC zone. If it appears
+    /// beside `ec2.internal`, the real zone remains unambiguous and survives.
+    #[test]
+    fn us_east_1_compute_internal_does_not_hide_ec2_internal() {
+        let groups = resolver_groups(&[readable(
+            RESOLV_CONF_SOURCES[0],
+            "nameserver 10.0.0.2\nsearch us-east-1.compute.internal ec2.internal\n",
+        )]);
+
+        assert_eq!(
+            search_domains_of(&search_narrowed_to_sole_aws_vpc_zone(groups)),
+            vec!["ec2.internal"],
+            "the unused spelling must not make us-east-1's real zone ambiguous"
+        );
+    }
+
     /// `foo.compute.internal` is a custom DHCP domain-name, not a region's VPC
     /// zone, and the measurement records the probed resolver answering it
     /// NXDOMAIN with no authority. A suffix test takes it for this host's zone,
@@ -1049,7 +1082,7 @@ mod tests {
             // One pattern covers every partition. `eusc-de-east-1` is the AWS
             // European Sovereign Cloud region whose shape the first version of
             // that pattern did not have (#891);
-            // `every_published_aws_region_label_survives_the_probe_narrowing`
+            // `every_published_aws_region_label_is_recognized`
             // runs AWS's whole published list through this path.
             "ap-southeast-4.compute.internal",
             "il-central-1.compute.internal",
@@ -1081,6 +1114,7 @@ mod tests {
             "us-west-.compute.internal",
             "us-west-1a.compute.internal",
             "ip-10-0-1-49.us-west-1.compute.internal",
+            "us-east-1.compute.internal",
         ];
         // Shaped like a region and not one. `is_aws_region_label` admits these
         // deliberately and says why: it no longer claims to know how long a
@@ -1130,8 +1164,8 @@ mod tests {
         }
     }
 
-    /// Every region code AWS publishes, run through the zone test, plus the
-    /// non-regions the test exists to reject.
+    /// Every region code AWS publishes, run through the region-label test,
+    /// plus the non-regions the zone test exists to reject.
     ///
     /// The list is the union of `partitions[].regions` in botocore's
     /// `endpoints.json` as shipped with aws-cli 2.32.28, which is AWS's own
@@ -1175,7 +1209,7 @@ mod tests {
     /// `true` for everything would pass, which is the shape of a check that
     /// cannot fail.
     #[test]
-    fn every_published_aws_region_label_survives_the_probe_narrowing() {
+    fn every_published_aws_region_label_is_recognized() {
         let regions = [
             "af-south-1",
             "ap-east-1",
@@ -1226,17 +1260,10 @@ mod tests {
         ];
 
         for region in regions {
-            let zone = format!("{region}.compute.internal");
-            let narrowed = search_narrowed_to_sole_aws_vpc_zone(vec![ResolverGroup {
-                servers: vec!["10.0.0.2".to_string()],
-                search_domains: vec![zone.clone()],
-            }]);
-            assert_eq!(
-                search_domains_of(&narrowed),
-                vec![zone.as_str()],
-                "{region} is a region AWS publishes today, so the label in \
-                 {zone} has to read as a region and not as a custom \
-                 domain-name"
+            assert!(
+                is_aws_region_label(region),
+                "{region} is a region AWS publishes today, so it has to read \
+                 as a region and not as a custom domain-name"
             );
         }
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -330,39 +330,54 @@ fn is_aws_vpc_internal_zone(domain: &str) -> bool {
             .is_some_and(is_aws_region_label)
 }
 
-/// An AWS region name: a two-letter area code, one or more words of at least
-/// three lowercase letters, and a decimal number. Every region in every
-/// partition has that form, `us-west-2` and `eu-central-1` through
-/// `ap-southeast-4`, `il-central-1`, `us-gov-west-1`, `cn-northwest-1` and
-/// `us-isob-east-1`.
+/// An AWS region name: two or more lowercase words of at least two letters,
+/// then a decimal number. `us-west-2` and `eu-central-1` through
+/// `ap-southeast-4`, `il-central-1`, `us-gov-west-1`, `cn-northwest-1`,
+/// `us-isob-east-1` and `eusc-de-east-1`.
 ///
-/// A pattern rather than a list of the regions that exist today, and the trade
-/// runs both ways. A list admits no non-region at all, which is the stronger
-/// guarantee, but it goes stale the day AWS opens a region: an instance there
-/// carries a real zone the list rejects, loses short-name completion, and
-/// nothing reports that the list is what did it. A pattern admits regions that
-/// do not exist yet, and with them a custom domain-name shaped like one
-/// (`my-test-1.compute.internal`).
+/// The shape is loose about word LENGTHS and POSITIONS because the first
+/// version of this check was not, and that is what broke it. It required a
+/// two-letter first word followed by words of at least three letters, and
+/// claimed in this comment that every region in every partition has that form.
+/// The AWS European Sovereign Cloud region in Brandenburg has neither: `eusc`
+/// is four letters and `de` is two. An instance there carries a real
+/// `eusc-de-east-1.compute.internal` zone that the check called a custom
+/// domain-name, so the probe path dropped the host's own zone (#891).
 ///
-/// The pattern is chosen because its false accept is bounded at both ends.
-/// Beside a real zone it makes the input ambiguous and [`sole_aws_vpc_zone`]
-/// forwards neither. Alone it is a `.compute.internal` name, which the probed
-/// resolver answers NXDOMAIN with no authority instead of recursing it into
-/// the public DNS the way it recurses `db.corp.example`, so the label reaches
-/// AWS's resolver and stops there. A stale list's failure has no such bound:
-/// it is a legitimate EC2 host silently losing its own zone for as long as
-/// nobody updates the list.
+/// That is the staleness failure a pattern was chosen over a list to avoid, so
+/// the argument has to be stated more carefully than it was. A list admits no
+/// non-region at all, which is the stronger guarantee, but it rejects a real
+/// zone the day AWS opens a region and reports nothing when it does. A pattern
+/// avoids that only where it encodes properties AWS's namespace actually has.
+/// Where it encodes a guess about them it goes stale on the same schedule and
+/// just as quietly, which is what a positional model of the name turned out to
+/// be. One uniform claim about every word makes fewer guesses to be wrong
+/// about, and `every_published_aws_region_label_survives_the_probe_narrowing`
+/// checks the remaining ones against AWS's own region list rather than against
+/// the examples someone remembered.
+///
+/// The looseness is affordable because a false accept is bounded at both ends
+/// and a false reject is not. Beside a real zone a false accept makes the input
+/// ambiguous and [`sole_aws_vpc_zone`] forwards neither. Alone it is a
+/// `.compute.internal` name, which the probed resolver answers NXDOMAIN with no
+/// authority instead of recursing it into the public DNS the way it recurses
+/// `db.corp.example`, so the label reaches AWS's resolver and stops there. A
+/// false reject is a legitimate EC2 host silently losing its own zone for as
+/// long as nobody notices.
+///
+/// So `my-test-1.compute.internal` and `usa-west-1.compute.internal` are
+/// accepted, and that is the price. `foo.compute.internal`, the custom
+/// domain-name whose NXDOMAIN the measurement on [`sole_aws_vpc_zone`] records,
+/// still is not: it names no region at all.
 fn is_aws_region_label(label: &str) -> bool {
-    let words: Vec<&str> = label.split('-').collect();
-    let [area, middle @ .., number] = words.as_slice() else {
+    let parts: Vec<&str> = label.split('-').collect();
+    let [words @ .., number] = parts.as_slice() else {
         return false;
     };
-    area.len() == 2
-        && area.bytes().all(|b| b.is_ascii_lowercase())
-        && !middle.is_empty()
-        && middle
+    words.len() >= 2
+        && words
             .iter()
-            .all(|word| word.len() >= 3 && word.bytes().all(|b| b.is_ascii_lowercase()))
+            .all(|word| word.len() >= 2 && word.bytes().all(|b| b.is_ascii_lowercase()))
         && !number.is_empty()
         && number.bytes().all(|b| b.is_ascii_digit())
 }
@@ -1031,13 +1046,17 @@ mod tests {
             "ec2.internal",
             "us-west-1.compute.internal",
             "eu-west-1.compute.internal",
-            // Every partition's regions have the same form, so one pattern
-            // covers commercial, GovCloud, China and the ISO partitions.
+            // One pattern covers every partition. `eusc-de-east-1` is the AWS
+            // European Sovereign Cloud region whose shape the first version of
+            // that pattern did not have (#891);
+            // `every_published_aws_region_label_survives_the_probe_narrowing`
+            // runs AWS's whole published list through this path.
             "ap-southeast-4.compute.internal",
             "il-central-1.compute.internal",
             "us-gov-west-1.compute.internal",
             "cn-northwest-1.compute.internal",
             "us-isob-east-1.compute.internal",
+            "eusc-de-east-1.compute.internal",
             "US-West-1.Compute.Internal",
             "us-west-1.compute.internal.",
         ];
@@ -1058,12 +1077,18 @@ mod tests {
             "us-1.compute.internal",
             "us-w-1.compute.internal",
             "u-west-1.compute.internal",
-            "usa-west-1.compute.internal",
             "us-west.compute.internal",
             "us-west-.compute.internal",
             "us-west-1a.compute.internal",
             "ip-10-0-1-49.us-west-1.compute.internal",
         ];
+        // Shaped like a region and not one. `is_aws_region_label` admits these
+        // deliberately and says why: it no longer claims to know how long a
+        // region's words are, because claiming that is what rejected
+        // `eusc-de-east-1`. Asserted rather than left unstated so that
+        // tightening the pattern again is a deliberate act with a test to
+        // change, not a silent one.
+        let admitted_false_accepts = ["usa-west-1.compute.internal", "my-test-1.compute.internal"];
 
         for domain in kept {
             let narrowed = search_narrowed_to_sole_aws_vpc_zone(vec![ResolverGroup {
@@ -1086,6 +1111,163 @@ mod tests {
                 search_domains_of(&narrowed).is_empty(),
                 "{domain} is not a zone the probed resolver serves, and asking \
                  it discloses the private label to the public DNS"
+            );
+        }
+
+        for domain in admitted_false_accepts {
+            let narrowed = search_narrowed_to_sole_aws_vpc_zone(vec![ResolverGroup {
+                servers: vec!["10.0.0.2".to_string()],
+                search_domains: vec![domain.to_string()],
+            }]);
+            assert_eq!(
+                search_domains_of(&narrowed),
+                vec![domain],
+                "{domain} is the shape of a region, so it is forwarded. The \
+                 probed resolver NXDOMAINs it without recursing it into the \
+                 public DNS, which is the bound that makes the false accept \
+                 cheaper than rejecting a region AWS has opened"
+            );
+        }
+    }
+
+    /// Every region code AWS publishes, run through the zone test, plus the
+    /// non-regions the test exists to reject.
+    ///
+    /// The list is the union of `partitions[].regions` in botocore's
+    /// `endpoints.json` as shipped with aws-cli 2.32.28, which is AWS's own
+    /// machine-readable region list. All 46 codes, all eight partitions.
+    /// Regenerate it with:
+    ///
+    /// ```text
+    /// python3 -c 'import json,sys; d=json.load(open(sys.argv[1]));
+    ///   print(sorted({r for p in d["partitions"] for r in p["regions"]}))' \
+    ///   $(dirname $(readlink -f $(command -v aws)))/awscli/botocore/data/endpoints.json
+    /// ```
+    ///
+    /// `eusc-de-east-1` is why this test exists. The first version of
+    /// [`is_aws_region_label`] required a two-letter first word and three-letter
+    /// words after it, and asserted in its own doc comment that "every region in
+    /// every partition has that form". The AWS European Sovereign Cloud region
+    /// in Brandenburg has neither: `eusc` is four letters and `de` is two. An
+    /// instance there carries `eusc-de-east-1.compute.internal` as its
+    /// DHCP domain-name, the shape test called it a custom domain-name, and the
+    /// probe path dropped the host's own zone.
+    ///
+    /// AWS documents the internal zone with no partition in it. The Route 53
+    /// autodefined-rules page lists `{Region-name}.compute.internal, for
+    /// example, eu-west-1.compute.internal. The us-east-1 Region doesn't use
+    /// this domain name.`, and lists the PUBLIC zone one line below as
+    /// `{Region-name}.compute.{amazon-domain-name}, for example,
+    /// eu-west-1.compute.amazonaws.com or cn-north-1.compute.amazonaws.com.cn`.
+    /// The partition domain is a placeholder in the public zone and absent from
+    /// the internal one, and us-east-1 is the only carve-out either page names
+    /// (EC2's hostname-types page says the same: "Format for an instance in any
+    /// other AWS Region: {private-ipv4-address.region}.compute.internal").
+    /// So `<region>.compute.internal` holds in aws-eusc as it does in aws-cn.
+    ///
+    /// The loop asserts that each published region code is RECOGNISED as one,
+    /// which is what [`is_aws_region_label`] decides. It is not a claim that
+    /// AWS serves every one of those zones: the same Route 53 page says
+    /// us-east-1 does not use `<region>.compute.internal`, and the zone it does
+    /// use is asserted separately below.
+    ///
+    /// The negatives are half the test. Without them a predicate that returned
+    /// `true` for everything would pass, which is the shape of a check that
+    /// cannot fail.
+    #[test]
+    fn every_published_aws_region_label_survives_the_probe_narrowing() {
+        let regions = [
+            "af-south-1",
+            "ap-east-1",
+            "ap-east-2",
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "ap-south-1",
+            "ap-south-2",
+            "ap-southeast-1",
+            "ap-southeast-2",
+            "ap-southeast-3",
+            "ap-southeast-4",
+            "ap-southeast-5",
+            "ap-southeast-6",
+            "ap-southeast-7",
+            "ca-central-1",
+            "ca-west-1",
+            "cn-north-1",
+            "cn-northwest-1",
+            "eu-central-1",
+            "eu-central-2",
+            "eu-isoe-west-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-south-2",
+            "eu-west-1",
+            "eu-west-2",
+            "eu-west-3",
+            "eusc-de-east-1",
+            "il-central-1",
+            "me-central-1",
+            "me-south-1",
+            "mx-central-1",
+            "sa-east-1",
+            "us-east-1",
+            "us-east-2",
+            "us-gov-east-1",
+            "us-gov-west-1",
+            "us-iso-east-1",
+            "us-iso-west-1",
+            "us-isob-east-1",
+            "us-isob-west-1",
+            "us-isof-east-1",
+            "us-isof-south-1",
+            "us-west-1",
+            "us-west-2",
+        ];
+
+        for region in regions {
+            let zone = format!("{region}.compute.internal");
+            let narrowed = search_narrowed_to_sole_aws_vpc_zone(vec![ResolverGroup {
+                servers: vec!["10.0.0.2".to_string()],
+                search_domains: vec![zone.clone()],
+            }]);
+            assert_eq!(
+                search_domains_of(&narrowed),
+                vec![zone.as_str()],
+                "{region} is a region AWS publishes today, so the label in \
+                 {zone} has to read as a region and not as a custom \
+                 domain-name"
+            );
+        }
+
+        // us-east-1's own zone, which is the one carve-out both AWS pages name.
+        let narrowed = search_narrowed_to_sole_aws_vpc_zone(vec![ResolverGroup {
+            servers: vec!["10.0.0.2".to_string()],
+            search_domains: vec!["ec2.internal".to_string()],
+        }]);
+        assert_eq!(search_domains_of(&narrowed), vec!["ec2.internal"]);
+
+        for domain in [
+            "corp.example",
+            "lab.internal",
+            "internal",
+            "compute.internal",
+            "foo.compute.internal",
+            "us.compute.internal",
+            "us-1.compute.internal",
+            "us-west.compute.internal",
+            "us-west-.compute.internal",
+            "us-west-1a.compute.internal",
+            "ip-10-0-1-49.us-west-1.compute.internal",
+        ] {
+            let narrowed = search_narrowed_to_sole_aws_vpc_zone(vec![ResolverGroup {
+                servers: vec!["10.0.0.2".to_string()],
+                search_domains: vec![domain.to_string()],
+            }]);
+            assert!(
+                search_domains_of(&narrowed).is_empty(),
+                "{domain} names no region, so it is not a VPC zone and asking \
+                 the probed resolver for it resolves nothing"
             );
         }
     }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -313,14 +313,58 @@ pub fn first_ipv6_nameserver(groups: &[ResolverGroup]) -> Option<String> {
 /// and the search-domain narrowing that depends on it cannot drift apart.
 pub const AWS_VPC_IPV6_RESOLVER: &str = "fd00:ec2::253";
 
-/// A search domain in the shape of an AWS VPC internal zone.
+/// A search domain that is an AWS VPC internal zone.
 ///
 /// The zone is `<region>.compute.internal`, or `ec2.internal` in us-east-1,
-/// and it is the domain-name AWS DHCP hands the host. The shape alone does not
-/// make a zone THIS host's, which is [`local_aws_vpc_zone`]'s job.
+/// and it is the domain-name AWS DHCP hands the host. The `<region>` label is
+/// validated, not merely the suffix: `foo.compute.internal` is a custom
+/// domain-name, and the measurement on [`sole_aws_vpc_zone`] records the
+/// probed resolver answering it NXDOMAIN exactly as it answers an unrelated
+/// private suffix. Accepting it forwards a suffix that cannot resolve, and
+/// hides a real zone named after it.
 fn is_aws_vpc_internal_zone(domain: &str) -> bool {
     let domain = normalized_zone(domain);
-    domain == "ec2.internal" || domain.ends_with(".compute.internal")
+    domain == "ec2.internal"
+        || domain
+            .strip_suffix(".compute.internal")
+            .is_some_and(is_aws_region_label)
+}
+
+/// An AWS region name: a two-letter area code, one or more words of at least
+/// three lowercase letters, and a decimal number. Every region in every
+/// partition has that form, `us-west-2` and `eu-central-1` through
+/// `ap-southeast-4`, `il-central-1`, `us-gov-west-1`, `cn-northwest-1` and
+/// `us-isob-east-1`.
+///
+/// A pattern rather than a list of the regions that exist today, and the trade
+/// runs both ways. A list admits no non-region at all, which is the stronger
+/// guarantee, but it goes stale the day AWS opens a region: an instance there
+/// carries a real zone the list rejects, loses short-name completion, and
+/// nothing reports that the list is what did it. A pattern admits regions that
+/// do not exist yet, and with them a custom domain-name shaped like one
+/// (`my-test-1.compute.internal`).
+///
+/// The pattern is chosen because its false accept is bounded at both ends.
+/// Beside a real zone it makes the input ambiguous and [`sole_aws_vpc_zone`]
+/// forwards neither. Alone it is a `.compute.internal` name, which the probed
+/// resolver answers NXDOMAIN with no authority instead of recursing it into
+/// the public DNS the way it recurses `db.corp.example`, so the label reaches
+/// AWS's resolver and stops there. A stale list's failure has no such bound:
+/// it is a legitimate EC2 host silently losing its own zone for as long as
+/// nobody updates the list.
+fn is_aws_region_label(label: &str) -> bool {
+    let words: Vec<&str> = label.split('-').collect();
+    let [area, middle @ .., number] = words.as_slice() else {
+        return false;
+    };
+    area.len() == 2
+        && area.bytes().all(|b| b.is_ascii_lowercase())
+        && !middle.is_empty()
+        && middle
+            .iter()
+            .all(|word| word.len() >= 3 && word.bytes().all(|b| b.is_ascii_lowercase()))
+        && !number.is_empty()
+        && number.bytes().all(|b| b.is_ascii_digit())
 }
 
 /// A search domain compared the way DNS compares names: case-insensitively,
@@ -329,8 +373,8 @@ fn normalized_zone(domain: &str) -> String {
     domain.trim_end_matches('.').to_ascii_lowercase()
 }
 
-/// The single AWS VPC internal zone the probed resolver answers for: this
-/// host's own.
+/// The one AWS VPC internal zone this host's search list names, or `None` when
+/// it names none or several.
 ///
 /// Measured on an EC2 instance in us-west-1, against [`AWS_VPC_IPV6_RESOLVER`]
 /// and against the same service's 10.0.0.2 and 169.254.169.253, all three
@@ -344,14 +388,13 @@ fn normalized_zone(domain: &str) -> String {
 /// | `db.corp.example` | NXDOMAIN carrying the root SOA |
 /// | `secret-host.internal.example.com` | NOERROR carrying example.com's SOA at Cloudflare |
 ///
-/// Row three is why a zone-shape test is not the answer on its own. AWS gives
-/// an instance exactly one internal zone and its resolver is authoritative for
-/// that one; another region's zone draws the same NXDOMAIN as an unrelated
-/// private suffix. The last two rows are why a suffix this resolver does not
-/// serve is dropped rather than merely tried later: it is recursed into the
-/// public DNS, which discloses the private label to AWS's resolver and then to
-/// the parent zone's authoritative servers (CWE-200), and still does not
-/// resolve. The kept zone is private to that resolver: the same
+/// AWS gives an instance exactly one internal zone and its resolver is
+/// authoritative for that one. Rows two and three are what a zone-shape test
+/// forwards and this resolver will not answer. Rows four and five are why a
+/// suffix it does not serve is dropped rather than merely tried later: it is
+/// recursed into the public DNS, which discloses the private label to AWS's
+/// resolver and then to the parent zone's authoritative servers (CWE-200), and
+/// still does not resolve. The kept zone is private to that resolver: the same
 /// `ip-10-0-1-49.us-west-1.compute.internal` is NXDOMAIN at 1.1.1.1.
 ///
 /// Read off the search list, with no lookup of any kind.
@@ -362,20 +405,31 @@ fn normalized_zone(domain: &str) -> String {
 /// request and the resolver's own verdict is a DNS query, both then taken at
 /// key time, and on a host that is not on EC2 both have to time out first.
 ///
-/// What the search list does carry is order. resolv.conf(5) completes a short
-/// name against the search domains in list order, so the first entry is the
-/// suffix the host itself resolves against, and on an EC2 instance that is the
-/// domain-name its DHCP lease carried: on the measured instance, the run file's
-/// sole `search us-west-1.compute.internal`. An AWS-shaped zone after it came
-/// from another link and belongs to another VPC.
-fn local_aws_vpc_zone(groups: &[ResolverGroup]) -> Option<String> {
-    search_domains_of(groups)
+/// Which leaves a host that names two. Nothing in a resolv.conf snapshot says
+/// which link a search domain came from. Order does not: it decides how a
+/// short name is expanded, and systemd-resolved merges every link's domains
+/// into one file in an order of its own, so a VPN link's zone can precede the
+/// host's. Pairing a domain with a nameserver does not either, because that
+/// same merge collapses every link onto the 127.0.0.53 stub. So do not pick
+/// one. Forward none and let the guest use fully qualified names: losing
+/// short-name completion is something a guest can work around, and handing a
+/// private label to a resolver that NXDOMAINs it while dropping the zone that
+/// would have worked is not.
+fn sole_aws_vpc_zone(groups: &[ResolverGroup]) -> Option<String> {
+    let mut zones: Vec<String> = search_domains_of(groups)
         .iter()
-        .find(|domain| is_aws_vpc_internal_zone(domain))
+        .filter(|domain| is_aws_vpc_internal_zone(domain))
         .map(|domain| normalized_zone(domain))
+        .collect();
+    zones.sort();
+    zones.dedup();
+    match zones.as_slice() {
+        [zone] => Some(zone.clone()),
+        _ => None,
+    }
 }
 
-/// The groups carrying this host's own AWS VPC internal zone and nothing else,
+/// The groups carrying this host's AWS VPC internal zone and nothing else,
 /// servers untouched.
 ///
 /// What routed mode applies when no source named an IPv6 server and
@@ -385,24 +439,29 @@ fn local_aws_vpc_zone(groups: &[ResolverGroup]) -> Option<String> {
 /// resolver list in the network config rather than in these groups, which is
 /// why only the search side narrows here.
 ///
-/// A host carrying no AWS VPC zone keeps no search domain, and two kinds of
-/// host reach that case.
+/// `sole_aws_vpc_zone` holds which zone that is, and names none on a host
+/// carrying none or several. Three kinds of host therefore keep no search
+/// domain.
 ///
-/// One is not on EC2 and lands here because "no source names an IPv6 server" is
-/// all `for_launch` can see. Nothing is lost: fd00:ec2::253 is a VPC-internal
-/// address that does not answer off EC2, so the probe returns None, routed
-/// hands the guest no IPv6 resolver at all, and the IPv4 servers it gets
-/// instead are unreachable from a routed guest. No suffix had a resolver to be
-/// completed against.
+/// One is not on EC2 and lands here because "no source names an IPv6 server"
+/// is all `for_launch` can see. Nothing is lost: fd00:ec2::253 is a
+/// VPC-internal address that does not answer off EC2, so the probe returns
+/// None, routed hands the guest no IPv6 resolver at all, and the IPv4 servers
+/// it gets instead are unreachable from a routed guest. No suffix had a
+/// resolver to be completed against.
 ///
-/// The other is an EC2 instance whose VPC overrides the DHCP domain-name, so
-/// its own zone is not AWS-shaped even though its resolver may serve it. That
-/// host loses short-name completion on routed. It is the conservative side of a
-/// decision made from the search list alone: keeping the list whole instead
-/// hands every private suffix to the AWS resolver on every host where the probe
-/// does answer, which is the leak this narrowing exists to close.
-pub fn search_narrowed_to_local_aws_vpc_zone(groups: Vec<ResolverGroup>) -> Vec<ResolverGroup> {
-    let local = local_aws_vpc_zone(&groups);
+/// One is an EC2 instance whose VPC overrides the DHCP domain-name, so its own
+/// zone names no region even though its resolver may serve it.
+///
+/// One names two VPC zones, its own and another VPC's arriving over a VPN link
+/// or a merged resolved list, and the snapshot does not say which is which.
+///
+/// The last two lose short-name completion on routed. That is the conservative
+/// side of a decision made from the search list alone: keeping the list whole
+/// instead hands every private suffix to the AWS resolver on every host where
+/// the probe does answer, which is the leak this narrowing exists to close.
+pub fn search_narrowed_to_sole_aws_vpc_zone(groups: Vec<ResolverGroup>) -> Vec<ResolverGroup> {
+    let zone = sole_aws_vpc_zone(&groups);
     groups
         .into_iter()
         .map(|group| ResolverGroup {
@@ -410,7 +469,7 @@ pub fn search_narrowed_to_local_aws_vpc_zone(groups: Vec<ResolverGroup>) -> Vec<
             search_domains: group
                 .search_domains
                 .into_iter()
-                .filter(|domain| local.as_deref() == Some(normalized_zone(domain).as_str()))
+                .filter(|domain| zone.as_deref() == Some(normalized_zone(domain).as_str()))
                 .collect(),
         })
         .collect()
@@ -802,7 +861,7 @@ mod tests {
             ),
         ]);
 
-        let narrowed = search_narrowed_to_local_aws_vpc_zone(groups);
+        let narrowed = search_narrowed_to_sole_aws_vpc_zone(groups);
         assert_eq!(
             search_domains_of(&narrowed),
             vec!["us-west-1.compute.internal"],
@@ -821,16 +880,91 @@ mod tests {
         );
     }
 
-    /// Two AWS VPC internal zones on one host: its own, and a foreign region's
-    /// arriving over a VPN link into another VPC. Only one of them is this
-    /// host's, and the probed resolver treats the other exactly as it treats an
-    /// unrelated private suffix. Measured on an EC2 instance in us-west-1:
-    /// `ip-10-0-1-49.us-west-1.compute.internal` is NOERROR with A 10.0.1.49
-    /// while `ip-10-0-1-49.eu-west-1.compute.internal` is NXDOMAIN carrying no
-    /// authority, so forwarding the foreign zone discloses the private label
-    /// and still does not resolve.
+    /// Two AWS VPC internal zones on one host: its own, and another VPC's
+    /// arriving over a VPN link or a merged systemd-resolved list. Exactly one
+    /// is this host's and the probed resolver answers NXDOMAIN for the other,
+    /// measured in us-west-1 as `ip-10-0-1-49.eu-west-1.compute.internal`
+    /// NXDOMAIN with no authority. Nothing in the snapshot says which is which.
+    ///
+    /// Order does not, which is what this test holds: it runs the same pair
+    /// both ways round, and the previous rule of taking the first AWS-shaped
+    /// entry answered differently for each. resolv.conf order decides how a
+    /// short name is expanded, not which link contributed a domain, and
+    /// resolved merges every link's domains into one file with no marking.
+    ///
+    /// So neither is forwarded. The guest loses short-name completion and
+    /// recovers it by using a fully qualified name; guessing instead hands a
+    /// private label to a resolver that cannot answer it and drops the zone
+    /// that would have worked, which the guest cannot recover from.
     #[test]
-    fn a_foreign_regions_vpc_zone_does_not_survive_the_probe_narrowing() {
+    fn two_aws_vpc_zones_are_ambiguous_so_the_probe_narrowing_forwards_neither() {
+        for (first, second) in [
+            ("us-west-1.compute.internal", "eu-west-1.compute.internal"),
+            ("eu-west-1.compute.internal", "us-west-1.compute.internal"),
+            ("ec2.internal", "us-west-1.compute.internal"),
+        ] {
+            let groups = resolver_groups(&[
+                readable(
+                    RESOLV_CONF_SOURCES[0],
+                    &format!("nameserver 10.0.0.2\nsearch {first}\n"),
+                ),
+                readable(
+                    ETC_RESOLV_CONF,
+                    &format!("nameserver 10.99.0.53\nsearch {second} corp.example\n"),
+                ),
+            ]);
+
+            let narrowed = search_narrowed_to_sole_aws_vpc_zone(groups);
+            assert!(
+                search_domains_of(&narrowed).is_empty(),
+                "{first} before {second}: two VPC zones, and the snapshot does not \
+                 say which one this host owns, so neither may be forwarded"
+            );
+            assert_eq!(
+                narrowed
+                    .iter()
+                    .flat_map(|group| group.servers.iter())
+                    .cloned()
+                    .collect::<Vec<_>>(),
+                vec!["10.0.0.2", "10.99.0.53"],
+                "the servers are untouched even when every suffix goes"
+            );
+        }
+    }
+
+    /// `foo.compute.internal` is a custom DHCP domain-name, not a region's VPC
+    /// zone, and the measurement records the probed resolver answering it
+    /// NXDOMAIN with no authority. A suffix test takes it for this host's zone,
+    /// which forwards a suffix that cannot resolve AND drops the real zone
+    /// named after it. Validating the region label separates the two.
+    #[test]
+    fn a_compute_internal_suffix_naming_no_region_is_not_a_vpc_zone() {
+        let groups = resolver_groups(&[
+            readable(
+                RESOLV_CONF_SOURCES[0],
+                "nameserver 10.0.0.2\nsearch foo.compute.internal\n",
+            ),
+            readable(
+                ETC_RESOLV_CONF,
+                "nameserver 10.99.0.53\nsearch us-west-1.compute.internal\n",
+            ),
+        ]);
+
+        assert_eq!(
+            search_domains_of(&search_narrowed_to_sole_aws_vpc_zone(groups)),
+            vec!["us-west-1.compute.internal"],
+            "foo names no region, so it is not a second VPC zone, the input is \
+             not ambiguous, and the real zone behind it survives"
+        );
+    }
+
+    /// Several sources naming the SAME zone is one zone, not an ambiguity. A
+    /// merged resolved list repeats a link's domain, and a host whose run file
+    /// and /etc/resolv.conf both carry the DHCP domain-name names it twice.
+    /// Case and a trailing root label are presentation, so those spellings are
+    /// the same zone too and the count stays at one.
+    #[test]
+    fn one_zone_named_by_several_sources_is_not_two_zones() {
         let groups = resolver_groups(&[
             readable(
                 RESOLV_CONF_SOURCES[0],
@@ -838,14 +972,15 @@ mod tests {
             ),
             readable(
                 ETC_RESOLV_CONF,
-                "nameserver 10.99.0.53\nsearch eu-west-1.compute.internal corp.example\n",
+                "nameserver 10.99.0.53\nsearch US-West-1.Compute.Internal. corp.example\n",
             ),
         ]);
 
         assert_eq!(
-            search_domains_of(&search_narrowed_to_local_aws_vpc_zone(groups)),
-            vec!["us-west-1.compute.internal"],
-            "only the host's own VPC zone resolves at the probed resolver"
+            search_domains_of(&search_narrowed_to_sole_aws_vpc_zone(groups)),
+            vec!["us-west-1.compute.internal", "US-West-1.Compute.Internal."],
+            "both spellings name the one zone, so it is forwarded in each \
+             source's own spelling and corp.example is not"
         );
     }
 
@@ -864,7 +999,7 @@ mod tests {
             "nameserver 10.99.0.53\nsearch corp.example lab.example\n",
         )]);
 
-        let narrowed = search_narrowed_to_local_aws_vpc_zone(groups);
+        let narrowed = search_narrowed_to_sole_aws_vpc_zone(groups);
         assert!(
             search_domains_of(&narrowed).is_empty(),
             "no zone here is one the probed resolver serves"
@@ -880,20 +1015,29 @@ mod tests {
         );
     }
 
-    /// The zone SHAPE, so the shape test is neither a substring match nor a
-    /// blanket `.internal` allowance. us-east-1's VPC zone is `ec2.internal`
-    /// and every other region's is `<region>.compute.internal`; measured on an
-    /// EC2 instance, the VPC resolver NXDOMAINs `foo.compute.internal` and
-    /// `host1.lab.internal` alike. Each domain is fed on its own, so each is
-    /// the host's own zone in its own case; which of SEVERAL AWS-shaped zones
-    /// is the host's is what
-    /// `a_foreign_regions_vpc_zone_does_not_survive_the_probe_narrowing` pins.
+    /// The zone SHAPE, which is the `.compute.internal` suffix AND a region in
+    /// front of it, not a substring match and not a blanket `.internal`
+    /// allowance. us-east-1's VPC zone is `ec2.internal` and every other
+    /// region's is `<region>.compute.internal`; measured on an EC2 instance,
+    /// the VPC resolver NXDOMAINs `foo.compute.internal` and `host1.lab.internal`
+    /// alike, so the suffix on its own is not the test. Each domain is fed by
+    /// itself, so each is the sole candidate in its own case; a host naming
+    /// SEVERAL is what
+    /// `two_aws_vpc_zones_are_ambiguous_so_the_probe_narrowing_forwards_neither`
+    /// pins.
     #[test]
     fn only_an_aws_internal_zone_survives_the_probe_narrowing() {
         let kept = [
             "ec2.internal",
             "us-west-1.compute.internal",
             "eu-west-1.compute.internal",
+            // Every partition's regions have the same form, so one pattern
+            // covers commercial, GovCloud, China and the ISO partitions.
+            "ap-southeast-4.compute.internal",
+            "il-central-1.compute.internal",
+            "us-gov-west-1.compute.internal",
+            "cn-northwest-1.compute.internal",
+            "us-isob-east-1.compute.internal",
             "US-West-1.Compute.Internal",
             "us-west-1.compute.internal.",
         ];
@@ -905,10 +1049,24 @@ mod tests {
             "notec2.internal",
             "ec2.internal.example.com",
             "compute.internal.example.com",
+            // Right suffix, and the label in front of it is not a region: a
+            // custom DHCP domain-name, a truncated or malformed region, an
+            // availability zone, and a hostname that already carries the zone.
+            "foo.compute.internal",
+            "dev.compute.internal",
+            "us.compute.internal",
+            "us-1.compute.internal",
+            "us-w-1.compute.internal",
+            "u-west-1.compute.internal",
+            "usa-west-1.compute.internal",
+            "us-west.compute.internal",
+            "us-west-.compute.internal",
+            "us-west-1a.compute.internal",
+            "ip-10-0-1-49.us-west-1.compute.internal",
         ];
 
         for domain in kept {
-            let narrowed = search_narrowed_to_local_aws_vpc_zone(vec![ResolverGroup {
+            let narrowed = search_narrowed_to_sole_aws_vpc_zone(vec![ResolverGroup {
                 servers: vec!["10.0.0.2".to_string()],
                 search_domains: vec![domain.to_string()],
             }]);
@@ -920,7 +1078,7 @@ mod tests {
         }
 
         for domain in dropped {
-            let narrowed = search_narrowed_to_local_aws_vpc_zone(vec![ResolverGroup {
+            let narrowed = search_narrowed_to_sole_aws_vpc_zone(vec![ResolverGroup {
                 servers: vec!["10.0.0.2".to_string()],
                 search_domains: vec![domain.to_string()],
             }]);

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -306,6 +306,65 @@ pub fn first_ipv6_nameserver(groups: &[ResolverGroup]) -> Option<String> {
         .cloned()
 }
 
+/// The IPv6 address of the AWS VPC resolver, which routed mode probes when no
+/// resolv.conf source names an IPv6 server.
+///
+/// Spelled once, next to the rule for what this resolver serves, so the probe
+/// and the search-domain narrowing that depends on it cannot drift apart.
+pub const AWS_VPC_IPV6_RESOLVER: &str = "fd00:ec2::253";
+
+/// Whether the AWS VPC resolver is authoritative for a search domain.
+///
+/// The VPC's internal zone is `<region>.compute.internal`, or `ec2.internal`
+/// in us-east-1, and it is the domain-name AWS DHCP hands the host. Measured
+/// on an EC2 instance in us-west-1, against [`AWS_VPC_IPV6_RESOLVER`] and
+/// against the same service's 10.0.0.2 and 169.254.169.253, all three
+/// returning identical verdicts:
+///
+/// | query | verdict |
+/// |---|---|
+/// | `ip-10-0-1-49.us-west-1.compute.internal` | NOERROR, A 10.0.1.49 |
+/// | `foo.compute.internal` | NXDOMAIN, no authority |
+/// | `ip-10-0-1-49.eu-west-1.compute.internal` | NXDOMAIN, no authority |
+/// | `db.corp.example` | NXDOMAIN carrying the root SOA |
+/// | `secret-host.internal.example.com` | NOERROR carrying example.com's SOA at Cloudflare |
+///
+/// The last two rows are why this is a filter and not a preference. A suffix
+/// the VPC resolver does not serve is recursed into the public DNS, so a short
+/// name expanded with it discloses the private label to AWS's resolver and
+/// then to the public authoritative servers for the parent zone (CWE-200), and
+/// still does not resolve. Dropping it loses nothing.
+///
+/// The kept zone is private to that resolver: the same
+/// `ip-10-0-1-49.us-west-1.compute.internal` is NXDOMAIN at 1.1.1.1.
+fn aws_vpc_resolver_serves(domain: &str) -> bool {
+    let domain = domain.trim_end_matches('.').to_ascii_lowercase();
+    domain == "ec2.internal" || domain.ends_with(".compute.internal")
+}
+
+/// The groups with every search domain the probed AWS VPC resolver cannot
+/// serve removed, servers untouched.
+///
+/// What routed mode applies when no source named an IPv6 server and
+/// `detect_ipv6_dns` fell back to probing [`AWS_VPC_IPV6_RESOLVER`]. That
+/// address belongs to no source, so there is no group to select and
+/// [`narrowed_to`] does not apply; the probed server replaces the guest's
+/// resolver list in the network config rather than in these groups, which is
+/// why only the search side narrows here.
+pub fn search_narrowed_to_aws_vpc_zones(groups: Vec<ResolverGroup>) -> Vec<ResolverGroup> {
+    groups
+        .into_iter()
+        .map(|group| ResolverGroup {
+            servers: group.servers,
+            search_domains: group
+                .search_domains
+                .into_iter()
+                .filter(|domain| aws_vpc_resolver_serves(domain))
+                .collect(),
+        })
+        .collect()
+}
+
 /// The groups narrowed to one server: those that named it, carrying only it.
 ///
 /// What a mode that forwards a single resolver applies. Dropping the other
@@ -674,6 +733,90 @@ mod tests {
         assert_eq!(narrowed.len(), 1, "only the group that named it survives");
         assert_eq!(narrowed[0].servers, vec!["2001:db8::53"]);
         assert_eq!(search_domains_of(&narrowed), vec!["lab.example"]);
+    }
+
+    /// Routed's probe fallback selects a resolver no source named, so there is
+    /// no group to narrow to. The search domains narrow instead, to the zones
+    /// the probed AWS VPC resolver answers (#886).
+    #[test]
+    fn the_probed_aws_resolver_keeps_only_the_zones_it_serves() {
+        let groups = resolver_groups(&[
+            readable(
+                RESOLV_CONF_SOURCES[0],
+                "nameserver 10.0.0.2\nsearch us-west-1.compute.internal\n",
+            ),
+            readable(
+                ETC_RESOLV_CONF,
+                "nameserver 10.99.0.53\nsearch corp.example lab.internal\n",
+            ),
+        ]);
+
+        let narrowed = search_narrowed_to_aws_vpc_zones(groups);
+        assert_eq!(
+            search_domains_of(&narrowed),
+            vec!["us-west-1.compute.internal"],
+            "the VPC zone resolves at the probed server; the other suffixes are \
+             recursed into the public DNS and never resolve"
+        );
+        assert_eq!(
+            narrowed
+                .iter()
+                .flat_map(|group| group.servers.iter())
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec!["10.0.0.2", "10.99.0.53"],
+            "the probed server replaces the guest's resolver in the network \
+             config, so the servers here are not the thing being narrowed"
+        );
+    }
+
+    /// The zone boundary, so the filter is neither a substring test nor a
+    /// blanket `.internal` allowance. us-east-1's VPC zone is `ec2.internal`
+    /// and every other region's is `<region>.compute.internal`; measured on an
+    /// EC2 instance, the VPC resolver NXDOMAINs `foo.compute.internal` and
+    /// `host1.lab.internal` alike.
+    #[test]
+    fn only_the_aws_internal_zones_survive_the_probe_narrowing() {
+        let kept = [
+            "ec2.internal",
+            "us-west-1.compute.internal",
+            "eu-west-1.compute.internal",
+            "US-West-1.Compute.Internal",
+            "us-west-1.compute.internal.",
+        ];
+        let dropped = [
+            "corp.example",
+            "lab.internal",
+            "internal",
+            "compute.internal",
+            "notec2.internal",
+            "ec2.internal.example.com",
+            "compute.internal.example.com",
+        ];
+
+        for domain in kept {
+            let narrowed = search_narrowed_to_aws_vpc_zones(vec![ResolverGroup {
+                servers: vec!["10.0.0.2".to_string()],
+                search_domains: vec![domain.to_string()],
+            }]);
+            assert_eq!(
+                search_domains_of(&narrowed),
+                vec![domain],
+                "{domain} is an AWS VPC internal zone"
+            );
+        }
+
+        for domain in dropped {
+            let narrowed = search_narrowed_to_aws_vpc_zones(vec![ResolverGroup {
+                servers: vec!["10.0.0.2".to_string()],
+                search_domains: vec![domain.to_string()],
+            }]);
+            assert!(
+                search_domains_of(&narrowed).is_empty(),
+                "{domain} is not a zone the probed resolver serves, and asking \
+                 it discloses the private label to the public DNS"
+            );
+        }
     }
 
     /// The other half of #875: the search list and the nameserver list have to

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -313,12 +313,27 @@ pub fn first_ipv6_nameserver(groups: &[ResolverGroup]) -> Option<String> {
 /// and the search-domain narrowing that depends on it cannot drift apart.
 pub const AWS_VPC_IPV6_RESOLVER: &str = "fd00:ec2::253";
 
-/// Whether the AWS VPC resolver is authoritative for a search domain.
+/// A search domain in the shape of an AWS VPC internal zone.
 ///
-/// The VPC's internal zone is `<region>.compute.internal`, or `ec2.internal`
-/// in us-east-1, and it is the domain-name AWS DHCP hands the host. Measured
-/// on an EC2 instance in us-west-1, against [`AWS_VPC_IPV6_RESOLVER`] and
-/// against the same service's 10.0.0.2 and 169.254.169.253, all three
+/// The zone is `<region>.compute.internal`, or `ec2.internal` in us-east-1,
+/// and it is the domain-name AWS DHCP hands the host. The shape alone does not
+/// make a zone THIS host's, which is [`local_aws_vpc_zone`]'s job.
+fn is_aws_vpc_internal_zone(domain: &str) -> bool {
+    let domain = normalized_zone(domain);
+    domain == "ec2.internal" || domain.ends_with(".compute.internal")
+}
+
+/// A search domain compared the way DNS compares names: case-insensitively,
+/// with the trailing root label a presentation detail rather than a difference.
+fn normalized_zone(domain: &str) -> String {
+    domain.trim_end_matches('.').to_ascii_lowercase()
+}
+
+/// The single AWS VPC internal zone the probed resolver answers for: this
+/// host's own.
+///
+/// Measured on an EC2 instance in us-west-1, against [`AWS_VPC_IPV6_RESOLVER`]
+/// and against the same service's 10.0.0.2 and 169.254.169.253, all three
 /// returning identical verdicts:
 ///
 /// | query | verdict |
@@ -329,21 +344,39 @@ pub const AWS_VPC_IPV6_RESOLVER: &str = "fd00:ec2::253";
 /// | `db.corp.example` | NXDOMAIN carrying the root SOA |
 /// | `secret-host.internal.example.com` | NOERROR carrying example.com's SOA at Cloudflare |
 ///
-/// The last two rows are why this is a filter and not a preference. A suffix
-/// the VPC resolver does not serve is recursed into the public DNS, so a short
-/// name expanded with it discloses the private label to AWS's resolver and
-/// then to the public authoritative servers for the parent zone (CWE-200), and
-/// still does not resolve. Dropping it loses nothing.
-///
-/// The kept zone is private to that resolver: the same
+/// Row three is why a zone-shape test is not the answer on its own. AWS gives
+/// an instance exactly one internal zone and its resolver is authoritative for
+/// that one; another region's zone draws the same NXDOMAIN as an unrelated
+/// private suffix. The last two rows are why a suffix this resolver does not
+/// serve is dropped rather than merely tried later: it is recursed into the
+/// public DNS, which discloses the private label to AWS's resolver and then to
+/// the parent zone's authoritative servers (CWE-200), and still does not
+/// resolve. The kept zone is private to that resolver: the same
 /// `ip-10-0-1-49.us-west-1.compute.internal` is NXDOMAIN at 1.1.1.1.
-fn aws_vpc_resolver_serves(domain: &str) -> bool {
-    let domain = domain.trim_end_matches('.').to_ascii_lowercase();
-    domain == "ec2.internal" || domain.ends_with(".compute.internal")
+///
+/// Read off the search list, with no lookup of any kind.
+/// `GuestBootInputs::for_launch` runs before `RoutedNetwork::setup` probes, and
+/// its result is hashed into the snapshot key, so this has to be a pure
+/// function of the same resolv.conf snapshot the key is computed from. That is
+/// what rules out the alternatives: the instance's region from IMDS is an HTTP
+/// request and the resolver's own verdict is a DNS query, both then taken at
+/// key time, and on a host that is not on EC2 both have to time out first.
+///
+/// What the search list does carry is order. resolv.conf(5) completes a short
+/// name against the search domains in list order, so the first entry is the
+/// suffix the host itself resolves against, and on an EC2 instance that is the
+/// domain-name its DHCP lease carried: on the measured instance, the run file's
+/// sole `search us-west-1.compute.internal`. An AWS-shaped zone after it came
+/// from another link and belongs to another VPC.
+fn local_aws_vpc_zone(groups: &[ResolverGroup]) -> Option<String> {
+    search_domains_of(groups)
+        .iter()
+        .find(|domain| is_aws_vpc_internal_zone(domain))
+        .map(|domain| normalized_zone(domain))
 }
 
-/// The groups with every search domain the probed AWS VPC resolver cannot
-/// serve removed, servers untouched.
+/// The groups carrying this host's own AWS VPC internal zone and nothing else,
+/// servers untouched.
 ///
 /// What routed mode applies when no source named an IPv6 server and
 /// `detect_ipv6_dns` fell back to probing [`AWS_VPC_IPV6_RESOLVER`]. That
@@ -351,7 +384,25 @@ fn aws_vpc_resolver_serves(domain: &str) -> bool {
 /// [`narrowed_to`] does not apply; the probed server replaces the guest's
 /// resolver list in the network config rather than in these groups, which is
 /// why only the search side narrows here.
-pub fn search_narrowed_to_aws_vpc_zones(groups: Vec<ResolverGroup>) -> Vec<ResolverGroup> {
+///
+/// A host carrying no AWS VPC zone keeps no search domain, and two kinds of
+/// host reach that case.
+///
+/// One is not on EC2 and lands here because "no source names an IPv6 server" is
+/// all `for_launch` can see. Nothing is lost: fd00:ec2::253 is a VPC-internal
+/// address that does not answer off EC2, so the probe returns None, routed
+/// hands the guest no IPv6 resolver at all, and the IPv4 servers it gets
+/// instead are unreachable from a routed guest. No suffix had a resolver to be
+/// completed against.
+///
+/// The other is an EC2 instance whose VPC overrides the DHCP domain-name, so
+/// its own zone is not AWS-shaped even though its resolver may serve it. That
+/// host loses short-name completion on routed. It is the conservative side of a
+/// decision made from the search list alone: keeping the list whole instead
+/// hands every private suffix to the AWS resolver on every host where the probe
+/// does answer, which is the leak this narrowing exists to close.
+pub fn search_narrowed_to_local_aws_vpc_zone(groups: Vec<ResolverGroup>) -> Vec<ResolverGroup> {
+    let local = local_aws_vpc_zone(&groups);
     groups
         .into_iter()
         .map(|group| ResolverGroup {
@@ -359,7 +410,7 @@ pub fn search_narrowed_to_aws_vpc_zones(groups: Vec<ResolverGroup>) -> Vec<Resol
             search_domains: group
                 .search_domains
                 .into_iter()
-                .filter(|domain| aws_vpc_resolver_serves(domain))
+                .filter(|domain| local.as_deref() == Some(normalized_zone(domain).as_str()))
                 .collect(),
         })
         .collect()
@@ -736,10 +787,10 @@ mod tests {
     }
 
     /// Routed's probe fallback selects a resolver no source named, so there is
-    /// no group to narrow to. The search domains narrow instead, to the zones
-    /// the probed AWS VPC resolver answers (#886).
+    /// no group to narrow to. The search domains narrow instead, to the one
+    /// zone the probed AWS VPC resolver answers (#886).
     #[test]
-    fn the_probed_aws_resolver_keeps_only_the_zones_it_serves() {
+    fn the_probed_aws_resolver_keeps_only_the_zone_it_serves() {
         let groups = resolver_groups(&[
             readable(
                 RESOLV_CONF_SOURCES[0],
@@ -751,7 +802,7 @@ mod tests {
             ),
         ]);
 
-        let narrowed = search_narrowed_to_aws_vpc_zones(groups);
+        let narrowed = search_narrowed_to_local_aws_vpc_zone(groups);
         assert_eq!(
             search_domains_of(&narrowed),
             vec!["us-west-1.compute.internal"],
@@ -770,13 +821,75 @@ mod tests {
         );
     }
 
-    /// The zone boundary, so the filter is neither a substring test nor a
+    /// Two AWS VPC internal zones on one host: its own, and a foreign region's
+    /// arriving over a VPN link into another VPC. Only one of them is this
+    /// host's, and the probed resolver treats the other exactly as it treats an
+    /// unrelated private suffix. Measured on an EC2 instance in us-west-1:
+    /// `ip-10-0-1-49.us-west-1.compute.internal` is NOERROR with A 10.0.1.49
+    /// while `ip-10-0-1-49.eu-west-1.compute.internal` is NXDOMAIN carrying no
+    /// authority, so forwarding the foreign zone discloses the private label
+    /// and still does not resolve.
+    #[test]
+    fn a_foreign_regions_vpc_zone_does_not_survive_the_probe_narrowing() {
+        let groups = resolver_groups(&[
+            readable(
+                RESOLV_CONF_SOURCES[0],
+                "nameserver 10.0.0.2\nsearch us-west-1.compute.internal\n",
+            ),
+            readable(
+                ETC_RESOLV_CONF,
+                "nameserver 10.99.0.53\nsearch eu-west-1.compute.internal corp.example\n",
+            ),
+        ]);
+
+        assert_eq!(
+            search_domains_of(&search_narrowed_to_local_aws_vpc_zone(groups)),
+            vec!["us-west-1.compute.internal"],
+            "only the host's own VPC zone resolves at the probed resolver"
+        );
+    }
+
+    /// A host that is not on EC2 reaches the probe path whenever no source
+    /// names an IPv6 server, and `for_launch` cannot know the probe will fail
+    /// there. It carries no AWS VPC zone, so nothing is forwarded. Nothing is
+    /// lost: `detect_ipv6_dns` returns None on that host, routed gives the
+    /// guest no IPv6 resolver, and the IPv4 servers the guest is handed instead
+    /// are unreachable from a routed guest, so no suffix had a resolver to be
+    /// completed against. Keeping the list whole would send those private
+    /// suffixes to the AWS resolver on every host where the probe DOES answer.
+    #[test]
+    fn a_host_with_no_aws_vpc_zone_forwards_no_suffix_on_the_probe_path() {
+        let groups = resolver_groups(&[readable(
+            ETC_RESOLV_CONF,
+            "nameserver 10.99.0.53\nsearch corp.example lab.example\n",
+        )]);
+
+        let narrowed = search_narrowed_to_local_aws_vpc_zone(groups);
+        assert!(
+            search_domains_of(&narrowed).is_empty(),
+            "no zone here is one the probed resolver serves"
+        );
+        assert_eq!(
+            narrowed
+                .iter()
+                .flat_map(|group| group.servers.iter())
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec!["10.99.0.53"],
+            "the servers are untouched even when every suffix goes"
+        );
+    }
+
+    /// The zone SHAPE, so the shape test is neither a substring match nor a
     /// blanket `.internal` allowance. us-east-1's VPC zone is `ec2.internal`
     /// and every other region's is `<region>.compute.internal`; measured on an
     /// EC2 instance, the VPC resolver NXDOMAINs `foo.compute.internal` and
-    /// `host1.lab.internal` alike.
+    /// `host1.lab.internal` alike. Each domain is fed on its own, so each is
+    /// the host's own zone in its own case; which of SEVERAL AWS-shaped zones
+    /// is the host's is what
+    /// `a_foreign_regions_vpc_zone_does_not_survive_the_probe_narrowing` pins.
     #[test]
-    fn only_the_aws_internal_zones_survive_the_probe_narrowing() {
+    fn only_an_aws_internal_zone_survives_the_probe_narrowing() {
         let kept = [
             "ec2.internal",
             "us-west-1.compute.internal",
@@ -795,7 +908,7 @@ mod tests {
         ];
 
         for domain in kept {
-            let narrowed = search_narrowed_to_aws_vpc_zones(vec![ResolverGroup {
+            let narrowed = search_narrowed_to_local_aws_vpc_zone(vec![ResolverGroup {
                 servers: vec!["10.0.0.2".to_string()],
                 search_domains: vec![domain.to_string()],
             }]);
@@ -807,7 +920,7 @@ mod tests {
         }
 
         for domain in dropped {
-            let narrowed = search_narrowed_to_aws_vpc_zones(vec![ResolverGroup {
+            let narrowed = search_narrowed_to_local_aws_vpc_zone(vec![ResolverGroup {
                 servers: vec!["10.0.0.2".to_string()],
                 search_domains: vec![domain.to_string()],
             }]);

--- a/src/network/routed.rs
+++ b/src/network/routed.rs
@@ -1149,8 +1149,8 @@ async fn generate_link_local_from_mac(iface: &str) -> Option<String> {
 /// IPv4 DNS (e.g. VPC's 10.0.0.2) is unreachable from the VM without MASQUERADE.
 /// The server is either:
 /// 1. `selected`, the IPv6 nameserver the launch's resolv.conf snapshot named
-/// 2. a probe of known cloud IPv6 DNS endpoints (AWS fd00:ec2::253), which runs
-///    only when that snapshot named no IPv6 server
+/// 2. a probe of the AWS VPC resolver at [`crate::network::AWS_VPC_IPV6_RESOLVER`],
+///    which runs only when that snapshot named no IPv6 server
 async fn detect_ipv6_dns(selected: Option<String>) -> Option<String> {
     // `selected` is network::first_ipv6_nameserver applied to the launch's one
     // resolv.conf snapshot, the same snapshot GuestBootInputs::for_launch
@@ -1163,14 +1163,15 @@ async fn detect_ipv6_dns(selected: Option<String>) -> Option<String> {
         return Some(server);
     }
 
-    // The snapshot named no IPv6 nameserver. Probe known cloud IPv6 endpoints.
-    // AWS VPCs provide dual-stack DNS at fd00:ec2::253.
+    // The snapshot named no IPv6 nameserver. Fall back to the AWS VPC
+    // resolver, which every dual-stack VPC provides at a well-known ULA.
+    let server = crate::network::AWS_VPC_IPV6_RESOLVER;
     let probe = tokio::process::Command::new("dig")
         .args([
             "+short",
             "+timeout=2",
             "+tries=1",
-            "@fd00:ec2::253",
+            &format!("@{server}"),
             "example.com",
         ])
         .output()
@@ -1178,8 +1179,8 @@ async fn detect_ipv6_dns(selected: Option<String>) -> Option<String> {
         .ok()?;
 
     if probe.status.success() && !String::from_utf8_lossy(&probe.stdout).trim().is_empty() {
-        info!("detected IPv6 DNS at fd00:ec2::253 (AWS VPC)");
-        return Some("fd00:ec2::253".to_string());
+        info!("detected IPv6 DNS at {server} (AWS VPC)");
+        return Some(server.to_string());
     }
 
     None
@@ -1412,8 +1413,8 @@ mod tests {
     /// cached snapshot then preserves that mismatch.
     ///
     /// 2001:db8::53 is the documentation range (RFC 3849). No host's
-    /// resolv.conf names it, and the probe fallback can only return
-    /// fd00:ec2::253 or None, so a second read of THIS machine cannot produce
+    /// resolv.conf names it, and the probe fallback can only return the AWS
+    /// VPC resolver or None, so a second read of THIS machine cannot produce
     /// it. Returning it is therefore proof that the launch snapshot decided.
     /// Before the snapshot was threaded through, this returned whatever the
     /// host named at setup time (or None), never the argument.
@@ -1434,7 +1435,7 @@ mod tests {
     async fn routed_probes_only_when_the_snapshot_named_no_ipv6_resolver() {
         let probed = detect_ipv6_dns(None).await;
         assert!(
-            probed.is_none() || probed.as_deref() == Some("fd00:ec2::253"),
+            probed.is_none() || probed.as_deref() == Some(crate::network::AWS_VPC_IPV6_RESOLVER),
             "with no snapshot resolver the only outcomes are the AWS VPC probe \
              or nothing, got {probed:?}"
         );


### PR DESCRIPTION
## Defect

Routed mode gives a guest one resolver. When no resolv.conf source names an IPv6 server, fcvm probes the AWS VPC resolver at `fd00:ec2::253`. That address belongs to no source group, so the previous configuration retained the whole merged search list. A short name could then be expanded with a private suffix from an unselected resolver and sent to the VPC resolver (CWE-200).

Measured on an EC2 instance in us-west-1, all three addresses for the VPC resolver returned the same results:

| query | result |
|---|---|
| `ip-10-0-1-49.us-west-1.compute.internal` | NOERROR, A 10.0.1.49 |
| `foo.compute.internal` | NXDOMAIN, no authority |
| `ip-10-0-1-49.eu-west-1.compute.internal` | NXDOMAIN, no authority |
| `db.corp.example` | NXDOMAIN with the root SOA |
| `secret-host.internal.example.com` | NOERROR with the public parent SOA |

The resolver serves the local VPC internal zone. Queries outside that zone either fail there or recurse into public DNS.

## Rule

On the routed probe path, fcvm keeps one unambiguous AWS VPC internal zone and drops every other search suffix:

- `ec2.internal` in us-east-1
- `<region>.compute.internal` in every other region
- no suffix when the input names no VPC zone or more than one distinct VPC zone

The region-label predicate is checked against all 46 region codes in the AWS CLI 2.32.28 endpoint data. It accepts `eusc-de-east-1`, rejects non-region labels such as `foo`, and excludes the unused `us-east-1.compute.internal` spelling. Case and a trailing root label do not create a second zone.

Resolver servers are unchanged. Modes that forward every resolver keep every corresponding search domain. The selected search list remains snapshot-key material, so an affected cached routed snapshot is invalidated once when this lands.

## Regression evidence

The current review finding is covered by:

- `network::tests::us_east_1_compute_internal_is_not_a_vpc_zone`
- `network::tests::us_east_1_compute_internal_does_not_hide_ec2_internal`

Both tests failed on the unfixed predicate. The lone unused suffix survived, and the pair produced no suffix instead of retaining `ec2.internal`. Both passed with the fix, failed again when only the predicate fix was reverted, and passed after restoration.

The earlier commits retain red-verified coverage for foreign zones, ambiguous ordering, malformed region labels, all published AWS region labels, and the end-to-end routed launch configuration.

After rebasing onto `8b237e45`:

```
make _test-unit
Summary: 983 tests run, 983 passed, 0 skipped

make lint
exit 0
```

Closes #886.