### PR TITLE
fix: make Cargo dependencies resolvable by Dependabot

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -656,8 +656,8 @@ sudo sysctl -w vm.unprivileged_userfaultfd=1
 #    check-disk moves it there), recreate the target first: mkdir -p /mnt/fcvm-btrfs/cargo
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
-# 6. Sources on the DURABLE disk, sibling layout is required (fuse-pipe uses
-#    a ../fuse-backend-rs path dependency)
+# 6. Sources on the DURABLE disk. Cargo.lock pins the FUSE forks; sibling
+#    checkouts are for local dependency development and container mounts.
 mkdir -p ~/src && cd ~/src
 git clone https://github.com/ejc3/fcvm.git
 git clone https://github.com/ejc3/fuse-backend-rs.git
@@ -1937,12 +1937,25 @@ that leaked. If teardown matters, it must survive SIGKILL.
 
 **Symlinks for sudo access**: The Containerfile creates symlinks in `/usr/local/bin/` so that `sudo cargo` works (sudo uses secure_path which includes `/usr/local/bin`). This matches how the host is configured.
 
-The `fuse-pipe/Cargo.toml` uses a local path dependency:
-```toml
-fuse-backend-rs = { path = "../../fuse-backend-rs", ... }
+Cargo.lock pins the Git revision of `fuse-backend-rs` for normal builds and CI.
+Host builds do not need a sibling checkout. Container recipes retain the
+`FUSE_BACKEND_RS` and `FUSER` source mounts, so those directories must exist;
+an explicit backend override replaces that mount's source directory.
+To compile uncommitted changes in a local checkout, opt in explicitly:
+```bash
+make build FUSE_BACKEND_RS_OVERRIDE=../fuse-backend-rs
+make container-test FUSE_BACKEND_RS_OVERRIDE=../fuse-backend-rs
+make clippy FUSE_BACKEND_RS_OVERRIDE=../fuse-backend-rs
 ```
 
-This ensures changes to fuse-backend-rs are immediately available without git commits.
+The override uses a Cargo path patch, including local manifest dependency changes.
+Container targets mount that checkout and rewrite the path for the inner build.
+An override changes Cargo.lock to the local source; do not commit that local-only
+lockfile change. After removing the override, `make dependency-metadata` resolves
+the Git dependency again; review its lockfile diff before committing.
+`make lint` audits the default Git dependency graph and rejects a local override:
+the pinned cargo-deny version cannot receive the local Cargo patch configuration.
+Use `make clippy` to lint local dependency development without that audit.
 
 ### Container KVM Access (Rootless Podman)
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1941,7 +1941,8 @@ Cargo.lock pins the Git revision of `fuse-backend-rs` for normal builds and CI.
 Host builds do not need a sibling checkout. Container recipes retain the
 `FUSE_BACKEND_RS` and `FUSER` source mounts, so those directories must exist;
 an explicit backend override replaces that mount's source directory.
-To compile uncommitted changes in a local checkout, opt in explicitly:
+The local override is Make-only. To compile uncommitted changes in a local
+checkout, opt in explicitly:
 ```bash
 make build FUSE_BACKEND_RS_OVERRIDE=../fuse-backend-rs
 make container-test FUSE_BACKEND_RS_OVERRIDE=../fuse-backend-rs
@@ -1956,6 +1957,9 @@ the Git dependency again; review its lockfile diff before committing.
 `make lint` audits the default Git dependency graph and rejects a local override:
 the pinned cargo-deny version cannot receive the local Cargo patch configuration.
 Use `make clippy` to lint local dependency development without that audit.
+The standalone `scripts/run_fuse_pipe_tests.sh` uses the default Git dependency
+and rejects a local override. For local FUSE tests, use
+`make test-root FILTER='-p fuse-pipe' FUSE_BACKEND_RS_OVERRIDE=../fuse-backend-rs`.
 
 ### Container KVM Access (Rootless Podman)
 

--- a/.github/actions/checkout-deps/action.yml
+++ b/.github/actions/checkout-deps/action.yml
@@ -1,7 +1,8 @@
 name: Checkout Dependencies
 description: Checkout fuser and fuse-backend-rs dependencies
 
