### PR TITLE
Migrate Unix HTTP APIs to Hyper 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,10 +125,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -158,8 +158,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -672,8 +672,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "exec-proto",
- "hyper 0.14.32",
- "hyperlocal",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "libc",
  "nix 0.29.0",
  "serde",
@@ -701,7 +702,9 @@ dependencies = [
  "fuse-pipe",
  "glob",
  "hex",
- "hyper 0.14.32",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "hyperlocal",
  "libc",
  "memmap2",
@@ -749,12 +752,6 @@ name = "find-msvc-tools"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -864,17 +861,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,7 +879,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
- "futures-macro",
  "futures-sink",
  "futures-task",
  "pin-project-lite",
@@ -996,17 +981,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -1017,23 +991,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -1044,8 +1007,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1063,29 +1026,6 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -1094,8 +1034,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1112,8 +1052,8 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.4.0",
- "hyper 1.8.1",
+ "http",
+ "hyper",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -1134,14 +1074,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.8.1",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1149,15 +1089,17 @@ dependencies = [
 
 [[package]]
 name = "hyperlocal"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
- "futures-util",
  "hex",
- "hyper 0.14.32",
- "pin-project",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
  "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1693,26 +1635,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "pin-project"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1813,7 +1735,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.1",
+ "socket2",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -1850,7 +1772,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2057,10 +1979,10 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -2389,16 +2311,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
@@ -2606,7 +2518,7 @@ dependencies = [
  "mio 1.1.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2753,8 +2665,8 @@ dependencies = [
  "bitflags 2.10.0",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -2875,7 +2787,7 @@ checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http",
  "httparse",
  "log",
  "rand 0.9.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,10 @@ chrono = { version = "0.4", features = ["serde"] }
 tempfile = "3"
 rand = "0.8"
 async-trait = "0.1"
-hyper = { version = "0.14", features = ["client", "http1"] }
-hyperlocal = "0.8"
+hyper = { version = "1", features = ["client", "http1"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "http1", "tokio"] }
+http-body-util = "0.1"
+hyperlocal = { version = "0.9", default-features = false, features = ["client"] }
 shellexpand = "3"
 userfaultfd = { version = "0.9", features = ["linux5_13"] }
 memmap2 = "0.9"

--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,10 @@ ignore = true
 # Warn on duplicate crate versions
 multiple-versions = "warn"
 wildcards = "allow"
+deny = [
+    { name = "hyper", version = "<1.0" },
+    { name = "hyperlocal", version = "<0.9" },
+]
 
 [sources]
 # Only allow crates.io

--- a/fc-mock/Cargo.toml
+++ b/fc-mock/Cargo.toml
@@ -12,8 +12,9 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 exec-proto = { path = "../exec-proto" }
-hyper = { version = "0.14", features = ["server", "client", "http1"] }
-hyperlocal = "0.8"
+hyper = { version = "1", features = ["server", "http1"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
+http-body-util = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "fs", "signal", "io-util", "sync", "time", "net"] }

--- a/fc-mock/src/api_server.rs
+++ b/fc-mock/src/api_server.rs
@@ -4,8 +4,11 @@
 //! and triggers container launch on InstanceStart.
 
 use anyhow::{Context, Result};
+use http_body_util::{BodyExt, Full};
+use hyper::body::{Bytes, Incoming};
 use hyper::service::service_fn;
-use hyper::{Body, Method, Request, Response, StatusCode};
+use hyper::{Method, Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::{Mutex, Notify};
@@ -81,8 +84,8 @@ pub async fn start_server(
                     let state = state.clone();
                     async move { handle_request(req, state).await }
                 });
-                if let Err(e) = hyper::server::conn::Http::new()
-                    .serve_connection(stream, service)
+                if let Err(e) = hyper::server::conn::http1::Builder::new()
+                    .serve_connection(TokioIo::new(stream), service)
                     .await
                 {
                     // Connection reset is normal during shutdown
@@ -102,15 +105,15 @@ pub async fn start_server(
 
 /// Handle a single API request.
 async fn handle_request(
-    req: Request<Body>,
+    req: Request<Incoming>,
     state: SharedState,
-) -> Result<Response<Body>, hyper::Error> {
+) -> Result<Response<Full<Bytes>>, hyper::Error> {
     let method = req.method().clone();
     let path = req.uri().path().to_string();
 
     debug!(%method, %path, "API request");
 
-    let body_bytes = hyper::body::to_bytes(req.into_body()).await?;
+    let body_bytes = req.into_body().collect().await?.to_bytes();
 
     let result: Result<(), String> = match (method, path.as_str()) {
         // Boot source - extract boot_args for network config
@@ -243,16 +246,16 @@ async fn handle_request(
             let msg = format!("{{\"fault_message\": \"{}\"}}", e);
             Ok(Response::builder()
                 .status(StatusCode::BAD_REQUEST)
-                .body(Body::from(msg))
+                .body(Full::new(Bytes::from(msg)))
                 .unwrap())
         }
     }
 }
 
-fn response_204() -> Response<Body> {
+fn response_204() -> Response<Full<Bytes>> {
     Response::builder()
         .status(StatusCode::NO_CONTENT)
-        .body(Body::empty())
+        .body(Full::default())
         .unwrap()
 }
 

--- a/src/firecracker/api.rs
+++ b/src/firecracker/api.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
-use hyper::{Body, Client, Method, Request, StatusCode};
+use http_body_util::{BodyExt, Full};
+use hyper::body::Bytes;
+use hyper::{Method, Request, StatusCode};
+use hyper_util::client::legacy::Client;
 use hyperlocal::{UnixClientExt, Uri as UnixUri};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -9,7 +12,7 @@ use std::time::Duration;
 #[derive(Debug, Clone)]
 pub struct FirecrackerClient {
     socket_path: PathBuf,
-    client: Client<hyperlocal::UnixConnector>,
+    client: Client<hyperlocal::UnixConnector, Full<Bytes>>,
     /// Timeout for individual API requests
     request_timeout: Duration,
 }
@@ -51,7 +54,7 @@ impl FirecrackerClient {
             .method(Method::PUT)
             .uri(self.uri(path))
             .header("Content-Type", "application/json")
-            .body(Body::from(json))?;
+            .body(Full::new(Bytes::from(json)))?;
 
         let resp = tokio::time::timeout(self.request_timeout, self.client.request(req))
             .await
@@ -64,7 +67,7 @@ impl FirecrackerClient {
             })??;
         if resp.status() != StatusCode::NO_CONTENT && resp.status() != StatusCode::OK {
             let status = resp.status();
-            let body_bytes = hyper::body::to_bytes(resp.into_body()).await?;
+            let body_bytes = resp.into_body().collect().await?.to_bytes();
             let body_str = String::from_utf8_lossy(&body_bytes);
             anyhow::bail!("Firecracker API error: {} - {}", status, body_str);
         }
@@ -78,7 +81,7 @@ impl FirecrackerClient {
             .method(Method::PATCH)
             .uri(self.uri(path))
             .header("Content-Type", "application/json")
-            .body(Body::from(json))?;
+            .body(Full::new(Bytes::from(json)))?;
 
         let resp = tokio::time::timeout(self.request_timeout, self.client.request(req))
             .await
@@ -91,7 +94,7 @@ impl FirecrackerClient {
             })??;
         if resp.status() != StatusCode::NO_CONTENT && resp.status() != StatusCode::OK {
             let status = resp.status();
-            let body_bytes = hyper::body::to_bytes(resp.into_body()).await?;
+            let body_bytes = resp.into_body().collect().await?.to_bytes();
             let body_str = String::from_utf8_lossy(&body_bytes);
             anyhow::bail!("Firecracker API error: {} - {}", status, body_str);
         }

--- a/src/hypervisor/cloud_hypervisor/api.rs
+++ b/src/hypervisor/cloud_hypervisor/api.rs
@@ -10,7 +10,10 @@
 //! `ch-remote info` output on v52).
 
 use anyhow::Result;
-use hyper::{Body, Client, Method, Request, StatusCode};
+use http_body_util::{BodyExt, Full};
+use hyper::body::Bytes;
+use hyper::{Method, Request, StatusCode};
+use hyper_util::client::legacy::Client;
 use hyperlocal::{UnixClientExt, Uri as UnixUri};
 use serde::Serialize;
 use std::path::PathBuf;
@@ -23,7 +26,7 @@ const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 #[derive(Debug, Clone)]
 pub struct ChClient {
     socket_path: PathBuf,
-    client: Client<hyperlocal::UnixConnector>,
+    client: Client<hyperlocal::UnixConnector, Full<Bytes>>,
     request_timeout: Duration,
 }
 
@@ -56,7 +59,7 @@ impl ChClient {
             .method(Method::PUT)
             .uri(self.uri(path))
             .header("Content-Type", "application/json")
-            .body(Body::from(json))?;
+            .body(Full::new(Bytes::from(json)))?;
         self.send(path, req).await
     }
 
@@ -65,11 +68,11 @@ impl ChClient {
         let req = Request::builder()
             .method(Method::PUT)
             .uri(self.uri(path))
-            .body(Body::empty())?;
+            .body(Full::default())?;
         self.send(path, req).await
     }
 
-    async fn send(&self, path: &str, req: Request<Body>) -> Result<()> {
+    async fn send(&self, path: &str, req: Request<Full<Bytes>>) -> Result<()> {
         let resp = tokio::time::timeout(self.request_timeout, self.client.request(req))
             .await
             .map_err(|_| {
@@ -81,7 +84,7 @@ impl ChClient {
             })??;
         let status = resp.status();
         if status != StatusCode::NO_CONTENT && status != StatusCode::OK {
-            let body_bytes = hyper::body::to_bytes(resp.into_body()).await?;
+            let body_bytes = resp.into_body().collect().await?.to_bytes();
             let body_str = String::from_utf8_lossy(&body_bytes);
             anyhow::bail!(
                 "Cloud Hypervisor API error: {} {} - {}",
@@ -98,7 +101,7 @@ impl ChClient {
         let req = Request::builder()
             .method(Method::GET)
             .uri(self.uri("/api/v1/vmm.ping"))
-            .body(Body::empty())?;
+            .body(Full::default())?;
         self.send("/api/v1/vmm.ping", req).await
     }
 

--- a/tests/test_dependency_policy.rs
+++ b/tests/test_dependency_policy.rs
@@ -1,6 +1,43 @@
 //! Dependency policies that must remain true when Cargo resolves a new lockfile.
 
 #[test]
+fn unix_api_clients_need_no_legacy_hyper() {
+    let lock: toml::Value = toml::from_str(include_str!("../Cargo.lock")).unwrap();
+    let policy: toml::Value = toml::from_str(include_str!("../deny.toml")).unwrap();
+    let mut findings = Vec::new();
+    for (name, minimum, requirement) in [("hyper", (1, 0), "<1.0"), ("hyperlocal", (0, 9), "<0.9")]
+    {
+        for package in lock["package"].as_array().unwrap() {
+            if package["name"].as_str() != Some(name) {
+                continue;
+            }
+            let version = package["version"].as_str().unwrap();
+            let mut parts = version.split('.');
+            let major: u64 = parts.next().unwrap().parse().unwrap();
+            let minor: u64 = parts.next().unwrap().parse().unwrap();
+            if (major, minor) < minimum {
+                findings.push(format!("Cargo.lock contains {name} {version}"));
+            }
+        }
+        assert!(
+            policy["bans"]["deny"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|ban| {
+                    ban["name"].as_str() == Some(name)
+                        && ban["version"].as_str() == Some(requirement)
+                }),
+            "deny.toml must forbid {name} {requirement}"
+        );
+    }
+    assert!(
+        findings.is_empty(),
+        "legacy Unix HTTP dependencies: {findings:?}"
+    );
+}
+
+#[test]
 fn mmds_client_needs_no_legacy_h2_or_advisory_exemption() {
     let lock: toml::Value = toml::from_str(include_str!("../Cargo.lock")).unwrap();
     let mut findings = Vec::new();

--- a/tests/test_hypervisor_api.rs
+++ b/tests/test_hypervisor_api.rs
@@ -1,0 +1,156 @@
+//! Wire contracts for the Unix HTTP clients, without starting a VMM.
+
+use axum::body::Bytes;
+use axum::http::{HeaderMap, Method, StatusCode, Uri};
+use axum::Router;
+use fcvm::firecracker::FirecrackerClient;
+use fcvm::hypervisor::cloud_hypervisor::api::ChClient;
+use serde_json::json;
+use std::path::PathBuf;
+use std::time::Duration;
+use tokio::sync::mpsc;
+
+struct ApiServer {
+    _dir: tempfile::TempDir,
+    path: PathBuf,
+    requests: mpsc::UnboundedReceiver<(Method, Uri, HeaderMap, Bytes)>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl ApiServer {
+    async fn start(response: Option<(StatusCode, &'static str)>) -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("api.sock");
+        let listener = tokio::net::UnixListener::bind(&path).unwrap();
+        let (sender, requests) = mpsc::unbounded_channel();
+        let app = Router::new().fallback(
+            move |method: Method, uri: Uri, headers: HeaderMap, body: Bytes| {
+                let sender = sender.clone();
+                async move {
+                    sender.send((method, uri, headers, body)).unwrap();
+                    match response {
+                        Some(reply) => reply,
+                        None => std::future::pending().await,
+                    }
+                }
+            },
+        );
+        let task = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        Self {
+            _dir: dir,
+            path,
+            requests,
+            task,
+        }
+    }
+
+    async fn assert_request(
+        &mut self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+    ) {
+        let (actual_method, uri, headers, bytes) =
+            tokio::time::timeout(Duration::from_secs(5), self.requests.recv())
+                .await
+                .unwrap()
+                .unwrap();
+        assert_eq!(actual_method, method);
+        assert_eq!(uri.path(), path);
+        if let Some(body) = body {
+            assert_eq!(headers["content-type"], "application/json");
+            assert_eq!(
+                serde_json::from_slice::<serde_json::Value>(&bytes).unwrap(),
+                body
+            );
+        } else {
+            assert!(bytes.is_empty(), "body must be empty: {bytes:?}");
+        }
+    }
+}
+
+impl Drop for ApiServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+#[tokio::test]
+async fn firecracker_unix_api_preserves_requests_responses_and_deadlines() {
+    let data = json!({"latest": {"message": "snowman ☃"}});
+    for status in [StatusCode::OK, StatusCode::NO_CONTENT] {
+        let mut server = ApiServer::start(Some((status, ""))).await;
+        let client = FirecrackerClient::new(server.path.clone()).unwrap();
+        client.put_mmds(data.clone()).await.unwrap();
+        server
+            .assert_request(Method::PUT, "/mmds", Some(data.clone()))
+            .await;
+        client.patch_mmds(data.clone()).await.unwrap();
+        server
+            .assert_request(Method::PATCH, "/mmds", Some(data.clone()))
+            .await;
+    }
+
+    let server = ApiServer::start(Some((StatusCode::BAD_REQUEST, "invalid config"))).await;
+    let client = FirecrackerClient::new(server.path.clone()).unwrap();
+    for error in [
+        client.put_mmds(data.clone()).await.unwrap_err(),
+        client.patch_mmds(data.clone()).await.unwrap_err(),
+    ] {
+        assert_eq!(
+            error.to_string(),
+            "Firecracker API error: 400 Bad Request - invalid config"
+        );
+    }
+
+    let server = ApiServer::start(None).await;
+    let client = FirecrackerClient::new(server.path.clone())
+        .unwrap()
+        .with_timeout(Duration::from_millis(10));
+    assert_eq!(
+        client.put_mmds(data.clone()).await.unwrap_err().to_string(),
+        "Firecracker API PUT /mmds timed out after 10ms"
+    );
+    assert_eq!(
+        client.patch_mmds(data).await.unwrap_err().to_string(),
+        "Firecracker API PATCH /mmds timed out after 10ms"
+    );
+}
+
+#[tokio::test]
+async fn cloud_hypervisor_unix_api_preserves_requests_responses_and_deadlines() {
+    for status in [StatusCode::OK, StatusCode::NO_CONTENT] {
+        let mut server = ApiServer::start(Some((status, ""))).await;
+        let client = ChClient::new(server.path.clone());
+        client.ping().await.unwrap();
+        server
+            .assert_request(Method::GET, "/api/v1/vmm.ping", None)
+            .await;
+        client.boot_vm().await.unwrap();
+        server
+            .assert_request(Method::PUT, "/api/v1/vm.boot", None)
+            .await;
+        client.snapshot_vm("file:///snapshot").await.unwrap();
+        server
+            .assert_request(
+                Method::PUT,
+                "/api/v1/vm.snapshot",
+                Some(json!({"destination_url": "file:///snapshot"})),
+            )
+            .await;
+    }
+
+    let server = ApiServer::start(Some((StatusCode::BAD_REQUEST, "invalid config"))).await;
+    let client = ChClient::new(server.path.clone());
+    assert_eq!(
+        client.boot_vm().await.unwrap_err().to_string(),
+        "Cloud Hypervisor API error: /api/v1/vm.boot 400 Bad Request - invalid config"
+    );
+
+    let server = ApiServer::start(None).await;
+    let client = ChClient::new(server.path.clone()).with_timeout(Duration::from_millis(10));
+    assert_eq!(
+        client.boot_vm().await.unwrap_err().to_string(),
+        "Cloud Hypervisor API /api/v1/vm.boot timed out after 10ms"
+    );
+}


### PR DESCRIPTION
Migrate both Unix HTTP clients and fc-mock to Hyper 1.

**Stacked on:** `fix/campaign-diag-errors-900` (PR #916).

Closes #859. The reqwest/h2 security cleanup already landed in #913.

## Contract

FirecrackerClient and ChClient use hyper-util's pooled Unix client with
hyperlocal 0.9. fc-mock uses Hyper 1's HTTP/1 server. Request methods, paths,
JSON bodies, accepted 200/204 responses, error text, and request-header
deadlines are unchanged. No VM lifecycle changes.

Cargo.lock contains Hyper 1.8.1 and hyperlocal 0.9.1, with no legacy Hyper,
HTTP 0.2, or h2. cargo-deny bans Hyper <1 and hyperlocal <0.9.

Downstream impact: host-to-hypervisor API traffic and the container-mode mock.

## Evidence

- `unix_api_clients_need_no_legacy_hyper` failed before the migration, passed
  with it, and failed after a production-only reversion.
- Four focused tests passed without retries: both dependency-policy tests and
  both Unix-client wire-contract tests (PUT/PATCH/GET, empty bodies, status
  handling, error text and deadlines).
- `make lint` passed on 884dbd0c: formatting, Clippy, audit and deny.
- Complete-delta self-review found no blocking issue.

- Four runtime tests passed without retries in 28.781s on the frozen head:
  Firecracker sanity (7.523s), direct snapshot/restore/exec (12.230s),
  Cloud Hypervisor cold boot (3.854s), and the 15-endpoint fc-mock test (5.175s).
  The outer command received SIGTERM after nextest printed its passing summary;
  its sender is not known. An independent final run of all four VM-free checks
  exited 0. The runtime test results are passes, not a claim that the outer
  command completed normally.
- Codex reviewed 884dbd0c with no findings. CodeRabbit's dependency-policy
  finding was answered against #859's stated version boundary and withdrawn.
  The local review gate is CLEAR. Required CI remains pending.
