### PR TITLE
corpus_campaign.sh: record dns-evidence.json file names run-relative

### DIFF
--- a/bench/chromium/corpus_campaign.sh
+++ b/bench/chromium/corpus_campaign.sh
@@ -479,8 +479,12 @@ write_dns_evidence() {
     # busy box at the start, and the record is what says how busy it got.
     # Prints the final verdict; a verdict that could not be written is
     # unclean and the function returns 1.
-    local verdict="$1" reason="${2:-}" log="$RESULTS/dns-owner.log"
-    local out="$RESULTS/dns-evidence.json"
+    # owner_log and verify_files are names inside $RESULTS, not paths. The
+    # run directory is committed and read from other checkouts, where a path
+    # of this box names nothing; campaign_summary resolves each name beside
+    # the record, and verify_file_sha256 is keyed by the same names.
+    local verdict="$1" reason="${2:-}" owner_log="dns-owner.log"
+    local log="$RESULTS/$owner_log" out="$RESULTS/dns-evidence.json"
     local samples=0 first_mismatch="" before=false after=false after_state f
     local sampler_alive=false load_stats load_samples=0 load_max=null
     # The run this bundle is evidence for. Every file in it (the brackets,
@@ -537,7 +541,7 @@ write_dns_evidence() {
     # unclean.
     local verify_sha='{}' sha
     for f in pre before-run after-run; do
-        if [ -f "$RESULTS/verify-dns-$f.json" ]; then files+=("$RESULTS/verify-dns-$f.json"); fi
+        if [ -f "$RESULTS/verify-dns-$f.json" ]; then files+=("verify-dns-$f.json"); fi
         if ! jq -e '.passed == true' "$RESULTS/verify-dns-$f.json" >/dev/null 2>&1; then
             verdict=unclean; reason="${reason:-the $f verify bracket is missing or did not pass}"
         fi
@@ -580,7 +584,7 @@ write_dns_evidence() {
         --arg after_state "$after_state" --argjson sampler_alive "$sampler_alive" \
         --argjson samples "$samples" --argjson interval "$DNS_SAMPLE_INTERVAL" \
         --argjson load_max "$load_max" --argjson load_samples "$load_samples" \
-        --arg first "$first_mismatch" --arg reason "$reason" --arg owner_log "$log" \
+        --arg first "$first_mismatch" --arg reason "$reason" --arg owner_log "$owner_log" \
         --arg dns_sha "$(sha256_or_empty "$RESULTS/corpus-dns.log")" \
         --arg replay_queries_sha "$(sha256_or_empty "$RESULTS/replay-queries.log")" \
         --arg access_sha "$(sha256_or_empty "$RESULTS/corpus-access.log")" \

--- a/bench/chromium/test_campaign.py
+++ b/bench/chromium/test_campaign.py
@@ -1590,12 +1590,47 @@ wait_sampler_gone() {
             self.assertGreaterEqual(evidence["samples"], 3)
             self.assertIsNone(evidence["first_mismatch"])
             self.assertEqual(evidence["verify_files"],
-                             [os.path.join(results, f"verify-dns-{s}.json")
-                              for s in self.BRACKETS])
+                             [f"verify-dns-{s}.json" for s in self.BRACKETS])
             for key, name in (("corpus_dns_log_sha256", "corpus-dns.log"),
                               ("corpus_access_log_sha256", "corpus-access.log")):
                 self.assertEqual(evidence[key],
                                  hashlib.sha256((name + "\n").encode()).hexdigest())
+
+    def test_the_evidence_names_its_files_relative_to_the_run_directory(self):
+        """owner_log and verify_files are names inside the run directory
+        (dns-owner.log, verify-dns-<stage>.json), the names verify_file_sha256
+        is keyed by. The record outlives the box that wrote it: the run
+        directory is committed under results/ and read from other checkouts,
+        where an absolute path of the producing box names nothing. The cells
+        sealed before this change carry such paths and are never rewritten
+        (each campaign index cites dns-evidence.json by sha256), so the
+        consumer keeps resolving by basename; test_dns_evidence_paths.py
+        holds campaign_summary to both forms.
+
+        RED BEFORE THE FIX: `/tmp/.../results/dns-owner.log does not resolve
+        inside the relocated run directory`; owner_log and every verify_files
+        entry named the results directory of the box that wrote them.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            env, results = self._fakes(tmp)
+            evidence, _ = self._sample(env, results)
+            self.assertEqual(evidence["verdict"], "clean", evidence)
+            cited = [evidence["owner_log"], *evidence["verify_files"]]
+            # A reader that has only the run directory, wherever it is now.
+            moved = os.path.join(tmp, "elsewhere", "reqbench-20260902-000000-corpus")
+            os.makedirs(os.path.dirname(moved))
+            os.rename(results, moved)
+            for name in cited:
+                self.assertTrue(
+                    os.path.isfile(os.path.join(moved, name)),
+                    f"{name} does not resolve inside the relocated run directory")
+            self.assertEqual(evidence["owner_log"], "dns-owner.log")
+            self.assertEqual(evidence["verify_files"],
+                             [f"verify-dns-{s}.json" for s in self.BRACKETS])
+            self.assertEqual(set(evidence["verify_files"]),
+                             set(evidence["verify_file_sha256"]))
+            self.assertNotIn(results, json.dumps(evidence),
+                             "a clean record names the directory of the box that wrote it")
 
     def test_the_evidence_pins_each_bracket_by_hash(self):
         """The bracket files are the only record that a restored clone

--- a/bench/chromium/test_corpus_mem.py
+++ b/bench/chromium/test_corpus_mem.py
@@ -6364,9 +6364,10 @@ os.fsync = _fsync
         RED BEFORE THE FIX: the terminal checks named only Z, so the X
         (EXIT_DEAD) window that wait_task_zombie() holds open between storing
         EXIT_DEAD and calling release_task() read an already-exited process as
-        still running. Observed once in 200 local runs of
-        test_phase_supervisor_finalizes_after_parent_sigkill, and in CI on
-        5028c718 as "AssertionError: 'X' not found in (None, 'Z')".
+        still running. CI hit that window on 5028c718 in
+        test_phase_supervisor_finalizes_after_parent_sigkill:
+        "AssertionError: 'X' not found in (None, 'Z')"
+        (actions/runs/33618696866/job/100210498405).
         """
         for state in ("Z", "X"):
             with self.subTest(state=state), self._reported_state(state):

--- a/bench/chromium/test_corpus_mem.py
+++ b/bench/chromium/test_corpus_mem.py
@@ -63,6 +63,33 @@ def proc_state(pid):
     return None if identity is None else identity["state"]
 
 
+# Teardown walks a process through Z (EXIT_ZOMBIE) and then X (EXIT_DEAD)
+# before its procfs entry disappears. wait_task_zombie() stores EXIT_DEAD, then
+# does rusage accounting and a copy to user space, and only then calls
+# release_task() to unhash the pid (kernel/exit.c), so /proc/<pid>/stat reads
+# "X" for a process that has already exited. A terminal check naming only Z
+# reads that window as a running process.
+TERMINAL_PROCESS_STATES = (None, "Z", "X")
+
+
+def process_is_gone(pid):
+    """True once pid no longer runs: absent, reaped (Z), or released (X)."""
+    return proc_state(pid) in TERMINAL_PROCESS_STATES
+
+
+def wait_process_gone(test, pid, what, timeout=10):
+    """Poll pid to a terminal state, failing test while it is still running."""
+    deadline = time.monotonic() + timeout
+    while True:
+        state = proc_state(pid)
+        if state in TERMINAL_PROCESS_STATES:
+            return state
+        if time.monotonic() >= deadline:
+            test.fail(
+                f"{what} is still running in state {state!r} after {timeout}s")
+        time.sleep(0.01)
+
+
 def kill_and_reap_test_process_group(process):
     """Kill the session rooted at process and drain its captured pipes."""
     try:
@@ -1883,7 +1910,7 @@ exec {real_date!r} "$@"
                 self.assertIsNotNone(
                     producer.poll(), "timed-out test left hostcdp running")
                 deadline = time.monotonic() + 5
-                while proc_state(create_pid) not in (None, "Z"):
+                while not process_is_gone(create_pid):
                     if time.monotonic() >= deadline:
                         self.fail("timed-out test left podman create running")
                     time.sleep(0.01)
@@ -1891,13 +1918,13 @@ exec {real_date!r} "$@"
                 if producer.poll() is None:
                     os.killpg(producer.pid, signal.SIGKILL)
                     producer.communicate(timeout=5)
-                if create_pid is not None and proc_state(create_pid) not in (None, "Z"):
+                if create_pid is not None and not process_is_gone(create_pid):
                     try:
                         os.kill(create_pid, signal.SIGKILL)
                     except ProcessLookupError:
                         pass
                     deadline = time.monotonic() + 5
-                    while proc_state(create_pid) not in (None, "Z"):
+                    while not process_is_gone(create_pid):
                         if time.monotonic() >= deadline:
                             self.fail("emergency cleanup could not reap podman create")
                         time.sleep(0.01)
@@ -1960,7 +1987,7 @@ exec {real_date!r} "$@"
                     producer.poll(), "group cleanup left its session leader alive"
                 )
                 deadline = time.monotonic() + 5
-                while proc_state(child_pid) not in (None, "Z"):
+                while not process_is_gone(child_pid):
                     if time.monotonic() >= deadline:
                         self.fail("group cleanup left its pipe-holding child alive")
                     time.sleep(0.01)
@@ -1971,7 +1998,7 @@ exec {real_date!r} "$@"
                     pass
                 if producer.poll() is None:
                     producer.communicate(timeout=5)
-                if child_pid is not None and proc_state(child_pid) not in (None, "Z"):
+                if child_pid is not None and not process_is_gone(child_pid):
                     try:
                         os.kill(child_pid, signal.SIGKILL)
                     except ProcessLookupError:
@@ -4864,10 +4891,10 @@ os.fsync = _fsync
                     proc.returncode, 1,
                     "an escaped descendant was omitted from phase integrity",
                 )
-                self.assertIn(proc_state(child), (None, "Z"),
-                              "the escaped descendant survived supervision")
+                wait_process_gone(self, child,
+                                  "the escaped descendant after supervision")
             finally:
-                if proc_state(child) not in (None, "Z"):
+                if not process_is_gone(child):
                     pidfd = os.pidfd_open(child)
                     try:
                         signal.pidfd_send_signal(pidfd, signal.SIGKILL)
@@ -4954,9 +4981,9 @@ os.fsync = _fsync
                         )
                 with open(child_file) as handle:
                     child = int(handle.read())
-                self.assertIn(
-                    proc_state(child), (None, "Z"),
-                    "a post-leader drain error left an adopted descendant alive",
+                wait_process_gone(
+                    self, child,
+                    "the adopted descendant after a post-leader drain error",
                 )
                 self.assertGreaterEqual(
                     scan_calls, 2,
@@ -4966,7 +4993,7 @@ os.fsync = _fsync
                 if child is None and os.path.isfile(child_file):
                     with open(child_file) as handle:
                         child = int(handle.read())
-                if child is not None and proc_state(child) not in (None, "Z"):
+                if child is not None and not process_is_gone(child):
                     pidfd = os.pidfd_open(child)
                     try:
                         signal.pidfd_send_signal(pidfd, signal.SIGKILL)
@@ -5317,9 +5344,9 @@ os.fsync = _fsync
             os.kill(parent.pid, signal.SIGKILL)
             parent.communicate(timeout=20)
 
-            self.assertIn(proc_state(supervisor_pid), (None, "Z"))
-            self.assertIn(proc_state(phase_pid), (None, "Z"),
-                          "parent death left the measured phase alive")
+            wait_process_gone(self, supervisor_pid, "the phase supervisor")
+            wait_process_gone(self, phase_pid,
+                              "the measured phase after parent death")
 
     def test_phase_supervisor_finalizes_after_parent_sigkill(self):
         """A registered finalizer runs after the phase has been reaped.
@@ -5388,8 +5415,8 @@ os.fsync = _fsync
 
                 with open(state_path) as handle:
                     self.assertEqual(handle.read(), "active\n")
-                self.assertIn(proc_state(supervisor_pid), (None, "Z"))
-                self.assertIn(proc_state(phase_pid), (None, "Z"))
+                wait_process_gone(self, supervisor_pid, "the phase supervisor")
+                wait_process_gone(self, phase_pid, "the finalized phase")
             finally:
                 if parent.poll() is None:
                     parent.kill()
@@ -5483,7 +5510,7 @@ os.fsync = _fsync
                 )
                 with open(state_path) as handle:
                     self.assertEqual(handle.read(), "active\n")
-                self.assertIn(proc_state(finalizer_pid), (None, "Z"))
+                wait_process_gone(self, finalizer_pid, "the finalizer")
             finally:
                 try:
                     os.write(release_fd, b"R")
@@ -5494,9 +5521,9 @@ os.fsync = _fsync
                     parent.kill()
                     parent.wait(timeout=5)
                 if (finalizer_pidfd is not None
-                        and proc_state(finalizer_pid) not in (None, "Z")):
+                        and not process_is_gone(finalizer_pid)):
                     signal.pidfd_send_signal(finalizer_pidfd, signal.SIGKILL)
-                if proc_state(supervisor_pid) not in (None, "Z"):
+                if not process_is_gone(supervisor_pid):
                     signal.pidfd_send_signal(supervisor_pidfd, signal.SIGKILL)
                 if finalizer_pidfd is not None:
                     os.close(finalizer_pidfd)
@@ -5587,11 +5614,11 @@ os.fsync = _fsync
                 while time.monotonic() < deadline:
                     with open(state_path) as handle:
                         state = handle.read()
-                    if state == "active\n" and proc_state(supervisor_pid) in (None, "Z"):
+                    if state == "active\n" and process_is_gone(supervisor_pid):
                         break
                     time.sleep(0.01)
                 self.assertEqual(state, "active\n")
-                self.assertIn(proc_state(supervisor_pid), (None, "Z"))
+                wait_process_gone(self, supervisor_pid, "the phase supervisor")
                 with open(calls_path) as handle:
                     self.assertEqual(
                         handle.read().splitlines(),
@@ -5827,7 +5854,7 @@ os.fsync = _fsync
                     os.killpg(campaign.pid, signal.SIGKILL)
                     campaign.communicate(timeout=5)
                 if (detached_ready and guardian_pid is not None
-                        and proc_state(guardian_pid) not in (None, "Z")):
+                        and not process_is_gone(guardian_pid)):
                     try:
                         os.killpg(guardian_pid, signal.SIGKILL)
                     except ProcessLookupError:
@@ -6041,8 +6068,8 @@ os.fsync = _fsync
                 os.kill(sudo_pid, signal.SIGKILL)
                 wait_for(restore_started, "the blocked DNS finalizer")
                 self.assertIsNone(campaign.poll())
-                self.assertNotIn(proc_state(guardian_pid), (None, "Z"))
-                self.assertNotIn(proc_state(supervisor_pid), (None, "Z"))
+                self.assertFalse(process_is_gone(guardian_pid))
+                self.assertFalse(process_is_gone(supervisor_pid))
                 self.assertNotEqual(
                     subprocess.run(
                         ["flock", "-n", lock_path, "true"],
@@ -6090,7 +6117,7 @@ os.fsync = _fsync
                     os.killpg(campaign.pid, signal.SIGKILL)
                     campaign.communicate(timeout=5)
                 for pid in (guardian_pid, supervisor_pid, sudo_pid):
-                    if pid is not None and proc_state(pid) not in (None, "Z"):
+                    if pid is not None and not process_is_gone(pid):
                         try:
                             os.kill(pid, signal.SIGKILL)
                         except ProcessLookupError:
@@ -6253,11 +6280,11 @@ os.fsync = _fsync
 
                 os.kill(guardian_pid, signal.SIGTERM)
                 time.sleep(0.1)
-                self.assertNotIn(
-                    proc_state(guardian_pid), (None, "Z"),
+                self.assertFalse(
+                    process_is_gone(guardian_pid),
                     "TERM killed the guardian before its child finished",
                 )
-                self.assertNotIn(proc_state(child_pid), (None, "Z"))
+                self.assertFalse(process_is_gone(child_pid))
                 self.assertFalse(os.path.exists(status_path))
                 self.assertNotEqual(
                     subprocess.run(
@@ -6278,7 +6305,7 @@ os.fsync = _fsync
                 with open(child_release, "w"):
                     pass
                 for pid in (child_pid, guardian_pid):
-                    if pid is not None and proc_state(pid) not in (None, "Z"):
+                    if pid is not None and not process_is_gone(pid):
                         try:
                             os.kill(pid, signal.SIGKILL)
                         except ProcessLookupError:
@@ -6323,6 +6350,84 @@ os.fsync = _fsync
         self.assertIn('--lease-fd 9 --control-fd "$SERVE_CONTROL_FD"', source)
         self.assertIn('--completion-path "$SERVE_COMPLETION_PATH"', source)
         self.assertIn('--completion-token "$SERVE_COMPLETION_TOKEN"', source)
+
+    @staticmethod
+    def _reported_state(state):
+        return mock.patch.object(
+            phase_supervisor, "read_process_stat",
+            return_value={"pid": 4242, "state": state, "ppid": 1,
+                          "pgid": 4242, "starttime": 0})
+
+    def test_terminal_process_checks_accept_the_whole_release_window(self):
+        """A process that has exited reads as gone in every teardown state.
+
+        RED BEFORE THE FIX: the terminal checks named only Z, so the X
+        (EXIT_DEAD) window that wait_task_zombie() holds open between storing
+        EXIT_DEAD and calling release_task() read an already-exited process as
+        still running. Observed once in 200 local runs of
+        test_phase_supervisor_finalizes_after_parent_sigkill, and in CI on
+        5028c718 as "AssertionError: 'X' not found in (None, 'Z')".
+        """
+        for state in ("Z", "X"):
+            with self.subTest(state=state), self._reported_state(state):
+                self.assertTrue(
+                    process_is_gone(4242),
+                    f"an exited process in state {state} read as running")
+                self.assertEqual(
+                    wait_process_gone(self, 4242, "the probe", timeout=0),
+                    state)
+        with mock.patch.object(phase_supervisor, "read_process_stat",
+                               return_value=None):
+            self.assertTrue(process_is_gone(4242))
+            self.assertIsNone(wait_process_gone(self, 4242, "the probe",
+                                                timeout=0))
+
+    def test_terminal_process_checks_still_fail_on_a_running_process(self):
+        """Every live kernel state must keep failing the terminal check.
+
+        Widening the accepted set to cover the release window must not turn the
+        check into one that cannot fire: a supervisor still scheduled, sleeping,
+        in uninterruptible I/O, or stopped is a defect these tests exist to
+        catch.
+        """
+        for state in ("R", "S", "D", "T", "t", "I", "P"):
+            with self.subTest(state=state), self._reported_state(state):
+                self.assertFalse(
+                    process_is_gone(4242),
+                    f"a process running in state {state} read as gone")
+                with self.assertRaises(self.failureException):
+                    wait_process_gone(self, 4242, "the probe", timeout=0.05)
+
+    def test_terminal_process_checks_still_fail_on_a_live_process(self):
+        """The same check, against a real process rather than a reported state.
+
+        Mocked states prove the predicate; this proves the call sites, which
+        read /proc. A sleeping child and a SIGSTOPped one are the states a
+        supervisor that failed to exit actually sits in.
+        """
+        child = subprocess.Popen([sys.executable, "-c", "import time;"
+                                  " time.sleep(120)"])
+        try:
+            for signum, expected in ((None, "S"), (signal.SIGSTOP, "T")):
+                if signum is not None:
+                    os.kill(child.pid, signum)
+                deadline = time.monotonic() + 5
+                while proc_state(child.pid) != expected:
+                    if time.monotonic() >= deadline:
+                        self.fail(f"child never reached state {expected}")
+                    time.sleep(0.01)
+                with self.subTest(state=expected):
+                    self.assertFalse(
+                        process_is_gone(child.pid),
+                        f"a live child in state {expected} read as gone")
+                    with self.assertRaises(self.failureException):
+                        wait_process_gone(self, child.pid, "the live child",
+                                          timeout=0.2)
+        finally:
+            os.kill(child.pid, signal.SIGCONT)
+            child.kill()
+            child.wait(timeout=5)
+        wait_process_gone(self, child.pid, "the reaped child", timeout=5)
 
     def test_proc_state_readers_treat_disappearance_during_read_as_gone(self):
         class VanishedProcStat:

--- a/bench/chromium/test_dns_evidence_paths.py
+++ b/bench/chromium/test_dns_evidence_paths.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Where the file names in dns-evidence.json resolve, pinned on the reader.
+
+corpus_campaign.sh records owner_log and verify_files as names inside the
+run directory (dns-owner.log, verify-dns-<stage>.json); test_campaign.py
+holds the producer to that. The runs sealed before that change carry the
+absolute paths of the box that produced them, and a sealed record is never
+rewritten: each campaign index cites dns-evidence.json by sha256. So
+campaign_summary.py resolves every cited name inside the run directory it
+was handed, whichever form the record carries, and trusts neither: the
+directory it indexes is a checkout on some other box.
+
+Run: python3 -m unittest test_dns_evidence_paths -v
+"""
+
+import glob
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+import campaign_summary  # noqa: E402
+from test_campaign_summary import VERIFY_STAGES, write_run  # noqa: E402
+
+# What dns-evidence.json cites by name: the owner sampler's log and the
+# three verify brackets.
+CITED_NAMES = ("dns-owner.log", *(f"verify-dns-{s}.json" for s in VERIFY_STAGES))
+
+
+def summarize(out, run_dir):
+    stdout, stderr = io.StringIO(), io.StringIO()
+    with redirect_stdout(stdout), redirect_stderr(stderr):
+        rc = campaign_summary.main_with(["--out", out, run_dir])
+    return rc, stdout.getvalue() + stderr.getvalue()
+
+
+def cited_paths(index):
+    """The index's generated_from paths for the files the evidence cites."""
+    return {
+        os.path.basename(entry["path"]): entry["path"]
+        for entry in index["generated_from"]
+        if os.path.basename(entry["path"]) in CITED_NAMES
+    }
+
+
+def assert_cited_inside(test, index, run_dir):
+    """Every cited file was read from run_dir, not from where the record said."""
+    cited = cited_paths(index)
+    test.assertEqual(set(cited), set(CITED_NAMES), cited)
+    for name, path in cited.items():
+        test.assertEqual(path, os.path.join(run_dir, name))
+        test.assertTrue(os.path.isfile(path), path)
+
+
+class EvidenceNamesResolveInTheRunDirectory(unittest.TestCase):
+    """Both record forms index from a directory the record does not name.
+
+    A contract pin, not a defect: campaign_summary resolved by basename
+    before this test existed. It fails against a reader that opens the
+    names as recorded: the run-relative form resolves against the working
+    directory and the legacy form against a directory this box never had.
+    """
+
+    def _index(self, run_dir, evidence_overrides):
+        write_run(run_dir, evidence_overrides=evidence_overrides)
+        out = os.path.join(os.path.dirname(run_dir), "campaign-x-summary.json")
+        rc, text = summarize(out, run_dir)
+        self.assertEqual(rc, 0, text)
+        with open(out) as handle:
+            index = json.load(handle)
+        self.assertEqual([cell["dns_verdict"] for cell in index["cells"]], ["clean"])
+        assert_cited_inside(self, index, run_dir)
+        return index
+
+    def test_run_relative_names(self):
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "reqbench-20260902-000000-corpus")
+            self._index(run_dir, {
+                "owner_log": "dns-owner.log",
+                "verify_files": [f"verify-dns-{s}.json" for s in VERIFY_STAGES],
+            })
+
+    def test_legacy_absolute_names_of_a_box_that_is_gone(self):
+        with tempfile.TemporaryDirectory() as d:
+            run_dir = os.path.join(d, "reqbench-20260902-000000-corpus")
+            # The path shape of the sealed 2026-09-02 cells, under a
+            # directory that exists on no box.
+            gone = os.path.join(d, "box-that-wrote-it", "src", "fcvm", "bench",
+                                "chromium", "results", "corpus-20260902-031115",
+                                "reqbench")
+            self.assertFalse(os.path.exists(gone))
+            index = self._index(run_dir, {
+                "owner_log": os.path.join(gone, "dns-owner.log"),
+                "verify_files": [os.path.join(gone, f"verify-dns-{s}.json")
+                                 for s in VERIFY_STAGES],
+            })
+            self.assertFalse(
+                any(entry["path"].startswith(gone) for entry in index["generated_from"]),
+                "the index read a file from the directory the record named")
+
+
+class SealedRecordsIndexFromThisCheckout(unittest.TestCase):
+    """Every clean, unwithdrawn dns-evidence.json committed under results/
+    indexes from wherever this checkout lives.
+
+    The records sealed before the producer wrote run-relative names carry
+    absolute paths of the boxes that produced them and stay in that form for
+    good; at least one of them has to be present, or this says nothing about
+    the legacy form. A run is withdrawn by a WITHDRAWN file beside its
+    records or by "withdrawn": true in its analysis.json (campaign_summary
+    refuses either), so those are not expected to index.
+    """
+
+    RESULTS = os.path.join(HERE, "results")
+
+    @staticmethod
+    def withdrawn(run_dir):
+        if os.path.exists(os.path.join(run_dir, "WITHDRAWN")):
+            return True
+        try:
+            with open(os.path.join(run_dir, "analysis.json")) as handle:
+                return json.load(handle).get("withdrawn") is True
+        except (OSError, ValueError):
+            return False
+
+    def sealed_runs(self):
+        runs = {}
+        for path in sorted(glob.glob(os.path.join(self.RESULTS, "*", "dns-evidence.json"))):
+            run_dir = os.path.dirname(path)
+            with open(path) as handle:
+                evidence = json.load(handle)
+            if evidence.get("verdict") == "clean" and not self.withdrawn(run_dir):
+                runs[run_dir] = evidence
+        return runs
+
+    def test_every_sealed_clean_record_indexes(self):
+        runs = self.sealed_runs()
+        legacy = [d for d, e in runs.items() if os.path.isabs(e.get("owner_log", ""))]
+        self.assertTrue(
+            legacy,
+            "no sealed record in the legacy absolute form is left under results/, "
+            "so only the fixture above covers that form")
+        for run_dir in runs:
+            with self.subTest(run=os.path.basename(run_dir)), \
+                    tempfile.TemporaryDirectory() as d:
+                out = os.path.join(d, "campaign-x-summary.json")
+                rc, text = summarize(out, run_dir)
+                self.assertEqual(rc, 0, text)
+                with open(out) as handle:
+                    index = json.load(handle)
+                self.assertEqual([cell["dns_verdict"] for cell in index["cells"]], ["clean"])
+                assert_cited_inside(self, index, run_dir)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #899

`write_dns_evidence` in `bench/chromium/corpus_campaign.sh` recorded `owner_log` and `verify_files` as absolute paths of the run directory on the box that ran the campaign (`/home/ubuntu/src/fcvm/bench/chromium/results/<run>/dns-owner.log` on the 2026-08-30 cell, `/mnt/work/src/fcvm/.../reqbench/verify-dns-pre.json` on the 2026-09-02 cells). The run directory is committed under `results/` and read from other checkouts, where those paths name nothing. Raised by CodeRabbit on #898; dispositioned DISAGREE there because a sealed record is not rewritten.

## Change

- `corpus_campaign.sh`: the record carries the names inside the run directory (`dns-owner.log`, `verify-dns-pre.json`, `verify-dns-before-run.json`, `verify-dns-after-run.json`), the names `verify_file_sha256` is already keyed by. The reads inside the function still go through `$RESULTS/<name>`.
- `campaign_summary.py` is unchanged. It resolves `dns-owner.log` and each bracket by basename inside the run directory it was handed, so it accepts both forms today; the sealed cells keep their absolute paths because each campaign index cites `dns-evidence.json` by sha256.
- `test_campaign.py`: new producer test, and the existing form assertion in `test_a_steady_owner_with_dnsmasq_down_is_clean` follows the new names.
- `test_dns_evidence_paths.py` (new): consumer side, both forms plus every sealed record under `results/`.

## Red first

Producer test against the unfixed `corpus_campaign.sh`:

```
FAIL: test_the_evidence_names_its_files_relative_to_the_run_directory (test_campaign.DnsBrackets...)
AssertionError: False is not true : /tmp/tmp1q6mdtsx/results/dns-owner.log does not resolve inside the relocated run directory
```

With the fix, `make test-chromium FILTER=DnsBrackets`: `Ran 40 tests in 4.734s OK`. Fix reverted once more: the same failure plus the updated form assertion (`Lists differ: ['/tmp/.../results/verify-dns-pre.json', ...] != ['verify-dns-pre.json', ...]`), then restored (sha256 checked).

Consumer tests pin a contract rather than a defect (`campaign_summary.py` already resolved by basename). Against a reader that opens `evidence["owner_log"]` as recorded (temporary local mutation, reverted), all of them fail:

```
FAIL: test_run_relative_names ... dns-owner.log cited by dns-evidence.json is missing
FAIL: test_legacy_absolute_names_of_a_box_that_is_gone ... dns-owner.log cited by dns-evidence.json is missing
FAIL: test_every_sealed_clean_record_indexes (run='reqbench-20260830-171007-corpus') ... dns-owner.log cited by dns-evidence.json is missing
  (and the three reqbench-20260902-*-corpus-c* cells)
```

## Checks

```
$ make test-chromium
Ran 997 tests in 245.490s, OK
$ make lint
advisories ok, bans ok, licenses ok, sources ok   (exit 0; no Rust touched)
$ bash -n bench/chromium/corpus_campaign.sh && shellcheck bench/chromium/corpus_campaign.sh
same two pre-existing findings as main (SC2015 line 324, SC2024 line 782, was 778); nothing new
$ ruff check bench/chromium/test_campaign.py bench/chromium/test_dns_evidence_paths.py
All checks passed!
```

Not in this PR: the `reason` strings of an unclean verdict still embed `$RESULTS/analysis.json` and `$RESULTS/corpus-serve.status`; unclean records are never indexed. The comment in `campaign_summary.py` (`the evidence's own absolute paths are not trusted`) now describes only the sealed records; that file is being edited by #897.


## Second commit: a pre-existing flake in `test_corpus_mem.py`

`Bench Harness Tests` failed on 5028c718 in a file this PR does not touch:

```
FAIL: test_phase_supervisor_finalizes_after_parent_sigkill
  self.assertIn(proc_state(supervisor_pid), (None, "Z"))
AssertionError: 'X' not found in (None, 'Z')
```

`test_corpus_mem.py` and `corpus_mem.py` landed in #893; this branch changes
only `corpus_campaign.sh`, `test_campaign.py` and `test_dns_evidence_paths.py`.
`main` at af07a25a is green, and this branch's merge-base is af07a25a, so it is
not behind. The failure is a race in the assertion, not in the change.

The supervisor had exited. Teardown walks a process through Z (EXIT_ZOMBIE)
and then X (EXIT_DEAD) before its procfs entry disappears: `wait_task_zombie()`
stores `EXIT_DEAD` (`kernel/exit.c:1193`), then does rusage accounting,
`sched_annotate_sleep()` and a copy to user space, and only calls
`release_task()` at line 1273. The pid stays hashed across that window, so
`/proc/<pid>/stat` reports `X` for a process that is already dead. Checks
naming only `Z` read the window as a running process. The `assertNotIn`
liveness checks carried the same two-of-three enumeration in the false-pass
direction, reading a dying process as alive: 36 call sites in total, so the
fix is a shared `TERMINAL_PROCESS_STATES` / `process_is_gone()` /
`wait_process_gone()` rather than a widened tuple per site.

`wait_process_gone()` also closes a second race those assertions had: they
sampled once, so a supervisor that had not exited *yet* failed exactly as a
reaped one did. It polls to disappearance against a bounded deadline and names
the state it saw.

### Red first

Unfixed tree, 200 runs of the single test: **1 failure**, same assertion.
Deterministic form, reporting `X` for every process already gone:

```
FAIL: test_phase_supervisor_finalizes_after_parent_sigkill
  File "bench/chromium/test_corpus_mem.py", line 5392
    self.assertIn(proc_state(phase_pid), (None, "Z"))
AssertionError: 'X' not found in (None, 'Z')
```

Red / green / red on `TERMINAL_PROCESS_STATES`:

```
(None, "Z")       AssertionError: False is not true : an exited process in state X read as running
(None, "Z", "X")  Ran 2 tests in 0.355s   OK
(None, "Z")       AssertionError: False is not true : an exited process in state X read as running
```

### The widened check still fails on a live process

Over-widening the set to accept `R/S/D/T/t/I/P` gives 9 failures across the
mocked-state and real-process arms. Retargeting the converted call site in
`test_phase_supervisor_finalizes_after_parent_sigkill` at a running pid:

```
AssertionError: the phase supervisor is still running in state 'R' after 1s
```

Product mutation (`arm_parent_death` returns before `PR_SET_PDEATHSIG`, so the
supervisor outlives its parent) also takes the test red, at
`parent.communicate(timeout=20)`, since the surviving supervisor holds the
inherited pipes.

### Not failures

Four `FAILED:` lines earlier in the same job log are the product's own stderr
diagnostics from tests that drive those paths deliberately
(`phase_supervisor.py:338`, `serve_guardian.py:204`), not unittest failures.
The job reported `FAILED (failures=1)`.

```
$ make test-chromium
Ran 1000 tests in 248.151s, OK
$ make test-chromium
Ran 1000 tests in 245.425s, OK
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - DNS evidence now uses run-relative filenames, allowing evidence to remain valid when result directories are moved.
  - Evidence processing continues to support legacy absolute-path records when resolving referenced files.
  - Process completion checks now correctly recognize all terminal process states, reducing intermittent test failures.

- **Tests**
  - Added coverage for relocated run directories, legacy evidence records, file references, and terminal process-state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->