-# UPDATE BRANCHES HERE - this is the single source of truth
+# These checkouts supply container mounts and local dependency development.
+# Normal builds use the Git revisions pinned in fcvm's Cargo.lock.
 # fuser: https://github.com/ejc3/fuser
 # fuse-backend-rs: https://github.com/ejc3/fuse-backend-rs
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,6 +803,7 @@ dependencies = [
 [[package]]
 name = "fuse-backend-rs"
 version = "0.13.1"
+source = "git+https://github.com/ejc3/fuse-backend-rs.git?branch=master#f42317dc90341d73c42897d5a260d28d07760d6c"
 dependencies = [
  "arc-swap",
  "bitflags 1.3.2",

--- a/Makefile
+++ b/Makefile
@@ -632,12 +632,17 @@ test-fc-mock: show-notes check-disk build build-fc-mock setup-fcvm _test-fc-mock
 FC_MOCK_CONTAINER_FILTER := package(fcvm) & (test(/fc_mock/) | test(/state_manager/) | test(/health_monitor/) | test(/no_sudo/)) & not test(=test_fc_mock_sanity) & not test(=test_fc_mock_container_launch)
 container-test-fc-mock: check-disk container-build setup-btrfs
 	@echo "==> Running fc-mock tests in container (unit tests only)..."
-	$(CONTAINER_RUN) $(CONTAINER_TAG) bash -c '\
-		make build build-fc-mock && \
-		FCVM_FIRECRACKER_BIN=/usr/local/bin/fc-mock \
-		RUST_LOG="$(TEST_LOG)" \
-		$(NEXTEST) $(NEXTEST_CAPTURE) --profile fc-mock --features privileged-tests -E "$(FC_MOCK_CONTAINER_FILTER)" $(FILTER) || \
-		{ echo "TEST FAILED (fc-mock container mode)"; exit 1; }'
+	$(CONTAINER_RUN) $(CONTAINER_TAG) bash -c 'make build build-fc-mock && exec make _test-container-fc-mock "$$@"' -- \
+		FILTER='$(FILTER)' STREAM='$(STREAM)' LIST='$(LIST)' TEST_LOG='$(TEST_LOG)' \
+		FC_MOCK_CONTAINER_FILTER='$(FC_MOCK_CONTAINER_FILTER)'
+
+# Construct Cargo arguments after the dependency override is remapped inside.
+.PHONY: _test-container-fc-mock
+_test-container-fc-mock: cargo-target-link
+	FCVM_FIRECRACKER_BIN=/usr/local/bin/fc-mock \
+	RUST_LOG="$(TEST_LOG)" \
+	$(NEXTEST) $(NEXTEST_CAPTURE) --profile fc-mock --features privileged-tests -E "$(FC_MOCK_CONTAINER_FILTER)" $(FILTER) || \
+	{ echo "TEST FAILED (fc-mock container mode)"; exit 1; }
 
 container-test-unit: check-disk container-build
 	@echo "==> Running unit tests in container..."

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ CARGO_BIN ?= cargo
 # exclusively before pruning idle artifacts, so age-check -> delete cannot race
 # a build.  `override` prevents `make CARGO=cargo ...` from silently bypassing
 # the safety protocol; CARGO_BIN remains available for toolchain selection.
-override CARGO = "$(MAKEFILE_DIR)scripts/cargo-target-run.sh" $(CARGO_BIN)
+override CARGO = "$(MAKEFILE_DIR)scripts/cargo-target-run.sh" $(CARGO_BIN) $(CARGO_LOCAL_CONFIG)
 
 # Custom dependencies bin directory
 CUSTOM_DEPS_BIN := /mnt/fcvm-btrfs/deps/bin
@@ -41,6 +41,7 @@ show-notes:
 
 # Paths (can be overridden via environment)
 FUSE_BACKEND_RS ?= /home/ubuntu/fuse-backend-rs
+FUSE_BACKEND_RS_OVERRIDE ?=
 FUSER ?= /home/ubuntu/fuser
 
 # Container settings
@@ -148,12 +149,23 @@ endif
 BTRFS_ROOT ?= /mnt/fcvm-btrfs
 export BTRFS_ROOT
 MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# A Make-only patch leaves the checked-in manifests resolvable by Dependabot.
+# Use one absolute path for Cargo, provenance, and the container bind mount.
+FUSE_BACKEND_RS_OVERRIDE_PATH := $(if $(strip $(FUSE_BACKEND_RS_OVERRIDE)),$(shell realpath -m -- "$(FUSE_BACKEND_RS_OVERRIDE)"))
+CARGO_LOCAL_CONFIG = $(if $(FUSE_BACKEND_RS_OVERRIDE_PATH),--config 'patch."https://github.com/ejc3/fuse-backend-rs.git".fuse-backend-rs.path="$(FUSE_BACKEND_RS_OVERRIDE_PATH)"')
+# cargo-deny 0.18.9 cannot consume Cargo's CLI patch configuration.
+ifneq ($(FUSE_BACKEND_RS_OVERRIDE_PATH),)
+ifneq ($(filter lint,$(MAKECMDGOALS)),)
+$(error lint audits the locked Git graph; unset FUSE_BACKEND_RS_OVERRIDE and run make dependency-metadata first, or use make clippy for local code)
+endif
+endif
 
 # Base test command
 # `target` is a symlink into BTRFS_ROOT, created by the cargo-target-link target
 # (a prerequisite of every build/test target).
 export CARGO_TARGET_DIR := target
-NEXTEST := $(CARGO) nextest $(NEXTEST_CMD) --release
+# Cargo does not forward global --config to external subcommands.
+NEXTEST := $(CARGO) nextest $(NEXTEST_CMD) $(CARGO_LOCAL_CONFIG) --release
 TEST_CONFIG_WRAPPER := ./scripts/with-test-config.sh
 # Extra flags forwarded to every criterion bench recipe (see bench-quick).
 #
@@ -217,7 +229,8 @@ CONTAINER_RUN_BASE := "$(MAKEFILE_DIR)scripts/cargo-target-run.sh" \
 	--security-opt label=disable --group-add keep-groups \
 	-v .:/workspace/fcvm \
 	$(TARGET_MOUNT) \
-	-v $(FUSE_BACKEND_RS):/workspace/fuse-backend-rs -v $(FUSER):/workspace/fuser \
+	-v "$(if $(FUSE_BACKEND_RS_OVERRIDE_PATH),$(FUSE_BACKEND_RS_OVERRIDE_PATH),$(FUSE_BACKEND_RS)):/workspace/fuse-backend-rs" -v $(FUSER):/workspace/fuser \
+	$(if $(FUSE_BACKEND_RS_OVERRIDE_PATH),-e FUSE_BACKEND_RS_OVERRIDE=/workspace/fuse-backend-rs) \
 	--device /dev/fuse -v /dev/kvm:/dev/kvm -v /dev/userfaultfd:/dev/userfaultfd \
 	--ulimit nofile=65536:65536 --ulimit nproc=-1:-1 \
 	-v /mnt/fcvm-btrfs:/mnt/fcvm-btrfs \
@@ -457,36 +470,25 @@ clean-test-data: build
 	mkdir -p /tmp/fcvm-test-logs
 	@echo "==> Cleaned test data (preserved cached assets)"
 
-# Record which FUSE dependency code this build compiles against. Two
-# dependencies, two mechanisms:
-#   fuse-backend-rs is a sibling path dependency (fuse-pipe/Cargo.toml points
-#   at ../../fuse-backend-rs), so the compiled code is whatever that directory
-#   holds, not what any lockfile pins. Reported as git describe of the
-#   checkout, or MISSING when there is no checkout. When the tree is dirty
-#   the line appends +<first 12 hex of sha256 over `git diff HEAD`>, because
-#   every possible local edit against one commit otherwise prints the same
-#   -dirty value. Untracked files are excluded from the digest: describe
-#   --dirty does not flag them, and an untracked file cannot reach the build
-#   unless a tracked file references it, which dirties the tree.
-#   fuser is a git dependency (fuse-pipe/Cargo.toml declares the URL,
-#   Cargo.lock pins the revision). Cargo compiles the locked revision from
-#   its git cache, never the sibling /workspace/fuser mount, so the line
-#   reports the lock's resolved source, which carries the exact commit
-#   after '#'.
+# Record Cargo.lock's resolved FUSE Git sources, not unused sibling checkouts.
+# An explicit fuse-backend-rs override reports the selected checkout instead:
+# git describe plus a tracked-diff digest distinguishes local dirty states.
 # Issue #807: two local fuse-backend-rs checkouts drifted 19 commits apart
 # and no build log recorded which one a given binary used. Pinned by
 # tests/test_dep_provenance.rs.
 .PHONY: dep-provenance
 dep-provenance:
-	@dir="$(MAKEFILE_DIR)../fuse-backend-rs"; \
-	if desc=$$(git -C "$$dir" describe --always --dirty 2>/dev/null); then \
-		case "$$desc" in \
-			*-dirty) desc="$$desc+$$(git -C "$$dir" diff --no-ext-diff HEAD | sha256sum | cut -c1-12)" ;; \
-		esac; \
+	@if [ -n "$(FUSE_BACKEND_RS_OVERRIDE_PATH)" ]; then \
+		dir="$(FUSE_BACKEND_RS_OVERRIDE_PATH)"; \
+		if desc=$$(git -C "$$dir" describe --always --dirty 2>/dev/null); then \
+			case "$$desc" in \
+				*-dirty) desc="$$desc+$$(git -C "$$dir" diff --no-ext-diff HEAD | sha256sum | cut -c1-12)" ;; \
+			esac; \
+		else desc=MISSING; fi; \
 	else \
