### PR TITLE
hostcdp: drive the corpus URL list, not one URL

### DIFF
--- a/bench/chromium/AGENTS.md
+++ b/bench/chromium/AGENTS.md
@@ -78,7 +78,11 @@ extra, the way `reqbench.py` reads `--reps`/`--warmup`
 WARMUP=28` hands both arms the same schedule instead of leaving the host with
 174 measured rows and a partial final cycle. `run.json` carries `total_reps`
 beside `reps` and `warmup`; a record without `total_reps` predates this and its
-`reps` is a total. `CPUS=` bounds the container's CPU budget
+`reps` is a total. `summary.json` names its own `p50_convention`
+(`statistics.median`, what `reqanalyze` publishes), so a reader can tell whether
+a ratio against a VM p50 is between two numbers of the same kind, and every
+jsonl row carries `loadavg1` the way `reqbench.py` stamps it, summarised over
+the measured reps as `loadavg1_measured`. `CPUS=` bounds the container's CPU budget
 (`podman run --cpus`) and is recorded as `cpus` in `run.json`, null when unset,
 which means the whole machine: a host baseline on every core compared against a
 2-vCPU VM arm is two variables, not one.

--- a/bench/chromium/AGENTS.md
+++ b/bench/chromium/AGENTS.md
@@ -65,6 +65,18 @@ The host control takes the same variable directly:
 `make bench-chromium-hostcdp BENCH_RESOLVE_ALL_TO=10.0.2.2`, recorded as
 `resolve_all_to` in its `run.json` (null when unset).
 
+`URL=` on the host control names one url or a comma-separated list, and a list
+is cycled the way `reqbench.url_for_rep` cycles the VM arm's: `urls[rep %
+len(urls)]`, rep counted from 0 across warmup and measured reps alike. Each
+record carries the `url` it rendered and `summary.json` carries `per_url`
+medians beside the aggregate, so a corpus host baseline is comparable to a
+corpus VM arm url by url. A multi-url run with fewer than two full cycles of
+warmup is refused rather than run, because a cold host arm against a warm VM
+arm is not a control for it. `CPUS=` bounds the container's CPU budget
+(`podman run --cpus`) and is recorded as `cpus` in `run.json`, null when unset,
+which means the whole machine: a host baseline on every core compared against a
+2-vCPU VM arm is two variables, not one.
+
 `bench-chromium-request-diag` (and its `bench-webkit-request-diag` twin)
 answers what holds a page's load event inside a restored clone, on the
 golden the run uses, on the run's backend and UFFD mode (`BACKEND=`,

--- a/bench/chromium/AGENTS.md
+++ b/bench/chromium/AGENTS.md
@@ -72,7 +72,13 @@ record carries the `url` it rendered and `summary.json` carries `per_url`
 medians beside the aggregate, so a corpus host baseline is comparable to a
 corpus VM arm url by url. A multi-url run with fewer than two full cycles of
 warmup is refused rather than run, because a cold host arm against a warm VM
-arm is not a control for it. `CPUS=` bounds the container's CPU budget
+arm is not a control for it. `REPS=` is the MEASURED rep count and `WARMUP=` is
+extra, the way `reqbench.py` reads `--reps`/`--warmup`
+(`for rep in range(args.warmup + args.reps)`), so the campaign's `REPS=202
+WARMUP=28` hands both arms the same schedule instead of leaving the host with
+174 measured rows and a partial final cycle. `run.json` carries `total_reps`
+beside `reps` and `warmup`; a record without `total_reps` predates this and its
+`reps` is a total. `CPUS=` bounds the container's CPU budget
 (`podman run --cpus`) and is recorded as `cpus` in `run.json`, null when unset,
 which means the whole machine: a host baseline on every core compared against a
 2-vCPU VM arm is two variables, not one.

--- a/bench/chromium/hostcdp.sh
+++ b/bench/chromium/hostcdp.sh
@@ -141,8 +141,15 @@ for rep in $(seq 0 $((TOTAL_REPS - 1))); do
     t_end=$(date +%s.%N)
     wall_ms=$(python3 -c "print(f'{(${t_end}-${t_start})*1000:.1f}')")
     warm=$([ "$rep" -lt "$WARMUP" ] && echo true || echo false)
-    printf '{"rep": %d, "ok": %s, "warmup": %s, "wall_ms": %s, "url": %s, "driver": %s}\n' \
-        "$rep" "$ok" "$warm" "$wall_ms" \
+    # Per-rep 1-minute load, the same field reqbench.py puts on every record
+    # (rec["loadavg1"]) and reqanalyze reports as min/median/max "during run".
+    # The start-of-run reading in run.json cannot show contention that arrived
+    # mid-run, which is the contention that would move these numbers. A
+    # non-numeric read becomes null rather than killing a run mid-loop.
+    la_rep=$(cut -d' ' -f1 "$LOADAVG_FILE" 2>/dev/null || true)
+    [[ "$la_rep" =~ ^[0-9]+([.][0-9]+)?$ ]] || la_rep=null
+    printf '{"rep": %d, "ok": %s, "warmup": %s, "wall_ms": %s, "loadavg1": %s, "url": %s, "driver": %s}\n' \
+        "$rep" "$ok" "$warm" "$wall_ms" "$la_rep" \
         "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$rep_url")" \
         "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1][-2000:]))' "$out")" >> "$OUT"
     [ "$ok" = true ] || { log "rep $rep FAILED ($rep_url): $out"; exit 4; }
@@ -190,9 +197,20 @@ if any("url" in r for r in measured_rows):
         print("per-url wall p50 (ms):")
         for url, s in sorted(per_url.items(), key=lambda kv: kv[1]["p50_ms"]):
             print(f"  {s['p50_ms']:8.1f}  n={s['n']:3d}  {url}")
+# Name the convention in the record, not only in the code that produced it: a
+# ratio between this p50 and a reqanalyze median is only meaningful if both are
+# statistics.median, and a reader of summary.json alone cannot otherwise tell.
+la = [r["loadavg1"] for r in measured_rows if isinstance(r.get("loadavg1"), (int, float))]
+load = None
+if la:
+    load = {"n": len(la), "min": round(min(la), 2),
+            "median": round(statistics.median(la), 2), "max": round(max(la), 2)}
+    print(f"loadavg1 during measured reps: min={load['min']} median={load['median']} "
+          f"max={load['max']}   <-- contention check")
 json.dump({"n": n, "p50_ms": round(p50, 1), "p95_ms": round(p95, 1),
            "mean_ms": round(statistics.mean(measured), 1),
-           "failures": 0, "per_url": per_url},
+           "failures": 0, "p50_convention": "statistics.median",
+           "loadavg1_measured": load, "per_url": per_url},
           open(sys.argv[3], "w"), indent=1)
 PY
 log "results in $RESULTS"

--- a/bench/chromium/hostcdp.sh
+++ b/bench/chromium/hostcdp.sh
@@ -24,6 +24,22 @@ LOADAVG_FILE="${LOADAVG_FILE:-/proc/loadavg}"
 mkdir -p "$RESULTS"
 log() { printf '%s %s\n' "$(date +%H:%M:%S)" "$*" >&2; }
 
+# URL may name ONE url (today's contract) or a comma-separated list. The list is
+# cycled exactly as reqbench.py cycles the VM arm's schedule -- url_for_rep()
+# returns urls[rep % len(urls)], rep counted from 0 across warmup and measured
+# reps alike -- so this host control can run the SAME corpus schedule as the VM
+# arm rather than a different workload. Whitespace around a member is stripped
+# and empty members are dropped, matching reqbench.parse_urls.
+mapfile -t URLS < <(printf '%s' "$URL" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | awk 'NF')
+[ "${#URLS[@]}" -gt 0 ] || { log "REFUSING: URL names no urls"; exit 2; }
+# reqbench refuses a multi-URL run with fewer than two full cycles of warmup;
+# the same floor here keeps the two schedules the same shape rather than
+# comparing a warmed VM arm against a cold host arm.
+if [ "${#URLS[@]}" -gt 1 ] && [ "$WARMUP" -lt $((2 * ${#URLS[@]})) ]; then
+    log "REFUSING: a ${#URLS[@]}-url schedule needs WARMUP >= $((2 * ${#URLS[@]})) (two full cycles), got $WARMUP"
+    exit 2
+fi
+
 # Same quiet-box refusal as the VM harness: a contaminated baseline poisons
 # every ratio computed against it. SETTLE_WAIT_SECS > 0 bounds a wait for the
 # box to go quiet before refusing (same knob as reqbench.sh guard_quiet; the
@@ -74,9 +90,15 @@ if [ -n "${BENCH_RESOLVE_ALL_TO:-}" ]; then
 fi
 resolve_json=$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1] or None))' \
     "${BENCH_RESOLVE_ALL_TO:-}")
+urls_json=$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1:]))' "${URLS[@]}")
 
 log "starting host container ($IMAGE) with CDP on $CDP_PORT"
-podman run -d --name "$CNAME" --network host "${resolve_env[@]}" "$IMAGE" >/dev/null
+cpus_arg=()
+if [ -n "${CPUS:-}" ]; then
+    cpus_arg=(--cpus "$CPUS")
+fi
+cpus_json=$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1] or None))' "${CPUS:-}")
+podman run -d --name "$CNAME" --network host "${cpus_arg[@]}" "${resolve_env[@]}" "$IMAGE" >/dev/null
 
 # Ready = the same two conditions the VM golden gates on: warm marker file AND
 # a live CDP round trip that finds a page target (cdp_health inside the image).
@@ -91,6 +113,7 @@ log "warm marker up after $((SECONDS - t0))s; measuring $REPS reps ($WARMUP warm
 {
     echo "{\"image\": \"$IMAGE\", \"image_id\": \"$(podman inspect --format '{{.Image}}' "$CNAME")\","
     echo " \"reps\": $REPS, \"warmup\": $WARMUP, \"url\": \"$URL\", \"cdp_port\": $CDP_PORT,"
+    echo " \"urls\": $urls_json, \"url_count\": ${#URLS[@]}, \"cpus\": $cpus_json,"
     echo " \"driver\": \"cdpdrive.py\", \"network\": \"host (no VM, no DNAT)\","
     echo " \"resolve_all_to\": $resolve_json,"
     echo " \"host_kernel\": \"$(uname -r)\", \"loadavg_at_start\": \"$la\"}"
@@ -99,8 +122,9 @@ log "warm marker up after $((SECONDS - t0))s; measuring $REPS reps ($WARMUP warm
 OUT="$RESULTS/hostcdp.jsonl"
 : > "$OUT"
 for rep in $(seq 0 $((REPS - 1))); do
+    rep_url="${URLS[$((rep % ${#URLS[@]}))]}"
     t_start=$(date +%s.%N)
-    if out=$(python3 "$HERE/cdpdrive.py" "127.0.0.1:$CDP_PORT" "$URL" --format jpeg --nav-timing 2>&1); then
+    if out=$(python3 "$HERE/cdpdrive.py" "127.0.0.1:$CDP_PORT" "$rep_url" --format jpeg --nav-timing 2>&1); then
         ok=true
     else
         ok=false
@@ -108,21 +132,57 @@ for rep in $(seq 0 $((REPS - 1))); do
     t_end=$(date +%s.%N)
     wall_ms=$(python3 -c "print(f'{(${t_end}-${t_start})*1000:.1f}')")
     warm=$([ "$rep" -lt "$WARMUP" ] && echo true || echo false)
-    printf '{"rep": %d, "ok": %s, "warmup": %s, "wall_ms": %s, "driver": %s}\n' \
+    printf '{"rep": %d, "ok": %s, "warmup": %s, "wall_ms": %s, "url": %s, "driver": %s}\n' \
         "$rep" "$ok" "$warm" "$wall_ms" \
+        "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$rep_url")" \
         "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1][-2000:]))' "$out")" >> "$OUT"
-    [ "$ok" = true ] || { log "rep $rep FAILED: $out"; exit 4; }
+    [ "$ok" = true ] || { log "rep $rep FAILED ($rep_url): $out"; exit 4; }
 done
 
-python3 - "$OUT" "$WARMUP" <<'PY'
+python3 - "$OUT" "$WARMUP" "$RESULTS/summary.json" <<'PY'
 import json, statistics, sys
 rows = [json.loads(l) for l in open(sys.argv[1])]
-measured = [r["wall_ms"] for r in rows if not r["warmup"]]
-measured.sort()
+measured_rows = [r for r in rows if not r["warmup"]]
+
+
+def pct(values, p):
+    """p50 is statistics.median, which is what reqanalyze uses for every median
+    it publishes, so a ratio taken between this number and a VM arm's median is
+    between two numbers computed the same way. Other percentiles are
+    nearest-rank."""
+    values = sorted(values)
+    n = len(values)
+    if p == 50:
+        return statistics.median(values)
+    return values[max(0, -(-p * n // 100) - 1)]
+
+
+measured = [r["wall_ms"] for r in measured_rows]
 n = len(measured)
-p50 = measured[max(0, -(-50*n//100) - 1)]
-p95 = measured[max(0, -(-95*n//100) - 1)]
+if n == 0:
+    # Every rep was warmup. The reps ran, so the run looks successful; without
+    # this the summary dies on an IndexError after minutes of work and the
+    # record holds a jsonl with no summary beside it.
+    sys.exit(f"REFUSING: all {len(rows)} reps were warmup (REPS must exceed WARMUP); nothing to summarise")
+p50, p95 = pct(measured, 50), pct(measured, 95)
 print(f"host direct-CDP warm pool: n={n} p50={p50:.1f}ms p95={p95:.1f}ms "
       f"mean={statistics.mean(measured):.1f}ms failures=0")
+per_url = {}
+if any("url" in r for r in measured_rows):
+    by_url = {}
+    for r in measured_rows:
+        by_url.setdefault(r.get("url", ""), []).append(r["wall_ms"])
+    for url, vals in by_url.items():
+        per_url[url] = {"n": len(vals), "p50_ms": round(pct(vals, 50), 1),
+                        "p95_ms": round(pct(vals, 95), 1),
+                        "mean_ms": round(statistics.mean(vals), 1)}
+    if len(by_url) > 1:
+        print("per-url wall p50 (ms):")
+        for url, s in sorted(per_url.items(), key=lambda kv: kv[1]["p50_ms"]):
+            print(f"  {s['p50_ms']:8.1f}  n={s['n']:3d}  {url}")
+json.dump({"n": n, "p50_ms": round(p50, 1), "p95_ms": round(p95, 1),
+           "mean_ms": round(statistics.mean(measured), 1),
+           "failures": 0, "per_url": per_url},
+          open(sys.argv[3], "w"), indent=1)
 PY
 log "results in $RESULTS"

--- a/bench/chromium/hostcdp.sh
+++ b/bench/chromium/hostcdp.sh
@@ -12,7 +12,11 @@ set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 IMAGE="${IMAGE:-localhost/chromium-bench-req}"
-REPS="${REPS:-202}"
+# REPS is the MEASURED rep count and WARMUP is EXTRA, exactly as reqbench.py
+# reads --reps/--warmup ("for rep in range(args.warmup + args.reps)"), so the
+# campaign's REPS/WARMUP can be handed to both arms and produce the same
+# schedule. The default measured count is what REPS=202 WARMUP=2 used to yield.
+REPS="${REPS:-200}"
 WARMUP="${WARMUP:-2}"
 URL="${URL:-http://127.0.0.1:8000/medium.html}"
 CDP_PORT="${CDP_PORT:-9222}"
@@ -32,6 +36,9 @@ log() { printf '%s %s\n' "$(date +%H:%M:%S)" "$*" >&2; }
 # and empty members are dropped, matching reqbench.parse_urls.
 mapfile -t URLS < <(printf '%s' "$URL" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | awk 'NF')
 [ "${#URLS[@]}" -gt 0 ] || { log "REFUSING: URL names no urls"; exit 2; }
+# Nothing to summarise, and the summary would die on an empty list after the
+# warmup reps had already run.
+[ "$REPS" -ge 1 ] || { log "REFUSING: REPS must be >= 1 (it is the MEASURED count; WARMUP is extra), got $REPS"; exit 2; }
 # reqbench refuses a multi-URL run with fewer than two full cycles of warmup;
 # the same floor here keeps the two schedules the same shape rather than
 # comparing a warmed VM arm against a cold host arm.
@@ -107,12 +114,13 @@ until podman exec "$CNAME" test -f /run/bench-ready 2>/dev/null; do
     [ $((SECONDS - t0)) -lt 120 ] || { log "container never became ready"; podman logs "$CNAME" | tail -20 >&2; exit 1; }
     sleep 0.5
 done
-log "warm marker up after $((SECONDS - t0))s; measuring $REPS reps ($WARMUP warmup) against $URL"
+log "warm marker up after $((SECONDS - t0))s; measuring $REPS reps after $WARMUP warmup ($((WARMUP + REPS)) total) against $URL"
 
 # Record the measured configuration beside the numbers, not in prose.
 {
     echo "{\"image\": \"$IMAGE\", \"image_id\": \"$(podman inspect --format '{{.Image}}' "$CNAME")\","
-    echo " \"reps\": $REPS, \"warmup\": $WARMUP, \"url\": \"$URL\", \"cdp_port\": $CDP_PORT,"
+    echo " \"reps\": $REPS, \"warmup\": $WARMUP, \"total_reps\": $((WARMUP + REPS)),"
+    echo " \"url\": \"$URL\", \"cdp_port\": $CDP_PORT,"
     echo " \"urls\": $urls_json, \"url_count\": ${#URLS[@]}, \"cpus\": $cpus_json,"
     echo " \"driver\": \"cdpdrive.py\", \"network\": \"host (no VM, no DNAT)\","
     echo " \"resolve_all_to\": $resolve_json,"
@@ -121,7 +129,8 @@ log "warm marker up after $((SECONDS - t0))s; measuring $REPS reps ($WARMUP warm
 
 OUT="$RESULTS/hostcdp.jsonl"
 : > "$OUT"
-for rep in $(seq 0 $((REPS - 1))); do
+TOTAL_REPS=$((WARMUP + REPS))
+for rep in $(seq 0 $((TOTAL_REPS - 1))); do
     rep_url="${URLS[$((rep % ${#URLS[@]}))]}"
     t_start=$(date +%s.%N)
     if out=$(python3 "$HERE/cdpdrive.py" "127.0.0.1:$CDP_PORT" "$rep_url" --format jpeg --nav-timing 2>&1); then
@@ -160,10 +169,11 @@ def pct(values, p):
 measured = [r["wall_ms"] for r in measured_rows]
 n = len(measured)
 if n == 0:
-    # Every rep was warmup. The reps ran, so the run looks successful; without
-    # this the summary dies on an IndexError after minutes of work and the
-    # record holds a jsonl with no summary beside it.
-    sys.exit(f"REFUSING: all {len(rows)} reps were warmup (REPS must exceed WARMUP); nothing to summarise")
+    # REPS >= 1 is enforced before any rep runs and measured == REPS, so this
+    # can only mean the jsonl and the warmup count disagree. Refuse rather than
+    # die on an IndexError after minutes of work with no summary beside the
+    # jsonl.
+    sys.exit(f"REFUSING: no measured reps in {len(rows)} rows (warmup={sys.argv[2]}); nothing to summarise")
 p50, p95 = pct(measured, 50), pct(measured, 95)
 print(f"host direct-CDP warm pool: n={n} p50={p50:.1f}ms p95={p95:.1f}ms "
       f"mean={statistics.mean(measured):.1f}ms failures=0")

--- a/bench/chromium/test_hostcdp_corpus.py
+++ b/bench/chromium/test_hostcdp_corpus.py
@@ -2,7 +2,9 @@
 """hostcdp.sh runs the corpus schedule, not one URL repeated.
 
 The VM arm cycles its URL list with reqbench.url_for_rep -- urls[rep % len(urls)],
-rep counted from 0 across warmup and measured reps alike. A host control that
+rep counted from 0 across warmup and measured reps alike, over
+range(warmup + reps), so its --reps is the MEASURED count and --warmup is extra.
+hostcdp.sh reads REPS and WARMUP the same way. A host control that
 rendered ONE page while the VM arm rendered fourteen would not be a control for
 it, so these pin the cycle, the per-record url, the run.json fields, and the
 two-full-cycles warmup floor.
@@ -81,22 +83,24 @@ exec {sys.executable} "$@"
 
     def test_reps_cycle_the_list_the_way_the_vm_arm_does(self):
         """Red: every rep recorded the whole comma-separated spec as one URL."""
-        reps = 8
-        proc, urls, _, _ = self._run(",".join(URLS), reps, 6)
+        reps, warmup = 3, 6
+        proc, urls, _, _ = self._run(",".join(URLS), reps, warmup)
         self.assertEqual(proc.returncode, 0, proc.stderr[-2000:])
-        self.assertEqual(urls, [URLS[rep % len(URLS)] for rep in range(reps)])
+        self.assertEqual(urls, [URLS[rep % len(URLS)] for rep in range(warmup + reps)])
 
     def test_each_record_carries_the_url_it_rendered(self):
         """Red: records had no url field, so per-URL medians were underivable."""
-        proc, _, _, d = self._run(",".join(URLS), 9, 6)
+        reps, warmup = 3, 6
+        proc, _, _, d = self._run(",".join(URLS), reps, warmup)
         self.assertEqual(proc.returncode, 0, proc.stderr[-2000:])
-        rows = [json.loads(line) for line in open(os.path.join(d, "results", "hostcdp.jsonl"))]
+        with open(os.path.join(d, "results", "hostcdp.jsonl")) as handle:
+            rows = [json.loads(line) for line in handle]
         self.assertEqual([r["url"] for r in rows],
-                         [URLS[rep % len(URLS)] for rep in range(9)])
+                         [URLS[rep % len(URLS)] for rep in range(warmup + reps)])
 
     def test_run_json_records_the_parsed_corpus(self):
         """Red: KeyError 'urls' -- the record could not say what was rendered."""
-        _, _, meta, _ = self._run(",".join(URLS) + " , ", 6, 6)
+        _, _, meta, _ = self._run(",".join(URLS) + " , ", 3, 6)
         self.assertEqual(meta["urls"], URLS)
         self.assertEqual(meta["url_count"], 3)
 
@@ -104,19 +108,41 @@ exec {sys.executable} "$@"
         """One URL keeps today's contract: a one-element list, every rep on it."""
         proc, urls, meta, _ = self._run(URLS[0], 3, 1)
         self.assertEqual(proc.returncode, 0, proc.stderr[-2000:])
-        self.assertEqual(urls, [URLS[0]] * 3)
+        self.assertEqual(urls, [URLS[0]] * 4)
         self.assertEqual(meta["urls"], [URLS[0]])
         self.assertEqual(meta["url_count"], 1)
 
-    def test_all_warmup_refuses_instead_of_dying_in_the_summary(self):
-        """Red: IndexError out of the summary after every rep had already run."""
-        proc, _, _, _ = self._run(URLS[0], 3, 3)
-        self.assertNotEqual(proc.returncode, 0)
-        self.assertIn("all 3 reps were warmup", proc.stderr)
+    def test_reps_is_the_measured_count_like_the_vm_arm(self):
+        """Red: REPS counted warmup in, so the campaign's REPS=202 WARMUP=28
+        gave 174 measured host rows against the VM arm's 202 and a partial
+        final URL cycle. reqbench.py runs range(warmup + reps)."""
+        reps, warmup = 6, 6
+        proc, urls, meta, d = self._run(",".join(URLS), reps, warmup)
+        self.assertEqual(proc.returncode, 0, proc.stderr[-2000:])
+        self.assertEqual(len(urls), warmup + reps)
+        self.assertEqual(urls, [URLS[rep % len(URLS)] for rep in range(warmup + reps)])
+        self.assertEqual(meta["reps"], reps)
+        self.assertEqual(meta["warmup"], warmup)
+        self.assertEqual(meta["total_reps"], warmup + reps)
+        with open(os.path.join(d, "results", "summary.json")) as handle:
+            summary = json.load(handle)
+        self.assertEqual(summary["n"], reps)
+        # A whole number of cycles measured means per_url is balanced, which is
+        # what makes an aggregate median comparable to the VM arm's.
+        self.assertEqual({u: v["n"] for u, v in summary["per_url"].items()},
+                         {u: reps // len(URLS) for u in URLS})
+
+    def test_zero_reps_refuses_before_running_anything(self):
+        """Red: the summary died on IndexError after the warmup reps had run."""
+        proc, urls, meta, _ = self._run(URLS[0], 0, 2)
+        self.assertEqual(proc.returncode, 2, proc.stdout + proc.stderr)
+        self.assertIn("REPS must be >= 1", proc.stderr)
+        self.assertEqual(urls, [])
+        self.assertIsNone(meta)
 
     def test_multi_url_refuses_less_than_two_full_cycles_of_warmup(self):
         """Red: exit 0 -- a cold host arm would have been compared to a warm VM arm."""
-        proc, urls, meta, _ = self._run(",".join(URLS), 9, 5)
+        proc, urls, meta, _ = self._run(",".join(URLS), 3, 5)
         self.assertEqual(proc.returncode, 2, proc.stdout + proc.stderr)
         self.assertIn("two full cycles", proc.stderr)
         self.assertEqual(urls, [])

--- a/bench/chromium/test_hostcdp_corpus.py
+++ b/bench/chromium/test_hostcdp_corpus.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""hostcdp.sh runs the corpus schedule, not one URL repeated.
+
+The VM arm cycles its URL list with reqbench.url_for_rep -- urls[rep % len(urls)],
+rep counted from 0 across warmup and measured reps alike. A host control that
+rendered ONE page while the VM arm rendered fourteen would not be a control for
+it, so these pin the cycle, the per-record url, the run.json fields, and the
+two-full-cycles warmup floor.
+
+Driven with a stub podman and a python3 shim that answers for cdpdrive.py and
+appends the URL it was handed, so the schedule is checked with no container and
+no browser. ALLOW_BUSY=1 passes the quiet-box gate.
+
+The same script gained a CPUS budget knob, covered by HostCdpCpuBudget below,
+because a host baseline on every core compared against a 2-vCPU VM arm is two
+variables.
+
+Watched red against the unpatched hostcdp.sh: the cycle test failed with every
+rep recording https://a.example/ (the whole spec passed through as one URL),
+the run.json test with KeyError 'urls', the warmup floor test with exit 0 where
+2 was required, and the CPUS tests with '--cpus' absent from the podman argv
+and KeyError 'cpus' out of run.json.
+
+Run: python3 -m unittest test_hostcdp_corpus -v
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SH = os.environ.get("HOSTCDP_SH", os.path.join(HERE, "hostcdp.sh"))
+URLS = ["https://a.example/", "https://b.example/", "https://c.example/"]
+
+
+def write_exec(path, body):
+    with open(path, "w") as handle:
+        handle.write(body)
+    os.chmod(path, 0o755)
+
+
+class HostCdpCorpusSchedule(unittest.TestCase):
+    def _run(self, url_spec, reps, warmup):
+        d = tempfile.mkdtemp(prefix="hostcdp-corpus-")
+        self.addCleanup(lambda: subprocess.run(["rm", "-rf", d], check=True))
+        binx = os.path.join(d, "bin")
+        os.makedirs(binx)
+        seen = os.path.join(d, "cdpdrive-urls")
+        write_exec(os.path.join(binx, "podman"), '''#!/bin/bash
+case "$1" in
+  run) echo 0123456789ab ;;
+  inspect) echo sha256:''' + "c" * 64 + ''' ;;
+esac
+exit 0
+''')
+        write_exec(os.path.join(binx, "python3"), f'''#!/bin/bash
+case "${{1:-}}" in
+  *cdpdrive.py) printf '%s\\n' "$3" >> {seen}; echo '{{"stub": true}}'; exit 0 ;;
+esac
+exec {sys.executable} "$@"
+''')
+        env = dict(os.environ)
+        env.update({
+            "PATH": binx + os.pathsep + env["PATH"],
+            "ALLOW_BUSY": "1",
+            "RESULTS": os.path.join(d, "results"),
+            "URL": url_spec,
+            "REPS": str(reps),
+            "WARMUP": str(warmup),
+        })
+        proc = subprocess.run(["bash", SH], env=env, capture_output=True, text=True)
+        urls = []
+        if os.path.exists(seen):
+            urls = open(seen).read().split()
+        run_json = os.path.join(d, "results", "run.json")
+        meta = json.load(open(run_json)) if os.path.exists(run_json) else None
+        return proc, urls, meta, d
+
+    def test_reps_cycle_the_list_the_way_the_vm_arm_does(self):
+        """Red: every rep recorded the whole comma-separated spec as one URL."""
+        reps = 8
+        proc, urls, _, _ = self._run(",".join(URLS), reps, 6)
+        self.assertEqual(proc.returncode, 0, proc.stderr[-2000:])
+        self.assertEqual(urls, [URLS[rep % len(URLS)] for rep in range(reps)])
+
+    def test_each_record_carries_the_url_it_rendered(self):
+        """Red: records had no url field, so per-URL medians were underivable."""
+        proc, _, _, d = self._run(",".join(URLS), 9, 6)
+        self.assertEqual(proc.returncode, 0, proc.stderr[-2000:])
+        rows = [json.loads(line) for line in open(os.path.join(d, "results", "hostcdp.jsonl"))]
+        self.assertEqual([r["url"] for r in rows],
+                         [URLS[rep % len(URLS)] for rep in range(9)])
+
+    def test_run_json_records_the_parsed_corpus(self):
+        """Red: KeyError 'urls' -- the record could not say what was rendered."""
+        _, _, meta, _ = self._run(",".join(URLS) + " , ", 6, 6)
+        self.assertEqual(meta["urls"], URLS)
+        self.assertEqual(meta["url_count"], 3)
+
+    def test_a_single_url_is_unchanged(self):
+        """One URL keeps today's contract: a one-element list, every rep on it."""
+        proc, urls, meta, _ = self._run(URLS[0], 3, 1)
+        self.assertEqual(proc.returncode, 0, proc.stderr[-2000:])
+        self.assertEqual(urls, [URLS[0]] * 3)
+        self.assertEqual(meta["urls"], [URLS[0]])
+        self.assertEqual(meta["url_count"], 1)
+
+    def test_all_warmup_refuses_instead_of_dying_in_the_summary(self):
+        """Red: IndexError out of the summary after every rep had already run."""
+        proc, _, _, _ = self._run(URLS[0], 3, 3)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("all 3 reps were warmup", proc.stderr)
+
+    def test_multi_url_refuses_less_than_two_full_cycles_of_warmup(self):
+        """Red: exit 0 -- a cold host arm would have been compared to a warm VM arm."""
+        proc, urls, meta, _ = self._run(",".join(URLS), 9, 5)
+        self.assertEqual(proc.returncode, 2, proc.stdout + proc.stderr)
+        self.assertIn("two full cycles", proc.stderr)
+        self.assertEqual(urls, [])
+        self.assertIsNone(meta)
+
+
+class HostCdpCpuBudget(unittest.TestCase):
+    """The host control's CPU budget has to be settable and recorded.
+
+    A host baseline run on every core, compared against a 2-vCPU VM arm, is two
+    variables. CPUS names the budget, hostcdp.sh passes it to podman as --cpus,
+    and run.json records it so a reader of the record can tell which budget the
+    baseline ran under (null when unset, which is the whole machine).
+    """
+
+    def _run(self, cpus):
+        d = tempfile.mkdtemp(prefix="hostcdp-cpus-")
+        self.addCleanup(lambda: subprocess.run(["rm", "-rf", d], check=True))
+        binx = os.path.join(d, "bin")
+        os.makedirs(binx)
+        run_argv = os.path.join(d, "podman-run-argv")
+        write_exec(os.path.join(binx, "podman"), f'''#!/bin/bash
+case "$1" in
+  run) printf '%s\\0' "$@" > {run_argv} ; echo 0123456789ab ;;
+  inspect) echo sha256:{"c" * 64} ;;
+esac
+exit 0
+''')
+        write_exec(os.path.join(binx, "python3"), f'''#!/bin/bash
+case "${{1:-}}" in
+  *cdpdrive.py) echo '{{"stub": true}}'; exit 0 ;;
+esac
+exec {sys.executable} "$@"
+''')
+        env = dict(os.environ)
+        env.pop("CPUS", None)
+        env.update({
+            "PATH": binx + os.pathsep + env["PATH"],
+            "ALLOW_BUSY": "1",
+            "RESULTS": os.path.join(d, "results"),
+            "URL": URLS[0],
+            "REPS": "3",
+            "WARMUP": "1",
+        })
+        if cpus is not None:
+            env["CPUS"] = cpus
+        proc = subprocess.run(["bash", SH], env=env, capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0, proc.stderr[-2000:])
+        with open(run_argv) as handle:
+            argv = handle.read().split("\0")
+        with open(os.path.join(d, "results", "run.json")) as handle:
+            meta = json.load(handle)
+        return argv, meta
+
+    def test_cpus_reaches_podman_and_the_record(self):
+        """Red: no --cpus in the podman argv and KeyError 'cpus' in run.json."""
+        argv, meta = self._run("2")
+        self.assertIn("--cpus", argv)
+        self.assertEqual(argv[argv.index("--cpus") + 1], "2")
+        self.assertEqual(meta["cpus"], "2")
+
+    def test_unset_cpus_leaves_the_budget_alone_and_records_null(self):
+        """Unset means the whole machine, and the record says so rather than lying."""
+        argv, meta = self._run(None)
+        self.assertNotIn("--cpus", argv)
+        self.assertIsNone(meta["cpus"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/chromium/test_hostcdp_corpus.py
+++ b/bench/chromium/test_hostcdp_corpus.py
@@ -28,6 +28,7 @@ Run: python3 -m unittest test_hostcdp_corpus -v
 
 import json
 import os
+import statistics
 import subprocess
 import sys
 import tempfile
@@ -64,10 +65,14 @@ case "${{1:-}}" in
 esac
 exec {sys.executable} "$@"
 ''')
+        loadavg = os.path.join(d, "loadavg")
+        with open(loadavg, "w") as handle:
+            handle.write("1.23 0.50 0.40 1/100 999\n")
         env = dict(os.environ)
         env.update({
             "PATH": binx + os.pathsep + env["PATH"],
             "ALLOW_BUSY": "1",
+            "LOADAVG_FILE": loadavg,
             "RESULTS": os.path.join(d, "results"),
             "URL": url_spec,
             "REPS": str(reps),
@@ -147,6 +152,42 @@ exec {sys.executable} "$@"
         self.assertIn("two full cycles", proc.stderr)
         self.assertEqual(urls, [])
         self.assertIsNone(meta)
+
+
+class HostCdpSummaryProvenance(unittest.TestCase):
+    """summary.json has to say how its p50 was computed and what load it ran under.
+
+    A host p50 is only divisible into a VM p50 if both are statistics.median,
+    and a reader of summary.json alone cannot check that unless the record says
+    so; the previous corpus run needed a post-hoc resummarize to add it.
+    Contention is the other half: reqbench.py stamps loadavg1 on every record
+    and reqanalyze reports min/median/max "during run", while this control
+    recorded only the load at start, which cannot show contention that arrived
+    mid-run.
+    """
+
+    def _summary_and_rows(self, reps, warmup):
+        proc, _, _, d = HostCdpCorpusSchedule._run(self, URLS[0], reps, warmup)
+        self.assertEqual(proc.returncode, 0, proc.stderr[-2000:])
+        with open(os.path.join(d, "results", "summary.json")) as handle:
+            summary = json.load(handle)
+        with open(os.path.join(d, "results", "hostcdp.jsonl")) as handle:
+            rows = [json.loads(line) for line in handle]
+        return summary, rows
+
+    def test_summary_names_its_p50_convention(self):
+        """Red: KeyError 'p50_convention' -- only the code knew."""
+        summary, rows = self._summary_and_rows(4, 1)
+        self.assertEqual(summary["p50_convention"], "statistics.median")
+        measured = [r["wall_ms"] for r in rows if not r["warmup"]]
+        self.assertEqual(summary["p50_ms"], round(statistics.median(measured), 1))
+
+    def test_every_rep_records_load_and_the_summary_reports_it(self):
+        """Red: KeyError 'loadavg1' -- only the start-of-run reading existed."""
+        summary, rows = self._summary_and_rows(4, 1)
+        self.assertEqual([r["loadavg1"] for r in rows], [1.23] * 5)
+        self.assertEqual(summary["loadavg1_measured"],
+                         {"n": 4, "min": 1.23, "median": 1.23, "max": 1.23})
 
 
 class HostCdpCpuBudget(unittest.TestCase):


### PR DESCRIPTION
`URL=` took exactly one url. A host control pointed at the campaign's 14-url corpus rendered the whole comma-separated spec as a single URL and failed, so the host baseline could only ever run a different workload from the VM arm it was supposed to control for. Fixing that surfaced two more ways the two arms did not match, both from review.

Three commits.

## 1. `hostcdp: drive the corpus URL list, not one URL` (02e3705)

- Parses `URL=` as a comma-separated list (whitespace stripped, empty members dropped, matching `reqbench.parse_urls`) and cycles it as `reqbench.url_for_rep` does: `urls[rep % len(urls)]`, rep counted from 0 across warmup and measured reps alike.
- Records the `url` on every jsonl row, and the parsed list plus `url_count` in `run.json`.
- Writes `summary.json` with n/p50/p95/mean and `per_url` medians. p50 is `statistics.median`, what reqanalyze publishes; p95 stays nearest-rank.
- Refuses a multi-url run with fewer than two full cycles of warmup. A cold host arm compared against a warm VM arm is not a control for it.
- `CPUS=` bounds the container's CPU budget (`podman run --cpus`) and lands in `run.json` as `cpus`, null when unset. A host baseline on every core against a 2-vCPU VM arm is two variables.

## 2. `hostcdp: REPS is the measured count, matching reqbench` (3b013ab)

Codex P1. The script looped `seq 0 $((REPS - 1))` with warmup counted inside, while `reqbench.py` runs `range(args.warmup + args.reps)` and treats `--reps` as the measured count. Handing both arms `corpus_campaign.sh`'s own `REPS=202 WARMUP=28` gave the host **174** measured rows against the VM arm's **202**, ending part-way through a cycle of the corpus, so the two arms weighted the urls differently and a url could drop out of `per_url` entirely. The previous corpus run compensated by hand, recording `reps 230` to get 202 measured.

- Loop `WARMUP + REPS`. Default `REPS` 202 to 200, which is the measured count the old default produced.
- `run.json` carries `total_reps` beside `reps` and `warmup`. A record without `total_reps` predates this and its `reps` is a total.
- Refuse `REPS < 1` before any rep runs. The all-warmup case can no longer arise, so its refusal is replaced.

## 3. `hostcdp: name the p50 convention and record load per rep` (90197ba)

CodeRabbit, both halves.

- `summary.json` computed `statistics.median` and did not say so, so the corpus run's host summary needed a post-hoc resummarize to add `"p50_convention": "statistics.median"` before its p50 could be divided into the VM arm's median. It writes the field itself now.
- `reqbench.py` stamps `rec["loadavg1"]` on every record and reqanalyze reports min/median/max "during run" as its contention check; this control carried only `loadavg_at_start`, which cannot show contention arriving mid-run. Every jsonl row now carries `loadavg1` read from `LOADAVG_FILE`, summarised over the measured reps as `loadavg1_measured` and printed beside the medians. A non-numeric read becomes null rather than killing a run mid-loop.

`bench/chromium/AGENTS.md` documents `URL=` lists, the warmup floor, the `REPS`/`WARMUP` convention, `total_reps`, `p50_convention`, `loadavg1_measured` and `CPUS=` next to the existing `BENCH_RESOLVE_ALL_TO` paragraph.

## Tests

`bench/chromium/test_hostcdp_corpus.py`, 11 tests, each watched failing before its fix:

| test | failure without the fix | against |
|---|---|---|
| `test_reps_cycle_the_list_the_way_the_vm_arm_does` | every rep recorded the whole spec as one URL | origin/main |
| `test_each_record_carries_the_url_it_rendered` | rows had no `url` field | origin/main |
| `test_run_json_records_the_parsed_corpus` | `KeyError: 'urls'` | origin/main |
| `test_a_single_url_is_unchanged` | green before and after; pins the existing contract | - |
| `test_multi_url_refuses_less_than_two_full_cycles_of_warmup` | exit 0 where 2 was required | origin/main |
| `test_cpus_reaches_podman_and_the_record` | `'--cpus' not found in ['run', '-d', '--name', ...]` | origin/main |
| `test_unset_cpus_leaves_the_budget_alone_and_records_null` | `KeyError: 'cpus'` | origin/main |
| `test_reps_is_the_measured_count_like_the_vm_arm` | exit 1, "all 6 reps were warmup", instead of 12 reps with 6 measured | 02e3705 |
| `test_zero_reps_refuses_before_running_anything` | exit 1 from the summary instead of exit 2 before any rep | 02e3705 |
| `test_summary_names_its_p50_convention` | `KeyError: 'p50_convention'` | 3b013ab |
| `test_every_rep_records_load_and_the_summary_reports_it` | `KeyError: 'loadavg1'` | 3b013ab |

They drive the script with a stub `podman`, a `python3` shim standing in for `cdpdrive.py`, and a fixture `LOADAVG_FILE`, so no container and no browser are needed. `HOSTCDP_SH=` points them at another copy of the script, which is how every red run above was taken.

Single-URL callers are unchanged: the default `URL=` is one url and `make bench-chromium-hostcdp` passes no list. `bench/chromium/test_hostcdp.py`'s resolver-rule tests still pass.

```
$ make test-chromium
Ran 616 tests in 181.048s

OK
```

## Provenance

Commit 02e3705 lands the script byte-identical to the frozen `harness/` copy that produced `bench/chromium/results/corpusextra-hostcdp-20260830-172413` and the host arm of `corpusextra-memory-20260830-181830`, so it hashes to the `hostcdp.sh` sha256 those runs' `provenance.json` records (`7ea77ec7e25759d9dcd955a968a71eff9c44dbd83acbbd63e982e8c973ba1d5c`). The two later commits change it in response to review, so the tip no longer matches; the byte-identical version stays reachable at 02e3705.