### PR TITLE
Backport the ARM64 VNCR fixmap state fix

### DIFF
--- a/kernel/patches-arm64/vncr-fixmap-state.patch
+++ b/kernel/patches-arm64/vncr-fixmap-state.patch
@@ -1,0 +1,75 @@
+From 5949004d7032767e8fde1e8c986a33f241b2a192 Mon Sep 17 00:00:00 2001
+From: Oliver Upton <oupton@kernel.org>
+Date: Tue, 2 Jun 2026 16:54:47 -0700
+Subject: [PATCH] KVM: arm64: nv: Fully update VNCR fixmap state in
+ kvm_translate_vncr()
+
+kvm_translate_vncr() first invalidates the pseudo-TLB entry and
+corresponding fixmap in anticipation of installing a new translation.
+
+While the fixmap invalidation does clear the mapping from host stage-1,
+it does not clear the L1_VNCR_MAPPED flag. Depending on the state of the
+VNCR TLB at vcpu_put(), this could potentially precipitate a BUG_ON() if
+vt->cpu is reset.
+
+Share a helper with kvm_vcpu_put_hw_mmu(), ensuring that KVM's view of
+the VNCR fixmap is in sync with the state of the VNCR TLB. Give it a
+slightly verbose name to make it obvious that it is meant to be used
+local to a CPU, unlike other VNCR TLB maintenance.
+
+Fixes: 069a05e535496 ("KVM: arm64: nv: Handle VNCR_EL2-triggered faults")
+Signed-off-by: Oliver Upton <oupton@kernel.org>
+Link: https://patch.msgid.link/20260602235450.103057-3-oupton@kernel.org
+Signed-off-by: Marc Zyngier <maz@kernel.org>
+---
+ arch/arm64/kvm/nested.c | 27 +++++++++++++++++----------
+ 1 file changed, 17 insertions(+), 10 deletions(-)
+
+diff --git a/arch/arm64/kvm/nested.c b/arch/arm64/kvm/nested.c
+index 4fa82e96454dd6..d0545144eaac6e 100644
+--- a/arch/arm64/kvm/nested.c
++++ b/arch/arm64/kvm/nested.c
+@@ -797,18 +797,24 @@ void kvm_vcpu_load_hw_mmu(struct kvm_vcpu *vcpu)
+ 	}
+ }
+ 
++static void this_cpu_reset_vncr_fixmap(struct kvm_vcpu *vcpu)
++{
++	if (!host_data_test_flag(L1_VNCR_MAPPED))
++		return;
++
++	BUG_ON(vcpu->arch.vncr_tlb->cpu != smp_processor_id());
++	BUG_ON(is_hyp_ctxt(vcpu));
++
++	clear_fixmap(vncr_fixmap(vcpu->arch.vncr_tlb->cpu));
++	vcpu->arch.vncr_tlb->cpu = -1;
++	host_data_clear_flag(L1_VNCR_MAPPED);
++	atomic_dec(&vcpu->kvm->arch.vncr_map_count);
++}
++
+ void kvm_vcpu_put_hw_mmu(struct kvm_vcpu *vcpu)
+ {
+ 	/* Unconditionally drop the VNCR mapping if we have one */
+-	if (host_data_test_flag(L1_VNCR_MAPPED)) {
+-		BUG_ON(vcpu->arch.vncr_tlb->cpu != smp_processor_id());
+-		BUG_ON(is_hyp_ctxt(vcpu));
+-
+-		clear_fixmap(vncr_fixmap(vcpu->arch.vncr_tlb->cpu));
+-		vcpu->arch.vncr_tlb->cpu = -1;
+-		host_data_clear_flag(L1_VNCR_MAPPED);
+-		atomic_dec(&vcpu->kvm->arch.vncr_map_count);
+-	}
++	this_cpu_reset_vncr_fixmap(vcpu);
+ 
+ 	/*
+ 	 * Keep a reference on the associated stage-2 MMU if the vCPU is
+@@ -1282,7 +1288,8 @@ static int kvm_translate_vncr(struct kvm_vcpu *vcpu, bool *is_gmem)
+ 	 * We also prepare the next walk wilst we're at it.
+ 	 */
+ 	scoped_guard(write_lock, &vcpu->kvm->mmu_lock) {
+-		invalidate_vncr(vt);
++		this_cpu_reset_vncr_fixmap(vcpu);
++		vt->valid = false;
+ 
+ 		vt->wi = (struct s1_walk_info) {
+ 			.regime	= TR_EL20,

--- a/tests/fixtures/vncr/harness.c
+++ b/tests/fixtures/vncr/harness.c
@@ -1,0 +1,123 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/* Single-CPU state regression. Page walks and allocation are stubbed; the
+ * production translation/reset/put functions execute from patched nested.c.
+ * This does not emulate hardware TLBs or prove cross-CPU invalidation. */
+#include <assert.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef uint64_t u64;
+struct s1_walk_info { int regime; bool as_el0, pan; };
+struct s1_walk_result { u64 pa; bool pw; };
+struct vncr_tlb {
+    u64 gva;
+    struct s1_walk_info wi;
+    struct s1_walk_result wr;
+    u64 hpa;
+    bool hpa_writable;
+    int cpu;
+    bool valid;
+};
+struct kvm_s2_mmu { int refcnt; };
+struct kvm {
+    struct { int vncr_map_count; struct kvm_s2_mmu mmu; } arch;
+    int mmu_lock, srcu;
+    unsigned long mmu_invalidate_seq;
+};
+struct kvm_vcpu {
+    struct { struct vncr_tlb *vncr_tlb; struct kvm_s2_mmu *hw_mmu; } arch;
+    struct kvm *kvm;
+    bool scheduled_out;
+};
+struct kvm_memory_slot { int flags; };
+struct page { int unused; };
+static struct kvm_memory_slot slot;
+static bool mapped, pte_present;
+static int clears, translation_result;
+
+#define scoped_guard(kind, lock) for (int once = 1; once; once = 0)
+#define guard(kind) (void)
+#define BUG_ON(condition) assert(!(condition))
+#define host_data_test_flag(flag) mapped
+#define host_data_clear_flag(flag) (mapped = false)
+#define smp_processor_id() 3
+#define is_hyp_ctxt(vcpu) false
+#define vncr_fixmap(cpu) (cpu)
+#define atomic_dec(value) (--*(value))
+#define vcpu_get_flag(vcpu, flag) false
+#define kvm_is_nested_s2_mmu(kvm, mmu) false
+#define get_s2_mmu_nested(vcpu) (&(vcpu)->kvm->arch.mmu)
+#define __vcpu_sys_reg(vcpu, reg) 0
+#define HCR_NV 1
+#define kvm_make_request(request, vcpu) ((void)0)
+#define TR_EL20 0
+#define read_vncr_el2(vcpu) 0x1000ULL
+#define kvm_is_write_fault(vcpu) false
+#define smp_rmb() ((void)0)
+#define PAGE_SHIFT 12
+#define PAGE_SIZE (1UL << PAGE_SHIFT)
+#define gfn_to_memslot(kvm, gfn) (&slot)
+#define fail_s1_walk(result, fault, level) ((void)0)
+#define kvm_slot_has_gmem(slot) false
+#define FOLL_WRITE 1
+#define __kvm_faultin_pfn(slot, gfn, flags, writable, page) \
+    (*(writable) = true, *(page) = NULL, 1ULL)
+#define is_error_noslot_pfn(pfn) false
+#define kvm_gmem_get_pfn(kvm, slot, gfn, pfn, page, order) \
+    (*(pfn) = 1, *(page) = NULL, 0)
+#define kvm_prepare_memory_fault_exit(...) ((void)0)
+#define KVM_MEM_READONLY 1
+#define pfn_is_map_memory(pfn) true
+#define kvm_release_faultin_page(...) ((void)0)
+#define mmu_invalidate_retry(kvm, seq) false
+#define mark_page_dirty(kvm, gfn) ((void)0)
+
+static void clear_fixmap(int cpu)
+{
+    assert(cpu == smp_processor_id());
+    pte_present = false;
+    clears++;
+}
+
+static int __kvm_translate_va(struct kvm_vcpu *vcpu,
+                              struct s1_walk_info *wi,
+                              struct s1_walk_result *wr, u64 va)
+{
+    wr->pa = 0x1000;
+    wr->pw = true;
+    return translation_result;
+}
+
+#include "arch/arm64/kvm/nested.c"
+
+int main(int argc, char **argv)
+{
+    assert(argc == 2);
+    int scenario = atoi(argv[1]);
+    assert(scenario >= 0 && scenario <= 2);
+    bool initially_mapped = scenario != 0;
+    mapped = pte_present = initially_mapped;
+    translation_result = scenario == 2 ? -EFAULT : 0;
+    struct vncr_tlb vt = { .cpu = initially_mapped ? 3 : -1, .valid = true };
+    /* One other CPU's mapping must not be decremented by this vCPU's reset. */
+    struct kvm kvm = { .arch.vncr_map_count = 1 + initially_mapped };
+    struct kvm_vcpu vcpu = { .arch.vncr_tlb = &vt, .kvm = &kvm };
+    bool is_gmem = false;
+
+    assert(kvm_translate_vncr(&vcpu, &is_gmem) == translation_result);
+    fprintf(stderr, "scenario=%d cpu=%d mapped=%d count=%d pte=%d clears=%d valid=%d\n",
+            scenario, vt.cpu, mapped, kvm.arch.vncr_map_count, pte_present, clears, vt.valid);
+    assert(!mapped && vt.cpu == -1 && kvm.arch.vncr_map_count == 1 && !pte_present);
+    assert(clears == initially_mapped);
+    assert(vt.valid == (translation_result == 0));
+
+    /* A successful retranslation used to leave mapped=true and cpu=-1 here,
+     * causing the actual put function's CPU ownership BUG_ON to fire. */
+    kvm_vcpu_put_hw_mmu(&vcpu);
+    assert(!mapped && vt.cpu == -1 && kvm.arch.vncr_map_count == 1 && !pte_present);
+    assert(clears == initially_mapped);
+    return 0;
+}

--- a/tests/fixtures/vncr/nested.c
+++ b/tests/fixtures/vncr/nested.c
@@ -1,0 +1,166 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/* Copyright (C) 2017 - Columbia University and Linaro Ltd.
+ * Author: Jintack Lim <jintack.lim@linaro.org>
+ */
+/*
+ * Verbatim function excerpts from Linux v6.18.44 arch/arm64/kvm/nested.c:
+ * https://raw.githubusercontent.com/gregkh/linux/v6.18.44/arch/arm64/kvm/nested.c
+ * Complete source SHA256: 6d9e8d4eaf264de6bcbb7b73c2c58f6da1488b0dc195b78074445dcf4d5ea12d
+ * kvm_vcpu_load_hw_mmu is retained as context for the upstream patch.
+ * The test applies the production patch to this file, then executes the C.
+ */
+
+void kvm_vcpu_load_hw_mmu(struct kvm_vcpu *vcpu)
+{
+	/*
+	 * If the vCPU kept its reference on the MMU after the last put,
+	 * keep rolling with it.
+	 */
+	if (is_hyp_ctxt(vcpu)) {
+		if (!vcpu->arch.hw_mmu)
+			vcpu->arch.hw_mmu = &vcpu->kvm->arch.mmu;
+	} else {
+		if (!vcpu->arch.hw_mmu) {
+			scoped_guard(write_lock, &vcpu->kvm->mmu_lock)
+				vcpu->arch.hw_mmu = get_s2_mmu_nested(vcpu);
+		}
+
+		if (__vcpu_sys_reg(vcpu, HCR_EL2) & HCR_NV)
+			kvm_make_request(KVM_REQ_MAP_L1_VNCR_EL2, vcpu);
+	}
+}
+
+void kvm_vcpu_put_hw_mmu(struct kvm_vcpu *vcpu)
+{
+	/* Unconditionally drop the VNCR mapping if we have one */
+	if (host_data_test_flag(L1_VNCR_MAPPED)) {
+		BUG_ON(vcpu->arch.vncr_tlb->cpu != smp_processor_id());
+		BUG_ON(is_hyp_ctxt(vcpu));
+
+		clear_fixmap(vncr_fixmap(vcpu->arch.vncr_tlb->cpu));
+		vcpu->arch.vncr_tlb->cpu = -1;
+		host_data_clear_flag(L1_VNCR_MAPPED);
+		atomic_dec(&vcpu->kvm->arch.vncr_map_count);
+	}
+
+	/*
+	 * Keep a reference on the associated stage-2 MMU if the vCPU is
+	 * scheduling out and not in WFI emulation, suggesting it is likely to
+	 * reuse the MMU sometime soon.
+	 */
+	if (vcpu->scheduled_out && !vcpu_get_flag(vcpu, IN_WFI))
+		return;
+
+	if (kvm_is_nested_s2_mmu(vcpu->kvm, vcpu->arch.hw_mmu))
+		atomic_dec(&vcpu->arch.hw_mmu->refcnt);
+
+	vcpu->arch.hw_mmu = NULL;
+}
+static void invalidate_vncr(struct vncr_tlb *vt)
+{
+	vt->valid = false;
+	if (vt->cpu != -1)
+		clear_fixmap(vncr_fixmap(vt->cpu));
+}
+static int kvm_translate_vncr(struct kvm_vcpu *vcpu, bool *is_gmem)
+{
+	struct kvm_memory_slot *memslot;
+	bool write_fault, writable;
+	unsigned long mmu_seq;
+	struct vncr_tlb *vt;
+	struct page *page;
+	u64 va, pfn, gfn;
+	int ret;
+
+	vt = vcpu->arch.vncr_tlb;
+
+	/*
+	 * If we're about to walk the EL2 S1 PTs, we must invalidate the
+	 * current TLB, as it could be sampled from another vcpu doing a
+	 * TLBI *IS. A real CPU wouldn't do that, but we only keep a single
+	 * translation, so not much of a choice.
+	 *
+	 * We also prepare the next walk wilst we're at it.
+	 */
+	scoped_guard(write_lock, &vcpu->kvm->mmu_lock) {
+		invalidate_vncr(vt);
+
+		vt->wi = (struct s1_walk_info) {
+			.regime	= TR_EL20,
+			.as_el0	= false,
+			.pan	= false,
+		};
+		vt->wr = (struct s1_walk_result){};
+	}
+
+	guard(srcu)(&vcpu->kvm->srcu);
+
+	va =  read_vncr_el2(vcpu);
+
+	ret = __kvm_translate_va(vcpu, &vt->wi, &vt->wr, va);
+	if (ret)
+		return ret;
+
+	write_fault = kvm_is_write_fault(vcpu);
+
+	mmu_seq = vcpu->kvm->mmu_invalidate_seq;
+	smp_rmb();
+
+	gfn = vt->wr.pa >> PAGE_SHIFT;
+	memslot = gfn_to_memslot(vcpu->kvm, gfn);
+	if (!memslot) {
+		fail_s1_walk(&vt->wr, ESR_ELx_FSC_EXTABT, false);
+		return -EFAULT;
+	}
+
+	*is_gmem = kvm_slot_has_gmem(memslot);
+	if (!*is_gmem) {
+		pfn = __kvm_faultin_pfn(memslot, gfn, write_fault ? FOLL_WRITE : 0,
+					&writable, &page);
+		if (is_error_noslot_pfn(pfn)) {
+			fail_s1_walk(&vt->wr, ESR_ELx_FSC_EXTABT, false);
+			return -EFAULT;
+		}
+	} else {
+		ret = kvm_gmem_get_pfn(vcpu->kvm, memslot, gfn, &pfn, &page, NULL);
+		if (ret) {
+			kvm_prepare_memory_fault_exit(vcpu, vt->wr.pa, PAGE_SIZE,
+					      write_fault, false, false);
+			return ret;
+		}
+
+		writable = !(memslot->flags & KVM_MEM_READONLY);
+	}
+
+	/*
+	 * FIXME: This check is too restrictive as KVM allows cacheable memory
+	 * attributes for PFNMAP VMAs that have cacheable attributes in host
+	 * stage-1.
+	 */
+	if (!pfn_is_map_memory(pfn)) {
+		kvm_release_faultin_page(vcpu->kvm, page, true, false);
+		fail_s1_walk(&vt->wr, ESR_ELx_FSC_EXTABT, false);
+		return -EINVAL;
+	}
+
+	scoped_guard(write_lock, &vcpu->kvm->mmu_lock) {
+		if (mmu_invalidate_retry(vcpu->kvm, mmu_seq)) {
+			kvm_release_faultin_page(vcpu->kvm, page, true, false);
+			return -EAGAIN;
+		}
+
+		vt->gva = va;
+		vt->hpa = pfn << PAGE_SHIFT;
+		vt->hpa_writable = writable;
+		vt->valid = true;
+		vt->cpu = -1;
+
+		kvm_make_request(KVM_REQ_MAP_L1_VNCR_EL2, vcpu);
+		kvm_release_faultin_page(vcpu->kvm, page, false, vt->wr.pw && vt->hpa_writable);
+	}
+
+	if (vt->wr.pw && vt->hpa_writable)
+		mark_page_dirty(vcpu->kvm, gfn);
+
+	return 0;
+}

--- a/tests/test_kernel_patch_invariants.rs
+++ b/tests/test_kernel_patch_invariants.rs
@@ -4,6 +4,74 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
+/// Exercise the actual stable-kernel functions after applying our carried fix.
+/// Stub only their dependencies, so removing the production patch reintroduces
+/// the stale CPU/flag/count state without running a kernel-crashing NV2 guest.
+#[test]
+fn arm64_vncr_retranslation_releases_cpu_mapping_before_vcpu_put() {
+    let temp = tempfile::tempdir().expect("create isolated VNCR fixture");
+    let source_dir = temp.path().join("arch/arm64/kvm");
+    fs::create_dir_all(&source_dir).unwrap();
+    fs::write(
+        source_dir.join("nested.c"),
+        include_str!("fixtures/vncr/nested.c"),
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("harness.c"),
+        include_str!("fixtures/vncr/harness.c"),
+    )
+    .unwrap();
+
+    let patch = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("kernel/patches-arm64/vncr-fixmap-state.patch");
+    // When the fix is absent, execute the original functions and fail on the
+    // broken state, not merely on a missing patch file.
+    if patch.exists() {
+        let applied = Command::new("patch")
+            .args(["--batch", "--forward", "--fuzz=0", "-p1", "-i"])
+            .arg(patch)
+            .current_dir(temp.path())
+            .output()
+            .expect("apply the VNCR fix to stable source excerpts");
+        assert!(
+            applied.status.success(),
+            "VNCR patch did not apply:\n{}{}",
+            String::from_utf8_lossy(&applied.stdout),
+            String::from_utf8_lossy(&applied.stderr)
+        );
+    }
+
+    let binary = temp.path().join("vncr-regression");
+    let compiled = Command::new("cc")
+        .args(["-std=gnu11", "-Werror=implicit-function-declaration", "-o"])
+        .arg(&binary)
+        .arg(temp.path().join("harness.c"))
+        .output()
+        .expect("compile the actual VNCR functions with test dependencies");
+    assert!(
+        compiled.status.success(),
+        "VNCR fixture failed to compile:\n{}",
+        String::from_utf8_lossy(&compiled.stderr)
+    );
+
+    let mut failures = Vec::new();
+    for (scenario, name) in [
+        ("1", "mapped successful retranslation"),
+        ("2", "mapped translation failure"),
+        ("0", "unmapped control"),
+    ] {
+        let result = Command::new(&binary).arg(scenario).output().unwrap();
+        if !result.status.success() {
+            failures.push(format!(
+                "{name}: {}",
+                String::from_utf8_lossy(&result.stderr)
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
 /// Apply the ARM64 vsock patch to a minimal source file with the same line and
 /// statement layout as Linux 7.1.7, then ask a C compiler to parse it.
 ///


### PR DESCRIPTION
Backport upstream Linux 5949004d7032767e8fde1e8c986a33f241b2a192 to the carried ARM64 kernel patches. The pinned 6.18.44 source still invalidates the VNCR fixmap without clearing its per-CPU flag or map count. Successful retranslation then sets the CPU ID to -1, leaving state that can trigger the schedule-out BUG_ON.

Targets `main` after parent #919 merged.

The production patch is byte-identical to upstream, with its authorship retained: 17 additions and 10 deletions in nested.c. It shares the CPU-local reset helper between translation and vCPU put. The normal patch globs include it in both ARM host and guest build inputs. No kernel version, DSB barrier, PSCI/WFx patch, or FUSE change is included.

Evidence:
- `arm64_vncr_retranslation_releases_cpu_mapping_before_vcpu_put` compiles and executes verbatim v6.18.44 C functions with dependencies stubbed, after applying the carried patch.
- Unfixed successful retranslation produced cpu=-1, mapped=1, map count=2 and no PTE. The early-error case also retained inconsistent ownership. Both fail the state invariant; the unmapped control passes.
- All three cases pass with the fix. Removing only the production patch makes the two mapped cases fail again; the unmapped control remains green. Restoring the patch passes all cases. The complete kernel-patch test binary passes 4/4.
- Source excerpts match the official stable source. The full kernel archive SHA-256 is 0f72d938f06828e82c90405174fe572287db7bfe089e2fc46572a99a7f240d43.
- All nine host-side carried patches apply to the complete v6.18.44 source with --fuzz=0.
- make lint passes. Main-agent review of the complete four-file delta found no blocking issue.
- The normal content-addressed nested guest-kernel build passed locally. CI run [34176079318](https://github.com/ejc3/fcvm/actions/runs/34176079318) also passed on this exact head: both ARM Host-Root jobs built and selected `vmlinux-nested-6.18.44-aarch64-0f3464ff2fe9.bin`. All 16 expected jobs are present (15 passed; the unrelated benchmark harness job was skipped).

The C regression proves this single-CPU state transition, not hardware TLB behavior or the remaining nested-ARM hypotheses. Without the fix, it fails its inconsistent-state assertion before the later vCPU-put call; it does not reproduce a hardware kernel crash. No host kernel has been installed, no host reboot or crashing nested reproduction has been attempted, and no upstream submission has been opened.

Addresses the VNCR-fix item in #770. The remaining patch audit and ARM validation stay open.

Upstream: https://github.com/torvalds/linux/commit/5949004d7032767e8fde1e8c986a33f241b2a192


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected ARM64 KVM VNCR mapping cleanup during translation and virtual CPU transitions.
  - Ensured fixmap ownership, translation validity, and mapping counters remain synchronized.
  - Prevented stale CPU mappings that could trigger failures when releasing a virtual CPU.

- **Tests**
  - Added integration coverage for successful translations, translation failures, and unmapped control scenarios.
  - Verified mapping cleanup and translation state across virtual CPU release and retranslation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->