### PR TITLE
Run daily benchmarks and fix the container target mount

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,8 +1,8 @@
-name: Weekly
+name: Daily
 
 on:
   schedule:
-    - cron: '0 4 * * 1'  # 4 AM UTC every Monday (weekly)
+    - cron: '0 4 * * *'  # 4 AM UTC daily
   workflow_dispatch:  # Manual trigger
 
 env:

--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,11 @@ TEST_LOG_DIR := /tmp/fcvm-test-logs
 # Container run command (base)
 # Note: Use -v instead of --device for /dev/kvm to preserve group permissions in rootless mode
 # See: https://github.com/containers/podman/issues/16701
-CONTAINER_RUN_BASE := podman run --rm --privileged \
+# The cache mount presents a different inode inside the container. Pass the
+# host generation's lease through FD 3 so it also survives the Podman CLI.
+CONTAINER_RUN_BASE := "$(MAKEFILE_DIR)scripts/cargo-target-run.sh" \
+	/bin/bash -ec 'exec 3<target; flock -s 3; exec "$$@"' -- \
+	podman run --preserve-fds=1 --rm --privileged \
 	--security-opt label=disable --group-add keep-groups \
 	-v .:/workspace/fcvm \
 	$(TARGET_MOUNT) \
@@ -659,7 +663,7 @@ container-build:
 	|| podman build -t $(CONTAINER_TAG) -f Containerfile --build-arg ARCH=$(CONTAINER_ARCH) \
 		--layers --cache-from $(CONTAINER_CACHE_REPO) .
 
-container-shell: container-build
+container-shell: cargo-target-link container-build
 	$(CONTAINER_RUN) -it $(CONTAINER_TAG) bash
 
 container-clean:
@@ -778,7 +782,7 @@ install-host-kernel: build setup-btrfs
 	sudo ./target/release/fcvm setup --kernel-profile nested --build-kernels --install-host-kernel
 
 # Run setup inside container (for CI - container has Firecracker)
-container-setup-fcvm: container-build setup-btrfs
+container-setup-fcvm: cargo-target-link container-build setup-btrfs
 	@echo "==> Running fcvm setup in container..."
 	@# Fix ownership for rootless podman: container UID 0 maps to host user,
 	@# so /mnt/fcvm-btrfs/firecracker must be writable by current user (not root)

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -112,19 +112,28 @@ WT_TARGET="$BTRFS_ROOT/cargo-target/$name-$hash"
 # payload is reachable only while target/ names it.
 LOCAL_TARGET_PREFIX="$p/.cargo-target-local"
 
