### PR TITLE
Make review effort risk proportional

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1433,7 +1433,9 @@ git push origin feature-b --force
 ### THREE BROAD REVIEW PASSES, NOT AN OPEN-ENDED REVIEW LOOP
 
 Three broad passes are a ceiling, not a checklist. Set the minimum bar before
-work starts from the impact of a bad merge:
+work starts from the downstream impact of a bad merge, not from where the code
+runs. A CI, release, or review gate that can approve or ship bad code is high
+risk when it fails open.
 
 - **High risk:** production runtime, security or isolation, persistent data,
   migrations, recovery, or public compatibility. Use the architecture,
@@ -1441,8 +1443,9 @@ work starts from the impact of a bad merge:
 - **Normal risk:** user-visible behavior with a bounded, reversible failure.
   Require focused regression coverage, the relevant suite, self-review of the
   complete delta, required CI, and exact-head review coverage.
-- **Low risk:** benchmarks, test harnesses, internal developer tooling, and
-  documentation that production does not execute. The normal minimum is one
+- **Low risk:** benchmarks, non-gating test harnesses, internal developer tools,
+  and documentation whose failure cannot approve or ship production code. The
+  normal minimum is one
   focused regression for each accepted defect class, one run of the relevant
   suite, self-review of the complete delta, required CI, and one exact-head
   automated review result. Do not add broad review passes, soak tests, fuzzing,

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1432,27 +1432,25 @@ git push origin feature-b --force
 
 ### THREE BROAD REVIEW PASSES, NOT AN OPEN-ENDED REVIEW LOOP
 
-Three broad passes are a ceiling, not a checklist. Set the minimum bar before
-work starts from the downstream impact of a bad merge, not from where the code
-runs. A CI, release, or review gate that can approve or ship bad code is high
-risk when it fails open.
+Three broad passes are a ceiling, not a checklist. Every PR has the same minimum
+bar: focused regression coverage for each accepted defect class, one run of the
+relevant suite, self-review of the complete delta, required CI, and exact-head
+review coverage.
 
-- **High risk:** production runtime, security or isolation, persistent data,
-  migrations, recovery, or public compatibility. Use the architecture,
-  candidate, and closure passes when they apply.
-- **Normal risk:** user-visible behavior with a bounded, reversible failure.
-  Require focused regression coverage, the relevant suite, self-review of the
-  complete delta, required CI, and exact-head review coverage.
-- **Low risk:** benchmarks, non-gating test harnesses, internal developer tools,
-  and documentation whose failure cannot approve or ship production code. The
-  normal minimum is one
-  focused regression for each accepted defect class, one run of the relevant
-  suite, self-review of the complete delta, required CI, and one exact-head
-  automated review result. Do not add broad review passes, soak tests, fuzzing,
-  platform matrices, or historical research unless the user asks for them or
-  the demonstrated failure mechanism needs them.
+Set any additional review from the downstream impact and demonstrated failure
+mechanisms, not from where the code runs. Production runtime, security,
+isolation, persistent data, migrations, recovery, public compatibility, and any
+CI, release, or review gate that can fail open may need the architecture,
+candidate, and closure passes below.
 
-Write the PR's contract, risk class, and minimum evidence in the PR description.
+For benchmarks, non-gating test harnesses, internal developer tools, and
+documentation whose failure cannot approve or ship production code, the minimum
+bar is normally sufficient. Do not add broad review passes, soak tests, fuzzing,
+platform matrices, or historical research unless the user asks for them or the
+demonstrated failure mechanism needs them.
+
+Write the PR's contract, downstream impact, and minimum evidence in the PR
+description.
 A race in benchmark output can invalidate the benchmark and must be fixed, but
 it does not turn benchmark tooling into a production safety system. Once the
 stated evidence is green, stop.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1432,6 +1432,28 @@ git push origin feature-b --force
 
 ### THREE BROAD REVIEW PASSES, NOT AN OPEN-ENDED REVIEW LOOP
 
+Three broad passes are a ceiling, not a checklist. Set the minimum bar before
+work starts from the impact of a bad merge:
+
+- **High risk:** production runtime, security or isolation, persistent data,
+  migrations, recovery, or public compatibility. Use the architecture,
+  candidate, and closure passes when they apply.
+- **Normal risk:** user-visible behavior with a bounded, reversible failure.
+  Require focused regression coverage, the relevant suite, self-review of the
+  complete delta, required CI, and exact-head review coverage.
+- **Low risk:** benchmarks, test harnesses, internal developer tooling, and
+  documentation that production does not execute. The normal minimum is one
+  focused regression for each accepted defect class, one run of the relevant
+  suite, self-review of the complete delta, required CI, and one exact-head
+  automated review result. Do not add broad review passes, soak tests, fuzzing,
+  platform matrices, or historical research unless the user asks for them or
+  the demonstrated failure mechanism needs them.
+
+Write the PR's contract, risk class, and minimum evidence in the PR description.
+A race in benchmark output can invalidate the benchmark and must be fixed, but
+it does not turn benchmark tooling into a production safety system. Once the
+stated evidence is green, stop.
+
 A review campaign has at most three broad passes:
 
 1. **Architecture pass, before implementation.** Write the invariants, ownership
@@ -1467,6 +1489,11 @@ passes four, five, and six. This does not waive a concrete defect: fix it and pr
 using a fixture or source-level assertion for a non-runtime contract. Keep the follow-up
 review targeted to that repair and the final exact head.
 
+There is one closure repair batch. If another blocking finding appears after that batch,
+reduce or split the PR to its last proven contract before adding more machinery. If the
+contract cannot be preserved by reduction, report the blocker and ask the user whether to
+continue. Do not silently begin another repair and review cycle.
+
 When a user-controlled remote is authorized, push each signed, focused-green frozen
 checkpoint before beginning the next pass. A remote checkpoint is recovery and visibility;
 it is not merge authorization and its old checks do not cover later local commits.
@@ -1492,6 +1519,20 @@ hostage to unrelated improvements either. A review thread classified as a follow
 needs the gate's existing disposition vocabulary. Reply with `DISAGREE: this PR does not
 cause or worsen the reported behavior; tracked in #N` and resolve it only when the diff and
 tests substantiate that statement. If they do not, the finding blocks this PR.
+
+### REMOVE GOLD PLATING BEFORE CLOSURE
+
+Every changed file, abstraction, test, and evidence artifact must do at least one of these:
+
+- implement the PR's stated contract;
+- close an accepted blocking finding caused or worsened by the PR;
+- provide evidence that is not already supplied by a cheaper test or summary.
+
+Remove or split everything else. Prefer deleting optional behavior or reverting to the last
+proven implementation over expanding a low-risk PR to defend it. Use one deterministic test
+per defect class, not several tests of the same invariant. Do not generalize a one-caller fix
+without a second required caller. Do not commit raw benchmark output when a small summary and
+the command that produced it carry the required evidence.
 
 ### Claude Review Workflow
 


### PR DESCRIPTION
## Contract

Set a minimum review bar from merge impact, cap closure at one repair batch, and require a gold-plating check before closure.

Risk class: low, documentation only.

## Verification

- `git diff --check`
- self-review of the complete 41-line documentation delta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for minimum review requirements, including focused regression coverage, self-review, CI validation, and exact-head coverage.
  * Clarified when broader review passes are warranted based on downstream impact and demonstrated failure mechanisms.
  * Added rules for limiting closure to a single repair batch and removing unnecessary changes before completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->