### PR TITLE
Add manual one-job ephemeral runner acceptance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,8 @@ jobs:
         # claude.yml's run blocks are fixed; actionlint's own checks
         # (expressions, action inputs, needs references, runner labels) apply.
         run: /tmp/actionlint -shellcheck=
+      - name: Test runner acceptance contract without AWS credentials
+        run: make test-runner-acceptance
 
   skip-check:
     name: Skip Check

--- a/.github/workflows/runner-acceptance.yml
+++ b/.github/workflows/runner-acceptance.yml
@@ -29,6 +29,7 @@ jobs:
           import os
           from pathlib import Path
           import re
+          import shlex
           import stat
           import subprocess
           import time
@@ -51,10 +52,16 @@ jobs:
                       or not any(service in group for group in groups)):
                   raise ValueError('Job does not belong to the recorded runner service')
               expected_dropin = ['[Service]', 'Restart=no',
+                                 'Environment=GITHUB_ACTIONS_SERVICE_EXIT_AFTER_N_FAILURES=1',
                                  'ExecStopPost=+/usr/bin/systemctl --no-block poweroff']
               if (data['dropin'].splitlines() != expected_dropin or data['dropin_uid'] != 0
                       or data['dropin_mode'] & 0o022):
                   raise ValueError('Missing or unsafe broker ephemeral service drop-in')