-# Classify aliases consistently without following generation symlinks. Reject
-# paths through a reserved generation component before normalization can erase
-# that traversal and cleanup can remove a directory target/ still needs.
+# Classify aliases without following symlinks. Only a generation directly under
+# this checkout belongs to cleanup; the same basename in an external cache does
+# not. Check before normalizing away traversal through an owned generation.
 target_link_destination() {
 	local destination
 	destination="$(readlink target)" || return 1
-	case "/$destination" in
-		*/.cargo-target-local.generation-*/*)
-			echo "ERROR: invalid fallback target $destination; expected one generation basename" >&2
-			return 1
-			;;
-	esac
-	realpath -m -s -- "$destination"
+	/usr/bin/python3 -c '
+import posixpath
+import sys
+
+checkout, destination = sys.argv[1:3]
+parts = destination.split("/")
+parent = "/" if destination.startswith("/") else checkout
+for index, part in enumerate(parts):
+    if (parent == checkout and part.startswith(".cargo-target-local.generation-")
+            and index + 1 < len(parts)):
+        print(f"ERROR: invalid fallback target {destination}; expected one generation basename",
+              file=sys.stderr)
+        raise SystemExit(1)
+    parent = posixpath.normpath(posixpath.join(parent, part))
+print(parent)
+' "$p" "$destination"
 }
 
 # Validate before any filesystem mutation, including when btrfs is available.

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -27,7 +27,7 @@
 #    self-heals for exactly this reason; target/ did not.
 #
 # 3. A FALLBACK MUST BE REVERSIBLE, AND MUST NOT SURVIVE ITS OUTAGE. A real
-#    target/ the script did not create is retained for good (its dentry may
+#    target/ or explicit container cache mount is retained (its dentry may
 #    carry a mount visible only in another mount namespace), so a fallback
 #    shaped as a real target/ would keep every later build on the root
 #    filesystem after the volume returned. The fallback is a symlink to a
@@ -640,11 +640,27 @@ finally:
 
 mkdir -p -- "$(dirname "$WT_TARGET")"
 
+# Podman can mount its cache through the fallback symlink. Retain that mount
+# just like a real target/ directory, even when btrfs has become writable.
+mounted_target=0
+if [ -L target ] && [ -d target ]; then
+	mount_rc=0
+	mountpoint -q -- target || mount_rc=$?
+	case "$mount_rc" in
+		0) mounted_target=1 ;;
+		32) ;;
+		*)
+			echo "ERROR: cannot determine whether target/ is mounted (mountpoint rc=$mount_rc); refusing to replace it" >&2
+			exit 1
+			;;
+	esac
+fi
+
 # A pre-protocol real target cannot be replaced safely: another mount
 # namespace may have a mount on that exact dentry. Keep it local and unmanaged;
 # the disk guard will fail its hard floor and quarantine the runner rather than
 # corrupt a hidden mount. Fresh checkouts always take the managed-symlink path.
-if [ -e target ] && ! [ -L target ]; then
+if [ -e target ] && { [ ! -L target ] || ((mounted_target)); }; then
 	if [ ! -d target ]; then
 		echo "ERROR: target exists but is not a usable directory:" >&2
 		ls -ld target >&2

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -118,6 +118,7 @@ published_fallback() {
 	[ -L target ] || return 1
 	local linked
 	linked="$(readlink target)"
+	[[ $linked = /* ]] || linked="$p/$linked"
 	case "$linked" in
 		"$LOCAL_TARGET_PREFIX".generation-*) printf '%s' "$linked" ;;
 		*) return 1 ;;
@@ -418,7 +419,9 @@ require_writable_local_target() {
 				ls -ld -- "$p" >&2 2>/dev/null || true
 				exit 1
 			fi
-			publish_target_link "$payload"
+			# The checkout is mounted at /workspace/fcvm inside containers.
+			# A host-absolute fallback is dangling in that mount namespace.
+			publish_target_link "$(basename -- "$payload")"
 			echo "==> Symlinked target/ → $payload (local fallback)" >&2
 		fi
 	fi
@@ -455,6 +458,7 @@ drop_managed_link() {
 	[ -L target ] || return 0
 	local linked
 	linked="$(readlink target)"
+	[[ $linked = /* ]] || linked="$p/$linked"
 	case "$linked" in
 		"$BTRFS_ROOT"/cargo-target/* | "$LOCAL_TARGET_PREFIX".generation-*) ;;
 		*) return 0 ;;

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -112,17 +112,24 @@ WT_TARGET="$BTRFS_ROOT/cargo-target/$name-$hash"
 # payload is reachable only while target/ names it.
 LOCAL_TARGET_PREFIX="$p/.cargo-target-local"
 
-# A fallback names one direct child. Traversing through that child would let
-# cleanup remove an intermediate directory that target/ still needs to resolve.
-if [ -L target ]; then
-	linked="$(readlink target)"
-	[[ $linked = /* ]] || linked="$p/$linked"
-	case "$linked" in
-		"$LOCAL_TARGET_PREFIX".generation-*/*)
-			echo "ERROR: invalid fallback target $linked; expected one generation basename" >&2
-			exit 1
+# Classify aliases consistently without following generation symlinks. Reject
+# paths through a reserved generation component before normalization can erase
+# that traversal and cleanup can remove a directory target/ still needs.
+target_link_destination() {
+	local destination
+	destination="$(readlink target)" || return 1
+	case "/$destination" in
+		*/.cargo-target-local.generation-*/*)
+			echo "ERROR: invalid fallback target $destination; expected one generation basename" >&2
+			return 1
 			;;
 	esac
+	realpath -m -s -- "$destination"
+}
+
+# Validate before any filesystem mutation, including when btrfs is available.
+if [ -L target ]; then
+	target_link_destination >/dev/null || exit 1
 fi
 
 # The fallback payload target/ publishes right now, on stdout. Non-zero when
@@ -130,8 +137,7 @@ fi
 published_fallback() {
 	[ -L target ] || return 1
 	local linked
-	linked="$(readlink target)"
-	[[ $linked = /* ]] || linked="$p/$linked"
+	linked="$(target_link_destination)" || exit 1
 	case "$linked" in
 		"$LOCAL_TARGET_PREFIX".generation-*) printf '%s' "$linked" ;;
 		*) return 1 ;;
@@ -470,8 +476,7 @@ it is removed by hand" >&2
 drop_managed_link() {
 	[ -L target ] || return 0
 	local linked
-	linked="$(readlink target)"
-	[[ $linked = /* ]] || linked="$p/$linked"
+	linked="$(target_link_destination)" || exit 1
 	case "$linked" in
 		"$BTRFS_ROOT"/cargo-target/* | "$LOCAL_TARGET_PREFIX".generation-*) ;;
 		*) return 0 ;;
@@ -690,7 +695,7 @@ fi
 
 candidate="$WT_TARGET"
 if [ -L target ]; then
-	linked="$(readlink target)"
+	linked="$(target_link_destination)" || exit 1
 	# target/ is replaced only under an exclusive lease on the generation it
 	# publishes: a cargo wrapper past the checkout→target lock handoff holds
 	# only that lease, shared, and the flock below blocks until it is done. A

--- a/scripts/cargo-target-link.sh
+++ b/scripts/cargo-target-link.sh
@@ -112,6 +112,19 @@ WT_TARGET="$BTRFS_ROOT/cargo-target/$name-$hash"
 # payload is reachable only while target/ names it.
 LOCAL_TARGET_PREFIX="$p/.cargo-target-local"
 
+# A fallback names one direct child. Traversing through that child would let
+# cleanup remove an intermediate directory that target/ still needs to resolve.
+if [ -L target ]; then
+	linked="$(readlink target)"
+	[[ $linked = /* ]] || linked="$p/$linked"
+	case "$linked" in
+		"$LOCAL_TARGET_PREFIX".generation-*/*)
+			echo "ERROR: invalid fallback target $linked; expected one generation basename" >&2
+			exit 1
+			;;
+	esac
+fi
+
 # The fallback payload target/ publishes right now, on stdout. Non-zero when
 # target/ publishes something else.
 published_fallback() {

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -3348,6 +3348,7 @@ fn assert_local_fallback_link(checkout: &Path, btrfs_root: &Path, ctx: &str) -> 
             std::fs::symlink_metadata(&target).map(|m| m.file_type())
         )
     });
