### PR TITLE
Report browser request errors in campaign indexes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,7 @@ CONTAINER_RUN := $(CONTAINER_RUN_BASE) --ulimit nproc=65536:65536 --pids-limit=6
 	container-build container-test container-test-unit container-test-fast container-test-all container-test-fc-mock \
 	container-setup-fcvm container-shell container-clean container-bench \
 	cargo-target-link build-host-tools setup-btrfs setup-default release-default-kernel setup-fcvm setup-pjdfstest setup-hugepages bench bench-vm bench-hugepages bench-hugepages-test \
-	bench-container-import bench-chromium analyze-chromium-request bench-clone-latency test-chromium-request \
+	bench-container-import bench-chromium analyze-chromium-request analyze-chromium-campaign bench-clone-latency test-chromium-request \
 	bench-chromium-request-build bench-webkit-request-build bench-webkit-request-golden bench-webkit-request-verify bench-webkit-request-run test-chromium bench-chromium-request-golden bench-chromium-request-verify \
 	bench-chromium-corpus bench-chromium-corpus-extra bench-stop \
 	bench-chromium-request-run bench-chromium-request-all bench-chromium-hostcdp bench-chromium-fault \
@@ -325,6 +325,7 @@ help:
 	@echo "  bench-chromium-hostcdp         Host direct-CDP baseline (COMPARISON_LABEL=standalone CPU_BUDGET=unlimited; CPUS= needs CPU_BUDGET=vm-matched)"
 	@echo "  bench-chromium-fault           Page-fault bench (FAULT_OUT= required; needs bench.sh goldens)"
 	@echo "  analyze-chromium-request  Re-run publication gates for RESULTS=/path/to/run"
+	@echo "  analyze-chromium-campaign  Index retained CAMPAIGN_RUNS='run1 run2' into CAMPAIGN_OUT=path"
 	@echo "  test-chromium          Run ALL bench unit tests (what CI runs)"
 	@echo "  test-chromium-request  Run the request benchmark's deterministic unit tests"
 	@echo "  bench-chromium-scale  Open-loop FILE/UFFD Chromium request scalability run"
@@ -1121,6 +1122,11 @@ analyze-chromium-request:
 	@test -f "$(RESULTS)/reqbench.jsonl" || { echo "ERROR: no $(RESULTS)/reqbench.jsonl" >&2; exit 2; }
 	@python3 bench/chromium/reqanalyze.py --json-out "$(RESULTS)/analysis.json" \
 		$(if $(STALL_MAX_MS),--stall-max-ms $(STALL_MAX_MS),) "$(RESULTS)/reqbench.jsonl"
+
+analyze-chromium-campaign:
+	@test -n "$(CAMPAIGN_OUT)" || { echo "ERROR: CAMPAIGN_OUT required" >&2; exit 2; }
+	@test -n "$(CAMPAIGN_RUNS)" || { echo "ERROR: CAMPAIGN_RUNS required" >&2; exit 2; }
+	@python3 bench/chromium/campaign_summary.py --out "$(CAMPAIGN_OUT)" $(CAMPAIGN_RUNS)
 
 # What CI runs (ci.yml globs test_*.py). The per-harness targets below are
 # narrower dev conveniences; run THIS before pushing, because a new test file is

--- a/bench/chromium/campaign_summary.py
+++ b/bench/chromium/campaign_summary.py
@@ -42,7 +42,8 @@ during the measured run, when the evidence records it), load_evidence with
 descriptive statistics from the continuous owner sampler and every measured
 request (overall and per arm), the headline median
 blocking_ms per arm with its CI, and for the diag its verdict, violation
-count and slowest load event per URL.
+count, slowest load event and browser request error counts per URL. Request
+errors are reported separately from the limits that determine the verdict.
 
 The publication rule (REVIEW.md) is to quote only from sealed runs that passed
 their gates and were never withdrawn, and publishable=true alone proves none