+              # Inspect only the expected setting; never print the unit environment.
+              failure_limit = [item for item in shlex.split(data['environment'])
+                               if item.startswith('GITHUB_ACTIONS_SERVICE_EXIT_AFTER_N_FAILURES=')]
+              if failure_limit != ['GITHUB_ACTIONS_SERVICE_EXIT_AFTER_N_FAILURES=1']:
+                  raise ValueError('Effective service retry limit is missing or incorrect')
               stop_post = data['stop_post']
               if (data['restart'] != 'no' or data['active'] != 'active'
                       or stop_post.count('path=') != 1
@@ -82,7 +89,7 @@ jobs:
           if not stat.S_ISREG(info.st_mode):
               raise ValueError('Ephemeral drop-in must be a regular file')
           properties = {}
-          for key in ('Restart', 'ActiveState', 'ExecStopPost'):
+          for key in ('Restart', 'ActiveState', 'ExecStopPost', 'Environment'):
               properties[key] = subprocess.check_output(
                   ['systemctl', 'show', service, '--property=' + key, '--value'],
                   text=True, timeout=5).strip()
@@ -91,7 +98,8 @@ jobs:
               'service': service, 'cgroup': Path('/proc/self/cgroup').read_text(),
               'dropin': dropin.read_text(), 'dropin_uid': info.st_uid,
               'dropin_mode': stat.S_IMODE(info.st_mode), 'restart': properties['Restart'],
-              'active': properties['ActiveState'], 'stop_post': properties['ExecStopPost']})
+              'active': properties['ActiveState'], 'stop_post': properties['ExecStopPost'],
+              'environment': properties['Environment']})
           if sum(range(100)) != 4950:
               raise RuntimeError('Benign Python smoke test failed')
           print(json.dumps({'phase': 'ready-for-observer', 'runner': os.environ['ACCEPTANCE_RUNNER_NAME'],

--- a/.github/workflows/runner-acceptance.yml
+++ b/.github/workflows/runner-acceptance.yml
@@ -12,8 +12,21 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Reject any dispatch outside main
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" != workflow_dispatch || "$GITHUB_REF" != refs/heads/main ]]; then
+            echo '::error::Runner acceptance must be manually dispatched on main.'
+            exit 1
+          fi
+
   accept:
-    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    needs: authorize
     runs-on: [self-hosted, Linux, ARM64]
     timeout-minutes: 5
     steps:

--- a/.github/workflows/runner-acceptance.yml
+++ b/.github/workflows/runner-acceptance.yml
@@ -107,7 +107,7 @@ jobs:
                   ['systemctl', 'show', service, '--property=' + key, '--value'],
                   text=True, timeout=5).strip()
           validate({'identity': identity, 'runner_name': os.environ['ACCEPTANCE_RUNNER_NAME'],
-              'machine': os.uname().machine, 'settings': json.loads((directory / '.runner').read_text()),
+              'machine': os.uname().machine, 'settings': json.loads((directory / '.runner').read_bytes()),
               'service': service, 'cgroup': Path('/proc/self/cgroup').read_text(),
               'dropin': dropin.read_text(), 'dropin_uid': info.st_uid,
               'dropin_mode': stat.S_IMODE(info.st_mode), 'restart': properties['Restart'],

--- a/.github/workflows/runner-acceptance.yml
+++ b/.github/workflows/runner-acceptance.yml
@@ -1,0 +1,104 @@
+name: Runner Bootstrap Acceptance
+
+# Operator-controlled acceptance only. First drain/select a newly brokered host;
+# an old reusable runner must fail, never count as a successful migration.
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: runner-bootstrap-acceptance
+  cancel-in-progress: false
+
+jobs:
+  accept:
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    runs-on: [self-hosted, Linux, ARM64]
+    timeout-minutes: 5
+    steps:
+      - name: Verify ephemeral host, smoke test, and hold for independent observation
+        env:
+          ACCEPTANCE_RUNNER_NAME: ${{ runner.name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import datetime
+          import json
+          import os
+          from pathlib import Path
+          import re
+          import stat
+          import subprocess
+          import time
+          import urllib.request
+
+          def validate(data):
+              identity = data['identity']
+              instance = identity['instanceId']
+              if (identity['accountId'] != '928413605543' or identity['region'] != 'us-west-1'
+                      or identity['architecture'] != 'arm64' or data['machine'] != 'aarch64'
+                      or not re.fullmatch(r'i-[0-9a-f]{17}', instance)):
+                  raise ValueError('Unexpected instance identity or architecture')
+              expected_name = 'runner-' + instance
+              if (data['runner_name'] != expected_name or data['settings']['agentName'] != expected_name
+                      or data['settings'].get('ephemeral') is not True):
+                  raise ValueError('Not this instance\'s ephemeral runner: legacy hosts cannot pass')
+              service = data['service']
+              groups = [line.rsplit(':', 1)[-1].split('/') for line in data['cgroup'].splitlines()]
+              if (not re.fullmatch(r'actions\.runner\.[A-Za-z0-9_.-]+\.service', service)
+                      or not any(service in group for group in groups)):
+                  raise ValueError('Job does not belong to the recorded runner service')
+              expected_dropin = ['[Service]', 'Restart=no',
+                                 'ExecStopPost=+/usr/bin/systemctl --no-block poweroff']
+              if (data['dropin'].splitlines() != expected_dropin or data['dropin_uid'] != 0
+                      or data['dropin_mode'] & 0o022):
+                  raise ValueError('Missing or unsafe broker ephemeral service drop-in')
+              stop_post = data['stop_post']
+              if (data['restart'] != 'no' or data['active'] != 'active'
+                      or stop_post.count('path=') != 1
+                      or 'path=/usr/bin/systemctl ;' not in stop_post
+                      or not re.search(r'argv\[\]=/usr/bin/systemctl --no-block poweroff\s*;', stop_post)):
+                  raise ValueError('Effective runner service does not power off after one job')
+
+          # No credential endpoint: only an IMDSv2 session and public instance identity.
+          opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+          request = urllib.request.Request('http://169.254.169.254/latest/api/token', method='PUT',
+              headers={'X-aws-ec2-metadata-token-ttl-seconds': '60'})
+          with opener.open(request, timeout=5) as response:
+              imds_token = response.read(4096).decode()
+          request = urllib.request.Request('http://169.254.169.254/latest/dynamic/instance-identity/document',
+              headers={'X-aws-ec2-metadata-token': imds_token})
+          with opener.open(request, timeout=5) as response:
+              identity = json.loads(response.read(16384))
+          del imds_token, request
+          directory = Path('/opt/actions-runner')
+          service = (directory / '.service').read_text().strip()
+          if not re.fullmatch(r'actions\.runner\.[A-Za-z0-9_.-]+\.service', service):
+              raise ValueError('Invalid runner service name')
+          dropin = Path('/etc/systemd/system') / (service + '.d') / 'ephemeral.conf'
+          info = dropin.lstat()
+          if not stat.S_ISREG(info.st_mode):
+              raise ValueError('Ephemeral drop-in must be a regular file')
+          properties = {}
+          for key in ('Restart', 'ActiveState', 'ExecStopPost'):
+              properties[key] = subprocess.check_output(
+                  ['systemctl', 'show', service, '--property=' + key, '--value'],
+                  text=True, timeout=5).strip()
+          validate({'identity': identity, 'runner_name': os.environ['ACCEPTANCE_RUNNER_NAME'],
+              'machine': os.uname().machine, 'settings': json.loads((directory / '.runner').read_text()),
+              'service': service, 'cgroup': Path('/proc/self/cgroup').read_text(),
+              'dropin': dropin.read_text(), 'dropin_uid': info.st_uid,
+              'dropin_mode': stat.S_IMODE(info.st_mode), 'restart': properties['Restart'],
+              'active': properties['ActiveState'], 'stop_post': properties['ExecStopPost']})
+          if sum(range(100)) != 4950:
+              raise RuntimeError('Benign Python smoke test failed')
+          print(json.dumps({'phase': 'ready-for-observer', 'runner': os.environ['ACCEPTANCE_RUNNER_NAME'],
+              'instance_id': identity['instanceId'], 'region': identity['region'],
+              'observed_at': datetime.datetime.now(datetime.timezone.utc).isoformat()}), flush=True)
+          # The administrator checks parameter metadata while this job is alive;
+          # the job itself never reads or deletes the bootstrap credential.
+          time.sleep(90)
+          print(json.dumps({'phase': 'smoke-complete', 'instance_id': identity['instanceId']}), flush=True)
+          PY

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ endif
 show-notes:
 	@echo "━━━ fcvm ━━━  FILTER=$(FILTER) STREAM=$(STREAM)  Assets=SHA-cached  (see .claude/CLAUDE.md)"
 
+.PHONY: test-runner-acceptance
+test-runner-acceptance:
+	python3 scripts/test-runner-acceptance.py
+
 # Paths (can be overridden via environment)
 FUSE_BACKEND_RS ?= /home/ubuntu/fuse-backend-rs
 FUSE_BACKEND_RS_OVERRIDE ?=

--- a/scripts/test-runner-acceptance.py
+++ b/scripts/test-runner-acceptance.py
@@ -3,6 +3,7 @@
 import ast
 from pathlib import Path
 import re
+import shlex
 import textwrap
 import unittest
 
@@ -16,7 +17,7 @@ class RunnerAcceptanceTests(unittest.TestCase):
         body = cls.workflow.split("          python3 - <<'PY'\n", 1)[1].split('\n          PY', 1)[0]
         tree = ast.parse(textwrap.dedent(body))
         functions = [node for node in tree.body if isinstance(node, ast.FunctionDef)]
-        namespace = {'re': re}
+        namespace = {'re': re, 'shlex': shlex}
         exec(compile(ast.Module(body=functions, type_ignores=[]), '<workflow>', 'exec'), namespace)
         cls.validate = staticmethod(namespace['validate'])
 
@@ -29,9 +30,10 @@ class RunnerAcceptanceTests(unittest.TestCase):
             'runner_name': f'runner-{instance}', 'machine': 'aarch64',
             'settings': {'agentName': f'runner-{instance}', 'ephemeral': True},
             'service': service, 'cgroup': f'0::/system.slice/{service}\n',
-            'dropin': '[Service]\nRestart=no\nExecStopPost=+/usr/bin/systemctl --no-block poweroff\n',
+            'dropin': '[Service]\nRestart=no\nEnvironment=GITHUB_ACTIONS_SERVICE_EXIT_AFTER_N_FAILURES=1\nExecStopPost=+/usr/bin/systemctl --no-block poweroff\n',
             'dropin_uid': 0, 'dropin_mode': 0o644,
             'restart': 'no', 'active': 'active',
+            'environment': 'GITHUB_ACTIONS_SERVICE_EXIT_AFTER_N_FAILURES=1',
             'stop_post': '{ path=/usr/bin/systemctl ; argv[]=/usr/bin/systemctl --no-block poweroff ; ignore_errors=no ; }',
         }
 
@@ -85,6 +87,18 @@ class RunnerAcceptanceTests(unittest.TestCase):
             data['stop_post'] = value
             with self.assertRaises(ValueError):
                 self.validate(data)
+
+    def test_failure_retry_environment_must_be_effective_and_exact(self):
+        for value in ('', 'GITHUB_ACTIONS_SERVICE_EXIT_AFTER_N_FAILURES=2',
+                      'PREFIX_GITHUB_ACTIONS_SERVICE_EXIT_AFTER_N_FAILURES=1',
+                      'GITHUB_ACTIONS_SERVICE_EXIT_AFTER_N_FAILURES=1 GITHUB_ACTIONS_SERVICE_EXIT_AFTER_N_FAILURES=2'):
+            data = self.valid()
+            data['environment'] = value
+            with self.assertRaises(ValueError):
+                self.validate(data)
+        data = self.valid()
+        data['environment'] += ' "OTHER=unrelated value"'
+        self.validate(data)
 
     def test_workflow_is_manual_main_only_single_short_arm_job(self):
         self.assertIn('on:\n  workflow_dispatch:\n', self.workflow)

--- a/scripts/test-runner-acceptance.py
+++ b/scripts/test-runner-acceptance.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Offline tests of the exact manual runner-acceptance workflow (no AWS calls)."""
+import ast
+from pathlib import Path
+import re
+import textwrap
+import unittest
+
+WORKFLOW = Path(__file__).resolve().parent.parent / '.github/workflows/runner-acceptance.yml'
+
+
+class RunnerAcceptanceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.workflow = WORKFLOW.read_text()
+        body = cls.workflow.split("          python3 - <<'PY'\n", 1)[1].split('\n          PY', 1)[0]
+        tree = ast.parse(textwrap.dedent(body))
+        functions = [node for node in tree.body if isinstance(node, ast.FunctionDef)]
+        namespace = {'re': re}
+        exec(compile(ast.Module(body=functions, type_ignores=[]), '<workflow>', 'exec'), namespace)
+        cls.validate = staticmethod(namespace['validate'])
+
+    def valid(self):
+        instance = 'i-0123456789abcdef0'
+        service = f'actions.runner.ejc3-fcvm.runner-{instance}.service'
+        return {
+            'identity': {'accountId': '928413605543', 'region': 'us-west-1',
+                         'instanceId': instance, 'architecture': 'arm64'},
+            'runner_name': f'runner-{instance}', 'machine': 'aarch64',
+            'settings': {'agentName': f'runner-{instance}', 'ephemeral': True},
+            'service': service, 'cgroup': f'0::/system.slice/{service}\n',
+            'dropin': '[Service]\nRestart=no\nExecStopPost=+/usr/bin/systemctl --no-block poweroff\n',
+            'dropin_uid': 0, 'dropin_mode': 0o644,
+            'restart': 'no', 'active': 'active',
+            'stop_post': '{ path=/usr/bin/systemctl ; argv[]=/usr/bin/systemctl --no-block poweroff ; ignore_errors=no ; }',
+        }
+
+    def test_brokered_host_is_accepted(self):
+        self.validate(self.valid())
+
+    def test_legacy_or_missing_ephemeral_flag_is_rejected(self):
+        for value in (False, None, 'true', 1):
+            data = self.valid()
+            data['settings']['ephemeral'] = value
+            with self.assertRaises(ValueError):
+                self.validate(data)
+
+    def test_wrong_identity_is_rejected(self):
+        for key, value in [('accountId', '111111111111'), ('region', 'us-east-1'),
+                           ('instanceId', 'not-an-instance'), ('architecture', 'x86_64')]:
+            data = self.valid()
+            data['identity'][key] = value
+            with self.assertRaises(ValueError):
+                self.validate(data)
+
+    def test_runner_name_and_settings_are_bound_to_instance(self):
+        for key in ('runner_name', 'settings'):
+            data = self.valid()
+            data[key] = 'runner-other' if key == 'runner_name' else {'ephemeral': True, 'agentName': 'other'}
+            with self.assertRaises(ValueError):
+                self.validate(data)
+
+    def test_inactive_restarting_or_foreign_service_is_rejected(self):
+        for key, value in [('restart', 'always'), ('active', 'inactive'),
+                           ('service', '../other.service'), ('cgroup', '0::/other.service'),
+                           ('machine', 'x86_64')]:
+            data = self.valid()
+            data[key] = value
+            with self.assertRaises(ValueError):
+                self.validate(data)
+
+    def test_missing_unprivileged_or_writable_dropin_is_rejected(self):
+        for key, value in [('dropin', ''), ('dropin_uid', 1000), ('dropin_mode', 0o666),
+                           ('dropin', self.valid()['dropin'].replace('=+', '='))]:
+            data = self.valid()
+            data[key] = value
+            with self.assertRaises(ValueError):
+                self.validate(data)
+
+    def test_effective_poweroff_must_match_without_extra_commands(self):
+        for value in ('', '{ path=/bin/true ; argv[]=/bin/true ; }',
+                      self.valid()['stop_post'].replace('poweroff ;', 'poweroff extra ;'),
+                      self.valid()['stop_post'] + ' { path=/bin/true ; }'):
+            data = self.valid()
+            data['stop_post'] = value
+            with self.assertRaises(ValueError):
+                self.validate(data)
+
+    def test_workflow_is_manual_main_only_single_short_arm_job(self):
+        self.assertIn('on:\n  workflow_dispatch:\n', self.workflow)
+        self.assertIn("if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'", self.workflow)
+        self.assertIn('runs-on: [self-hosted, Linux, ARM64]', self.workflow)
+        self.assertIn('timeout-minutes: 5', self.workflow)
+        self.assertIn('permissions: {}', self.workflow)
+        jobs = self.workflow.split('jobs:\n', 1)[1]
+        self.assertEqual(re.findall(r'^  [\w-]+:$', jobs, re.M), ['  accept:'])
+        for forbidden in ['pull_request:', 'push:', 'schedule:', 'workflow_run:', 'inputs:',
+                          'uses:', 'secrets.', 'id-token:', 'configure-aws', 'aws ssm',
+                          'iam/security-credentials', 'get-secret-value']:
+            self.assertNotIn(forbidden, self.workflow)
+
+    def test_runtime_uses_imdsv2_identity_only_and_read_only_systemctl(self):
+        self.assertIn("method='PUT'", self.workflow)
+        self.assertIn('X-aws-ec2-metadata-token-ttl-seconds', self.workflow)
+        self.assertIn('latest/dynamic/instance-identity/document', self.workflow)
+        self.assertIn('urllib.request.ProxyHandler({})', self.workflow)
+        self.assertIn("['systemctl', 'show', service", self.workflow)
+        self.assertIn('timeout=5', self.workflow)
+
+    def test_observer_window_follows_validation_and_smoke(self):
+        window = self.workflow.index('time.sleep(90)')
+        self.assertLess(self.workflow.index("validate({'identity': identity"), window)
+        self.assertLess(self.workflow.index('if sum(range(100)) != 4950:'), window)
+        self.assertLess(self.workflow.index("'phase': 'ready-for-observer'"), window)
+        self.assertGreater(self.workflow.index("'phase': 'smoke-complete'"), window)
+        self.assertEqual(self.workflow.count('time.sleep('), 1)
+
+    def test_offline_tests_run_on_the_hosted_linter(self):
+        ci = WORKFLOW.with_name('ci.yml').read_text()
+        lint = ci.split('  actionlint:\n', 1)[1].split('\n  skip-check:', 1)[0]
+        self.assertIn('runs-on: ubuntu-latest', lint)
+        self.assertIn('run: make test-runner-acceptance', lint)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/scripts/test-runner-acceptance.py
+++ b/scripts/test-runner-acceptance.py
@@ -4,6 +4,7 @@ import ast
 from pathlib import Path
 import re
 import shlex
+import subprocess
 import textwrap
 import unittest
 
@@ -102,12 +103,13 @@ class RunnerAcceptanceTests(unittest.TestCase):
 
     def test_workflow_is_manual_main_only_single_short_arm_job(self):
         self.assertIn('on:\n  workflow_dispatch:\n', self.workflow)
-        self.assertIn("if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'", self.workflow)
+        self.assertIn('  accept:\n    needs: authorize\n', self.workflow)
         self.assertIn('runs-on: [self-hosted, Linux, ARM64]', self.workflow)
         self.assertIn('timeout-minutes: 5', self.workflow)
         self.assertIn('permissions: {}', self.workflow)
         jobs = self.workflow.split('jobs:\n', 1)[1]
-        self.assertEqual(re.findall(r'^  [\w-]+:$', jobs, re.M), ['  accept:'])
+        self.assertEqual(re.findall(r'^  [\w-]+:$', jobs, re.M), ['  authorize:', '  accept:'])
+        self.assertEqual(self.workflow.count('runs-on: [self-hosted,'), 1)
         for forbidden in ['pull_request:', 'push:', 'schedule:', 'workflow_run:', 'inputs:',
                           'uses:', 'secrets.', 'id-token:', 'configure-aws', 'aws ssm',
                           'iam/security-credentials', 'get-secret-value']:
@@ -134,6 +136,21 @@ class RunnerAcceptanceTests(unittest.TestCase):
         lint = ci.split('  actionlint:\n', 1)[1].split('\n  skip-check:', 1)[0]
         self.assertIn('runs-on: ubuntu-latest', lint)
         self.assertIn('run: make test-runner-acceptance', lint)
+
+    def test_non_main_dispatch_fails_instead_of_skipping_green(self):
+        gate = re.search(r'^  authorize:\n(.*?)(?=^  accept:)', self.workflow, re.M | re.S)
+        self.assertIsNotNone(gate, 'No executing authorization job: a skipped acceptance can look green')
+        self.assertIn('runs-on: ubuntu-latest', gate[1])
+        self.assertIsNone(re.search(r'^    if:', gate[1], re.M))
+        script = textwrap.dedent(gate[1].split('        run: |\n', 1)[1])
+        for event, ref, allowed in [('workflow_dispatch', 'refs/heads/main', True),
+                                   ('workflow_dispatch', 'refs/heads/feature', False),
+                                   ('workflow_dispatch', 'refs/tags/main', False),
+                                   ('pull_request', 'refs/heads/main', False),
+                                   ('workflow_dispatch', '', False)]:
+            result = subprocess.run(['/bin/bash', '-c', script], text=True, capture_output=True,
+                                    env={'GITHUB_EVENT_NAME': event, 'GITHUB_REF': ref}, timeout=5)
+            self.assertEqual(result.returncode == 0, allowed, (event, ref, result.stderr))
 
 
 if __name__ == '__main__':

--- a/scripts/test-runner-acceptance.py
+++ b/scripts/test-runner-acceptance.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 """Offline tests of the exact manual runner-acceptance workflow (no AWS calls)."""
 import ast
+import json
 from pathlib import Path
 import re
 import shlex
 import subprocess
+import tempfile
 import textwrap
 import unittest
 
@@ -17,6 +19,7 @@ class RunnerAcceptanceTests(unittest.TestCase):
         cls.workflow = WORKFLOW.read_text()
         body = cls.workflow.split("          python3 - <<'PY'\n", 1)[1].split('\n          PY', 1)[0]
         tree = ast.parse(textwrap.dedent(body))
+        cls.workflow_tree = tree
         functions = [node for node in tree.body if isinstance(node, ast.FunctionDef)]
         namespace = {'re': re, 'shlex': shlex}
         exec(compile(ast.Module(body=functions, type_ignores=[]), '<workflow>', 'exec'), namespace)
@@ -40,6 +43,28 @@ class RunnerAcceptanceTests(unittest.TestCase):
 
     def test_brokered_host_is_accepted(self):
         self.validate(self.valid())
+
+    def test_actual_settings_loader_accepts_utf8_with_or_without_bom(self):
+        # The pinned runner writes a UTF-8 BOM to .runner. Execute the shipped
+        # loader expression, not a test-only decoder or the validation function.
+        loaders = [node for node in ast.walk(self.workflow_tree)
+                   if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                   and isinstance(node.func.value, ast.Name)
+                   and node.func.value.id == 'json' and node.func.attr == 'loads'
+                   and any(isinstance(child, ast.Constant) and child.value == '.runner'
+                           for child in ast.walk(node))]
+        self.assertEqual(len(loaders), 1)
+        loader = compile(ast.Expression(loaders[0]), '<workflow-settings-loader>', 'eval')
+        expected = self.valid()['settings']
+        with tempfile.TemporaryDirectory(prefix='runner-settings-') as temporary:
+            directory = Path(temporary)
+            for prefix in (b'', b'\xef\xbb\xbf'):
+                with self.subTest(bom=bool(prefix)):
+                    (directory / '.runner').write_bytes(prefix + json.dumps(expected).encode())
+                    self.assertEqual(eval(loader, {'json': json, 'directory': directory}), expected)
+            (directory / '.runner').write_bytes(b'\xef\xbb\xbf{')
+            with self.assertRaises(json.JSONDecodeError):
+                eval(loader, {'json': json, 'directory': directory})
 
     def test_legacy_or_missing_ephemeral_flag_is_rejected(self):
         for value in (False, None, 'true', 1):
@@ -78,6 +103,15 @@ class RunnerAcceptanceTests(unittest.TestCase):
             data = self.valid()
             data[key] = value
             with self.assertRaises(ValueError):
+                self.validate(data)
+
+    def test_root_owned_nonwritable_modes_satisfy_the_contract(self):
+        # The gate requires root ownership and no untrusted writers, not an
+        # exact copy of the bootstrap's 0644 mode. Effective service checks remain.
+        for mode in (0o644, 0o600, 0o444, 0o755):
+            with self.subTest(mode=oct(mode)):
+                data = self.valid()
+                data['dropin_mode'] = mode
                 self.validate(data)
 
     def test_effective_poweroff_must_match_without_extra_commands(self):


### PR DESCRIPTION
## Purpose

Provide a small, explicit runtime acceptance check for the AWS runner credential migration. This is a separate change from PR #914.

## Safety and behavior

- Manual dispatch on main only; an explicit credential-free hosted authorization job rejects other refs before the single ARM self-hosted job (five-minute timeout).
- Empty GitHub token permissions, no checkout, actions, OIDC, inputs, repository secrets, or AWS credential/SSM calls.
- Match IMDSv2 instance identity to runner.name and the configured ephemeral runner; reject legacy reusable hosts.
- Require the actual service cgroup, root-owned non-writable ephemeral drop-in, effective Restart=no and poweroff ExecStopPost.
- Read the runner's JSON settings as bytes so both ordinary UTF-8 and the UTF-8 BOM emitted by the pinned runner are accepted. Malformed JSON still fails.
- Benign smoke test then a 90-second observer window. The administrator must independently verify launch/user-data provenance and bootstrap-parameter metadata absence during this window, then job success and automatic host/runner retirement. This is functional acceptance, not hostile-host attestation.
- Adds fifteen offline acceptance tests to the existing GitHub-hosted linter; does not change normal matrix gates. The normal merge of main preserves its CI/AMI security targets.

## Verification

On ARM dev at exact head 9b74451e45c5e5df3491dddb992d00dd74144ccf, `make test-runner-acceptance test-ci-security` passes 30 tests: 15 acceptance, 9 CI workflow security, and 6 AMI security. Checksum-verified actionlint 1.7.10 passes all workflows. `git diff --check` passes.

RED-VERIFIED: `test_actual_settings_loader_accepts_utf8_with_or_without_bom` executes the actual settings-loader expression from the workflow against ordinary UTF-8, UTF-8 BOM, and malformed JSON fixtures. The BOM case failed with `read_text()`, passed with `read_bytes()`, failed again when the fix was reverted, and passed after restoration. The defect was also observed in the pinned runner's actual `.runner` file during read-only runtime inspection. Focused mode-contract tests accept safe root-owned non-writable modes without weakening the existing ownership, writable-mode, content, or effective-service checks.

## Deployment hold

Do not dispatch until the broker user data is deployed and the operator has arranged fresh-host selection/draining. The job intentionally fails if GitHub selects a legacy runner. No acceptance workflow or AMI build was dispatched by this PR preparation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added offline acceptance tests for runner identity, configuration, service behavior, and poweroff safeguards.
  * Added validation for workflow triggers, permissions, runtime metadata, and observer status reporting.
  * Added CI coverage for runner acceptance tests without cloud credentials.

* **Chores**
  * Added a manually triggered acceptance workflow for ARM64 Linux runner bootstrap validation.
  * Added Make targets for runner, CI workflow, and AMI security checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