+    let link = checkout.join(link);
     assert!(
         !link.starts_with(btrfs_root),
         "{ctx}: target/ -> {link:?} points into the btrfs root {btrfs_root:?}"
@@ -3539,6 +3540,39 @@ fn cargo_target_link_returns_to_btrfs_after_a_volume_outage() {
     );
 }
 
+/// The hosted benchmark mounts the checkout at /workspace/fcvm before mounting
+/// its Cargo cache over target/. The fallback must resolve in that new view
+/// before the container starts. Moving a scratch checkout removes its old
+/// pathname and exercises the same resolution without a container or privileges.
+#[test]
+fn cargo_target_link_fallback_survives_a_remapped_checkout() {
+    let root = tempfile::tempdir().expect("scratch root");
+    let host = root.path().join("host-checkout");
+    let container = root.path().join("container-checkout");
+    let absent_volume = root.path().join("absent-volume");
+    std::fs::create_dir(&host).expect("host checkout");
+    let (ok, out) = run_link(&host, &absent_volume);
+    assert!(ok, "host target setup failed:\n{out}");
+    std::fs::write(host.join("target/artifact"), b"cached").expect("cached artifact");
+
+    std::fs::rename(&host, &container).expect("remap checkout");
+    assert_target_usable(&container, "remapped checkout before container startup");
+    let before = std::fs::symlink_metadata(container.join("target")).unwrap();
+    let (ok, out) = run_link(&container, &absent_volume);
+    assert!(ok, "container target setup failed:\n{out}");
+    let after = std::fs::symlink_metadata(container.join("target")).unwrap();
+    assert_eq!(
+        before.ino(),
+        after.ino(),
+        "setup replaced the published link"
+    );
+    assert_eq!(
+        std::fs::read(container.join("target/artifact")).expect("read cached artifact"),
+        b"cached",
+        "container target setup discarded the published payload"
+    );
+}
+
 /// A real target/ the script did not create is retained, volume or no volume.
 /// Its dentry may carry a mount that exists only in another mount namespace,
 /// and renaming or removing it could move or detach that mount; only the
