### PR TITLE
check-review-threads: an empty review object is not head coverage

### DIFF
--- a/scripts/check-review-threads.sh
+++ b/scripts/check-review-threads.sh
@@ -273,7 +273,8 @@ fetch_payload() {
             commits(last: 1) { nodes { commit { committedDate checkSuites(first: 10) { nodes { createdAt } } } } }
             reviews(first: $REVIEWS_PAGE_SIZE$rafter) {
               pageInfo { hasNextPage endCursor }
-              nodes { author { login } state body submittedAt commit { oid } }
+              nodes { author { login } state body submittedAt commit { oid }
+                    comments(first: $REVIEWS_PAGE_SIZE) { totalCount nodes { replyTo { id } } } }
             } } } }" 2>/dev/null) || return 1
     require_page "$rresp" data.repository.pullRequest.reviews "the reviews" "$pr" || return 2
     reviews=$(jq -s '.[0] + (.[1].data.repository.pullRequest.reviews.nodes // [])' \
@@ -375,7 +376,8 @@ fetch_payload() {
           pullRequest(number: $pr) {
             reviews(first: $REVIEWS_PAGE_SIZE$rv2after) {
               pageInfo { hasNextPage endCursor }
-              nodes { author { login } state body submittedAt commit { oid } }
+              nodes { author { login } state body submittedAt commit { oid }
+                    comments(first: $REVIEWS_PAGE_SIZE) { totalCount nodes { replyTo { id } } } }
             } } } }" 2>/dev/null) || return 1
     require_page "$rv2resp" data.repository.pullRequest.reviews "the second read of the reviews" "$pr" || return 2
     rv2=$(jq -s '.[0] + (.[1].data.repository.pullRequest.reviews.nodes // [])' \
@@ -1153,9 +1155,78 @@ if [ "${REQUIRE_REVIEWED_HEAD:-1}" = "1" ]; then
   # author's own `gh pr review --comment` disposition — posted after the push, as the
   # workflow requires — marked the commit reviewed. The check certified precisely the
   # race it was built to catch.
-  reviewed=$(jq -r --arg h "$headoid" --arg me "$prauthor" \
-             '[ .[] | select((.commit.oid // "") == $h) | select(.author.login != $me) ] | length' \
+  #
+  # And a review OBJECT on the head is not the same thing as a review of it. GitHub mints
+  # an empty COMMENTED review as the CONTAINER for every reply to an inline thread, bound
+  # to whatever the head is at the time. #897 merged on head 27b1b943 with its last two
+  # commits reviewed by nobody: CodeRabbit reviewed the previous head 34f66d47, posted two
+  # findings, was refused under Fair Usage on every request after that, and the two
+  # containers minted when it replied in the answered threads
+  #     [coderabbitai] COMMENTED body_len=0 14:16:37Z commit=27b1b943
+  #     [coderabbitai] COMMENTED body_len=0 14:16:41Z commit=27b1b943
+  # counted as coverage. The gate said CLEAR and the merge went through 12 minutes later.
+  # #901 merged the same way 40 minutes after that, on head e35ff1a2. This is the same
+  # fail-open as the missing `jq` and the rate-limited CodeRabbit check: "the reviewer never
+  # ran" reading as "the reviewer approved".
+  #
+  # So an object counts only when it carries something that could ONLY exist because a
+  # review ran. Three things can, and a reply container has none of them:
+  #   - a non-empty BODY. The reviewer wrote a summary. A container's body is "".
+  #   - a state of APPROVED or CHANGES_REQUESTED. GitHub mints those only from the review
+  #     form; a reply container is always COMMENTED. DISMISSED is a review withdrawn and
+  #     PENDING one never submitted, so neither covers on its own.
+  #   - an inline comment of its own that is not a reply, which is a finding this review
+  #     placed. No review on ejc3/fcvm has that shape today: every bot review here writes a
+  #     summary body (checked across #844, #853, #867, #872, #874, #887, #893, #897, #901).
+  #     It is admitted because POST /pulls/N/reviews takes `event: COMMENT` with `comments`
+  #     and no `body`, so a reviewer who only comments inline submits it, and refusing that
+  #     would leave the head uncoverable once its threads were answered. A gate that cries
+  #     wolf on a real review gets switched off, and then it catches nothing.
+  # Emptiness is judged on the object, not on who wrote it. Authorship has decided nothing
+  # in this gate since the claimable rule was rewritten, and a human's reply container is
+  # as empty as a bot's: #897 carried two of each.
+  covering_jq='def covers:
+      (((.body // "") | type) == "string" and ((.body // "") | test("[^[:space:]]")))
+      or (((.state // "") | type) == "string" and ((.state // "") | IN("APPROVED", "CHANGES_REQUESTED")))
+      or (any(.comments.nodes[]?; has("replyTo") and .replyTo == null));'
+  headreviews=$(jq -c --arg h "$headoid" --arg me "$prauthor" \
+             '[ .[] | select((.commit.oid // "") == $h) | select(.author.login != $me) ]' \
              <<<"$reviews") || {
+    echo "verdict: BLOCKED — could not evaluate head-commit review coverage." >&2; exit 2; }
+  # A review object this gate cannot read is not one it may wave through as coverage, and
+  # not one it may silently drop either. `state` is what separates a submitted verdict from
+  # a reply container, so a non-string one is unreadable and blocks.
+  if ! jq -e 'all(((.state // null) | type) == "string")' >/dev/null 2>&1 <<<"$headreviews"; then
+    echo "verdict: BLOCKED — a review object on the head has no readable state, so this" >&2
+    echo "gate cannot tell a submitted review from the empty container GitHub mints for a" >&2
+    echo "reply to a comment thread. Re-run, or re-capture the fixture." >&2
+    exit 2
+  fi
+  if ! jq -e 'all((has("comments") | not)
+                  or (((.comments | type) == "object") and ((.comments.nodes | type) == "array")))' \
+       >/dev/null 2>&1 <<<"$headreviews"; then
+    echo "verdict: BLOCKED — a review object on the head has an unreadable comments" >&2
+    echo "connection, so this gate cannot tell whether that review placed a finding." >&2
+    exit 2
+  fi
+  # A comments connection that does not account for every comment it reports cannot answer
+  # "did this review place a finding of its own": the one non-reply may be the comment that
+  # was not fetched. Only asked of an object that is not already coverage by body or state.
+  # An ABSENT connection is a different thing and declines rather than blocking: it is the
+  # shape of every fixture captured before this gate read review comments, and no evidence
+  # is not evidence of a review.
+  truncated=$(jq -r "$covering_jq"'[ .[] | select(covers | not) | select(has("comments"))
+    | select((((.comments.totalCount | type) == "number")
+              and (.comments.totalCount == (.comments.nodes | length))) | not) ] | length' \
+    <<<"$headreviews") || {
+    echo "verdict: BLOCKED — could not evaluate the head reviews' comment connections." >&2; exit 2; }
+  if [ "${truncated:-0}" -gt 0 ]; then
+    echo "verdict: BLOCKED — $truncated review object(s) on the head report more inline" >&2
+    echo "comments than were fetched, so this gate cannot tell whether they placed a" >&2
+    echo "finding or only replied to one. Re-run, or re-capture the fixture." >&2
+    exit 2
+  fi
+  reviewed=$(jq -r "$covering_jq"'[ .[] | select(covers) ] | length' <<<"$headreviews") || {
     echo "verdict: BLOCKED — could not evaluate head-commit review coverage." >&2; exit 2; }
   # A no-findings result leaves no review object (see VERDICT_JQ), so it carries no commit
   # of its own. It counts for THIS head only when the bot itself names the head. A result
@@ -1264,7 +1335,7 @@ if [ "${REQUIRE_REVIEWED_HEAD:-1}" = "1" ]; then
     echo "  HEAD COVERED  ${headoid:0:9}: no review object, but $verdicts no-findings verdict(s) bound to it (arrived $arrived)"
   elif [ "${reviewed:-0}" -eq 0 ]; then
     echo
-    echo "  UNREVIEWED HEAD  ${headoid:0:9} — no review object on this commit from anyone but the author, and no no-findings verdict bound to it"
+    echo "  UNREVIEWED HEAD  ${headoid:0:9} — no review of this commit from anyone but the author (an empty review object is a reply container, not a review), and no no-findings verdict bound to it"
     echo
     echo "verdict: BLOCKED — the head commit has not been reviewed."
     echo "Every finding raised so far is answered, but the code being merged is not the code"

--- a/scripts/test-check-review-threads.sh
+++ b/scripts/test-check-review-threads.sh
@@ -181,7 +181,7 @@ run_case "reviews exist but none cover the head blocks" \
   "$(wrap5 deadbeef '[{"author":{"login":"codex"},"state":"COMMENTED","submittedAt":"2026-01-01T00:00:00Z","body":"","commit":{"oid":"0ldc0mm1t"}}]')" \
   1 "UNREVIEWED HEAD"
 run_case "a review covering the head clears" \
-  "$(wrap5 deadbeef '[{"author":{"login":"codex"},"state":"COMMENTED","submittedAt":"2026-01-01T00:00:00Z","body":"","commit":{"oid":"deadbeef"}}]')" \
+  "$(wrap5 deadbeef '[{"author":{"login":"codex"},"state":"COMMENTED","submittedAt":"2026-01-01T00:00:00Z","body":"","commit":{"oid":"deadbeef"},"comments":{"totalCount":1,"nodes":[{"replyTo":null}]}}]')" \
   0 "CLEAR"
 # Flipped by finding 29: this case expected CLEAR, which was the fail-open itself.
 run_case "no reviews at all is an unreviewed head, not a clear one (was CLEAR)" \
@@ -212,7 +212,7 @@ run_case "only the author reviewed the head" \
   "$(wrap5 deadbeef '[{"author":{"login":"codex"},"state":"COMMENTED","submittedAt":"2026-01-01T00:00:00Z","body":"","commit":{"oid":"0ldc0mm1t"}},{"author":{"login":"me"},"state":"COMMENTED","submittedAt":"2026-01-02T00:00:00Z","body":"NOT-A-DEFECT: fixed","commit":{"oid":"deadbeef"}}]')" \
   1 "UNREVIEWED HEAD"
 run_case "someone else reviewed the head" \
-  "$(wrap5 deadbeef '[{"author":{"login":"codex"},"state":"COMMENTED","submittedAt":"2026-01-02T00:00:00Z","body":"","commit":{"oid":"deadbeef"}}]')" \
+  "$(wrap5 deadbeef '[{"author":{"login":"codex"},"state":"COMMENTED","submittedAt":"2026-01-02T00:00:00Z","body":"","commit":{"oid":"deadbeef"},"comments":{"totalCount":1,"nodes":[{"replyTo":null}]}}]')" \
   0 "CLEAR"
 
 echo "== finding 19: a reviewer with nothing to say posts no review object =="
@@ -238,7 +238,7 @@ cmt() { printf '{"author":{"login":"%s","__typename":"%s"},"createdAt":"%s","upd
 #
 # wrap9 is the wrap6 head with a review object already on it, for cases about whether a
 # comment needs a disposition rather than about what covers the head.
-wrap9() { printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{"nodes":[{"createdAt":"2026-01-02T00:30:00Z"}]}}}]},"reviewThreads":{"nodes":[]},"reviews":{"nodes":[{"author":{"login":"codex"},"state":"COMMENTED","submittedAt":"2026-01-03T00:00:00Z","body":"","commit":{"oid":"deadbeef"}}]},"comments":{"nodes":[%s]},"recheck":{"comments":{"nodes":[%s]}}}}}}' "$1" "${2:-$1}"; }
+wrap9() { printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{"nodes":[{"createdAt":"2026-01-02T00:30:00Z"}]}}}]},"reviewThreads":{"nodes":[]},"reviews":{"nodes":[{"author":{"login":"codex"},"state":"COMMENTED","submittedAt":"2026-01-03T00:00:00Z","body":"","commit":{"oid":"deadbeef"},"comments":{"totalCount":1,"nodes":[{"replyTo":null}]}}]},"comments":{"nodes":[%s]},"recheck":{"comments":{"nodes":[%s]}}}}}}' "$1" "${2:-$1}"; }
 # Codex's no-findings comment as posted: the phrase with sign-off $1, the reviewed commit
 # $2, and the folded About Codex block. Emits a JSON string literal.
 codex_body() { jq -n --arg s "$1" --arg sha "$2" '"Codex Review: Didn\u0027t find any major issues.\($s)\n\n**Reviewed commit:** `\($sha)`\n\n<details> <summary>ℹ️ About Codex in GitHub</summary>\n<br/>\n\n[Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you\n- Open a pull request for review\n- Mark a draft as ready\n- Comment \"@codex review\".\n\nIf Codex has suggestions, it will comment; otherwise it will react with 👍.\n\n\n\n\nCodex can also answer questions or update the PR. Try commenting \"@codex address that feedback\".\n            \n</details>"'; }