@@ -1162,7 +1163,7 @@ DIAG_IDENTITY = (
 
 
 def summarize_diag(run_dir, diag, cell, measured_urls, addresses, stall_max_ms):
-    """The diag's verdict, violation count and slowest load per URL; RunError otherwise.
+    """The diag's verdict, violations, loads and request errors; RunError otherwise.
 
     addresses is the set recorded_addresses derived for the cell, and
     stall_max_ms the run's armed stall gate: the two things the diag's
@@ -1264,7 +1265,12 @@ def summarize_diag(run_dir, diag, cell, measured_urls, addresses, stall_max_ms):
             f"{len(violations)} violation(s) {kinds}; a run whose diag failed is not indexed"
         )
     check_diag_limits(run_dir, diag, measured_urls, addresses, stall_max_ms)
-    return {"diag_passed": True, "violations_count": 0, "max_load_ms": max_load}
+    return {
+        "diag_passed": True,
+        "violations_count": 0,
+        "max_load_ms": max_load,
+        "errors": {url: data.get("errors") for url, data in urls.items()},
+    }
 
 
 def check_diag_limits(run_dir, diag, measured_urls, addresses, stall_max_ms):

--- a/bench/chromium/campaign_summary.py
+++ b/bench/chromium/campaign_summary.py
@@ -1245,6 +1245,15 @@ def summarize_diag(run_dir, diag, cell, measured_urls, addresses, stall_max_ms):
         if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
             raise RunError(f"{run_dir}: diag/summary.json max_load_ms for {url} is {value!r}")
         max_load[url] = value
+        counts = data.get("errors")
+        if not isinstance(counts, dict) or any(
+            not isinstance(error, str) or type(count) is not int or count < 0
+            for error, count in counts.items()
+        ):
+            raise RunError(
+                f"{run_dir}: diag/summary.json errors for {url} must map "
+                "error texts to nonnegative integer counts"
+            )
     # A diag over other pages says nothing about the pages this run measured,
     # and a cell that names no url gives the comparison nothing to hold the
     # diag to.