-		desc=MISSING; \
+		desc=$$(awk -F'"' '/^name = "fuse-backend-rs"$$/ {f=1; next} f && /^\[\[package\]\]/ {exit} f && /^source = / {print $$2; exit}' "$(MAKEFILE_DIR)Cargo.lock" 2>/dev/null); \
 	fi; \
-	echo "fuse-backend-rs: $$desc"
+	echo "fuse-backend-rs: $${desc:-MISSING}"
 	@src=$$(awk -F'"' '/^name = "fuser"$$/ {f=1; next} f && /^\[\[package\]\]/ {exit} f && /^source = / {print $$2; exit}' "$(MAKEFILE_DIR)Cargo.lock" 2>/dev/null); \
 	echo "fuser: $${src:-MISSING}"
 
@@ -1378,13 +1380,21 @@ setup-lint-tools: cargo-target-link
 
 lint: setup-lint-tools
 	$(CARGO) fmt -p fcvm -p fuse-pipe -p fc-agent -p failpoint --check
-	$(CARGO) clippy --all-targets -- -D warnings
+	$(MAKE) clippy
 	$(CARGO) audit
 	$(CARGO) deny check
+
+.PHONY: clippy
+clippy: cargo-target-link
+	$(CARGO) clippy $(CARGO_LOCAL_CONFIG) --all-targets -- -D warnings
 
 update-dependency: cargo-target-link
 	@test -n "$(PACKAGE)" || (echo "ERROR: PACKAGE required"; exit 1)
 	$(CARGO) update -p "$(PACKAGE)" $(if $(VERSION),--precise "$(VERSION)")
+
+.PHONY: dependency-metadata
+dependency-metadata: cargo-target-link
+	@$(CARGO) metadata --format-version 1 $(METADATA_FLAGS)
 
 # CI merge train - pooled CI for a batch of independent low-risk PRs.
 # One full CI matrix validates the whole batch instead of one per PR.