@@ -771,7 +771,7 @@ printf '{"data":{"repository":{"pullRequest":{"comments":{"pageInfo":{"hasNextPa
 printf '{"data":{"repository":{"pullRequest":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}' > "$TMP/comments2.json"
 printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}' > "$TMP/threads.json"
 printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"T1","isResolved":false,"comments":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"reviewer"},"path":"a.ts","line":1,"body":"P1: this landed while the gate was paging"}]}}]}}}}}' > "$TMP/threads2.json"
-review_payload() { printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{"nodes":[{"createdAt":"2026-01-02T00:30:00Z"}]}}}]},"prcommits":{"totalCount":1,"nodes":[{"commit":{"oid":"deadbeef"}}]},"reviews":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"reviewer"},"state":"COMMENTED","submittedAt":"2026-01-02T01:00:00Z","body":%s,"commit":{"oid":"deadbeef"}}]}}}}}' "$1"; }
+review_payload() { printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{"nodes":[{"createdAt":"2026-01-02T00:30:00Z"}]}}}]},"prcommits":{"totalCount":1,"nodes":[{"commit":{"oid":"deadbeef"}}]},"reviews":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"reviewer"},"state":"COMMENTED","submittedAt":"2026-01-02T01:00:00Z","body":%s,"commit":{"oid":"deadbeef"},"comments":{"totalCount":1,"nodes":[{"replyTo":null}]}}]}}}}}' "$1"; }
 review_payload '""' > "$TMP/reviews.json"
 review_payload '"P1: this landed while the gate was paging"' > "$TMP/reviews2.json"
 cat > "$TMP/bin/gh" <<'SHIM'