--- a/bench/chromium/results/campaign-20260830-box2-summary.json
+++ b/bench/chromium/results/campaign-20260830-box2-summary.json
@@ -1,53 +1,53 @@
 {
   "generated_from": [
     {
-      "path": "/home/ubuntu/src/fcvm/bench/chromium/results/reqbench-20260830-171007-corpus/analysis.json",
+      "path": "bench/chromium/results/reqbench-20260830-171007-corpus/analysis.json",
       "sha256": "85031fe2fc4655aa08e41830ae57987f517c0aa165354d71c8cdb0248de830c0"
     },
     {
-      "path": "/home/ubuntu/src/fcvm/bench/chromium/results/reqbench-20260830-171007-corpus/dns-evidence.json",
+      "path": "bench/chromium/results/reqbench-20260830-171007-corpus/dns-evidence.json",
       "sha256": "b490d4dc741b11b261f109159432ece3bce944d17c2b93021794f1000c62d56c"
     },
     {
-      "path": "/home/ubuntu/src/fcvm/bench/chromium/results/reqbench-20260830-171007-corpus/dns-owner.log",
+      "path": "bench/chromium/results/reqbench-20260830-171007-corpus/dns-owner.log",
       "sha256": "e575f41c4191117501b9258dbfce5f16d0ff5ed9b5884b22b5a4feda8ec5c612"
     },
     {
-      "path": "/home/ubuntu/src/fcvm/bench/chromium/results/reqbench-20260830-171007-corpus/verify-dns-pre.json",
+      "path": "bench/chromium/results/reqbench-20260830-171007-corpus/verify-dns-pre.json",
       "sha256": "c769476621d97e795e00ab5d379e88e516bfdd4817cd1337dc585b5e8eaddcc3"
     },
     {
-      "path": "/home/ubuntu/src/fcvm/bench/chromium/results/reqbench-20260830-171007-corpus/verify-dns-before-run.json",
+      "path": "bench/chromium/results/reqbench-20260830-171007-corpus/verify-dns-before-run.json",
       "sha256": "f965102e59903a6db53dfc3357fa42e28e965a8c6f6d3b79dc85fe0cfac7eb52"
     },
     {
-      "path": "/home/ubuntu/src/fcvm/bench/chromium/results/reqbench-20260830-171007-corpus/verify-dns-after-run.json",
+      "path": "bench/chromium/results/reqbench-20260830-171007-corpus/verify-dns-after-run.json",
       "sha256": "91f769a80087b79b703e54c8de094a4851b709419f4a3c44e7be34ac43057c01"
     },
     {
-      "path": "/home/ubuntu/src/fcvm/bench/chromium/results/reqbench-20260830-171007-corpus/corpus-dns.log",
+      "path": "bench/chromium/results/reqbench-20260830-171007-corpus/corpus-dns.log",
       "sha256": "c54276e60c329e4b9f50840b90f698b9198ac0b7e188fbfc201c20399289c7f8"
     },
     {
-      "path": "/home/ubuntu/src/fcvm/bench/chromium/results/reqbench-20260830-171007-corpus/corpus-access.log",
+      "path": "bench/chromium/results/reqbench-20260830-171007-corpus/corpus-access.log",
       "sha256": "b205f24f5fa3508e818c3db46d79280d35dd92d7e32a07b5654ada278d41c201"
     },
     {
-      "path": "/home/ubuntu/src/fcvm/bench/chromium/results/reqbench-20260830-171007-corpus/replay-queries.log",
+      "path": "bench/chromium/results/reqbench-20260830-171007-corpus/replay-queries.log",
       "sha256": "ef74d7ac1c09ccbcf7d94a2869b4c8dfdfa7e6e4fc857e5eb5b047a366f7f9b0"
     },
     {
-      "path": "/home/ubuntu/src/fcvm/bench/chromium/results/reqbench-20260830-171007-corpus/diag/summary.json",
+      "path": "bench/chromium/results/reqbench-20260830-171007-corpus/diag/summary.json",
       "sha256": "5122d51d7f3ef1009092f6f8e05a3b4c4f857222164230542c0caa54621e4cc0"
     },
     {
-      "path": "/home/ubuntu/src/fcvm/bench/chromium/results/reqbench-20260830-171007-corpus/reqbench.jsonl",
+      "path": "bench/chromium/results/reqbench-20260830-171007-corpus/reqbench.jsonl",
       "sha256": "fbf87fc4f368b3edac75b4df1c3804cb13dcfd94d0a73a537736d59f09b4dfc9"
     }
   ],
   "cells": [
     {
-      "run_dir": "/home/ubuntu/src/fcvm/bench/chromium/results/reqbench-20260830-171007-corpus",
+      "run_dir": "bench/chromium/results/reqbench-20260830-171007-corpus",
       "run_id": "b6c7c20926674e76aa8bdc8e329dd6aa",
       "engine": "chromium",
       "cpu": 2,
@@ -71,7 +71,7 @@
       "load_max_1min": 2.87,
       "load_evidence": {
         "continuous_owner_log": {
-          "artifact": "/home/ubuntu/src/fcvm/bench/chromium/results/reqbench-20260830-171007-corpus/dns-owner.log",
+          "artifact": "bench/chromium/results/reqbench-20260830-171007-corpus/dns-owner.log",
           "samples": 40,
           "min": 0.59,
           "median": 1.935,
@@ -79,7 +79,7 @@
           "interval_seconds": 10
         },
         "measured_requests": {
-          "artifact": "/home/ubuntu/src/fcvm/bench/chromium/results/reqbench-20260830-171007-corpus/reqbench.jsonl",
+          "artifact": "bench/chromium/results/reqbench-20260830-171007-corpus/reqbench.jsonl",
           "samples": 404,
           "min": 1.48,
           "median": 2.03,
@@ -136,6 +136,29 @@
           "https://www.elmundo.es/": 3679.8611429999255,
           "https://www.rtp.pt/noticias/": 2648.604731999967,
           "https://www.theguardian.com/international": 1293.2883470000434
+        },
+        "errors": {
+          "https://blog.cloudflare.com/": {},
+          "https://developer.mozilla.org/en-US/": {},
+          "https://developers.cloudflare.com/": {},
+          "https://en.wikipedia.org/": {},
+          "https://example.com/": {},
+          "https://news.ycombinator.com/": {},
+          "https://todomvc.com/examples/angular/dist/browser/": {},
+          "https://todomvc.com/examples/javascript-es6/dist/": {},
+          "https://todomvc.com/examples/preact/dist/": {},
+          "https://todomvc.com/examples/react/dist/index.html": {},
+          "https://todomvc.com/examples/vue/dist/": {},
+          "https://www.elmundo.es/": {
+            "net::ERR_ABORTED": 45,
+            "net::ERR_CONNECTION_RESET": 3
+          },
+          "https://www.rtp.pt/noticias/": {
+            "net::ERR_ABORTED": 8
+          },
+          "https://www.theguardian.com/international": {
+            "net::ERR_ABORTED": 27
+          }
         }
       }
     }

--- a/bench/chromium/results/campaign-20260902-box2-ladder-summary.json
+++ b/bench/chromium/results/campaign-20260902-box2-ladder-summary.json
@@ -224,6 +224,29 @@
           "https://www.elmundo.es/": 4663.620985999842,
           "https://www.rtp.pt/noticias/": 2853.7569860000076,
           "https://www.theguardian.com/international": 1296.8793689997256
+        },
+        "errors": {
+          "https://blog.cloudflare.com/": {},
+          "https://developer.mozilla.org/en-US/": {},
+          "https://developers.cloudflare.com/": {},
+          "https://en.wikipedia.org/": {},
+          "https://example.com/": {},
+          "https://news.ycombinator.com/": {},
+          "https://todomvc.com/examples/angular/dist/browser/": {},
+          "https://todomvc.com/examples/javascript-es6/dist/": {},
+          "https://todomvc.com/examples/preact/dist/": {},
+          "https://todomvc.com/examples/react/dist/index.html": {},
+          "https://todomvc.com/examples/vue/dist/": {},
+          "https://www.elmundo.es/": {
+            "net::ERR_ABORTED": 47,
+            "net::ERR_CONNECTION_RESET": 3
+          },
+          "https://www.rtp.pt/noticias/": {
+            "net::ERR_ABORTED": 10
+          },
+          "https://www.theguardian.com/international": {
+            "net::ERR_ABORTED": 27
+          }
         }
       }
     },