--- a/fuse-pipe/Cargo.toml
+++ b/fuse-pipe/Cargo.toml
@@ -35,8 +35,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-log = "0.2"  # Bridge log crate to tracing
 
 # fuse-backend-rs for passthrough filesystem (Cloud Hypervisor's production-grade FUSE backend)
-# Using local path for development - synced to EC2 via `make sync`
-fuse-backend-rs = { path = "../../fuse-backend-rs", default-features = false, features = ["fusedev"] }
+# Cargo.lock pins the fork; Make's FUSE_BACKEND_RS_OVERRIDE opts into local development.
+fuse-backend-rs = { git = "https://github.com/ejc3/fuse-backend-rs.git", branch = "master", default-features = false, features = ["fusedev"] }
 
 # FUSE client (fork with clone_fd for true parallel readers + remap_file_range)
 # Based on upstream PR #636 (clone_fd for parallel processing) + remap_file_range

--- a/scripts/run_fuse_pipe_tests.sh
+++ b/scripts/run_fuse_pipe_tests.sh
@@ -14,6 +14,11 @@
 #   STRESS_WORKERS - overrides stress worker count
 set -euo pipefail
 
+if [[ -n "${FUSE_BACKEND_RS_OVERRIDE:-}" ]]; then
+    echo "ERROR: FUSE_BACKEND_RS_OVERRIDE is Make-only. Run make test-root FILTER='-p fuse-pipe' with the same override." >&2
+    exit 2
+fi
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${ROOT}"
 make cargo-target-link