@@ -904,7 +904,7 @@ echo "== finding 19: a 128 KiB thread body must not kill the live-path merge =="
 mkdir -p "$TMP/bin"
 big_body=$(printf 'x%.0s' $(seq 1 200000))
 printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"T1","isResolved":true,"comments":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"databaseId":1,"author":{"login":"reviewer"},"path":"a.ts","line":1,"createdAt":"2026-01-01T00:00:00Z","body":"%s"},{"databaseId":2,"author":{"login":"me"},"path":"a.ts","line":1,"createdAt":"2026-01-02T00:00:00Z","body":"NOT-A-DEFECT: fixture padding, not a finding"}]}}]}}}}}' "$big_body" > "$TMP/threads.json"
-printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","reviews":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"reviewer"},"state":"COMMENTED","submittedAt":"2026-01-02T00:00:00Z","body":"","commit":{"oid":"deadbeef"}}]}}}}}' > "$TMP/reviews.json"
+printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","reviews":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"reviewer"},"state":"COMMENTED","submittedAt":"2026-01-02T00:00:00Z","body":"","commit":{"oid":"deadbeef"},"comments":{"totalCount":1,"nodes":[{"replyTo":null}]}}]}}}}}' > "$TMP/reviews.json"
 printf '{"data":{"repository":{"pullRequest":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}' > "$TMP/comments.json"
 # Quoted delimiter: nothing in the shim expands at write time; GATE_TEST_DIR
 # arrives via the environment when the gate execs gh.
@@ -1058,7 +1058,7 @@ thread_read() {  # $1 the reply on the thread, $2 totalCount, $3.. the page-1 co
 }
 thread_read '"NOT-A-DEFECT: renamed only, no behaviour change"' > "$TMP/threads.json"
 thread_read '"Actually the rename changed behaviour, this still drops the row"' > "$TMP/threads2.json"
-printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{"nodes":[{"createdAt":"2026-01-02T00:30:00Z"}]}}}]},"reviews":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"reviewer"},"state":"COMMENTED","submittedAt":"2026-01-02T01:00:00Z","body":"","commit":{"oid":"deadbeef"}}]}}}}}' > "$TMP/reviews.json"
+printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{"nodes":[{"createdAt":"2026-01-02T00:30:00Z"}]}}}]},"reviews":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"reviewer"},"state":"COMMENTED","submittedAt":"2026-01-02T01:00:00Z","body":"","commit":{"oid":"deadbeef"},"comments":{"totalCount":1,"nodes":[{"replyTo":null}]}}]}}}}}' > "$TMP/reviews.json"
 printf '{"data":{"repository":{"pullRequest":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}' > "$TMP/comments.json"
 # An oversized thread: page 1 holds the finding and one line of chatter, page 2 holds the
 # reply, and the reply is what gets edited between the reads.
@@ -1176,7 +1176,7 @@ printf '{"data":{"node":{"comments":{"pageInfo":{"hasNextPage":true,"endCursor":
 # list) already says another page follows and names no cursor. The disposition is on the
 # page nobody can ask for, so a run that skips the paging judges the thread undisposed.
 printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"T1","isResolved":true,"isOutdated":false,"comments":{"totalCount":3,"pageInfo":{"hasNextPage":true,"endCursor":null},"nodes":[{"author":{"login":"reviewer"},"path":"a.ts","line":1,"originalLine":1,"body":"this drops the last row"},{"author":{"login":"onlooker"},"path":"a.ts","line":1,"originalLine":1,"body":"discussion"}]}}]}}}}}' > "$TMP/pagednocursor.json"
-printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{"nodes":[{"createdAt":"2026-01-02T00:30:00Z"}]}}}]},"reviews":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"reviewer"},"state":"COMMENTED","submittedAt":"2026-01-02T01:00:00Z","body":"","commit":{"oid":"deadbeef"}}]}}}}}' > "$TMP/reviews.json"
+printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{"nodes":[{"createdAt":"2026-01-02T00:30:00Z"}]}}}]},"reviews":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"reviewer"},"state":"COMMENTED","submittedAt":"2026-01-02T01:00:00Z","body":"","commit":{"oid":"deadbeef"},"comments":{"totalCount":1,"nodes":[{"replyTo":null}]}}]}}}}}' > "$TMP/reviews.json"
 printf '{"data":{"repository":{"pullRequest":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[%s]}}}}}' "$CLAIM42" > "$TMP/comments.json"
 printf '{"data":{"repository":{"pullRequest":{"comments":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}' > "$TMP/nocomments.json"
 printf '%s' "$PRCOMMITS_LIVE" > "$TMP/prcommits.json"
@@ -1545,6 +1545,75 @@ else
   echo "  FAIL  every discard in VERDICT_JQ is a declared region or a listed normalization"
   sed 's/^/          /' <<<"$out" | head -8; fail=$((fail+1))
 fi