@@ -317,6 +340,29 @@
           "https://www.elmundo.es/": 2750.362707000022,
           "https://www.rtp.pt/noticias/": 2401.5811819999726,
           "https://www.theguardian.com/international": 741.9693390002067
+        },
+        "errors": {
+          "https://blog.cloudflare.com/": {},
+          "https://developer.mozilla.org/en-US/": {},
+          "https://developers.cloudflare.com/": {},
+          "https://en.wikipedia.org/": {},
+          "https://example.com/": {},
+          "https://news.ycombinator.com/": {},
+          "https://todomvc.com/examples/angular/dist/browser/": {},
+          "https://todomvc.com/examples/javascript-es6/dist/": {},
+          "https://todomvc.com/examples/preact/dist/": {},
+          "https://todomvc.com/examples/react/dist/index.html": {},
+          "https://todomvc.com/examples/vue/dist/": {},
+          "https://www.elmundo.es/": {
+            "net::ERR_ABORTED": 45,
+            "net::ERR_CONNECTION_RESET": 4
+          },
+          "https://www.rtp.pt/noticias/": {
+            "net::ERR_ABORTED": 6
+          },
+          "https://www.theguardian.com/international": {
+            "net::ERR_ABORTED": 27
+          }
         }
       }
     },
@@ -410,6 +456,29 @@
           "https://www.elmundo.es/": 2582.250804999603,
           "https://www.rtp.pt/noticias/": 2272.7131779993215,
           "https://www.theguardian.com/international": 682.5176779993853