@@ -3606,7 +3640,9 @@ fn cargo_target_link_rotate_refuses_the_local_fallback_while_the_volume_is_down(
         "--rotate reported a clean it cannot perform on the fallback link:\n{out}"
     );
     assert_eq!(
-        std::fs::read_link(&target).expect("readlink"),
+        checkout
+            .path()
+            .join(std::fs::read_link(&target).expect("readlink")),
         payload,
         "a refused rotation must leave the fallback link in place"
     );

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -687,6 +687,15 @@ fn makefile_delegates_to_the_script() {
          behaviour every other test in this file verifies is not what `make` runs. Commands \
          found: {recipe:?}"
     );
+    for target in ["container-shell:", "container-setup-fcvm:"] {
+        assert!(
+            mk.lines().any(|line| line.starts_with(target)
+                && line
+                    .split_whitespace()
+                    .any(|word| word == "cargo-target-link")),
+            "{target} must initialize the host target before leasing it"
+        );
+    }
 }
 
 /// The disk preflight selects per-worktree children, never the parent
@@ -4804,6 +4813,164 @@ fn open_fifo(path: &Path) -> std::fs::File {
         .write(true)
         .open(path)
         .unwrap_or_else(|error| panic!("open {path:?}: {error}"))
+}
+
+/// The container cache mount hides the host generation inode. The launch
+/// command must pass its host lease into that namespace even when the CLI
+/// closes every copy of the descriptor it holds itself.
+#[cfg(feature = "privileged-tests")]
+#[test]
+fn container_recipe_pins_host_generation_across_mount_namespace() {
+    let scratch = tempfile::tempdir().expect("scratch root");
+    std::fs::set_permissions(scratch.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+    let checkout = scratch.path().join("checkout");
+    let btrfs = scratch.path().join("btrfs");
+    let cache = scratch.path().join("cache");
+    let tools = scratch.path().join("tools");
+    for directory in [&checkout, &cache, &tools] {
+        std::fs::create_dir(directory).unwrap();
+    }
+    let generation = stage_outage_fallback(&checkout, &btrfs);
+    let before = std::fs::read_link(checkout.join("target")).unwrap();
+    std::fs::write(cache.join("artifact"), b"cache").unwrap();
+    let ready_path = scratch.path().join("ready");
+    let ready = open_fifo(&ready_path);
+    write_script(
+        &tools.join("podman"),
+        r#"#!/usr/bin/python3
+import os
+import subprocess
+import sys
+
+if sys.argv[1] == "login":
+    raise SystemExit(1)
+preserved = (3,) if "--preserve-fds=1" in sys.argv else ()
+os.closerange(4 if preserved else 3, 1048576)
+os.environ.pop("FCVM_TARGET_LEASE_HELD", None)
+child = subprocess.Popen([
+    "unshare", "--mount", "--propagation", "private", "/bin/bash", "-c",
+    '''set -euo pipefail
+mount --bind -- "$CACHE" target
+mounted=$(readlink -f target)
+trap 'umount -- "$mounted"' EXIT
+"$LINK_SCRIPT"
+"$LEASE_SCRIPT" /bin/bash -c 'printf R >"$READY"; IFS= read -r _; test "$(cat target/artifact)" = cache; exit 23'
+'''], pass_fds=preserved)
+if preserved:
+    os.close(3)
+raise SystemExit(child.wait())
+"#,
+    );
+    hand_tree_to_make_child(scratch.path());
+    let path = std::env::join_paths(
+        std::iter::once(tools.clone())
+            .chain(std::env::split_paths(&std::env::var_os("PATH").unwrap())),
+    )
+    .unwrap();
+    let makefile = repo_root().join("Makefile");
+    let printed = scratch_make(
+        &checkout,
+        &btrfs,
+        &[
+            "--no-print-directory",
+            "-f",
+            makefile.to_str().unwrap(),
+            "-n",
+            "-o",
+            "container-build",
+            "-o",
+            "cargo-target-link",
+            "container-shell",
+        ],
+    )
+    .env("PATH", &path)
+    .output()
+    .unwrap();
+    assert!(
+        printed.status.success(),
+        "dry run failed: {}",
+        String::from_utf8_lossy(&printed.stderr)
+    );
+    let printed = String::from_utf8(printed.stdout).unwrap();
+    let command = printed
+        .lines()
+        .find(|line| line.contains("podman run "))
+        .expect("container run command");
+    std::fs::create_dir(&btrfs).expect("container-build creates btrfs root");
+    let log_path = scratch.path().join("container.log");
+    let log = std::fs::File::create(&log_path).unwrap();
+    let mut container = ChildGuard(Some(
+        Command::new("/bin/bash")
+            .args(["-c", command])
+            .current_dir(&checkout)
+            .env("PATH", &path)
+            .env("BTRFS_ROOT", &btrfs)
+            .env("CARGO_TARGET_DIR", "target")
+            .env("CACHE", &cache)
+            .env("READY", &ready_path)
+            .env(
+                "LINK_SCRIPT",
+                repo_root().join("scripts/cargo-target-link.sh"),
+            )
+            .env(
+                "LEASE_SCRIPT",
+                repo_root().join("scripts/cargo-target-run.sh"),
+            )
+            .env_remove("CARGO_TARGET_LINK_LOCKED")
+            .stdin(Stdio::piped())
+            .stdout(log.try_clone().unwrap())
+            .stderr(log)
+            .spawn()
+            .unwrap(),
+    ));
+    assert_eq!(
+        read_marker_with_timeout(ready, "container cache lease"),
+        b'R'
+    );
+    let host_leased = !lease_is_available(&generation, "-x");
+    let cache_leased = !lease_is_available(&cache, "-x");
+    let republish = Command::new("timeout")
+        .arg("2")
+        .arg(repo_root().join("scripts/cargo-target-link.sh"))
+        .env("BTRFS_ROOT", &btrfs)
+        .env_remove("CARGO_TARGET_LINK_LOCKED")
+        .current_dir(&checkout)
+        .output()
+        .unwrap();
+    let held_link = std::fs::read_link(checkout.join("target")).unwrap();
+    container
+        .child_mut()
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"release\n")
+        .unwrap();
+    let status = container.wait().unwrap();
+    let log = std::fs::read_to_string(log_path).unwrap();
+    assert!(
+        host_leased && cache_leased,
+        "host and container must lease their separate inodes:\n{log}"
+    );
+    assert_eq!(
+        republish.status.code(),
+        Some(124),
+        "host setup replaced a live container target: {}{}",
+        String::from_utf8_lossy(&republish.stdout),
+        String::from_utf8_lossy(&republish.stderr)
+    );
+    assert_eq!(held_link, before, "host setup republished the live target");
+    assert_eq!(
+        status.code(),
+        Some(23),
+        "container exit status was lost:\n{log}"
+    );
+    assert!(
+        lease_is_available(&generation, "-x"),
+        "host lease outlived container"
+    );
+    let (ok, out) = run_link(&checkout, &btrfs);
+    assert!(ok, "host could not republish after container exit:\n{out}");
+    assert_eq!(std::fs::read(cache.join("artifact")).unwrap(), b"cache");
 }
 
 /// `build` produces `fc-agent` through the link, copies it back through the

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -3573,11 +3573,56 @@ fn cargo_target_link_fallback_survives_a_remapped_checkout() {
     );
 }
 