+
+echo "== finding 46: an EMPTY review object is not a review =="
+# #897 merged on head 27b1b943 with its last two commits reviewed by nobody. CodeRabbit
+# reviewed the previous head 34f66d47, posted two findings, and was refused under Fair
+# Usage on every request after that. The author fixed both findings, pushed, replied in
+# both threads and resolved them. GitHub minted an empty COMMENTED review object as the
+# container for each of those bot replies, bound to the new head:
+#     [coderabbitai] COMMENTED body_len=0  14:16:37Z  commit=27b1b943
+#     [coderabbitai] COMMENTED body_len=0  14:16:41Z  commit=27b1b943
+# `reviewed` counted them, the gate said CLEAR, and the merge went through 12 minutes
+# later. A reply to a comment thread is not a review of the code; the container carries
+# nothing that could only exist because a review ran.
+#
+# What counts now, and why each: a non-empty BODY (the reviewer wrote something), a state
+# of APPROVED or CHANGES_REQUESTED (GitHub only mints those from the review form; a reply
+# container is always COMMENTED), or an inline comment of its own that is not a reply
+# (the reviewer placed a finding). The last is not decoration: a human who reviews with
+# inline comments and no summary submits exactly that shape, and refusing it would leave
+# such a head permanently uncoverable once its threads were answered.
+CR_REVIEW='**Actionable comments posted: 2**\n\n<details>\n<summary>scripts/x.sh (1)</summary>\n\nP1: this drops the last row.\n\n</details>'
+# A review object as GraphQL returns it: $1 login, $2 state, $3 submittedAt, $4 commit,
+# $5 body, $6 the comments connection (default: none, the shape of a fixture captured
+# before the gate read them).
+rev() { printf '{"author":{"login":"%s"},"state":"%s","submittedAt":"%s","commit":{"oid":"%s"},"body":"%s"%s}' \
+  "$1" "$2" "$3" "$4" "$5" "${6:+,\"comments\":$6}"; }
+REPLY_CONTAINER='{"totalCount":1,"nodes":[{"replyTo":{"id":"PRRC_reply"}}]}'
+INLINE_FINDING='{"totalCount":1,"nodes":[{"replyTo":null}]}'
+# The #897 payload: findings raised on the OLD head, both threads answered and resolved,
+# the author's disposition review, and two empty bot containers on the current head.
+wrap11() { printf '{"data":{"repository":{"pullRequest":{"author":{"login":"me"},"headRefOid":"deadbeef","commits":{"nodes":[{"commit":{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{"nodes":[{"createdAt":"2026-01-02T00:30:00Z"}]}}}]},"reviewThreads":{"nodes":%s},"reviews":{"nodes":%s},"comments":{"nodes":[]},"recheck":{"comments":{"nodes":[]}}}}}}' "${2:-$ANSWERED_THREADS}" "$1"; }
+ANSWERED_THREADS='[{"id":"PRRT_1","isResolved":true,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"path":"scripts/x.sh","line":10,"originalLine":10,"body":"P1: this drops the last row"},{"author":{"login":"me"},"path":"scripts/x.sh","line":10,"originalLine":10,"body":"RED-VERIFIED: tests/row.rs"}]}},{"id":"PRRT_2","isResolved":true,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"},"path":"scripts/x.sh","line":20,"originalLine":20,"body":"P2: the count is off by one"},{"author":{"login":"me"},"path":"scripts/x.sh","line":20,"originalLine":20,"body":"NOT-A-DEFECT: reworded the message only"}]}}]'
+PR897=$(printf '[%s,%s,%s,%s]' \
+  "$(rev coderabbitai COMMENTED 2026-01-02T00:10:00Z 0ldc0mm1t "$CR_REVIEW")" \
+  "$(rev me COMMENTED 2026-01-02T01:00:00Z deadbeef 'RED-VERIFIED: tests/row.rs — both findings answered')" \
+  "$(rev coderabbitai COMMENTED 2026-01-02T00:50:00Z deadbeef '' "$REPLY_CONTAINER")" \
+  "$(rev coderabbitai COMMENTED 2026-01-02T00:50:04Z deadbeef '' "$REPLY_CONTAINER")")
+run_case "the #897 shape: two empty bot reply containers on the head cover nothing" \
+  "$(wrap11 "$PR897")" 1 "UNREVIEWED HEAD"
+run_case "one empty-bodied COMMENTED review on the head is not coverage" \
+  "$(wrap5 deadbeef "[$(rev coderabbitai COMMENTED 2026-01-02T00:50:00Z deadbeef '' "$REPLY_CONTAINER")]")" \
+  1 "UNREVIEWED HEAD"
+# A fixture captured before the gate read review comments carries no comments connection
+# at all. That is no evidence, not evidence of a review, and it declines.
+run_case "an empty COMMENTED review with no comments connection is not coverage" \
+  "$(wrap5 deadbeef "[$(rev coderabbitai COMMENTED 2026-01-02T00:50:00Z deadbeef '')]")" \
+  1 "UNREVIEWED HEAD"
+
+# The other direction, which matters just as much: an over-tight rule refuses real
+# coverage, and a gate that cries wolf gets switched off. Each of these must still cover.
+run_case "a bot review with findings on the head covers it" \
+  "$(wrap11 "$(printf '[%s,%s]' \
+     "$(rev coderabbitai COMMENTED 2026-01-02T00:40:00Z deadbeef "$CR_REVIEW" '{"totalCount":2,"nodes":[{"replyTo":null},{"replyTo":null}]}')" \
+     "$(rev me COMMENTED 2026-01-02T01:00:00Z deadbeef 'RED-VERIFIED: tests/row.rs')")")" \
+  0 "CLEAR"
+run_case "a stranger's APPROVED review with an empty body covers the head" \
+  "$(wrap5 deadbeef "[$(rev reviewer APPROVED 2026-01-02T00:50:00Z deadbeef '')]")" 0 "CLEAR"
+run_case "a CHANGES_REQUESTED review with an empty body covers the head" \
+  "$(wrap5 deadbeef "[$(rev reviewer CHANGES_REQUESTED 2026-01-02T00:50:00Z deadbeef '')]")" 0 "CLEAR"
+run_case "a review that placed an inline finding but wrote no summary covers the head" \
+  "$(wrap11 "[$(rev reviewer COMMENTED 2026-01-02T00:40:00Z deadbeef '' "$INLINE_FINDING")]")" \
+  0 "CLEAR"
+# A review object this gate cannot read must block, not be waved past as coverage and not
+# be silently dropped from the count.
+run_case "a review on the head with a non-string state exits 2" \
+  "$(wrap5 deadbeef '[{"author":{"login":"reviewer"},"state":null,"submittedAt":"2026-01-02T00:50:00Z","commit":{"oid":"deadbeef"},"body":""}]')" \
+  2 "BLOCKED"
+run_case "a review whose comments connection is truncated exits 2" \
+  "$(wrap5 deadbeef "[$(rev reviewer COMMENTED 2026-01-02T00:50:00Z deadbeef '' '{"totalCount":7,"nodes":[{"replyTo":{"id":"PRRC_reply"}}]}')]")" \
+  2 "BLOCKED"
 
 
 echo

--- a/tests/fixtures/review-threads-clear.json
+++ b/tests/fixtures/review-threads-clear.json
@@ -33,6 +33,10 @@
               "body": "",
               "commit": {
                 "oid": "dff10de24c30fe5c61175fe8d355af2a01a0ef46"
+              },
+              "comments": {
+                "totalCount": 0,
+                "nodes": []
               }
             }
           ]

