### PR TITLE
fix: relaunch Cloud Hypervisor at guest reset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -795,6 +795,9 @@ jobs:
         run: |
           echo 512 | sudo tee /proc/sys/vm/nr_hugepages
           echo "Allocated $(cat /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages) hugepages"
+      - name: Build Cloud Hypervisor backend for reboot regression
+        working-directory: fcvm
+        run: make setup-cloud-hypervisor
       - name: test-root
         working-directory: fcvm
         run: |

--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,7 @@ CONTAINER_RUN := $(CONTAINER_RUN_BASE) --ulimit nproc=65536:65536 --pids-limit=6
 	_test-unit _test-agent-unit _test-fast _test-all _test-root _setup-fcvm _bench \
 	container-build container-test container-test-unit container-test-fast container-test-all container-test-fc-mock \
 	container-setup-fcvm container-shell container-clean container-bench \
-	cargo-target-link build-host-tools setup-btrfs setup-default release-default-kernel setup-fcvm setup-passt setup-pjdfstest setup-hugepages bench bench-vm bench-hugepages bench-hugepages-test \
+	cargo-target-link build-host-tools setup-btrfs setup-default release-default-kernel setup-fcvm setup-cloud-hypervisor setup-passt setup-pjdfstest setup-hugepages bench bench-vm bench-hugepages bench-hugepages-test \
 	bench-container-import bench-chromium analyze-chromium-request analyze-chromium-campaign bench-clone-latency test-chromium-request \
 	bench-chromium-request-build bench-webkit-request-build bench-webkit-request-golden bench-webkit-request-verify bench-webkit-request-run test-chromium bench-chromium-request-golden bench-chromium-request-verify \
 	bench-chromium-corpus bench-chromium-corpus-extra bench-stop \
@@ -679,6 +679,9 @@ container-clean:
 	podman rmi $(CONTAINER_TAG) 2>/dev/null || true
 
 # Setup targets
+setup-cloud-hypervisor: build
+	./target/release/fcvm setup --cloud-hypervisor
+
 setup-passt:
 	./scripts/build-passt.sh
 

--- a/src/hypervisor/cloud_hypervisor/mod.rs
+++ b/src/hypervisor/cloud_hypervisor/mod.rs
@@ -17,10 +17,13 @@ pub mod api;
 
 use anyhow::{anyhow, bail, Context, Result};
 use std::collections::VecDeque;
+use std::os::fd::AsRawFd;
+use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -87,6 +90,8 @@ pub struct CloudHypervisorBackend {
     /// Guest console (hvc0) lines observed by the console tail since spawn
     /// (see [`Hypervisor::console_line_counter`]).
     console_lines: Arc<std::sync::atomic::AtomicU64>,
+    /// One event reader per VMM child. It must finish before the API path is reused.
+    reboot_monitor: Option<JoinHandle<Result<()>>>,
 }
 
 impl CloudHypervisorBackend {
@@ -110,11 +115,21 @@ impl CloudHypervisorBackend {
             vsock_path: None,
             console_tail: None,
             console_lines: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            reboot_monitor: None,
         }
     }
 
     fn client(&self) -> Result<&ChClient> {
         self.client.as_ref().context("Cloud Hypervisor not started")
+    }
+
+    async fn stop_reboot_monitor(&mut self) {
+        // Keep ownership across await: wait() can be cancelled by the VM loop.
+        if let Some(monitor) = self.reboot_monitor.as_mut() {
+            monitor.abort();
+            let _ = monitor.await;
+        }
+        self.reboot_monitor = None;
     }
 
     /// Merge a spawn spec into the retained namespace isolation: only fields the spec