+#[test]
+fn cargo_target_link_preserves_fallback_path_aliases() {
+    for prefix in ["", "./", "././", ".//./"] {
+        for absolute in [false, true] {
+            let root = tempfile::tempdir().expect("scratch root");
+            let checkout = root.path().join("checkout");
+            let generation = checkout.join(".cargo-target-local.generation-existing");
+            std::fs::create_dir_all(&generation).expect("generation directory");
+            std::fs::write(generation.join("artifact"), b"cached").expect("cached artifact");
+            let relative = format!("{prefix}.cargo-target-local.generation-existing");
+            let destination = if absolute {
+                checkout.join(&relative)
+            } else {
+                PathBuf::from(relative)
+            };
+            std::os::unix::fs::symlink(&destination, checkout.join("target"))
+                .expect("fallback alias");
+
+            let (ok, out) = run_link(&checkout, &root.path().join("absent-volume"));
+            assert!(ok, "fallback alias {destination:?} failed:\n{out}");
+            assert_eq!(
+                std::fs::read(checkout.join("target/artifact"))
+                    .ok()
+                    .as_deref(),
+                Some(b"cached".as_slice()),
+                "fallback alias {destination:?} lost its cache:\n{out}"
+            );
+        }
+    }
+    // Parent components remain valid for an ordinary external cache link.
+    let root = tempfile::tempdir().expect("scratch root");
+    let checkout = root.path().join("checkout");
+    let outside = root.path().join("outside");
+    std::fs::create_dir(&checkout).expect("checkout");
+    std::fs::create_dir(&outside).expect("outside cache");
+    std::fs::write(outside.join("artifact"), b"cached").expect("cached artifact");
+    std::os::unix::fs::symlink("../outside", checkout.join("target")).expect("external cache link");
+    let (ok, out) = run_link(&checkout, &root.path().join("absent-volume"));
+    assert!(ok, "external cache link failed:\n{out}");
+    assert_eq!(
+        std::fs::read(checkout.join("target/artifact")).unwrap(),
+        b"cached"
+    );
+}
+
 /// A fallback identifies one checkout-local generation, not a path through it.
 /// Reject malformed links before mkdir or cleanup can alter either directory.
 #[test]
 fn cargo_target_link_rejects_fallback_path_traversal_before_mutation() {
-    for absolute in [false, true] {
+    for (absolute, prefix) in [(false, ""), (true, ""), (false, "././"), (true, ".//./")] {
         for outside_exists in [false, true] {
             let root = tempfile::tempdir().expect("scratch root");
             let checkout = root.path().join("checkout");
@@ -3589,11 +3634,13 @@ fn cargo_target_link_rejects_fallback_path_traversal_before_mutation() {
                 std::fs::create_dir(&outside).expect("outside directory");
                 std::fs::write(outside.join("sentinel"), b"untouched").expect("outside sentinel");
             }
-            let relative = Path::new(".cargo-target-local.generation-existing/../../outside");
+            let relative = PathBuf::from(format!(
+                "{prefix}.cargo-target-local.generation-existing/../../outside"
+            ));
             let destination = if absolute {
-                checkout.join(relative)
+                checkout.join(&relative)
             } else {
-                relative.to_path_buf()
+                relative
             };
             let target = checkout.join("target");
             std::os::unix::fs::symlink(&destination, &target).expect("malformed fallback link");

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -3773,6 +3773,52 @@ fn stage_outage_fallback(checkout: &Path, absent_volume: &Path) -> PathBuf {
     assert_local_fallback_link(checkout, absent_volume, "volume down")
 }
 
+/// Podman mounts the Cargo cache through the fallback symlink before build
+/// setup runs again, now with a usable btrfs root. The mounted cache must stay
+/// published, including when target/ itself is still a symlink.
+#[cfg(feature = "privileged-tests")]
+#[test]
+fn cargo_target_link_keeps_a_mounted_fallback_after_btrfs_recovery() {
+    let checkout = tempfile::tempdir().expect("checkout tempdir");
+    let volume_parent = tempfile::tempdir().expect("volume parent");
+    let btrfs = volume_parent.path().join("fcvm-btrfs");
+    let payload = stage_outage_fallback(checkout.path(), &btrfs);
+    let target = checkout.path().join("target");
+    let before = std::fs::read_link(&target).expect("fallback link");
+    let cache = tempfile::tempdir().expect("container cache");
+    std::fs::write(cache.path().join("artifact"), b"container cache").expect("cached artifact");
+    let status = Command::new("mount")
+        .arg("--bind")
+        .arg(cache.path())
+        .arg(&target)
+        .status()
+        .expect("mount container cache through target");
+    assert!(status.success(), "bind mount failed: {status:?}");
+    let mount = BindMountGuard(payload);
+    for volume_available in [false, true] {
+        if volume_available {
+            std::fs::create_dir(&btrfs).expect("container-build creates btrfs root");
+        }
+        let (ok, out) = run_link(checkout.path(), &btrfs);
+        assert!(ok, "setup failed with a mounted fallback:\n{out}");
+        let (ok, out) = run_link_with(checkout.path(), &btrfs, &["--rotate"]);
+        assert!(
+            !ok && out.contains("refusing unsafe clean"),
+            "rotated a mounted cache:\n{out}"
+        );
+        assert_eq!(
+            std::fs::read_link(&target).unwrap(),
+            before,
+            "setup replaced the mounted fallback"
+        );
+        assert_eq!(
+            std::fs::read(target.join("artifact")).unwrap(),
+            b"container cache"
+        );
+    }
+    mount.unmount();
+}
+
 /// Reclaiming an unpublished payload must not cross a mount boundary.
 ///
 /// `rm -rf` descends into whatever is mounted underneath and unlinks it. A

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -3573,6 +3573,53 @@ fn cargo_target_link_fallback_survives_a_remapped_checkout() {
     );
 }
 
+/// A fallback identifies one checkout-local generation, not a path through it.
+/// Reject malformed links before mkdir or cleanup can alter either directory.
+#[test]
+fn cargo_target_link_rejects_fallback_path_traversal_before_mutation() {
+    for absolute in [false, true] {
+        for outside_exists in [false, true] {
+            let root = tempfile::tempdir().expect("scratch root");
+            let checkout = root.path().join("checkout");
+            let generation = checkout.join(".cargo-target-local.generation-existing");
+            std::fs::create_dir_all(&generation).expect("generation directory");
+            std::fs::write(generation.join("artifact"), b"cached").expect("cached artifact");
+            let outside = root.path().join("outside");
+            if outside_exists {
+                std::fs::create_dir(&outside).expect("outside directory");
+                std::fs::write(outside.join("sentinel"), b"untouched").expect("outside sentinel");
+            }
+            let relative = Path::new(".cargo-target-local.generation-existing/../../outside");
+            let destination = if absolute {
+                checkout.join(relative)
+            } else {
+                relative.to_path_buf()
+            };
+            let target = checkout.join("target");
+            std::os::unix::fs::symlink(&destination, &target).expect("malformed fallback link");
+
+            let (ok, out) = run_link(&checkout, &root.path().join("absent-volume"));
+            assert!(!ok, "accepted malformed fallback (absolute={absolute}, outside_exists={outside_exists}):\n{out}");
+            assert_eq!(std::fs::read_link(&target).unwrap(), destination);
+            assert_eq!(
+                std::fs::read(generation.join("artifact")).unwrap(),
+                b"cached"
+            );
+            assert_eq!(
+                outside.exists(),
+                outside_exists,
+                "created outside directory"
+            );
+            if outside_exists {
+                assert_eq!(
+                    std::fs::read(outside.join("sentinel")).unwrap(),
+                    b"untouched"
+                );
+            }
+        }
+    }
+}
+
 /// A real target/ the script did not create is retained, volume or no volume.
 /// Its dentry may carry a mount that exists only in another mount namespace,
 /// and renaming or removing it could move or detach that mount; only the

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -3618,6 +3618,31 @@ fn cargo_target_link_preserves_fallback_path_aliases() {
     );
 }
 
+#[test]
+fn cargo_target_link_keeps_external_generation_paths() {
+    for absolute in [false, true] {
+        let root = tempfile::tempdir().expect("scratch root");
+        let checkout = root.path().join("checkout");
+        let relative = Path::new("../external/.cargo-target-local.generation-shared/output");
+        let cache = checkout.join(relative);
+        std::fs::create_dir(&checkout).expect("checkout");
+        std::fs::create_dir_all(&cache).expect("external cache");
+        std::fs::write(cache.join("artifact"), b"cached").expect("cached artifact");
+        let destination = if absolute {
+            cache.clone()
+        } else {
+            relative.to_path_buf()
+        };
+        let target = checkout.join("target");
+        std::os::unix::fs::symlink(&destination, &target).expect("external cache link");
+
+        let (ok, out) = run_link(&checkout, &root.path().join("absent-volume"));
+        assert!(ok, "external generation path was rejected:\n{out}");
+        assert_eq!(std::fs::read_link(&target).unwrap(), destination);
+        assert_eq!(std::fs::read(target.join("artifact")).unwrap(), b"cached");
+    }
+}
+
 /// A fallback identifies one checkout-local generation, not a path through it.
 /// Reject malformed links before mkdir or cleanup can alter either directory.
 #[test]


### PR DESCRIPTION
The scheduled container benchmark fails before startup because target/ points at an absolute host path that does not exist inside the container's /workspace/fcvm checkout. Publish checkout-local fallback targets as relative symlinks and recognize them in the existing lease and recovery logic. Cached artifacts and target identity survive the remapped checkout.

Retain the container's explicitly mounted Cargo cache when setup runs inside the container and finds btrfs available. Replacing that link makes fallback reclamation reject the bind mount. Rotation still refuses the mounted cache, and reclamation still refuses to cross mount boundaries.

Pass the host generation lease into containers through FD 3. Host setup cannot see the container-only cache mount, so both the original host inode and mounted cache must remain leased. The host lease survives Podman client death and releases when the container exits. Container entry points initialize the host target before acquiring it.

Reject malformed fallback paths containing further components after the generation basename. Otherwise cleanup can remove an intermediate generation and leave target dangling after reporting success. Ordinary external cache links are unchanged.

Normalize lexical aliases consistently for validation and classification, so `./` prefixes and repeated separators do not hide the published fallback from cleanup. Restrict traversal rejection to generations directly under this checkout; matching basenames in external cache directories remain supported.

Run the scheduled build and benchmark workflow daily at 04:00 UTC. Its existing benchmark and lifecycle-fuzz jobs remain enabled.

Failure: https://github.com/ejc3/fcvm/actions/runs/34082775774/job/101621104733

Validation: all 62 unprivileged and 72 privileged target-link tests passed with no skips. Each regression was observed failing before its fix, passing with it, failing again after a code-only revert, and passing after restoration. Formatting, shell syntax, and actionlint 1.7.10 checks passed. Real rootful and rootless Podman probes retained the host lease after client SIGKILL, then released it after container exit. Both GitHub reviewers cleared the final head. All 16 final-head CI jobs passed: https://github.com/ejc3/fcvm/actions/runs/34089786003

All four daily jobs passed at 21874549429a51fc7b28a733276cf36967c86d9f: hosted container benchmarks, x64 and ARM64 VM benchmarks, and lifecycle fuzz. https://github.com/ejc3/fcvm/actions/runs/34089845640

The optional benchmark archive upload found no files; timings are in the successful job log. Track the output-path correction separately in #909.