--- a/tests/fixtures/review-threads-live-867.json
+++ b/tests/fixtures/review-threads-live-867.json
@@ -610,6 +610,14 @@
               "submittedAt": "2026-08-28T06:53:53Z",
               "commit": {
                 "oid": "8040074f5b1f4223b1ff709af3b70a177f334cff"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": null
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -621,6 +629,10 @@
               "submittedAt": "2026-08-28T07:00:05Z",
               "commit": {
                 "oid": "8040074f5b1f4223b1ff709af3b70a177f334cff"
+              },
+              "comments": {
+                "nodes": [],
+                "totalCount": 0
               }
             },
             {
@@ -632,6 +644,16 @@
               "submittedAt": "2026-08-28T07:02:27Z",
               "commit": {
                 "oid": "8040074f5b1f4223b1ff709af3b70a177f334cff"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": {
+                      "id": "PRRC_kwDOQSXJos7nLa2I"
+                    }
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -643,6 +665,10 @@
               "submittedAt": "2026-08-28T07:02:29Z",
               "commit": {
                 "oid": "9cb530fc6cf6c85e035e67daae17e0d63b08959c"
+              },
+              "comments": {
+                "nodes": [],
+                "totalCount": 0
               }
             },
             {
@@ -654,6 +680,17 @@
               "submittedAt": "2026-08-28T07:08:19Z",
               "commit": {
                 "oid": "9cb530fc6cf6c85e035e67daae17e0d63b08959c"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": null
+                  },
+                  {
+                    "replyTo": null
+                  }
+                ],
+                "totalCount": 2
               }
             },
             {
@@ -665,6 +702,16 @@
               "submittedAt": "2026-08-28T07:45:30Z",
               "commit": {
                 "oid": "9cb530fc6cf6c85e035e67daae17e0d63b08959c"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": {
+                      "id": "PRRC_kwDOQSXJos7nLt0s"
+                    }
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -676,6 +723,16 @@
               "submittedAt": "2026-08-28T07:45:32Z",
               "commit": {
                 "oid": "2a4201e2a86de2630f94514206f6171a2ff32852"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": {
+                      "id": "PRRC_kwDOQSXJos7nLt0t"
+                    }
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -687,6 +744,10 @@
               "submittedAt": "2026-08-28T07:45:33Z",
               "commit": {
                 "oid": "2a4201e2a86de2630f94514206f6171a2ff32852"
+              },
+              "comments": {
+                "nodes": [],
+                "totalCount": 0
               }
             },
             {
@@ -698,6 +759,14 @@
               "submittedAt": "2026-08-28T07:50:31Z",
               "commit": {
                 "oid": "2a4201e2a86de2630f94514206f6171a2ff32852"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": null
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -709,6 +778,16 @@
               "submittedAt": "2026-08-28T08:32:41Z",
               "commit": {
                 "oid": "2a4201e2a86de2630f94514206f6171a2ff32852"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": {
+                      "id": "PRRC_kwDOQSXJos7nMsMT"
+                    }
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -720,6 +799,10 @@
               "submittedAt": "2026-08-28T08:32:42Z",
               "commit": {
                 "oid": "63f8b3d5db1bfcfc75ecbc89713835467dc19b7f"
+              },
+              "comments": {
+                "nodes": [],
+                "totalCount": 0
               }
             },
             {
@@ -731,6 +814,14 @@
               "submittedAt": "2026-08-28T08:36:54Z",
               "commit": {
                 "oid": "63f8b3d5db1bfcfc75ecbc89713835467dc19b7f"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": null
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -742,6 +833,16 @@
               "submittedAt": "2026-08-28T09:50:18Z",
               "commit": {
                 "oid": "63f8b3d5db1bfcfc75ecbc89713835467dc19b7f"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": {
+                      "id": "PRRC_kwDOQSXJos7nNzlj"
+                    }
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -753,6 +854,10 @@
               "submittedAt": "2026-08-28T09:50:20Z",
               "commit": {
                 "oid": "6ae47ade9a737d37ef95d2419abfb215d8cad7cb"
+              },
+              "comments": {
+                "nodes": [],
+                "totalCount": 0
               }
             },
             {
@@ -764,6 +869,14 @@
               "submittedAt": "2026-08-28T09:53:54Z",
               "commit": {
                 "oid": "6ae47ade9a737d37ef95d2419abfb215d8cad7cb"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": null
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -775,6 +888,16 @@
               "submittedAt": "2026-08-28T11:18:16Z",
               "commit": {
                 "oid": "6ae47ade9a737d37ef95d2419abfb215d8cad7cb"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": {
+                      "id": "PRRC_kwDOQSXJos7nPwLQ"
+                    }
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -786,6 +909,10 @@
               "submittedAt": "2026-08-28T11:18:18Z",
               "commit": {
                 "oid": "55892ace22af5847b7195ed9b150aae4023ed1dd"
+              },
+              "comments": {
+                "nodes": [],
+                "totalCount": 0
               }
             },
             {
@@ -797,6 +924,14 @@
               "submittedAt": "2026-08-28T11:22:52Z",
               "commit": {
                 "oid": "55892ace22af5847b7195ed9b150aae4023ed1dd"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": null
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -808,6 +943,16 @@
               "submittedAt": "2026-08-28T13:05:46Z",
               "commit": {
                 "oid": "55892ace22af5847b7195ed9b150aae4023ed1dd"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": {
+                      "id": "PRRC_kwDOQSXJos7nRtKJ"
+                    }
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -819,6 +964,10 @@
               "submittedAt": "2026-08-28T13:05:48Z",
               "commit": {
                 "oid": "2747c0a23929090af383704f343b5c89fa94eac3"
+              },
+              "comments": {
+                "nodes": [],
+                "totalCount": 0
               }
             },
             {
@@ -830,6 +979,17 @@
               "submittedAt": "2026-08-28T13:10:37Z",
               "commit": {
                 "oid": "2747c0a23929090af383704f343b5c89fa94eac3"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": null
+                  },
+                  {
+                    "replyTo": null
+                  }
+                ],
+                "totalCount": 2
               }
             },
             {
@@ -841,6 +1001,14 @@
               "submittedAt": "2026-08-28T13:15:07Z",
               "commit": {
                 "oid": "2747c0a23929090af383704f343b5c89fa94eac3"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": null
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -852,6 +1020,16 @@
               "submittedAt": "2026-08-28T13:52:01Z",
               "commit": {
                 "oid": "2747c0a23929090af383704f343b5c89fa94eac3"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": {
+                      "id": "PRRC_kwDOQSXJos7nUOrX"
+                    }
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -863,6 +1041,16 @@
               "submittedAt": "2026-08-28T13:52:02Z",
               "commit": {
                 "oid": "ad3b805682456fece2508321ab877fed53972d6e"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": {
+                      "id": "PRRC_kwDOQSXJos7nUOrm"
+                    }
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -874,6 +1062,16 @@
               "submittedAt": "2026-08-28T13:52:05Z",
               "commit": {
                 "oid": "ad3b805682456fece2508321ab877fed53972d6e"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": {
+                      "id": "PRRC_kwDOQSXJos7nUWEC"
+                    }
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -885,6 +1083,10 @@
               "submittedAt": "2026-08-28T13:52:07Z",
               "commit": {
                 "oid": "ad3b805682456fece2508321ab877fed53972d6e"
+              },
+              "comments": {
+                "nodes": [],
+                "totalCount": 0
               }
             },
             {
@@ -896,6 +1098,16 @@
               "submittedAt": "2026-08-28T13:52:23Z",
               "commit": {
                 "oid": "ad3b805682456fece2508321ab877fed53972d6e"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": {
+                      "id": "PRRC_kwDOQSXJos7nUWEC"
+                    }
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -907,6 +1119,14 @@
               "submittedAt": "2026-08-28T13:56:04Z",
               "commit": {
                 "oid": "ad3b805682456fece2508321ab877fed53972d6e"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": null
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -918,6 +1138,16 @@
               "submittedAt": "2026-08-28T14:43:08Z",
               "commit": {
                 "oid": "ad3b805682456fece2508321ab877fed53972d6e"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": {
+                      "id": "PRRC_kwDOQSXJos7nVahn"
+                    }
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -929,6 +1159,10 @@
               "submittedAt": "2026-08-28T14:43:10Z",
               "commit": {
                 "oid": "0d5fb58b07df9143860d0cbc0f920f184606f5a7"
+              },
+              "comments": {
+                "nodes": [],
+                "totalCount": 0
               }
             },
             {
@@ -940,6 +1174,14 @@
               "submittedAt": "2026-08-28T14:46:31Z",
               "commit": {
                 "oid": "0d5fb58b07df9143860d0cbc0f920f184606f5a7"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": null
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -951,6 +1193,16 @@
               "submittedAt": "2026-08-28T15:54:38Z",
               "commit": {
                 "oid": "0d5fb58b07df9143860d0cbc0f920f184606f5a7"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": {
+                      "id": "PRRC_kwDOQSXJos7nW2Tm"
+                    }
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -962,6 +1214,10 @@
               "submittedAt": "2026-08-28T15:54:40Z",
               "commit": {
                 "oid": "c486e99c638df4870119d8c175fa3598f91b7f8a"
+              },
+              "comments": {
+                "nodes": [],
+                "totalCount": 0
               }
             },
             {
@@ -973,6 +1229,14 @@
               "submittedAt": "2026-08-28T15:58:26Z",
               "commit": {
                 "oid": "c486e99c638df4870119d8c175fa3598f91b7f8a"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": null
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -984,6 +1248,16 @@
               "submittedAt": "2026-08-28T17:47:36Z",
               "commit": {
                 "oid": "c486e99c638df4870119d8c175fa3598f91b7f8a"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": {
+                      "id": "PRRC_kwDOQSXJos7nY0zr"
+                    }
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -995,6 +1269,10 @@
               "submittedAt": "2026-08-28T17:47:39Z",
               "commit": {
                 "oid": "506e1eb88aa006d639ddc4ec89026765094d4fd5"
+              },
+              "comments": {
+                "nodes": [],
+                "totalCount": 0
               }
             },
             {
@@ -1006,6 +1284,14 @@
               "submittedAt": "2026-08-28T17:51:22Z",
               "commit": {
                 "oid": "506e1eb88aa006d639ddc4ec89026765094d4fd5"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": null
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -1017,6 +1303,16 @@
               "submittedAt": "2026-08-28T19:14:44Z",
               "commit": {
                 "oid": "506e1eb88aa006d639ddc4ec89026765094d4fd5"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": {
+                      "id": "PRRC_kwDOQSXJos7nbsFc"
+                    }
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -1028,6 +1324,10 @@
               "submittedAt": "2026-08-28T19:14:46Z",
               "commit": {
                 "oid": "c4bce833ffc5408f39ced92cf743ffcbaa6fd4bc"
+              },
+              "comments": {
+                "nodes": [],
+                "totalCount": 0
               }
             },
             {
@@ -1039,6 +1339,14 @@
               "submittedAt": "2026-08-28T19:18:11Z",
               "commit": {
                 "oid": "c4bce833ffc5408f39ced92cf743ffcbaa6fd4bc"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": null
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -1050,6 +1358,16 @@
               "submittedAt": "2026-08-28T20:58:50Z",
               "commit": {
                 "oid": "9ebed542aae2ba99c7379381f432a0572e520875"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": {
+                      "id": "PRRC_kwDOQSXJos7nd8l2"
+                    }
+                  }
+                ],
+                "totalCount": 1
               }
             },
             {
@@ -1061,6 +1379,10 @@
               "submittedAt": "2026-08-28T20:58:52Z",
               "commit": {
                 "oid": "9ebed542aae2ba99c7379381f432a0572e520875"
+              },
+              "comments": {
+                "nodes": [],
+                "totalCount": 0
               }
             },
             {
@@ -1072,6 +1394,17 @@
               "submittedAt": "2026-08-28T21:03:48Z",
               "commit": {
                 "oid": "9ebed542aae2ba99c7379381f432a0572e520875"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": null
+                  },
+                  {
+                    "replyTo": null
+                  }
+                ],
+                "totalCount": 2
               }
             },
             {
@@ -1083,6 +1416,14 @@
               "submittedAt": "2026-08-28T22:15:10Z",
               "commit": {
                 "oid": "9ebed542aae2ba99c7379381f432a0572e520875"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "replyTo": null
+                  }
+                ],
+                "totalCount": 1
               }
             }
           ]