@@ -299,6 +314,7 @@ impl Hypervisor for CloudHypervisorBackend {
     }
 
     async fn spawn(&mut self, spec: &ProcessSpec) -> Result<()> {
+        self.stop_reboot_monitor().await;
         // A reboot relaunch re-enters spawn() with a minimal spec (binary + args). Update
         // retained state only when the spec provides a value, so the namespace isolation
         // and name captured on the first spawn persist across reboots (mirrors the
@@ -320,6 +336,11 @@ impl Hypervisor for CloudHypervisorBackend {
 
         let mut cmd = Command::new(&spec.binary);
         cmd.arg("--api-socket").arg(&self.api_socket);
+        let (events, child_events) = UnixStream::pair().context("creating CH event socketpair")?;
+        events.set_nonblocking(true)?;
+        let events = tokio::net::UnixStream::from_std(events)?;
+        let event_fd = child_events.as_raw_fd();
+        cmd.arg("--event-monitor").arg(format!("fd={event_fd}"));
         if let Some(log_path) = &self.log_path {
             cmd.arg("--log-file").arg(log_path);
             cmd.arg("-v");
@@ -330,6 +351,18 @@ impl Hypervisor for CloudHypervisorBackend {
             }
         }
 
+        // Clear CLOEXEC only in this child. Changing it in the parent would let
+        // unrelated concurrent spawns inherit the event socket. Namespace setup
+        // remains the last pre_exec so its post-setns PDEATHSIG is preserved.
+        // SAFETY: fcntl is async-signal-safe, and child_events owns the fd until spawn returns.
+        unsafe {
+            cmd.pre_exec(move || {
+                if libc::fcntl(event_fd, libc::F_SETFD, 0) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
         install_namespace_pre_exec(&mut cmd, &self.namespace)?;
 
         let stderr_tail = Arc::clone(&self.stderr_tail);
@@ -353,11 +386,23 @@ impl Hypervisor for CloudHypervisorBackend {
             }
         })
         .context("spawning Cloud Hypervisor process")?;
+        drop(child_events);
 
         self.process = Some(spawned.child);
         self.stderr_reader = Some(spawned.stderr_reader);
         self.wait_for_api().await?;
         self.client = Some(ChClient::new(self.api_socket.clone()));
+        let client = self.client()?.clone();
+        self.reboot_monitor = Some(tokio::spawn(async move {
+            if read_reboot_event(BufReader::new(events)).await? {
+                // The guest's vsock notification is early intent, before shutdown
+                // writeback. CH emits this event only when it handles the actual
+                // reset. Exit the VMM here so fcvm consumes intent and cold-relaunches.
+                info!("Cloud Hypervisor guest reset, shutting down VMM for host relaunch");
+                client.shutdown_vmm().await?;
+            }
+            Ok(())
+        }));
 
         // Tail the guest console (hvc0 → file) into fcvm's tracing logs, mirroring the
         // Firecracker serial-to-stdout capture. Abort any prior tail first: a reboot
@@ -387,6 +432,9 @@ impl Hypervisor for CloudHypervisorBackend {
         match self.process.as_mut() {
             Some(p) => match p.try_wait().context("checking Cloud Hypervisor status")? {
                 Some(status) => {
+                    if let Some(monitor) = &self.reboot_monitor {
+                        monitor.abort();
+                    }
                     self.process = None;
                     Ok(Some(status))
                 }
@@ -397,17 +445,43 @@ impl Hypervisor for CloudHypervisorBackend {
     }
 
     async fn wait(&mut self) -> Result<ExitStatus> {
-        match self.process.as_mut() {
-            Some(p) => {
-                let status = p.wait().await.context("waiting for Cloud Hypervisor")?;
-                self.process = None;
-                Ok(status)
+        let process = self
+            .process
+            .as_mut()
+            .context("Cloud Hypervisor process not running")?;
+        let mut monitor_failure = None;
+        let status = if let Some(monitor) = self.reboot_monitor.as_mut() {
+            tokio::select! {
+                biased;
+                status = process.wait() => status,
+                result = monitor => {
+                    self.reboot_monitor = None;
+                    if let Err(error) = result.context("CH reboot monitor task failed").and_then(|r| r) {
+                        warn!(%error, "CH reboot monitor failed, terminating VMM");
+                        // The caller treats any wait() return as child termination.
+                        // Never report this failure while the VMM can still be alive.
+                        process.start_kill().context("terminating CH after event monitor failure")?;
+                        monitor_failure = Some(error);
+                    }
+                    process.wait().await
+                }
             }
-            None => bail!("Cloud Hypervisor process not running"),
+        } else {
+            process.wait().await
         }
+        .context("waiting for Cloud Hypervisor")?;
+        self.stop_reboot_monitor().await;
+        self.process = None;
+        if let Some(error) = monitor_failure {
+            return Err(error);
+        }
+        Ok(status)
     }
 
     fn start_kill(&mut self) -> Result<()> {
+        if let Some(monitor) = &self.reboot_monitor {
+            monitor.abort();
+        }
         if let Some(tail) = self.console_tail.take() {
             tail.abort();
         }
@@ -420,6 +494,7 @@ impl Hypervisor for CloudHypervisorBackend {
     }
 
     async fn reap(&mut self) {
+        self.stop_reboot_monitor().await;
         if let Some(mut p) = self.process.take() {
             let _ = p.wait().await;
         }
@@ -536,6 +611,43 @@ impl Hypervisor for CloudHypervisorBackend {
     }
 }
 
+impl Drop for CloudHypervisorBackend {
+    fn drop(&mut self) {
+        if let Some(monitor) = &self.reboot_monitor {
+            monitor.abort();
+        }
+    }
+}
+
+/// CH writes pretty-printed JSON objects separated by a blank line, not JSONL.
+async fn read_reboot_event(reader: impl AsyncBufRead + Unpin) -> Result<bool> {
+    #[derive(serde::Deserialize)]
+    struct Event {
+        source: String,
+        event: String,
+    }
+
+    let mut lines = reader.lines();
+    let mut frame = String::new();
+    while let Some(line) = lines.next_line().await.context("reading CH events")? {
+        if line.is_empty() {
+            if frame.is_empty() {
+                continue;
+            }
+            let event: Event = serde_json::from_str(&frame).context("decoding CH event")?;
+            if event.source == "vm" && event.event == "rebooting" {
+                return Ok(true);
+            }
+            frame.clear();
+        } else {
+            frame.push_str(&line);
+            frame.push('\n');
+        }
+    }
+    anyhow::ensure!(frame.is_empty(), "CH event stream ended within an event");
+    Ok(false)
+}
+
 /// The default guest CID Cloud Hypervisor uses for the host↔guest vsock device.
 pub const fn default_guest_cid() -> u32 {
     GUEST_CID
@@ -601,6 +713,86 @@ async fn tail_console_to_tracing(path: PathBuf, console_lines: Arc<std::sync::at
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn reboot_monitor_cleanup_retains_handle_when_cancelled() {
+        use std::future::Future;
+
+        let mut be = backend();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        // A started blocking task models a reader still in its current poll:
+        // abort requests cancellation but cannot finish the join until it yields.
+        be.reboot_monitor = Some(tokio::task::spawn_blocking(move || {
+            let _ = started_tx.send(());
+            let _ = release_rx.recv();
+            Ok(())
+        }));
+        started_rx.await.unwrap();
+        let pending = {
+            let mut cleanup = std::pin::pin!(be.stop_reboot_monitor());
+            let mut context = std::task::Context::from_waker(std::task::Waker::noop());
+            cleanup.as_mut().poll(&mut context).is_pending()
+        };
+        let retained = be.reboot_monitor.is_some();
+        // Release even on a failed assertion, so the fixture cannot strand a worker.
+        drop(release_tx);
+        be.stop_reboot_monitor().await;
+        assert!(pending, "cleanup must wait for the reader to finish");
+        assert!(
+            retained,
+            "cancelled cleanup must retain the reader's join handle"
+        );
+        assert!(be.reboot_monitor.is_none());
+    }
+
+    #[tokio::test]
+    async fn reboot_monitor_failure_reaps_child_before_returning() {
+        let mut be = backend();
+        be.process = Some(
+            Command::new("sleep")
+                .arg("60")
+                .kill_on_drop(true)
+                .spawn()
+                .unwrap(),
+        );
+        be.reboot_monitor = Some(tokio::spawn(async { bail!("injected CH event failure") }));
+        let result = tokio::time::timeout(Duration::from_secs(2), be.wait()).await;
+        let reaped = be.process.is_none();
+        be.start_kill().unwrap();
+        be.reap().await;
+        assert!(result
+            .unwrap()
+            .unwrap_err()
+            .to_string()
+            .contains("injected CH event failure"));
+        assert!(
+            reaped,
+            "wait must not report a monitor failure with a live VMM child"
+        );
+    }
+
+    #[tokio::test]
+    async fn reboot_monitor_requires_complete_vm_reset_event() {
+        let other_events = concat!(
+            "{\n  \"source\": \"vmm\",\n  \"event\": \"rebooting\"\n}\n\n",
+            "{\n  \"source\": \"vm\",\n  \"event\": \"rebooted\"\n}\n\n",
+        );
+        assert!(!read_reboot_event(other_events.as_bytes()).await.unwrap());
+        let events = format!(
+            "{other_events}{{\n  \"source\": \"vm\",\n  \"event\": \"rebooting\",\n  \"properties\": null\n}}\n\n"
+        );
+        // One-byte reads split both the JSON and its delimiter across reads.
+        assert!(
+            read_reboot_event(BufReader::with_capacity(1, events.as_bytes()))
+                .await
+                .unwrap()
+        );
+        assert!(read_reboot_event(b"{\n  \"source\": \"vm\"".as_slice())
+            .await
+            .is_err());
+        assert!(read_reboot_event(b"not-json\n\n".as_slice()).await.is_err());
+    }
 
     fn backend() -> CloudHypervisorBackend {
         CloudHypervisorBackend::new(

--- a/src/setup/kernel.rs
+++ b/src/setup/kernel.rs
@@ -2642,13 +2642,11 @@ pub async fn ensure_cloud_hypervisor(repo: &str, branch: &str) -> Result<PathBuf
             .context("removing old cloud-hypervisor build directory")?;
     }
 
-    // Clone repo (shallow, single branch, as the sudo invoker so the
-    // checkout is not root-owned)
+    // Clone the selected branch as the sudo invoker so the checkout is not root-owned.
     let clone_url = format!("https://github.com/{}", repo);
     let mut clone_cmd = Command::new("git");
     clone_cmd.args([
         "clone",
-        "--depth=1",
         "-b",
         branch,
         &clone_url,

--- a/tests/test_reboot.rs
+++ b/tests/test_reboot.rs
@@ -4,7 +4,7 @@
 //! relaunches in place from the same provisioned disk and comes back healthy, with
 //! the container's writable layer ("the work") preserved and its identity
 //! regenerated. The fcvm process (and therefore its PID) stays stable across the
-//! reboot — only the Firecracker child restarts.
+//! reboot, only the VMM child restarts.
 //!
 //! Both VM lifecycle paths are covered:
 //!   * fresh `podman run` boot (`--no-snapshot` pins the run_vm_loop path)
@@ -34,7 +34,7 @@ async fn reboot_and_assert_relaunch(pid: u32, token: &str) -> Result<()> {
 
     // `reboot` goes through systemd, which starts fcvm-reboot-notify.service
     // (WantedBy=reboot.target) -> fc-agent --notify-reboot -> host relaunches
-    // Firecracker in place. The exec dies mid-command as the VM resets.
+    // the VMM in place. The exec dies mid-command as the VM resets.
     let _ = common::exec_in_vm(pid, &["reboot"]).await;
 
     let deadline = Instant::now() + Duration::from_secs(150);
@@ -122,6 +122,54 @@ async fn test_vm_reboot_comes_back_healthy_and_preserves_work() -> Result<()> {
     common::kill_process(pid).await;
     let _ = child.kill().await;
     Ok(())
+}
+
+/// A normal Cloud Hypervisor VM must consume reboot intent before its final exit.
+// Host-Root CI provisions Cloud Hypervisor; container-test-all does not.
+#[cfg(feature = "privileged-tests")]
+#[tokio::test]
+async fn test_cloud_hypervisor_reboot_recovers_and_then_exits() -> Result<()> {
+    fcvm::commands::common::find_cloud_hypervisor()
+        .context("CH reboot test requires the backend")?;
+    let (name, _, _, _) = common::unique_names("ch-reboot");
+    let (mut child, pid) = common::spawn_fcvm_with_logs(
+        &[
+            "podman",
+            "run",
+            "--name",
+            &name,
+            "--hypervisor",
+            "cloud-hypervisor",
+            "--no-snapshot",
+            "nginx:alpine",
+            "sh",
+            "-c",
+            "while [ ! -e /stop ]; do sleep 1; done",
+        ],
+        "ch-reboot-base",
+    )
+    .await?;
+    let result = async {
+        common::poll_health_by_pid(pid, 120).await?;
+        let token = format!("ch-reboot-token-{pid}");
+        write_work_marker(pid, &token).await?;
+        reboot_and_assert_relaunch(pid, &token).await?;
+
+        // The exec response may disappear when its container exits; the process
+        // exit below proves the stop marker was consumed and the final boot ended.
+        let _ = common::exec_in_container(pid, &["touch", "/stop"]).await;
+        let status = tokio::time::timeout(Duration::from_secs(60), child.wait())
+            .await
+            .context("CH VM did not terminate after its container exited")??;
+        anyhow::ensure!(status.success(), "CH VM final exit must be zero: {status}");
+        Ok::<_, anyhow::Error>(())
+    }
+    .await;
+    if child.try_wait()?.is_none() {
+        common::kill_process(pid).await;
+        let _ = child.kill().await;
+    }
+    result
 }
 
 /// Data-disk preservation: an in-place reboot must NOT rebuild --disk-dir


### PR DESCRIPTION
Closes #709.

Cloud Hypervisor reboots the guest without exiting its VMM process. fcvm's reboot intent then survives until a later container exit, which is incorrectly treated as another reboot.

## Changes

- Read CH events through an owned per-child socketpair and request VMM shutdown on `vm/rebooting`. The existing host relaunch consumes the reboot intent.
- Retain the monitor's join handle across cancellation, join it before reusing the API path, and terminate/reap the VMM before reporting a monitor failure.
- Add a normal-VM regression covering identity regeneration, preserved writable-layer data, recovered health, and a later container exit that terminates fcvm with status 0.
- Run that mandatory regression only with `privileged-tests`. `make test-root` provisions CH through its `setup-cloud-hypervisor` prerequisite, so local root runs and Host-Root CI take the same path. There is no runtime skip or container-setup expansion.
- Lease `setup-cloud-hypervisor` like the other setup targets, so a concurrent make cannot repoint the target link while it runs `./target/release/fcvm`.
- Remove the CH builder's shallow-clone argument, preserving branch selection, cache identity and locking.

The guest's vsock notification is early shutdown intent. CH emits [`vm/rebooting` when handling the actual guest reset](https://github.com/ejc3/cloud-hypervisor/blob/5c25d82f598433353fc96122afe15cf9bb0aa650/vmm/src/lib.rs#L2013), so normal shutdown/writeback is not interrupted by the early notification. There are no Firecracker changes or new clone-reboot support.

## Verification

Observed locally before rebasing:

- The actual CH reboot regression failed after 74.077s because the later successful container exit caused another relaunch. It passed with the fix, and reverting only CH production code made the unchanged test fail again after 73.702s.
- The cancellation and monitor-failure/reaping unit regressions each failed without their fixes, passed with them, and failed again after the two production methods were reverted. The parser test covers complete pretty-JSON frames, split reads, unrelated events and malformed/truncated input.
- Default-feature nextest selection incorrectly included the mandatory CH test before its feature gate. Adding the gate removed it; reverting the gate reproduced the selection failure.
- The final pre-rebase batch passed all four tests in 9.384s, including the actual CH VM test in 9.336s, using installed `cloud-hypervisor v52.0-46-g5c25d82f5`.

```sh
make _test-root FILTER="-p fcvm --lib --test test_reboot -E 'test(/reboot_monitor_/) | test(=test_cloud_hypervisor_reboot_recovers_and_then_exits)' --retries 0" STREAM=1
make lint
```

The rebase onto merged main changed no patch content: both heads have stable patch ID `2a8f12d6b740954a14d2cb1916e2a6ef12a3675a`. `make lint` passed on final head `93dce2b8405cd1e634a456619e944fc749a869b8`.

The attempted final-head local rerun was blocked before test execution because the release binary and VM assets are now absent. The three unit tests and real VM test were **not rerun after rebase**. The config guard was not bypassed, and no VM environment or kernel was rebuilt. Final-head runtime signal from provisioned CI is required before merge.

The five-file diff has been reviewed locally. It is independent of held VNCR PR #920 and contains only this reboot fix, its tests, and the narrow provisioning changes above.


## Follow-up commit: lease and local provisioning

CI on `93dce2b8` ran the CH reboot regression on both architectures and it passed (`test_cloud_hypervisor_reboot_recovers_and_then_exits ... ok` in Host-Root-x64-SnapshotEnabled and Host-Root-arm64-SnapshotEnabled). Every Host, Host-Root and Container job failed on one test instead, `makefile_leases_every_raw_target_access`, because the new `setup-cloud-hypervisor` recipe ran `./target/release/fcvm` without the target generation lease.

A Codex finding also held: `make test-root` enables `privileged-tests`, so the CH test runs locally, but nothing on that path built CH. CI passed only because it ran `setup-cloud-hypervisor` as a separate step.

`6e1945af` leases the target, makes `test-root` depend on it, and removes the now-redundant CI step. CH setup is content-addressed, so the second `test-root` pass in SnapshotEnabled mode skips the build. `test_root_provisions_the_cloud_hypervisor_its_reboot_test_requires` pins the prerequisite.

```
red, unfixed tree:            2 tests run: 0 passed, 2 failed
green, with the fix:          2 tests run: 2 passed
red again, Makefile reverted: 2 tests run: 0 passed, 2 failed
affected binaries:            102 tests run: 102 passed (test_cargo_target_link 62, test_ci_workflow_coverage 23, test_documented_make_targets 17)
make lint:                    exit 0 (cargo-deny: advisories ok, bans ok, licenses ok, sources ok)
```

## Follow-up commit: Cloud Hypervisor guest memory without transparent hugepages

`6e1945af` passed every job except Host-Root-arm64-SnapshotEnabled, which failed on its second `test-root` pass only. That is the first run on this PR where `make test-root` provisions CH on both passes, so the CH tests ran for real twice.

- `test_cloud_hypervisor_cold_boot`: `vm.boot` timed out after 30 s; the retry reached fc-agent at 150 s of guest uptime (1.4 s on main, same job).
- `test_cloud_hypervisor_reboot_recovers_and_then_exits`: the guest reached fc-agent at 94 s of uptime and the test failed both tries.
- `test_cloud_hypervisor_snapshot_roundtrip` passed, but its clone's file restore took 183 s against 11 s on pass 1.

pidstat for 14:45 to 14:53 on that runner:

| process | pass 1 | pass 2 |
|---|---|---|
| cloud-hypervisor, mean %system | 22.2 | 82.3 (peaks 175.7) |
| firecracker (default profile), mean %system | 4.4 | 4.4 |
| kcompactd0, mean %system | 36.1 | 62.4 (94 or more in 10 of 15 samples, 14:45:44 to 14:53:14) |
| khugepaged | absent | up to 43.7 |

sar showed the host 86% idle. The CH binary was the same as main's (`cloud-hypervisor-6bb88929652f.bin`); the fork branch last moved 2026-05-22.

fcvm's `vm.create` memory config carried no `thp` field. CH defaults it to true and then calls `madvise(MADV_HUGEPAGE)` on guest RAM ([`memory_manager.rs`](https://github.com/ejc3/cloud-hypervisor/blob/5c25d82f598433353fc96122afe15cf9bb0aa650/vmm/src/memory_manager.rs#L2155-L2157)). Hosts run `defrag=madvise`, so each fault on that memory may compact synchronously in the VMM's own thread, and khugepaged only works on madvised memory. Firecracker guest RAM is not madvised, which is why its processes were unaffected. Ruled out: the new event socket (CH's monitor thread blocks on `recv()` and ignores write errors), a changed CH binary, and leftovers from pass 1 (its reboot test exited 0 and cleaned up; the post-suite guard found no stray processes).

The memory config now sends `thp: false`. `vm_config_opts_guest_memory_out_of_transparent_hugepages` serializes the `vm.create` payload and requires `memory.thp == false`.

```
red, unfixed tree:          left: Null, right: Bool(false)
green, with the fix:        1 test run: 1 passed
red again, fix reverted:    left: Null, right: Bool(false)
cloud_hypervisor unit tests: 11 tests run: 11 passed
make lint:                  exit 0
```

One 1 GiB CH VM per build on an unfragmented arm64 host, guest RAM mapping from `/proc/<ch>/smaps`:

| build | VmFlags `hg` | THPeligible | AnonHugePages | thp_fault_alloc |
|---|---|---|---|---|
| pre-fix | yes | 1 | 530432 kB | +259 |
| fixed | no | 0 | 0 kB | +0 |

That host has free 2 MB blocks, so it shows the madvise, not the stall. The stall is checked by this commit's CI second pass.

```
make test-root FILTER="-E 'test(/test_cloud_hypervisor/)'"
3 tests run: 3 passed (cold_boot 3.8 s, reboot 9.4 s, snapshot_roundtrip 16.4 s)
```

## Follow-up commit: setup-cloud-hypervisor waits for the assets-store mount

CodeRabbit's review of `e8416429` found that `setup-cloud-hypervisor` depended only on `build`, although `fcvm setup --cloud-hypervisor` writes under `/mnt/fcvm-btrfs`. Under `make -j test-root` it is a sibling of `setup-fcvm`, which reaches `setup-btrfs` only through `setup-default`, so on a host that is not btrfs it could write into the bare directory before the loopback is mounted over it. Every other target that runs `fcvm setup` already reaches `setup-btrfs`.

`fb907481` adds the prerequisite. `targets_that_run_fcvm_setup_mount_the_assets_store_first` requires `setup-btrfs` among the transitive prerequisites of every target whose recipe runs `fcvm setup` (not `--generate-config`, which writes the user's config, and not `_` targets, which run inside the container their wrapper starts).

```
red, unfixed tree:             1 test run: 0 passed, 1 failed
green, with the fix:           1 test run: 1 passed
red again, fix reverted:       1 test run: 0 passed, 1 failed
test_documented_make_targets:  18 tests run: 18 passed
make lint:                     exit 0
```

CI on `e8416429` also lost Host-arm64 before any build step: `Install dependencies` failed with `E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 3180 (apt)`, 74 s after its runner launched. That is a boot-time apt race on fresh self-hosted runners, not this change, and it is fixed separately.

## Follow-up commit: a reboot is witnessed only against a real machine-id

CodeRabbit's review of `fb907481` found that `reboot_and_assert_relaunch` read the pre-reboot machine-id with `unwrap_or_default()`. A failed or timed-out read left an empty baseline, and the recovery loop then accepted any non-empty machine-id as regenerated, including one read from a VM that never rebooted. `test_cloud_hypervisor_reboot_recovers_and_then_exits` relies on that helper, so its identity check could pass on nothing. `test_vm_reboot_preserves_disk_dir_writes` had the same read and the same comparison, so both sites now share one fix:

- each pre-reboot read propagates its error and must return a non-empty id;
- both recovery loops call `machine_id_regenerated(before, after)`, which is false for an empty or blank baseline, an empty result, or an unchanged id.

`a_regenerated_machine_id_needs_a_real_baseline` pins the comparison.

```
red, comparison as it was:           1 test run: 0 passed, 1 failed  ("an empty pre-reboot machine-id witnesses nothing")
green, with the fix:                 1 test run: 1 passed
red again, helper reverted:          1 test run: 0 passed, 1 failed
test_reboot, whole binary on VMs:    5 tests run: 5 passed
make lint:                           exit 0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Cloud Hypervisor now detects reboot events and relaunches virtual machines while preserving writable-layer state.
  - Cloud Hypervisor is provisioned automatically before privileged test runs.

- **Bug Fixes**
  - Improved cleanup and process handling when Cloud Hypervisor exits or reboot monitoring fails.
  - Disabled transparent huge pages for guest memory for more consistent VM configuration.
  - Improved Cloud Hypervisor source retrieval during setup.

- **Documentation**
  - Updated reboot documentation to describe virtual machine restart and recovery behavior.

- **Tests**
  - Added coverage for reboot recovery, writable-layer preservation, shutdown, cleanup, and setup prerequisites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
