### PR TITLE
Remove an HTML comment only where GitHub hides it

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -251,10 +251,19 @@ Earlier versions also guessed which findings were defects from a `panic|crash|le
 That failed BOTH ways: "this drops the final game from the schedule" matched nothing and closed
 on an assertion, while a *wrong* defect claim could never be closed at all. Do not guess; answer.
 
-The gate has its own tests, each written against the unfixed script and observed failing first:
-`scripts/test-check-review-threads.sh`, plus `scripts/probe-review-gate-pagination.sh` for the
-live oversized-thread path that fixtures cannot reach. CI state cannot tell you whether a
-finding was answered.
+The gate has its own tests, each written against the unfixed script and observed failing first.
+There are two harnesses and only one of them runs in CI, so run both before pushing a gate
+change:
+
+```bash
+bash scripts/test-check-review-threads.sh                 # shell fixtures, not run by CI
+make test-unit FILTER="-E 'binary(test_log_scan)'"        # tests/test_log_scan.rs, run by CI
+```
+
+`make test-unit FILTER=log_scan` runs 0 tests and exits 4: FILTER is passed to nextest as-is
+and no test NAME contains that substring, so the plain form selects nothing while looking like
+a pass. `scripts/probe-review-gate-pagination.sh` covers the live oversized-thread path that
+fixtures cannot reach. CI state cannot tell you whether a finding was answered.
 
 ### "LOAD RELATED" IS NOT A DIAGNOSIS. NEITHER IS "FLAKY", "TIMING", OR "CONTENTION"
 

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -379,4 +379,13 @@ Write the disposition as the FIRST thing in a reply of its own (`RED-VERIFIED: .
 AFTER the finding it answers, and use the same three words for findings that arrive in a
 review body rather than inline. All three are enforced, and all three were once holes.
 
-Verify the gate itself with `scripts/test-check-review-threads.sh` before trusting a CLEAR.
+Verify the gate itself before trusting a CLEAR. It has two harnesses and CI runs only the
+second, so a gate change needs both:
+
+```bash
+bash scripts/test-check-review-threads.sh                 # shell fixtures, not run by CI
+make test-unit FILTER="-E 'binary(test_log_scan)'"        # tests/test_log_scan.rs, run by CI
+```
+
+`make test-unit FILTER=log_scan` selects nothing (0 tests, exit 4): FILTER matches test names,
+and no test name carries that substring.

--- a/scripts/check-review-threads.sh
+++ b/scripts/check-review-threads.sh
@@ -681,23 +681,49 @@ TRIGGER_RE='\A[[:space:]]*@(codex[[:space:]]+(security[[:space:]]+)?review|coder
 #
 # ACCOUNTING. A body is exempt from dispositions only if the classifier read every byte of
 # it. Content removed before classification is content nobody evaluated, so a finding in a
-# removed region is exempt and never answered. That is one defect class and it landed three
-# times: the notice payload (any line starting with ">"), the CodeRabbit tips block, and
-# the folded About Codex block, the last of which also bound no-findings COVERAGE to the
-# head. Every removal now goes through strip_accounted, which deletes a region declared in
-# accounted_regions only after every non-blank line inside it matches one of that region's
-# shapes, and returns null otherwise, which makes the whole body claimable. The regions:
+# removed region is exempt and never answered. That is one defect class and it landed four
+# times: the notice payload (any line starting with ">"), the CodeRabbit tips block, the
+# folded About Codex block, and an HTML comment a reader can see. The third and fourth also
+# bound no-findings COVERAGE to the head. Every removal now goes through strip_accounted,
+# and a region is removed only under the justification it declares: a RENDERED region is
+# removed after every non-blank line inside it matches one of that region's shapes, and the
+# one UNRENDERED region is removed only where GitHub is known to hide it. A rendered region
+# that fails its shapes returns null, which makes the whole body claimable; an unrendered
+# one that cannot be shown hidden stays in the body, where it is an unlisted line and the
+# body is claimable the same way. The regions:
 #
 #   cr_tips       <!-- tips_start --> .. <!-- tips_end -->        rendered, shape-checked
 #   codex_about   <details> <summary>ℹ️ About Codex ..</details>  rendered, shape-checked
-#   html_comment  <!-- .. -->                                     not rendered, no shapes
+#   html_comment  <!-- .. -->                                     removed only where
+#                                                                 CommonMark hides it
 #
-# html_comment carries no shapes because GitHub renders none of it: nothing inside one is a
-# claim a reader can see or answer. Both shape lists were read off what the bots posted on
-# ejc3/fcvm #789 through #901 (13 About blocks, 17 tips blocks) and match all of it with
-# nothing left over. Every shape is anchored, because an unanchored one matches the head of
-# a line and lets the rest ride along. An unlisted line costs one disposition; accepting
-# one costs a finding nobody has to answer.
+# Both shape lists were read off what the bots posted on ejc3/fcvm #789 through #901 (13
+# About blocks, 17 tips blocks) and match all of it with nothing left over. Every shape is
+# anchored, because an unanchored one matches the head of a line and lets the rest ride
+# along. An unlisted line costs one disposition; accepting one costs a finding nobody has
+# to answer.
+#
+# html_comment carries no shapes because it is justified by INVISIBILITY instead, and that
+# justification is checked per occurrence by strip_hidden_comments. "GitHub renders none of
+# it" is false as a blanket premise: CommonMark's HTML-block start condition 2 admits at
+# most three spaces of indentation, so at four columns the same bytes are an indented code
+# block and every reader sees them. Verified against GitHub's own renderer (POST /markdown,
+# mode gfm): `<!-- P1 -->` at 0-3 spaces renders as nothing, at 4 spaces or after a tab it
+# comes back as a <pre><code> block, and inside a fenced block it comes back the same way.
+# A body carrying a visible finding there was exempt from dispositions AND bound
+# no-findings coverage to the head.
+#
+# strip_hidden_comments walks the body one line at a time and removes a comment only where
+# GitHub is known to hide it. It removes a COMPLETE single-line `<!-- .. -->`, at line start
+# or inline, on a line that is not indented four columns (tabs count as four) and is not
+# inside a fenced code block, measuring both after any blockquote markers so a `>`-quoted
+# line is judged by its own content. Everything else stays in the body, where it is an
+# unlisted line and the body is claimable. Two things it therefore declines to remove that
+# GitHub does hide, both fail-closed and both costing one disposition: a comment spanning
+# lines, and a comment indented four columns under an open paragraph. Neither has occurred
+# in the 1602 HTML comments the two bots posted on ejc3/fcvm #789 through #901, every one
+# of which sits at column 0 on one line (1350) or inline on a column-0 line (252). Judged
+# over those 350 comment bodies, the narrowed region changes no verdict.
 #
 # scripts/gate-discard-sites.sh enumerates every discarding call in VERDICT_JQ and blocks
 # on any that is neither this primitive nor a listed normalization, so the next stripping