--- a/tests/fixtures/review-threads-resolved-proven.json
+++ b/tests/fixtures/review-threads-resolved-proven.json
@@ -33,6 +33,10 @@
               "body": "",
               "commit": {
                 "oid": "f688cc21b85784a9bcd55f0d3d5b5b26bbc9069d"
+              },
+              "comments": {
+                "totalCount": 0,
+                "nodes": []
               }
             }
           ]

--- a/tests/fixtures/review-threads-resolved-unproven.json
+++ b/tests/fixtures/review-threads-resolved-unproven.json
@@ -33,6 +33,10 @@
               "body": "",
               "commit": {
                 "oid": "cb226f8d3418b51af89484d7bfc5387fed6c5114"
+              },
+              "comments": {
+                "totalCount": 0,
+                "nodes": []
               }
             }
           ]

--- a/tests/fixtures/review-threads-selfproof.json
+++ b/tests/fixtures/review-threads-selfproof.json
@@ -33,6 +33,10 @@
               "body": "",
               "commit": {
                 "oid": "800c03843fe060b6ec0cb3661614577b7f85bde1"
+              },
+              "comments": {
+                "totalCount": 0,
+                "nodes": []
               }
             }
           ]

--- a/tests/fixtures/review-threads-unresolved.json
+++ b/tests/fixtures/review-threads-unresolved.json
@@ -33,6 +33,10 @@
               "body": "",
               "commit": {
                 "oid": "2ea0c9d5b2f7399d33667ae3dbeaacef47191d22"
+              },
+              "comments": {
+                "totalCount": 0,
+                "nodes": []
               }
             }
           ]

--- a/tests/test_log_scan.rs
+++ b/tests/test_log_scan.rs
@@ -434,6 +434,44 @@ fn fixture_shape_problem(name: &str, text: &str) -> Option<String> {
             ));
         }
     }
+    // A review's own inline comments, which is how the gate tells a submitted review from
+    // the empty container GitHub mints for a reply to a comment thread. A fixture without
+    // them makes every empty review on the head decline coverage for the wrong reason.
+    for (i, review) in pr["reviews"]["nodes"]
+        .as_array()
+        .expect("checked above")
+        .iter()
+        .enumerate()
+    {
+        let at = format!("reviews.nodes[{i}]");
+        for (path, value) in [("state", &review["state"]), ("body", &review["body"])] {
+            if !value.is_string() {
+                return Some(format!(
+                    "fixture {name}: {at}.{path} is not a string. {hint}"
+                ));
+            }
+        }
+        if !review["comments"]["totalCount"].is_number() {
+            return Some(format!(
+                "fixture {name}: {at}.comments.totalCount is not a number, so a truncated \
+                 connection cannot be told from a complete one. {hint}"
+            ));
+        }
+        let Some(comments) = review["comments"]["nodes"].as_array() else {
+            return Some(format!(
+                "fixture {name}: {at}.comments.nodes is not an array. {hint}"
+            ));
+        };
+        for (j, comment) in comments.iter().enumerate() {
+            if comment.get("replyTo").is_none() {
+                return Some(format!(
+                    "fixture {name}: {at}.comments.nodes[{j}] has no `replyTo` key, and it \
+                     is the field that separates a finding this review placed from a reply \
+                     to someone else's. {hint}"
+                ));
+            }
+        }
+    }
     for (i, thread) in pr["reviewThreads"]["nodes"]
         .as_array()
         .expect("checked above")
@@ -1261,5 +1299,117 @@ fn a_region_stripped_before_classification_is_validated_or_the_body_stays_claima
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr)
     );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// An EMPTY review object is not a review.