+        },
+        "errors": {
+          "https://blog.cloudflare.com/": {},
+          "https://developer.mozilla.org/en-US/": {},
+          "https://developers.cloudflare.com/": {},
+          "https://en.wikipedia.org/": {},
+          "https://example.com/": {},
+          "https://news.ycombinator.com/": {},
+          "https://todomvc.com/examples/angular/dist/browser/": {},
+          "https://todomvc.com/examples/javascript-es6/dist/": {},
+          "https://todomvc.com/examples/preact/dist/": {},
+          "https://todomvc.com/examples/react/dist/index.html": {},
+          "https://todomvc.com/examples/vue/dist/": {},
+          "https://www.elmundo.es/": {
+            "net::ERR_ABORTED": 47,
+            "net::ERR_CONNECTION_RESET": 3
+          },
+          "https://www.rtp.pt/noticias/": {
+            "net::ERR_ABORTED": 7
+          },
+          "https://www.theguardian.com/international": {
+            "net::ERR_ABORTED": 27
+          }
         }
       }
     }

--- a/bench/chromium/test_campaign_summary.py
+++ b/bench/chromium/test_campaign_summary.py
@@ -926,6 +926,45 @@ class CampaignSummary(unittest.TestCase):
         })
         self.assertIn(paths["diag"], {entry["path"] for entry in index["generated_from"]})
 
+    def test_diag_error_counts_require_nonnegative_integers(self):
+        """Missing or malformed request counts cannot be published as evidence.
+
+        Watched all seven invalid shapes publish successfully before the
+        validator and again after reverting only the validator.
+        """
+        cases = (
+            ("missing", None, False),
+            ("null", None, False),
+            ("list", [], False),
+            ("negative", {"net::ERR_ABORTED": -1}, False),
+            ("boolean", {"net::ERR_ABORTED": True}, False),
+            ("float", {"net::ERR_ABORTED": 1.0}, False),
+            ("string", {"net::ERR_ABORTED": "1"}, False),
+            ("empty", {}, True),
+            ("zero", {"net::ERR_ABORTED": 0}, True),
+        )
+        url = "https://example.com/"
+        for label, errors, valid in cases:
+            with self.subTest(case=label), tempfile.TemporaryDirectory() as d:
+                summary = diag_summary()
+                if label == "missing":
+                    del summary["urls"][url]["errors"]
+                else:
+                    summary["urls"][url]["errors"] = errors
+                if valid:
+                    run_dir = os.path.join(d, "run")
+                    write_run(run_dir, diag=summary)
+                    out = os.path.join(d, "campaign-x-summary.json")
+                    rc, text = self._summarize(out, [run_dir])
+                    self.assertEqual(rc, 0, text)
+                    with open(out) as handle:
+                        self.assertEqual(json.load(handle)["cells"][0]["diag"]["errors"],
+                                         {url: errors})
+                else:
+                    _, text = self._refused(d, diag=summary)
+                    self.assertIn("errors", text)
+                    self.assertIn(url, text)
+
     def test_a_corpus_cell_without_its_diag_is_refused(self):
         """A run whose guest resolved through the baked resolver had the
         diag run before it; a run directory without the summary is a run

--- a/bench/chromium/test_campaign_summary.py
+++ b/bench/chromium/test_campaign_summary.py
@@ -523,6 +523,7 @@ class CampaignSummary(unittest.TestCase):
         self.assertEqual(cell["diag"], {
             "diag_passed": True, "violations_count": 0,
             "max_load_ms": {"https://example.com/": 812.5},
+            "errors": {"https://example.com/": {}},
         })
 
     def test_an_unclean_dns_verdict_refuses_and_writes_nothing(self):
@@ -884,16 +885,23 @@ class CampaignSummary(unittest.TestCase):
             self.assertIn("dns-evidence.json", text)
 
     def test_diag_fields_flow_into_the_cell(self):
-        """The cell carries the diag's verdict, its violation count and the
-        slowest load event per URL, and the index names the summary among
-        the files it was generated from.
+        """The cell carries the diag verdict, loads and request error counts.
 
         Watched red 2026-08-28 at 55d6fb7d: the cell's diag was the whole
         summary object (`AssertionError: {'engine': 'chromium', ...} != {'diag_passed': True, ...}`).
+
+        #900: a passing diag with request errors must retain their counts,
+        including pages with no errors, without calling them violations.
+        Watched red with errors absent from the index, then green, then red
+        again after removing only the production change.
         """
         urls = ("https://example.com/", "https://news.ycombinator.com/")
         summary = diag_summary(urls=urls)
         summary["urls"]["https://news.ycombinator.com/"]["max_load_ms"] = 2210.0