--- a/tests/test_cargo_target_link.rs
+++ b/tests/test_cargo_target_link.rs
@@ -2445,6 +2445,8 @@ fn fuse_pipe_privileged_cargo_preserves_target_protocol_environment() {
     path.push(":");
     path.push(inherited_path);
     let output = Command::new(repo_root().join("scripts/run_fuse_pipe_tests.sh"))
+        // This fixture exercises the standalone script's default Git dependency mode.
+        .env_remove("FUSE_BACKEND_RS_OVERRIDE")
         .env("PATH", path)
         .env("FCVM_TEST_LOG", &observed)
         .env("LOG_DIR", &log_dir)

--- a/tests/test_dep_provenance.rs
+++ b/tests/test_dep_provenance.rs
@@ -1,11 +1,10 @@
 //! The build recipes must record which FUSE dependency code they compiled
 //! against, and that record must stay honest.
 //!
-//! Two dependencies, two mechanisms:
+//! Both FUSE forks use their Cargo.lock Git revision by default.
 //!
-//! * `fuse-backend-rs` is a sibling path dependency (`fuse-pipe/Cargo.toml`:
-//!   `path = "../../fuse-backend-rs"`), so the compiled code is whatever that
-//!   directory holds, not what any lockfile pins. Its provenance line is
+//! * An explicit `FUSE_BACKEND_RS_OVERRIDE` compiles the selected local
+//!   checkout, including uncommitted changes. Its provenance line is
 //!   `git describe --always --dirty` of the checkout, `MISSING` when there is
 //!   no checkout, and when the tree is dirty a `+<12 hex>` digest of
 //!   `git diff HEAD`, because every possible local edit against one commit
@@ -243,7 +242,8 @@ fn run_make(fcvm_dir: &Path, target: &str) -> std::process::Output {
         // A -j inherited from the make that started the test suite would
         // interleave other goals' output into the lines under assertion.
         .env_remove("MAKEFLAGS")
-        .env_remove("MFLAGS");
+        .env_remove("MFLAGS")
+        .env_remove("FUSE_BACKEND_RS_OVERRIDE");
     drop_priv(&mut cmd);
     // The test process may have written into the scratch since the last
     // chown; hand the whole tree back to the identity the children run as.
@@ -303,7 +303,14 @@ fn dep_provenance_reports_describe_lock_source_and_missing() {
     let dep_dir = scratch.join("fuse-backend-rs");
     fs::create_dir_all(&fcvm_dir).unwrap();
     fs::create_dir_all(&dep_dir).unwrap();
-    fs::write(fcvm_dir.join("Makefile"), repo_makefile()).unwrap();
+    fs::write(
+        fcvm_dir.join("Makefile"),
+        format!(
+            "FUSE_BACKEND_RS_OVERRIDE := ../fuse-backend-rs\n{}",
+            repo_makefile()
+        ),
+    )
+    .unwrap();
     fs::write(dep_dir.join("lib.rs"), "// scratch\n").unwrap();
     chown_tree(&scratch);
 
@@ -418,6 +425,246 @@ fn write_executable(path: &Path, body: &str) {
     fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
 }
 
+/// Exercise the Makefile's Cargo command with a local Git remote, without
+/// network access or a sibling checkout. The dependency declaration comes
+/// from fuse-pipe's real manifest; only its remote URL changes for the fixture.
+#[test]
+fn fuse_backend_dependency_resolves_without_a_sibling_checkout() {
+    let scratch = tempfile::tempdir().unwrap();
+    let remote = scratch.path().join("remote");
+    let checkout = scratch.path().join("fcvm");
+    fs::create_dir_all(&remote).unwrap();
+    fs::create_dir_all(checkout.join("scripts")).unwrap();
+    fs::create_dir_all(checkout.join("target")).unwrap();
+    fs::write(
+        remote.join("Cargo.toml"),
+        "[package]\nname = \"fuse-backend-rs\"\nversion = \"0.14.0\"\nedition = \"2021\"\n\
+         [lib]\npath = \"lib.rs\"\n[features]\nfusedev = []\n",
+    )
+    .unwrap();
+    fs::write(remote.join("lib.rs"), "pub fn value() -> u32 { 1 }\n").unwrap();
+    chown_tree(scratch.path());
+    git(&remote, &["init", "-q", "--initial-branch=master"]);
+    git(&remote, &["add", "."]);
+    git(&remote, &["commit", "-q", "-m", "fixture"]);
+
+    let url = format!("file://{}", remote.display());
+    let manifest = fs::read_to_string(repo_root().join("fuse-pipe/Cargo.toml")).unwrap();
+    let dependency = manifest
+        .lines()
+        .find(|line| line.starts_with("fuse-backend-rs = "))
+        .unwrap()
+        .replace("https://github.com/ejc3/fuse-backend-rs.git", &url);
+    fs::write(
+        checkout.join("Cargo.toml"),
+        format!(
+            "[package]\nname = \"fcvm\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\
+             [[bin]]\nname = \"fcvm\"\npath = \"main.rs\"\n[dependencies]\n{dependency}\n"
+        ),
+    )
+    .unwrap();
+    fs::write(
+        checkout.join("main.rs"),
+        "fn main() { println!(\"VALUE={}\", fuse_backend_rs::value()); }\n",
+    )
+    .unwrap();
+    fs::write(
+        checkout.join("Makefile"),
+        format!(
+            "{}\nfixture-run:\n\t@$(CARGO) run --quiet\n\
+             fixture-nextest:\n\t@$(NEXTEST)\n\
+             fixture-clippy:\n\t{}\n",
+            repo_makefile().replace("https://github.com/ejc3/fuse-backend-rs.git", &url),
+            rule(&repo_makefile(), "clippy")
+                .or_else(|| rule(&repo_makefile(), "lint"))
+                .unwrap()
+                .1
+                .into_iter()
+                .find(|line| line.contains("$(CARGO) clippy"))
+                .unwrap()
+        ),
+    )
+    .unwrap();
+    for name in ["cargo-target-run.sh", "cargo-target-lib.sh"] {
+        fs::copy(
+            repo_root().join("scripts").join(name),
+            checkout.join("scripts").join(name),
+        )
+        .unwrap();
+    }
+
+    let run = |expected: u32| {
+        let out = run_make(&checkout, "fixture-run");
+        assert!(
+            out.status.success(),
+            "Make Cargo dependency resolution failed:\n{}\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(String::from_utf8_lossy(&out.stdout).contains(&format!("VALUE={expected}")));
+    };
+    run(1);
+    assert!(line_for(&run_dep_provenance(&checkout), "fuse-backend-rs").starts_with("git+file://"));
+    let locked = fs::read_to_string(checkout.join("Cargo.lock")).unwrap();
+    run(1);
+    assert_eq!(
+        fs::read_to_string(checkout.join("Cargo.lock")).unwrap(),
+        locked
+    );
+
+    // An opt-in override compiles uncommitted source and manifest changes.
+    let local = scratch.path().join("local");
+    git(
+        scratch.path(),
+        &[
+            "clone",
+            "-q",
+            remote.to_str().unwrap(),
+            local.to_str().unwrap(),
+        ],
+    );
+    let makefile = fs::read_to_string(checkout.join("Makefile")).unwrap();
+    fs::write(
+        checkout.join("Makefile"),
+        format!(
+            "FUSE_BACKEND_RS_OVERRIDE := {}\n{makefile}",
+            local.display()
+        ),
+    )
+    .unwrap();
+    fs::write(local.join("lib.rs"), "pub fn value() -> u32 { 2 }\n").unwrap();
+    run(2);
+    assert!(line_for(&run_dep_provenance(&checkout), "fuse-backend-rs").contains("-dirty+"));
+
+    fs::create_dir(local.join("helper")).unwrap();
+    fs::write(
+        local.join("helper/Cargo.toml"),
+        "[package]\nname = \"fixture-helper\"\nversion = \"0.1.0\"\nedition = \"2021\"\n[lib]\npath = \"lib.rs\"\n",
+    )
+    .unwrap();
+    fs::write(local.join("helper/lib.rs"), "pub fn value() -> u32 { 3 }\n").unwrap();
+    let manifest = fs::read_to_string(local.join("Cargo.toml")).unwrap();
+    fs::write(
+        local.join("Cargo.toml"),
+        format!("{manifest}\n[dependencies]\nfixture-helper = {{ path = \"helper\" }}\n"),
+    )
+    .unwrap();
+    fs::write(
+        local.join("lib.rs"),
+        "pub fn value() -> u32 { fixture_helper::value() }\n",
+    )
+    .unwrap();
+    run(3);
+
+    // External Cargo subcommands do not inherit Cargo's global --config.
+    // Require a symbol that exists only in the uncommitted local override.
+    fs::write(
+        local.join("lib.rs"),
+        "pub fn local_only() -> u32 { fixture_helper::value() }\n",
+    )
+    .unwrap();
+    fs::write(
+        checkout.join("main.rs"),
+        "fn main() { println!(\"{}\", fuse_backend_rs::local_only()); }\n\
+         #[test] fn selected_override() { assert_eq!(fuse_backend_rs::local_only(), 3); }\n",
+    )
+    .unwrap();
+    for target in ["fixture-nextest", "fixture-clippy"] {
+        let out = run_make(&checkout, target);
+        assert!(
+            out.status.success(),
+            "{target} must compile the local override:\n{}\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+}
+
+#[test]
+fn container_dependency_override_mounts_and_rewrites_the_selected_path() {
+    let scratch = tempfile::tempdir().unwrap();
+    let checkout = scratch.path().join("fcvm");
+    let local = scratch.path().join("selected-backend");
+    fs::create_dir_all(checkout.join("scripts")).unwrap();
+    fs::create_dir_all(&local).unwrap();
+    // The fake launcher only records the actual expanded container command.
+    write_executable(
+        &checkout.join("scripts/cargo-target-run.sh"),
+        "#!/bin/bash\nprintf '%s\\n' \"$@\"\n",
+    );
+    fs::write(
+        checkout.join("Makefile"),
+        format!(
+            "FUSE_BACKEND_RS_OVERRIDE := {}\n{}\nfixture-container:\n\t@$(CONTAINER_RUN_BASE) /bin/true\n",
+            local.display(),
+            repo_makefile()
+        ),
+    )
+    .unwrap();
+    let out = run_make(&checkout, "fixture-container");
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout
+            .lines()
+            .any(|line| line == format!("{}:/workspace/fuse-backend-rs", local.display())),
+        "the selected override must be mounted: {stdout}"
+    );
+    assert!(
+        stdout
+            .lines()
+            .any(|line| line == "FUSE_BACKEND_RS_OVERRIDE=/workspace/fuse-backend-rs"),
+        "the inner Make must receive the container-visible override: {stdout}"
+    );
+}
+
+#[test]
+fn fuse_backend_provenance_reports_the_locked_source_without_an_override() {
+    let scratch = tempfile::tempdir().unwrap();
+    let checkout = scratch.path().join("fcvm");
+    fs::create_dir(&checkout).unwrap();
+    fs::write(checkout.join("Makefile"), repo_makefile()).unwrap();
+    let source = "git+https://github.com/ejc3/fuse-backend-rs.git?branch=master#cafef00d";
+    fs::write(
+        checkout.join("Cargo.lock"),
+        format!("version = 4\n[[package]]\nname = \"fuse-backend-rs\"\nversion = \"0.13.1\"\nsource = \"{source}\"\n"),
+    )
+    .unwrap();
+    assert_eq!(
+        line_for(&run_dep_provenance(&checkout), "fuse-backend-rs"),
+        source
+    );
+}
+
+#[test]
+fn dependency_auditing_rejects_a_local_override_before_running_tools() {
+    let scratch = tempfile::tempdir().unwrap();
+    let checkout = scratch.path().join("fcvm");
+    fs::create_dir(&checkout).unwrap();
+    fs::write(
+        checkout.join("Makefile"),
+        format!(
+            "FUSE_BACKEND_RS_OVERRIDE := ../local\n{}\n\
+             setup-lint-tools:\n\t@echo UNEXPECTED-TOOL-SETUP; exit 1\n",
+            repo_makefile()
+        ),
+    )
+    .unwrap();
+    let out = run_make(&checkout, "lint");
+    assert!(!out.status.success());
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("use make clippy for local code"),
+        "lint must reject an override before auditing a different graph:\n{}\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(!String::from_utf8_lossy(&out.stdout).contains("UNEXPECTED-TOOL-SETUP"));
+}
+
 /// Execute the real `build-host-tools` recipe with a stub cargo wrapper and
 /// prove the mid-build guard behaviorally: a sibling checkout mutated while
 /// "cargo" runs must fail the build with the provenance error, and an
@@ -448,7 +695,14 @@ fn mid_build_dependency_change_fails_the_build() {
     let dep_dir = scratch.join("fuse-backend-rs");
     fs::create_dir_all(fcvm_dir.join("scripts")).unwrap();
     fs::create_dir_all(&dep_dir).unwrap();
-    fs::write(fcvm_dir.join("Makefile"), repo_makefile()).unwrap();
+    fs::write(
+        fcvm_dir.join("Makefile"),
+        format!(
+            "FUSE_BACKEND_RS_OVERRIDE := ../fuse-backend-rs\n{}",
+            repo_makefile()
+        ),
+    )
+    .unwrap();
     // The cargo-target-link prerequisite manages btrfs target routing, which
     // a scratch tree has no business touching.
     write_executable(

--- a/tests/test_dep_provenance.rs
+++ b/tests/test_dep_provenance.rs
@@ -587,15 +587,20 @@ fn container_dependency_override_mounts_and_rewrites_the_selected_path() {
     let local = scratch.path().join("selected-backend");
     fs::create_dir_all(checkout.join("scripts")).unwrap();
     fs::create_dir_all(&local).unwrap();
-    // The fake launcher only records the actual expanded container command.
+    // Run the actual mock-container caller without its host setup prerequisites.
+    // The fake launcher records argv rather than starting Podman.
     write_executable(
         &checkout.join("scripts/cargo-target-run.sh"),
-        "#!/bin/bash\nprintf '%s\\n' \"$@\"\n",
+        "#!/bin/bash\nprintf 'ARGV\\0'; printf '%s\\0' \"$@\"; printf 'ENDARGV\\0'\n",
     );
+    let caller = rule(&repo_makefile(), "container-test-fc-mock")
+        .unwrap()
+        .1
+        .join("\n\t");
     fs::write(
         checkout.join("Makefile"),
         format!(
-            "FUSE_BACKEND_RS_OVERRIDE := {}\n{}\nfixture-container:\n\t@$(CONTAINER_RUN_BASE) /bin/true\n",
+            "FUSE_BACKEND_RS_OVERRIDE := {}\nSTREAM := 1\nLIST := 1\nFILTER := --test selected_mock\nTEST_LOG := trace\n{}\nFC_MOCK_CONTAINER_FILTER := package(fcvm) & test(=selected_mock)\nfixture-container:\n\t{caller}\n",
             local.display(),
             repo_makefile()
         ),
@@ -608,18 +613,85 @@ fn container_dependency_override_mounts_and_rewrites_the_selected_path() {
         String::from_utf8_lossy(&out.stderr)
     );
     let stdout = String::from_utf8(out.stdout).unwrap();
+    let argv = stdout
+        .split_once("ARGV\0")
+        .unwrap()
+        .1
+        .split_once("ENDARGV\0")
+        .unwrap()
+        .0
+        .split_terminator('\0')
+        .collect::<Vec<_>>();
     assert!(
-        stdout
-            .lines()
-            .any(|line| line == format!("{}:/workspace/fuse-backend-rs", local.display())),
+        argv.contains(&format!("{}:/workspace/fuse-backend-rs", local.display()).as_str()),
         "the selected override must be mounted: {stdout}"
     );
     assert!(
-        stdout
-            .lines()
-            .any(|line| line == "FUSE_BACKEND_RS_OVERRIDE=/workspace/fuse-backend-rs"),
+        argv.contains(&"FUSE_BACKEND_RS_OVERRIDE=/workspace/fuse-backend-rs"),
         "the inner Make must receive the container-visible override: {stdout}"
     );
+    let image = argv
+        .iter()
+        .position(|arg| *arg == "fcvm-test:latest")
+        .unwrap();
+    let command = &argv[image + 1..];
+    assert!(
+        !command
+            .iter()
+            .any(|arg| arg.contains(local.to_str().unwrap())),
+        "host-expanded Cargo arguments leaked into the container command: {command:?}"
+    );
+
+    // Execute that command as the container would, with its own override path.
+    // Stub only setup/build work and Cargo execution; inner Make must construct
+    // the nextest command and preserve the caller's flags and build ordering.
+    fs::write(
+        checkout.join("Makefile"),
+        format!(
+            "FUSE_BACKEND_RS_OVERRIDE := /workspace/fuse-backend-rs\n{}\n\
+             build build-fc-mock:\n\t@echo BUILD-$@\n",
+            repo_makefile()
+        ),
+    )
+    .unwrap();
+    write_executable(
+        &checkout.join("scripts/cargo-target-link.sh"),
+        "#!/bin/bash\nexit 0\n",
+    );
+    write_executable(
+        &checkout.join("scripts/cargo-target-run.sh"),
+        "#!/bin/bash\nif [[ $1 == -c ]]; then exec /bin/bash \"$@\"; fi\n\
+         printf 'MOCK=%s LOG=%s\\n' \"$FCVM_FIRECRACKER_BIN\" \"$RUST_LOG\"\n\
+         printf 'CARGO-ARGV\\n'; printf '%s\\n' \"$@\"\n",
+    );
+    chown_tree(scratch.path());
+    let mut inner = Command::new(command[0]);
+    inner
+        .args(&command[1..])
+        .current_dir(&checkout)
+        .env_remove("MAKEFLAGS")
+        .env_remove("MFLAGS");
+    drop_priv(&mut inner);
+    let out = inner.output().unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let cargo = stdout.find("CARGO-ARGV\n").unwrap();
+    assert!(stdout.find("BUILD-build\n").unwrap() < stdout.find("BUILD-build-fc-mock\n").unwrap());
+    assert!(stdout.find("BUILD-build-fc-mock\n").unwrap() < cargo);
+    assert!(stdout.contains("MOCK=/usr/local/bin/fc-mock LOG=trace"));
+    let args = &stdout[cargo..];
+    for expected in [
+        "patch.\"https://github.com/ejc3/fuse-backend-rs.git\".fuse-backend-rs.path=\"/workspace/fuse-backend-rs\"",
+        "nextest\nlist\n", "--no-capture", "--profile\nfc-mock", "--features\nprivileged-tests",
+        "-E\npackage(fcvm) & test(=selected_mock)", "--test\nselected_mock",
+    ] {
+        assert!(args.contains(expected), "missing {expected:?} from inner Cargo argv: {args}");
+    }
+    assert!(!args.contains(local.to_str().unwrap()));
 }
 
 #[test]

--- a/tests/test_dep_provenance.rs
+++ b/tests/test_dep_provenance.rs
@@ -737,6 +737,49 @@ fn dependency_auditing_rejects_a_local_override_before_running_tools() {
     assert!(!String::from_utf8_lossy(&out.stdout).contains("UNEXPECTED-TOOL-SETUP"));
 }
 
+#[test]
+fn standalone_fuse_sweep_rejects_a_local_override_before_setup() {
+    let scratch = tempfile::tempdir().unwrap();
+    let bin = scratch.path().join("bin");
+    let probe = scratch.path().join("setup-ran");
+    let logs = scratch.path().join("logs");
+    fs::create_dir(&bin).unwrap();
+    write_executable(
+        &bin.join("make"),
+        "#!/bin/bash\nprintf 'setup ran\\n' > \"$FCVM_SWEEP_PROBE\"\nexit 97\n",
+    );
+    chown_tree(scratch.path());
+    let mut command = Command::new(repo_root().join("scripts/run_fuse_pipe_tests.sh"));
+    command
+        .env("FUSE_BACKEND_RS_OVERRIDE", scratch.path().join("local"))
+        .env("LOG_DIR", &logs)
+        .env("FCVM_SWEEP_PROBE", &probe)
+        .env(
+            "PATH",
+            format!("{}:{}", bin.display(), std::env::var("PATH").unwrap()),
+        );
+    drop_priv(&mut command);
+    let out = command.output().unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(out.status.code(), Some(2), "{stderr}");
+    assert!(
+        stderr.contains("FUSE_BACKEND_RS_OVERRIDE is Make-only"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("make test-root FILTER='-p fuse-pipe'"),
+        "{stderr}"
+    );
+    assert!(
+        !probe.exists(),
+        "the script reached setup before rejecting the override"
+    );
+    assert!(
+        !logs.exists(),
+        "the rejected invocation created a log directory"
+    );
+}
+
 /// Execute the real `build-host-tools` recipe with a stub cargo wrapper and
 /// prove the mid-build guard behaviorally: a sibling checkout mutated while
 /// "cargo" runs must fail the build with the provenance error, and an


### PR DESCRIPTION
Use the `ejc3/fuse-backend-rs` Git dependency so Dependabot can resolve the workspace without an external sibling checkout. Cargo.lock pins `f42317dc90341d73c42897d5a260d28d07760d6c`; no dependency code or registry versions change.

Built on #910, which is now merged. This PR targets main.

Contract: normal builds and CI use the committed Git revision. `FUSE_BACKEND_RS_OVERRIDE=<path>` is a Make-only option for uncommitted local development through build, test, clippy, and container targets. Provenance reports the source actually selected. Nextest and clippy receive the patch configuration explicitly. Full `make lint` rejects the local override because the pinned cargo-deny cannot consume it.

Local overrides can change Cargo.lock. After removing an override, run `make dependency-metadata` and review the lockfile diff before committing. The development instructions document the commands and retained container mounts.

The standalone `scripts/run_fuse_pipe_tests.sh` continues to use the locked Git dependency. It rejects a nonempty local override before setup and directs local testing to `make test-root FILTER='-p fuse-pipe'`. This keeps the override implementation in Make instead of duplicating it across script Cargo calls.

Validation: the four initial regression checks were observed red on a code-only revert and green after restoration. The tests execute Cargo, nextest, and clippy against a local Git fixture, then compile uncommitted source and dependency-graph changes. Removing each external-command patch flag also failed the local-only-symbol test. Final results: 86 unprivileged tests and 97 privileged tests passed, with no skips. `make dependency-metadata METADATA_FLAGS=--locked` resolved the actual workspace without changing Cargo.lock. `make lint` passed formatting, all-target Clippy, audit, and deny. Bash syntax validation and complete-diff self-review passed.

The container mock-test caller now constructs Cargo arguments through inner Make after both builds, using the remapped dependency path. The existing regression executes the actual caller and verifies its filters, capture/list flags, and log level. It was observed red on the original caller, green with the repair, red on a code-only revert, and green after restoration. The standalone-script rejection test was also observed red, green, code-only-revert red, and restored green. Its default-mode fixture was checked with an inherited override and retains all existing assertions.

The official Dependabot updater [reproduced the unfixed missing-manifest failure](https://github.com/ejc3/fcvm/actions/runs/34126995620). The [same updater on final head 5a660699](https://github.com/ejc3/fcvm/actions/runs/34132436656) resolved the workspace and produced an `anyhow` 1.0.103 to 1.0.104 update proposal with zero error records. The recorded input and proposal base both name the exact PR head. This was a dry run; the proposed dependency update is not part of this PR.

Closes #907.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build and Development**
  - Normal builds now use the dependency revisions locked in `Cargo.lock` without requiring a sibling checkout.
  - Added an optional local override for testing uncommitted dependency changes.
  - Added dedicated commands for linting, Clippy checks, and dependency metadata reporting.
  - Dependency provenance now clearly reports either the locked source or selected local checkout.

- **Testing**
  - Improved container-based testing with local dependency overrides.
  - Added validation for dependency resolution, provenance reporting, and unsupported override usage in lint and standalone test commands.

- **Documentation**
  - Updated development guidance for dependency sources, local overrides, containers, and applicable commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->