### PR TITLE
check-review-threads: a bot's notice that it did not review is not a finding

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -224,6 +224,18 @@ Three rules the gate enforces, each of them a hole it once had:
   answers nothing, it has simply stopped being a question. Treating every non-empty body as a
   finding blocked PRs that had none at all, `@codex review` included, which is the command
   the docs tell you to post.
+- **A reviewer saying it did not run is not a claim either.** Out of quota, Codex's bot
+  posts "You have reached your Codex usage limits for code reviews" as a top-level comment;
+  CodeRabbit answers a trigger it cannot serve with "Review rate limited." under an "Action
+  not completed" fold, and until a review has run its summary comment holds only a "Review
+  limit reached" or "Review skipped" notice. Both bots are listed reviewers, so none of that
+  was a notification bot's comment, and the gate counted each one as a finding: on
+  2026-09-02 #898 carried three Codex quota notices reported UNANSWERED, aws #46 one more,
+  and the author posted a `NOT-A-DEFECT:` review to answer text that claimed nothing. A
+  listed bot's comment whose whole body is one of those notices, matched line for line, now
+  needs no disposition and covers no head. The same words with anything added, or from any
+  other account, stay claimable, and a summary comment that has grown a walkthrough is a
+  walkthrough.
 - **The head commit must have been reviewed.** Answering every finding proves nothing if
   nobody reviewed the code you are merging. This gate shipped with five open findings that
   way: the branch was pushed, the prior round was answered, the gate went CLEAR, and it

--- a/scripts/check-review-threads.sh
+++ b/scripts/check-review-threads.sh
@@ -573,8 +573,9 @@ fi
 #     can wear it; an empty or absent author matches nothing, because on a payload that
 #     names no author "" == "" would exempt every unattributed body on it.
 #   - TOP-LEVEL COMMENTS have no state, so everything counts unless it is on a short,
-#     documented ignore list: bot logins that only ever post notifications, and the
-#     literal trigger phrases this skill tells you to post. An unknown bot counts, and so
+#     documented ignore list: bot logins that only ever post notifications, the literal
+#     trigger phrases this skill tells you to post, and a listed reviewer's notice that it
+#     did NOT review (the shapes above VERDICT_JQ). An unknown bot counts, and so
 #     does the AUTHOR: a comment is where a self-reported defect lands, and a review is
 #     where an answer does. That asymmetry is the whole rule.
 #
@@ -641,6 +642,36 @@ TRIGGER_RE='\A[[:space:]]*@(codex[[:space:]]+(security[[:space:]]+)?review|coder
 # the comment, which is the right direction; extend the list when Codex says something
 # new. Only the About Codex block is stripped, and only under that exact summary text:
 # a details block with any other summary is where a bot folds its findings.