+        summary["urls"]["https://news.ycombinator.com/"]["errors"] = {
+            "net::ERR_ABORTED": 45,
+            "net::ERR_CONNECTION_RESET": 4,
+        }
         with tempfile.TemporaryDirectory() as d:
             run_dir = os.path.join(d, "run")
             paths = write_run(run_dir, diag=summary)
@@ -908,6 +916,13 @@ class CampaignSummary(unittest.TestCase):
             "violations_count": 0,
             "max_load_ms": {"https://example.com/": 812.5,
                             "https://news.ycombinator.com/": 2210.0},
+            "errors": {
+                "https://example.com/": {},
+                "https://news.ycombinator.com/": {
+                    "net::ERR_ABORTED": 45,
+                    "net::ERR_CONNECTION_RESET": 4,
+                },
+            },
         })
         self.assertIn(paths["diag"], {entry["path"] for entry in index["generated_from"]})
 

--- a/bench/chromium/test_reqbench.py
+++ b/bench/chromium/test_reqbench.py
@@ -10816,6 +10816,7 @@ class CampaignSummaryFromAnalyzerOutput(unittest.TestCase):
         self.assertEqual(cell["diag"], {
             "diag_passed": True, "violations_count": 0,
             "max_load_ms": {url: 812.5 for url in self.CORPUS},
+            "errors": {url: {} for url in self.CORPUS},
         })
         self.assertEqual(
             {os.path.basename(entry["path"]) for entry in index["generated_from"]},


### PR DESCRIPTION
Include retained browser request-error counts in each campaign diagnostic summary.

**Stacked on:** `fix/stale-state-sweep-870` (PR #915).

Closes #900.

## Contract

`diag.errors` maps each URL to its existing error-text/count map. Each map is
required and must contain string keys and nonnegative integer counts. Invalid
counts are refused before publishing an index. Diagnostic
pass/fail, violation counts, measured benchmark records, and input hashes do not
change. The two current tracked indexes are regenerated; the withdrawn index
and sealed input records are untouched. August's derived paths become
repository-relative when regenerated locally.

`make analyze-chromium-campaign CAMPAIGN_OUT=... CAMPAIGN_RUNS='...'` reproduces
an index through the Makefile.

Downstream impact: the derived benchmark index, not VM runtime or a release gate.

## Evidence

`test_diag_fields_flow_into_the_cell` failed without the change, passed with it,
failed after reverting only production code, and passed after restoring it.
The review regression `test_diag_error_counts_require_nonnegative_integers`
likewise passed red/green/production-only revert red/restored green for seven
malformed shapes, with empty maps and zero counts remaining valid.
`make test-chromium` passed all 1,026 tests in 259.657 seconds after the repair.

The four indexed error maps exactly match their retained diagnostic summaries.
Event totals: August 30 = 83; September 2 (2/4/8 vCPU) = 87/82/84. The 4-vCPU
elmundo page contributes 49 of its cell's 82 events. These are diagnostic request
events, not failures in the measured benchmark repetitions.

Full-delta self-review completed. Remote exact-head review and required CI remain
the merge gates.
