### PR TITLE
fix: persist daily benchmark artifacts

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           name: benchmark-results-${{ github.run_id }}
           path: /tmp/fcvm-container-target/criterion/
-          if-no-files-found: warn
+          if-no-files-found: error
 
   # Seeded lifecycle chaos fuzz (tests/test_fuzz_chaos.rs): 20 seeds x 25 ops
   # against real rootless VMs. Schedule-deterministic per seed — a failure names

--- a/Makefile
+++ b/Makefile
@@ -1255,8 +1255,8 @@ define run_privileged_bench
 	exit $$bench_rc
 endef
 
-# One criterion suite as the invoking user. Nothing here writes as root, so
-# there is no ownership to repair.
+# One criterion suite without privilege elevation. Container callers already
+# run as root and do not need the host ownership repair.
 define run_unprivileged_bench
 	CRITERION_HOME='$(CRITERION_HOME)' $(CARGO) bench -p fuse-pipe --bench $(1) $(BENCH_SEPARATED); \
 	bench_rc=$$?; \
@@ -1364,9 +1364,9 @@ container-bench: check-disk container-build
 
 _bench: cargo-target-link
 	@echo "==> Running benchmarks..."
-	$(CARGO) bench -p fuse-pipe --bench throughput
-	$(CARGO) bench -p fuse-pipe --bench operations
-	$(CARGO) bench -p fuse-pipe --bench protocol
+	$(call run_unprivileged_bench,throughput)
+	$(call run_unprivileged_bench,operations)
+	$(call run_unprivileged_bench,protocol)
 
 # Lint tools versions (keep in sync with CI)
 CARGO_AUDIT_VERSION := 0.22.0

--- a/tests/test_ci_workflow_coverage.rs
+++ b/tests/test_ci_workflow_coverage.rs
@@ -51,6 +51,32 @@ fn workflow_job<'a>(workflow: &'a Value, name: &str) -> &'a Value {
         .unwrap_or_else(|| panic!("workflow has no `{name}` job"))
 }
 
+#[test]
+fn daily_benchmarks_require_results_from_the_container_target_mount() {
+    let daily = parse_workflow("weekly.yml");
+    let steps = workflow_job(&daily, "benchmarks")["steps"]
+        .as_sequence()
+        .expect("benchmark steps");
+    let upload = steps
+        .iter()
+        .find(|step| {
+            step["uses"]
+                .as_str()
+                .is_some_and(|action| action.starts_with("actions/upload-artifact@"))
+        })
+        .expect("benchmark result upload");
+    assert_eq!(
+        upload["with"]["path"].as_str(),
+        Some("/tmp/fcvm-container-target/criterion/"),
+        "upload the target directory mounted by container-bench"
+    );
+    assert_eq!(
+        upload["with"]["if-no-files-found"].as_str(),
+        Some("error"),
+        "a daily benchmark with no saved results must fail"
+    );
+}
+
 /// A base-branch filter on `pull_request` silently excludes stacked PRs.
 #[test]
 fn ci_runs_on_pull_requests_regardless_of_base_branch() {

--- a/tests/test_documented_make_targets.rs
+++ b/tests/test_documented_make_targets.rs
@@ -605,26 +605,28 @@ fn parallel_make_never_runs_two_benchmark_suites_at_once() {
 /// criterion reports the failure and carries on.
 #[test]
 fn bench_recipes_pin_criterion_output_to_an_absolute_path() {
-    let run = Harness::new("criterion-home", &["bench"])
-        .keep_default_criterion_home()
-        .run();
-    assert!(run.ok, "make bench failed: {}", run.stderr);
-    assert_eq!(
-        run.criterion_homes.len(),
-        3,
-        "expected one criterion home per suite; got {:?}",
-        run.criterion_homes
-    );
-
-    let target = repo_root().join("target/criterion");
-    for home in &run.criterion_homes {
+    for goal in ["bench", "_bench"] {
+        let run = Harness::new("criterion-home", &[goal])
+            .keep_default_criterion_home()
+            .run();
+        assert!(run.ok, "make {goal} failed: {}", run.stderr);
         assert_eq!(
-            Path::new(home),
-            target,
-            "a bench recipe leaves criterion to choose its own output directory. Its second \
-             choice is $CARGO_TARGET_DIR/criterion, relative to the bench binary's working \
-             directory, which is the package root and not the repo root."
+            run.criterion_homes.len(),
+            3,
+            "expected one criterion home per suite; got {:?}",
+            run.criterion_homes
         );
+
+        let target = repo_root().join("target/criterion");
+        for home in &run.criterion_homes {
+            assert_eq!(
+                Path::new(home),
+                target,
+                "{goal} leaves criterion to choose its own output directory. Its second \
+                 choice is $CARGO_TARGET_DIR/criterion, relative to the bench binary's working \
+                 directory, which is the package root and not the repo root."
+            );
+        }
     }
 }
 
@@ -687,7 +689,7 @@ fn a_failed_ownership_repair_fails_the_privileged_bench_target() {
 /// ran and left nothing behind.
 #[test]
 fn a_bench_that_persisted_nothing_fails_its_target() {
-    for goal in ["bench-throughput", "bench-protocol"] {
+    for goal in ["bench-throughput", "bench-protocol", "_bench"] {
         let missing = Harness::new("criterion-home-missing", &[goal])
             .without_criterion_output()
             .run();


### PR DESCRIPTION
Persist container benchmark results in the target mount that the daily workflow uploads. `_bench` now uses the existing absolute `CRITERION_HOME` recipes. The upload fails if no results exist.

Contract: save the existing throughput, operations, and protocol results without changing their workloads or adding reporting machinery. This affects benchmark output only.

Validation: the three regression tests were observed red without the production fix, green with it, red after a code-only revert, and green after restoration. `make _test-unit FILTER='--test test_documented_make_targets --test test_ci_workflow_coverage'` passed all 39 tests with no skips. `make fmt` and `git diff --check` passed.

The [daily run on the final head](https://github.com/ejc3/fcvm/actions/runs/34127190918) passed all four jobs. Its [benchmark artifact](https://github.com/ejc3/fcvm/actions/runs/34127190918/artifacts/10021207999) contains 809 files (1,281,741 bytes), including valid sample and estimate JSON for all 42 cases: 16 throughput, 18 operations, and 8 protocol. Each sample has matching, nonempty, positive iteration/time arrays; every estimate has positive mean and median values. The benchmark workloads are unchanged.

Closes #909.