+///
+/// #897 merged at 14:28:38Z on head 27b1b943 with its last two commits reviewed by nobody.
+/// CodeRabbit reviewed the previous head 34f66d47, posted two findings, and was refused
+/// under Fair Usage on every request after that. The author fixed both, pushed, replied in
+/// both threads and resolved them. GitHub mints an empty COMMENTED review object as the
+/// container for each reply to an inline thread, and both landed on the new head:
+///
+/// ```text
+/// [coderabbitai[bot]] COMMENTED body_len=0  14:16:37Z  commit=27b1b943
+/// [coderabbitai[bot]] COMMENTED body_len=0  14:16:41Z  commit=27b1b943
+/// ```
+///
+/// The coverage predicate counted any review object on the head from a non-author, so those
+/// two containers certified a commit nobody had read and the gate reported CLEAR. Same
+/// failure class the gate already carries two scars from: "the reviewer never ran" must not
+/// be indistinguishable from "the reviewer approved".
+///
+/// A review object is coverage only when it carries something that could only exist because
+/// a review ran: a non-empty body, a state of APPROVED or CHANGES_REQUESTED (a reply
+/// container is always COMMENTED), or an inline comment of its own that is not a reply.
+/// The last is not decoration, and the second half of this test pins it: a human who
+/// reviews with inline comments and no summary submits exactly that shape, and refusing it
+/// would leave such a head permanently uncoverable once its threads were answered.
+///
+/// The shell harness (scripts/test-check-review-threads.sh, "finding 46") carries the full
+/// matrix, including the truncated and unparsable review objects; these run in CI.
+#[test]
+fn an_empty_review_object_is_not_head_coverage() {
+    require_jq();
+    // The two threads CodeRabbit raised on the old head, answered and resolved.
+    const THREADS: &str = r#"[
+      {"id":"PRRT_1","isResolved":true,"isOutdated":false,"comments":{"nodes":[
+        {"author":{"login":"coderabbitai"},"path":"scripts/x.sh","line":10,"originalLine":10,
+         "body":"P1: this drops the last row"},
+        {"author":{"login":"me"},"path":"scripts/x.sh","line":10,"originalLine":10,
+         "body":"RED-VERIFIED: tests/row.rs"}]}},
+      {"id":"PRRT_2","isResolved":true,"isOutdated":false,"comments":{"nodes":[
+        {"author":{"login":"coderabbitai"},"path":"scripts/x.sh","line":20,"originalLine":20,
+         "body":"P2: the count is off by one"},
+        {"author":{"login":"me"},"path":"scripts/x.sh","line":20,"originalLine":20,
+         "body":"NOT-A-DEFECT: reworded the message only"}]}}]"#;
+    // The real review of the OLD head, the author's disposition, and the two empty
+    // containers GitHub minted for the bot's two thread replies on the new head.
+    const PR897_REVIEWS: &str = r#"[
+      {"author":{"login":"coderabbitai"},"state":"COMMENTED","submittedAt":"2026-01-02T00:10:00Z",
+       "commit":{"oid":"0ldc0mm1t"},"body":"**Actionable comments posted: 2**",
+       "comments":{"totalCount":2,"nodes":[{"replyTo":null},{"replyTo":null}]}},
+      {"author":{"login":"me"},"state":"COMMENTED","submittedAt":"2026-01-02T01:00:00Z",
+       "commit":{"oid":"deadbeef"},"body":"RED-VERIFIED: tests/row.rs, both findings answered",
+       "comments":{"totalCount":0,"nodes":[]}},
+      {"author":{"login":"coderabbitai"},"state":"COMMENTED","submittedAt":"2026-01-02T00:50:00Z",
+       "commit":{"oid":"deadbeef"},"body":"",
+       "comments":{"totalCount":1,"nodes":[{"replyTo":{"id":"PRRC_a"}}]}},
+      {"author":{"login":"coderabbitai"},"state":"COMMENTED","submittedAt":"2026-01-02T00:50:04Z",
+       "commit":{"oid":"deadbeef"},"body":"",
+       "comments":{"totalCount":1,"nodes":[{"replyTo":{"id":"PRRC_b"}}]}}]"#;
+    // The shape an over-tight rule would refuse: inline findings, no summary body.
+    const INLINE_ONLY: &str = r#"[
+      {"author":{"login":"reviewer"},"state":"COMMENTED","submittedAt":"2026-01-02T00:40:00Z",
+       "commit":{"oid":"deadbeef"},"body":"",
+       "comments":{"totalCount":1,"nodes":[{"replyTo":null}]}}]"#;
+
+    let payload = |threads: &str, reviews: &str| {
+        format!(
+            r#"{{"data":{{"repository":{{"pullRequest":{{"author":{{"login":"me"}},"headRefOid":"deadbeef","commits":{{"nodes":[{{"commit":{{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{{"nodes":[{{"createdAt":"2026-01-02T00:30:00Z"}}]}}}}}}]}},"reviewThreads":{{"nodes":{threads}}},"reviews":{{"nodes":{reviews}}},"comments":{{"nodes":[]}},"recheck":{{"comments":{{"nodes":[]}}}}}}}}}}}}"#
+        )
+    };
+
+    let dir = std::env::temp_dir().join(format!("fcvm-gate-empty-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let run = |name: &str, body: String| {
+        let f = dir.join(name);
+        std::fs::write(&f, body).unwrap();
+        let out = Command::new("bash")
+            .arg(repo_root().join("scripts/check-review-threads.sh"))
+            .arg("--from-file")
+            .arg(&f)
+            .output()
+            .expect("check-review-threads.sh must be runnable");
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        (combined, out.status.code().unwrap_or(-1))
+    };
+
+    let (out, code) = run("pr897.json", payload(THREADS, PR897_REVIEWS));
+    assert_eq!(
+        code, 1,
+        "every finding on this PR is answered and resolved, and the only review objects on \
+         the head are the empty containers GitHub minted for two thread replies. Nobody \
+         reviewed the head. Exit 0 here is the #897 merge.\n{out}"
+    );
+    assert!(
+        out.contains("UNREVIEWED HEAD"),
+        "the gate must name the uncovered head rather than blocking for some other \
+         reason.\n{out}"
+    );
+
+    let (out, code) = run("inline-only.json", payload("[]", INLINE_ONLY));
+    assert_eq!(
+        code, 0,
+        "a review that placed an inline finding of its own is a review, whatever its \
+         summary body says. Refusing it would leave a head permanently uncoverable once \
+         its threads were answered, and a gate that cries wolf gets switched off.\n{out}"
+    );
+    assert!(out.contains("CLEAR"), "{out}");
     let _ = std::fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
The head-coverage check counted any review object on the head from a non-author. GitHub mints an empty COMMENTED review as the container for every reply to an inline comment thread, bound to whatever the head is at the time, so replying in an already-answered thread certified a commit nobody had read.

One commit: `check-review-threads: an empty review object is not head coverage`.

## The problem

#897 merged at 14:28:38Z on head 27b1b943 with its last two commits, de9be216 and 27b1b943, reviewed by nobody. CodeRabbit reviewed the previous head 34f66d47, posted two findings, and was refused under Fair Usage on every subsequent request. The author fixed both, pushed, replied in both threads and resolved them. The review objects bound to the merged head:

```
ejc3          COMMENTED body_len=0     14:16:00Z
ejc3          COMMENTED body_len=0     14:16:12Z
coderabbitai  COMMENTED body_len=0     14:16:37Z   <- counted as coverage
coderabbitai  COMMENTED body_len=0     14:16:41Z   <- counted as coverage
ejc3          COMMENTED body_len=981   14:28:29Z   author disposition
```

Every one of those has `comments.totalCount = 1` and that one comment's `replyTo` is non-null. They are reply containers.

#901 merged the same way 41 minutes later, on head e35ff1a2: its only non-author review object on the head was one empty CodeRabbit container.

The predicate, `scripts/check-review-threads.sh` line 1156 on main:

```bash
reviewed=$(jq -r --arg h "$headoid" --arg me "$prauthor" \
           '[ .[] | select((.commit.oid // "") == $h) | select(.author.login != $me) ] | length' \
           <<<"$reviews")
```

## The rule

A review object is coverage only if it carries something that could only exist because a review ran:

| signal | why it cannot be a reply container |
|---|---|
| non-empty `body` | the reviewer wrote a summary; a container's body is `""` |
| `state` APPROVED or CHANGES_REQUESTED | GitHub mints those only from the review form; a reply container is always COMMENTED |
| an inline comment with `replyTo == null` | a finding this review placed, not a reply to someone else's |

DISMISSED is a review withdrawn and PENDING one never submitted, so neither covers on its own.

The third signal admits a review submitted with inline comments and no summary. No review on this repo has that shape today (checked across #844, #853, #867, #872, #874, #887, #893, #897, #901: every bot review writes a summary body), but `POST /pulls/N/reviews` accepts `event: COMMENT` with `comments` and no `body`, and refusing it would leave such a head uncoverable once its threads were answered. An over-tight gate cries wolf and gets switched off.

The three no-findings paths are untouched, because a genuine clean result leaves no review object at all: Codex's legacy verdict (`verdict_sha`), Codex's review-summary table (`summary_rows`), CodeRabbit's walkthrough (`walkthrough_sha`).

## Fail closed

Both reviews queries now select `comments(first: N) { totalCount nodes { replyTo { id } } }`. On a review object bound to the head from a non-author:

- a non-string `state` exits 2. The gate cannot tell a submitted review from a reply container.
- an unreadable comments connection exits 2.
- a connection reporting more comments than were fetched exits 2, when the object is not already coverage by body or state. The one non-reply may be the comment that was not fetched.
- an **absent** connection declines coverage rather than blocking. That is the shape of a fixture captured before the gate read review comments, and no evidence is not evidence of a review.

## Red first, in both harnesses

Against the unfixed script:

```
== finding 46: an EMPTY review object is not a review ==
  FAIL  the #897 shape: two empty bot reply containers on the head cover nothing (rc=0 want=1)
          review threads: 2 total, 0 unresolved
          verdict: CLEAR — every thread resolved and disposed, every review body answered.
  FAIL  one empty-bodied COMMENTED review on the head is not coverage (rc=0 want=1)
  FAIL  an empty COMMENTED review with no comments connection is not coverage (rc=0 want=1)
  FAIL  a review on the head with a non-string state exits 2 (rc=0 want=2)
  FAIL  a review whose comments connection is truncated exits 2 (rc=0 want=2)
passed=238 failed=5
```

```
TRY 1 FAIL fcvm::test_log_scan an_empty_review_object_is_not_head_coverage
  assertion `left == right` failed: every finding on this PR is answered and resolved, and
  the only review objects on the head are the empty containers GitHub minted for two thread
  replies. Nobody reviewed the head. Exit 0 here is the #897 merge.
    left: 0
   right: 1
```

With the fix: `passed=243 failed=0`, and `27 tests run: 27 passed`. Reverted once more: the same five shell cases and the same Rust assertion go red again.

## Replay of #897

One payload, two scripts:

```
$ bash scripts/check-review-threads.sh --dump-payload 897 > pr897.json
$ bash <origin/main gate> --from-file pr897.json
review threads: 7 total, 0 unresolved
verdict: CLEAR — every thread resolved and disposed, every review body answered.
exit=0

$ bash scripts/check-review-threads.sh --from-file pr897.json
review threads: 7 total, 0 unresolved

  UNREVIEWED HEAD  27b1b9435 — no review of this commit from anyone but the author
  (an empty review object is a reply container, not a review), and no no-findings
  verdict bound to it

verdict: BLOCKED — the head commit has not been reviewed.
exit=1
```

#901 flips the same way; #893 and #867 report the same verdict under both scripts.

## The other direction

Cases added under finding 46 that must still grant coverage, and do:

- a bot review with findings on the head (non-empty body, two non-reply inline comments)
- a stranger's APPROVED review with an empty body
- a CHANGES_REQUESTED review with an empty body
- a review that placed an inline finding and wrote no summary

The existing Codex-verdict, Codex-summary-table and CodeRabbit-walkthrough coverage cases are unchanged and still pass.

## Mutations

| mutation | caught by |
|---|---|
| re-admit empty bodies | the three #897 shell cases, and `an_empty_review_object_is_not_head_coverage` |
| accept an empty body only from a review bot | the three #897 shell cases |
| drop the APPROVED / CHANGES_REQUESTED clause | 27 cases, including the two state-coverage cases |
| an unparsable review counts as coverage | `a review on the head with a non-string state exits 2` |
| drop the truncated-comments block | `a review whose comments connection is truncated exits 2` |

## Fixtures

Six fixtures gained the reviews' comments connection. The five hand-written ones get an empty connection; `review-threads-live-867.json` carries the real per-review data fetched from PR 867 (2 of its 4 head reviews have non-reply inline comments). `tests/test_log_scan.rs` now rejects a fixture whose review nodes lack `state`, `body`, `comments.totalCount`, `comments.nodes`, or a `replyTo` key on a comment.

Six harness fixtures granted coverage from an empty-bodied COMMENTED review on the head. They were encoding this bug; they now carry an inline comment of their own.

## Tests

```
bash scripts/test-check-review-threads.sh   243 passed, 0 failed
make test-unit                              987 tests run: 987 passed, 0 skipped
make lint                                   advisories ok, bans ok, licenses ok, sources ok
```

CI runs the Rust harness (`tests/test_log_scan.rs`) only. The shell harness is local.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Review coverage now distinguishes actual reviews from empty reply containers.
  * Inline comments, review content, and approval states are evaluated more accurately.
  * Invalid review data or incomplete comment results now block coverage checks with a clear failure.
  * Unreviewed-head messages identify empty review objects as reply containers.

* **Tests**
  * Expanded validation for review states, comment structures, pagination, and inline comments.
  * Added coverage scenarios for empty review objects and updated review fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Third instance: #898

The replay above names #897 and #901. A third merge went through this hole the same day: **#898**, merged head `12a2e8d52`.

```
$ bash scripts/check-review-threads.sh --dump-payload 898 > pr898.json
$ bash <origin/main check-review-threads.sh> --from-file pr898.json
  review threads: 6 total, 0 unresolved
  verdict: CLEAR — every thread resolved and disposed, every review body answered.
$ bash scripts/check-review-threads.sh --from-file pr898.json
  verdict: BLOCKED — the head commit has not been reviewed.
  ... Wait for a review of 12a2e8d52, or re-request one.
```

Its review objects on that head are three `coderabbitai` COMMENTED with `body_len=0` plus one `ejc3` with `body_len=1262`, the author own disposition. No non-author review carries a body, the same shape as the other two.

So three merges went through this hole on 2026-09-02, not two.