+# NOTICES: a listed reviewer saying that its review did NOT run. Neither a finding nor
+# coverage. Both bots post one, and because both are in VERDICT_BOTS none of it fell under
+# the notification-bot exemption below: every notice was a PR-level claim needing a
+# disposition dated after it. On 2026-09-02 #898 carried three Codex quota notices and the
+# gate reported all three UNANSWERED (aws #46 one more); the author cleared them with a
+# NOT-A-DEFECT review answering text that claimed nothing. A gate that blocks on ordinary
+# bot traffic gets switched off, which is the failure the withdrawn last-word rule had.
+#
+# A notice is matched as the WHOLE body, line for line, against the shapes the bots have
+# posted here, and belongs to the bot that posts it (see CODERABBIT_LOGIN): the same words
+# with anything added, or from any other account, are a comment like any other and stay
+# claimable. The shapes, with where each was observed:
+#   - Codex, a plain top-level comment: "You have reached your Codex usage limits for code
+#     reviews. You can see your limits in the [Codex usage dashboard](...)." alone (#898 at
+#     05:16Z, #842) or followed by "To continue using code reviews, add credits to your
+#     account and enable them for code reviews in your [settings](...)." (#898 at 05:20Z
+#     and 06:04Z, aws #46, aws #27).
+#   - CodeRabbit's reply to a command it did not carry out: one of "Review rate limited.",
+#     "Already reviewed.", "Already reviewed the last commit. Use `@coderabbitai full
+#     review` to rerun a review of the entire changeset.", "No files to review." or "Pull
+#     request is closed." folded under "⚠️ Action not completed", with or without the
+#     incremental-review note (#847, #864, #846, #869, #853); or "Review rate limited." over
+#     a rule and the Fair Usage Limits paragraph naming a wait (#844, #887, aws #17).
+#   - CodeRabbit's chat reply "### Rate Limit Exceeded" naming the user and a wait (#893).
+#   - CodeRabbit's summary comment before any review has run: the summarize marker, ONE
+#     notice between its "rate limited", "skip review" or "review paused" markers, every
+#     line of it blockquoted under a "Review limit reached", "Review skipped" or "Reviews
+#     paused" heading, the tips block, and nothing else (#874, #843, #789, #832). The range
+#     that notice quotes is not coverage (walkthrough_sha never read it). Once the comment
+#     holds a walkthrough or a recent-review block it is a walkthrough, judged as one.
 VERDICT_JQ='def cr_note: "> Note: CodeRabbit is an incremental review system and does not re-review already reviewed commits. This command is applicable only when automatic reviews are paused.";
 def verdict_lines:
   ((. // "") | gsub("<!--(.|\n)*?-->"; "")
@@ -700,7 +731,41 @@ def walkthrough_sha:
      | select(test("(?m)^>[[:space:]]*##") | not)
      | capture("<!-- recent_review_start -->(?<r>(.|\n)*?)<!-- recent_review_end -->") | .r
      | select(test("No actionable comments were generated in the recent review"))
-     | capture(cr_range_re) | .sha ] | first) // "";'
+     | capture(cr_range_re) | .sha ] | first) // "";
+def codex_limit_line1: "You have reached your Codex usage limits for code reviews. You can see your limits in the [Codex usage dashboard](https://chatgpt.com/codex/cloud/settings/usage).";
+def codex_limit_line2: "To continue using code reviews, add credits to your account and enable them for code reviews in your [settings](https://chatgpt.com/codex/cloud/settings/code-review).";
+def is_codex_limit_notice:
+  verdict_lines as $l | ($l == [codex_limit_line1]) or ($l == [codex_limit_line1, codex_limit_line2]);
+def cr_not_done_re: "^(Review rate limited\\.|Already reviewed\\.|Already reviewed the last commit\\. Use `@coderabbitai full review` to rerun a review of the entire changeset\\.|No files to review\\.|Pull request is closed\\.)$";
+def cr_fair_usage_re: "^Your included review limit is currently reached under our \\[Fair Usage Limits Policy\\]\\(https://docs\\.coderabbit\\.ai/management/plans#fair-usage-limits-policy\\)\\. This review may still proceed through usage-based billing if eligible\\. Your next included review will be available in [0-9]+ (minutes?|seconds?|hours?)\\.$";
+def cr_chat_limit_re: "^`@[A-Za-z0-9-]+` have exceeded the limit for the number of chat messages per hour\\. Please wait \\*\\*[0-9]+ (minutes?|seconds?|hours?)( and [0-9]+ (minutes?|seconds?))?\\*\\* before sending another message\\.$";
+def is_cr_reply_notice:
+  verdict_lines as $l
+  | (($l | length) == 4 and $l[0] == "<details>" and $l[1] == "<summary>⚠️ Action not completed</summary>"
+     and ($l[2] | test(cr_not_done_re)) and $l[3] == "</details>")
+    or (($l | length) == 6 and $l[0] == "<details>" and $l[1] == "<summary>⚠️ Action not completed</summary>"
+        and $l[2] == "Review rate limited." and $l[3] == "---" and ($l[4] | test(cr_fair_usage_re))
+        and $l[5] == "</details>")
+    or (($l | length) == 2 and $l[0] == "### Rate Limit Exceeded" and ($l[1] | test(cr_chat_limit_re)));
+def cr_notice_start_re: "^<!-- This is an auto-generated comment: (?<k>rate limited|skip review|review paused) by coderabbit\\.ai -->$";
+def cr_notice_heading_re: "^> ## (Review limit reached|Review skipped|Reviews paused)$";
+def cr_tips_re: "<!-- tips_start -->(.|\n)*?<!-- tips_end -->";
+def is_cr_summary_notice:
+  (. // "") as $b
+  | [$b | scan(cr_marker_re)] as $m
+  | ($m | length) == 2 and $m[0] == cr_summarize_marker
+    and (($m[1] | capture(cr_notice_start_re) // null) != null)
+    and (($b | split($m[1])) as $p
+         | ($p | length) == 2
+           and (($p[1] | split("<!-- end of auto-generated comment: \($m[1] | capture(cr_notice_start_re).k) by coderabbit.ai -->")) as $q
+                | ($q | length) == 2
+                  and (($q[0] | split("\n") | map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) | map(select(length > 0))) as $n
+                       | ($n | length) >= 2 and all($n[]; startswith(">"))
+                         and ($n[0] | test("^> \\[!(WARNING|IMPORTANT|NOTE)\\]$"))
+                         and ($n[1] | test(cr_notice_heading_re)))
+                  and (($p[0] + $q[1]) | gsub(cr_tips_re; "") | gsub("<!--(.|\n)*?-->"; "")
+                       | test("[^[:space:]]") | not)));
+def is_cr_notice: is_cr_reply_notice or is_cr_summary_notice;'
 # Only these bots issue verdicts, and only from the account GitHub types as a Bot.
 # Anyone else posting the same words has written an ordinary comment: claimable like
 # any other, never coverage. Entries are logins; their mention handles (@codex,
@@ -710,6 +775,10 @@ VERDICT_BOTS=${VERDICT_BOTS:-chatgpt-codex-connector,coderabbitai}
 # CodeRabbit comment carrying the marker a Codex verdict: exempt from dispositions, with its
 # table read as head coverage.
 CODEX_LOGIN=${CODEX_LOGIN:-chatgpt-codex-connector}
+# Each notice belongs to its bot the same way: the quota notice is Codex's, the rate-limit,
+# not-completed and summary notices are CodeRabbit's. From any other account they are
+# ordinary comments.
+CODERABBIT_LOGIN=${CODERABBIT_LOGIN:-coderabbitai}
 
 prauthor=$(jq -r '.data.repository.pullRequest.author.login // ""' <<<"$payload" 2>/dev/null)
 
@@ -793,7 +862,7 @@ fi
 # The coverage check below asks only whether some row names the head and postdates its
 # arrival, so a comment carrying several results is judged row by row.
 bodies=$(jq -s --arg ignore "$IGNORED_COMMENT_AUTHORS" --arg trig "$TRIGGER_RE" --arg bots "$VERDICT_BOTS" \
-   --arg codex "$CODEX_LOGIN" --arg me "$prauthor" \
+   --arg codex "$CODEX_LOGIN" --arg cr "$CODERABBIT_LOGIN" --arg me "$prauthor" \
    "$VERDICT_JQ"'($ignore | split(",")) as $skip
   | ($bots | split(",")) as $botlogins
   | (.[0] | map({author, state, body, at: .submittedAt,
@@ -803,16 +872,19 @@ bodies=$(jq -s --arg ignore "$IGNORED_COMMENT_AUTHORS" --arg trig "$TRIGGER_RE" 
       | (($c.author.__typename // "") == "Bot" and ($c.author.login | IN($botlogins[]))) as $listed
       | ($listed and ($c.body | is_verdict)) as $v
       | ($listed and (($c.author.login // "") == $codex) and ($c.body | is_codex_summary)) as $sum
+      | ($listed and ((($c.author.login // "") == $codex and ($c.body | is_codex_limit_notice))
+                      or (($c.author.login // "") == $cr and ($c.body | is_cr_notice)))) as $notice
       | {author, state: "COMMENT", body, at: .updatedAt,
-         verdict: ($v or $sum),
-         reviewed_rows: ((if $v then [{sha: ($c.body | verdict_sha), at: .createdAt}]
+         verdict: ($v or $sum), notice: $notice,
+         reviewed_rows: ((if $notice then []
+                          elif $v then [{sha: ($c.body | verdict_sha), at: .createdAt}]
                           elif $sum then ($c.body | summary_rows)
                           elif $listed then [{sha: ($c.body | walkthrough_sha), at: (.updatedAt // "")}]
                           else [] end)
                          | map(select((.sha // "") != "" and (.at // "") != ""))),
          claimable: ((.author.login | IN($skip[]) | not)
                      and ((.body // "") | test($trig; "i") | not)
-                     and (($v or $sum) | not))}))' \
+                     and (($v or $sum or $notice) | not))}))' \
          <(echo "$reviews") <(echo "$prcomments")) || {
   echo "verdict: BLOCKED — could not merge PR-level bodies." >&2; exit 2; }
 

--- a/scripts/check-review-threads.sh
+++ b/scripts/check-review-threads.sh
@@ -667,9 +667,13 @@ TRIGGER_RE='\A[[:space:]]*@(codex[[:space:]]+(security[[:space:]]+)?review|coder
 #     a rule and the Fair Usage Limits paragraph naming a wait (#844, #887, aws #17).
 #   - CodeRabbit's chat reply "### Rate Limit Exceeded" naming the user and a wait (#893).
 #   - CodeRabbit's summary comment before any review has run: the summarize marker, ONE
-#     notice between its "rate limited", "skip review" or "review paused" markers, every
-#     line of it blockquoted under a "Review limit reached", "Review skipped" or "Reviews
-#     paused" heading, the tips block, and nothing else (#874, #843, #789, #832). The range
+#     notice between its "rate limited", "skip review" or "review paused" markers, its
+#     payload blockquoted under a "Review limit reached", "Review skipped" or "Reviews
+#     paused" heading, the tips block, and nothing else (#874, #843, #789, #832). The
+#     payload is parsed line by line against the shapes CodeRabbit posts
+#     (cr_notice_payload_res), not skimmed for a leading ">": accepting any quoted line
+#     made "> P1: this drops the last row" part of the notice, and a notice needs no
+#     disposition. The range
 #     that notice quotes is not coverage (walkthrough_sha never read it). Once the comment
 #     holds a walkthrough or a recent-review block it is a walkthrough, judged as one.
 VERDICT_JQ='def cr_note: "> Note: CodeRabbit is an incremental review system and does not re-review already reviewed commits. This command is applicable only when automatic reviews are paused.";
@@ -748,8 +752,61 @@ def is_cr_reply_notice:
         and $l[5] == "</details>")
     or (($l | length) == 2 and $l[0] == "### Rate Limit Exceeded" and ($l[1] | test(cr_chat_limit_re)));
 def cr_notice_start_re: "^<!-- This is an auto-generated comment: (?<k>rate limited|skip review|review paused) by coderabbit\\.ai -->$";
-def cr_notice_heading_re: "^> ## (Review limit reached|Review skipped|Reviews paused)$";
+def cr_notice_heading_re: "^## (Review limit reached|Review skipped|Reviews paused)$";
 def cr_tips_re: "<!-- tips_start -->(.|\n)*?<!-- tips_end -->";
+# The notice payload, one accepted shape per line, with the parts that vary between
+# postings generalized: counts, durations, shas, run and org ids, backticked names, and the
+# handle the rate-limit line addresses. An apostrophe is written "." so this list can live
+# inside VERDICT_JQ. Every shape was read off a notice CodeRabbit posted in ejc3/fcvm or
+# ejc3/aws; the 46 such bodies fetched on 2026-09-02 are matched by this list with nothing
+# left over. A line outside it makes the comment claimable, which is what it was before the
+# exemption existed: the cost of an unlisted shape is one disposition, and the cost of
+# accepting one is a finding nobody has to answer.
+def cr_notice_payload_res:
+  [ "^$"
+  , "^</?details>$"
+  , "^<summary>(⚙️ Run configuration|📥 Commits|📒 Files selected for processing \\([0-9]+\\)|⛔ Files ignored due to path filters \\([0-9]+\\)|How can I continue\\?|How do review limits work\\?|Review details|View limit details)</summary>$"
+  , "^\\* `[^`]+`( is excluded by `[^`]+`)?$"
+  , "^- \\[ \\] <!-- \\{\"checkboxId\": ?\"[0-9a-f-]+\"\\} --> 🔍 Trigger review$"
+  , "^\\*\\*(Configuration used|Review profile|Plan)\\*\\*: [A-Za-z0-9 +]+$"
+  , "^\\*\\*Run ID\\*\\*: `[0-9a-f-]+`$"
+  , "^\\*\\*Review configuration:\\*\\*$"
+  , "^\\*\\*Next review available in:\\*\\* \\*\\*[0-9]+ (minutes?|seconds?|hours?)\\*\\*$"
+  , "^\\*\\*Next included review available in [0-9]+ (minutes?|seconds?|hours?)\\.\\*\\*$"
+  , "^\\*\\*Limit details:\\*\\* You.ve used (all [0-9]+ included review|the included review) currently available( under your plan)?\\.$"
+  , "^Reviewing files that changed from the base of the PR and between [0-9a-f]{40} and [0-9a-f]{40}\\.$"
+  , "^You can disable this status message by setting the `reviews\\.review_status` to `false` in the CodeRabbit configuration file\\.$"
+  , "^Please check the settings in the CodeRabbit UI or the `\\.coderabbit\\.yaml` file in this repository\\. To trigger a single review, invoke the `@coderabbitai review` command\\.$"
+  , "^Use the checkbox below for a quick retry:$"
+  , "^`@[A-Za-z0-9-]+`, you.ve reached your PR review limit, so we couldn.t start this review\\.$"
+  , "^After more reviews become available, a review can be triggered using the `@coderabbitai review` command as a PR comment\\. Alternatively, push new commits to this PR\\.$"
+  , "^To avoid repeated limits, reduce automatic review volume by pausing incremental auto-reviews earlier, using label-based review opt-in, excluding WIP or generated PR titles, or requesting reviews manually when the PR is ready\\. If your team needs uninterrupted high-volume reviews, an organization admin can enable usage-based reviews\\.$"
+  , "^CodeRabbit enforces per-developer PR review limits for each organization\\. Most developers receive the normal plan review availability\\.$"
+  , "^For paid Pro and Pro\\+ PR reviews, CodeRabbit uses adaptive limits for sustained high-volume activity\\. When a developer.s recent PR review activity reaches the 95th percentile or higher among CodeRabbit users, additional reviews become available more gradually as earlier reviews age out of the rolling window\\.$"
+  , "^Please refer \\[docs\\]\\(https://docs\\.coderabbit\\.ai/management/plans#rate-limits\\) for additional details\\.$"
+  , "^You.ve used all free OSS reviews for now\\. Wait for the free limit to reset to keep reviewing this public repository\\.$"
+  , "^Auto reviews are disabled on base/target branches other than the default branch\\.$"
+  , "^Draft detected\\.$"
+  , "^Enable \\*\\*\\[usage-based reviews\\]\\(https://app\\.coderabbit\\.ai/settings/billing\\?tab=usage&orgId=[0-9a-f-]+\\)\\*\\* in Billing to review now\\. Otherwise, wait until the next included review is available\\.$"
+  , "^You.re only billed for reviews past your plan.s rate limits \\(\\$[0-9]+\\.[0-9]+/file\\)\\.$"
+  , "^\\[Learn how review limits work\\]\\(https://docs\\.coderabbit\\.ai/management/plans#rate-limits\\)\\.$"
+  , "^Too many files!$"
+  , "^This PR contains [0-9]+ files, which is [0-9]+ over the limit of [0-9]+\\.$"
+  , "^To get a review, reduce the PR to [0-9]+ files or fewer by splitting it into smaller PRs or changing its base branch\\.$"
+  , "^Upgrade to a paid plan to raise the limit\\.$"
+  , "^Usage-priced reviews support at most [0-9]+ files\\.$"
+  , "^\\[Check out review usage here\\]\\(https://app\\.coderabbit\\.ai/dashboard/review-capacity\\?orgId=[0-9a-f-]+\\)\\.$"
+  ];
+# The blockquote between the notice markers: an alert marker, one of the listed headings,
+# then payload. Accepting any line that merely starts with ">" made "> P1: this drops the
+# last row" part of a notice, and a notice needs no disposition.
+def cr_notice_payload_ok:
+  . as $n
+  | ($n | length) >= 2 and all($n[]; startswith(">"))
+    and (($n | map(sub("^>[[:space:]]*"; ""))) as $t
+         | ($t[0] | test("^\\[!(WARNING|IMPORTANT|NOTE)\\]$"))
+           and ($t[1] | test(cr_notice_heading_re))
+           and all($t[2:][]; . as $line | any(cr_notice_payload_res[]; . as $re | $line | test($re))));
 def is_cr_summary_notice:
   (. // "") as $b
   | [$b | scan(cr_marker_re)] as $m
@@ -759,10 +816,8 @@ def is_cr_summary_notice:
          | ($p | length) == 2
            and (($p[1] | split("<!-- end of auto-generated comment: \($m[1] | capture(cr_notice_start_re).k) by coderabbit.ai -->")) as $q
                 | ($q | length) == 2
-                  and (($q[0] | split("\n") | map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) | map(select(length > 0))) as $n
-                       | ($n | length) >= 2 and all($n[]; startswith(">"))
-                         and ($n[0] | test("^> \\[!(WARNING|IMPORTANT|NOTE)\\]$"))
-                         and ($n[1] | test(cr_notice_heading_re)))
+                  and (($q[0] | split("\n") | map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) | map(select(length > 0)))
+                       | cr_notice_payload_ok)
                   and (($p[0] + $q[1]) | gsub(cr_tips_re; "") | gsub("<!--(.|\n)*?-->"; "")
                        | test("[^[:space:]]") | not)));
 def is_cr_notice: is_cr_reply_notice or is_cr_summary_notice;'

--- a/scripts/check-review-threads.sh
+++ b/scripts/check-review-threads.sh
@@ -676,12 +676,78 @@ TRIGGER_RE='\A[[:space:]]*@(codex[[:space:]]+(security[[:space:]]+)?review|coder
 #     disposition. The range
 #     that notice quotes is not coverage (walkthrough_sha never read it). Once the comment
 #     holds a walkthrough or a recent-review block it is a walkthrough, judged as one.
+#
+# ACCOUNTING. A body is exempt from dispositions only if the classifier read every byte of
+# it. Content removed before classification is content nobody evaluated, so a finding in a
+# removed region is exempt and never answered. That is one defect class and it landed three
+# times: the notice payload (any line starting with ">"), the CodeRabbit tips block, and
+# the folded About Codex block, the last of which also bound no-findings COVERAGE to the
+# head. Every removal now goes through strip_accounted, which deletes a region declared in
+# accounted_regions only after every non-blank line inside it matches one of that region's
+# shapes, and returns null otherwise, which makes the whole body claimable. The regions:
+#
+#   cr_tips       <!-- tips_start --> .. <!-- tips_end -->        rendered, shape-checked
+#   codex_about   <details> <summary>ℹ️ About Codex ..</details>  rendered, shape-checked
+#   html_comment  <!-- .. -->                                     not rendered, no shapes
+#
+# html_comment carries no shapes because GitHub renders none of it: nothing inside one is a
+# claim a reader can see or answer. Both shape lists were read off what the bots posted on
+# ejc3/fcvm #789 through #901 (13 About blocks, 17 tips blocks) and match all of it with
+# nothing left over. Every shape is anchored, because an unanchored one matches the head of
+# a line and lets the rest ride along. An unlisted line costs one disposition; accepting
+# one costs a finding nobody has to answer.
+#
+# scripts/gate-discard-sites.sh enumerates every discarding call in VERDICT_JQ and blocks
+# on any that is neither this primitive nor a listed normalization, so the next stripping
+# step fails a test unless it declares a region. Both harnesses run it.
 VERDICT_JQ='def cr_note: "> Note: CodeRabbit is an incremental review system and does not re-review already reviewed commits. This command is applicable only when automatic reviews are paused.";
+def cr_tips_res:
+  [ "^---$"
+  , "^</?details>$"
+  , "^<summary>❤️ Share</summary>$"
+  , "^- \\[(X|Mastodon|Reddit|LinkedIn)\\]\\(https://[^)]*\\)$"
+  , "^Thanks for using \\[CodeRabbit\\]\\(https://coderabbit\\.ai\\?utm_source=oss&utm_medium=github&utm_campaign=[^)]+\\)! It.s free for OSS, and your support helps us grow\\. If you like it, consider giving us a shout-out\\.$"
+  , "^<sub>Comment `@coderabbitai help` to get the list of available commands\\.</sub>$"
+  ];
+def codex_about_res:
+  [ "^<br/>$"
+  , "^\\[Your team has set up Codex to review pull requests in this repo\\]\\(https://chatgpt\\.com/codex/cloud/settings/general\\)\\. Reviews are triggered when you$"
+  , "^- Open a pull request for review$"
+  , "^- Mark a draft as ready$"
+  , "^- Comment \"@codex review\"( or \"@codex security review\")?\\.$"
+  , "^If Codex has suggestions, it will comment; otherwise it will react with 👍\\.$"
+  , "^Codex reacts with 👀 while any review is running, comments if it has suggestions, and reacts with 👍 once all reviews finish with no findings\\.$"
+  , "^Codex can also answer questions or update the PR\\. Try commenting \"@codex address that feedback\"\\.$"
+  ];
+def accounted_regions:
+  [ { name: "cr_tips", rendered: true, lines: cr_tips_res,
+      re: "<!-- tips_start -->(?<inner>(.|\n)*?)<!-- tips_end -->" }
+  , { name: "codex_about", rendered: true, lines: codex_about_res,
+      re: "<details> <summary>ℹ️ About Codex in GitHub</summary>(?<inner>(.|\n)*?)</details>" }
+  , { name: "html_comment", rendered: false, lines: null,
+      re: "<!--(.|\n)*?-->" }
+  ];
+def strip_accounted($names):
+  if ($names | any(. as $n | ([accounted_regions[] | .name] | index($n)) == null)) then null
+  else reduce accounted_regions[] as $r (.;
+    if . == null then null
+    elif ($r.name | IN($names[]) | not) then .
+    elif ($r.rendered | not) then gsub($r.re; "")
+    elif (($r.lines // []) | length) == 0 then null
+    elif ([match($r.re; "g")] | all(.[];
+            [.captures[] | select(.name == "inner") | .string] as $c
+            | ($c | length) == 1
+              and (($c[0] // "") | split("\n")
+                   | map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) | map(select(length > 0))
+                   | all(.[]; . as $line | any($r.lines[]; . as $re | $line | test($re))))))
+      then gsub($r.re; "")
+    else null end)
+  end;
 def verdict_lines:
-  ((. // "") | gsub("<!--(.|\n)*?-->"; "")
-    | gsub("<details> <summary>ℹ️ About Codex in GitHub</summary>(.|\n)*?</details>"; "")
-    | split("\n") | map(gsub("^[[:space:]]+|[[:space:]]+$"; ""))
-    | map(select(length > 0 and . != cr_note)));
+  ((. // "") | strip_accounted(["codex_about", "html_comment"])) as $s
+  | if $s == null then null
+    else ($s | split("\n") | map(gsub("^[[:space:]]+|[[:space:]]+$"; ""))
+             | map(select(length > 0 and . != cr_note))) end;
 def codex_line_re: "^Codex Review: Didn.t find any major issues\\.?( Bravo\\.| Keep it up!| Keep them coming!| Hooray!| Swish!| You.re on a roll\\.| :\\+1:| :rocket:| :tada:| Nice work[.!]| Great job[.!]| 👍)?$";
 def reviewed_re: "^\\*\\*Reviewed commit:\\*\\* `(?<sha>[0-9a-f]{7,40})`$";
 def is_verdict:
@@ -698,10 +764,10 @@ def summary_cells:
   | (if (.[0] // "") == "" then .[1:] else . end)
   | (if (.[-1] // "") == "" then .[:-1] else . end);
 def summary_lines:
-  ((. // "") | gsub("<!--(.|\n)*?-->"; "")
-    | gsub("<details> <summary>ℹ️ About Codex in GitHub</summary>(.|\n)*?</details>"; "")
-    | split("\n") | map(gsub("^[[:space:]]+|[[:space:]]+$"; ""))
-    | map(select(length > 0)));
+  ((. // "") | strip_accounted(["codex_about", "html_comment"])) as $s
+  | if $s == null then null
+    else ($s | split("\n") | map(gsub("^[[:space:]]+|[[:space:]]+$"; ""))
+             | map(select(length > 0))) end;
 def is_codex_summary:
   (((. // "") | sub("^[[:space:]]+"; "")) | startswith(codex_summary_marker))
   and (summary_lines as $l
@@ -753,7 +819,6 @@ def is_cr_reply_notice:
     or (($l | length) == 2 and $l[0] == "### Rate Limit Exceeded" and ($l[1] | test(cr_chat_limit_re)));
 def cr_notice_start_re: "^<!-- This is an auto-generated comment: (?<k>rate limited|skip review|review paused) by coderabbit\\.ai -->$";
 def cr_notice_heading_re: "^## (Review limit reached|Review skipped|Reviews paused)$";
-def cr_tips_re: "<!-- tips_start -->(.|\n)*?<!-- tips_end -->";
 # The notice payload, one accepted shape per line, with the parts that vary between
 # postings generalized: counts, durations, shas, run and org ids, backticked names, and the
 # handle the rate-limit line addresses. An apostrophe is written "." so this list can live
@@ -818,8 +883,8 @@ def is_cr_summary_notice:
                 | ($q | length) == 2
                   and (($q[0] | split("\n") | map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) | map(select(length > 0)))
                        | cr_notice_payload_ok)
-                  and (($p[0] + $q[1]) | gsub(cr_tips_re; "") | gsub("<!--(.|\n)*?-->"; "")
-                       | test("[^[:space:]]") | not)));
+                  and ((($p[0] + $q[1]) | strip_accounted(["cr_tips", "html_comment"])) as $rest
+                       | $rest != null and ($rest | test("[^[:space:]]") | not))));
 def is_cr_notice: is_cr_reply_notice or is_cr_summary_notice;'
 # Only these bots issue verdicts, and only from the account GitHub types as a Bot.
 # Anyone else posting the same words has written an ordinary comment: claimable like

--- a/scripts/gate-discard-sites.sh
+++ b/scripts/gate-discard-sites.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Enumerate every call in check-review-threads.sh's VERDICT_JQ that DISCARDS part of a
+# comment body, and block on one that is neither the accounting primitive nor a listed
+# normalization.
+#
+# Why this exists. Three rounds of one defect class landed on the same shape: content
+# removed before classification is content the classifier did not read, so a finding placed
+# in the removed region made a bot comment "a notice" and needed no disposition. Round 1
+# was the notice payload (every line starting with ">" was accepted). Round 2 was the
+# CodeRabbit tips block. Round 3 was the folded About Codex block, which also bound
+# no-findings COVERAGE to the head. Fixing sites one at a time is what produced rounds 2
+# and 3, so this pin fails on the NEXT one instead.
+#
+# The invariant: a body is exempt from dispositions only if the classifier accounted for
+# every byte of it. A removal is accounted for when it goes through strip_accounted, which
+# removes a declared region only after every non-blank line inside it matches one of that
+# region's shapes, and returns null (body claimable) otherwise. Everything else must be a
+# NORMALIZATION: it drops nothing a reader could have read, and what survives it is still
+# shape-checked. The list below is the whole set, written out; a call that is not in it is
+# reported and this script exits 1, whatever it is named.
+#
+# Run by both harnesses: scripts/test-check-review-threads.sh (finding 45) and
+# tests/test_log_scan.rs (a_region_stripped_before_classification_is_validated_...), the
+# second of which is the one CI runs.
+set -uo pipefail
+
+for tool in awk; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "BLOCKED: '$tool' missing" >&2; exit 2; }
+done
+
+GATE=${1:-"$(dirname "$0")/check-review-threads.sh"}
+[ -r "$GATE" ] || { echo "BLOCKED: cannot read $GATE" >&2; exit 2; }
+
+awk -v gate="$GATE" '
+# Read the whole file, then pull out the single-quoted VERDICT_JQ program. A single-quoted
+# shell string cannot contain a quote, so the first one after the opener ends it.
+{ file = file $0 "\n" }
+function callat(s, i,   d, q, c, j) {
+  d = 0; q = 0
+  for (j = i; j <= length(s); j++) {
+    c = substr(s, j, 1)
+    if (q) { if (c == "\\") j++; else if (c == "\"") q = 0; continue }
+    if (c == "\"") { q = 1; continue }
+    if (c == "(") d++
+    else if (c == ")") { d--; if (d == 0) return substr(s, i, j - i + 1) }
+  }
+  return ""
+}
+function norm(t,   r) { r = t; gsub(/[ \t\n]+/, " ", r); gsub(/^ | $/, "", r); return r }
+END {
+  k = index(file, "VERDICT_JQ=\x27")
+  if (k == 0) { print "BLOCKED: no VERDICT_JQ assignment in " gate > "/dev/stderr"; exit 2 }
+  rest = substr(file, k + length("VERDICT_JQ=\x27"))
+  e = index(rest, "\x27")
+  if (e == 0) { print "BLOCKED: unterminated VERDICT_JQ in " gate > "/dev/stderr"; exit 2 }
+  jq = substr(rest, 1, e - 1)
+
+  # The accounting primitive: every discard inside it is the primitive doing its job.
+  ps = index(jq, "def strip_accounted(")
+  if (ps == 0) { print "BLOCKED: strip_accounted is gone; nothing accounts for a removal" > "/dev/stderr"; exit 2 }
+  tail = substr(jq, ps + 1)
+  pe = index(tail, "\ndef ")
+  pe = (pe == 0) ? length(jq) : ps + pe
+
+  # Normalizations. Each drops nothing a reader could read, and what survives is still
+  # shape-checked by the caller.
+  ok[norm("gsub(\"^[[:space:]]+|[[:space:]]+$\"; \"\")")] = "trim a line"
+  ok[norm("sub(\"^[[:space:]]+\"; \"\")")] = "trim the head of a body before a startswith test"
+  ok[norm("sub(\"^>[[:space:]]*\"; \"\")")] = "drop a blockquote marker; the rest is shape-checked"
+  ok[norm("select(length > 0 and . != cr_note)")] = "drop blank lines and the one exact note line"
+  ok[norm("select(length > 0)")] = "drop blank lines"
+  ok[norm("select(startswith(\"|\"))")] = "keep table rows (coverage side; every kept row is parsed)"
+  ok[norm("select((((.[0] // \"\") == \"Review\") and ((.[1] // \"\") == \"Status\")) | not)")] = "drop the table header row"
+  ok[norm("select(((length > 0) and all(.[]; test(\"^:?-{3,}:?$\"))) | not)")] = "drop the table separator row"
+  ok[norm("select([scan(cr_marker_re)] == [cr_summarize_marker])")] = "whole-comment guard: the summarize marker is the only marker"
+  ok[norm("select(test(\"(?m)^>[[:space:]]*##\") | not)")] = "whole-comment guard: no blockquoted notice heading"
+  ok[norm("select(test(\"No actionable comments were generated in the recent review\"))")] = "whole-block guard: the review finished clean"
+
+  bad = 0
+  split("gsub( sub( select(", kw, " ")
+  for (n = 1; n <= 3; n++) {
+    key = kw[n]
+    pos = 0
+    while (1) {
+      hit = index(substr(jq, pos + 1), key)
+      if (hit == 0) break
+      pos = pos + hit
+      if (key == "sub(" && pos > 1 && substr(jq, pos - 1, 1) == "g") continue
+      call = callat(jq, pos + length(key) - 1)
+      if (call == "") { print "BLOCKED: unbalanced parentheses at offset " pos > "/dev/stderr"; exit 2 }
+      text = norm(substr(jq, pos, length(key) - 1) call)
+      inside = (pos >= ps && pos <= pe)
+      total++
+      if (inside) { printf "  primitive     %s\n", text }
+      else if (text in ok) { printf "  %-13s %s\n", "normalization", text }
+      else { printf "  UNACCOUNTED   %s\n", text; bad++ }
+    }
+  }
+  printf "%d discarding call(s) in VERDICT_JQ, %d unaccounted\n", total, bad
+  if (bad > 0) {
+    print "" > "/dev/stderr"
+    print "A call that discards part of a body must remove a region declared in" > "/dev/stderr"
+    print "accounted_regions (through strip_accounted, which checks the region content" > "/dev/stderr"
+    print "against that region\x27s line shapes) or be one of the normalizations listed in" > "/dev/stderr"
+    print "this script. An undeclared removal is a region nobody read, which is how a" > "/dev/stderr"
+    print "finding becomes exempt from dispositions." > "/dev/stderr"
+    exit 1
+  }
+  exit 0
+}
+' "$GATE"

--- a/scripts/test-check-review-threads.sh
+++ b/scripts/test-check-review-threads.sh
@@ -1320,7 +1320,7 @@ CR_CHAT=$(jq -n '"<!-- This is an auto-generated reply by CodeRabbit -->\n### Ra
 CR_TIPS=$'<!-- tips_start -->\n\n---\n\nThanks for using [CodeRabbit](https://coderabbit.ai?utm_source=oss&utm_medium=github&utm_campaign=ejc3/fcvm&utm_content=874)! It\'s free for OSS, and your support helps us grow. If you like it, consider giving us a shout-out.\n\n<details>\n<summary>❤️ Share</summary>\n\n- [X](https://twitter.com/intent/tweet?text=I%20just%20used%20%40coderabbitai%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21&url=https%3A//coderabbit.ai)\n\n</details>\n\n\n<sub>Comment `@coderabbitai help` to get the list of available commands.</sub>\n\n<!-- tips_end -->'
 # CodeRabbit's summary comment before any review has run: the summarize marker, one notice
 # of kind $1 holding the blockquote $2, the tips block, and $3 (default nothing) after it.
-cr_summary_notice() { jq -n --arg k "$1" --arg n "$2" --arg x "${3:-}" --arg tips "$CR_TIPS" '"<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n<!-- This is an auto-generated comment: \($k) by coderabbit.ai -->\n\n\($n)\n\n<!-- end of auto-generated comment: \($k) by coderabbit.ai -->\n\n\($tips)" + (if $x == "" then "" else "\n\n" + $x end)'; }
+cr_summary_notice() { jq -n --arg k "$1" --arg n "$2" --arg x "${3:-}" --arg tips "${4:-$CR_TIPS}" '"<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n<!-- This is an auto-generated comment: \($k) by coderabbit.ai -->\n\n\($n)\n\n<!-- end of auto-generated comment: \($k) by coderabbit.ai -->\n\n\($tips)" + (if $x == "" then "" else "\n\n" + $x end)'; }
 # The #874 notice quotes the range a review WOULD have covered, ending at the head.
 LIMIT_NOTICE=$'> [!WARNING]\n> ## Review limit reached\n> \n> **Next included review available in 53 minutes.**\n> \n> <details>\n> <summary>View limit details</summary>\n> \n> **Limit details:** You’ve used the included review currently available.\n> \n> [Learn how review limits work](https://docs.coderabbit.ai/management/plans#rate-limits).\n> \n> **Review configuration:**\n> \n> <details>\n> <summary>📥 Commits</summary>\n> \n> Reviewing files that changed from the base of the PR and between '"$BASE40"$' and '"$HEAD40"$'.\n> \n> </details>\n> \n> </details>'
 SKIP_NOTICE=$'> [!IMPORTANT]\n> ## Review skipped\n> \n> Auto reviews are disabled on base/target branches other than the default branch.\n> \n> Please check the settings in the CodeRabbit UI or the `.coderabbit.yaml` file in this repository. To trigger a single review, invoke the `@coderabbitai review` command.\n> \n> <details>\n> <summary>⚙️ Run configuration</summary>\n> \n> **Configuration used**: defaults\n> \n> **Run ID**: `29692184-5f4e-43c5-8f4f-ccb92b0cf21e`\n> \n> </details>\n> \n> Use the checkbox below for a quick retry:\n> - [ ] <!-- {"checkboxId": "e9bb8d72-00e8-4f67-9cb2-caf3b22574fe"} --> 🔍 Trigger review'
@@ -1459,6 +1459,92 @@ run_case "a summary notice of a kind this gate does not list is claimable" \
   "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice failure $'> [!CAUTION]\n> ## Review failed\n> \n> The pull request is closed.')" 2026-01-02T01:00:00Z)")" 1 "carry no disposition"
 run_case "a summary notice beside a walkthrough is a walkthrough, still claimable" \
   "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_walk "$NOTICE_LIMITED" clean "$BASE40" "$HEAD40")" 2026-01-02T01:00:00Z)")" 1 "carry no disposition"
+
+
+echo "== finding 45: a region removed before classification is a region nobody read =="
+# Round 1 of this class (finding 44) was the notice payload: every line starting with ">"
+# was accepted, so "> P1: this drops the last row" rode inside a notice and needed no
+# disposition. The payload is now parsed against shapes. That fixed one SITE, not the
+# class: three more regions were REMOVED from the body before the shapes ever ran, and
+# content removed before classification is content the classifier did not read.
+#
+#   region                                    removed by                    rendered
+#   <!-- tips_start --> .. <!-- tips_end -->  is_cr_summary_notice residue  yes
+#   <details> <summary>ℹ️ About Codex ..      verdict_lines, summary_lines  yes
+#   <!-- .. -->                               verdict_lines, summary_lines,
+#                                             is_cr_summary_notice residue  no
+#
+# Both rendered regions were live holes, verified red before the fix: a finding inside the
+# tips block made a CodeRabbit summary notice exempt from dispositions, and a finding
+# inside the About Codex block made a Codex verdict exempt AND still bound coverage to the
+# head. The invariant now: a body is exempt only if the classifier accounted for every
+# byte of it, so each removal names a declared region whose content must match that
+# region's line shapes, and a region holding anything else makes the whole body claimable.
+# HTML comments are declared unrendered: GitHub shows none of it, so nothing inside one is
+# a claim anybody can read or answer. Shapes were read off the 13 About blocks and 17 tips
+# blocks the two bots posted on ejc3/fcvm #789 through #901.
+CR_TIPS_FINDING=${CR_TIPS/'<sub>Comment'/'P1: this drops the last row'$'\n\n''<sub>Comment'}
+[ "$CR_TIPS_FINDING" != "$CR_TIPS" ] || { echo "  FAIL  tips fixture edit did not apply"; fail=$((fail+1)); }
+CR_TIPS_UNLISTED=${CR_TIPS/'<sub>Comment'/'<sub>A tips line this gate has never seen.</sub>'$'\n\n''<sub>Comment'}
+[ "$CR_TIPS_UNLISTED" != "$CR_TIPS" ] || { echo "  FAIL  tips fixture edit did not apply"; fail=$((fail+1)); }
+run_case "a summary notice with a finding in its tips block is claimable" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'rate limited' "$LIMIT_NOTICE" '' "$CR_TIPS_FINDING")" 2026-01-02T01:00:00Z)")" 1 "carry no disposition"
+run_case "a summary notice whose tips block holds an unlisted line is claimable" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'rate limited' "$LIMIT_NOTICE" '' "$CR_TIPS_UNLISTED")" 2026-01-02T01:00:00Z)")" 1 "carry no disposition"
+# A finding APPENDED to a line that is itself a listed shape. This is what the anchors in
+# each shape list are for: without them the shape matches the head of the line and the rest
+# rides along, which is round 1 of this class with a different marker.
+CR_TIPS_TRAILING=${CR_TIPS/'available commands.</sub>'/'available commands.</sub> P1: this drops the last row'}
+[ "$CR_TIPS_TRAILING" != "$CR_TIPS" ] || { echo "  FAIL  tips fixture edit did not apply"; fail=$((fail+1)); }
+run_case "a summary notice whose tips line carries a finding after it is claimable" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'rate limited' "$LIMIT_NOTICE" '' "$CR_TIPS_TRAILING")" 2026-01-02T01:00:00Z)")" 1 "carry no disposition"
+run_case "a summary notice with a finding in its tips block covers no head" \
+  "$(wrap7 "[$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'rate limited' "$LIMIT_NOTICE" '' "$CR_TIPS_FINDING")" 2026-01-02T01:00:00Z)]")" 1 "UNREVIEWED HEAD"
+# The About Codex block, in both comments Codex folds one into: the legacy verdict, which
+# names the commit it covers, and the review-summary table, whose rows do.
+CODEX_VERDICT=$(codex_body ' Bravo.' deadbeef)
+CODEX_VERDICT_FINDING=${CODEX_VERDICT/'If Codex has suggestions'/'P1: this drops the last row\n\nIf Codex has suggestions'}
+[ "$CODEX_VERDICT_FINDING" != "$CODEX_VERDICT" ] || { echo "  FAIL  About-block fixture edit did not apply"; fail=$((fail+1)); }
+CODEX_SUM=$(codex_summary "$(sum_row Completed 2026-01-02T01:00:00.123456Z deadbee)")
+CODEX_SUM_FINDING=${CODEX_SUM/'Codex reacts with'/'P1: this drops the last row\n\nCodex reacts with'}
+[ "$CODEX_SUM_FINDING" != "$CODEX_SUM" ] || { echo "  FAIL  About-block fixture edit did not apply"; fail=$((fail+1)); }
+CODEX_VERDICT_TRAILING=${CODEX_VERDICT/'- Mark a draft as ready'/'- Mark a draft as ready. P1: this drops the last row'}
+[ "$CODEX_VERDICT_TRAILING" != "$CODEX_VERDICT" ] || { echo "  FAIL  About-block fixture edit did not apply"; fail=$((fail+1)); }
+run_case "a codex verdict whose About line carries a finding after it is claimable" \
+  "$(wrap9 "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$CODEX_VERDICT_TRAILING")")" 1 "carry no disposition"
+run_case "a codex verdict with a finding in its About block is claimable" \
+  "$(wrap9 "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$CODEX_VERDICT_FINDING")")" 1 "carry no disposition"
+run_case "a codex verdict with a finding in its About block covers no head" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$CODEX_VERDICT_FINDING")")" 1 "UNREVIEWED HEAD"
+run_case "a codex review summary with a finding in its About block is claimable" \
+  "$(wrap9 "$(cmt "$CODEX" Bot 2026-01-02T00:20:00Z "$CODEX_SUM_FINDING" 2026-01-02T01:00:05Z)")" 1 "carry no disposition"
+run_case "a codex review summary with a finding in its About block covers no head" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T00:20:00Z "$CODEX_SUM_FINDING" 2026-01-02T01:00:05Z)")" 1 "UNREVIEWED HEAD"
+# The negative cases the exemption exists for, green before and after: the same bodies with
+# the regions as the bots actually post them stay exempt, and the verdict still covers.
+run_case "the same summary notice with the real tips block still needs no disposition" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'rate limited' "$LIMIT_NOTICE")" 2026-01-02T01:00:00Z)")" 0 "CLEAR"
+run_case "the same summary notice with the real tips block still covers no head" \
+  "$(wrap7 "[$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'rate limited' "$LIMIT_NOTICE")" 2026-01-02T01:00:00Z)]")" 1 "UNREVIEWED HEAD"
+run_case "the same codex verdict with the real About block still covers the head" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$CODEX_VERDICT")")" 0 "HEAD COVERED"
+run_case "the same codex review summary with the real About block still covers the head" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T00:20:00Z "$CODEX_SUM" 2026-01-02T01:00:05Z)")" 0 "HEAD COVERED"
+run_case "a codex quota notice is still exempt and still covers no head" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$CODEX_LIMIT2")")" 1 "UNREVIEWED HEAD"
+run_case "a coderabbit rate-limit reply is still exempt and still covers no head" \
+  "$(wrap8 "$SUITE" "$(cmt coderabbitai Bot 2026-01-02T01:00:00Z "$CR_LIMITED")")" 1 "UNREVIEWED HEAD"
+# Structural pin. Fixing sites one at a time is what produced rounds 1, 2 and 3, so the
+# NEXT removal must fail a test unless it declares a region. gate-discard-sites.sh reads
+# VERDICT_JQ, enumerates every call that discards content, and blocks on any that is
+# neither the accounting primitive nor one of the listed normalizations. It enumerates
+# rather than naming, so a step added under any name is caught.
+if out=$(bash "$(dirname "$GATE")/gate-discard-sites.sh" 2>&1); then
+  echo "  PASS  every discard in VERDICT_JQ is a declared region or a listed normalization"; pass=$((pass+1))
+else
+  echo "  FAIL  every discard in VERDICT_JQ is a declared region or a listed normalization"
+  sed 's/^/          /' <<<"$out" | head -8; fail=$((fail+1))
+fi
 
 
 echo

--- a/scripts/test-check-review-threads.sh
+++ b/scripts/test-check-review-threads.sh
@@ -1372,6 +1372,89 @@ run_case "a summary notice with text after the tips is claimable" \
   "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'rate limited' "$LIMIT_NOTICE" 'P1: this drops the last row')" 2026-01-02T01:00:00Z)")" 1 "carry no disposition"
 run_case "a summary notice with an unquoted line inside it is claimable" \
   "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'rate limited' "$LIMIT_NOTICE"$'\n\nP1: this drops the last row')" 2026-01-02T01:00:00Z)")" 1 "carry no disposition"
+# The payload between a notice's markers is parsed, not skimmed for a leading ">". This
+# body is CodeRabbit's current rate-limit copy in full (aws #17): the prose paragraphs, the
+# nested Review details block, the run configuration and the file list. Every line of it is
+# a shape the gate lists, so it is still a notice.
+LIMIT_NOTICE_ADAPTIVE=$(cat <<'CRNOTICE'
+> [!WARNING]
+> ## Review limit reached
+> 
+> `@ejc3`, you've reached your PR review limit, so we couldn't start this review.
+> 
+> **Next review available in:** **54 minutes**
+> 
+> You've used all free OSS reviews for now. Wait for the free limit to reset to keep reviewing this public repository.
+> 
+> <details>
+> <summary>How can I continue?</summary>
+> 
+> After more reviews become available, a review can be triggered using the `@coderabbitai review` command as a PR comment. Alternatively, push new commits to this PR.
+> 
+> To avoid repeated limits, reduce automatic review volume by pausing incremental auto-reviews earlier, using label-based review opt-in, excluding WIP or generated PR titles, or requesting reviews manually when the PR is ready. If your team needs uninterrupted high-volume reviews, an organization admin can enable usage-based reviews.
+> 
+> </details>
+> 
+> 
+> <details>
+> <summary>How do review limits work?</summary>
+> 
+> CodeRabbit enforces per-developer PR review limits for each organization. Most developers receive the normal plan review availability.
+> 
+> For paid Pro and Pro+ PR reviews, CodeRabbit uses adaptive limits for sustained high-volume activity. When a developer's recent PR review activity reaches the 95th percentile or higher among CodeRabbit users, additional reviews become available more gradually as earlier reviews age out of the rolling window.
+> 
+> Please refer [docs](https://docs.coderabbit.ai/management/plans#rate-limits) for additional details.
+> 
+> </details>
+> 
+> <details>
+> <summary>Review details</summary>
+> 
+> <details>
+> <summary>⚙️ Run configuration</summary>
+> 
+> **Configuration used**: defaults
+> 
+> **Review profile**: CHILL
+> 
+> **Plan**: Pro Plus
+> 
+> **Run ID**: `d307059f-0ec1-452c-b65f-d1401be25dd9`
+> 
+> </details>
+> 
+> <details>
+> <summary>📥 Commits</summary>
+> 
+> Reviewing files that changed from the base of the PR and between b7de97dc7f93551685f6933646dc75dac7cff83b and 2f6be9ef3599cff99406a5fe176bdbdfae6863b0.
+> 
+> </details>
+> 
+> <details>
+> <summary>📒 Files selected for processing (5)</summary>
+> 
+> * `.github/workflows/drift.yml`
+> * `.terraform.lock.hcl`
+> * `README.md`
+> * `cloudflare.tf`
+> * `main.tf`
+> 
+> </details>
+> 
+> </details>
+CRNOTICE
+)
+run_case "today's rate-limit copy, prose and file list and all, needs no disposition (aws #17)" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'rate limited' "$LIMIT_NOTICE_ADAPTIVE")" 2026-01-02T01:00:00Z)")" 0 "CLEAR"
+# A finding quoted INSIDE the notice is the same hole as one appended after the tips: the
+# body is exempted from dispositions and the claim is never answered. Both positions, and
+# both notice kinds, must stay claimable.
+run_case "a summary notice with a quoted finding appended is claimable" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'rate limited' "$LIMIT_NOTICE"$'\n> \n> P1: this drops the last row')" 2026-01-02T01:00:00Z)")" 1 "carry no disposition"
+run_case "a summary notice with a quoted finding inside its details block is claimable" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'rate limited' "${LIMIT_NOTICE_ADAPTIVE/'> <summary>How can I continue?</summary>'/'> <summary>How can I continue?</summary>'$'\n> \n> P1: this drops the last row'}")" 2026-01-02T01:00:00Z)")" 1 "carry no disposition"
+run_case "a skipped notice with a quoted finding is claimable" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'skip review' "$SKIP_NOTICE"$'\n> \n> P1: this drops the last row')" 2026-01-02T01:00:00Z)")" 1 "carry no disposition"
 run_case "a summary notice of a kind this gate does not list is claimable" \
   "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice failure $'> [!CAUTION]\n> ## Review failed\n> \n> The pull request is closed.')" 2026-01-02T01:00:00Z)")" 1 "carry no disposition"
 run_case "a summary notice beside a walkthrough is a walkthrough, still claimable" \

--- a/scripts/test-check-review-threads.sh
+++ b/scripts/test-check-review-threads.sh
@@ -1283,6 +1283,101 @@ COMMENTS_PAGE_SIZE=2 GATE_TEST_THREADS=pagednocursor GATE_TEST_COMMENTS=nocommen
 # above ends that way, so a rule written as "endCursor must be a string" would fail here.
 page_case "a last page with hasNextPage false and a null cursor still reaches a verdict" 1 "carry no disposition"
 
+echo "== finding 44: a bot saying its review did not run is not a finding =="
+# Each listed reviewer posts a notice when it cannot review. Codex out of quota posts a
+# plain top-level comment, "You have reached your Codex usage limits for code reviews",
+# either that one line or the line plus an "add credits" line. CodeRabbit answers a trigger
+# it cannot serve with "Review rate limited." (or "Already reviewed.", "No files to
+# review.", "Pull request is closed.") folded under "Action not completed", answers a chat
+# it cannot serve with "Rate Limit Exceeded", and before any review has run its summary
+# comment holds nothing but a "Review limit reached" or "Review skipped" notice. Both bots
+# are in VERDICT_BOTS, so none of that fell under the notification-bot exemption, and every
+# such comment was a PR-level claim needing a disposition dated after it. On 2026-09-02
+# #898 carried three Codex quota notices and the gate reported all three UNANSWERED (aws
+# #46 one more); the author cleared them with a NOT-A-DEFECT review answering text that
+# claimed nothing. That is the block-on-ordinary-traffic shape the withdrawn last-word rule
+# had. A notice is now matched as a whole body, line for line, against the shapes the bots
+# post here, and belongs to the bot that posts it. It needs no disposition and covers no
+# head. Bodies copied from #898, aws #46, #847, #844, #846, #893, #874 and #789.
+CODEX_LIMIT1=$(jq -n '"You have reached your Codex usage limits for code reviews. You can see your limits in the [Codex usage dashboard](https://chatgpt.com/codex/cloud/settings/usage)."')
+CODEX_LIMIT2=$(jq -n '"You have reached your Codex usage limits for code reviews. You can see your limits in the [Codex usage dashboard](https://chatgpt.com/codex/cloud/settings/usage).\nTo continue using code reviews, add credits to your account and enable them for code reviews in your [settings](https://chatgpt.com/codex/cloud/settings/code-review)."')
+# CodeRabbit's reply to a command it did not carry out, folding $1 under "Action not completed".
+cr_not_done() { jq -n --arg t "$1" '"<!-- This is an auto-generated reply by CodeRabbit -->\n<!-- CodeRabbit review command invocation: 03686aea-15d0-48ab-a4bd-bf524726db31 -->\n<details>\n<summary>⚠️ Action not completed</summary>\n\n\($t)\n\n</details>"'; }
+CR_INCREMENTAL_NOTE='> Note: CodeRabbit is an incremental review system and does not re-review already reviewed commits. This command is applicable only when automatic reviews are paused.'
+CR_LIMITED=$(cr_not_done "Review rate limited.
+
+$CR_INCREMENTAL_NOTE")
+CR_FAIR=$(cr_not_done "Review rate limited.
+
+---
+
+Your included review limit is currently reached under our [Fair Usage Limits Policy](https://docs.coderabbit.ai/management/plans#fair-usage-limits-policy). This review may still proceed through usage-based billing if eligible. Your next included review will be available in 7 minutes.")
+CR_ALREADY=$(cr_not_done "Already reviewed.
+
+$CR_INCREMENTAL_NOTE")
+CR_CHAT=$(jq -n '"<!-- This is an auto-generated reply by CodeRabbit -->\n### Rate Limit Exceeded\n\n`@ejc3` have exceeded the limit for the number of chat messages per hour. Please wait **3 minutes and 10 seconds** before sending another message."')
+# The tips block CodeRabbit appends to its summary comment, whatever else the comment holds.
+CR_TIPS=$'<!-- tips_start -->\n\n---\n\nThanks for using [CodeRabbit](https://coderabbit.ai?utm_source=oss&utm_medium=github&utm_campaign=ejc3/fcvm&utm_content=874)! It\'s free for OSS, and your support helps us grow. If you like it, consider giving us a shout-out.\n\n<details>\n<summary>❤️ Share</summary>\n\n- [X](https://twitter.com/intent/tweet?text=I%20just%20used%20%40coderabbitai%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21&url=https%3A//coderabbit.ai)\n\n</details>\n\n\n<sub>Comment `@coderabbitai help` to get the list of available commands.</sub>\n\n<!-- tips_end -->'
+# CodeRabbit's summary comment before any review has run: the summarize marker, one notice
+# of kind $1 holding the blockquote $2, the tips block, and $3 (default nothing) after it.
+cr_summary_notice() { jq -n --arg k "$1" --arg n "$2" --arg x "${3:-}" --arg tips "$CR_TIPS" '"<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n<!-- This is an auto-generated comment: \($k) by coderabbit.ai -->\n\n\($n)\n\n<!-- end of auto-generated comment: \($k) by coderabbit.ai -->\n\n\($tips)" + (if $x == "" then "" else "\n\n" + $x end)'; }
+# The #874 notice quotes the range a review WOULD have covered, ending at the head.
+LIMIT_NOTICE=$'> [!WARNING]\n> ## Review limit reached\n> \n> **Next included review available in 53 minutes.**\n> \n> <details>\n> <summary>View limit details</summary>\n> \n> **Limit details:** You’ve used the included review currently available.\n> \n> [Learn how review limits work](https://docs.coderabbit.ai/management/plans#rate-limits).\n> \n> **Review configuration:**\n> \n> <details>\n> <summary>📥 Commits</summary>\n> \n> Reviewing files that changed from the base of the PR and between '"$BASE40"$' and '"$HEAD40"$'.\n> \n> </details>\n> \n> </details>'
+SKIP_NOTICE=$'> [!IMPORTANT]\n> ## Review skipped\n> \n> Auto reviews are disabled on base/target branches other than the default branch.\n> \n> Please check the settings in the CodeRabbit UI or the `.coderabbit.yaml` file in this repository. To trigger a single review, invoke the `@coderabbitai review` command.\n> \n> <details>\n> <summary>⚙️ Run configuration</summary>\n> \n> **Configuration used**: defaults\n> \n> **Run ID**: `29692184-5f4e-43c5-8f4f-ccb92b0cf21e`\n> \n> </details>\n> \n> Use the checkbox below for a quick retry:\n> - [ ] <!-- {"checkboxId": "e9bb8d72-00e8-4f67-9cb2-caf3b22574fe"} --> 🔍 Trigger review'
+run_case "a codex usage-limit comment needs no disposition (#898)" \
+  "$(wrap9 "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$CODEX_LIMIT2")")" 0 "CLEAR"
+run_case "the one-line codex usage-limit comment needs no disposition (#898, 05:16Z)" \
+  "$(wrap9 "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$CODEX_LIMIT1")")" 0 "CLEAR"
+run_case "a coderabbit rate-limited reply needs no disposition (#847)" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-02T01:00:00Z "$CR_LIMITED")")" 0 "CLEAR"
+run_case "a rate-limited reply naming the fair-usage wait needs no disposition (#844)" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-02T01:00:00Z "$CR_FAIR")")" 0 "CLEAR"
+run_case "an already-reviewed reply needs no disposition (#846)" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-02T01:00:00Z "$CR_ALREADY")")" 0 "CLEAR"
+run_case "a chat rate-limit reply needs no disposition (#893)" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-02T01:00:00Z "$CR_CHAT")")" 0 "CLEAR"
+run_case "a summary comment holding only a rate-limit notice needs no disposition (#874)" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'rate limited' "$LIMIT_NOTICE")" 2026-01-02T01:00:00Z)")" 0 "CLEAR"
+run_case "a summary comment holding only a skipped notice needs no disposition (#789)" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'skip review' "$SKIP_NOTICE")" 2026-01-02T01:00:00Z)")" 0 "CLEAR"
+# The #898 shape: quota notices around a finding that was answered, on a covered head. The
+# last notice is dated after the disposition, so under the old rule nothing answered it.
+run_case "quota notices beside an answered finding on a covered head clear" \
+  "$(wrap9 "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$CODEX_LIMIT2"),$(cmt reviewer User 2026-01-02T01:10:00Z '"P1: this drops the last row"'),$(cmt coderabbitai Bot 2026-01-02T01:15:00Z "$CR_LIMITED"),$(cmt me User 2026-01-02T01:20:00Z '"RED-VERIFIED: tests/row.rs"'),$(cmt "$CODEX" Bot 2026-01-02T01:30:00Z "$CODEX_LIMIT1")")" \
+  0 "CLEAR"
+# Guards, green before and after. A notice covers no head: an unreviewed head under a quota
+# notice stays unreviewed, and the range a summary notice quotes binds nothing.
+run_case "a codex usage-limit comment covers no head" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$CODEX_LIMIT2")")" 1 "UNREVIEWED HEAD"
+run_case "a coderabbit rate-limited reply covers no head" \
+  "$(wrap8 "$SUITE" "$(cmt coderabbitai Bot 2026-01-02T01:00:00Z "$CR_LIMITED")")" 1 "UNREVIEWED HEAD"
+run_case "a summary notice quoting the head's range covers no head" \
+  "$(wrap7 "[$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'rate limited' "$LIMIT_NOTICE")" 2026-01-02T01:00:00Z)]")" 1 "UNREVIEWED HEAD"
+# The match is the whole body, and a notice belongs to the bot that posts it.
+run_case "the codex notice with a finding appended is claimable" \
+  "$(wrap9 "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(jq -n --argjson b "$CODEX_LIMIT2" '$b + "\n\nP1: this drops the last row"')")")" 1 "carry no disposition"
+run_case "a human posting the codex notice is claimable" \
+  "$(wrap9 "$(cmt helpful-human User 2026-01-02T01:00:00Z "$CODEX_LIMIT2")")" 1 "carry no disposition"
+run_case "coderabbit posting the codex notice is claimable" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-02T01:00:00Z "$CODEX_LIMIT2")")" 1 "carry no disposition"
+run_case "codex posting the coderabbit reply notice is claimable" \
+  "$(wrap9 "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$CR_LIMITED")")" 1 "carry no disposition"
+run_case "a finding folded under Action not completed is claimable" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-02T01:00:00Z "$(cr_not_done 'P1: this drops the last row')")")" 1 "carry no disposition"
+run_case "a rate-limited reply with a finding appended is claimable" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-02T01:00:00Z "$(cr_not_done "Review rate limited.
+
+P1: this drops the last row")")")" 1 "carry no disposition"
+run_case "a summary notice with text after the tips is claimable" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'rate limited' "$LIMIT_NOTICE" 'P1: this drops the last row')" 2026-01-02T01:00:00Z)")" 1 "carry no disposition"
+run_case "a summary notice with an unquoted line inside it is claimable" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'rate limited' "$LIMIT_NOTICE"$'\n\nP1: this drops the last row')" 2026-01-02T01:00:00Z)")" 1 "carry no disposition"
+run_case "a summary notice of a kind this gate does not list is claimable" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice failure $'> [!CAUTION]\n> ## Review failed\n> \n> The pull request is closed.')" 2026-01-02T01:00:00Z)")" 1 "carry no disposition"
+run_case "a summary notice beside a walkthrough is a walkthrough, still claimable" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_walk "$NOTICE_LIMITED" clean "$BASE40" "$HEAD40")" 2026-01-02T01:00:00Z)")" 1 "carry no disposition"
+
+
 echo
 echo "passed=$pass failed=$fail"
 [ "$fail" -eq 0 ]