@@ -726,15 +752,43 @@ def accounted_regions:
       re: "<!-- tips_start -->(?<inner>(.|\n)*?)<!-- tips_end -->" }
   , { name: "codex_about", rendered: true, lines: codex_about_res,
       re: "<details> <summary>ℹ️ About Codex in GitHub</summary>(?<inner>(.|\n)*?)</details>" }
-  , { name: "html_comment", rendered: false, lines: null,
-      re: "<!--(.|\n)*?-->" }
+  , { name: "html_comment", rendered: false, lines: null, re: null }
   ];
+# One complete comment on one line. Spanning lines is deliberately not matched: GitHub
+# hides such a comment, this leaves it in the body, and the body is claimable.
+def hidden_comment_re: "<!--[^\n]*?-->";
+# A line is judged by its own content, so the blockquote markers in front of it are not
+# part of its indentation and do not hide a fence opened inside the quote.
+def quote_prefix_re: "^(?: {0,3}> ?)+";
+def fence_mark: [ match("^ {0,3}(?<f>`{3,}|~{3,})") | .captures[] | select(.name == "f") | .string ] | first;
+# CommonMark closes a fence with at least as many of the SAME character and nothing else on
+# the line, so a closer that does not match leaves the block open and its content in place.
+def fence_close_re: "^ {0,3}(?:`{3,}|~{3,})[ \t]*$";
+def lead_cols: (([ match("^[ \t]*") | .string ] | first) // "") | gsub("\t"; "    ") | length;
+def strip_hidden_comments:
+  ((. // "") | split("\n"))
+  | reduce .[] as $raw ({fence: null, out: []};
+      . as $st
+      | ($raw | sub(quote_prefix_re; "")) as $c
+      | if $st.fence != null then
+          ($c | fence_mark) as $f
+          | { fence: (if ($f != null) and ($f[0:1] == ($st.fence | .[0:1]))
+                         and (($f | length) >= ($st.fence | length)) and ($c | test(fence_close_re))
+                      then null else $st.fence end),
+              out: ($st.out + [$raw]) }
+        elif ($c | lead_cols) >= 4 then { fence: null, out: ($st.out + [$raw]) }
+        else ($c | fence_mark) as $f
+          | if $f != null then { fence: $f, out: ($st.out + [$raw]) }
+            else { fence: null, out: ($st.out + [($raw | gsub(hidden_comment_re; ""))]) }
+            end
+        end)
+  | .out | join("\n");
 def strip_accounted($names):
   if ($names | any(. as $n | ([accounted_regions[] | .name] | index($n)) == null)) then null
   else reduce accounted_regions[] as $r (.;
     if . == null then null
     elif ($r.name | IN($names[]) | not) then .
-    elif ($r.rendered | not) then gsub($r.re; "")
+    elif ($r.rendered | not) then strip_hidden_comments
     elif (($r.lines // []) | length) == 0 then null
     elif ([match($r.re; "g")] | all(.[];
             [.captures[] | select(.name == "inner") | .string] as $c

--- a/scripts/check-review-threads.sh
+++ b/scripts/check-review-threads.sh
@@ -717,13 +717,13 @@ TRIGGER_RE='\A[[:space:]]*@(codex[[:space:]]+(security[[:space:]]+)?review|coder
 # GitHub is known to hide it. It removes a COMPLETE single-line `<!-- .. -->`, at line start
 # or inline, on a line that is not indented four columns (tabs count as four) and is not
 # inside a fenced code block, measuring both after any blockquote markers so a `>`-quoted
-# line is judged by its own content. Everything else stays in the body, where it is an
-# unlisted line and the body is claimable. Two things it therefore declines to remove that
-# GitHub does hide, both fail-closed and both costing one disposition: a comment spanning
+# line is judged by its own content. A comment followed by a backtick could be inside a
+# code span, so that line stays unchanged. Unpaired backtick runs on a non-fence line
+# could open a multiline code span, so that whole body stays unchanged.
+# It also leaves two shapes GitHub does hide, both costing one disposition: a comment spanning
 # lines, and a comment indented four columns under an open paragraph. Neither has occurred
 # in the 1602 HTML comments the two bots posted on ejc3/fcvm #789 through #901, every one
-# of which sits at column 0 on one line (1350) or inline on a column-0 line (252). Judged
-# over those 350 comment bodies, the narrowed region changes no verdict.
+# of which sits at column 0 on one line (1350) or inline on a column-0 line (252).
 #
 # scripts/gate-discard-sites.sh enumerates every discarding call in VERDICT_JQ and blocks
 # on any that is neither this primitive nor a listed normalization, so the next stripping
@@ -766,7 +766,14 @@ def fence_mark: [ match("^ {0,3}(?<f>`{3,}|~{3,})") | .captures[] | select(.name
 def fence_close_re: "^ {0,3}(?:`{3,}|~{3,})[ \t]*$";
 def lead_cols: (([ match("^[ \t]*") | .string ] | first) // "") | gsub("\t"; "    ") | length;
 def strip_hidden_comments:
-  ((. // "") | split("\n"))
+  (. // "") as $body
+  | ($body | split("\n")) as $lines
+  # Do not infer inline-code boundaries across lines. An unpaired delimiter length
+  # makes the body ambiguous; preserving it costs a disposition rather than a finding.
+  | if any($lines[]; sub(quote_prefix_re; "")
+           | (fence_mark == null)
+             and ([scan("`+")] | group_by(length) | any(length % 2 != 0))) then $body
+    else $lines
   | reduce .[] as $raw ({fence: null, out: []};
       . as $st
       | ($raw | sub(quote_prefix_re; "")) as $c
@@ -779,10 +786,11 @@ def strip_hidden_comments:
         elif ($c | lead_cols) >= 4 then { fence: null, out: ($st.out + [$raw]) }
         else ($c | fence_mark) as $f
           | if $f != null then { fence: $f, out: ($st.out + [$raw]) }
+            elif ($c | test("<!--.*`")) then { fence: null, out: ($st.out + [$raw]) }
             else { fence: null, out: ($st.out + [($raw | gsub(hidden_comment_re; ""))]) }
             end
         end)
-  | .out | join("\n");
+  | .out | join("\n") end;
 def strip_accounted($names):
   if ($names | any(. as $n | ([accounted_regions[] | .name] | index($n)) == null)) then null
   else reduce accounted_regions[] as $r (.;

--- a/scripts/check-review-threads.sh
+++ b/scripts/check-review-threads.sh
@@ -773,8 +773,8 @@ def strip_hidden_comments:
   | if any($lines[]; sub(quote_prefix_re; "")
            | (fence_mark == null)
              and ([scan("`+")] | group_by(length) | any(length % 2 != 0))) then $body
-    else $lines
-  | reduce .[] as $raw ({fence: null, out: []};
+    # Collect emitted lines once; carrying the output prefix in state copies it per line.
+    else [foreach $lines[] as $raw ({fence: null, line: ""};
       . as $st
       | ($raw | sub(quote_prefix_re; "")) as $c
       | if $st.fence != null then
@@ -782,15 +782,15 @@ def strip_hidden_comments:
           | { fence: (if ($f != null) and ($f[0:1] == ($st.fence | .[0:1]))
                          and (($f | length) >= ($st.fence | length)) and ($c | test(fence_close_re))
                       then null else $st.fence end),
-              out: ($st.out + [$raw]) }
-        elif ($c | lead_cols) >= 4 then { fence: null, out: ($st.out + [$raw]) }
+              line: $raw }
+        elif ($c | lead_cols) >= 4 then { fence: null, line: $raw }
         else ($c | fence_mark) as $f
-          | if $f != null then { fence: $f, out: ($st.out + [$raw]) }
-            elif ($c | test("<!--.*`")) then { fence: null, out: ($st.out + [$raw]) }
-            else { fence: null, out: ($st.out + [($raw | gsub(hidden_comment_re; ""))]) }
+          | if $f != null then { fence: $f, line: $raw }
+            elif ($c | test("<!--.*`")) then { fence: null, line: $raw }
+            else { fence: null, line: ($raw | gsub(hidden_comment_re; "")) }
             end
-        end)
-  | .out | join("\n") end;
+        end; .line)]
+  | join("\n") end;
 def strip_accounted($names):
   if ($names | any(. as $n | ([accounted_regions[] | .name] | index($n)) == null)) then null
   else reduce accounted_regions[] as $r (.;

--- a/scripts/gate-discard-sites.sh
+++ b/scripts/gate-discard-sites.sh
@@ -55,12 +55,20 @@ END {
   if (e == 0) { print "BLOCKED: unterminated VERDICT_JQ in " gate > "/dev/stderr"; exit 2 }
   jq = substr(rest, 1, e - 1)
 
-  # The accounting primitive: every discard inside it is the primitive doing its job.
-  ps = index(jq, "def strip_accounted(")
-  if (ps == 0) { print "BLOCKED: strip_accounted is gone; nothing accounts for a removal" > "/dev/stderr"; exit 2 }
-  tail = substr(jq, ps + 1)
-  pe = index(tail, "\ndef ")
-  pe = (pe == 0) ? length(jq) : ps + pe
+  # The accounting primitives: every discard inside one is that primitive doing its job.
+  # strip_accounted removes a declared region after checking its content against the
+  # shapes that region declares. strip_hidden_comments is the check the html_comment
+  # region declares instead: it removes a comment only where CommonMark hides it, and
+  # leaves every other one in the body.
+  nprim = split("def strip_accounted(|def strip_hidden_comments:", prim, "|")
+  for (i = 1; i <= nprim; i++) {
+    p = index(jq, prim[i])
+    if (p == 0) { print "BLOCKED: " prim[i] " is gone; nothing accounts for a removal" > "/dev/stderr"; exit 2 }
+    pstart[i] = p
+    tail = substr(jq, p + 1)
+    q = index(tail, "\ndef ")
+    pend[i] = (q == 0) ? length(jq) : p + q
+  }
 
   # Normalizations. Each drops nothing a reader could read, and what survives is still
   # shape-checked by the caller.
@@ -75,6 +83,8 @@ END {
   ok[norm("select([scan(cr_marker_re)] == [cr_summarize_marker])")] = "whole-comment guard: the summarize marker is the only marker"
   ok[norm("select(test(\"(?m)^>[[:space:]]*##\") | not)")] = "whole-comment guard: no blockquoted notice heading"
   ok[norm("select(test(\"No actionable comments were generated in the recent review\"))")] = "whole-block guard: the review finished clean"
+  ok[norm("select(.name == \"f\")")] = "pick a named capture out of a match; no body text is touched"
+  ok[norm("gsub(\"\\t\"; \"    \")")] = "count a tab as four columns while measuring indentation; no body text is touched"
 
   bad = 0
   split("gsub( sub( select(", kw, " ")
@@ -89,7 +99,8 @@ END {
       call = callat(jq, pos + length(key) - 1)
       if (call == "") { print "BLOCKED: unbalanced parentheses at offset " pos > "/dev/stderr"; exit 2 }
       text = norm(substr(jq, pos, length(key) - 1) call)
-      inside = (pos >= ps && pos <= pe)
+      inside = 0
+      for (i = 1; i <= nprim; i++) if (pos >= pstart[i] && pos <= pend[i]) inside = 1
       total++
       if (inside) { printf "  primitive     %s\n", text }
       else if (text in ok) { printf "  %-13s %s\n", "normalization", text }

--- a/scripts/test-check-review-threads.sh
+++ b/scripts/test-check-review-threads.sh
@@ -1639,6 +1639,13 @@ TAB_FINDING=$'\t<!-- P1: the restore path drops the last row -->'
 SPAN_FINDING=$'    <!-- P1: the restore path drops the last row\n    and the compaction pass never reruns\n    -->'
 FENCE_FINDING=$'```\n<!-- P1: the restore path drops the last row -->\n```'
 QUOTED_FINDING='>     <!-- P1: the restore path drops the last row -->'
+INLINE_CODE_VERDICT=$(jq -n '"Codex Review: Didn\u0027t find any major issues.\n\n**Reviewed commit:** `deadbeef<!-- P1: drops last row -->`"')
+run_case "a finding inside the reviewed-commit code span is claimable" \
+  "$(wrap9 "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$INLINE_CODE_VERDICT")")" \
+  1 "carry no disposition"
+run_case "a finding inside the reviewed-commit code span covers no head" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$INLINE_CODE_VERDICT")")" \
+  1 "UNREVIEWED HEAD"
 # The four-space case, in both of the things a verdict decides.
 run_case "a verdict with a four-space indented finding is claimable" \
   "$(wrap9 "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_plus "$SPACE_FINDING")")")" \
@@ -1749,6 +1756,7 @@ scan_case "a blockquote-indented comment is kept" '>     <!-- P1 -->'       '>  
 scan_case "a comment spanning lines is kept"     $'<!-- P1\nmore\n-->'      $'<!-- P1\nmore\n-->'
 scan_case "an inline comment is removed"         '- [ ] <!-- {"checkboxId":"a"} --> Trigger review' '- [ ]  Trigger review'
 scan_case "a quoted column-0 comment is removed" '> <!-- m -->'             '> '
+scan_case "a comment inside a multiline code span is kept" $'`code\n<!-- P1 -->\ncode`' $'`code\n<!-- P1 -->\ncode`'
 
 echo
 echo "passed=$pass failed=$fail"

--- a/scripts/test-check-review-threads.sh
+++ b/scripts/test-check-review-threads.sh
@@ -1616,6 +1616,140 @@ run_case "a review whose comments connection is truncated exits 2" \
   2 "BLOCKED"
 
 
+echo "== finding 46: a comment is removed unread only where GitHub actually hides it =="
+# Round 4 of the same class. Finding 45 gave the two RENDERED regions shape lists and left
+# the third, html_comment, stripped with no check at all, on the premise that "GitHub
+# renders none of it". That premise is false. CommonMark's HTML-block start condition 2
+# admits at most three spaces of indentation; at four columns the same bytes are an indented
+# code block and every reader sees them. Confirmed against GitHub's own renderer
+# (POST /markdown, mode gfm): `<!-- P1 -->` returns nothing at 0-3 spaces and comes back as
+# a <pre><code> block at 4 spaces, after a tab, and inside a fenced block.
+#
+# So a finding a reader could see was removed before classification, which made the comment
+# a no-findings verdict: exempt from dispositions AND binding coverage to the head. The
+# region is now removed by strip_hidden_comments, which takes out a complete single-line
+# comment only on a line that is not indented four columns and not inside a fence, measured
+# after any blockquote markers. Anything else stays in the body and the body is claimable.
+# Codex's no-findings verdict with $1 appended: the two lines it must reduce to, plus the
+# bytes under test. The apostrophe is written \u0027 so this can live in a single-quoted
+# shell string, as codex_body above does.
+codex_plus() { jq -n --arg x "$1" '"Codex Review: Didn\u0027t find any major issues.\n\n**Reviewed commit:** `deadbeef`\n\n\($x)"'; }
+SPACE_FINDING='    <!-- P1: the restore path drops the last row -->'
+TAB_FINDING=$'\t<!-- P1: the restore path drops the last row -->'
+SPAN_FINDING=$'    <!-- P1: the restore path drops the last row\n    and the compaction pass never reruns\n    -->'
+FENCE_FINDING=$'```\n<!-- P1: the restore path drops the last row -->\n```'
+QUOTED_FINDING='>     <!-- P1: the restore path drops the last row -->'
+# The four-space case, in both of the things a verdict decides.
+run_case "a verdict with a four-space indented finding is claimable" \
+  "$(wrap9 "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_plus "$SPACE_FINDING")")")" \
+  1 "carry no disposition"
+run_case "a verdict with a four-space indented finding covers no head" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_plus "$SPACE_FINDING")")")" \
+  1 "UNREVIEWED HEAD"
+# A tab is four columns, so a tab-indented comment renders the same way and a space-only
+# indentation test cannot see it.
+run_case "a verdict with a tab-indented finding is claimable" \
+  "$(wrap9 "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_plus "$TAB_FINDING")")")" \
+  1 "carry no disposition"
+run_case "a verdict with a tab-indented finding covers no head" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_plus "$TAB_FINDING")")")" \
+  1 "UNREVIEWED HEAD"
+# An indented comment SPANNING lines shows every line of itself in the code block, so the
+# more text it carries the more a reader sees and the more the old region removed.
+run_case "a verdict with an indented finding spanning lines is claimable" \
+  "$(wrap9 "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_plus "$SPAN_FINDING")")")" \
+  1 "carry no disposition"
+# The same bytes in the two other comments the exemption covers: Codex's review-summary
+# table, whose rows bind coverage, and a CodeRabbit summary notice, whose residue check
+# runs after the region is removed.
+run_case "a codex review summary with an indented finding is claimable" \
+  "$(wrap9 "$(cmt "$CODEX" Bot 2026-01-02T00:20:00Z "$(codex_summary_plus "$(sum_row Completed 2026-01-02T01:00:00.123456Z deadbee)" "$SPACE_FINDING")" 2026-01-02T01:00:05Z)")" \
+  1 "carry no disposition"
+run_case "a codex review summary with an indented finding covers no head" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T00:20:00Z "$(codex_summary_plus "$(sum_row Completed 2026-01-02T01:00:00.123456Z deadbee)" "$SPACE_FINDING")" 2026-01-02T01:00:05Z)")" \
+  1 "UNREVIEWED HEAD"
+run_case "a summary notice with an indented finding appended is claimable" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'rate limited' "$LIMIT_NOTICE" "$SPACE_FINDING")" 2026-01-02T01:00:00Z)")" \
+  1 "carry no disposition"
+# A fenced block renders its content literally the same way. This pair was already green:
+# the fence markers themselves survive the removal and no shape list accepts a line of
+# backticks, so the shape lists caught it rather than the region rule. strip_hidden_comments
+# tracks fences so that protection stops depending on that coincidence; the scanner
+# assertion below is what goes red if the fence handling is dropped.
+run_case "a verdict with a fenced finding is claimable" \
+  "$(wrap9 "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_plus "$FENCE_FINDING")")")" \
+  1 "carry no disposition"
+run_case "a verdict with a fenced finding covers no head" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_plus "$FENCE_FINDING")")")" \
+  1 "UNREVIEWED HEAD"
+# Indentation is measured inside the blockquote, not from the start of the line: GitHub
+# renders `>     <!-- .. -->` as a code block inside the quote.
+run_case "a verdict with a finding indented inside a blockquote is claimable" \
+  "$(wrap9 "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_plus "$QUOTED_FINDING")")")" \
+  1 "carry no disposition"
+# The negative cases the exemption exists for. Every HTML comment the two bots posted on
+# ejc3/fcvm #789 through #901 (1602 of them) sits at column 0 on one line or inline on a
+# column-0 line, and all of it must stay exempt: an over-tight rule blocks on ordinary bot
+# traffic, which is how a gate gets switched off.
+run_case "a verdict carrying a column-0 hidden marker still covers the head" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_plus '<!-- an ordinary hidden marker -->')")")" \
+  0 "HEAD COVERED"
+run_case "a verdict whose reviewed-commit line carries an inline marker still covers" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(jq -n '"Codex Review: Didn\u0027t find any major issues.\n\n**Reviewed commit:** `deadbeef` <!-- run 4c1f -->"')")")" \
+  0 "HEAD COVERED"
+run_case "the real codex verdict with its About block still covers the head" \
+  "$(wrap8 "$SUITE" "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_body ' Bravo.' deadbeef)")")" \
+  0 "HEAD COVERED"
+run_case "the real summary notice still needs no disposition" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'rate limited' "$LIMIT_NOTICE")" 2026-01-02T01:00:00Z)")" \
+  0 "CLEAR"
+# The skip notice carries CodeRabbit's inline checkbox marker inside its blockquote, which
+# is the live inline case; it must stay a notice.
+run_case "the real skip notice with its inline checkbox marker still needs no disposition" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'skip review' "$SKIP_NOTICE")" 2026-01-02T01:00:00Z)")" \
+  0 "CLEAR"
+
+# The other two regions were checked for the same premise. Their DELIMITERS can be moved
+# into a code context the same way, but that hides nothing: what a rendered region removes
+# still has to match that region's line shapes, and a finding matches none of them. All four
+# were green before this change too, which is the answer to "is this the same class twice":
+# it is not, because those regions are justified by their shapes rather than by invisibility.
+run_case "a finding inside an indented About Codex block is claimable" \
+  "$(wrap9 "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_plus $'    <details> <summary>\u2139\ufe0f About Codex in GitHub</summary>\n    <br/>\n    P1: this drops the last row\n    </details>')")")" \
+  1 "carry no disposition"
+run_case "a finding inside a fenced About Codex block is claimable" \
+  "$(wrap9 "$(cmt "$CODEX" Bot 2026-01-02T01:00:00Z "$(codex_plus $'```\n<details> <summary>\u2139\ufe0f About Codex in GitHub</summary>\n<br/>\nP1: this drops the last row\n</details>\n```')")")" \
+  1 "carry no disposition"
+run_case "a finding inside an indented tips block is claimable" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'rate limited' "$LIMIT_NOTICE" '' $'    <!-- tips_start -->\n    ---\n    P1: this drops the last row\n    <!-- tips_end -->')" 2026-01-02T01:00:00Z)")" \
+  1 "carry no disposition"
+run_case "a finding inside a fenced tips block is claimable" \
+  "$(wrap9 "$(cmt coderabbitai Bot 2026-01-01T00:00:00Z "$(cr_summary_notice 'rate limited' "$LIMIT_NOTICE" '' $'```\n<!-- tips_start -->\n---\nP1: this drops the last row\n<!-- tips_end -->\n```')" 2026-01-02T01:00:00Z)")" \
+  1 "carry no disposition"
+
+# The scanner, exercised directly from the gate's own VERDICT_JQ. The end-to-end cases above
+# cannot go red for the fence and blockquote rules, because today the leftover fence markers
+# and quote markers are themselves unlisted lines. This asserts the rule instead of the
+# coincidence, so dropping either one fails here.
+jqprog=$(awk '{f = f $0 "\n"}
+  END { k = index(f, "VERDICT_JQ=\047"); if (k == 0) exit 1
+        r = substr(f, k + length("VERDICT_JQ=\047")); e = index(r, "\047"); if (e == 0) exit 1
+        printf "%s", substr(r, 1, e - 1) }' "$GATE")
+scan_case() {
+  local name=$1 body=$2 want=$3 got
+  got=$(printf '%s' "$body" | jq -Rrs "$jqprog"' strip_hidden_comments' 2>&1)
+  if [ "$got" = "$want" ]; then echo "  PASS  $name"; pass=$((pass+1))
+  else echo "  FAIL  $name"; printf '          want %q\n          got  %q\n' "$want" "$got"; fail=$((fail+1)); fi
+}
+scan_case "a column-0 comment is removed"         '<!-- m -->'              ''
+scan_case "a fenced comment is kept"             $'```\n<!-- P1 -->\n```'    $'```\n<!-- P1 -->\n```'
+scan_case "a four-space comment is kept"         '    <!-- P1 -->'          '    <!-- P1 -->'
+scan_case "a tab-indented comment is kept"       $'\t<!-- P1 -->'           $'\t<!-- P1 -->'
+scan_case "a blockquote-indented comment is kept" '>     <!-- P1 -->'       '>     <!-- P1 -->'
+scan_case "a comment spanning lines is kept"     $'<!-- P1\nmore\n-->'      $'<!-- P1\nmore\n-->'
+scan_case "an inline comment is removed"         '- [ ] <!-- {"checkboxId":"a"} --> Trigger review' '- [ ]  Trigger review'
+scan_case "a quoted column-0 comment is removed" '> <!-- m -->'             '> '
+
 echo
 echo "passed=$pass failed=$fail"
 [ "$fail" -eq 0 ]

--- a/tests/test_log_scan.rs
+++ b/tests/test_log_scan.rs
@@ -1588,9 +1588,22 @@ fn a_comment_is_removed_unread_only_where_github_hides_it() {
         .and_then(|(_, rest)| rest.split_once('\''))
         .map(|(prog, _)| prog.to_string())
         .expect("VERDICT_JQ must be a single-quoted assignment in the gate");
+    // Rebuilding the accumulated output array took 4.08s for 30,000 short lines on
+    // the reproducing host. Pin constant-size foreach state, not a wall-clock limit.
+    let scanner = jq_prog
+        .split_once("def strip_hidden_comments:")
+        .and_then(|(_, rest)| rest.split_once("\ndef "))
+        .map(|(scanner, _)| scanner)
+        .expect("strip_hidden_comments must be a named scanner");
+    assert!(
+        scanner.contains("[foreach $lines[] as $raw ({fence: null, line: \"\"};")
+            && scanner.contains("; .line)]")
+            && !scanner.contains(".out"),
+        "emit each line from constant-size state, without rebuilding the output prefix"
+    );
     let strip = |body: &str| -> String {
         let out = Command::new("jq")
-            .args(["-Rrs", &format!("{jq_prog} strip_hidden_comments")])
+            .args(["-Rrjs", &format!("{jq_prog} strip_hidden_comments")])
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
@@ -1606,9 +1619,11 @@ fn a_comment_is_removed_unread_only_where_github_hides_it() {
             "strip_hidden_comments must exist and run: {}",
             String::from_utf8_lossy(&out.stderr)
         );
-        // jq -Rrs adds no trailing newline of its own beyond the input's.
+        // Join-output suppresses jq's record separator so this is the scanner's exact text.
         String::from_utf8_lossy(&out.stdout).into_owned()
     };
+    let many_lines = "x\n".repeat(30_000);
+    assert_eq!(strip(&many_lines), many_lines);
     for (name, body, want) in [
         ("a column-0 comment is removed", "<!-- m -->", ""),
         (

--- a/tests/test_log_scan.rs
+++ b/tests/test_log_scan.rs
@@ -1413,3 +1413,221 @@ fn an_empty_review_object_is_not_head_coverage() {
     assert!(out.contains("CLEAR"), "{out}");
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// A comment is removed unread only where GitHub actually hides it.
+///
+/// Round 4 of the same class as `a_region_stripped_before_classification_is_validated_...`.
+/// That round gave the two rendered regions shape lists and left the third, `html_comment`,
+/// stripped with no check at all, on the premise that GitHub renders nothing inside
+/// `<!-- .. -->`. The premise is false. CommonMark's HTML-block start condition 2 admits at
+/// most three spaces of indentation, so at four columns the same bytes are an indented code
+/// block and every reader sees them. Confirmed against GitHub's own renderer (POST
+/// /markdown, mode gfm): `<!-- P1 -->` returns nothing at 0-3 spaces and comes back as a
+/// `<pre><code>` block at 4 spaces, after a tab, and inside a fenced block.
+///
+/// So a finding a reader could see was removed before classification, which left the
+/// comment a no-findings verdict: exempt from dispositions AND binding coverage to the
+/// head. `strip_hidden_comments` now removes a complete single-line comment only on a line
+/// that is not indented four columns and not inside a fenced block, measured after any
+/// blockquote markers; everything else stays in the body and the body is claimable.
+///
+/// The shell harness (scripts/test-check-review-threads.sh, "finding 46") carries the full
+/// matrix; these run in CI.
+#[test]
+fn a_comment_is_removed_unread_only_where_github_hides_it() {
+    require_jq();
+    const HEAD: &str =
+        r"Codex Review: Didn't find any major issues.\n\n**Reviewed commit:** `deadbeef`";
+    // Codex's no-findings verdict with `extra` appended, as a JSON string literal.
+    let verdict = |extra: &str| format!(r#""{HEAD}\n\n{extra}""#);
+    // The CodeRabbit rate-limit notice with `extra` appended after its tips block.
+    let notice = |extra: &str| {
+        format!(
+            r#""<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n\n> [!WARNING]\n> ## Review limit reached\n> \n> **Next included review available in 53 minutes.**\n\n<!-- end of auto-generated comment: rate limited by coderabbit.ai -->\n\n<!-- tips_start -->\n\n---\n\n<sub>Comment `@coderabbitai help` to get the list of available commands.</sub>\n\n<!-- tips_end -->{extra}""#
+        )
+    };
+    const COVERED: &str = r#"[{"author":{"login":"reviewer"},"state":"APPROVED","submittedAt":"2026-01-02T00:40:00Z","body":"","commit":{"oid":"deadbeef"}}]"#;
+    let comment = |login: &str, body: &str| {
+        format!(
+            r#"{{"author":{{"login":"{login}","__typename":"Bot"}},"createdAt":"2026-01-02T01:00:00Z","updatedAt":"2026-01-02T01:00:00Z","body":{body}}}"#
+        )
+    };
+    let payload = |reviews: &str, comments: &str| {
+        format!(
+            r#"{{"data":{{"repository":{{"pullRequest":{{"author":{{"login":"me"}},"headRefOid":"deadbeef","commits":{{"nodes":[{{"commit":{{"committedDate":"2026-01-02T00:00:00Z","checkSuites":{{"nodes":[{{"createdAt":"2026-01-02T00:30:00Z"}}]}}}}}}]}},"reviewThreads":{{"nodes":[]}},"reviews":{{"nodes":{reviews}}},"comments":{{"nodes":[{comments}]}},"recheck":{{"comments":{{"nodes":[{comments}]}}}}}}}}}}}}"#
+        )
+    };
+    let dir = std::env::temp_dir().join(format!("fcvm-gate-hidden-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let run = |name: &str, body: String| {
+        let f = dir.join(name);
+        std::fs::write(&f, body).unwrap();
+        let out = Command::new("bash")
+            .arg(repo_root().join("scripts/check-review-threads.sh"))
+            .arg("--from-file")
+            .arg(&f)
+            .output()
+            .expect("check-review-threads.sh must be runnable");
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        (combined, out.status.code().unwrap_or(-1))
+    };
+
+    // Four columns of indentation. The gate reported CLEAR on exactly this body, with no
+    // review object anywhere on the PR.
+    let (out, code) = run(
+        "indent-verdict.json",
+        payload(
+            "[]",
+            &comment(
+                "chatgpt-codex-connector",
+                &verdict(r"    <!-- P1: the restore path drops the last row -->"),
+            ),
+        ),
+    );
+    assert_eq!(
+        code, 1,
+        "an indented comment is an indented code block: GitHub shows it, so the finding \
+         inside it is a finding and the comment is not a no-findings verdict.\n{out}"
+    );
+    assert!(out.contains("carry no disposition"), "{out}");
+    assert!(
+        !out.contains("HEAD COVERED"),
+        "coverage was bound by a comment carrying a finding every reader can see.\n{out}"
+    );
+
+    // A tab is four columns, so a rule written in spaces alone cannot see this one.
+    let (out, code) = run(
+        "tab-verdict.json",
+        payload(
+            "[]",
+            &comment(
+                "chatgpt-codex-connector",
+                &verdict("\\t<!-- P1: the restore path drops the last row -->"),
+            ),
+        ),
+    );
+    assert_eq!(code, 1, "a tab indents four columns.\n{out}");
+    assert!(out.contains("carry no disposition"), "{out}");
+    assert!(!out.contains("HEAD COVERED"), "{out}");
+
+    // The same bytes appended to a real rate-limit notice, whose residue check runs after
+    // the region is removed.
+    let (out, code) = run(
+        "indent-notice.json",
+        payload(
+            COVERED,
+            &comment(
+                "coderabbitai",
+                &notice(r"\n\n    <!-- P1: the restore path drops the last row -->"),
+            ),
+        ),
+    );
+    assert_eq!(
+        code, 1,
+        "a notice is exempt because it claims nothing; one carrying a visible finding \
+         claims something.\n{out}"
+    );
+    assert!(out.contains("carry no disposition"), "{out}");
+
+    // The negative cases the exemption exists for. Every HTML comment the two bots posted
+    // on ejc3/fcvm #789 through #901 sits at column 0 on one line or inline on a column-0
+    // line; an over-tight rule blocks on ordinary bot traffic.
+    let (out, code) = run(
+        "marker-verdict.json",
+        payload(
+            "[]",
+            &comment(
+                "chatgpt-codex-connector",
+                &verdict("<!-- an ordinary hidden marker -->"),
+            ),
+        ),
+    );
+    assert_eq!(
+        code, 0,
+        "a marker at column 0 is hidden and must stay exempt.\n{out}"
+    );
+    assert!(out.contains("HEAD COVERED"), "{out}");
+    let (out, code) = run(
+        "notice-clean.json",
+        payload(COVERED, &comment("coderabbitai", &notice(""))),
+    );
+    assert_eq!(
+        code, 0,
+        "the rate-limit notice CodeRabbit actually posts still needs no disposition.\n{out}"
+    );
+    assert!(out.contains("CLEAR"), "{out}");
+
+    // The scanner, exercised directly from the gate's own VERDICT_JQ. The end-to-end cases
+    // above cannot go red for the fence and blockquote rules: today the leftover fence and
+    // quote markers are themselves unlisted lines, so the shape lists catch those bodies
+    // rather than the region rule. This asserts the rule instead of the coincidence.
+    let gate = std::fs::read_to_string(repo_root().join("scripts/check-review-threads.sh"))
+        .expect("the gate must be readable");
+    let jq_prog = gate
+        .split_once("VERDICT_JQ='")
+        .and_then(|(_, rest)| rest.split_once('\''))
+        .map(|(prog, _)| prog.to_string())
+        .expect("VERDICT_JQ must be a single-quoted assignment in the gate");
+    let strip = |body: &str| -> String {
+        let out = Command::new("jq")
+            .args(["-Rrs", &format!("{jq_prog} strip_hidden_comments")])
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .and_then(|mut c| {
+                use std::io::Write;
+                c.stdin.as_mut().unwrap().write_all(body.as_bytes())?;
+                c.wait_with_output()
+            })
+            .expect("jq must be runnable");
+        assert!(
+            out.status.success(),
+            "strip_hidden_comments must exist and run: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        // jq -Rrs adds no trailing newline of its own beyond the input's.
+        String::from_utf8_lossy(&out.stdout).into_owned()
+    };
+    for (name, body, want) in [
+        ("a column-0 comment is removed", "<!-- m -->", ""),
+        (
+            "an inline comment is removed",
+            r#"- [ ] <!-- {"checkboxId":"a"} --> Trigger review"#,
+            "- [ ]  Trigger review",
+        ),
+        ("a quoted column-0 comment is removed", "> <!-- m -->", "> "),
+        (
+            "a four-column comment is kept",
+            "    <!-- P1 -->",
+            "    <!-- P1 -->",
+        ),
+        (
+            "a tab-indented comment is kept",
+            "\t<!-- P1 -->",
+            "\t<!-- P1 -->",
+        ),
+        (
+            "a fenced comment is kept",
+            "```\n<!-- P1 -->\n```",
+            "```\n<!-- P1 -->\n```",
+        ),
+        (
+            "a blockquote-indented comment is kept",
+            ">     <!-- P1 -->",
+            ">     <!-- P1 -->",
+        ),
+        (
+            "a comment spanning lines is kept",
+            "<!-- P1\nmore\n-->",
+            "<!-- P1\nmore\n-->",
+        ),
+    ] {
+        assert_eq!(strip(body).trim_end_matches('\n'), want, "{name}");
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/tests/test_log_scan.rs
+++ b/tests/test_log_scan.rs
@@ -1476,6 +1476,22 @@ fn a_comment_is_removed_unread_only_where_github_hides_it() {
         (combined, out.status.code().unwrap_or(-1))
     };
 
+    // HTML comment bytes inside the commit's code span are visible. Removing them would
+    // turn this finding into a clean verdict naming the head.
+    let (out, code) = run(
+        "inline-code-verdict.json",
+        payload(
+            "[]",
+            &comment(
+                "chatgpt-codex-connector",
+                r#""Codex Review: Didn't find any major issues.\n\n**Reviewed commit:** `deadbeef<!-- P1: drops last row -->`""#,
+            ),
+        ),
+    );
+    assert_eq!(code, 1, "a code-span finding must remain claimable.\n{out}");
+    assert!(out.contains("carry no disposition"), "{out}");
+    assert!(!out.contains("HEAD COVERED"), "{out}");
+
     // Four columns of indentation. The gate reported CLEAR on exactly this body, with no
     // review object anywhere on the PR.
     let (out, code) = run(
@@ -1625,6 +1641,11 @@ fn a_comment_is_removed_unread_only_where_github_hides_it() {
             "a comment spanning lines is kept",
             "<!-- P1\nmore\n-->",
             "<!-- P1\nmore\n-->",
+        ),
+        (
+            "a comment inside a multiline code span is kept",
+            "`code\n<!-- P1 -->\ncode`",
+            "`code\n<!-- P1 -->\ncode`",
         ),
     ] {
         assert_eq!(strip(body).trim_end_matches('\n'), want, "{name}");


### PR DESCRIPTION
## Change

Preserve HTML-comment text wherever the review gate cannot establish that GitHub hides it. The old unconditional removal could turn a visible finding into a clean review verdict and grant head coverage.

The scanner keeps comments in indented and fenced code, and measures indentation inside blockquotes. It removes complete single-line hidden markers in the supported contexts. Multiline comments and ambiguous inline-code contexts remain claimable rather than being discarded.

Final self-review found the same defect inside inline backticks: a comment embedded in the reviewed commit string was removed, leaving a valid-looking clean verdict. The correction preserves a line when a comment opener is followed by a backtick and preserves the whole body when unmatched non-fence backtick runs make multiline code ambiguous. It does not add a general Markdown parser.

Rebased onto main after #904. Both PRs' regression tests are preserved; the rebase changes only their insertion context.

## Verification

- Original indented-comment regressions were observed failing before the fix in both harnesses.
- The inline-code regression failed before the correction and after a code-only reversion: three shell checks and `a_comment_is_removed_unread_only_where_github_hides_it` failed. Restoring the fix passed both harnesses.
- Integrated shell harness: 274 passed, 0 failed.
- Integrated Rust harness: `make test-unit FILTER='-p fcvm --test test_log_scan'`, 28 passed, 0 skipped.
- Existing hidden-marker, no-findings, and review-notice cases remain supported.

The closure correction replaces the growing output array with `foreach` state containing only the current fence and line, collecting emitted lines once. The parser conditions are unchanged. On the reproducing host, 7,500 / 15,000 / 30,000 short lines took 0.44 / 1.32 / 4.08 seconds before and 0.27 / 0.55 / 1.14 seconds after. The existing Rust scanner regression pins bounded accumulation state and checks exact output for a 60 KB body; its structural assertion failed before the fix and after a code-only reversion. CI does not depend on a wall-clock threshold.

The changed accounting check recognizes the scanner as the HTML-comment removal primitive. Workflow documentation names both gate harnesses, including the one run by CI.

## Merge contract

Visible findings must remain claimable and must not provide clean head coverage. Missing or ambiguous evidence blocks. Merge requires the integrated local checks, required CI, dispositions for actual review findings, and review coverage of the final head.
