### PR TITLE
deps: update fc-agent reqwest and remove legacy h2 exceptions

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,11 +1,3 @@
 # cargo-audit configuration. Keep in sync with deny.toml [advisories].
 [advisories]
-ignore = [
-    # h2 0.3 queues empty DATA frames without limit (low-severity DoS). The
-    # patch exists only in h2 >= 0.4.16, which requires the hyper 1.x line;
-    # fcvm/fc-mock sit on hyper 0.14 + hyperlocal and fc-agent on reqwest
-    # 0.11. h2 here runs only in client mode over trusted local transports
-    # (Unix socket to firecracker, guest-local HTTP), so the condition is not
-    # reachable from an untrusted peer. Remove with the migration: issue #859.
-    "RUSTSEC-2026-0258",
-]
+ignore = []

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -141,7 +141,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
  "tower",
@@ -163,17 +163,11 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
 ]
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -397,16 +391,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,15 +603,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,7 +656,7 @@ dependencies = [
  "fuse-pipe",
  "libc",
  "nix 0.29.0",
- "reqwest 0.11.27",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
@@ -734,7 +709,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.6",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_norway",
@@ -970,25 +945,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,7 +1071,6 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -1174,7 +1129,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -2095,47 +2050,11 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
- "tokio",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-core",
  "http 1.4.0",
@@ -2154,7 +2073,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tower",
@@ -2519,12 +2438,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -2541,27 +2454,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -2845,7 +2737,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -3577,16 +3469,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -7,11 +7,6 @@ ignore = [
     # bincode is unmaintained but v1.3.3 is considered complete
     # Not a security issue - maintainers ceased development
     "RUSTSEC-2025-0141",
-    # h2 0.3 unbounded empty DATA frames (low-severity DoS); patched only in
-    # h2 >= 0.4.16, which needs the hyper 1.x line. Client-mode-only use over
-    # trusted local transports here. Tracked by issue #859; remove with the
-    # hyper 1.x / reqwest 0.12 migration. Keep in sync with .cargo/audit.toml.
-    "RUSTSEC-2026-0258",
 ]
 
 [licenses]

--- a/fc-agent/Cargo.toml
+++ b/fc-agent/Cargo.toml
@@ -8,7 +8,7 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "fs", "io-util", "signal", "sync", "time"] }
-reqwest = { version = "0.11", default-features = false, features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json"] }
 libc = "0.2"
 nix = { version = "0.29", features = ["socket", "poll", "fs", "net"] }
 fs2 = "0.4"

--- a/tests/test_dependency_policy.rs
+++ b/tests/test_dependency_policy.rs
@@ -1,0 +1,31 @@
+//! Dependency policies that must remain true when Cargo resolves a new lockfile.
+
+#[test]
+fn mmds_client_needs_no_legacy_h2_or_advisory_exemption() {
+    let lock: toml::Value = toml::from_str(include_str!("../Cargo.lock")).unwrap();
+    let mut findings = Vec::new();
+    if lock["package"].as_array().unwrap().iter().any(|package| {
+        package["name"].as_str() == Some("h2")
+            && package["version"].as_str().unwrap().starts_with("0.3.")
+    }) {
+        findings.push("Cargo.lock contains h2 0.3, which has no fix for RUSTSEC-2026-0258");
+    }
+    for (path, source) in [
+        (".cargo/audit.toml", include_str!("../.cargo/audit.toml")),
+        ("deny.toml", include_str!("../deny.toml")),
+    ] {
+        let config: toml::Value = toml::from_str(source).unwrap();
+        if config["advisories"]["ignore"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|advisory| advisory.as_str() == Some("RUSTSEC-2026-0258"))
+        {
+            findings.push(path);
+        }
+    }
+    assert!(
+        findings.is_empty(),
+        "legacy h2 or its retired advisory exception returned: {findings:?}"
+    );
+}


### PR DESCRIPTION
## Change

Update fc-agent from reqwest 0.11 to the already-locked reqwest 0.12.28, retaining disabled default features and JSON support. This removes the last h2 0.3 dependency and its `RUSTSEC-2026-0258` exceptions from Cargo audit and deny.

Stacked on #912 (`browser-report-closeout`). Addresses the security slice of #859; the separate Hyper API migration remains outside this PR.

Five files change, with 42 insertions and 142 deletions. Cargo.lock removes nine obsolete package versions without updating retained versions. There are no runtime API or Makefile changes.

## Verification

- `mmds_client_needs_no_legacy_h2_or_advisory_exemption` failed before the change, passed with it, failed after a production-only reversion, and passed after restoration. It rejects h2 0.3 and both retired exceptions, without forbidding future safe h2 versions.
- Locked dependency metadata: no h2; reqwest 0.12.28 only; fc-agent default features disabled, JSON enabled.
- `make build`: rebuilt the statically linked aarch64-musl agent.
- `make test-agent-unit FILTER='--retries 0'`: 119 passed.
- Focused `make setup-default _test-root`: five real-VM tests passed, with no retries: `test_bootplan_over_vsock` (including normal MMDS cold boot), `test_sanity_rootless`, `test_sanity_bridged`, `test_snapshot_run_direct_rootless`, and `test_snapshot_run_exec_rootless`.
- Integrated-head policy test and `make lint` passed, including audit and deny.
- Rebase range-diff confirms the dependency patch is unchanged.

The merge contract is unchanged MMDS boot and snapshot-restore behavior, removal of the vulnerable dependency and its exceptions, required CI, and disposition of actual findings on the final head.