--- a/tests/test_log_scan.rs
+++ b/tests/test_log_scan.rs
@@ -908,3 +908,152 @@ fn review_gate_orders_timestamps_as_instants_not_as_strings() {
     );
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// A bot saying that its review did NOT run is not a finding, and covers no head.
+///
+/// Codex out of quota posts "You have reached your Codex usage limits for code reviews" as
+/// a top-level comment, and CodeRabbit answers a trigger it cannot serve with "Review rate
+/// limited." folded under "Action not completed". Both bots are listed in VERDICT_BOTS, so
+/// neither comment fell under the notification-bot exemption, and each was a PR-level claim
+/// needing a disposition dated after it. On 2026-09-02 #898 carried three Codex quota
+/// notices and the gate reported all three UNANSWERED (aws #46 one more); the author
+/// cleared them with a NOT-A-DEFECT review answering text that claimed nothing. A gate that
+/// blocks on ordinary bot traffic gets switched off, which is why the last-word rule was
+/// withdrawn (AGENTS.md).
+///
+/// A notice is matched as a whole body, line for line, and belongs to the bot that posts
+/// it: the same words with a finding appended stay claimable, and a notice still covers no
+/// head. The shell harness (scripts/test-check-review-threads.sh, "finding 44") carries the
+/// full matrix, including CodeRabbit's summary comment holding only a notice; these three
+/// run in CI.
+#[test]
+fn a_bot_notice_that_no_review_ran_is_neither_a_finding_nor_coverage() {
+    require_jq();
+    // Bodies as the bots posted them: the two-line Codex notice (#898 at 05:20Z, aws #46),
+    // its one-line form (#898 at 05:16Z), and CodeRabbit's rate-limited reply (#847).
+    const CODEX_LIMIT: &str = r#""You have reached your Codex usage limits for code reviews. You can see your limits in the [Codex usage dashboard](https://chatgpt.com/codex/cloud/settings/usage).\nTo continue using code reviews, add credits to your account and enable them for code reviews in your [settings](https://chatgpt.com/codex/cloud/settings/code-review).""#;
+    const CODEX_LIMIT_SHORT: &str = r#""You have reached your Codex usage limits for code reviews. You can see your limits in the [Codex usage dashboard](https://chatgpt.com/codex/cloud/settings/usage).""#;
+    const CR_LIMITED: &str = r#""<!-- This is an auto-generated reply by CodeRabbit -->\n<!-- CodeRabbit review command invocation: 03686aea-15d0-48ab-a4bd-bf524726db31 -->\n<details>\n<summary>⚠️ Action not completed</summary>\n\nReview rate limited.\n\n> Note: CodeRabbit is an incremental review system and does not re-review already reviewed commits. This command is applicable only when automatic reviews are paused.\n\n</details>""#;
+    const COVERED: &str = r#"[{"author":{"login":"reviewer"},"state":"APPROVED","submittedAt":"2026-01-02T00:40:00Z","body":"","commit":{"oid":"deadbeef"}}]"#;
+    let comment = |login: &str, kind: &str, at: &str, body: &str| {
+        format!(
+            r#"{{"author":{{"login":"{login}","__typename":"{kind}"}},"createdAt":"{at}","updatedAt":"{at}","body":{body}}}"#
+        )
+    };
+    // The head, the check suite dating its arrival, the reviews on it, and the comments as
+    // both reads of them (the gate re-reads the comments after paging and compares).
+    let payload = |reviews: &str, comments: &str| {
+        format!(
+            r#"{{"data":{{"repository":{{"pullRequest":{{"author":{{"login":"me"}},"headRefOid":"deadbeef","commits":{{"nodes":[{{"commit":{{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{{"nodes":[{{"createdAt":"2026-01-02T00:30:00Z"}}]}}}}}}]}},"reviewThreads":{{"nodes":[]}},"reviews":{{"nodes":{reviews}}},"comments":{{"nodes":[{comments}]}},"recheck":{{"comments":{{"nodes":[{comments}]}}}}}}}}}}}}"#
+        )
+    };
+
+    let dir = std::env::temp_dir().join(format!("fcvm-gate-notice-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let run = |name: &str, body: String| {
+        let f = dir.join(name);
+        std::fs::write(&f, body).unwrap();
+        let out = Command::new("bash")
+            .arg(repo_root().join("scripts/check-review-threads.sh"))
+            .arg("--from-file")
+            .arg(&f)
+            .output()
+            .expect("check-review-threads.sh must be runnable");
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        (combined, out.status.code().unwrap_or(-1))
+    };
+
+    // The #898 shape: quota notices around a finding that was answered, on a covered head.
+    // The last notice postdates the disposition, so under the old rule nothing answered it.
+    let comments = [
+        comment(
+            "chatgpt-codex-connector",
+            "Bot",
+            "2026-01-02T01:00:00Z",
+            CODEX_LIMIT,
+        ),
+        comment(
+            "reviewer",
+            "User",
+            "2026-01-02T01:10:00Z",
+            r#""P1: this drops the last row""#,
+        ),
+        comment("coderabbitai", "Bot", "2026-01-02T01:15:00Z", CR_LIMITED),
+        comment(
+            "me",
+            "User",
+            "2026-01-02T01:20:00Z",
+            r#""RED-VERIFIED: tests/row.rs""#,
+        ),
+        comment(
+            "chatgpt-codex-connector",
+            "Bot",
+            "2026-01-02T01:30:00Z",
+            CODEX_LIMIT_SHORT,
+        ),
+    ]
+    .join(",");
+    let (out, code) = run("notices-answered.json", payload(COVERED, &comments));
+    assert_eq!(
+        code, 0,
+        "a bot's notice that its review did not run claims nothing, so a PR whose one \
+         finding is answered and whose head is covered is CLEAR. Demanding a disposition \
+         for a quota notice is the gate blocking on ordinary bot traffic.\n{out}"
+    );
+    assert!(out.contains("CLEAR"), "{out}");
+
+    // A notice covers no head: the same quota notice on a PR nobody reviewed leaves the
+    // head unreviewed, and the gate must say so rather than read the notice as a result.
+    let (out, code) = run(
+        "notice-unreviewed.json",
+        payload(
+            "[]",
+            &comment(
+                "chatgpt-codex-connector",
+                "Bot",
+                "2026-01-02T01:00:00Z",
+                CODEX_LIMIT,
+            ),
+        ),
+    );
+    assert_eq!(
+        code, 1,
+        "a quota notice is not a review of the head; a PR with no other review result \
+         must block as an unreviewed head.\n{out}"
+    );
+    assert!(out.contains("UNREVIEWED HEAD"), "{out}");
+    assert!(
+        !out.contains("HEAD COVERED"),
+        "a quota notice was read as a no-findings verdict.\n{out}"
+    );
+
+    // The match is the whole body: the notice with a finding appended is a finding.
+    let with_finding = format!(
+        "{}{}",
+        CODEX_LIMIT.trim_end_matches('"'),
+        r#"\n\nP1: this drops the last row""#
+    );
+    let (out, code) = run(
+        "notice-plus-finding.json",
+        payload(
+            COVERED,
+            &comment(
+                "chatgpt-codex-connector",
+                "Bot",
+                "2026-01-02T01:00:00Z",
+                &with_finding,
+            ),
+        ),
+    );
+    assert_eq!(
+        code, 1,
+        "the quota notice followed by a finding is a finding; only the exact notice body \
+         is exempt.\n{out}"
+    );
+    assert!(out.contains("carry no disposition"), "{out}");
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/tests/test_log_scan.rs
+++ b/tests/test_log_scan.rs
@@ -923,9 +923,11 @@ fn review_gate_orders_timestamps_as_instants_not_as_strings() {
 ///
 /// A notice is matched as a whole body, line for line, and belongs to the bot that posts
 /// it: the same words with a finding appended stay claimable, and a notice still covers no
-/// head. The shell harness (scripts/test-check-review-threads.sh, "finding 44") carries the
-/// full matrix, including CodeRabbit's summary comment holding only a notice; these three
-/// run in CI.
+/// head. CodeRabbit's summary comment carries its notice as a blockquote, so the payload
+/// between the notice markers is parsed against the line shapes CodeRabbit posts; a quoted
+/// line that is not one of them (`> P1: this drops the last row`) makes the comment
+/// claimable again. The shell harness (scripts/test-check-review-threads.sh, "finding 44")
+/// carries the full matrix; these four run in CI.
 #[test]
 fn a_bot_notice_that_no_review_ran_is_neither_a_finding_nor_coverage() {
     require_jq();
@@ -1053,6 +1055,50 @@ fn a_bot_notice_that_no_review_ran_is_neither_a_finding_nor_coverage() {
         code, 1,
         "the quota notice followed by a finding is a finding; only the exact notice body \
          is exempt.\n{out}"
+    );
+    assert!(out.contains("carry no disposition"), "{out}");
+
+    // CodeRabbit's summary comment before any review has run holds the notice as a
+    // blockquote (#874). Accepting every line that merely starts with ">" exempted the
+    // whole comment from dispositions, so a finding quoted among the notice's own lines
+    // was never answered. The payload is parsed instead.
+    const CR_SUMMARY_NOTICE: &str = r#""<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n\n> [!WARNING]\n> ## Review limit reached\n> \n> **Next included review available in 53 minutes.**\n> \n> <details>\n> <summary>View limit details</summary>\n> \n> **Limit details:** You\u2019ve used the included review currently available.\n> \n> </details>\n\n<!-- end of auto-generated comment: rate limited by coderabbit.ai -->""#;
+    let (out, code) = run(
+        "summary-notice.json",
+        payload(
+            COVERED,
+            &comment(
+                "coderabbitai",
+                "Bot",
+                "2026-01-02T01:00:00Z",
+                CR_SUMMARY_NOTICE,
+            ),
+        ),
+    );
+    assert_eq!(
+        code, 0,
+        "a summary comment holding nothing but a rate-limit notice says no review ran; \
+         it claims nothing and needs no disposition.\n{out}"
+    );
+    assert!(out.contains("CLEAR"), "{out}");
+
+    let smuggled = CR_SUMMARY_NOTICE.replace(
+        r"> </details>\n\n<!-- end of",
+        r"> </details>\n> \n> P1: this drops the last row\n\n<!-- end of",
+    );
+    assert_ne!(smuggled, CR_SUMMARY_NOTICE, "the fixture edit must apply");
+    let (out, code) = run(
+        "summary-notice-plus-finding.json",
+        payload(
+            COVERED,
+            &comment("coderabbitai", "Bot", "2026-01-02T01:00:00Z", &smuggled),
+        ),
+    );
+    assert_eq!(
+        code, 1,
+        "a finding quoted inside the notice is still a finding; exempting every line that \
+         starts with a quote marker removes it from the disposition check and reports \
+         CLEAR.\n{out}"
     );
     assert!(out.contains("carry no disposition"), "{out}");
     let _ = std::fs::remove_dir_all(&dir);

--- a/tests/test_log_scan.rs
+++ b/tests/test_log_scan.rs
@@ -1103,3 +1103,163 @@ fn a_bot_notice_that_no_review_ran_is_neither_a_finding_nor_coverage() {
     assert!(out.contains("carry no disposition"), "{out}");
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// A region removed before classification is a region the classifier never read.
+///
+/// Finding 44 parsed the notice PAYLOAD against shapes, because accepting every line that
+/// starts with ">" let `> P1: this drops the last row` ride inside a notice and need no
+/// disposition. That closed one site. Three more regions were removed from the body before
+/// any shape ran: the CodeRabbit tips block (stripped from the summary-notice residue), the
+/// folded "About Codex in GitHub" block (stripped by both Codex paths), and HTML comments.
+/// A finding placed in either of the first two vanished the same way, and the About-block
+/// one was worse than an exemption: the comment stayed a Codex verdict, so it still bound
+/// no-findings coverage to the head.
+///
+/// The invariant is that a body is exempt only when the classifier accounted for every byte
+/// of it. Each removal now names a declared region whose content must match that region's
+/// line shapes; a region holding anything else makes the whole body claimable. HTML
+/// comments are declared unrendered, so nothing inside one is a claim anyone can read.
+/// scripts/gate-discard-sites.sh enumerates every discarding call in VERDICT_JQ and blocks
+/// on one that is neither the accounting primitive nor a listed normalization, so the next
+/// stripping step fails a test unless it declares a region.
+///
+/// The shell harness (scripts/test-check-review-threads.sh, "finding 45") carries the full
+/// matrix, including the review-summary table and the unlisted-tips-line case; these run in
+/// CI.
+#[test]
+fn a_region_stripped_before_classification_is_validated_or_the_body_stays_claimable() {
+    require_jq();
+    // The tips block as CodeRabbit posts it, under a rate-limit notice (#874, #901).
+    const CR_SUMMARY_NOTICE: &str = r#""<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n\n> [!WARNING]\n> ## Review limit reached\n> \n> **Next included review available in 53 minutes.**\n\n<!-- end of auto-generated comment: rate limited by coderabbit.ai -->\n\n<!-- tips_start -->\n\n---\n\nThanks for using [CodeRabbit](https://coderabbit.ai?utm_source=oss&utm_medium=github&utm_campaign=ejc3/fcvm&utm_content=901)! It's free for OSS, and your support helps us grow. If you like it, consider giving us a shout-out.\n\n<sub>Comment `@coderabbitai help` to get the list of available commands.</sub>\n\n<!-- tips_end -->""#;
+    // Codex's legacy no-findings verdict with its folded About block (#867 and earlier).
+    const CODEX_VERDICT: &str = r#""Codex Review: Didn't find any major issues. Bravo.\n\n**Reviewed commit:** `deadbeef`\n\n<details> <summary>ℹ️ About Codex in GitHub</summary>\n<br/>\n\n[Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you\n- Open a pull request for review\n- Mark a draft as ready\n- Comment \"@codex review\".\n\nIf Codex has suggestions, it will comment; otherwise it will react with 👍.\n\n</details>""#;
+    const COVERED: &str = r#"[{"author":{"login":"reviewer"},"state":"APPROVED","submittedAt":"2026-01-02T00:40:00Z","body":"","commit":{"oid":"deadbeef"}}]"#;
+    let comment = |login: &str, body: &str| {
+        format!(
+            r#"{{"author":{{"login":"{login}","__typename":"Bot"}},"createdAt":"2026-01-02T01:00:00Z","updatedAt":"2026-01-02T01:00:00Z","body":{body}}}"#
+        )
+    };
+    let payload = |reviews: &str, comments: &str| {
+        format!(
+            r#"{{"data":{{"repository":{{"pullRequest":{{"author":{{"login":"me"}},"headRefOid":"deadbeef","commits":{{"nodes":[{{"commit":{{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{{"nodes":[{{"createdAt":"2026-01-02T00:30:00Z"}}]}}}}}}]}},"reviewThreads":{{"nodes":[]}},"reviews":{{"nodes":{reviews}}},"comments":{{"nodes":[{comments}]}},"recheck":{{"comments":{{"nodes":[{comments}]}}}}}}}}}}}}"#
+        )
+    };
+    let dir = std::env::temp_dir().join(format!("fcvm-gate-region-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let run = |name: &str, body: String| {
+        let f = dir.join(name);
+        std::fs::write(&f, body).unwrap();
+        let out = Command::new("bash")
+            .arg(repo_root().join("scripts/check-review-threads.sh"))
+            .arg("--from-file")
+            .arg(&f)
+            .output()
+            .expect("check-review-threads.sh must be runnable");
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        (combined, out.status.code().unwrap_or(-1))
+    };
+
+    // A finding inside the tips block. The residue check ran after the block was removed,
+    // so the whole comment passed as a notice and the claim was never answered.
+    let tips_finding = CR_SUMMARY_NOTICE.replace(
+        r"\n<sub>Comment",
+        r"\nP1: this drops the last row\n\n<sub>Comment",
+    );
+    assert_ne!(
+        tips_finding, CR_SUMMARY_NOTICE,
+        "the fixture edit must apply"
+    );
+    let (out, code) = run(
+        "tips-finding.json",
+        payload(COVERED, &comment("coderabbitai", &tips_finding)),
+    );
+    assert_eq!(
+        code, 1,
+        "a finding inside the tips block is a finding: the block is removed before the \
+         notice shapes run, so nothing evaluated it.\n{out}"
+    );
+    assert!(out.contains("carry no disposition"), "{out}");
+
+    // A finding APPENDED to a line that is itself a listed shape. This is what the anchors
+    // in each shape list are for: unanchored, the shape matches the head of the line and
+    // the rest of it rides along, which is round 1 of this class with a different marker.
+    let tips_trailing = CR_SUMMARY_NOTICE.replace(
+        r"available commands.</sub>",
+        r"available commands.</sub> P1: this drops the last row",
+    );
+    assert_ne!(
+        tips_trailing, CR_SUMMARY_NOTICE,
+        "the fixture edit must apply"
+    );
+    let (out, code) = run(
+        "tips-trailing.json",
+        payload(COVERED, &comment("coderabbitai", &tips_trailing)),
+    );
+    assert_eq!(
+        code, 1,
+        "a shape must match the WHOLE line: a finding appended to a listed tips line is \
+         still a finding.\n{out}"
+    );
+    assert!(out.contains("carry no disposition"), "{out}");
+
+    // A finding inside the About Codex block. This one also bound coverage to the head.
+    let about_finding = CODEX_VERDICT.replace(
+        r"\nIf Codex has suggestions",
+        r"\nP1: this drops the last row\n\nIf Codex has suggestions",
+    );
+    assert_ne!(about_finding, CODEX_VERDICT, "the fixture edit must apply");
+    let (out, code) = run(
+        "about-finding.json",
+        payload("[]", &comment("chatgpt-codex-connector", &about_finding)),
+    );
+    assert_eq!(
+        code, 1,
+        "a finding inside the About Codex block is a finding, and a comment carrying one \
+         is not a no-findings verdict of the head.\n{out}"
+    );
+    assert!(
+        !out.contains("HEAD COVERED"),
+        "coverage was granted by a comment whose About block was never read.\n{out}"
+    );
+
+    // The negative cases the exemption exists for: the same bodies with the regions as the
+    // bots post them stay exempt, and the verdict still covers the head.
+    let (out, code) = run(
+        "tips-clean.json",
+        payload(COVERED, &comment("coderabbitai", CR_SUMMARY_NOTICE)),
+    );
+    assert_eq!(
+        code, 0,
+        "a rate-limit notice with the tips block CodeRabbit actually posts says no review \
+         ran; it claims nothing and needs no disposition.\n{out}"
+    );
+    assert!(out.contains("CLEAR"), "{out}");
+    let (out, code) = run(
+        "about-clean.json",
+        payload("[]", &comment("chatgpt-codex-connector", CODEX_VERDICT)),
+    );
+    assert_eq!(
+        code, 0,
+        "Codex's no-findings verdict with the About block it actually posts still covers \
+         the head.\n{out}"
+    );
+    assert!(out.contains("HEAD COVERED"), "{out}");
+
+    // The structural pin: a stripping step added later must declare a region.
+    let out = Command::new("bash")
+        .arg(repo_root().join("scripts/gate-discard-sites.sh"))
+        .output()
+        .expect("gate-discard-sites.sh must be runnable");
+    assert!(
+        out.status.success(),
+        "every call in VERDICT_JQ that discards content must be the accounting primitive \
+         or a listed normalization.\n{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
Two commits.

1. `check-review-threads: a bot's notice that it did not review is not a finding`: the gate fix, finding 44 in the shell harness, and one CI-run test in `tests/test_log_scan.rs`.
2. `AGENTS.md: a reviewer saying it did not run is not a claim`: one bullet in the gate section.

## The defect

The gate counts every non-empty top-level comment from anyone but the PR author as a finding, exempting only the listed notification bots and the documented trigger commands. Codex and CodeRabbit are listed reviewers, so the notices they post when they cannot review were claims needing a disposition dated after them:

- Codex out of quota: `You have reached your Codex usage limits for code reviews...` as a plain top-level comment.
- CodeRabbit declining a trigger: `Review rate limited.` (also `Already reviewed.`, `No files to review.`, `Pull request is closed.`) folded under `⚠️ Action not completed`; its chat reply `### Rate Limit Exceeded`; and its summary comment while it holds nothing but a `Review limit reached` or `Review skipped` notice.

On 2026-09-02 #898 carried three Codex quota notices reported UNANSWERED (aws #46 one more), and the author posted a `NOT-A-DEFECT:` review to answer text that claimed nothing. That is the block-on-ordinary-traffic failure the withdrawn last-word rule had.

## The rule now

`VERDICT_JQ` gains `is_codex_limit_notice` and `is_cr_notice`. A notice is matched as the whole body, line for line, against the shapes the bots have posted in this repo and ejc3/aws, and it belongs to the bot that posts it (`CODERABBIT_LOGIN` joins `CODEX_LOGIN`). A notice is not claimable and its `reviewed_rows` are empty, so it grants no head coverage. The same words with anything added, or from any other account, stay claimable. A summary comment holding a walkthrough or a recent-review block is still judged as a walkthrough.

Exact shapes accepted, with where each was observed (all bodies in the sweep of both repos' comments since 2026-08-10):

| bot | body, after dropping HTML comments and blank lines | seen |
|---|---|---|
| Codex | `You have reached your Codex usage limits for code reviews. You can see your limits in the [Codex usage dashboard](https://chatgpt.com/codex/cloud/settings/usage).` | #898 05:16Z, #842 (18 times) |
| Codex | the line above, then `To continue using code reviews, add credits to your account and enable them for code reviews in your [settings](https://chatgpt.com/codex/cloud/settings/code-review).` | #898 05:20Z and 06:04Z, #897, aws #46, aws #27 (24 times) |
| CodeRabbit | `<details>` / `<summary>⚠️ Action not completed</summary>` / one of `Review rate limited.`, `Already reviewed.`, `Already reviewed the last commit. Use `@coderabbitai full review` to rerun a review of the entire changeset.`, `No files to review.`, `Pull request is closed.` / `</details>`, with or without the incremental-review note | #847, #864, #846, #869, #853, aws #28 (116 rate-limited alone) |
| CodeRabbit | the fold above with `Review rate limited.` / `---` / `Your included review limit is currently reached under our [Fair Usage Limits Policy](...). This review may still proceed through usage-based billing if eligible. Your next included review will be available in N minutes.` | #844, #887, aws #17 (45 times) |
| CodeRabbit | `### Rate Limit Exceeded` / `` `@login` have exceeded the limit for the number of chat messages per hour. Please wait **N minutes and N seconds** before sending another message.`` | #893 |
| CodeRabbit | summary comment: the summarize marker, one notice between its `rate limited`, `skip review` or `review paused` markers, every line blockquoted under `> ## Review limit reached`, `> ## Review skipped` or `> ## Reviews paused`, the tips block, nothing else | #874, #843, #789, #832 (13 rate-limited, 37 skipped) |

Notices seen and deliberately left claimable: `✅ Action performed` acks (`Reviews resumed.`, `Comments resolved...`), the aws-only `Review available on request` / `fewer than 10 stars` summary notices, `Review failed`, the in-progress notice, and any summary comment mixing a notice with a walkthrough, a review stack entry or finishing touches (#811).

## Red first, in both harnesses

`scripts/test-check-review-threads.sh`, finding 44 (22 cases; 9 red before, 13 boundary guards green before and after):

```
== finding 44: a bot saying its review did not run is not a finding ==
  FAIL  a codex usage-limit comment needs no disposition (#898) (rc=1 want=0)
          review threads: 0 total, 0 unresolved
            UNANSWERED chatgpt-codex-connector (COMMENT)
              You have reached your Codex usage limits for code reviews. ...
  FAIL  the one-line codex usage-limit comment needs no disposition (#898, 05:16Z) (rc=1 want=0)
  FAIL  a coderabbit rate-limited reply needs no disposition (#847) (rc=1 want=0)
  FAIL  a rate-limited reply naming the fair-usage wait needs no disposition (#844) (rc=1 want=0)
  FAIL  an already-reviewed reply needs no disposition (#846) (rc=1 want=0)
  FAIL  a chat rate-limit reply needs no disposition (#893) (rc=1 want=0)
  FAIL  a summary comment holding only a rate-limit notice needs no disposition (#874) (rc=1 want=0)
  FAIL  a summary comment holding only a skipped notice needs no disposition (#789) (rc=1 want=0)
  FAIL  quota notices beside an answered finding on a covered head clear (rc=1 want=0)
  PASS  a codex usage-limit comment covers no head
  PASS  a coderabbit rate-limited reply covers no head
  PASS  a summary notice quoting the head's range covers no head
  PASS  the codex notice with a finding appended is claimable
  ... (13 guards)
passed=205 failed=9
```
after the fix: `passed=214 failed=0`; fix reverted once more: `passed=205 failed=9`.

`tests/test_log_scan.rs::a_bot_notice_that_no_review_ran_is_neither_a_finding_nor_coverage`, run with `make test-unit FILTER="-E 'binary(test_log_scan)'"` (`FILTER=log_scan` matches test names, not file names: `0 tests run, 985 skipped`):

```
  TRY 1 FAIL [   0.117s] fcvm::test_log_scan a_bot_notice_that_no_review_ran_is_neither_a_finding_nor_coverage
    thread ... panicked at tests/test_log_scan.rs:981:5:
    assertion `left == right` failed: a bot's notice that its review did not run claims nothing, so a PR whose one finding is answered and whose head is covered is CLEAR. ...
     Summary [   5.229s] 25 tests run: 24 passed, 1 failed, 0 skipped
```
after the fix: `Summary [ 0.316s] 25 tests run: 25 passed, 0 skipped`; fix reverted once more: `FAILED ... panicked at tests/test_log_scan.rs:1001:5`.

The ten live bodies from the sweep (both Codex shapes; the rate-limited, fair-usage, already-reviewed and chat replies; the limit-reached and skipped summary comments, #843's "couldn't start this review" variant included) read CLEAR on a covered head through the fixed script; the mixed #811 summary comment and the `Reviews resumed.` ack stay claimable.

## Live gate

`scripts/check-review-threads.sh 897` (open, carries a Codex quota comment):

- 10:03:28Z, unfixed: `BLOCKED — 4 PR-level review body/bodies carry no disposition`: the CodeRabbit review body (`Actionable comments posted: 3`), the Codex review body, the CodeRabbit walkthrough, and the Codex quota comment.
- 10:09:18Z the author posted a review opening `NOT-A-DEFECT: the four PR-level bodies on this head state no defect of their own...` on 4390a7e17, dated after every body.
- After that, unfixed and fixed both read `review threads: 5 total, 0 unresolved` / `verdict: CLEAR`, exit 0. That CLEAR is that review's doing, not this change's.
- #897's dumped payload with that one review removed: unfixed `BLOCKED — 4`, fixed `BLOCKED — 3` (the quota comment is the one that drops out; the two bot review bodies and the walkthrough stay).

## CI coverage

The Rust test runs under `make test-unit` in the host and container jobs. `scripts/test-check-review-threads.sh` is not invoked by `ci.yml` or the Makefile; its 214 cases ran locally only.

`make lint`: fmt check clean, clippy clean, audit and deny ok. `make test-unit`: `Summary [  71.158s] 985 tests run: 985 passed (1 slow), 0 skipped`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Review checks now recognize exact quota-limit and rate-limit notices from supported review bots as neither findings nor review coverage.
  * Recognized notices no longer require a disposition.
  * Modified notices, notices from unrecognized accounts, and notices containing additional finding content continue to be evaluated normally.

* **Tests**
  * Added coverage for Codex and CodeRabbit notice formats, including blocked and clear review scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->